### PR TITLE
pgw#1093: minted-but-never-installed — and the degrade that reached the wire as nothing

### DIFF
--- a/changelog.d/pgw1093.md
+++ b/changelog.d/pgw1093.md
@@ -1,0 +1,54 @@
+- **pgw#1093: an ARMED compile target that owns no installed target is now an
+  IMPOSSIBLE state, and an installed-then-DEGRADED target no longer reads
+  exactly like one that was never installed.** minimax-h3 0.4.4 on 0.98.0
+  (master stack, pod `kwiz5n9o41yn5i`, request `55971bce-…`, \$1.15) armed a
+  regional JIT-intake target, compiled it whole — `jit_compile/minted
+  n_graphs=2 n_breaks=0 total_s=39.36`, everything pgw#1082 fixed working
+  correctly — and then served every request eager at 6.30 s/step against a
+  rig-measured 4.31. The pod's 59 activity rows contain **no**
+  `serve_eager_posture` and **no** `self_mint_abort`: the whole boot reached
+  the wire as `metrics.lane=…+eager`, `fallback_reason=uncompiled`,
+  `self_mint_skipped/boot_ended_uncompiled`, and nothing else. Two different
+  defects produce that reading and nothing could tell them apart:
+  - **Every permanent degrade now confesses, whatever raised it.**
+    `_guarded_regional` and `_guarded` gave a graph break and a
+    `DeclaredRangeExceeded` their own wire rows (pgw#1082) and sent **every
+    other exception class** to `logger.warning` — on a hub-spawned pod whose
+    stdout nobody can read, which is pgw#824's ruling verbatim. Both guards now
+    emit a typed `compiled_degraded` degrade row and carry a
+    `degrade_reason` on the failure signal, which `_eager_posture` surfaces so
+    the request row names the exception instead of the terminal `uncompiled`.
+  - **The confession reaches a record that exists.** `_bind_compile_guard`
+    installs the revocation callback inside `_install_compile_targets`, which
+    runs AFTER the boot warmup — so a target that armed, compiled and then
+    broke *during* that warmup had no callback to fire and no record to write
+    on, making pgw#1082's entire path structurally unreachable for it.
+    `_note_boot_degrade` reads the reason off the pipeline's own signal at the
+    first moment a record exists.
+  - **No silent exit from `_install_compile_targets`.** The bare
+    `if not has_compile_target(...): continue` and the empty-candidate case
+    were two of the three exits that emitted nothing at all (the third,
+    `cfg is None`, cannot be reached by an armed boot); the trailing
+    "no addressable target" confession is gated on a MANDATORY quant lane,
+    which `bf16-w16a16` is not. Both now name the slot, the declared targets
+    and the predicate that refused, as `armed_target_unresolved` /
+    `no_compile_candidates`.
+  - **The terminus.** `_assert_armed_targets_installed` closes setup on one
+    typed, wire-visible refusal: an arm that RETURNED TRUE and owns no
+    installed target. Keyed on the arm fact (`_InjectionResult.armed_objects`,
+    recorded on both scopes), never on a live `is_compile_armed()` probe — a
+    degrade flips that probe to False and would let the invariant excuse
+    exactly the boot it exists to catch. It overrides a weaker
+    already-recorded token, because "no candidates survived" is a consequence
+    of it, not a rival cause.
+  - **pgw#1078's disproof-clear moved above the re-scan gate.** It sat after
+    `if not has_compile_target(...): continue`, so an armed object that failed
+    the re-scan kept the stale injection-time `no_compile_target` — and
+    first-token-wins then let that stale token outrank the real cause. Same
+    wrong-cause defect pgw#1078 fixed, on the one path its fix could not reach.
+
+  `tests/test_armed_target_install_pgw1093.py` drives the real `ensure_setup()`
+  on the live shape (a `Slot(..., selected_by=…)` class-annotated slot whose
+  component hydrates inside `setup()`, a regional `Compile`, JIT intake, only
+  `torch.cuda.is_available` faked): a control that must stay `+compiled`, plus
+  the two defect classes, both RED on 0.98.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.98.0"
+version = "0.99.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -135,6 +135,27 @@ class EagerPhase(StrEnum):
     #: actually cost minimax-h3 its compiled wall.
     DECLARED_RANGE_EXCEEDED = "declared_range_exceeded"
 
+    #: pgw#1093: the target WAS installed and armed, and a served call then
+    #: failed permanently for a reason that is neither a graph break nor a
+    #: declared-range refusal — a kernel that refuses this shape, an OOM
+    #: inside the region, a module the endpoint mutated after the arm. Before
+    #: this token that degrade reached the wire as NOTHING, so it was
+    #: indistinguishable from "no target was ever installed" and both read
+    #: `uncompiled`. The distinction is the whole point: one is an execution
+    #: failure with a named exception, the other is a WIRING failure.
+    COMPILED_DEGRADED = "compiled_degraded"
+
+    #: pgw#1093: an arm SUCCEEDED inside `setup()` and `_install_compile_targets`
+    #: then resolved no declared target on the same object — the boot compiled
+    #: graphs it can never dispatch to. The pgw#1078 D2 class, one layer up,
+    #: and previously a bare `continue` with no note, no counter, no event.
+    ARMED_TARGET_UNRESOLVED = "armed_target_unresolved"
+
+    #: pgw#1093: the record ended setup owning ZERO compile-capable candidate
+    #: objects while its spec declares a compile family. The candidate loop
+    #: never ran, so not one of the per-candidate omission tokens could fire.
+    NO_COMPILE_CANDIDATES = "no_compile_candidates"
+
     #: `_fail_closed`'s default, for a caller that has not classified its exit.
     #: A new decline landing here rather than on its own member is the
     #: regression pgw#824 exists to catch.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -414,6 +414,18 @@ GRAPH_BREAK_TOKEN = "graph_break"
 #: pgw#1082: the declaration named a dynamic range its own inputs leave.
 DECLARED_RANGE_TOKEN = "declared_range_exceeded"
 
+#: pgw#1093: the CATCH-ALL permanent degrade. A regional/whole-graph target
+#: that raised anything OTHER than a graph break, a declared-range refusal or
+#: a recompile miss used to degrade to eager on a `logger.warning` alone —
+#: and a hub-spawned pod has no reachable stdout, so the degrade was invisible
+#: (pgw#824's own ruling). Worse, `is_compile_armed` then reads False, which
+#: makes an INSTALLED-THEN-DEGRADED target byte-identical on the wire to a
+#: NEVER-INSTALLED one: same `metrics.lane=…+eager`, same
+#: `fallback_reason=uncompiled`, same `boot_ended_uncompiled`, zero other
+#: rows. Two different defects, one indistinguishable reading — which is
+#: exactly how pgw#1093 spent a pod attributing the wrong cause.
+COMPILED_DEGRADE_TOKEN = "compiled_degraded"
+
 
 def _is_graph_break_error(exc: BaseException) -> bool:
     """True for dynamo's fullgraph refusal — the region did NOT trace whole.
@@ -469,6 +481,38 @@ def _emit_graph_break_event(label: str, exc: BaseException) -> None:
         )
     except Exception:  # pragma: no cover — telemetry never fails the serve
         logger.debug("compile-cache: graph-break event emission failed",
+                     exc_info=True)
+
+
+def _emit_compiled_degrade_event(
+    label: str, exc: BaseException, *, lane: str, fail_closed: bool,
+) -> None:
+    """pgw#1093: confess EVERY permanent degrade, whatever raised it.
+
+    The two classified degrades (graph break, declared range) have had their
+    own rows since pgw#1082. Everything else — a kernel that refuses this
+    shape, a dtype mismatch the marks let through, an OOM inside the compiled
+    region, an endpoint mutating a module the arm wrapped — took the
+    `logger.warning` path and reached the wire as nothing at all. This row is
+    what makes "installed and then broke, HERE, for THIS reason" a different
+    fact from "never installed", instead of the same `uncompiled`.
+    """
+    try:
+        from . import activity as activity_mod
+
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            detail=(
+                f"target={label} lane={lane} {COMPILED_DEGRADE_TOKEN}: this "
+                f"target was ARMED and is now permanently EAGER for the rest "
+                f"of this process — {type(exc).__name__}: "
+                f"{_clip(str(exc), 600)}"
+                + (" (mandatory lane)" if fail_closed else "")
+            ),
+            phase=COMPILED_DEGRADE_TOKEN,
+        )
+    except Exception:  # pragma: no cover — telemetry never fails the serve
+        logger.debug("compile-cache: degrade event emission failed",
                      exc_info=True)
 
 
@@ -2891,6 +2935,13 @@ def _guarded(
             # while every request ran eager (the gw#586 class, one lane over).
             if isinstance(failure_signal, dict):
                 failure_signal["degraded"] = True
+                failure_signal["degrade_reason"] = _clip(
+                    f"{type(exc).__name__}: {exc}", 600)
+            # pgw#1093: the whole-graph twin of the regional confession — the
+            # tier flip below is a CAPABILITY projection, not an event, so
+            # without this row the degrade leaves no dated, greppable fact.
+            _emit_compiled_degrade_event(
+                label, exc, lane="whole", fail_closed=fail_closed)
             # Revoke scheduler-visible compiled proof synchronously before the
             # eager fallback: the tier flips to explicit eager on the wire.
             revoke(state["detail"])
@@ -3022,6 +3073,12 @@ def _guarded_regional(
                 # against the rig's 4.31 for the identical recipe).
                 if isinstance(failure_signal, dict):
                     failure_signal["degraded"] = True
+                    # pgw#1093: the reason is carried on the SIGNAL, not only
+                    # in a log line, so `_eager_posture` can name it on every
+                    # request the pod serves afterwards instead of falling
+                    # through to the generic `uncompiled`.
+                    failure_signal["degrade_reason"] = _clip(
+                        f"{type(exc).__name__}: {exc}", 600)
                     if broke:
                         failure_signal["graph_break"] = _clip(str(exc), 600)
                 if broke:
@@ -3031,6 +3088,12 @@ def _guarded_regional(
                         failure_signal["declared_range_exceeded"] = _clip(
                             str(exc), 600)
                     _emit_declared_range_event(label, exc)
+                else:
+                    # pgw#1093: the catch-all that used to reach the wire as
+                    # NOTHING. Without it an installed-then-degraded target
+                    # and a never-installed one are the same reading.
+                    _emit_compiled_degrade_event(
+                        label, exc, lane="regional", fail_closed=fail_closed)
                 # Regional eager state is real only after the in-place block
                 # compilations are gone. Revoke proof after that mutation and
                 # before a state delta can be scheduled.
@@ -3471,6 +3534,23 @@ def graph_break_reason(pipeline: Any) -> str:
     signal = marker.get("failure_signal") if isinstance(marker, dict) else None
     if isinstance(signal, dict):
         return str(signal.get("graph_break") or "")
+    return ""
+
+
+def degrade_reason(pipeline: Any) -> str:
+    """pgw#1093: why this ARMED pipeline is permanently eager, or "".
+
+    Non-empty means `apply()` DID install the compiled callables and a served
+    call then failed permanently. That is a different fact from "no target
+    was ever installed", and before this the two were the same reading:
+    `is_compile_armed` False, `metrics.lane=…+eager`,
+    `fallback_reason=uncompiled`. The executor turns this into a
+    `compiled_degraded` eager posture so the distinction survives to the wire.
+    """
+    marker = getattr(pipeline, _MARKER_ATTR, None)
+    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
+    if isinstance(signal, dict):
+        return str(signal.get("degrade_reason") or "")
     return ""
 
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2957,6 +2957,13 @@ class _InjectionResult:
     # resolve. Kept separately because shared-lane residency may replace the
     # bookkeeping object with a ModuleDict while setup receives the pipeline.
     compile_objects: List[_CompileObjectCandidate] = dc_field(default_factory=list)
+    # pgw#1093: the ARM FACT — every object an arm RETURNED TRUE for, on
+    # either scope (slot injection or `arm_compile()` inside setup()).
+    # Recorded before any later re-scan can drop it, and never re-derived
+    # from `is_compile_armed()`: a permanent degrade flips that probe to
+    # False, which would let the end-of-setup invariant excuse exactly the
+    # boot it exists to catch.
+    armed_objects: List[Any] = dc_field(default_factory=list)
     # id(pipeline) -> exact attached artifact that successfully armed it.
     # Installed only after the setup warmup completes.
     active_compile_artifacts: Dict[int, _CompileArtifactSelection] = dc_field(
@@ -4370,6 +4377,7 @@ class Executor:
 
     def _note_eager_posture(
         self, rec: _ClassRecord, token: str, detail: str = "",
+        *, override: bool = False,
     ) -> None:
         """pgw#824: record (and, once, confess) WHY this record has no cell.
 
@@ -4377,9 +4385,17 @@ class Executor:
         one. The typed event fires only on the transition, so a decline that
         happens per-object on a many-slot record coalesces to ONE row instead
         of N identical ones — counts, not silence, and not a flood.
+
+        pgw#1093 ``override``: for the ONE token that is never a competing
+        cause but the CAUSE OF the causes already recorded. "An arm returned
+        True and nothing owns it" makes "no compile candidates survived" a
+        consequence, not a rival — and first-token-wins would otherwise leave
+        the record naming its own symptom.
         """
         token = str(token or "").strip()
-        if not token or rec.eager_posture:
+        if not token or (rec.eager_posture and not override):
+            return
+        if override and rec.eager_posture == token:
             return
         rec.eager_posture = token
         activity_mod.emit_event(
@@ -4388,6 +4404,85 @@ class Executor:
             f"serves EAGER — {detail or token}. Every request it serves "
             f"reports fallback_reason={token}.",
             phase=token,
+        )
+
+    def _note_boot_degrade(self, rec: _ClassRecord, pipeline: Any) -> None:
+        """pgw#1093: confess a degrade that happened BEFORE any guard was bound.
+
+        `_bind_compile_guard` installs the revocation callback in
+        `_install_compile_targets`, which runs AFTER the boot warmup. So a
+        target that armed, compiled, and then broke DURING that warmup has no
+        callback to fire and no record to write on: pgw#1082's whole
+        confession path is unreachable for it, and every reader afterwards
+        falls through to the generic `uncompiled`. This reads the reason
+        straight off the pipeline's own failure signal instead.
+        """
+        broke = compile_cache.graph_break_reason(pipeline)
+        out_of_range = compile_cache.declared_range_refusal(pipeline)
+        reason = compile_cache.degrade_reason(pipeline)
+        if broke:
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.GRAPH_BREAK.value,
+                f"the declared regional target did not trace WHOLE under "
+                f"fullgraph during the boot warmup: {broke}")
+        elif out_of_range:
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.DECLARED_RANGE_EXCEEDED.value,
+                out_of_range)
+        elif reason:
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.COMPILED_DEGRADED.value,
+                f"the compiled target was ARMED and a call during the boot "
+                f"warmup failed permanently, so this instance is eager for "
+                f"the rest of its life: {reason}")
+
+    def _assert_armed_targets_installed(
+        self, rec: _ClassRecord, spec: EndpointSpec,
+        armed_objects: typing.Iterable[Any],
+    ) -> None:
+        """pgw#1093 THE INVARIANT: armed at setup => an installed target owns it.
+
+        "``compile_cache`` minted graphs into this object and nothing on this
+        record can dispatch to them" is not a degraded state — it is an
+        IMPOSSIBLE one, and it has now cost two releases (pgw#1078 D2, this
+        issue) because every route to it was a log line or a bare ``continue``.
+
+        Keyed on the ARM FACT — what ``arm_compile()``/the injection scan
+        RETURNED — never on a live ``is_compile_armed()`` probe. A permanent
+        degrade flips that probe to False, so probing would let the invariant
+        excuse exactly the boot it exists to catch.
+
+        Not fatal (pgw#672: a broken optimization never kills a serving
+        worker). It is a TYPED, wire-visible refusal with a named cause, which
+        is what the pod telemetry did not have.
+        """
+        owned = {id(t.pipeline) for t in rec.compile_targets.values()}
+        orphans = [p for p in armed_objects if id(p) not in owned]
+        if not orphans:
+            return
+        detail = "; ".join(
+            f"{type(p).__name__} armed={compile_cache.is_compile_armed(p)} "
+            f"targets_resolve="
+            f"{compile_cache.has_compile_target(p, spec.compile_cell())} "
+            f"degrade={compile_cache.degrade_reason(p) or '-'}"
+            for p in orphans
+        )
+        logger.error(
+            "%s: %d ARMED compile object(s) own NO installed target — this "
+            "boot compiled graphs nothing can dispatch to (%s)",
+            spec.name, len(orphans), detail)
+        self._note_eager_posture(
+            rec, cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value,
+            f"{len(orphans)} object(s) armed during setup own no installed "
+            f"compile target, so the compiled graphs this boot paid for are "
+            f"undispatchable: {detail}",
+            override=True)
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            detail=(
+                f"fn={spec.name}: {len(orphans)} ARMED compile object(s) own "
+                f"no installed target after setup — {detail}"),
+            phase=cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value,
         )
 
     def _install_compile_targets(
@@ -4427,6 +4522,25 @@ class Executor:
             else _CompileObjectCandidate(item, set(all_slots))
             for item in objects
         ]
+        # pgw#1093: a permanent degrade that happened during the BOOT WARMUP
+        # has no record to confess on — `_bind_compile_guard` installs the
+        # revocation callback HERE, after the warmup, so pgw#1082's whole
+        # confession path is structurally unreachable for a target that broke
+        # while it was being warmed. This is the late confession: read the
+        # reason off the pipeline's own failure signal, at the first moment a
+        # record exists to carry it.
+        for candidate in candidates:
+            self._note_boot_degrade(rec, candidate.pipeline)
+        if not candidates:
+            # The candidate loop below never runs, so not one of its omission
+            # tokens can fire — the exact shape that reached pgw#1093 as zero
+            # rows and a generic `uncompiled` on every request.
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.NO_COMPILE_CANDIDATES.value,
+                f"setup produced no compile-capable object for declared "
+                f"family {str(getattr(cfg, 'family', '') or '?')!r} "
+                f"targets={[str(t) for t in (getattr(cfg, 'targets', ()) or ())]} "
+                f"over held slots {sorted(all_slots)}")
         requested_execution_lane = self._mandatory_execution_lane_of_bound(
             wire_ref(spec.models[slot]) for slot in self._setup_slots(spec)
         )
@@ -4441,6 +4555,28 @@ class Executor:
                 continue
             seen.add(id(pipeline))
             if not compile_cache.has_compile_target(pipeline, cfg):
+                # pgw#1093: NOT a bare `continue` any more. An object reaches
+                # this list only because something already decided it was
+                # compile-capable — the injection scan or an `arm_compile()`
+                # that RETURNED TRUE. Resolving no target here therefore means
+                # the object changed under the arm (a lazily-hydrated
+                # component replaced after setup, a slot swapped by the
+                # endpoint), which is a WIRING fact and has to say so. It was
+                # one of exactly three exits from this method that emitted
+                # nothing at all, and this issue burned a $1.15 pod because of
+                # it.
+                self._note_eager_posture(
+                    rec, cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value
+                    if compile_cache.is_compile_armed(pipeline)
+                    else cell_adopt.EagerPhase.NO_COMPILE_TARGET.value,
+                    f"{type(pipeline).__name__} owning slots "
+                    f"{sorted(candidate.slots)} resolves none of the declared "
+                    f"targets "
+                    f"{[str(t) for t in (getattr(cfg, 'targets', ()) or ())]} "
+                    f"at install time"
+                    + (" — yet compile_cache reports it ARMED, so this boot "
+                       "compiled graphs it can never dispatch to"
+                       if compile_cache.is_compile_armed(pipeline) else ""))
                 continue
             bindings = tuple(sorted(
                 binding for binding in rec.held_bindings
@@ -5223,6 +5359,14 @@ class Executor:
         stored = str(rec.eager_posture or "")
         if stored:
             return stored
+        # pgw#1093: a target that ARMED and then degraded is not "uncompiled"
+        # — it is a named execution failure, and reporting it as the generic
+        # terminal token is what made an installed-then-degraded target read
+        # identically to a never-installed one. Live, because a degrade can
+        # land after boot on a target whose guard callback was never bound.
+        for target in rec.compile_targets.values():
+            if compile_cache.degrade_reason(target.pipeline):
+                return cell_adopt.EagerPhase.COMPILED_DEGRADED.value
         if not any(
             s.compile is not None and s.compile.family for s in rec.specs
         ):
@@ -6677,19 +6821,31 @@ class Executor:
                     await self._report_cell_selection_bug(
                         spec, compile_selection, bug)
                 for pipe, armed in arming_scope.objects:
+                    if armed:
+                        if not any(p is pipe for p in inj.armed_objects):
+                            # pgw#1093: BEFORE the re-scan below can drop it.
+                            # This object is armed compiled code; if nothing
+                            # ends up owning it, that is the impossible state
+                            # the end-of-setup invariant refuses — never a
+                            # silent skip.
+                            inj.armed_objects.append(pipe)
+                        # pgw#1078: this arm DISPROVES whatever the injection-
+                        # time attempt concluded about the same object — that
+                        # attempt ran before setup hydrated it.
+                        #
+                        # pgw#1093 moved the clear ABOVE the re-scan gate. It
+                        # used to sit after it, so an armed object that failed
+                        # the re-scan kept the stale injection-time
+                        # `no_compile_target` — and first-token-wins then let
+                        # that stale token outrank the REAL cause the install
+                        # was about to name. Same wrong-cause defect pgw#1078
+                        # fixed, on the one path its fix could not reach.
+                        inj.eager_postures.clear()
                     if not compile_cache.has_compile_target(pipe, spec.compile):
                         continue
                     owning = injected_slot_of.get(id(pipe))
                     inj.add_compile_object(
                         pipe, (owning,) if owning else self_loaded_slots)
-                    if armed:
-                        # pgw#1078: this arm DISPROVES whatever the injection
-                        # -time attempt concluded about the same object — that
-                        # attempt ran before setup hydrated it. First-token-
-                        # wins across the two scopes is what put
-                        # `no_compile_target` on every 0.4.2 request while the
-                        # target resolved fine.
-                        inj.eager_postures.clear()
                     mint = scope_mints.get(id(pipe))
                     selection = _selection_for(compile_selection, mint)
                     if getattr(mint, "delegated", False):
@@ -7386,6 +7542,11 @@ class Executor:
                 inj.active_compile_artifacts,
                 function_proofs,
             )
+            # pgw#1093: the terminus. Every route from "an arm returned True"
+            # to "no installed target owns it" now ends on ONE typed,
+            # wire-visible refusal instead of a log line nobody on a
+            # hub-spawned pod can read.
+            self._assert_armed_targets_installed(rec, spec, inj.armed_objects)
             rec.stale = False
             await self._clear_host_ram_capacity(list(slot_refs.values()))
         return instance
@@ -8557,6 +8718,11 @@ class Executor:
                                     spec, compile_selection, bug)
                             raise
                         armed = outcome.armed
+                        if armed and not any(
+                                p is pipe for p in result.armed_objects):
+                            # pgw#1093: the injection-scope half of the arm
+                            # fact (the scope half is in `_setup_instance`).
+                            result.armed_objects.append(pipe)
                         pipe_mint = outcome.self_mint
                         result.adoptions.extend(outcome.adoptions)
                         # pgw#824: the arming brain already classified WHY it

--- a/tests/test_armed_target_install_pgw1093.py
+++ b/tests/test_armed_target_install_pgw1093.py
@@ -1,0 +1,351 @@
+"""pgw#1093: "armed at setup, no installed target" is an IMPOSSIBLE state, and
+a target that armed and then DEGRADED must never read as one that was never
+installed.
+
+The live failure (master stack, pod `kwiz5n9o41yn5i`, request
+`55971bce-…`, minimax-h3 0.4.4 on gen-worker 0.98.0, $1.15): the boot armed a
+regional JIT-intake target, inductor compiled it WHOLE
+(`jit_compile/minted n_graphs=2 n_breaks=0 total_s=39.36`), and every request
+then served eager at 6.30 s/step against a rig-measured 4.31. The pod's 59
+activity rows carry no `serve_eager_posture` and no `self_mint_abort` — the
+whole boot reported `metrics.lane=bf16-w16a16+eager`,
+`fallback_reason=uncompiled`, `self_mint_skipped/boot_ended_uncompiled` and
+nothing else.
+
+TWO different defects produce that exact reading, and before this issue they
+were indistinguishable:
+
+  (A) NEVER INSTALLED — `_install_compile_targets` dropped the candidate on one
+      of three exits that emitted nothing at all: `cfg is None`, the bare
+      `if not has_compile_target(...): continue`, or an empty candidate list
+      (whose only confession is gated on a MANDATORY quant lane, which
+      `bf16-w16a16` is not).
+  (B) INSTALLED THEN DEGRADED — `_guarded_regional` caught an exception on a
+      served call, set `degraded=True` and cleared the region. A graph break
+      and a `DeclaredRangeExceeded` each got their own wire row from pgw#1082;
+      EVERY OTHER exception class took `logger.warning` and reached the wire as
+      nothing. On a hub-spawned pod stdout is unreachable — pgw#824's ruling
+      verbatim. `is_compile_armed` then reads False and every downstream reader
+      falls through to the generic `uncompiled`.
+
+pgw#1082's body predicted this ambiguity for the PRE-0.98.0 guard and fixed the
+LIE (`jit_cell` on an eager pod); raising the degrade flag made (B) look like
+(A) rather than making (B) say "degraded".
+
+REVERT-TURNS-RED: each test below fails on 0.98.0 — no posture is recorded, no
+`serve_eager_posture` row is emitted, and `_eager_posture()` answers
+`uncompiled` for a target that demonstrably armed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List
+
+import msgspec
+import pytest
+import torch
+
+import gen_worker
+import gen_worker.executor as ex_mod
+from gen_worker import (
+    Compile,
+    DynamicDim,
+    RequestContext,
+    Resources,
+    Slot,
+    activity,
+    cell_adopt,
+    endpoint,
+    worker_function,
+)
+from gen_worker import compile_cache as cc
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+FAMILY = "minimax-h3"
+REF = "tensorhub/minimax-h3:serve-narrowed"
+
+_COMPILE = Compile(
+    family=FAMILY,
+    shapes=((1344, 768, 124),),
+    targets=("transformer",),
+    regional=True,
+    dynamic=(DynamicDim("sequence", min=2, max=116126),),
+)
+
+
+class GenIn(msgspec.Struct):
+    prompt: str = "x"
+    # minimax-h3's slot is `Slot(..., selected_by="model")`; the payload must
+    # carry the field or registration refuses.
+    model: str = ""
+    num_inference_steps: int = 2
+
+
+class Out(msgspec.Struct):
+    y: str = "ok"
+
+
+class _Block(torch.nn.Module):
+    def forward(self, x: Any, **_kw: Any) -> Any:
+        return x
+
+
+class _DiT(torch.nn.Module):
+    """Stands in for the 20.1B denoiser: a real Module (the regional rollback
+    walks `.modules()`), owning `compile_repeated_blocks` so the REGIONAL arm
+    path is the one exercised."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.transformer_blocks = torch.nn.ModuleList([_Block(), _Block()])
+
+    def compile_repeated_blocks(self, dynamic: Any = None, fullgraph: bool = False) -> None:
+        return None
+
+    def forward(self, hidden_states: Any = None, **_kw: Any) -> Any:
+        return hidden_states
+
+
+class LazyPipe:
+    """A `ModularPipeline`-shaped slot: worker-loaded (class-annotated), but
+    the weight-bearing component hydrates only INSIDE setup(), so the
+    injection-time arm legitimately declines `no_compile_target` first."""
+
+    def __init__(self) -> None:
+        self.transformer: Any = None
+
+    @classmethod
+    def from_pretrained(cls, path: Any, **_kw: Any) -> "LazyPipe":
+        return cls()
+
+    def hydrate(self) -> None:
+        self.transformer = _DiT()
+
+    def __call__(self, *_a: Any, **_kw: Any) -> dict:
+        self.transformer.forward(hidden_states=None)
+        return {"out": 1}
+
+
+@endpoint(
+    models={"pipeline": Slot(LazyPipe, selected_by="model")},
+    resources=Resources(gpu=True),
+    compile=_COMPILE,
+)
+class H3:
+    def setup(self, pipeline: LazyPipe) -> None:
+        self.pipeline = pipeline
+        pipeline.hydrate()
+        self.armed = gen_worker.arm_compile(pipeline)
+
+    @worker_function()
+    def generate(self, ctx: RequestContext, p: GenIn) -> Out:
+        self.pipeline()
+        return Out()
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """One real `ensure_setup()` on the real arm path.
+
+    The ONLY environment fake is `torch.cuda.is_available` — `arming_block`
+    refuses a cardless process, and the defect is not about cards. `apply`,
+    `arm_jit_intake`, `ArmingScope`, the warm plan and the target install are
+    all the production code.
+    """
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    events: List[Any] = []
+    real_emit = activity.emit_event
+
+    def _spy(kind: str, detail: str = "", **kw: Any) -> Any:
+        events.append((kind, kw.get("phase", ""), detail))
+        try:
+            return real_emit(kind, detail, **kw)
+        except Exception:
+            return None
+
+    monkeypatch.setattr(activity, "emit_event", _spy)
+    monkeypatch.setattr(ex_mod.activity_mod, "emit_event", _spy)
+    monkeypatch.setattr(cc.logger, "warning", cc.logger.warning)
+
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor(extract_specs(H3), _send)
+    ex.store._cache_dir = tmp_path / "cas"
+
+    async def _fake_download(ref: str, **_kw: Any) -> Path:
+        p = tmp_path / ref.replace("/", "_").replace(":", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+
+    from gen_worker import dispatch
+
+    eff = ex._dispatched_spec(
+        ex.specs["generate"],
+        {"pipeline": dispatch.SlotOrder(ref=REF, components=())},
+    )
+    snaps = {
+        REF: pb.Snapshot(
+            digest="blake3:" + "a" * 64,
+            files=[pb.SnapshotFile(
+                path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+                url="http://r2.invalid/p")],
+        )
+    }
+    return ex, eff, snaps, events
+
+
+def _postures(events: List[Any]) -> List[str]:
+    return [phase for kind, phase, _d in events if kind == "serve_eager_posture"]
+
+
+def test_the_healthy_boot_installs_its_target(boot) -> None:
+    """The control. Same shape, nothing broken: the scope-armed, lazily
+    hydrated, `selected_by` slot ends the boot OWNING an installed target and
+    serving compiled. Without this, the two red tests below could pass for the
+    wrong reason."""
+    ex, eff, snaps, events = boot
+
+    async def _go() -> None:
+        inst = await ex.ensure_setup(eff, snaps)
+        rec = ex._classes[eff.instance_key]
+        assert inst.armed is True
+        assert rec.compile_targets, "the arm resolved; a target must own it"
+        assert rec.eager_posture == ""
+        assert ex._served_execution_lane(eff).endswith("+compiled")
+        assert _postures(events) == []
+
+    asyncio.run(_go())
+
+
+def test_an_armed_object_that_resolves_no_target_is_typed_not_silent(
+    boot, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defect class (A). The arm succeeds inside setup(); by install time the
+    object no longer resolves the declared target (the pgw#1078 D2 shape one
+    layer up — a component replaced under a live arm).
+
+    On 0.98.0 this is `if not has_compile_target(...): continue` — a bare
+    `continue`. No posture, no counter, no event, and every request afterwards
+    reports the generic `uncompiled`. That reading is identical to a healthy
+    pod that simply declares no compile, which is why nobody could see it.
+    """
+    ex, eff, snaps, events = boot
+    real_has = cc.has_compile_target
+    seen: dict = {"armed": False}
+
+    def _has(pipeline: Any, cfg: Any) -> bool:
+        # Truthful until the object is armed; afterwards the declared target
+        # no longer resolves on it.
+        if cc.is_compile_armed(pipeline):
+            seen["armed"] = True
+            return False
+        return real_has(pipeline, cfg)
+
+    monkeypatch.setattr(cc, "has_compile_target", _has)
+    monkeypatch.setattr(ex_mod.compile_cache, "has_compile_target", _has)
+
+    async def _go() -> None:
+        await ex.ensure_setup(eff, snaps)
+        rec = ex._classes[eff.instance_key]
+        assert seen["armed"], "the arm must have succeeded for this to be the case"
+        assert not rec.compile_targets
+
+        # THE INVARIANT: an arm that returned True and owns no installed
+        # target is a typed, wire-visible refusal — never a bare `continue`.
+        assert rec.eager_posture == (
+            cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value), (
+            "0.98.0 records NOTHING here: the boot compiles graphs it can "
+            "never dispatch to and every request reports `uncompiled`"
+        )
+        assert cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value in _postures(events)
+        assert any(
+            phase == cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value
+            and kind == activity.KIND_SERVE_DEGRADE
+            for kind, phase, _d in events
+        ), "the terminus must ALSO ride the degrade stream, not only a posture"
+        # And the request path names the real cause instead of the terminal
+        # fallback token.
+        assert ex._eager_posture(eff, rec) == (
+            cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value)
+
+    asyncio.run(_go())
+
+
+def test_a_boot_warmup_degrade_is_named_not_reported_as_uncompiled(
+    boot, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defect class (B), and the reason (A) was misdiagnosed.
+
+    `_bind_compile_guard` installs the revocation callback inside
+    `_install_compile_targets`, which runs AFTER the boot warmup. So a target
+    that armed, compiled, and then broke DURING that warmup has no callback to
+    fire and no record to write on — pgw#1082's entire confession path is
+    structurally unreachable for it.
+
+    A `RuntimeError` from a kernel is neither a graph break nor a
+    `DeclaredRangeExceeded`, so on 0.98.0 it takes `logger.warning` and reaches
+    the wire as NOTHING, and `_eager_posture()` answers `uncompiled` — the
+    exact token request `55971bce` carries.
+    """
+    ex, eff, snaps, events = boot
+
+    # The COMPILED call breaks; the eager fallback the guard then runs
+    # succeeds — the real degrade shape (pgw#672: a broken optimization never
+    # kills a serving worker, it just silently stops being an optimization).
+    calls = {"n": 0}
+
+    def _explode(self: Any, hidden_states: Any = None, **_kw: Any) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("fa3 kernel refuses this packed sequence")
+        return hidden_states
+
+    monkeypatch.setattr(_DiT, "forward", _explode)
+
+    async def _go() -> None:
+        await ex.ensure_setup(eff, snaps)
+        rec = ex._classes[eff.instance_key]
+
+        # The target IS installed — this is NOT the never-installed class, and
+        # that is precisely the distinction 0.98.0 could not express.
+        assert rec.compile_targets, (
+            "the arm resolved and the target installed; the failure is an "
+            "EXECUTION failure, not a wiring one"
+        )
+        pipe = next(iter(rec.compile_targets.values())).pipeline
+        assert cc.is_compile_armed(pipe) is False, "the guard degraded it"
+        assert "fa3 kernel refuses" in cc.degrade_reason(pipe)
+
+        assert rec.eager_posture == cell_adopt.EagerPhase.COMPILED_DEGRADED.value, (
+            "0.98.0 leaves this EMPTY, so `_eager_posture` falls through to "
+            "the generic `uncompiled` and an installed-then-degraded target "
+            "reads exactly like one that was never installed"
+        )
+        assert ex._eager_posture(eff, rec) == (
+            cell_adopt.EagerPhase.COMPILED_DEGRADED.value)
+        assert ex._eager_posture(eff, rec) != cell_adopt.EagerPhase.UNCOMPILED.value
+
+        # And it is a dated, greppable row — not a log line on a pod whose
+        # stdout nobody can reach (pgw#824).
+        assert any(
+            kind == activity.KIND_SERVE_DEGRADE
+            and phase == cc.COMPILED_DEGRADE_TOKEN
+            for kind, phase, _d in events
+        ), "every permanent degrade confesses, whatever raised it"
+
+    asyncio.run(_go())

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -216,6 +216,18 @@ def test_the_eager_phase_values_are_a_wire_contract() -> None:
         # for its whole life reporting `serving_mode=jit_cell`.
         "GRAPH_BREAK": "graph_break",
         "DECLARED_RANGE_EXCEEDED": "declared_range_exceeded",
+        # pgw#1093: the three tokens that separate TWO defects the wire could
+        # not tell apart. A target that armed and then broke, and a target
+        # that was never installed at all, both left `is_compile_armed` False
+        # and every reader falling through to `uncompiled` — same
+        # `metrics.lane=…+eager`, same `boot_ended_uncompiled`, zero other
+        # rows (minimax-h3 0.4.4 on 0.98.0, request `55971bce`, $1.15 spent
+        # attributing the wrong one). `compiled_degraded` is an EXECUTION
+        # failure carrying its exception; the other two are WIRING failures
+        # naming the slot and the predicate that refused.
+        "COMPILED_DEGRADED": "compiled_degraded",
+        "ARMED_TARGET_UNRESOLVED": "armed_target_unresolved",
+        "NO_COMPILE_CANDIDATES": "no_compile_candidates",
     }
     # The join the ArmOutcome docstring claims: a delegated mint's decline and
     # the serving posture that describes it are ONE token, not two that happen

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.98.0"
+version = "0.99.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The measurement

minimax-h3 0.4.4 on gen-worker 0.98.0 — master stack, pod `kwiz5n9o41yn5i`, request `55971bce-ebb1-4f52-a49a-f7df8faed056`, \$1.15, 404-verified. The boot armed a regional JIT-intake target and **compiled it whole**:

```
18:34:50.563  self_mint_skipped/no_compile_target   lane=plain (injection arm: pipeline.transformer is None — modular lazy hydration)
18:35:27.755  residency_profile/serve_recipe        w8a8 per-row fp8 on 300 Linears; fa3 exact bf16; compile ARMED
18:40:31.847  jit_compile/shape:boot                lane=bf16-w16a16+eager route=intake compile_s=39.36
18:40:31.851  jit_compile/minted                    n_shapes=1 n_graphs=2 n_breaks=0 total_s=39.36
18:40:31.862  self_mint_skipped/boot_ended_uncompiled   fn=generate
```

`request.completed` for `55971bce`: `metrics.lane = "bf16-w16a16+eager"`. 6.30 s/step against a rig-measured 4.31.

Everything pgw#1082 built is working correctly here — the region traces whole, the declared marks apply, the recipe engages, and the wire no longer claims `jit_cell`. And the pod's **59 activity rows contain no `serve_eager_posture` and no `self_mint_abort`.** The whole boot reached the hub as `+eager` / `uncompiled` / `boot_ended_uncompiled` and nothing else.

## The root cause: one reading, two defects

That triple is produced by **two different failures**, and after pgw#1082 they are still indistinguishable:

* **(A) never installed** — `_install_compile_targets` dropped the candidate;
* **(B) installed then degraded** — `_guarded_regional` caught an exception on a served call, set `degraded=True`, cleared the region. `is_compile_armed` then reads False and every downstream reader (`_served_execution_lane`, `_served_identity`, `_mark_warm_complete`, `_eager_posture`) answers eager, with the *terminal fallback* token `uncompiled`.

pgw#1082's own body predicted exactly this ("an installed-then-degraded target and a never-installed one report identically") and fixed the **lie**. Raising the degrade flag made B look like A rather than making B say "degraded".

And B is invisible by construction: a graph break gets `_emit_graph_break_event`, a `DeclaredRangeExceeded` gets `_emit_declared_range_event`, and **every other exception class** takes `logger.warning`. A hub-spawned pod's stdout is unreachable — pgw#824's ruling verbatim.

Worse, the confession machinery cannot fire for a boot-warmup degrade **at all**: `_bind_compile_guard` installs the revocation callback inside `_install_compile_targets`, which runs *after* the warmup. A target that armed, compiled and broke during warmup has no callback and no record to write on.

On the A side, three exits from `_install_compile_targets` emit nothing: `cfg is None`, the bare `if not has_compile_target(...): continue`, and an empty candidate list — whose only trailing confession is gated on a MANDATORY quant lane, which `bf16-w16a16` is not.

## The fix

1. **Every permanent degrade confesses**, whatever raised it — typed `compiled_degraded` degrade row from both guards, plus a `degrade_reason` on the failure signal that `_eager_posture` surfaces, so the request row names the exception instead of the terminal `uncompiled`.
2. **`_note_boot_degrade`** reads that reason off the pipeline at the first moment a record exists, closing the pre-guard-bind window.
3. **No silent exit from `_install_compile_targets`** — the `has_compile_target` skip and the empty-candidate case each name the slot, the declared targets and the predicate that refused (`armed_target_unresolved` / `no_compile_candidates`).
4. **`_assert_armed_targets_installed`** — the terminus. An arm that RETURNED TRUE and owns no installed target is one typed, wire-visible refusal. Keyed on the **arm fact** (`_InjectionResult.armed_objects`, recorded on both scopes), never on a live `is_compile_armed()` probe: a degrade flips that probe to False and would let the invariant excuse exactly the boot it exists to catch. Overrides a weaker already-recorded token, because "no candidates survived" is a *consequence* of it.
5. **pgw#1078's disproof-clear moved above the re-scan gate** — it sat after the `continue`, so an armed object that failed the re-scan kept the stale injection-time `no_compile_target` and first-token-wins let that stale token outrank the real cause.

## Test

`tests/test_armed_target_install_pgw1093.py` drives the **real `ensure_setup()`** on the live shape: a `Slot(LazyPipe, selected_by="model")` class-annotated slot whose component hydrates inside `setup()`, a regional `Compile` with a `DynamicDim`, JIT intake, `arm_compile()` at the end of setup. The only environment fake is `torch.cuda.is_available` — `apply`, `arm_jit_intake`, `ArmingScope`, the warm plan and the target install are production code. The reproduction replays the pod's arm sequence line for line.

* a **control** that must stay `+compiled` with an empty posture (so the two red tests cannot pass for the wrong reason);
* defect class A — armed, no target resolves at install → `armed_target_unresolved` posture + degrade row;
* defect class B — a `RuntimeError` from the compiled call during boot warmup → target **installed**, `degrade_reason` set, posture `compiled_degraded`, and explicitly `!= uncompiled`.

Both defect tests are RED on 0.98.0; the control passes. Neighbouring suites (pgw#1078, pgw#517, pgw#654, pgw#1001, pgw#764, th#959) 31 passed / 1 skipped.

`gen-worker 0.98.0 -> 0.99.0`.

Draft until the H100 billed proof lands — this lane does not claim the 4.3 s/step wall on code review.