### PR TITLE
pgw#1080 (ie#638): the mint child builds its compile targets from code + config — a weightless export

### DIFF
--- a/changelog.d/pgw1080.md
+++ b/changelog.d/pgw1080.md
@@ -12,3 +12,56 @@
   form (buffers at `__init__`, no device pin) stays SILENT — a gate that fires on correctly-authored
   code teaches authors to route around it. Fake tensors are treated as virtual by TYPE, since
   `FakeTensorMode` reports a real device by design.
+
+- **pgw#1080 (ie#638 unblock, increment 2): the mint child builds its compile
+  targets from CODE + CONFIG, so export and compile never need the checkpoint
+  resident.** `models/structure_only.py` builds one named component with
+  `accelerate.init_empty_weights()` + `from_config` — the shape `models/w8a8.py`
+  already uses — and injects it through the loader's existing `components=`
+  seam, so the pipeline is composed by its own class either way. Parameters end
+  up as FAKE tensors on the target device (faithful shape/dtype/device, zero
+  storage) and buffers stay REAL, both by measurement: meta parameters cannot be
+  exported beside a real input (*Tensor device mismatch … cpu and meta*) and
+  cannot be compiled for a card, while a fake buffer would make a
+  literal-bearing cell unpackable. A compile-target class with no
+  `load_config`/`from_config`, a tree whose `model_index.json` does not name the
+  component, and the quantized artifact lanes each refuse typed
+  (`StructureOnlyUnsupported`) and the slot falls back to a real-weight load
+  with the reason recorded on the report — honest partial coverage instead of a
+  silent one.
+
+  Three things had to be true for the resulting cell to be worth anything, and
+  each was measured rather than assumed:
+
+  - `aot_compile` asserts every input shares ONE fake mode, and `torch.export`
+    builds its own ShapeEnv — so the compile runs inside the program's mode
+    *with the program's ShapeEnv installed*, without which inductor refuses
+    (`vr must not be None for symbol s21`).
+  - inductor folds constants at COMPILE time by default, **baking the values it
+    saw**. On a weightless mint those are fake: the micro decoder's
+    `norm.weight`/`norm.bias` disappeared from the artifact's bindable set and
+    the adopted cell scored cosine 0.13 against eager. Weightless entries now
+    compile with `aot_inductor.use_runtime_constant_folding`, which is also what
+    the pgw#1056 folding fence asks for — a rebindable weight must never have
+    its value compiled in.
+  - the entry pool hands each program to a compile child by serializing it, and
+    a fake-parameter program cannot round-trip, so a weightless mint compiles
+    serially and says so.
+
+  The pgw#984 warm proof runs on RANDOM values (fixed seed, finite by
+  construction) and the child gives them back before it exports; the pgw#947
+  lane A/B is recorded as `verdict=unmeasured, reason=meta-mint` rather than
+  spending weight-scale residency on a verdict no card below Blackwell consumes.
+  `MintReport` now carries the fake-export footprint —
+  `structure_only_components`, `virtual_param_bytes`, `structure_real_bytes`,
+  `warm_proof_peak_bytes`/`warm_proof_values`, `export_peak_bytes` — and it
+  rides the same outcome line the hub already reads, so "the child held no
+  weights" is an observation and not a claim.
+
+  ie#628's call-time half is enforced where it can be: inside a fake-mode export
+  every allocation is fake, so the mode-based gate cannot see a lazily-built
+  pinned table — but the warm proof runs the handler for real, and any tensor
+  left on the tree afterwards that is neither parameter nor buffer is refused by
+  name (`transformer.rope.freqs_cis`) with the authoring fix. The new
+  `micro-rope` gauntlet member is that RED control, transcribed from upstream
+  z-image; the base `micro` row is its green twin.

--- a/examples/micro-diffusion/FAMILIES
+++ b/examples/micro-diffusion/FAMILIES
@@ -30,3 +30,4 @@ micro-diffusion
 micro-escape
 micro-pad32
 micro-pad32-branchy
+micro-rope

--- a/examples/micro-diffusion/src/micro_diffusion/aot_declaration_rope.py
+++ b/examples/micro-diffusion/src/micro_diffusion/aot_declaration_rope.py
@@ -1,0 +1,62 @@
+"""The pgw#1080 RED-control declaration: the pinned-rope graph, one entry.
+
+Deliberately identical in SHAPE to the escape variant's — one target,
+fork-free, batch fixed, two token rows collapsing to a single entry — so the
+only variable against the base family is the pinned lazy table in the
+denoiser's forward. A difference in outcome is therefore a statement about
+the meta-instantiation gate and about nothing else.
+"""
+
+from __future__ import annotations
+
+from gen_worker import (
+    Compile,
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+)
+
+FAMILY = "micro-rope"
+
+LATENT_ROWS = (32, 48)
+VAE_SCALE = 8
+PIXEL_ROWS = tuple((n * VAE_SCALE, n * VAE_SCALE) for n in LATENT_ROWS)
+#: Token-shaped like the base family: the dynamic extent stays LINEAR in one
+#: symbol (pgw#998), so the only new facts in this cell are the ops.
+TOKEN_ROWS = tuple(n * n for n in LATENT_ROWS)
+COND_LEN = 16
+ARITY = 1
+
+
+def build_declaration() -> Compile:
+    return Compile(
+        family=FAMILY,
+        targets=("transformer",),
+        shapes=PIXEL_ROWS,
+        text_len=COND_LEN,
+        dims=(
+            Dim("N", carried_by=(("t", 0),)),
+            Dim("T", carried_by=(("x", 0),)),
+        ),
+        classes=tuple(
+            GraphClass(dims={"N": ARITY, "T": tokens})
+            for tokens in TOKEN_ROWS),
+        inputs=(
+            Input("x", shape=("T", ("config", "in_channels")),
+                  repeat="N", dtype="float32"),
+            Input("t", shape=("N",), dtype="float32"),
+            Input("cond", shape=(COND_LEN, ("config", "cond_dim")),
+                  repeat="N", dtype="float32"),
+        ),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+
+
+DECLARATION = build_declaration()
+
+register_export_declaration(DECLARATION, replace=True)
+
+__all__ = ["ARITY", "COND_LEN", "DECLARATION", "FAMILY", "LATENT_ROWS",
+           "PIXEL_ROWS", "TOKEN_ROWS", "VAE_SCALE", "build_declaration"]

--- a/examples/micro-diffusion/src/micro_diffusion/main_rope.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_rope.py
@@ -1,0 +1,84 @@
+"""The pgw#1080 RED control's worker function — the pinned-rope graph.
+
+A separate FAMILY (`micro-rope`) whose only difference from the base family
+is the denoiser's lazily-built, CPU-PINNED table. It exists to be REFUSED by
+the meta-instantiation gate, so its gauntlet expectation is `red`; the base
+family is the green twin (ie#630's registered buffer), and the pair is the
+control the gate is judged by.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import msgspec
+import torch
+
+from gen_worker import Compile, RequestContext, Resources, Slot, endpoint
+from gen_worker.families import GenerationDefaults, family
+
+from .aot_declaration_rope import (  # noqa: F401 — registers at import
+    ARITY,
+    COND_LEN,
+    DECLARATION,
+    FAMILY,
+    PIXEL_ROWS,
+    TOKEN_ROWS,
+)
+from .pipeline import MicroRopePipeline
+
+
+@family(FAMILY)
+class MicroRopeDefaults(GenerationDefaults, frozen=True):
+    steps: int = 2
+
+
+class MicroRopeIn(msgspec.Struct):
+    prompt: str = ""
+    model: str = ""
+
+
+class MicroRopeOut(msgspec.Struct):
+    checkpoint: str = ""
+    shape: str = ""
+
+
+@endpoint(
+    models={"pipeline": Slot(MicroRopePipeline, selected_by="model")},
+    compile=Compile(
+        family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
+        text_len=COND_LEN),
+    resources=Resources(gpu=True),
+)
+class GenerateRope:
+    def setup(self, pipeline: MicroRopePipeline) -> None:
+        self.pipe = pipeline
+
+    def generate_rope(
+        self, ctx: RequestContext[MicroRopeDefaults], data: MicroRopeIn,
+    ) -> MicroRopeOut:
+        resolved = ctx.slots["pipeline"]
+        tokens = TOKEN_ROWS[0]
+        device = self.pipe.device
+        config = self.pipe.config
+        generator = ctx.generator(1080)
+        x: List[torch.Tensor] = [
+            torch.randn(tokens, config.in_channels, generator=generator,
+                        device=device, dtype=torch.float32)
+            for _ in range(ARITY)
+        ]
+        t = torch.full((ARITY,), 100.0, device=device, dtype=torch.float32)
+        cond: List[torch.Tensor] = [
+            torch.randn(COND_LEN, config.cond_dim, generator=generator,
+                        device=device, dtype=torch.float32)
+            for _ in range(ARITY)
+        ]
+        with torch.no_grad():
+            out = self.pipe.transformer(x, t, cond)
+        return MicroRopeOut(
+            checkpoint=str(resolved.ref.path),
+            shape=str(tuple(int(n) for n in out.shape)))
+
+
+__all__ = ["DECLARATION", "FAMILY", "GenerateRope", "MicroRopeDefaults",
+           "MicroRopeIn", "MicroRopeOut"]

--- a/examples/micro-diffusion/src/micro_diffusion/model.py
+++ b/examples/micro-diffusion/src/micro_diffusion/model.py
@@ -222,6 +222,23 @@ class MicroDecoder(nn.Module):
         h = torch.nn.functional.silu(self.proj_in(latent))
         return torch.tanh(self.proj_out(self.norm(h)))
 
+    # The same deliberate ConfigMixin surface the denoiser exposes, and for a
+    # second reason (pgw#1080): a compile target the forge must be able to
+    # build from CODE + CONFIG needs it, and `decoder` is one of this
+    # family's two targets. A target without it is stranded on the
+    # real-weight mint — honestly, by a typed refusal, but stranded.
+
+    @classmethod
+    def load_config(cls, directory: str, **_kw: Any) -> Dict[str, Any]:
+        return json.loads(
+            (Path(directory) / "config.json").read_text("utf-8"))
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any], **_kw: Any) -> "MicroDecoder":
+        fields = set(MicroConfig().as_dict())
+        return cls(MicroConfig(
+            **{k: v for k, v in dict(config).items() if k in fields}))
+
 
 __all__ = ["MicroConfig", "MicroDecoder", "MicroDenoiser",
            "MicroGridDenoiser"]

--- a/examples/micro-diffusion/src/micro_diffusion/model_rope.py
+++ b/examples/micro-diffusion/src/micro_diffusion/model_rope.py
@@ -1,0 +1,73 @@
+"""The pgw#1080 RED CONTROL: upstream z-image's lazy CPU-pinned rope table.
+
+Transcribed from `transformer_z_image.RopeEmbedder`, whose shape is the whole
+reason ie#628 widened the meta-instantiation gate from ``__init__`` to CALL
+time: the table is ``None`` until first use, and the build pins
+``torch.device("cpu")``, which OVERRIDES any ambient context. Nothing happens
+at construction — an ``__init__``-inspecting gate sees a clean instantiation —
+and the violation lands mid-forward.
+
+The GREEN twin is the base family: :class:`~micro_diffusion.model.MicroDenoiser`
+registers its frequency table as a BUFFER at ``__init__`` with no device pin,
+which is exactly ie#630's fix (`rope_buffers`), and it must mint green while
+this one does not. Both halves are the control: a gate that fires on
+correctly-authored code teaches authors to route around it.
+
+This variant exists to FAIL. It is a gauntlet member whose declared
+expectation is a refusal, so a green run here is news.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+
+from .model import MicroConfig, MicroDenoiser
+
+
+class PinnedRopeTable:
+    """Not an ``nn.Module``, holds ``None``, builds under a device pin.
+
+    All three properties are load-bearing and all three are upstream's:
+    a plain object owns no buffers so nothing can register it; the lazy
+    ``None`` moves the work out of ``__init__``; the pin makes the ambient
+    device irrelevant.
+    """
+
+    def __init__(self, width: int) -> None:
+        self.width = int(width)
+        self.freqs_cis: Optional[torch.Tensor] = None
+
+    def __call__(self, rows: int) -> torch.Tensor:
+        if self.freqs_cis is None:
+            with torch.device("cpu"):
+                self.freqs_cis = torch.arange(
+                    self.width, dtype=torch.float32) / float(self.width)
+        return self.freqs_cis[None, :].expand(rows, self.width)
+
+
+class MicroRopeDenoiser(MicroDenoiser):
+    """The base denoiser with its table taken OFF the module and pinned."""
+
+    def __init__(self, config: MicroConfig) -> None:
+        super().__init__(config)
+        self.rope = PinnedRopeTable(config.hidden)
+
+    def forward(
+        self, x: List[torch.Tensor], t: torch.Tensor, cond: List[torch.Tensor],
+    ) -> torch.Tensor:
+        temb = self.time_embed(t)
+        outs: List[torch.Tensor] = []
+        for index, tokens in enumerate(x):
+            h = self.proj_in(tokens) + temb[index][None, :]
+            # The ONE difference from the green twin: the table comes from a
+            # pinned lazy build instead of a registered buffer.
+            h = h + self.rope(h.shape[0]).to(h.dtype)
+            for block in self.blocks:
+                h = block(h, cond[index])
+            outs.append(self.proj_out(self.norm_out(h)))
+        return torch.stack(outs, dim=0)
+
+
+__all__ = ["MicroRopeDenoiser", "PinnedRopeTable"]

--- a/examples/micro-diffusion/src/micro_diffusion/pipeline.py
+++ b/examples/micro-diffusion/src/micro_diffusion/pipeline.py
@@ -54,7 +54,19 @@ class MicroPipeline:
         self.config = transformer.config
 
     @classmethod
-    def from_pretrained(cls, path: str, **_kw: Any) -> "MicroPipeline":
+    def from_pretrained(
+        cls, path: str, *, transformer: Any = None, decoder: Any = None,
+        **_kw: Any,
+    ) -> "MicroPipeline":
+        """``transformer=`` / ``decoder=`` are PRELOADED components.
+
+        The SDK's ``components=`` seam (gw#479, and pgw#1080's structure-only
+        compile targets) hands a module in already built. Honoring it is the
+        contract, not an optimization: a class that quietly ignored the
+        keyword and loaded the checkpoint anyway would give a structure-only
+        mint every weight it exists to avoid — silently. Diffusers pipelines
+        take these by the same names.
+        """
         root = Path(path)
         if not (root / "config.json").is_file():
             # A pod whose binding resolved to an empty dir, or a boot before
@@ -62,9 +74,16 @@ class MicroPipeline:
             # the family's whole premise, so do it and say where.
             materialize(root, seed=SEED)
         config = load_config(root)
+        if transformer is not None and decoder is not None:
+            return cls(transformer.eval(), decoder.eval(), source=str(root))
         state = load_state(root)
-        transformer = MicroDenoiser(config)
-        decoder = MicroDecoder(config)
+        built = []
+        if transformer is None:
+            transformer = MicroDenoiser(config)
+            built.append(("transformer", transformer))
+        if decoder is None:
+            decoder = MicroDecoder(config)
+            built.append(("decoder", decoder))
         # STRICT, and it is load-bearing (pgw#999). With `strict=False` a
         # checkpoint written under a different prefix loads ZERO tensors and
         # leaves the module randomly initialized — silently. That is exactly
@@ -75,8 +94,8 @@ class MicroPipeline:
         # numerics gate, which was right all along.
         #
         # A loader that cannot find its weights must fail, not shrug.
-        _load_prefixed(transformer, state, "transformer")
-        _load_prefixed(decoder, state, "decoder")
+        for prefix, module in built:
+            _load_prefixed(module, state, prefix)
         return cls(transformer.eval(), decoder.eval(), source=str(root))
 
     def to(self, device: Any) -> "MicroPipeline":
@@ -137,7 +156,8 @@ class MicroPipeline:
 
 __all__ = ["MicroConfig", "MicroConvPipeline", "MicroEscapePipeline",
            "MicroGridPipeline", "MicroPad32BranchyPipeline",
-           "MicroPad32Pipeline", "MicroPipeline", "MicroW8a8Pipeline"]
+           "MicroPad32Pipeline", "MicroPipeline", "MicroRopePipeline",
+           "MicroW8a8Pipeline"]
 
 
 class MicroGridPipeline(MicroPipeline):
