### PR TITLE
pgw#498 + pgw#884: a tenant pickle could execute code in a convert pod, and a mounted C2PA key booted green

### DIFF
--- a/changelog.d/pgw498.md
+++ b/changelog.d/pgw498.md
@@ -1,0 +1,31 @@
+- **pgw#498: a tenant-submitted pickle can no longer execute code in a convert
+  pod.** `convert/repackage.py` loaded a component's legacy `.bin` with a bare
+  `torch.load(path, map_location="cpu")`, reachable from the clone lane's
+  layout-repackage branch on ARBITRARY tenant-submitted repos. Its safety
+  rested entirely on torch's 2.6 `weights_only=True` default — a default torch
+  itself hands operators a switch for: `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1`
+  restores unpickling *"only if callsite did not explicitly set
+  weights_only"*, which described this line exactly and not its safe twin in
+  the same package. Measured under that variable, a `.bin` carrying a
+  `__reduce__` payload executed inside the process. The `.bin` path now goes
+  through `writer.materialize_pickle_to_safetensors` — the package's one
+  pickle reader, passing `weights_only=True` explicitly — and a checkpoint
+  that only opens with unpickling enabled is refused by name
+  (`unsafe_weight_format:<file>`) instead of loaded. Legitimate `.bin` repos,
+  which seven conversion-endpoint families declare `bin_base` for, still
+  convert. A tree guard fails any future `torch.load` written without the
+  argument.
+
+- **pgw#884: a C2PA private key mounted at `/run/secrets` now kills the boot.**
+  th#1307's "a pod holding key material refuses to start" guard read
+  `os.environ` alone. A PEM delivered as
+  `/run/secrets/GEN_WORKER_C2PA_KEY_PEM`, a `.env` line or a yaml entry was
+  neither loaded (`_normalize_key` dropped the name as "not a Settings field")
+  nor refused, so the worker booted green with a private key sitting
+  world-readable to tenant code at a mounted path — the exact scenario the
+  guard exists to make impossible, and the one that matters for the non-RunPod
+  shapes `/run/secrets` exists for. `config.loader.REFUSED_KEY_MATERIAL` now
+  refuses those names inside `_normalize_key(strict=True)`, which every
+  hand-authored source already passes through: one dict lookup per key, the
+  VALUE is never read, and `load_settings()` raises `RefusedKeyMaterialError`.
+  The env arm stays the per-read ratchet it became in pgw#931.

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -90,16 +90,38 @@ _DOTENV_PATH = "./.env"
 #: variable — see :func:`_normalize_key`.
 _OWNED_PREFIXES = ("GEN_WORKER_", "TENSORHUB_", "WORKER_", "COZY_")
 
+#: Owned-namespace names carrying SECRET MATERIAL this program refuses to
+#: hold at all — name -> why it is refused. Unlike the rest of
+#: :data:`_OWNED_NON_SETTINGS`, these are not "read by somebody else": NOBODY
+#: may read them, and their PRESENCE in any config source is a boot refusal.
+#:
+#: pgw#884: the th#1307 refusal read `os.environ` alone. A PEM delivered as
+#: `/run/secrets/GEN_WORKER_C2PA_KEY_PEM`, a `.env` line or a yaml entry was
+#: therefore neither LOADED (the name is not a Settings field, so
+#: `_normalize_key` dropped it) NOR REFUSED — the pod booted green with a
+#: private key sitting world-readable to tenant code at a mounted path, which
+#: is the precise scenario th#1307 exists to make impossible. The file sources
+#: are hand-authored and pass through `_normalize_key(strict=True)` already,
+#: so the refusal belongs exactly there: it costs one dict lookup per key, it
+#: never reads the VALUE (presence is the fact), and it kills the boot.
+REFUSED_KEY_MATERIAL: Dict[str, str] = {
+    "GEN_WORKER_C2PA_KEY_PEM": (
+        "a C2PA PRIVATE KEY must never be delivered to a pod (th#1307 — tenant "
+        "code runs in this process and can read it). Signing is hub-side: the "
+        "hub holds the key and signs claims over POST /v1/worker/c2pa/sign"
+    ),
+    "GEN_WORKER_C2PA_KEY_PATH": (
+        "a C2PA PRIVATE KEY must never be delivered to a pod (th#1307 — tenant "
+        "code runs in this process and can read it). Signing is hub-side: the "
+        "hub holds the key and signs claims over POST /v1/worker/c2pa/sign"
+    ),
+}
+
 #: Owned-namespace names that are deliberately NOT Settings fields. Each one
 #: is read by a named mechanism other than this loader, and listing it here is
 #: what keeps :func:`_normalize_key`'s refusal from firing on a legitimate
 #: value. Anything not here and not in `_ENV_TO_FIELD` is a typo.
-_OWNED_NON_SETTINGS: frozenset[str] = frozenset({
-    # th#1307: refused at boot by content_credentials.configure(); deliberately
-    # never bound to a field, because a private key must not be readable by
-    # tenant code in this process.
-    "GEN_WORKER_C2PA_KEY_PEM",
-    "GEN_WORKER_C2PA_KEY_PATH",
+_OWNED_NON_SETTINGS: frozenset[str] = frozenset(REFUSED_KEY_MATERIAL) | frozenset({
     # pgw#929 CHILD IPC HANDOFF: parent-minted, per-child, no config origin.
     "GEN_WORKER_COMPUTE_CHILD",
     "GEN_WORKER_COMPUTE_UID",
@@ -151,6 +173,15 @@ _OWNED_NON_SETTINGS: frozenset[str] = frozenset({
 })
 
 
+class RefusedKeyMaterialError(ValueError):
+    """A config source delivered secret material this pod refuses to hold.
+
+    pgw#884. Terminal at boot by design: the material is already on the box
+    when this raises, so the only honest outcome is that nothing tenant-facing
+    starts beside it.
+    """
+
+
 class UnknownSettingError(ValueError):
     """A key inside an owned namespace matches no Settings field.
 
@@ -172,13 +203,22 @@ def _normalize_key(raw: str, *, strict: bool = False) -> str | None:
 
     Returns None for a key that is not ours. When `strict`, an unrecognised key
     inside an owned namespace raises `UnknownSettingError` instead of being
-    silently dropped.
+    silently dropped, and a key naming REFUSED secret material raises
+    `RefusedKeyMaterialError` (pgw#884) instead of being dropped as "not a
+    Settings field".
     """
     key = raw.strip()
     if key in _ENV_TO_FIELD:
         return _ENV_TO_FIELD[key]
     if key in _FIELD_NAMES:
         return key
+    # Before the _OWNED_NON_SETTINGS drop, never after: these names are in
+    # that set (so the process-env census knows them), and reaching the drop
+    # first is exactly how a mounted secret booted green.
+    if strict and (why := REFUSED_KEY_MATERIAL.get(key.upper())):
+        raise RefusedKeyMaterialError(
+            f"{key} was delivered to this pod through a config source: {why}"
+        )
     if strict and key.upper() in _OWNED_NON_SETTINGS:
         return None
     if strict and any(key.upper().startswith(p) for p in _OWNED_PREFIXES):

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -159,7 +159,12 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # mounts) — and takes precedence over *_PATH. Chain = leaf first.
     # th#1307: there is NO key field. The PRIVATE KEY never reaches a pod;
     # the hub signs claims over POST /v1/worker/c2pa/sign. A pod that finds
-    # GEN_WORKER_C2PA_KEY_PEM/_KEY_PATH in its env refuses to start.
+    # GEN_WORKER_C2PA_KEY_PEM/_KEY_PATH in ANY config source refuses to start
+    # — env via content_credentials._refuse_pod_private_key_material (a
+    # ratchet, re-checked at every read of the signing state), and .env /
+    # /run/secrets / yaml via loader.REFUSED_KEY_MATERIAL (pgw#884: this
+    # sentence used to say "in its env", and a PEM mounted at
+    # /run/secrets/GEN_WORKER_C2PA_KEY_PEM booted green).
     c2pa_cert_pem: str = ""   # GEN_WORKER_C2PA_CERT_PEM (inline PEM chain)
     c2pa_cert_path: str = ""  # GEN_WORKER_C2PA_CERT_PATH
     c2pa_alg: str = "es256"   # GEN_WORKER_C2PA_ALG (COSE alg matching the cert key)

--- a/src/gen_worker/content_credentials.py
+++ b/src/gen_worker/content_credentials.py
@@ -356,6 +356,15 @@ def _refuse_pod_private_key_material(settings: Any = None) -> None:
 
     ``settings`` is checked too when supplied, so a field smuggled back into
     Settings is refused on the same breath as the env.
+
+    **This arm covers the ENV only, and that is deliberate** (pgw#884). The
+    other delivery vectors — ``.env``, ``/run/secrets``, yaml — never reach
+    ``os.environ``, and until pgw#884 nothing refused them either: the loader
+    dropped the names as "not a Settings field" and the pod booted green with
+    a private key mounted where tenant code could read it. They are refused
+    where they are READ, in ``config.loader.REFUSED_KEY_MATERIAL``, which is
+    the one component that sees every source and does so once per boot rather
+    than once per signed asset.
     """
     for env_name in _REFUSED_KEY_ENVS:
         if str(os.environ.get(env_name, "") or "").strip() or str(

--- a/src/gen_worker/convert/repackage.py
+++ b/src/gen_worker/convert/repackage.py
@@ -30,8 +30,10 @@ from .registry import (
 from .repack_spec import ComponentRepack, DtypePolicy, RepackageFamily
 from .writer import (
     NEVER_SHARD_MAX_SIZE,
+    PICKLE_CACHE_DIR,
     ConversionImplementationError,
     assert_one_file_per_component,
+    materialize_pickle_to_safetensors,
 )
 
 if TYPE_CHECKING:
@@ -104,7 +106,7 @@ def _load_component_state_dict(
       downloads keep the suffix — e.g. diffusion_pytorch_model.fp16.safetensors
       in repo-cas mirrors cloned with a dtype preference)
 
-    Optional legacy fallback (unsafe for untrusted repos):
+    Legacy pickle fallback, through the package's ONE pickle reader:
     - <bin_base>.bin
     """
     for raw_base in safetensors_bases:
@@ -136,8 +138,19 @@ def _load_component_state_dict(
     if bin_base:
         bin_path = component_dir / f"{bin_base}.bin"
         if bin_path.exists():
-            torch_mod = _torch()
-            return cast(dict[str, Any], torch_mod.load(str(bin_path), map_location="cpu"))
+            # pgw#498: the clone lane feeds this ARBITRARY tenant-submitted
+            # repos, so a `.bin` here is an untrusted pickle and unpickling it
+            # is arbitrary code execution inside a pod holding hub credentials
+            # and other tenants' work (cozy_snapshot.py:285-292). This used to
+            # be a bare `torch.load(path, map_location="cpu")`. Its safety then
+            # rested entirely on torch's 2.6 `weights_only` DEFAULT, which
+            # `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` in the pod env flips back
+            # for exactly the call sites that did not pass the argument
+            # (torch/serialization.py:1496 — "can only override if callsite did
+            # not explicitly set weights_only"). One pickle reader, one
+            # implementation, and it passes `weights_only=True` explicitly.
+            return _st_load(materialize_pickle_to_safetensors(
+                bin_path, component_dir / PICKLE_CACHE_DIR))
     raise FileNotFoundError(f"missing weights for {component_dir.name}")
 
 

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -249,14 +249,37 @@ def _weight_component_dirs() -> frozenset[str]:
     return frozenset(weight_components())
 
 
+#: Where a converted pickle is staged, beside the component it came from.
+#: One spelling, because there is one pickle reader (pgw#498).
+PICKLE_CACHE_DIR = ".__pickle_cache__"
+
+
 def materialize_pickle_to_safetensors(pickle_path: Path, work_dir: Path) -> Path:
-    """Convert a pickle weight file to safetensors (``weights_only=True``)."""
+    """Convert a pickle weight file to safetensors (``weights_only=True``).
+
+    **The only pickle reader in this package** (pgw#498). Conversion ingests
+    ARBITRARY tenant-submitted repos, so every ``.bin``/``.ckpt`` reaching this
+    process is untrusted bytes; ``weights_only=True`` is passed EXPLICITLY and
+    never left to torch's default, which ``TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD``
+    in the pod environment silently flips back for any call site that omitted
+    the argument.
+    """
     import torch
     from safetensors.torch import save_file
 
     try:
         state = torch.load(str(pickle_path), map_location="cpu", weights_only=True)
     except Exception as exc:
+        # A checkpoint the SAFE unpickler cannot read is a checkpoint whose
+        # bytes ask to construct something other than tensors. That is the
+        # refusal this vocabulary exists for; there is no permissive retry.
+        if "weights only" in str(exc).lower() or type(exc).__name__ == "UnpicklingError":
+            raise ConversionImplementationError(
+                f"unsafe_weight_format:{pickle_path.name}: the file only loads "
+                f"with unpickling enabled, which executes arbitrary code in "
+                f"this pod. Republish it as safetensors. "
+                f"({type(exc).__name__}: {str(exc)[:200]})"
+            ) from exc
         raise ConversionImplementationError(
             f"pickle_load_failed: {type(exc).__name__}: {str(exc)[:200]}"
         ) from exc
@@ -301,7 +324,7 @@ def iter_component_tensors(component_dir: Path) -> Iterator[tuple[str, "torch.Te
             found = sorted(component_dir.glob(f"*{ext}"))
             if found:
                 entry = materialize_pickle_to_safetensors(
-                    found[0], component_dir / ".__pickle_cache__")
+                    found[0], component_dir / PICKLE_CACHE_DIR)
                 break
     if entry is None:
         return

--- a/tests/test_untrusted_pickle_and_secret_sources_pgw498_pgw884.py
+++ b/tests/test_untrusted_pickle_and_secret_sources_pgw498_pgw884.py
@@ -1,0 +1,320 @@
+"""pgw#498 + pgw#884 — the two places untrusted bytes and refused secrets
+crossed a boundary that was supposed to be closed.
+
+**pgw#498.** `convert/repackage.py` loaded a component's legacy `.bin` with a
+bare `torch.load(path, map_location="cpu")`. The convert/clone lane ingests
+ARBITRARY tenant-submitted repos, so those bytes are hostile by assumption and
+unpickling them is arbitrary code execution inside a pod holding hub
+credentials and other tenants' work — the threat this repo states in its own
+words at `models/cozy_snapshot.py:285-292`.
+
+The interesting part is WHY it looked safe. On torch >= 2.6 the `weights_only`
+default is `True`, so on the pinned toolchain the bare call refuses a hostile
+pickle all by itself. That safety is a DEFAULT, not a decision — and torch
+publishes the switch that flips it back:
+
+    TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
+
+which torch applies *"only if callsite did not explicitly set weights_only"*
+(`torch/serialization.py:1496`). One environment variable in a pod turns every
+argument-less `torch.load` in the process back into an unpickle, and the
+variable is outside this program's owned namespaces, so nothing here would ever
+report it. `test_a_poisoned_bin_cannot_execute_code` runs exactly that.
+
+**pgw#884.** th#1307's guard — "a pod holding C2PA key material refuses to
+start" — read `os.environ` alone. A PEM delivered as
+`/run/secrets/GEN_WORKER_C2PA_KEY_PEM`, or as a `.env` / yaml entry, was
+neither loaded (the loader dropped the name as "not a Settings field") nor
+refused: the pod booted green with a private key sitting world-readable to
+tenant code at a mounted path, which is precisely the scenario th#1307 exists
+to make impossible.
+
+Every payload below writes a marker file into a pytest `tmp_path` and does
+nothing else. It proves EXECUTION; it does not do anything harmful.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.config import loader as loader_mod  # noqa: E402
+from gen_worker.convert import repackage, writer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# pgw#498 — the untrusted-pickle boundary in the convert lane
+# ---------------------------------------------------------------------------
+
+
+class _MarkerPayload:
+    """A pickle whose reconstruction calls `Path.write_text`.
+
+    `__reduce__` returns the (callable, args) pair; the callable runs at
+    UNPICKLE time, not at pickle time, so building and saving this object has
+    no side effect at all. Only reading it back does.
+    """
+
+    def __init__(self, marker: Path) -> None:
+        self._marker = marker
+
+    def __reduce__(self) -> tuple:  # type: ignore[type-arg]
+        return (pathlib.Path.write_text, (self._marker, "arbitrary code ran"))
+
+
+def _poisoned_component(tmp_path: Path) -> tuple[Path, Path]:
+    """A diffusers-shaped component dir whose only weight file is a torch
+    checkpoint carrying the payload. Returns (component_dir, marker_path)."""
+    component = tmp_path / "unet"
+    component.mkdir(parents=True)
+    marker = tmp_path / "EXECUTED.txt"
+    # torch.save writes its real container format, so the pre-fix call path
+    # loads this file successfully rather than dying on a header check.
+    torch.save({"weight": _MarkerPayload(marker)}, component / "diffusion_pytorch_model.bin")
+    return component, marker
+
+
+def test_the_payload_is_inert_until_it_is_read(tmp_path: Path) -> None:
+    """Sanity: building and saving the fixture executes nothing. Without this
+    a green result below could mean the harness never armed."""
+    component, marker = _poisoned_component(tmp_path)
+    assert (component / "diffusion_pytorch_model.bin").is_file()
+    assert not marker.exists()
+
+
+def test_the_payload_really_does_execute_through_an_unguarded_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The RED half, pinned as a fact about torch rather than about us.
+
+    This is the exact call `repackage.py` used to make, under the exact pod
+    environment that makes it unsafe. It executes the payload. If this ever
+    stops being true the guard below is measuring nothing and must be re-cut,
+    which is why the negative result is not left implicit.
+    """
+    component, marker = _poisoned_component(tmp_path)
+    monkeypatch.setenv("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
+    with pytest.warns(UserWarning, match="TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"):
+        torch.load(str(component / "diffusion_pytorch_model.bin"), map_location="cpu")
+    assert marker.exists(), (
+        "the payload did not run — torch no longer honours "
+        "TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD, so this file's guard is stale"
+    )
+
+
+def test_a_poisoned_bin_cannot_execute_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#498: the production path refuses, and nothing runs.
+
+    Same bytes, same environment, through `_load_component_state_dict` —
+    reached from the clone lane's layout-repackage branch
+    (`convert/clone.py:335-350`) on arbitrary cloned upstream sources.
+    """
+    component, marker = _poisoned_component(tmp_path)
+    monkeypatch.setenv("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
+
+    with pytest.raises(writer.ConversionImplementationError) as excinfo:
+        repackage._load_component_state_dict(
+            component,
+            safetensors_bases=("diffusion_pytorch_model",),
+            bin_base="diffusion_pytorch_model",
+        )
+
+    assert not marker.exists(), "a tenant-supplied pickle executed code in this process"
+    # A named refusal, not a generic load failure: a checkpoint that only opens
+    # with unpickling enabled is refused BY THAT FACT.
+    assert "unsafe_weight_format" in str(excinfo.value)
+
+
+def test_a_legitimate_bin_still_converts(tmp_path: Path) -> None:
+    """The refusal is about executable pickles, not about `.bin` repos.
+
+    The conversion endpoint declares `bin_base` for seven real families
+    (`training-endpoints/.../declarations/families.py`), which is the whole
+    reason the branch cannot simply be deleted: turning upstream `.bin` into
+    safetensors is what this lane is FOR.
+    """
+    component = tmp_path / "unet"
+    component.mkdir(parents=True)
+    torch.save(
+        {"a.weight": torch.zeros(2, 3), "a.bias": torch.ones(3)},
+        component / "diffusion_pytorch_model.bin",
+    )
+
+    state = repackage._load_component_state_dict(
+        component,
+        safetensors_bases=("diffusion_pytorch_model",),
+        bin_base="diffusion_pytorch_model",
+    )
+    assert sorted(state) == ["a.bias", "a.weight"]
+    assert state["a.weight"].shape == (2, 3)
+
+
+def test_safetensors_still_wins_over_the_pickle(tmp_path: Path) -> None:
+    """Preference order is unchanged: a component carrying both loads the
+    safetensors and never opens the pickle at all."""
+    component, marker = _poisoned_component(tmp_path)
+    from safetensors.torch import save_file
+
+    save_file({"a.weight": torch.zeros(1)}, str(component / "diffusion_pytorch_model.safetensors"))
+
+    state = repackage._load_component_state_dict(
+        component,
+        safetensors_bases=("diffusion_pytorch_model",),
+        bin_base="diffusion_pytorch_model",
+    )
+    assert list(state) == ["a.weight"]
+    assert not marker.exists()
+
+
+def test_there_is_exactly_one_pickle_reader_in_the_tree() -> None:
+    """One operation, one implementation (the pgw#498 ruling).
+
+    A second `torch.load` is how the first one got its safety from a default:
+    the safe twin already existed in the same package and one of the two call
+    sites simply did not have the argument. Scanning for the shape is what
+    stops that recurring, since a new site is silently safe on today's torch
+    and silently unsafe under `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD`.
+
+    `torch.export.load` is deliberately out of scope: an AOTI `.pt2` is
+    admitted through the cell-key identity gate and the org/endpoint trust
+    model (§4.26), not through this lane's tenant-repo assumption.
+    """
+    src_root = Path(writer.__file__).resolve().parent.parent
+    offenders: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "torch.load(" not in stripped and "torch_mod.load(" not in stripped:
+                continue
+            if "weights_only" in stripped:
+                continue
+            offenders.append(f"{path.relative_to(src_root)}:{lineno}: {stripped}")
+    assert offenders == [], (
+        "torch.load without an explicit weights_only= — its safety would rest "
+        "on a torch default that TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD flips back:\n"
+        + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# pgw#884 — refused key material, at every source that can deliver it
+# ---------------------------------------------------------------------------
+
+
+_PEM = "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n"
+
+
+@pytest.mark.parametrize("key", sorted(loader_mod.REFUSED_KEY_MATERIAL))
+def test_key_material_mounted_at_run_secrets_refuses(tmp_path: Path, key: str) -> None:
+    """RED for pgw#884's headline: a PEM at `/run/secrets/<KEY>` used to boot
+    green, because `_normalize_key` dropped the name before anything looked at
+    it and the th#1307 refusal only ever read `os.environ`."""
+    (tmp_path / key).write_text(_PEM, encoding="utf-8")
+    with pytest.raises(loader_mod.RefusedKeyMaterialError) as excinfo:
+        loader_mod._load_secrets_dir(str(tmp_path))
+    assert key in str(excinfo.value)
+
+
+@pytest.mark.parametrize("key", sorted(loader_mod.REFUSED_KEY_MATERIAL))
+def test_key_material_in_yaml_refuses(tmp_path: Path, key: str) -> None:
+    cfg = tmp_path / "gen-worker.yaml"
+    cfg.write_text(f"{key}: {_PEM!r}\n", encoding="utf-8")
+    with pytest.raises(loader_mod.RefusedKeyMaterialError):
+        loader_mod._load_yaml([str(cfg)])
+
+
+@pytest.mark.parametrize("key", sorted(loader_mod.REFUSED_KEY_MATERIAL))
+def test_key_material_in_dotenv_refuses(tmp_path: Path, key: str) -> None:
+    env = tmp_path / ".env"
+    env.write_text(f"{key}=inline-key-material\n", encoding="utf-8")
+    with pytest.raises(loader_mod.RefusedKeyMaterialError):
+        loader_mod._load_dotenv(str(env))
+
+
+def test_load_settings_dies_on_a_mounted_pem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole boot, not one source reader: the acceptance is that nothing
+    tenant-facing comes up beside the key."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "GEN_WORKER_C2PA_KEY_PEM").write_text(_PEM, encoding="utf-8")
+    monkeypatch.setattr(loader_mod, "_SECRETS_DIR", str(secrets))
+    monkeypatch.setattr(loader_mod, "_DOTENV_PATH", str(tmp_path / "absent.env"))
+    monkeypatch.setattr(loader_mod, "_YAML_CANDIDATE_PATHS", ())
+    with pytest.raises(loader_mod.RefusedKeyMaterialError):
+        loader_mod.load_settings()
+
+
+def test_an_ordinary_secret_still_mounts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal is keyed on the two names, not on `/run/secrets` existing —
+    a mounted `HF_TOKEN` is still an ordinary, loadable secret."""
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "HF_TOKEN").write_text("hf_abc\n", encoding="utf-8")
+    monkeypatch.setattr(loader_mod, "_SECRETS_DIR", str(secrets))
+    monkeypatch.setattr(loader_mod, "_DOTENV_PATH", str(tmp_path / "absent.env"))
+    monkeypatch.setattr(loader_mod, "_YAML_CANDIDATE_PATHS", ())
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    assert loader_mod.load_settings().hf_token == "hf_abc"
+
+
+def test_the_env_arm_is_still_the_ratchet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loader arm ADDS to th#1307's env refusal; it does not replace it.
+    Pod env is the hub's only delivery vector today, and that arm is checked
+    at every read of the signing state, not once at boot."""
+    from gen_worker import content_credentials
+
+    monkeypatch.setenv("GEN_WORKER_C2PA_KEY_PEM", _PEM)
+    with pytest.raises(content_credentials.C2paSigningError):
+        content_credentials._refuse_pod_private_key_material()
+
+
+def test_refused_names_are_known_to_the_process_env_census() -> None:
+    """They must not read as unrecognised owned-namespace names: they are
+    recognised precisely, and refused."""
+    assert set(loader_mod.REFUSED_KEY_MATERIAL) <= loader_mod._OWNED_NON_SETTINGS
+
+
+# ---------------------------------------------------------------------------
+# pgw#884 box 3 — the pgw#848 sweep test was blind to a rename here
+# ---------------------------------------------------------------------------
+
+
+def test_worker_credential_reads_the_literal_field_name() -> None:
+    """`worker_credential` is the ONE sanctioned reader of the boot token. It
+    used to reach it as `getattr(get_settings(), "bootstrap_worker_jwt", "")`
+    inside a bare `except Exception: return ""` — the C8 shape that swallows
+    exactly the `AttributeError` pgw#848's rename existed to raise. pgw#931
+    replaced it with direct attribute access; this pins that, because the
+    pgw#848 sweep test greps `settings.worker_jwt` and would never have seen
+    a getattr on the NEW name.
+    """
+    import ast
+    import inspect
+
+    from gen_worker import worker_credential
+
+    src = inspect.getsource(worker_credential)
+    assert "settings.bootstrap_worker_jwt" in src
+    # AST, not text: the module's own comments narrate the old getattr shape,
+    # and a grep that its documentation can turn red is a grep nobody keeps.
+    defaulted = [
+        node.lineno for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name) and node.func.id == "getattr"
+    ]
+    assert defaulted == [], (
+        f"a defaulted attribute read in worker_credential (line(s) {defaulted}) "
+        "re-arms the pgw#848 silent-stale-credential class"
+    )


### PR DESCRIPTION
Two security-boundary defects the pgw adjudication sweep flagged, both verified live on `master` before touching code.

## pgw#498 — unguarded `torch.load` on tenant repos

`convert/repackage.py:140` loaded a component's legacy `.bin` with a bare `torch.load(path, map_location="cpu")`, reachable from the clone lane's layout-repackage branch (`convert/clone.py:335-350`) on **arbitrary tenant-submitted repos**. The repo states the threat itself at `models/cozy_snapshot.py:285-292`.

**Why it read as safe, and why that was the bug.** On torch ≥ 2.6 `weights_only` defaults to `True`, so the bare call refuses a hostile pickle on the pinned toolchain. That safety is a *default*, not a decision — and torch ships the switch that flips it back:

```
TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
```

applied *"only if callsite did not explicitly set weights_only"* (`torch/serialization.py:1496`) — which described this line exactly, and not its safe twin in the same package. The variable is outside this program's owned namespaces, so `unrecognised_owned_env()` would never report it either.

**RED, sandboxed on this box.** The payload writes one marker file into a temp dir; it does nothing harmful.

| | unmodified `master` | this branch |
|---|---|---|
| marker before load | `False` | `False` |
| result | returned, no refusal | `ConversionImplementationError: unsafe_weight_format:…` |
| **marker after load** | **`True` ← code executed** | **`False`** |

**Fix.** The `.bin` path routes through `writer.materialize_pickle_to_safetensors` — the package's one pickle reader, passing `weights_only=True` explicitly. A checkpoint that only opens with unpickling enabled is refused by name. Deleting the branch (the older ruling) is not available: the conversion endpoint declares `bin_base` for seven live families and turning upstream `.bin` into safetensors is what this lane is for. A tree guard fails any future argument-less `torch.load`.

## pgw#884 — a PEM at `/run/secrets` booted green

th#1307's refusal read `os.environ` alone. A key delivered as `/run/secrets/GEN_WORKER_C2PA_KEY_PEM`, a `.env` line or a yaml entry was neither loaded (`_normalize_key` dropped the name) nor refused — the worker came up with a private key world-readable to tenant code at a mounted path, in exactly the deployments `/run/secrets` exists for.

`config.loader.REFUSED_KEY_MATERIAL` now refuses inside `_normalize_key(strict=True)`, which every hand-authored source already passes through: one dict lookup per key, the **value is never read**, `load_settings()` raises `RefusedKeyMaterialError`. The env arm stays the per-read ratchet pgw#931 made it.

Boxes 2 and 3 were already discharged on `master` and are recorded rather than re-fixed; the sweep test now pins `worker_credential`'s literal field read by AST.

## Gates

mypy clean (254 files) · ruff clean · all seven fast-gate lint guards green · 17 new tests · 197 passed in the config/credential/convert neighbourhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq