### PR TITLE
th#1757: @worker_function(accepts_references=...) — the endpoint's opt-in to the platform reference layer

### DIFF
--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -25,6 +25,7 @@ from .api.decorators import (
     endpoint,
     variant_of,
     worker_function,
+    AcceptsReferences,
 )
 from .api.export_contract import (
     Arg,
@@ -112,6 +113,7 @@ __all__ = [
     "endpoint",
     "variant_of",
     "worker_function",
+    "AcceptsReferences",
     "Resources",
     "Compile",
     "CompileAxis",

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -371,6 +371,85 @@ def _validate_warmup_decl(owner: str, warmup: Optional[NoWarmup]) -> Optional[No
 WF_ATTR = "__gen_worker_function__"
 
 
+REFERENCE_MODALITIES = ("image", "video", "audio")
+
+
+class AcceptsReferences(msgspec.Struct, frozen=True, kw_only=True):
+    """th#1757: this handler OPTS IN to the platform reference layer.
+
+    A reference is a tenant-defined character/object/place/style that a user
+    writes as ``@handle`` in a prompt. The concept is PLATFORM-side: the hub
+    resolves the handle, rewrites the prompt into plain English and delivers
+    the reference's media onto an input this handler ALREADY declares. Nothing
+    here reaches the handler at runtime — a reference-bearing request arrives
+    as ordinary assets on ``delivery`` and a prompt with no ``@`` in it.
+
+    ``max`` — how many distinct references one request may name.
+    ``modalities`` — what this handler can absorb (image/video/audio).
+    ``per_ref_images`` — how many media items ONE reference contributes, as an
+    int (exactly n) or a ``(min, max)`` pair.
+    ``delivery`` — the declared media input the media lands on, in the
+    discovery contract's dotted path syntax (``references[].image``). The HUB
+    validates at publish that this names a real media field of this function;
+    declaring a path that does not exist fails the release, not a request.
+    """
+
+    max: int
+    modalities: Tuple[str, ...]
+    delivery: str
+    per_ref_images: Any = 1
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        if not isinstance(self.max, int) or self.max < 1:
+            raise ValueError(f"accepts_references: max must be a positive int, got {self.max!r}")
+        mods = tuple(str(m).strip().lower() for m in self.modalities)
+        if not mods:
+            raise ValueError("accepts_references: modalities is required")
+        for m in mods:
+            if m not in REFERENCE_MODALITIES:
+                raise ValueError(
+                    f"accepts_references: modality {m!r} is not one of "
+                    f"{'|'.join(REFERENCE_MODALITIES)}"
+                )
+        force(self, "modalities", mods)
+        delivery = str(self.delivery or "").strip()
+        if not delivery:
+            raise ValueError("accepts_references: delivery is required")
+        force(self, "delivery", delivery)
+        lo, hi = _per_ref_bounds(self.per_ref_images)
+        force(self, "per_ref_images", (lo, hi))
+
+    def to_manifest(self) -> Dict[str, Any]:
+        lo, hi = self.per_ref_images
+        return {
+            "max": int(self.max),
+            "modalities": list(self.modalities),
+            "per_ref_images": {"min": lo, "max": hi},
+            "delivery": self.delivery,
+        }
+
+
+def _per_ref_bounds(raw: Any) -> Tuple[int, int]:
+    if isinstance(raw, int) and not isinstance(raw, bool):
+        lo = hi = int(raw)
+    elif isinstance(raw, (tuple, list)) and len(raw) == 2:
+        lo, hi = int(raw[0]), int(raw[1])
+    elif isinstance(raw, Mapping):
+        lo = int(raw.get("min", 1))
+        hi = int(raw.get("max", lo))
+    else:
+        raise ValueError(
+            "accepts_references: per_ref_images must be an int, a (min, max) pair "
+            f"or a mapping, got {raw!r}"
+        )
+    if lo < 1 or hi < lo:
+        raise ValueError(
+            f"accepts_references: per_ref_images must satisfy 1 <= min <= max, got {lo}..{hi}"
+        )
+    return lo, hi
+
+
 class WorkerFunctionDecl(msgspec.Struct, frozen=True, kw_only=True):
     """``@worker_function`` marker: this handler's own contract facts.
 
@@ -411,6 +490,9 @@ class WorkerFunctionDecl(msgspec.Struct, frozen=True, kw_only=True):
     text_len: Optional[int] = None
     warm: Optional[Dict[str, Any]] = None
     warm_reason: str = ""
+    # th#1757: the opt-in reference contract. None = this handler never sees
+    # the concept and a ref_text sent to it is refused hub-side.
+    accepts_references: Optional[AcceptsReferences] = None
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -477,6 +559,7 @@ def worker_function(
     text_len: Optional[int] = None,
     warm: Optional[Mapping[str, Any]] = None,
     warm_reason: str = "",
+    accepts_references: Optional[AcceptsReferences] = None,
 ) -> Callable[[T], T]:
     """Per-handler contract facts (pgw#654), declared AT the definition
     site — on class handler methods and on bare ``@endpoint`` functions::
@@ -495,6 +578,7 @@ def worker_function(
         text_len=text_len,
         warm=dict(warm) if warm is not None else None,
         warm_reason=warm_reason,
+        accepts_references=accepts_references,
     )
 
     def apply(fn: T) -> T:

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -805,6 +805,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         # resolves unmeasured (serves at base precision).
         if es.tasks is not None:
             fn["tasks"] = list(es.tasks)
+        # th#1757: the opt-in reference contract. Omitted = this function
+        # never sees the concept; the hub refuses a ref_text sent to it.
+        if es.accepts_references is not None:
+            fn["accepts_references"] = es.accepts_references.to_manifest()
         # th#1050: opt-in declared lane bodies (behavioral divergence marker).
         if es.handles:
             fn["handles"] = list(es.handles)

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -171,6 +171,9 @@ class EndpointSpec:
     # None = undeclared, which resolves NO quant approval hub-side.
     tasks: Optional[tuple] = None
     distilled: Optional[bool] = None
+    # th#1757: this handler's opt-in reference contract (@worker_function).
+    # None = it never participates in the platform reference layer.
+    accepts_references: Optional[Any] = None
     # pgw#654 gap #6: this handler's effective text pin
     # (@worker_function(text_len=) else the class Compile.text_len).
     text_len: Optional[int] = None
@@ -610,6 +613,7 @@ def _spec_for_handler(
         objectives=(tuple(wf.objectives) if wf is not None and wf.objectives is not None else None),
         tasks=(tuple(wf.tasks) if wf is not None and wf.tasks is not None else None),
         distilled=(wf.distilled if wf is not None else None),
+        accepts_references=(wf.accepts_references if wf is not None else None),
         text_len=(wf_text_len if wf_text_len is not None
                   else (decl.compile.text_len if decl.compile is not None else None)),
         warm_overrides=warm_overrides,

--- a/tests/test_accepts_references_th1757.py
+++ b/tests/test_accepts_references_th1757.py
@@ -1,0 +1,100 @@
+"""th#1757: the opt-in reference contract, declaration to manifest.
+
+The value type validates what it can see. What it CANNOT see — whether
+``delivery`` names a media field this function actually declares — is the
+hub's check at publish, deliberately: only the hub has the input schema and
+the moderation media list side by side, and a wrong path must fail a release
+rather than a paying request.
+"""
+
+import pytest
+
+from gen_worker import AcceptsReferences
+
+
+def test_manifest_shape_is_what_the_hub_parses():
+    ar = AcceptsReferences(
+        max=3, modalities=["image"], per_ref_images=(1, 4), delivery="references[].image"
+    )
+    assert ar.to_manifest() == {
+        "max": 3,
+        "modalities": ["image"],
+        "per_ref_images": {"min": 1, "max": 4},
+        "delivery": "references[].image",
+    }
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (1, {"min": 1, "max": 1}),
+        (4, {"min": 4, "max": 4}),
+        ((1, 4), {"min": 1, "max": 4}),
+        ([2, 3], {"min": 2, "max": 3}),
+        ({"min": 1, "max": 9}, {"min": 1, "max": 9}),
+        ({"min": 2}, {"min": 2, "max": 2}),
+    ],
+)
+def test_per_ref_images_forms(raw, expected):
+    ar = AcceptsReferences(max=1, modalities=["image"], per_ref_images=raw, delivery="d[]")
+    assert ar.to_manifest()["per_ref_images"] == expected
+
+
+def test_modalities_are_case_folded_and_trimmed():
+    ar = AcceptsReferences(max=1, modalities=["IMAGE", " video "], delivery="d[]")
+    assert ar.to_manifest()["modalities"] == ["image", "video"]
+
+
+@pytest.mark.parametrize(
+    "kwargs,message",
+    [
+        (dict(max=0, modalities=["image"], delivery="d"), "max must be a positive int"),
+        (dict(max=-1, modalities=["image"], delivery="d"), "max must be a positive int"),
+        (dict(max=1, modalities=[], delivery="d"), "modalities is required"),
+        (dict(max=1, modalities=["hologram"], delivery="d"), "is not one of image|video|audio"),
+        (dict(max=1, modalities=["image"], delivery="   "), "delivery is required"),
+        (
+            dict(max=1, modalities=["image"], delivery="d", per_ref_images=(4, 2)),
+            "1 <= min <= max",
+        ),
+        (
+            dict(max=1, modalities=["image"], delivery="d", per_ref_images=0),
+            "1 <= min <= max",
+        ),
+        (
+            dict(max=1, modalities=["image"], delivery="d", per_ref_images="lots"),
+            "per_ref_images must be an int",
+        ),
+    ],
+)
+def test_refusals(kwargs, message):
+    with pytest.raises(ValueError) as exc:
+        AcceptsReferences(**kwargs)
+    assert message in str(exc.value)
+
+
+def test_worker_function_carries_the_declaration_into_the_registry_spec():
+    from gen_worker import worker_function
+    from gen_worker.api.decorators import WF_ATTR
+
+    ar = AcceptsReferences(max=2, modalities=["image"], delivery="references[].image")
+
+    @worker_function(accepts_references=ar)
+    def reference_to_video(self, ctx, payload):  # pragma: no cover - never called
+        raise AssertionError
+
+    decl = getattr(reference_to_video, WF_ATTR)
+    assert decl.accepts_references is ar
+
+
+def test_undeclared_is_absent_not_empty():
+    """Omitting the block means the endpoint never sees the concept. It must
+    not become a default-permissive `{}` anywhere in the chain."""
+    from gen_worker import worker_function
+    from gen_worker.api.decorators import WF_ATTR
+
+    @worker_function()
+    def generate(self, ctx, payload):  # pragma: no cover - never called
+        raise AssertionError
+
+    assert getattr(generate, WF_ATTR).accepts_references is None


### PR DESCRIPTION
Paired with tensorhub **#1001** (the hub half). Design: th#1757, Paul 2026-08-10.

The hub resolves `@handle` references in a prompt, rewrites them into plain English, and delivers the reference's media onto an input the endpoint **already declares**. This PR is how an endpoint says it wants that — and it is the whole worker-side surface, on purpose.

```python
@worker_function(accepts_references=AcceptsReferences(
    max=3, modalities=["image"], per_ref_images=(1, 4),
    delivery="references[].image"))
def reference_to_video(self, ctx, payload: ReferenceToVideoInput) -> GenerateOutput:
    ...
```

**Nothing here reaches the handler at runtime.** A reference-bearing request arrives as ordinary assets on `delivery` and a prompt with no `@` in it. That is the point: the platform-specific concept never crosses the worker boundary and endpoint code stays generic.

## What it validates, and what it deliberately does not

`AcceptsReferences` checks what it can see — `max` positive, the modality vocabulary (`image|video|audio`), the `per_ref_images` bounds, a non-empty `delivery` — and rides into the manifest as `functions[].accepts_references`:

```json
{"max": 3, "modalities": ["image"], "per_ref_images": {"min": 1, "max": 4}, "delivery": "references[].image"}
```

What it does **not** check is whether `delivery` names a media field this function actually declares. Only the hub has the input schema and the moderation media list side by side, and it refuses a wrong path **at publish** — so a bad declaration fails a release, not a paying request.

`per_ref_images` accepts an int, a `(min, max)` pair or a mapping and normalizes to one shape. Omitting the block is the default and means the endpoint never sees the concept — it must not become a permissive `{}` anywhere in the chain, which the tests pin.

## Version

No bump. The number is claimed at publish, one artifact per number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHywnqnYgUUFKJ7zagNUJ1