### PR TITLE
pgw#1101: micro-diffusion README step 1 — current pin guidance (0.100.0 / 0.97.0 floor)

### DIFF
--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -268,12 +268,15 @@ GET /api/v1/repos/tensorhub/micro-diffusion/checkpoints     # model_family stamp
 **ESTIMATE: < 1 min.** No commit to `inference-endpoints` is wanted — this is a
 proof artifact, not a fleet pin.
 
-> ⚠️ **The pin must carry pgw#994 (`2165c2d5`) — 0.93.4 or a master build.**
-> This family declares a container input with a plain input after it, which is
-> exactly the shape whose contract positions pgw#994 fixed. On 0.93.3 the cell
-> mints and seals and then **refuses at ingress on its first served call**, so
-> the run would burn a pod to rediscover a fixed defect. The local rig runs
-> against master and its parity leg is a green proof of that fix.
+> ⚠️ **Pin at 0.100.0 (current), never below the 0.97.0 fleet floor.** This
+> family declares a container input with a plain input after it — the shape
+> pgw#994 (`2165c2d5`, 0.93.4) fixed; below it the cell mints and seals and then
+> **refuses at ingress on its first served call**, burning a pod to rediscover a
+> fixed defect. 0.97.0 is the fleet floor (pgw#1084, four-axis `ck1`); 0.100.0
+> additionally carries the AOT re-key — boot-derived cell key (pgw#1089/1090),
+> the folding fence (pgw#1097) and AOT-local mint (pgw#1096). Keep this pin on
+> the SAME wheel the fleet serves (the example's `pyproject.toml` pin is the
+> source of truth) so the gauntlet stays a usable probe.
 
 ### 2. Publish the release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.100.0"
+version = "0.100.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.100.0"
+version = "0.100.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
The adopt lane flagged step 1's pin warning in `examples/micro-diffusion/README.md` as stale.

**Before:** "The pin must carry pgw#994 (`2165c2d5`) — 0.93.4 or a master build."

**Now:** pin at **0.100.0** (current), never below the **0.97.0** fleet floor. pgw#994 (0.93.4) is long subsumed; the example's `pyproject.toml` already pins 0.97.0 (the ie#639 fleet hardcut), and 0.100.0 — just published — carries the AOT re-key (boot-derived cell key pgw#1089/1090, folding fence pgw#1097, AOT-local mint pgw#1096). The warning now names the real floor and current version, and points at `pyproject.toml` as the source of truth for the pin.

Docs-only; `examples/` is excluded from the wheel (`packages = ["src/gen_worker"]`), so no artifact impact. Not bumping the `pyproject.toml` pin (0.97.0) — it deliberately tracks what the fleet serves until the repin lands.