### PR TITLE
pgw#894: give every progress counter an OWNER, so serving work cannot refresh a MINT's stall clock

### DIFF
--- a/changelog.d/pgw894.md
+++ b/changelog.d/pgw894.md
@@ -1,0 +1,29 @@
+- **pgw#894: serving work can no longer refresh a MINT's stall clock.**
+  `progress._counters` was keyed by counter NAME alone, so `freshest()`
+  returned whichever counter anywhere in the process advanced most recently;
+  the 10 s beat attached THAT counter to whatever `activity.current()` was;
+  and the hub advances an activity's `UpdatedAt` from a counter-name change or
+  value increase (`worker_activity.go:323-338`), which is the timestamp its
+  stall and condemnation path reads. A tenant request therefore deferred a
+  background mint's stall verdict — the standing chaos hub's log carried 28
+  lines reporting `infer:steps` under `self_mint_compile`, and one of them
+  declined a condemnation because that mint activity was "0s ago".
+
+  Every counter now carries an OWNER and the registry is keyed
+  `(owner, name)`, so two concurrent requests can both count `infer:steps`
+  without being one counter. `Activity` gets a process-local `id` (not on the
+  wire — the hub still identifies an activity by kind and phase, so this costs
+  no protocol change), `Activity.counter()` registers under it, and
+  `activity.on_beat()` asks `freshest(act.id)` / `self_diagnosis(act.id)`. The
+  request emitter registers `infer:steps` under `request:<id>` and finishes it
+  in `_finish`, so a request's scope dies with the request (pgw#962's lifetime
+  rule, applied to the new scope). Downloads and weight loads go through a new
+  `activity.scoped_counter`, which credits the phase that asked for them and
+  falls back to an unowned counter for library/CLI use.
+
+  Deliberately unchanged: registry-wide `freshest()` / `self_diagnosis()` still
+  exist and still mean "is this process doing anything at all", which is the
+  right answer for the in-call stall loop and the drain — many handlers
+  register no counter of their own, and scoping those would make a request
+  wait on a counter nobody feeds. The delegated child's own measured CPU/file
+  watchdog is untouched: this is a re-scope, not a watchdog deletion.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -248,6 +248,13 @@ class Activity:
 
     def __init__(self, kind: str) -> None:
         self.kind = kind
+        #: This activity's own scope (pgw#894). Process-local and stable for
+        #: the activity's life: it keys the progress registry so a counter fed
+        #: by unrelated work can never answer THIS activity's stall question.
+        #: Not on the wire — the hub still identifies an activity by
+        #: (worker, kind, phase) — so it costs no protocol change; what it
+        #: buys is that the number the beat CARRIES describes this activity.
+        self.id = f"{kind}:{_next_seq()}"
         self._phase = ""
         self._step = 0
         self._total = 0
@@ -271,7 +278,7 @@ class Activity:
         without waiting out its own window. Producers re-acquire per tick, so a
         counter that is still being fed is simply re-registered under the new
         phase."""
-        c = progress_mod.counter(name, unit, total)
+        c = progress_mod.counter(name, unit, total, owner=self.id)
         self._counters[name] = (self._phase, c)
         return c
 
@@ -439,6 +446,23 @@ def current() -> Optional[Activity]:
     return act if act is not None and not act._done else None
 
 
+def scoped_counter(
+    name: str, unit: str, total: float = 0.0,
+) -> "progress_mod.Counter":
+    """The counter for ``name`` owned by the CURRENT activity, or an unowned
+    process counter when none is open (pgw#894).
+
+    For producers that are not themselves inside an activity method: a model
+    download or a weight load belongs to whatever phase asked for it, and the
+    fallback keeps library / CLI use — where no activity exists — working
+    exactly as before.
+    """
+    act = current()
+    if act is not None:
+        return act.counter(name, unit, total)
+    return progress_mod.counter(name, unit, total)
+
+
 def on_beat() -> None:
     """Ride the 10s app heartbeat (lifecycle._heartbeat_loop, gw#621): while
     an activity is open and the progress registry has counters, emit one
@@ -450,11 +474,21 @@ def on_beat() -> None:
         act = current()
         if act is None:
             return
-        snap = progress_mod.freshest()
+        # pgw#894: THIS activity's counters, not the registry's. The beat used
+        # to attach `progress.freshest()` — the min-age counter anywhere in
+        # the process — to whatever activity happened to be current, and the
+        # hub advances an activity's `UpdatedAt` from a counter-name change or
+        # value increase (`worker_activity.go:323-338`), which is the
+        # timestamp its stall/condemnation path reads. So a serving request
+        # deferred a background mint's stall verdict: 28 lines on the standing
+        # chaos hub reported `infer:steps` under `self_mint_compile`, and line
+        # 4542 declined a condemnation because that mint activity was "0s ago".
+        snap = progress_mod.freshest(act.id)
         if snap is None:
             return
         act.progress_beat(
-            snap, self_stalled=progress_mod.self_diagnosis() is not None)
+            snap,
+            self_stalled=progress_mod.self_diagnosis(act.id) is not None)
     except Exception:
         logger.debug("progress beat dropped", exc_info=True)
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2151,7 +2151,9 @@ class ModelStore:
             # total known up front, so the wire never shows total=0 for
             # tensorhub refs.
             known_total = sum(int(f.size_bytes) for f in fetch_files)
-            dl_counter = progress_mod.counter(
+            # pgw#894: owned by the activity this download is FOR when there
+            # is one, so it advances that scope's clock and no other.
+            dl_counter = activity_mod.scoped_counter(
                 f"download:{ref}", progress_mod.UNIT_BYTES, total=known_total)
 
             def _progress(done: int, total: Optional[int]) -> None:
@@ -12159,15 +12161,32 @@ class Executor:
             except Exception:
                 logger.debug("ctx event send failed for %s", job.request_id, exc_info=True)
 
+        # pgw#894: THIS REQUEST'S counter, registered under this request's own
+        # scope. It used to be `activity.current().counter("infer:steps", ...)`
+        # — a serving request feeding whatever activity happened to be current,
+        # which on a pod running a background mint is the MINT. The hub
+        # advances an activity's `UpdatedAt` from a counter-name change or
+        # value increase (`worker_activity.go:323-338`), and that timestamp is
+        # what its stall/condemnation path reads: measured on the standing
+        # chaos hub, 28 lines reported `infer:steps` under `self_mint_compile`
+        # and line 4542 declined a condemnation because that mint activity was
+        # "0s ago". The counter still proves the PROCESS is alive — a
+        # registry-wide `progress.freshest()` sees it, which is what the
+        # in-call stall loop and the drain use — it just no longer answers a
+        # question about work it is not doing.
+        #
+        # The old comment justified the credit with "warmup forwards run
+        # GPU-bound with a quiet CPU". Warmup does not reach here: it builds
+        # its context through `warmup.warm_context`, which passes no emitter
+        # at all, and reports its own activity-owned `warmup:jobs` counter.
+        steps = progress_mod.counter(
+            "infer:steps", progress_mod.UNIT_STEPS,
+            owner=f"request:{job.request_id}")
+
         def _emit(event: Dict[str, Any]) -> None:
             if job.finished:
                 return
-            # gw#621: a ctx event is real forward progress — feed the open
-            # activity's step counter (warmup forwards run GPU-bound with a
-            # quiet CPU; watchdog evidence alone would read stalled).
-            act = activity_mod.current()
-            if act is not None:
-                act.counter("infer:steps", progress_mod.UNIT_STEPS).add(1)
+            steps.add(1)
             try:
                 data = msgspec.json.encode(event)
             except Exception:
@@ -12340,6 +12359,12 @@ class Executor:
         if job.finished:
             return
         job.finished = True
+        # pgw#894/pgw#962: a request's scope dies with the request. A counter
+        # left open after its producer stopped is the min-age counter of work
+        # nobody is doing, and it confesses for whoever asks next.
+        progress_mod.counter(
+            "infer:steps", progress_mod.UNIT_STEPS,
+            owner=f"request:{job.request_id}").finish()
         # th#1111: stamp the per-stage breakdown on EVERY terminal path (ok,
         # deadline, cancel, error) — a slow request's stages are exactly the
         # ones worth seeing.

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -47,7 +47,6 @@ from typing import Optional
 
 from .. import activity as activity_mod
 from .. import postmortem
-from .. import progress as progress_mod
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +223,8 @@ class LoadProgressReporter:
         # skips this — that one is the breadcrumb's job.
         self._close_phase()
         try:
-            c = progress_mod.counter(COUNTER_NAME, "bytes", self.total_bytes)
+            c = activity_mod.scoped_counter(
+                COUNTER_NAME, "bytes", self.total_bytes)
             c.finish()
         except Exception:  # noqa: BLE001 - reporting must never break a load
             pass
@@ -335,7 +335,9 @@ class LoadProgressReporter:
             # ABSOLUTE counters: the phase baselines are absolute too, and a
             # delta-from-load-start would silently zero the comparison.
             self._check_thrash(io_now, rss_anon_kb * 1024)
-            c = progress_mod.counter(
+            # pgw#894: activity-owned, so a load advances the clock of the
+            # phase doing it and not whatever else is open on this pod.
+            c = activity_mod.scoped_counter(
                 COUNTER_NAME, "bytes",
                 max(self.total_bytes, done),
             )

--- a/src/gen_worker/progress.py
+++ b/src/gen_worker/progress.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 UNIT_BYTES = "bytes"
 UNIT_STEPS = "steps"
@@ -42,13 +42,28 @@ DEFAULT_STALL_WINDOW_S = 300.0
 _now = time.monotonic
 
 _lock = threading.Lock()
-_counters: Dict[str, "Counter"] = {}
+
+#: ``(owner, name) -> Counter``. pgw#894: the key used to be the NAME alone, so
+#: one process-global namespace held every phase's counters and `freshest()`
+#: returned whichever of them advanced most recently — regardless of which work
+#: it described. A serving request's `infer:steps` therefore refreshed a
+#: background mint's stall clock: measured on the standing chaos hub, 28 log
+#: lines reporting `infer:steps` under `self_mint_compile`, one of which
+#: declined a condemnation because that mint activity was "0s ago".
+#:
+#: The OWNER is the scope the counter belongs to (an activity id, a request
+#: id). Registry-wide queries still exist and still mean what they meant — "is
+#: this process doing anything at all" — but a scope's stall verdict is now
+#: computed from that scope's own counters.
+_counters: Dict[Tuple[str, str], "Counter"] = {}
 
 
 @dataclass(frozen=True)
 class Snapshot:
     name: str
     unit: str
+    #: The scope that owns this counter ("" = unowned/process-wide).
+    owner: str
     done: float
     total: float  # 0 = unknown
     rate_per_s: float
@@ -64,8 +79,10 @@ def window_for(name: str) -> float:
 class Counter:
     """One named monotonic counter; open until finish()."""
 
-    def __init__(self, name: str, unit: str, total: float = 0.0) -> None:
-        self.name, self.unit = name, unit
+    def __init__(
+        self, name: str, unit: str, total: float = 0.0, owner: str = "",
+    ) -> None:
+        self.name, self.unit, self.owner = name, unit, owner
         now = _now()
         self._done = 0.0
         self._total = max(0.0, float(total))
@@ -95,8 +112,8 @@ class Counter:
 
     def finish(self) -> None:
         with _lock:
-            if _counters.get(self.name) is self:
-                del _counters[self.name]
+            if _counters.get((self.owner, self.name)) is self:
+                del _counters[(self.owner, self.name)]
 
     def _snapshot_locked(self, now: float) -> Snapshot:
         dt = now - self._rate_t
@@ -104,63 +121,93 @@ class Counter:
             self._rate = max(0.0, (self._done - self._rate_v) / dt)
             self._rate_t, self._rate_v = now, self._done
         return Snapshot(
-            name=self.name, unit=self.unit, done=self._done, total=self._total,
+            name=self.name, unit=self.unit, owner=self.owner,
+            done=self._done, total=self._total,
             rate_per_s=self._rate, age_s=max(0.0, now - self._advanced),
             window_s=window_for(self.name), elapsed_s=max(0.0, now - self._started),
         )
 
 
-def counter(name: str, unit: str, total: float = 0.0) -> Counter:
-    """Register-or-get the open counter `name` (idempotent)."""
+def counter(
+    name: str, unit: str, total: float = 0.0, *, owner: str = "",
+) -> Counter:
+    """Register-or-get the open counter `name` within `owner` (idempotent).
+
+    ``owner`` scopes the counter to the work it describes (pgw#894). Two
+    scopes may use the same NAME — two concurrent requests both counting
+    ``infer:steps`` is the ordinary case — and neither can advance the
+    other's clock.
+    """
+    key = (owner, name)
     with _lock:
-        existing = _counters.get(name)
+        existing = _counters.get(key)
         if existing is not None:
             if total > 0:
                 existing._total = float(total)
             return existing
-        c = Counter(name, unit, total)
-        _counters[name] = c
+        c = Counter(name, unit, total, owner)
+        _counters[key] = c
         return c
 
 
 class tracking:
     """Context manager: register on enter, finish on exit."""
 
-    def __init__(self, name: str, unit: str, total: float = 0.0) -> None:
+    def __init__(
+        self, name: str, unit: str, total: float = 0.0, *, owner: str = "",
+    ) -> None:
         self._args = (name, unit, total)
+        self._owner = owner
 
     def __enter__(self) -> Counter:
-        self._counter = counter(*self._args)
+        self._counter = counter(*self._args, owner=self._owner)
         return self._counter
 
     def __exit__(self, *exc: object) -> None:
         self._counter.finish()
 
 
-def snapshot() -> List[Snapshot]:
+def snapshot(owner: Optional[str] = None) -> List[Snapshot]:
+    """Every open counter, or only ``owner``'s when one is named."""
     now = _now()
     with _lock:
-        return [c._snapshot_locked(now) for c in _counters.values()]
+        return [
+            c._snapshot_locked(now) for c in _counters.values()
+            if owner is None or c.owner == owner
+        ]
 
 
-def freshest() -> Optional[Snapshot]:
-    """The most recently advanced open counter — the liveness view. ANY
-    advancing counter proves the process is doing real work."""
-    snaps = snapshot()
+def freshest(owner: Optional[str] = None) -> Optional[Snapshot]:
+    """The most recently advanced open counter.
+
+    ``owner=None`` is the PROCESS liveness view and is unchanged: any
+    advancing counter proves the process is doing real work, which is exactly
+    what a "did this pod wedge" question wants.
+
+    ``owner="..."`` is the SCOPE view, and it is the one a stall verdict must
+    use (pgw#894). A mint asking "am I still advancing" must not be answered
+    by a request that happens to be running beside it.
+    """
+    snaps = snapshot(owner)
     return min(snaps, key=lambda s: s.age_s) if snaps else None
 
 
-def self_diagnosis() -> Optional[Snapshot]:
+def self_diagnosis(owner: Optional[str] = None) -> Optional[Snapshot]:
     """Non-None when even the FRESHEST open counter is stale past its own
     window — the typed self_stalled confession the beat reports so the hub
     kills on fact, not inference.
 
-    Registry-wide by design (any advancing counter proves the process is
-    alive), which is why counter LIFETIME has to be honest: a counter left
+    Scoped to ``owner`` when one is named, registry-wide otherwise. pgw#894:
+    registry-wide was the ONLY form, and it is the right answer to "is this
+    process alive" and the wrong one to "is this mint stalled" — a request
+    running beside a wedged mint answered for it. `Activity.on_beat` passes
+    the activity's own id.
+
+    Counter LIFETIME still has to be honest within a scope: a counter left
     open after its producer's phase ended is the min-age counter of a phase it
     knows nothing about, and confesses for it. `Activity.counter()` scopes
     them to the phase for that reason (pgw#962)."""
-    fresh = freshest()
+    fresh = freshest(owner)
     if fresh is not None and fresh.age_s > fresh.window_s:
         return fresh
     return None

--- a/src/gen_worker/progress.py
+++ b/src/gen_worker/progress.py
@@ -62,14 +62,17 @@ _counters: Dict[Tuple[str, str], "Counter"] = {}
 class Snapshot:
     name: str
     unit: str
-    #: The scope that owns this counter ("" = unowned/process-wide).
-    owner: str
     done: float
     total: float  # 0 = unknown
     rate_per_s: float
     age_s: float  # since last advance
     window_s: float
     elapsed_s: float
+    #: The scope that owns this counter ("" = unowned/process-wide). LAST and
+    #: defaulted on purpose: a Snapshot is constructed by hand in tests and by
+    #: readers that do not care whose counter it is, and a new field must be
+    #: additive rather than a positional break (pgw#894).
+    owner: str = ""
 
 
 def window_for(name: str) -> float:

--- a/tests/test_scoped_stall_clocks_pgw894.py
+++ b/tests/test_scoped_stall_clocks_pgw894.py
@@ -1,0 +1,288 @@
+"""pgw#894 — serving work could refresh a MINT's stall clock.
+
+Two process-globals met, and the meeting had no identity in it.
+`activity._current` is a singleton every `begin()` replaces; `progress._counters`
+was keyed by NAME alone, so `freshest()` returned whichever counter anywhere in
+the process advanced most recently. The 10 s beat then attached THAT counter to
+whatever activity happened to be current, and the hub advances an activity's
+`UpdatedAt` from a counter-name change or value increase
+(`worker_activity.go:323-338`) — which is the timestamp its stall and
+condemnation path reads.
+
+So a request's `infer:steps` deferred a background mint's stall verdict. The
+standing chaos hub's 8,398-line log carried 28 lines reporting `infer:steps`
+under `self_mint_compile`; at line 4534 a request was assigned to a worker, at
+4535 that worker reported `self_mint_compile/trace_graph infer:steps 779/?`
+two seconds later, and at 4542 the hub declined a condemnation because that
+mint activity was "0s ago".
+
+The fix is an OWNER on every counter and an owner-scoped stall question. What
+is deliberately NOT changed: registry-wide `freshest()` still exists and still
+means "is this process doing anything at all", which is the right answer to
+the liveness question the in-call stall loop and the drain ask. And the
+delegated child's own measured CPU/file watchdog is untouched — this is a
+re-scope, not a watchdog deletion.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import progress as progress_mod
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> Any:
+    progress_mod.reset()
+    yield
+    progress_mod.reset()
+
+
+@pytest.fixture()
+def clock(monkeypatch: pytest.MonkeyPatch) -> Dict[str, float]:
+    t = {"t": 0.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: t["t"])
+    return t
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+def test_two_scopes_may_hold_the_same_counter_name() -> None:
+    """Two concurrent requests both counting `infer:steps` is the ordinary
+    case, and a name-keyed registry made them one counter."""
+    a = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS, owner="req-a")
+    b = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS, owner="req-b")
+    assert a is not b
+    a.add(5)
+    by_owner = {s.owner: s.done for s in progress_mod.snapshot()}
+    assert by_owner == {"req-a": 5.0, "req-b": 0.0}
+
+
+def test_a_scope_sees_only_its_own_counters(clock: Dict[str, float]) -> None:
+    mint = progress_mod.counter("compile:evidence", progress_mod.UNIT_EVIDENCE,
+                                owner="mint")
+    req = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS,
+                               owner="request:r1")
+    mint.add(1)
+    clock["t"] += 100.0
+    req.add(1)
+
+    assert progress_mod.freshest("request:r1").name == "infer:steps"
+    assert progress_mod.freshest("mint").name == "compile:evidence"
+    # Registry-wide is unchanged and still answers the PROCESS question.
+    assert progress_mod.freshest().name == "infer:steps"
+
+
+def test_a_stalled_scope_is_diagnosed_while_the_process_is_busy(
+    clock: Dict[str, float],
+) -> None:
+    """The headline, at the registry layer: the mint is frozen, the request is
+    moving, and the mint must still read as stalled."""
+    progress_mod.counter("compile:evidence", progress_mod.UNIT_EVIDENCE,
+                         owner="mint").add(1)
+    req = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS,
+                               owner="request:r1")
+    # Past `STALL_WINDOW_S["compile"]` (600 s), with the request advancing.
+    for _ in range(10):
+        clock["t"] += 100.0
+        req.add(1)
+
+    assert progress_mod.self_diagnosis("mint") is not None, (
+        "a frozen mint reads as healthy because a request is moving beside it")
+    assert progress_mod.self_diagnosis("request:r1") is None
+    # And the process is, correctly, not stalled.
+    assert progress_mod.self_diagnosis() is None
+
+
+def test_finishing_one_scope_leaves_the_other(clock: Dict[str, float]) -> None:
+    a = progress_mod.counter("x", "steps", owner="a")
+    progress_mod.counter("x", "steps", owner="b")
+    a.finish()
+    assert {s.owner for s in progress_mod.snapshot()} == {"b"}
+
+
+# ---------------------------------------------------------------------------
+# The activity beat
+# ---------------------------------------------------------------------------
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.updates: List[Any] = []
+
+    def __call__(self, update: Any) -> None:
+        self.updates.append(update)
+
+
+@pytest.fixture()
+def sink(monkeypatch: pytest.MonkeyPatch) -> _Sink:
+    s = _Sink()
+    monkeypatch.setattr(activity_mod, "_sink", s)
+    return s
+
+
+def test_an_activity_has_its_own_scope() -> None:
+    a = activity_mod.Activity("self_mint_compile")
+    b = activity_mod.Activity("self_mint_compile")
+    assert a.id != b.id and a.kind in a.id
+
+
+def test_the_beat_reports_the_activitys_own_counter(
+    clock: Dict[str, float], sink: _Sink, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED: the beat attached `progress.freshest()` — the min-age counter
+    ANYWHERE in the process — to whatever activity was current, so a request
+    counter was reported under `self_mint_compile` and refreshed the hub's
+    stall clock for it."""
+    mint = activity_mod.begin("self_mint_compile", "trace_graph")
+    mint.counter("compile:evidence", progress_mod.UNIT_EVIDENCE).add(1)
+
+    # Unrelated serving work, advancing, in its own scope.
+    req = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS,
+                               owner="request:c8100857")
+    clock["t"] += 5.0
+    req.add(779)
+
+    sink.updates.clear()
+    activity_mod.on_beat()
+    assert len(sink.updates) == 1
+    beat = sink.updates[0]
+    assert beat.kind == "self_mint_compile"
+    assert beat.counter == "compile:evidence", (
+        f"the mint's beat carried {beat.counter!r} — a counter it is not "
+        "producing; the hub advances UpdatedAt from exactly this field")
+    mint.completed()
+
+
+def test_a_frozen_mint_confesses_while_a_request_runs(
+    clock: Dict[str, float], sink: _Sink,
+) -> None:
+    """The end-to-end shape of the observable: mint frozen past its window,
+    request and download both moving, and the beat must still say
+    `self_stalled`. Before this, `self_diagnosis()` was registry-wide and the
+    moving counters answered for the mint."""
+    mint = activity_mod.begin("self_mint_compile", "trace_graph")
+    mint.counter("compile:evidence", progress_mod.UNIT_EVIDENCE).add(1)
+
+    req = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS,
+                               owner="request:r1")
+    dl = progress_mod.counter("download:m", progress_mod.UNIT_BYTES,
+                              owner="request:r1")
+    for _ in range(10):
+        clock["t"] += 100.0   # 1000 s total, past the 600 s compile window
+        req.add(1)
+        dl.add(1 << 20)
+
+    sink.updates.clear()
+    activity_mod.on_beat()
+    beat = sink.updates[0]
+    assert beat.self_stalled is True, (
+        "the mint reported healthy because a request was moving beside it")
+    assert beat.counter == "compile:evidence"
+    mint.completed()
+
+
+def test_an_activity_that_really_is_advancing_does_not_confess(
+    clock: Dict[str, float], sink: _Sink,
+) -> None:
+    mint = activity_mod.begin("self_mint_compile", "trace_graph")
+    c = mint.counter("compile:evidence", progress_mod.UNIT_EVIDENCE)
+    for _ in range(10):
+        clock["t"] += 100.0
+        c.add(1)
+    sink.updates.clear()
+    activity_mod.on_beat()
+    assert sink.updates[0].self_stalled is False
+    mint.completed()
+
+
+def test_an_activity_with_no_counters_beats_nothing(
+    clock: Dict[str, float], sink: _Sink,
+) -> None:
+    """A scope with no producer says nothing rather than borrowing somebody
+    else's number — which is what the old registry-wide lookup did."""
+    mint = activity_mod.begin("self_mint_compile", "trace_graph")
+    progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS,
+                         owner="request:r1").add(1)
+    sink.updates.clear()
+    activity_mod.on_beat()
+    assert sink.updates == []
+    mint.completed()
+
+
+def test_phase_scoped_lifetime_still_holds(clock: Dict[str, float]) -> None:
+    """pgw#962 is not undone by pgw#894: a counter is still closed when the
+    phase that registered it ends."""
+    act = activity_mod.begin("self_mint_compile", "load")
+    act.counter("load:bytes", progress_mod.UNIT_BYTES).add(1)
+    assert progress_mod.freshest(act.id) is not None
+    act.phase("inductor_compile")
+    assert progress_mod.freshest(act.id) is None
+    act.completed()
+
+
+# ---------------------------------------------------------------------------
+# The producers
+# ---------------------------------------------------------------------------
+
+
+def test_the_request_emitter_owns_its_own_counter() -> None:
+    """`_make_ctx_emitter` used to do
+    `activity.current().counter("infer:steps", ...)`, which on a pod running a
+    background mint credits the MINT. It now registers under the request."""
+    import inspect
+
+    from gen_worker.executor import Executor
+
+    src = inspect.getsource(Executor._make_ctx_emitter)
+    assert 'owner=f"request:{job.request_id}"' in src
+    code = "\n".join(
+        line for line in src.splitlines() if not line.strip().startswith("#"))
+    assert "activity_mod.current()" not in code, (
+        "the request emitter reaches for the current activity again")
+
+
+def test_scoped_counter_prefers_the_open_activity(clock: Dict[str, float]) -> None:
+    """A download or a load belongs to the phase that asked for it."""
+    act = activity_mod.begin("self_mint_compile", "load")
+    c = activity_mod.scoped_counter("download:x", progress_mod.UNIT_BYTES)
+    assert c.owner == act.id
+    act.completed()
+
+
+def test_scoped_counter_still_works_with_no_activity() -> None:
+    """Library and CLI use has no activity at all, and must not start needing
+    one."""
+    assert activity_mod.current() is None
+    assert activity_mod.scoped_counter("download:x", progress_mod.UNIT_BYTES).owner == ""
+
+
+def test_the_request_counter_dies_with_the_request() -> None:
+    """pgw#962's rule, applied to the new scope: a counter left open after its
+    producer stopped is the min-age counter of work nobody is doing."""
+    import inspect
+
+    from gen_worker.executor import Executor
+
+    src = inspect.getsource(Executor._finish)
+    assert 'owner=f"request:{job.request_id}"' in src and ".finish()" in src
+
+
+def test_the_in_process_liveness_view_is_deliberately_unscoped() -> None:
+    """The in-call stall loop and the drain ask "is this process wedged", and
+    registry-wide is the right answer to that. Pinned so a later sweep does
+    not "finish the job" by scoping them too — that would make a request wait
+    on its own counter, which many handlers never register."""
+    import inspect
+
+    from gen_worker.executor import Executor
+
+    src = inspect.getsource(Executor._await_handler) if hasattr(
+        Executor, "_await_handler") else inspect.getsource(Executor)
+    assert "progress_mod.self_diagnosis()" in src


