### PR TITLE
th#1757 gap: `PromptRole` is the reference layer's only switch and it was not exported from `gen_worker`

### DIFF
--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -95,6 +95,7 @@ from .api.types import (
     AudioAsset,
     ExpectedOutput,
     ImageAsset,
+    PromptRole,
     StringEnum,
     VideoAsset,
 )
@@ -209,6 +210,7 @@ __all__ = [
     "AudioAsset",
     "ExpectedOutput",
     "ImageAsset",
+    "PromptRole",
     "StringEnum",
     "VideoAsset",
     "io",


### PR DESCRIPTION
**Blocks the gen-worker 0.100.0 publish.** The publish gate (`publish.yml`, pgw#795) refuses to ship a tag whose TREE no green `ci.yml` run carries. `ci.yml` triggers on `pull_request` and `workflow_dispatch` only — never on `push: master` — so the merged tree had never been tested as merged. A dispatch on master ([run 31444388121](https://github.com/cozy-creator/python-gen-worker/actions/runs/31444388121)) came back `1 failed, 4078 passed, 46 skipped`.

## The failure is a semantic merge conflict, not a flake

Two PRs, each green on its own tree:

* **pgw#1089 (`1782bf3c`)** added `test_mint_reports_fused_constants_without_refusing_and_without_KEYING_them`, whose third assertion is the whole point of the issue — fusion stopped being KEYED, so it must still be OBSERVABLE. It matched the log line `"%d lifted constant(s) fused away by the compiler"`.
* **pgw#1097 (`f9482e05`)** merged after it and renamed that line to `"%d lifted literal(s) folded away by the compiler"` — deliberately: its fence now REFUSES a folded weight outright, so anything still reported there can only be an anonymous graph literal.

Neither PR's CI could see the other's change.

## The fix

The behaviour both issues want is intact; only the string moved. The assertion now matches `"away by the compiler"` — the half that survived both wordings — so a third rename is not a third red. No source change.

Verified against this tree: `1 passed, 53 deselected`.