### PR TITLE
pgw#1104: `metrics.lane` follows the weights AS EXECUTED — a serve-time quantize is no longer invisible (0.103.0)

### DIFF
--- a/changelog.d/pgw1104.md
+++ b/changelog.d/pgw1104.md
@@ -1,0 +1,33 @@
+- **pgw#1104: `metrics.lane` follows the WEIGHTS AS EXECUTED, not the binding —
+  a serve-time quantization recipe is no longer invisible.**
+  `executor._served_execution_lane` derived the reported lane from
+  `binding.flavor` / `binding.storage_dtype` (the checkpoint the hub resolved)
+  plus live compile state, and read nothing about what `setup()` did to the
+  weights. minimax-h3 binds `tensorhub/minimax-h3:serve-narrowed` — a bare tag
+  with an EMPTY flavor — and then quantizes 300 transformer Linears to w8a8 fp8
+  with torchao in place inside `setup()`, so production reported
+  `bf16-w16a16+compiled` while a **21.7 GiB fp8 DiT** executed against a
+  37.5 GiB bf16 checkpoint (pod `x7cenpmm785q27`, requests `4f73d00c` /
+  `be2a4c00`). The lane id is a KEY, not a label: th#935 verdicts, compile
+  cells, serving floors, pricing and the executed-lane proof all join on it, so
+  every one of them was keyed to a lane the fleet did not run — and it cost
+  pgw#1093 an issue's worth of "the fp8 lane is not routing" that was never
+  true. New SDK call `gen_worker.report_applied_lane(component, lane_body,
+  modules=…, kept_bf16=…)`: the recipe that converted the weights reports the
+  lane it APPLIED, right after `quantize_()` returns, exactly where
+  `arm_compile()` is called after placement. `lane_body` must be a member of
+  `known_execution_lane_bodies()` (the th#1050 vocabulary, byte-identical to
+  the hub's `precision.KnownExecutionLaneBodies()`); an unknown token is a
+  typed `ValueError` at report time, so the platform-wide lane string set is
+  never extended from an endpoint, and the execution axis stays the worker's
+  (`+compiled` / `+eager` from live compile state through the lane table's own
+  support rule). The call is scoped to the executor's `setup()` (contextvar,
+  `ArmingScope`'s pattern) so it cannot be forged from a handler or a
+  background thread, dies with the instance at vacate, and emits a typed
+  `applied_lane` activity event carrying the applied body, the module counts
+  and the BOUND lane it diverged from — "which pods serve a lane their
+  checkpoint does not name" is one query instead of an inference from
+  allocated-bytes rows. A STATIC declaration was deliberately rejected (the
+  alternative recorded in pgw#1104): H3's recipe is runtime-gated on sm89 and
+  on the compile preflight, so a declaration would report fp8 on the card that
+  skips the conversion — the same defect in the unsafe direction.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -687,6 +687,36 @@ not servable through these calls, and a green integrity result is **not** a
 quality signal — a melted or over-smoothed render scores HIGHER on this
 statistic than a clean one. See `gen_worker.output_integrity`.
 
+## If `setup()` quantizes, report the lane it applied (pgw#1104)
+
+A serve-time recipe — torchao `quantize_()`, an fp8 cast, anything that
+converts the weights inside `setup()` — moves the lane the endpoint EXECUTES
+away from the checkpoint the hub bound. The worker cannot see that (sniffing
+tensor subclasses is deliberately not done), so the recipe says so:
+
+```python
+def setup(self, pipeline: Pipe) -> None:
+    if not w8a8_capable():          # runtime gate: report only what APPLIED
+        return
+    quantize_(pipeline.transformer, _w8a8_config(), filter_fn=...)
+    gen_worker.report_applied_lane(
+        "transformer", "fp8-w8a8-dynamic", modules=300, kept_bf16=70)
+```
+
+`metrics.lane` / `ctx.lane` then report `fp8-w8a8-dynamic+compiled` instead of
+the binding's `bf16-w16a16`. This matters because the lane id is a KEY: quality
+verdicts, compile cells, serving floors and pricing all join on it, and
+minimax-h3 spent four issues being priced as bf16 while serving a 21.7 GiB fp8
+DiT.
+
+Rules: the second argument must be one of
+`gen_worker.models.execution_lanes.known_execution_lane_bodies()` (the same
+vocabulary `handles=` uses) — anything else raises `ValueError`, because the
+lane vocabulary is shared with the hub. Never name the execution axis
+(`+compiled` / `+eager`): the platform owns it. Call it AFTER the conversion
+returns, never on the strength of an intention — outside a `setup()` scope it
+logs and returns `False` instead of raising, so it is safe under `cozy run`.
+
 ## Local dev
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.102.0"
+version = "0.103.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -39,7 +39,7 @@ from .api.export_contract import (
 from .api.formula import RuntimeFormula
 from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
-from .models.provision import arm_compile
+from .models.provision import arm_compile, report_applied_lane
 from .text_pin import TextLengthExceededError, pad_text_sequence
 from .geometry import (
     FamilyGeometry,
@@ -131,6 +131,8 @@ __all__ = [
     "ConfigParam",
     "NoWarmup",
     "arm_compile",
+    # pgw#1104: the serve-time recipe reports the lane it APPLIED.
+    "report_applied_lane",
     # SDK v2 per-request views + text pinning.
     "for_request",
     "FetchedUrl",

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -129,6 +129,13 @@ KIND_OUTPUT_INTEGRITY = "output_integrity"
 KIND_ROTATION_PRELOAD = "rotation_preload"
 KIND_CAPABILITY_RENEWAL = "capability_renewal"
 KIND_RESIDENCY_FAULT = "residency_fault"
+# pgw#1104: a serve-time recipe reported the lane it APPLIED to the weights
+# (`gen_worker.report_applied_lane`), and `metrics.lane` now follows it instead
+# of the binding. `phase` is the component, `detail` carries the applied lane
+# body, the module counts and the BOUND lane it diverged from — so "which pods
+# serve a lane their checkpoint does not name" is one query, not an inference
+# from allocated-bytes rows.
+KIND_APPLIED_LANE = "applied_lane"
 # th#1322: JIT (dynamo/inductor) compile duration, as a typed numeric event.
 # It used to be `logger.info("compiled %s in %.0fs")` and nothing else, so on a
 # hub-spawned pod (no stdout, pgw#760) the one number an AOT-vs-JIT comparison

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2790,6 +2790,12 @@ class _ClassRecord:
     # IDs are minted after successful setup and cleared before vacate; they do
     # not derive from mutable refs, authored specs, or object memory addresses.
     compile_targets: Dict[str, _CompileTargetRecord] = dc_field(default_factory=dict)
+    # pgw#1104: lanes this record's setup() APPLIED to its own weights
+    # (`gen_worker.report_applied_lane`). The binding names the checkpoint the
+    # hub resolved; a serve-time recipe moves the executed lane away from it,
+    # and `_served_execution_lane` must report the lane that RUNS. Dies with
+    # the instance — a new setup re-reports or the lane reverts to the binding.
+    applied_lanes: List[lanespec.AppliedLane] = dc_field(default_factory=list)
     # gw#661: consecutive will-retry setup losses; reset by any success.
     transient_setup_failures: int = 0
     # pgw#748 phase 1: the armed degree-D rank group serving THIS record, or
@@ -5429,40 +5435,55 @@ class Executor:
         body = lanespec.execution_lane_body_id(req.execution_lane)
         return body if body in spec.handles else ""
 
-    def _served_execution_lane(self, spec: EndpointSpec, instructed: str = "") -> str:
-        """The CONCRETE lane this spec's instance executes as, for
-        JobMetrics.lane and ctx.lane reporting: the most-quantized pipeline
-        binding's lane (table rank), with live compile state as a preference.
-        Fixed-mode bodies override it; a declared (handles=) instruction owns
-        the full lane outright."""
+    def _record_applied_lanes(
+        self,
+        spec: EndpointSpec,
+        rec: _ClassRecord,
+        applied: Tuple[lanespec.AppliedLane, ...],
+    ) -> None:
+        """pgw#1104: bank what ``setup()`` reported it did to the weights.
 
-        # pgw#1082: the SAME reading `serving_mode.classify_mode` takes. A
-        # ref-only test made `metrics.lane` report `+eager` while
-        # `serving_mode` correctly reported `jit_cell` on the same request —
-        # a contradiction `_served_identity`'s docstring says cannot happen,
-        # because a JIT INTAKE arm names no artifact by construction.
-        compiled = False
-        if spec.cls is not None:
-            rec = self._classes.get(spec.instance_key)
-            if rec is not None:
-                compiled = any(
-                    getattr(t, "active_compile_ref", "")
-                    or compile_cache.is_compile_armed(t.pipeline)
-                    for t in rec.compile_targets.values())
-        handled = self._handled_execution_lane_body(spec, instructed)
-        if handled:
-            return lanespec.execution_lane_id(lanespec.parse_execution_lane(instructed))
-        # Report the most-quantized binding's lane: quantized lanes always
-        # outrank bf16 (a bf16 VAE riding a w8a16 pipeline is still the
-        # w8a16 lane), ties by table rank.
+        A report that DIVERGES from the binding is the whole point of the
+        mechanism, so it is a wire row and not a log line: the reader must be
+        able to see, from the events alone, that this instance stopped
+        executing the checkpoint's lane and which lane it executes instead."""
+        rec.applied_lanes = list(applied)
+        if not applied:
+            return
+        bound = lanespec.execution_lane_body_id(
+            self._bound_execution_lane(spec, compiled=False))
+        for entry in applied:
+            activity_mod.emit_event(
+                activity_mod.KIND_APPLIED_LANE,
+                detail=f"{entry.detail()} bound={bound}",
+                phase=entry.component)
+
+    def _bound_execution_lane(
+        self, spec: EndpointSpec, compiled: bool,
+    ) -> lanespec.ExecutionLane:
+        """The most-quantized lane this spec's BINDINGS resolve to — what the
+        hub handed the worker, before any serve-time recipe."""
+        return self._most_quantized_lane(
+            [
+                lanespec.execution_lane_of_binding(
+                    getattr(binding, "flavor", "") or "",
+                    getattr(binding, "storage_dtype", "") or "",
+                    compiled)
+                for binding in spec.models.values()
+            ],
+            compiled)
+
+    @staticmethod
+    def _most_quantized_lane(
+        candidates: List[lanespec.ExecutionLane], compiled: bool,
+    ) -> lanespec.ExecutionLane:
+        """Quantized lanes always outrank bf16 (a bf16 VAE riding a w8a16
+        pipeline is still the w8a16 lane), ties by lane-table rank. Empty
+        candidates are the plain bf16 lane at the live compile posture."""
         ranked = {body: i for i, body in enumerate(lanespec.known_execution_lanes())}
         best = None
         best_key: Tuple[int, int] = (2, len(ranked) + 1)
-        for binding in spec.models.values():
-            execution_lane = lanespec.execution_lane_of_binding(
-                getattr(binding, "flavor", "") or "",
-                getattr(binding, "storage_dtype", "") or "",
-                compiled)
+        for execution_lane in candidates:
             quant = 1 if lanespec.family_of(execution_lane) == lanespec.FAMILY_BF16 else 0
             key = (quant, ranked.get(lanespec.execution_lane_id(execution_lane), len(ranked)))
             if best is None or key < best_key:
@@ -5471,7 +5492,57 @@ class Executor:
             best = lanespec.ExecutionLane(
                 weights=lanespec.WEIGHTS_BF16, activation=lanespec.ACT_W16A16,
                 execution=lanespec.EXEC_COMPILED if compiled else lanespec.EXEC_EAGER)
-        return lanespec.execution_lane_id(best)
+        return best
+
+    def _served_execution_lane(self, spec: EndpointSpec, instructed: str = "") -> str:
+        """The CONCRETE lane this spec's instance executes as, for
+        JobMetrics.lane and ctx.lane reporting: the most-quantized lane over
+        the pipeline bindings AND whatever this instance's ``setup()``
+        reported it APPLIED to the weights (table rank), with live compile
+        state as a preference. Fixed-mode bodies override it; a declared
+        (handles=) instruction owns the full lane outright.
+
+        pgw#1104: the applied half is not decoration. minimax-h3 binds a bare
+        tag (empty flavor) and quantizes 300 Linears to w8a8 fp8 inside
+        setup(), so a binding-only derivation priced, verdicted and "proved" a
+        37.4 GiB bf16 lane against a 21.7 GiB fp8 one that was really running.
+        The lane id is a KEY (th#935 verdicts, compile cells, floors,
+        pricing), so it follows the WEIGHTS AS EXECUTED — reported by the
+        recipe that converted them, never sniffed off tensor subclasses."""
+
+        # pgw#1082: the SAME reading `serving_mode.classify_mode` takes. A
+        # ref-only test made `metrics.lane` report `+eager` while
+        # `serving_mode` correctly reported `jit_cell` on the same request —
+        # a contradiction `_served_identity`'s docstring says cannot happen,
+        # because a JIT INTAKE arm names no artifact by construction.
+        compiled = False
+        applied: Tuple[lanespec.AppliedLane, ...] = ()
+        if spec.cls is not None:
+            rec = self._classes.get(spec.instance_key)
+            if rec is not None:
+                compiled = any(
+                    getattr(t, "active_compile_ref", "")
+                    or compile_cache.is_compile_armed(t.pipeline)
+                    for t in rec.compile_targets.values())
+                applied = tuple(rec.applied_lanes)
+        handled = self._handled_execution_lane_body(spec, instructed)
+        if handled:
+            return lanespec.execution_lane_id(lanespec.parse_execution_lane(instructed))
+        candidates = [
+            lanespec.execution_lane_of_binding(
+                getattr(binding, "flavor", "") or "",
+                getattr(binding, "storage_dtype", "") or "",
+                compiled)
+            for binding in spec.models.values()
+        ]
+        # The applied report is validated against the lane table at report
+        # time (`report_applied_lane`), so it can only name a real lane body;
+        # the execution axis stays the platform's.
+        candidates.extend(
+            lanespec.execution_lane_of_body(entry.body, compiled)
+            for entry in applied)
+        return lanespec.execution_lane_id(
+            self._most_quantized_lane(candidates, compiled))
 
     async def ensure_desired_instance(
         self,
@@ -6823,11 +6894,16 @@ class Executor:
                     self.store._cache_dir, compile_artifact,
                     enable=self._arming_enable,
                 )
-                with arming_scope:
+                # pgw#1104: NOT gated on spec.compile — a serve-time recipe
+                # quantizes whether or not this release compiles, and the lane
+                # it applied is what every request then executes.
+                applied_lane_scope = provision.AppliedLaneScope()
+                with arming_scope, applied_lane_scope:
                     if asyncio.iscoroutinefunction(setup):
                         await setup(**inj.kwargs)
                     else:
                         await _to_thread_complete(setup, **inj.kwargs)
+                self._record_applied_lanes(spec, rec, applied_lane_scope.applied)
                 # arm_compile() is the sole unambiguous ownership seam for a
                 # self-loaded pipeline. Such a pipeline may be built from any
                 # path-valued setup input, so freeze every self-loaded slot
@@ -9748,6 +9824,7 @@ class Executor:
                 rec, reason="worker shutdown", code="shutdown")
             inst, rec.instance, rec.ready = rec.instance, None, False
             rec.compile_targets.clear()
+            rec.applied_lanes.clear()
             shutdown = getattr(inst, "shutdown", None)
             if inst is not None and callable(shutdown):
                 try:
@@ -9894,6 +9971,9 @@ class Executor:
         old_obj: Any = None
         inst, rec.instance, rec.ready = rec.instance, None, False
         rec.compile_targets.clear()
+        # pgw#1104: the applied lane belonged to THESE weights; the next setup
+        # re-reports it or the lane honestly reverts to the binding's.
+        rec.applied_lanes.clear()
         # The next full StateDelta must remove the old address before any
         # replacement can become READY. Do this synchronously before teardown
         # awaits; adoption's second validation then rejects the stale ID.

--- a/src/gen_worker/models/execution_lanes.py
+++ b/src/gen_worker/models/execution_lanes.py
@@ -144,6 +144,55 @@ def known_execution_lane_bodies() -> list[str]:
     ]
 
 
+def _body_for_token(token: str) -> Optional[_ExecutionLaneBody]:
+    tok = str(token or "").strip().lower()
+    for body in _KNOWN_BODIES:
+        if execution_lane_body_id(_execution_lane_for_body(body, EXEC_EAGER)) == tok:
+            return body
+    return None
+
+
+def valid_execution_lane_body(token: str) -> bool:
+    """Twin of the hub's ``precision.ValidExecutionLaneBody``."""
+    return _body_for_token(token) is not None
+
+
+def execution_lane_of_body(token: str, compiled: bool) -> ExecutionLane:
+    """The concrete lane a known BODY token executes as under live compile
+    state. Raises ValueError on a token outside the table: the lane
+    vocabulary is platform-wide (the hub joins verdicts, cells and pricing on
+    it) and no caller extends it."""
+    body = _body_for_token(token)
+    if body is None:
+        raise ValueError(
+            f"lane body {token!r} is not a known lane body "
+            f"(known: {', '.join(known_execution_lane_bodies())})")
+    return _with_supported_execution(
+        _execution_lane_for_body(body, EXEC_EAGER), compiled)
+
+
+class AppliedLane(msgspec.Struct, frozen=True, kw_only=True):
+    """What a SERVE-TIME recipe actually did to the weights (pgw#1104).
+
+    The lane a request reports must be the lane its weights execute. A
+    binding names the CHECKPOINT the hub resolved; an endpoint that quantizes
+    inside ``setup()`` (torchao ``quantize_``, wan-2.2's ``_quantize_fp8``,
+    minimax-h3's ``serve_recipe.quantize_dit``) moves the executed lane away
+    from it, and only the code that did the conversion can say so provably.
+    ``body`` is a ``known_execution_lane_bodies()`` token — the same th#1050
+    vocabulary ``handles=`` uses; eager/compiled stays the platform's axis."""
+
+    component: str
+    body: str
+    modules: int = 0
+    kept_bf16: int = 0
+
+    def detail(self) -> str:
+        return (
+            f"component={self.component} applied={self.body} "
+            f"modules={self.modules} kept_bf16={self.kept_bf16}")
+
+
 def valid_execution_lane(execution_lane: ExecutionLane) -> bool:
     if execution_lane.execution not in (EXEC_EAGER, EXEC_COMPILED):
         return False
@@ -281,6 +330,7 @@ class ExecutionLaneUnavailableError(ValueError):
 
 __all__ = [
     "ACT_W16A16",
+    "AppliedLane",
     "ACT_W4A4",
     "ACT_W8A16",
     "ACT_W8A8",
@@ -307,6 +357,8 @@ __all__ = [
     "execution_lane_body_id",
     "execution_lane_id",
     "execution_lane_of_binding",
+    "execution_lane_of_body",
+    "valid_execution_lane_body",
     "parse_execution_lane",
     "parse_execution_lane_spec",
     "valid_execution_lane",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -754,6 +754,96 @@ def arm_compile(pipe: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# pgw#1104: the APPLIED-LANE report. `metrics.lane` used to be a pure function
+# of the binding, so a recipe that quantized in setup() served fp8 under a
+# bf16 label — and the lane id is a KEY (th#935 verdicts, compile cells,
+# pricing, the executed-lane proof). A static `handles=`-style declaration
+# cannot fix it: the recipe is runtime-gated (sm89 for w8a8, the compile
+# preflight), so a declaration would over-claim on the card that skips it.
+# Only the code that converted the weights can report provably, so it does —
+# through the same contextvar scope `arm_compile` uses, so the report is
+# attributed to exactly the setup() that made it and cannot be forged later.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _AppliedLaneContext:
+    applied: list[Any]  # list[execution_lanes.AppliedLane]; owned by the scope
+
+
+_APPLIED_LANE_CTX: "contextvars.ContextVar[Optional[_AppliedLaneContext]]" = (
+    contextvars.ContextVar("gen_worker_applied_lane_ctx", default=None)
+)
+
+
+class AppliedLaneScope:
+    """Context manager the executor/CLI holds open around one ``setup()`` call
+    so ``report_applied_lane()`` lands on that instance. Re-entrant-safe."""
+
+    def __init__(self) -> None:
+        self._applied: list[Any] = []
+        self._value = _AppliedLaneContext(applied=self._applied)
+        self._token: Optional["contextvars.Token[Optional[_AppliedLaneContext]]"] = None
+
+    def __enter__(self) -> "AppliedLaneScope":
+        self._token = _APPLIED_LANE_CTX.set(self._value)
+        return self
+
+    def __exit__(self, *_exc_info: Any) -> None:
+        if self._token is not None:
+            _APPLIED_LANE_CTX.reset(self._token)
+            self._token = None
+
+    @property
+    def applied(self) -> tuple[Any, ...]:
+        """Every ``AppliedLane`` reported inside this setup scope, in order."""
+        return tuple(self._applied)
+
+
+def report_applied_lane(
+    component: str,
+    lane_body: str,
+    *,
+    modules: int = 0,
+    kept_bf16: int = 0,
+) -> bool:
+    """Report the lane a serve-time recipe just APPLIED to ``component``'s
+    weights. Call it from ``setup()`` immediately after the conversion
+    returns — the way ``arm_compile()`` is called after placement.
+
+    ``lane_body`` is one of ``known_execution_lane_bodies()`` (the th#1050
+    vocabulary, e.g. ``"fp8-w8a8-dynamic"``); an unknown token raises
+    ``ValueError`` — the lane vocabulary is shared with the hub and is never
+    extended from an endpoint. The execution axis is NOT the author's: the
+    worker composes ``+compiled``/``+eager`` from live compile state.
+
+    Returns whether the report was recorded. Outside a setup scope (hub-less
+    ``cozy run``, a unit rig) it logs once and returns False — never raises,
+    so every endpoint can call it unconditionally."""
+    from . import execution_lanes
+
+    body = str(lane_body or "").strip().lower()
+    if not execution_lanes.valid_execution_lane_body(body):
+        raise ValueError(
+            f"report_applied_lane({component!r}, {lane_body!r}): not a known "
+            "lane body (known: "
+            f"{', '.join(execution_lanes.known_execution_lane_bodies())})")
+    ctx = _APPLIED_LANE_CTX.get()
+    if ctx is None:
+        logger.info(
+            "gen_worker.report_applied_lane(): no active setup scope; "
+            "%s applied %s is not attributed to an instance", component, body)
+        return False
+    ctx.applied.append(execution_lanes.AppliedLane(
+        component=str(component or "").strip() or "instance",
+        body=body,
+        modules=max(0, int(modules)),
+        kept_bf16=max(0, int(kept_bf16)),
+    ))
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Standalone (hub-less) resolution — the CLI's half. The executor's bytes
 # come from orchestrator-resolved snapshots via ModelStore.ensure_local.
 # ---------------------------------------------------------------------------

--- a/tests/test_applied_lane_pgw1104.py
+++ b/tests/test_applied_lane_pgw1104.py
@@ -1,0 +1,255 @@
+"""pgw#1104: the lane a request REPORTS must be the lane its weights EXECUTE.
+
+The live defect (master stack, pod `x7cenpmm785q27`, requests `4f73d00c` /
+`be2a4c00`, minimax-h3 0.4.6): the endpoint binds `tensorhub/minimax-h3:
+serve-narrowed` — a bare tag with an EMPTY flavor — and then quantizes 300
+Linears of the DiT to w8a8 fp8 with torchao INSIDE `setup()`. Every request
+reported `bf16-w16a16+compiled` while a 21.7 GiB fp8 DiT executed against a
+37.5 GiB bf16 checkpoint. The lane id is a KEY (th#935 verdicts, compile
+cells, floors, pricing, the executed-lane proof), so the label was wrong
+everywhere the key is joined.
+
+REVERT-TURNS-RED: `test_a_serve_time_recipe_moves_the_reported_lane` fails on
+the pre-fix tree (checked on both 0.101.0 and 0.102.0) — `_served_execution_lane`
+was a pure function of the binding, so with the report stubbed out it answers,
+verbatim,
+`assert 'bf16-w16a16+eager' == 'fp8-w8a8-dynamic+compiled'` for an instance
+whose setup() had just converted the weights.
+
+The control matters as much as the red test: `test_an_unapplied_recipe_keeps
+_the_binding_lane` is why position 2 (a STATIC `handles=`-style declaration)
+was rejected in the tracker. H3's recipe is runtime-gated on sm89 and on the
+compile preflight; a declaration would report fp8 on the card that skips it —
+the same defect in the UNSAFE direction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List
+
+import msgspec
+import pytest
+
+import gen_worker
+import gen_worker.executor as ex_mod
+from gen_worker import (
+    RequestContext,
+    Resources,
+    Slot,
+    activity,
+    endpoint,
+    worker_function,
+)
+from gen_worker.executor import Executor
+from gen_worker.models import execution_lanes as lanespec
+from gen_worker.models import provision
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+REF = "tensorhub/minimax-h3:serve-narrowed"
+
+#: Flipped by the fixture to stand in for `serve_recipe.w8a8_capable()`.
+W8A8_CAPABLE = True
+
+
+class GenIn(msgspec.Struct):
+    prompt: str = "x"
+    model: str = ""
+
+
+class Out(msgspec.Struct):
+    y: str = "ok"
+
+
+class Pipe:
+    """A self-hydrating pipeline whose weights setup() converts in place."""
+
+    def __init__(self) -> None:
+        self.quantized = False
+
+    @classmethod
+    def from_pretrained(cls, path: Any, **_kw: Any) -> "Pipe":
+        return cls()
+
+    def __call__(self, *_a: Any, **_kw: Any) -> dict:
+        return {"out": 1}
+
+
+@endpoint(models={"pipeline": Slot(Pipe, selected_by="model")},
+          resources=Resources(gpu=True))
+class H3:
+    def setup(self, pipeline: Pipe) -> None:
+        self.pipeline = pipeline
+        # The shape of `minimax_h3.serve_recipe.quantize_dit`: a capability
+        # gate, an in-place `quantize_()`, then the report — never before.
+        if not W8A8_CAPABLE:
+            return
+        pipeline.quantized = True
+        gen_worker.report_applied_lane(
+            "transformer", "fp8-w8a8-dynamic", modules=300, kept_bf16=70)
+
+    @worker_function()
+    def generate(self, ctx: RequestContext, p: GenIn) -> Out:
+        return Out()
+
+
+@pytest.fixture
+def boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """One real `ensure_setup()`. Nothing about the lane derivation is faked:
+    the executor's own AppliedLaneScope, `_record_applied_lanes` and
+    `_served_execution_lane` all run."""
+    events: List[Any] = []
+    real_emit = activity.emit_event
+
+    def _spy(kind: str, detail: str = "", **kw: Any) -> Any:
+        events.append((kind, kw.get("phase", ""), detail))
+        try:
+            return real_emit(kind, detail, **kw)
+        except Exception:
+            return None
+
+    monkeypatch.setattr(activity, "emit_event", _spy)
+    monkeypatch.setattr(ex_mod.activity_mod, "emit_event", _spy)
+
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor(extract_specs(H3), _send)
+    ex.store._cache_dir = tmp_path / "cas"
+
+    async def _fake_download(ref: str, **_kw: Any) -> Path:
+        p = tmp_path / ref.replace("/", "_").replace(":", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+
+    from gen_worker import dispatch
+
+    eff = ex._dispatched_spec(
+        ex.specs["generate"],
+        {"pipeline": dispatch.SlotOrder(ref=REF, components=())},
+    )
+    snaps = {
+        REF: pb.Snapshot(
+            digest="blake3:" + "a" * 64,
+            files=[pb.SnapshotFile(
+                path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+                url="http://r2.invalid/p")],
+        )
+    }
+    return ex, eff, snaps, events
+
+
+def test_a_serve_time_recipe_moves_the_reported_lane(boot) -> None:
+    """The red test. The binding is a bare tag (empty flavor, bf16), setup()
+    quantizes to w8a8 fp8 and says so — the served lane is the fp8 one."""
+    ex, eff, snaps, events = boot
+
+    async def _go() -> None:
+        inst = await ex.ensure_setup(eff, snaps)
+        assert inst.pipeline.quantized is True
+        rec = ex._classes[eff.instance_key]
+        assert [a.body for a in rec.applied_lanes] == ["fp8-w8a8-dynamic"]
+        # The binding on its own still says bf16 — the divergence is real,
+        # not a mis-resolved binding.
+        assert lanespec.execution_lane_body_id(
+            ex._bound_execution_lane(eff, compiled=False)) == "bf16-w16a16"
+        assert ex._served_execution_lane(eff) == "fp8-w8a8-dynamic+compiled"
+
+    asyncio.run(_go())
+
+
+def test_the_divergence_is_a_wire_row(boot) -> None:
+    """A lane that stopped following its checkpoint must be visible from the
+    events alone — pgw#1093 cost an issue to a fact that was only inferable
+    from allocated-bytes rows."""
+    ex, eff, snaps, events = boot
+
+    async def _go() -> None:
+        await ex.ensure_setup(eff, snaps)
+        rows = [(phase, detail) for kind, phase, detail in events
+                if kind == activity.KIND_APPLIED_LANE]
+        assert len(rows) == 1
+        phase, detail = rows[0]
+        assert phase == "transformer"
+        assert "applied=fp8-w8a8-dynamic" in detail
+        assert "modules=300 kept_bf16=70" in detail
+        assert "bound=bf16-w16a16" in detail
+
+    asyncio.run(_go())
+
+
+def test_an_unapplied_recipe_keeps_the_binding_lane(
+    boot, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Why the report is the mechanism and a declaration is not: the recipe's
+    capability gate refuses, no conversion happens, and the lane stays the
+    binding's. A static declaration would over-claim here."""
+    ex, eff, snaps, events = boot
+    monkeypatch.setattr(__import__(__name__), "W8A8_CAPABLE", False)
+
+    async def _go() -> None:
+        inst = await ex.ensure_setup(eff, snaps)
+        assert inst.pipeline.quantized is False
+        assert ex._classes[eff.instance_key].applied_lanes == []
+        assert ex._served_execution_lane(eff).startswith("bf16-w16a16+")
+        assert not [e for e in events if e[0] == activity.KIND_APPLIED_LANE]
+
+    asyncio.run(_go())
+
+
+def test_the_lane_dies_with_the_instance(boot) -> None:
+    """An applied lane describes THESE weights. A vacated record must not keep
+    reporting fp8 for the bf16 instance that replaces it."""
+    ex, eff, snaps, events = boot
+
+    async def _go() -> None:
+        await ex.ensure_setup(eff, snaps)
+        rec = ex._classes[eff.instance_key]
+        assert rec.applied_lanes
+        await ex._vacate_record(rec)
+        assert rec.applied_lanes == []
+        assert ex._served_execution_lane(eff).startswith("bf16-w16a16+")
+
+    asyncio.run(_go())
+
+
+# --- the vocabulary is platform-wide: an endpoint never extends it ---------
+
+
+def test_an_unknown_lane_body_is_refused_at_report_time() -> None:
+    with pytest.raises(ValueError) as e:
+        gen_worker.report_applied_lane("transformer", "fp8-w8a8")  # no scale axis
+    assert "not a known lane body" in str(e.value)
+    with pytest.raises(ValueError):
+        gen_worker.report_applied_lane("transformer", "fp6-w6a6-dynamic")
+    # The execution axis is the platform's, never the author's.
+    with pytest.raises(ValueError):
+        gen_worker.report_applied_lane("transformer", "fp8-w8a8-dynamic+compiled")
+
+
+def test_every_reportable_body_composes_into_a_known_lane_id() -> None:
+    """Whatever an endpoint may report must land inside `known_execution_lanes()`
+    — the byte-identical twin of the hub's `precision.KnownExecutionLanes()`,
+    which every verdict, cell and price joins on."""
+    known = set(lanespec.known_execution_lanes())
+    for body in lanespec.known_execution_lane_bodies():
+        for compiled in (True, False):
+            lane = lanespec.execution_lane_of_body(body, compiled)
+            assert lanespec.execution_lane_id(lane) in known
+
+
+def test_a_report_outside_setup_is_not_attributed_and_never_raises() -> None:
+    """`arm_compile`'s contract: hub-less runs and unit rigs call it too."""
+    assert gen_worker.report_applied_lane("transformer", "fp8-w8a8-dynamic") is False
+    with provision.AppliedLaneScope() as scope:
+        assert gen_worker.report_applied_lane(
+            "transformer", "fp8-w8a8-dynamic", modules=300, kept_bf16=70) is True
+    assert [a.body for a in scope.applied] == ["fp8-w8a8-dynamic"]
+    # The scope closed: a later report reaches nothing.
+    assert gen_worker.report_applied_lane("transformer", "fp8-w8a8-dynamic") is False

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.102.0"
+version = "0.103.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
`_served_execution_lane` derived the lane from `binding.flavor` /
`binding.storage_dtype` plus live compile state and read nothing about what
`setup()` did to the weights. minimax-h3 binds a bare tag with an EMPTY flavor
and then quantizes 300 transformer Linears to w8a8 fp8 with torchao in place
inside `setup()`, so production reported `bf16-w16a16+compiled` while a
21.7 GiB fp8 DiT executed against a 37.5 GiB bf16 checkpoint (pod
`x7cenpmm785q27`, requests `4f73d00c` / `be2a4c00`). The lane id is a KEY —
th#935 verdicts, compile cells, floors, pricing and the executed-lane proof all
join on it — so all of them were keyed to a lane the fleet did not run, and it
cost pgw#1093 an issue's worth of "the fp8 lane is not routing" that was never
true.

POSITION 1 of the two the issue named, decided in the tracker first: the lane
follows the weights, reported TYPED by the recipe that converted them. A static
`handles=`-style declaration was rejected on its own criterion — H3's recipe is
runtime-gated (sm89 for w8a8, the compile preflight), so a declaration would
report fp8 on the card that skips the conversion: the same defect in the UNSAFE
direction. A subclass sniff was never on the table.

- `gen_worker.report_applied_lane(component, lane_body, modules=, kept_bf16=)`
  — called right after `quantize_()` returns, exactly where `arm_compile()` is
  called after placement, and scoped to the executor's `setup()` through the
  same contextvar pattern (`provision.AppliedLaneScope`), so a report cannot be
  forged from a handler or a background thread.
- The vocabulary is NOT extended: `lane_body` must be a
  `known_execution_lane_bodies()` token (the th#1050 set, byte-identical to the
  hub's `precision.KnownExecutionLaneBodies()`); anything else is a typed
  ValueError at report time. The execution axis stays the worker's, composed
  from live compile state through the lane table's own support rule.
- `_served_execution_lane` now ranks bindings AND applied lanes under the same
  most-quantized-wins rule; `_bound_execution_lane` / `_most_quantized_lane`
  factor the binding half out so the DIVERGENCE can be named.
- A divergence is a wire row (`applied_lane` activity event: applied body,
  module counts, and the bound lane it left), not a log line — pgw#1093 lost an
  issue to a fact that was only inferable from allocated-bytes rows.
- `rec.applied_lanes` dies with the instance (vacate + shutdown): an applied
  lane describes THOSE weights.

Tests: `tests/test_applied_lane_pgw1104.py`, one real `ensure_setup()`. Red on
the pre-fix tree with the report stubbed — `assert 'bf16-w16a16+eager' ==
'fp8-w8a8-dynamic+compiled'`, verified on 0.101.0 and again on 0.102.0 after
the rebase. The control (capability gate refuses, nothing applied, lane stays
the binding's) is the executable form of why position 2 was rejected.

VERSION: 0.103.0. A new name in `gen_worker.__all__` is a MINOR bump (the
fleet's `[supported]` allowlist is keyed on MAJOR.MINOR), and 0.102.0 is
already published and floored by the fleet1020 train.

The endpoint half is ie#644: minimax-h3 and wan-2.2 must CALL this on
gen-worker >=0.103.0 before their labels become true in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHywnqnYgUUFKJ7zagNUJ1