### PR TITLE
pgw#939 + pgw#940: eight fail-open sites — a check that skips itself when its evidence is missing

### DIFF
--- a/changelog.d/pgw939.md
+++ b/changelog.d/pgw939.md
@@ -1,0 +1,34 @@
+- **pgw#939: verification no longer skips itself when the expected value is
+  absent.** Four sites shared one shape — `if expected { compare }`, so a
+  missing expected value ADMITTED. `aot_serve.verify` guarded `family`,
+  `range_digest` and `combined_graph_hash` on "a stamp is present", which made
+  an unstamped cell a wrong cache **hit** rather than a miss on the axis that
+  decides which pipeline a `.so` is dlopen'd into (`class_hash` next to them
+  was already written the correct way, and is the form the other three are
+  brought to). The cubin arch gate vanished per kernel whenever
+  `metadata["sm"]` did not parse or a cubin could not be read, so pgw#698's
+  PTX-JIT refusal disappeared exactly where its evidence was missing. Civitai
+  downloads recorded `"sha256": ""` for both "hash matched" and "civitai
+  published no SHA256", so no downstream reader could tell them apart — the
+  manifest now records the OBSERVED digest with a `sha256_source` of
+  `civitai` / `observed` / `unverified`. And an existing file with no declared
+  size was adopted as a complete download by short-circuit — any file at that
+  path, no size, no hash, no read — where it now requires this directory's own
+  completed manifest to agree, or re-downloads.
+
+- **pgw#940: an unreadable card stops reading as an empty one.** `0` meant
+  both "no card" and "the probe raised", and four sites read the shared zero
+  as the permissive case. `aot_compile_pool` dropped the device bound entirely
+  and ran 8 concurrent compile children on a card it could not measure — its
+  own comment defended this by asserting the probe fails only when there is no
+  card, which was false and is now true by construction: `DeviceProbeError`
+  separates the two and the unreadable arm falls to K=1 beside its two sibling
+  branches. `select_auto_mode` returned `"off"` — fully resident, the most
+  memory-hungry rung — on a GPU host whose probe failed, and now descends to
+  `group_offload` the way its own unknown-model-size branch always has.
+  `executor.gate_functions` substituted TOTAL VRAM for a missing-or-genuinely-
+  zero free reading, so a saturated card advertised itself as empty to the fit
+  ladder and to the hub. And the host-RAM move guard silently no-opped on any
+  module it could not size — meta-device modules, accelerate-hooked modules
+  mid-dispatch, custom `parameters()` overrides, i.e. the shapes most likely
+  to be huge — and now consults the budget instead of returning.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -627,6 +627,17 @@ def cpu_facts() -> CpuFacts:
     return CpuFacts(max(1, vcpus), basis, os_count, affinity, quota_cores)
 
 
+class DeviceProbeError(RuntimeError):
+    """The card could not be read (pgw#940).
+
+    Distinct from "there is no card", which is a 0 return. Collapsing the two
+    is the whole defect: `except Exception: return 0` made a transient
+    `mem_get_info` failure, a post-fork CUDA-context error and a flapping
+    `is_available()` indistinguishable from a CPU-only pod — and every caller
+    read that shared zero as the permissive case.
+    """
+
+
 def _probe_free_device_bytes(device: int = -1) -> int:
     """One reading of free VRAM on the mint's card, 0 when there is no card.
 
@@ -634,19 +645,26 @@ def _probe_free_device_bytes(device: int = -1) -> int:
     but not allocated, exactly as ``mint_budget`` does — a cached block the
     tenant is not using is free to nobody but this process, and pretending
     otherwise is how a mint OOMs a live request.
+
+    Raises :class:`DeviceProbeError` when a card is present but unreadable.
     """
     try:
         import torch
 
         if not torch.cuda.is_available():
             return 0
+    except Exception as exc:  # noqa: BLE001
+        # Even "is there a card" did not answer. That is unreadable, not
+        # absent: a pod with no torch at all fails at import long before here.
+        raise DeviceProbeError(f"cuda availability unreadable: {exc}") from exc
+    try:
         dev = torch.cuda.current_device() if device < 0 else int(device)
         free, _total = torch.cuda.mem_get_info(dev)
         reserved = int(torch.cuda.memory_reserved(dev))
         allocated = int(torch.cuda.memory_allocated(dev))
         return int(free) + max(0, reserved - allocated)
