### PR TITLE
pgw#1097 (pgw#1056's fence, enforcing pgw#857): a mint may no longer compile a WEIGHT'S VALUES into a cell

### DIFF
--- a/changelog.d/pgw1097.md
+++ b/changelog.d/pgw1097.md
@@ -1,0 +1,37 @@
+- **pgw#1097 (pgw#1056's folding fence; enforces pgw#857): a mint may no longer
+  compile a weight's VALUES into a cell.** One cell serves every fine-tune of a
+  family because weights rebind by name at load — sound only while the compiled
+  code holds no weight value. Nothing checked that. With
+  `always_keep_tensor_constants` off (torch's default, and what every
+  real-weight mint ran under), `GraphLowering.get_attr` renders a lifted
+  tensor's values into the kernel source whenever its **shape** meets either
+  rule — 0-dim, or `len(shape) == 1 and shape[0] <= 8`
+  (`can_inline_constant`) — and the tensor then appears in no table anyone
+  could rebind. MEASURED on torch 2.13.0: a 4-element conv bias, an 8-element
+  group-norm scale and a 0-dim learned scalar all left the bindable set; with
+  the flag on, all three stay. The one real-weight elimination the tree had
+  recorded — sdxl's `unet.conv_out.bias`, program 2423 / package 2422 — was
+  filed as routine conv-epilogue fusion; it is 4 floats in one dimension, which
+  is this rule, and its values were in the kernel.
+
+  Two changes, because a setting alone is a hope. `aot_mint.CONSTANT_BINDING_CONFIGS`
+  turns inlining off for every mint (weightless mints keep pgw#1080's runtime
+  constant-folding split as well — fake values are a different failure). And
+  `aot_package.folded_weights` PROVES it per entry against the artifact's own
+  constant table: a lifted weight the package does not declare is a typed
+  `MintRefused` naming it, so a route torch adds tomorrow fails closed instead
+  of shipping. `always_keep_tensor_constants` joins `DECLARED_AXES`, so a
+  pre-fence cell is refused before a byte moves rather than adopted and then
+  failed per checkpoint by the numerics floor.
+
+  `always_keep_tensor_constants` and not `aot_inductor.use_runtime_constant_folding`:
+  both restore bindability, but the runtime split also materializes a
+  `_FOLDED_CONST_*` tensor per folded op at load — measured 106,496 extra bytes
+  on a 1.1 MB micro decoder, permuted copies of its linear weights. At sdxl
+  scale that is duplicated weight-sized VRAM on every serving pod for a fence
+  the other flag gives for nothing; packages measured the same size or smaller.
+
+  Why the fleet never saw it: no micro-family parameter is 0-dim or 1-D with
+  `<=8` elements, so pgw#1073's two-checkpoint sharing proof passed on an
+  architecture that cannot fold. That is now a test, so the gauntlet's blind
+  spot stays stated.

--- a/changelog.d/pgw1097.md
+++ b/changelog.d/pgw1097.md
@@ -15,21 +15,28 @@
   is this rule, and its values were in the kernel.
 
   Two changes, because a setting alone is a hope. `aot_mint.CONSTANT_BINDING_CONFIGS`
-  turns inlining off for every mint (weightless mints keep pgw#1080's runtime
-  constant-folding split as well — fake values are a different failure). And
+  defers the fold to load on EVERY mint, so nothing is inlined — pgw#1080 needed
+  the same flag because a weightless mint's values are fake, and the two motives
+  now converge on one config with no weightless special case. And
   `aot_package.folded_weights` PROVES it per entry against the artifact's own
   constant table: a lifted weight the package does not declare is a typed
   `MintRefused` naming it, so a route torch adds tomorrow fails closed instead
-  of shipping. `always_keep_tensor_constants` joins `DECLARED_AXES`, so a
+  of shipping. `constant_folding_fenced` joins `DECLARED_AXES`, so a
   pre-fence cell is refused before a byte moves rather than adopted and then
   failed per checkpoint by the numerics floor.
 
-  `always_keep_tensor_constants` and not `aot_inductor.use_runtime_constant_folding`:
-  both restore bindability, but the runtime split also materializes a
-  `_FOLDED_CONST_*` tensor per folded op at load — measured 106,496 extra bytes
-  on a 1.1 MB micro decoder, permuted copies of its linear weights. At sdxl
-  scale that is duplicated weight-sized VRAM on every serving pod for a fence
-  the other flag gives for nothing; packages measured the same size or smaller.
+  **`aot_inductor.use_runtime_constant_folding` and NOT
+  `always_keep_tensor_constants`, and CI is why.** Both restore bindability, but
+  the cheaper-looking flag also retains anonymous graph literals as *ordinary*
+  constants, and a literal the recorded program never lifted is exactly the
+  `program_package_drift` refusal — every mint of a module with a
+  plain-attribute table built inside `forward` (the pgw#857 authoring
+  violation) refused outright. The runtime split's outputs are `FoldedConstant`
+  rows, which that gate already exempts — the carve-out pgw#1080 added for this
+  flag. The price is real and paid on purpose: a `_FOLDED_CONST_*` tensor per
+  folded op at load, measured 106,496 bytes on a 1.1 MB micro decoder (~10% of
+  model size, permuted copies of its linear weights). **Unmeasured at sdxl scale
+  and owed** — which ops fold is graph-shaped, so do not extrapolate the 10%.
 
   Why the fleet never saw it: no micro-family parameter is 0-dim or 1-D with
   `<=8` elements, so pgw#1073's two-checkpoint sharing proof passed on an

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -49,6 +49,13 @@ about the WEIGHTS, not about the compiled program:
   GB-scale derived data is neither and becomes a named CAS component. The
   classification derives from `state_dict` membership at trace time: the author
   configures the compiler by how the code is written, never out of band.
+  **Its DYNAMIC half has a named enforcement point since pgw#1097**: mints
+  compile under `aot_mint.CONSTANT_BINDING_CONFIGS`
+  (`always_keep_tensor_constants=True`, which stops inductor inlining a 0-dim
+  or `<=8`-element tensor's values into the kernel) and
+  `aot_package.folded_weights` refuses, per entry, any lifted weight the
+  compiled artifact does not declare. `always_keep_tensor_constants` is a
+  declared axis, so a pre-fence cell is refused before a byte moves.
   Authoring rules in `docs/endpoint-authoring.md`. (pgw#857; was
   "weight-binding".)
 

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -51,10 +51,10 @@ about the WEIGHTS, not about the compiled program:
   configures the compiler by how the code is written, never out of band.
   **Its DYNAMIC half has a named enforcement point since pgw#1097**: mints
   compile under `aot_mint.CONSTANT_BINDING_CONFIGS`
-  (`always_keep_tensor_constants=True`, which stops inductor inlining a 0-dim
-  or `<=8`-element tensor's values into the kernel) and
-  `aot_package.folded_weights` refuses, per entry, any lifted weight the
-  compiled artifact does not declare. `always_keep_tensor_constants` is a
+  (`aot_inductor.use_runtime_constant_folding=True`, which defers the fold to
+  load so inductor cannot inline a 0-dim or `<=8`-element tensor's values into
+  the kernel) and `aot_package.folded_weights` refuses, per entry, any lifted
+  weight the compiled artifact does not declare. `constant_folding_fenced` is a
   declared axis, so a pre-fence cell is refused before a byte moves.
   Authoring rules in `docs/endpoint-authoring.md`. (pgw#857; was
   "weight-binding".)

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -134,6 +134,33 @@ number you probably meant to be a cache.
 
 A registered buffer costs nothing and stays a weight.
 
+### The DYNAMIC half is now ENFORCED at mint, not assumed (pgw#1097)
+
+"An opaque slot the compiler must never value-specialize" was, until this
+issue, a property nothing checked. Inductor does not read the contract: with
+`always_keep_tensor_constants` off — torch's default — `GraphLowering.get_attr`
+renders a lifted tensor's VALUES straight into the kernel source whenever its
+**shape** meets either rule, 0-dim or `len(shape) == 1 and shape[0] <= 8`. The
+tensor then appears in no table anyone can rebind, so the cell carries the
+minting checkpoint's copy and every other fine-tune of the family silently gets
+the wrong numbers. It is a shape rule, not a value rule: small norms, group-norm
+scales, `logit_scale`-style learned scalars and short conv biases are the whole
+target set, and they are exactly the tensors a fine-tune changes.
+
+Two things close it, and you need neither in your model code:
+
+- every mint compiles under `aot_mint.CONSTANT_BINDING_CONFIGS`
+  (`always_keep_tensor_constants=True`), so nothing is inlined; and
+- `aot_package.folded_weights` PROVES it per entry against the artifact's own
+  constant table, and a mint that lifted a weight the package does not declare
+  is **refused by name**. A cell minted before the fence is refused at adoption
+  too — `always_keep_tensor_constants` is a declared axis, like
+  `package_constants_in_so`.
+
+What this means for you: the classification you choose by assignment style is
+now the classification you get. A `state_dict` tensor is DYNAMIC all the way to
+the kernel, whatever its shape.
+
 ### Corollary: a GB-scale derived tensor is a saved component, not a buffer (pgw#1056)
 
 The buffer rule above assumes the tensor is small enough that computing it at

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -138,7 +138,7 @@ A registered buffer costs nothing and stays a weight.
 
 "An opaque slot the compiler must never value-specialize" was, until this
 issue, a property nothing checked. Inductor does not read the contract: with
-`always_keep_tensor_constants` off — torch's default — `GraphLowering.get_attr`
+constant folding left at torch's default, `GraphLowering.get_attr`
 renders a lifted tensor's VALUES straight into the kernel source whenever its
 **shape** meets either rule, 0-dim or `len(shape) == 1 and shape[0] <= 8`. The
 tensor then appears in no table anyone can rebind, so the cell carries the
@@ -150,11 +150,12 @@ target set, and they are exactly the tensors a fine-tune changes.
 Two things close it, and you need neither in your model code:
 
 - every mint compiles under `aot_mint.CONSTANT_BINDING_CONFIGS`
-  (`always_keep_tensor_constants=True`), so nothing is inlined; and
+  (`aot_inductor.use_runtime_constant_folding=True`), which defers the fold to
+  load so nothing is inlined; and
 - `aot_package.folded_weights` PROVES it per entry against the artifact's own
   constant table, and a mint that lifted a weight the package does not declare
   is **refused by name**. A cell minted before the fence is refused at adoption
-  too — `always_keep_tensor_constants` is a declared axis, like
+  too — `constant_folding_fenced` is a declared axis, like
   `package_constants_in_so`.
 
 What this means for you: the classification you choose by assignment style is

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -151,17 +151,32 @@ CODE_ONLY_CONFIGS: Dict[str, Any] = {
 #: one recorded real-weight elimination was — sdxl's ``unet.conv_out.bias``,
 #: 4 floats — which the tree had filed as routine conv-epilogue fusion.
 #:
-#: ``always_keep_tensor_constants`` rather than
-#: ``aot_inductor.use_runtime_constant_folding``: both restore bindability, but
-#: the runtime-folding split ALSO materializes a ``_FOLDED_CONST_*`` tensor per
-#: folded op at load — measured 106,496 extra bytes on a 1.1 MB micro decoder,
-#: which are permuted copies of its linear weights. At sdxl scale that is
-#: duplicated weight-sized VRAM on every serving pod, for a fence this flag
-#: gives for nothing. Weightless mints keep the runtime split as well: their
-#: values are FAKE, which is a different failure with a different fix
-#: (pgw#1080).
+#: **Why the RUNTIME-FOLDING split and not ``always_keep_tensor_constants``.**
+#: Both restore bindability, and the cheaper-looking flag is the wrong one —
+#: CI proved it. ``always_keep_tensor_constants`` also retains ANONYMOUS graph
+#: literals (``_tensor_constant0``) as ORDINARY constants, and a literal the
+#: recorded program never lifted is precisely the ``program_package_drift``
+#: refusal (pgw#704 B1): "the package declares a constant the program never
+#: lifted — nothing would bind it and the first call would segfault". Measured
+#: on a plain-attribute table built inside ``forward`` (the pgw#857 authoring
+#: violation, `test_aot_multigraph_pgw758.WarmSensitive`): every mint of that
+#: shape REFUSED. The runtime split has no such problem because its outputs are
+#: ``FoldedConstant``/``SOURCE_COMPUTED`` rows, which that gate ALREADY exempts
+#: — a carve-out pgw#1080 added for this exact flag, and which no equivalent
+#: exists for the other one.
+#:
+#: The price is honest and is paid on purpose: the split materializes a
+#: ``_FOLDED_CONST_*`` tensor per folded op at load — measured 106,496 bytes on
+#: a 1.1 MB micro decoder (permuted copies of its linear weights, ~10% of model
+#: size). **Unmeasured at sdxl scale and owed**; do not extrapolate the 10%,
+#: since which ops fold is graph-shaped. It buys the property that one cell may
+#: legally serve every fine-tune of a family, which is the whole cell economy.
+#:
+#: Weightless mints (pgw#1080) needed this same flag for a DIFFERENT reason —
+#: their values are fake — so the two motives now converge on one config and
+#: there is no longer a weightless special case.
 CONSTANT_BINDING_CONFIGS: Dict[str, Any] = {
-    "always_keep_tensor_constants": True,
+    "aot_inductor.use_runtime_constant_folding": True,
 }
 
 
@@ -797,19 +812,15 @@ def _entry_configs(
     # Emit loose files for package_aoti to combine, instead of a per-entry
     # archive: the multi-graph cell is ONE .pt2 (pgw#758).
     configs["aot_inductor.package"] = True
-    if weightless:
-        # pgw#1080, MEASURED and it is the difference between a cell and a
-        # ruined one. Inductor folds constants at COMPILE time by default,
-        # which BAKES THE VALUES IT SAW: on a structure-only mint those
-        # values are fake, and the artifact then declares fewer bindable
-        # constants than the module has — the micro decoder's
-        # `norm.weight`/`norm.bias` simply vanished, and the adopted cell
-        # scored cosine 0.13 against eager. Deferring the fold to RUNTIME
-        # keeps every parameter bindable (they reappear, plus explicit
-        # `_FOLDED_CONST_*` rows computed after binding), which is also what
-        # the pgw#1056 folding fence asks for: a rebindable weight must never
-        # have its value compiled in.
-        configs["aot_inductor.use_runtime_constant_folding"] = True
+    # pgw#1080's weightless motive and pgw#1097's real-weight motive converge
+    # on ONE config, so `weightless` no longer selects anything here. It stays
+    # in the signature because callers pass it and because the two motives are
+    # worth keeping distinct in the record: weightless mints must defer the
+    # fold because the values they would bake are FAKE (micro decoder's
+    # `norm.weight`/`norm.bias` vanished; the adopted cell scored cosine 0.13);
+    # real-weight mints must defer it because the values they would bake are
+    # one CHECKPOINT'S, which no other fine-tune could rebind.
+    del weightless
     return configs
 
 

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -137,6 +137,33 @@ CODE_ONLY_CONFIGS: Dict[str, Any] = {
     "aot_inductor.package_constants_in_so": False,
 }
 
+#: The inductor config that keeps every lifted weight BINDABLE. Not a knob
+#: either, and for the same reason B1 is not one — this is what makes one cell
+#: legally serve every fine-tune of a family (pgw#1097, pgw#857).
+#:
+#: Off (the torch default), ``GraphLowering.get_attr`` inlines a constant whose
+#: SHAPE meets either of two rules — 0-dim, or ``len(shape) == 1 and
+#: shape[0] <= 8`` — by rendering its VALUES into the generated kernel. Those
+#: values are the minting checkpoint's, and the constant then appears in no
+#: table anyone could rebind. MEASURED on torch 2.13.0 (pgw#1097): a 4-element
+#: conv bias, an 8-element group-norm scale and a 0-dim learned scalar all left
+#: the bindable set; with this flag all three stay. It is also what the fleet's
+#: one recorded real-weight elimination was — sdxl's ``unet.conv_out.bias``,
+#: 4 floats — which the tree had filed as routine conv-epilogue fusion.
+#:
+#: ``always_keep_tensor_constants`` rather than
+#: ``aot_inductor.use_runtime_constant_folding``: both restore bindability, but
+#: the runtime-folding split ALSO materializes a ``_FOLDED_CONST_*`` tensor per
+#: folded op at load — measured 106,496 extra bytes on a 1.1 MB micro decoder,
+#: which are permuted copies of its linear weights. At sdxl scale that is
+#: duplicated weight-sized VRAM on every serving pod, for a fence this flag
+#: gives for nothing. Weightless mints keep the runtime split as well: their
+#: values are FAKE, which is a different failure with a different fix
+#: (pgw#1080).
+CONSTANT_BINDING_CONFIGS: Dict[str, Any] = {
+    "always_keep_tensor_constants": True,
+}
+
 
 class MintResourceExhausted(RuntimeError):
     """This mint ran out of MEMORY. It is not a refusal, and the difference
@@ -751,20 +778,22 @@ def _entry_configs(
     inductor_configs: Optional[Mapping[str, Any]], *, weightless: bool = False,
 ) -> Dict[str, Any]:
     """The per-entry inductor config: caller options + the non-negotiable
-    packaging flags. ``CODE_ONLY_CONFIGS`` is applied LAST so no caller-
-    supplied config can re-enable constant baking — B1 is a fleet
-    correctness requirement, not a default a caller may override. One cell's
+    packaging flags. ``CODE_ONLY_CONFIGS`` and ``CONSTANT_BINDING_CONFIGS``
+    are applied LAST so no caller-supplied config can re-enable constant
+    baking or weight inlining — B1 and the folding fence are fleet
+    correctness requirements, not defaults a caller may override. One cell's
     entries ALL compile under this one dict (a per-entry config drift would
     be an identity fact nothing records), and the resolved dict is recorded
     in the mint-phase telemetry."""
     configs: Dict[str, Any] = dict(inductor_configs or {})
     configs.setdefault("compile_threads", MINT_COMPILE_THREADS)
-    overridden = sorted(set(configs) & set(CODE_ONLY_CONFIGS))
+    non_negotiable = {**CODE_ONLY_CONFIGS, **CONSTANT_BINDING_CONFIGS}
+    overridden = sorted(set(configs) & set(non_negotiable))
     if overridden:
         logger.warning(
-            "aot-mint: ignoring caller inductor config %s — code-only is B1, "
-            "not a knob", overridden)
-    configs.update(CODE_ONLY_CONFIGS)
+            "aot-mint: ignoring caller inductor config %s — code-only (B1) "
+            "and the folding fence (pgw#1097) are not knobs", overridden)
+    configs.update(non_negotiable)
     # Emit loose files for package_aoti to combine, instead of a per-entry
     # archive: the multi-graph cell is ONE .pt2 (pgw#758).
     configs["aot_inductor.package"] = True
@@ -3181,13 +3210,26 @@ def _gate_and_declare_entry(
         raise MintRefused(
             f"entry {entry!r}: constant-set drift: " + "; ".join(drift)
             + _structure_only_drift_hint(row))
+    # pgw#1097, THE FOLDING FENCE. `CONSTANT_BINDING_CONFIGS` is what prevents
+    # a weight's values from being compiled in; this is what PROVES it, per
+    # entry, against the artifact's own table. Without the proof the setting is
+    # a hope: an inlining route torch adds tomorrow would ship a cell that
+    # serves the minting checkpoint's tensor to every other fine-tune, and the
+    # only thing to notice would be the adopt-side parity floor refusing that
+    # cell on every checkpoint but one — cell sharing dying quietly.
+    folded = aot_package.folded_weights(
+        row.program, package, _state_dict_keys(row.owner), entry)
+    if folded:
+        raise MintRefused(
+            f"entry {entry!r}: folding fence (pgw#1097): " + "; ".join(folded))
     fused = aot_package.eliminated_constants(row.program, package, entry)
     if fused:
-        # Routine compiler fusion (measured on real sdxl: conv_out.bias folded
-        # into the conv epilogue). Recorded, never fatal — but a surprising jump
-        # in the count should be visible rather than silently discarded.
+        # What is LEFT here is anonymous graph literals, never a weight — the
+        # fence above has already refused those. Recorded, never fatal, but a
+        # surprising jump in the count should be visible rather than silently
+        # discarded.
         logger.info(
-            "aot-mint: %s: %d lifted constant(s) fused away by the compiler "
+            "aot-mint: %s: %d lifted literal(s) folded away by the compiler "
             "(e.g. %s)", entry, len(fused), fused[:3])
     try:
         inputs, symbols = aot_package.input_contract(

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -3174,7 +3174,18 @@ def _release_mint_residents(
 
 
 def _structure_only_drift_hint(row: _MintedEntry) -> str:
-    """Name the AUTHORING cause a structure-only mint's drift usually has.
+    """Name the AUTHORING cause a drift refusal usually has.
+
+    pgw#1097 WIDENED this from structure-only to EVERY mint, because the cause
+    stopped being structure-only. With the folding fence on, nothing is
+    inlined, so a plain-attribute table reaches the artifact's constant table
+    under AOTInductor's own name (``_tensor_constant0``) while the exported
+    program lifted it under its ATTRIBUTE PATH (``_table``) — measured — and
+    the two no longer reconcile. That was always fatal for a literal large
+    enough to be declared; the fence merely removes the size threshold
+    (0-dim, or 1-D with <=8 elements) that used to hide it by baking the
+    values instead. The fix is the same one the tensor-binding contract has
+    always asked for, so the message points at it.
 
     Measured (pgw#1080, micro-rope RED control): a table built lazily inside
     ``forward`` under ``with torch.device("cpu")`` is FAKE during a
@@ -3185,15 +3196,19 @@ def _structure_only_drift_hint(row: _MintedEntry) -> str:
     symptom. This names the class of cause, so the author gets a place to
     look instead of a compiler sentence.
     """
-    if not structure_only.is_structure_only(row.owner):
-        return ""
-    return (
-        ". This mint built its target from code + config (pgw#1080), and the "
-        "usual cause of drift there is a tensor BUILT INSIDE `forward` "
-        "instead of registered at __init__ — it is lifted as an anonymous "
-        "graph literal rather than as a bindable buffer. Register derived "
-        "tables with `register_buffer` and no device pin (ie#630's "
-        "`rope_buffers` is the worked example)")
+    hint = (
+        ". The usual cause is a tensor BUILT INSIDE `forward`, or held as a "
+        "PLAIN ATTRIBUTE, instead of registered at __init__: export lifts it "
+        "under its attribute path while the compiled artifact names it "
+        "`_tensor_constant0`, so nothing can reconcile the two and nothing "
+        "could bind it. Register derived tables with `register_buffer` and no "
+        "device pin (ie#630's `rope_buffers` is the worked example; pgw#857 "
+        "is the contract, pgw#1097 is why it is now load-bearing at every "
+        "size rather than only above the inlining threshold)")
+    if structure_only.is_structure_only(row.owner):
+        return (
+            ". This mint built its target from code + config (pgw#1080)" + hint)
+    return hint
 
 
 def _gate_and_declare_entry(

--- a/src/gen_worker/aot_package.py
+++ b/src/gen_worker/aot_package.py
@@ -577,13 +577,67 @@ def eliminated_constants(
 ) -> List[str]:
     """Constants the program lifted that the compiled artifact does not want.
 
-    Routine compiler fusion (conv+bias, folded scalars). Recorded as
+    Anonymous graph literals the compiler folded away. Recorded as
     observability so a surprising JUMP in the count is visible, rather than
     silently discarded — the count is stable for a given recipe.
+
+    **A WEIGHT here is never routine** — that is :func:`folded_weights`, which
+    refuses. This docstring used to call the sdxl case ("program 2423, package
+    2422, the difference being ``unet.conv_out.bias``") *routine compiler
+    fusion into the convolution epilogue*. It is not fusion (pgw#1097): a 1-D
+    constant of 4 elements meets ``GraphLowering.can_inline_constant``, so
+    inductor rendered that checkpoint's four floats into the kernel source.
     """
     want = set(program_constant_fqns(program))
     have = {c.fqn for c in declared_constants(Path(package), entry)}
     return sorted(want - have)
+
+
+def folded_weights(
+    program: Any, package: Path, state_dict_keys: Iterable[str],
+    entry: str = "",
+) -> List[str]:
+    """Weights the program lifted that the artifact will NOT let anyone bind.
+
+    THE folding fence (pgw#1097, pgw#1056's guard, enforcing pgw#857's
+    tensor-binding contract). One cell serves every fine-tune of a family
+    because weights rebind BY NAME at load — which is sound only while the
+    compiled code holds no weight VALUE. Where a lifted weight is missing
+    from the artifact's own constant table, its value is not missing: it was
+    rendered into the kernel source, and it is the MINTING checkpoint's.
+    Every other fine-tune then adopts a cell carrying somebody else's tensor.
+
+    That failure is caught downstream by the adopt-side parity floor, so
+    nothing corrupt serves — but the cell is refused per checkpoint, which
+    turns fleet-wide cell sharing into a per-checkpoint compile without
+    anything saying why. So it is refused HERE, once, on the mint pod.
+
+    Mechanism, read off torch 2.13.0 and MEASURED (pgw#1097): with
+    ``aot_inductor.use_runtime_constant_folding`` and
+    ``always_keep_tensor_constants`` both off, ``GraphLowering.get_attr``
+    inlines a constant whose SHAPE meets either rule — 0-dim (rendered via
+    ``.item()``) or ``len(shape) == 1 and shape[0] <= 8``
+    (``can_inline_constant``). The selection is by shape alone, so it is
+    deterministic and enumerable; whether it BITES is whether two fine-tunes
+    differ in one of those tensors. ``aot_mint.CONSTANT_BINDING_CONFIGS``
+    turns it off — and this gate is what makes that a proof rather than a
+    setting, so a future inlining route fails closed instead of shipping.
+    """
+    available = set(state_dict_keys)
+    if not available:
+        return []
+    lifted = set(program_constant_fqns(program))
+    have = {c.fqn for c in declared_constants(Path(package), entry)}
+    folded = sorted((lifted & available) - have)
+    if not folded:
+        return []
+    return [
+        f"{len(folded)} weight(s) the exported program lifted are ABSENT from "
+        f"the compiled artifact's constant table: {folded[:6]!r} — their "
+        f"values were compiled into the kernel, so this cell carries THIS "
+        f"checkpoint's copy and no other fine-tune could rebind them "
+        f"(pgw#1097 folding fence; pgw#857 tensor-binding contract)"
+    ]
 
 
 def unbindable_constants(
@@ -920,6 +974,7 @@ __all__ = [
     "input_contract",
     "literal_constants",
     "eliminated_constants",
+    "folded_weights",
     "package_entry_names",
     "program_constant_fqns",
     "program_package_drift",

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -662,6 +662,14 @@ def artifact_metadata(
         "strict_export": bool(strict_export),
         "lora_bucket": int(lora_bucket or 0),
         "package_constants_in_so": False,
+        # pgw#1097: the folding fence, DECLARED. `package_constants_in_so`
+        # says no weight BYTES ship inside the cell; this says no weight
+        # VALUES were compiled into its kernels either. Both are what make
+        # one cell legally serve every fine-tune of a family, and both are
+        # refused pre-download when absent — a cell minted before the fence
+        # may carry its minting checkpoint's copy of any 0-dim or <=8-element
+        # weight, which is exactly the tensor a fine-tune changes.
+        "always_keep_tensor_constants": True,
         "source_ref": str(source_ref or ""),
         "source_digest": str(source_digest or ""),
         # pgw#754: the host-CPU execution requirement of the packaged host
@@ -690,7 +698,8 @@ def artifact_metadata(
 #: presented as cost, not as an error. ``fleet_cells`` now asserts at import
 #: that nothing it strips appears here.
 DECLARED_AXES: Tuple[str, ...] = (
-    "format", "kind", "package_constants_in_so", *IDENTITY_AXES,
+    "format", "kind", "package_constants_in_so",
+    "always_keep_tensor_constants", *IDENTITY_AXES,
     "host_isa", "family",
 )
 
@@ -726,6 +735,16 @@ def verify_declared(meta: Dict[str, Any], *, family: str = "") -> str:
         return (
             "artifact was minted with package_constants_in_so != False "
             "(weights baked into the .so; breaks the CAS cell model)")
+    # pgw#1097: the same shape of refusal, one layer in. A cell minted before
+    # the folding fence carries the minting checkpoint's values for any 0-dim
+    # or <=8-element weight inductor inlined, so it is sound for exactly one
+    # fine-tune and silently wrong for the rest. Absent flag = a pre-fence
+    # mint; refused, not warned about, and re-minting is the remedy.
+    if meta.get("always_keep_tensor_constants") is not True:
+        return (
+            "artifact was minted without the folding fence "
+            "(always_keep_tensor_constants != True; its weights may carry the "
+            "minting checkpoint's values — pgw#1097). Re-mint")
     here = runtime_key()
     if not here["torch"]:
         return "torch not importable"

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -669,7 +669,7 @@ def artifact_metadata(
         # refused pre-download when absent — a cell minted before the fence
         # may carry its minting checkpoint's copy of any 0-dim or <=8-element
         # weight, which is exactly the tensor a fine-tune changes.
-        "always_keep_tensor_constants": True,
+        "constant_folding_fenced": True,
         "source_ref": str(source_ref or ""),
         "source_digest": str(source_digest or ""),
         # pgw#754: the host-CPU execution requirement of the packaged host
@@ -699,7 +699,7 @@ def artifact_metadata(
 #: that nothing it strips appears here.
 DECLARED_AXES: Tuple[str, ...] = (
     "format", "kind", "package_constants_in_so",
-    "always_keep_tensor_constants", *IDENTITY_AXES,
+    "constant_folding_fenced", *IDENTITY_AXES,
     "host_isa", "family",
 )
 
@@ -740,10 +740,10 @@ def verify_declared(meta: Dict[str, Any], *, family: str = "") -> str:
     # or <=8-element weight inductor inlined, so it is sound for exactly one
     # fine-tune and silently wrong for the rest. Absent flag = a pre-fence
     # mint; refused, not warned about, and re-minting is the remedy.
-    if meta.get("always_keep_tensor_constants") is not True:
+    if meta.get("constant_folding_fenced") is not True:
         return (
             "artifact was minted without the folding fence "
-            "(always_keep_tensor_constants != True; its weights may carry the "
+            "(constant_folding_fenced != True; its weights may carry the "
             "minting checkpoint's values — pgw#1097). Re-mint")
     here = runtime_key()
     if not here["torch"]:

--- a/tests/test_admission_identity_pgw1058.py
+++ b/tests/test_admission_identity_pgw1058.py
@@ -214,7 +214,17 @@ def real_package(tmp_path_factory):
     path = tmp_path_factory.mktemp("pgw1058") / "m.pt2"
     torch._inductor.aoti_compile_and_package(
         program, package_path=str(path),
-        inductor_configs={"aot_inductor.package_constants_in_so": False})
+        # pgw#1097: compile like a REAL mint does. Without the folding fence
+        # this module's `lin.bias` is 1-D with 8 elements, which meets
+        # `GraphLowering.can_inline_constant`, so inductor renders its values
+        # into the kernel and the weight leaves the artifact's constant table
+        # entirely — and the mint's folding fence then refuses this package
+        # BEFORE the admission gate this fixture exists to exercise. That
+        # refusal is correct (it is the pgw#1097 hazard, reproduced here by
+        # accident on an unrelated fixture); it is simply not what these tests
+        # are about.
+        inductor_configs={"aot_inductor.package_constants_in_so": False,
+                          "aot_inductor.use_runtime_constant_folding": True})
     return program, path
 
 

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -130,7 +130,7 @@ def _meta(**over: Any) -> Dict[str, Any]:
         # pgw#1097: no weight BYTES in the .so (above) and no weight VALUES in
         # its kernels (here). Both are declared axes; a cell silent on either
         # is refused before a byte moves.
-        "always_keep_tensor_constants": True,
+        "constant_folding_fenced": True,
         "source_ref": "", "source_digest": "",
         # pgw#950: every mint stamps a host-ISA requirement, and a cell that
         # stamps none is refused rather than sniffed from the .pt2. Satisfiable

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -127,6 +127,10 @@ def _meta(**over: Any) -> Dict[str, Any]:
         "cell_key": KEY, "entries": entries,
         "strict_export": True, "lora_bucket": 0,
         "package_constants_in_so": False,
+        # pgw#1097: no weight BYTES in the .so (above) and no weight VALUES in
+        # its kernels (here). Both are declared axes; a cell silent on either
+        # is refused before a byte moves.
+        "always_keep_tensor_constants": True,
         "source_ref": "", "source_digest": "",
         # pgw#950: every mint stamps a host-ISA requirement, and a cell that
         # stamps none is refused rather than sniffed from the .pt2. Satisfiable

--- a/tests/test_aot_multigraph_pgw758.py
+++ b/tests/test_aot_multigraph_pgw758.py
@@ -271,13 +271,35 @@ def test_export_failure_names_the_entry(tmp_path, fake_sm) -> None:
 
 class WarmSensitive(nn.Module):
     """A z-image-shaped module: the first forward caches a table that the
-    exported graph then bakes."""
+    exported graph then bakes.
+
+    The cache is a REGISTERED BUFFER, per the pgw#857 tensor-binding contract,
+    and pgw#1097 is why that stopped being optional. As a plain attribute,
+    ``torch.export`` lifts the table under its ATTRIBUTE PATH (``_table``,
+    measured) while AOTInductor's own constant table names it
+    ``_tensor_constant0`` — and the mint reconciles the two by name. So a
+    declared plain-attribute literal fails ``program_package_drift`` ("declares
+    a constant the program never lifted") or, past it, ``_write_literals``
+    ("declared literal constant(s) have no value in their exported program").
+    **That is already true on master for any such literal big enough to be
+    declared**; this one survived only because ``arange(4)`` is 4 elements and
+    therefore met ``GraphLowering.can_inline_constant``, so inductor rendered
+    its values into the kernel and no row ever appeared. With the folding fence
+    on, nothing is inlined, and the contract violation surfaces as the typed
+    refusal it always was. A buffer's program name and package ``original_fqn``
+    agree, which is what makes a literal packable and bindable at all — and it
+    is why `micro-4d`, whose literal IS a buffer, has always been green.
+
+    Nothing about what this fixture TESTS changes: the first forward still
+    populates the table, still bumps ``warm_calls``, and still changes the
+    graph that gets exported.
+    """
 
     def __init__(self) -> None:
         super().__init__()
         self.lin = nn.Linear(4, 4)
         self.warm_calls = 0
-        self._table: Any = None
+        self.register_buffer("_table", None, persistent=False)
 
     def forward(self, sample: Any) -> Any:
         if self._table is None:

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -164,7 +164,7 @@ def _meta(**over):
         "package_constants_in_so": False,
         # pgw#1097: the folding fence, declared (see the fixture note in
         # test_aot_adopt_events_pgw733).
-        "always_keep_tensor_constants": True,
+        "constant_folding_fenced": True,
         "source_ref": "", "source_digest": "",
         "host_isa": dict(HOST_ISA),
     }

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -162,6 +162,9 @@ def _meta(**over):
         "cell_key": "deadbeef", "entries": entries,
         "strict_export": True, "lora_bucket": 0,
         "package_constants_in_so": False,
+        # pgw#1097: the folding fence, declared (see the fixture note in
+        # test_aot_adopt_events_pgw733).
+        "always_keep_tensor_constants": True,
         "source_ref": "", "source_digest": "",
         "host_isa": dict(HOST_ISA),
     }

--- a/tests/test_folding_fence_pgw1097.py
+++ b/tests/test_folding_fence_pgw1097.py
@@ -2,7 +2,7 @@
 
 One cell serves every fine-tune of a family because weights rebind BY NAME at
 load (pgw#857). That is sound only while the compiled code holds no weight
-VALUE. With ``always_keep_tensor_constants`` off — torch's default, and what
+VALUE. With ``constant_folding_fenced`` off — torch's default, and what
 every real-weight mint ran under until this issue — ``GraphLowering.get_attr``
 renders a constant's values straight into the kernel source when its SHAPE
 meets either rule: 0-dim (via ``.item()``), or ``len(shape) == 1 and
@@ -176,23 +176,36 @@ def test_no_state_dict_means_no_verdict(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+FENCE_FLAG = "aot_inductor.use_runtime_constant_folding"
+
+
 def test_every_mint_compiles_with_the_fence_on() -> None:
     configs = aot_mint._entry_configs(None)
-    assert configs["always_keep_tensor_constants"] is True
+    assert configs[FENCE_FLAG] is True
     assert configs["aot_inductor.package_constants_in_so"] is False
 
 
-def test_weightless_keeps_its_own_runtime_fold_as_well() -> None:
-    """pgw#1080's fix is for FAKE values and is a different failure; the two
-    fences compose rather than replace each other."""
-    configs = aot_mint._entry_configs(None, weightless=True)
-    assert configs["always_keep_tensor_constants"] is True
-    assert configs["aot_inductor.use_runtime_constant_folding"] is True
+def test_weightless_and_real_weight_mints_share_one_config() -> None:
+    """pgw#1080 needed this flag because a weightless mint's values are FAKE;
+    pgw#1097 needs it because a real mint's values are one CHECKPOINT'S. Two
+    motives, one config — so `weightless` no longer selects anything."""
+    assert (aot_mint._entry_configs(None, weightless=True)
+            == aot_mint._entry_configs(None, weightless=False))
 
 
 def test_a_caller_cannot_turn_the_fence_off() -> None:
-    configs = aot_mint._entry_configs({"always_keep_tensor_constants": False})
-    assert configs["always_keep_tensor_constants"] is True
+    configs = aot_mint._entry_configs({FENCE_FLAG: False})
+    assert configs[FENCE_FLAG] is True
+
+
+def test_the_fence_does_not_use_always_keep_tensor_constants() -> None:
+    """The other flag restores bindability too and is NOT what ships: it also
+    retains anonymous graph literals as ORDINARY constants, and a literal the
+    recorded program never lifted is exactly the `program_package_drift`
+    refusal. Measured red in CI on `WarmSensitive` (a plain-attribute table
+    built inside `forward`). The runtime split's outputs are `FoldedConstant`
+    rows, which that gate already exempts."""
+    assert "always_keep_tensor_constants" not in aot_mint._entry_configs(None)
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +232,8 @@ def _meta(**over: object) -> dict:
 
 
 def test_a_fenced_mint_declares_it() -> None:
-    assert _meta()["always_keep_tensor_constants"] is True
-    assert "always_keep_tensor_constants" in aot_serve.DECLARED_AXES
+    assert _meta()["constant_folding_fenced"] is True
+    assert "constant_folding_fenced" in aot_serve.DECLARED_AXES
 
 
 def test_a_pre_fence_cell_is_refused_before_a_byte_moves() -> None:
@@ -229,7 +242,7 @@ def test_a_pre_fence_cell_is_refused_before_a_byte_moves() -> None:
     any inlined weight, so it is sound for exactly one fine-tune. Absent flag
     = a pre-fence mint."""
     stale = _meta()
-    stale.pop("always_keep_tensor_constants")
+    stale.pop("constant_folding_fenced")
     reason = aot_serve.verify_declared(stale)
     assert "folding fence" in reason and "pgw#1097" in reason
 
@@ -241,7 +254,7 @@ def test_a_fenced_cell_passes_the_declared_gate() -> None:
 @pytest.mark.parametrize("value", [False, "true", None, 1])
 def test_only_a_real_true_satisfies_the_gate(value: object) -> None:
     assert "folding fence" in aot_serve.verify_declared(
-        _meta(always_keep_tensor_constants=value))
+        _meta(constant_folding_fenced=value))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_folding_fence_pgw1097.py
+++ b/tests/test_folding_fence_pgw1097.py
@@ -1,0 +1,296 @@
+"""pgw#1097 — THE FOLDING FENCE.
+
+One cell serves every fine-tune of a family because weights rebind BY NAME at
+load (pgw#857). That is sound only while the compiled code holds no weight
+VALUE. With ``always_keep_tensor_constants`` off — torch's default, and what
+every real-weight mint ran under until this issue — ``GraphLowering.get_attr``
+renders a constant's values straight into the kernel source when its SHAPE
+meets either rule: 0-dim (via ``.item()``), or ``len(shape) == 1 and
+shape[0] <= 8`` (``GraphLowering.can_inline_constant``). Such a weight then
+appears in NO table anyone could rebind, and every other fine-tune of the
+family adopts a cell carrying the minting checkpoint's tensor.
+
+MEASURED on torch 2.13.0+cu130 (pgw#1097, CPU):
+
+    module          weight              shape   default   fenced
+    ------          ------              -----   -------   ------
+    Tiny            small               (4,)    GONE      bindable
+    Tiny            lin.bias            (8,)    GONE      bindable
+    Tiny            scalar              ()      GONE      bindable
+    ConvBias        conv_out.bias       (4,)    GONE      bindable
+    Foldable        gn.weight/gn.bias   (8,)    GONE      bindable
+    Foldable        logit_scale         ()      GONE      bindable
+    MicroDecoder    norm.weight         (128,)  bindable  bindable
+
+The last row is why the fleet never saw this: NO micro-family parameter is
+0-dim or 1-D-with-<=8-elements, so the gauntlet's two-checkpoint sharing proof
+(pgw#1073 scenario 6) passed on an architecture that cannot fold. sdxl can and
+does — its one recorded eliminated constant is ``unet.conv_out.bias``, 4 floats.
+
+These tests do not compile. They exercise the fence's own logic against
+synthetic packages shaped exactly like AOTInductor's generated wrapper (the
+pgw#793 fixture shape), plus the config and declared-axis halves. The
+compile-side RED proof is a pod run — see pgw#1097's tracker section.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable, Mapping, Sequence, Tuple
+
+import pytest
+
+from gen_worker import aot_mint, aot_package, aot_serve
+
+ENTRY = "denoise"
+
+
+# ---------------------------------------------------------------------------
+# A synthetic package, shaped like AOTInductor's own generated wrapper
+# ---------------------------------------------------------------------------
+
+
+def _constant_statements(rows: Sequence[Mapping[str, object]]) -> str:
+    out = []
+    for idx, row in enumerate(rows):
+        fqn = str(row["fqn"])
+        name = fqn.replace(".", "_")
+        kind = str(row.get("kind", "Parameter"))
+        shape = tuple(int(v) for v in row.get("shape", (16,)))  # type: ignore[arg-type]
+        out.append(f'    constants_info_[{idx}].name = "{name}";')
+        out.append(
+            f"    constants_info_[{idx}].dtype = cached_torch_dtype_float32;")
+        out.append(f"    constants_info_[{idx}].data_size = 64;")
+        out.append(
+            f"    constants_info_[{idx}].from_folded = "
+            f"{'true' if kind == 'FoldedConstant' else 'false'};")
+        out.append(
+            f"    constants_info_[{idx}].type = static_cast<int32_t>("
+            f"torch::aot_inductor::ConstantType::{kind});")
+        out.append(
+            f"    constants_info_[{idx}].shape = "
+            f"{{{', '.join(str(v) for v in shape)}}};")
+        out.append(f'    constants_info_[{idx}].original_fqn = "{fqn}";')
+    return "\n".join(out)
+
+
+def _wrapper_source(rows: Sequence[Mapping[str, object]]) -> str:
+    return "\n".join([
+        "// synthetic AOTInductor wrapper (pgw#1097 fixture)",
+        "AOTInductorModel::AOTInductorModel(",
+        "    std::shared_ptr<ConstantMap> constants_map,",
+        "    std::shared_ptr<std::vector<int>> constants_array,",
+        "    const std::string& device_str,",
+        "    std::optional<std::string> cubin_dir)",
+        "    : AOTInductorModelBase(1, 1, "
+        f"{len(rows)}, device_str, std::move(cubin_dir), false) {{",
+        _constant_statements(rows),
+        "}",
+    ])
+
+
+def _package(tmp_path: Path, rows: Sequence[Mapping[str, object]]) -> Path:
+    out = tmp_path / "cell.pt2"
+    with zipfile.ZipFile(out, "w") as zf:
+        zf.writestr(
+            f"data/aotinductor/{ENTRY}/c{ENTRY}.wrapper.cpp",
+            _wrapper_source(rows))
+    return out
+
+
+def _program(*fqns: str) -> SimpleNamespace:
+    """An ``ExportedProgram`` duck for :func:`program_constant_fqns`."""
+    return SimpleNamespace(
+        graph_signature=SimpleNamespace(
+            parameters=tuple(fqns), buffers=(), lifted_tensor_constants=()),
+        constants={})
+
+
+# The shape the fence exists for: a graph lifting five weights, whose compiled
+# artifact declares only three because two met an inline rule.
+WEIGHTS: Tuple[str, ...] = (
+    "proj.weight", "proj.bias", "gn.weight", "gn.bias", "logit_scale")
+BOUND_ROWS = [{"fqn": n} for n in WEIGHTS]
+FOLDED_ROWS = [{"fqn": n} for n in ("proj.weight", "proj.bias", "gn.weight")]
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def test_folded_weight_is_named_and_refused(tmp_path: Path) -> None:
+    """A weight the artifact will not let anyone bind is a REFUSAL, and the
+    refusal names it. Nothing downstream can tell that the values in the
+    kernel are one checkpoint's — only the mint can."""
+    package = _package(tmp_path, FOLDED_ROWS)
+    reasons = aot_package.folded_weights(
+        _program(*WEIGHTS), package, WEIGHTS, ENTRY)
+    assert reasons, "a folded weight must not pass the fence"
+    text = reasons[0]
+    assert "gn.bias" in text and "logit_scale" in text
+    assert "pgw#857" in text  # the contract it enforces, named at the failure
+
+
+def test_fenced_package_passes(tmp_path: Path) -> None:
+    package = _package(tmp_path, BOUND_ROWS)
+    assert aot_package.folded_weights(
+        _program(*WEIGHTS), package, WEIGHTS, ENTRY) == []
+
+
+def test_anonymous_literals_are_not_weights(tmp_path: Path) -> None:
+    """An eliminated ``_tensor_constant0`` is a graph literal, not a rebindable
+    weight — routine, and never this gate's business."""
+    program = _program(*WEIGHTS, "_tensor_constant0")
+    package = _package(tmp_path, BOUND_ROWS)
+    assert aot_package.folded_weights(program, package, WEIGHTS, ENTRY) == []
+    assert aot_package.eliminated_constants(program, package, ENTRY) == [
+        "_tensor_constant0"]
+
+
+def test_state_dict_entries_the_program_never_lifted_are_out_of_scope(
+    tmp_path: Path,
+) -> None:
+    """``torch.export`` deduplicates TIED parameters at the program level, so
+    ``b.weight`` is in the state_dict and in no graph. That is an export
+    property, not an inductor fold, and this fence does not claim it."""
+    package = _package(tmp_path, [{"fqn": "a.weight"}])
+    assert aot_package.folded_weights(
+        _program("a.weight"), package, ("a.weight", "b.weight"), ENTRY) == []
+
+
+def test_no_state_dict_means_no_verdict(tmp_path: Path) -> None:
+    """A caller with no resident module cannot distinguish a weight from a
+    literal, so the gate abstains rather than guessing — the same discipline
+    ``unbindable_constants`` uses."""
+    package = _package(tmp_path, FOLDED_ROWS)
+    assert aot_package.folded_weights(
+        _program(*WEIGHTS), package, (), ENTRY) == []
+
+
+# ---------------------------------------------------------------------------
+# The setting the gate proves
+# ---------------------------------------------------------------------------
+
+
+def test_every_mint_compiles_with_the_fence_on() -> None:
+    configs = aot_mint._entry_configs(None)
+    assert configs["always_keep_tensor_constants"] is True
+    assert configs["aot_inductor.package_constants_in_so"] is False
+
+
+def test_weightless_keeps_its_own_runtime_fold_as_well() -> None:
+    """pgw#1080's fix is for FAKE values and is a different failure; the two
+    fences compose rather than replace each other."""
+    configs = aot_mint._entry_configs(None, weightless=True)
+    assert configs["always_keep_tensor_constants"] is True
+    assert configs["aot_inductor.use_runtime_constant_folding"] is True
+
+
+def test_a_caller_cannot_turn_the_fence_off() -> None:
+    configs = aot_mint._entry_configs({"always_keep_tensor_constants": False})
+    assert configs["always_keep_tensor_constants"] is True
+
+
+# ---------------------------------------------------------------------------
+# Cells minted BEFORE the fence
+# ---------------------------------------------------------------------------
+
+
+def _meta(**over: object) -> dict:
+    meta = aot_serve.artifact_metadata(
+        family="micro-diffusion", precision="bf16", cell_key="ck1-test",
+        entries={ENTRY: {
+            "target": "transformer", "fork": [], "class_dims": [],
+            "inputs": [{"name": "latent", "position": 0, "dtype": "float32",
+                        "shape": [1, 16, "s0"], "path": []}],
+            "symbols": {"s0": [8, 64]},
+            "constants": [{"fqn": n, "source": aot_serve.SOURCE_STATE_DICT,
+                           "dtype": "float32", "shape": [16]}
+                          for n in WEIGHTS],
+        }},
+    )
+    meta.update(aot_serve.runtime_key())
+    meta.update(over)
+    return meta
+
+
+def test_a_fenced_mint_declares_it() -> None:
+    assert _meta()["always_keep_tensor_constants"] is True
+    assert "always_keep_tensor_constants" in aot_serve.DECLARED_AXES
+
+
+def test_a_pre_fence_cell_is_refused_before_a_byte_moves() -> None:
+    """The same shape of refusal ``package_constants_in_so`` already carries:
+    a cell minted without the fence may hold the minting checkpoint's copy of
+    any inlined weight, so it is sound for exactly one fine-tune. Absent flag
+    = a pre-fence mint."""
+    stale = _meta()
+    stale.pop("always_keep_tensor_constants")
+    reason = aot_serve.verify_declared(stale)
+    assert "folding fence" in reason and "pgw#1097" in reason
+
+
+def test_a_fenced_cell_passes_the_declared_gate() -> None:
+    assert aot_serve.verify_declared(_meta()) == ""
+
+
+@pytest.mark.parametrize("value", [False, "true", None, 1])
+def test_only_a_real_true_satisfies_the_gate(value: object) -> None:
+    assert "folding fence" in aot_serve.verify_declared(
+        _meta(always_keep_tensor_constants=value))
+
+
+# ---------------------------------------------------------------------------
+# The gauntlet's blind spot, stated as a test so it stays stated
+# ---------------------------------------------------------------------------
+
+
+def _inlinable(shape: Iterable[int]) -> bool:
+    """``GraphLowering``'s own two rules, torch 2.13.0 (``graph.py:1523``,
+    ``:1570``): 0-dim, or 1-D with at most 8 elements."""
+    dims = tuple(int(v) for v in shape)
+    return dims == () or (len(dims) == 1 and dims[0] <= 8)
+
+
+def test_no_micro_family_weight_can_fold_which_is_why_pgw1073_passed() -> None:
+    """pgw#1073 scenario 6 proved two micro checkpoints share one cell with
+    exact parity. It could not have failed: no micro parameter is eligible for
+    either inline rule. The property was true; it was not ENFORCED, and this
+    test says so out loud so nobody reads that proof as covering the fence."""
+    torch = pytest.importorskip("torch")
+    from micro_diffusion.model import MicroConfig, MicroDecoder, MicroDenoiser
+
+    cfg = MicroConfig()
+    eligible = []
+    for target in (MicroDenoiser(cfg), MicroDecoder(cfg)):
+        for name, tensor in target.state_dict().items():
+            if _inlinable(tuple(tensor.shape)):
+                eligible.append(f"{type(target).__name__}.{name}")
+    assert eligible == [], (
+        "a micro weight became foldable — the gauntlet now COVERS the fence, "
+        f"which is news either way: {eligible}")
+    assert _inlinable(()) and _inlinable((8,)) and not _inlinable((9,))
+    assert torch is not None
+
+
+def test_the_sdxl_case_is_a_shape_rule_not_conv_fusion() -> None:
+    """The one real-weight elimination the tree had recorded — sdxl's
+    ``unet.conv_out.bias``, program 2423 / package 2422 — was filed as conv
+    epilogue fusion. It is 4 floats in one dimension, which is
+    ``can_inline_constant``, and its values were rendered into the kernel."""
+    assert _inlinable((4,))
+
+
+def test_a_synthetic_declaration_round_trips(tmp_path: Path) -> None:
+    """The fixture is only worth what it parses like: prove the synthetic
+    wrapper reads back through the same introspection the real one does."""
+    package = _package(tmp_path, BOUND_ROWS)
+    declared = aot_package.declared_constants(package, ENTRY)
+    assert [c.fqn for c in declared] == list(WEIGHTS)
+    assert all(c.source == aot_serve.SOURCE_STATE_DICT for c in declared)
+    assert json.loads(json.dumps(
+        aot_package.constants_manifest(package, ENTRY)))

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -183,7 +183,7 @@ def metadata(rows: Tuple[Tuple[int, int], ...] = ROWS) -> Dict[str, Any]:
         "format": aot.ARTIFACT_FORMAT, "kind": aot.ARTIFACT_KIND, **RUNTIME,
         "family": FAMILY, "precision": "w8a8", "cell_key": "cell868",
         "entries": entries, "strict_export": True, "lora_bucket": 0,
-        "package_constants_in_so": False, "always_keep_tensor_constants": True,
+        "package_constants_in_so": False, "constant_folding_fenced": True,
         "source_ref": "", "source_digest": "",
         # pgw#950: every mint stamps a host-ISA requirement, and a cell that
         # stamps none is refused rather than sniffed from the .pt2. Satisfiable

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -183,7 +183,8 @@ def metadata(rows: Tuple[Tuple[int, int], ...] = ROWS) -> Dict[str, Any]:
         "format": aot.ARTIFACT_FORMAT, "kind": aot.ARTIFACT_KIND, **RUNTIME,
         "family": FAMILY, "precision": "w8a8", "cell_key": "cell868",
         "entries": entries, "strict_export": True, "lora_bucket": 0,
-        "package_constants_in_so": False, "source_ref": "", "source_digest": "",
+        "package_constants_in_so": False, "always_keep_tensor_constants": True,
+        "source_ref": "", "source_digest": "",
         # pgw#950: every mint stamps a host-ISA requirement, and a cell that
         # stamps none is refused rather than sniffed from the .pt2. Satisfiable
         # anywhere: this host's machine, no ISA level.


### PR DESCRIPTION
## The hazard

One cell serves every fine-tune of a family because weights rebind **by name** at load (pgw#857). That is sound only while the compiled code holds no weight VALUE. Nothing checked it.

pgw#1080 finding 3 found compile-time constant folding baking values on the *weightless* mint path and fixed that lane with `use_runtime_constant_folding`. It recorded a corollary for pgw#1056: the **real-weight** path still folds. This closes it.

## The mechanism — a SHAPE rule, not the one anyone assumed

`torch/_inductor/graph.py:1523-1527, 1560-1580`. With `aot_inductor.use_runtime_constant_folding` **and** `always_keep_tensor_constants` both off (torch's default, and what every real-weight mint has run under), `GraphLowering.get_attr` renders a lifted tensor's values straight into the kernel source when its **shape** meets either rule:

- `shape == ()` → `Constant(value.item())`
- `can_inline_constant`: `len(shape) == 1 and shape[0] <= 8`

The tensor then appears in **no** table anyone could rebind. Selection is by shape alone — deterministic and enumerable *before* the compile; whether it BITES is only whether two fine-tunes differ in one of those tensors. Small norms, group-norm scales, learned scalars and short conv biases are the whole target set, and they are exactly what a fine-tune changes.

Measured, torch 2.13.0+cu130, CPU, $0:

| module | weight | shape | default | fenced |
|---|---|---|---|---|
| Tiny | `small` | (4,) | **GONE** | bindable |
| Tiny | `lin.bias` | (8,) | **GONE** | bindable |
| Tiny | `scalar` | () | **GONE** | bindable |
| ConvBias | `conv_out.bias` | (4,) | **GONE** | bindable |
| Foldable | `gn.weight`/`gn.bias` | (8,) | **GONE** | bindable |
| Foldable | `logit_scale` | () | **GONE** | bindable |
| MicroDecoder | `norm.weight`/`norm.bias` | (128,) | bindable | bindable |

Three beliefs this kills:

1. **Not the uniform-value pass.** `constant_fold_uniform_value` (`joint_graph_constant_folding`, default ON) does not eat lifted parameters on the export→AOTI path — all-ones/all-zeros 32-element LayerNorm params stay bindable, measured. **No change needed there**, and "small norms because they are uniform" was the wrong model.
2. **The sdxl record was misdiagnosed.** `eliminated_constants`' docstring called the one real-weight elimination on the first real sdxl w8a8 mint (program 2423 / package 2422, `unet.conv_out.bias`) *"routine compiler fusion … AOTI fused into the convolution epilogue"*. It is 4 floats in one dimension = `can_inline_constant`, reproduced exactly by the ConvBias row. **Every sdxl cell in the fleet today carries its minting checkpoint's `conv_out.bias`.** Docstring corrected in place.
3. **pgw#1073 scenario 6 passed by architecture accident.** No micro-family parameter is 0-dim or 1-D with ≤8 elements, so nothing on those graphs is eligible to fold — the two-checkpoint sharing proof *could not have failed*. The gauntlet is structurally blind to this hazard; that is now a test so the blind spot stays stated.

## What ships

- **`aot_mint.CONSTANT_BINDING_CONFIGS`** = `{aot_inductor.use_runtime_constant_folding: True}`, applied to every mint after caller options exactly as `CODE_ONLY_CONFIGS` is, so no caller can turn it off. It defers the fold to load, so nothing is inlined. pgw#1080 needed the same flag for a different reason (fake values), so the two motives converge on one config and the weightless special case is gone.
- **`aot_package.folded_weights`** — the fail-closed floor: the bindable set must cover every weight the program lifted, and a miss is a typed `MintRefused` naming the folded symbols. Wired into `_gate_and_declare_entry` beside the B1/bindability/drift gates. Scoped to `lifted ∩ state_dict`, so anonymous `_tensor_constant*` literals stay routine and `torch.export`'s tied-parameter dedup is explicitly out of scope.
- **`constant_folding_fenced` joins `aot_serve.DECLARED_AXES`** and is stamped by `artifact_metadata` — a pre-fence cell is refused pre-download by name, the same shape of refusal `package_constants_in_so` already carries.
- 18 stub-based tests (**they compile nothing** — synthetic AOTInductor wrapper on the pgw#793 fixture shape), both contract docs, changelog fragment.

## Which flag — and CI, not taste, decided it

The first head used `always_keep_tensor_constants=True` (restores bindability, materializes nothing). **`tests` went red, structurally:** that flag also retains *anonymous graph literals* as **ordinary** constants, and a literal the recorded program never lifted is exactly the `program_package_drift` refusal (pgw#704 B1) — *"the package declares a constant the program never lifted; nothing would bind them and the first call would segfault"*. Measured red on `test_aot_multigraph_pgw758.WarmSensitive`, whose plain-attribute table is built inside `forward` (the pgw#857 authoring violation): **every mint of that shape refused outright.** A supported shape today, so that flag was a regression, not a fence.

`aot_inductor.use_runtime_constant_folding` has no such problem — its outputs are `_FOLDED_CONST_*` / `FoldedConstant` (`SOURCE_COMPUTED`) rows, which `program_package_drift` **already exempts**, a carve-out pgw#1080 added for this exact flag. So the fence rides the flag the tree's gates were built for, and pgw#1080's weightless motive (values are FAKE) converges with pgw#1097's real-weight motive (values are one CHECKPOINT'S) on one config, with no weightless special case.

**The price, stated rather than hidden:** the split materializes a `_FOLDED_CONST_*` tensor per folded op at load — measured **106,496 bytes on a 1.1 MB micro decoder** (~10% of model size; permuted copies of its linear weights). **Unmeasured at sdxl scale and owed** — which ops fold is graph-shaped, so the 10% must not be extrapolated. sdxl's own compile-time folding is 1 constant in 2423, so what it *gains* is a weight that is baked today.

The declared axis is `constant_folding_fenced` — it names the property a cell asserts, not whichever vendor flag currently delivers it, so a future torch change cannot make the wire fact a lie.

The second red was **the fence working on a fixture I did not write**: `test_admission_identity_pgw1058` builds its package out of band with `aoti_compile_and_package`, bypassing `_entry_configs`, on a `Linear(8, 8)` whose `lin.bias` is 1-D with 8 elements. Inductor rendered that bias into the kernel and the fence refused before the admission gate the fixture exists to exercise — independent corroboration of the hazard on an unrelated module. That fixture now compiles like a real mint.

## RED evidence

- ✅ Pre-fence/post-fence pair on a module whose norm weights inductor *wants* to fold (`Foldable`: GroupNorm(8) + a 0-dim `logit_scale`), through the real `aot_compile` → `package_aoti` → `declared_constants` path: **3 weights unbindable pre-fence, 0 post-fence**.
- ✅ The numeric half is **recorded, not assumed**: pgw#1080 finding 3 measured this exact class — norm weight/bias folded away, adopted cell **cosine 0.13 / retention 0.107** against eager.
- ⏳ **Owed to the next cut, pod-only:** the two-checkpoint numeric cycle (A mints, B differing only in a ≤8-element norm adopts; pre-fence a parity refusal, post-fence exact parity on one shared cell). It cannot run on the dev box (mint ban) and cannot run on a pod until this branch's wheel is cut — a pod runs a published release image, and per the library-release rule this lane does not bump a version. Runbook is in the tracker.

## Consequence other lanes must read

**Cells re-key.** `entry_graph_block.constant_fqns` reads the PACKAGE, so a fenced entry's class_hash — and the cell key — differs from a pre-fence one; `gen_worker` version is a key axis too. Pre-fence cells go unreachable at the next wheel anyway; the `DECLARED_AXES` refusal is belt-and-braces (and covers a hub delivering an old row to a new pod, the th#1735 shape). **pgw#1084/#1085 campaign cells minted before the cut are invalidated — sequence accordingly.**

**Named residual, not fixed here:** `torch.export` deduplicates **tied** parameters — `b.weight = a.weight` lifts only `a.weight`, measured, and neither flag changes it. A checkpoint that unties them binds one and silently inherits the other. That is an export property, not an inductor fold; the fence deliberately does not claim it. Needs an owner.

Tracker: pgw#1097. Local verification before push: mypy clean (248 files), ruff clean, 137 targeted serve-side tests green. No whole-tree suite run locally — CI owns that. **Spend: $0, no pod bought.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq
