### PR TITLE
pgw#900: AOTI mint operator CLI gates on the C++ linker, not any C compiler

### DIFF
--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -114,7 +114,7 @@ from .aot_contract import (  # re-exported: the declaration layer's vocabulary
 from .aot_preconditions import LIFTED_LORA_TORCH_FLOOR, torch_version_gap
 from .compile_cache import (
     _resolve_target,
-    toolchain_present,
+    cxx_toolchain_present,
 )
 from dataclasses import replace
 import inspect
@@ -4140,7 +4140,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         help="publish through the fleet CellPublisher")
     parser.add_argument("--require-toolchain", action="store_true",
                         default=True,
-                        help="refuse without a C toolchain (default on)")
+                        help="refuse without a C++ AOTI toolchain (default on)")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -4160,10 +4160,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     except MintRefused as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 2
-    if args.require_toolchain and not toolchain_present():
+    if args.require_toolchain and not cxx_toolchain_present():
+        # pgw#900: an AOTI mint links a real `.so` through inductor's C++
+        # wrapper, so a C-only image (`cc`/`gcc` but no working C++) passes
+        # `toolchain_present()` yet dies 336 s later at the linker
+        # (`InvalidCxxCompiler`, measured on L4 0.84.0). Gate on the SAME
+        # predicate the mint child uses (`cxx_toolchain_present`), not the
+        # dynamo-lane `toolchain_present`, so the CLI refuses at second zero.
         print(
-            "REFUSED: no C toolchain (cc/gcc) — an AOTI mint needs the "
-            "compile-job image, not a prod worker image", file=sys.stderr)
+            "REFUSED: no C++ AOTI toolchain — inductor cannot link a kernel "
+            "on this image. An AOTI mint needs the compile-job image, not a "
+            "prod worker image", file=sys.stderr)
         return 2
 
     model = args.model or spec.source_ref

--- a/tests/test_aot_mint_cli_cxx_gate_pgw900.py
+++ b/tests/test_aot_mint_cli_cxx_gate_pgw900.py
@@ -1,0 +1,76 @@
+"""pgw#900: the AOTI mint operator CLI must gate on the C++ linker, not any C
+compiler.
+
+An AOTI mint links a real ``.so`` through inductor's C++ wrapper. A C-only
+image (``cc``/``gcc`` present, no working C++) satisfies ``toolchain_present()``
+— the dynamo-lane predicate — but the mint then loads the model, exports both
+graph classes, and only discovers the missing C++ compiler 336 s later at the
+linker (``InvalidCxxCompiler``, measured on a real L4 at 0.84.0). The CLI must
+refuse at second zero on the SAME predicate the mint child already uses,
+``cxx_toolchain_present``.
+
+These tests drive ``aot_mint.main`` only as far as the toolchain gate — the
+declaration load is stubbed and the request carries no model, so no compile is
+ever reached (CPU-minimal / no-local-mint safe). RED on master: with a C
+compiler present and no C++, master's ``toolchain_present`` gate PASSES and
+``main`` falls through to the no-model BAD REQUEST (rc 3) instead of refusing.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gen_worker import aot_mint
+
+
+def _request(tmp_path: Path) -> Path:
+    # A valid family so `_load_spec` succeeds, but NO source_ref and (below) no
+    # --model, so a run that passes the toolchain gate stops at BAD REQUEST
+    # (rc 3) BEFORE any model load or compile.
+    req = tmp_path / "mint_request.json"
+    req.write_text(json.dumps({"family": "sdxl"}))
+    return req
+
+
+@pytest.fixture(autouse=True)
+def _stub_declaration(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The gate sits after `aot_declaration.load_declaration`; stub it so no real
+    # family module (or compile) is needed to reach the gate.
+    monkeypatch.setattr(
+        "gen_worker.aot_declaration.load_declaration",
+        lambda body, request_path=None: None,
+        raising=True,
+    )
+
+
+def test_c_only_image_is_refused_at_the_gate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # C compiler present, C++ linker absent: the exact L4 shape.
+    monkeypatch.setattr(aot_mint, "cxx_toolchain_present", lambda: False,
+                        raising=False)
+    monkeypatch.setattr(aot_mint, "toolchain_present", lambda: True,
+                        raising=False)  # master's predicate — deliberately True
+
+    rc = aot_mint.main([str(_request(tmp_path)), "--out", str(tmp_path / "out")])
+
+    # Branch: refused at the gate (rc 2). Master: gate passes on the C-only
+    # image, falls through to no-model BAD REQUEST (rc 3) — the fail-open.
+    assert rc == 2
+
+
+def test_full_cxx_toolchain_passes_the_gate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Control: a working C++ image must NOT be refused. It passes the gate and
+    # stops at the no-model BAD REQUEST, proving the gate does not over-refuse.
+    monkeypatch.setattr(aot_mint, "cxx_toolchain_present", lambda: True,
+                        raising=False)
+    monkeypatch.setattr(aot_mint, "toolchain_present", lambda: True,
+                        raising=False)
+
+    rc = aot_mint.main([str(_request(tmp_path)), "--out", str(tmp_path / "out")])
+
+    assert rc == 3  # BAD REQUEST: no --model and no source_ref


### PR DESCRIPTION
`aot_mint.main`'s `--require-toolchain` gate called `toolchain_present()` — the **dynamo-lane** predicate (any of cc/gcc/g++/clang). An AOTI mint links a real `.so` through inductor's C++ wrapper, so a **C-only image passes that gate** and then dies 336 s later at the linker (`InvalidCxxCompiler`, measured on a real L4 at 0.84.0). The mint child already gates on the correct predicate (`cxx_toolchain_present`, `mint_child.py:829`); only the operator CLI was left on the loose one — pgw#823's fix never reached it.

**Fix:** gate on `cxx_toolchain_present()` so the CLI refuses at second zero on an image that cannot link.

**RED proof ($0, no pod, no compile):** the test drives `main` only as far as the gate — declaration load stubbed, request carries no model, so no compile is ever reached. A C-only image (`toolchain_present`=True, `cxx_toolchain_present`=False) returns **rc 3** (fall-through to BAD REQUEST) on master vs **rc 2** (REFUSED) on the fix; a full C++ image passes the gate on both (control). Verified RED against `origin/master`'s `aot_mint.py`.

Closes pgw#900.