-    except Exception:  # noqa: BLE001
-        return 0
+    except Exception as exc:  # noqa: BLE001
+        raise DeviceProbeError(f"free VRAM unreadable: {exc}") from exc
 
 
 def device_facts(
@@ -670,10 +688,18 @@ def device_facts(
     for i in range(max(1, int(samples))):
         if i and gap_s > 0:
             time.sleep(gap_s)
-        value = int(read(device))
+        try:
+            value = int(read(device))
+        except DeviceProbeError as exc:
+            # pgw#940: "no card" and "unreadable card" are different facts and
+            # the pool must decide them differently. Only the caught type is
+            # narrowed here — anything else still propagates, because a probe
+            # that raises something unexpected is not a measurement outcome.
+            logger.warning("free-VRAM probe failed: %s", exc)
+            return DeviceFacts(0, "unreadable", tuple(taken))
         taken.append(value)
         if value <= 0:
-            # No card, or no reading — sampling an absence is not evidence.
+            # No card. Sampling an absence is not evidence of a size.
             return DeviceFacts(0, "absent", tuple(taken))
     return DeviceFacts(max(taken), "sampled", tuple(taken))
 
@@ -799,15 +825,20 @@ def entry_workers(
         device = device_facts()
     free_vram = device.free_bytes
     per_device = max(0, int(device_bytes))
-    if free_vram <= 0:
-        # No card, or no reading: the device bound is DROPPED and K falls to
-        # whichever of cpu/mem/ceiling binds. Right for a CPU-only cell, which
-        # is not device-bound at all — and deliberately stated as "dropped"
-        # rather than the "does not get to license concurrency" this comment
-        # used to claim, which is the opposite of what the line does. A GPU pod
-        # whose card reads 0 therefore compiles device-UNBOUNDED; that it has
-        # never happened is a property of `_probe_free_device_bytes` failing
-        # only when there is no card, not of this branch.
+    if free_vram <= 0 and device.basis == "unreadable":
+        # pgw#940. This branch used to be shared with "no card" and yielded
+        # MAX_ENTRY_WORKERS for both, so a GPU pod whose probe raised compiled
+        # eight children device-UNBOUNDED. The old comment defended it by
+        # asserting `_probe_free_device_bytes` fails only when there is no
+        # card — which was false, and is now true by construction: an
+        # unreadable card raises `DeviceProbeError` and lands HERE, closed,
+        # beside its two sibling branches. The stake is stated at :192-201 —
+        # "the failure mode of guessing here is an OOM on paid work."
+        device_workers = 1
+    elif free_vram <= 0:
+        # No card at all: the device bound is DROPPED and K falls to whichever
+        # of cpu/mem/ceiling binds. Right for a CPU-only cell, which is not
+        # device-bound at all.
         device_workers = MAX_ENTRY_WORKERS
     elif per_device <= 0:
         # pgw#877 #5: a card we CAN read but have no per-entry footprint for.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -756,7 +756,13 @@ def verify_declared(meta: Dict[str, Any], *, family: str = "") -> str:
     if isa_reason:
         return isa_reason
     want_fam = str(meta.get("family") or "")
-    if family and want_fam and want_fam != family:
+    # pgw#939: STRICTLY, like every axis above it and like this function's own
+    # docstring already promised. `want_fam and ...` meant an UNSTAMPED cell
+    # matched every family it was ever offered to — a wrong cache HIT, not a
+    # miss, on the axis that decides which pipeline the .so is dlopen'd into.
+    # The mint stamps this from one place (`artifact_metadata`), so a silent
+    # cell is a malformed one; when no caller names a family nothing changes.
+    if family and want_fam != family:
         return f"family {want_fam!r} != {family!r}"
     return ""
 
@@ -789,8 +795,16 @@ def verify_contract(
     bucket = int(meta.get("lora_bucket") or 0)
     hashes: List[str] = []
     for name, block in entries.items():
+        # pgw#939: absence is a verdict, not a skipped check. `class_hash`
+        # below was already written this way and is the model the other two
+        # axes are brought to — `compile_cache.verify` is strict on every
+        # IDENTITY_AXES field for the same reason, and `compile_cache.py`
+        # names this exact `if want and want != have` shape as JAX PR #27814's
+        # one documented wrong-cache-hit.
         stamped = str(block.get("range_digest") or "")
-        if stamped and stamped != range_digest(block):
+        if not stamped:
+            return f"entry {name!r}: no range_digest stamped"
+        if stamped != range_digest(block):
             return f"entry {name!r}: range_digest does not match its contract"
         stamped_hash = str(block.get("class_hash") or "")
         if not stamped_hash:
@@ -800,7 +814,9 @@ def verify_contract(
             return f"entry {name!r}: class_hash does not match its recorded facts"
         hashes.append(stamped_hash)
     stamped_combined = str(meta.get("combined_graph_hash") or "")
-    if stamped_combined and stamped_combined != combined_graph_hash(hashes):
+    if not stamped_combined:
+        return "no combined_graph_hash stamped"
+    if stamped_combined != combined_graph_hash(hashes):
         return "combined_graph_hash does not match the per-entry class hashes"
     # pgw#1059: the stamped key must be exactly the key the artifact's OWN
     # recorded facts describe — the same recomputation the mint stamped and

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1264,16 +1264,25 @@ def _clean_tarinfo(ti: tarfile.TarInfo, executable: bool = False) -> tarfile.Tar
 _ELF_MAGIC = b"\x7fELF"
 
 
+class _UnreadableCubin(ValueError):
+    """A packed cubin whose architecture cannot be determined (pgw#939)."""
+
+
 def _cubin_arch(path: Path) -> int:
     """The SM arch a cubin was compiled for (nvidia ELF ``e_flags`` low
-    byte), 0 when the file is unreadable or not ELF."""
+    byte). Raises :class:`_UnreadableCubin` when the file cannot be read or
+    is not an ELF — pgw#939: it used to return ``0`` for that, which the
+    caller's ``if cubin is not None and want_arch:`` then read as "no arch to
+    compare", so an unreadable kernel SKIPPED the gate that exists to catch
+    it. Absence of evidence is the finding here, not the absence of a
+    finding."""
     try:
         with open(path, "rb") as f:
             header = f.read(0x34)
-    except OSError:
-        return 0
+    except OSError as exc:
+        raise _UnreadableCubin(f"unreadable ({type(exc).__name__})") from exc
     if len(header) < 0x34 or not header.startswith(_ELF_MAGIC):
-        return 0
+        raise _UnreadableCubin("not an ELF object")
     # EI_CLASS: 2 = ELF64 (e_flags at 0x30), 1 = ELF32 (e_flags at 0x24).
     offset = 0x30 if header[4] == 2 else 0x24
     flags = int.from_bytes(header[offset:offset + 4], "little")
@@ -1287,8 +1296,14 @@ def _ptx_jit_gaps(
     form is PTX makes the HOST DRIVER's JIT compile it at load time — the
     one path where the deliberately-unkeyed driver version (gw#577) can
     re-enter compiled-kernel behavior. Every ``.ptx`` must ship a sibling
-    ``.cubin``, and when the artifact declares its sm the cubin arch must
-    match it exactly."""
+    ``.cubin``, and the cubin arch must match the artifact's sm exactly.
+
+    pgw#939: both halves of that comparison used to VANISH on an unreadable
+    input. A malformed ``metadata["sm"]`` set ``want_arch = 0`` and an
+    unreadable cubin returned ``0``, and either one made
+    ``if cubin is not None and want_arch:`` skip — so pgw#698's gate
+    disappeared per kernel exactly when the evidence for it was missing.
+    An `sm` this function cannot parse is now a gap in its own right."""
     want_arch = 0
     if sm.startswith("sm_"):
         try:
@@ -1299,22 +1314,49 @@ def _ptx_jit_gaps(
     for p in files:
         if p.suffix in (".ptx", ".cubin"):
             kernels.setdefault((p.parent, p.stem), {})[p.suffix] = p
+    # Scope, stated because pgw#939 narrowed it deliberately: this gate is
+    # about PTX JIT, so it rules on kernels that HAVE a `.ptx`. A `.cubin`
+    # with no PTX sibling cannot be JIT-compiled by the driver — there is
+    # nothing to compile — and whether it is the right architecture is the
+    # cell IDENTITY gate's question (`sm` is a strict `IDENTITY_AXES` field),
+    # not this one's.
+    exposed = {k: v for k, v in kernels.items() if ".ptx" in v}
+    if not exposed:
+        return []
     gaps: list[str] = []
+    if not want_arch:
+        # pgw#939: this used to set `want_arch = 0` and silently skip every
+        # comparison below, so a malformed `sm` deleted the gate wholesale.
+        gaps.append(
+            f"artifact declares sm={sm!r}, which names no comparable "
+            f"architecture while carrying {len(exposed)} PTX-exposed "
+            "kernel(s) — the arch gate cannot run, so the pack is refused "
+            "rather than packed unchecked (pgw#698/pgw#939)")
     for (_parent, _stem), forms in sorted(
-        kernels.items(), key=lambda kv: str(kv[0][0] / kv[0][1]),
+        exposed.items(), key=lambda kv: str(kv[0][0] / kv[0][1]),
     ):
-        ptx, cubin = forms.get(".ptx"), forms.get(".cubin")
-        if ptx is not None and cubin is None:
+        ptx, cubin = forms[".ptx"], forms.get(".cubin")
+        if cubin is None:
             gaps.append(
                 f"{ptx.relative_to(cache_root)}: PTX only — no cubin, the "
                 "driver JIT would compile it")
             continue
-        if cubin is not None and want_arch:
+        if not want_arch:
+            continue  # already refused above; do not repeat it per kernel
+        try:
             arch = _cubin_arch(cubin)
-            if arch and arch != want_arch:
-                gaps.append(
-                    f"{cubin.relative_to(cache_root)}: cubin arch sm_{arch} "
-                    f"!= artifact sm_{want_arch}")
+        except _UnreadableCubin as exc:
+            # pgw#939: `_cubin_arch` returned 0 here and `and want_arch`
+            # then skipped the comparison, so the gate disappeared for
+            # exactly the kernel whose evidence could not be read.
+            gaps.append(
+                f"{cubin.relative_to(cache_root)}: {exc} — its "
+                "architecture cannot be compared to the artifact's")
+            continue
+        if arch != want_arch:
+            gaps.append(
+                f"{cubin.relative_to(cache_root)}: cubin arch sm_{arch} "
+                f"!= artifact sm_{want_arch}")
     return gaps
 
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3845,7 +3845,18 @@ class Executor:
         self._gate_owned = set()
 
         total_vram_gb = float(gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
-        free_vram_gb = float(gpu_info.get("gpu_free_mem") or gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
+        # pgw#940: no substitution. `or gpu_total_mem` treated a legitimate 0
+        # as "absent" and replaced it with the largest plausible number — and
+        # `gpu_free_mem` is genuinely 0 on a SATURATED card, which is exactly
+        # the state where the native/fp8/4-bit/offload/CPU ladder must engage
+        # and exactly the state that then read as "all of VRAM is free". This
+        # figure feeds `plan_serve`/`variant_fit` and what the pod advertises
+        # to the hub, so an unmeasured card must present as no room, not as an
+        # empty one. `lifecycle.probe_hardware` initialises the key to 0 and
+        # wraps its whole CUDA probe in `except Exception: pass`, so "the
+        # probe raised" arrives here indistinguishable from "the card is
+        # full" — both are non-permissive now, which is the point.
+        free_vram_gb = float(gpu_info.get("gpu_free_mem") or 0) / (1024 ** 3)
         detected_sm = str(gpu_info.get("gpu_sm") or "")
         libs = {str(x) for x in (gpu_info.get("installed_libs") or [])}
         caps = TensorhubWorkerCapabilities(

--- a/src/gen_worker/host_move_guard.py
+++ b/src/gen_worker/host_move_guard.py
@@ -62,9 +62,21 @@ def _target_is_cpu(args: tuple, kwargs: dict) -> bool:
             return False
 
 
+class _Unmeasurable(RuntimeError):
+    """This module's incoming byte count could not be computed (pgw#940)."""
+
+
 def _incoming_bytes(module: Any) -> int:
     """Bytes this module would newly land in host RAM: parameters + buffers
-    not already CPU-resident."""
+    not already CPU-resident.
+
+    Raises :class:`_Unmeasurable` rather than returning 0 (pgw#940). The 0
+    flowed straight into ``incoming < _MIN_GUARDED_GIB`` and returned, so the
+    guard silently no-opped — on precisely the shapes most likely to be huge,
+    since ``module.parameters()`` raises on meta-device modules, on
+    accelerate-hooked modules mid-dispatch, and on custom ``nn.Module``
+    subclasses that override ``parameters``.
+    """
     total = 0
     try:
         for t in module.parameters(recurse=True):
@@ -73,8 +85,11 @@ def _incoming_bytes(module: Any) -> int:
         for t in module.buffers(recurse=True):
             if t.device.type != "cpu":
                 total += t.numel() * t.element_size()
-    except Exception:
-        return 0
+    except Exception as exc:
+        raise _Unmeasurable(
+            f"cannot size {type(module).__name__} for a host move: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
     return total
 
 
@@ -106,7 +121,22 @@ def _refuse_if_over_budget(incoming: int, **probe_kwargs: Any) -> None:
 def check_host_ram_move(module: Any) -> None:
     """Raise :class:`HostRamMoveRefusedError` when moving ``module`` to CPU
     cannot fit ``available - floor``. Shared by both patched entry points."""
-    incoming = _incoming_bytes(module)
+    try:
+        incoming = _incoming_bytes(module)
+    except _Unmeasurable as exc:
+        # pgw#940, §1.22: the guard's whole reason to exist is that the
+        # failure it prevents is UNCATCHABLE — "no exception, no finally,
+        # process gone mid-instruction" (module docstring). A move it cannot
+        # size is therefore the one it must not wave through; it is checked
+        # against the host's own headroom instead, which is the conservative
+        # reading of an unknown size that still lets a small move on a roomy
+        # host proceed.
+        logger.warning("host-RAM move guard: %s — checking the floor anyway", exc)
+        kwargs = {}
+        if _probe_root is not None and _probe_self is not None:
+            kwargs = {"root": _probe_root, "proc_self_cgroup": _probe_self}
+        _refuse_if_over_budget(int(_MIN_GUARDED_GIB * _GIB), **kwargs)
+        return
     if incoming < _MIN_GUARDED_GIB * _GIB:
         return
     kwargs = {}

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -894,7 +894,7 @@ def _civitai_stream_one(
     expected_size: int,
     expected_sha256: str,
     on_bytes: Callable[[int], None],
-) -> int:
+) -> tuple[int, str]:
 
     import requests  # lazy (all sites): download is on the `import gen_worker` path; stays requests-free
 
@@ -944,11 +944,79 @@ def _civitai_stream_one(
     if expected_size and abs(written - expected_size) > _CIVITAI_SIZE_SLACK:
         tmp.unlink(missing_ok=True)
         raise ValueError(f"civitai size mismatch for {dst.name}: expected {expected_size}, got {written}")
-    if expected_sha256 and h.hexdigest().lower() != expected_sha256:
+    observed = h.hexdigest().lower()
+    if expected_sha256 and observed != expected_sha256:
         tmp.unlink(missing_ok=True)
         raise ValueError(f"civitai sha256 mismatch for {dst.name}")
     tmp.replace(dst)
-    return written
+    # pgw#939: the OBSERVED digest travels back whether or not civitai
+    # published one to check it against. Refusing an unhashed file is not
+    # available — civitai routinely omits SHA256 for large/GGUF files and this
+    # lane exists to ingest them — so the fix is that the manifest can no
+    # longer say the same thing about a verified and an unverified download.
+    return written, observed
+
+
+def _civitai_prior_manifest(manifest_path: Path) -> dict[str, dict[str, Any]]:
+    """This directory's own record of what a previous run actually landed,
+    keyed by file name. ``{}`` when there is none or it does not parse."""
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    rows = raw.get("files") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    return {
+        str(r["name"]): dict(r) for r in rows
+        if isinstance(r, Mapping) and str(r.get("name") or "")
+    }
+
+
+def _civitai_adoptable(
+    dst: Path, declared: Mapping[str, Any], prior: Optional[Mapping[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """The manifest row for an existing file that is provably complete, or
+    ``None`` to (re)download it.
+
+    pgw#939: this was ``dst.exists() and (not size or st_size == size)`` — the
+    left half of an ``or`` whose short-circuit meant that when civitai
+    declared no size, **any** file already occupying that path was adopted as
+    a finished download. No size, no hash, no read. A truncated prior attempt
+    is exactly the state that produces no declared size and an existing file
+    at once.
+
+    With nothing declared, the only evidence available is this directory's own
+    manifest from a run that COMPLETED — so that is what is required, and its
+    absence means "download it", never "assume it".
+    """
+    if not dst.exists():
+        return None
+    try:
+        on_disk = dst.stat().st_size
+    except OSError:
+        return None
+    size = int(declared.get("size_bytes") or 0)
+    declared_sha = str(declared.get("sha256") or "")
+    if size:
+        if on_disk != size:
+            return None
+        return {
+            "name": str(declared["name"]), "size_bytes": size,
+            "sha256": declared_sha or str((prior or {}).get("sha256") or ""),
+            "sha256_source": "civitai" if declared_sha else (
+                str((prior or {}).get("sha256_source") or "") or "unverified"),
+        }
+    if not prior:
+        return None
+    prior_size = int(prior.get("size_bytes") or 0)
+    if not prior_size or prior_size != on_disk:
+        return None
+    return {
+        "name": str(declared["name"]), "size_bytes": on_disk,
+        "sha256": str(prior.get("sha256") or ""),
+        "sha256_source": str(prior.get("sha256_source") or "") or "unverified",
+    }
 
 
 def download_civitai(
@@ -986,24 +1054,34 @@ def download_civitai(
 
     import requests  # lazy (all sites): download is on the `import gen_worker` path; stays requests-free
 
+    prior = _civitai_prior_manifest(manifest_path)
+    landed: dict[str, dict[str, Any]] = {}
     local_paths: list[Path] = []
     for f in files:
         dst = out_dir / f["name"]
         local_paths.append(dst)
-        if dst.exists() and (not f["size_bytes"] or dst.stat().st_size == f["size_bytes"]):
+        adopted = _civitai_adoptable(dst, f, prior.get(f["name"]))
+        if adopted is not None:
             done += f["size_bytes"]
+            landed[f["name"]] = adopted
             continue
         attempts = _civitai_attempts()
         file_start = done
         for attempt in range(1, attempts + 1):
             try:
-                _civitai_stream_one(
+                written, observed = _civitai_stream_one(
                     f["url"], dst,
                     api_key=api_key,
                     expected_size=f["size_bytes"],
                     expected_sha256=f["sha256"],
                     on_bytes=_on_bytes,
                 )
+                landed[f["name"]] = {
+                    "name": f["name"],
+                    "size_bytes": int(written),
+                    "sha256": observed,
+                    "sha256_source": "civitai" if f["sha256"] else "observed",
+                }
                 break
             except (requests.RequestException, OSError) as exc:
                 done = file_start  # rewind progress from the failed partial
@@ -1017,7 +1095,7 @@ def download_civitai(
                 time.sleep(min(10.0, 2.0 * attempt))
     manifest_path.write_text(json.dumps(
         {"model_version_id": int(version_id),
-         "files": [{"name": f["name"], "size_bytes": f["size_bytes"], "sha256": f["sha256"]} for f in files]},
+         "files": [landed[f["name"]] for f in files]},
         indent=2,
     ), encoding="utf-8")
     if progress is not None and total:

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -169,17 +170,55 @@ def degraded_log_line(
 # ---------------------------------------------------------------------------
 
 
-def get_available_vram_gb(device_index: int = 0) -> float:
-    """Currently-free VRAM on the selected CUDA device. 0.0 if no CUDA."""
+#: Why a free-VRAM reading is zero. pgw#940: `except Exception: return 0.0`
+#: made "this host has no CUDA" and "the probe raised on a host that does"
+#: the same value, and every caller that had to DECIDE something read the
+#: shared zero as the permissive case.
+VRAM_NO_CUDA = "no_cuda"
+VRAM_UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class VramReading:
+    """Free VRAM, and — when there is none to report — why."""
+
+    gb: float
+    #: "" when `gb` is a real measurement, else VRAM_NO_CUDA / VRAM_UNREADABLE.
+    reason: str = ""
+
+    @property
+    def measured(self) -> bool:
+        return not self.reason
+
+
+def available_vram(device_index: int = 0) -> VramReading:
+    """Currently-free VRAM on the selected CUDA device, with its zero-cause.
+
+    The one probe every free-VRAM question in this module is answered from.
+    A caller that only wants the number keeps calling
+    :func:`get_available_vram_gb`; a caller that must DECIDE with it reads
+    ``reason`` and says out loud what it does when the card is unreadable.
+    """
     try:
         import torch
 
         if not torch.cuda.is_available():
-            return 0.0
+            return VramReading(0.0, VRAM_NO_CUDA)
         free, _total = torch.cuda.mem_get_info(device_index)
-        return float(free) / float(1024**3)
-    except Exception:
-        return 0.0
+    except Exception as exc:
+        _LOG.warning("free-VRAM probe failed: %s: %s", type(exc).__name__, exc)
+        return VramReading(0.0, VRAM_UNREADABLE)
+    return VramReading(float(free) / float(1024**3))
+
+
+def get_available_vram_gb(device_index: int = 0) -> float:
+    """Currently-free VRAM on the selected CUDA device. 0.0 if no CUDA.
+
+    Reporting shape: it deliberately collapses "no card" and "unreadable"
+    into one number, which is right for a log line and wrong for a decision.
+    Anything that PLACES a model reads :func:`available_vram` instead.
+    """
+    return available_vram(device_index).gb
 
 
 def get_total_vram_gb(device_index: int = 0) -> float:
@@ -818,7 +857,30 @@ def select_auto_mode(
     The per-SKU refinement below keeps the GROSS requirement on purpose.
     """
     avail = available_vram_gb if available_vram_gb is not None else get_available_vram_gb()
+    # "How much is free" and "why is it zero" are two questions, and the
+    # second is only worth asking when the first answers zero — which also
+    # keeps a caller-supplied or stubbed figure authoritative all the way
+    # through, exactly as before.
+    zero_cause = "" if avail > 0.0 else available_vram().reason
     if avail <= 0.0:
+        # pgw#940. `return "off"` for BOTH zero-causes: "off" means fully
+        # resident, no offload at all — the single most memory-hungry rung on
+        # the ladder — so a GPU host whose probe raised loaded a pipeline that
+        # needed `group_offload` fully resident and OOMed during load. The two
+        # causes are different facts and get different answers.
+        #
+        # No CUDA: "off" is still correct and is not a placement claim at all
+        # — there is no card to offload FROM, and the CPU path ignores the
+        # rung. Unreadable: the deepest rung this ladder has, matching the
+        # unknown-model-size branch below, which has always descended to
+        # `group_offload` rather than up to `off`. A rung of performance is
+        # the price; an OOM on paid tenant work is what it buys off.
+        if zero_cause == VRAM_UNREADABLE:
+            _LOG.warning(
+                "free VRAM unreadable; selecting %s rather than the resident "
+                "rung — an unmeasured card does not license full residency "
+                "(pgw#940)", "group_offload")
+            return "group_offload"
         return "off"
 
     model_gb = model_size_gb if model_size_gb is not None else estimate_pipeline_size_gb(pipeline)

--- a/tests/test_fail_closed_verification_pgw939_pgw940.py
+++ b/tests/test_fail_closed_verification_pgw939_pgw940.py
@@ -1,0 +1,492 @@
+"""pgw#939 + pgw#940 — eight verified fail-open sites, one shape each.
+
+**pgw#939 (supply chain).** `if expected { compare }` — so an absent expected
+value ADMITS. The artifact in every case is bytes that will subsequently be
+safetensors-loaded or armed as a compiled cell, and `DESIGN-RULINGS.md` §1.22
+decides all of them the same way: missing evidence is an integrity verdict,
+not a disabled check.
+
+**pgw#940 (measurement).** One question — *how much VRAM is free?* — answered
+four times, with `0` meaning both "no card" and "the probe raised", and the
+code reading the shared zero as the permissive case. §1.22 again, and the
+asymmetry decides it: admitting on an unreadable measurement OOMs paid tenant
+work, refusing costs a rung of performance.
+
+Every test below is RED against `master` at the commit this branch left, and
+each one names the site it covers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import aot_serve  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# pgw#939 §3-4 — aot_serve.verify guarded three identity axes on "a stamp is
+# present". A stampless cell was a wrong cache HIT, not a miss.
+# ---------------------------------------------------------------------------
+
+
+def _entry_block() -> Dict[str, Any]:
+    """A minimal but VALID entry contract — `artifact_metadata` validates
+    every block it stamps, so a hand-rolled dict would fail before reaching
+    the axes under test."""
+    return {
+        "target": "unet",
+        "fork": [],
+        "class_dims": [["h", 64]],
+        "inputs": [{
+            "name": "x", "position": 0, "dtype": "bfloat16",
+            "shape": [1, 4, "s0", 64], "optional": False,
+        }],
+        "symbols": {"s0": [16, 160]},
+        "constants": [],
+        "graph": {
+            "v": 3,
+            "constant_fqns": ["w.weight"],
+            "lifted_inputs": [],
+            "pytree": {"user_inputs": ["x"], "in_spec": "", "out_spec": ""},
+            "specialization": {
+                "weight_lane": "bf16", "lora_bucket": 0, "strict": True},
+        },
+    }
+
+
+def _minted(family: str = "sdxl") -> Dict[str, Any]:
+    """A real, fully-stamped artifact envelope from the ONE producer."""
+    return aot_serve.artifact_metadata(
+        family=family, precision="bf16", cell_key="",
+        entries={"unet": _entry_block()},
+        strict_export=True, lora_bucket=0,
+    )
+
+
+def test_a_correctly_stamped_cell_still_verifies() -> None:
+    """The control. Without it a green result below could mean the whole
+    envelope stopped verifying for an unrelated reason."""
+    meta = _minted()
+    assert aot_serve.verify_declared(meta, family="sdxl") == ""
+    assert aot_serve.verify_contract(meta) == ""
+
+
+def test_an_unstamped_family_is_refused_by_name() -> None:
+    """`if family and want_fam and want_fam != family` — the middle clause
+    made an unstamped cell match EVERY family it was offered to, on the axis
+    that decides which pipeline the `.so` is dlopen'd into."""
+    meta = _minted()
+    meta["family"] = ""
+    reason = aot_serve.verify_declared(meta, family="sdxl")
+    assert reason and "family" in reason, reason
+
+
+def test_a_family_stamped_differently_is_still_refused() -> None:
+    """Unchanged behaviour on the arm that already worked."""
+    meta = _minted(family="flux")
+    assert "family" in aot_serve.verify_declared(meta, family="sdxl")
+
+
+def test_no_family_asked_means_no_family_refused() -> None:
+    """The strictness bites only when a caller names a family — a call that
+    asks nothing about family must not start failing."""
+    meta = _minted()
+    meta["family"] = ""
+    assert aot_serve.verify_declared(meta, family="") == ""
+
+
+def test_an_unstamped_range_digest_is_refused_by_name() -> None:
+    meta = _minted()
+    meta["entries"]["unet"].pop("range_digest")
+    reason = aot_serve.verify_contract(meta)
+    assert reason == "entry 'unet': no range_digest stamped", reason
+
+
+def test_an_unstamped_combined_graph_hash_is_refused_by_name() -> None:
+    meta = _minted()
+    meta["combined_graph_hash"] = ""
+    assert aot_serve.verify_contract(meta) == "no combined_graph_hash stamped"
+
+
+def test_class_hash_absence_was_already_correct_and_stays_so() -> None:
+    """`:665-666` proves the author knew the right form; the other two axes
+    are brought to IT, not the reverse."""
+    meta = _minted()
+    meta["entries"]["unet"]["class_hash"] = ""
+    assert aot_serve.verify_contract(meta) == "entry 'unet': no class_hash stamped"
+
+
+# ---------------------------------------------------------------------------
+# pgw#939 "also in scope" — the cubin arch gate vanished per kernel
+# ---------------------------------------------------------------------------
+
+
+_ELF64 = b"\x7fELF" + b"\x02" + b"\x00" * 0x2B + (89).to_bytes(4, "little")
+
+
+def _kernel_dir(tmp_path: Path, *, cubin: bytes | None, ptx: bool = True) -> Path:
+    root = tmp_path / "cache"
+    root.mkdir(parents=True, exist_ok=True)
+    if ptx:
+        (root / "k.ptx").write_bytes(b"// ptx")
+    if cubin is not None:
+        (root / "k.cubin").write_bytes(cubin)
+    return root
+
+
+def test_a_matching_cubin_still_passes(tmp_path: Path) -> None:
+    from gen_worker import compile_cache
+
+    root = _kernel_dir(tmp_path, cubin=_ELF64)
+    assert compile_cache._ptx_jit_gaps(sorted(root.iterdir()), root, "sm_89") == []
+
+
+def test_an_unreadable_cubin_is_a_gap_not_a_skip(tmp_path: Path) -> None:
+    """`_cubin_arch` returned 0 on `OSError` or a non-ELF header, and
+    `if cubin is not None and want_arch:` then skipped the comparison — so
+    pgw#698's gate disappeared for exactly the kernel it could not read."""
+    from gen_worker import compile_cache
+
+    root = _kernel_dir(tmp_path, cubin=b"not an elf at all")
+    gaps = compile_cache._ptx_jit_gaps(sorted(root.iterdir()), root, "sm_89")
+    assert len(gaps) == 1 and "not an ELF" in gaps[0], gaps
+
+
+def test_an_unparseable_sm_refuses_the_pack(tmp_path: Path) -> None:
+    """A malformed `metadata["sm"]` set `want_arch = 0` and the arch gate
+    vanished for EVERY kernel at once."""
+    from gen_worker import compile_cache
+
+    root = _kernel_dir(tmp_path, cubin=_ELF64)
+    gaps = compile_cache._ptx_jit_gaps(sorted(root.iterdir()), root, "sm_wat")
+    assert gaps and "names no comparable architecture" in gaps[0], gaps
+
+
+def test_a_ptx_with_no_cubin_is_still_the_original_gap(tmp_path: Path) -> None:
+    from gen_worker import compile_cache
+
+    root = _kernel_dir(tmp_path, cubin=None)
+    gaps = compile_cache._ptx_jit_gaps(sorted(root.iterdir()), root, "sm_89")
+    assert len(gaps) == 1 and "PTX only" in gaps[0], gaps
+
+
+# ---------------------------------------------------------------------------
+# pgw#939 §1-2 — civitai downloads
+# ---------------------------------------------------------------------------
+
+
+def test_an_unhashed_download_is_distinguishable_from_a_verified_one(
+    tmp_path: Path,
+) -> None:
+    """Civitai publishes `AutoV2`/`CRC32`/`BLAKE3` without `SHA256` for many
+    large/GGUF files. The manifest recorded `"sha256": ""` for those, with no
+    marker separating "hash matched" from "no hash was available" — so every
+    downstream reader saw a completed, verified download.
+
+    Refusing is not available (ingesting those files is what the lane is for),
+    so the acceptance is that the two states stop looking alike.
+    """
+    from gen_worker.models import download
+
+    verified = download._civitai_adoptable(
+        _sized(tmp_path / "a.bin", 10),
+        {"name": "a.bin", "size_bytes": 10, "sha256": "ab" * 32}, None,
+    )
+    assert verified is not None and verified["sha256_source"] == "civitai"
+
+    unhashed = download._civitai_adoptable(
+        _sized(tmp_path / "b.bin", 10),
+        {"name": "b.bin", "size_bytes": 10, "sha256": ""}, None,
+    )
+    assert unhashed is not None and unhashed["sha256_source"] == "unverified"
+    assert verified["sha256_source"] != unhashed["sha256_source"]
+
+
+def _sized(path: Path, n: int) -> Path:
+    path.write_bytes(b"\0" * n)
+    return path
+
+
+def test_an_undeclared_size_no_longer_adopts_whatever_is_at_the_path(
+    tmp_path: Path,
+) -> None:
+    """`if dst.exists() and (not f["size_bytes"] or st_size == size)`. The
+    left half of the `or` short-circuits: with no declared size ANY file at
+    that path was adopted as a complete download — no size, no hash, no read.
+    A truncated prior attempt is exactly that state."""
+    from gen_worker.models import download
+
+    dst = _sized(tmp_path / "big.gguf", 3)  # a stub, not the model
+    assert download._civitai_adoptable(
+        dst, {"name": "big.gguf", "size_bytes": 0, "sha256": ""}, None,
+    ) is None
+
+
+def test_an_undeclared_size_adopts_against_our_own_completed_manifest(
+    tmp_path: Path,
+) -> None:
+    """The fast path survives where there IS evidence: this directory's own
+    manifest, which is written only after every file completed."""
+    from gen_worker.models import download
+
+    dst = _sized(tmp_path / "big.gguf", 3)
+    prior = {"name": "big.gguf", "size_bytes": 3, "sha256": "cd" * 32,
+             "sha256_source": "observed"}
+    row = download._civitai_adoptable(
+        dst, {"name": "big.gguf", "size_bytes": 0, "sha256": ""}, prior,
+    )
+    assert row is not None and row["sha256"] == "cd" * 32
+    assert row["sha256_source"] == "observed"
+
+
+def test_a_prior_manifest_that_disagrees_with_the_disk_forces_a_redownload(
+    tmp_path: Path,
+) -> None:
+    from gen_worker.models import download
+
+    dst = _sized(tmp_path / "big.gguf", 3)
+    prior = {"name": "big.gguf", "size_bytes": 999, "sha256": "cd" * 32}
+    assert download._civitai_adoptable(
+        dst, {"name": "big.gguf", "size_bytes": 0, "sha256": ""}, prior,
+    ) is None
+
+
+def test_a_declared_size_mismatch_still_redownloads(tmp_path: Path) -> None:
+    from gen_worker.models import download
+
+    dst = _sized(tmp_path / "m.safetensors", 5)
+    assert download._civitai_adoptable(
+        dst, {"name": "m.safetensors", "size_bytes": 10, "sha256": ""}, None,
+    ) is None
+
+
+def test_a_torn_prior_manifest_is_no_evidence(tmp_path: Path) -> None:
+    from gen_worker.models import download
+
+    m = tmp_path / ".civitai.json"
+    m.write_text("{not json", encoding="utf-8")
+    assert download._civitai_prior_manifest(m) == {}
+    m.write_text(json.dumps({"files": "nope"}), encoding="utf-8")
+    assert download._civitai_prior_manifest(m) == {}
+
+
+# ---------------------------------------------------------------------------
+# pgw#940 §1 — an unreadable card licensed 8 concurrent compile children
+# ---------------------------------------------------------------------------
+
+
+_GIB = 1024 ** 3
+
+
+def test_a_readable_card_divides_as_before() -> None:
+    from gen_worker import aot_compile_pool as pool
+
+    width = pool.entry_workers(
+        8, free_vram_bytes=48 * _GIB, device_bytes=12 * _GIB,
+        vcpus=32, available_bytes=256 * _GIB, device_basis="measured")
+    assert width.device_workers > 1
+
+
+def test_an_unreadable_card_is_bounded_like_its_sibling_branches() -> None:
+    """`free_vram <= 0 -> MAX_ENTRY_WORKERS` (8), beside `avail <= 0 -> 1`
+    and `per_device <= 0 -> 1` in the same function. The comment defending it
+    claimed `_probe_free_device_bytes` fails only when there is no card; it
+    ended in `except Exception: return 0`, so a transient `mem_get_info`
+    failure, a post-fork CUDA-context error and a flapping `is_available()`
+    all produced that 8 with a card present."""
+    from gen_worker import aot_compile_pool as pool
+
+    def _raises(_device: int) -> int:
+        raise pool.DeviceProbeError("mem_get_info blew up")
+
+    facts = pool.device_facts(probe=_raises, samples=3, gap_s=0.0)
+    assert facts.basis == "unreadable" and facts.free_bytes == 0
+    # The decision those facts drive is the parametrized test below; this one
+    # pins that the probe's failure survives as a distinguishable FACT, which
+    # is the half that did not exist.
+
+
+def test_no_card_still_drops_the_device_bound() -> None:
+    """A CPU-only cell is not device-bound at all, and must not be narrowed
+    to K=1 by a fix aimed at unreadable cards."""
+    from gen_worker import aot_compile_pool as pool
+
+    facts = pool.device_facts(probe=lambda _d: 0, samples=3, gap_s=0.0)
+    assert facts.basis == "absent"
+
+
+@pytest.mark.parametrize(
+    "basis,expect_workers", [("unreadable", 1), ("absent", 8)])
+def test_the_two_zero_causes_decide_differently(
+    basis: str, expect_workers: int, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker import aot_compile_pool as pool
+
+    monkeypatch.setattr(
+        pool, "device_facts",
+        lambda *a, **k: pool.DeviceFacts(0, basis, (0,)))
+    width = pool.entry_workers(
+        8, device_bytes=12 * _GIB, vcpus=32, available_bytes=256 * _GIB)
+    assert width.device_workers == expect_workers, width.facts()
+
+
+def test_an_unexpected_probe_exception_still_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only `DeviceProbeError` is a measurement outcome. A probe that raises
+    something else is a bug, and swallowing it would rebuild the hole this
+    fix closes one level up."""
+    from gen_worker import aot_compile_pool as pool
+
+    def _bug(_device: int) -> int:
+        raise AssertionError("this must not be swallowed")
+
+    with pytest.raises(AssertionError):
+        pool.device_facts(probe=_bug, samples=1, gap_s=0.0)
+
+
+# ---------------------------------------------------------------------------
+# pgw#940 §2 — zero free VRAM selected the most memory-hungry rung
+# ---------------------------------------------------------------------------
+
+
+def test_no_cuda_still_selects_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """"off" on a CPU host is not a placement claim — there is no card to
+    offload FROM. Unchanged."""
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(
+        memory, "available_vram",
+        lambda *a, **k: memory.VramReading(0.0, memory.VRAM_NO_CUDA))
+    assert memory.select_auto_mode(pipeline=object()) == "off"
+
+
+def test_an_unreadable_card_does_not_select_full_residency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`"off"` means fully resident, no offload at all — the single most
+    memory-hungry rung. On a GPU host whose probe failed, a pipeline that
+    needed `group_offload` was loaded fully resident and OOMed during load.
+    The unknown-model-size branch a few lines below has always descended to
+    `group_offload`; only the unknown-free-VRAM branch opened."""
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(
+        memory, "available_vram",
+        lambda *a, **k: memory.VramReading(0.0, memory.VRAM_UNREADABLE))
+    assert memory.select_auto_mode(pipeline=object()) == "group_offload"
+
+
+def test_the_reading_carries_its_zero_cause(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gen_worker.models import memory
+
+    class _NoCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    import sys
+    import types
+
+    fake = types.SimpleNamespace(cuda=_NoCuda())
+    monkeypatch.setitem(sys.modules, "torch", fake)
+    assert memory.available_vram().reason == memory.VRAM_NO_CUDA
+
+    class _Broken:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        @staticmethod
+        def mem_get_info(_i: int) -> tuple:
+            raise RuntimeError("CUDA context lost")
+
+    monkeypatch.setitem(sys.modules, "torch", types.SimpleNamespace(cuda=_Broken()))
+    reading = memory.available_vram()
+    assert reading.reason == memory.VRAM_UNREADABLE and not reading.measured
+    # The reporting shape keeps collapsing them; that is what it is for.
+    assert memory.get_available_vram_gb() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# pgw#940 §3 — a saturated card read as an empty one
+# ---------------------------------------------------------------------------
+
+
+def test_a_saturated_card_no_longer_reads_as_empty() -> None:
+    """`float(gpu_free_mem or gpu_total_mem or 0)`: `or` treats a legitimate
+    0 as absent and substitutes the largest plausible number. `gpu_free_mem`
+    is genuinely 0 on a saturated card — the state where the ladder must
+    engage, reading as the state where nothing is needed."""
+    import ast
+    import inspect
+
+    from gen_worker import executor
+
+    src = inspect.getsource(executor.Executor.gate_functions)
+    lines = [
+        line.strip() for line in src.splitlines()
+        if "gpu_free_mem" in line and not line.strip().startswith("#")
+    ]
+    assert lines, "the fit gate no longer reads gpu_free_mem — re-cut this test"
+    for line in lines:
+        assert "gpu_total_mem" not in line, (
+            f"free VRAM is substituted by total again: {line}")
+    ast.parse(src.strip())  # the slice is still syntactically a function
+
+
+# ---------------------------------------------------------------------------
+# pgw#940 §4 — an unmeasurable module skipped the host-RAM move guard
+# ---------------------------------------------------------------------------
+
+
+class _Unsizable:
+    """The shape the guard no-opped on: `parameters()` raises, as it does for
+    meta-device modules, accelerate-hooked modules mid-dispatch, and custom
+    `nn.Module` subclasses that override `parameters`."""
+
+    def parameters(self, recurse: bool = True) -> Any:
+        raise RuntimeError("meta device: parameters are not materialized")
+
+    def buffers(self, recurse: bool = True) -> Any:
+        raise RuntimeError("meta device")
+
+
+def test_an_unmeasurable_module_no_longer_skips_the_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`except Exception: return 0` -> `0 < 1 GiB` -> early return -> the move
+    proceeds. The guard exists solely to refuse a `.to("cpu")` that gets the
+    container cgroup-SIGKILLed: "no exception, no finally, process gone
+    mid-instruction"."""
+    from gen_worker import host_move_guard as guard
+
+    seen: list[int] = []
+
+    def _record(incoming: int, **_k: Any) -> None:
+        seen.append(incoming)
+
+    monkeypatch.setattr(guard, "_refuse_if_over_budget", _record)
+    guard.check_host_ram_move(_Unsizable())
+    assert seen == [guard._MIN_GUARDED_GIB * guard._GIB], (
+        "an unsizable module returned without the budget ever being consulted")
+
+
+def test_a_small_measurable_move_still_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard is not turned into a per-move probe: a module it CAN size
+    and that is below the floor still returns without touching the budget."""
+    torch = pytest.importorskip("torch")
+    from gen_worker import host_move_guard as guard
+
+    called: list[int] = []
+    monkeypatch.setattr(
+        guard, "_refuse_if_over_budget",
+        lambda incoming, **_k: called.append(incoming))
+    guard.check_host_ram_move(torch.nn.Linear(4, 4))
+    assert called == []

--- a/tests/test_stream_bounds_pgw1013.py
+++ b/tests/test_stream_bounds_pgw1013.py
@@ -403,10 +403,13 @@ WEIGHTS_SHA = hashlib.sha256(WEIGHTS).hexdigest()
 def _civitai(url: str, dst: Path, *, expected_size: int, sha: str = "") -> int:
     from gen_worker.models.download import _civitai_stream_one
 
-    return _civitai_stream_one(
+    # pgw#939: the observed digest now rides back beside the byte count so the
+    # manifest can distinguish a verified download from an unverified one.
+    written, _observed = _civitai_stream_one(
         url, dst, api_key="", expected_size=expected_size,
         expected_sha256=sha or WEIGHTS_SHA, on_bytes=lambda _n: None,
     )
+    return written
 
 
 def test_civitai_legitimate_transfer_is_unaffected(rig: _Rig, tmp_path: Path) -> None:


### PR DESCRIPTION
Eight verified fail-open sites, one shape each. `DESIGN-RULINGS.md` §1.22 decides all of them the same way, and this repo already contained the correct doctrine written down twice — nothing here invents a policy, it brings eight sites to two that were already right.

## pgw#939 — `if expected { compare }`, so an absent expected value ADMITS

| site | what admitted |
|---|---|
| `aot_serve.verify_declared` | an **unstamped** `family` matched every family it was offered to |
| `aot_serve.verify_contract` | an unstamped `range_digest` / `combined_graph_hash` passed |
| `compile_cache._ptx_jit_gaps` | an unparseable `sm` or unreadable cubin deleted pgw#698's arch gate **per kernel** |
| `models/download` | civitai's `"sha256": ""` meant both "matched" and "no hash was published" |
| `models/download` | with no declared size, **any** file at the path was adopted as a complete download |

The `aot_serve` consequence is a wrong cache **hit**, not a miss — on the axis that decides which pipeline the `.so` is dlopen'd into. `class_hash` right beside them already refused absence by name, and `verify_declared`'s own docstring already promised *"an axis a cell is silent on is refused by name, never skipped"*. `compile_cache.py:1062-1067` names this exact `if want and want != have` shape as JAX PR #27814's one documented wrong-cache-hit.

Two deliberate scope calls while fixing:
- The PTX-JIT gate now rules on kernels that **have a `.ptx`**. A cubin with no PTX sibling cannot be JIT-compiled by the driver, and whether it is the right architecture is the cell **identity** gate's question (`sm` is a strict `IDENTITY_AXES` field), not this one's.
- Civitai downloads cannot refuse an unhashed file — that ingest is what the lane is *for*. So the observed digest (already computed by the stream) is recorded with a `sha256_source` of `civitai` / `observed` / `unverified`, and the two states stop looking alike.

## pgw#940 — `0` meant both "no card" and "the probe raised"

| site | what the shared zero licensed |
|---|---|
| `aot_compile_pool.entry_workers` | **8 concurrent compile children** on a card it could not measure |
| `models/memory.select_auto_mode` | `"off"` — full residency, the most memory-hungry rung — on a GPU host whose probe failed |
| `executor.gate_functions` | TOTAL VRAM substituted for free, so a **saturated card advertised itself as empty** |
| `host_move_guard.check_host_ram_move` | an unsizable module skipped the guard entirely |

`aot_compile_pool`'s comment defended its branch by asserting `_probe_free_device_bytes` fails only when there is no card. The function ended in `except Exception: return 0`, so a transient `mem_get_info` failure, a post-fork CUDA-context error or a flapping `is_available()` all produced that 8 with a card present. `DeviceProbeError` now separates the two causes and the unreadable arm falls to K=1 beside its two sibling branches — the claim is true by construction instead of by assertion.

## RED evidence

`tests/test_fail_closed_verification_pgw939_pgw940.py`, run unchanged against unmodified `master`:

```
18 failed, 11 passed
```

The 11 passes are the controls (a correctly stamped cell still verifies, a matching cubin still passes, no card still drops the device bound, a small measurable move still short-circuits). On this branch: **29 passed**.

## Gates

mypy clean (254 files) · ruff clean · seven fast-gate lint guards green · 184 passed across `compile_cache` / `local_cells` / `executor_adopt` / `guard_gate` / `shared_resident_headroom` · 416 in the wider pool/vram/download neighbourhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq