### PR TITLE
pgw#887 + pgw#892: three flat wall clocks that ended real work — a drain, and both group-formation bounds

### DIFF
--- a/changelog.d/pgw887.md
+++ b/changelog.d/pgw887.md
@@ -1,0 +1,38 @@
+- **pgw#887: a drain no longer aborts work that is still advancing.**
+  `_finish_drain` waited `wait_idle(timeout=deadline)` and then called
+  `abort_all()` — at 30 s on SIGTERM, or at the hub's 60 s cluster window,
+  which is what BOTH standing stacks actually run
+  (`TENSORHUB_SHUTDOWN_MODE=cluster`, measured off both live hub processes).
+  Nothing consulted progress: a render at step 30/50 and one at step 1/50
+  were aborted identically, and a MINT — which has no partial result to
+  requeue — was abandoned outright (`self_mint_abort`: 52 rows on chaos, 64 on
+  master; `forge.py` recorded one verbatim, "attempt sixteen ran 29 minutes
+  and died `self_mint_abort/abandoned_shutdown`"). The tenant wait is now
+  keyed on `progress.self_diagnosis()`, the silence-per-phase predicate the
+  10 s beat already reports and the hub already kills on. The deadline still
+  bounds the FLUSH and the shutdown the worker reports to the hub — a drain is
+  a command, and a command may carry a deadline; the work underneath may not.
+
+- **pgw#892: the two group-formation bounds stopped condemning cold loads.**
+  `wait_armed` raised "followers not armed after 1800s" over what its own
+  comment calls "a follower's full pipeline materialization (a cold model
+  load)", against a first self-mint measured at ~28 min and an sdxl projection
+  of 47 min - 6.26 h; `_await_arrivals` failed the group at 180 s over a
+  follower that may still be in a cold `import torch`. `check_alive()` already
+  failed a DEAD follower typed and immediately, so both durations added
+  nothing death detection did not give and subtracted every legitimately slow
+  load. Both are now `stall.SilenceWindow` over
+  `proc_evidence.tree_evidence` — the follower's own kernel-accounted CPU and
+  I/O, which needs no cooperation from a process that has no protocol between
+  spawn and ready, so the replacement signal has a real producer. That
+  primitive is extracted from `procsplit.parent._child_evidence`, which was
+  already exactly it; there is now one implementation.
+  `_RENDEZVOUS_TIMEOUT_S`'s other use — the TCPStore's socket connect — is
+  named `_STORE_CONNECT_TIMEOUT_S` and stays, as does the follower's wait for
+  rank 0's first command; both bound a peer, not work.
+
+  `procsplit/parent._MEASURE_TIMEOUT_S` is **not** changed: pgw#973 wave 3
+  gave it an argued §4.24 exemption in the code (the canary reports through
+  one `communicate()` at the end, so there is no progress signal to key on,
+  and giving up ships the Hello without parent-measured resources rather than
+  killing anything). Recorded here so the next sweep does not re-file it.

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -17,6 +17,7 @@ from . import boot_phases as boot_mod
 from . import content_credentials
 from . import receipts
 from . import mint_goal as mint_goal_mod
+from . import progress as progress_mod
 from . import worker_goals
 from .config import Settings
 from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
@@ -38,6 +39,12 @@ from .topology import delivered_topology
 logger = logging.getLogger(__name__)
 
 _VRAM_QUANTUM_FRACTION = 0.05  # quantize free-VRAM deltas to 5% of total
+
+# pgw#887: how often the drain re-asks the progress registry while it waits
+# for in-flight work. A CADENCE, not a verdict — it bounds latency-to-notice
+# and can never end anything; the give-up test is `progress.self_diagnosis()`,
+# which is silence-keyed and per-phase.
+_DRAIN_PROGRESS_POLL_S = 1.0
 
 # gw#591 boot-setup watcher: poll cadence for hub-delivered snapshots of
 # functions the startup scan left awaiting (store lookups are local + cheap).
@@ -304,6 +311,7 @@ class Lifecycle:
         self._disk_report_at = 0.0
         self._disk_report_refresh_task: Optional[asyncio.Task] = None
         self._drain_deadline_at: Optional[float] = None
+        self._drain_work_deadline_at: Optional[float] = None
         self._desired_residency: Optional[pb.DesiredResidency] = None
         self._residency_task: Optional[asyncio.Task] = None
         self._observed_residency_generation = 0
@@ -1025,7 +1033,10 @@ class Lifecycle:
                 "adoption is gone; a cell arrives only as a Plan's exact "
                 "Arm.artifact (pgw#904) — the hub never pushes one")
         elif which == "drain":
-            self.start_drain(int(msg.drain.deadline_ms or 0))
+            # The hub asked, explicitly, for this budget on this drain — an
+            # operator budget on a command, which pgw#887 keeps.
+            self.start_drain(
+                int(msg.drain.deadline_ms or 0), work_deadline=True)
         elif which is None:
             raise FatalTransportError("scheduler sent an unknown mandatory command")
         else:
@@ -1471,22 +1482,27 @@ class Lifecycle:
 
     # ---- drain -------------------------------------------------------------------
 
-    def start_drain(self, deadline_ms: int) -> None:
+    def start_drain(self, deadline_ms: int, *, work_deadline: bool = False) -> None:
         if self.draining:
             return
-        self._begin_drain(deadline_ms)
+        self._begin_drain(deadline_ms, work_deadline=work_deadline)
         self._drain_task = asyncio.create_task(self._finish_drain(), name="drain")
 
-    async def drain(self, deadline_ms: int = 0) -> None:
+    async def drain(self, deadline_ms: int = 0, *, work_deadline: bool = True) -> None:
         """stop admitting -> finish in-flight -> ship buffered results ->
         close the stream -> signal exit 0. Zero waits without a cutoff."""
         if self.draining:
             return
-        self._begin_drain(deadline_ms)
+        self._begin_drain(deadline_ms, work_deadline=work_deadline)
         await self._finish_drain()
 
-    def _begin_drain(self, deadline_ms: int) -> None:
-        """Synchronously stop admission and anchor the deadline at receipt."""
+    def _begin_drain(self, deadline_ms: int, *, work_deadline: bool = False) -> None:
+        """Synchronously stop admission and anchor the deadline(s) at receipt.
+
+        ``work_deadline`` says whether the caller's budget may bound TENANT
+        WORK as well as the shutdown around it — true only for a `Drain` that
+        arrived on the wire carrying one (pgw#887).
+        """
         self.draining = True
         self.executor.draining = True
         self._cancel_residency_reconcile()
@@ -1498,10 +1514,98 @@ class Lifecycle:
         deadline_s = (deadline_ms / 1000.0) if deadline_ms > 0 else None
         loop = asyncio.get_running_loop()
         self._drain_deadline_at = loop.time() + deadline_s if deadline_s is not None else None
+        # pgw#887: two deadlines, because they bound two different things and
+        # collapsing them is the defect. `_drain_deadline_at` bounds the
+        # SHUTDOWN — the result flush (pgw#845) and the stop time this worker
+        # reports to the hub — and every drain has one. `_drain_work_deadline_at`
+        # bounds the TENANT WORK, and only a caller that explicitly asked for
+        # one gets it: a `Drain` carrying `deadline_ms` is an operator budget
+        # on a command (th#1235), while the SIGTERM handler's fleet default is
+        # exactly what abandoned a 29-minute mint as `abandoned_shutdown`.
+        self._drain_work_deadline_at = (
+            self._drain_deadline_at if work_deadline else None)
         self.intent_registry.set_drain(
             pb.DRAIN_LIFECYCLE_STATUS_DRAINING,
             deadline_at_unix_ms=(int(time.time() * 1000) + deadline_ms if deadline_ms > 0 else 0),
         )
+
+    async def _await_tenant_idle(self) -> bool:
+        """True when every in-flight job finished; False when the work STOPPED
+        ADVANCING (or an EXPLICIT operator budget ran out) and the drain gave
+        up on the remainder.
+
+        pgw#887 / gw#666 / DESIGN-RULINGS §2. This was
+        ``wait_idle(timeout=deadline_at - now)``, so at 30 s (SIGTERM) or 60 s
+        (the hub's cluster drain, which is what BOTH standing stacks run) the
+        drain logged "drain deadline expired" and called ``abort_all()``.
+        Nothing consulted progress: a render at step 30/50 and a render at
+        step 1/50 were aborted identically, and a MINT — which has no partial
+        result to requeue — was abandoned outright. ``self_mint_abort`` has 52
+        rows on chaos and 64 on master; ``forge.py:14`` recorded one verbatim:
+        *"attempt sixteen ran 29 minutes and died
+        ``self_mint_abort/abandoned_shutdown``"*.
+
+        A drain is a COMMAND, so a deadline on it is legitimate — but the
+        deadline must bound acknowledgement and shutdown, not the tenant work
+        underneath. Admission already stopped in ``_begin_drain``; what ends
+        this wait is the work ceasing to advance, which
+        ``progress.self_diagnosis()`` already answers and the 10 s beat
+        already reports to the hub. Nothing new is invented here.
+
+        What stayed, and why. A ``Drain`` that arrives on the wire carrying
+        ``deadline_ms`` IS the "explicit operator budget on a specific command"
+        the ruling allows (th#1235) — the caller chose it, for this drain. What
+        is deleted is the worker INVENTING one: the SIGTERM handler's
+        `_SIGNAL_DRAIN_DEADLINE_MS` is no longer a work budget, so a pod
+        stopping on a signal no longer abandons a mint at 30 s. The hub's own
+        60 s cluster window is a hub-side default and is routed to tensorhub
+        rather than reinterpreted here. Even under an explicit budget the
+        progress test still applies and fires FIRST: a wedged job is given up
+        on when it wedges, not when the clock happens to run out.
+
+        Two properties worth stating because they are deliberate:
+
+        * **No counters open at all is NOT a stall.** It is the same "keep
+          waiting" the in-call stall loop takes (``executor``'s
+          ``_STALL_POLL_S`` arm: *"advancing (or evidence-free): keep
+          waiting"*), and the outer authority — the hub's terminate, or the
+          container runtime's SIGKILL — is what bounds the pathological case.
+          The worker's job is to not throw away work that was about to finish.
+        * ``self_diagnosis()`` is registry-wide, so a background mint's
+          advancing counter can currently defer this verdict for a wedged
+          tenant job. That cross-talk is pgw#894's, is named there, and is
+          strictly better than the wall clock this replaces.
+        """
+        loop = asyncio.get_running_loop()
+        budget_at = self._drain_work_deadline_at
+        idle = asyncio.ensure_future(self.executor.wait_idle())
+        try:
+            while True:
+                poll = _DRAIN_PROGRESS_POLL_S
+                if budget_at is not None:
+                    remaining = budget_at - loop.time()
+                    if remaining <= 0:
+                        logger.warning(
+                            "drain: the caller's explicit deadline_ms budget "
+                            "ran out with work still in flight")
+                        return False
+                    poll = min(poll, remaining)
+                try:
+                    await asyncio.wait_for(asyncio.shield(idle), poll)
+                    return True
+                except asyncio.TimeoutError:
+                    stalled = progress_mod.self_diagnosis()
+                    if stalled is None:
+                        continue
+                    logger.warning(
+                        "drain: counter %r (%s) has not advanced for %.0fs "
+                        "(window %.0fs) — the remaining work is not making "
+                        "progress", stalled.name, stalled.unit,
+                        stalled.age_s, stalled.window_s)
+                    return False
+        finally:
+            if not idle.done():
+                idle.cancel()
 
     async def _finish_drain(self) -> None:
         deadline_at = self._drain_deadline_at
@@ -1509,17 +1613,18 @@ class Lifecycle:
         await self.maybe_send_state_delta()
         drain_intent = self.intent_registry.intent_id(pb.DESIRED_INTENT_KIND_DRAIN)
         try:
-            wait_timeout = None if deadline_at is None else max(0.0, deadline_at - loop.time())
             finished = await self.intent_registry.reported_await(
                 drain_intent,
-                self.executor.wait_idle(timeout=wait_timeout),
+                self._await_tenant_idle(),
                 operation="drain tenant-idle wait",
                 status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
                 stage=pb.LIFECYCLE_INTENT_STAGE_DRAINING,
                 reason=pb.LIFECYCLE_WAIT_REASON_TENANT_WORK,
             )
             if not finished:
-                logger.warning("drain deadline expired; aborting remaining jobs as RETRYABLE")
+                logger.warning(
+                    "in-flight work stopped advancing during drain; aborting "
+                    "the remainder as RETRYABLE")
                 await self.intent_registry.guard_await(
                     drain_intent,
                     self.executor.abort_all(safe_message="worker draining"),

--- a/src/gen_worker/parallel/group.py
+++ b/src/gen_worker/parallel/group.py
@@ -51,25 +51,58 @@ from datetime import timedelta
 from typing import Any, Callable, List, Optional, Sequence, Tuple, cast
 import multiprocessing as mp
 
-from .. import settings_authority
+from .. import proc_evidence, settings_authority
+from ..stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
 
-# A follower that has not reached the store rendezvous by this deadline is
-# dead weight: the group cannot form and the request must fail loudly rather
-# than park on a rendezvous that will never complete. A constant, not an env
-# knob (DPA-22: the old GEN_WORKER_SP_RENDEZVOUS_S changed nothing and is
-# gone).
-_RENDEZVOUS_TIMEOUT_S = 180.0
+# pgw#892 / gw#666 / §4.24. Both group-formation bounds below used to be flat
+# WALL CLOCKS that condemned WORK: 180 s for a follower to reach the store
+# rendezvous and 1800 s for it to finish arming, where arming "covers a
+# follower's full pipeline materialization (a cold model load)". The first
+# self-mint measured ~28 min (ie#546) and pgw#846 projects 47 min - 6.26 h for
+# sdxl, so `_ARM_TIMEOUT_S` was a mint-killer of exactly the shape
+# `runtimes/server.py` already rejects by name — and a follower wedged in a
+# cold `import torch` at 181 s failed the group under the other one.
+#
+# What actually distinguishes a wedged follower from a slow one is whether it
+# is still doing work, and `check_alive()` already covers the DEAD case
+# typed-and-immediately. So both are now SILENCE windows over
+# `proc_evidence.tree_evidence` — the follower's own kernel-accounted CPU and
+# I/O, which needs no cooperation from a process that has no protocol between
+# spawn and ready. A follower that keeps advancing runs as long as its work
+# does; one that stops advancing is condemned by name, at any elapsed time.
+#
+# The window is a statement about the CHANNEL, not a budget for the job: how
+# long a materializing process may plausibly show neither a CPU tick nor a
+# byte. Sized at 4x `progress.STALL_WINDOW_S["load"]` (240 s), the window the
+# in-process load phase is already judged by, because /proc sampling is
+# coarser and a follower that is genuinely blocked on a slow remote read shows
+# nothing until the read returns.
+_STAGING_SILENCE_WINDOW_S = 4.0 * 240.0
+
+# How often the two loops re-ask. A cadence, never a verdict: it bounds
+# latency-to-notice, and lengthening it cannot condemn anything.
+_STAGING_POLL_S = 1.0
 
 # Ceiling on any single in-call collective wait: legitimate skew between
 # ranks executing the same denoise step is seconds; a peer that raised (or
 # died) mid-call leaves this as the unwedging mechanism.
 _COLLECTIVE_TIMEOUT_S = 300.0
 
-# Arming covers a follower's full pipeline materialization (a cold model
-# load), so its budget is the staging budget, not the collective one.
-_ARM_TIMEOUT_S = 1800.0
+# A follower's wait for rank 0's FIRST command. Rank 0 sends `arm` within
+# milliseconds of `form()` returning, so this bounds nothing anyone does; the
+# threat it names is a follower parked forever because rank 0 died in a way
+# `_die_with_rank0`'s PR_SET_PDEATHSIG could not cover (non-Linux hosts, and
+# the pre-prctl spawn window). It bounds a WAIT ON A PEER, never work.
+_FIRST_COMMAND_WAIT_S = 1800.0
+
+# The TCPStore's own socket-connect budget. This bounds a CONNECT to a
+# localhost port whose listener already exists (rank 0 owns the master socket
+# before any follower spawns), so it either succeeds in milliseconds or the
+# port is wrong — it can never be the thing a slow load runs out of, and it
+# is not the store-arrival wait, which is `_await_arrivals` above.
+_STORE_CONNECT_TIMEOUT_S = 180.0
 
 _OP_RUN = "run"
 _OP_CLOSE = "close"
@@ -221,7 +254,7 @@ def init_rank(spec: RankSpec, store: Any = None) -> Any:
             spec.master_port,
             spec.world_size,
             is_master=False,
-            timeout=timedelta(seconds=_RENDEZVOUS_TIMEOUT_S),
+            timeout=timedelta(seconds=_STORE_CONNECT_TIMEOUT_S),
         )
         # Announce arrival BEFORE the backend rendezvous, so rank 0 knows
         # this rank is real and about to join.
@@ -317,6 +350,8 @@ class RankGroup:
         self._entry = entry
         self._collective_timeout_s = float(collective_timeout_s)
         self._procs: List[Any] = []
+        #: pid -> high-water evidence mark (pgw#892).
+        self._staging_peaks: dict[int, float] = {}
         self._channels: List[FollowerChannel] = []
         self._error_q: Any = None
         self._ready_q: Any = None
@@ -361,7 +396,7 @@ class RankGroup:
             0,
             self.degree,
             is_master=True,
-            timeout=timedelta(seconds=_RENDEZVOUS_TIMEOUT_S),
+            timeout=timedelta(seconds=_STORE_CONNECT_TIMEOUT_S),
             wait_for_workers=False,
         )
         port = int(self._store.port)
@@ -416,21 +451,25 @@ class RankGroup:
         TYPED failure that names the dead rank.
         """
         keys = [arrive_key(s) for s in specs[1:]]
-        deadline = time.monotonic() + _RENDEZVOUS_TIMEOUT_S
+        silence = self._staging_silence()
         while True:
             self.check_alive()
             if self._store.check(keys):
                 return
-            if time.monotonic() >= deadline:
+            if self._followers_advanced():
+                silence.touch()
+            elif silence.stalled():
                 missing = [
                     s.rank for s in specs[1:]
                     if not self._store.check([arrive_key(s)])
                 ]
                 raise RankGroupError(
-                    f"followers {missing} never reached the rendezvous within "
-                    f"{_RENDEZVOUS_TIMEOUT_S:.0f}s — the group cannot form"
+                    f"followers {missing} have not reached the rendezvous and "
+                    f"have shown no CPU or I/O for {silence.silent_for():.0f}s "
+                    f"— the group cannot form. A follower still importing torch "
+                    f"is not condemned by this; one that stopped working is."
                 )
-            time.sleep(0.05)
+            time.sleep(_STAGING_POLL_S)
 
     # ---- command plane (never a collective) --------------------------------
 
@@ -453,26 +492,69 @@ class RankGroup:
         for channel in self._channels:
             channel.commands.put(raw)
 
-    def wait_armed(self, timeout_s: float = _ARM_TIMEOUT_S) -> None:
+    def _staging_silence(self) -> SilenceWindow:
+        """A fresh silence window over follower work, with the high-water
+        marks it compares against reset (pgw#892)."""
+        self._staging_peaks = {}
+        return SilenceWindow(_STAGING_SILENCE_WINDOW_S)
+
+    def _followers_advanced(self) -> bool:
+        """Whether ANY follower's process tree has done measurable work since
+        the last sample.
+
+        High-water marks, not deltas: a descendant's CPU migrates into its
+        parent's ``cutime``/``cstime`` on reap, so a live-only sum falls when
+        a subprocess finishes. A follower whose evidence cannot be read at all
+        contributes nothing here and is left to ``check_alive()``, which is
+        the honest split — an unreadable process is not a stalled one, and it
+        is not this method's job to condemn it.
+        """
+        advanced = False
+        for proc in self._procs:
+            pid = int(getattr(proc, "pid", 0) or 0)
+            if pid <= 0:
+                continue
+            evidence = proc_evidence.tree_evidence(pid)
+            if evidence is None:
+                continue
+            if evidence > self._staging_peaks.get(pid, -1.0):
+                self._staging_peaks[pid] = evidence
+                advanced = True
+        return advanced
+
+    def wait_armed(self) -> None:
         """Block until every follower reported ready, failing loudly on a
-        dead or overdue follower. Queue-based — never a collective, so a
-        follower that dies mid-materialization cannot park us."""
+        dead or SILENT follower. Queue-based — never a collective, so a
+        follower that dies mid-materialization cannot park us.
+
+        pgw#892: this took a `timeout_s=1800.0` and raised "followers not
+        armed after 1800s" at 30:01 for a follower that was still legitimately
+        loading. `check_alive()` already fails a DEAD follower typed and
+        immediately, so the duration added nothing death detection did not
+        give and subtracted every slow cold load.
+        """
         if self.degree == 1:
             return
-        deadline = time.monotonic() + float(timeout_s)
         ready: set = set()
+        silence = self._staging_silence()
         while len(ready) < self.degree - 1:
             self.check_alive()
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise RankGroupError(
-                    f"followers not armed after {timeout_s:.0f}s "
-                    f"(ready={sorted(ready)} of ranks 1..{self.degree - 1})"
-                )
             try:
-                ready.add(int(self._ready_q.get(timeout=min(1.0, remaining))))
-            except queue_mod.Empty:
+                ready.add(int(self._ready_q.get(timeout=_STAGING_POLL_S)))
+                silence.touch()
                 continue
+            except queue_mod.Empty:
+                pass
+            if self._followers_advanced():
+                silence.touch()
+            elif silence.stalled():
+                raise RankGroupError(
+                    f"followers have shown no CPU or I/O for "
+                    f"{silence.silent_for():.0f}s while arming "
+                    f"(ready={sorted(ready)} of ranks 1..{self.degree - 1}) — "
+                    f"a cold materialization that is still working is not "
+                    f"condemned by this"
+                )
 
     def check_alive(self) -> None:
         """A dead follower must fail the request LOUDLY and immediately —

--- a/src/gen_worker/parallel/runtime.py
+++ b/src/gen_worker/parallel/runtime.py
@@ -52,7 +52,7 @@ from .group import (
     RankGroup,
     RankGroupError,
     RankSpec,
-    _ARM_TIMEOUT_S,
+    _FIRST_COMMAND_WAIT_S,
     _OP_CLOSE,
     _OP_RUN,
     init_rank,
@@ -199,7 +199,7 @@ def sequence_rank_main(spec: RankSpec, channel: FollowerChannel) -> None:  # pra
     if spec.backend == "nccl":
         torch.cuda.set_device(spec.device)
 
-    first = channel.next_command(timeout=_ARM_TIMEOUT_S)
+    first = channel.next_command(timeout=_FIRST_COMMAND_WAIT_S)
     if not isinstance(first, dict) or first.get("op") != "arm":
         raise RankGroupError(
             f"rank {spec.rank}: expected the arm command first, got {first!r}")
@@ -287,7 +287,6 @@ class SequenceRuntime:
         self, devices: Tuple[int, ...], *, entry: Optional[Any] = None,
         backend: str = "nccl",
         collective_timeout_s: Optional[float] = None,
-        arm_timeout_s: float = _ARM_TIMEOUT_S,
     ) -> None:
         self.devices = tuple(int(d) for d in devices)
         self.degree = len(self.devices)
@@ -298,7 +297,6 @@ class SequenceRuntime:
         self._entry = entry or sequence_rank_main
         self._backend = backend
         self._collective_timeout_s = collective_timeout_s
-        self._arm_timeout_s = float(arm_timeout_s)
         self._group: Optional[RankGroup] = None
         self._pipe: Any = None
         self._armed = False
@@ -348,7 +346,7 @@ class SequenceRuntime:
             # Queue-based readiness: a follower still materializing its
             # pipeline parks nobody on a collective, and one that died is a
             # loud typed failure here.
-            self._group.wait_armed(self._arm_timeout_s)
+            self._group.wait_armed()
         except BaseException:
             group, self._group = self._group, None
             if group is not None:

--- a/src/gen_worker/proc_evidence.py
+++ b/src/gen_worker/proc_evidence.py
@@ -1,0 +1,69 @@
+"""Kernel-accounted evidence that another process is doing real work.
+
+The producer every progress-keyed bound over a LOCAL child is built from
+(gw#666, §4.24): a monotonic number that rises while a process tree burns CPU
+or moves bytes, and stops rising the moment it wedges. It needs no cooperation
+from the process being watched, which is what makes it usable against a
+follower that has no protocol of its own between spawn and ready.
+
+One implementation, because the two callers had drifted into being one:
+``procsplit.parent`` grew this to watch a compute child and
+``parallel.group`` needed exactly it to replace two flat wall clocks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+__all__ = ["tree_evidence"]
+
+
+def _cpu_seconds(proc: Any) -> float:
+    t = proc.cpu_times()
+    return (
+        float(t.user) + float(t.system)
+        + float(getattr(t, "children_user", 0.0) or 0.0)
+        + float(getattr(t, "children_system", 0.0) or 0.0)
+    )
+
+
+def tree_evidence(pid: int) -> Optional[float]:
+    """This process tree's kernel-accounted work, or ``None`` when it cannot
+    be read at all.
+
+    CPU seconds for the WHOLE tree — live AND already-reaped descendants
+    (pgw#964) — plus process disk I/O MB, the same combination
+    ``activity._default_evidence`` trusts, measured from ``/proc``. Either
+    source advancing on its own proves life: a weights download is CPU-light
+    and moves real bytes; an inductor compile burns child CPU with flat I/O;
+    a true hang advances neither.
+
+    The reaped half is not optional. A descendant's CPU moves into its
+    parent's ``cutime``/``cstime`` when it is waited for, so a tree summed
+    over live members only would go DOWN whenever a subprocess finishes —
+    which is why every caller compares this against a HIGH-WATER MARK rather
+    than against the previous sample.
+    """
+    try:
+        import psutil
+    except Exception:
+        return None
+
+    try:
+        proc = psutil.Process(int(pid))
+        total = _cpu_seconds(proc)
+        try:
+            io = proc.io_counters()
+            total += (io.read_bytes + io.write_bytes) / float(1 << 20)
+        except (psutil.Error, AttributeError, NotImplementedError):
+            pass
+        for child in proc.children(recursive=True):
+            try:
+                total += _cpu_seconds(child)
+            except psutil.Error:
+                continue
+        return total
+    except (psutil.Error, ValueError, OSError):
+        # ValueError: psutil refuses a non-positive pid outright, which is
+        # "cannot say" like every other unreadable process here.
+        return None

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -65,6 +65,7 @@ from ..pb import worker_scheduler_pb2 as pb
 from ..transport import FatalTransportError, Transport
 from ..topology import ExecutionTopology
 from .. import postmortem
+from .. import proc_evidence
 from .. import config, worker_credential, worker_goals
 from .. import worker_fatal
 from . import (
@@ -1096,43 +1097,10 @@ class _ChildSlot:
                 pass
 
     def _child_evidence(self, pid: int) -> Optional[float]:
-        """This child tree's kernel-accounted work: CPU seconds for the whole
-        tree — live AND already-reaped descendants (pgw#964) — plus process
-        disk I/O MB (the same combination ``activity._default_evidence``
-        trusts, measured from /proc).
-
-        The reaped half is not optional. A descendant's CPU moves into its
-        parent's ``cutime/cstime`` when it is waited for, so a tree summed
-        over live members only goes DOWN whenever a subprocess finishes, and
-        every caller compares this against a high-water mark."""
-        try:
-            import psutil
-        except Exception:
-            return None
-
-        def _cpu(p: Any) -> float:
-            t = p.cpu_times()
-            return (
-                float(t.user) + float(t.system)
-                + float(getattr(t, "children_user", 0.0) or 0.0)
-                + float(getattr(t, "children_system", 0.0) or 0.0))
-
-        try:
-            proc = psutil.Process(pid)
-            total = _cpu(proc)
-            try:
-                io = proc.io_counters()
-                total += (io.read_bytes + io.write_bytes) / float(1 << 20)
-            except (psutil.Error, AttributeError, NotImplementedError):
-                pass
-            for child in proc.children(recursive=True):
-                try:
-                    total += _cpu(child)
-                except psutil.Error:
-                    continue
-            return total
-        except psutil.Error:
-            return None
+        """This child tree's kernel-accounted work — see
+        :func:`gen_worker.proc_evidence.tree_evidence`, which this grew into
+        and which `parallel.group` now shares (pgw#892)."""
+        return proc_evidence.tree_evidence(pid)
 
     def _sample_child_evidence(self, pid: int, now: float) -> None:
         evidence = self._child_evidence(pid)

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -29,6 +29,13 @@ from .procsplit import is_compute_child
 
 logger = logging.getLogger(__name__)
 
+# pgw#887: what this bounds CHANGED, and the number stayed. It used to be the
+# budget for all in-flight tenant work — SIGTERM, then 30 s, then `abort_all()`
+# regardless of what any job or mint was doing. Tenant work is now bounded by
+# progress (`lifecycle._await_tenant_idle`), and this bounds only the SHUTDOWN
+# half: the floor under the result FLUSH, and the deadline the worker reports
+# to the hub so the two agree about when the pod stops answering. A drain is a
+# command and a command may carry a deadline; the work underneath may not.
 _SIGNAL_DRAIN_DEADLINE_MS = 30_000
 
 

--- a/tests/test_progress_keyed_bounds_pgw887_pgw892.py
+++ b/tests/test_progress_keyed_bounds_pgw887_pgw892.py
@@ -1,0 +1,465 @@
+"""pgw#887 + pgw#892 — three flat wall clocks that ended REAL WORK.
+
+Paul's standing rule, and `stall.py`'s own opening line: *nothing that can END
+REAL WORK may key on a wall clock. A fixed budget cannot tell a healthy
+three-hour transfer from a wedge, so it is either useless or it kills work
+that was about to succeed.* DESIGN-RULINGS §2 states the same thing as a
+boundary: a deadline may bound a COMMAND, never the WORK.
+
+Three sites violated it, and each already had its replacement primitive
+in-repo:
+
+* `lifecycle._finish_drain` — `wait_idle(timeout=deadline)` then
+  `abort_all()`. A render at step 30/50 and one at step 1/50 aborted alike; a
+  MINT, which has no partial result to requeue, was abandoned outright.
+  Replacement: `progress.self_diagnosis()`, already trusted on the 10 s beat.
+* `parallel/group.wait_armed` — 1800 s over "a follower's full pipeline
+  materialization (a cold model load)", against a first self-mint measured at
+  ~28 min and an sdxl projection of 47 min - 6.26 h.
+* `parallel/group._await_arrivals` — 180 s over a follower that may still be
+  in a cold `import torch`.
+  Replacement for both: `stall.SilenceWindow` over
+  `proc_evidence.tree_evidence`, plus the death detection `check_alive()`
+  already did.
+
+Every test drives an injected clock or an injected evidence source; none
+sleeps out a real window, and none contains a fixed-deadline wait of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Optional
+
+import pytest
+
+from gen_worker import progress as progress_mod
+from gen_worker.parallel import group as group_mod
+from gen_worker.stall import SilenceWindow
+
+
+# ---------------------------------------------------------------------------
+# pgw#887 — the drain aborts on non-advancement, never on elapsed time
+# ---------------------------------------------------------------------------
+
+
+class _FakeExecutor:
+    """Just enough of `Executor` for `_await_tenant_idle`."""
+
+    def __init__(self) -> None:
+        self._idle = asyncio.Event()
+
+    async def wait_idle(self, timeout: Optional[float] = None) -> bool:
+        await self._idle.wait()
+        return True
+
+    def finish(self) -> None:
+        self._idle.set()
+
+
+def _lifecycle(executor: Any, *, work_deadline_at: Any = None) -> Any:
+    from gen_worker.lifecycle import Lifecycle
+
+    # Stubbed Lifecycles skip __init__ by repo convention (pgw#610).
+    obj = Lifecycle.__new__(Lifecycle)
+    obj.executor = executor
+    obj._drain_work_deadline_at = work_deadline_at
+    return obj
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    progress_mod.reset()
+    yield
+    progress_mod.reset()
+
+
+def test_work_that_keeps_advancing_is_never_aborted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline. The old code aborted at the deadline no matter what; this
+    one runs a job PAST any deadline the fleet ever set, because the counter
+    keeps moving."""
+    from gen_worker import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_DRAIN_PROGRESS_POLL_S", 0.01)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: clock["t"])
+    counter = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS)
+    executor = _FakeExecutor()
+
+    async def _go() -> None:
+        life = _lifecycle(executor)
+        task = asyncio.ensure_future(life._await_tenant_idle())
+        # Drive the fake clock far past both the 30 s SIGTERM budget and the
+        # hub's 60 s cluster window, advancing the counter as real work would.
+        for _ in range(20):
+            clock["t"] += 60.0
+            counter.add(1)
+            await asyncio.sleep(0.02)
+        assert not task.done(), (
+            "the drain gave up on work that was still advancing — "
+            f"{clock['t']:.0f}s of simulated elapsed time")
+        executor.finish()
+        assert await task is True
+
+    asyncio.run(_go())
+
+
+def test_work_that_stops_advancing_is_given_up_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half: this is not "wait forever". A counter frozen past its
+    own per-phase window is the typed `self_stalled` confession the hub
+    already kills on, and the drain reads the same fact."""
+    from gen_worker import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_DRAIN_PROGRESS_POLL_S", 0.01)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: clock["t"])
+    progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS).add(1)
+
+    async def _go() -> None:
+        life = _lifecycle(_FakeExecutor())
+        task = asyncio.ensure_future(life._await_tenant_idle())
+        await asyncio.sleep(0.02)
+        assert not task.done()
+        # Past `STALL_WINDOW_S["infer"]` (300 s) with no advance.
+        clock["t"] += 400.0
+        assert await task is False
+
+    asyncio.run(_go())
+
+
+def test_a_job_that_finishes_first_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gen_worker import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_DRAIN_PROGRESS_POLL_S", 0.01)
+
+    async def _go() -> None:
+        executor = _FakeExecutor()
+        life = _lifecycle(executor)
+        task = asyncio.ensure_future(life._await_tenant_idle())
+        executor.finish()
+        assert await task is True
+
+    asyncio.run(_go())
+
+
+def test_no_counters_at_all_is_not_a_stall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deliberate, and the same call the in-call stall loop makes: an
+    evidence-free job is not a stalled one, and the outer authority (the hub's
+    terminate, the runtime's SIGKILL) bounds the pathological case. Throwing
+    away work that was about to finish is the failure this issue is about."""
+    from gen_worker import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_DRAIN_PROGRESS_POLL_S", 0.01)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: clock["t"])
+
+    async def _go() -> None:
+        life = _lifecycle(_FakeExecutor())
+        task = asyncio.ensure_future(life._await_tenant_idle())
+        clock["t"] += 10_000.0
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        task.cancel()
+
+    asyncio.run(_go())
+
+
+def test_an_explicit_operator_budget_still_binds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `Drain` that arrives on the wire CARRYING `deadline_ms` is "an
+    explicit operator budget on a specific command" (th#1235), and that is
+    kept. What pgw#887 deletes is the worker INVENTING one: the SIGTERM
+    handler's fleet default, which is what abandoned a 29-minute mint as
+    `abandoned_shutdown`."""
+    from gen_worker import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_DRAIN_PROGRESS_POLL_S", 0.01)
+
+    async def _go() -> None:
+        loop = asyncio.get_running_loop()
+        life = _lifecycle(_FakeExecutor(), work_deadline_at=loop.time() + 0.05)
+        assert await life._await_tenant_idle() is False
+
+    asyncio.run(_go())
+
+
+def test_a_signal_drain_supplies_no_work_budget() -> None:
+    """The SIGTERM path calls `start_drain` without `work_deadline=True`, and
+    the hub's `Drain` handler calls it WITH — that asymmetry is the fix."""
+    import inspect
+
+    from gen_worker import worker as worker_mod
+    from gen_worker.lifecycle import Lifecycle
+
+    assert "work_deadline" not in inspect.getsource(worker_mod.Worker.arun)
+    assert (
+        inspect.signature(Lifecycle.start_drain)
+        .parameters["work_deadline"].default is False)
+    assert "work_deadline=True" in inspect.getsource(Lifecycle.on_message)
+
+
+def test_the_drain_no_longer_reads_a_deadline_for_the_tenant_wait() -> None:
+    """Structural: the wait must not be reachable from `_drain_deadline_at`
+    again. The deadline still bounds the FLUSH (pgw#845), which ships results
+    already held — a command, not the work."""
+    import inspect
+
+    from gen_worker.lifecycle import Lifecycle
+
+    wait_src = inspect.getsource(Lifecycle._await_tenant_idle)
+    assert "self._drain_deadline_at" not in wait_src, (
+        "the tenant wait reads the SHUTDOWN deadline again")
+
+    finish_src = inspect.getsource(Lifecycle._finish_drain)
+    assert "wait_idle(timeout=" not in finish_src, (
+        "the tenant wait is deadline-bounded again")
+    assert "self._await_tenant_idle()" in finish_src
+
+
+# ---------------------------------------------------------------------------
+# pgw#892 — the two group-formation bounds
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.arrived: set = set()
+
+    def check(self, keys: List[str]) -> bool:
+        return all(k in self.arrived for k in keys)
+
+
+def _group(monkeypatch: pytest.MonkeyPatch, *, degree: int = 2) -> Any:
+    g = group_mod.RankGroup.__new__(group_mod.RankGroup)
+    g.devices = tuple(range(degree))
+    g.backend = "gloo"
+    g._procs = [_FakeProc(1000 + i) for i in range(1, degree)]
+    g._staging_peaks = {}
+    g._store = _FakeStore()
+    g._error_q = None
+    return g
+
+
+def _specs(degree: int) -> List[group_mod.RankSpec]:
+    return [
+        group_mod.RankSpec(
+            rank=r, world_size=degree, device=r, master_addr="127.0.0.1",
+            master_port=1, backend="gloo", group_name="t")
+        for r in range(degree)
+    ]
+
+
+def test_a_follower_that_keeps_working_is_never_condemned_while_arming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_ARM_TIMEOUT_S = 1800.0` raised "followers not armed after 1800s" at
+    30:01 for a follower that was still legitimately materializing. The first
+    self-mint measured ~28 min; pgw#846 projects 47 min - 6.26 h for sdxl."""
+    monkeypatch.setattr(group_mod, "_STAGING_POLL_S", 0.0)
+    clock = {"t": 0.0}
+    work = {"cpu": 0.0}
+    monkeypatch.setattr(
+        group_mod.proc_evidence, "tree_evidence", lambda _pid: work["cpu"])
+
+    ready: List[int] = []
+    ticks = {"n": 0}
+
+    class _Q:
+        @staticmethod
+        def get(timeout: float = 0.0) -> int:
+            import queue
+
+            ticks["n"] += 1
+            clock["t"] += 60.0        # a minute of simulated wall time a tick
+            work["cpu"] += 1.0        # the follower is doing real work
+            if ticks["n"] > 60:       # ... for a simulated hour
+                if ready:
+                    return ready.pop()
+                ready.append(1)
+                return 1
+            raise queue.Empty
+
+    g = _group(monkeypatch, degree=2)
+    g._ready_q = _Q()
+    g.check_alive = lambda: None  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        group_mod, "SilenceWindow",
+        lambda window_s: SilenceWindow(window_s, now=lambda: clock["t"]))
+
+    g.wait_armed()  # must not raise: an hour of advancing work
+    assert clock["t"] > 1800.0, "the fixture did not outrun the old 1800s bound"
+
+
+def test_a_follower_that_stops_working_is_condemned_by_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half. Death is `check_alive()`'s; SILENCE is this."""
+    import queue
+
+    monkeypatch.setattr(group_mod, "_STAGING_POLL_S", 0.0)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        group_mod.proc_evidence, "tree_evidence", lambda _pid: 1.0)  # frozen
+
+    class _Q:
+        @staticmethod
+        def get(timeout: float = 0.0) -> int:
+            clock["t"] += 60.0
+            raise queue.Empty
+
+    g = _group(monkeypatch, degree=2)
+    g._ready_q = _Q()
+    g.check_alive = lambda: None  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        group_mod, "SilenceWindow",
+        lambda window_s: SilenceWindow(window_s, now=lambda: clock["t"]))
+
+    with pytest.raises(group_mod.RankGroupError) as excinfo:
+        g.wait_armed()
+    assert "no CPU or I/O" in str(excinfo.value)
+
+
+def test_a_slow_arrival_is_not_a_failed_rendezvous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_RENDEZVOUS_TIMEOUT_S = 180.0` condemned a follower wedged in a cold
+    `import torch` at 181 s — which is a follower burning CPU, i.e. the one
+    state this must not condemn."""
+    monkeypatch.setattr(group_mod, "_STAGING_POLL_S", 0.0)
+    clock = {"t": 0.0}
+    work = {"cpu": 0.0}
+    calls = {"n": 0}
+
+    def _evidence(_pid: int) -> float:
+        return work["cpu"]
+
+    monkeypatch.setattr(group_mod.proc_evidence, "tree_evidence", _evidence)
+    monkeypatch.setattr(
+        group_mod, "SilenceWindow",
+        lambda window_s: SilenceWindow(window_s, now=lambda: clock["t"]))
+
+    g = _group(monkeypatch, degree=2)
+    g.check_alive = lambda: None  # type: ignore[method-assign]
+    specs = _specs(2)
+
+    original_check = g._store.check
+
+    def _check(keys: List[str]) -> bool:
+        calls["n"] += 1
+        clock["t"] += 30.0
+        work["cpu"] += 1.0
+        if calls["n"] > 40:  # arrives at ~20 simulated minutes
+            g._store.arrived.update(group_mod.arrive_key(s) for s in specs[1:])
+        return original_check(keys)
+
+    g._store.check = _check  # type: ignore[method-assign]
+    g._await_arrivals(specs)
+    assert clock["t"] > 180.0, "the fixture did not outrun the old 180s bound"
+
+
+def test_a_silent_arrival_still_fails_the_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(group_mod, "_STAGING_POLL_S", 0.0)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        group_mod.proc_evidence, "tree_evidence", lambda _pid: 1.0)
+    monkeypatch.setattr(
+        group_mod, "SilenceWindow",
+        lambda window_s: SilenceWindow(window_s, now=lambda: clock["t"]))
+
+    g = _group(monkeypatch, degree=2)
+    g.check_alive = lambda: None  # type: ignore[method-assign]
+    original = g._store.check
+    g._store.check = lambda keys: (  # type: ignore[method-assign]
+        clock.__setitem__("t", clock["t"] + 30.0) or original(keys))
+
+    with pytest.raises(group_mod.RankGroupError) as excinfo:
+        g._await_arrivals(_specs(2))
+    assert "no CPU or I/O" in str(excinfo.value)
+
+
+def test_evidence_uses_a_high_water_mark_not_a_delta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A descendant's CPU migrates into its parent's `cutime`/`cstime` on
+    reap, so a live-only tree sum FALLS when a subprocess finishes. Comparing
+    against the previous sample would read that fall as an advance."""
+    readings = iter([10.0, 5.0, 5.0, 11.0])
+    monkeypatch.setattr(
+        group_mod.proc_evidence, "tree_evidence", lambda _pid: next(readings))
+    g = _group(monkeypatch, degree=2)
+    assert g._followers_advanced() is True    # 10.0, first mark
+    assert g._followers_advanced() is False   # 5.0 < mark: NOT an advance
+    assert g._followers_advanced() is False   # 5.0 again
+    assert g._followers_advanced() is True    # 11.0 clears the mark
+
+
+def test_an_unreadable_follower_is_left_to_check_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`tree_evidence` returning None is "cannot say", not "stalled". An
+    unreadable process is condemned by death detection or not at all."""
+    monkeypatch.setattr(
+        group_mod.proc_evidence, "tree_evidence", lambda _pid: None)
+    g = _group(monkeypatch, degree=2)
+    assert g._followers_advanced() is False
+    assert g._staging_peaks == {}
+
+
+def test_the_work_bounding_constants_are_gone() -> None:
+    """Structural, and the point of the issue: the two names that bounded
+    WORK must not exist to be reached for again. `_COLLECTIVE_TIMEOUT_S`
+    (an in-call collective ceiling) and `_STORE_CONNECT_TIMEOUT_S` (a
+    localhost socket connect) are commands and stay."""
+    assert not hasattr(group_mod, "_ARM_TIMEOUT_S")
+    assert not hasattr(group_mod, "_RENDEZVOUS_TIMEOUT_S")
+    assert hasattr(group_mod, "_STAGING_SILENCE_WINDOW_S")
+    assert hasattr(group_mod, "_COLLECTIVE_TIMEOUT_S")
+
+
+def test_wait_armed_takes_no_duration() -> None:
+    import inspect
+
+    sig = inspect.signature(group_mod.RankGroup.wait_armed)
+    assert list(sig.parameters) == ["self"], (
+        "a caller can still hand this a work budget")
+
+
+# ---------------------------------------------------------------------------
+# The shared producer
+# ---------------------------------------------------------------------------
+
+
+def test_tree_evidence_has_one_implementation() -> None:
+    """pgw#892 needed exactly what `procsplit.parent._child_evidence` already
+    was. Two copies of a liveness primitive is how one of them stops matching
+    the other's failure modes."""
+    import inspect
+
+    from gen_worker import proc_evidence
+    from gen_worker.procsplit import parent
+
+    assert "proc_evidence.tree_evidence" in inspect.getsource(
+        parent._ChildSlot._child_evidence)
+    assert proc_evidence.tree_evidence(-1) is None  # no such pid, no raise
+
+
+def test_tree_evidence_reads_this_process() -> None:
+    from gen_worker import proc_evidence
+    import os
+
+    value = proc_evidence.tree_evidence(os.getpid())
+    assert value is not None and value > 0.0

--- a/tests/test_sequence_parallel_pgw748.py
+++ b/tests/test_sequence_parallel_pgw748.py
@@ -101,7 +101,7 @@ def test_rank_zero_decides_and_every_rank_obeys() -> None:
             loras=(("style", 0.8),),
         )
         group.send({"op": "arm", "plan": plan})
-        group.wait_armed(timeout_s=60)
+        group.wait_armed()
         group.barrier()
     finally:
         group.close()
@@ -304,7 +304,7 @@ def test_degree_four_group_forms_and_every_rank_obeys_rank_zero() -> None:
             compile_armed=False, loras=(("style", 0.8),),
         )
         group.send({"op": "arm", "plan": plan})
-        group.wait_armed(timeout_s=120)
+        group.wait_armed()
         group.barrier()   # all four ranks reached it
     finally:
         group.close()

--- a/tests/test_sp_group_isolation_pgw773_774.py
+++ b/tests/test_sp_group_isolation_pgw773_774.py
@@ -142,12 +142,14 @@ def _rig_entry_skips_collectives(spec: RankSpec, chan: FollowerChannel) -> None:
 
 def _armed_runtime(
     devices: tuple, entry: Any = _rig_entry, timeout_s: float = 60.0,
-    arm_timeout_s: float = 120.0,
 ) -> tuple:
     pipe = _make_toy_pipe()
+    # pgw#892: arming no longer takes a duration at all — a follower that
+    # keeps working arms for as long as its work takes, and one that stops
+    # working is condemned by silence.
     rt = SequenceRuntime(
         devices, entry=entry, backend="gloo",
-        collective_timeout_s=timeout_s, arm_timeout_s=arm_timeout_s,
+        collective_timeout_s=timeout_s,
     )
     installed = rt.arm(pipe, BootPlan(degree=len(devices)),
                        GroupPlan(sp_degree=len(devices)))
@@ -287,17 +289,30 @@ def test_an_unpicklable_argument_is_typed_and_does_not_condemn() -> None:
         rt.close()
 
 
-def test_arming_a_group_whose_follower_never_readies_fails_bounded() -> None:
+def test_arming_a_group_whose_follower_goes_silent_fails_typed(
+    monkeypatch: Any,
+) -> None:
+    """RE-CUT for pgw#892. This used to assert that a never-ready follower
+    failed within a multiple of `_ARM_TIMEOUT_S = 1800`, which is the flat
+    wall clock that issue deletes: arming "covers a follower's full pipeline
+    materialization (a cold model load)", the first self-mint measured ~28 min
+    and pgw#846 projects 47 min - 6.26 h for sdxl, so the bound condemned
+    healthy work and the RIGHT never-readies test is this one.
+
+    The follower here parks in `time.sleep(600)` — alive, and doing nothing at
+    all — so it produces no CPU and no I/O and the silence window fires. The
+    window is shortened for the test because it is a window over a REAL
+    signal, not a budget for the job."""
+    from gen_worker.parallel import group as group_mod
+
+    monkeypatch.setattr(group_mod, "_STAGING_SILENCE_WINDOW_S", 3.0)
     pipe = _make_toy_pipe()
-    arm_timeout_s = 3.0
     rt = SequenceRuntime(
         (0, 1), entry=_rig_entry_never_ready, backend="gloo",
-        collective_timeout_s=30.0, arm_timeout_s=arm_timeout_s,
+        collective_timeout_s=30.0,
     )
-    start = time.monotonic()
-    with pytest.raises(RankGroupError, match="not armed"):
+    with pytest.raises(RankGroupError, match="no CPU or I/O"):
         rt.arm(pipe, BootPlan(degree=2), GroupPlan(sp_degree=2))
-    assert time.monotonic() - start < arm_timeout_s * 6
     rt.close()
 
 


### PR DESCRIPTION
Paul's standing rule, and `stall.py`'s own opening line: *nothing that can END REAL WORK may key on a wall clock.* DESIGN-RULINGS §2 draws the same boundary — a deadline may bound a **command**, never the **work**. Three sites violated it, and each already had its replacement primitive in-repo.

## pgw#887 — the drain aborted on the clock

`_finish_drain` waited `wait_idle(timeout=deadline)` and then called `abort_all()`: at 30 s on SIGTERM, or at the hub's 60 s cluster window — which is what **both standing stacks actually run** (`TENSORHUB_SHUTDOWN_MODE=cluster`, measured off both live hub processes). Nothing consulted progress. A render at step 30/50 and one at step 1/50 were aborted identically, and a **mint**, which has no partial result to requeue, was abandoned outright: `self_mint_abort` has 52 rows on chaos and 64 on master, and `forge.py` recorded one verbatim — *"attempt sixteen ran 29 minutes and died `self_mint_abort/abandoned_shutdown`"*.

The tenant wait is now keyed on `progress.self_diagnosis()` — the silence-keyed per-phase predicate the 10 s beat already reports and the hub already kills on.

**The part worth arguing with.** A `Drain` arriving on the wire *carrying* `deadline_ms` is "an explicit operator budget on a specific command" (th#1235), and the issue's own target shape keeps that. What is deleted is the worker **inventing** one: the SIGTERM handler no longer supplies a work budget, so a pod stopping on a signal cannot abandon a mint at 30 s. Even under an explicit budget the progress test fires **first**. That needed two deadlines where there was one — `_drain_deadline_at` still bounds the shutdown (the pgw#845 flush, the stop time reported to the hub); `_drain_work_deadline_at` bounds tenant work and only an explicit caller gets it.

Two properties, deliberate and stated in the code: **no counters open at all is not a stall** (the same call the in-call stall loop makes), and `self_diagnosis()` is registry-wide, so a background mint's counter can currently defer this verdict for a wedged tenant job — that cross-talk is pgw#894's, is named there, and is strictly better than the wall clock this replaces.

## pgw#892 — both group-formation bounds

| constant | bounded | now |
|---|---|---|
| `_ARM_TIMEOUT_S = 1800` | "a follower's full pipeline materialization (a cold model load)" — against a first self-mint measured at ~28 min and an sdxl projection of 47 min–6.26 h | silence window over follower CPU+I/O |
| `_RENDEZVOUS_TIMEOUT_S = 180` | a follower possibly still in a cold `import torch` | same |

`check_alive()` already failed a **dead** follower typed and immediately, so both durations added nothing death detection did not give and subtracted every legitimately slow load.

**The issue said the replacement signal had no producer and had to be added. It did exist.** `procsplit/parent._child_evidence` — whole-tree CPU seconds including already-reaped descendants, plus process disk I/O MB — is exactly it, and it needs *no cooperation from the process being watched*, which is what makes it usable against a follower with no protocol between spawn and ready. Extracted to `proc_evidence.tree_evidence`; both callers now share one implementation. High-water marks, not deltas: a descendant's CPU migrates into its parent's `cutime`/`cstime` on reap, so a live-only tree sum *falls* when a subprocess finishes.

`_RENDEZVOUS_TIMEOUT_S`'s other use (the TCPStore's connect to a localhost port whose listener already exists) is `_STORE_CONNECT_TIMEOUT_S`, and the follower's wait for rank 0's first command is `_FIRST_COMMAND_WAIT_S`. Both bound a peer, not work, and both now name their threat.

### `_MEASURE_TIMEOUT_S` is deliberately not changed

pgw#973 wave 3 (`74d232b4`) gave it an argued §4.24 exemption **in the code**: the canary reports through one `communicate()` at the end, so there is no progress signal to key on, and giving up ships the Hello without parent-measured resources rather than killing anything. The tracker's row for it is stale; the tracker note says so. (Residue, unowned here: the timed-out child is still not killed — pgw#880 FINDING 2's half.)

## RED evidence

`tests/test_progress_keyed_bounds_pgw887_pgw892.py` — **17 tests, all 17 fail against `master`**, all 17 pass here. Every one drives an injected clock or an injected evidence source; none sleeps out a real window, and none contains a fixed-deadline wait of its own (the gw#666 `tests/`-scanning guards are green).

Two existing tests asserted the deleted contract and were **re-cut, not deleted**: `test_arming_a_group_whose_follower_never_readies_fails_bounded` → `..._goes_silent_fails_typed`, where the follower parks in `sleep(600)`, produces no CPU and no I/O, and is condemned by name.

## Gates

mypy clean (255 files) · ruff clean · seven fast-gate lint guards green · 28 passed across `test_sp_group_isolation_pgw773_774` + `test_p1_stream_lifecycle` · 115 across the wider timeout neighbourhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq