### PR TITLE
release: 0.100.1 → 0.101.0 — this tree adds a name to `gen_worker.__all__`, and [supported] is keyed on MAJOR.MINOR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.100.1"
+version = "0.101.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.100.1"
+version = "0.101.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Not a style preference — the label is load-bearing.

inference-endpoints `fleet-floors.toml` has `[supported]` entries of the form `"0.100"`; `parse_line()` **refuses** a patch component and `matches()` compares `(major, minor)` only. Patch is ignored *by design*: *"if its minor version is supported, all patch versions of that are supported as well"* (Paul, 2026-07-30).

So a **0.100.1** label asserts that **published 0.100.0 satisfies any endpoint on the 0.100 line.** It does not. `4a003302` exported `PromptRole` from the top-level `gen_worker` and added it to `__all__`; the published 0.100.0 artifact does not carry it (verified against the PyPI wheel, not a local build). An endpoint writing `from gen_worker import PromptRole` — which is the entire point of that commit, since th#1757's reference layer is inert without the annotation — would be told by the allowlist that 0.100.0 is fine, and would fail at import on a rented pod.

**This repo has already made exactly this call once and wrote down why.** The 0.93.0 cut was prepared as 0.92.2 and renumbered on Paul's instruction *before the tag was pushed*, because it added the public module `gen_worker.references` and 11 names to `__all__` — *"the allowlist would have been false at exactly the granularity it governs"* (fleet-floors.toml). Same shape, same answer.

Supersedes #615 (same correction, cut from 0.100.0, overtaken by a parallel bump to 0.100.1). `uv.lock` regenerated in the same commit. No behaviour change.