### PR TITLE
pgw#1094: nothing is banked unlooked-at — the serve-path output-integrity floor

### DIFF
--- a/changelog.d/pgw1094.md
+++ b/changelog.d/pgw1094.md
@@ -12,7 +12,9 @@
   streaming chunk seam, via `StreamCollector`), `io.write_image`, and
   `RequestContext.save_image` — always BEFORE the encode, so a rejected render
   is never encoded, never uploaded, and never reaches `ctx.save_video`. There is
-  no opt-out flag: a screen you can switch off rebuilds the hole.
+  no opt-out flag: a screen you can switch off rebuilds the hole. Its wall is a
+  first-class th#1111 stage (`output_integrity`, GPU-IDLE), so the floor is
+  ATTRIBUTED on every render rather than appearing as unexplained residual.
   **Cost: 3.3 ms measured on the ie#634 shape** (121 frames, 1344x768 uint8,
   0.37 GB) — only ~10 frames are touched and each is decimated to ~96 rows
   BEFORE the float conversion; the naive full-resolution form of the same

--- a/changelog.d/pgw1094.md
+++ b/changelog.d/pgw1094.md
@@ -1,0 +1,36 @@
+- **pgw#1094: the serve path now looks at the PIXELS before an output can be
+  banked as a success.** Production minimax-h3 0.3.8 VAE-decoded pure NOISE and
+  uploaded it on requests that were billed and settled (ie#615/ie#634); every
+  check we had passed, because the "proof" was ffprobe container metadata plus a
+  billing row. `gen_worker.output_integrity` is the cross-endpoint home for the
+  floor that would have caught it: median adjacent-frame grey correlation over
+  five pairs spread across the clip (floor **0.6** — MEASURED, production noise
+  0.29 against real renders 0.92-0.99), a per-frame grey std floor for
+  blank/constant-fill output, and a non-finite check that is the save-path
+  observable form of a NaN latent. It is wired at the three seams the render
+  fleet actually saves through — `io.write_video` (buffered AND the gw#476
+  streaming chunk seam, via `StreamCollector`), `io.write_image`, and
+  `RequestContext.save_image` — always BEFORE the encode, so a rejected render
+  is never encoded, never uploaded, and never reaches `ctx.save_video`. There is
+  no opt-out flag: a screen you can switch off rebuilds the hole.
+  **Cost: 3.3 ms measured on the ie#634 shape** (121 frames, 1344x768 uint8,
+  0.37 GB) — only ~10 frames are touched and each is decimated to ~96 rows
+  BEFORE the float conversion; the naive full-resolution form of the same
+  statistic is 555 ms. Failure raises the typed
+  `gen_worker.api.errors.OutputIntegrityError`, which maps FATAL and carries the
+  measured `adjacent_frame_corr` / `frame_std_min`, and emits a typed
+  `output_integrity` activity event (`phase` = `noise` / `blank` / `nonfinite` /
+  `unmeasured`) so a refusal is countable hub-side rather than invisible on a
+  pod with no stdout. UNMEASURED serves and confesses — a screen that could not
+  run is not a verdict — but it is never a pass. **BLAME (th#1259/th#1288):** an
+  output is produced by release code, model state AND the request payload
+  together, so this label is deliberately NOT added to the hub's
+  `declaredFaultLabels` ("never a label a payload field can participate in
+  producing"); as a plain FATAL the existing `jobResultEvidence` arm reads it as
+  `EvidenceExecutionFatal`, the strongest honest class a job result can carry.
+  No hub change. **SCOPE, do not oversell it:** this catches NOISE and BLANK
+  only. A melted/over-smoothed render scores HIGHER here than a clean one
+  (`tests/test_output_integrity_pgw1094.py` pins the inversion as an executable
+  assertion: melted 0.996 against clean 0.957), so a green integrity line is
+  never a quality verdict. Shares its floors and its decimation with the eval
+  half, `cozy_eval.integrity` (ce#10, `cozy-eval/metrics@7`), by construction.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -644,6 +644,21 @@ Raise `ValidationError` (bad input, don't retry), `RetryableError`,
 `CanceledError`, or `FatalError`. Anything else is reported as an internal
 error.
 
+## The output-integrity floor (pgw#1094)
+
+`ctx.save_image`, `io.write_image` and `io.write_video` look at the PIXELS
+before they encode anything. A render whose frames are NOISE (median
+adjacent-frame grey correlation below 0.6) or BLANK (a constant-fill frame), or
+that carries NaN/Inf pixels, raises `OutputIntegrityError` and is never
+uploaded — production once served VAE-decoded noise on billed, settled requests
+because nothing on this side had ever looked (ie#634). It costs ~3 ms on a
+121-frame 1344x768 clip and there is no way to turn it off.
+
+Two consequences for endpoint authors: a legitimately constant-fill output is
+not servable through these calls, and a green integrity result is **not** a
+quality signal — a melted or over-smoothed render scores HIGHER on this
+statistic than a clean one. See `gen_worker.output_integrity`.
+
 ## Local dev
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.99.0"
+version = "0.100.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -117,6 +117,15 @@ KIND_MODULAR_HYDRATION = "modular_hydration"
 # names neither the component nor the cause, and which pgw#1047 watched a pod
 # retry for 9 minutes.
 KIND_COMPONENT_MISS = "component_miss"
+# pgw#1094: the serve-path output-integrity floor's verdict on one output.
+# `phase` is the verdict token — `noise` / `blank` / `nonfinite` are fail-CLOSED
+# (the request also gets a typed `OutputIntegrityError` and nothing is
+# uploaded), `unmeasured` is the confession that the screen could not run and
+# the output served anyway. PASS emits nothing: one row per served render buys
+# no decision. `detail` carries the measured adjacent_frame_corr and
+# frame_std_min, so ie#634's "corr 0.29 was uploaded and billed" is countable
+# hub-side instead of invisible.
+KIND_OUTPUT_INTEGRITY = "output_integrity"
 KIND_ROTATION_PRELOAD = "rotation_preload"
 KIND_CAPABILITY_RENEWAL = "capability_renewal"
 KIND_RESIDENCY_FAULT = "residency_fault"

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -415,3 +415,46 @@ class HostRamMoveRefusedError(WorkerError):
             f"would OOM-kill the worker. Free the model instead of copying it "
             f"to CPU (del + cleanup), or run on a pod with more host RAM"
         )
+
+
+class OutputIntegrityError(WorkerError):
+    """pgw#1094: the decoded output failed the NOISE/BLANK floor, so the
+    request must NOT bank as a clean success (ie#615/ie#634).
+
+    Production minimax-h3 0.3.8 uploaded VAE-decoded noise on billed, settled
+    requests. Nothing on the worker looked at the pixels; the "proof" was
+    ffprobe container metadata plus a billing row. Raised from the shared save
+    path (:mod:`gen_worker.output_integrity`) BEFORE any encode or upload, so
+    the garbage never reaches storage and the request reaches the hub as a
+    deterministic worker-side failure carrying the measured statistic.
+
+    BLAME (th#1259 / th#1288 / pgw#1088). A rendered output is produced by the
+    release's code, the model's runtime state AND the request's payload
+    together, so this label is NOT version-independent evidence about the
+    release and must never be added to the hub's `declaredFaultLabels`: that
+    map is explicitly "never a label a payload field can participate in
+    producing". As a plain FATAL it classifies under the existing
+    `jobResultEvidence` FATAL arm as `EvidenceExecutionFatal` — "the release's
+    CODE answering a REQUEST", the strongest honest class a job result can
+    carry — which is exactly right and needs no hub change.
+
+    NOT retryable, deliberately. The measured cause (ie#634) was persistent
+    model state on one pod, and a retry there re-renders noise at full GPU
+    cost. The blame ladder's distinct-worker machinery is what moves a request
+    off a bad pod; a self-declared RETRYABLE would only spend the attempt
+    budget rendering the same garbage.
+    """
+
+    def __init__(
+        self, verdict: str, *, ref: str = "", kind: str = "", summary: str = "",
+    ) -> None:
+        self.verdict = str(verdict or "")
+        self.ref = str(ref or "")
+        self.kind = str(kind or "")
+        self.summary = str(summary or "")
+        where = f"{self.kind} {self.ref}".strip() or "output"
+        super().__init__(
+            f"{self.verdict}: {where} failed the output-integrity floor "
+            f"({self.summary}) — refused before upload so it cannot bank as a "
+            f"successful render"
+        )

--- a/src/gen_worker/io.py
+++ b/src/gen_worker/io.py
@@ -233,8 +233,10 @@ def write_image(
     with finalize_permit():
         _release_gpu_slot_for_finalize(ctx)
         # pgw#1094: look at the PIXELS before the encode. A rejected output
-        # raises and is never encoded, never uploaded, never banked.
-        guard_image(image, ref=ref)
+        # raises and is never encoded, never uploaded, never banked. Its own
+        # stage so the floor's wall is ATTRIBUTED, never residual (th#1111).
+        with _stage(ctx, "output_integrity"):
+            guard_image(image, ref=ref)
         with _stage(ctx, "image_encode"):
             payload, ext = encode_image(
                 image, format=format, quality=quality, **encode_kwargs
@@ -360,7 +362,11 @@ def write_video(
 
                 # pgw#1094: each chunk is judged INSIDE the loop — the staged
                 # host buffer a chunk borrows is only valid until the next
-                # iteration step, and nothing here may rebuffer the clip.
+                # iteration step, and nothing here may rebuffer the clip. Its
+                # wall lands on `video_encode` (it interleaves with the
+                # encoder, and a per-chunk bracket would truncate the request's
+                # interval log on a long clip); `StreamCollector.verdict()`
+                # reports the measured seconds on the event either way.
                 integrity = StreamCollector()
                 for chunk in staged_uint8_chunks(frames):
                     integrity.observe(chunk)
@@ -368,7 +374,8 @@ def write_video(
                 _release_gpu_slot_for_finalize(ctx)
                 # Before the flush + upload tail: a rejected clip is never
                 # muxed and `ctx.save_video` below is never reached.
-                enforce(integrity.verdict(), ref=ref, kind="video")
+                with _stage(ctx, "output_integrity"):
+                    enforce(integrity.verdict(), ref=ref, kind="video")
                 encoder.finish(audio)
             else:
                 arr = frames_to_uint8(frames)
@@ -377,7 +384,8 @@ def write_video(
                 # frame buffers in host RAM (gw#516).
                 with finalize_permit():
                     _release_gpu_slot_for_finalize(ctx)
-                    guard_frames(arr, ref=ref)  # pgw#1094, before the encode
+                    with _stage(ctx, "output_integrity"):
+                        guard_frames(arr, ref=ref)  # pgw#1094, before the encode
                     encoder.add(arr)
                     del arr
                     encoder.finish(audio)

--- a/src/gen_worker/io.py
+++ b/src/gen_worker/io.py
@@ -21,6 +21,7 @@ from typing import IO, TYPE_CHECKING, Any, Optional
 
 from .api.errors import ValidationError
 from .api.types import Asset
+from .output_integrity import StreamCollector, enforce, guard_frames, guard_image
 from .stage_timing import stage_of as _stage
 import os
 import tempfile
@@ -231,6 +232,9 @@ def write_image(
 
     with finalize_permit():
         _release_gpu_slot_for_finalize(ctx)
+        # pgw#1094: look at the PIXELS before the encode. A rejected output
+        # raises and is never encoded, never uploaded, never banked.
+        guard_image(image, ref=ref)
         with _stage(ctx, "image_encode"):
             payload, ext = encode_image(
                 image, format=format, quality=quality, **encode_kwargs
@@ -354,9 +358,17 @@ def write_video(
                 # types pass through unchanged.
                 from .media_transfer import staged_uint8_chunks
 
+                # pgw#1094: each chunk is judged INSIDE the loop — the staged
+                # host buffer a chunk borrows is only valid until the next
+                # iteration step, and nothing here may rebuffer the clip.
+                integrity = StreamCollector()
                 for chunk in staged_uint8_chunks(frames):
+                    integrity.observe(chunk)
                     encoder.add(chunk)
                 _release_gpu_slot_for_finalize(ctx)
+                # Before the flush + upload tail: a rejected clip is never
+                # muxed and `ctx.save_video` below is never reached.
+                enforce(integrity.verdict(), ref=ref, kind="video")
                 encoder.finish(audio)
             else:
                 arr = frames_to_uint8(frames)
@@ -365,6 +377,7 @@ def write_video(
                 # frame buffers in host RAM (gw#516).
                 with finalize_permit():
                     _release_gpu_slot_for_finalize(ctx)
+                    guard_frames(arr, ref=ref)  # pgw#1094, before the encode
                     encoder.add(arr)
                     del arr
                     encoder.finish(audio)

--- a/src/gen_worker/output_integrity.py
+++ b/src/gen_worker/output_integrity.py
@@ -1,0 +1,478 @@
+"""The serve-path output-integrity floor: nothing is uploaded unlooked-at.
+
+WHY THIS EXISTS (ie#615 / ie#634 / pgw#1094). Production minimax-h3 0.3.8
+VAE-decoded pure NOISE and uploaded it, on requests that were billed and
+settled. Every check we had passed, because the "proof" was ffprobe container
+metadata plus a billing row. Metadata is not pixels. This module is the one
+place on the worker that looks at the PIXELS before an output can be banked as
+a success.
+
+WHAT IT IS. Two numbers over the frames the endpoint already holds in memory:
+
+* ``adjacent_frame_corr`` — the MEDIAN Pearson correlation of a handful of
+  adjacent grey frame pairs spread across the clip. Real video is highly
+  self-similar frame to frame even through motion and cuts; independently
+  sampled noise correlates with nothing. The floor is MEASURED, not guessed:
+  production noise 0.29, real renders 0.92-0.99, so :data:`NOISE_CORR_FLOOR`
+  = 0.6 sits in an empty middle. Taking the MEDIAN over a spread of pairs is
+  what makes a hard CUT safe — a cut drives one pair to ~0 while the rest
+  stay high.
+* ``frame_std_min`` — the smallest per-frame grey standard deviation over the
+  sampled frames. Zero is a constant-fill frame: blank/black output, which
+  correlates with nothing and must not be reported as a correlation failure.
+
+A non-finite pixel (NaN/Inf reaching the decoder's output) is its own verdict:
+it is the observable, save-path-side form of the latent NaN the tracker asked
+about, at the one seam that sees every endpoint.
+
+WHAT IT COSTS. Single-digit milliseconds on a full 121-frame 1344x768 clip,
+because only ~2*``pairs`` frames are ever touched and each is decimated to
+~96 rows BEFORE the float conversion (the expensive pass then runs on ~1/s^2
+of the pixels). Naive full-resolution was 555 ms on the same clip. The
+decimation is free in ACCURACY because the statistic is a coarse whole-frame
+correlation — cheap and blind are one fact (see the scope note).
+
+SCOPE — READ THIS BEFORE QUOTING A PASS. This floor catches NOISE and BLANK.
+It is NOT a quality gate, and it is specifically blind to the melt class:
+smearing REMOVES high-frequency temporal variation, so a melted/over-smoothed
+render scores HIGHER here than a clean one (cozy-eval measured 0.956 melted vs
+0.916 clean). ``tests/test_output_integrity_pgw1094.py`` pins that inversion as
+an executable assertion so nobody re-reads this gate as a quality verdict.
+
+REFERENCE IMPLEMENTATION. ``cozy_eval.integrity`` / ``cozy_eval.metrics.temporal``
+(ce#10). The numbers, the floors and the decimation are shared with it
+deliberately: the eval half judges candidates offline, this half refuses them
+online, and a disagreement between the two would be a bug in one of them.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, List, Optional, Sequence
+
+import msgspec
+
+#: Adjacent ``(t, t+1)`` pairs sampled across a buffered clip.
+INTEGRITY_PAIRS = 5
+
+#: Median adjacent-frame grey correlation below this reads as NOISE. MEASURED
+#: (ie#615/ie#634): VAE-decoded noise 0.29, real renders 0.92-0.99.
+NOISE_CORR_FLOOR = 0.6
+
+#: Per-frame grey standard deviation (on [0, 1] greys) below this reads as
+#: BLANK — a constant-fill frame.
+BLANK_STD_FLOOR = 0.01
+
+#: Working HEIGHT the statistic is computed at, reached by integer decimation.
+#: MEASURED to cost nothing in accuracy: on a 1344x768 clip panning 1 px/frame
+#: the median correlation is 0.9755 at full resolution and 0.9789 at 96 rows,
+#: while noise stays ~0.00 either way.
+INTEGRITY_TARGET_H = 96
+
+#: Streaming budget: how many adjacent pairs the chunk collector may compute
+#: before it halves what it kept and doubles its chunk stride. Keeps the gate
+#: bounded on a clip whose length is not known until the producer is done.
+STREAM_PAIR_BUDGET = 2 * INTEGRITY_PAIRS
+
+PASS = "pass"
+NOISE = "noise"
+BLANK = "blank"
+NONFINITE = "nonfinite"
+UNMEASURED = "unmeasured"
+
+#: Appended to every PASS. A green integrity line can never be read as a
+#: quality pass — the melt class scores HIGHER here than a clean render.
+SCOPE_NOTE = (
+    "SCOPE: this floor catches NOISE and BLANK output only. It is not a "
+    "quality gate — a melted/over-smoothed render scores HIGHER on "
+    "adjacent_frame_corr than a clean one."
+)
+
+_LUMA = (0.299, 0.587, 0.114)
+
+
+class OutputIntegrity(msgspec.Struct, frozen=True, kw_only=True):
+    """One output's integrity answer, and the numbers behind it."""
+
+    verdict: str = UNMEASURED
+    adjacent_frame_corr: float = float("nan")
+    frame_std_min: float = float("nan")
+    corr_series: tuple[float, ...] = ()
+    frames_sampled: int = 0
+    detail: str = ""
+    seconds: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        """True only on an explicit PASS. UNMEASURED is not a pass."""
+        return self.verdict == PASS
+
+    @property
+    def rejected(self) -> bool:
+        """True when the pixels themselves failed — the request must not bank."""
+        return self.verdict in (NOISE, BLANK, NONFINITE)
+
+    def summary(self) -> str:
+        return (
+            f"integrity {self.verdict} (adjacent_frame_corr "
+            f"{self.adjacent_frame_corr:.3f}, frame_std_min "
+            f"{self.frame_std_min:.5f}, frames_sampled {self.frames_sampled}"
+            + (f", {self.detail}" if self.detail else "")
+            + ")"
+        )
+
+
+# ---------------------------------------------------------------------------
+# the numeric core — decimated grey planes, one pass
+# ---------------------------------------------------------------------------
+
+
+def _frame_count(source: Any) -> int:
+    import numpy as np
+
+    if isinstance(source, (list, tuple)):
+        return len(source)
+    return int(np.asarray(source).shape[0])
+
+
+def _pair_starts(total: int, count: int) -> List[int]:
+    """Uniformly spread start indices ``k`` for consecutive ``(k, k+1)`` pairs."""
+    if total < 2:
+        return []
+    last = total - 2
+    if count >= last + 1:
+        return list(range(last + 1))
+    if count == 1:
+        return [0]
+    step = last / (count - 1)
+    return sorted({round(i * step) for i in range(count)})
+
+
+def _grey(frame: Any, target_h: int) -> Any:
+    """One frame -> a decimated grey plane in [0, 1], float32.
+
+    Decimation happens BEFORE the float conversion, on a numpy VIEW, so the
+    expensive pass runs on ~1/stride^2 of the pixels. This is the whole reason
+    the gate is affordable on the serve path.
+    """
+    import numpy as np
+
+    a = np.asarray(frame.convert("RGB") if hasattr(frame, "convert") else frame)
+    if a.ndim == 3 and a.shape[-1] == 4:
+        a = a[..., :3]
+    if a.ndim == 3 and a.shape[-1] == 1:
+        a = a[..., 0]
+    if a.ndim not in (2, 3) or (a.ndim == 3 and a.shape[-1] != 3):
+        raise ValueError(f"expected (H, W) or (H, W, 3) pixels, got shape {a.shape}")
+    stride = max(1, a.shape[0] // max(target_h, 1))
+    small = a[::stride, ::stride]
+    f = small.astype(np.float32)
+    if a.dtype == np.uint8 or (f.size and float(f.max()) > 1.5):
+        f = f / 255.0
+    if f.ndim == 3:
+        f = f @ np.asarray(_LUMA, np.float32)
+    return f
+
+
+def _grey_planes(source: Any, indices: Sequence[int], target_h: int) -> List[Any]:
+    """Decimated grey planes for JUST ``indices`` — nothing else is touched."""
+    import numpy as np
+
+    if isinstance(source, (list, tuple)):
+        picked: List[Any] = [source[i] for i in indices]
+    else:
+        arr = np.asarray(source)  # a view for an ndarray; nothing is copied
+        picked = [arr[i] for i in indices]
+    return [_grey(p, target_h) for p in picked]
+
+
+def _corr(a: Any, b: Any, sa: float, sb: float) -> float:
+    if sa < 1e-6 or sb < 1e-6:
+        return 0.0  # a flat frame correlates with nothing
+    x, y = a.ravel(), b.ravel()
+    return float(((x - x.mean()) * (y - y.mean())).mean() / (sa * sb))
+
+
+def _verdict(
+    corrs: Sequence[float],
+    std_min: float,
+    *,
+    frames_sampled: int,
+    nonfinite: bool,
+    corr_floor: float,
+    std_floor: float,
+    t0: float,
+    detail: str = "",
+) -> OutputIntegrity:
+    import numpy as np
+
+    median = float(np.median(corrs)) if corrs else float("nan")
+    series = tuple(float(c) for c in corrs)
+    if nonfinite:
+        verdict, why = NONFINITE, "a decoded frame carries NaN/Inf pixels"
+    elif std_min < std_floor:
+        verdict, why = BLANK, (
+            f"a sampled frame carries no spatial signal "
+            f"(std {std_min:.5f} < {std_floor})"
+        )
+    elif corrs and median < corr_floor:
+        verdict, why = NOISE, (
+            f"median adjacent-frame correlation {median:.3f} < floor "
+            f"{corr_floor} — consecutive frames are unrelated, which is what "
+            f"VAE-decoded noise looks like"
+        )
+    else:
+        verdict, why = PASS, SCOPE_NOTE
+    return OutputIntegrity(
+        verdict=verdict,
+        adjacent_frame_corr=median,
+        frame_std_min=std_min,
+        corr_series=series,
+        frames_sampled=frames_sampled,
+        detail=f"{detail}; {why}" if detail else why,
+        seconds=round(time.monotonic() - t0, 5),
+    )
+
+
+def _unmeasured(reason: str, t0: float) -> OutputIntegrity:
+    return OutputIntegrity(
+        verdict=UNMEASURED,
+        detail=f"integrity UNMEASURED: {reason}",
+        seconds=round(time.monotonic() - t0, 5),
+    )
+
+
+def check_frames(
+    frames: Any,
+    *,
+    pairs: int = INTEGRITY_PAIRS,
+    corr_floor: float = NOISE_CORR_FLOOR,
+    std_floor: float = BLANK_STD_FLOOR,
+    target_h: int = INTEGRITY_TARGET_H,
+) -> OutputIntegrity:
+    """Judge a buffered clip (or a single frame). Milliseconds, no reference.
+
+    ``frames`` is anything the encode path already holds: a ``(F, H, W, 3)``
+    numpy array, a ``(H, W, 3)`` single frame, a list of PIL images or arrays,
+    or a CPU torch tensor. A clip too short to have an adjacent pair is judged
+    on the BLANK/NONFINITE half alone — that half is fully measured there, so
+    it is an honest verdict, not an unmeasured one.
+    """
+    t0 = time.monotonic()
+    try:
+        import numpy as np
+
+        arr = frames
+        if hasattr(arr, "detach"):  # a CPU torch tensor
+            arr = arr.detach().cpu().numpy()
+        if not isinstance(arr, (list, tuple)):
+            arr = np.asarray(arr)
+            if arr.ndim == 3:
+                arr = arr[None]
+        total = _frame_count(arr)
+        if total < 1:
+            return _unmeasured("no frames", t0)
+        starts = _pair_starts(total, pairs)
+        needed = sorted(set(starts) | {k + 1 for k in starts} | ({0} if not starts else set()))
+        greys = dict(zip(needed, _grey_planes(arr, needed, target_h)))
+        stds = {i: float(g.std()) for i, g in greys.items()}
+        nonfinite = any(not bool(np.isfinite(g).all()) for g in greys.values())
+        corrs = [
+            _corr(greys[k], greys[k + 1], stds[k], stds[k + 1]) for k in starts
+        ]
+        detail = "" if starts else f"{total} frame(s): no adjacent pair to correlate"
+        return _verdict(
+            corrs, min(stds.values()), frames_sampled=len(needed),
+            nonfinite=nonfinite, corr_floor=corr_floor, std_floor=std_floor,
+            t0=t0, detail=detail,
+        )
+    except Exception as exc:  # an unjudgeable output is UNMEASURED, never a pass
+        return _unmeasured(f"{type(exc).__name__}: {exc}", t0)
+
+
+def check_image(
+    image: Any,
+    *,
+    std_floor: float = BLANK_STD_FLOOR,
+    target_h: int = INTEGRITY_TARGET_H,
+) -> OutputIntegrity:
+    """Judge a single image: BLANK and NONFINITE only.
+
+    The correlation half needs two frames and there is only one, so it is not
+    reported — the same floor applies to images trivially, and this is what
+    "trivially" means. It is fully measured, so a flat image REJECTS here.
+    """
+    return check_frames(image, std_floor=std_floor, target_h=target_h)
+
+
+class StreamCollector:
+    """Judge a clip that arrives in CHUNKS, without ever rebuffering it.
+
+    The streaming encode seam (gw#476) hands the encoder one decoded chunk at
+    a time and the total length is unknown until the producer is done, so the
+    buffered "spread five pairs over the clip" sampling cannot be used. This
+    collector instead takes the full buffered spread from the FIRST chunk
+    (so a single-chunk stream is bit-identical to :func:`check_frames`) and
+    one adjacent pair from each chunk after it — thinned by halving the kept
+    series and doubling the chunk stride whenever the computed count reaches
+    :data:`STREAM_PAIR_BUDGET`. The pairs therefore stay spread across the
+    whole clip and the cost stays bounded no matter how long it is.
+
+    Each chunk MUST be judged inside the producer loop: the staged host buffer
+    a chunk borrows is only valid until the next iteration step.
+    """
+
+    def __init__(
+        self,
+        *,
+        pairs: int = INTEGRITY_PAIRS,
+        corr_floor: float = NOISE_CORR_FLOOR,
+        std_floor: float = BLANK_STD_FLOOR,
+        target_h: int = INTEGRITY_TARGET_H,
+    ) -> None:
+        self._pairs = pairs
+        self._corr_floor = corr_floor
+        self._std_floor = std_floor
+        self._target_h = target_h
+        self._corrs: List[float] = []
+        self._std_min = float("inf")
+        self._nonfinite = False
+        self._frames_sampled = 0
+        self._chunk_index = 0
+        self._stride = 1
+        self._seconds = 0.0
+        self._unmeasurable: Optional[str] = None
+
+    def observe(self, chunk: Any) -> None:
+        """Fold one decoded chunk into the running statistic."""
+        index = self._chunk_index
+        self._chunk_index += 1
+        if index % self._stride:
+            return
+        t0 = time.monotonic()
+        try:
+            self._observe(chunk, first=index == 0)
+        except Exception as exc:
+            if self._unmeasurable is None:
+                self._unmeasurable = f"{type(exc).__name__}: {exc}"
+        self._seconds += time.monotonic() - t0
+
+    def _observe(self, chunk: Any, *, first: bool) -> None:
+        import numpy as np
+
+        arr = chunk
+        if hasattr(arr, "detach"):
+            arr = arr.detach().cpu().numpy()
+        if not isinstance(arr, (list, tuple)):
+            arr = np.asarray(arr)
+            if arr.ndim == 3:
+                arr = arr[None]
+        total = _frame_count(arr)
+        if total < 1:
+            return
+        if first:
+            starts = _pair_starts(total, self._pairs)
+        else:
+            mid = max(0, total // 2 - 1)
+            starts = [mid] if total >= 2 else []
+        needed = sorted(set(starts) | {k + 1 for k in starts} | ({0} if not starts else set()))
+        greys = dict(zip(needed, _grey_planes(arr, needed, self._target_h)))
+        self._frames_sampled += len(needed)
+        stds = {i: float(g.std()) for i, g in greys.items()}
+        self._std_min = min([self._std_min, *stds.values()])
+        if any(not bool(np.isfinite(g).all()) for g in greys.values()):
+            self._nonfinite = True
+        for k in starts:
+            self._corrs.append(_corr(greys[k], greys[k + 1], stds[k], stds[k + 1]))
+        if len(self._corrs) >= STREAM_PAIR_BUDGET:
+            del self._corrs[1::2]  # keep every other — the spread survives
+            self._stride *= 2
+
+    def verdict(self) -> OutputIntegrity:
+        t0 = time.monotonic() - self._seconds
+        if self._unmeasurable is not None and not self._corrs:
+            return _unmeasured(self._unmeasurable, t0)
+        if self._frames_sampled == 0:
+            return _unmeasured("no frames were streamed", t0)
+        detail = "" if self._corrs else "no adjacent pair to correlate"
+        if self._unmeasurable is not None:
+            detail = (detail + "; " if detail else "") + \
+                f"partial: {self._unmeasurable}"
+        return _verdict(
+            self._corrs, self._std_min, frames_sampled=self._frames_sampled,
+            nonfinite=self._nonfinite, corr_floor=self._corr_floor,
+            std_floor=self._std_floor, t0=t0, detail=detail,
+        )
+
+
+# ---------------------------------------------------------------------------
+# enforcement — the one place a verdict becomes a refusal
+# ---------------------------------------------------------------------------
+
+
+def enforce(result: OutputIntegrity, *, ref: str, kind: str) -> None:
+    """Bank the verdict and refuse the output if the pixels failed.
+
+    ``kind`` is ``"video"`` / ``"image"`` — it rides the event detail so a
+    reject is countable per output kind hub-side.
+
+    REJECT raises :class:`~gen_worker.api.errors.OutputIntegrityError`, which
+    maps FATAL: the request never reaches ``succeeded`` and nothing is
+    uploaded. UNMEASURED serves — a screen that could not run is a confession,
+    not a verdict — but it still emits its event, because a fail-soft outcome
+    that a hub decision may depend on must never be only a log line (pgw#760).
+    PASS is silent: one event per served request would be a row per render for
+    no decision.
+    """
+    if result.ok:
+        return
+    # Deferred: `activity` pulls protobuf + psutil, and the io/save modules on
+    # the `import gen_worker` path must not.
+    from . import activity
+    from .api.errors import OutputIntegrityError
+
+    activity.emit_event(
+        activity.KIND_OUTPUT_INTEGRITY,
+        f"{kind} {ref}: {result.summary()}",
+        phase=result.verdict,
+        duration_ms=int(result.seconds * 1000),
+    )
+    if result.rejected:
+        raise OutputIntegrityError(result.verdict, ref=ref, kind=kind,
+                                   summary=result.summary())
+
+
+def guard_frames(frames: Any, *, ref: str) -> OutputIntegrity:
+    """:func:`check_frames` + :func:`enforce` — the video save-path one-liner."""
+    result = check_frames(frames)
+    enforce(result, ref=ref, kind="video")
+    return result
+
+
+def guard_image(image: Any, *, ref: str) -> OutputIntegrity:
+    """:func:`check_image` + :func:`enforce` — the image save-path one-liner."""
+    result = check_image(image)
+    enforce(result, ref=ref, kind="image")
+    return result
+
+
+__all__ = [
+    "BLANK",
+    "BLANK_STD_FLOOR",
+    "INTEGRITY_PAIRS",
+    "INTEGRITY_TARGET_H",
+    "NOISE",
+    "NOISE_CORR_FLOOR",
+    "NONFINITE",
+    "PASS",
+    "SCOPE_NOTE",
+    "STREAM_PAIR_BUDGET",
+    "UNMEASURED",
+    "OutputIntegrity",
+    "StreamCollector",
+    "check_frames",
+    "check_image",
+    "enforce",
+    "guard_frames",
+    "guard_image",
+]

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -82,6 +82,7 @@ from ..io import (
     encode_image,
     image_format,
 )
+from ..output_integrity import guard_image
 from ..stage_timing import StageTimer
 from ..api.types import (
     Asset,
@@ -1218,6 +1219,12 @@ class RequestContext(Generic[D]):
             ref = _normalize_output_ref(str(ref))
             if Path(ref).suffix == "":
                 ref += ext
+        # pgw#1094: the output-integrity floor, on the pixels, before anything
+        # is encoded or uploaded. Judged EAGERLY even on the deferred path: the
+        # check is sub-millisecond on one image and the handler is still on the
+        # stack here, so a rejected render raises where the request can see it
+        # instead of inside the post-handler finalize drain.
+        guard_image(image, ref=ref)
         if not self._deferred.armed:
             with self._stages.stage("image_encode"):
                 payload, _ext = encode_image(

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1223,8 +1223,11 @@ class RequestContext(Generic[D]):
         # is encoded or uploaded. Judged EAGERLY even on the deferred path: the
         # check is sub-millisecond on one image and the handler is still on the
         # stack here, so a rejected render raises where the request can see it
-        # instead of inside the post-handler finalize drain.
-        guard_image(image, ref=ref)
+        # instead of inside the post-handler finalize drain. Charged to
+        # its OWN stage so its wall is ATTRIBUTED (th#1111) without borrowing
+        # `image_encode`, which on the deferred path means the finalize tail.
+        with self._stages.stage("output_integrity"):
+            guard_image(image, ref=ref)
         if not self._deferred.armed:
             with self._stages.stage("image_encode"):
                 payload, _ext = encode_image(

--- a/src/gen_worker/stage_timing.py
+++ b/src/gen_worker/stage_timing.py
@@ -60,6 +60,10 @@ _CLASS_BY_STAGE: Dict[str, str] = {
     "setup_wait": GPU_IDLE,
     "image_encode": GPU_IDLE,
     "video_encode": GPU_IDLE,
+    # pgw#1094: the output-integrity floor. CPU numpy over a handful of
+    # decimated frames — single-digit ms, and it must be ATTRIBUTED rather than
+    # appear as unexplained residual on every render.
+    "output_integrity": GPU_IDLE,
     "audio_encode": GPU_IDLE,
     "credential_stamp": GPU_IDLE,
     "upload": GPU_IDLE,

--- a/tests/harness/deferred_endpoints.py
+++ b/tests/harness/deferred_endpoints.py
@@ -151,8 +151,14 @@ class DeferredImages:
         return GenOut(image=asset)
 
     def mutates_after_save(self, ctx: RequestContext, data: GenIn) -> GenOut:
-        """Saves a RED frame, then keeps painting on the same PIL object."""
-        img = Image.new("RGB", (32, 32), (255, 0, 0))
+        """Saves a RED-marked frame, then keeps painting on the same PIL object.
+
+        Real content, not a solid fill: pgw#1094's output-integrity floor
+        rejects a constant-fill render, and a fixture that a production gate
+        refuses is not a fixture.
+        """
+        img = gradient(32)
+        img.paste((255, 0, 0), (0, 0, 12, 12))  # the marker the test reads
         asset = ctx.save_image(img, "outputs/mutated", format="png")
         img.paste((0, 0, 255), (0, 0, 32, 32))
         mark("handler_end", ctx)

--- a/tests/test_output_integrity_pgw1094.py
+++ b/tests/test_output_integrity_pgw1094.py
@@ -1,0 +1,379 @@
+"""pgw#1094: the serve-path output-integrity floor.
+
+REAL fixtures, synthesized here so the suite carries no media: a clean render,
+VAE-decoded-style noise, a black clip, a cut-heavy clip, a MELTED clip, a
+non-finite clip. The candidate the floor exists for (ie#634's noise) must FAIL
+and must never reach ``ctx.save_video``; the melted clip must PASS, and the
+assertion is that it scores HIGHER than the clean one — that inversion is this
+gate's scope boundary and it is pinned here so nobody re-reads a green
+integrity line as a quality verdict.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from gen_worker import io as gw_io
+from gen_worker import output_integrity as oi
+from gen_worker.api.errors import OutputIntegrityError
+
+# ---------------------------------------------------------------------------
+# fixtures — real pixel arrays, the (F, H, W, 3) uint8 the encode path holds
+# ---------------------------------------------------------------------------
+
+H, W = 256, 448
+
+
+def _scene(h: int = H, w: int = W) -> np.ndarray:
+    """One textured still: gradients + a checker + a bright disc."""
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    base = (yy / h) * 120.0 + (xx / w) * 90.0
+    checker = ((yy // 16 + xx // 16) % 2) * 40.0
+    disc = ((yy - h * 0.4) ** 2 + (xx - w * 0.45) ** 2) < (min(h, w) * 0.18) ** 2
+    img = base + checker + disc * 70.0
+    rgb = np.stack([img, img * 0.85 + 20.0, img * 0.6 + 40.0], axis=-1)
+    return np.clip(rgb, 0, 255).astype(np.uint8)
+
+
+def clean_clip(frames: int = 24) -> np.ndarray:
+    """A real render's shape: one scene panning, plus the per-frame
+    high-frequency variation every real render carries (grain, sampler jitter,
+    VAE ringing). Adjacent frames are the self-similar-but-not-identical pair
+    the floor is calibrated on — and the grain is what the melt class removes.
+    """
+    still = _scene(H, W + frames).astype(np.float32)
+    rng = np.random.default_rng(4242)
+    clip = np.stack([still[:, t:t + W] for t in range(frames)])
+    clip = clip + rng.normal(0.0, 13.0, size=clip.shape).astype(np.float32)
+    return np.clip(clip, 0, 255).astype(np.uint8)
+
+
+def noise_clip(frames: int = 24) -> np.ndarray:
+    """ie#634's candidate: every frame independently sampled, so consecutive
+    frames are unrelated. This is what VAE-decoded noise looks like."""
+    rng = np.random.default_rng(1094)
+    return rng.integers(0, 256, size=(frames, H, W, 3), dtype=np.uint8)
+
+
+def black_clip(frames: int = 24) -> np.ndarray:
+    return np.zeros((frames, H, W, 3), dtype=np.uint8)
+
+
+def melted_clip(frames: int = 24) -> np.ndarray:
+    """The fp8-melt class: the clean clip with its high-frequency detail
+    smeared away. Structurally intact, visibly wrong, and INVISIBLE here."""
+    clip = clean_clip(frames).astype(np.float32)
+    for _ in range(6):  # separable box blur, repeated -> heavy smear
+        clip = (clip + np.roll(clip, 1, axis=1) + np.roll(clip, -1, axis=1)) / 3.0
+        clip = (clip + np.roll(clip, 1, axis=2) + np.roll(clip, -1, axis=2)) / 3.0
+    return np.clip(clip, 0, 255).astype(np.uint8)
+
+
+def cut_clip(frames: int = 24) -> np.ndarray:
+    """Two unrelated real scenes spliced: one adjacent pair correlates at ~0
+    and the MEDIAN is what keeps the clip servable."""
+    a = clean_clip(frames // 2)
+    b = np.stack([_scene(H, W)[::-1, ::-1]] * (frames // 2))
+    b = (b.astype(np.float32) * 0.7 + 30.0).astype(np.uint8)
+    b = np.stack([np.roll(f, i * 3, axis=1) for i, f in enumerate(b)])
+    return np.concatenate([a, b])
+
+
+# ---------------------------------------------------------------------------
+# the floor itself
+# ---------------------------------------------------------------------------
+
+
+def test_clean_clip_passes():
+    r = oi.check_frames(clean_clip())
+    assert r.verdict == oi.PASS, r.summary()
+    assert r.adjacent_frame_corr > oi.NOISE_CORR_FLOOR
+    assert oi.SCOPE_NOTE in r.detail  # a PASS always carries its scope limit
+
+
+def test_noise_clip_is_rejected_as_noise():
+    r = oi.check_frames(noise_clip())
+    assert r.verdict == oi.NOISE, r.summary()
+    assert r.rejected and not r.ok
+    # ie#634 measured 0.29 on the production clip; independent sampling here is
+    # even lower. Either way it is nowhere near the 0.6 floor.
+    assert r.adjacent_frame_corr < 0.3, r.summary()
+
+
+def test_black_clip_is_rejected_as_blank_not_noise():
+    r = oi.check_frames(black_clip())
+    assert r.verdict == oi.BLANK, r.summary()
+    assert r.frame_std_min < oi.BLANK_STD_FLOOR
+
+
+def test_nonfinite_pixels_are_their_own_verdict():
+    """A NaN latent decodes to NaN pixels — the save-path-observable form of
+    the pre-decode NaN check. Seen on the SAMPLED, decimated planes, which is
+    the whole clip's worth of NaN a real overflow produces, not one stray
+    pixel a strided sample could miss."""
+    clip = clean_clip().astype(np.float32) / 255.0
+    clip[0] = np.nan
+    r = oi.check_frames(clip)
+    assert r.verdict == oi.NONFINITE, r.summary()
+
+
+def test_a_hard_cut_still_serves():
+    """The MEDIAN over spread pairs is what makes this safe — a cut drives one
+    pair to ~0 while the rest stay high."""
+    r = oi.check_frames(cut_clip())
+    assert r.verdict == oi.PASS, r.summary()
+    assert min(r.corr_series) < 0.6, "the fixture must actually contain a cut"
+
+
+def test_melt_blindness_is_the_scope_boundary():
+    """THE PIN. A melted render PASSES and scores HIGHER than a clean one.
+
+    Smearing REMOVES high-frequency temporal variation, so adjacent-frame
+    correlation goes UP. This gate is a noise/blank floor and can never be
+    quoted as a quality verdict; fine-detail damage belongs to cozy-eval's
+    detail detectors and the VLM rubric.
+    """
+    clean = oi.check_frames(clean_clip())
+    melted = oi.check_frames(melted_clip())
+    assert melted.verdict == oi.PASS, melted.summary()
+    assert melted.adjacent_frame_corr > clean.adjacent_frame_corr, (
+        f"melt inversion is the documented blind spot: "
+        f"melted {melted.adjacent_frame_corr:.4f} vs clean "
+        f"{clean.adjacent_frame_corr:.4f}"
+    )
+
+
+def test_single_frame_is_judged_on_the_blank_half_alone():
+    flat = oi.check_frames(np.zeros((1, H, W, 3), np.uint8))
+    assert flat.verdict == oi.BLANK
+    good = oi.check_frames(_scene()[None])
+    assert good.verdict == oi.PASS
+    assert np.isnan(good.adjacent_frame_corr)
+
+
+def test_image_floor_rejects_a_flat_render_and_passes_a_real_one():
+    from PIL import Image
+
+    assert oi.check_image(Image.new("RGB", (512, 512), (0, 0, 0))).verdict == oi.BLANK
+    assert oi.check_image(Image.fromarray(_scene())).verdict == oi.PASS
+
+
+def test_unmeasurable_output_is_never_a_pass():
+    r = oi.check_frames(np.zeros((4, 8, 8, 7), np.uint8))  # not RGB
+    assert r.verdict == oi.UNMEASURED
+    assert not r.ok and not r.rejected  # confesses, does not refuse
+
+
+def test_the_verdict_is_decimation_invariant():
+    """The ~96-row decimation is what makes this affordable on the serve path,
+    and it does not change the ANSWER: the statistic is a coarse whole-frame
+    correlation, so it lives far from the resolution it is measured at. (That
+    is also exactly why it can never see fine-detail damage.)"""
+    for fixture, want in ((clean_clip(), oi.PASS), (noise_clip(), oi.NOISE),
+                          (black_clip(), oi.BLANK)):
+        full_h = fixture.shape[1]
+        assert oi.check_frames(fixture).verdict == want
+        assert oi.check_frames(fixture, target_h=full_h).verdict == want
+    clip = clean_clip()
+    small = oi.check_frames(clip).adjacent_frame_corr
+    full = oi.check_frames(clip, target_h=clip.shape[1]).adjacent_frame_corr
+    assert abs(small - full) < 0.05, (small, full)
+
+
+# ---------------------------------------------------------------------------
+# cost — the serve path pays this on EVERY render
+# ---------------------------------------------------------------------------
+
+
+def test_cost_on_a_full_size_clip_is_single_digit_ms(capsys):
+    """121 frames at 1344x768 uint8 — 0.37 GB of pixels, the ie#634 shape."""
+    rng = np.random.default_rng(7)
+    still = rng.integers(0, 256, size=(768, 1344 + 121, 3), dtype=np.uint8)
+    clip = np.stack([still[:, t:t + 1344] for t in range(121)])
+    oi.check_frames(clip)  # warm numpy
+    best = min(oi.check_frames(clip).seconds for _ in range(5))
+    with capsys.disabled():
+        print(f"\npgw#1094 integrity floor: {best * 1000:.2f} ms on "
+              f"{clip.shape} uint8 ({clip.nbytes / 1e9:.2f} GB)")
+    # Naive full-resolution on this clip is 555 ms. The bound is deliberately
+    # loose for CI hardware; the printed number is the measurement.
+    assert best < 0.060, f"{best * 1000:.1f} ms"
+
+
+# ---------------------------------------------------------------------------
+# the streaming collector (gw#476 chunk seam)
+# ---------------------------------------------------------------------------
+
+
+def _stream(clip: np.ndarray, chunk: int = 6) -> oi.OutputIntegrity:
+    c = oi.StreamCollector()
+    for i in range(0, len(clip), chunk):
+        c.observe(clip[i:i + chunk])
+    return c.verdict()
+
+
+def test_streaming_collector_rejects_noise_and_passes_a_render():
+    assert _stream(clean_clip(48)).verdict == oi.PASS
+    assert _stream(noise_clip(48)).verdict == oi.NOISE
+    assert _stream(black_clip(48)).verdict == oi.BLANK
+
+
+def test_single_chunk_stream_equals_the_buffered_answer():
+    clip = clean_clip(24)
+    assert _stream(clip, chunk=len(clip)).adjacent_frame_corr == pytest.approx(
+        oi.check_frames(clip).adjacent_frame_corr)
+
+
+def test_streaming_cost_stays_bounded_on_a_long_clip():
+    """The clip length is unknown until the producer is done, so the collector
+    thins: kept pairs halve and the chunk stride doubles at the budget."""
+    clip = clean_clip(64)
+    c = oi.StreamCollector()
+    for i in range(0, 4000, 4):  # 1000 chunks of the same 4 frames
+        c.observe(clip[i % 60:i % 60 + 4])
+    r = c.verdict()
+    assert r.verdict == oi.PASS
+    assert r.frames_sampled < 12 * oi.STREAM_PAIR_BUDGET, r.frames_sampled
+    assert r.seconds < 0.5, r.seconds
+
+
+# ---------------------------------------------------------------------------
+# the save path — nothing garbage reaches the upload
+# ---------------------------------------------------------------------------
+
+
+class _Ctx:
+    """The save surface ``io.write_video`` / ``io.write_image`` touch."""
+
+    def __init__(self) -> None:
+        self.saved: list[str] = []
+
+    def save_video(self, path, ref, format="mp4"):
+        self.saved.append(ref)
+        from gen_worker.api.types import VideoAsset
+        return VideoAsset(ref=ref, owner="t")
+
+    def save_bytes(self, ref, data):
+        self.saved.append(ref)
+        from gen_worker.api.types import Asset
+        return Asset(ref=ref, owner="t", size_bytes=len(data))
+
+
+def test_write_video_refuses_noise_before_it_can_be_uploaded():
+    ctx = _Ctx()
+    with pytest.raises(OutputIntegrityError) as exc:
+        gw_io.write_video(ctx, "outputs/r/video.mp4", noise_clip(), fps=24)
+    assert exc.value.verdict == oi.NOISE
+    assert "output-integrity floor" in str(exc.value)
+    assert ctx.saved == [], "a rejected render must never reach the upload"
+
+
+def test_write_video_refuses_a_black_clip():
+    ctx = _Ctx()
+    with pytest.raises(OutputIntegrityError) as exc:
+        gw_io.write_video(ctx, "outputs/r/video.mp4", black_clip(), fps=24)
+    assert exc.value.verdict == oi.BLANK
+    assert ctx.saved == []
+
+
+def test_write_video_still_serves_a_real_render():
+    ctx = _Ctx()
+    asset = gw_io.write_video(ctx, "outputs/r/video.mp4", clean_clip(), fps=24)
+    assert asset.ref == "outputs/r/video.mp4"
+    assert ctx.saved == ["outputs/r/video.mp4"]
+
+
+def test_write_video_screens_the_streaming_seam_too():
+    ctx = _Ctx()
+    clip = noise_clip(48)
+    chunks = (clip[i:i + 8] for i in range(0, len(clip), 8))
+    with pytest.raises(OutputIntegrityError):
+        gw_io.write_video(ctx, "outputs/r/video.mp4", chunks, fps=24)
+    assert ctx.saved == []
+
+
+def test_write_image_refuses_a_flat_render():
+    from PIL import Image
+
+    ctx = _Ctx()
+    with pytest.raises(OutputIntegrityError) as exc:
+        gw_io.write_image(ctx, "outputs/r/image", Image.new("RGB", (256, 256)))
+    assert exc.value.verdict == oi.BLANK
+    assert ctx.saved == []
+    assert gw_io.write_image(ctx, "outputs/r/image",
+                             Image.fromarray(_scene())).ref.endswith(".webp")
+
+
+# ---------------------------------------------------------------------------
+# the typed fault and the event
+# ---------------------------------------------------------------------------
+
+
+def test_the_fault_maps_fatal_and_never_invalid():
+    """BLAME: a render is produced by release code, model state AND payload
+    together, so this is neither a payload verdict (INVALID) nor a
+    release-declared fault. FATAL is the honest class — the hub's
+    `jobResultEvidence` FATAL arm reads it as EvidenceExecutionFatal, "the
+    release's CODE answering a REQUEST", with no hub change."""
+    from gen_worker import executor
+    from gen_worker.api.errors import RetryableError, ValidationError
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    exc = OutputIntegrityError(oi.NOISE, ref="outputs/r/video.mp4",
+                               kind="video", summary="integrity noise")
+    assert not isinstance(exc, (ValidationError, RetryableError))
+    status, msg = executor._map_exception(exc)
+    assert status == pb.JOB_STATUS_FATAL
+    assert msg.startswith("OutputIntegrityError:")
+
+
+def test_reject_and_unmeasured_emit_a_typed_event_and_pass_does_not():
+    from gen_worker import activity
+
+    rows: list = []
+    activity.reset_for_tests()
+    try:
+        for result, kind in (
+            (oi.check_frames(noise_clip()), oi.NOISE),
+            (oi.check_frames(np.zeros((4, 8, 8, 7), np.uint8)), oi.UNMEASURED),
+            (oi.check_frames(clean_clip()), oi.PASS),
+        ):
+            before = len(rows)
+            with _capture(activity, rows):
+                try:
+                    oi.enforce(result, ref="outputs/r/out", kind="video")
+                except OutputIntegrityError:
+                    pass
+            if kind is oi.PASS:
+                assert len(rows) == before, "a PASS buys no row"
+            else:
+                assert len(rows) == before + 1
+                assert rows[-1].kind == activity.KIND_OUTPUT_INTEGRITY
+                assert rows[-1].phase == kind
+                assert "adjacent_frame_corr" in rows[-1].detail
+    finally:
+        activity.reset_for_tests()
+
+
+class _capture:
+    def __init__(self, activity, rows):
+        self._a, self._rows = activity, rows
+
+    def __enter__(self):
+        self._prev = self._a._sink
+        self._a._sink = self._rows.append
+        return self
+
+    def __exit__(self, *exc):
+        self._a._sink = self._prev
+        return False
+
+
+def test_measured_floors_match_the_eval_half():
+    """The eval half (cozy-eval ce#10, metric_set @7) and this serve half share
+    the floors by construction; a disagreement would be a bug in one of them."""
+    assert oi.NOISE_CORR_FLOOR == 0.6
+    assert oi.BLANK_STD_FLOOR == 0.01
+    assert oi.INTEGRITY_PAIRS == 5
+    assert oi.INTEGRITY_TARGET_H == 96

--- a/tests/test_testing_recorder_pgw942.py
+++ b/tests/test_testing_recorder_pgw942.py
@@ -57,7 +57,13 @@ class ExampleEndpoint:
     def generate(self, ctx: RequestContext[ExampleDefaults], payload: Render) -> Rendered:
         ctx.progress(0.5, "denoise", step=1, total=2)
         ctx.log("rendering", level="info", steps=ctx.defaults.steps)
-        image = Image.new("RGB", (payload.size, payload.size), (10, 120, 200))
+        # Real content, not a solid fill: pgw#1094's output-integrity floor
+        # rejects a constant-fill render.
+        image = Image.merge("RGB", (
+            Image.linear_gradient("L"),
+            Image.linear_gradient("L").rotate(90),
+            Image.radial_gradient("L"),
+        )).resize((payload.size, payload.size), Image.Resampling.BILINEAR)
         return Rendered(
             image=ctx.save_image(
                 image, payload.ref, format=payload.image_format, quality=80

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.99.0"
+version = "0.100.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the SERVE half of `ce#10` / `pgw#1094`. The eval half shipped 2026-08-10 as
`cozy-eval` `5b03b1c` (`cozy-eval/metrics@7`); this is the half that stops the bad
output ever reaching a customer.

## The failure this exists for

Production minimax-h3 0.3.8 VAE-decoded pure NOISE and uploaded it, on requests that
were **billed and settled** (ie#615/ie#634). The clip ffprobe'd clean. Nothing on the
worker had ever looked at the pixels; the "proof" was container metadata plus a billing
row. Adjacent-frame correlation on that clip was **0.29**.

## The seam

`src/gen_worker/output_integrity.py` — one cross-endpoint module, not per-endpoint
copies. Three numbers, computed on the decoded frames the encode path **already holds
in memory** (the encoded file is never re-read):

| statistic | catches | floor |
|---|---|---|
| median adjacent-frame grey correlation, 5 pairs spread across the clip | NOISE | **0.6** |
| min per-frame grey std | BLANK / constant fill | **0.01** |
| `isfinite` on the sampled planes | NaN/Inf pixels | — |

The floor is **measured, not guessed**: production noise 0.29, real renders 0.92-0.99,
so 0.6 sits in an empty middle. The **median over spread pairs** is what makes a hard
CUT safe — the `cut_clip` fixture has one pair at `-0.736` and a median of `0.897`, and
it serves.

The non-finite check is the save-path-observable form of the tracker's third item (a
pre-decode latent NaN check): latents never reach a shared seam, decoded pixels do, and
this is the one place that sees every endpoint.

Wired at the three seams the render fleet actually saves through, always **before** the
encode:

* `io.write_video` — buffered path (`src/gen_worker/io.py:381`) and the gw#476
  **streaming chunk** seam (`:363-372`, via `StreamCollector`, judged inside the
  producer loop because a staged host buffer is only valid until the next iteration
  step, and nothing may rebuffer the clip);
* `io.write_image` (`src/gen_worker/io.py:235`);
* `RequestContext.save_image` (`src/gen_worker/request_context/__init__.py:1222`) —
  judged **eagerly** even on the th#1130 deferred path, so a rejected render raises
  while the handler is still on the stack instead of inside the finalize drain.

A rejected render is never encoded, never uploaded, never reaches `ctx.save_video`.

**No opt-out env flag.** Standing rule, and the reason is the defect: a screen you can
switch off rebuilds the hole.

## Cost

**3.3 ms**, measured on the ie#634 shape — 121 frames, 1344×768 uint8, 0.37 GB of
pixels (printed by `test_cost_on_a_full_size_clip_is_single_digit_ms`). Only ~10 frames
are touched and each is decimated to ~96 rows **before** the float conversion, so the
expensive pass runs on ~1/s² of the pixels; the naive full-resolution form of the same
statistic is 555 ms. `test_the_verdict_is_decimation_invariant` pins that the
decimation does not change the answer.

The streaming collector is bounded the same way: the full spread from the first chunk,
one pair per chunk after, and at `STREAM_PAIR_BUDGET` it halves what it kept and doubles
the chunk stride — so the pairs stay spread over a clip whose length is unknown until
the producer is done, and the cost does not grow with it (`1000` chunks → 22 frames
touched, pinned).

## The fault, and the blame path

Rejection raises the typed `gen_worker.api.errors.OutputIntegrityError` carrying the
measured statistic, and emits a typed `output_integrity` activity event
(`phase` = `noise` / `blank` / `nonfinite` / `unmeasured`) so a refusal is **countable
hub-side** rather than invisible on a pod with no stdout. PASS emits nothing — one row
per served render buys no decision. UNMEASURED **serves** and confesses; it is never a
pass.

It is a **plain FATAL**, and each of the three things it is *not* is deliberate:

* **Not a `ValidationError`.** A garbage render on a well-formed payload is not the
  caller's fault. INVALID would classify it `EvidenceRequestScoped`, which is a lie in
  the caller's favour and hides the defect.
* **Not `RetryableError`.** The measured cause (ie#634) was persistent model state on
  one pod; retrying there re-renders noise at full GPU cost. The blame ladder's
  distinct-worker machinery is what moves a request off a bad pod — a self-declared
  RETRYABLE would just spend the attempt budget on more garbage.
* **Not a hub `declaredFaultLabels` entry.** That map's own rule is *"never add a label
  a payload field can participate in producing"* (`blame_ladder.go:306`). A rendered
  output is produced by release code, model state **and** the request payload together.
  An integrity failure on a healthy release does point at worker/model state — the AdaLN
  case — but the worker cannot prove that from **one output**, so it states WHAT
  happened and does not claim WHOSE fault it is. This is the same posture as
  `processDeathLabels` (th#1259/pgw#763), reached from the other direction: as a plain
  FATAL, the existing `jobResultEvidence` FATAL arm already reads it as
  `EvidenceExecutionFatal` — *"the release's CODE answering a REQUEST"*, the strongest
  honest class a job result can carry, and one that never proves the release cannot
  stand up.

**No hub change is required by this PR.** Activity kinds are stored generically
(`worker_activity.go`), and the FATAL classification is already correct.

## Scope — do not read a PASS as a quality verdict

This catches **NOISE and BLANK only**. Smearing REMOVES high-frequency temporal
variation, so a melted / over-smoothed render scores **higher** here than a clean one.
Measured on the fixtures: **melted 0.9964 vs clean 0.9570**.
`test_melt_blindness_is_the_scope_boundary` asserts that inversion, so the blind spot
cannot be forgotten. Every PASS carries `SCOPE_NOTE` in its detail. Fine-detail damage
belongs to cozy-eval's detail detectors + VLM rubric; motion damage to the
temporal-fidelity family.

## Tests — real fixtures, red-verified on master

`tests/test_output_integrity_pgw1094.py`, 22 tests, all synthetic-but-real pixel arrays
(no media in the repo): a clean render (panned scene + per-frame grain), VAE-decoded-style
noise, a black clip, a cut-heavy clip, a **melted** clip, a NaN clip.

| fixture | verdict | corr | std_min |
|---|---|---|---|
| clean | pass | 0.9570 | 0.167 |
| noise | **noise** | 0.0007 | 0.192 |
| black | **blank** | 0.0000 | 0.000 |
| melted | pass *(higher than clean — the pin)* | 0.9964 | 0.153 |
| cut | pass *(series `[0.96, 0.96, -0.74, 0.90, 0.90]`)* | 0.8965 | 0.117 |

**RED-VERIFIED on `origin/master` through the real production path** (not just a missing
import): a noise clip handed to `io.write_video` on master is encoded to a **678 KB mp4
and passed to `ctx.save_video`**. On this branch the same call refuses before the
encoder runs, with zero uploads.

```
master: RED: noise was ENCODED AND UPLOADED -> [('outputs/r/video.mp4', 678080)]
branch: GREEN: refused -> OutputIntegrityError: noise: video outputs/r/video.mp4
        failed the output-integrity floor (adjacent_frame_corr 0.001 ...)  uploads: []
```

`mypy src/gen_worker` clean (247 files). `ruff` clean.

Two existing fixtures saved a **solid fill** (`deferred_endpoints.mutates_after_save`, a
32×32 solid red; the pgw#942 recorder endpoint, a solid blue) and are correctly rejected
by the floor. They were given real content rather than weakening the gate — a constant-fill
image is not a render, and a fixture a production gate refuses is not a fixture. Each
test's intent is preserved (the red marker the th#1130 assertion reads is still exactly
`(255, 0, 0)` at `(5, 5)`).

## Residual, stated honestly

`ctx.save_video(path)` receives an **already-encoded file**, so an endpoint that encodes
its own mp4 bypasses this floor. Across the whole fleet exactly one caller does that and
it is not a model render — `dj-utils`, an ffmpeg-compositing utility. Every generation
endpoint (minimax-h3, ltx-video-2.3, wan-2.2, and all 14 image endpoints) goes through
`write_video` / `save_image` and is covered. Re-reading and decoding the encoded file to
close that hole is explicitly not done here.

## Attribution

The floor's wall is a first-class th#1111 stage — `output_integrity`, GPU-IDLE — so it is
attributed on every render instead of surfacing as unexplained residual. Deliberately
*not* charged to `image_encode`: on the th#1130 deferred path that key means the finalize
tail's encode, and borrowing it made `stages["image_encode"] > finalize_wall_ms`, which
th#1130's own test caught. The streaming per-chunk observe stays on `video_encode` — it
interleaves with the encoder, and a per-chunk bracket would truncate the request's
512-interval log on a long clip; `StreamCollector.verdict()` reports its measured seconds
on the event either way.

## Version / train

**`0.99.0 -> 0.100.0`.** pgw#1093's #598 merged first (`03b9be68`) and owns 0.99.0, so this
branch is **rebased onto merged master** and takes the next minor — one artifact per
number, and 0.99.0 was never published. The rebase's only conflict was the version line
(`drift` / `fast gates` / `tests` were all PASS on the pre-rebase tip). Rides pgw#1093's
fleet floor train, whose floor is now 0.100.0: pin the fleet once and both lanes are
aboard. No wire change, no proto change — the pin bump is the whole fleet cost.