@@ -257,6 +277,44 @@ class MicroConvPipeline:
     @property
     def device(self) -> torch.device:
         return next(self.unet.parameters()).device
+
+
+class MicroRopePipeline(MicroPipeline):
+    """The pgw#1080 RED control's pipeline: same weights, PINNED-ROPE
+    transformer (:class:`~micro_diffusion.model_rope.MicroRopeDenoiser`).
+
+    Composed exactly like its siblings, so the gate's verdict is about the
+    denoiser's table and not about how the pipeline was built.
+    """
+
+    @classmethod
+    def from_pretrained(
+        cls, path: str, *, transformer: Any = None, decoder: Any = None,
+        **_kw: Any,
+    ) -> "MicroRopePipeline":
+        from gen_worker.models import structure_only
+
+        from .model_rope import MicroRopeDenoiser
+
+        base = MicroPipeline.from_pretrained(
+            path, transformer=transformer, decoder=decoder)
+        if transformer is not None and structure_only.is_structure_only(
+                transformer):
+            # This family's denoiser is a SUBCLASS of the class the tree's
+            # model_index names, so the injected structure is the wrong type.
+            # Rebuilding it structure-only — instead of loading the
+            # checkpoint into a real one — is the authoring answer to that,
+            # and it keeps the mint weightless (pgw#1080).
+            from accelerate import init_empty_weights
+
+            with init_empty_weights():
+                pinned = MicroRopeDenoiser(base.config)
+            structure_only.virtualize(
+                pinned, device=str(next(transformer.parameters()).device))
+            return cls(pinned.eval(), base.decoder, source=base.source)
+        pinned = MicroRopeDenoiser(base.config)
+        pinned.load_state_dict(base.transformer.state_dict(), strict=True)
+        return cls(pinned.eval(), base.decoder, source=base.source)
 
 
 class MicroEscapePipeline(MicroPipeline):

--- a/examples/micro-diffusion/src/micro_diffusion/weights.py
+++ b/examples/micro-diffusion/src/micro_diffusion/weights.py
@@ -33,7 +33,10 @@ WEIGHTS_NAME = "micro_diffusion.safetensors"
 
 #: The state-dict LAYOUT. Part of the cached tree's identity, so a component
 #: rename invalidates the cache instead of leaving bytes no loader can read.
-LAYOUT_VERSION = 2
+#: 3 (pgw#1080): the flat tree also carries a `model_index.json` and a
+#: config-only dir per component, so the SDK can resolve each compile
+#: target's CLASS and build it from config alone. No weights move.
+LAYOUT_VERSION = 3
 
 #: The one seed the fleet's micro family is defined by. Changing it is a new
 #: checkpoint, not a new build of the same one.
