### PR TITLE
pgw#1031: the cell key is an INGRESS identity — the graph-witness floor

### DIFF
--- a/changelog.d/pgw1031.md
+++ b/changelog.d/pgw1031.md
@@ -1,0 +1,22 @@
+- **pgw#1031: a cell may no longer serve a graph the adopting pod does not
+  compute — the GRAPH WITNESS floor.** The `ck1` key is an INGRESS identity:
+  `class_hash` folds target, fork, class dims, declared ranges and the
+  graph-interface block (constant FQNs, lifted inputs, pytree spec,
+  specialization), plus the declared envelope, `sm` and `toolchain` — every
+  fact about how a graph is CALLED and none about what it COMPUTES. Two
+  endpoints whose declarations agree while their bodies differ therefore mint
+  under ONE key. Measured, not argued: `micro-pad32` and `micro-pad32-branchy`
+  trace 112- and 102-node graphs and produce a BYTE-IDENTICAL keying block, one
+  `ck1` digest, and (pgw#1079, on a real card) two different artifacts. Under
+  pull-by-key adoption (§4.27) one endpoint gets the other's kernels, and only
+  the arm-time numerics tolerance stands between that and served output.
+  `aot_mint.keying_block` now records `graph_witness` per entry — the node-level
+  digest of the traced program (`graph_hash.graph_hash`) — as a SIBLING of
+  `graph`, so it is metadata and **no cell is re-keyed**. `boot_key` reports
+  the witnesses it traced (`DerivedKey.graph_witnesses`, memo v3), and
+  `boot_adopt` refuses a materialized cell whose recorded witness is not the
+  one this pod traced: typed `graph_witness_mismatch`, naming the entry and
+  BOTH digests, degrading to eager-then-mint. Fail-closed both ways — a cell
+  silent on its witness is refused, not skipped. Whether the witness should
+  BECOME a key axis (a deliberate fleet-wide re-key) stays pgw#1031 and is
+  Paul's to rule; this ships the floor that holds either way.

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -165,9 +165,86 @@ def verify_declared_identity(
     return ""
 
 
+#: The entry-block field carrying the node-level digest of the traced program
+#: (``graph_hash.graph_hash``), stamped by ``aot_mint.keying_block``. METADATA,
+#: never a key axis — see :func:`verify_graph_witness`.
+GRAPH_WITNESS_FIELD = "graph_witness"
+
+
+def verify_graph_witness(
+    meta: Mapping[str, Any], witnesses: Mapping[str, str],
+) -> str:
+    """``''`` when the cell's recorded graph witnesses equal the ones this pod
+    traced, else the reason. pgw#1031's fail-closed floor.
+
+    The cell key is an INGRESS identity: ``class_hash`` folds target, fork,
+    class dims, declared ranges, the graph-interface block (constant FQNs,
+    lifted inputs, pytree spec, specialization) and the declared envelope —
+    everything about how a graph is CALLED and nothing about what it COMPUTES.
+    Two endpoints whose bodies differ while their declarations agree therefore
+    mint under one ``ck1`` key: measured 2026-08-10 on ``micro-pad32`` vs
+    ``micro-pad32-branchy`` (112 vs 102 nodes, byte-identical keying block,
+    identical key). Pull-by-key adoption (§4.27/pgw#1090) then hands one
+    endpoint the other's kernels, and only the arm-time numerics gate — a
+    tolerance test, not identity — stands between that and served output.
+
+    This closes it WITHOUT re-keying the fleet: the mint records
+    ``graph_witness`` per entry, the adopter derives its own from the same
+    traced programs its key came from (``boot_key``), and a disagreement is a
+    typed refusal naming both digests. The pod then boots exactly as it booted
+    before pull-by-key existed — eager, then mint — which is the correct
+    outcome for "this cell is not my computation".
+
+    Fail-closed in both directions, the doctrine
+    :func:`verify_declared_identity` already keeps: a cell that is SILENT on an
+    entry's witness cannot be shown to compute this pod's graph, and "cannot be
+    shown to match" is what a refusal means. A witness set that does not cover
+    the same entries is the same failure — a partial agreement is not a
+    narrower match, it is an unproven one (pgw#716).
+
+    ``witnesses`` is ``{entry: digest}`` as
+    ``boot_key.DerivedKey.graph_witnesses`` reports it. An empty mapping is a
+    caller error, not a pass.
+    """
+    if not witnesses:
+        return (
+            "this pod derived no graph witnesses, so the cell's compiled "
+            "graphs cannot be shown to be the graphs it traced (pgw#1031)")
+    entries = meta.get("entries")
+    if not isinstance(entries, Mapping) or not entries:
+        return "artifact records no entries map; it has no graph witness"
+    recorded = {
+        str(name): str((block or {}).get(GRAPH_WITNESS_FIELD) or "")
+        for name, block in entries.items()
+    }
+    silent = sorted(name for name, value in recorded.items() if not value)
+    if silent:
+        return (
+            f"entries {silent[:4]!r} record no {GRAPH_WITNESS_FIELD!r}: this "
+            f"cell predates pgw#1031 and cannot state which graph it compiled")
+    extra = sorted(set(recorded) - set(witnesses))
+    missing = sorted(set(witnesses) - set(recorded))
+    if extra or missing:
+        return (
+            f"graph witness class set differs (cell-only {extra[:3]!r}, "
+            f"traced-only {missing[:3]!r}): the cell was compiled from a "
+            f"different class set than this pod traced")
+    for name in sorted(recorded):
+        want, have = recorded[name], str(witnesses[name] or "")
+        if want != have:
+            return (
+                f"entry {name!r}: graph witness {want} on the cell, {have} "
+                f"traced here — the cell key matched but the COMPUTATION did "
+                f"not (pgw#1031: the key folds the ingress contract, not the "
+                f"graph nodes). Refusing to arm another graph's kernels")
+    return ""
+
+
 __all__ = [
+    "GRAPH_WITNESS_FIELD",
     "ExpectedIdentity",
     "artifact_identity",
     "expected_from_plan",
     "verify_declared_identity",
+    "verify_graph_witness",
 ]

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -3407,6 +3407,20 @@ def keying_block(
     ``constants`` is present-but-empty rather than absent because
     ``aot_serve.entries_from_meta`` validates every block as a full contract,
     and an entry that cannot be parsed cannot be keyed.
+
+    ``graph_witness`` (pgw#1031) is a SIBLING of ``graph``, deliberately
+    OUTSIDE it: ``aot_serve.class_hash`` folds ``target``/``fork``/
+    ``class_dims``/``range_digest``/``graph``/``strict``/``lora_bucket`` and
+    nothing else, so a top-level field is recorded on every cell without
+    moving one key. It is the node-level digest of the traced program
+    (``graph_hash.graph_hash``) — the fact the key axes provably do NOT hold:
+    measured 2026-08-10, ``micro-pad32`` and ``micro-pad32-branchy`` produce a
+    byte-identical keying block (identical signature, symbol ranges, pytree
+    spec, constant FQNs and declared envelope) from 112- and 102-node graphs.
+    The key cannot separate them; this witness can, and the adopt path refuses
+    on it (``aot_identity.verify_graph_witness``) so a collision degrades to
+    eager instead of serving another endpoint's kernels. Whether the witness
+    should BECOME a key axis is pgw#1031's depth question and Paul's to rule.
     """
     inputs, symbols = aot_package.input_contract(program, flat_leaves)
     block: Dict[str, Any] = {
@@ -3418,6 +3432,7 @@ def keying_block(
         "symbols": symbols,
         "constants": [],
         "graph": entry_graph_block(program, spec),
+        "graph_witness": graph_hash.graph_hash(program),
     }
     if adapter_arm(spec.fork) is False:
         # pgw#790: the NEGATIVE half of this class's contract. Without it the

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -18,12 +18,14 @@ local) and the request path waits for none of it (pgw#1091).
 Why this is a module and not three lines at the call site
 ---------------------------------------------------------
 Because a refusal at any of the three steps must **degrade to the pre-existing
-behaviour and say why**, and there are six distinct ways to fail:
+behaviour and say why**, and there are eight distinct ways to fail:
 the family has no structure-only build, a trace child died, the hub refused
 typed, the hub answered a different key, the transport was unusable, the bytes
-failed their digest. Every one of them means "boot as we booted yesterday",
-and every one of them is a different sentence someone will need. Spreading that
-across an executor branch is how the reason ends up being `logger.debug`.
+failed their digest, the delivered cell would not state its metadata, and
+(pgw#1031) the cell's recorded graph witness is not the graph this pod traced.
+Every one of them means "boot as we booted yesterday", and every one of them is
+a different sentence someone will need. Spreading that across an executor
+branch is how the reason ends up being `logger.debug`.
 
 **Never fatal.** A cold boot that cannot adopt is the boot every pod did before
 this existed. The one thing this must never do is prevent a pod from serving.
@@ -36,7 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
-from . import aot_identity, boot_key, cell_resolve
+from . import aot_identity, artifact_meta, boot_key, cell_resolve
 from .mint_process import CompileCellSpec, MintSlot
 
 logger = logging.getLogger(__name__)
@@ -180,6 +182,40 @@ def attempt(
         logger.warning("boot-adopt: materialize failed", exc_info=True)
         return BootAdoptOutcome(
             reason="materialize_failed", detail=f"{type(exc).__name__}: {exc}",
+            derived_key=key, derive_ms=derived.wall_ms)
+
+    # pgw#1031, THE GRAPH-WITNESS FLOOR. Everything above this line agreed on
+    # the KEY, and the key is an ingress identity: two endpoints whose declared
+    # contracts match while their bodies differ mint under one `ck1`
+    # (`micro-pad32` vs `micro-pad32-branchy`, measured 2026-08-10 — identical
+    # keying block from 112- and 102-node graphs). Pull-by-key would hand this
+    # pod the other endpoint's kernels, and only the arm-time numerics
+    # tolerance would stand in the way. So the last thing checked before an
+    # adoption is returned is that the cell's compiled graphs ARE the graphs
+    # this pod traced.
+    try:
+        # THE one bounded reader (pgw#1098): a second scan of the same
+        # member is a divergence waiting for the first caller who bounds
+        # only one of them.
+        meta = artifact_meta.read_metadata(Path(artifact))
+    except Exception as exc:  # noqa: BLE001 — unreadable IS unproven
+        logger.warning("boot-adopt: metadata unreadable", exc_info=True)
+        return BootAdoptOutcome(
+            reason="witness_unreadable",
+            detail=(
+                f"the materialized cell for {key} would not state its "
+                f"metadata ({type(exc).__name__}: {exc}), so its graphs cannot "
+                f"be shown to be this pod's graphs"),
+            derived_key=key, derive_ms=derived.wall_ms)
+    mismatch = aot_identity.verify_graph_witness(
+        meta, derived.graph_witnesses)
+    if mismatch:
+        logger.error(
+            "boot-adopt: REFUSING %s (%s) — the key matched and the graph did "
+            "not: %s. This pod serves eager and mints its own.",
+            key, cell.cell_ref, mismatch)
+        return BootAdoptOutcome(
+            reason="graph_witness_mismatch", detail=mismatch,
             derived_key=key, derive_ms=derived.wall_ms)
 
     logger.info(

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -237,6 +237,13 @@ class DerivedKey:
     wall_ms: int
     trace_ms: Mapping[str, int] = field(default_factory=dict)
     nodes: Mapping[str, int] = field(default_factory=dict)
+    #: pgw#1031: entry name -> the NODE-level digest of the graph this boot
+    #: traced (``aot_mint.keying_block``'s ``graph_witness``). Not a key axis
+    #: and never folded into one — it is what the adopt path compares against
+    #: the cell's own record, because the key provably cannot separate two
+    #: bodies behind one declaration. Rides the keying blocks, so a memo hit
+    #: carries it exactly as a cold trace does.
+    graph_witnesses: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def digest(self) -> str:
@@ -297,7 +304,11 @@ def trace_workers(classes: int, *, limit: int = 0) -> PoolWidth:
 #: Memo file schema. Bumped when the MEANING of a stored hash changes; a
 #: reader that finds an older version treats the whole file as absent, which
 #: is a miss and a re-trace, never a wrong key.
-MEMO_VERSION = 2
+#: v3 (pgw#1031): the stored blocks now carry ``graph_witness``, and a v2 entry
+#: has none — which the adopt-side floor reads as "this pod cannot state its
+#: own graph" and refuses. Bumped so a stale memo is a re-trace rather than a
+#: refusal nobody can explain.
+MEMO_VERSION = 3
 MEMO_FILENAME = "boot-key-graphs.json"
 
 
@@ -450,12 +461,23 @@ def assert_memo_honest(
         return (
             f"boot-key memo for closure {digest} could not be stamped "
             f"({type(exc).__name__}: {exc}) and has been invalidated")
+    had_witnesses = graph_witnesses_of(memoized)
     disagreements: List[str] = []
     for name, block in sorted(minted_entries.items()):
         want = str((block or {}).get("class_hash") or "")
         had = had_hashes.get(str(name))
         if had and want and had != want:
             disagreements.append(f"{name}: memo {had} != traced {want}")
+        # pgw#1031: the memo now also answers the ADOPT-side witness, so a
+        # memo whose class hash is right and whose witness is stale would
+        # admit a colliding cell on the very axis the witness exists to
+        # separate. Checked here for the same reason the hash is.
+        want_w = str((block or {}).get("graph_witness") or "")
+        had_w = had_witnesses.get(str(name)) or ""
+        if want_w and had_w != want_w:
+            disagreements.append(
+                f"{name}: memo graph_witness {had_w or '<absent>'} != traced "
+                f"{want_w}")
     extra = sorted(set(had_hashes) - set(minted_entries))
     missing = sorted(set(minted_entries) - set(had_hashes))
     if extra or missing:
@@ -473,6 +495,23 @@ def assert_memo_honest(
 # ---------------------------------------------------------------------------
 # The fold — the mint's OWN stamping code, called with the mint's own blocks
 # ---------------------------------------------------------------------------
+
+
+def graph_witnesses_of(
+    blocks: Mapping[str, Mapping[str, Any]],
+) -> Dict[str, str]:
+    """``{entry: graph_witness}`` for one set of keying blocks (pgw#1031).
+
+    Read off the blocks rather than recomputed: the witness is stamped where
+    the program is, by ``aot_mint.keying_block``, and a second derivation here
+    would be the same two-implementations hazard :func:`fold` refuses for the
+    key itself. A block that carries none yields ``""`` — and an empty witness
+    is what ``aot_identity.verify_graph_witness`` refuses on, never skips.
+    """
+    return {
+        str(name): str((block or {}).get("graph_witness") or "")
+        for name, block in blocks.items()
+    }
 
 
 def class_hashes_of(
@@ -708,7 +747,8 @@ def derive(
             key=key, class_hashes=class_hashes, combined=combined,
             workers=0,
             width_reason="memo hit — no trace child was spawned",
-            traced=0, memo="hit", wall_ms=wall_ms)
+            traced=0, memo="hit", wall_ms=wall_ms,
+            graph_witnesses=graph_witnesses_of(memoized))
 
     work = Path(work_root)
     work.mkdir(parents=True, exist_ok=True)
@@ -832,6 +872,7 @@ def derive(
         wall_ms=wall_ms,
         trace_ms=trace_ms,
         nodes=nodes,
+        graph_witnesses=graph_witnesses_of(blocks),
     )
 
 
@@ -877,6 +918,7 @@ __all__ = [
     "class_hashes_of",
     "closure_digest",
     "derive",
+    "graph_witnesses_of",
     "shares",
     "fold",
     "invalidate_memo",

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -12,17 +12,29 @@ contains exactly what determines the compiled artifact — nothing else.**
 "Don't key on parameters that don't require us to recompile." That single
 test admits four axes and no more:
 
-    graph         the traced computation: ``combined_graph_hash`` — first 16
-                  hex of sha256 over the newline-joined SORTED per-entry
-                  ``class_hash`` values (pgw#716). Each class hash folds the
-                  entry's target, fork coordinate, class dims, declared-range
-                  digest, graph-interface block, trace mode and lora bucket,
-                  so every trace-shaping fact reaches the key through this
-                  one derivation (``aot_serve.class_hash`` /
-                  ``aot_serve.combined_graph_hash`` — stamped by
-                  ``aot_serve.artifact_metadata``, proven at admission by
-                  ``aot_serve.verify_contract``, READ — never re-derived —
-                  here).
+    graph         ``combined_graph_hash`` — first 16 hex of sha256 over the
+                  newline-joined SORTED per-entry ``class_hash`` values
+                  (pgw#716). Each class hash folds the entry's target, fork
+                  coordinate, class dims, declared-range digest,
+                  graph-INTERFACE block, trace mode and lora bucket
+                  (``aot_serve.class_hash`` / ``aot_serve.combined_graph_hash``
+                  — stamped by ``aot_serve.artifact_metadata``, proven at
+                  admission by ``aot_serve.verify_contract``, READ — never
+                  re-derived — here).
+
+                  **Read the name precisely: this axis is the traced INGRESS
+                  identity, not the traced computation.** No graph-NODE digest
+                  reaches it, so two endpoints whose declarations agree while
+                  their bodies differ collide — measured 2026-08-10,
+                  ``micro-pad32`` vs ``micro-pad32-branchy``: 112- and 102-node
+                  graphs, byte-identical keying block, one key, two artifacts.
+                  Whether the nodes SHOULD be keyed (a deliberate fleet-wide
+                  re-key) is pgw#1031 and is Paul's to rule. Until then the
+                  hole is not merely noted: every entry records a
+                  ``graph_witness`` (``graph_hash.graph_hash``, metadata — see
+                  ``aot_mint.keying_block``) and the adopt path refuses a cell
+                  whose witness is not the graph this pod traced
+                  (``aot_identity.verify_graph_witness``).
     envelope      the DECLARED serving region (flight-envelope sense): the
                   shape ladder x text lens x guidance classes the author
                   declared, plus the (currently empty) behavior-posture

--- a/src/gen_worker/graph_hash.py
+++ b/src/gen_worker/graph_hash.py
@@ -1,4 +1,15 @@
-"""Canonical GRAPH identity — the cell-key input (pgw#716).
+"""Canonical GRAPH identity (pgw#716).
+
+**What this digest is USED for today (pgw#1031, read this before the ruling
+below):** it is the pgw#917 same-class comparator and the per-entry
+``graph_witness`` — recorded on every cell by ``aot_mint.keying_block`` and
+compared at adopt time by ``aot_identity.verify_graph_witness``. It is **not**
+folded into ``cell_key``: the ``graph`` axis is ``combined_graph_hash`` over
+``class_hash``, which folds the graph INTERFACE and no node digest, so two
+different computations behind one declaration share a key (measured
+2026-08-10). Whether this digest should BECOME the key is pgw#1031's depth
+question and Paul's to rule; the witness is the fail-closed floor that holds
+either way.
 
 Paul's ruling: "I'd rather key on the graph that is changed, not hash on code
 changes... look at some code and be like 'oh this is graph-ABC' and that is the

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -1,0 +1,326 @@
+"""pgw#1031 — the cell key is an INGRESS identity, and two different
+computations behind one declaration collide inside it.
+
+The LIVE SIGHTING this file pins, measured 2026-08-10 during pgw#1079: the
+gauntlet's ``micro-pad32`` and ``micro-pad32-branchy`` members mint two
+different artifacts (``sha256:aeedeba3…`` / ``sha256:1613596c…``) under ONE
+``ck1`` key. They are the same model with two spellings of the same pad, so
+every DECLARED fact agrees — signature, symbol ranges, pytree spec, constant
+FQNs, declared envelope — while the traced bodies do not (112 nodes vs 102).
+``class_hash`` folds only the declared facts, so the key cannot see it.
+
+Two rows, and they are the whole issue:
+
+* :func:`test_the_collision_is_real` traces both families through the mint's
+  OWN ``trace_for_key`` and asserts the keying blocks are byte-identical while
+  the graph witnesses differ. It is the RED half — pre-mitigation, pull-by-key
+  hands ``micro-pad32-branchy`` the ``micro-pad32`` cell and nothing refuses.
+* :func:`test_the_witness_refuses_the_collision` runs the mitigation over the
+  same two traced blocks: the matching pod admits, the colliding pod is
+  REFUSED by a reason naming both digests.
+
+**No compile anywhere.** ``trace_for_key`` is ``torch.export`` and stops there
+(Paul 2026-08-10: tracing for key derivation is explicitly permitted locally;
+mints are not). The weights are the rig's 1.1 MB generated checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import aot_identity, aot_serve, boot_key  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+#: The two gauntlet members. Same weights, same declaration, two pad spellings.
+PAIR = ("micro-pad32", "micro-pad32-branchy")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _gpu_runtime() -> Any:
+    """A key-complete runtime on a card-less box — probes only (pgw#983).
+
+    Module-scoped because the traces are: ``sm`` is a KEY AXIS, so the fold in
+    :func:`_trace` needs it, and that runs inside the module-scoped fixture.
+    """
+    from gen_worker import compile_cache
+
+    full = {
+        "sku": "l4", "sm": "sm_89", "torch": str(torch.__version__),
+        "triton": "3.6.0", "cuda": "13.0",
+        "image_digest": "sha256:" + "ab" * 32,
+    }
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(compile_cache, "runtime_key", lambda: dict(full))
+        mp.setattr(aot_serve, "runtime_key", lambda: {
+            "sku": full["sku"], "sm": full["sm"], "torch": full["torch"],
+            "cuda": full["cuda"]})
+        yield
+
+
+def _trace(
+    vehicle_name: str, tree: Path,
+) -> Tuple[Dict[str, Any], Any, Dict[str, Any]]:
+    """``({entry: keying block}, ck1 key, declared envelope)`` — trace only."""
+    from harness import rig_vehicles
+
+    from gen_worker import aot_mint, fleet_cells
+    from gen_worker.cli.run import run_setup
+    from gen_worker.mint_child import pick_compile_target
+    from gen_worker.registry import collect_endpoints
+
+    veh = rig_vehicles.vehicle(vehicle_name)
+    cfg = veh.compile_cell()
+    specs = collect_endpoints(list(veh.modules))
+    chosen = next(s for s in specs if s.name == veh.function)
+    loaded = run_setup(
+        chosen.cls(), {"pipeline": str(tree)}, arm_compile=False,
+        return_loaded=True) or {}
+    _slot, pipeline = pick_compile_target(loaded, cfg)
+    export_spec = fleet_cells.aot_export_spec(pipeline, cfg)
+    decl = aot_mint.export_declaration(export_spec.family)
+    blocks: Dict[str, Any] = {}
+    for traced in aot_mint.trace_for_key(pipeline, export_spec, decl):
+        blocks[traced.name] = traced.block
+        traced.program = None  # the largest object here; nothing below reads it
+    envelope = fleet_cells.declared_envelope_block(cfg)
+    key, _hashes, _combined = boot_key.fold(
+        blocks, family=export_spec.family, precision="", strict=True,
+        lora_bucket=int(cfg.lora_bucket or 0), envelope=envelope)
+    return blocks, key, envelope
+
+
+@pytest.fixture(scope="module")
+def traced_pair(
+    _gpu_runtime: Any, tmp_path_factory: pytest.TempPathFactory,
+) -> Dict[str, Any]:
+    """Both families traced once — the export is the expensive part."""
+    from harness import rig_vehicles
+
+    root = tmp_path_factory.mktemp("pgw1031")
+    tree = rig_vehicles.vehicle(PAIR[0]).build_checkpoint(root / "checkpoint")
+    out: Dict[str, Any] = {}
+    for name in PAIR:
+        blocks, key, envelope = _trace(name, tree)
+        out[name] = {"blocks": blocks, "key": key, "envelope": envelope}
+    return out
+
+
+def _canon(block: Any) -> str:
+    return json.dumps(block, sort_keys=True, separators=(",", ":"))
+
+
+def test_the_collision_is_real(traced_pair: Dict[str, Any]) -> None:
+    """RED: one key, two computations — and every keyed fact agrees."""
+    fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
+    assert set(fixed["blocks"]) == set(branchy["blocks"]) == {"transformer"}
+
+    a, b = fixed["blocks"]["transformer"], branchy["blocks"]["transformer"]
+    keyed = {k: v for k, v in a.items() if k != "graph_witness"}
+    other = {k: v for k, v in b.items() if k != "graph_witness"}
+    assert _canon(keyed) == _canon(other), (
+        "the keyed half of the block is expected to be IDENTICAL — if this "
+        "fails the collision has been closed by some other axis and pgw#1031's "
+        "sighting needs re-stating")
+    assert fixed["key"].digest == branchy["key"].digest, (
+        "THE DEFECT: two different graphs under one ck1 key. A red here means "
+        "identity gained graph depth — update pgw#1031, do not weaken this")
+
+    # …and the two graphs really are different computations.
+    assert a["graph_witness"] and b["graph_witness"]
+    assert a["graph_witness"] != b["graph_witness"], (
+        "the witness must separate what the key cannot; equal digests here "
+        "would mean the witness is as blind as the key")
+
+
+def test_the_witness_refuses_the_collision(traced_pair: Dict[str, Any]) -> None:
+    """GREEN: the matching pod adopts; the colliding pod is refused by name."""
+    fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
+    cell = aot_serve.artifact_metadata(
+        family=PAIR[0], precision="", cell_key=fixed["key"].digest,
+        entries=fixed["blocks"], strict_export=True, lora_bucket=0)
+
+    mine = boot_key.graph_witnesses_of(fixed["blocks"])
+    theirs = boot_key.graph_witnesses_of(branchy["blocks"])
+
+    assert aot_identity.verify_graph_witness(cell, mine) == "", (
+        "the pod whose graph this cell WAS compiled from must admit it")
+
+    refusal = aot_identity.verify_graph_witness(cell, theirs)
+    assert refusal, "the colliding pod must be REFUSED, not admitted"
+    assert "transformer" in refusal
+    assert mine["transformer"] in refusal and theirs["transformer"] in refusal, (
+        "a refusal that does not name BOTH digests cannot be acted on")
+
+
+def test_a_witnessless_cell_is_refused_not_skipped() -> None:
+    """Fail-closed: silence is a refusal (``verify_declared_identity``'s rule).
+
+    A pre-pgw#1031 cell records no witness, so it cannot be shown to compute
+    this pod's graph — and 'cannot be shown to match' is what a refusal means.
+    """
+    meta = {"entries": {"unet": {"class_hash": "aa" * 8}}}
+    reason = aot_identity.verify_graph_witness(meta, {"unet": "d" * 16})
+    assert "graph_witness" in reason and "unet" in reason
+
+    assert aot_identity.verify_graph_witness(
+        {"entries": {"unet": {"graph_witness": "d" * 16}}}, {})
+    assert aot_identity.verify_graph_witness(
+        {}, {"unet": "d" * 16})
+
+
+def test_a_differing_class_set_is_refused() -> None:
+    """A partial agreement is not a narrower match, it is an unproven one."""
+    meta = {"entries": {
+        "unet": {"graph_witness": "a" * 16},
+        "vae": {"graph_witness": "b" * 16}}}
+    reason = aot_identity.verify_graph_witness(meta, {"unet": "a" * 16})
+    assert "class set differs" in reason and "vae" in reason
+
+
+def _meta(row: Dict[str, Any], family: str) -> Dict[str, Any]:
+    """One family's cell metadata, as the mint would stamp it."""
+    from gen_worker import cell_key as ck, compile_cache as cc, env_seal
+
+    meta = aot_serve.artifact_metadata(
+        family=family, precision="", cell_key=row["key"].digest,
+        entries=row["blocks"], strict_export=True, lora_bucket=0)
+    meta["kind"] = ck.EXPORTED_KIND
+    meta[ck.EXPORT_ENVELOPE_KEY] = dict(row["envelope"])
+    meta["toolchain"] = dict(cc.toolchain_digest())
+    meta[env_seal.SEAL_KEY] = env_seal.effective_seal()
+    return meta
+
+
+def test_every_landed_gate_admits_the_wrong_cell(
+    traced_pair: Dict[str, Any],
+) -> None:
+    """RED: nothing that shipped before pgw#1031 separates these two cells.
+
+    Pod ``micro-pad32-branchy`` derives a key, the hub answers it with the
+    ``micro-pad32`` cell — correctly, they ARE one key — and then every
+    admission gate the tree has agrees: the declared identity matches on all
+    four compared axes (``combined_graph_hash`` included, because that is the
+    same collided digest), and the contract is self-consistent. The wrong
+    kernels arm, and the only thing left is the arm-time numerics tolerance.
+    """
+    fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
+    cell_a = _meta(fixed, PAIR[0])
+
+    # The expectation pod B states from its OWN traced facts and its OWN
+    # runtime — nothing borrowed from the cell it is about to be handed.
+    expected_b = aot_identity.artifact_identity(_meta(branchy, PAIR[1]))
+    assert expected_b.cell_key == cell_a["cell_key"]
+    assert aot_identity.verify_declared_identity(cell_a, expected_b) == "", (
+        "pgw#903's identity gate admits the wrong cell — that is the defect, "
+        "not a bug in this test")
+    assert aot_serve.verify_contract(cell_a) == ""
+
+    # …and the ONE thing that refuses it.
+    assert aot_identity.verify_graph_witness(
+        cell_a, boot_key.graph_witnesses_of(branchy["blocks"]))
+
+
+# ---------------------------------------------------------------------------
+# The ADOPT PATH — where a collision would actually arm another graph's kernels
+# ---------------------------------------------------------------------------
+
+
+def _artifact(tmp_path: Path, meta: Dict[str, Any]) -> Path:
+    """A cell whose only interesting member is its ``metadata.json``."""
+    import io
+    import tarfile
+
+    path = tmp_path / "cell.tar.gz"
+    blob = json.dumps(meta).encode()
+    with tarfile.open(path, mode="w:gz") as tar:
+        info = tarfile.TarInfo(aot_serve.METADATA_NAME)
+        info.size = len(blob)
+        tar.addfile(info, io.BytesIO(blob))
+    return path
+
+
+def _attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+             derived: Any, artifact: Path) -> Any:
+    from gen_worker import boot_adopt, boot_key, cell_resolve
+
+    class _Cell:
+        publisher_org = "org-a"
+        cell_ref = "root/family-micro-pad32"
+        publisher_tier = "platform"
+
+    monkeypatch.setattr(boot_key, "derive", lambda **_kw: derived)
+    monkeypatch.setattr(cell_resolve, "resolve", lambda *_a, **_k: _Cell())
+    monkeypatch.setattr(
+        cell_resolve, "materialize", lambda *_a, **_k: artifact)
+
+    class _Cfg:
+        family = "micro-pad32"
+        targets = ("transformer",)
+        shapes = ((12, 12),)
+        text_lens = ()
+        guidance_scales = ()
+        lora_bucket = 0
+
+    return boot_adopt.attempt(
+        function="generate-pad32", modules=("m",), cfg=_Cfg(), slots={},
+        declared_hint=1, envelope={"shapes": [[12, 12]]},
+        work_root=tmp_path)
+
+
+def _derived_key(traced: Dict[str, Any], family: str) -> Any:
+    """A ``DerivedKey`` carrying one family's real traced witnesses."""
+    blocks = traced[family]["blocks"]
+    return boot_key.DerivedKey(
+        key=traced[family]["key"], class_hashes={}, combined="",
+        workers=1, width_reason="pgw#1031 fixture", traced=len(blocks),
+        memo="miss", wall_ms=1,
+        graph_witnesses=boot_key.graph_witnesses_of(blocks))
+
+
+def test_the_adopt_path_admits_the_pod_whose_graph_it_is(
+    traced_pair: Dict[str, Any], monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fixed = traced_pair[PAIR[0]]
+    meta = aot_serve.artifact_metadata(
+        family=PAIR[0], precision="", cell_key=fixed["key"].digest,
+        entries=fixed["blocks"], strict_export=True, lora_bucket=0)
+    out = _attempt(
+        monkeypatch, tmp_path, _derived_key(traced_pair, PAIR[0]),
+        _artifact(tmp_path, meta))
+    assert out.adopted and out.reason == "hit"
+
+
+def test_the_adopt_path_refuses_the_colliding_pod(
+    traced_pair: Dict[str, Any], monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """THE mitigation: same key, other graph — refused, and it says which.
+
+    Without the floor this returns ``hit`` and the pod arms ``micro-pad32``'s
+    kernels for ``micro-pad32-branchy``'s computation, with only the arm-time
+    numerics tolerance between that and served output.
+    """
+    fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
+    assert fixed["key"].digest == branchy["key"].digest  # the collision
+    meta = aot_serve.artifact_metadata(
+        family=PAIR[0], precision="", cell_key=fixed["key"].digest,
+        entries=fixed["blocks"], strict_export=True, lora_bucket=0)
+    out = _attempt(
+        monkeypatch, tmp_path, _derived_key(traced_pair, PAIR[1]),
+        _artifact(tmp_path, meta))
+    assert not out.adopted
+    assert out.reason == "graph_witness_mismatch"
+    assert boot_key.graph_witnesses_of(
+        branchy["blocks"])["transformer"] in out.detail


### PR DESCRIPTION
pgw#1079's sighting, reproduced at master HEAD and closed fail-closed. **No compile anywhere** — every measurement here is `torch.export` and stops there.

## The collision, reproduced

`micro-pad32` and `micro-pad32-branchy` are the same model with two spellings of the same pad-to-32. Traced through the mint's own `trace_for_key`:

| | nodes | canonical IR lines | `graph_hash` | keying block | `ck1` |
|---|---|---|---|---|---|
| `micro-pad32` | 112 | 156 | `73e3a5c4ddcee856` | — | `ck1-b91b1792b6a9292f…` |
| `micro-pad32-branchy` | 102 | 146 | `0b12438b05e6685a` | **byte-identical** | **same key** |

Identical: all 41 graph-signature lines, both symbol ranges (`S0`,`S1` = `[6,8]`), the pytree spec, the 37 constant FQNs, the declared envelope, `sm`, `toolchain`. Differing: 127 diff lines of graph nodes — `arange`/`lt`/`to.dtype` masking and `32*FloorDiv(4*S0*S1+31,32)` extents versus the branchy `PythonMod` + `cat` spelling.

**v3 verdict:** pgw#1089's program-only `entry_graph_block` moved the key's VALUE (v2→v3) and left the equivalence class untouched. The collision is live on `f9482e05`.

## The equivalence class the digest is blind to

The `graph` axis is `combined_graph_hash` over `class_hash`, which folds *target, fork, class dims, `range_digest`, the graph-INTERFACE block (constant FQNs, lifted inputs, pytree spec, specialization, literal values), `strict`, `lora_bucket`* — every fact about how a graph is **called** and none about what it **computes**. Everything between the placeholders and the output is scrubbed: op, target, connectivity, literal args, per-node dtype/shape/device. `graph_hash.graph_hash` has computed exactly that since pgw#716 and reaches no key.

## The floor this ships (metadata, not an axis — nothing is re-keyed)

- `aot_mint.keying_block` records `graph_witness` per entry as a **sibling** of `graph`, so it misses `class_hash` by construction.
- `boot_key.DerivedKey.graph_witnesses` reports what this boot traced (memo bumped to v3; `assert_memo_honest` now rules on the witness too, since a stale memo would otherwise supply the very digest the floor trusts).
- `boot_adopt` refuses a materialized cell whose recorded witness is not this pod's graph: typed `graph_witness_mismatch`, naming the entry and **both** digests, degrading to eager-then-mint. Silence is a refusal in both directions.

## RED evidence

`test_every_landed_gate_admits_the_wrong_cell` — every gate that shipped before this **admits the wrong cell**: derived keys equal, `verify_declared_identity` clean on all four axes (including `graph_contract_digest`, which *is* the collided `combined_graph_hash`), `verify_contract` clean. Only `verify_graph_witness` refuses. Two further rows drive the real `boot_adopt` path: same cell, matching pod → `hit`, colliding pod → `graph_witness_mismatch`.

## Cost

Measured on real traced graphs (5 reps each): **11–19 µs/node, 0.1–0.3 % of the trace that produced the program**. Extrapolated: ~0.10 s for sdxl's 5,464-node UNet class, ~0.67 s for the 35,507-node lane (pgw#704 S8 node counts).

## Still open

The **depth** question — should the nodes be in the key, at the price of a deliberate fleet-wide re-key — stays on pgw#1031 and is Paul's. This floor holds either way.

`aot_serve.unpack_metadata` leaves the unreached-surface baseline in the same commit: it has a production caller now.