### PR TITLE
pgw#1100: fix pgw#1089×pgw#1097 merge-skew (test greps 'fused away', log says 'folded away') — master is red

### DIFF
--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -494,7 +494,7 @@ def test_mint_reports_fused_constants_without_refusing_and_without_KEYING_them(
     # 3. STILL OBSERVABLE — reported where a surprising jump in the count is
     #    visible, rather than silently discarded.
     assert any(
-        "fused away by the compiler" in rec.getMessage()
+        "folded away by the compiler" in rec.getMessage()
         for rec in caplog.records), (
         "compiler fusion stopped being observable when it stopped being keyed "
         "— it must be one or the other, not neither")


### PR DESCRIPTION
## The red

Master HEAD (5c4bfc87, tree c53f150f) fails CI: run 31444388121, `tests` job — **1 failed, 4078 passed**.

```
tests/test_aot_mint_pgw723.py:496
AssertionError: compiler fusion stopped being observable when it stopped being keyed — it must be one or the other, not neither
```

## Root cause — a merge-skew between two of the AOT re-key merges

- **pgw#1097** (folding fence, `f9482e05`) deliberately reworded the observability log in `aot_mint.py:3259`:
  `"...%d lifted constant(s) fused away by the compiler"` → `"...%d lifted literal(s) folded away by the compiler"` (reserving *folding/literal* vs *fusion/constant*).
- **pgw#1089** (`1782bf3c`), on a sibling branch, added the test asserting the substring `"fused away by the compiler"`.

Each PR was green in isolation (the fence branch lacked the test; the test branch still logged "fused away"). Merged, the code logs "folded away" and the test greps "fused away" → red, with no textual git conflict to catch it.

## The fix

One substring: the test now greps `"folded away by the compiler"`, matching the authoritative production wording. The assertion's contract is unchanged (fused constants may stop being KEYED but must stay OBSERVABLE).

**RED-verify:** the existing master red run (31444388121) is itself the proof the assertion discriminates on this substring — it failed *because* "fused away" was absent from the "folded away" log, so the match is not vacuous. This PR's green CI confirms the aligned wording passes.

Unblocks the 0.100.0 release (currently blocked: pyproject is 0.100.0, PyPI at 0.99.0).