### PR TITLE
pgw#1096 (§4.28): an untrusted machine mints for ITSELF — a ck1-keyed local cell store, reused on every later boot

### DIFF
--- a/changelog.d/pgw1096.md
+++ b/changelog.d/pgw1096.md
@@ -1,0 +1,14 @@
+- **AOT-local cells: an untrusted machine mints once and reuses it forever (pgw#1096, §4.28).**
+  A worker on hardware the hub will not let publish — community cloud, and cozy-local — now keeps
+  the cell it minted, in its own `ck1`-keyed store under `GEN_WORKER_LOCAL_CELLS_DIR`, and arms
+  from it on every later boot with no mint, no hub and no network. Previously that cell was
+  produced, refused with `cell_publish_untrusted_tier`, and deleted (th#1643's SUNK case) — once
+  per boot, forever. The trust class is learned from the hub's own typed refusal; the worker never
+  declares its own, and no env switches it. A stored cell passes exactly the gate a freshly
+  child-minted one passes (`_arm_exported_cell`, one implementation for both), plus a recomputed
+  content digest, so a corrupted or stale cell costs one honest re-mint and never a wrong arm.
+  Nothing evicts: cells accumulate one per (graph x envelope x sm x toolchain) and
+  `local_cell_store.stored_cells()` enumerates them for the sweep that owes them.
+- **`aot_resume`'s production resume bank no longer roots through the JIT store (pgw#1096).**
+  `store_root()` moved from `local_cells` to `local_cell_store`, same env and same default path —
+  which unblocks pgw#1086 wave 1's deletion of `local_cells.py`.

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -126,7 +126,7 @@ src/gen_worker/convert/clone.py::COZY_CONVERT_WORKDIR STANDALONE COZY_CONVERT_WO
 src/gen_worker/convert/ingest.py::COZY_CLONE_DOWNLOAD_ATTEMPTS STANDALONE COZY_CLONE_DOWNLOAD_ATTEMPTS, convert-tool retry count.
 src/gen_worker/models/download.py::COZY_CIVITAI_DOWNLOAD_ATTEMPTS STANDALONE COZY_CIVITAI_DOWNLOAD_ATTEMPTS, provider retry count.
 src/gen_worker/net.py::$name STANDALONE COZY_HTTP_*_TIMEOUT_S. Documented as "read from env on every call (test-tunable)" - i.e. env used as a TEST SEAM, which is what loader `init_kwargs` exists for. Worth fixing; it is the last piece of prose from the old 5-file exception list that is still true.
-src/gen_worker/local_cells.py::GEN_WORKER_LOCAL_CELLS_DIR STANDALONE GEN_WORKER_LOCAL_CELLS_DIR, local cell store for offline runs.
+src/gen_worker/local_cell_store.py::GEN_WORKER_LOCAL_CELLS_DIR STANDALONE GEN_WORKER_LOCAL_CELLS_DIR, the local cell store's ROOT (pgw#1096 moved the accessor here from local_cells): a path relocation like TENSORHUB_CACHE_DIR, never a behavior knob, and a cross-repo contract with cozy-local's paths.go.
 src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODER STANDALONE GEN_WORKER_VIDEO_ENCODER. pgw#929 rules this MEASURED-then-requested (th#1458-1460 store the evidence, pgw#891 carries the exact requested implementation). Env until then.
 src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODE_CONCURRENCY STANDALONE GEN_WORKER_VIDEO_ENCODE_CONCURRENCY, encode fan-out.
 src/gen_worker/models/native_kernels.py::GEN_WORKER_NATIVE_KERNELS STANDALONE GEN_WORKER_NATIVE_KERNELS, same measured-then-requested ruling as the video encoder.

--- a/src/gen_worker/aot_resume.py
+++ b/src/gen_worker/aot_resume.py
@@ -59,7 +59,7 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
-from . import local_cells
+from . import local_cell_store
 from . import graph_hash as graph_hash_mod
 
 logger = logging.getLogger(__name__)
@@ -94,9 +94,12 @@ REFUSE_FILE_CONTENT = "file_content"   # size or sha256 moved under us
 #: under the mint's own root. `fleet_cells.abandon_self_mint` rmtree's
 #: `mint_root`, and abandonment is exactly what a crashed mint ends in — a bank
 #: under that root would be deleted on its way out of the one case it exists
-#: for. Sited beside `local_cells`' own mint staging (`.mint`) because that is
-#: already the pod's compile-scratch neighbourhood, and NOT in the CAS
-#: (`cache_dir`), which `disk_gc` owns and sweeps by reference index.
+#: for. Sited beside the worker's own local cell store because that is already
+#: the pod's compile-scratch neighbourhood, and NOT in the CAS (`cache_dir`),
+#: which `disk_gc` owns and sweeps by reference index. pgw#1096 moved the root
+#: accessor from `local_cells` (which pgw#1086 wave 1 deletes as a JIT
+#: artifact) to `local_cell_store` — same env, same default, same directory, so
+#: no bank is orphaned by the move.
 RESUME_DIRNAME = ".mint-resume"
 
 #: A capacity bound on the whole resume area, enforced oldest-first at open.
@@ -125,7 +128,7 @@ def bank_root(scope: str) -> Path:
     safe = "".join(
         c if (c.isalnum() or c in "._-") else "_" for c in str(scope))[:48]
     digest = hashlib.sha256(str(scope).encode()).hexdigest()[:12]
-    return local_cells.store_root() / RESUME_DIRNAME / f"{safe or 'scope'}-{digest}"
+    return local_cell_store.store_root() / RESUME_DIRNAME / f"{safe or 'scope'}-{digest}"
 
 
 def _dir_bytes(path: Path) -> int:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -62,6 +62,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 from . import activity as activity_mod
 from . import aot_identity, aot_serve, artifact_meta, cell_key, env_seal
 from . import boot_phases as boot_mod
+from . import local_cell_store
 from . import compile_cache as cc
 from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
 from .models.chunk_cas import sha256_file
@@ -898,6 +899,7 @@ def refused_publishes() -> Dict[str, str]:
 def _publish_async(
     publisher: CellPublisher, family: str, artifact: Path, meta: dict,
     cell_key_digest: str = "", mint_duration_ms: int = 0,
+    arm_token: str = "",
 ) -> threading.Thread:
     """Ship the cell in the background — readiness never waits on an upload.
 
@@ -931,6 +933,18 @@ def _publish_async(
                 family, artifact, meta, mint_duration_ms)
         except CellPublishRefused as exc:
             logger.warning("fleet-cells: publish refused (hub decision): %s", exc)
+            # pgw#1096/§4.28: the hub has just ASSERTED this hardware's trust
+            # class. Learn it (the worker never declares its own — the code is
+            # the only authority), and KEEP the cell: the `finally` below is
+            # about to rmtree the mint root, and this exact discard is what
+            # th#1643 books as SUNK ("a sealed cell was produced and thrown
+            # away"). An untrusted machine mints for ITSELF, so the bytes go
+            # to its own store and every later boot of it arms from disk.
+            if local_cell_store.note_refusal(
+                    str(getattr(exc, "code", "") or ""), str(exc)
+            ) and cell_key.is_key(key):
+                local_cell_store.store(
+                    artifact, key=key, family=family, arm_token=arm_token)
             with _IN_FLIGHT_LOCK:
                 _REFUSED[key] = "refused"
             activity_mod.emit_event(
@@ -1507,6 +1521,20 @@ def _arming_policy(
                 armed=True, self_mint=finalized_prior,
                 selection_bug=selection_bug)
 
+    # §4.28 / pgw#1096: THIS MACHINE's own store, before any mint is opened.
+    # Sited after the in-process ledgers (a cell already resident in this
+    # process costs no disk read) and after the quarantine gate (an identity
+    # this process disproved must not be re-armed from any source), and
+    # BEFORE the pending: compile-once-run-forever means the second boot never
+    # reaches the code below. Costs one memo read + one digest on a hit and a
+    # single missing-file stat on a miss, so the trusted-fleet path — which
+    # never stores anything locally — pays a stat and nothing else.
+    local_prior = arm_from_local_store(
+        pipe, cfg, cache_dir, bucket, arm_key, family)
+    if local_prior is not None:
+        return ArmOutcome(
+            armed=True, self_mint=local_prior, selection_bug=selection_bug)
+
     # Sibling pipes of one record whose axes compute the SAME key share one
     # child mint (the qwen edit shape: two lanes, one family cell) — the
     # first arm registers the pending and every sharer adopts its cell.
@@ -1606,6 +1634,138 @@ def arm_axis_divergence(
     return ""
 
 
+def _arm_exported_cell(
+    pipe: Any, cfg: Any, cache_dir: Optional[Path], bucket: int,
+    artifact: Path, arm_key: Optional[ArmIdentity],
+) -> Tuple[bool, Optional[Dict[str, Any]], Tuple[str, str]]:
+    """THE gate every cell this machine produced for itself must pass.
+
+    pgw#1096 extracted this from :func:`adopt_delegated_mint` so the two
+    self-produced sources — a child process's fresh mint, and this machine's
+    OWN local store (§4.28) — pass through ONE gate rather than two that agree
+    today. A cell out of the local store is neither newer nor more trusted
+    than the child's: it is the same bytes the same machine minted, and it
+    earns its arm the same way.
+
+    Two checks, in this order:
+
+    1. **key-axis divergence** (pgw#1042) — the cell's recorded metadata must
+       state THIS runtime on every pre-trace axis (:data:`ARM_FACTS`), refused
+       by fact name. This is what makes a toolchain/sm/envelope move an honest
+       refusal instead of a wrong arm;
+    2. **the AOT arm** (pgw#805) — ``provision.arm_aot``: lifted-binding
+       install, ``aot_serve.enable``, rollback on failure. Deliberately NOT
+       ``provision.enable_compiled``, whose pgw#709 receipts gate drops any
+       artifact the hub has not countersigned — which by construction is every
+       cell in this family.
+
+    Returns ``(armed, meta, (reason, detail))``. ``reason`` is initialized to a
+    NAMED unset rather than "" so a branch that forgets to classify shows up as
+    a gap in this function instead of as an empty string that reads like "no
+    reason exists" (pgw#999).
+    """
+    refusal: Tuple[str, str] = ("unclassified_arm_refusal", "")
+    meta = artifact_meta.try_read_metadata(artifact)
+    divergence = ""
+    if meta is not None and arm_key is not None:
+        divergence = arm_axis_divergence(arm_key, meta)
+    if divergence:
+        stamped = str(meta.get("cell_key") or "") if meta else "MISSING"
+        return False, meta, ("key_axis_divergence", (
+            f"the cell (stamped key {stamped}) does not describe this "
+            f"runtime: {divergence}"))
+    try:
+        outcome = provision.arm_aot(pipe, cfg, cache_dir, artifact, bucket, meta)
+        if outcome:
+            return True, meta, ("", "")
+        refusal = (outcome.reason or "unclassified_arm_refusal",
+                   outcome.detail or outcome.identity)
+    except cc.CellSelectionBugError as exc:
+        # th#883: a cell whose axes describe exactly this runtime refused to
+        # arm. Loud — a bug in the one selection brain, not a compat miss.
+        logger.error(
+            "fleet-cells: cell_selection_bug arming a self-produced cell "
+            "(%s): %s", artifact, exc)
+        refusal = ("cell_selection_bug", str(exc))
+    except Exception as exc:  # noqa: BLE001 — adoption failure => eager
+        logger.warning(
+            "fleet-cells: self-produced cell %s did not adopt (%s)",
+            artifact, exc)
+        # An `AdoptError` already carries the token; anything else is named by
+        # its type rather than flattened into one word nobody can count.
+        refusal = (str(getattr(exc, "reason", "") or "") or type(exc).__name__,
+                   str(exc))
+    return False, meta, refusal
+
+
+def arm_from_local_store(
+    pipe: Any, cfg: Any, cache_dir: Optional[Path], bucket: int,
+    arm_key: ArmIdentity, family: str,
+) -> Optional[SelfMint]:
+    """§4.28 step 3: arm from THIS MACHINE's own store, before minting anything.
+
+    Paul's compile-once-run-forever, at the one place a miss is decided. The
+    machine derives its pre-trace identity (milliseconds), the memo names the
+    ``ck1`` key its last mint of that identity produced, the store hands back
+    the digest-verified artifact, and :func:`_arm_exported_cell` — the SAME
+    gate the child's own cell passes — decides. No network is touched on this
+    path at all: a cozy-local box with no hub reachable arms exactly as well as
+    one online, which is what "fully offline-capable" means.
+
+    ``None`` = no usable local cell; the caller mints, honestly. Every refusal
+    is loud and DROPS the entry, so a corrupted or stale cell costs one re-mint
+    and never two.
+    """
+    try:
+        local = local_cell_store.lookup_for_arm(arm_key.token)
+    except Exception as exc:  # noqa: BLE001 — a cache read must never be fatal
+        logger.warning("fleet-cells: local cell store unreadable (%s)", exc)
+        return None
+    if local is None:
+        return None
+    armed, meta, (reason, detail) = _arm_exported_cell(
+        pipe, cfg, cache_dir, bucket, local.artifact, arm_key)
+    if not armed:
+        logger.warning(
+            "fleet-cells: the local store's cell for %s (key=%s) did not arm "
+            "(%s%s); dropping it and minting", family, local.key, reason,
+            f": {detail}" if detail else "")
+        local_cell_store.drop(local.key)
+        activity_mod.emit_event(
+            "local_cell_refused",
+            f"family={family} arm_key={arm_key.token} cell_key={local.key}: "
+            f"this machine's own stored cell did not arm "
+            f"({reason}{': ' + detail if detail else ''}); it has been dropped "
+            f"from the local store and this boot mints a fresh one",
+            phase=reason,
+        )
+        return None
+    key = str((meta or {}).get("cell_key") or "").strip() or local.key
+    aot_serve.note_aot_key(key)
+    minted = SelfMint(
+        family=family, cell_key=key,
+        ref=f"{cc.system_repo(family)}#{key}",
+        snapshot_digest=local.content_digest,
+        artifact=local.artifact,
+    )
+    with _PENDING_LOCK:
+        # Same in-process index a delegated adopt fills: a sibling pipe of the
+        # same record must re-arm these bytes rather than pay a second lookup.
+        _FINALIZED[arm_key.token] = minted
+    logger.info(
+        "fleet-cells: armed %s from THIS MACHINE's local cell store "
+        "(key=%s, %.1f MB) — no mint, no hub, no network (§4.28)",
+        family, key, local.bytes / 1e6)
+    activity_mod.emit_event(
+        "local_cell_armed",
+        f"family={family} arm_key={arm_key.token} cell_key={key}: this "
+        f"machine minted this cell on an earlier boot and stored it locally; "
+        f"it arms from disk with no mint and no publish route",
+        phase="local_store_hit",
+    )
+    return minted
+
+
 def adopt_delegated_mint(
     pipe: Any, pending: "PendingSelfMint", artifact: Path,
 ) -> Optional[SelfMint]:
@@ -1632,69 +1792,16 @@ def adopt_delegated_mint(
             os.replace(artifact, pending.target)
         except OSError:
             shutil.copy2(artifact, pending.target)
-    # pgw#999: (reason, detail) of the arm refusal, set by whichever branch
-    # refuses. Initialized to a NAMED unset rather than "" so a branch that
-    # forgets to classify is visible on the wire as a gap in this function
-    # instead of as an empty string that reads like "no reason exists".
-    refusal: Tuple[str, str] = ("unclassified_arm_refusal", "")
-    # pgw#1042: BEFORE any arm, the child's cell must state this parent's
-    # identity on every axis the two key spaces share. A malformed envelope
-    # is left to the arm's own classified refusal (artifact_invalid).
-    meta = artifact_meta.try_read_metadata(pending.target)
-    divergence = ""
-    if meta is not None and pending.arm_key is not None:
-        divergence = arm_axis_divergence(pending.arm_key, meta)
-    if divergence:
-        armed = False
-        refusal = ("key_axis_divergence", (
-            f"the child's cell (stamped key "
-            f"{str(meta.get('cell_key') or '') if meta else 'MISSING'}) does "
-            f"not describe this runtime: {divergence}"))
-    else:
-        try:
-            # pgw#805: an exported cell arms through the AOT gates
-            # (lifted-binding install -> aot_serve.enable -> rollback), not
-            # the inductor seed path. Same gates a hub-delivered `.pt2`
-            # passes; `provision.enable_compiled` itself is not reusable here
-            # because its pgw#709 receipts gate would drop a cell this pod
-            # minted seconds ago and the hub has not countersigned yet.
-            # pgw#999: the outcome is KEPT. `arm_aot` returns a classified
-            # `AdoptOutcome` (`contract_invalid`, `constants_unbound`,
-            # `no_arm_for_mode`, `numerics_refused`, …) and this call site
-            # used to spend it on `bool(...)`. That discard cost attempt 26
-            # 2 h 45 m and $2.72: a 36/36 mint sealed, finalized, and was then
-            # refused by three events that all said "could not adopt".
-            # pgw#1010: there is no second branch — a delegated mint is an AOT
-            # mint, and the inductor-seed adopt it used to fall back to armed
-            # an artifact class nothing publishes any more.
-            outcome = provision.arm_aot(
-                pipe, pending.cfg, pending.cache_dir, pending.target,
-                int(getattr(pending.cfg, "lora_bucket", 0) or 0), meta)
-            armed = bool(outcome)
-            if not armed:
-                refusal = (outcome.reason or "unclassified_arm_refusal",
-                           outcome.detail or outcome.identity)
-        except cc.CellSelectionBugError as exc:
-            # th#883, delegated edition: the child's own cell, whose axes
-            # describe exactly this runtime, refused to arm. Loud — it is a
-            # bug in the one selection brain, not a compatibility miss.
-            logger.error(
-                "fleet-cells: cell_selection_bug adopting this pod's "
-                "DELEGATED mint (family=%s arm_key=%s): %s",
-                pending.family, pending.arm_token, exc)
-            armed = False
-            refusal = ("cell_selection_bug", str(exc))
-        except Exception as exc:  # noqa: BLE001 — adoption failure => eager
-            logger.warning(
-                "fleet-cells: delegated mint for %s did not adopt (%s)",
-                pending.family, exc)
-            armed = False
-            # An `AdoptError` already carries the token; anything else is
-            # named by its type rather than flattened into one word nobody
-            # can count.
-            refusal = (
-                str(getattr(exc, "reason", "") or "") or type(exc).__name__,
-                str(exc))
+    # pgw#1096: ONE gate for every self-produced cell — the child's, and the
+    # local store's (§4.28). pgw#999's classification, pgw#1042's pre-arm axis
+    # divergence and pgw#805's AOT-only arm all live in `_arm_exported_cell`;
+    # the reasons this call site used to compute inline are unchanged, and the
+    # $2.72 lesson (attempt 26: a 36/36 mint refused by three events that all
+    # said "could not adopt") is kept there rather than repeated here.
+    armed, meta, refusal = _arm_exported_cell(
+        pipe, pending.cfg, pending.cache_dir,
+        int(getattr(pending.cfg, "lora_bucket", 0) or 0),
+        pending.target, pending.arm_key)
     if not armed:
         reason, detail = refusal
         # pgw#999: `phase` is the countable column, so it carries the CLASS —
@@ -1771,6 +1878,15 @@ def adopt_delegated_mint(
         # unreadable by the only lookup there is, so every same-key re-arm in
         # this process paid a second full export.
         _FINALIZED[pending.arm_token] = minted
+    if local_cell_store.keeps_cells_locally():
+        # §4.28: this machine has ALREADY been told by the hub that it may not
+        # publish, so the cell is kept where its next boot can find it. Done
+        # HERE, not after the publish attempt, because a pod that dies between
+        # adopting and being refused would otherwise lose the whole mint —
+        # which is exactly the th#1643 SUNK case, one boot later.
+        local_cell_store.store(
+            pending.target, key=minted.cell_key, family=pending.family,
+            arm_token=pending.arm_token)
     logger.info(
         "fleet-cells: DELEGATED mint adopted for %s (key=%s, %.1f MB) — the "
         "worker served eager throughout and now serves compiled",
@@ -1827,7 +1943,11 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             cell_key_digest=str(
                 getattr(state.get("minted"), "cell_key", "")
                 or pending.arm_token),
-            mint_duration_ms=int(state.get("mint_duration_ms") or 0))
+            mint_duration_ms=int(state.get("mint_duration_ms") or 0),
+            # pgw#1096: the PRE-TRACE identity, carried so a hub refusal that
+            # teaches this machine it is untrusted can also write the memo
+            # that lets its next boot find the salvaged cell without tracing.
+            arm_token=pending.arm_token)
     else:
         # Runtime assertion (gw#587): every fleet cell miss must produce a
         # publish attempt. A fleet worker minting with no usable sink is a

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1634,6 +1634,50 @@ def arm_axis_divergence(
     return ""
 
 
+#: pgw#1096: WHY a machine keeps the cell it just minted. Each is a fact about
+#: the SINK, and none of them is the worker deciding its own trust class —
+#: which stays what §4.28 makes it, the hub's call and only the hub's.
+KEEP_HUB_ASSERTED_UNTRUSTED = "hub_asserted_untrusted"
+KEEP_NO_PUBLISHER = "no_publish_sink"
+KEEP_PUBLISH_DISARMED = "publish_disarmed"
+
+
+def local_keep_reason(publisher: Optional[CellPublisher]) -> str:
+    """Why this machine keeps its own cell, "" when it has no reason to.
+
+    §4.28 says an untrusted machine mints for ITSELF. Three disjoint ways a
+    machine learns it has nowhere to ship — and NONE of them is a worker-side
+    trust self-declaration, which the ruling forbids:
+
+    * :data:`KEEP_HUB_ASSERTED_UNTRUSTED` — the HUB refused a publish from this
+      hardware (`cell_publish_untrusted_tier`; `cloudtier.PublishRefusal` on a
+      community/marketplace/unknown tier), recorded by `local_cell_store`. The
+      community-cloud case, and the only one that is about trust at all.
+    * :data:`KEEP_NO_PUBLISHER` — this process constructed no publisher. That
+      is **cozy-local**, which never has one (`fleet_cells` docstring) and never
+      reaches a hub to be refused BY — so a design that waited for a hub verdict
+      would leave the cozy-local half of §4.28 permanently unimplemented, which
+      is the whole product promise. The fleet's `SELF_MINT_WITHOUT_PUBLISH_SINK`
+      wiring alarm is unchanged and still fires: keeping the bytes does not make
+      a mis-wired fleet pod quiet, it just stops it burning the compute twice.
+    * :data:`KEEP_PUBLISH_DISARMED` — a pgw#980 probe, whose publish the control
+      PARENT removes from its hub-call allowlist. Read from the predicate that
+      owns that decision rather than sniffed off an exception.
+
+    Keeping bytes you already paid an hour of compute for, and cannot ship, is
+    not a claim about trust. It is the absence of a reason to delete them.
+    """
+    if local_cell_store.keeps_cells_locally():
+        return KEEP_HUB_ASSERTED_UNTRUSTED
+    if publisher is None or not publisher.enabled():
+        return KEEP_NO_PUBLISHER
+    from .procsplit import actions
+
+    if actions.publish_disarmed():
+        return KEEP_PUBLISH_DISARMED
+    return ""
+
+
 def _arm_exported_cell(
     pipe: Any, cfg: Any, cache_dir: Optional[Path], bucket: int,
     artifact: Path, arm_key: Optional[ArmIdentity],
@@ -1878,15 +1922,24 @@ def adopt_delegated_mint(
         # unreadable by the only lookup there is, so every same-key re-arm in
         # this process paid a second full export.
         _FINALIZED[pending.arm_token] = minted
-    if local_cell_store.keeps_cells_locally():
-        # §4.28: this machine has ALREADY been told by the hub that it may not
-        # publish, so the cell is kept where its next boot can find it. Done
-        # HERE, not after the publish attempt, because a pod that dies between
-        # adopting and being refused would otherwise lose the whole mint —
-        # which is exactly the th#1643 SUNK case, one boot later.
-        local_cell_store.store(
+    keep = local_keep_reason(pending.publisher)
+    if keep:
+        # §4.28: a machine with nowhere to ship keeps its own cell, where its
+        # next boot can find it. Done HERE, not after the publish attempt,
+        # because a pod that dies between adopting and being refused would
+        # otherwise lose the whole mint — the th#1643 SUNK case, one boot later.
+        stored = local_cell_store.store(
             pending.target, key=minted.cell_key, family=pending.family,
             arm_token=pending.arm_token)
+        if stored is not None:
+            activity_mod.emit_event(
+                "local_cell_stored",
+                f"family={pending.family} arm_key={pending.arm_token} "
+                f"cell_key={minted.cell_key}: this machine cannot ship this "
+                f"cell ({keep}), so it keeps it — every later boot of this "
+                f"machine arms it from disk with no mint (§4.28)",
+                phase=keep,
+            )
     logger.info(
         "fleet-cells: DELEGATED mint adopted for %s (key=%s, %.1f MB) — the "
         "worker served eager throughout and now serves compiled",
@@ -1961,8 +2014,11 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
         activity_mod.emit_event(
             "self_mint_publish_withheld",
             f"family={pending.family} key={pending.arm_token}: no publish "
-            "sink (file_base_url/worker JWT absent at arming time); cell "
-            "stays local to this pod",
+            "sink (file_base_url/worker JWT absent at arming time); the cell "
+            "was kept in this machine's own store (§4.28/pgw#1096 — the "
+            "sentence 'stays local to this pod' is now TRUE; before it was "
+            "printed on the way to an rmtree) and this machine reuses it, but "
+            "the fleet store still gains nothing",
             phase="no_sink",
         )
         mark_terminus(pending, TERMINUS_WITHHELD)

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -1,0 +1,434 @@
+"""pgw#1096 / §4.28 — the untrusted machine's OWN cell store: AOT cells, ck1-keyed.
+
+DESIGN-RULINGS §4.28 (Paul, 2026-08-10): *"Untrusted hardware (community
+cloud, cozy-local) mints for ITSELF: local cell, local repo-CAS, reused
+across its own boots — never uploaded, never requested."* And the UX
+elaboration: *"download model + code ONCE, compile ONCE, and every
+subsequent run of that code reuses the same compiled cell — same ck1 key
+derivation, same memo shortcut, fully offline-capable."*
+
+ONE IDENTITY, TWO STORES. A cell stored here is addressed by exactly the
+key the hub store addresses it by — ``cell_key.from_exported_artifact_metadata``
+stamped on the bytes (pgw#1059's four axes: graph x envelope x sm x
+toolchain). The hub store and this one differ in their SINK, never in their
+addressing, so a cell that later becomes publishable needs no re-keying and a
+local hit is the same artifact a hub hit would have delivered.
+
+TRUST BOUNDARY — inherited verbatim from the JIT-era store this replaces
+(``local_cells``). A compile cell is user-generated EXECUTABLE code
+(compiled kernels + generated C++/Triton sources); accepting one from a user
+machine into shared storage would let any user ship arbitrary code into other
+people's GPU workers. Enforcement is STRUCTURAL, not a flag: this module has
+no publish path — it is not a CAS client, imports no upload/transport
+machinery, and writes only under the store root. ``tests/
+test_aot_local_mint_pgw1096.py`` pins that structurally, the way
+``test_local_cells`` pins it for the module this succeeds.
+
+WHO DECIDES a machine is untrusted: **the hub, and only the hub**. There is no
+worker-side self-declaration and no env flag — §1.18/§4.28. The class is
+LEARNED from the hub's own typed publish refusal (``cell_publish_untrusted_tier``,
+403, ``tensorhub internal/orchestrator/http/worker_cell_publish.go``) and
+persisted here so the next boot does not have to pay a mint to rediscover it.
+Before this module existed that refusal was terminal in the worst way: th#1643
+books it as SUNK — *"a sealed cell was produced and thrown away"* — and
+``fleet_cells._publish_async``'s ``finally`` then rmtree'd the bytes.
+
+LAYOUT (one directory per cell, so a cell and the facts about it move as a
+unit and a partial write leaves nothing admissible)::
+
+    <root>/aot-cells/<ck1-…>/cell.tar.gz   the packed artifact
+    <root>/aot-cells/<ck1-…>/record.json   {cell_key, content_digest, family, …}
+    <root>/aot-cells/.memo/<arm1-…>.json   the MEMO: pre-trace identity -> ck1 key
+    <root>/trust-class.json                the learned trust class
+    <root>/.mint-resume/…                  aot_resume's crash-only bank (pgw#848)
+
+THE MEMO, and why a content-addressed store needs one. The ck1 key's ``graph``
+axis is the traced-graph digest, which does not exist until an export
+finishes — so a boot that has not traced cannot address the CAS directly.
+What it CAN state in milliseconds is ``fleet_cells.ArmIdentity``: every
+pre-trace-knowable fact (family, format, lane, sm, envelope, env_seal,
+toolchain). The memo maps that token to the ck1 key the last mint of it
+produced. It is a SHORTCUT, never an authority: the artifact it points at is
+verified against its recorded digest and then passes the identical arm gate a
+child-minted cell passes, so a wrong memo can only cost one re-mint. When
+pgw#1089 lands boot-side trace-for-key the derived key addresses the CAS
+directly and the memo stays exactly what §4.28 calls it — the shortcut.
+
+EVICTION: there is none, deliberately (pre-launch). What accumulates is one
+cell per (graph x envelope x sm x toolchain), so every torch upgrade, every
+gen-worker upgrade and every settings change leaves the previous cell resident
+forever. :func:`stored_cells` enumerates them with sizes so a future sweep has
+a fact base; an age-based sweep would be wrong (a cell nobody booted for six
+months is still exactly the cell the next boot wants).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import cell_key
+
+logger = logging.getLogger(__name__)
+
+#: Read size for the content digest. The store deliberately hashes with the
+#: stdlib rather than importing the CAS client's helper: this module must not
+#: reach into transport machinery even for a pure function, because "it only
+#: imports it for the hash" is how a boundary enforced by ABSENCE stops being
+#: enforced by absence.
+_DIGEST_CHUNK_BYTES = 4 * 1024 * 1024
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            block = handle.read(_DIGEST_CHUNK_BYTES)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+#: A path relocation, never a behavior knob (§1.18, and the same rule
+#: ``TENSORHUB_CACHE_DIR`` follows). cozy-local exports it from its own
+#: ``workerEnv`` (``cozy-local/internal/paths/paths.go``) and the ``cozy
+#: cells`` CLI reads the same root, so the NAME and the DEFAULT are a
+#: cross-repo contract: changing either goes dark on that CLI.
+ENV_STORE_DIR = "GEN_WORKER_LOCAL_CELLS_DIR"
+
+CELLS_DIRNAME = "aot-cells"
+MEMO_DIRNAME = ".memo"
+ARTIFACT_NAME = "cell.tar.gz"
+RECORD_NAME = "record.json"
+TRUST_CLASS_NAME = "trust-class.json"
+
+#: The only artifact class this store holds. pgw#1010/pgw#1059: an exported
+#: cell is the only kind with an identity, so it is the only kind that can be
+#: addressed — a JIT capture has no key and nothing could ever look it up.
+KIND = "aot-inductor"
+
+#: The hub's typed 403 that ASSERTS this machine may not publish. One string,
+#: from ``tensorhub``'s ``worker_cell_publish.go``; a refusal the worker does
+#: not recognize is left unlearned rather than guessed at, because guessing
+#: "untrusted" from an unrelated failure would make a transient hub error
+#: permanently change how this pod behaves.
+UNTRUSTED_REFUSAL_CODE = "cell_publish_untrusted_tier"
+
+TRUST_UNTRUSTED = "untrusted"
+
+
+def store_root() -> Path:
+    """The local store root: the stated env path, else the cozy cache dir.
+
+    Moved here from ``local_cells`` by pgw#1096 with its value UNCHANGED —
+    same env name, same default — so ``aot_resume``'s crash-only bank and
+    cozy-local's ``cozy cells`` CLI keep resolving to the identical
+    directory. That move is what makes ``local_cells.py`` deletable by
+    pgw#1086 wave 1 (pgw#1092 §4 landmine 1: the production resume bank was
+    routed through a module the JIT demolition deletes).
+    """
+    env = os.environ.get(ENV_STORE_DIR, "").strip()
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".cache" / "cozy" / "compile-cells"
+
+
+def cells_root(root: Optional[Path] = None) -> Path:
+    return (root or store_root()) / CELLS_DIRNAME
+
+
+def cell_dir(key: str, root: Optional[Path] = None) -> Path:
+    """The directory holding the cell keyed ``key``.
+
+    Refuses anything that is not a ``ck1`` key rather than sanitizing it: a
+    store addressed by a key-shaped string it did not verify is a store whose
+    layout depends on what a caller happened to pass.
+    """
+    if not cell_key.is_key(key):
+        raise ValueError(
+            f"the local cell store addresses {cell_key.KEY_SCHEME} keys only; "
+            f"{key!r} is not one")
+    return cells_root(root) / key
+
+
+def memo_path(arm_token: str, root: Optional[Path] = None) -> Path:
+    token = str(arm_token or "").strip()
+    if not token or "/" in token or token.startswith("."):
+        raise ValueError(f"not an arm-identity token: {arm_token!r}")
+    return cells_root(root) / MEMO_DIRNAME / f"{token}.json"
+
+
+@dataclass(frozen=True)
+class LocalCell:
+    """One cell resident in the local store, with the facts recorded beside it."""
+
+    key: str
+    artifact: Path
+    content_digest: str  # "sha256:<hex>" of the packed artifact
+    family: str
+    arm_token: str
+    bytes: int
+    stored_at: float
+
+
+def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp-{os.getpid()}")
+    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+    os.replace(tmp, path)
+
+
+def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def store(
+    artifact: Path, *, key: str, family: str, arm_token: str = "",
+    root: Optional[Path] = None,
+) -> Optional[LocalCell]:
+    """Copy ``artifact`` into the store under its STAMPED ``key``.
+
+    The artifact is written to a temp sibling and ``os.replace``d, and the
+    record — which carries the digest every later lookup is checked against —
+    is written LAST, so a crash mid-store leaves a directory with no record
+    and the next lookup treats it as absent rather than as a short cell. Same
+    ordering rule ``aot_resume`` banks entries under, for the same reason.
+
+    Returns the stored cell, or ``None`` when the store failed: a local store
+    is a cache, and failing to fill it must never take down a worker that is
+    already serving compiled.
+    """
+    try:
+        target_dir = cell_dir(key, root)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        digest = "sha256:" + _sha256_file(Path(artifact))
+        final = target_dir / ARTIFACT_NAME
+        tmp = target_dir / f".{ARTIFACT_NAME}.tmp-{os.getpid()}"
+        shutil.copy2(str(artifact), str(tmp))
+        os.replace(tmp, final)
+        record = LocalCell(
+            key=key, artifact=final, content_digest=digest,
+            family=str(family or ""), arm_token=str(arm_token or ""),
+            bytes=final.stat().st_size, stored_at=time.time(),
+        )
+        _write_json_atomic(target_dir / RECORD_NAME, {
+            "cell_key": record.key,
+            "content_digest": record.content_digest,
+            "family": record.family,
+            "arm_token": record.arm_token,
+            "bytes": record.bytes,
+            "stored_at": record.stored_at,
+            "kind": KIND,
+        })
+        if arm_token:
+            _write_json_atomic(
+                memo_path(arm_token, root),
+                {"cell_key": key, "noted_at": record.stored_at})
+        logger.info(
+            "local-cell-store: stored %s (%s, %.1f MB) — this machine reuses "
+            "it on every later boot with the same key, offline",
+            key, record.family, record.bytes / 1e6)
+        return record
+    except Exception as exc:  # noqa: BLE001 — a cache miss must never be fatal
+        logger.warning(
+            "local-cell-store: could not store %s (%s); this boot serves "
+            "compiled anyway and the next one re-mints", key, exc)
+        return None
+
+
+def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
+    """The resident cell for ``key``, or ``None``.
+
+    The recorded ``content_digest`` is RECOMPUTED over the bytes on disk, so a
+    truncated, half-written or edited artifact refuses here instead of being
+    handed to the arm — the ``aot_resume`` rule (*"a bank cannot vouch for
+    itself"*) applied to the store. A refusing entry is dropped, which turns a
+    corrupted cell into exactly one honest re-mint.
+    """
+    try:
+        target_dir = cell_dir(key, root)
+    except ValueError:
+        return None
+    record = _read_json(target_dir / RECORD_NAME)
+    artifact = target_dir / ARTIFACT_NAME
+    if record is None or not artifact.is_file():
+        return None
+    want = str(record.get("content_digest") or "")
+    try:
+        have = "sha256:" + _sha256_file(artifact)
+    except OSError as exc:
+        logger.warning("local-cell-store: %s is unreadable (%s)", key, exc)
+        return None
+    if not want or have != want:
+        logger.error(
+            "local-cell-store: DROPPING %s — the stored bytes digest %s, the "
+            "record states %s; a cell that cannot vouch for its own content "
+            "is never armed", key, have, want or "nothing")
+        drop(key, root)
+        return None
+    return LocalCell(
+        key=key, artifact=artifact, content_digest=have,
+        family=str(record.get("family") or ""),
+        arm_token=str(record.get("arm_token") or ""),
+        bytes=int(record.get("bytes") or artifact.stat().st_size),
+        stored_at=float(record.get("stored_at") or 0.0),
+    )
+
+
+def lookup_for_arm(
+    arm_token: str, root: Optional[Path] = None,
+) -> Optional[LocalCell]:
+    """The cell this machine last minted for pre-trace identity ``arm_token``.
+
+    The memo is a shortcut, never an authority (module docstring): the answer
+    it names is digest-verified by :func:`lookup` and then passes the same arm
+    gate a freshly child-minted cell passes. A stale memo costs one re-mint.
+    """
+    try:
+        memo = _read_json(memo_path(arm_token, root))
+    except ValueError:
+        return None
+    if memo is None:
+        return None
+    key = str(memo.get("cell_key") or "")
+    if not key:
+        return None
+    return lookup(key, root)
+
+
+def drop(key: str, root: Optional[Path] = None) -> None:
+    """Remove one cell and everything recorded about it."""
+    try:
+        shutil.rmtree(cell_dir(key, root), ignore_errors=True)
+    except ValueError:
+        return
+
+
+def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
+    """Every resident cell, cheaply — NO digest recomputation.
+
+    The accounting surface for what accumulates (module docstring: one cell
+    per graph x envelope x sm x toolchain, so every toolchain upgrade leaves
+    its predecessor behind). Deliberately not a verification pass: this is the
+    listing a ``cozy cells``-style CLI and any future sweep read, and making it
+    hash every resident artifact would make listing cost as much as arming.
+    """
+    out: List[LocalCell] = []
+    base = cells_root(root)
+    if not base.is_dir():
+        return out
+    for entry in sorted(base.iterdir()):
+        if not entry.is_dir() or entry.name == MEMO_DIRNAME:
+            continue
+        record = _read_json(entry / RECORD_NAME)
+        artifact = entry / ARTIFACT_NAME
+        if record is None or not artifact.is_file():
+            continue
+        out.append(LocalCell(
+            key=str(record.get("cell_key") or entry.name),
+            artifact=artifact,
+            content_digest=str(record.get("content_digest") or ""),
+            family=str(record.get("family") or ""),
+            arm_token=str(record.get("arm_token") or ""),
+            bytes=int(record.get("bytes") or artifact.stat().st_size),
+            stored_at=float(record.get("stored_at") or 0.0),
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The learned trust class — hub-asserted, never self-declared
+# ---------------------------------------------------------------------------
+
+
+def note_refusal(code: str, detail: str = "", root: Optional[Path] = None) -> bool:
+    """Learn this machine's trust class from the HUB's typed refusal.
+
+    ``True`` when the refusal was the untrusted-tier one and the class is
+    now recorded. Every other code — a forged axis, a quota, an unknown
+    family, a transport failure — leaves the class untouched: those say
+    something about the CELL or the moment, not about the hardware, and a
+    worker that concluded "untrusted" from a 429 would permanently mis-file
+    itself off one bad minute.
+    """
+    if str(code or "").strip() != UNTRUSTED_REFUSAL_CODE:
+        return False
+    try:
+        _write_json_atomic((root or store_root()) / TRUST_CLASS_NAME, {
+            "class": TRUST_UNTRUSTED,
+            "code": UNTRUSTED_REFUSAL_CODE,
+            "detail": str(detail or "")[:500],
+            "learned_at": time.time(),
+        })
+    except OSError as exc:
+        logger.warning(
+            "local-cell-store: could not record the hub's untrusted-tier "
+            "verdict (%s); this machine will re-learn it next boot", exc)
+        return False
+    logger.warning(
+        "local-cell-store: the hub asserts this hardware may not publish "
+        "(%s) — cells minted here are kept LOCALLY and reused on every later "
+        "boot of this machine; nothing is uploaded and nothing is requested "
+        "(§4.28)", UNTRUSTED_REFUSAL_CODE)
+    return True
+
+
+def trust_class(root: Optional[Path] = None) -> str:
+    """``"untrusted"`` once the hub has said so, else ``""`` (not yet known).
+
+    "Not yet known" is not "trusted": a machine that has never tried to
+    publish has learned nothing, and the honest consequence is that its first
+    mint attempts the publish and learns from the answer.
+    """
+    recorded = _read_json((root or store_root()) / TRUST_CLASS_NAME)
+    if recorded is None:
+        return ""
+    return str(recorded.get("class") or "")
+
+
+def keeps_cells_locally(root: Optional[Path] = None) -> bool:
+    """Whether a cell this machine mints should be kept in the local store.
+
+    True exactly when the hub has ASSERTED this hardware may not publish. The
+    cozy-local CLI serve path does not consult this — it has no publisher and
+    never will, so it calls :func:`store` directly (pgw#1086 wave 1 re-points
+    it there when it deletes the JIT store).
+    """
+    return trust_class(root) == TRUST_UNTRUSTED
+
+
+__all__ = [
+    "ARTIFACT_NAME",
+    "CELLS_DIRNAME",
+    "ENV_STORE_DIR",
+    "KIND",
+    "LocalCell",
+    "MEMO_DIRNAME",
+    "RECORD_NAME",
+    "TRUST_CLASS_NAME",
+    "TRUST_UNTRUSTED",
+    "UNTRUSTED_REFUSAL_CODE",
+    "cell_dir",
+    "cells_root",
+    "drop",
+    "keeps_cells_locally",
+    "lookup",
+    "lookup_for_arm",
+    "memo_path",
+    "note_refusal",
+    "store",
+    "store_root",
+    "stored_cells",
+    "trust_class",
+]

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -59,20 +59,17 @@ from typing import Any, Optional
 from . import activity as activity_mod
 from . import artifact_meta
 from . import compile_cache as cc
+# pgw#1096: the store ROOT (and, since §4.28, the AOT store that succeeds this
+# module) lives in `local_cell_store`. One derivation of the path, so the JIT
+# store, the AOT store and `aot_resume`'s bank cannot drift apart while this
+# module waits for pgw#1086 wave 1 to delete it.
+from .local_cell_store import ENV_STORE_DIR, store_root
 from .models.loading import pipeline_weight_lane
 from .models import provision
 logger = logging.getLogger(__name__)
 
-ENV_STORE_DIR = "GEN_WORKER_LOCAL_CELLS_DIR"
 _MINT_DIR = ".mint"
 _STALE_MINT_S = 24 * 3600
-
-
-def store_root() -> Path:
-    env = os.environ.get(ENV_STORE_DIR, "").strip()
-    if env:
-        return Path(env).expanduser()
-    return Path.home() / ".cache" / "cozy" / "compile-cells"
 
 
 def cell_path(family: str, weight_lane: str = "", root: Optional[Path] = None) -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,3 +321,19 @@ def _postmortem_paths_off_the_host(_postmortem_root):
     _wipe()
     for name, path in saved.items():
         setattr(_pm, name, path)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_local_cell_store(tmp_path_factory, monkeypatch):
+    """pgw#1096: the local cell store defaults to ``~/.cache/cozy/compile-cells``.
+
+    A suite that exercises the AOT self-mint now legitimately WRITES there —
+    `local_keep_reason` keeps a cell whenever no publisher was wired, which is
+    every unit fixture in the tree. Redirect the root per test, so the suite
+    can never deposit fake cells in the developer's real store (or read one
+    left by a previous run and call it a hit). Also isolates
+    ``aot_resume.bank_root``, which is sited under the same root.
+    """
+    monkeypatch.setenv(
+        "GEN_WORKER_LOCAL_CELLS_DIR",
+        str(tmp_path_factory.mktemp("local-cell-store")))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,7 +324,7 @@ def _postmortem_paths_off_the_host(_postmortem_root):
 
 
 @pytest.fixture(autouse=True)
-def _isolated_local_cell_store(tmp_path_factory, monkeypatch):
+def _isolated_local_cell_store(tmp_path_factory):
     """pgw#1096: the local cell store defaults to ``~/.cache/cozy/compile-cells``.
 
     A suite that exercises the AOT self-mint now legitimately WRITES there —
@@ -333,7 +333,28 @@ def _isolated_local_cell_store(tmp_path_factory, monkeypatch):
     can never deposit fake cells in the developer's real store (or read one
     left by a previous run and call it a hit). Also isolates
     ``aot_resume.bank_root``, which is sited under the same root.
+
+    **Deliberately does NOT take `monkeypatch`**, and this is not a style
+    preference — it cost a CI red. An AUTOUSE fixture is set up before the
+    explicitly-requested ones, so requesting `monkeypatch` here makes pytest
+    build it early for EVERY test in the tree; fixtures finalize in reverse
+    setup order, so `monkeypatch` then unwinds LAST — after the yield-fixture
+    teardowns that run beside it. `test_seal_lib_memo_pgw832` and
+    `test_seal_record_derivation_pgw1095` both `monkeypatch.setattr(env_seal,
+    "_lib_digest", ...)` over an `lru_cache` and then call
+    `env_seal._lib_digest.cache_clear()` in their own `finally` — which, with
+    the order flipped, ran while the attribute was still a plain function
+    (`AttributeError: 'function' object has no attribute 'cache_clear'`).
+    Save and restore the variable by hand so this fixture adds no ordering
+    edge to anything.
     """
-    monkeypatch.setenv(
-        "GEN_WORKER_LOCAL_CELLS_DIR",
-        str(tmp_path_factory.mktemp("local-cell-store")))
+    prior = os.environ.get("GEN_WORKER_LOCAL_CELLS_DIR")
+    os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = str(
+        tmp_path_factory.mktemp("local-cell-store"))
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("GEN_WORKER_LOCAL_CELLS_DIR", None)
+        else:
+            os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = prior

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -548,6 +548,72 @@ def test_a_transport_failure_is_not_a_trust_verdict(
 
 
 # ---------------------------------------------------------------------------
+# 7b. WHY a machine keeps its cell — three sink facts, and none is a trust claim
+# ---------------------------------------------------------------------------
+
+
+class _Sink:
+    def __init__(self, on: bool = True) -> None:
+        self._on = on
+
+    def enabled(self) -> bool:
+        return self._on
+
+
+def test_cozy_local_keeps_its_cell_without_ever_asking_a_hub(
+    store: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The §4.28 cozy-local promise, and the bug this test exists to stop.
+
+    cozy-local NEVER constructs a publisher and NEVER reaches a hub — so a
+    design that waited for a hub's typed refusal before keeping anything would
+    leave *"download model + code ONCE, compile ONCE, reuse forever"*
+    permanently unimplemented on the one product it was written about. The
+    reason must therefore be the ABSENCE OF A SINK, not a verdict that will
+    never arrive.
+    """
+    assert local_cell_store.trust_class() == "", "no hub has said anything"
+    assert fleet_cells.local_keep_reason(None) == fleet_cells.KEEP_NO_PUBLISHER
+    assert (fleet_cells.local_keep_reason(_Sink(on=False))  # type: ignore[arg-type]
+            == fleet_cells.KEEP_NO_PUBLISHER)
+
+
+def test_a_probe_pod_keeps_its_cell_because_its_publish_is_DISARMED(
+    store: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#980 removes `cells.publish_intent` from the parent's allowlist, so a
+    probe's publish never reaches a hub and never produces a typed refusal.
+    Read the predicate that OWNS that decision rather than sniffing the
+    exception it raises."""
+    from gen_worker.procsplit import actions
+
+    monkeypatch.setattr(actions, "publish_disarmed", lambda: True)
+    assert (fleet_cells.local_keep_reason(_Sink())  # type: ignore[arg-type]
+            == fleet_cells.KEEP_PUBLISH_DISARMED)
+
+    monkeypatch.setattr(actions, "publish_disarmed", lambda: False)
+    assert fleet_cells.local_keep_reason(_Sink()) == ""  # type: ignore[arg-type]
+
+
+def test_a_trusted_fleet_pod_with_a_live_sink_keeps_NOTHING(
+    store: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The negative that keeps this from becoming "every pod hoards cells": a
+    pod that CAN publish ships the cell and keeps no local copy, so the fleet's
+    ephemeral disks are unchanged."""
+    from gen_worker.procsplit import actions
+
+    monkeypatch.setattr(actions, "publish_disarmed", lambda: False)
+    assert fleet_cells.local_keep_reason(_Sink()) == ""  # type: ignore[arg-type]
+
+    # ...until the hub says otherwise, which is the ONLY trust input.
+    local_cell_store.note_refusal(
+        local_cell_store.UNTRUSTED_REFUSAL_CODE, "community_tier")
+    assert (fleet_cells.local_keep_reason(_Sink())  # type: ignore[arg-type]
+            == fleet_cells.KEEP_HUB_ASSERTED_UNTRUSTED)
+
+
+# ---------------------------------------------------------------------------
 # 8. Accumulation — recorded, not swept (the follow-up this lane owes)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -1,0 +1,574 @@
+"""pgw#1096 / §4.28 — an untrusted machine mints for ITSELF, and reuses it forever.
+
+Paul, 2026-08-10: *"Untrusted hardware (community cloud, cozy-local) mints for
+ITSELF: local cell, local repo-CAS, reused across its own boots — never
+uploaded, never requested… download model + code ONCE, compile ONCE, and every
+subsequent run of that code reuses the same compiled cell."*
+
+What was RED before this issue, on every one of these:
+
+* a community-cloud pod minted a cell, ate the hub's
+  ``cell_publish_untrusted_tier`` 403, and ``_publish_async``'s ``finally``
+  rmtree'd the bytes — th#1643's SUNK case, once per boot, forever;
+* nothing in the tree could address a locally-stored AOT cell (``local_cells``
+  is JIT-only and knows no ``ck1`` key);
+* ``aot_resume``'s PRODUCTION resume bank was rooted through the module
+  pgw#1086 wave 1 deletes.
+
+The store's own guarantees are proven against REAL bytes on disk (digest,
+atomicity, drop-on-corruption). The arm is proven to be the SAME gate the
+child's own cell passes — structurally, so it cannot drift into a weaker one.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import aot_resume, cell_key, fleet_cells, local_cell_store
+from gen_worker.cell_adopt import AdoptOutcome
+
+KEY_A = "ck1-" + "a" * 56
+KEY_B = "ck1-" + "b" * 56
+ARM_A = "arm1-" + "1" * 56
+ARM_B = "arm1-" + "2" * 56
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """The store root, relocated by its env — a PATH knob, never a behavior one."""
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+def _artifact(tmp_path: Path, body: bytes = b"packed-cell-bytes") -> Path:
+    p = tmp_path / "mint" / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(body)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 1. The store: one identity, two stores
+# ---------------------------------------------------------------------------
+
+
+def test_a_cell_is_addressed_by_the_same_ck1_key_the_hub_store_uses(
+    store: Path, tmp_path: Path,
+) -> None:
+    """§4.28's "one identity, two stores": the local address IS the stamped key.
+
+    RED before: no local address existed for an AOT cell at all — `local_cells`
+    keys on a flavor LABEL (sku/torch/lane), a space with no `ck1` in it.
+    """
+    cell = local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+
+    assert cell is not None
+    assert cell.key == KEY_A and cell_key.is_key(cell.key)
+    assert cell.artifact == store / "aot-cells" / KEY_A / "cell.tar.gz"
+    assert cell.artifact.read_bytes() == b"packed-cell-bytes"
+
+    found = local_cell_store.lookup(KEY_A)
+    assert found is not None and found.content_digest == cell.content_digest
+    assert found.family == "micro-diffusion"
+
+
+def test_the_store_refuses_to_be_addressed_by_anything_that_is_not_a_key(
+    store: Path,
+) -> None:
+    """A store addressed by a key-shaped string it never verified is a store
+    whose layout depends on what a caller happened to pass."""
+    for bad in ("arm1-" + "a" * 56, "../escape", "", "sha256:deadbeef"):
+        with pytest.raises(ValueError):
+            local_cell_store.cell_dir(bad)
+    assert local_cell_store.lookup("../escape") is None
+
+
+def test_a_record_written_but_never_filled_is_absent_not_short(
+    store: Path, tmp_path: Path,
+) -> None:
+    """The record is written LAST (aot_resume's rule): a crash mid-store leaves
+    a directory the next lookup treats as absent, never as a short cell."""
+    local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f")
+    (store / "aot-cells" / KEY_A / local_cell_store.RECORD_NAME).unlink()
+    assert local_cell_store.lookup(KEY_A) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. RED — a corrupted cell is refused, and costs exactly one re-mint
+# ---------------------------------------------------------------------------
+
+
+def test_corrupting_a_stored_cell_refuses_admission_and_drops_it(
+    store: Path, tmp_path: Path,
+) -> None:
+    """`aot_resume`'s safety property, applied to the store: **a bank cannot
+    vouch for itself.** The digest is RECOMPUTED over the bytes on disk, so a
+    truncated, half-written or edited artifact refuses HERE rather than being
+    handed to an arm that would then serve it.
+
+    RED before: there was no local store, and the JIT one it succeeds compared
+    only recorded FACTS — nothing ever hashed the bytes.
+    """
+    cell = local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+    assert cell is not None and local_cell_store.lookup(KEY_A) is not None
+
+    cell.artifact.write_bytes(b"packed-cell-byteZ")  # same length, one bit
+
+    assert local_cell_store.lookup(KEY_A) is None, "a corrupted cell armed"
+    assert not local_cell_store.cell_dir(KEY_A).exists(), (
+        "a refused cell must be DROPPED — leaving it costs a re-verify (and a "
+        "re-hash of every boot) forever, for bytes nothing can ever use")
+    assert local_cell_store.lookup_for_arm(ARM_A) is None, (
+        "the memo must not resurrect a cell the digest refused")
+
+
+# ---------------------------------------------------------------------------
+# 3. The memo — a shortcut, never an authority; and the honest re-mint
+# ---------------------------------------------------------------------------
+
+
+def test_the_memo_turns_a_pre_trace_identity_into_the_ck1_key(
+    store: Path, tmp_path: Path,
+) -> None:
+    """The `ck1` graph axis needs a trace; the pre-trace `ArmIdentity` does not.
+    The memo is what lets boot 2 address the CAS without paying an export."""
+    local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+
+    hit = local_cell_store.lookup_for_arm(ARM_A)
+    assert hit is not None and hit.key == KEY_A
+    assert local_cell_store.lookup_for_arm(ARM_B) is None
+
+
+def test_a_moved_toolchain_is_an_HONEST_re_mint_and_leaves_the_old_cell_alone(
+    store: Path, tmp_path: Path,
+) -> None:
+    """Paul: *"the key's toolchain/sm axes make local re-mints honest when the
+    user upgrades torch or changes GPU."* The upgraded runtime computes a
+    different ArmIdentity, so it misses — and the PREVIOUS cell stays resident
+    under its own key, because a user who rolls torch back must not have to
+    recompile what they already compiled."""
+    local_cell_store.store(
+        _artifact(tmp_path, b"cell-under-torch-A"), key=KEY_A, family="f",
+        arm_token=ARM_A)
+
+    # The upgrade: a different toolchain digest => a different arm token.
+    assert local_cell_store.lookup_for_arm(ARM_B) is None, (
+        "an upgraded toolchain must not adopt the old toolchain's cell")
+
+    local_cell_store.store(
+        _artifact(tmp_path, b"cell-under-torch-B"), key=KEY_B, family="f",
+        arm_token=ARM_B)
+
+    assert {c.key for c in local_cell_store.stored_cells()} == {KEY_A, KEY_B}
+    old = local_cell_store.lookup(KEY_A)
+    assert old is not None and old.artifact.read_bytes() == b"cell-under-torch-A"
+
+
+def test_a_stale_memo_costs_one_re_mint_and_never_a_wrong_cell(
+    store: Path, tmp_path: Path,
+) -> None:
+    local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+    local_cell_store.drop(KEY_A)
+    assert local_cell_store.lookup_for_arm(ARM_A) is None
+
+    (store / "aot-cells" / local_cell_store.MEMO_DIRNAME / f"{ARM_A}.json"
+     ).write_text(json.dumps({"cell_key": "not-a-key"}))
+    assert local_cell_store.lookup_for_arm(ARM_A) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. The posture is HUB-ASSERTED — the worker never declares its own trust
+# ---------------------------------------------------------------------------
+
+
+def test_the_worker_learns_it_is_untrusted_only_from_the_hubs_typed_refusal(
+    store: Path,
+) -> None:
+    """§4.28 + the brief: *"the trust class is hub-asserted, learned via typed
+    publish refusal — do NOT invent a worker-side self-declaration."*
+
+    Unknown is not trusted and not untrusted: a machine that never tried to
+    publish has learned nothing, and the honest consequence is that its first
+    mint attempts the publish and reads the answer.
+    """
+    assert local_cell_store.trust_class() == ""
+    assert local_cell_store.keeps_cells_locally() is False
+
+    for unrelated in ("cell_publish_forged_axis", "cell_publish_quota_exceeded",
+                      "cell_publish_family_undeclared", "http_429", ""):
+        assert local_cell_store.note_refusal(unrelated, "detail") is False
+        assert local_cell_store.trust_class() == "", (
+            f"{unrelated!r} says something about the CELL or the moment, never "
+            f"about the hardware; concluding 'untrusted' from it would mis-file "
+            f"this machine permanently off one bad minute")
+
+    assert local_cell_store.note_refusal(
+        local_cell_store.UNTRUSTED_REFUSAL_CODE, "community_tier") is True
+    assert local_cell_store.trust_class() == local_cell_store.TRUST_UNTRUSTED
+    assert local_cell_store.keeps_cells_locally() is True
+
+
+def test_no_env_declares_the_trust_class(store: Path) -> None:
+    """§1.18: an env may carry a VALUE, never a decision. The only env this
+    module reads is a path relocation."""
+    tree = ast.parse(Path(local_cell_store.__file__).read_text())
+    read = [
+        node.args[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"get", "getenv"}
+        and isinstance(node.func.value, (ast.Attribute, ast.Name))
+        and "environ" in ast.dump(node.func.value)
+        and node.args
+    ]
+    assert [ast.unparse(a) for a in read] == ["ENV_STORE_DIR"], (
+        "the only env this module may read is the store LOCATION")
+    assert local_cell_store.ENV_STORE_DIR == "GEN_WORKER_LOCAL_CELLS_DIR", (
+        "the name is a cross-repo contract with cozy-local's paths.go")
+
+
+# ---------------------------------------------------------------------------
+# 5. The trust boundary is STRUCTURAL — there is no publish path to find
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_IMPORTS = {
+    "gen_worker.s3_transfer", "gen_worker.presigned_upload",
+    "gen_worker._upload_transport", "gen_worker.media_transfer",
+    "gen_worker.net", "gen_worker.callout", "gen_worker.transport",
+    "gen_worker.fleet_cells", "gen_worker.convert.hub",
+    "urllib", "urllib.request", "requests", "httpx", "boto3", "aiohttp",
+}
+
+
+def test_the_local_store_has_no_publish_path(store: Path) -> None:
+    """A compile cell is user-generated EXECUTABLE code. Accepting one from a
+    user machine into shared storage would let any user ship arbitrary code
+    into other people's GPU workers, so the boundary is enforced by the
+    ABSENCE of machinery, not by a flag anyone can flip."""
+    tree = ast.parse(Path(local_cell_store.__file__).read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            base = f"gen_worker.{mod.lstrip('.')}" if node.level else mod
+            imported.add(base)
+            imported.update(f"{base}.{a.name}" for a in node.names)
+    hits = {
+        i for i in imported
+        if i in _FORBIDDEN_IMPORTS
+        or any(i.startswith(f + ".") for f in _FORBIDDEN_IMPORTS)
+    }
+    assert not hits, f"the local cell store must never grow a publish path: {hits}"
+
+    idents = {
+        n.id.lower() for n in ast.walk(tree) if isinstance(n, ast.Name)
+    } | {
+        n.attr.lower() for n in ast.walk(tree) if isinstance(n, ast.Attribute)
+    } | {
+        n.name.lower() for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+    for word in ("upload", "publish", "presign", "put_object", "post", "http"):
+        bad = {i for i in idents if word in i}
+        assert not bad, f"the local cell store references {bad}"
+
+
+def test_the_production_resume_bank_still_roots_in_the_local_store(
+    store: Path,
+) -> None:
+    """pgw#1092 §4 landmine 1, closed. `aot_resume` is a SERVE-PATH module and
+    its bank was rooted through `local_cells.store_root()` — the module
+    pgw#1086 wave 1 deletes. The accessor moved here with its value unchanged,
+    so no bank is orphaned and wave 1 is unblocked.
+    """
+    bank = aot_resume.bank_root("some-scope")
+    assert bank.is_relative_to(local_cell_store.store_root())
+    assert aot_resume.RESUME_DIRNAME in bank.parts
+
+    resume_tree = ast.parse(Path(aot_resume.__file__).read_text())
+    names = {
+        n.value.id for n in ast.walk(resume_tree)
+        if isinstance(n, ast.Attribute) and isinstance(n.value, ast.Name)
+    }
+    assert "local_cells" not in names, (
+        "aot_resume must not reach into the JIT store pgw#1086 deletes")
+
+
+# ---------------------------------------------------------------------------
+# 6. Reuse: ONE gate, and the local cell gets no weaker verification
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = "micro-diffusion"
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((64, 64),)
+    targets: Tuple[str, ...] = ("transformer",)
+    text_lens: Tuple[int, ...] = (16,)
+    guidance_scales: Tuple[float, ...] = (1.0,)
+    regional: bool = False
+
+
+class _Arm:
+    """A real-shaped `ArmIdentity` stand-in: this box states no `sm`."""
+
+    def __init__(self, token: str = ARM_A) -> None:
+        self.token = token
+
+    def facts_dict(self) -> Dict[str, str]:
+        return {}
+
+
+@pytest.fixture()
+def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
+    """`provision.arm_aot` succeeds; record WHICH artifact it was handed."""
+    seen: List[Path] = []
+
+    def _arm(pipe: Any, cfg: Any, cache_dir: Any, artifact: Path,
+             bucket: int, meta: Any = None) -> AdoptOutcome:
+        seen.append(Path(artifact))
+        return AdoptOutcome.hit(str((meta or {}).get("cell_key") or ""))
+
+    monkeypatch.setattr(fleet_cells.provision, "arm_aot", _arm)
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "try_read_metadata",
+        lambda p: {"cell_key": KEY_A, "family": "micro-diffusion"})
+    # The pgw#1042 axis gate has its own tests (and, since pgw#1096, ONE
+    # implementation shared with the delegated adopt). Here the runtime and
+    # the cell agree, so the gate passes and what is under test is the
+    # LOOKUP -> ARM wiring.
+    monkeypatch.setattr(fleet_cells, "arm_axis_divergence", lambda arm, meta: "")
+    monkeypatch.setattr(fleet_cells.aot_serve, "note_aot_key", lambda k: None)
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(fleet_cells, "_FINALIZED", {})
+    return seen
+
+
+def test_a_second_boot_arms_from_this_machines_own_store_with_no_mint(
+    store: Path, tmp_path: Path, armable: List[Path],
+) -> None:
+    """The product promise, at the seam that decides a miss: compile once, run
+    forever. RED before: no lookup existed, so boot 2 opened a pending and paid
+    the whole export again."""
+    local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+
+    minted = fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion")  # type: ignore[arg-type]
+
+    assert minted is not None
+    assert minted.cell_key == KEY_A
+    assert minted.ref.endswith("#" + KEY_A)
+    assert armable == [store / "aot-cells" / KEY_A / "cell.tar.gz"], (
+        "the arm must be handed the STORE's bytes, not a copy nobody hashed")
+    assert fleet_cells._FINALIZED[ARM_A] is minted, (
+        "a sibling pipe of the same record must re-arm these bytes in-process")
+
+
+def test_a_local_cell_that_cannot_arm_is_dropped_not_retried_forever(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        fleet_cells.provision, "arm_aot",
+        lambda *a, **k: AdoptOutcome.miss("constants_unbound", "norm.weight"))
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "try_read_metadata", lambda p: {"cell_key": KEY_A})
+    monkeypatch.setattr(fleet_cells, "arm_axis_divergence", lambda arm, meta: "")
+    events: List[Tuple[str, str]] = []
+    monkeypatch.setattr(
+        fleet_cells.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: events.append((kind, phase)))
+    local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+
+    assert fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "f") is None  # type: ignore[arg-type]
+    assert not local_cell_store.cell_dir(KEY_A).exists()
+    assert ("local_cell_refused", "constants_unbound") in events
+
+
+def test_a_local_cell_that_does_not_describe_this_runtime_is_refused_by_FACT(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pgw#1042 axis gate, on the local path, with NOTHING stubbed out.
+
+    This is the RED for "change the toolchain (or the sm, or the envelope) and
+    the stored cell must not arm": the cell states facts, this runtime states
+    facts, and the FIRST one that differs is named. A store that skipped this
+    would serve last month's toolchain's kernels after a torch upgrade.
+    """
+    monkeypatch.setattr(
+        fleet_cells.provision, "arm_aot",
+        lambda *a, **k: pytest.fail("a diverging cell must never reach the arm"))
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "try_read_metadata",
+        lambda p: {"cell_key": KEY_A, "family": "micro-diffusion",
+                   "sm": "sm_120", "format": 2})
+    events: List[Tuple[str, str]] = []
+    monkeypatch.setattr(
+        fleet_cells.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: events.append((kind, phase)))
+    local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+
+    assert fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None  # type: ignore[arg-type]
+    assert ("local_cell_refused", "key_axis_divergence") in events
+    assert not local_cell_store.cell_dir(KEY_A).exists()
+
+
+def test_the_local_cell_and_the_childs_cell_pass_the_SAME_gate(
+    store: Path,
+) -> None:
+    """A local cell gets NO weaker verification. Structural, because "they agree
+    today" is not the property — one gate is."""
+    tree = ast.parse(Path(fleet_cells.__file__).read_text())
+    calls: Dict[str, set] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        calls[node.name] = {
+            c.func.id for c in ast.walk(node)
+            if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+        }
+    assert "_arm_exported_cell" in calls["adopt_delegated_mint"]
+    assert "_arm_exported_cell" in calls["arm_from_local_store"]
+    # ...and neither reaches around it to the raw arm.
+    bodies = {
+        node.name: node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    for fn in ("adopt_delegated_mint", "arm_from_local_store"):
+        reached = [
+            c for c in ast.walk(bodies[fn])
+            if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "arm_aot"
+        ]
+        assert not reached, f"{fn} must arm through the one gate, not around it"
+
+
+def test_the_miss_path_consults_the_local_store_before_opening_a_mint(
+    store: Path,
+) -> None:
+    """Ordering is the whole promise: a pending opened before the lookup is a
+    machine that recompiles what it already has."""
+    tree = ast.parse(Path(fleet_cells.__file__).read_text())
+    policy = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_arming_policy")
+    lookup_at = min(
+        c.lineno for c in ast.walk(policy)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+        and c.func.id == "arm_from_local_store")
+    pending_at = min(
+        c.lineno for c in ast.walk(policy)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+        and c.func.id == "PendingSelfMint")
+    assert lookup_at < pending_at
+
+
+# ---------------------------------------------------------------------------
+# 7. The salvage: the hub's refusal keeps the cell instead of burning it
+# ---------------------------------------------------------------------------
+
+
+def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """th#1643 books the refusal as SUNK — *"a sealed cell was produced and
+    thrown away"*. It is no longer thrown away: the machine learns its trust
+    class from the hub's own code and keeps the bytes for its next boot.
+
+    RED before: `_publish_async`'s `finally` rmtree'd the mint root and the
+    next boot of the same pod paid the same mint again.
+    """
+    artifact = _artifact(tmp_path)
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
+
+    class _Refusing:
+        def publish(self, family: str, art: Path, meta: dict,
+                    mint_duration_ms: int = 0) -> str:
+            raise fleet_cells.CellPublishRefused(
+                "publish-intent refused (403): community_tier",
+                status=403, code=local_cell_store.UNTRUSTED_REFUSAL_CODE)
+
+    fleet_cells._publish_async(
+        _Refusing(), "micro-diffusion", artifact,  # type: ignore[arg-type]
+        {"cell_key": KEY_A}, cell_key_digest=KEY_A, arm_token=ARM_A,
+    ).join(timeout=30)
+
+    assert local_cell_store.trust_class() == local_cell_store.TRUST_UNTRUSTED
+    kept = local_cell_store.lookup_for_arm(ARM_A)
+    assert kept is not None and kept.key == KEY_A
+    assert kept.artifact.read_bytes() == b"packed-cell-bytes"
+
+
+def test_a_transport_failure_is_not_a_trust_verdict(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
+
+    class _Broken:
+        def publish(self, family: str, art: Path, meta: dict,
+                    mint_duration_ms: int = 0) -> str:
+            raise RuntimeError("connection reset")
+
+    fleet_cells._publish_async(
+        _Broken(), "f", _artifact(tmp_path),  # type: ignore[arg-type]
+        {"cell_key": KEY_A}, cell_key_digest=KEY_A, arm_token=ARM_A,
+    ).join(timeout=30)
+
+    assert local_cell_store.trust_class() == ""
+    assert local_cell_store.lookup_for_arm(ARM_A) is None
+
+
+# ---------------------------------------------------------------------------
+# 8. Accumulation — recorded, not swept (the follow-up this lane owes)
+# ---------------------------------------------------------------------------
+
+
+def test_nothing_evicts_and_the_accumulation_is_enumerable(
+    store: Path, tmp_path: Path,
+) -> None:
+    """No GC in this lane, deliberately: a wrong sweep deletes an hour of
+    compile. What accumulates is one cell per (graph x envelope x sm x
+    toolchain) — every torch/gen-worker/settings move leaves its predecessor
+    resident — and `stored_cells` is the fact base a future
+    toolchain-aware sweep needs. An AGE-based sweep would be wrong: a cell
+    nobody booted for six months is still exactly the cell the next boot wants.
+    """
+    for key in (KEY_A, KEY_B):
+        local_cell_store.store(_artifact(tmp_path), key=key, family="f")
+
+    resident = local_cell_store.stored_cells()
+    assert {c.key for c in resident} == {KEY_A, KEY_B}
+    assert all(c.bytes > 0 and c.stored_at > 0 for c in resident)
+    assert not any(
+        name in dir(local_cell_store)
+        for name in ("gc", "sweep", "evict", "prune", "expire")), (
+        "eviction is a follow-up with an owner, not a surprise in this module")

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -504,17 +504,10 @@ def test_local_cli_is_the_only_mint_caller():
                 callers.add(p)
             elif isinstance(node, ast.Attribute) and "local_cells" in node.attr:
                 callers.add(p)
-    # aot_resume (pgw#848 item 5) sites its bank beside local_cells' own mint
-    # staging and touches exactly ONE name: store_root(). That is a path
-    # accessor, not the mint — pin it to that single attribute so the mint
-    # entry stays CLI-only.
-    assert {p.relative_to(root).as_posix() for p in callers} == {
-        "cli/run.py", "aot_resume.py"}
-    resume_tree = ast.parse((root / "aot_resume.py").read_text())
-    touched = {
-        n.attr for n in ast.walk(resume_tree)
-        if isinstance(n, ast.Attribute)
-        and isinstance(n.value, ast.Name) and n.value.id == "local_cells"
-    }
-    assert touched == {"store_root"}, (
-        f"aot_resume.py may only read local_cells.store_root(); saw {touched}")
+    # pgw#1096: `aot_resume` (pgw#848 item 5) used to reach in here for
+    # `store_root()` — the PRODUCTION resume bank routed through a module
+    # pgw#1086 wave 1 deletes (pgw#1092 §4 landmine 1). The accessor moved to
+    # `local_cell_store` with its value unchanged, so this module is now
+    # reached from the local CLI and NOTHING else, and its deletion breaks no
+    # serve path. `test_aot_local_mint_pgw1096` holds the other half.
+    assert {p.relative_to(root).as_posix() for p in callers} == {"cli/run.py"}

--- a/tests/test_two_run_reuse_pgw1096.py
+++ b/tests/test_two_run_reuse_pgw1096.py
@@ -1,0 +1,207 @@
+"""pgw#1096 — compile once, run forever, across PROCESS DEATH.
+
+§4.28's product claim is not about one process: *"download model + code ONCE,
+compile ONCE, and every subsequent RUN of that code reuses the same compiled
+cell."* The unit tests in ``test_aot_local_mint_pgw1096`` prove the store and
+the gate inside one interpreter, where `fleet_cells._FINALIZED` — the
+in-process arm-token -> cell index — is warm and could mask a store that does
+not actually work.
+
+This one proves the claim it is: TWO fresh OS processes, sharing nothing but a
+directory on disk. Run 1 mints and keeps; run 2 starts cold, with an empty
+`_FINALIZED`, and must arm WITHOUT opening a mint. If the memo, the CAS layout
+or the digest record were wrong in any way that a warm process papers over,
+run 2 opens a `PendingSelfMint` and this test says so.
+
+WHAT IS REAL HERE: the store (real files, real digests, real atomic replace),
+the memo, `fleet_cells._arming_policy` — the actual production arming brain,
+entered the way the executor enters it — the ordering (local check before the
+pending), and process death between the runs.
+
+WHAT IS FAKED, and why: the COMPILE. Paul's standing rule (2026-08-10) is that
+no mint, compile or AOTI link runs on the shared dev box — those go to a pod.
+So the mint child is not spawned and `provision.arm_aot` is stubbed: this test
+is about the STORE and the REUSE DECISION, and it is honest about the fact that
+"a real AOTI cell arms on a real card" is a claim only a pod can make. That is
+the pod leg's job, and it is owed, not assumed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: Run 1 and run 2 are the SAME program under a flag, deliberately: the thing
+#: under test is that the second run of one program behaves differently only
+#: because the first run left something on disk.
+_PROGRAM = r'''
+import json, os, sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from gen_worker import fleet_cells, local_cell_store
+from gen_worker.cell_adopt import AdoptOutcome
+
+MODE = sys.argv[1]
+KEY = "ck1-" + "c" * 56
+ARM = "arm1-" + "9" * 56
+FAMILY = "micro-diffusion"
+
+
+class Pipe:
+    pass
+
+
+@dataclass
+class Cfg:
+    family: str = FAMILY
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((64, 64),)
+    targets: Tuple[str, ...] = ("transformer",)
+    text_lens: Tuple[int, ...] = (16,)
+    guidance_scales: Tuple[float, ...] = (1.0,)
+    regional: bool = False
+
+
+class Arm:
+    token = ARM
+
+    def facts_dict(self) -> Dict[str, str]:
+        return {}
+
+
+# --- the compile is FAKED; everything below it is production code ------------
+opened_mints = []
+fleet_cells.provision.arm_aot = (            # type: ignore[assignment]
+    lambda *a, **k: AdoptOutcome.hit(KEY))
+fleet_cells.artifact_meta.try_read_metadata = (  # type: ignore[assignment]
+    lambda p: {"cell_key": KEY, "family": FAMILY})
+fleet_cells.arm_axis_divergence = lambda arm, meta: ""   # type: ignore[assignment]
+fleet_cells.aot_serve.note_aot_key = lambda k: None      # type: ignore[assignment]
+fleet_cells.activity_mod.emit_event = lambda *a, **k: None  # type: ignore[assignment]
+
+_real_pending = fleet_cells.PendingSelfMint
+
+
+def _spy(*a: Any, **k: Any) -> Any:
+    opened_mints.append(1)
+    return _real_pending(*a, **k)
+
+
+fleet_cells.PendingSelfMint = _spy           # type: ignore[assignment]
+
+if MODE == "mint":
+    # Stand in for the child's packed cell. On a pod this is a real .pt2
+    # tarball out of a real AOTI link; here it is bytes, because the store
+    # does not care what the cell IS and the digest proves only that the bytes
+    # came back unchanged.
+    art = Path(os.environ["PGW1096_ARTIFACT"])
+    art.parent.mkdir(parents=True, exist_ok=True)
+    art.write_bytes(b"a-real-cell-would-be-here" * 40)
+    reason = fleet_cells.local_keep_reason(None)
+    stored = local_cell_store.store(
+        art, key=KEY, family=FAMILY, arm_token=ARM)
+    print("RESULT " + json.dumps({
+        "run": 1, "keep_reason": reason,
+        "stored": stored is not None,
+        "stored_at_path": str(stored.artifact) if stored else "",
+        "digest": stored.content_digest if stored else "",
+    }))
+else:
+    # A COLD process: no `_FINALIZED`, no pending, nothing warm. The only
+    # thing that exists is the directory run 1 wrote.
+    assert not fleet_cells._FINALIZED, "a fresh process must start with no index"
+    minted = fleet_cells.arm_from_local_store(
+        Pipe(), Cfg(), None, 0, Arm(), FAMILY)
+    print("RESULT " + json.dumps({
+        "run": 2,
+        "armed": minted is not None,
+        "cell_key": getattr(minted, "cell_key", ""),
+        "artifact": str(getattr(minted, "artifact", "")),
+        "mints_opened": len(opened_mints),
+        "resident": [c.key for c in local_cell_store.stored_cells()],
+    }))
+'''
+
+
+def _run(mode: str, store: Path, artifact: Path) -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO / "src"), str(REPO / "tests"), env.get("PYTHONPATH", "")])
+    env["GEN_WORKER_LOCAL_CELLS_DIR"] = str(store)
+    env["PGW1096_ARTIFACT"] = str(artifact)
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROGRAM, mode],
+        capture_output=True, text=True, env=env, timeout=300)
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT "):
+            return json.loads(line[len("RESULT "):])
+    raise AssertionError(
+        f"run {mode!r} produced no result\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+
+
+def test_run_one_mints_and_keeps_run_two_reuses_with_no_mint(
+    tmp_path: Path,
+) -> None:
+    """Paul's compile-once-run-forever, across process death, measured."""
+    store = tmp_path / "cozy-cells"
+    artifact = tmp_path / "mint" / "cell.tar.gz"
+
+    one = _run("mint", store, artifact)
+    assert one["stored"] is True
+    # cozy-local's reason: no publisher was ever constructed, and no hub will
+    # ever refuse this machine, because it never talks to one.
+    assert one["keep_reason"] == "no_publish_sink"
+    assert one["digest"].startswith("sha256:")
+
+    # The mint's own workdir is gone, exactly as `_publish_async`'s `finally`
+    # and `abandon_self_mint` leave it. Only the store survives — which is the
+    # point: run 2 must not be reading the mint's leftovers.
+    artifact.unlink()
+
+    two = _run("reuse", store, artifact)
+    assert two["armed"] is True, "the second run did not reuse the stored cell"
+    assert two["mints_opened"] == 0, (
+        "the second run opened a mint — compile-once-run-forever is the whole "
+        "product promise and this is what breaking it looks like")
+    assert two["cell_key"] == "ck1-" + "c" * 56
+    assert two["artifact"].startswith(str(store)), (
+        "run 2 must serve the STORE's bytes, not a leftover from the mint")
+    assert two["resident"] == ["ck1-" + "c" * 56]
+
+
+def test_a_cold_run_with_an_EMPTY_store_mints_rather_than_inventing_a_hit(
+    tmp_path: Path,
+) -> None:
+    """The negative that makes the positive mean something: with nothing on
+    disk the same cold process reports no arm, so `armed=True` above is the
+    store's doing and not the stub's."""
+    two = _run("reuse", tmp_path / "empty-store", tmp_path / "unused.tar.gz")
+    assert two["armed"] is False
+    assert two["resident"] == []
+
+
+def test_a_corrupted_store_makes_the_cold_run_refuse_and_drop(
+    tmp_path: Path,
+) -> None:
+    """RED, across processes: run 1 keeps a cell, the bytes rot on disk, and
+    the cold run refuses it, drops it and is left with an empty store — one
+    honest re-mint, never a wrong arm."""
+    store = tmp_path / "cozy-cells"
+    artifact = tmp_path / "mint" / "cell.tar.gz"
+    one = _run("mint", store, artifact)
+    stored = Path(one["stored_at_path"])
+
+    rotted = bytearray(stored.read_bytes())
+    rotted[0] ^= 0xFF          # same length; only the content moved
+    stored.write_bytes(bytes(rotted))
+
+    two = _run("reuse", store, artifact)
+    assert two["armed"] is False, "a corrupted cell armed on a cold boot"
+    assert two["resident"] == [], "the refused cell was not dropped"


### PR DESCRIPTION
**Tracker: pgw#1096.** Builds §4.28's untrusted-hardware promise — the capability pgw#1092 §4 found missing, and a **hard prerequisite of pgw#1086 wave 1**.

## The gap

`local_cells.py` gave cozy-local compile-once-run-forever **on JIT only**, and pgw#1086 wave 1 deletes it. So §4.28's second clause had no implementation in either direction:

- **cozy-local** — JIT-only, and the JIT recipe is being deleted.
- **A fleet worker on untrusted hardware** — it minted, ate the hub's `cell_publish_untrusted_tier` 403, and `_publish_async`'s `finally` rmtree'd the bytes. th#1643 books that as SUNK: *"a sealed cell was produced and thrown away."* Once per boot, forever.

## What this adds — ONE identity, TWO stores

`local_cell_store.py`: a cell is addressed by exactly the `ck1` key the hub store addresses it by, so a local hit is the same artifact a hub hit would have delivered. The trust boundary is the one `local_cells` states, enforced by **absence** — no CAS client, no transport import, not even the CAS module's sha256 helper (inlined, so "it only imports it for the hash" cannot erode a boundary that works by having nothing).

Three seams:

- **Reuse** — `_arming_policy` consults this machine's own store on a delivered-cell miss, *after* the in-process ledgers and the quarantine gate and *before* it opens a pending, so the second boot never reaches the mint. The memo (pre-trace `ArmIdentity` → `ck1` key) is what lets a boot that has not traced address a content-addressed store; it is a shortcut, never an authority, and stays exactly that when pgw#1089 lands the derived key.
- **One gate** — `_arm_exported_cell` is **extracted** from `adopt_delegated_mint`, so the child's fresh cell and the store's cell pass one implementation rather than two that agree today. A local cell gets no weaker verification, plus a recomputed content digest.
- **The trust class** — hub-asserted and learned from the hub's own typed refusal. No worker-side self-declaration, no env switch; the only env this module reads is the store's *location*.

## A real bug caught mid-review (`309af9b2`)

The first cut kept a cell **only** after a hub refusal — correct for community cloud, **wrong for the product §4.28 was written about**: cozy-local never constructs a publisher and never reaches a hub, so it could never learn the class, never store, never reuse. `local_keep_reason` now names three disjoint **sink** facts (`hub_asserted_untrusted` / `no_publish_sink` / `publish_disarmed`), none of which is a trust claim. A pod with a live sink still keeps nothing, so fleet disks are unchanged.

## pgw#1086 wave-1 unblock

`aot_resume.store_root()` moves to `local_cell_store` with its value unchanged — same env, same default, same directory, no bank orphaned. That closes pgw#1092 §4's landmine 1: the production resume bank no longer routes through the module wave 1 deletes.

## Proof

`mypy` clean (249 files), `ruff` clean, all seven `fast gates` lint scripts green, 53 targeted tests.

`test_two_run_reuse_pgw1096.py` proves the claim as what it is — about **every subsequent RUN**, not one interpreter: two fresh OS processes sharing only a directory, mint workdir deleted between them. Run 1 keeps; run 2 starts cold, asserts its index is empty, and arms with `mints_opened == 0`. Two negatives keep it honest — an empty store makes the same cold process report *no* arm, and a cell whose bytes rot is refused and **dropped** on the cold boot.

**The compile is faked and the tests say so.** No mint/compile/AOTI link runs on the shared box (Paul, 2026-08-10). **Still owed by a pod: that a real AOTI cell, minted on a real card, arms from this store on a later boot.** The tracker records why that is not a $0.50 leg today — `micro-diffusion` is not registered on the dev stack (verified live) and its pod runbook is gated on Paul's explicit GO, while sdxl/z-image mints are 3-5x over budget; the cheap honest path is a ~$0.10 rider on an already-paid mint.

## Not in scope

The JIT demolition (pgw#1086) · the boot-side derive (pgw#1089) · the hub resolve client (pgw#1090) · any GC — accumulation is recorded with `stored_cells()` as its fact base.