### PR TITLE
pgw#1084 §8.4.1: pair examples/micro-diffusion with tensorhub's family registry (worker half)

### DIFF
--- a/changelog.d/pgw1084.md
+++ b/changelog.d/pgw1084.md
@@ -3,3 +3,16 @@
   (ie#639). It sits outside that train, so it had been left on `==0.96.1`, a line
   `fleet-floors.toml` has since deleted from `[supported]`. Cells minted from this pin
   carry pgw#1059's four-axis `ck1` and are live-scheme (pgw#1084).
+- **The micro-family cross-repo fence (pgw#1084 §8.4.1).** Three times a member
+  was added to `examples/micro-diffusion` without the matching tensorhub
+  `internal/modelfamily` registration (`micro-escape` pgw#1068, `micro-conv`
+  pgw#1073, `micro-pad32` + `micro-pad32-branchy` pgw#1079) — and because
+  discovery walks the whole package, each one failed EVERY build carrying the
+  example until it was worked around by excluding files from the tarball.
+  `examples/micro-diffusion/FAMILIES` is now the shared constant two gates read:
+  `tests/test_micro_family_registration_pgw1084.py` runs the real discovery scan
+  and asserts the set matches (both directions — a listed family whose member is
+  gone is flagged too), and tensorhub vendors the same file behind an offline
+  registry test plus a peer-fetch drift job. The example's README gains the
+  four-step add-a-member checklist and the per-function `?bindings=` seed step
+  that `micro-conv` was missing (§8.4.2).

--- a/examples/micro-diffusion/FAMILIES
+++ b/examples/micro-diffusion/FAMILIES
@@ -1,0 +1,32 @@
+# The architecture families `python -m gen_worker.discover` finds in THIS
+# package. One per line, sorted, `#` comments ignored.
+#
+# THIS FILE IS HALF OF A CROSS-REPO FENCE. It is the shared constant two gates
+# read, in two repositories that cannot see each other's trees:
+#
+#   pgw side  tests/test_micro_family_registration_pgw1084.py — runs the REAL
+#             discovery scan over this package and asserts the set it produces
+#             equals this file. Adding a member without listing it is RED here.
+#
+#   hub side  tensorhub scripts/micro-family-drift.sh fetches this file from
+#             python-gen-worker@master and diffs it against the vendored copy
+#             at internal/modelfamily/MICRO_EXAMPLE_FAMILIES, whose own offline
+#             test asserts every name is registered in modelfamily.go (and that
+#             no registered micro-* family has lost its member here).
+#
+# WHY. Discovery walks the WHOLE package — `top_level = main.split(".")[0]` —
+# so ONE unregistered family fails EVERY build that carries the tarball, not
+# just its own function. That happened three times: micro-escape (pgw#1068),
+# micro-conv (pgw#1073), and micro-pad32 + micro-pad32-branchy (pgw#1079,
+# discovered by pgw#1084 §8.4.1 at the cost of a campaign leg). The fourth
+# recurrence is what this file exists to make impossible.
+#
+# ADDING A FAMILY: see this directory's README, "Adding a member". The line
+# below is step 2 of four; step 3 is a tensorhub commit and there is no runtime
+# registration path.
+micro-4d
+micro-conv
+micro-diffusion
+micro-escape
+micro-pad32
+micro-pad32-branchy

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -25,7 +25,43 @@ src/micro_diffusion/
   *_pad32.py          micro-pad32: ie#637's PAD-TO-32 shape — the token extent is
                       `32*FloorDiv(H*W+31, 32)`, and one collapsed artifact serves
                       three L values whose pads are 0, 16 and 28
+  *_pad32_branchy.py  micro-pad32-branchy: the RED twin — branches on the pad, so
+                      the declared-range gate must REFUSE it (pgw#1079)
+  FAMILIES            the six families discovery finds here — half of the
+                      cross-repo fence below
 ```
+
+## Adding a member — FOUR steps, and three of them are outside this file
+
+**Discovery walks the WHOLE package** (`top_level = main.split(".")[0]`), so a
+member whose family is unregistered hub-side fails **every build that carries
+this example**, not just its own function. That has happened three times —
+`micro-escape` (pgw#1068), `micro-conv` (pgw#1073), `micro-pad32` +
+`micro-pad32-branchy` (pgw#1079, found mid-campaign by pgw#1084 §8.4.1, which
+could only proceed by excluding `*pad32*` from the proof tarball). The typed
+refusal is not the problem; it fires against a live hub with the tarball already
+uploaded, which is too late and costs a lane its leg.
+
+1. **The example** — `main_<x>.py` + `aot_declaration_<x>.py` + a pipeline class,
+   with its own `FAMILY = "micro-<x>"`.
+2. **`FAMILIES`** — add the name, sorted. `tests/test_micro_family_registration_pgw1084.py`
+   runs the REAL discovery scan and goes RED until you do; it also goes red on a
+   line here whose member is gone.
+3. **The tensorhub registration** — `internal/modelfamily/modelfamily.go`:
+   `canonicalFamilies`, plus a `rootOverrides` entry to `micro-diffusion` when
+   the member loads the base transformer's `state_dict` (all of them so far do,
+   which is why ONE seeded checkpoint satisfies every slot). Update the vendored
+   `internal/modelfamily/MICRO_EXAMPLE_FAMILIES` in the same commit — its
+   offline test is in the required `gates` check, and `scripts/micro-family-drift.sh`
+   diffs the vendored copy against THIS file on `python-gen-worker@master`.
+   There is no runtime registration path; it takes effect at the next hub deploy.
+   **pgw lands first** — the hub gate reads pgw's default branch.
+4. **The stack binding** — step 0 below. Registered-but-unbound is the *second*
+   failure, one layer deeper, and it is what still blocks `micro-conv`:
+   `declared slot has no binding: function "generate-conv" slot "pipeline" has no
+   code default and current prod release … has no matching family "micro-conv"`
+   (pgw#1084 §8.4.2). Bindings are stack state, not repo state — nothing in any
+   repository seeds them, so a fresh stack owes step 0 for every family here.
 
 ## The three entries, and why exactly three
 
@@ -175,9 +211,48 @@ Two things that are easy to get wrong:
   Without it the gate fails closed on `binding_incompatible`: *"slot declares
   family … but the artifact's family is undeterminable"*.
 
-One checkpoint serves all three families: `micro-4d` and `micro-escape` both
-root to `micro-diffusion` (they `load_state_dict(base.transformer.state_dict(),
-strict=True)`), so the seed-997 tree satisfies every slot the package declares.
+One checkpoint serves **all six** families: every variant either
+`load_state_dict(base.transformer.state_dict(), strict=True)` or (micro-conv)
+derives its weights from the same tree's declared seed, and all of them root to
+`micro-diffusion` in tensorhub's `rootOverrides` — so the seed-997 tree
+satisfies every slot the package declares.
+
+### 0b. One binding PER FUNCTION — the second failure, and what blocked micro-conv
+
+A checkpoint that resolves is not a binding. Every function here declares
+`Slot(..., selected_by="model")` with **no code default**, so each one needs its
+own entry, and the build refuses per function:
+
+```
+declared slot has no binding: function "generate-conv" slot "pipeline" has no
+code default and current prod release … has no matching family "micro-conv"
+```
+
+That is pgw#1084 §8.4.2 — `micro-conv` was registered in tensorhub and still
+unbuildable, so the campaign's gauntlet was 3 families, not 5. A new function
+inherits nothing, because there is no prior prod release declaring it; supply the
+binding **on the publish that first declares it**, with `?bindings=` (the tarball
+form of th#1087's payload — the JSON deploy form takes the same map as
+`{"bindings": …}`):
+
+```
+POST /api/v1/endpoints/tensorhub/micro-diffusion/releases?dev=true&skip_profiling=true
+     &bindings={"generate-conv":{"pipeline":{"ref":"tensorhub/micro-diffusion","tag":"prod"}}}
+```
+
+Function names are the NORMALIZED spellings (`generate_conv` → `generate-conv`).
+Thereafter the binding is config and is patchable without a rebuild:
+
+```
+PATCH /api/v1/endpoints/tensorhub/micro-diffusion/config?tag=prod
+      {"bindings":{"generate-conv":{"pipeline":{"ref":"tensorhub/micro-diffusion"}}}}
+```
+
+**Bindings are STACK state.** No repository holds them — grep for
+`micro-diffusion` across tensorhub, e2e and the gitops repo and you find the
+family registration and nothing else — so every fresh stack owes this step for
+all nine functions, and a family added to the package is unbuildable on an
+existing stack until its function is bound here.
 
 Verify before spending anything — the tag must resolve:
 

--- a/tests/test_micro_family_registration_pgw1084.py
+++ b/tests/test_micro_family_registration_pgw1084.py
@@ -1,0 +1,150 @@
+"""pgw#1084 §8.4.1 — the worker half of the micro-family cross-repo fence.
+
+THE DEFECT CLASS, three times in three weeks. `examples/micro-diffusion` gains
+a member; tensorhub's `internal/modelfamily` does not learn about it; and
+because build-time discovery walks the WHOLE package
+(`top_level = main_module.split(".", 1)[0]`, discovery/discover.py), the
+unregistered family fails EVERY build that carries the tarball — not only its
+own function. Each occurrence was found by a lane that had already paid for the
+build:
+
+    micro-escape        pgw#1068   worked around by excluding *_escape.py
+    micro-conv          pgw#1073   same shape, recorded in modelfamily.go
+    micro-pad32(+…)     pgw#1079   found by pgw#1084 §8.4.1, mid-campaign:
+                                   `invalid discovery manifest: family
+                                    "micro-pad32" is not a known architecture
+                                    family`
+
+The refusal is already TYPED and already names its remedy (tensorhub
+`modelfamily.HowToRegister`). That was not enough, three times over, because it
+can only fire against a live hub with a tarball already uploaded. Neither repo's
+CI can reach the other's registry, so the fence is two halves over one shared
+constant, `examples/micro-diffusion/FAMILIES`:
+
+    this file          the FAMILIES list equals what discovery ACTUALLY finds
+    tensorhub          the same list, vendored + peer-fetched, is registered
+                       (internal/modelfamily/MICRO_EXAMPLE_FAMILIES,
+                        scripts/micro-family-drift.sh)
+
+RED-PROVEN: adding a member declaring a family absent from FAMILIES fails
+`test_families_declared_equal_the_shared_constant`, naming the family, the file
+and the tensorhub commit it also owes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+import pytest
+
+from gen_worker.discovery.discover import discover_manifest
+
+REPO = Path(__file__).resolve().parents[1]
+MICRO = REPO / "examples" / "micro-diffusion"
+FAMILIES_FILE = MICRO / "FAMILIES"
+
+#: Where the peer half lives. Quoted in every failure below, because the whole
+#: point of this fence is that the author is in the WRONG REPOSITORY to fix it.
+PEER_REGISTRY = "tensorhub internal/modelfamily/modelfamily.go"
+PEER_VENDORED = "tensorhub internal/modelfamily/MICRO_EXAMPLE_FAMILIES"
+
+
+def _shared_constant() -> List[str]:
+    lines = []
+    for raw in FAMILIES_FILE.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _manifest_families(manifest: Dict[str, Any]) -> Set[str]:
+    """Every family spelling tensorhub's manifest gates will read.
+
+    The hub applies `modelfamily.IsKnown` in three places on this document —
+    `slots[].family` and `bindings[].family` (manifest_contract.go, the walk
+    attempt-27 actually hit) and `compile.family` (th#1310) — so the fence
+    collects all of them plus `config_family`, rather than guessing which gate
+    a future member will trip first.
+    """
+    out: Set[str] = set()
+
+    def add(value: Any) -> None:
+        if isinstance(value, str) and value.strip():
+            out.add(value.strip())
+
+    for fn in manifest.get("functions") or []:
+        add((fn.get("compile") or {}).get("family"))
+        add(fn.get("config_family"))
+        for slot in fn.get("slots") or []:
+            add(slot.get("family"))
+        for binding in (fn.get("bindings") or {}).values():
+            if isinstance(binding, dict):
+                add(binding.get("family"))
+    return out
+
+
+@pytest.fixture(scope="module")
+def declared() -> Set[str]:
+    """The REAL build-time scan, not a grep over the source.
+
+    `discover_manifest` is the exact entry point the image's build step runs
+    (`python -m gen_worker.discover`), so a member this fence cannot see is a
+    member the hub cannot see either. It needs no GPU and no network.
+    """
+    return _manifest_families(discover_manifest(MICRO))
+
+
+def test_families_declared_equal_the_shared_constant(declared: Set[str]) -> None:
+    listed = set(_shared_constant())
+    unlisted = sorted(declared - listed)
+    dead = sorted(listed - declared)
+    assert not unlisted, (
+        f"{unlisted} reach the discovery manifest but are not in "
+        f"{FAMILIES_FILE.relative_to(REPO)}.\n"
+        f"A family is not usable until it exists in BOTH repositories, and "
+        f"discovery scans the whole package — so until then EVERY build "
+        f"carrying this example fails, not just the new function.\n"
+        f"  1. add it to {FAMILIES_FILE.relative_to(REPO)}\n"
+        f"  2. register it in {PEER_REGISTRY} (canonicalFamilies, plus "
+        f"rootOverrides if it shares micro-diffusion's weight envelope) and "
+        f"update {PEER_VENDORED} in the SAME commit — there is no runtime "
+        f"registration path, it takes effect at the next hub deploy\n"
+        f"  3. seed the catalog binding on the stack (examples/micro-diffusion/"
+        f"README.md step 0)")
+    assert not dead, (
+        f"{dead} are listed in {FAMILIES_FILE.relative_to(REPO)} but no longer "
+        f"reach the discovery manifest. Delete the line here and the matching "
+        f"entry in {PEER_REGISTRY}, or the hub keeps a family nothing declares.")
+
+
+def test_the_shared_constant_is_sorted_and_unique() -> None:
+    """It is diffed byte-for-byte against a vendored copy in another repo."""
+    listed = _shared_constant()
+    assert listed == sorted(set(listed)), (
+        "FAMILIES must be sorted with no duplicates: tensorhub's "
+        "scripts/micro-family-drift.sh compares it to a vendored copy, and an "
+        "ordering difference there is indistinguishable from a real one")
+    for name in listed:
+        assert re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", name), (
+            f"{name!r} is not a normalized family spelling; tensorhub's "
+            f"modelfamily.Normalize lowercases and strips dots, so a name that "
+            f"needs normalizing is registered under a DIFFERENT key than the "
+            f"one written here")
+
+
+def test_every_declared_family_is_reachable_from_the_package(declared: Set[str]) -> None:
+    """Guards the fence's own premise: the scan sees more than `main`.
+
+    If `discover_manifest` ever stopped walking submodules this test would
+    still pass trivially against a shrunken FAMILIES file, so assert the
+    property that makes the fence meaningful — the scan finds families declared
+    in modules `endpoint.toml`'s `main` never imports.
+    """
+    assert "micro-pad32-branchy" in declared, (
+        "the discovery scan no longer reaches main_pad32_branchy.py — either a "
+        "member was deleted (update FAMILIES) or the walk stopped covering the "
+        "package, which would make this whole fence vacuous")
+    assert len(declared) >= 6


### PR DESCRIPTION
Closes the follow-up pgw#1084 §8.4.1 named with an owner: *"the `modelfamily` registration for pad32 (tensorhub, §8.4.1)"* — and fixes the CLASS rather than the instance.

## The defect class, three times in three weeks

A member is added to `examples/micro-diffusion`; the matching `internal/modelfamily` registration in tensorhub is not. Build-time discovery walks the **whole package** (`top_level = main_module.split(".", 1)[0]`), so the unregistered family fails **every build carrying the tarball**, not just its own function.

| when | family | how it was worked around |
|---|---|---|
| pgw#1068 | `micro-escape` | excluded `*_escape.py` from the tarball |
| pgw#1073 | `micro-conv` | same shape; lesson recorded in `modelfamily.go` |
| pgw#1079 | `micro-pad32`, `micro-pad32-branchy` | found **mid-campaign** by pgw#1084 §8.4.1; excluded `*pad32*` |

The hub refusal is already typed and already names its remedy (`modelfamily.HowToRegister`), and `modelfamily.go`'s own comments already recorded two prior occurrences. Neither stopped the third: both are read only by someone who has **already paid for a build against a live hub**.

## The fence — two halves, one shared constant

`examples/micro-diffusion/FAMILIES` is the constant. Neither repo's CI can read the other's registry, so:

- **this PR** — `tests/test_micro_family_registration_pgw1084.py` runs the **real** discovery scan (`discover_manifest` on the example — the same entry point `python -m gen_worker.discover` runs; no GPU, no network) and asserts the family set equals `FAMILIES`, **both directions**: an unlisted member is red, and so is a listed family whose member is gone.
- **tensorhub, next** — a vendored copy of this file behind an offline registry test in the required `gates` check, plus `scripts/micro-family-drift.sh` fetching this file from `master`. **pgw lands first**, the same law and the same asymmetry as th#1678's worker-constant gate.

## RED proof

```
+ main_redprobe.py declaring FAMILY = "micro-redprobe"
  -> FAILED test_families_declared_equal_the_shared_constant
     ['micro-redprobe'] reach the discovery manifest but are not in
     examples/micro-diffusion/FAMILIES ... 2. register it in tensorhub
     internal/modelfamily/modelfamily.go ...

+ a `micro-zombie` line with no member
  -> FAILED ... ['micro-zombie'] are listed ... but no longer reach the
     discovery manifest. Delete the line here and the matching entry ...
```

## Runbook (§8.4.2)

`examples/micro-diffusion/README.md` gains the four-step **add-a-member** checklist (example → `FAMILIES` → tensorhub registration → stack binding) and a new **step 0b**: the per-function `?bindings=` seed `micro-conv` never got, which is why the campaign's buildable gauntlet was 3 families and not 5. Bindings are **stack state** — no repository holds them — so every fresh stack owes that step for all nine functions.