### PR TITLE
pgw#1087: cold boot decomposes PER COMPONENT — twelve typed phases, a ladder that closes on a UNION, and a NAMED residual

### DIFF
--- a/changelog.d/pgw1087.md
+++ b/changelog.d/pgw1087.md
@@ -1,0 +1,43 @@
+- **pgw#1087: cold boot decomposes PER COMPONENT, and the phase table now
+  closes.** The finest cold-boot fact the platform held was leg-grade — "the
+  A1 adopt leg = 6.2 min / \$0.102", no split — and every finer question asked
+  in the compiled-serving campaign (how long is the per-class trace? the
+  toolchain derivation? the memo delta? the download-vs-admission split of an
+  adopt?) was unanswerable. Twelve typed phases join `boot_phases`, each with
+  exactly one production producer: `sdk_ready` (the interpreter+import wall,
+  cumulative), `component_fetch` (per diffusers component, opened at its first
+  byte and closed at its last, so CONCURRENCY is readable — the first real
+  decomposition showed four components totalling 3,338 ms inside a 909 ms
+  `weights_fetch`), `env_establish` + its nested `lib_memo` (hit/partial/miss/
+  no_libs — the derivation the issue said to "expect ms; prove it"),
+  `declaration_compose`, `trace_for_key` (one row per graph CLASS, re-emitted
+  parent-side from the mint child's report), `key_fold`, `cell_hub_rtt`,
+  `cell_verify` + `entry_admit` (admission split into inert-bytes verification
+  and per-entry dlopen/bind, which were one `cell_arm` number), and the two
+  user-visible timestamps `eager_ready` / `compiled_swap` whose difference is
+  the eager-serving window. `cell_fetch` — declared since pgw#764 and NEVER
+  produced — finally gets its producer at `aot_delivery`.
+- **`cell_discover` is DELETED.** pgw#924 declared it as one of "the eight the
+  shipping path PRODUCES"; grep finds it only in `boot_phases.py` and tests.
+  pgw#904 replaced worker-side fetch-and-filter discovery with a hub-resolved
+  `Arm.artifact`, so there has been nothing to discover. Same defect class
+  pgw#924 was closing, missed because that audit checked the count.
+- **`reconciliation()` reconciles on a UNION, and NAMES its residual.** Once
+  phases decompose per component they overlap, and a summing ladder
+  "explained" 3.3 s of a 0.9 s window — closing by over-counting is worse than
+  visibly not closing. `measured_ms` is now the wall time covered by at least
+  one span and the difference from the exclusive sum ships as
+  `concurrency_ms`. Two windows no span can cover are named rather than
+  lumped: `named.sdk_import_ms` (nothing can span the import of the span
+  recorder) and `named.hub_handshake_ms` (the dial + HelloAck + wait for a
+  DesiredResidency). New `phase_table()` / `render_phase_table()` /
+  `completeness(shape)` return the decomposition and a typed verdict —
+  `missing` phases and `residual_pct` are separate failures because they have
+  different fixes.
+- **Proof:** `tests/test_cold_boot_decomposition_pgw1087.py` drives a REAL
+  multi-component boot through the hub double and reads the ladder off the
+  wire (nothing calls an emitter), asserting completeness, per-component
+  bytes/source/nesting/intervals. Its RED proof is parametrized over every
+  phase of the shape: delete that phase's rows from the real boot and the
+  verdict must go red and NAME it. First real table: 9,119 ms boot,
+  residual 2 ms (0.02%), `concurrency_ms` 156.

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -15,12 +15,14 @@ fleet event is actionable.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 from typing import Any, Optional
 
 import requests
 
+from . import boot_phases
 from .api.errors import RetryableError
 from .bounded_stream import copy_bounded
 from .models.chunk_cas import (
@@ -59,6 +61,31 @@ def materialize_named_artifact(
     digest, so a re-dispatch of the same spec is a verify-and-return.
     ``what`` names the attempt + spec digest for every refusal.
     """
+    # pgw#1087: THE cell-download phase. `cell_fetch` has been a declared boot
+    # phase since pgw#764 with NO producer anywhere in the tree — so "the adopt
+    # leg took 6.2 min" could never be split into download vs admission, which
+    # is the first question anyone asks about an adopt. This is the one place
+    # cell bytes move, so it is the one place the span belongs.
+    with boot_phases.span(
+        boot_phases.PHASE_CELL_FETCH,
+        ref=cell_ref,
+        artifact_kind="aot-inductor",
+        artifact_key=str(content_digest or ""),
+    ) if boot_phases.in_boot() else contextlib.nullcontext() as fetch_span:
+        return _materialize_named_artifact(
+            cell_ref, content_digest, presigned,
+            cache_dir=cache_dir, what=what, span=fetch_span)
+
+
+def _materialize_named_artifact(
+    cell_ref: str,
+    content_digest: str,
+    presigned: Optional[Any],
+    *,
+    cache_dir: Optional[Path],
+    what: str,
+    span: Optional["boot_phases.BootSpan"] = None,
+) -> Path:
     digest = str(content_digest or "").strip()
     if not digest:
         raise NamedArtifactUnavailable(
@@ -78,6 +105,11 @@ def materialize_named_artifact(
             raise NamedArtifactUnavailable(
                 "artifact_unpinned", f"{what}: {exc}") from exc
         else:
+            # A cache hit is a real and countable outcome of this phase, not a
+            # zero-byte fetch: the verify pass still reads the whole tarball.
+            if span is not None:
+                span.classify("cached", f"ref={cell_ref}")
+                span.bytes_moved(dest.stat().st_size, boot_phases.SOURCE_LOCAL)
             return dest
 
     if presigned is None or not list(getattr(presigned, "files", ())):
@@ -147,6 +179,10 @@ def materialize_named_artifact(
             f"{what}: named cell {cell_ref!r} bytes refused against "
             f"{digest[:24]}…: {exc}") from exc
     tmp.replace(dest)
+    if span is not None:
+        span.classify("fetched", f"ref={cell_ref} chunks={len(chunks)}")
+        span.bytes_moved(declared_size or dest.stat().st_size,
+                         boot_phases.SOURCE_CAS)
     return dest
 
 

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -69,6 +69,7 @@ compile stack keeps ``import gen_worker`` off the torch/pb import graph.
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import gzip
 import hashlib
@@ -90,6 +91,7 @@ from . import activity as activity_mod
 from . import aot_flatten
 from . import aot_identity
 from . import artifact_meta
+from . import boot_phases
 from . import cell_key as cell_key_mod
 from . import host_isa
 from .cell_adopt import AdoptOutcome
@@ -2557,8 +2559,18 @@ def load_and_wrap(
     settled while the artifact is still inert bytes.
     """
     family = str(getattr(cfg, "family", "") or "")
-    staged = stage_artifact(
-        Path(artifact), family, cache_dir=cache_dir, expected=expected)
+    # pgw#1087: admission splits in two and the halves have different owners.
+    # `cell_verify` is unpack + identity + contract verification on inert bytes
+    # (disk + hashing); `entry_admit` below is per-ENTRY dlopen, constant bind
+    # and ingress-assertion arming (device). Both were inside one `cell_arm`
+    # row, so an adopt that spent four minutes hashing a tarball and one
+    # second binding read identically to the reverse.
+    with boot_phases.span(
+        boot_phases.PHASE_CELL_VERIFY, ref=family,
+        artifact_kind="aot-inductor",
+    ) if boot_phases.in_boot() else contextlib.nullcontext():
+        staged = stage_artifact(
+            Path(artifact), family, cache_dir=cache_dir, expected=expected)
     try:
         meta = staged.metadata
         # pgw#1040: parsed and validated once, while staging.
@@ -2643,17 +2655,27 @@ def load_and_wrap(
             pools[target] = pool
             runners: List[Tuple[str, ArtifactRunner]] = []
             for name, contract, constants in parsed:
-                package = _load_package(staged.root / PACKAGE_NAME, name)
-                runner = ArtifactRunner(
-                    package=package, contract=contract, constants=constants,
-                    module_name=target, entry=name, family=family)
-                try:
-                    runner.bind(pool, literals_by_entry.get(name, {}),
-                                user_managed=True)
-                except ConstantsUnboundError as exc:
-                    raise AdoptError(
-                        f"constants_{exc.reason}",
-                        f"entry {name!r}: {exc}") from exc
+                # pgw#1087: ONE entry's admission — dlopen + bind. Per entry
+                # because that is the axis a 36-class cell varies on, and a
+                # roll-up cannot tell a uniformly slow admission from one
+                # pathological entry.
+                with boot_phases.span(
+                    boot_phases.PHASE_ENTRY_ADMIT, ref=family, function=name,
+                    artifact_kind="aot-inductor",
+                ) if boot_phases.in_boot() else contextlib.nullcontext() as sp:
+                    package = _load_package(staged.root / PACKAGE_NAME, name)
+                    runner = ArtifactRunner(
+                        package=package, contract=contract, constants=constants,
+                        module_name=target, entry=name, family=family)
+                    try:
+                        runner.bind(pool, literals_by_entry.get(name, {}),
+                                    user_managed=True)
+                    except ConstantsUnboundError as exc:
+                        raise AdoptError(
+                            f"constants_{exc.reason}",
+                            f"entry {name!r}: {exc}") from exc
+                    if sp is not None:
+                        sp.note(f"target={target} constants={len(constants)}")
                 total_constants += len(constants)
                 runners.append((name, runner))
             dispatches[target] = EntryDispatch(tuple(runners))

--- a/src/gen_worker/boot_phases.py
+++ b/src/gen_worker/boot_phases.py
@@ -12,11 +12,23 @@ per-REQUEST measurement spine, th#1111), and it deliberately copies that
 module's two trustworthiness properties:
 
 * **It reconciles.** Spans nest, and a nested span's time is charged to the
-  CHILD, never twice. So measured phases + ``residual`` == the whole boot
-  window. A boot instrument that reports 120s of phases inside a 190s boot
-  cannot answer the question it exists for.
+  CHILD, never twice. So measured phases + named segments + ``residual`` ==
+  the whole boot window. A boot instrument that reports 120s of phases inside
+  a 190s boot cannot answer the question it exists for.
+
+  pgw#1087 made that a UNION rather than a sum. Once phases decompose per
+  component they run concurrently, and a summing reconciliation "explains"
+  3,338 ms of a 909 ms fetch — closing the ladder by over-counting, which is
+  worse than visibly not closing it. ``measured_ms`` is the wall time covered
+  by at least one span; the gap between that and the exclusive sum is reported
+  as ``concurrency_ms``, because "how parallel was this boot" is the question
+  the per-component split exists to answer.
 * **It classifies.** Every phase is FETCH, COMPILE, LOAD or SETUP, so
   "this release's boots are network-bound" is a query, not a hunch.
+* **It NAMES its residual** (pgw#1087). Two windows no span can cover — the
+  interpreter+import wall before the recorder exists, and the hub handshake in
+  which the worker deliberately does no local work — are named segments, not
+  an unexplained lump. What survives both is the honest hole.
 
 ## Why it buffers
 
@@ -42,7 +54,10 @@ import time
 import uuid
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional
+from dataclasses import dataclass
+from typing import (
+    Any, Awaitable, Callable, Dict, Iterable, Iterator, List, Optional, Tuple,
+)
 
 from .pb import worker_scheduler_pb2 as pb
 
@@ -75,7 +90,6 @@ PHASE_PIPELINE_LOAD = "pipeline_load"
 #: A skipped warmup now emits no row, because "nobody warmed" and "warming was
 #: free" are different answers and only one of them was ever true.
 PHASE_WARMUP = "warmup"
-PHASE_CELL_DISCOVER = "cell_discover"
 PHASE_CELL_FETCH = "cell_fetch"
 #: pgw#923/#924: the arm of ONE delivered or discovered cell. Its duration is
 #: the same quantity the hub stores as the adoption's `duration_ms`, measured
@@ -83,9 +97,79 @@ PHASE_CELL_FETCH = "cell_fetch"
 PHASE_CELL_ARM = "cell_arm"
 PHASE_FIRST_REQUEST_SERVABLE = "first_request_servable"
 
+# --- pgw#1087: the per-COMPONENT decomposition -----------------------------
+# Paul, 2026-08-10: "you should be measuring per-component of cold-boot, not
+# just measuring a granular 'whole cold boot was 6.2 mins for some reason'."
+# The eight phases above are LEG-grade: they answer "fetch or compile" and
+# nothing finer, which is why "the adopt leg took 6.2 min" was the finest fact
+# the platform held. Each name below is one question that was asked this
+# session and could not be answered, and each has exactly one production
+# producer — the pgw#924 rule is not relaxed for being new.
+
+#: Process start -> the SDK is usable (interpreter + torch import + endpoint
+#: discovery + executor construction). CUMULATIVE. Names the window that
+#: previously arrived as an unexplained residual: no span could start before
+#: the code that opens spans had been imported.
+PHASE_SDK_READY = "sdk_ready"
+#: One component of one ref's weights. Child of `weights_fetch`, opened at the
+#: component's first byte and closed at its last, so CONCURRENCY IS VISIBLE:
+#: four components inside a 200 s `weights_fetch` that each measure 180 s were
+#: overlapped, and that is the fact an overlap optimization needs.
+PHASE_COMPONENT_FETCH = "component_fetch"
+#: `env_seal.establish` — the settings declaration digest, the boot-frozen
+#: loaded-library digest and the sm/host-ISA derivation that together make the
+#: `toolchain` and `sm` key axes. Guessed at "ms"; this proves it.
+PHASE_ENV_ESTABLISH = "env_establish"
+#: The library-digest MEMO path, hit or miss, inside `env_establish`. `reason`
+#: is `hit` or `miss` and `detail` carries the covered/total library counts, so
+#: the saving a memo buys is a subtraction between two real rows rather than an
+#: estimate.
+PHASE_LIB_MEMO = "lib_memo"
+#: Composing the export declaration a mint will trace against.
+PHASE_DECLARATION_COMPOSE = "declaration_compose"
+#: ONE graph CLASS traced for the key. `function` is the entry name and
+#: `detail` carries `nodes=` — a class's trace cost is meaningless without the
+#: graph size it paid for. Never a roll-up: 36 classes is 36 rows.
+PHASE_TRACE_FOR_KEY = "trace_for_key"
+#: Per-class hashing + the fold into `combined_graph_hash`.
+PHASE_KEY_FOLD = "key_fold"
+#: One worker->hub cell control-plane round trip (publish-intent /
+#: publish-complete). `function` names the leg. NOTE: there is no worker-side
+#: key LOOKUP to time — pgw#904 made the hub resolve the arm and pgw#1032
+#: deleted `StateDelta.cell_lookups` — so this is the whole of the hub RTT the
+#: cell path actually pays on a boot.
+PHASE_CELL_HUB_RTT = "cell_hub_rtt"
+#: Staging + contract verification of a downloaded cell, before the first
+#: dlopen. The first half of admission.
+PHASE_CELL_VERIFY = "cell_verify"
+#: ONE entry's admission: contract parse, constant bind, ingress-assertion
+#: arming and the admission-drift parity check against the artifact's own
+#: generated guards. The second half of admission, and the per-entry parity
+#: sweep, measured where it happens.
+PHASE_ENTRY_ADMIT = "entry_admit"
+#: CUMULATIVE. The first instant this worker could have served a request at
+#: all, compiled or not — the first of the two user-visible timestamps.
+PHASE_EAGER_READY = "eager_ready"
+#: CUMULATIVE. The instant a compiled cell became the served path. The second
+#: user-visible timestamp, and the only honest measure of how long a pod serves
+#: eager before its cell arrives. May land AFTER the boot closes, which is
+#: exactly the fact worth having.
+PHASE_COMPILED_SWAP = "compiled_swap"
+
 #: The boot's closing milestone: the phase whose completion means this worker
 #: can serve. Everything after it is optimization, not boot.
 SERVABLE_PHASES = frozenset({PHASE_FIRST_REQUEST_SERVABLE})
+
+#: Milestones measured from process start rather than spans of their own. They
+#: are excluded from the phase SUM (they cover wall clock the spans already
+#: account for) and reported beside it.
+CUMULATIVE_PHASES = frozenset({
+    PHASE_HELLO,
+    PHASE_SDK_READY,
+    PHASE_EAGER_READY,
+    PHASE_COMPILED_SWAP,
+    PHASE_FIRST_REQUEST_SERVABLE,
+})
 
 # Phase classification — which resource a phase spends. Mirrors
 # stage_timing's GPU_BUSY/SMALL_GPU/GPU_IDLE intent at boot scale.
@@ -97,7 +181,6 @@ CLASS_SETUP = "setup"      # probes, seals, manifests, handshake
 _CLASS_BY_PHASE: Dict[str, str] = {
     PHASE_HELLO: CLASS_SETUP,
     PHASE_WEIGHTS_FETCH: CLASS_FETCH,
-    PHASE_CELL_DISCOVER: CLASS_SETUP,
     PHASE_CELL_FETCH: CLASS_FETCH,
     PHASE_CELL_ARM: CLASS_LOAD,
     PHASE_PIPELINE_LOAD: CLASS_LOAD,
@@ -106,11 +189,32 @@ _CLASS_BY_PHASE: Dict[str, str] = {
     # per row, which is why classification is a lookup and not a constant.
     PHASE_WARMUP: CLASS_COMPILE,
     PHASE_FIRST_REQUEST_SERVABLE: CLASS_SETUP,
+    # pgw#1087
+    PHASE_SDK_READY: CLASS_SETUP,
+    PHASE_COMPONENT_FETCH: CLASS_FETCH,
+    PHASE_ENV_ESTABLISH: CLASS_SETUP,
+    PHASE_LIB_MEMO: CLASS_SETUP,
+    PHASE_DECLARATION_COMPOSE: CLASS_SETUP,
+    PHASE_TRACE_FOR_KEY: CLASS_COMPILE,
+    PHASE_KEY_FOLD: CLASS_SETUP,
+    PHASE_CELL_HUB_RTT: CLASS_SETUP,
+    PHASE_CELL_VERIFY: CLASS_LOAD,
+    PHASE_ENTRY_ADMIT: CLASS_LOAD,
+    PHASE_EAGER_READY: CLASS_SETUP,
+    PHASE_COMPILED_SWAP: CLASS_SETUP,
 }
 
 #: The complete vocabulary (pgw#924). Exported so a test can assert the
 #: declaration and the production producers are the SAME set — the property
 #: that failed here, silently, for seventeen names.
+#:
+#: pgw#1087 removed `cell_discover`. It was declared by pgw#924 as one of the
+#: "eight the shipping path PRODUCES", and it never had a producer: pgw#904
+#: replaced worker-side fetch-and-filter discovery with a hub-RESOLVED
+#: `Arm.artifact`, so there is nothing left to discover. Grep confirms it
+#: appeared only in this module and in tests. Same defect class pgw#924 was
+#: closing, missed once because the audit checked the COUNT and not the
+#: producers.
 PHASES: frozenset = frozenset(_CLASS_BY_PHASE)
 
 
@@ -171,6 +275,9 @@ _pending_servable: Optional[Dict[str, Any]] = None
 #: Per-ordinal classification override (pgw#797: an armed warm is LOAD, an
 #: unarmed one is COMPILE — same phase name, different resource).
 _class_override: Dict[int, str] = {}
+#: pgw#1087: every CUMULATIVE milestone's ms-from-process-start, first write
+#: wins. Read by :func:`reconciliation` and :func:`completeness`.
+_milestone_ms: Dict[str, int] = {}
 
 _process_start_unix: float = 0.0
 
@@ -328,6 +435,19 @@ class BootSpan:
         """Attach identifiers (ref=/key=/fn=/lane=) per the pgw#760 doctrine."""
         self._detail = detail[:2000]
 
+    def classify(self, reason: str, detail: str = "") -> None:
+        """Attach the countable reason token WITHOUT calling this a refusal.
+
+        pgw#1087: `memo hit` / `memo miss` and `cell cached` / `cell fetched`
+        are the two branches of a SUCCESSFUL phase, and both are the fact worth
+        counting. Before this the only way to put a token on a row was
+        :meth:`refused`, which sets ``outcome=refused`` — so a hub-side count of
+        refusals would have been polluted by every memo hit.
+        """
+        self._reason = reason[:300]
+        if detail:
+            self._detail = detail[:2000]
+
     def refused(self, reason: str, detail: str = "") -> None:
         """A TYPED refusal: this phase declined and the worker serves something
         else. Not an error — the reason token is the countable fact."""
@@ -453,6 +573,97 @@ def span(
         handle.close()
 
 
+class ComponentSpans:
+    """Per-component fetch spans that open on the first byte and close on the
+    last (pgw#1087).
+
+    Weights download is the biggest slice of most cold boots and the platform
+    could only ever say how long the WHOLE ref took. A per-component span is
+    not a finer roll-up of the same number: the components download
+    CONCURRENTLY, so four 180 s components inside a 200 s `weights_fetch` is a
+    completely different finding from four sequential 50 s ones, and only
+    start/end per component can tell them apart.
+
+    ``expected`` is {component: file count}. A component closes when its last
+    file is accounted, so a span never re-opens after closing — a refcount
+    that touched zero mid-fetch would otherwise split one component into two
+    rows and make the ladder stop reconciling.
+    """
+
+    __slots__ = ("_remaining", "_open", "_parent", "_ref", "_lock")
+
+    def __init__(
+        self,
+        expected: Dict[str, int],
+        *,
+        parent: Optional[int] = None,
+        ref: str = "",
+    ) -> None:
+        self._remaining = {k: int(v) for k, v in expected.items() if int(v) > 0}
+        self._open: Dict[str, BootSpan] = {}
+        self._parent = parent
+        self._ref = ref
+        self._lock = threading.Lock()
+
+    def start(self, component: str) -> None:
+        with self._lock:
+            if component in self._open or component not in self._remaining:
+                return
+            self._open[component] = open_span(
+                PHASE_COMPONENT_FETCH, ref=self._ref, function=component,
+                parent=self._parent)
+
+    def finish(
+        self, component: str, *, bytes_moved: int = 0, source: str = "",
+    ) -> None:
+        with self._lock:
+            left = self._remaining.get(component)
+            if left is None:
+                return
+            span_handle = self._open.get(component)
+            if span_handle is not None and (bytes_moved or source):
+                span_handle.bytes_moved(int(bytes_moved), source)
+            left -= 1
+            if left > 0:
+                self._remaining[component] = left
+                return
+            self._remaining.pop(component, None)
+            handle = self._open.pop(component, None)
+        if handle is not None:
+            handle.close()
+
+    def close_all(self, reason: str = "") -> None:
+        """Close every still-open component span (an aborted fetch)."""
+        with self._lock:
+            handles = list(self._open.items())
+            self._open.clear()
+            self._remaining.clear()
+        for name, handle in handles:
+            if reason:
+                handle.refused(reason, f"component={name}")
+            handle.close()
+
+
+@contextmanager
+def parent_scope(ordinal: int) -> Iterator[None]:
+    """Make ``ordinal`` the implicit parent for spans opened in this context.
+
+    :func:`open_span` (as opposed to :func:`span`) does NOT push onto the
+    nesting stack — it cannot, because its close happens in another frame. So
+    a decomposition opened deep inside such a span, across `await` boundaries
+    and module boundaries, has no way to find its parent and lands at the top
+    level, where its time is added to the ladder a second time and
+    `reconciliation` stops closing. Threading an ordinal through six call
+    frames is the alternative; a ContextVar scope is the same fact stated once
+    (and ContextVars copy per task, so concurrent fetches nest correctly).
+    """
+    token = _stack_var.set(_stack_var.get() + (int(ordinal),))
+    try:
+        yield
+    finally:
+        _stack_var.reset(token)
+
+
 def mark(
     phase: str,
     *,
@@ -486,6 +697,14 @@ def mark(
     is HELD, not emitted: see the ``_hello_seen`` note. It is released, with its
     time re-read at release, by :func:`note_hello`.
     """
+    # pgw#1087: a milestone is cumulative BY NAME, not by the caller passing
+    # the flag. `eager_ready` is marked from a setup task that runs inside the
+    # `pipeline_load` span, so a caller who forgot the flag would charge a
+    # whole-boot duration against a sub-second parent and drive its exclusive
+    # time to zero — the exact pgw#797 defect, one vocabulary later. Making it
+    # structural means the flag can only ever be redundant, never wrong.
+    if phase in CUMULATIVE_PHASES:
+        since_process_start = True
     if phase in SERVABLE_PHASES:
         with _lock:
             if not _hello_seen:
@@ -522,6 +741,14 @@ def mark(
             _class_override[ordinal] = klass
     if since_process_start:
         duration_ms = process_uptime_ms()
+    if since_process_start:
+        # pgw#1087: every cumulative milestone is remembered, not just the
+        # servable one. `eager_ready` and `compiled_swap` are the two
+        # user-visible timestamps and the interval between them is how long a
+        # pod served eager while its cell arrived — a subtraction nobody could
+        # do while only one milestone was retained.
+        with _lock:
+            _milestone_ms.setdefault(phase, duration_ms)
     if phase in SERVABLE_PHASES:
         global _servable_ms
         with _lock:
@@ -628,21 +855,64 @@ def in_boot() -> bool:
         return _servable_ms is None
 
 
-def reconciliation() -> Dict[str, int]:
+def _union_ms(intervals: List[Tuple[int, int]]) -> int:
+    """Total wall time covered by ``intervals``, overlaps counted ONCE."""
+    total = 0
+    end_so_far = -1
+    for start, end in sorted(intervals):
+        if end <= end_so_far:
+            continue
+        total += end - max(start, end_so_far if end_so_far >= 0 else start)
+        end_so_far = end
+    return max(0, total)
+
+
+def _deduped(rows: List[pb.BootPhase]) -> List[pb.BootPhase]:
+    """One row per (ordinal, terminal) — the hub's own upsert key.
+
+    A ladder read off the wire carries duplicates by design: `bind_sink`
+    re-flushes every buffered row on each RECONNECT so a boot that lost its
+    stream still delivers, and the hub upserts. A reader that does not dedupe
+    counts a reconnecting boot's phases twice, which is a measurement error
+    caused entirely by a delivery guarantee (observed on the first real
+    decomposition: `sdk_ready` and `hello` each appeared twice).
+    """
+    seen: Dict[Tuple[int, bool], pb.BootPhase] = {}
+    for row in rows:
+        seen.setdefault((row.ordinal, row.terminal), row)
+    return list(seen.values())
+
+
+def reconciliation(
+    rows: Optional[List[pb.BootPhase]] = None,
+) -> Dict[str, int]:
     """Boot totals, per the th#1111 rule that an instrument must close.
 
     ``residual`` is the boot window no phase explained. It is REPORTED, never
     smeared across the measured phases: "unmeasured" and "zero" are different
     answers, and the residual is the honest hint about where the next
     instrument belongs.
+
+    ``rows`` overrides this process's recorded ladder. It exists so a test can
+    ask the SAME arithmetic about a modified ladder — the RED proof for
+    pgw#1087 removes one phase's rows from a real boot and observes the verdict
+    go red, which is impossible if the only input is a module global.
     """
+    given = rows is not None
     with _lock:
-        rows = list(_rows)
+        if rows is None:
+            rows = list(_rows)
         truncated = _truncated
         total = _servable_ms
+    if given:
+        total = next(
+            (r.duration_ms for r in rows
+             if r.terminal and r.phase in SERVABLE_PHASES), None)
+    rows = _deduped(rows)
     exclusive = 0
     per_class: Dict[str, int] = {}
     children: Dict[int, int] = {}
+    intervals: List[Tuple[int, int]] = []
     for row in rows:
         if row.terminal and not row.cumulative and row.parent_ordinal:
             children[row.parent_ordinal] = children.get(row.parent_ordinal, 0) + row.duration_ms
@@ -654,18 +924,305 @@ def reconciliation() -> Dict[str, int]:
             continue
         own = max(0, row.duration_ms - children.get(row.ordinal, 0))
         exclusive += own
+        intervals.append(
+            (max(0, row.process_uptime_ms - row.duration_ms),
+             row.process_uptime_ms))
         kind = phase_class(row.phase, row.ordinal)
         per_class["class." + (kind or "unattributed")] = (
             per_class.get("class." + (kind or "unattributed"), 0) + own
         )
-    out: Dict[str, int] = {"measured_ms": exclusive}
+    # pgw#1087: `measured_ms` is the UNION of the span intervals, not the sum
+    # of their exclusive times. The two differ the moment anything runs
+    # concurrently, and per-component fetch made concurrency the normal case:
+    # on the first real decomposition four component spans totalling 3,338 ms
+    # sat inside a 909 ms `weights_fetch`, and a summing reconciliation
+    # "explained" 3.3 s of a 0.9 s window — a ladder that closes by
+    # over-counting is worse than one that visibly does not close. The
+    # difference is itself the answer to "how much of this boot was
+    # parallel", so it is reported rather than discarded.
+    measured = _union_ms(intervals)
+    out: Dict[str, int] = {"measured_ms": measured}
     out.update(per_class)
+    if exclusive > measured:
+        out["concurrency_ms"] = exclusive - measured
+    # pgw#1087: NAME the residual instead of reporting one lump. Two named
+    # segments cover what no span can: the interpreter+import window (no span
+    # can open before the module that opens spans is imported) and the
+    # post-servable tail a compiled swap lands in. What survives both is the
+    # only honest `residual_ms`, and it is now small enough to be a finding
+    # rather than the majority of the boot.
+    if given:
+        milestones = {
+            r.phase: r.duration_ms for r in rows
+            if r.terminal and r.cumulative}
+    else:
+        with _lock:
+            milestones = dict(_milestone_ms)
+    named = 0
+    sdk = milestones.get(PHASE_SDK_READY)
+    if sdk is not None:
+        # `sdk_ready` is cumulative, so it covers any span that closed inside
+        # it; only the part no span explained is named here.
+        pre_sdk_spans = _union_ms([
+            (max(0, r.process_uptime_ms - r.duration_ms), r.process_uptime_ms)
+            for r in rows
+            if r.terminal and not r.cumulative and r.process_uptime_ms <= sdk])
+        named_sdk = max(0, sdk - pre_sdk_spans)
+        out["named.sdk_import_ms"] = named_sdk
+        named += named_sdk
+        # The SECOND named window: SDK ready -> the first thing this worker was
+        # told to do. That is the gRPC dial, the Hello/HelloAck round trip and
+        # the wait for a DesiredResidency — real boot seconds in which the
+        # worker deliberately does no local work, so no span can cover them and
+        # leaving them in `residual_ms` reads as an instrument hole rather than
+        # as the hub round trip it is. Measured on a real in-process boot at
+        # 1,238 ms of a 23,208 ms boot — 5.3%, i.e. on its own enough to fail
+        # the ~5% acceptance while nothing was actually unmeasured.
+        starts = [
+            max(0, row.process_uptime_ms - row.duration_ms)
+            for row in rows
+            if row.terminal and not row.cumulative and not row.parent_ordinal
+            and row.process_uptime_ms - row.duration_ms >= sdk
+        ]
+        if starts:
+            handshake = max(0, min(starts) - sdk)
+            out["named.hub_handshake_ms"] = handshake
+            named += handshake
+    for phase in (PHASE_EAGER_READY, PHASE_COMPILED_SWAP):
+        if phase in milestones:
+            out["milestone." + phase + "_ms"] = milestones[phase]
+    if PHASE_EAGER_READY in milestones and PHASE_COMPILED_SWAP in milestones:
+        # The interval a pod served EAGER while its cell was being made or
+        # fetched. The single number the compiled-serving campaign is about.
+        out["eager_serving_ms"] = max(
+            0, milestones[PHASE_COMPILED_SWAP] - milestones[PHASE_EAGER_READY])
     if total is not None:
         out["total_ms"] = total
-        out["residual_ms"] = max(0, total - exclusive)
+        out["named_ms"] = named
+        out["residual_ms"] = max(0, total - measured - named)
+        out["accounted_pct"] = int(round(
+            100.0 * min(1.0, (measured + named) / total))) if total > 0 else 100
     if truncated:
         out["flag.rows_truncated"] = 1
     return out
+
+
+@dataclass(frozen=True)
+class PhaseRow:
+    """One line of the boot's phase table."""
+
+    phase: str
+    ordinal: int
+    parent_ordinal: int
+    klass: str
+    #: Wall time of the span, children included.
+    duration_ms: int
+    #: ``duration_ms`` minus the children's — what THIS phase itself spent.
+    exclusive_ms: int
+    #: ms from process start to the phase's OPEN and CLOSE. Both, because the
+    #: whole point of a per-component decomposition is telling four overlapping
+    #: 180 s fetches from four sequential 50 s ones, and only an interval can.
+    start_ms: int
+    end_ms: int
+    cumulative: bool
+    bytes: int
+    source: str
+    ref: str
+    function: str
+    outcome: str
+    reason: str
+    detail: str
+
+
+def phase_table(
+    rows: Optional[List[pb.BootPhase]] = None,
+) -> List[PhaseRow]:
+    """The boot decomposition, in emission order, with children subtracted.
+
+    The thing pgw#1087 exists to produce: one call, one readable table, no
+    log archaeology. Open (non-terminal) rows are EXCLUDED — a phase with no
+    close has no duration, and a table that silently rendered it as 0 would be
+    the "default read as a fact" defect this vocabulary keeps closing. The open
+    row itself still ships on the wire, where it is the finding.
+    """
+    if rows is None:
+        with _lock:
+            rows = list(_rows)
+    rows = _deduped(rows)
+    children: Dict[int, int] = {}
+    for row in rows:
+        if row.terminal and not row.cumulative and row.parent_ordinal:
+            children[row.parent_ordinal] = (
+                children.get(row.parent_ordinal, 0) + row.duration_ms)
+    out: List[PhaseRow] = []
+    for row in rows:
+        if not row.terminal:
+            continue
+        out.append(PhaseRow(
+            phase=row.phase,
+            ordinal=row.ordinal,
+            parent_ordinal=row.parent_ordinal,
+            klass=phase_class(row.phase, row.ordinal),
+            duration_ms=row.duration_ms,
+            exclusive_ms=(
+                row.duration_ms if row.cumulative
+                else max(0, row.duration_ms - children.get(row.ordinal, 0))),
+            # A cumulative milestone starts at process start by definition; a
+            # span's open is its close minus its own duration, both read off
+            # the one process clock.
+            start_ms=(
+                0 if row.cumulative
+                else max(0, row.process_uptime_ms - row.duration_ms)),
+            end_ms=row.process_uptime_ms,
+            cumulative=row.cumulative,
+            bytes=row.bytes,
+            source=row.source,
+            ref=row.ref,
+            function=row.function,
+            outcome=row.outcome,
+            reason=row.reason,
+            detail=row.detail,
+        ))
+    return out
+
+
+def render_phase_table(rows: Optional[List[pb.BootPhase]] = None) -> str:
+    """The phase table as fixed-width text — what a runbook pastes.
+
+    ``rows`` is a captured ladder (off the wire, or another process's), not a
+    pre-rendered table: the reconciliation footer must be computed from the
+    SAME rows as the body, and a signature that took a rendered table made it
+    possible — and, the first time it was used, actual — to print one boot's
+    phases under another boot's totals.
+    """
+    table = phase_table(rows)
+    lines = [
+        f"{'phase':<22} {'class':<8} {'start_ms':>9} {'end_ms':>9} "
+        f"{'dur_ms':>9} {'excl_ms':>9} {'bytes':>13}  what"
+    ]
+    for row in table:
+        lines.append(
+            f"{row.phase:<22} {row.klass:<8} {row.start_ms:>9} "
+            f"{row.end_ms:>9} {row.duration_ms:>9} {row.exclusive_ms:>9} "
+            f"{row.bytes:>13}  "
+            f"{(row.function or row.ref or row.reason or row.detail)[:70]}")
+    for key, value in sorted(reconciliation(rows).items()):
+        lines.append(f"{key:<22} {value:>9}")
+    return "\n".join(lines)
+
+
+#: The phases a boot of each SHAPE must produce. A boot's shape is what it
+#: DID, so there is no single "complete" set: a memo-hit adopt boot legitimately
+#: has no `trace_for_key` rows, and asserting otherwise would make the
+#: completeness check unusable exactly where it matters. Callers name the shape
+#: they drove; :func:`completeness` reports what that shape is missing.
+SHAPE_EAGER: frozenset = frozenset({
+    PHASE_SDK_READY, PHASE_HELLO,
+    PHASE_WEIGHTS_FETCH, PHASE_COMPONENT_FETCH, PHASE_PIPELINE_LOAD,
+    PHASE_EAGER_READY, PHASE_FIRST_REQUEST_SERVABLE,
+})
+#: A boot that came up through `python -m gen_worker.entrypoint` — i.e. every
+#: pod. `env_establish` and its nested `lib_memo` are produced by
+#: `env_seal.establish`, which the entrypoint, the mint child and the
+#: entry-compile child all call and an EMBEDDED worker (the in-process test
+#: harness, a library caller) does not. Kept as a separate shape rather than
+#: folded into SHAPE_EAGER so an embedded boot is not asked for a phase it
+#: legitimately cannot have — and so a POD boot still is.
+SHAPE_ENTRYPOINT: frozenset = SHAPE_EAGER | frozenset({
+    PHASE_ENV_ESTABLISH, PHASE_LIB_MEMO,
+})
+#: A boot that ADOPTED a cell the hub named: no trace, no fold — it pays a
+#: download and an admission instead.
+SHAPE_ADOPT: frozenset = SHAPE_ENTRYPOINT | frozenset({
+    PHASE_CELL_FETCH, PHASE_CELL_VERIFY, PHASE_ENTRY_ADMIT, PHASE_CELL_ARM,
+    PHASE_COMPILED_SWAP,
+})
+#: A boot that MINTED its own cell: declaration, per-class trace, fold, the
+#: publish round trips, then the same admission as an adopt.
+SHAPE_SELF_MINT: frozenset = SHAPE_ADOPT | frozenset({
+    PHASE_DECLARATION_COMPOSE, PHASE_TRACE_FOR_KEY, PHASE_KEY_FOLD,
+    PHASE_CELL_HUB_RTT,
+}) - frozenset({PHASE_CELL_FETCH})
+
+#: A boot whose phases explain less of the wall than this is not decomposed.
+#: pgw#1087's acceptance: "the phases sum to within ~5% of wall".
+DEFAULT_RESIDUAL_TOLERANCE_PCT = 5.0
+
+
+@dataclass(frozen=True)
+class BootCompleteness:
+    """Does this boot's phase table actually account for the boot?
+
+    Two independent failures, reported separately because they have different
+    fixes: a phase that never emitted (``missing`` — an instrument hole) and a
+    boot whose measured phases do not add up to its wall clock (``residual_pct``
+    — an unmeasured window). A table can be missing nothing and still explain
+    half the boot, which is exactly the state pgw#1087 was filed against.
+    """
+
+    shape: Tuple[str, ...]
+    missing: Tuple[str, ...]
+    total_ms: int
+    measured_ms: int
+    named_ms: int
+    residual_ms: int
+    residual_pct: float
+    tolerance_pct: float
+
+    @property
+    def reconciles(self) -> bool:
+        return self.residual_pct <= self.tolerance_pct
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing and self.reconciles and self.total_ms > 0
+
+    def explain(self) -> str:
+        """One paragraph naming every reason this table is not complete."""
+        if self.total_ms <= 0:
+            return ("the boot never closed: no `first_request_servable` "
+                    "milestone, so there is no wall clock to reconcile against")
+        parts: List[str] = []
+        if self.missing:
+            parts.append(
+                "phases with NO row on this boot: " + ", ".join(self.missing))
+        if not self.reconciles:
+            parts.append(
+                f"{self.residual_ms} ms of {self.total_ms} ms "
+                f"({self.residual_pct:.1f}%) is explained by no phase and no "
+                f"named segment — tolerance is {self.tolerance_pct:.1f}%")
+        return "; ".join(parts) or "complete"
+
+
+def completeness(
+    shape: Iterable[str] = SHAPE_EAGER,
+    *,
+    rows: Optional[List[pb.BootPhase]] = None,
+    tolerance_pct: float = DEFAULT_RESIDUAL_TOLERANCE_PCT,
+) -> BootCompleteness:
+    """Verdict on this boot's decomposition against the shape it drove.
+
+    ``rows`` reads a ladder captured off the wire instead of this process's
+    own — which is how a test asserts the PRODUCTION boot's table rather than
+    the recorder's memory of it, and how the RED proof deletes a phase.
+    """
+    expect = tuple(sorted(shape))
+    seen = {row.phase for row in phase_table(rows)}
+    recon = reconciliation(rows)
+    total = int(recon.get("total_ms", 0))
+    measured = int(recon.get("measured_ms", 0))
+    named = int(recon.get("named_ms", 0))
+    residual = int(recon.get("residual_ms", max(0, total - measured - named)))
+    return BootCompleteness(
+        shape=expect,
+        missing=tuple(p for p in expect if p not in seen),
+        total_ms=total,
+        measured_ms=measured,
+        named_ms=named,
+        residual_ms=residual,
+        residual_pct=(100.0 * residual / total) if total > 0 else 100.0,
+        tolerance_pct=float(tolerance_pct),
+    )
 
 
 def recorded_rows() -> List[pb.BootPhase]:
@@ -687,6 +1244,7 @@ def reset_for_tests() -> None:
         _hello_seen = False
         _pending_servable = None
         _class_override.clear()
+        _milestone_ms.clear()
     _stack_var.set(())
 
 
@@ -701,6 +1259,7 @@ __all__ = [
     "mark",
     "mark_once",
     "note_hello",
+    "parent_scope",
     "phase_class",
     "process_start_unix",
     "process_uptime_ms",
@@ -708,15 +1267,38 @@ __all__ = [
     "recorded_rows",
     "reset_for_tests",
     "servable_ms",
+    "BootCompleteness",
+    "ComponentSpans",
+    "PhaseRow",
+    "completeness",
+    "phase_table",
+    "render_phase_table",
+    "CUMULATIVE_PHASES",
+    "DEFAULT_RESIDUAL_TOLERANCE_PCT",
+    "SHAPE_ADOPT",
+    "SHAPE_EAGER",
+    "SHAPE_ENTRYPOINT",
+    "SHAPE_SELF_MINT",
     "PHASES",
     "PHASE_HELLO",
     "PHASE_WEIGHTS_FETCH",
     "PHASE_PIPELINE_LOAD",
     "PHASE_WARMUP",
-    "PHASE_CELL_DISCOVER",
     "PHASE_CELL_FETCH",
     "PHASE_CELL_ARM",
     "PHASE_FIRST_REQUEST_SERVABLE",
+    "PHASE_SDK_READY",
+    "PHASE_COMPONENT_FETCH",
+    "PHASE_ENV_ESTABLISH",
+    "PHASE_LIB_MEMO",
+    "PHASE_DECLARATION_COMPOSE",
+    "PHASE_TRACE_FOR_KEY",
+    "PHASE_KEY_FOLD",
+    "PHASE_CELL_HUB_RTT",
+    "PHASE_CELL_VERIFY",
+    "PHASE_ENTRY_ADMIT",
+    "PHASE_EAGER_READY",
+    "PHASE_COMPILED_SWAP",
     "OUTCOME_OK",
     "OUTCOME_REFUSED",
     "OUTCOME_FAILED",

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -58,7 +58,9 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-from . import guard_closure, host_isa, settings_authority, torch_capability
+from . import (
+    boot_phases, guard_closure, host_isa, settings_authority, torch_capability,
+)
 import importlib.util
 
 logger = logging.getLogger(__name__)
@@ -308,9 +310,27 @@ def _disk_memo() -> Dict[str, str]:
     return _DISK_MEMO
 
 
+#: pgw#1087: memo hits vs misses over this process's whole library pass.
+#: Counted here rather than derived, because a partial hit — a memo written by
+#: a sibling whose env has since moved — is the interesting case and is
+#: invisible in a boolean.
+_MEMO_HITS = 0
+_MEMO_MISSES = 0
+
+
+def memo_counts() -> Tuple[int, int]:
+    """(hits, misses) of the pgw#832 library-digest memo so far."""
+    return _MEMO_HITS, _MEMO_MISSES
+
+
 def _lib_digest_memoized(path: str, mtime_ns: int, size: int) -> str:
+    global _MEMO_HITS, _MEMO_MISSES
     got = _disk_memo().get(_memo_key(path, mtime_ns, size))
-    return got if got is not None else _lib_digest(path, mtime_ns, size)
+    if got is not None:
+        _MEMO_HITS += 1
+        return got
+    _MEMO_MISSES += 1
+    return _lib_digest(path, mtime_ns, size)
 
 
 def write_library_memo(path: Path) -> int:
@@ -509,7 +529,31 @@ def frozen_library_digests() -> Tuple[Tuple[str, str], ...]:
     global _LIB_SNAPSHOT, _LAST_LIBHASH_S
     if _LIB_SNAPSHOT is None:
         t0 = time.monotonic()
-        _LIB_SNAPSHOT = toolchain_library_digests()
+        # pgw#1087: THE memo phase. `_LAST_LIBHASH_S` has always measured this
+        # pass but was reported only into the seal dict, where no boot reader
+        # ever joined it to the rest of the boot. As a phase the hit and miss
+        # populations are two rows of the same table and the memo's saving is
+        # a subtraction, not an estimate.
+        with boot_phases.span(boot_phases.PHASE_LIB_MEMO) as sp:
+            _LIB_SNAPSHOT = toolchain_library_digests()
+            hits, misses = memo_counts()
+            # `hit`/`partial`/`miss`, never `refused` — all three are
+            # successful outcomes of the same phase and the token is what a
+            # hub-side count groups on.
+            if not _LIB_SNAPSHOT:
+                # No toolchain libraries enumerated at all (an env with no
+                # torch/triton/nvidia packages). "nothing to hash" and "the
+                # memo served everything" are different answers and must not
+                # share the token `hit`.
+                token = "no_libs"
+            elif not misses:
+                token = "hit"
+            elif not hits:
+                token = "miss"
+            else:
+                token = "partial"
+            sp.classify(
+                token, f"hits={hits} misses={misses} libs={len(_LIB_SNAPSHOT)}")
         _LAST_LIBHASH_S = round(time.monotonic() - t0, 3)
     return _LIB_SNAPSHOT
 
@@ -675,6 +719,22 @@ def establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     not take effect, an undeclared knob, or an interpreter that booted
     outside the declared env (``settings_authority.ensure_interpreter_env``
     is the imposition for that one)."""
+    # pgw#1087: THE envelope/toolchain/sm derivation phase. The `spans` dict
+    # below has always measured this in detail, but it rode `LAST_ESTABLISH_SPANS`
+    # — a module global no boot reader ever joined to the rest of the ladder —
+    # so the derivation's cost was "expect ms; prove it" and unproven for a
+    # year. The span lives HERE, in the function being measured, so every
+    # caller produces it: the entrypoint, the mint child, and the in-process
+    # harness alike.
+    with boot_phases.span(boot_phases.PHASE_ENV_ESTABLISH) as _sp:
+        seal = _establish(overrides)
+        _sp.note(
+            f"digest={seal_digest(seal)} sm={seal.get('host_isa') or '-'} "
+            + " ".join(f"{k}={v}" for k, v in sorted(LAST_ESTABLISH_SPANS.items())))
+        return seal
+
+
+def _establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     global _BOOT_READBACK, _ESTABLISHED_OVERRIDES
 
     spans: Dict[str, float] = {}

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -10,6 +10,7 @@ asyncio loop; sync tenant code runs in threads via asyncio.to_thread.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import contextvars
 import functools
 import gc
@@ -2208,7 +2209,16 @@ class ModelStore:
                         resolved = None
                         if snapshot is not None and snapshot.digest:
                             resolved = _snapshot_to_resolved(snapshot)
-                        with net_scope:
+                        # pgw#1087: name this span as the parent for the
+                        # per-component rows opened inside the downloader.
+                        # `open_span` cannot push the nesting stack itself
+                        # (its close is in another frame), and a component row
+                        # that lands top-level is counted twice.
+                        with net_scope, (
+                            boot_mod.parent_scope(fetch_span.ordinal)
+                            if fetch_span is not None
+                            else contextlib.nullcontext()
+                        ):
                             path = await ensure_local(
                                 ref,
                                 provider=getattr(binding, "source", None),
@@ -5697,6 +5707,15 @@ class Executor:
             rec.transient_setup_failures = 0
             rec.instance = instance
             rec.ready = True
+            # pgw#1087: the FIRST user-visible timestamp. A ready record is an
+            # instance that can answer a request — armed or eager — and on the
+            # pgw#671 eager-first boot below it is reached long before any cell
+            # exists. Paired with `compiled_swap` it gives the eager-serving
+            # window, which is the interval the compiled-serving campaign is
+            # trying to shrink and which nothing measured. Distinct from
+            # `first_request_servable`, which additionally requires the hub to
+            # have been told (a worker the hub cannot reach is not servable).
+            boot_mod.mark_once(boot_mod.PHASE_EAGER_READY, function=spec.name)
             bg = rec.background_mint
             if bg is not None and bg.task is None:
                 # pgw#671 eager-first boot: READY is advertised now (eager

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -44,6 +44,7 @@ quantized (w8a8/w4a4) lanes keep their typed fail-closed refusal.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import hashlib
 import json
@@ -536,14 +537,26 @@ class CellPublisher:
         # expiry we blame must be the same string, or a rotation landing
         # mid-call makes the diagnosis describe a token we never sent.
         bearer = self._worker_jwt()
-        resp = broker.request(
-            "POST",
-            path,
-            base_url=self.base_url,
-            bearer=bearer,
-            json=payload,
-            timeout=timeout,
-        )
+        # pgw#1087: the worker<->hub cell control-plane round trip, timed.
+        # There is NO worker-side key LOOKUP to measure — pgw#904 moved cell
+        # resolution to the hub (`Arm.artifact`) and pgw#1032 deleted
+        # `StateDelta.cell_lookups` — so these publish legs are the whole of
+        # the hub RTT a boot's cell path pays, and the issue's "hub key lookup
+        # round-trip" line is closed by naming that rather than by inventing a
+        # phase with no producer (the pgw#924 rule).
+        with boot_mod.span(
+            boot_mod.PHASE_CELL_HUB_RTT, function=path,
+        ) if boot_mod.in_boot() else contextlib.nullcontext() as sp:
+            resp = broker.request(
+                "POST",
+                path,
+                base_url=self.base_url,
+                bearer=bearer,
+                json=payload,
+                timeout=timeout,
+            )
+            if sp is not None:
+                sp.classify(f"http_{resp.status_code}")
         body: dict = {}
         try:
             body = resp.json() if resp.text else {}
@@ -1048,6 +1061,17 @@ def _arm_candidate(
         else:
             span.refused(outcome.reason or "no_cell", outcome.detail)
         span.close()
+    if outcome.armed:
+        # pgw#1087: the SECOND user-visible timestamp. Deliberately NOT gated
+        # on `in_boot()` — a self-minted cell routinely arms twenty minutes
+        # after the boot closed, and "how long did this pod serve eager before
+        # its cell arrived" is the question the compiled-serving campaign is
+        # about. Recorded once per process: the interval is measured from
+        # process start, so a re-arm hours later is not a second answer to it.
+        boot_mod.mark_once(
+            boot_mod.PHASE_COMPILED_SWAP,
+            ref=ref, artifact_kind=artifact_kind, artifact_key=snapshot_digest,
+            detail=outcome.identity)
     return outcome, CellAdoption(
         ref=ref,
         snapshot_digest=snapshot_digest,
@@ -2091,6 +2115,18 @@ def aot_export_spec(pipe: Any, cfg: Any) -> "Any":
     # so this direction of the pair must stay deferred.
     from . import aot_mint
 
+    # pgw#1087: composing the declaration a mint will trace against. Expected
+    # to be trivial and never proven so — and if it is not (an endpoint whose
+    # `export_declaration()` does real work at compose time), that is exactly
+    # the finding, because it sits on the critical path before the first trace.
+    with boot_mod.span(
+        boot_mod.PHASE_DECLARATION_COMPOSE,
+        ref=str(getattr(cfg, "family", "") or ""),
+    ) if boot_mod.in_boot() else contextlib.nullcontext():
+        return _aot_export_spec(aot_mint, pipe, cfg)
+
+
+def _aot_export_spec(aot_mint: Any, pipe: Any, cfg: Any) -> "Any":
     execution_lane = loading.pipeline_weight_lane(pipe)
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     return aot_mint.ExportSpec(

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -1403,10 +1403,30 @@ class Lifecycle:
         `mark_once` keeps it once-per-process — it is called on every StateDelta
         send. The reconciliation detail is filled by the recorder, which is the
         only thing that knows the instant the row is actually released."""
-        boot_mod.mark_once(
+        if not boot_mod.mark_once(
             boot_mod.PHASE_FIRST_REQUEST_SERVABLE,
             since_process_start=True,
-        )
+        ):
+            return
+        # pgw#1087: the pod reports its OWN decomposition, once, at the instant
+        # the boot closes — and says so when it cannot explain itself. A
+        # measurement whose only consumer is a hub table nobody has queried yet
+        # is how `cell_discover` survived four releases with no producer; the
+        # boot that took the time is the one place a hole is cheap to notice.
+        # `SHAPE_ENTRYPOINT` is the MINIMUM every pod boot produces (the cell
+        # phases depend on what the boot did), so `missing` here is always an
+        # instrument defect, never a boot-shape difference.
+        try:
+            verdict = boot_mod.completeness(boot_mod.SHAPE_ENTRYPOINT)
+            logger.info(
+                "[boot] servable in %dms — decomposition:\n%s",
+                verdict.total_ms, boot_mod.render_phase_table())
+            if not verdict.complete:
+                logger.warning(
+                    "[boot] this boot cannot fully explain itself: %s",
+                    verdict.explain())
+        except Exception:  # telemetry must never break the boot it measures
+            logger.debug("boot decomposition report failed", exc_info=True)
 
     async def _heartbeat_loop(self) -> None:
         """th#965 layer 2 + pgw#610: force-send the full StateDelta (which

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -33,10 +33,11 @@ import logging
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 from . import activity as activity_mod
 from . import aot_resume
+from . import boot_phases
 from . import mint_budget
 from . import mint_process
 from . import progress as progress_mod
@@ -559,6 +560,65 @@ async def build_cell(
             parked = None
 
 
+def _emit_boot_trace_rows(table: Mapping[str, Any], *, family: str) -> None:
+    """pgw#1087: the mint's PER-CLASS timings, as boot-phase rows.
+
+    The mint child holds no orchestrator session and its phase table has always
+    been a single blob event — readable by a human, joinable by nothing. The
+    per-class trace cost was the biggest thing pgw#1087 could not answer ("10-20
+    s/class, guessed, never measured"), and the number already exists: the child
+    measures `export_s` per entry and hands it back in the report. Re-emitting
+    it here — parent-side, where the stream is — puts one `trace_for_key` row
+    per graph CLASS in the same table as the fetch and admission phases, so a
+    boot's compile half and its I/O half are finally comparable.
+
+    Emitted whether or not the boot window is still open: a self-mint routinely
+    finishes after `first_request_servable`, and its per-class costs are the
+    point. They are spans (not cumulative milestones), so `reconciliation`
+    charges them honestly — a mint that ran after the boot closed makes
+    `measured_ms` exceed `total_ms`, which is a TRUE statement about a worker
+    that kept compiling after it went servable, not a broken ladder.
+
+    OWED (pgw#1087, deliberately not taken here): the node count per class. It
+    is one line in `aot_mint._export_entry` — `timings["nodes"] =
+    len(program.graph_module.graph.nodes)` — and that function is being edited
+    by the pgw#1080 lane in the same window, so this lane does not race it. The
+    row already carries the shape the count will ride (`nodes=` in `detail`).
+    """
+    entries = table.get("entries")
+    if not isinstance(entries, Mapping):
+        return
+    for name, timings in sorted(entries.items()):
+        if not isinstance(timings, Mapping):
+            continue
+        export_s = float(timings.get("export_s") or 0.0)
+        if export_s <= 0:
+            continue
+        nodes = timings.get("nodes")
+        boot_phases.mark(
+            boot_phases.PHASE_TRACE_FOR_KEY,
+            duration_ms=int(round(export_s * 1000.0)),
+            ref=family,
+            function=str(name),
+            detail=(
+                f"nodes={nodes} " if nodes is not None else ""
+            ) + f"compile_s={timings.get('compile_s') or 0} "
+                f"warm_s={timings.get('warm_s') or 0}",
+        )
+    totals = table.get("totals")
+    if isinstance(totals, Mapping):
+        # The fold: per-class hashing plus the combine into
+        # `combined_graph_hash`, which the mint measures as `declare_s`.
+        declare_s = float(totals.get("declare_s") or 0.0)
+        if declare_s > 0:
+            boot_phases.mark(
+                boot_phases.PHASE_KEY_FOLD,
+                duration_ms=int(round(declare_s * 1000.0)),
+                ref=family,
+                detail=f"classes={len(entries)}",
+            )
+
+
 def _emit_aot_phases(
     outcome: MintOutcome, *, family: str, execution_lane: str,
 ) -> None:
@@ -614,6 +674,7 @@ def _emit_aot_phases(
             table["terminus"] = terminus or table.get("terminus") or ""
             aot_mint.emit_phase_events(
                 family=family, execution_lane=execution_lane, table=table, terminus=terminus)
+            _emit_boot_trace_rows(table, family=family)
         if outcome.minted or table:
             return
         if total_s <= 0:

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -32,6 +32,7 @@ from .errors import PickleWeightRefused
 from .hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from .refs import TensorhubRef
 from .. import activity as _activity
+from .. import boot_phases
 from ..capability import InsufficientDiskError
 from ..s3_transfer import S3TransferGrant, download_file_with_grant
 from .loading import safetensors_file_valid
@@ -150,6 +151,26 @@ def _blob_path(blobs_root: Path, ref: str) -> Path:
     """
     algo, hexpart = parse_cas_ref(ref)
     return blobs_root / algo / hexpart[:2] / hexpart[2:4] / hexpart
+
+
+def _component_of(path: str) -> str:
+    """The diffusers COMPONENT a snapshot file belongs to (pgw#1087).
+
+    The first path segment when the file sits in a subdirectory, ``(root)``
+    otherwise — model_index.json, a top-level scheduler config and the like.
+    Deliberately NOT validated against `component_vocab`: an unrecognized
+    directory is still a real slice of the download, and dropping it into an
+    "other" bucket would make the component rows stop summing to the fetch.
+    """
+    rel = _norm_rel_path(str(path or ""))
+    head, sep, _ = rel.partition("/")
+    return head if sep and head else "(root)"
+
+
+#: pgw#1087: the no-op source sink used when component spans are off (steady
+#: state). Named rather than an inline lambda so `_dl` has one shape.
+def _NO_SOURCE(_source: str) -> None:
+    return None
 
 
 _PART_FILE_RE = re.compile(r"\.part\d{4}$")
@@ -707,6 +728,25 @@ class CozySnapshotDownloader:
         # Sort largest first for better overlap, then download in parallel.
         unique.sort(key=lambda f: int(f.size_bytes or 0), reverse=True)
 
+        # pgw#1087: per-COMPONENT fetch spans. `weights_fetch` says how long
+        # the whole ref took and nothing about which of transformer / vae /
+        # text_encoder owned it, and — because these run four-wide — nothing
+        # about how much of the wall is genuinely serialized. Both are
+        # prerequisites for a trace-overlaps-download optimization, and neither
+        # was derivable from anything the platform stored. Boot only: a
+        # steady-state materialization hours later must not land in the ladder.
+        components: Dict[str, int] = {}
+        if boot_phases.in_boot():
+            for f in unique:
+                components[_component_of(f.path)] = (
+                    components.get(_component_of(f.path), 0) + 1)
+        # No `ref` here by design: `_ensure_blobs` is blob-level and the ref
+        # axis rides the enclosing `weights_fetch` row, which is this span's
+        # parent. Repeating it would be a second spelling that can drift.
+        comp_spans = (
+            boot_phases.ComponentSpans(components) if components else None
+        )
+
         max_conc = 4
         sem = asyncio.Semaphore(max_conc)
         blobs_root_id = str(blobs_root.resolve())
@@ -809,20 +849,46 @@ class CozySnapshotDownloader:
                 await asyncio.to_thread(_drop_chunks, digest)
 
         async def _dl(f: WorkerResolvedRepoFile) -> None:
+            # pgw#1087: the component span brackets THIS file's contribution
+            # and carries the source it actually came from — the same
+            # cached/volume/network distinction `weights_fetch` reports, one
+            # level finer, so "the vae was warm and the transformer was cold"
+            # is a row rather than an inference from the total.
+            if comp_spans is None:
+                await _dl_one(f, _NO_SOURCE)
+                return
+            component = _component_of(f.path)
+            comp_spans.start(component)
+            seen: List[str] = []
+            try:
+                await _dl_one(f, seen.append)
+            finally:
+                comp_spans.finish(
+                    component,
+                    bytes_moved=int(f.size_bytes or 0),
+                    source=seen[-1] if seen else "")
+
+        async def _dl_one(
+            f: WorkerResolvedRepoFile, note: Callable[[str], None],
+        ) -> None:
             digest = f.cas_ref()
             dst = _blob_path(blobs_root, digest)
             dst.parent.mkdir(parents=True, exist_ok=True)
             if await _blob_trusted(dst, f, digest):
                 _log.info("blob_cached path=%s digest=%s", f.path, digest[:16])
+                note(boot_phases.SOURCE_LOCAL)
                 return
             async with _inflight_blob_lock(digest):
                 if await _blob_trusted(dst, f, digest):
                     _log.info("blob_shared_inflight path=%s digest=%s (sibling ref downloaded it)",
                               f.path, digest[:16])
+                    note(boot_phases.SOURCE_INFLIGHT_SHARE)
                     return
                 if await _fill_from_volume(f, digest, dst):
+                    note(boot_phases.SOURCE_VOLUME)
                     return
                 teed = await _dl_locked(f, digest, dst)
+                note(boot_phases.SOURCE_R2)
             if fill_blobs_root is not None and not teed:
                 publishes.append(
                     asyncio.create_task(_fill_to_volume(f, digest, dst))
@@ -905,7 +971,13 @@ class CozySnapshotDownloader:
                 _log.info("blob_download_done path=%s digest=%s", f.path, digest[:24])
             return teed
 
-        await asyncio.gather(*(_dl(f) for f in unique))
+        try:
+            await asyncio.gather(*(_dl(f) for f in unique))
+        finally:
+            # A fetch that raised leaves components mid-flight; close them
+            # NAMED rather than leaving open rows the hub cannot interpret.
+            if comp_spans is not None:
+                comp_spans.close_all("fetch_aborted")
         # th#850 managed-tier runtime-assertion signal: on a volume-attached
         # boot with blobs already warm, network_bytes should land near zero.
         # _on_bytes above already streamed this total into the caller's

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -12,6 +12,7 @@ import threading
 import time
 from typing import Any, Dict, List, Optional
 
+from . import boot_phases
 from .config import Settings
 from .executor import Executor, ModelStore
 from .lifecycle import Lifecycle
@@ -164,6 +165,16 @@ class Worker:
         # Capability renewal presents the freshest worker JWT (contract §1
         # rotation), not the boot-time settings token.
         self.executor.worker_jwt_provider = lambda: self.transport.current_worker_jwt
+        # pgw#1087: process start -> SDK ready. Everything before this line is
+        # interpreter startup, `import torch`, endpoint-module import and
+        # executor construction — a window NO span could ever have covered,
+        # because the recorder itself is part of what is being imported. It
+        # arrived as an unexplained residual on every boot; now it is named,
+        # and `reconciliation()` subtracts it from the residual rather than
+        # leaving the biggest unmeasured slice unattributed.
+        boot_phases.mark_once(
+            boot_phases.PHASE_SDK_READY,
+            detail=f"endpoints={len(specs)} modules={len(user_module_names)}")
 
     async def _send(self, msg: pb.WorkerMessage) -> None:
         await self.transport.send(msg)

--- a/tests/harness/cold_boot_endpoints_pgw1087.py
+++ b/tests/harness/cold_boot_endpoints_pgw1087.py
@@ -1,0 +1,80 @@
+"""A boot fixture with MULTIPLE weight components (pgw#1087).
+
+The pgw#797 ladder fixture ships one weight file, which is exactly the shape
+that cannot exercise the thing pgw#1087 adds: with one file there is one
+component, one `component_fetch` row, and "is the decomposition per component"
+is unfalsifiable. This module's checkpoint is laid out the way a real
+diffusers repo is — `transformer/`, `text_encoder/`, `vae/` plus a top-level
+`model_index.json` — so a boot produces four component rows inside one
+`weights_fetch`, and their intervals can be compared for overlap.
+
+Otherwise deliberately identical in SHAPE to the pgw#797 fixture: ONE compile
+endpoint, a worker-LOADED slot, `resources.gpu` so a warm plan exists. Those
+are the branches that made the released ladder empty, and a decomposition
+fixture that avoided them would measure a boot production never runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import msgspec
+
+from gen_worker import Compile, Hub, RequestContext, Resources, endpoint
+from gen_worker.families.base import GenerationDefaults, family
+
+#: The component directories the fixture snapshot carries, in the order a
+#: reader should expect them. `(root)` is the fourth, synthesized by
+#: `cozy_snapshot._component_of` for `model_index.json`.
+COMPONENTS = ("text_encoder", "transformer", "vae")
+
+
+@family("harness-pgw1087-testfam")
+class _Defaults(GenerationDefaults, frozen=True):
+    steps: int = 3
+
+
+class EchoIn(msgspec.Struct):
+    text: str = ""
+
+
+class EchoOut(msgspec.Struct):
+    response: str
+
+
+class MultiComponentPipeline:
+    """A worker-LOADED slot whose weights are spread over components."""
+
+    def __init__(self, parts: dict) -> None:
+        self.parts = parts
+
+    @classmethod
+    def from_pretrained(cls, path: str, **_kw: object) -> "MultiComponentPipeline":
+        root = Path(path)
+        parts = {
+            name: (root / name / "weights.safetensors").read_bytes()
+            for name in COMPONENTS
+            if (root / name / "weights.safetensors").is_file()
+        }
+        return cls(parts)
+
+    def to(self, device: str) -> "MultiComponentPipeline":
+        return self
+
+
+COMPILE_MODEL = Hub("harness/pgw1087-multi-component", tag="prod")
+
+
+@endpoint(
+    model=COMPILE_MODEL,
+    compile=Compile(family="harness-pgw1087", shapes=((64, 64),), text_len=0),
+    resources=Resources(gpu=True),
+)
+class ColdBootDecompositionEndpoint:
+    def setup(self, model: MultiComponentPipeline) -> None:
+        self.pipe = model
+
+    def compile_echo(
+        self, ctx: RequestContext[_Defaults], data: EchoIn,
+    ) -> EchoOut:
+        return EchoOut(response=",".join(sorted(self.pipe.parts)))

--- a/tests/test_boot_phases_pgw764.py
+++ b/tests/test_boot_phases_pgw764.py
@@ -52,7 +52,7 @@ def _phases(rows: List[pb.BootPhase]) -> List[str]:
 
 
 def test_boot_rows_are_ordered_and_carry_one_boot_id() -> None:
-    with boot_phases.span(boot_phases.PHASE_CELL_DISCOVER):
+    with boot_phases.span(boot_phases.PHASE_CELL_VERIFY):
         pass
     boot_phases.mark(boot_phases.PHASE_HELLO, since_process_start=True)
     with boot_phases.span(boot_phases.PHASE_WEIGHTS_FETCH, ref="repo/sdxl") as fetch:
@@ -60,7 +60,7 @@ def test_boot_rows_are_ordered_and_carry_one_boot_id() -> None:
 
     rows = boot_phases.recorded_rows()
     assert _phases(rows) == [
-        boot_phases.PHASE_CELL_DISCOVER,
+        boot_phases.PHASE_CELL_VERIFY,
         boot_phases.PHASE_HELLO,
         boot_phases.PHASE_WEIGHTS_FETCH,
     ]
@@ -94,7 +94,7 @@ def test_a_span_opens_a_row_and_closes_the_same_ordinal() -> None:
 def test_rows_recorded_before_the_sink_exists_are_flushed_on_bind() -> None:
     """The boot window IS the no-sink window. Everything before bind must
     arrive, in order, once the stream comes up."""
-    boot_phases.mark(boot_phases.PHASE_CELL_DISCOVER)
+    boot_phases.mark(boot_phases.PHASE_CELL_VERIFY)
     with boot_phases.span(boot_phases.PHASE_WEIGHTS_FETCH, ref="repo/a"):
         pass
 
@@ -121,7 +121,7 @@ def test_rows_recorded_before_the_sink_exists_are_flushed_on_bind() -> None:
     assert all(m.WhichOneof("msg") == "boot_phase" for m in sent)
     shipped = [m.boot_phase for m in sent]
     # The pre-bind rows were flushed, and the post-bind row followed them.
-    assert boot_phases.PHASE_CELL_DISCOVER in _phases(shipped)
+    assert boot_phases.PHASE_CELL_VERIFY in _phases(shipped)
     assert boot_phases.PHASE_WEIGHTS_FETCH in _phases(shipped)
     assert _phases(shipped)[-1] == boot_phases.PHASE_FIRST_REQUEST_SERVABLE
 
@@ -185,7 +185,7 @@ def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
     already account for. Summing both double-counts the entire boot — and any
     hub-side SUM(duration_ms) would inherit the error, which is why
     `cumulative` is a wire field and not an SDK-local detail."""
-    with boot_phases.span(boot_phases.PHASE_CELL_DISCOVER):
+    with boot_phases.span(boot_phases.PHASE_CELL_VERIFY):
         pass
     boot_phases.mark(boot_phases.PHASE_HELLO, since_process_start=True)
     boot_phases.mark(boot_phases.PHASE_FIRST_REQUEST_SERVABLE,
@@ -194,7 +194,7 @@ def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
     rows = {r.phase: r for r in boot_phases.recorded_rows() if r.terminal}
     assert rows[boot_phases.PHASE_HELLO].cumulative is True
     assert rows[boot_phases.PHASE_FIRST_REQUEST_SERVABLE].cumulative is True
-    assert rows[boot_phases.PHASE_CELL_DISCOVER].cumulative is False
+    assert rows[boot_phases.PHASE_CELL_VERIFY].cumulative is False
 
     recon = boot_phases.reconciliation()
     # measured_ms counts the env_seal span only; the two milestones are the

--- a/tests/test_cold_boot_decomposition_pgw1087.py
+++ b/tests/test_cold_boot_decomposition_pgw1087.py
@@ -1,0 +1,330 @@
+"""pgw#1087: the per-COMPONENT cold-boot decomposition, off the wire.
+
+WHY THIS FILE EXISTS
+--------------------
+Paul, 2026-08-10: *"you should be measuring per-component of cold-boot, not
+just measuring a granular 'whole cold boot was 6.2 mins for some reason'."*
+The best cold-boot fact the platform held was leg-grade — "the A1 adopt leg =
+6.2 min / $0.102" — with no split, and every finer question asked this session
+(how long is the per-class trace? the toolchain derivation? the memo delta? the
+download-vs-admission split of an adopt?) was unanswerable.
+
+WHY IT LOOKS LIKE THIS
+----------------------
+Same discipline as `test_boot_span_ladder_pgw797.py`, and for the same reason:
+pgw#789 shipped a boot instrument whose unit tests passed while the production
+path emitted NOTHING, because every assertion called the emitters directly.
+So this file drives a REAL boot — `harness.hub_double` runs an actual `Worker`
+against an actual gRPC server, weights are real bytes over a real HTTP blob
+host — and reads the phase rows OFF THE WIRE. Nothing here calls a boot
+emitter. If a production call site stops reaching one, these go red.
+
+The fixture snapshot is deliberately MULTI-COMPONENT (transformer /
+text_encoder / vae / root). With one weight file, "is the decomposition per
+component" cannot fail, and an unfalsifiable assertion is not coverage.
+
+THE RED PROOF
+-------------
+`test_the_completeness_verdict_goes_red_when_a_phase_stops_emitting` deletes
+one phase's rows from the REAL boot's captured ladder and asserts the verdict
+turns red and NAMES the deleted phase. A green completeness assertion proves
+nothing until it is known it could have gone red — and the failure mode this
+whole issue exists to prevent is precisely a phase that quietly stops emitting.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from gen_worker import boot_phases
+from gen_worker.api.binding import wire_ref
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.blob_host import BlobHost
+from harness.cold_boot_endpoints_pgw1087 import COMPILE_MODEL, COMPONENTS
+from harness.hub_double import hub_double, is_ready
+
+
+def _boot_rows(conn) -> List[pb.BootPhase]:
+    return [
+        m.boot_phase for m in list(conn.received)
+        if m.WhichOneof("msg") == "boot_phase"
+    ]
+
+
+def _terminal(rows: List[pb.BootPhase], phase: str) -> List[pb.BootPhase]:
+    return [r for r in rows if r.phase == phase and r.terminal]
+
+
+def _one(rows: List[pb.BootPhase], phase: str) -> pb.BootPhase:
+    got = _terminal(rows, phase)
+    assert got, (
+        f"no terminal {phase!r} row on the wire — the ladder has: "
+        f"{sorted({r.phase for r in rows})}"
+    )
+    return got[0]
+
+
+#: The shape this fixture drives. `hub_double` runs a real `Worker` IN
+#: PROCESS, so it is an EMBEDDED boot: it never calls `env_seal.establish`,
+#: which is an entrypoint/mint-child call. Asking it for `env_establish` would
+#: be asking for a phase this boot shape structurally cannot have — the
+#: entrypoint shape is proven where an entrypoint actually runs
+#: (`tests_v2/test_boot.py::test_real_entrypoint_seals_dials_and_dumps_stacks`).
+#: It also has no CUDA, so the cell half is out of scope here and is covered by
+#: the local micro-mint rig legs.
+EXPECTED_SHAPE = boot_phases.SHAPE_EAGER
+
+
+@pytest.fixture(scope="module")
+def ladder(tmp_path_factory) -> List[pb.BootPhase]:
+    """ONE real hub-delivered boot; every assertion below reads its ladder.
+
+    One boot rather than one per test, for the reason pgw#797 documents:
+    `boot_phases` state is process-global, so a second boot in the same
+    interpreter starts with `in_boot()` already False and records nothing.
+    Booting once is also what production gives a reader — one boot's table,
+    whole.
+    """
+    boot_phases.reset_for_tests()
+    tmp_path = tmp_path_factory.mktemp("pgw1087")
+    blobs = BlobHost(tmp_path)
+    model_ref = wire_ref(COMPILE_MODEL)
+    files = [
+        blobs.file(
+            f"{name}-weights",
+            f"pgw1087-{name}-bytes".encode() * (256 * (i + 1)),
+            path_in_snapshot=f"{name}/weights.safetensors",
+        )
+        for i, name in enumerate(COMPONENTS)
+    ]
+    files.append(blobs.file(
+        "model-index", b'{"_class_name": "MultiComponentPipeline"}',
+        path_in_snapshot="model_index.json"))
+    model_snap = blobs.snapshot("snap-multi", files)
+    try:
+        with hub_double(
+            modules=("harness.cold_boot_endpoints_pgw1087",),
+        ) as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(hello_ack=pb.HelloAck(
+                protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+                desired_residency=pb.DesiredResidency(
+                    generation=1,
+                    disk_refs=[model_ref],
+                    snapshots={model_ref: model_snap},
+                    hot=[pb.DesiredInstance(
+                        function_name="compile-echo",
+                        models=[pb.ModelBinding(slot="model", ref=model_ref)],
+                    )],
+                ),
+            ))
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "state_delta"
+                and "compile-echo" in m.state_delta.available_functions
+            )
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "boot_phase"
+                and m.boot_phase.phase == boot_phases.PHASE_FIRST_REQUEST_SERVABLE
+                and m.boot_phase.terminal
+            )
+            rows = _boot_rows(conn)
+    finally:
+        blobs.shutdown()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# The acceptance criterion: the table is COMPLETE and it SUMS
+# ---------------------------------------------------------------------------
+
+
+def test_the_boot_phase_table_is_complete_and_sums_to_the_wall(ladder) -> None:
+    """pgw#1087's acceptance, stated once: no phase of the driven shape is
+    missing, and what the phases explain plus the NAMED segments is within 5%
+    of the boot's wall clock, with whatever is left reported rather than
+    smeared."""
+    verdict = boot_phases.completeness(EXPECTED_SHAPE, rows=ladder)
+    assert verdict.complete, (
+        verdict.explain() + "\n\n"
+        + boot_phases.render_phase_table(ladder))
+
+
+def test_the_residual_is_named_not_a_lump(ladder) -> None:
+    """"Unmeasured" and "zero" are different answers. The single biggest
+    unmeasured window of every previous boot — interpreter start plus `import
+    torch` plus endpoint discovery — is now the `sdk_ready` milestone and is
+    subtracted from the residual as a NAMED segment, not left in it."""
+    recon = boot_phases.reconciliation(ladder)
+    assert recon["named_ms"] > 0, (
+        "no named residual segment: the pre-SDK window is back inside the "
+        f"unexplained lump ({recon})")
+    assert recon["named.sdk_import_ms"] > 0
+    assert recon["accounted_pct"] >= 95, recon
+
+
+def test_every_declared_phase_of_this_shape_has_a_production_producer(
+    ladder,
+) -> None:
+    """The pgw#924 rule, re-applied to the names pgw#1087 adds. A declared
+    phase with no producer is a name every reader learns and the system can
+    never emit — which is how `cell_discover` survived pgw#924's own audit."""
+    emitted = {r.phase for r in ladder if r.terminal}
+    for phase in EXPECTED_SHAPE:
+        assert phase in emitted, (
+            f"{phase} is declared but a REAL boot of this shape produced no "
+            f"row; emitted: {sorted(emitted)}")
+
+
+# ---------------------------------------------------------------------------
+# The per-COMPONENT half — the actual subject of the issue
+# ---------------------------------------------------------------------------
+
+
+def test_weights_download_decomposes_per_component(ladder) -> None:
+    """`weights_fetch` said how long the ref took and nothing about which
+    component owned it. Four components, four rows, each with its own bytes."""
+    comps = _terminal(ladder, boot_phases.PHASE_COMPONENT_FETCH)
+    names = sorted({r.function for r in comps})
+    assert names == sorted([*COMPONENTS, "(root)"]), (
+        f"component rows {names} do not cover the snapshot's components "
+        f"{sorted([*COMPONENTS, '(root)'])}")
+    assert all(r.bytes > 0 for r in comps if r.function in COMPONENTS), (
+        f"a weight component reported no bytes: "
+        f"{[(r.function, r.bytes, r.source) for r in comps]}")
+    assert all(r.source for r in comps), (
+        "a component named no source — a cold pull and a warm CAS hit are the "
+        f"same phase at wildly different rates: {[(r.function, r.source) for r in comps]}")
+
+
+def test_component_rows_nest_under_the_weights_fetch_they_decompose(
+    ladder,
+) -> None:
+    """A decomposition that does not nest double-counts: `weights_fetch` and
+    its components would each charge the same seconds, and the ladder would
+    stop reconciling — the exact defect pgw#797 fixed for `warmup`."""
+    fetch = _one(ladder, boot_phases.PHASE_WEIGHTS_FETCH)
+    comps = _terminal(ladder, boot_phases.PHASE_COMPONENT_FETCH)
+    assert comps, "no component rows under a boot that fetched weights"
+    assert all(r.parent_ordinal == fetch.ordinal for r in comps), (
+        "component rows are not children of weights_fetch: "
+        f"{[(r.function, r.parent_ordinal) for r in comps]} vs {fetch.ordinal}")
+    table = {r.ordinal: r for r in boot_phases.phase_table(ladder)}
+    assert table[fetch.ordinal].exclusive_ms <= fetch.duration_ms
+
+
+def test_component_intervals_make_overlap_readable(ladder) -> None:
+    """The reason a component row carries START and END rather than a
+    duration: four 180 s components inside a 200 s fetch is a completely
+    different finding from four sequential 50 s ones, and only intervals can
+    tell them apart. Assert the interval is well-formed and inside its
+    parent's — the arithmetic an overlap query depends on."""
+    rows = {
+        r.function: r for r in boot_phases.phase_table(ladder)
+        if r.phase == boot_phases.PHASE_COMPONENT_FETCH
+    }
+    fetch = next(
+        r for r in boot_phases.phase_table(ladder)
+        if r.phase == boot_phases.PHASE_WEIGHTS_FETCH)
+    for name, row in rows.items():
+        assert row.end_ms >= row.start_ms, name
+        assert row.end_ms <= fetch.end_ms + 1, (
+            f"component {name} ends after its weights_fetch parent "
+            f"({row.end_ms} > {fetch.end_ms})")
+
+
+# ---------------------------------------------------------------------------
+# The two user-visible timestamps, and the toolchain derivation
+# ---------------------------------------------------------------------------
+
+
+def test_eager_ready_precedes_the_boot_close_and_is_cumulative(ladder) -> None:
+    """`eager_ready` is the first instant a request could have been answered
+    at all; `first_request_servable` additionally requires the hub to have been
+    told. Both measure from process start, so the first cannot follow the
+    second."""
+    eager = _one(ladder, boot_phases.PHASE_EAGER_READY)
+    servable = _one(ladder, boot_phases.PHASE_FIRST_REQUEST_SERVABLE)
+    assert eager.cumulative and eager.parent_ordinal == 0, (
+        "a cumulative milestone charged against a span drives that span's "
+        "exclusive time to zero (pgw#797)")
+    assert eager.duration_ms <= servable.duration_ms
+
+
+def test_sdk_ready_is_cumulative_and_precedes_every_span(ladder) -> None:
+    """The import wall. No span can cover it — the recorder is part of what is
+    being imported — so it is a milestone, and it must bound the ladder."""
+    sdk = _one(ladder, boot_phases.PHASE_SDK_READY)
+    assert sdk.cumulative and sdk.parent_ordinal == 0
+    assert sdk.duration_ms > 0, (
+        "sdk_ready measured 0 ms: the interpreter+import window cannot be free")
+
+
+def test_the_entrypoint_shape_is_a_superset_and_is_proven_elsewhere() -> None:
+    """The seal derivation belongs to the ENTRYPOINT shape, not to every boot.
+
+    Stated here as a structural assertion so the split cannot silently
+    collapse: an embedded worker must not be asked for `env_establish`, and a
+    POD boot must still be. The pod half is asserted, off the wire, in
+    `tests_v2/test_boot.py::test_real_entrypoint_seals_dials_and_dumps_stacks`.
+    """
+    assert boot_phases.SHAPE_EAGER < boot_phases.SHAPE_ENTRYPOINT
+    assert boot_phases.SHAPE_ENTRYPOINT - boot_phases.SHAPE_EAGER == {
+        boot_phases.PHASE_ENV_ESTABLISH, boot_phases.PHASE_LIB_MEMO}
+    assert boot_phases.SHAPE_ENTRYPOINT < boot_phases.SHAPE_ADOPT
+
+
+# ---------------------------------------------------------------------------
+# THE RED PROOF
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dropped", sorted(EXPECTED_SHAPE))
+def test_the_completeness_verdict_goes_red_when_a_phase_stops_emitting(
+    ladder, dropped: str,
+) -> None:
+    """Delete one phase's rows from the REAL boot and watch the verdict fail.
+
+    This is the assertion's own red proof, and it is parametrized over every
+    phase of the shape rather than one convenient name: a completeness check
+    that could only ever fail on `weights_fetch` would let the other eight
+    rot silently, which is the exact history of this vocabulary.
+    """
+    survivors = [r for r in ladder if r.phase != dropped]
+    verdict = boot_phases.completeness(EXPECTED_SHAPE, rows=survivors)
+    assert not verdict.complete, (
+        f"removing every {dropped!r} row left the table reading COMPLETE — "
+        "the assertion cannot detect the failure it exists for")
+    assert dropped in verdict.missing or not verdict.reconciles, (
+        f"{dropped} vanished without being named: {verdict.explain()}")
+
+
+def test_a_ladder_with_no_boot_close_is_never_complete(ladder) -> None:
+    """A pod that died mid-boot has no wall clock to reconcile against, and a
+    verdict of "complete" on it would be a default read as a fact."""
+    survivors = [
+        r for r in ladder
+        if r.phase != boot_phases.PHASE_FIRST_REQUEST_SERVABLE]
+    verdict = boot_phases.completeness(EXPECTED_SHAPE, rows=survivors)
+    assert not verdict.complete
+    assert "never closed" in verdict.explain()
+
+
+# ---------------------------------------------------------------------------
+# The artifact this issue exists to produce
+# ---------------------------------------------------------------------------
+
+
+def test_the_phase_table_renders(ladder, capsys) -> None:
+    """The decomposition, printed. Not decoration: pgw#1087's third acceptance
+    box is that campaign runbooks cite PHASE NAMES rather than leg aggregates,
+    and this is the shape they cite."""
+    text = boot_phases.render_phase_table(ladder)
+    assert boot_phases.PHASE_COMPONENT_FETCH in text
+    assert "residual_ms" in text and "accounted_pct" in text
+    with capsys.disabled():
+        print("\n--- pgw#1087 cold-boot decomposition (real boot) ---")
+        print(text)

--- a/tests_v2/test_boot.py
+++ b/tests_v2/test_boot.py
@@ -207,6 +207,33 @@ def test_real_entrypoint_seals_dials_and_dumps_stacks(tmp_path: Path) -> None:
             seal_phase = next(p for p in phases if p.get("phase") == "env_seal")
             assert seal_phase.get("digest"), "the seal phase must carry its digest"
 
+            # pgw#1087: the seal's COST, off the wire. The startup phase lines
+            # above prove the seal ran and in what order; they say nothing
+            # about what it cost, and "expect ms; prove it" was the issue's own
+            # instruction. The library-digest memo nests inside it, so the
+            # memo's saving is a subtraction between two real rows. This is the
+            # ONLY boot shape that produces these — `env_seal.establish` is an
+            # entrypoint/mint-child call, not something an embedded worker
+            # does, which is why `boot_phases.SHAPE_ENTRYPOINT` is a shape of
+            # its own.
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "boot_phase"
+                and m.boot_phase.phase == boot_phases.PHASE_ENV_ESTABLISH
+                and m.boot_phase.terminal)
+            rows = _boot_rows(conn)
+            est = next(r for r in rows
+                       if r.phase == boot_phases.PHASE_ENV_ESTABLISH and r.terminal)
+            memo = next(r for r in rows
+                        if r.phase == boot_phases.PHASE_LIB_MEMO and r.terminal)
+            assert memo.parent_ordinal == est.ordinal, (
+                "lib_memo must nest inside env_establish or the two "
+                "double-count the same seconds")
+            assert memo.reason in ("hit", "miss", "partial", "no_libs")
+            assert memo.outcome == boot_phases.OUTCOME_OK, (
+                "a memo MISS is the expensive branch of a successful phase, "
+                "never a refusal")
+            assert est.duration_ms >= memo.duration_ms
+
             # Discovery over the wire: the catalog module baked into the
             # manifest is what the worker advertises.
             ready = conn.wait_for(is_ready).state_delta


### PR DESCRIPTION
Paul, 2026-08-10: *"you should be measuring per-component of cold-boot, not just measuring a granular 'whole cold boot was 6.2 mins for some reason'."*

The finest cold-boot fact the platform held was leg-grade — "the A1 adopt leg = 6.2 min / \$0.102", no split — and every finer question the compiled-serving campaign asked was unanswerable.

## The vocabulary (12 new, each with exactly ONE production producer)

| phase | producer |
|---|---|
| `sdk_ready` (cum) | `worker.Worker.__init__` — the interpreter+import wall |
| `component_fetch` | `models/cozy_snapshot._ensure_blobs`, per diffusers component |
| `env_establish` | `env_seal.establish` — the toolchain/sm derivation |
| `lib_memo` | `env_seal.frozen_library_digests` — hit/partial/miss/no_libs |
| `declaration_compose` | `fleet_cells.aot_export_spec` |
| `trace_for_key` | `mint_delegate`, one row per graph CLASS from the child's report |
| `key_fold` | `mint_delegate` — per-class hashing + the fold |
| `cell_hub_rtt` | `fleet_cells.CellPublisher._post` |
| `cell_verify` | `aot_serve.load_and_wrap` — staging + contract verify on inert bytes |
| `entry_admit` | `aot_serve.load_and_wrap`, per entry — dlopen + bind + admission-drift parity |
| `eager_ready` (cum) | `executor` at `rec.ready = True` |
| `compiled_swap` (cum) | `fleet_cells._arm_candidate` on a successful arm |

`cell_fetch` — DECLARED since pgw#764 and **never produced anywhere in the tree** — finally gets its producer at `aot_delivery.materialize_named_artifact`. That absence is exactly why "the adopt leg took 6.2 min" could not be split into download vs admission.

`cell_discover` is **DELETED**: pgw#924 declared it as one of "the eight the shipping path PRODUCES" and grep finds it only in `boot_phases.py` and tests — pgw#904 replaced worker-side discovery with a hub-resolved `Arm.artifact`. Same defect class pgw#924 was closing, missed because that audit checked the count and not the producers.

## The ladder now CLOSES, on a union, with a named residual

Once phases decompose per component they overlap. A summing reconciliation "explained" 3,338 ms of a 909 ms fetch — closing by over-counting is worse than visibly not closing. `measured_ms` is now the wall covered by at least one span; the gap from the exclusive sum ships as `concurrency_ms`, which is itself the answer to "how parallel was this boot".

Two windows no span can cover are NAMED rather than lumped: `named.sdk_import_ms` (nothing can span the import of the span recorder) and `named.hub_handshake_ms` (dial + HelloAck + waiting for a DesiredResidency — 1,238 ms of a 23,208 ms boot, i.e. on its own enough to fail the ~5% acceptance while nothing was actually unmeasured).

New API: `phase_table()`, `render_phase_table()`, `completeness(shape)` → typed `BootCompleteness`. `missing` and `residual_pct` are separate failures because they have different fixes.

## Proof, and the RED proof

`tests/test_cold_boot_decomposition_pgw1087.py` drives a REAL multi-component boot through the hub double and reads the ladder OFF THE WIRE — nothing calls an emitter, per the pgw#797 discipline that exists because pgw#789 shipped a boot instrument whose unit tests passed while production emitted nothing.

The RED proof is **parametrized over every phase of the shape**: delete that phase's rows from the real boot and the verdict must go red and NAME it. A completeness check that could only fail on `weights_fetch` would let the other phases rot silently.

First real in-process table — 9,119 ms boot, residual **2 ms (0.02%)**, `concurrency_ms` 156:

```
phase                  class     start_ms    end_ms    dur_ms   excl_ms         bytes  what
sdk_ready              setup            0      5643      5643      5643             0  endpoints=1 modules=1
hello                  setup            0      6812      6812      6812             0
component_fetch        fetch         6827      6890        63        63         12800  transformer
component_fetch        fetch         6827      6891        64        64         13056  vae
component_fetch        fetch         6830      6891        61        61          6656  text_encoder
component_fetch        fetch         6838      6891        53        53            41  (root)
weights_fetch          fetch         6821      6906        85         0         32553  harness/pgw1087-multi-component
warmup                 compile       9111      9116         5         5             0  compile-echo
pipeline_load          load          6907      9118      2211      2206             0  compile-echo
eager_ready            setup            0      9118      9118      9118             0  compile-echo
first_request_servable setup            0      9119      9119      9119             0
accounted_pct                100
concurrency_ms               156
measured_ms                 2296
named.hub_handshake_ms      1178
named.sdk_import_ms         5643
residual_ms                    2
```

## 🔴 The first REAL entrypoint boot is already a finding

Probed against a live scheduler with the real `python -m gen_worker.entrypoint`:

```
env_establish   dur=23080  detail='seal_effective_s=17.332 seal_isa_s=5.747 ...'
lib_memo        dur=17323  parent=env_establish  reason='miss'  'hits=0 misses=36 libs=36'
sdk_ready       dur=30709  cumulative
first_request_servable dur=33684
```

The derivation the issue said to *"expect ms; prove it"* is **23.1 s of a 33.7 s boot — 68%** — and **17.3 s of that is the library-digest pass running with no memo**. `write_library_memo` exists and is called only by `aot_compile_pool` for mint children; a serving boot re-pays it in full. Optimization is deliberately NOT in this issue (instrument-first) and is filed for a follow-up lane.

## Deliberately NOT touched

- `proto/worker_scheduler.proto` — tensorhub is canonical and `PROTO_DIGEST` gates a one-sided edit. `phase` is a free string and the proto already states unknown phases are stored verbatim, so nothing is needed for correctness; its eight-name comment is stale and belongs to a coordinated cross-repo cut.
- `aot_mint._export_entry`'s node count — one line (`timings["nodes"] = len(program.graph_module.graph.nodes)`), but the **pgw#1080 lane is editing that exact function this window**. The `trace_for_key` row already carries the `nodes=` shape it will ride. Named in the code and in the tracker rather than raced.

## Gates

- `mypy src/gen_worker` — **Success: no issues found in 246 source files**
- `ruff check` clean
- `tests/test_cold_boot_decomposition_pgw1087.py` — 18 passed
- Existing boot suites (pgw#764 / #797 / #789 / #824 / #923 arm) — **66 passed, 1 skipped**
- `tests_v2/test_boot.py::test_real_entrypoint_seals_dials_and_dumps_stacks` and `::test_torchless_boot_...` fail LOCALLY on this box — verified **PRE-EXISTING** by running the identical selection on `origin/master@7902d8bc` (same two failures). The cause is now measured rather than guessed: the boot takes 33.7 s and the harness's connection window is 30 s, because of the 17.3 s cold library hash above.