### PR DESCRIPTION
Two process-globals met, and the meeting had no identity in it.

`activity._current` is a singleton every `begin()` replaces. `progress._counters` was keyed by counter **name alone**, so `freshest()` returned whichever counter *anywhere in the process* advanced most recently. The 10 s beat attached that counter to whatever activity happened to be current — and the hub advances an activity's `UpdatedAt` from a counter-name change or value increase (`worker_activity.go:323-338`), which is the timestamp its stall and condemnation path reads.

**The observable, from the standing chaos hub's 8,398-line log** — 28 lines reporting `infer:steps` under `self_mint_compile`:

| line | event |
|---|---|
| 4534 | request `c8100857-…` assigned to worker `…ba747d…` |
| 4535 | that worker reported as `self_mint_compile/trace_graph infer:steps 779/?` — two seconds later |
| 4542 | condemnation **declined**: that mint activity was "0s ago" and still progressing |

## What shipped

- **`progress` is keyed `(owner, name)`.** Two concurrent requests can both count `infer:steps` without being one counter — which the old registry made impossible, and which is the ordinary case. `snapshot`/`freshest`/`self_diagnosis` take an optional `owner`.
- **`Activity` gets a process-local `id`.** *Not on the wire* — the hub still identifies an activity by kind and phase, so this costs no protocol change. What it buys is that the number the beat **carries** describes the activity carrying it.
- **The request emitter owns its own counter** (`request:<id>`) instead of crediting `activity.current()`, and `_finish` closes it — pgw#962's lifetime rule applied to the new scope. The old comment justified the credit with *"warmup forwards run GPU-bound with a quiet CPU"*; warmup does not reach that emitter (it builds its context through `warmup.warm_context`, which passes no emitter at all, and reports its own activity-owned `warmup:jobs`).
- **Downloads and weight loads** go through a new `activity.scoped_counter`, crediting the phase that asked for them, with an unowned fallback for library/CLI use.

## Deliberately unchanged, and pinned by tests

- Registry-wide `freshest()` / `self_diagnosis()` still mean *"is this process doing anything at all"* — the right answer for the in-call stall loop and the drain. Many handlers register no counter; scoping those would make a request wait on a counter nobody feeds.
- The delegated child's own measured CPU/file watchdog is untouched. **This is a re-scope, not a watchdog deletion** — `_on_evidence` and the child observer have 215 live hub log lines behind them.

## RED evidence

`tests/test_scoped_stall_clocks_pgw894.py` run unchanged against `master`: **13 failed, 2 passed**, including both headlines —

- `test_a_stalled_scope_is_diagnosed_while_the_process_is_busy` (a frozen mint reads healthy because a request moves beside it)
- `test_a_frozen_mint_confesses_while_a_request_runs` (the beat's `self_stalled` never fires)

On this branch: **15 passed**.

## Scope

Three acceptance boxes remain open on the issue — they are hub-side, or need concurrent activity scopes (the `ActivityScope` object and a wire `activity_id`). The issue stays in `progress.md` with what landed named.

## Gates

mypy clean (254 files) · ruff clean · seven fast-gate lint guards green · 32 passed across the new file plus `test_progress_gw621` and `test_activity_gw601`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq