### PR TITLE
pgw#1095: the seal DERIVES library identity from the wheels' RECORDs — a serving boot stops SHA-256ing 3.96 GB (env_establish 8.9s -> 2.6s)

### DIFF
--- a/changelog.d/pgw1095.md
+++ b/changelog.d/pgw1095.md
@@ -1,0 +1,19 @@
+- **pgw#1095: a serving boot no longer SHA-256s 3.96 GB to learn what it
+  installed.** `env_seal`'s native-library identity — the seal's `loaded_libs`
+  fact, the live substitution probe and the `toolchain` key axis it folds into
+  — now derives each shipped `.so`'s content digest from the `dist-info/RECORD`
+  the wheel was installed from, and HASHES only what no RECORD covers. RECORD
+  already carries the sha256 the installer verified, so the value is
+  byte-identical to the hash it replaces: measured over the whole 36-library
+  torch env, `loaded_libs_digest` is `151aa8565a2f3cf0` either way, and a real
+  `python -m gen_worker.entrypoint` boot seals `48d03e2730d13f64` before and
+  after — **no cell re-keys.** pgw#1087's phase table, same box, minutes apart:
+  `lib_memo` 6,229 ms `reason=miss` -> 314 ms `reason=hit record=36 hashed=0`,
+  `env_establish` 8,945 -> 2,595 ms, `first_request_servable` 15,966 -> 8,492 ms.
+  On the pod that produced the finding the pass was 17.3 s of a 33.7 s boot.
+  A claim is honoured only under two guards (size matches RECORD; the file has
+  not been written since the RECORD describing it), and the one case a
+  full-hash boot caught that this does not — a same-size rewrite with `mtime_ns`
+  restored — is asserted in `tests/test_seal_record_derivation_pgw1095.py`
+  rather than left for a reader to discover. The pgw#832 memo survives as the
+  fallback store for libraries no wheel installed.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -71,7 +71,10 @@ import inspect
 import pickle
 import sys
 
-from . import cell_key, env_seal, guard_closure, hot_swap, settings_authority
+from . import (
+    cell_key, dist_records, env_seal, guard_closure, hot_swap,
+    settings_authority,
+)
 from .api.errors import RetryableError
 from .models import w8a8_lora
 from .models.loading import pipeline_weight_lane
@@ -953,30 +956,26 @@ def toolchain_digest() -> Tuple[Tuple[str, str], ...]:
       still re-key, and this is the axis that change honestly belongs to.
       The seal's GATE roles (boot verify, pre-trace tripwire) live in
       ``env_seal`` unchanged.
-    * ``loaded_libs`` — the boot-frozen combined digest of the native
-      ``.so`` set the python env actually maps (pgw#719): toolchain CONTENT
-      the RECORDs cannot see (the LD_PRELOAD/LD_LIBRARY_PATH substitution
-      hole).
+    * ``loaded_libs`` — the boot-frozen per-file manifest of the native
+      ``.so`` set the python env ships (pgw#719), which is what covers the
+      LD_PRELOAD/LD_LIBRARY_PATH substitution hole: it enumerates the FILES
+      rather than the packages, and pgw#1095 derives each digest from the
+      RECORD that installed the file while HASHING anything no RECORD
+      covers — a preloaded or non-wheel object is therefore still content,
+      not an assumption.
     """
-    from . import env_seal  # late: env_seal imports settings machinery only
-
     out: Dict[str, str] = {
         "settings_declaration": env_seal.declaration_digest(),
         "loaded_libs": env_seal.loaded_libs_digest(),
     }
-    try:
-        import importlib.metadata
-
-        # diffusers/transformers/peft ride here at package granularity
-        # (their VERSION axes left the key; content replaces them).
-        wanted = ("torch", "triton", "diffusers", "transformers", "peft")
-        for dist in importlib.metadata.distributions():
-            name = str(dist.metadata.get("Name") or "").lower()
-            if name in wanted or name.startswith("nvidia-"):
-                record = dist.read_text("RECORD") or ""
-                out[name] = hashlib.sha256(record.encode()).hexdigest()[:16]
-    except Exception:
-        logger.debug("toolchain_digest: dist-info walk failed", exc_info=True)
+    # ONE enumeration of the environment's RECORDs (pgw#1095): the seal's
+    # per-FILE digests and this axis's per-PACKAGE digests are two readings of
+    # the same manifests, and reading them twice is how two surfaces start
+    # disagreeing about what is installed.
+    wanted = ("torch", "triton", "diffusers", "transformers", "peft")
+    for name, record in dist_records.record_texts().items():
+        if name in wanted or name.startswith("nvidia-"):
+            out[name] = hashlib.sha256(record.encode()).hexdigest()[:16]
     try:
         import triton
 

--- a/src/gen_worker/dist_records.py
+++ b/src/gen_worker/dist_records.py
@@ -1,0 +1,232 @@
+"""Installed-distribution RECORD manifests — the declared content facts
+(pgw#1095, executing pgw#1050's ruling on the SEAL path).
+
+A wheel's ``dist-info/RECORD`` already carries, per installed file, the
+**sha256 the installer verified at install time** and the size it wrote. That
+is the same fact ``sha256(content)`` recomputes, so a boot that needs the
+content identity of ``libtorch_cuda.so`` can READ it instead of re-hashing
+3.96 GB of shipped toolchain (measured: 10.6-17.3 s per process, 68 % of a
+33.7 s cold boot through ``env_seal.establish``, pgw#1087).
+
+Two consumers, ONE derivation (the pgw#1059 fence pattern):
+
+* :func:`digest_for` — per-FILE identity for ``env_seal``'s native-library
+  manifest (the seal's ``loaded_libs`` fact and the live substitution check).
+* :func:`record_texts` — per-DISTRIBUTION RECORD text for
+  ``compile_cache.toolchain_digest``'s binary half (pgw#710), which has always
+  read exactly these files.
+
+**The digest is byte-identical to the hash it replaces.** RECORD stores
+``sha256=<urlsafe-b64 of the 32 raw bytes>``; decoding to hex and truncating
+to 16 chars reproduces ``hashlib.sha256(content).hexdigest()[:16]`` exactly.
+Proven over the whole 36-library manifest on this env (0 disagreements), which
+is what makes this a pure COST move: no seal value changes, no cell re-keys.
+
+**What RECORD trust is, precisely** (stated so the trade is ruled on, not
+buried — the honest scope of item (3) in this lane's brief):
+
+* The installer verified the hash when it wrote the file. It is NOT re-verified
+  at load time, so RECORD trust is a claim about install, extended forward by
+  the two guards :func:`digest_for` applies before honouring it — the file's
+  size still matches RECORD, and the file has not been written since the
+  RECORD that describes it was written (``mtime_ns <= RECORD's mtime_ns``).
+* CAUGHT, and hashed instead of trusted: any file absent from every RECORD
+  (system libs, an ``LD_PRELOAD`` object, a lib from a non-wheel install), any
+  size change, any in-place rewrite that leaves a newer mtime, any dist whose
+  RECORD does not describe itself.
+* NOT CAUGHT: an in-place rewrite that preserves the byte SIZE *and* restores
+  the original ``mtime_ns``. A full-hash boot would have seen that and moved
+  the seal. This is the one place RECORD trust is weaker than the status quo,
+  and it is the same forge the pgw#832 memo and the ``_lib_digest`` lru_cache
+  (both keyed on ``(path, mtime_ns, size)``) have always been open to — an
+  actor able to do it already holds write access to site-packages, i.e. to
+  ``env_seal.py`` itself.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import csv
+import functools
+import importlib.metadata
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, NamedTuple, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: How much of the sha256 hex our digests carry (``env_seal`` convention).
+DIGEST_HEX_LEN = 16
+
+_SHA256_FIELD = "sha256="
+
+#: Only NATIVE artifacts are indexed per-file: the seal's manifest is the
+#: shipped ``.so`` set, and indexing all 27k rows of a torch env costs memory
+#: for rows nothing looks up.
+_NATIVE_MARKER = ".so"
+
+
+@dataclass(frozen=True)
+class RecordedFile:
+    """One RECORD row, resolved to an absolute path.
+
+    ``digest`` is already in ``env_seal`` form (16 hex chars); ``record_mtime_ns``
+    is the mtime of the RECORD that made the claim, which is what bounds how
+    far forward the claim may be trusted.
+    """
+
+    path: str
+    digest: str
+    size: int
+    dist: str
+    record_mtime_ns: int
+
+
+def _decode_sha256(field: str) -> str:
+    """RECORD's ``sha256=<b64>`` -> the first :data:`DIGEST_HEX_LEN` hex chars,
+    or ``""`` when the row carries no usable sha256 (legacy md5 rows, the
+    hashless self-row, a truncated field)."""
+    if not field.startswith(_SHA256_FIELD):
+        return ""
+    raw = field[len(_SHA256_FIELD):]
+    try:
+        decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4))
+    except (binascii.Error, ValueError):
+        return ""
+    if len(decoded) != 32:
+        return ""
+    return decoded.hex()[:DIGEST_HEX_LEN]
+
+
+def _record_rows(text: str) -> List[List[str]]:
+    return [row for row in csv.reader(text.splitlines()) if len(row) == 3]
+
+
+class _Scan(NamedTuple):
+    texts: Dict[str, str]
+    native: Dict[str, RecordedFile]
+
+
+@functools.lru_cache(maxsize=1)
+def _scan() -> _Scan:
+    """ONE walk of the installed distributions, feeding both readers.
+
+    Measured on the reference env: 99 distributions, 2.8 MB of RECORD text,
+    ~0.26 s cold and free thereafter — against the 6.3-17.3 s of SHA-256 it
+    replaces. Paths are joined, never ``realpath``d, at scan time: resolving
+    27k rows costs 1.5 s while resolving the ~36 the seal asks about costs
+    nothing (:func:`digest_for` resolves the QUERY instead).
+    """
+    texts: Dict[str, str] = {}
+    native: Dict[str, RecordedFile] = {}
+    try:
+        dists = list(importlib.metadata.distributions())
+    except Exception:  # pragma: no cover - a broken site-packages
+        logger.debug("dist_records: distribution walk failed", exc_info=True)
+        return _Scan(texts, native)
+    for dist in dists:
+        try:
+            name = str(dist.metadata.get("Name") or "").lower()
+            text = dist.read_text("RECORD")
+        except Exception:
+            continue
+        if not name:
+            continue
+        # A distribution with NO RECORD is still recorded, as the empty text
+        # its reader has always seen (`compile_cache` hashed `read_text(...)
+        # or ""`): dropping the row here would silently move the `toolchain`
+        # key axis for any env that has one.
+        texts[name] = text or ""
+        if not text:
+            continue
+        rows = _record_rows(text)
+        record_mtime = _record_mtime_ns(dist, rows)
+        if not record_mtime:
+            continue  # an unanchored claim: those files get hashed
+        for rel, hash_field, size_field in rows:
+            if _NATIVE_MARKER not in os.path.basename(rel):
+                continue
+            digest = _decode_sha256(hash_field)
+            if not digest:
+                continue
+            try:
+                size = int(size_field)
+                path = os.path.normpath(str(dist.locate_file(rel)))
+            except (OSError, ValueError):
+                continue
+            native[path] = RecordedFile(
+                path=path, digest=digest, size=size, dist=name,
+                record_mtime_ns=record_mtime)
+    return _Scan(texts, native)
+
+
+def record_texts() -> Mapping[str, str]:
+    """``{distribution name (lowercased): RECORD text}`` for every installed
+    distribution that ships one — ``compile_cache.toolchain_digest``'s
+    per-PACKAGE binary half (pgw#710), reading the same scan the seal's
+    per-FILE half reads."""
+    return _scan().texts
+
+
+def _record_mtime_ns(dist: importlib.metadata.Distribution,
+                     rows: List[List[str]]) -> int:
+    """mtime of the RECORD file itself, located from its OWN row (installers
+    list ``<dist-info>/RECORD`` hashless). 0 when the file does not describe
+    itself — no anchor, so :func:`digest_for` refuses to trust that dist."""
+    for row in rows:
+        if not row[0].endswith(".dist-info/RECORD"):
+            continue
+        try:
+            return os.stat(str(dist.locate_file(row[0]))).st_mtime_ns
+        except OSError:
+            return 0
+    return 0
+
+
+def native_index() -> Mapping[str, RecordedFile]:
+    """``{absolute path: RecordedFile}`` for every native shared object any
+    installed distribution RECORDs — the seal's per-FILE half."""
+    return _scan().native
+
+
+def digest_for(path: str, mtime_ns: int, size: int) -> Optional[str]:
+    """The RECORDed content digest of ``path``, or ``None`` when no
+    distribution's RECORD covers it under both guards (see the module
+    docstring). ``None`` is the instruction to HASH the file — never a reason
+    to skip it."""
+    index = native_index()
+    entry = index.get(os.path.normpath(path))
+    if entry is None:
+        entry = index.get(os.path.realpath(path))
+    if entry is None:
+        return None
+    if entry.size != size:
+        return None  # rewritten to a different length: RECORD is stale
+    if mtime_ns > entry.record_mtime_ns:
+        return None  # written after the claim was made: RECORD is stale
+    return entry.digest
+
+
+def coverage() -> Tuple[int, int]:
+    """(distributions seen, native files indexed) — the number
+    a boot reports so a fleet-wide coverage regression is visible in the phase
+    row instead of arriving as a slow boot nobody explains."""
+    return len(record_texts()), len(native_index())
+
+
+def reset_cache() -> None:
+    """Forget the scan (tests that install a distribution mid-process)."""
+    _scan.cache_clear()
+
+
+__all__ = [
+    "DIGEST_HEX_LEN",
+    "RecordedFile",
+    "coverage",
+    "digest_for",
+    "native_index",
+    "record_texts",
+    "reset_cache",
+]

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -21,10 +21,13 @@ settings):
   (pgw#1049): ``settings_authority.declaration()`` facts plus the
   loaded-library digest (pgw#719: the native ``.so`` set the python env
   ships — closes the LD_PRELOAD/LD_LIBRARY_PATH substitution hole that env
-  vars and package RECORDs cannot see). Ambient mutation is structurally
-  unable to move the digest — torch wheel defaults ride the ``toolchain``
-  key axis, and everything else in the codegen surface is either declared
-  (sealed) or erased. ``seal_v`` versions the dict, so new sealed facts
+  vars and a package's *own* metadata cannot see; pgw#1095 derives each
+  shipped lib's content digest from the wheel RECORD that installed it and
+  HASHES anything no RECORD covers, which is exactly the preloaded-object
+  case, so the hole stays closed at a KB-scale read). Ambient mutation is
+  structurally unable to move the digest — torch wheel defaults ride the
+  ``toolchain`` key axis, and everything else in the codegen surface is
+  either declared (sealed) or erased. ``seal_v`` versions the dict, so new sealed facts
   change digest VALUES only, never the axis set.
 * :func:`assert_seal_unchanged` — the runtime TRIPWIRE (pgw#719, kept
   deliberately as read-back where the seal itself no longer is): boot
@@ -56,10 +59,11 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple
 
 from . import (
-    boot_phases, guard_closure, host_isa, settings_authority, torch_capability,
+    boot_phases, dist_records, guard_closure, host_isa, settings_authority,
+    torch_capability,
 )
 import importlib.util
 
@@ -259,27 +263,28 @@ def _lib_digest(path: str, mtime_ns: int, size: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# pgw#832: cross-process digest memo for short-lived workers
+# Where a library's identity digest comes from (pgw#1095, pgw#832)
 # ---------------------------------------------------------------------------
-# The identity pass SHA-256s every toolchain .so the image ships (measured:
-# 36 files, 3.96 GB, ~8 s). The lru_cache above amortizes it to once per
-# PROCESS — which stopped being "once" the moment pgw#809's pool made the
-# unit of parallelism a process that compiles one entry and exits: a
-# 72-entry mint re-paid the pass 72 times, K-wide, on the cores the
-# compiles wanted (28 % of per-entry compile_s, measured by pgw#830).
+# THREE sources, in this order, for the SAME value — the 16-hex prefix of the
+# file's sha256. Which one served it changes the cost of a boot by 17 s and
+# changes the seal by nothing:
 #
-# The memo moves WHERE a digest comes from, never what it is. A parent that
-# already paid the pass writes {(path, mtime_ns, size) -> digest} to a file
-# (:func:`write_library_memo`); a child pointed at it via
-# :data:`SEAL_LIB_MEMO_ENV` still enumerates the tree and stats every file
-# ITSELF, and uses a memo digest only when its own (path, mtime_ns, size)
-# matches an entry exactly — any mismatch, absence, or unreadable memo falls
-# back to the full rehash of that file. So the seal is byte-identical to a
-# full rehash in every detectable case, and the ONE undetectable case — a
-# file rewritten with content of the same size and its mtime_ns restored —
-# is exactly the case the in-process lru_cache (keyed on the same triple)
-# has always trusted. The memo widens that existing trust boundary across
-# processes; it does not create a new one.
+# 1. The installing wheel's dist-info RECORD (:mod:`dist_records`, pgw#1050's
+#    ruling: identification stays CONTENT, derived from the declared manifest
+#    rather than re-hashed). A KB-scale read covering, on the measured image,
+#    36 of 36 shipped toolchain libraries.
+# 2. The pgw#832 cross-process memo — now the fallback STORE for whatever
+#    RECORD does not cover, and still what a pgw#809 entry-compile child reads
+#    so a 72-entry mint does not re-pay the pass 72 times, K-wide, on the cores
+#    the compiles wanted (28 % of per-entry compile_s, measured by pgw#830).
+# 3. A full SHA-256 pass over the file — always correct, never skipped: a lib
+#    covered by neither manifest above is HASHED, never assumed.
+#
+# Sources 1 and 2 are trusted under the same shape of guard (see
+# :mod:`dist_records` for the exact statement of what that does and does not
+# catch): the reader stats the file ITSELF and honours a claim only when the
+# file it is looking at is the file the claim describes. Any mismatch, absence
+# or unreadable manifest falls through to (3) for that file alone.
 SEAL_LIB_MEMO_ENV = "GEN_WORKER_SEAL_LIB_MEMO"
 
 _MEMO_V = 1
@@ -310,31 +315,51 @@ def _disk_memo() -> Dict[str, str]:
     return _DISK_MEMO
 
 
-#: pgw#1087: memo hits vs misses over this process's whole library pass.
-#: Counted here rather than derived, because a partial hit — a memo written by
-#: a sibling whose env has since moved — is the interesting case and is
-#: invisible in a boolean.
-_MEMO_HITS = 0
-_MEMO_MISSES = 0
+class DigestSources(NamedTuple):
+    """Where this process's library digests came from (pgw#1087's phase
+    detail). Counted rather than derived: the interesting case is the PARTIAL
+    one — a manifest that covers most of the tree and leaves two files to hash
+    — and it is invisible in a boolean."""
+
+    record: int
+    memo: int
+    hashed: int
 
 
-def memo_counts() -> Tuple[int, int]:
-    """(hits, misses) of the pgw#832 library-digest memo so far."""
-    return _MEMO_HITS, _MEMO_MISSES
+_SOURCES = DigestSources(0, 0, 0)
 
 
-def _lib_digest_memoized(path: str, mtime_ns: int, size: int) -> str:
-    global _MEMO_HITS, _MEMO_MISSES
-    got = _disk_memo().get(_memo_key(path, mtime_ns, size))
-    if got is not None:
-        _MEMO_HITS += 1
-        return got
-    _MEMO_MISSES += 1
+def digest_sources() -> DigestSources:
+    """Per-source counts of the library-identity pass so far."""
+    return _SOURCES
+
+
+def _identity_digest(path: str, mtime_ns: int, size: int) -> str:
+    """THE library-identity resolver: RECORD, then memo, then a full hash.
+    Every caller (the identity manifest, the shipped-copy sets, the live
+    substitution probe) goes through it, so one boot cannot mix a derived
+    digest into one surface and a hashed digest into another."""
+    global _SOURCES
+    recorded = dist_records.digest_for(path, mtime_ns, size)
+    if recorded is not None:
+        _SOURCES = _SOURCES._replace(record=_SOURCES.record + 1)
+        return recorded
+    memoized = _disk_memo().get(_memo_key(path, mtime_ns, size))
+    if memoized is not None:
+        _SOURCES = _SOURCES._replace(memo=_SOURCES.memo + 1)
+        return memoized
+    _SOURCES = _SOURCES._replace(hashed=_SOURCES.hashed + 1)
     return _lib_digest(path, mtime_ns, size)
 
 
 def write_library_memo(path: Path) -> int:
     """Persist this process's toolchain digests for short-lived children.
+
+    pgw#1095 left this in place as the FALLBACK store: where RECORD covers a
+    library the child derives the digest itself and never consults the memo,
+    but a lib no wheel installed (a system object, a hand-patched ``.so``)
+    would otherwise be re-hashed per child, so the parent still banks what it
+    paid.
 
     Cheap in a process that already sealed (the lru_cache is warm: the pass
     degenerates to stats); pays the full hash exactly once otherwise. The
@@ -356,7 +381,7 @@ def write_library_memo(path: Path) -> int:
             try:
                 st = os.stat(lib_path)
                 digests[_memo_key(lib_path, st.st_mtime_ns, st.st_size)] = (
-                    _lib_digest_memoized(lib_path, st.st_mtime_ns, st.st_size))
+                    _identity_digest(lib_path, st.st_mtime_ns, st.st_size))
             except OSError:
                 continue  # the child will record <unreadable> on its own stat
     encoded = json.dumps(
@@ -378,7 +403,11 @@ def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
     """(basename, content digest) of every relevant native library the
     LOADER actually mapped into this process (``/proc/self/maps``).
     Deterministic: resolved real paths, sorted basenames. Empty off-Linux
-    (no maps surface — recorded as such)."""
+    (no maps surface — recorded as such).
+
+    Resolved through :func:`_identity_digest` like the manifest it is compared
+    against, so the comparison stays apples-to-apples and an LD_PRELOAD object
+    — which no RECORD covers — is HASHED and therefore named."""
     maps = _MAPS_PATH
     if not maps.is_file():
         return ()
@@ -401,7 +430,8 @@ def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
     for base in sorted(paths):
         try:
             st = os.stat(paths[base])
-            out[base] = _lib_digest(paths[base], st.st_mtime_ns, st.st_size)
+            out[base] = _identity_digest(
+                paths[base], st.st_mtime_ns, st.st_size)
         except OSError:
             out[base] = "<unreadable>"
     return tuple(sorted(out.items()))
@@ -481,14 +511,15 @@ def toolchain_library_digests() -> Tuple[Tuple[str, str], ...]:
     the python env SHIPS — deterministic in the installed content,
     independent of what has been dlopened so far. Unreadable files record
     ``<unreadable>``. Enumeration and stat are always THIS process's own;
-    only the per-file digest may come from the pgw#832 memo, and only on an
-    exact (path, mtime_ns, size) match."""
+    only the per-file digest may come from a manifest (:func:`_identity_digest`
+    — the installing wheel's RECORD, then the pgw#832 memo), and only when the
+    file on disk is still the file that manifest describes."""
     out: Dict[str, str] = {}
     paths = _toolchain_lib_paths()
     for base in sorted(paths):
         try:
             st = os.stat(paths[base][0])
-            out[base] = _lib_digest_memoized(
+            out[base] = _identity_digest(
                 paths[base][0], st.st_mtime_ns, st.st_size)
         except OSError:
             out[base] = "<unreadable>"
@@ -505,7 +536,7 @@ def _shipped_digest_sets() -> Dict[str, Tuple[str, ...]]:
         for lib_path in lib_paths:
             try:
                 st = os.stat(lib_path)
-                out.setdefault(base, []).append(_lib_digest_memoized(
+                out.setdefault(base, []).append(_identity_digest(
                     lib_path, st.st_mtime_ns, st.st_size))
             except OSError:
                 continue
@@ -514,14 +545,15 @@ def _shipped_digest_sets() -> Dict[str, Tuple[str, ...]]:
 
 # The identity manifest is FROZEN at first computation: the disk content is
 # already phase-independent (pgw#749), so the freeze is purely an
-# amortization — one hashing pass per process (multi-GB cold, near-free when
-# a pgw#832 memo serves the digests), never a semantic phase pin.
+# amortization — one identity pass per process (multi-GB when it has to hash,
+# a KB-scale manifest read when RECORD covers the tree), never a semantic
+# phase pin.
 _LIB_SNAPSHOT: Optional[Tuple[Tuple[str, str], ...]] = None
 
 #: Seconds the last COLD identity pass took (telemetry only, read by
-#: :func:`establish` into ``seal_libhash_s``). With a memo this measures the
-#: stat-and-lookup pass; without one, the full SHA-256 pass — which is the
-#: whole point of naming it.
+#: :func:`establish` into ``seal_libhash_s``). With RECORD coverage this
+#: measures the manifest-and-stat pass; with none, the full SHA-256 pass —
+#: which is the whole point of naming it.
 _LAST_LIBHASH_S: float = 0.0
 
 
@@ -529,31 +561,37 @@ def frozen_library_digests() -> Tuple[Tuple[str, str], ...]:
     global _LIB_SNAPSHOT, _LAST_LIBHASH_S
     if _LIB_SNAPSHOT is None:
         t0 = time.monotonic()
-        # pgw#1087: THE memo phase. `_LAST_LIBHASH_S` has always measured this
-        # pass but was reported only into the seal dict, where no boot reader
-        # ever joined it to the rest of the boot. As a phase the hit and miss
-        # populations are two rows of the same table and the memo's saving is
-        # a subtraction, not an estimate.
+        # pgw#1087: THE library-identity phase. `_LAST_LIBHASH_S` has always
+        # measured this pass but was reported only into the seal dict, where no
+        # boot reader ever joined it to the rest of the boot. As a phase the
+        # hit and miss populations are two rows of the same table and what a
+        # manifest saves is a subtraction, not an estimate.
         with boot_phases.span(boot_phases.PHASE_LIB_MEMO) as sp:
             _LIB_SNAPSHOT = toolchain_library_digests()
-            hits, misses = memo_counts()
+            src = digest_sources()
+            dists, indexed = dist_records.coverage()
             # `hit`/`partial`/`miss`, never `refused` — all three are
             # successful outcomes of the same phase and the token is what a
-            # hub-side count groups on.
+            # hub-side count groups on. The token answers ONE question: did
+            # this boot re-hash multi-GB of toolchain? The detail says which
+            # manifest spared it, so a coverage regression is a number here
+            # and not a slow boot nobody can explain.
             if not _LIB_SNAPSHOT:
                 # No toolchain libraries enumerated at all (an env with no
-                # torch/triton/nvidia packages). "nothing to hash" and "the
-                # memo served everything" are different answers and must not
-                # share the token `hit`.
+                # torch/triton/nvidia packages). "nothing to hash" and "a
+                # manifest served everything" are different answers and must
+                # not share the token `hit`.
                 token = "no_libs"
-            elif not misses:
+            elif not src.hashed:
                 token = "hit"
-            elif not hits:
+            elif not (src.record or src.memo):
                 token = "miss"
             else:
                 token = "partial"
             sp.classify(
-                token, f"hits={hits} misses={misses} libs={len(_LIB_SNAPSHOT)}")
+                token,
+                f"record={src.record} memo={src.memo} hashed={src.hashed} "
+                f"libs={len(_LIB_SNAPSHOT)} dists={dists} recorded={indexed}")
         _LAST_LIBHASH_S = round(time.monotonic() - t0, 3)
     return _LIB_SNAPSHOT
 
@@ -703,10 +741,11 @@ def assert_seal_unchanged(label: str = "") -> None:
 #: It exists because ``establish()`` is called once per pgw#809 entry-compile
 #: CHILD, so on a 72-entry mint its cost is multiplied by 72 and lands inside
 #: the recorded ``compile_s`` with no name. ``seal_libhash_s`` is the one that
-#: matters: the identity manifest SHA-256s every toolchain ``.so`` the env
-#: ships (measured off-pod: 36 files, 3.96 GB, ~8 s at 0.49 GB/s), and the
-#: memo that makes it "once" is an lru_cache — per PROCESS, so a pool of
-#: short-lived children re-pays it in full every time.
+#: matters: the identity manifest used to SHA-256 every toolchain ``.so`` the
+#: env ships (measured off-pod: 36 files, 3.96 GB, 10.6-17.3 s), once per
+#: PROCESS — so a pool of short-lived children re-paid it in full every time.
+#: pgw#1095 derives those digests from the wheels' RECORDs instead; the pass
+#: is a manifest read, and this span is how a coverage regression shows up.
 LAST_ESTABLISH_SPANS: Dict[str, float] = {}
 
 
@@ -768,11 +807,11 @@ def _establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     seal = effective_seal()
     mark("seal_effective_s")
     # The library pass is timed where it runs (frozen_library_digests), not
-    # inferred from `seal_effective_s`: with a pgw#832 memo the pass shrinks
-    # to stats while the rest of the seal (config read-back, inductor digest)
-    # does not, and naming the wrong part "libhash" would hide exactly the
-    # cost this span exists to expose. Still a split of `seal_effective_s`,
-    # never a partition member.
+    # inferred from `seal_effective_s`: under RECORD coverage the pass shrinks
+    # to a manifest read while the rest of the seal (config read-back, inductor
+    # digest) does not, and naming the wrong part "libhash" would hide exactly
+    # the cost this span exists to expose. Still a split of
+    # `seal_effective_s`, never a partition member.
     spans["seal_libhash_s"] = _LAST_LIBHASH_S if cold_libs else 0.0
     LAST_ESTABLISH_SPANS.clear()
     LAST_ESTABLISH_SPANS.update(spans)
@@ -781,12 +820,14 @@ def _establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
 
 __all__ = [
     "LAST_ESTABLISH_SPANS",
+    "DigestSources",
     "EnvSealError",
     "SCRUB_PREFIXES",
     "SEAL_KEY",
     "SEAL_LIB_MEMO_ENV",
     "SEAL_VERSION",
     "assert_seal_unchanged",
+    "digest_sources",
     "effective_config",
     "effective_seal",
     "establish",

--- a/tests/test_seal_record_derivation_pgw1095.py
+++ b/tests/test_seal_record_derivation_pgw1095.py
@@ -1,0 +1,317 @@
+"""pgw#1095: the seal's library identity is DERIVED from the installing
+wheel's RECORD, and re-hashed only where no RECORD covers the file.
+
+WHY THIS FILE EXISTS
+--------------------
+pgw#1087's first real cold-boot decomposition found `env_establish` at 23.1 s
+of a 33.7 s boot, 17.3 s of which was `lib_memo` re-SHA-256ing every toolchain
+`.so` the image ships (36 files, 3.96 GB) on EVERY serving boot. A wheel's
+`dist-info/RECORD` already carries the sha256 the installer verified for each
+of those files, so the boot can read the fact instead of recomputing it.
+
+WHAT IT HOLDS THE DERIVATION TO
+-------------------------------
+1. **The value may never move.** RECORD stores the same sha256 our digests
+   truncate, so a derived seal must be BYTE-IDENTICAL to a hashed one. If it
+   were not, every published cell would strand.
+2. **A claim is honoured only for the file it describes.** Size guard, and a
+   staleness guard against the RECORD's own mtime.
+3. **Anything no RECORD covers is HASHED, never trusted** — that is what keeps
+   the pgw#719 LD_PRELOAD hole closed, because a preloaded object is in no
+   wheel's manifest.
+4. **The blind spot is asserted, not hidden** (the last test). Tamper that
+   preserves size AND restores mtime is served from RECORD, exactly as the
+   pgw#832 memo and the `_lib_digest` lru_cache have always served it. A
+   full-hash boot would have caught that one; this is the trade, in a test,
+   where a future reader can find it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+import pytest
+
+from gen_worker import boot_phases, dist_records, env_seal
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _record_field(data: bytes) -> str:
+    raw = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+    return "sha256=" + raw.decode()
+
+
+def _install(
+    site: Path,
+    dist: str,
+    version: str,
+    files: Dict[str, bytes],
+    *,
+    self_row: bool = True,
+    lie_about_size: Optional[str] = None,
+) -> Dict[str, Path]:
+    """Write a wheel-shaped install: the real files, plus the dist-info RECORD
+    an installer would have written after verifying them."""
+    info = site / f"{dist}-{version}.dist-info"
+    info.mkdir(parents=True, exist_ok=True)
+    (info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist}\nVersion: {version}\n")
+    out: Dict[str, Path] = {}
+    rows: List[str] = []
+    for rel, content in files.items():
+        path = site / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        out[rel] = path
+        size = len(content) + (7 if rel == lie_about_size else 0)
+        rows.append(f"{rel},{_record_field(content)},{size}")
+    rows.append(f"{info.name}/METADATA,{_record_field(b'')},0")
+    if self_row:
+        rows.append(f"{info.name}/RECORD,,")
+    (info / "RECORD").write_text("\n".join(rows) + "\n")
+    return out
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> Iterator[Path]:
+    """A throwaway site-packages on `sys.path`, with every process-global the
+    identity pass touches saved and restored."""
+    site = tmp_path / "site-packages"
+    (site / "libs").mkdir(parents=True)
+    snapshot = (
+        env_seal._LIB_SNAPSHOT, env_seal._DISK_MEMO,
+        env_seal._TOOLCHAIN_LIB_DIRS_OVERRIDE, env_seal._SOURCES,
+    )
+    sys.path.insert(0, str(site))
+    importlib.invalidate_caches()
+    _fresh_process(site)
+    try:
+        yield site
+    finally:
+        sys.path.remove(str(site))
+        importlib.invalidate_caches()
+        (env_seal._LIB_SNAPSHOT, env_seal._DISK_MEMO,
+         env_seal._TOOLCHAIN_LIB_DIRS_OVERRIDE, env_seal._SOURCES) = snapshot
+        env_seal._lib_digest.cache_clear()
+        dist_records.reset_cache()
+        os.environ.pop(env_seal.SEAL_LIB_MEMO_ENV, None)
+
+
+def _fresh_process(site: Path) -> None:
+    """Reset exactly what a newly exec'd worker would not have inherited."""
+    env_seal._LIB_SNAPSHOT = None
+    env_seal._DISK_MEMO = None
+    env_seal._SOURCES = env_seal.DigestSources(0, 0, 0)
+    env_seal._TOOLCHAIN_LIB_DIRS_OVERRIDE = (site / "libs",)
+    env_seal._lib_digest.cache_clear()
+    dist_records.reset_cache()
+    importlib.invalidate_caches()
+    os.environ.pop(env_seal.SEAL_LIB_MEMO_ENV, None)
+
+
+_LIBS = {
+    "libs/libtorch_fake.so": b"A" * 4096,
+    "libs/libtriton_fake.so.1": b"B" * 2048,
+    "libs/libcudnn_fake.so.9": b"C" * 1024,
+}
+
+
+def _forbid_hashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _refuse(path: str, mtime_ns: int, size: int) -> str:
+        raise AssertionError(
+            f"full rehash of {path!r} ran despite an intact RECORD")
+
+    monkeypatch.setattr(env_seal, "_lib_digest", _refuse)
+
+
+# ---------------------------------------------------------------------------
+# 1. The value may never move
+# ---------------------------------------------------------------------------
+
+
+def test_the_recorded_digest_is_the_hash_it_replaces(env: Path) -> None:
+    """RECORD's urlsafe-b64 sha256, decoded to hex and truncated, IS
+    `sha256(content).hexdigest()[:16]`. This is the whole premise: if it were
+    a different value the change would re-key every published cell."""
+    files = _install(env, "fakewheel", "1.0", _LIBS)
+    for rel, content in _LIBS.items():
+        st = files[rel].stat()
+        derived = dist_records.digest_for(
+            str(files[rel]), st.st_mtime_ns, st.st_size)
+        assert derived == _sha256(content), rel
+
+
+def test_the_seal_is_byte_identical_derived_or_hashed(
+    env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(env, "fakewheel", "1.0", _LIBS)
+
+    # Ground truth: the pre-pgw#1095 behaviour, forced by making every RECORD
+    # lookup miss. Nothing else about the pass changes.
+    monkeypatch.setattr(dist_records, "digest_for",
+                        lambda path, mtime_ns, size: None)
+    hashed = env_seal.toolchain_library_digests()
+    assert env_seal.digest_sources().hashed == len(_LIBS)
+    monkeypatch.undo()
+
+    # The derived pass, with hashing forbidden outright: if any digest came
+    # from a re-read this fails loudly, so equality proves BOTH source and
+    # value.
+    _fresh_process(env)
+    _forbid_hashing(monkeypatch)
+    derived = env_seal.toolchain_library_digests()
+    assert derived == hashed
+    src = env_seal.digest_sources()
+    assert (src.record, src.memo, src.hashed) == (len(_LIBS), 0, 0)
+
+
+def test_the_phase_row_reports_hit_and_names_the_source(
+    env: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1087's `lib_memo` row is how a fleet-wide coverage regression is
+    seen. `hit` must mean "this boot hashed nothing", and the detail must say
+    which manifest spared it."""
+    _install(env, "fakewheel", "1.0", _LIBS)
+    boot_phases.reset_for_tests()
+    _forbid_hashing(monkeypatch)
+    env_seal.frozen_library_digests()
+    rows = [r for r in boot_phases.recorded_rows()
+            if r.phase == boot_phases.PHASE_LIB_MEMO and r.terminal]
+    assert len(rows) == 1
+    assert rows[0].reason == "hit"
+    assert f"record={len(_LIBS)}" in rows[0].detail
+    assert "hashed=0" in rows[0].detail
+    boot_phases.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 2 + 3. A claim covers one file, and only the file it describes
+# ---------------------------------------------------------------------------
+
+
+def test_a_library_no_record_covers_is_hashed_never_trusted(
+    env: Path,
+) -> None:
+    """The pgw#719 hole stays closed: an object no wheel installed — a system
+    lib, an LD_PRELOAD substitution — is content, not an assumption."""
+    _install(env, "fakewheel", "1.0", _LIBS)
+    stray = env / "libs" / "libnccl_stray.so.2"
+    stray.write_bytes(b"S" * 777)
+    _fresh_process(env)
+
+    digests = dict(env_seal.toolchain_library_digests())
+    assert digests["libnccl_stray.so.2"] == _sha256(b"S" * 777)
+    src = env_seal.digest_sources()
+    assert (src.record, src.hashed) == (len(_LIBS), 1)
+
+
+def test_a_record_that_lies_about_size_is_not_trusted(env: Path) -> None:
+    files = _install(env, "fakewheel", "1.0", _LIBS,
+                     lie_about_size="libs/libtorch_fake.so")
+    st = files["libs/libtorch_fake.so"].stat()
+    assert dist_records.digest_for(
+        str(files["libs/libtorch_fake.so"]), st.st_mtime_ns, st.st_size) is None
+
+
+def test_an_unanchored_record_is_not_trusted(env: Path) -> None:
+    """A RECORD that does not describe itself gives the staleness guard no
+    anchor, so the whole distribution falls back to hashing."""
+    files = _install(env, "fakewheel", "1.0", _LIBS, self_row=False)
+    st = files["libs/libtorch_fake.so"].stat()
+    assert dist_records.digest_for(
+        str(files["libs/libtorch_fake.so"]), st.st_mtime_ns, st.st_size) is None
+    _fresh_process(env)
+    assert dict(env_seal.toolchain_library_digests()) == {
+        Path(rel).name: _sha256(content) for rel, content in _LIBS.items()}
+    assert env_seal.digest_sources().hashed == len(_LIBS)
+
+
+# ---------------------------------------------------------------------------
+# 4. THE RED PROOFS — tamper under an intact RECORD
+# ---------------------------------------------------------------------------
+
+
+def test_tamper_that_changes_the_size_is_caught(env: Path) -> None:
+    files = _install(env, "fakewheel", "1.0", _LIBS)
+    _fresh_process(env)
+    before = dict(env_seal.toolchain_library_digests())
+
+    files["libs/libtorch_fake.so"].write_bytes(b"MUTATED" * 999)
+    _fresh_process(env)
+    after = dict(env_seal.toolchain_library_digests())
+    assert after["libtorch_fake.so"] == _sha256(b"MUTATED" * 999)
+    assert after["libtorch_fake.so"] != before["libtorch_fake.so"], (
+        "a size-changing in-place tamper was served from RECORD: the seal "
+        "would name content this host is not running")
+    assert env_seal.digest_sources().hashed == 1
+
+
+def test_tamper_that_leaves_a_newer_mtime_is_caught(env: Path) -> None:
+    """Same size, but written after the RECORD that describes it. The
+    staleness guard sends it to the hash, and the seal moves."""
+    files = _install(env, "fakewheel", "1.0", _LIBS)
+    _fresh_process(env)
+    before = dict(env_seal.toolchain_library_digests())
+
+    target = files["libs/libtriton_fake.so.1"]
+    replacement = b"X" * target.stat().st_size
+    target.write_bytes(replacement)
+    os.utime(target, ns=(target.stat().st_mtime_ns + 10**9,
+                         target.stat().st_mtime_ns + 10**9))
+    _fresh_process(env)
+    after = dict(env_seal.toolchain_library_digests())
+    assert after["libtriton_fake.so.1"] == _sha256(replacement)
+    assert after["libtriton_fake.so.1"] != before["libtriton_fake.so.1"]
+    assert env_seal.digest_sources().hashed == 1
+
+
+def test_same_size_mtime_restored_tamper_is_the_documented_blind_spot(
+    env: Path,
+) -> None:
+    """THE TRADE, asserted so it is ruled on rather than discovered.
+
+    Content rewritten at the same size with `mtime_ns` restored is served
+    from RECORD. A full-hash boot WOULD have caught this one — that is the
+    single case where RECORD derivation is weaker than what it replaces, and
+    it is the same forge the pgw#832 memo and the `_lib_digest` lru_cache
+    (both keyed on `(path, mtime_ns, size)`) already accept. An actor able to
+    do it holds write access to site-packages, i.e. to `env_seal.py` itself.
+
+    If this test starts FAILING, the derivation gained content verification:
+    claim the stronger property here and in `dist_records`' docstring.
+    """
+    files = _install(env, "fakewheel", "1.0", _LIBS)
+    _fresh_process(env)
+    before = dict(env_seal.toolchain_library_digests())
+
+    target = files["libs/libcudnn_fake.so.9"]
+    st = target.stat()
+    target.write_bytes(b"Z" * st.st_size)
+    os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns))
+    _fresh_process(env)
+    after = dict(env_seal.toolchain_library_digests())
+    assert after["libcudnn_fake.so.9"] == before["libcudnn_fake.so.9"]
+    assert after["libcudnn_fake.so.9"] != _sha256(b"Z" * st.st_size)
+
+
+# ---------------------------------------------------------------------------
+# One derivation: the seal and the key axis read the same manifests
+# ---------------------------------------------------------------------------
+
+
+def test_one_enumeration_serves_both_readers(env: Path) -> None:
+    _install(env, "fakewheel", "1.0", _LIBS)
+    texts = dist_records.record_texts()
+    assert "fakewheel" in texts
+    assert "libs/libtorch_fake.so" in texts["fakewheel"]
+    dists, indexed = dist_records.coverage()
+    assert dists >= 1 and indexed >= len(_LIBS)


### PR DESCRIPTION
Executes pgw#1087's headline finding under Paul's cold-boot priority, by pgw#1050's ruling
(*"identification stays CONTENT (RECORD digests), never version strings"*) rather than by
caching the hash.

## The finding

pgw#1087's first real cold-boot decomposition, off the wire:

```
env_establish   dur=23080  detail='seal_effective_s=17.332 seal_isa_s=5.747 ...'
lib_memo        dur=17323  parent=env_establish  reason='miss'  'hits=0 misses=36 libs=36'
first_request_servable  dur=33684
```

68 % of a 33.7 s boot in the seal, 17.3 s of it re-SHA-256ing every toolchain `.so` the image
ships (36 files, 3.96 GB) — on every serving boot, because `write_library_memo`'s only caller
seeds mint children.

## What this does

* **`dist_records.py`** (new): ONE walk of the installed distributions feeding both readers of
  those manifests — per-FILE `digest_for()` for `env_seal`, per-DIST `record_texts()` for
  `compile_cache.toolchain_digest`'s pgw#710 binary half (which has always read exactly these
  files, and now reads them once instead of twice).
* **`env_seal._identity_digest`** is THE resolver: RECORD, then the pgw#832 memo (kept as the
  fallback store for what no wheel installed), then a full hash. The identity manifest, the
  shipped-copy sets and the live `/proc/self/maps` substitution probe all go through it.
* **A lib covered by neither manifest is HASHED, never trusted** — which is what keeps pgw#719's
  LD_PRELOAD hole closed: a preloaded object is in no wheel's RECORD.

## The value does not move (zero re-key)

RECORD stores the same sha256 our digests truncate. `loaded_libs_digest` = `151aa8565a2f3cf0`
derived or hashed over the whole 36-lib torch env, and a real `python -m gen_worker.entrypoint`
boot seals `48d03e2730d13f64` before **and** after. No `SEAL_VERSION` bump.

## Measured (pgw#1087's table, same box, minutes apart)

| row | before (`origin/master@f77963f0`) | after |
|---|---|---|
| `lib_memo` | 6,229 ms `reason=miss hits=0 misses=36` | **314 ms `reason=hit record=36 hashed=0`** |
| `env_establish` | 8,945 ms | **2,595 ms** |
| `first_request_servable` | 15,966 ms | **8,492 ms** |

RECORD coverage **36/36**. This box's page cache is warm; the pod paid 17.3 s for the same pass.

## The trade, stated not buried

RECORD hashes were verified at INSTALL time. A claim is honoured only when the file still matches
RECORD's size and has not been written since the RECORD describing it. Caught (and hashed):
uncovered files, size changes, newer-mtime rewrites, unanchored RECORDs. **Not caught**: an
in-place rewrite preserving size with `mtime_ns` restored — the same forge the pgw#832 memo and
the `_lib_digest` lru_cache already accept, asserted as a test rather than left for a reader.

## Tests

10 new in `tests/test_seal_record_derivation_pgw1095.py`, including both RED directions and the
byte-identity proof with hashing forbidden outright. mypy clean (247 files); all eight fast-gate
lints exit 0 locally.