### PR TITLE
release: master's committed version is 0.101.0 — 0.100.0 is published and burned

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.100.0"
+version = "0.101.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.100.0"
+version = "0.101.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
`v0.100.0` was tagged at `6d76d1a6` and **published to PyPI at 00:41Z**. Master's `pyproject.toml` still said `0.100.0`, so every commit since has been claiming a number that already names a different, immutable artifact. Standing rule: one artifact per number; a library's committed version is not a lane claim token — bump at publish.

Four commits are already stranded above the published wheel, and this gives them a number to ship under:

| commit | what |
|---|---|
| `4a003302` | th#1757: export `PromptRole` from the top-level `gen_worker` |
| `1d8dc0c5` | pgw#939 + pgw#940: eight fail-open sites |
| `8d4fff83` | (#612) |
| `25179ae6` | pgw#887 + pgw#892: three flat wall clocks |

The first has a consumer waiting: th#1757's reference layer keys `ref_text` off `PromptRole`-annotated fields, and in published 0.100.0 that symbol is reachable only as `gen_worker.api.PromptRole`. minimax-h3 0.4.6 imports it from there with a comment to collapse the import at the next train — which is this number.

No behaviour change. `uv.lock` regenerated in the same commit.

*(Found by the fleet0100 train lane, which pins the fleet to the published 0.100.0 — that pin is correct and unaffected.)*