@@ -93,6 +96,7 @@ def materialize(
     root.mkdir(parents=True, exist_ok=True)
     save_file(state_dict(cfg, seed=seed), str(root / WEIGHTS_NAME))
     cfg_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    write_component_index(root, cfg, seed=seed)
     size = tree_bytes(root)
     if size > MAX_TREE_BYTES:
         raise WeightsRefused(
@@ -100,6 +104,38 @@ def materialize(
             f"{MAX_TREE_BYTES / 1e6:.0f} MB ceiling this family exists to stay "
             f"under — shrink the config rather than raising the ceiling")
     return root
+
+
+#: ``component -> [library, class]``, the map every diffusers-layout tree
+#: carries and the ONLY thing that tells the SDK which class a compile target
+#: is. Without it a structure-only build has nothing to instantiate
+#: (pgw#1080); the weights themselves stay in the flat file.
+COMPONENT_CLASSES = {
+    "transformer": ["micro_diffusion.model", "MicroDenoiser"],
+    "decoder": ["micro_diffusion.model", "MicroDecoder"],
+}
+
+
+def write_component_index(
+    root: Path, config: MicroConfig, *, seed: int = SEED,
+) -> None:
+    """Name each component's CLASS and give it a config to be built from.
+
+    Config only — no weights are written here and none move. A component dir
+    holding just ``config.json`` is the SDK's recognised weightless shape
+    (``loading._weightless_model_dir``), so the real-weight load still reads
+    the flat checkpoint exactly as before.
+    """
+    root = Path(root)
+    payload = dict(config.as_dict(), _layout=LAYOUT_VERSION, seed=int(seed))
+    for component, (_library, class_name) in COMPONENT_CLASSES.items():
+        directory = root / component
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / CONFIG_NAME).write_text(json.dumps(
+            dict(payload, _class_name=class_name), indent=2, sort_keys=True))
+    (root / "model_index.json").write_text(json.dumps(
+        dict({"_class_name": "MicroPipeline"}, **COMPONENT_CLASSES),
+        indent=2, sort_keys=True))
 
 
 def tree_bytes(root: Path) -> int:

--- a/scripts/rig_gauntlet.py
+++ b/scripts/rig_gauntlet.py
@@ -48,6 +48,7 @@ ORDER = (
     "micro-pad32-branchy",
     "micro-conv",
     "micro-escape",
+    "micro-rope",
     "micro-w8a8",
     "micro-w8a8-lora",
     "micro-lora-plain-parent",

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -122,7 +122,9 @@ from . import aot_flatten
 from . import aot_inputs
 from . import aot_declaration as _decl
 from .api.export_contract import export_declaration
+from . import meta_instantiation
 from .models import lora_lifted
+from .models import structure_only
 from . import compile_cache as cc
 from . import env_seal
 from . import config, worker_credential
@@ -745,7 +747,9 @@ def _pinning_guards(program: Any, declared_symbols: Sequence[Any]) -> List[str]:
 MINT_COMPILE_THREADS = 4
 
 
-def _entry_configs(inductor_configs: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+def _entry_configs(
+    inductor_configs: Optional[Mapping[str, Any]], *, weightless: bool = False,
+) -> Dict[str, Any]:
     """The per-entry inductor config: caller options + the non-negotiable
     packaging flags. ``CODE_ONLY_CONFIGS`` is applied LAST so no caller-
     supplied config can re-enable constant baking — B1 is a fleet
@@ -764,6 +768,19 @@ def _entry_configs(inductor_configs: Optional[Mapping[str, Any]]) -> Dict[str, A
     # Emit loose files for package_aoti to combine, instead of a per-entry
     # archive: the multi-graph cell is ONE .pt2 (pgw#758).
     configs["aot_inductor.package"] = True
+    if weightless:
+        # pgw#1080, MEASURED and it is the difference between a cell and a
+        # ruined one. Inductor folds constants at COMPILE time by default,
+        # which BAKES THE VALUES IT SAW: on a structure-only mint those
+        # values are fake, and the artifact then declares fewer bindable
+        # constants than the module has — the micro decoder's
+        # `norm.weight`/`norm.bias` simply vanished, and the adopted cell
+        # scored cosine 0.13 against eager. Deferring the fold to RUNTIME
+        # keeps every parameter bindable (they reappear, plus explicit
+        # `_FOLDED_CONST_*` rows computed after binding), which is also what
+        # the pgw#1056 folding fence asks for: a rebindable weight must never
+        # have its value compiled in.
+        configs["aot_inductor.use_runtime_constant_folding"] = True
     return configs
 
 
@@ -796,9 +813,17 @@ def compile_entry_files(
     gm = program.module(check_guards=False)
     args, kwargs = program.example_inputs
     try:
-        files = aot_compile(
-            gm, tuple(args), dict(kwargs or {}),
-            options=_entry_configs(inductor_configs))
+        # pgw#1080: a program exported from a structure-only target carries
+        # fake parameters, and `aot_compile` asserts every input belongs to
+        # ONE fake mode — so it runs inside that program's own mode. Identity
+        # context for a real-weight program.
+        with structure_only.compiling_under(program):
+            files = aot_compile(
+                gm, tuple(args), dict(kwargs or {}),
+                options=_entry_configs(
+                    inductor_configs,
+                    weightless=structure_only.fake_mode_of_program(
+                        program) is not None))
     except Exception as exc:
         raise MintRefused(
             f"entry {entry!r}: aot_compile failed: "
@@ -1188,6 +1213,40 @@ def _export_entry(
                 f"not, so the module about to be exported cannot take the "
                 f"adapter (lora_lifted.arm_lifted_lora_lanes installs both)")
 
+    # pgw#1080: a structure-only target's tensors are FAKE and belong to ONE
+    # fake mode. Everything that produces a tensor for this export — the
+    # example feed, the declared warm, the export itself — has to happen
+    # inside that mode or the pieces belong to different modes and
+    # `aot_compile` refuses them. `None` on a real-weight mint, where this
+    # whole block is the identity context it has always been.
+    fake_mode = structure_only.fake_mode_of(owner)
+    with structure_only.under(fake_mode):
+        return _export_entry_body(
+            pipeline, espec, plan, decl, entry=entry, owner=owner, attr=attr,
+            module=module, timings=timings, fake_mode=fake_mode,
+            inductor_configs=inductor_configs, compile_now=compile_now)
+
+
+def _export_entry_body(
+    pipeline: Any,
+    espec: Any,
+    plan: Any,
+    decl: Any,
+    *,
+    entry: str,
+    owner: Any,
+    attr: str,
+    module: Any,
+    timings: Dict[str, Any],
+    fake_mode: Any = None,
+    inductor_configs: Optional[Mapping[str, Any]] = None,
+    compile_now: bool = True,
+) -> _MintedEntry:
+    """The body of :func:`_export_entry`, run inside the target's fake mode.
+
+    Split out rather than indented so the structure-only window is one
+    statement and the real-weight path reads exactly as it did.
+    """
     builder = aot_inputs.builder_for(espec.family, espec.target)
     args, kwargs = builder(owner, espec)
     if kwargs:
@@ -1230,7 +1289,27 @@ def _export_entry(
             raise MintRefused(f"entry {entry!r}: {exc}") from exc
 
     t0 = time.monotonic()
-    program = _full_export()
+    if fake_mode is None:
+        program = _full_export()
+    else:
+        # pgw#1080 / ie#628: the TRACE half of the meta-instantiation gate. A
+        # structure-only target allocates nothing, so any real tensor born in
+        # this window is a model that materializes weights at CALL time — the
+        # z-image rope class — and it is refused with the ENDPOINT's own
+        # file:line rather than discovered as a mysterious pod OOM.
+        try:
+            with meta_instantiation.guard(
+                    f"trace:{entry}", actionable_only=True) as census:
+                program = _full_export()
+            if not census.clean:
+                # Real, but unattributable — torch's own machinery inside the
+                # fake mode. Reported, never refused: see `guard`.
+                logger.info(
+                    "aot-mint: entry %s traced with %d unattributable real "
+                    "allocation(s) (%s)", entry, len(census.events),
+                    ", ".join(sorted({e.op for e in census.events})[:6]))
+        except meta_instantiation.MetaMaterializationError as exc:
+            raise MintRefused(f"entry {entry!r}: {exc}") from exc
     timings["export_s"] = round(time.monotonic() - t0, 2)
     # pgw#1000, telemetry only: the one number that sized "export once,
     # re-propagate per row". Kept after pgw#847 was deleted because it prices
@@ -2064,6 +2143,24 @@ def _mint_cell(
         # the constant, and keeps saying so.
         peak_rss_bytes=int(entry_peak_rss_bytes or 0))
     parallel = width.workers > 1
+    if parallel and structure_only.is_structure_only(pipeline):
+        # pgw#1080, MEASURED on the micro-lora gauntlet member: the pool hands
+        # each entry to a compile CHILD by saving the ExportedProgram to
+        # `program.pt2`. A program whose parameters are fake tensors has no
+        # storage to serialize, and the child dies deserializing it
+        # ("We ran into an error when deserializing the saved file"). So a
+        # weightless mint compiles SERIALLY, in this process, which is the
+        # pre-pgw#809 path and is correct — just narrower.
+        #
+        # OWED, not hidden (pgw#1080 follow-up): the pool could carry a
+        # weightless program by saving it with META parameters and
+        # re-virtualizing them onto the device inside the child. That is a
+        # real change to the pool's contract and it is not this slice.
+        logger.warning(
+            "aot-mint: structure-only mint compiles SERIALLY — the entry pool "
+            "serializes the exported program and a fake-parameter program "
+            "cannot round-trip (pgw#1080). Width %d discarded.", width.workers)
+        parallel = False
     logger.info("aot-mint: entry compile width — %s", width.reason)
     if width.underwidth:
         # pgw#842: a pool narrower than the cell could use is a COST, and it
@@ -3036,6 +3133,29 @@ def _release_mint_residents(
     return facts
 
 
+def _structure_only_drift_hint(row: _MintedEntry) -> str:
+    """Name the AUTHORING cause a structure-only mint's drift usually has.
+
+    Measured (pgw#1080, micro-rope RED control): a table built lazily inside
+    ``forward`` under ``with torch.device("cpu")`` is FAKE during a
+    fake-mode export — so the meta-instantiation gate cannot see it — and
+    lands as an anonymous ``_tensor_constant0`` the exported program never
+    lifted. The drift gate refuses it, correctly and deterministically, but
+    "the package declares a constant the program never lifted" names a
+    symptom. This names the class of cause, so the author gets a place to
+    look instead of a compiler sentence.
+    """
+    if not structure_only.is_structure_only(row.owner):
+        return ""
+    return (
+        ". This mint built its target from code + config (pgw#1080), and the "
+        "usual cause of drift there is a tensor BUILT INSIDE `forward` "
+        "instead of registered at __init__ — it is lifted as an anonymous "
+        "graph literal rather than as a bindable buffer. Register derived "
+        "tables with `register_buffer` and no device pin (ie#630's "
+        "`rope_buffers` is the worked example)")
+
+
 def _gate_and_declare_entry(
     row: _MintedEntry, package: Path,
 ) -> Dict[str, Any]:
@@ -3059,7 +3179,8 @@ def _gate_and_declare_entry(
     drift = aot_package.program_package_drift(row.program, package, entry)
     if drift:
         raise MintRefused(
-            f"entry {entry!r}: constant-set drift: " + "; ".join(drift))
+            f"entry {entry!r}: constant-set drift: " + "; ".join(drift)
+            + _structure_only_drift_hint(row))
     fused = aot_package.eliminated_constants(row.program, package, entry)
     if fused:
         # Routine compiler fusion (measured on real sdxl: conv_out.bias folded

--- a/src/gen_worker/aot_package.py
+++ b/src/gen_worker/aot_package.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
 from . import aot_flatten
-from .aot_serve import SOURCE_LITERAL, SOURCE_STATE_DICT
+from .aot_serve import SOURCE_COMPUTED, SOURCE_LITERAL, SOURCE_STATE_DICT
 import hashlib
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,11 @@ _MODEL_BASE = "AOTInductorModelBase("
 #: in ``aot_serve.LITERALS_NAME`` or it can never be bound.
 _STATE_DICT_TYPES = ("Parameter", "Buffer")
 
+#: ``ConstantType`` values AOTInductor COMPUTES at load from the constants that
+#: were bound — the runtime constant-folding pass's outputs. They are in the
+#: package's table and in no exported program, by construction.
+_COMPUTED_TYPES = ("FoldedConstant",)
+
 
 @dataclass(frozen=True)
 class DeclaredConstant:
@@ -97,7 +102,9 @@ class DeclaredConstant:
     @property
     def source(self) -> str:
         """``aot_serve`` source class: from the state_dict, or a packed literal."""
-        return SOURCE_STATE_DICT if self.kind in _STATE_DICT_TYPES \
+        if self.kind in _STATE_DICT_TYPES:
+            return SOURCE_STATE_DICT
+        return SOURCE_COMPUTED if self.kind in _COMPUTED_TYPES \
             else SOURCE_LITERAL
 
     def as_manifest_row(self) -> Dict[str, Any]:
@@ -548,7 +555,12 @@ def program_package_drift(
     the package would want constants the recorded program never lifted.
     """
     want = set(program_constant_fqns(program))
-    have = {c.fqn for c in declared_constants(Path(package), entry)}
+    have = {c.fqn for c in declared_constants(Path(package), entry)
+            if c.source != SOURCE_COMPUTED}
+    # pgw#1080: a COMPUTED constant is package-only by design — the runtime
+    # fold produces it from the bound constants at load, so "the program never
+    # lifted it" is the expected state and not the segfault precondition this
+    # gate exists for.
     package_only = sorted(have - want)
     if not package_only:
         return []

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -151,6 +151,14 @@ SOURCE_STATE_DICT = "state_dict"
 #: literal). Tiny, so it ships inside the artifact rather than being
 #: reconstructed — nothing outside the artifact knows its value.
 SOURCE_LITERAL = "literal"
+#: pgw#1080: a constant AOTInductor COMPUTES for itself at load, from the
+#: constants that were bound (`_FOLDED_CONST_*`, produced by the runtime
+#: constant-folding pass). Nothing binds it and nothing ships its bytes — it
+#: is neither a weight nor a literal, and treating it as either is a refusal
+#: for a value that is not missing. Weightless mints (pgw#1080) defer folding
+#: to load precisely so a rebindable weight's VALUE is never compiled in, so
+#: this class exists wherever that fence is armed.
+SOURCE_COMPUTED = "computed"
 
 #: The hardware/toolchain axes an ``.pt2`` is genuinely pinned to (pgw#765).
 #: ``sm`` is the GPU identity: AOTInductor itself keys on
@@ -465,10 +473,11 @@ def constants_from_meta(meta: Mapping[str, Any]) -> Tuple[ConstantSpec, ...]:
         if not fqn:
             raise ValueError(f"constant {idx} has no fqn")
         source = str(row.get("source") or "").strip()
-        if source not in (SOURCE_STATE_DICT, SOURCE_LITERAL):
+        if source not in (SOURCE_STATE_DICT, SOURCE_LITERAL, SOURCE_COMPUTED):
             raise ValueError(
                 f"constant {fqn!r} has unknown source {source!r} "
-                f"(expected {SOURCE_STATE_DICT!r} or {SOURCE_LITERAL!r})")
+                f"(expected {SOURCE_STATE_DICT!r}, {SOURCE_LITERAL!r} or "
+                f"{SOURCE_COMPUTED!r})")
         shape = row.get("shape")
         if not isinstance(shape, list):
             raise ValueError(f"constant {fqn!r} has no shape list")
@@ -1680,6 +1689,12 @@ def resolve_constants(
     out: Dict[str, Any] = {}
     missing: List[str] = []
     for spec in specs:
+        if spec.source == SOURCE_COMPUTED:
+            # AOTInductor's own const-fold pass produces this one AFTER the
+            # bound constants land; handing it a value would be handing it a
+            # value it is about to overwrite, and demanding one would refuse a
+            # cell that is complete (pgw#1080).
+            continue
         table = state_dict if spec.source == SOURCE_STATE_DICT else literals
         if spec.fqn not in table:
             missing.append(f"{spec.fqn} (source={spec.source})")
@@ -2960,6 +2975,7 @@ __all__ = [
     "LITERALS_NAME",
     "METADATA_NAME",
     "PACKAGE_NAME",
+    "SOURCE_COMPUTED",
     "SOURCE_LITERAL",
     "SOURCE_STATE_DICT",
     "armed_metadata",

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -22,7 +22,7 @@ import types
 import typing
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import msgspec
 
@@ -549,6 +549,7 @@ def run_setup(
     instance: Any, resolved_models: Dict[str, str], *, device: str = "",
     arm_compile: bool = True, return_loaded: bool = False,
     component_paths: Optional[Dict[str, Dict[str, str]]] = None,
+    structure_only: Sequence[str] = (),
 ) -> Optional[Dict[str, Any]]:
     """Call ``instance.setup(...)`` once, passing exactly the resolved model
     slots its signature declares.
@@ -557,6 +558,17 @@ def run_setup(
     (pgw#784): the mint child drives its own cold arm + capture and must not
     have a cell armed under it. ``return_loaded=True`` returns the loaded slot
     objects so a caller can reach the pipeline it just built.
+
+    ``structure_only`` (pgw#1080) names the components every slot must build
+    from CODE + CONFIG instead of from the checkpoint — the mint child's
+    compile targets. They are constructed by
+    ``models.structure_only.build_component`` and injected through the same
+    ``components=`` seam a preloaded shared component uses, so the pipeline
+    the endpoint receives is composed by its own loader either way. A
+    component the slot's tree does not declare is skipped (a two-slot family's
+    auxiliary slot has no denoiser); a component that CANNOT be built from
+    config refuses typed (``StructureOnlyUnsupported``) rather than silently
+    loading its weights.
 
     ``component_paths`` (slot -> component -> local override tree, pgw#816)
     carries the caller's ALREADY-RESOLVED pgw#617 component overrides. The
@@ -622,7 +634,8 @@ def run_setup(
         k: _load_injected_model(
             hints.get(k), v, decl=decl, slot=k, device=device,
             arm_compile=arm_compile,
-            overrides=dict((component_paths or {}).get(k) or {}))
+            overrides=dict((component_paths or {}).get(k) or {}),
+            structure_only=tuple(structure_only))
         for k, v in resolved_models.items()
         if k in wanted
     }
@@ -638,10 +651,60 @@ _INJECTED_CACHE: Dict[Tuple[str, str], Any] = {}
 _ENDPOINT_ATTR = "__gen_worker_endpoint__"
 
 
+def _assert_structure_honored(
+    pipe: Any, injected: Dict[str, Any], *, slot: str = "",
+) -> None:
+    """The composed pipeline must actually CARRY the structure-only modules.
+
+    ``components=`` is a request, and a pipeline class is free to ignore an
+    unexpected keyword — ``**kwargs`` swallows it and the class loads the
+    checkpoint itself. That failure is SILENT and it is the exact failure this
+    slice cannot tolerate: the mint would hold every weight and still report a
+    weightless child. So it is checked, on the object that came back, and the
+    caller decides what to do about a refusal (the mint child falls back to a
+    real-weight load and records why).
+    """
+    from ..models.structure_only import STAMP, StructureOnlyUnsupported
+
+    for component, module in sorted(injected.items()):
+        got = getattr(pipe, component, None)
+        if got is module or getattr(got, STAMP, False):
+            continue
+        raise StructureOnlyUnsupported(
+            component=component,
+            cls_name=type(pipe).__name__,
+            lacks=(
+                f"the composed pipeline for slot {slot or '?'} does not carry "
+                f"the injected structure-only module — it built "
+                f"{type(got).__name__} instead, so this composition either "
+                f"ignores `components=` or rebuilds the target from the "
+                f"checkpoint"))
+
+
+def _structure_device(device: str) -> str:
+    """Where a structure-only component's VIRTUAL tensors claim to live.
+
+    Faithful device is the whole point (pgw#1080): AOTInductor codegens for
+    the device the traced tensors report, so a structure built as "cpu" on a
+    CUDA pod would compile a CPU cell. Fake tensors allocate nothing, so
+    claiming the card costs nothing.
+    """
+    want = (device or "").strip().lower()
+    if want:
+        return want
+    try:
+        import torch
+
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except Exception:  # noqa: BLE001 — torch-less environment
+        return "cpu"
+
+
 def _load_injected_model(
     annotation: Any, local_path: str, *, decl: Any = None, slot: str = "",
     device: str = "", arm_compile: bool = True,
     overrides: Optional[Dict[str, str]] = None,
+    structure_only: Sequence[str] = (),
 ) -> Any:
     """Load one setup slot via the shared core, with a per-process warm cache
     (so ``serve`` and repeated local dispatches never reload weights).
@@ -655,12 +718,31 @@ def _load_injected_model(
     key = (
         str(annotation),
         str(local_path) + "".join(
-            f"|{c}={p}" for c, p in sorted((overrides or {}).items())),
+            f"|{c}={p}" for c, p in sorted((overrides or {}).items()))
+        # A structure-only composition is a DIFFERENT object from the
+        # real-weight one; sharing a cache entry between them would hand a
+        # weightless pipeline to a caller that asked for weights.
+        + ("|structure=" + ",".join(sorted(structure_only))
+           if structure_only else ""),
     )
     if key in _INJECTED_CACHE:
         return _INJECTED_CACHE[key]
     binding = (getattr(decl, "models", None) or {}).get(slot) if decl is not None else None
     injected: Dict[str, Any] = {}
+    if structure_only:
+        from ..models.loading import model_index_components
+        from ..models.structure_only import build_component
+
+        declared = model_index_components(local_path)
+        for comp in sorted(set(structure_only)):
+            if comp not in declared:
+                # An auxiliary slot of a multi-slot family (a refiner, a
+                # second pipeline) legitimately has no denoiser of this name.
+                continue
+            module, _facts = build_component(
+                local_path, comp, device=_structure_device(device),
+                dtype=str(getattr(binding, "dtype", "") or ""))
+            injected[comp] = module
     if overrides:
         from ..models.loading import load_component_override
 
@@ -674,6 +756,8 @@ def _load_injected_model(
     )
     if not sl.is_pipeline:
         return sl.obj
+    if structure_only:
+        _assert_structure_honored(sl.obj, injected, slot=slot)
     compile_cfg = getattr(decl, "compile", None) if decl is not None else None
     if compile_cfg is not None:
         # SDK v2: the compile machinery consumes the enriched CompileCell

--- a/src/gen_worker/kernel_path.py
+++ b/src/gen_worker/kernel_path.py
@@ -202,6 +202,8 @@ BIND_FIT = "fit"
 BIND_VRAM_TIEBREAK = "vram_tiebreak"
 BIND_SOLE_CANDIDATE = "sole_candidate"
 BIND_NO_FIT = "no_fit"
+#: pgw#1080: the mint held no weights, so no whole-model A/B was run.
+BIND_UNMEASURED = "unmeasured"
 
 
 class ExecutionLaneProbeError(RuntimeError):
@@ -376,6 +378,26 @@ def select(
             f"({best.ms_per_step:.1f}-{rival.ms_per_step:.1f} ms/step); "
             f"smaller peak wins ({winner.execution_lane}, {winner.peak_bytes} B)"),
         **common)
+
+
+def unmeasured(execution_lane: str, detail: str) -> Verdict:
+    """The verdict for a mint that COULD have benchmarked and deliberately did
+    not (pgw#1080).
+
+    The lane A/B is a whole-model benchmark: it loads one full pipeline per
+    candidate and times a real step, so it needs weight-scale residency —
+    which is exactly the property a structure-only mint exists to keep. A
+    cell with no verdict is the documented conservative-default case on the
+    serving side, and below Blackwell the A/B has no candidates to compare
+    anyway (`fused_candidate_gap`), so this costs nothing that has a consumer
+    today. Recorded as a TYPED verdict with its reason rather than as an
+    absence, so the choice is one lookup instead of a re-derivation.
+    """
+    total, name, sm = device_facts()
+    return Verdict(
+        winner=execution_lane, binding=BIND_UNMEASURED, detail=detail,
+        device_total_bytes=total, device_name=name, sm=sm,
+        measured_at=time.time())
 
 
 def sole(execution_lane: str, detail: str) -> Verdict:

--- a/src/gen_worker/meta_instantiation.py
+++ b/src/gen_worker/meta_instantiation.py
@@ -143,6 +143,14 @@ def _endpoint_site(skip: int = 0) -> str:
         path = frame.filename.replace("\\", "/")
         if "/gen_worker/" in path or "/torch/" in path:
             continue
+        if path.startswith("<"):
+            # `<frozen runpy>`, `<frozen importlib._bootstrap>`, `<string>`:
+            # interpreter scaffolding, not a line anyone can edit. Treating
+            # one as the cause is how a torch-internal allocation gets
+            # reported as an authoring violation (measured on the micro rig:
+            # a 380-byte `empty` inside `torch.export` attributed to
+            # `<frozen runpy>:88`).
+            continue
         return f"{frame.filename}:{frame.lineno} in {frame.name}"
     return ""
 
@@ -180,17 +188,29 @@ def observe(phase: str, census: Optional[Census] = None) -> Iterator[Census]:
 
 
 @contextlib.contextmanager
-def guard(phase: str) -> Iterator[Census]:
+def guard(phase: str, *, actionable_only: bool = False) -> Iterator[Census]:
     """Refuse the FIRST real-device materialization in this block, typed.
 
     First rather than all: the census is for reporting, but a mint that has
     already allocated real weights has lost the property this gate exists to
     keep, and continuing would only produce a longer list of the same fact.
+
+    ``actionable_only`` refuses only an allocation this gate can NAME a
+    file:line for — i.e. one made by the endpoint's own code. It exists for
+    the TRACE window (pgw#1080), where ``torch.export`` legitimately allocates
+    small real tensors of its own inside the fake mode: measured on the micro
+    rig, a 380-byte ``empty`` with no endpoint frame anywhere on the stack.
+    Refusing that would fail every mint for something no author can fix,
+    while the class the gate exists for — a device pin inside model code —
+    always has a frame. Unattributable events stay in the census, so they are
+    reported rather than dropped.
     """
     with observe(phase) as census:
         yield census
-    if not census.clean:
-        first = census.events[0]
+    events = [e for e in census.events if e.site] if actionable_only \
+        else list(census.events)
+    if events:
+        first = events[0]
         raise MetaMaterializationError(
             phase=census.phase, op=first.op, device=first.device,
             shape=first.shape, dtype=first.dtype, site=first.site)

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -561,7 +561,9 @@ def _measure_execution_lane(execution_lane: str, load: Any) -> Any:
             execution_lane=execution_lane, unavailable=f"build: {type(exc).__name__}: {exc}")
 
 
-def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any, Any]:
+def execution_lane_verdict_for(
+    load: Any, *, meta_mint: bool = False,
+) -> Tuple[Any, Any, Any, Any]:
     """MEASURE which serving-kernel lane wins on THIS card (pgw#947).
 
     Returns ``(verdict, endpoint instance, pipeline, spec)`` — the winning
@@ -596,6 +598,24 @@ def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any, Any]:
     from . import kernel_path
 
     candidates = kernel_path.candidates_here()
+    if meta_mint and len(candidates) >= 2:
+        # pgw#1080, coordinator ruling 2026-08-10: option (a). The A/B is a
+        # WHOLE-MODEL benchmark (`bench_step` times a real pipeline step), so
+        # running it would put weight-scale values back in the one process
+        # this slice exists to keep empty — to buy a verdict with no consumer
+        # below Blackwell, where `fused_candidate_gap` leaves one candidate
+        # and no A/B runs at all. Typed absence, with its reason.
+        verdict = kernel_path.unmeasured(
+            candidates[0],
+            "meta-mint: this child holds no weights (pgw#1080) and the lane "
+            "A/B is a whole-model benchmark; the serving side treats a cell "
+            "with no verdict as the documented conservative default")
+        kernel_path.pin(verdict.winner, f"meta-mint: {verdict.detail}")
+        frame(phase="load",
+              note=f"kernel lane {verdict.winner} (unmeasured, meta-mint)")
+        instance, pipe, spec = load(verdict.winner)
+        return verdict, instance, pipe, spec
+
     if len(candidates) < 2:
         _axes, gaps = kernel_path.candidate_axes()
         detail = "; ".join(
@@ -639,6 +659,7 @@ def _mint_aot(
     started: float, sha256_file: Any,
     execution_lane_verdict: Any = None,
     spec: Any = None,
+    footprint: Optional[Dict[str, Any]] = None,
 ) -> MintReport:
     """pgw#805: the AOT recipe — torch.export + AOTInductor over the family's
     whole declared graph-class set, packed as ONE multi-graph cell (pgw#758).
@@ -730,6 +751,12 @@ def _mint_aot(
     peak = max(
         _peak_vram(),
         int(result.timings.get("peak_vram_before_release_bytes", 0) or 0))
+    # pgw#1080: the EXPORT half of the footprint, measured from the peak reset
+    # that follows the warm proof. This is the ceiling the pgw#992 census must
+    # size the next export child against — the whole point of the slice is
+    # that it is autotune-scratch scale and not weight scale.
+    marks = dict(footprint or {})
+    marks.setdefault("export_peak_bytes", peak)
     return MintReport(
         status="minted",
         artifact=str(target),
@@ -739,10 +766,19 @@ def _mint_aot(
             f"exported {len((result.metadata.get('entries') or {}))} graph "
             f"class(es) for family {cfg.family!r} as one aot-inductor cell"),
         phase="finalize",
-        peak_vram_bytes=peak,
+        peak_vram_bytes=max(
+            peak, int(marks.get("warm_proof_peak_bytes", 0) or 0)),
         elapsed_s=time.monotonic() - started,
         phases=_close_phases(),
         mint_phases=dict(result.metadata.get("mint_phases") or {}),
+        structure_only_components=tuple(
+            marks.get("structure_only_components") or ()),
+        structure_refusal=str(marks.get("structure_refusal") or ""),
+        virtual_param_bytes=int(marks.get("virtual_param_bytes", 0) or 0),
+        structure_real_bytes=int(marks.get("structure_real_bytes", 0) or 0),
+        warm_proof_peak_bytes=int(marks.get("warm_proof_peak_bytes", 0) or 0),
+        warm_proof_values=str(marks.get("warm_proof_values") or ""),
+        export_peak_bytes=int(marks.get("export_peak_bytes", 0) or 0),
     )
 
 
@@ -807,16 +843,34 @@ def mint(request: MintRequest) -> MintReport:
         + (f" (+{sum(len(c) for c in overrides.values())} component "
            f"override(s))" if overrides else "")))
 
+    # pgw#1080: the compile targets are built from CODE + CONFIG, so the
+    # process that exports and compiles never holds a checkpoint value. A
+    # component that cannot be built that way says so, typed, and that slot
+    # loads its weights the old way — the property is then reported as NOT
+    # held for this mint rather than silently assumed.
+    structure_targets = tuple(cfg.targets)
+    structure_refusals: List[str] = []
+
     def _load(_execution_lane: str) -> Tuple[Any, Any, Any]:
         """One full endpoint load on the currently pinned kernel lane: the
         endpoint instance, its compile-target pipeline, and that pipeline's
         export spec."""
         from . import fleet_cells
+        from .models.structure_only import StructureOnlyUnsupported
 
         obj = spec.cls()
-        got = run_setup(
-            obj, dict(paths), arm_compile=False,
-            return_loaded=True, component_paths=overrides) or {}
+        try:
+            got = run_setup(
+                obj, dict(paths), arm_compile=False,
+                return_loaded=True, component_paths=overrides,
+                structure_only=structure_targets) or {}
+        except StructureOnlyUnsupported as exc:
+            structure_refusals.append(str(exc))
+            frame(phase="load", note=f"structure-only declined: {exc}")
+            obj = spec.cls()
+            got = run_setup(
+                obj, dict(paths), arm_compile=False,
+                return_loaded=True, component_paths=overrides) or {}
         _slot, loaded_pipe = _pick_compile_target(got, cfg)
         frame(phase="load", note=f"compile target on slot {_slot!r}")
         if cfg.lora_bucket:
@@ -827,7 +881,26 @@ def mint(request: MintRequest) -> MintReport:
     # exported, so the cell can carry the verdict instead of the fleet
     # re-deriving it from a hand-maintained SM tuple. The probe loads once per
     # candidate; the winner's pipeline is what gets minted.
-    verdict, instance, pipe, aot_spec = execution_lane_verdict_for(_load)
+    verdict, instance, pipe, aot_spec = execution_lane_verdict_for(
+        _load, meta_mint=bool(structure_targets))
+    from .models import structure_only
+
+    facts = structure_only.facts_of(pipe)
+    virtual_modules = structure_only.modules_of(pipe)
+    footprint: Dict[str, Any] = {
+        "structure_only_components": tuple(name for name, _m in virtual_modules),
+        "virtual_param_bytes": sum(f.virtual_param_bytes for f in facts),
+        "structure_real_bytes": sum(f.real_buffer_bytes for f in facts),
+        "structure_refusal": "; ".join(structure_refusals)[:400],
+    }
+    if facts:
+        frame(phase="load", note=(
+            "structure-only "
+            + ", ".join(
+                f"{f.component}({f.cls_name}): "
+                f"{f.virtual_param_bytes / 2 ** 20:.1f} MiB virtual, "
+                f"{f.real_buffer_bytes / 2 ** 20:.1f} MiB real buffers"
+                for f in facts)))
     # pgw#984: PROVE the endpoint's own forward runs, before a byte is
     # exported. `torch.export` traces the declared graph classes off the
     # modules directly and never enters the handler, so an AOT mint's
@@ -841,7 +914,73 @@ def mint(request: MintRequest) -> MintReport:
     # a full eager pass would buy minutes and prove nothing more than the first
     # job does. Eager — nothing is armed here — so it specializes no graph the
     # export then has to trace around.
+    #
+    # pgw#1080 (coordinator ruling 2026-08-10): on a structure-only mint the
+    # proof runs on RANDOM values. It is a does-it-run proof, not a numerics
+    # one, and the ratified variability rule already forbids value-dependent
+    # program structure — so a handler whose control flow breaks under random
+    # weights is violating that rule and surfacing it here is the point.
+    # Random values are NOT checkpoint values, but they ARE weight-scale for
+    # the length of the proof, so the window is measured and reported
+    # separately from the export's, which is the number the pgw#992 census
+    # must size the next export child against.
+    device_label = _device_label(request)
+    if virtual_modules:
+        _reset_peak()
+        randomized = sum(
+            structure_only.materialize_random(module, device=device_label)
+            for _name, module in virtual_modules)
+        frame(phase="warmup_forward", note=(
+            f"values=random ({randomized / 2 ** 20:.1f} MiB) on "
+            f"{[name for name, _m in virtual_modules]}"))
+        # The BASELINE for the call-time check below. The lane installs real
+        # tensors of its own before any forward runs — LoRA branch containers
+        # are the standing example, and they are legitimate (a lifted adapter
+        # is a graph INPUT, not a baked constant). What the check is looking
+        # for is a tensor that APPEARS during the proof, so it compares
+        # against what was already there instead of hardcoding a vocabulary.
+        strays_before = {
+            f"{name}.{path}"
+            for name, module in virtual_modules
+            for path, _tensor in structure_only.stray_real_tensors(module)
+        }
     _drive_warm_plan(instance, _warm_jobs(siblings), request, proof_only=True)
+    if virtual_modules:
+        footprint["warm_proof_peak_bytes"] = _peak_vram()
+        footprint["warm_proof_values"] = "random"
+        for _name, module in virtual_modules:
+            structure_only.restore_virtual(module, device=device_label)
+        # ie#628's call-time class, caught where it CAN be caught on a
+        # weightless mint. Inside a fake-mode export every allocation is fake,
+        # so the mode-based gate cannot see a lazily-built pinned table — but
+        # the warm proof just ran the handler for real, so if one was built it
+        # is now cached on a plain attribute, still real, about to be traced.
+        strays = [
+            (f"{name}.{path}", tensor)
+            for name, module in virtual_modules
+            for path, tensor in structure_only.stray_real_tensors(module)
+            if f"{name}.{path}" not in strays_before
+        ]
+        if strays:
+            raise MintChildRefused(
+                "meta-instantiation gate (ie#628, call-time): after the warm "
+                "proof released its random values, "
+                + ", ".join(
+                    f"{path} still holds a REAL {tuple(t.shape)} "
+                    f"{t.dtype} tensor on {t.device}" for path, t in strays[:4])
+                + ". A weightless mint traces what the module holds, so this "
+                "tensor would be exported as an anonymous graph literal and "
+                "the cell would carry values no adopter can rebind. It is "
+                "built at CALL time instead of at __init__: register derived "
+                "tables with `register_buffer` and NO device pin (ie#630's "
+                "`rope_buffers` is the worked example); an explicit "
+                "`with torch.device(...)` inside model code is itself the "
+                "violation to remove.")
+        _release()
+        frame(phase="warmup_forward", note=(
+            f"random values released; warm-proof device peak "
+            f"{footprint['warm_proof_peak_bytes'] / 2 ** 20:.1f} MiB"))
+    _reset_peak()
     # Deliberately NOT `aot_mint.compose_for_mint` (which builds a pipeline
     # from a model ref for an operator's mint pod): the graphs this cell must
     # serve are the graphs the ENDPOINT's own composed pipeline runs, and
@@ -849,7 +988,40 @@ def mint(request: MintRequest) -> MintReport:
     # cannot adopt.
     return _mint_aot(
         request, pipe, cfg, target, started=started,
-        sha256_file=sha256_file, execution_lane_verdict=verdict, spec=aot_spec)
+        sha256_file=sha256_file, execution_lane_verdict=verdict, spec=aot_spec,
+        footprint=footprint)
+
+
+def _device_label(request: MintRequest) -> str:
+    """Where this child's tensors live — the ordinal the parent chose, or the
+    card this process defaults to. ``cpu`` on a cardless box, stated rather
+    than assumed: a structure built as "cpu" compiles a CPU cell."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return "cpu"
+    except Exception:  # noqa: BLE001 — torch-less: nothing to place
+        return "cpu"
+    ordinal = int(getattr(request, "device", -1) or -1)
+    return f"cuda:{ordinal}" if ordinal >= 0 else "cuda"
+
+
+def _reset_peak() -> None:
+    """Start a fresh device high-water window (pgw#1080).
+
+    The warm proof's random-value window and the export's window are two
+    different measurements, and reporting their max as one number is what let
+    weight residency size an export child that no longer needs it.
+    """
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+    except Exception:  # noqa: BLE001 — a probe never fails a mint
+        logger.debug("mint-child: reset_peak_memory_stats failed",
+                     exc_info=True)
 
 
 def _peak_vram() -> int:

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -315,6 +315,28 @@ class MintReport(msgspec.Struct, frozen=True, kw_only=True):
     #: measure pipe latency instead of work. Empty from a child that died before
     #: writing its report, which is honest: no measurement, not zero.
     phases: Dict[str, float] = msgspec.field(default_factory=dict)
+    #: pgw#1080 — the FAKE-EXPORT FOOTPRINT. The child builds its compile
+    #: targets from code + config, so the process that traces holds no
+    #: checkpoint values; these fields are how a reader knows that held, for
+    #: WHICH components, and what it cost instead.
+    #:
+    #: ``export_peak_bytes`` is the number the pgw#992 census must size the
+    #: next export child against: it is measured from a peak reset taken AFTER
+    #: the warm proof, so weight-scale random values cannot leak into it.
+    #: ``warm_proof_peak_bytes`` is the pgw#984 proof's own window, and
+    #: ``warm_proof_values`` records what it ran on (``random``) — a
+    #: numerics-adjacent surprise is then one lookup, not a re-derivation.
+    structure_only_components: Tuple[str, ...] = ()
+    #: Empty when the property held; the typed reason when a component could
+    #: not be built from config and that slot loaded its weights instead.
+    structure_refusal: str = ""
+    #: Checkpoint bytes the child would have held and did not.
+    virtual_param_bytes: int = 0
+    #: Config-derived tables it legitimately did hold (literals live here).
+    structure_real_bytes: int = 0
+    warm_proof_peak_bytes: int = 0
+    warm_proof_values: str = ""
+    export_peak_bytes: int = 0
     #: pgw#805: the AOT recipe's per-entry phase TABLE
     #: (``aot_mint._mint_phase_table``). The child emits it too, but a mint
     #: child holds no orchestrator session, so the child's events go nowhere —
@@ -383,6 +405,24 @@ class MintOutcome:
         if self.report is not None and self.report.peak_vram_bytes:
             parts.append(
                 f"child_peak_vram={self.report.peak_vram_bytes / (1 << 30):.2f}GiB")
+        # pgw#1080: the fake-export footprint travels on the SAME line the hub
+        # already reads, so "the child held no weights" is an observation
+        # anyone can make from the wire instead of a claim in a design doc.
+        if self.report is not None and self.report.structure_only_components:
+            parts.append(
+                "structure_only="
+                + ",".join(self.report.structure_only_components))
+            parts.append(
+                f"virtual_weights={self.report.virtual_param_bytes / (1 << 30):.2f}GiB")
+            parts.append(
+                f"export_peak={self.report.export_peak_bytes / (1 << 20):.1f}MiB")
+            if self.report.warm_proof_values:
+                parts.append(
+                    f"warm_proof_values={self.report.warm_proof_values} "
+                    f"peak={self.report.warm_proof_peak_bytes / (1 << 20):.1f}MiB")
+        if self.report is not None and self.report.structure_refusal:
+            parts.append(
+                f"structure_refusal={self.report.structure_refusal[:200]!r}")
         if self.detail:
             parts.append(f"detail={self.detail[:400]!r}")
         return " ".join(parts)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -638,6 +638,8 @@ def repair_device_placement(obj: Any, device: str) -> List[tuple[str, str, str]]
 def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
     import torch
 
+    from ..meta_instantiation import is_virtual
+
     total = 0
     seen: set[int] = set()  # data_ptr dedupe: shared storages counted ONCE
     for obj in objs:
@@ -649,6 +651,13 @@ def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
                 tensors.extend(c.buffers())
             for t in tensors:
                 if not isinstance(t, torch.Tensor):
+                    continue
+                # pgw#1080: a VIRTUAL tensor (fake/meta) is a faithful
+                # shape+dtype+device with NO storage. Counting one as
+                # resident bytes would make a structure-only mint child look
+                # weight-scale to the offload ladder and to the co-residency
+                # census — the exact clamp this slice exists to remove.
+                if is_virtual(t):
                     continue
                 if cuda_only and t.device.type != "cuda":
                     continue

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -638,8 +638,6 @@ def repair_device_placement(obj: Any, device: str) -> List[tuple[str, str, str]]
 def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
     import torch
 
-    from ..meta_instantiation import is_virtual
-
     total = 0
     seen: set[int] = set()  # data_ptr dedupe: shared storages counted ONCE
     for obj in objs:
@@ -651,13 +649,6 @@ def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
                 tensors.extend(c.buffers())
             for t in tensors:
                 if not isinstance(t, torch.Tensor):
-                    continue
-                # pgw#1080: a VIRTUAL tensor (fake/meta) is a faithful
-                # shape+dtype+device with NO storage. Counting one as
-                # resident bytes would make a structure-only mint child look
-                # weight-scale to the offload ladder and to the co-residency
-                # census — the exact clamp this slice exists to remove.
-                if is_virtual(t):
                     continue
                 if cuda_only and t.device.type != "cuda":
                     continue

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -1,0 +1,666 @@
+"""pgw#1080 increment 2: the COMPONENT-LEVEL structure-only builder.
+
+The mint child exports and compiles a family's declared compile targets. Until
+now it reached them by running the endpoint's own ``setup()``, which loads the
+checkpoint — so the process that traces held every byte the process that serves
+holds, and on a two-pipeline family (z-image, 42.53 GiB) the two copies do not
+fit on one card at all (ie#638). Paul's ruling: export and compile must not
+require real weights resident AT ALL.
+
+WHY THIS IS PER-COMPONENT AND NOT A ``structure_only=True`` LOADER FLAG
+-----------------------------------------------------------------------
+A device context cannot make ``from_pretrained`` structure-only: ``with
+torch.device("meta")`` is a CONSTRUCTION DEFAULT and the weight READ is
+unaffected (safetensors mmaps to CPU; the subsequent ``load_state_dict`` either
+refuses or copies real data in). The pattern that actually skips the state dict
+is ``init_empty_weights()`` + ``from_config`` — which is a per-CLASS capability
+(diffusers' ``ConfigMixin``), and which every quantized loader in this tree
+already uses to build its denoiser (:mod:`.w8a8` , :mod:`.w4a4`,
+:mod:`.svdq_native`). A PIPELINE's config is its component CLASS MAP
+(``model_index.json``), not a weights layout, so ``from_config`` on a pipeline
+builds nothing the export traces. Hence: build the COMPONENT, inject it through
+the ``components=`` seam the loader already has, and let the pipeline class
+compose the rest exactly as it composes a preloaded shared component.
+
+WHY THE PARAMETERS END UP **FAKE** AND THE BUFFERS STAY **REAL**
+---------------------------------------------------------------
+Measured on torch 2.13.0, not assumed (four variants, cardless rig):
+
+* meta parameters + real inputs → ``torch.export`` refuses: *Tensor device
+  mismatch … cpu and meta*. Meta is not a device the compile can target either
+  — AOTInductor would codegen for ``meta``, not for the card.
+* parameters as FAKE tensors on the TARGET device → export succeeds, and
+  ``aot_compile`` succeeds when it runs inside
+  ``torch._guards.tracing(TracingContext(<that fake mode>))``. Fake tensors
+  carry a faithful device, dtype and stride and allocate NOTHING, which is
+  exactly the property this slice exists for.
+* buffers stay REAL, on the device. They are pure functions of config (rope
+  tables, sinusoidal features) and they are KB-to-MB scale, and they are what
+  a literal-bearing family ships INSIDE the cell: a fake buffer would make
+  ``aot_package.literal_constants`` unpackable. Keeping them real also arms the
+  folding fence — a literal derived from a PARAMETER is fake and fails loudly,
+  and a value-dependent fold over a rebindable weight is precisely what
+  pgw#1056 forbids.
+
+WHAT IS REFUSED RATHER THAN GUESSED
+-----------------------------------
+A compile-target class with no ``load_config``/``from_config`` surface, a tree
+with no ``model_index.json`` entry naming the component's class, and the
+quantized artifact lanes whose denoiser is built from an artifact's own weight
+table. Each refuses typed, naming the class and what it lacks — honest partial
+coverage beats total coverage that lies.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from ..api.errors import WorkerError
+from .. import meta_instantiation as mi
+
+#: Stamped on a structure-only module and on the pipeline composed around it.
+STAMP = "_cozy_structure_only"
+#: The fake mode every virtual parameter of a structure-only tree belongs to.
+MODE_STAMP = "_cozy_structure_fake_mode"
+FACTS_STAMP = "_cozy_structure_facts"
+
+#: Standard deviation of the random values the pgw#984 warm proof runs on.
+#: Small enough that a deep stack of matmuls cannot overflow fp16, non-zero so
+#: a degenerate all-zero forward cannot pass a proof a real one would fail.
+RANDOM_STD = 0.02
+#: Fixed, because a proof that behaves differently on two runs of the same cell
+#: is not a proof. Not configurable: the value is not a tuning knob.
+RANDOM_SEED = 1080
+
+
+class StructureOnlyUnsupported(WorkerError):
+    """This component cannot be built from code + config alone.
+
+    Named-axis refusal: WHICH component, WHICH class, and WHAT it lacks — the
+    fix is always an authoring or packaging change (expose the ConfigMixin
+    surface; declare the component in ``model_index.json``), never a knob.
+    """
+
+    def __init__(self, *, component: str, cls_name: str, lacks: str,
+                 tree: str = "") -> None:
+        self.component = str(component or "")
+        self.cls_name = str(cls_name or "")
+        self.lacks = str(lacks or "")
+        self.tree = str(tree or "")
+        super().__init__(
+            f"structure-only build of component {self.component!r} "
+            f"({self.cls_name or 'unknown class'}) is not possible: "
+            f"{self.lacks}. The zero-download forge instantiates a compile "
+            f"target from CODE + CONFIG (`load_config` + `from_config` under "
+            f"`accelerate.init_empty_weights()` — the shape "
+            f"`models/w8a8.py` already uses), so a class without that surface "
+            f"has no structure-only path and this family is stranded on the "
+            f"real-weight mint until it grows one"
+            + (f" (tree: {self.tree})" if self.tree else "")
+        )
+
+
+@dataclass(frozen=True)
+class StructureFacts:
+    """What one structure-only component costs, and what it did NOT cost."""
+
+    component: str
+    cls_name: str
+    parameters: int = 0
+    #: Checkpoint bytes this process would have held and does not.
+    virtual_param_bytes: int = 0
+    #: Config-derived tables that legitimately stay real (literals live here).
+    real_buffer_bytes: int = 0
+    #: Real bytes allocated during ``__init__`` and NOT retained as a buffer —
+    #: transient by construction, reported because an unexplained one is the
+    #: first sign a class is doing weight work at construction.
+    transient_real_bytes: int = 0
+    #: Endpoint sites that allocated real tensors while building the structure.
+    sites: Tuple[str, ...] = ()
+
+    def as_event(self) -> Dict[str, Any]:
+        return {
+            "component": self.component,
+            "cls": self.cls_name,
+            "parameters": self.parameters,
+            "virtual_param_bytes": self.virtual_param_bytes,
+            "real_buffer_bytes": self.real_buffer_bytes,
+            "transient_real_bytes": self.transient_real_bytes,
+        }
+
+
+@dataclass
+class _Collected:
+    facts: List[StructureFacts] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Class resolution — the tree's own component map, never a guess
+# ---------------------------------------------------------------------------
+
+
+def _component_class(tree: Path, component: str) -> Any:
+    from .loading import model_index_components, model_index_entry
+
+    entry = model_index_entry(tree, component)
+    if entry is None:
+        known = sorted(model_index_components(tree))
+        raise StructureOnlyUnsupported(
+            component=component, cls_name="", tree=str(tree),
+            lacks=(
+                f"the tree names no class for it — model_index.json declares "
+                f"{known or 'nothing (no readable model_index.json)'}"),
+        )
+    library, class_name = entry
+    try:
+        module = importlib.import_module(library)
+    except Exception as exc:  # noqa: BLE001 — a missing library is a refusal
+        raise StructureOnlyUnsupported(
+            component=component, cls_name=f"{library}.{class_name}",
+            tree=str(tree),
+            lacks=f"its library {library!r} does not import ({exc})") from exc
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        raise StructureOnlyUnsupported(
+            component=component, cls_name=f"{library}.{class_name}",
+            tree=str(tree), lacks=f"{library} has no class {class_name!r}")
+    return cls
+
+
+def _require_config_surface(cls: Any, component: str, tree: Path) -> None:
+    missing = [name for name in ("load_config", "from_config")
+               if not callable(getattr(cls, name, None))]
+    if missing:
+        raise StructureOnlyUnsupported(
+            component=component, cls_name=getattr(cls, "__name__", str(cls)),
+            tree=str(tree),
+            lacks=f"it exposes no {' and no '.join(missing)} classmethod")
+
+
+def _refuse_artifact_lanes(root: Path, component: str, cls: Any) -> None:
+    """The quantized lanes build their denoiser from an ARTIFACT's own weight
+    table (which linears are quantized, at what scales). That table is a
+    property of the bytes, not of the config, so a structure-only build would
+    trace ``nn.Linear`` where serving runs ``Fp8ScaledLinear`` — a cell for a
+    graph the pod never executes. Refuse by name instead."""
+    from .svdq import detect_svdq_artifact
+    from .w4a4 import detect_w4a4_artifact
+    from .w8a8 import detect_w8a8_artifact
+    from .loading import detect_gguf_snapshot
+
+    for label, art in (
+        ("w8a8", detect_w8a8_artifact(root)),
+        ("w4a4", detect_w4a4_artifact(root)),
+        ("svdq", detect_svdq_artifact(root)),
+    ):
+        if art is not None and getattr(art, "component", component) in (
+                component, ""):
+            raise StructureOnlyUnsupported(
+                component=component,
+                cls_name=getattr(cls, "__name__", str(cls)), tree=str(root),
+                lacks=(
+                    f"this tree is a {label} artifact, whose module graph is "
+                    f"decided by the artifact's WEIGHT TABLE (which linears "
+                    f"are quantized, at which scales) and not by its config — "
+                    f"a structure-only build would trace a graph the pod does "
+                    f"not serve"))
+    if detect_gguf_snapshot(root) is not None:
+        raise StructureOnlyUnsupported(
+            component=component, cls_name=getattr(cls, "__name__", str(cls)),
+            tree=str(root),
+            lacks=("this tree is a GGUF snapshot: its denoiser is dequantized "
+                   "by the pipeline's own gguf loader, so there is no "
+                   "config-only structure for it"))
+
+
+# ---------------------------------------------------------------------------
+# The build
+# ---------------------------------------------------------------------------
+
+
+def _init_empty_weights() -> Any:
+    try:
+        from accelerate import init_empty_weights
+    except Exception as exc:  # noqa: BLE001
+        raise StructureOnlyUnsupported(
+            component="", cls_name="", lacks=(
+                f"`accelerate` is not importable ({exc}), and "
+                f"`init_empty_weights` is the mechanism that skips the state "
+                f"dict")) from exc
+    return init_empty_weights
+
+
+def build_component(
+    tree: str | Path, component: str, *, device: str = "", dtype: str = "",
+) -> Tuple[Any, StructureFacts]:
+    """Build ONE pipeline component from code + config, holding no weights.
+
+    Returns the module and its measured facts. The module's PARAMETERS are
+    fake tensors on ``device`` (faithful shape/dtype/device, zero storage); its
+    BUFFERS are real, because they are config-derived and a literal-bearing
+    family ships them.
+    """
+    import torch
+
+    root = Path(tree)
+    cls = _component_class(root, component)
+    _refuse_artifact_lanes(root, component, cls)
+    _require_config_surface(cls, component, root)
+    src = root / component if (root / component).is_dir() else root
+
+    config = dict(cls.load_config(str(src)))
+    # A quantization block describes bytes this build will never read, and
+    # diffusers reconstructs some of them into configs whose constructors
+    # refuse (pgw#689 defect 1).
+    config.pop("quantization_config", None)
+
+    init_empty_weights = _init_empty_weights()
+    with mi.observe(f"structure:{component}") as census:
+        with init_empty_weights():
+            module = cls.from_config(config)
+    if hasattr(module, "eval"):
+        module.eval()
+
+    torch_dtype = _torch_dtype(root, component, dtype)
+    virtualize(module, device=device, dtype=torch_dtype)
+
+    facts = _facts(module, component=component,
+                   cls_name=getattr(cls, "__name__", str(cls)), census=census)
+    setattr(module, FACTS_STAMP, facts)
+    if not torch.cuda.is_available() and device.startswith("cuda"):
+        raise StructureOnlyUnsupported(
+            component=component, cls_name=facts.cls_name, tree=str(root),
+            lacks=f"device {device!r} is not available in this process")
+    return module, facts
+
+
+def _torch_dtype(root: Path, component: str, dtype: str) -> Any:
+    """The compute dtype this component would have loaded at.
+
+    Same resolution ``loading.load_component`` uses, because a structure whose
+    precision differs from serving's is a different graph and a different cell.
+    """
+    from ..families.facts import component_dtype_for_class
+    from .loading import (
+        composition_compute_dtype, detect_on_disk_dtype,
+        get_torch_dtype, model_index_component_classes,
+    )
+
+    class_name = model_index_component_classes(root).get(component, "")
+    fact = component_dtype_for_class(class_name) if class_name else None
+    src = root / component if (root / component).is_dir() else root
+    wanted = (
+        (fact.dtype if fact is not None else "")
+        or composition_compute_dtype(root, dtype)
+        or detect_on_disk_dtype(src)
+    )
+    if wanted in ("bf16", "fp16", "bfloat16", "float16", "fp32", "float32"):
+        try:
+            return get_torch_dtype(wanted)
+        except ImportError:
+            return None
+    return None
+
+
+def virtualize(module: Any, *, device: str = "", dtype: Any = None) -> Any:
+    """Parameters → fake tensors on ``device``; buffers → real, on ``device``.
+
+    Returns the fake mode, which the export and the compile must both run
+    inside: ``aot_compile`` asserts that every input belongs to ONE mode.
+    """
+    import torch
+    import torch.nn as nn
+    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    dev = device or "cpu"
+    mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+    with mode, torch.device(dev):
+        for sub in module.modules():
+            for name, param in list(sub._parameters.items()):
+                if param is None:
+                    continue
+                want = dtype if (dtype is not None
+                                 and param.is_floating_point()) else param.dtype
+                sub._parameters[name] = nn.Parameter(
+                    torch.empty(tuple(param.shape), dtype=want),
+                    requires_grad=False)
+    for sub in module.modules():
+        for name, buf in list(sub._buffers.items()):
+            if buf is None:
+                continue
+            want = dtype if (dtype is not None
+                             and buf.is_floating_point()) else buf.dtype
+            sub._buffers[name] = buf.to(device=dev, dtype=want)
+    _freeze_placement(module)
+    setattr(module, STAMP, True)
+    setattr(module, MODE_STAMP, mode)
+    return mode
+
+
+def _freeze_placement(module: Any) -> None:
+    """Make ``.to()`` / ``.cuda()`` / ``.float()`` a no-op on this structure.
+
+    A virtual structure is ALREADY on the device and dtype it claims — that
+    is the whole point of building it there — and torch cannot move a fake
+    parameter anyway: the worker's placement pass dies with
+    ``RuntimeError: _apply(): Couldn't swap Linear.weight`` (measured on the
+    RTX 4070 rig, first GPU cycle). Silently declining the move is the honest
+    behaviour here, because a move that DID happen would re-key the graph the
+    cell is being minted for.
+    """
+    import types
+
+    def _apply(self: Any, *_args: Any, **_kwargs: Any) -> Any:
+        return self
+
+    module._apply = types.MethodType(_apply, module)
+
+
+def _facts(module: Any, *, component: str, cls_name: str,
+           census: mi.Census) -> StructureFacts:
+    virtual_bytes = 0
+    params = 0
+    for param in module.parameters():
+        params += 1
+        virtual_bytes += int(param.numel()) * int(param.element_size())
+    real_buffers = 0
+    for buf in module.buffers():
+        if not mi.is_virtual(buf):
+            real_buffers += int(buf.numel()) * int(buf.element_size())
+    observed = sum(_event_bytes(e) for e in census.events)
+    return StructureFacts(
+        component=component, cls_name=cls_name, parameters=params,
+        virtual_param_bytes=virtual_bytes, real_buffer_bytes=real_buffers,
+        transient_real_bytes=max(0, observed - real_buffers),
+        sites=tuple(sorted({e.site for e in census.events if e.site})[:8]),
+    )
+
+
+def _event_bytes(event: mi.Materialization) -> int:
+    """Bytes one observed real allocation holds, from its recorded shape."""
+    import torch
+
+    try:
+        shape = tuple(int(x) for x in
+                      event.shape.strip("()").replace(" ", "").split(",") if x)
+    except ValueError:
+        return 0
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    dtype = getattr(torch, event.dtype.replace("torch.", ""), None)
+    itemsize = getattr(dtype, "itemsize", 0) if dtype is not None else 0
+    return int(numel) * int(itemsize or 0)
+
+
+# ---------------------------------------------------------------------------
+# Reading a composed pipeline back
+# ---------------------------------------------------------------------------
+
+
+def is_structure_only(obj: Any) -> bool:
+    """Whether this module — or any component of this pipeline — is virtual."""
+    if getattr(obj, STAMP, False):
+        return True
+    return bool(structure_only_components(obj))
+
+
+def structure_only_components(pipe: Any) -> Tuple[str, ...]:
+    """Names of the pipeline attributes that are structure-only modules."""
+    out: List[str] = []
+    for name, value in list(vars(pipe).items() if hasattr(pipe, "__dict__")
+                            else []):
+        if getattr(value, STAMP, False):
+            out.append(str(name).lstrip("_"))
+    return tuple(sorted(set(out)))
+
+
+def modules_of(pipe: Any) -> Tuple[Tuple[str, Any], ...]:
+    """``(attribute, module)`` for every structure-only component of ``pipe``."""
+    out: List[Tuple[str, Any]] = []
+    if getattr(pipe, STAMP, False):
+        return ((getattr(pipe, "__class__").__name__, pipe),)
+    for name, value in list(vars(pipe).items() if hasattr(pipe, "__dict__")
+                            else []):
+        if getattr(value, STAMP, False):
+            out.append((str(name).lstrip("_"), value))
+    return tuple(sorted(out, key=lambda row: row[0]))
+
+
+def facts_of(pipe: Any) -> Tuple[StructureFacts, ...]:
+    out: List[StructureFacts] = []
+    for value in list(vars(pipe).values() if hasattr(pipe, "__dict__") else []):
+        facts = getattr(value, FACTS_STAMP, None)
+        if isinstance(facts, StructureFacts):
+            out.append(facts)
+    if not out:
+        facts = getattr(pipe, FACTS_STAMP, None)
+        if isinstance(facts, StructureFacts):
+            out.append(facts)
+    return tuple(out)
+
+
+def fake_mode_of(obj: Any) -> Optional[Any]:
+    """The fake mode this object's virtual tensors belong to, if any.
+
+    Derived from the tensors themselves rather than threaded through the
+    call stack: the export and the compile must run inside the SAME mode, and
+    the program itself is the only thing that knows which one that is.
+    """
+    mode = getattr(obj, MODE_STAMP, None)
+    if mode is not None:
+        return mode
+    seen: List[Any] = []
+    for getter in ("parameters", "buffers"):
+        fn = getattr(obj, getter, None)
+        if callable(fn):
+            try:
+                seen.extend(list(fn())[:8])
+            except Exception:  # noqa: BLE001 — probing, never fatal
+                continue
+    if not seen and hasattr(obj, "__dict__"):
+        for value in vars(obj).values():
+            mode = getattr(value, MODE_STAMP, None)
+            if mode is not None:
+                return mode
+    for tensor in seen:
+        mode = getattr(tensor, "fake_mode", None)
+        if mode is not None:
+            return mode
+    return None
+
+
+def fake_mode_of_program(program: Any) -> Optional[Any]:
+    """The fake mode an EXPORTED PROGRAM's tensors belong to, if any.
+
+    ``aot_compile`` asserts every one of its inputs shares one fake mode, so a
+    program exported from a structure-only module must be compiled inside that
+    same mode's tracing context. Read off the program rather than threaded
+    through three call frames: the program is the only thing that knows.
+    """
+    for holder in ("state_dict", "constants"):
+        table = getattr(program, holder, None)
+        if not isinstance(table, dict):
+            continue
+        for tensor in table.values():
+            mode = getattr(tensor, "fake_mode", None)
+            if mode is not None:
+                return mode
+    return None
+
+
+def program_shape_env(program: Any) -> Optional[Any]:
+    """The ShapeEnv the EXPORT built — the one that knows this program's
+    symbols and their value ranges."""
+    graph = getattr(getattr(program, "graph_module", None), "graph", None)
+    nodes = getattr(graph, "nodes", ()) if graph is not None else ()
+    for node in nodes:
+        value = getattr(node, "meta", {}).get("val")
+        for dim in getattr(value, "shape", ()) or ():
+            env = getattr(getattr(dim, "node", None), "shape_env", None)
+            if env is not None:
+                return env
+    return None
+
+
+@contextlib.contextmanager
+def compiling_under(program: Any) -> Iterator[None]:
+    """Run AOTInductor inside the program's own fake mode when it has one.
+
+    And inside the EXPORT's ShapeEnv, which is a separate fact and a
+    load-bearing one. ``torch.export`` builds its own ShapeEnv while tracing,
+    so the mode the structure was built in still carries the empty one it was
+    constructed with — and inductor then looks up a symbol it has never seen:
+    ``AssertionError: vr must not be None for symbol s21`` (measured; the
+    same graph compiles with the program's env installed). Restored after,
+    because the mode outlives this call.
+    """
+    mode = fake_mode_of_program(program)
+    if mode is None:
+        yield
+        return
+    import torch._guards as guards
+
+    env = program_shape_env(program)
+    previous = getattr(mode, "shape_env", None)
+    if env is not None:
+        mode.shape_env = env
+    try:
+        with guards.tracing(guards.TracingContext(mode)):
+            yield
+    finally:
+        if env is not None:
+            mode.shape_env = previous
+
+
+@contextlib.contextmanager
+def under(mode: Optional[Any]) -> Iterator[None]:
+    """Run inside ``mode`` when there is one; unchanged when there is not."""
+    if mode is None:
+        yield
+        return
+    with mode:
+        yield
+
+
+# ---------------------------------------------------------------------------
+# The pgw#984 warm proof runs on RANDOM values (coordinator ruling, 2026-08-10)
+# ---------------------------------------------------------------------------
+
+
+def materialize_random(module: Any, *, device: str = "") -> int:
+    """Give every virtual parameter REAL random values; return the bytes.
+
+    The endpoint's own handler is proved to RUN before a byte is exported
+    (pgw#984), and a handler cannot run against zero-storage tensors. The
+    ruling is random values — the proof is structural ("does it run"), and the
+    ratified variability rule already forbids value-dependent program
+    structure, so a handler whose control flow breaks under random weights is
+    violating that rule and surfacing it is the point.
+
+    Random values are NOT checkpoint values: nothing this process holds came
+    from the model's bytes. The cost is reported (``values=random``) rather
+    than hidden, because it IS weight-scale for the length of the proof.
+    """
+    import torch
+    import torch.nn as nn
+
+    dev = device or "cpu"
+    generator = torch.Generator(device=dev).manual_seed(RANDOM_SEED)
+    total = 0
+    for sub in module.modules():
+        for name, param in list(sub._parameters.items()):
+            if param is None:
+                continue
+            real = torch.empty(tuple(param.shape), dtype=param.dtype,
+                               device=dev)
+            if param.is_floating_point() and real.dtype in (
+                    torch.float16, torch.bfloat16, torch.float32,
+                    torch.float64):
+                real.normal_(0.0, RANDOM_STD, generator=generator)
+            else:
+                # fp8 and integer parameters have no `normal_`; a defined
+                # value beats an undefined one, and NaN/overflow would make
+                # every downstream cosine undefined (pgw#1056's guard).
+                real.zero_()
+            sub._parameters[name] = nn.Parameter(real, requires_grad=False)
+            total += int(real.numel()) * int(real.element_size())
+    return total
+
+
+def stray_real_tensors(module: Any) -> Tuple[Tuple[str, Any], ...]:
+    """Real tensors hanging off the tree that are NEITHER parameter nor buffer.
+
+    This is how the z-image rope class actually shows up on a weightless mint,
+    and it is the one place it CAN be seen. The gate's call-time half
+    (ie#628) watches for a real allocation — but inside a fake-mode export
+    every allocation is fake, so a lazily-built pinned table is invisible
+    there. What it cannot hide is the RESIDUE: the pgw#984 warm proof runs the
+    handler for real, the lazy build fires, and the table is cached on a plain
+    attribute where ``restore_virtual`` (which only re-fakes parameters) does
+    not reach. A real tensor still on the tree when the export begins is
+    exactly the property failing.
+
+    Searched: each module's own ``__dict__``, plus one level into plain
+    objects it holds — the shape upstream uses (``RopeEmbedder`` is not an
+    ``nn.Module``), and deep enough to name the attribute an author edits.
+    """
+    import torch
+
+    out: List[Tuple[str, Any]] = []
+    for prefix, sub in module.named_modules():
+        registered = set(sub._parameters) | set(sub._buffers)
+        for name, value in list(vars(sub).items()):
+            if name.startswith("_") or name in registered:
+                continue
+            path = f"{prefix}.{name}" if prefix else name
+            if isinstance(value, torch.Tensor):
+                if not mi.is_virtual(value):
+                    out.append((path, value))
+                continue
+            if isinstance(value, torch.nn.Module) or not hasattr(
+                    value, "__dict__"):
+                continue
+            for inner, held in list(vars(value).items()):
+                if isinstance(held, torch.Tensor) and not mi.is_virtual(held):
+                    out.append((f"{path}.{inner}", held))
+    return tuple(out)
+
+
+def restore_virtual(module: Any, *, device: str = "") -> Any:
+    """Return every parameter to a fake tensor, freeing the random values.
+
+    A NEW fake mode, deliberately: the values that ran the proof are gone and
+    the export must not carry a mode that ever held them.
+    """
+    return virtualize(module, device=device)
+
+
+__all__ = [
+    "FACTS_STAMP",
+    "MODE_STAMP",
+    "RANDOM_SEED",
+    "RANDOM_STD",
+    "STAMP",
+    "StructureFacts",
+    "StructureOnlyUnsupported",
+    "build_component",
+    "compiling_under",
+    "facts_of",
+    "fake_mode_of",
+    "fake_mode_of_program",
+    "is_structure_only",
+    "materialize_random",
+    "modules_of",
+    "program_shape_env",
+    "restore_virtual",
+    "stray_real_tensors",
+    "structure_only_components",
+    "virtualize",
+    "under",
+]

--- a/tests/harness/rig_vehicles.py
+++ b/tests/harness/rig_vehicles.py
@@ -1340,11 +1340,74 @@ MICRO_PAD32_BRANCHY = Vehicle(
 )
 
 
+# ---------------------------------------------------------------------------
+# micro-rope — pgw#1080's RED CONTROL, and the reason ie#628 widened the
+# meta-instantiation gate from `__init__` to CALL time.
+#
+# The denoiser's frequency table is upstream z-image's shape: a plain object
+# holding None, built on first use inside `with torch.device("cpu")`. The base
+# `micro` vehicle is the GREEN twin — ie#630's registered buffer, no device
+# pin — and it mints green in the same gauntlet. The pair is the control: a
+# gate that only ever fires, or only ever stays silent, has proved nothing.
+# ---------------------------------------------------------------------------
+
+
+def _micro_rope_cell() -> Any:
+    from gen_worker.registry import CompileCell
+
+    from micro_diffusion.aot_declaration_rope import COND_LEN, PIXEL_ROWS
+
+    return CompileCell(
+        shapes=PIXEL_ROWS, targets=("transformer",), family="micro-rope",
+        regional=False, text_len=COND_LEN, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=())
+
+
+_MICRO_ROPE_ADOPT = """
+import json, os, sys
+out = {"pid": os.getpid(), "ok": False,
+       "detail": "micro-rope is a REFUSAL vehicle: the mint never publishes a "
+                 "cell, so there is nothing to adopt"}
+print("RIG_ADOPT " + json.dumps(out))
+"""
+
+
+def _micro_rope_adopt_source(base: str, cache: Path, checkpoint: str) -> str:
+    return _MICRO_ROPE_ADOPT
+
+
+MICRO_ROPE = Vehicle(
+    name="micro-rope",
+    modules=(RUNTIME_HOOK, "micro_diffusion.main_rope"),
+    function="generate-rope",
+    family="micro-rope",
+    ref_path="cozy/micro-diffusion",
+    syspath=(str(MICRO_SRC),),
+    build_checkpoint=_micro_checkpoint,
+    checkpoint_bytes=_micro_checkpoint_bytes,
+    compile_cell=_micro_rope_cell,
+    adopt_source=_micro_rope_adopt_source,
+    expect="red",
+    expect_note=(
+        "the denoiser builds its table lazily under `with torch.device('cpu')`"
+        ". MEASURED 2026-08-10: inside a fake-mode export that allocation is "
+        "itself FAKE, so the MODE-based half of the gate cannot see it — the "
+        "residue can. The warm proof runs the handler for real, the lazy "
+        "build fires, and the child refuses naming "
+        "`transformer.rope.freqs_cis` and the authoring fix. The base "
+        "`micro` row is the green half of the same control"),
+    covers=("pgw#1080 / ie#628 RED CONTROL: upstream z-image's lazy "
+            "CPU-pinned rope table, transcribed. Clean __init__, violation "
+            "mid-forward. Green twin: the `micro` row, whose table is a "
+            "registered buffer (ie#630)"),
+)
+
+
 VEHICLES: Dict[str, Vehicle] = {
     v.name: v for v in (TINY, MICRO, MICRO_LORA, MICRO_LORA16,
                         MICRO_LORA_PLAIN_PARENT, MICRO_4D, MICRO_CONV,
                         MICRO_ESCAPE, MICRO_W8A8, MICRO_W8A8_LORA,
-                        MICRO_PAD32, MICRO_PAD32_BRANCHY)}
+                        MICRO_PAD32, MICRO_PAD32_BRANCHY, MICRO_ROPE)}
 DEFAULT_VEHICLE = TINY.name
 
 
@@ -1359,5 +1422,6 @@ def vehicle(name: str) -> Vehicle:
 __all__ = ["DEFAULT_VEHICLE", "MICRO", "MICRO_CONV", "MICRO_ESCAPE",
            "MICRO_LORA", "MICRO_LORA16", "MICRO_LORA16_BUCKET",
            "MICRO_LORA_BUCKET", "MICRO_4D", "MICRO_LORA_PLAIN_PARENT",
-           "MICRO_PAD32", "MICRO_PAD32_BRANCHY", "MICRO_W8A8",
+           "MICRO_PAD32", "MICRO_PAD32_BRANCHY", "MICRO_ROPE",
+           "MICRO_W8A8",
            "MICRO_W8A8_LORA", "TINY", "VEHICLES", "Vehicle", "vehicle"]

--- a/tests/test_structure_only_pgw1080.py
+++ b/tests/test_structure_only_pgw1080.py
@@ -1,0 +1,214 @@
+"""pgw#1080 increment 2: the component-level structure-only builder.
+
+The property under test is the one ie#638 needs: the process that EXPORTS a
+family's compile target never holds that family's checkpoint values. It is
+proved here on the micro family's real tree, through the real SDK seams —
+``run_setup`` -> ``provision.load_slot`` -> the pipeline class's own
+``from_pretrained`` — not against a stub, because the failure this replaces
+was precisely a load path that looked right and loaded weights anyway.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("accelerate")
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+from gen_worker import meta_instantiation as mi  # noqa: E402
+from gen_worker.models import structure_only as so  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from micro_diffusion.weights import SEED, materialize
+
+    root = tmp_path_factory.mktemp("micro-tree")
+    return materialize(root, seed=SEED)
+
+
+# ---------------------------------------------------------------------------
+# The builder
+# ---------------------------------------------------------------------------
+
+
+def test_a_compile_target_is_built_from_config_and_holds_no_weights(
+    tree: Path,
+) -> None:
+    module, facts = so.build_component(tree, "transformer", device="cpu")
+
+    assert facts.component == "transformer"
+    assert facts.cls_name == "MicroDenoiser"
+    assert facts.parameters > 0
+    assert facts.virtual_param_bytes > 0, "the facts must price what was SKIPPED"
+    for name, param in module.named_parameters():
+        assert mi.is_virtual(param), f"{name} holds real storage"
+
+
+def test_the_structure_claims_the_TARGET_device_not_meta(tree: Path) -> None:
+    """AOTInductor codegens for the device the traced tensors report, so a
+    structure that claimed ``meta`` would compile a cell for no card at all —
+    and a meta parameter cannot even be exported beside a real input
+    (measured: ``Tensor device mismatch … cpu and meta``)."""
+    module, _facts = so.build_component(tree, "transformer", device="cpu")
+    devices = {str(p.device) for p in module.parameters()}
+    assert devices == {"cpu"}
+
+
+def test_buffers_stay_REAL_because_literals_ship_from_them(tree: Path) -> None:
+    """A config-derived table is what a literal-bearing cell packs. Faking it
+    would make ``aot_package.literal_constants`` unpackable — and keeping it
+    real is also the folding fence: a literal derived from a PARAMETER stays
+    fake and fails loudly instead of baking one checkpoint into a shared
+    cell."""
+    module, facts = so.build_component(tree, "transformer", device="cpu")
+    buffers = dict(module.named_buffers())
+    assert buffers, "the micro denoiser registers a rope/frequency table"
+    assert all(not mi.is_virtual(b) for b in buffers.values())
+    assert facts.real_buffer_bytes > 0
+    assert facts.real_buffer_bytes < facts.virtual_param_bytes
+
+
+def test_a_class_without_the_config_surface_REFUSES_by_name(
+    tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NoConfigSurface:
+        pass
+
+    monkeypatch.setattr(so, "_component_class",
+                        lambda *_a, **_k: NoConfigSurface)
+    with pytest.raises(so.StructureOnlyUnsupported) as caught:
+        so.build_component(tree, "transformer", device="cpu")
+    message = str(caught.value)
+    assert "NoConfigSurface" in message
+    assert "load_config" in message and "from_config" in message
+    assert caught.value.component == "transformer"
+
+
+def test_a_component_the_tree_does_not_declare_REFUSES_by_name(
+    tree: Path,
+) -> None:
+    with pytest.raises(so.StructureOnlyUnsupported) as caught:
+        so.build_component(tree, "text_encoder", device="cpu")
+    assert "model_index.json" in str(caught.value)
+    assert "transformer" in str(caught.value), "it names what IS declared"
+
+
+# ---------------------------------------------------------------------------
+# Export + compile on the structure — the measurement that chose fake over meta
+# ---------------------------------------------------------------------------
+
+
+def test_the_structure_EXPORTS_and_AOT_COMPILES(tree: Path) -> None:
+    from gen_worker import aot_mint
+
+    module, _facts = so.build_component(tree, "decoder", device="cpu")
+    mode = so.fake_mode_of(module)
+    assert mode is not None
+
+    with so.under(mode):
+        latent = torch.randn(1, 8, 16)
+        program = aot_mint.export_program(module, (latent,), {})
+    assert so.fake_mode_of_program(program) is mode, (
+        "the compile has to find the program's own mode — `aot_compile` "
+        "asserts every input belongs to ONE mode")
+    files = aot_mint.compile_entry_files(program, "decoder")
+    assert files, "AOTInductor produced no loose files for the fake structure"
+
+
+# ---------------------------------------------------------------------------
+# The pgw#984 warm proof runs on RANDOM values, and gives them back
+# ---------------------------------------------------------------------------
+
+
+def test_random_values_are_defined_and_are_released_again(tree: Path) -> None:
+    module, facts = so.build_component(tree, "transformer", device="cpu")
+
+    materialized = so.materialize_random(module, device="cpu")
+    assert materialized == facts.virtual_param_bytes
+    values = torch.cat([p.detach().reshape(-1) for p in module.parameters()])
+    assert not mi.is_virtual(next(module.parameters()))
+    assert torch.isfinite(values).all(), (
+        "a NaN/inf init would make every downstream cosine undefined")
+    assert float(values.abs().max()) > 0.0
+
+    so.restore_virtual(module, device="cpu")
+    assert all(mi.is_virtual(p) for p in module.parameters())
+
+
+def test_the_random_values_are_REPRODUCIBLE(tree: Path) -> None:
+    """A proof that behaves differently on two runs of the same cell is not a
+    proof, so the seed is fixed rather than clock-derived."""
+    first, _ = so.build_component(tree, "decoder", device="cpu")
+    second, _ = so.build_component(tree, "decoder", device="cpu")
+    so.materialize_random(first, device="cpu")
+    so.materialize_random(second, device="cpu")
+    for (name, a), (_n, b) in zip(first.named_parameters(),
+                                  second.named_parameters()):
+        assert torch.equal(a, b), name
+
+
+# ---------------------------------------------------------------------------
+# The SDK seam — the composed pipeline, and the silent-ignore gate
+# ---------------------------------------------------------------------------
+
+
+def test_run_setup_composes_a_pipeline_whose_TARGETS_hold_no_weights(
+    tree: Path,
+) -> None:
+    from gen_worker.cli.run import run_setup
+
+    from micro_diffusion.main import Generate
+
+    instance = Generate()
+    loaded = run_setup(
+        instance, {"pipeline": str(tree)}, device="cpu", arm_compile=False,
+        return_loaded=True, structure_only=("transformer", "decoder")) or {}
+    pipe = loaded["pipeline"]
+
+    assert so.structure_only_components(pipe) == ("decoder", "transformer")
+    for param in pipe.transformer.parameters():
+        assert mi.is_virtual(param)
+    for param in pipe.decoder.parameters():
+        assert mi.is_virtual(param)
+    facts = so.facts_of(pipe)
+    assert len(facts) == 2
+    assert sum(f.virtual_param_bytes for f in facts) > 0
+
+
+def test_a_pipeline_that_IGNORES_the_injection_is_refused_not_trusted(
+    tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``components=`` is a REQUEST. A class free to swallow the keyword and
+    load the checkpoint itself would hand a mint every weight it exists to
+    avoid, silently — so the composed object is checked, and the refusal names
+    what it built instead."""
+    from gen_worker.cli import run as run_mod
+
+    class Ignores:
+        transformer = "a real module, loaded from the checkpoint"
+
+    with pytest.raises(so.StructureOnlyUnsupported) as caught:
+        run_mod._assert_structure_honored(
+            Ignores(), {"transformer": object()}, slot="pipeline")
+    assert "does not carry the injected structure-only module" in str(
+        caught.value)
+
+
+def test_the_micro_tree_names_its_component_classes(tree: Path) -> None:
+    """Without a component class map there is nothing to build from config;
+    this is the packaging half of the contract and it is part of the tree."""
+    from gen_worker.models.loading import model_index_entry
+
+    assert model_index_entry(tree, "transformer") == (
+        "micro_diffusion.model", "MicroDenoiser")
+    assert model_index_entry(tree, "decoder") == (
+        "micro_diffusion.model", "MicroDecoder")


### PR DESCRIPTION
Increment 2 of the pgw#1056 minimal slice (increment 1 = the meta-instantiation gate, `b22eeb89`). The process that exports and compiles no longer holds the checkpoint.

## What it does

`src/gen_worker/models/structure_only.py` builds ONE named component from code + config — `accelerate.init_empty_weights()` + `from_config`, the shape `models/w8a8.py:558` / `w4a4.py:523` / `svdq_native.py:504` already use — and injects it through the loader's existing `components=` seam, so each pipeline class composes it exactly as it composes a preloaded shared component. Not a `structure_only=True` flag threaded to `from_pretrained`: a device context cannot make `from_pretrained` structure-only, and a pipeline's config is a component CLASS MAP, not a weights layout.

## The four things that had to be measured

1. **Fake parameters, real buffers.** Meta parameters cannot be exported beside a real input (`Tensor device mismatch … cpu and meta`) and cannot be compiled for a card. Fake tensors on the target device export and compile, and allocate nothing. Buffers stay real because they are config-derived and a literal-bearing cell packs them.
2. **The compile needs the program's fake mode AND its ShapeEnv.** `torch.export` builds its own; without installing it inductor refuses with `AssertionError: vr must not be None for symbol s21`.
3. **Compile-time constant folding bakes the values it saw.** On a weightless mint those are fake: the micro decoder's `norm.weight`/`norm.bias` vanished from the artifact's bindable set and the adopted cell scored **cosine 0.13** against eager. Weightless entries now compile with `aot_inductor.use_runtime_constant_folding` — which is also what pgw#1056's folding fence asks for.
4. **The entry pool serializes the exported program**, and a fake-parameter program cannot round-trip, so a weightless mint compiles serially and says so. (Pool support for weightless programs is recorded as owed, not hidden.)

## Refusals, not silence

`StructureOnlyUnsupported` names the class and what it lacks (no `load_config`/`from_config`; no `model_index.json` entry; a quantized artifact lane whose graph is decided by its weight table). The slot then loads real weights and the reason rides `MintReport.structure_refusal` — honest partial coverage. `_assert_structure_honored` checks the composed pipeline actually carries the injected module, because a class free to swallow the keyword would give a mint every weight it exists to avoid, silently.

## Touchpoints (coordinator ruling, 2026-08-10)

- pgw#984 warm proof runs on **random values** (fixed seed, finite by construction), released back to virtual before the export; stamped `warm_proof_values=random`.
- pgw#947 lane A/B is recorded as `verdict=unmeasured, reason=meta-mint` — the A/B is a whole-model benchmark and no card below Blackwell consumes the verdict.

## Footprint

`MintReport` carries `structure_only_components`, `virtual_param_bytes`, `structure_real_bytes`, `warm_proof_peak_bytes`/`warm_proof_values` and `export_peak_bytes`, and they ride the outcome line the hub already reads.

## RED control

`micro-rope` (new gauntlet member) transcribes upstream z-image's lazy CPU-pinned rope. Inside a fake-mode export that allocation is itself fake, so the mode-based gate cannot see it — the residue can: the warm proof runs the handler for real, and a tensor left on the tree that is neither parameter nor buffer is refused by name (`transformer.rope.freqs_cis`) with the authoring fix. The base `micro` row is the green twin.

Tracker: pgw#1080 (parent pgw#1056, wall ie#638).