### PR TITLE
pgw#1031: fold the graph body into the cell key — the `graph` axis is the traced COMPUTATION

### DIFF
--- a/changelog.d/pgw1031.md
+++ b/changelog.d/pgw1031.md
@@ -1,22 +1,26 @@
-- **pgw#1031: a cell may no longer serve a graph the adopting pod does not
-  compute — the GRAPH WITNESS floor.** The `ck1` key is an INGRESS identity:
-  `class_hash` folds target, fork, class dims, declared ranges and the
-  graph-interface block (constant FQNs, lifted inputs, pytree spec,
+- **pgw#1031: the cell key is now the traced COMPUTATION, not the traced
+  ingress — two different graphs behind one declaration key APART.** Before
+  this, `class_hash` folded target, fork, class dims, declared ranges and the
+  graph-INTERFACE block (constant FQNs, lifted inputs, pytree spec,
   specialization), plus the declared envelope, `sm` and `toolchain` — every
-  fact about how a graph is CALLED and none about what it COMPUTES. Two
-  endpoints whose declarations agree while their bodies differ therefore mint
-  under ONE key. Measured, not argued: `micro-pad32` and `micro-pad32-branchy`
+  fact about how a graph is CALLED and none about what it COMPUTES — so two
+  endpoints whose declarations agreed while their bodies differed minted under
+  ONE `ck1` key. Measured, not argued: `micro-pad32` and `micro-pad32-branchy`
   trace 112- and 102-node graphs and produce a BYTE-IDENTICAL keying block, one
   `ck1` digest, and (pgw#1079, on a real card) two different artifacts. Under
-  pull-by-key adoption (§4.27) one endpoint gets the other's kernels, and only
-  the arm-time numerics tolerance stands between that and served output.
-  `aot_mint.keying_block` now records `graph_witness` per entry — the node-level
-  digest of the traced program (`graph_hash.graph_hash`) — as a SIBLING of
-  `graph`, so it is metadata and **no cell is re-keyed**. `boot_key` reports
-  the witnesses it traced (`DerivedKey.graph_witnesses`, memo v3), and
-  `boot_adopt` refuses a materialized cell whose recorded witness is not the
-  one this pod traced: typed `graph_witness_mismatch`, naming the entry and
-  BOTH digests, degrading to eager-then-mint. Fail-closed both ways — a cell
-  silent on its witness is refused, not skipped. Whether the witness should
-  BECOME a key axis (a deliberate fleet-wide re-key) stays pgw#1031 and is
-  Paul's to rule; this ships the floor that holds either way.
+  pull-by-key adoption (§4.27) one endpoint got the other's kernels, with only
+  the arm-time numerics tolerance between that and served output. Fix (Paul's
+  ruling, option a): `aot_serve.class_hash` (facts v3) now folds the node-level
+  `graph_witness` (`graph_hash.graph_hash`) that `aot_mint.keying_block` already
+  records per entry — the ONE derivation shared by mint stamp, admission
+  (`verify_contract`) and boot (`boot_key.fold`), so the key is sound by
+  construction and a collision is a MISS (eager + mint), the cheap outcome. This
+  RE-KEYS the fleet (pre-launch, expected and free — the corpus was already
+  re-keying for the pgw#1097 folding fence); `ck1` stays (no scheme bump). The
+  GRAPH WITNESS floor shipped earlier as this issue's fail-closed metadata
+  backstop stays as defense-in-depth: `graph_witness` remains a top-level
+  sibling, `boot_key` reports what it traced (`DerivedKey.graph_witnesses`, memo
+  v3), and `boot_adopt`/`aot_identity.verify_graph_witness` still refuse a
+  materialized cell whose recorded witness is not this pod's graph (typed
+  `graph_witness_mismatch`, naming the entry and BOTH digests) — belt-and-braces
+  beneath the now-sound key.

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -166,8 +166,10 @@ def verify_declared_identity(
 
 
 #: The entry-block field carrying the node-level digest of the traced program
-#: (``graph_hash.graph_hash``), stamped by ``aot_mint.keying_block``. METADATA,
-#: never a key axis — see :func:`verify_graph_witness`.
+#: (``graph_hash.graph_hash``), stamped by ``aot_mint.keying_block``. Since
+#: pgw#1031 (option a) it is FOLDED into ``class_hash`` (the key), and it also
+#: stays recorded here as a top-level sibling for the adopt backstop — see
+#: :func:`verify_graph_witness`.
 GRAPH_WITNESS_FIELD = "graph_witness"
 
 
@@ -175,25 +177,26 @@ def verify_graph_witness(
     meta: Mapping[str, Any], witnesses: Mapping[str, str],
 ) -> str:
     """``''`` when the cell's recorded graph witnesses equal the ones this pod
-    traced, else the reason. pgw#1031's fail-closed floor.
+    traced, else the reason. pgw#1031's fail-closed backstop.
 
-    The cell key is an INGRESS identity: ``class_hash`` folds target, fork,
-    class dims, declared ranges, the graph-interface block (constant FQNs,
-    lifted inputs, pytree spec, specialization) and the declared envelope —
-    everything about how a graph is CALLED and nothing about what it COMPUTES.
-    Two endpoints whose bodies differ while their declarations agree therefore
-    mint under one ``ck1`` key: measured 2026-08-10 on ``micro-pad32`` vs
-    ``micro-pad32-branchy`` (112 vs 102 nodes, byte-identical keying block,
-    identical key). Pull-by-key adoption (§4.27/pgw#1090) then hands one
-    endpoint the other's kernels, and only the arm-time numerics gate — a
-    tolerance test, not identity — stands between that and served output.
+    Since pgw#1031 (option a) the cell key IS the traced computation:
+    ``class_hash`` folds ``graph_witness`` (the node-level body digest) beside
+    target, fork, class dims, declared ranges, the graph-interface block and
+    the declared envelope, so two endpoints whose bodies differ while their
+    declarations agree now key APART — a collision is a MISS, not a wrong hit.
+    Before the fold they minted under one ``ck1`` key (measured 2026-08-10 on
+    ``micro-pad32`` vs ``micro-pad32-branchy``: 112 vs 102 nodes, byte-identical
+    keying block, identical key), and pull-by-key adoption (§4.27/pgw#1090)
+    would hand one endpoint the other's kernels with only the arm-time numerics
+    tolerance between that and served output.
 
-    This closes it WITHOUT re-keying the fleet: the mint records
-    ``graph_witness`` per entry, the adopter derives its own from the same
-    traced programs its key came from (``boot_key``), and a disagreement is a
-    typed refusal naming both digests. The pod then boots exactly as it booted
-    before pull-by-key existed — eager, then mint — which is the correct
-    outcome for "this cell is not my computation".
+    This function is the belt-and-braces beneath the now-sound key: the mint
+    records ``graph_witness`` per entry, the adopter derives its own from the
+    same traced programs its key came from (``boot_key``), and a disagreement —
+    a witness-blind cell, a hash-broken entry, a cross forced by any non-key
+    path — is a typed refusal naming both digests. The pod then boots exactly
+    as it booted before pull-by-key existed — eager, then mint — which is the
+    correct outcome for "this cell is not my computation".
 
     Fail-closed in both directions, the doctrine
     :func:`verify_declared_identity` already keeps: a cell that is SILENT on an

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -3408,19 +3408,19 @@ def keying_block(
     ``aot_serve.entries_from_meta`` validates every block as a full contract,
     and an entry that cannot be parsed cannot be keyed.
 
-    ``graph_witness`` (pgw#1031) is a SIBLING of ``graph``, deliberately
-    OUTSIDE it: ``aot_serve.class_hash`` folds ``target``/``fork``/
-    ``class_dims``/``range_digest``/``graph``/``strict``/``lora_bucket`` and
-    nothing else, so a top-level field is recorded on every cell without
-    moving one key. It is the node-level digest of the traced program
-    (``graph_hash.graph_hash``) — the fact the key axes provably do NOT hold:
-    measured 2026-08-10, ``micro-pad32`` and ``micro-pad32-branchy`` produce a
-    byte-identical keying block (identical signature, symbol ranges, pytree
-    spec, constant FQNs and declared envelope) from 112- and 102-node graphs.
-    The key cannot separate them; this witness can, and the adopt path refuses
-    on it (``aot_identity.verify_graph_witness``) so a collision degrades to
-    eager instead of serving another endpoint's kernels. Whether the witness
-    should BECOME a key axis is pgw#1031's depth question and Paul's to rule.
+    ``graph_witness`` (pgw#1031) is the node-level digest of the traced
+    program (``graph_hash.graph_hash``). It is recorded as a top-level SIBLING
+    of ``graph`` AND folded into the key: since pgw#1031 (option a, Paul-ruled)
+    ``aot_serve.class_hash`` (facts v3) folds it, so the ``graph`` axis is the
+    traced COMPUTATION, not merely the traced ingress. It was measured that the
+    interface alone could not separate two bodies — 2026-08-10, ``micro-pad32``
+    and ``micro-pad32-branchy`` produced a byte-identical keying block
+    (identical signature, symbol ranges, pytree spec, constant FQNs and
+    declared envelope) from 112- and 102-node graphs, one key, two artifacts.
+    The witness closes that at the key: two bodies key apart, a collision is a
+    MISS (eager + mint). It stays a top-level field for the adopt backstop
+    (``aot_identity.verify_graph_witness``, defense-in-depth), which refuses a
+    materialized cell whose recorded witness is not this pod's graph.
     """
     inputs, symbols = aot_package.input_contract(program, flat_leaves)
     block: Dict[str, Any] = {

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -558,18 +558,36 @@ def class_hash(
     Folds the entry's coordinate (target, fork, class dims), its
     ``range_digest`` (the MEASURED node-only-collision fix: three exports
     differing only in declared range hashed identically), its graph
-    interface block, and the trace-mode/lora facts. 16-hex, recomputable
-    from the entry block alone — so a consumer can prove the stamp and a
-    mismatch NAMES the class (the receipts principle).
+    interface block, the node-level ``graph_witness`` body digest, and the
+    trace-mode/lora facts. 16-hex, recomputable from the entry block alone —
+    so a consumer can prove the stamp and a mismatch NAMES the class (the
+    receipts principle).
+
+    ``graph_witness`` (v3, pgw#1031): the node-level digest of the traced
+    program (``graph_hash.graph_hash``, recorded on every keying block by
+    ``aot_mint.keying_block``). Before v3 this axis folded only the graph
+    INTERFACE (``graph``) — the traced ingress identity — so two endpoints
+    whose declarations agreed while their bodies differed shared a key
+    (measured 2026-08-10: ``micro-pad32`` 112 nodes vs ``micro-pad32-branchy``
+    102 nodes, byte-identical keying block, one key, two artifacts). Folding
+    the witness here makes the key sound BY CONSTRUCTION: two different bodies
+    key apart, a collision becomes a MISS (eager + mint), which is the cheap
+    outcome. The witness stays recorded as a top-level sibling for the adopt
+    backstop (``aot_identity.verify_graph_witness``) — defense-in-depth. The
+    fold is tolerant of a missing witness (folds ``""``) so a pre-witness
+    entry is body-blind rather than unhashable; production entries always
+    carry it (``keying_block``), and such stale cells are refused by the
+    envelope/structure gates and the witness backstop regardless.
     """
     facts = {
-        "v": 2,
+        "v": 3,
         "target": str(entry.get("target") or ""),
         "fork": [[str(n), v] for n, v in (entry.get("fork") or [])],
         "class_dims": [
             [str(n), int(v)] for n, v in (entry.get("class_dims") or [])],
         "range_digest": str(entry.get("range_digest") or ""),
         "graph": dict(entry.get("graph") or {}),
+        "graph_witness": str(entry.get("graph_witness") or ""),
         "strict": bool(strict),
         "lora_bucket": int(lora_bucket or 0),
     }

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -238,11 +238,11 @@ class DerivedKey:
     trace_ms: Mapping[str, int] = field(default_factory=dict)
     nodes: Mapping[str, int] = field(default_factory=dict)
     #: pgw#1031: entry name -> the NODE-level digest of the graph this boot
-    #: traced (``aot_mint.keying_block``'s ``graph_witness``). Not a key axis
-    #: and never folded into one — it is what the adopt path compares against
-    #: the cell's own record, because the key provably cannot separate two
-    #: bodies behind one declaration. Rides the keying blocks, so a memo hit
-    #: carries it exactly as a cold trace does.
+    #: traced (``aot_mint.keying_block``'s ``graph_witness``). Since option a it
+    #: is FOLDED into ``class_hash`` (so the key now separates two bodies behind
+    #: one declaration) AND kept here for the adopt backstop, which compares it
+    #: against the cell's own record (defense-in-depth). Rides the keying
+    #: blocks, so a memo hit carries it exactly as a cold trace does.
     graph_witnesses: Mapping[str, str] = field(default_factory=dict)
 
     @property
@@ -521,10 +521,11 @@ def class_hashes_of(
 
     Stamped by ``aot_serve.artifact_metadata`` — the mint's own function — so a
     hash computed here and a hash the mint stamped are the same computation.
-    The envelope/precision/strict arguments do not reach ``class_hash``
-    (it folds target/fork/class_dims/range_digest/graph/strict/lora_bucket),
-    which is why this can answer without them; ``strict``/``lora_bucket`` DO,
-    so they are read off the blocks' own ``graph.specialization``.
+    The envelope/precision/strict arguments do not reach ``class_hash`` (it
+    folds target/fork/class_dims/range_digest/graph/graph_witness/strict/
+    lora_bucket), which is why this can answer without them; ``strict``/
+    ``lora_bucket`` DO, so they are read off the blocks' own
+    ``graph.specialization``.
     """
     head = next(iter(blocks.values()), {}) if blocks else {}
     spec = dict((head.get("graph") or {}).get("specialization") or {})

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -16,24 +16,25 @@ test admits four axes and no more:
                   newline-joined SORTED per-entry ``class_hash`` values
                   (pgw#716). Each class hash folds the entry's target, fork
                   coordinate, class dims, declared-range digest,
-                  graph-INTERFACE block, trace mode and lora bucket
-                  (``aot_serve.class_hash`` / ``aot_serve.combined_graph_hash``
-                  — stamped by ``aot_serve.artifact_metadata``, proven at
-                  admission by ``aot_serve.verify_contract``, READ — never
-                  re-derived — here).
+                  graph-INTERFACE block, the node-level ``graph_witness`` body
+                  digest, trace mode and lora bucket (``aot_serve.class_hash``
+                  / ``aot_serve.combined_graph_hash`` — stamped by
+                  ``aot_serve.artifact_metadata``, proven at admission by
+                  ``aot_serve.verify_contract``, READ — never re-derived —
+                  here).
 
-                  **Read the name precisely: this axis is the traced INGRESS
-                  identity, not the traced computation.** No graph-NODE digest
-                  reaches it, so two endpoints whose declarations agree while
-                  their bodies differ collide — measured 2026-08-10,
-                  ``micro-pad32`` vs ``micro-pad32-branchy``: 112- and 102-node
-                  graphs, byte-identical keying block, one key, two artifacts.
-                  Whether the nodes SHOULD be keyed (a deliberate fleet-wide
-                  re-key) is pgw#1031 and is Paul's to rule. Until then the
-                  hole is not merely noted: every entry records a
-                  ``graph_witness`` (``graph_hash.graph_hash``, metadata — see
-                  ``aot_mint.keying_block``) and the adopt path refuses a cell
-                  whose witness is not the graph this pod traced
+                  **This axis is the traced COMPUTATION** (pgw#1031, option a,
+                  Paul-ruled): since class_hash facts v3 the per-node digest
+                  (``graph_hash.graph_hash``) folds in, so two endpoints whose
+                  declarations agree while their bodies differ key APART. Before
+                  v3 the axis folded the graph INTERFACE only and they collided
+                  — measured 2026-08-10, ``micro-pad32`` vs
+                  ``micro-pad32-branchy``: 112- and 102-node graphs,
+                  byte-identical keying block, one key, two artifacts; post-fix
+                  two keys. A residual collision (a witness-blind or hash-broken
+                  entry) is still caught belt-and-braces: every entry records a
+                  ``graph_witness`` top-level sibling and the adopt path refuses
+                  a cell whose witness is not the graph this pod traced
                   (``aot_identity.verify_graph_witness``).
     envelope      the DECLARED serving region (flight-envelope sense): the
                   shape ladder x text lens x guidance classes the author

--- a/src/gen_worker/graph_hash.py
+++ b/src/gen_worker/graph_hash.py
@@ -1,15 +1,16 @@
 """Canonical GRAPH identity (pgw#716).
 
-**What this digest is USED for today (pgw#1031, read this before the ruling
-below):** it is the pgw#917 same-class comparator and the per-entry
-``graph_witness`` — recorded on every cell by ``aot_mint.keying_block`` and
-compared at adopt time by ``aot_identity.verify_graph_witness``. It is **not**
-folded into ``cell_key``: the ``graph`` axis is ``combined_graph_hash`` over
-``class_hash``, which folds the graph INTERFACE and no node digest, so two
-different computations behind one declaration share a key (measured
-2026-08-10). Whether this digest should BECOME the key is pgw#1031's depth
-question and Paul's to rule; the witness is the fail-closed floor that holds
-either way.
+**What this digest is USED for (pgw#1031, Paul-ruled option a):** it is the
+pgw#917 same-class comparator, the per-entry ``graph_witness`` recorded on
+every cell by ``aot_mint.keying_block``, AND — since pgw#1031 — a folded input
+to the key. ``aot_serve.class_hash`` (facts v3) folds ``graph_witness`` so the
+``graph`` axis (``combined_graph_hash`` over ``class_hash``) is the traced
+COMPUTATION, not merely the traced ingress: two different computations behind
+one declaration now key APART (before the fold they shared a key — measured
+2026-08-10, ``micro-pad32`` vs ``micro-pad32-branchy``). The witness also
+stays recorded as a top-level sibling and is compared at adopt time by
+``aot_identity.verify_graph_witness`` — the fail-closed backstop that catches
+any residual witness-blind collision (defense-in-depth).
 
 Paul's ruling: "I'd rather key on the graph that is changed, not hash on code
 changes... look at some code and be like 'oh this is graph-ABC' and that is the

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -1,23 +1,28 @@
-"""pgw#1031 — the cell key is an INGRESS identity, and two different
-computations behind one declaration collide inside it.
+"""pgw#1031 — the cell key is the traced COMPUTATION, and two different
+computations behind one declaration now key APART (option a, Paul-ruled).
 
 The LIVE SIGHTING this file pins, measured 2026-08-10 during pgw#1079: the
-gauntlet's ``micro-pad32`` and ``micro-pad32-branchy`` members mint two
-different artifacts (``sha256:aeedeba3…`` / ``sha256:1613596c…``) under ONE
-``ck1`` key. They are the same model with two spellings of the same pad, so
-every DECLARED fact agrees — signature, symbol ranges, pytree spec, constant
-FQNs, declared envelope — while the traced bodies do not (112 nodes vs 102).
-``class_hash`` folds only the declared facts, so the key cannot see it.
+gauntlet's ``micro-pad32`` and ``micro-pad32-branchy`` members are the same
+model with two spellings of the same pad, so every DECLARED fact agrees —
+signature, symbol ranges, pytree spec, constant FQNs, declared envelope —
+while the traced bodies do not (112 nodes vs 102). Before pgw#1031's depth fix
+``class_hash`` folded only the declared/interface facts, so the key could not
+see the body and both minted under ONE ``ck1`` key. The fix folds the
+node-level ``graph_witness`` into ``class_hash`` (facts v3), so the ``graph``
+axis is now the computation: the two members derive DIFFERENT keys and a
+collision is a MISS (eager + mint), the cheap outcome.
 
-Two rows, and they are the whole issue:
+The rows:
 
-* :func:`test_the_collision_is_real` traces both families through the mint's
-  OWN ``trace_for_key`` and asserts the keying blocks are byte-identical while
-  the graph witnesses differ. It is the RED half — pre-mitigation, pull-by-key
-  hands ``micro-pad32-branchy`` the ``micro-pad32`` cell and nothing refuses.
-* :func:`test_the_witness_refuses_the_collision` runs the mitigation over the
-  same two traced blocks: the matching pod admits, the colliding pod is
-  REFUSED by a reason naming both digests.
+* :func:`test_the_bodies_now_key_apart` traces both families through the mint's
+  OWN ``trace_for_key`` and asserts the keying blocks are byte-identical on the
+  INTERFACE half while the graph witnesses differ — AND the derived keys now
+  differ. It is the RED→GREEN proof: pre-fix one key, post-fix two.
+* :func:`test_the_witness_backstops_a_residual_collision` runs the
+  defense-in-depth backstop over the same two traced blocks: even given a cell
+  built from one member's blocks, the matching pod admits and the colliding pod
+  is REFUSED by a reason naming both digests. The witness stays as belt-and-
+  braces beneath the now-sound key.
 
 **No compile anywhere.** ``trace_for_key`` is ``torch.export`` and stops there
 (Paul 2026-08-10: tracing for key derivation is explicitly permitted locally;
@@ -120,31 +125,48 @@ def _canon(block: Any) -> str:
     return json.dumps(block, sort_keys=True, separators=(",", ":"))
 
 
-def test_the_collision_is_real(traced_pair: Dict[str, Any]) -> None:
-    """RED: one key, two computations — and every keyed fact agrees."""
+def test_the_bodies_now_key_apart(traced_pair: Dict[str, Any]) -> None:
+    """GREEN (was RED): the INTERFACE half is identical, the bodies differ,
+    and the depth fix makes the two members derive DIFFERENT keys.
+
+    Pre-pgw#1031 this asserted ONE shared key (the collision). The fix folds
+    ``graph_witness`` into ``class_hash``, so the same identical-declaration /
+    different-body pair keys apart — a collision is now a MISS, not a wrong hit.
+    """
     fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
     assert set(fixed["blocks"]) == set(branchy["blocks"]) == {"transformer"}
 
     a, b = fixed["blocks"]["transformer"], branchy["blocks"]["transformer"]
-    keyed = {k: v for k, v in a.items() if k != "graph_witness"}
-    other = {k: v for k, v in b.items() if k != "graph_witness"}
-    assert _canon(keyed) == _canon(other), (
-        "the keyed half of the block is expected to be IDENTICAL — if this "
-        "fails the collision has been closed by some other axis and pgw#1031's "
-        "sighting needs re-stating")
-    assert fixed["key"].digest == branchy["key"].digest, (
-        "THE DEFECT: two different graphs under one ck1 key. A red here means "
-        "identity gained graph depth — update pgw#1031, do not weaken this")
+    interface_a = {k: v for k, v in a.items() if k != "graph_witness"}
+    interface_b = {k: v for k, v in b.items() if k != "graph_witness"}
+    assert _canon(interface_a) == _canon(interface_b), (
+        "the INTERFACE half of the block is expected to be IDENTICAL — the two "
+        "members declare the same ingress; if this fails the pair no longer "
+        "isolates the body axis and pgw#1031's sighting needs re-stating")
 
-    # …and the two graphs really are different computations.
+    # The two graphs really are different computations…
     assert a["graph_witness"] and b["graph_witness"]
     assert a["graph_witness"] != b["graph_witness"], (
-        "the witness must separate what the key cannot; equal digests here "
-        "would mean the witness is as blind as the key")
+        "the witness must separate the bodies; equal digests here would mean "
+        "the pair no longer differs in its computation")
+
+    # …and THE FIX: the key now sees the body, so the members key apart.
+    assert fixed["key"].digest != branchy["key"].digest, (
+        "THE FIX (pgw#1031 option a): identical ingress, different bodies must "
+        "derive DIFFERENT keys. A red here means the graph axis went body-blind "
+        "again — class_hash must fold graph_witness")
 
 
-def test_the_witness_refuses_the_collision(traced_pair: Dict[str, Any]) -> None:
-    """GREEN: the matching pod adopts; the colliding pod is refused by name."""
+def test_the_witness_backstops_a_residual_collision(
+    traced_pair: Dict[str, Any],
+) -> None:
+    """Defense-in-depth: given a cell built from one member's blocks, the
+    matching pod adopts and the colliding pod is refused by name.
+
+    The key now separates the two members (``test_the_bodies_now_key_apart``),
+    so pull-by-key never hands the wrong cell over in the first place. This
+    proves the backstop still holds beneath the sound key: were a witness-blind
+    cell ever handed over, the adopt path still refuses on the witness."""
     fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
     cell = aot_serve.artifact_metadata(
         family=PAIR[0], precision="", cell_key=fixed["key"].digest,
@@ -202,17 +224,23 @@ def _meta(row: Dict[str, Any], family: str) -> Dict[str, Any]:
     return meta
 
 
-def test_every_landed_gate_admits_the_wrong_cell(
+def test_the_key_now_separates_what_the_gates_could_not(
     traced_pair: Dict[str, Any],
 ) -> None:
-    """RED: nothing that shipped before pgw#1031 separates these two cells.
+    """GREEN (was RED): the depth fix separates the two cells AT THE KEY.
 
-    Pod ``micro-pad32-branchy`` derives a key, the hub answers it with the
-    ``micro-pad32`` cell — correctly, they ARE one key — and then every
-    admission gate the tree has agrees: the declared identity matches on all
-    four compared axes (``combined_graph_hash`` included, because that is the
-    same collided digest), and the contract is self-consistent. The wrong
-    kernels arm, and the only thing left is the arm-time numerics tolerance.
+    Before pgw#1031 nothing that shipped separated these cells: pod
+    ``micro-pad32-branchy`` derived the SAME key as ``micro-pad32``, the hub
+    answered its pull with the wrong cell, and every admission gate agreed
+    (``verify_declared_identity`` clean on all four axes, ``verify_contract``
+    self-consistent) — only the arm-time numerics tolerance stood between that
+    and wrong output. The fix folds the body into ``graph``, so:
+
+    * the two members derive DIFFERENT keys — pull-by-key never even offers
+      cell A to pod B; the collision is a MISS, not a wrong hit;
+    * were the wrong cell forced across anyway, ``verify_declared_identity``
+      now REFUSES on the ``graph`` axis (``combined_graph_hash`` differs); and
+    * the witness backstop still refuses beneath both.
     """
     fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
     cell_a = _meta(fixed, PAIR[0])
@@ -220,13 +248,18 @@ def test_every_landed_gate_admits_the_wrong_cell(
     # The expectation pod B states from its OWN traced facts and its OWN
     # runtime — nothing borrowed from the cell it is about to be handed.
     expected_b = aot_identity.artifact_identity(_meta(branchy, PAIR[1]))
-    assert expected_b.cell_key == cell_a["cell_key"]
-    assert aot_identity.verify_declared_identity(cell_a, expected_b) == "", (
-        "pgw#903's identity gate admits the wrong cell — that is the defect, "
-        "not a bug in this test")
-    assert aot_serve.verify_contract(cell_a) == ""
+    assert expected_b.cell_key != cell_a["cell_key"], (
+        "THE FIX: pod B must derive a different key from cell A's, so the hub "
+        "never answers B's pull with A. A red here means the key went body-"
+        "blind — class_hash must fold graph_witness")
 
-    # …and the ONE thing that refuses it.
+    # Cell A is still self-consistent (its own stamp verifies)…
+    assert aot_serve.verify_contract(cell_a) == ""
+    # …but the identity gate now REFUSES the cross, naming the graph axis.
+    refusal = aot_identity.verify_declared_identity(cell_a, expected_b)
+    assert refusal, "the identity gate must refuse the wrong cell post-fix"
+
+    # …and the witness backstop refuses it too (defense-in-depth).
     assert aot_identity.verify_graph_witness(
         cell_a, boot_key.graph_witnesses_of(branchy["blocks"]))
 
@@ -306,14 +339,16 @@ def test_the_adopt_path_refuses_the_colliding_pod(
     traced_pair: Dict[str, Any], monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """THE mitigation: same key, other graph — refused, and it says which.
-
-    Without the floor this returns ``hit`` and the pod arms ``micro-pad32``'s
-    kernels for ``micro-pad32-branchy``'s computation, with only the arm-time
-    numerics tolerance between that and served output.
+    """THE backstop: a FORCED cross — pod B handed cell A — is refused, and it
+    says which. Post-fix the keys differ, so pull-by-key never offers this cross
+    on its own; the monkeypatched ``derive`` forces it to prove the backstop
+    still refuses beneath the sound key. Without it this returns ``hit`` and the
+    pod arms ``micro-pad32``'s kernels for ``micro-pad32-branchy``'s
+    computation, with only the arm-time numerics tolerance between that and
+    served output.
     """
     fixed, branchy = traced_pair[PAIR[0]], traced_pair[PAIR[1]]
-    assert fixed["key"].digest == branchy["key"].digest  # the collision
+    assert fixed["key"].digest != branchy["key"].digest  # the fix: keys differ
     meta = aot_serve.artifact_metadata(
         family=PAIR[0], precision="", cell_key=fixed["key"].digest,
         entries=fixed["blocks"], strict_export=True, lora_bucket=0)


### PR DESCRIPTION
## pgw#1031 — the cell key is now the traced COMPUTATION (depth fix, option a)

Closes the key-collision soundness hole at its source. Paul authorized "keep going and finish" → **option (a)**: deepen the `graph` axis so the key is sound by construction; keep the merged `graph_witness` floor (`5774f68c`, #607) as defense-in-depth.

### The defect (measured, reproduced)
`aot_serve.class_hash` folded the graph SIGNATURE/interface (symbol ranges, pytree specs, constant FQNs, envelope/sm/toolchain) but **not the body** — op, target, connectivity, literal args, per-node tensor meta. Two structurally-different programs with identical ingress (`micro-pad32` masking-arange, 112 nodes vs `micro-pad32-branchy` PythonMod+cat, 102 nodes) produced a byte-identical keying block and the **same `ck1` key**. A body-aware digest already existed (`graph_hash.graph_hash`, pgw#716) but never reached the key.

### The fix (one derivation)
`aot_serve.class_hash` (facts **v3**) now folds `graph_witness` — the node-level digest `aot_mint.keying_block` already records per entry. `class_hash` is THE single derivation, shared by mint (`artifact_metadata`), admission (`verify_contract`) and boot (`boot_key.fold`), so no second implementation exists (the pgw#1059 fence pattern). The fold is tolerant of a missing witness (`""`); production entries always carry it.

### Result
- **RED → distinct keys**: `tests/test_graph_witness_pgw1031.py::test_the_bodies_now_key_apart` — identical ingress, different bodies now derive **DIFFERENT** keys (pre-fix: one key). A collision is a MISS (eager + mint), the cheap outcome.
- Witness floor **stays** as belt-and-braces: `graph_witness` remains a top-level sibling; `aot_identity.verify_graph_witness` still refuses a cell whose recorded witness is not this pod's graph.
- Docstrings across `cell_key`, `graph_hash`, `aot_identity`, `boot_key`, `aot_mint` corrected from "the key is an INGRESS identity" to "the key is the computation".

### Re-key note
This **re-keys the fleet** — pre-launch, expected and free (the corpus was already re-keying for the pgw#1097 folding fence). `ck1` stays; **no scheme-prefix bump** (per Paul: version-1 while pre-launch; the identity FACT rides the content digest, not a new axis or scheme number).

### Cost
Measured 11–19 µs/node, ~0.10 s for sdxl's 5,464-node UNet class, ~0.67 s for the 35,507-node lane — a non-factor against a boot budget of <60 s.

### Tests (local, targeted; no compile — export-only tracing)
- `test_graph_witness_pgw1031` (RED proof), `test_cell_key_pgw1059` (membership axiom — `_REQUIRED` unchanged, still 4 axes), `test_graph_hash_pgw716`: **42 passed**.
- Broader AOT cell-identity cluster (cell_key, entry_canonicalization, multigraph, publish_v2, fail_closed, boot_key_pgw1089, cell_resolve_pgw1090, aot_serve_pgw721, artifact_identity_pgw903, adopt_events, literal_value_identity, adapter_fork): **230 passed**.
- `mypy src/gen_worker`: clean (255 files). ruff clean. All fast-gate lint scripts exit 0. `assemble_changelog --check` OK (`changelog.d/pgw1031.md` updated in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq
