### PR TITLE
th#1771: the derived warm payload must satisfy the payload's OWN invariants — a one-of struct synthesized empty and billed the caller for it

### DIFF
--- a/changelog.d/th1771.md
+++ b/changelog.d/th1771.md
@@ -1,0 +1,20 @@
+- **th#1771: the derived warm payload now SATISFIES the payload's own
+  invariants.** `_struct_factory` filled required fields only, so a nested
+  struct whose fields are all optional but which asserts *exactly one of these
+  is set* in `__post_init__` — the ordinary one-of media shape (minimax-h3's
+  `ReferenceInput`: `image | video | audio`) — synthesized as the all-`None`
+  instance and raised its own `ValueError` the first time the warm plan built
+  it. That is not a sparse legal set (`IllegalCombination`, which the plan
+  drops on purpose); it is the synthesizer emitting a value the schema forbids
+  unconditionally. Live it cost an H100 and a billed request: minimax-h3 0.4.6
+  loaded fine, `self_mint_compile phase=warmup_forward` died 3 ms in, and the
+  hub booked `ValueError: each references[] entry carries exactly one of image
+  / video / audio, got none` as the CALLER's fatal error on a request whose own
+  `references[]` were perfectly formed — then bought two replacement pods
+  reproducing it. Required-only construction is now attempted first (unchanged
+  for every payload that accepts it, so neutral defaults still stand); when the
+  struct refuses itself, the synthesizable OPTIONAL fields are added one at a
+  time in declaration order until it constructs. `IllegalCombination` is
+  re-raised untouched at every step, and an unsatisfiable struct re-raises its
+  own original refusal rather than a synthesized one
+  (`tests/test_warmup_oneof_invariant_th1771.py`).

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -220,10 +220,40 @@ def _field_factory(t: Any, depth: int) -> Tuple[Optional[_Factory], str]:
     return None, f"required field type {t!r} is not synthesizable"
 
 
+def _present_factory(t: Any, depth: int) -> Optional[_Factory]:
+    """A factory that POPULATES a field — never the `None` arm of an option.
+
+    `_field_factory` answers `None` for any optional type, which is right for
+    a neutral default and useless for repairing a one-of (th#1771).
+    """
+    t = _unwrap(t)
+    if depth > _MAX_DEPTH:
+        return None
+    origin = typing.get_origin(t)
+    if origin in (typing.Union, py_types.UnionType):
+        for arm in typing.get_args(t):
+            if arm is type(None):
+                continue
+            factory = _present_factory(arm, depth + 1)
+            if factory is not None:
+                return factory
+        return None
+    factory, _ = _field_factory(t, depth)
+    return factory
+
+
 def _struct_factory(payload_type: type, depth: int = 0) -> Tuple[Optional[_Factory], str]:
     field_factories: List[Tuple[str, _Factory]] = []
+    # th#1771: the one-of repair set. A struct whose fields are ALL optional
+    # but which asserts "exactly one of these is set" (the standard one-of
+    # media shape) is not sparse — it is unconditionally illegal empty, and
+    # required-only synthesis built exactly that.
+    optional_factories: List[Tuple[str, _Factory]] = []
     for f in msgspec.structs.fields(payload_type):
         if not f.required:
+            factory = _present_factory(f.type, depth)
+            if factory is not None:
+                optional_factories.append((f.name, factory))
             continue
         factory, reason = _field_factory(f.type, depth)
         if factory is None:
@@ -234,7 +264,25 @@ def _struct_factory(payload_type: type, depth: int = 0) -> Tuple[Optional[_Facto
         field_factories.append((f.name, factory))
 
     def build(dir_path: str) -> Any:
-        return payload_type(**{name: fac(dir_path) for name, fac in field_factories})
+        required = {name: fac(dir_path) for name, fac in field_factories}
+        try:
+            return payload_type(**required)
+        except IllegalCombination:
+            # A declared sparse legal set — the plan's own signal. Never a
+            # shape this repair may paper over.
+            raise
+        except (ValueError, TypeError):
+            # Populate one optional field at a time, in declaration order,
+            # until the struct accepts itself. Re-raise the ORIGINAL refusal
+            # when nothing satisfies it, so the reason stays the schema's.
+            for name, fac in optional_factories:
+                try:
+                    return payload_type(**required, **{name: fac(dir_path)})
+                except IllegalCombination:
+                    raise
+                except (ValueError, TypeError):
+                    continue
+            raise
 
     return build, ""
 

--- a/tests/test_warmup_oneof_invariant_th1771.py
+++ b/tests/test_warmup_oneof_invariant_th1771.py
@@ -1,0 +1,105 @@
+"""th#1771: the derived warm payload must SATISFY the payload's own invariants.
+
+`_struct_factory` filled REQUIRED fields only. A nested struct whose fields are
+all optional but which asserts "exactly one of these is set" in `__post_init__`
+— the standard one-of media shape (minimax-h3 `ReferenceInput`: image | video |
+audio) — therefore synthesized as the all-`None` instance and raised its own
+`ValueError` the first time the warm plan built it.
+
+That is not a sparse legal set (`IllegalCombination`, which the plan drops); it
+is the synthesizer emitting a value the schema forbids unconditionally. Live it
+cost a live H100 and a billed request: the endpoint served fine, the warm plan
+could not build a payload, and the hub booked the ValueError as the CALLER's
+fatal error on a request whose own `references[]` were perfectly formed.
+
+The fix: when required-only construction is refused, add the synthesizable
+OPTIONAL fields, in declaration order, until the struct constructs.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import msgspec
+import pytest
+
+from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
+from gen_worker.warmup import synthesize_factory
+
+
+class OneOfMedia(msgspec.Struct, forbid_unknown_fields=True):
+    """minimax-h3's `ReferenceInput`, verbatim in shape."""
+
+    image: ImageAsset | None = None
+    video: VideoAsset | None = None
+    audio: AudioAsset | None = None
+
+    def __post_init__(self) -> None:
+        populated = [
+            name
+            for name, value in (
+                ("image", self.image), ("video", self.video), ("audio", self.audio))
+            if value is not None
+        ]
+        if len(populated) != 1:
+            raise ValueError(
+                "each references[] entry carries exactly one of image / video / audio, "
+                f"got {populated or 'none'}"
+            )
+
+
+class RefToVideoIn(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+    references: list[OneOfMedia]
+    duration_s: int = 5
+
+
+class OnlyUnsynthesizableOptions(msgspec.Struct):
+    """No arm the synthesizer can fill — must be a REASON, never a crash."""
+
+    video: VideoAsset | None = None
+
+    def __post_init__(self) -> None:
+        if self.video is None:
+            raise ValueError("video is required in practice")
+
+
+def _build(payload_type: type):
+    factory, reason = synthesize_factory(payload_type)
+    assert factory is not None, reason
+    with tempfile.TemporaryDirectory() as tmp:
+        return factory(tmp)
+
+
+def test_oneof_nested_struct_synthesizes_a_legal_instance() -> None:
+    payload = _build(RefToVideoIn)
+    assert len(payload.references) == 1
+    entry = payload.references[0]
+    assert entry.image is not None, "the one-of arm must be populated"
+    assert entry.video is None and entry.audio is None
+    assert entry.image.local_path, "the synthetic image must exist on disk"
+
+
+def test_oneof_struct_alone_synthesizes() -> None:
+    entry = _build(OneOfMedia)
+    assert entry.image is not None
+
+
+def test_unsatisfiable_oneof_is_a_reason_not_a_crash() -> None:
+    factory, reason = synthesize_factory(OnlyUnsynthesizableOptions)
+    if factory is None:
+        assert reason
+        return
+    with tempfile.TemporaryDirectory() as tmp, pytest.raises(Exception):
+        factory(tmp)
+
+
+def test_plain_struct_still_keeps_its_defaults() -> None:
+    class Plain(msgspec.Struct):
+        prompt: str
+        steps: int = 7
+        image: ImageAsset | None = None
+
+    payload = _build(Plain)
+    assert payload.steps == 7
+    assert payload.image is None, "an unconstrained optional stays at its default"


### PR DESCRIPTION
## Root cause (th#1771, the th#1757 P1 blocker)

th#1757's reference layer was reported as "hub-injected reference media does not survive dispatch". It does. The hub is exonerated at the bytes:

- `requests.input_payload` for the failing request `3d1b9c6a-a82c-4dee-b68d-579fbddbba86` decodes — with the REAL `ReferenceToVideoInput`/`ReferenceInput` shape and this wheel's `ImageAsset` — into two populated `ReferenceInput(image=ImageAsset(ref=…))` entries. `buildRunJob` copies those bytes verbatim (`req.InputPayload = append([]byte(nil), requestState.InputPayload...)`).
- A decode failure would have been `msgspec.ValidationError … - at $.references[0]` and `JOB_STATUS_INVALID`. What the hub banked is `JOB_STATUS_FATAL`, `execute_ms=393214`, and a bare `ValueError: …`.

`worker_activity_events` names the real site:

```
self_mint_compile | warmup_forward | failed |
  ValueError: each references[] entry carries exactly one of image / video / audio, got none
```

— 3 ms after `warmup_forward running`. That is payload SYNTHESIS, not the caller's payload.

`warmup._struct_factory` iterates `msgspec.structs.fields(...)` and keeps only `f.required`. `ReferenceInput`'s three fields are all optional-with-default, so the derived factory is `ReferenceInput()` — and `__post_init__` forbids exactly that, unconditionally. `ReferenceToVideoInput.references` is required, so `[ReferenceInput()]` is what the warm plan built.

The module docstring already draws the line this violates: a sparse legal set declares itself with `IllegalCombination` and the plan drops those rows; *"every OTHER exception during payload construction is still a load failure"*. A one-of invariant is not sparsity — it is illegal empty always, and the synthesizer was the thing in the wrong.

## Fix

`_struct_factory` attempts required-only construction first (byte-identical behaviour for every payload that accepts it — neutral defaults still stand). When the struct refuses itself, the synthesizable OPTIONAL fields are added one at a time in declaration order until it constructs. `_present_factory` is the new helper: `_field_factory` answers `None` for any optional type, which is right for a neutral default and useless for repairing a one-of.

`IllegalCombination` is re-raised untouched at every step, so the plan's sparsity signal is unchanged. An unsatisfiable struct re-raises its own ORIGINAL refusal, so the reason stays the schema's and the load failure stays loud.

## Tests

`tests/test_warmup_oneof_invariant_th1771.py` — RED before the fix with the verbatim production string, on minimax-h3's `ReferenceInput` shape verbatim. Covers the nested list case, the struct alone, an unsatisfiable one-of (reason or loud raise, never a silent bad instance), and that an unconstrained optional still keeps its default.

Neighbouring suites green: `test_warm_tax_pgw654`, `test_warmup_media_variants_gw614`, `test_warmup_kind_collision_pgw1067`, `test_compile_nowarmup_contradiction_th959`, `test_mint_child_warm_context_pgw828` (26 passed).

## Cost of the bug, for the record

One billed H100 render refused, then two replacement pods bought to reproduce a deterministic synthesis fault, and the failure attributed to the caller's input.