### PR TITLE
pgw#1107: declaration-inference + the migration safety gate (SDK foundation)

### DIFF
--- a/changelog.d/pgw1107.md
+++ b/changelog.d/pgw1107.md
@@ -1,0 +1,12 @@
+- **Declaration inference + the migration safety gate (pgw#1107, Phase-1 SDK foundation).**
+  `gen_worker.cfg_image_classes()` derives the `aspect rows x CFG regimes` graph-class
+  cross-product for CFG-batched image denoisers — the `//vae_scale` latent math and the
+  `dict.fromkeys` transposed-row dedupe move into the SDK, byte-identical to sdxl's and
+  z-image's hand-written `_..._graph_classes()` helpers (dim names are parameters, so one
+  deriver serves both). `contract_delta()` / `override_delta()` / `assert_faithful()` are the
+  reusable byte-identical migration gate: `Compile.contract_axes()` is the cell-key contract
+  digest input (pgw#647), so an empty `contract_delta` proves a minimal decorator is
+  key-identical to the standing `aot_declaration.py` it replaces — the guarantee that lets a
+  family fold its declaration onto the `@endpoint` decorator and delete the file with no
+  re-key. `override_delta` covers the must-survive facts that are not contract axes
+  (`numerics_floor`/`numerics_warn`). Pure Python: no model, no trace, no inductor.

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -36,6 +36,14 @@ from .api.export_contract import (
     import_export_declaration,
     register_export_declaration,
 )
+from .api.derive import (
+    DeclarationMismatch,
+    assert_faithful,
+    cfg_image_classes,
+    class_set_delta,
+    contract_delta,
+    override_delta,
+)
 from .api.formula import RuntimeFormula
 from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
@@ -127,6 +135,12 @@ __all__ = [
     "Input",
     "Arg",
     "register_export_declaration",
+    "DeclarationMismatch",
+    "assert_faithful",
+    "cfg_image_classes",
+    "class_set_delta",
+    "contract_delta",
+    "override_delta",
     "import_export_declaration",
     "ConfigParam",
     "NoWarmup",

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -2,6 +2,14 @@
 
 from .binding import Binding, Civitai, HF, Hub, ModelRef, ModelScope
 from .decorators import ConfigParam, Resources, endpoint
+from .derive import (
+    DeclarationMismatch,
+    assert_faithful,
+    cfg_image_classes,
+    class_set_delta,
+    contract_delta,
+    override_delta,
+)
 from .slot import ResolvedSlot, Slot, resolve_slot
 from .errors import (
     AuthError,
@@ -46,6 +54,12 @@ __all__ = [
     "Hub",
     "ModelRef",
     "ModelScope",
+    "DeclarationMismatch",
+    "assert_faithful",
+    "cfg_image_classes",
+    "class_set_delta",
+    "contract_delta",
+    "override_delta",
     "ResolvedSlot",
     "Resources",
     "Slot",

--- a/src/gen_worker/api/derive.py
+++ b/src/gen_worker/api/derive.py
@@ -1,0 +1,224 @@
+"""Declaration inference + the migration safety gate (pgw#1107).
+
+pgw#1107 collapses ``aot_declaration.py`` and the inline ``@endpoint(
+compile=Compile(...))`` into ONE declaration on the class decorator. Two
+pieces of that live here — both pure Python, no model, no trace, no inductor,
+so they run anywhere including this box:
+
+1. :func:`cfg_image_classes` — the MECHANICAL half of "the SDK derives
+   ``classes``". For a CFG-batched image UNet/DiT whose legal request set is
+   ``aspect rows x the two CFG regimes`` (sdxl, z-image), the graph-class
+   cross-product is a pure function of the author's kept ``shapes`` + the
+   latent scale + ``text_len``. The author stops hand-writing the
+   ``_..._graph_classes()`` helper; the loop, the ``//vae_scale`` latent math
+   and the ``dict.fromkeys`` transposed-row dedupe move here, byte-identical.
+
+   It is deliberately NOT a universal deriver. qwen (ceil-div token grid),
+   flux2 (token-COUNT collapse), wan (3-D latent + relational ``N_tok``) and
+   ltx (audio-token formula x two-stage x keyframe axis x frame-legality x
+   H100/B200 tier) embed model-specific token math that IS the endpoint's own
+   legality oracle (pgw#669). For those the class SET is family-declared; only
+   the collapse-onto-the-decorator and the gate below apply.
+
+2. :func:`contract_delta` / :func:`assert_faithful` — the MIGRATION SAFETY
+   GATE. ``Compile.contract_axes()`` is exactly what feeds the cell key's
+   contract digest (pgw#647), so two declarations with an identical
+   ``contract_axes()`` produce an identical contract digest and — the traced
+   graph being a pure function of the same declaration under fixed model code
+   and toolchain — an identical ``combined_graph_hash``. Deleting the standing
+   ``aot_declaration.py`` in favour of a minimal decorator is therefore safe
+   iff the two declarations' contract axes match. A non-empty delta is a STOP,
+   not a merge: it is the surprise re-key (or the silently-lost hard-won fact)
+   the gate exists to catch before a family being minted RIGHT NOW is disturbed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Sequence, Tuple
+
+from .decorators import Compile
+from .export_contract import GraphClass
+
+__all__ = [
+    "DeclarationMismatch",
+    "assert_faithful",
+    "cfg_image_classes",
+    "class_set_delta",
+    "contract_delta",
+]
+
+#: The sdxl/z-image regime table: CFG on traces ONE batch-2 forward, turbo /
+#: no-CFG pins the batch-1 graph. Each arm is its own graph class of one cell
+#: (ie#345, gw#627). ``(fork_value, traced_batch)`` — the two families that
+#: batch CFG into a single forward share this exact pair.
+CFG_BATCH_REGIMES: Tuple[Tuple[bool, int], ...] = ((True, 2), (False, 1))
+
+
+def cfg_image_classes(
+    *,
+    shapes: Sequence[Sequence[int]],
+    latent_scale: int,
+    text_len: int,
+    batch_dim: str = "B",
+    height_dim: str = "H_lat",
+    width_dim: str = "W_lat",
+    text_dim: str = "T_txt",
+    cfg_fork: str = "cfg",
+    regimes: Sequence[Tuple[bool, int]] = CFG_BATCH_REGIMES,
+) -> Tuple[GraphClass, ...]:
+    """The ``aspect rows x CFG regimes`` graph-class cross-product.
+
+    Reproduces sdxl's ``_sdxl_graph_classes`` and z-image's
+    ``_z_image_graph_classes`` byte-identically (same iteration order, same
+    ``//latent_scale`` latent math, same ``dict.fromkeys`` dedupe of
+    transposed rows). ``shapes`` is the author's kept ``(w, h)`` aspect table
+    — single-sourced from the payload preset enum, never re-declared.
+
+    The dim NAMES differ per family (sdxl ``B``/``T_txt`` vs z-image
+    ``N``/``T_cap``) and are parameters, not literals, so one deriver serves
+    both. The fork→batch effect is the ``regimes`` pair: it is CFG-specific
+    (only these two families batch CFG into one forward — qwen/flux2/wan run
+    CFG as two sequential batch-1 calls, so they do NOT use this deriver).
+    """
+    if latent_scale <= 0:
+        raise ValueError(f"latent_scale must be positive, got {latent_scale!r}")
+    if int(text_len) <= 0:
+        raise ValueError(
+            f"cfg_image_classes needs a positive text_len, got {text_len!r}")
+    out: List[GraphClass] = []
+    for row in shapes:
+        w, h = int(row[0]), int(row[1])
+        for cfg, batch in regimes:
+            out.append(GraphClass(
+                dims={
+                    batch_dim: batch,
+                    height_dim: h // latent_scale,
+                    width_dim: w // latent_scale,
+                    text_dim: int(text_len),
+                },
+                fork={cfg_fork: cfg},
+            ))
+    return tuple(dict.fromkeys(out))
+
+
+# ---------------------------------------------------------------------------
+# The migration safety gate
+# ---------------------------------------------------------------------------
+
+class DeclarationMismatch(AssertionError):
+    """A migrated declaration's cell-key contract differs from the standing
+    one — deleting the standing file would re-key or drop a fact. STOP."""
+
+
+def _canonical(value: Any) -> str:
+    """Order-stable JSON for a ``contract_axes()`` value, so the comparison
+    sees a byte difference, never a dict-ordering artefact."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False)
+
+
+def contract_delta(standing: Compile, migrated: Compile) -> Dict[str, Tuple[Any, Any]]:
+    """``{axis: (standing_value, migrated_value)}`` for every cell-key contract
+    axis the two declarations disagree on; ``{}`` iff identical.
+
+    ``{}`` is the migration's green light: identical ``contract_axes()`` ⟹
+    identical contract digest ⟹ identical ``combined_graph_hash`` (the trace
+    is a pure function of the declaration under fixed code + toolchain), so
+    the standing ``aot_declaration.py`` can be deleted with no re-key. Any
+    entry is a STOP.
+    """
+    a = standing.contract_axes()
+    b = migrated.contract_axes()
+    delta: Dict[str, Tuple[Any, Any]] = {}
+    for key in sorted(set(a) | set(b)):
+        av, bv = a.get(key, _MISSING), b.get(key, _MISSING)
+        if _canonical(_repr(av)) != _canonical(_repr(bv)):
+            delta[key] = (av, bv)
+    return delta
+
+
+class _Missing:
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic only
+        return "<absent>"
+
+
+_MISSING = _Missing()
+
+
+def _repr(value: Any) -> Any:
+    """``contract_axes()`` values are already JSON-able except the sentinel."""
+    return None if value is _MISSING else value
+
+
+#: Must-survive facts that are NOT part of ``contract_axes()`` (so a change
+#: does not re-key) but ARE hard-won measured decisions the migration must not
+#: drop: the numerics ADOPT band (pgw#812/#814). ``shape_strategy``,
+#: ``warm_changes_key`` and ``eager`` are already contract axes and covered by
+#: :func:`contract_delta`; these two are the gap.
+OVERRIDE_FACTS: Tuple[str, ...] = ("numerics_floor", "numerics_warn")
+
+
+def override_delta(standing: Compile, migrated: Compile) -> Dict[str, Tuple[Any, Any]]:
+    """``{field: (standing, migrated)}`` for must-survive overrides that live
+    OUTSIDE ``contract_axes()`` — dropping one loosens the adopt gate without
+    re-keying, so :func:`contract_delta` alone would wave it through. ``{}`` iff
+    every such fact is preserved."""
+    delta: Dict[str, Tuple[Any, Any]] = {}
+    for field in OVERRIDE_FACTS:
+        av, bv = getattr(standing, field), getattr(migrated, field)
+        if av != bv:
+            delta[field] = (av, bv)
+    return delta
+
+
+def class_set_delta(
+    standing: Sequence[GraphClass], migrated: Sequence[GraphClass],
+) -> Dict[str, Any]:
+    """A focused diff of just the graph-class tuples — order-sensitive, since
+    ``contract_axes()`` serialises ``classes`` as an ordered list. ``{}`` iff
+    the derived class tuple is byte-identical to the standing one.
+    """
+    sa = [c.as_row() for c in standing]
+    sb = [c.as_row() for c in migrated]
+    if _canonical(sa) == _canonical(sb):
+        return {}
+    out: Dict[str, Any] = {"count": (len(sa), len(sb))}
+    if len(sa) == len(sb):
+        out["rows"] = [
+            {"index": i, "standing": x, "migrated": y}
+            for i, (x, y) in enumerate(zip(sa, sb))
+            if _canonical(x) != _canonical(y)
+        ]
+    else:
+        out["standing_only"] = [x for x in sa if x not in sb]
+        out["migrated_only"] = [y for y in sb if y not in sa]
+    return out
+
+
+def assert_faithful(
+    standing: Compile, migrated: Compile, *, family: str = "",
+) -> None:
+    """Raise :class:`DeclarationMismatch` unless the migrated declaration's
+    cell-key contract is byte-identical to the standing one. The reusable
+    per-family migration gate: run it in the endpoint's test with the standing
+    ``aot_declaration`` Compile and the new decorator's ``compile`` BEFORE the
+    file is deleted.
+    """
+    cdelta = contract_delta(standing, migrated)
+    odelta = override_delta(standing, migrated)
+    if not cdelta and not odelta:
+        return
+    who = f" for {family!r}" if family else ""
+    lines = [f"migrated declaration{who} is not faithful to the standing one:"]
+    if cdelta:
+        lines.append(
+            f"  cell-key contract re-keys ({len(cdelta)} axis(es) differ):")
+        for axis, (av, bv) in cdelta.items():
+            lines.append(f"    - {axis}: standing={av!r} migrated={bv!r}")
+    if odelta:
+        lines.append(
+            f"  must-survive override dropped ({len(odelta)} field(s)):")
+        for field, (av, bv) in odelta.items():
+            lines.append(f"    - {field}: standing={av!r} migrated={bv!r}")
+    raise DeclarationMismatch("\n".join(lines))

--- a/tests/test_aot_derive_pgw1107.py
+++ b/tests/test_aot_derive_pgw1107.py
@@ -1,0 +1,174 @@
+"""pgw#1107: the classes deriver reproduces sdxl/z-image byte-identically, and
+the migration safety gate catches a re-key.
+
+The two hand-written ``_..._graph_classes()`` helpers are transcribed here as
+the STANDING oracle. If :func:`gen_worker.cfg_image_classes` ever
+stops reproducing them the SDK deriver has drifted from the file it is meant to
+replace — which is exactly the mismatch the gate exists to stop, caught in the
+SDK's own suite instead of on a pod mid-mint.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from gen_worker import (
+    Compile,
+    DeclarationMismatch,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+    assert_faithful,
+    cfg_image_classes,
+    class_set_delta,
+    contract_delta,
+    override_delta,
+)
+
+# --- standing oracles (verbatim structure from the endpoint files) ---------
+
+_SDXL_ASPECT_ROWS: Tuple[Tuple[int, int], ...] = (
+    (1536, 640), (1344, 768), (1216, 832), (1152, 896), (1024, 1024),
+    (896, 1152), (832, 1216), (768, 1344), (640, 1536),
+)
+_Z_IMAGE_ASPECT_ROWS: Tuple[Tuple[int, int], ...] = (
+    (1024, 1024), (1344, 768), (768, 1344), (1536, 640), (640, 1536),
+)
+
+
+def _sdxl_graph_classes() -> Tuple[GraphClass, ...]:
+    out = []
+    for w, h in _SDXL_ASPECT_ROWS:
+        for cfg, batch in ((True, 2), (False, 1)):
+            out.append(GraphClass(
+                dims={"B": batch, "H_lat": h // 8, "W_lat": w // 8,
+                      "T_txt": 77},
+                fork={"cfg": cfg}))
+    return tuple(dict.fromkeys(out))
+
+
+def _z_image_graph_classes() -> Tuple[GraphClass, ...]:
+    out = []
+    for w, h in _Z_IMAGE_ASPECT_ROWS:
+        for cfg, arity in ((True, 2), (False, 1)):
+            out.append(GraphClass(
+                dims={"N": arity, "H_lat": h // 8, "W_lat": w // 8,
+                      "T_cap": 512},
+                fork={"cfg": cfg}))
+    return tuple(dict.fromkeys(out))
+
+
+# --- the deriver reproduces both helpers byte-identically ------------------
+
+def test_sdxl_classes_derive_byte_identical() -> None:
+    derived = cfg_image_classes(
+        shapes=_SDXL_ASPECT_ROWS, latent_scale=8, text_len=77)
+    standing = _sdxl_graph_classes()
+    assert class_set_delta(standing, derived) == {}
+    # order-sensitive equality, the exact thing contract_axes serialises
+    assert [c.as_row() for c in derived] == [c.as_row() for c in standing]
+
+
+def test_z_image_classes_derive_byte_identical() -> None:
+    derived = cfg_image_classes(
+        shapes=_Z_IMAGE_ASPECT_ROWS, latent_scale=8, text_len=512,
+        batch_dim="N", text_dim="T_cap")
+    standing = _z_image_graph_classes()
+    assert class_set_delta(standing, derived) == {}
+    assert [c.as_row() for c in derived] == [c.as_row() for c in standing]
+
+
+def test_transposed_rows_are_kept_not_deduped() -> None:
+    # (1536,640) and (640,1536) swap H_lat/W_lat -> distinct classes; only
+    # exact duplicates collapse. sdxl has 9 rows x 2 regimes and no collision.
+    derived = cfg_image_classes(
+        shapes=_SDXL_ASPECT_ROWS, latent_scale=8, text_len=77)
+    assert len(derived) == len(_SDXL_ASPECT_ROWS) * 2
+
+
+# --- the migration gate: identical contract passes, a re-key STOPS ---------
+
+def _sdxl_standing_compile(classes: Tuple[GraphClass, ...]) -> Compile:
+    return Compile(
+        family="sdxl",
+        targets=("unet",),
+        text_len=77,
+        shapes=_SDXL_ASPECT_ROWS,
+        dims=(
+            Dim("B", carried_by=(("sample", 0),
+                                 ("encoder_hidden_states", 0),
+                                 ("added_cond_kwargs.text_embeds", 0),
+                                 ("added_cond_kwargs.time_ids", 0))),
+            Dim("H_lat", carried_by=(("sample", 2),), multiple_of=8),
+            Dim("W_lat", carried_by=(("sample", 3),), multiple_of=8),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+        ),
+        forks=(Fork("cfg", served=(True, False), why="CFG batch-2 forward"),),
+        classes=classes,
+        inputs=(
+            Input("sample",
+                  shape=("B", ("config", "in_channels"), "H_lat", "W_lat"),
+                  dtype="model"),
+            Input("timestep", shape=(), dtype="float32", value=1.0),
+            Input("encoder_hidden_states",
+                  shape=("B", "T_txt", ("config", "cross_attention_dim")),
+                  dtype="model"),
+            Input("added_cond_kwargs.text_embeds", shape=("B", 1280),
+                  dtype="model"),
+            Input("added_cond_kwargs.time_ids", shape=("B", 6), dtype="model"),
+        ),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+        numerics_floor=0.995,
+        numerics_warn=0.999,
+    )
+
+
+def test_gate_passes_when_only_classes_source_changes() -> None:
+    # The migration: hand-written helper -> derived cross-product, everything
+    # else identical. The contract MUST be byte-identical.
+    standing = _sdxl_standing_compile(_sdxl_graph_classes())
+    migrated = _sdxl_standing_compile(
+        cfg_image_classes(shapes=_SDXL_ASPECT_ROWS, latent_scale=8, text_len=77))
+    assert contract_delta(standing, migrated) == {}
+    assert_faithful(standing, migrated, family="sdxl")
+
+
+def test_gate_stops_a_dropped_timestep_dtype() -> None:
+    # attempt-32 scar: deriving timestep dtype instead of forcing float32.
+    standing = _sdxl_standing_compile(_sdxl_graph_classes())
+    bad = Compile(
+        **{**_struct_kwargs(standing),
+           "inputs": tuple(
+               Input("timestep", shape=(), dtype="model", value=1.0)
+               if i.name == "timestep" else i
+               for i in standing.inputs)})
+    assert "inputs" in contract_delta(standing, bad)
+    try:
+        assert_faithful(standing, bad, family="sdxl")
+    except DeclarationMismatch as exc:
+        assert "inputs" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("gate failed to STOP a dropped timestep dtype")
+
+
+def test_gate_stops_a_loosened_numerics_floor() -> None:
+    # numerics_floor is NOT a contract_axes field (loosening it does not
+    # re-key), so contract_delta alone would wave it through — but it IS a
+    # must-survive override, so override_delta + assert_faithful STOP it.
+    standing = _sdxl_standing_compile(_sdxl_graph_classes())
+    loosened = Compile(**{**_struct_kwargs(standing), "numerics_floor": 0.98})
+    assert contract_delta(standing, loosened) == {}
+    assert override_delta(standing, loosened) == {"numerics_floor": (0.995, 0.98)}
+    try:
+        assert_faithful(standing, loosened, family="sdxl")
+    except DeclarationMismatch as exc:
+        assert "numerics_floor" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("gate failed to STOP a loosened numerics floor")
+
+
+def _struct_kwargs(c: Compile) -> dict:
+    import msgspec
+    return {fi.name: getattr(c, fi.name) for fi in msgspec.structs.fields(c)}


### PR DESCRIPTION
Phase-1 SDK foundation for the one-declaration compile program. Additive only (a new module + its test) — it cannot disturb any family currently minting.

## What lands
`gen_worker.aot_derive`:
- **`cfg_image_classes()`** — the mechanical half of "the SDK derives `classes`". Reproduces sdxl's `_sdxl_graph_classes()` and z-image's `_z_image_graph_classes()` **byte-identically** (proven in the test): the `aspect rows x CFG regimes` cross-product, `//vae_scale` latent math and `dict.fromkeys` transposed-row dedupe move into the SDK. Dim names are parameters (sdxl `B`/`T_txt` vs z-image `N`/`T_cap`).
- **`contract_delta()` / `override_delta()` / `assert_faithful()`** — the reusable **byte-identical migration gate**. `Compile.contract_axes()` is the cell-key contract digest input (pgw#647): identical contract axes ⟹ identical digest ⟹ identical `combined_graph_hash`. A family is safe to delete its `aot_declaration.py` iff `contract_delta == {}`. `override_delta` covers the must-survive facts that are *not* contract axes (`numerics_floor/warn`). Pure Python — no model, no trace, no inductor, so the gate runs in CI and on any box.

The test pins the two scars: it STOPS a timestep dtype dropped `float32 -> "model"` (attempt-32) and a `numerics_floor` loosened `0.995 -> 0.98`.

## Finding (the important one)
pgw#1107's premise that `classes` is "a PURE cross-product the SDK derives" is faithful for exactly **2 of 7 families** (sdxl, z-image). qwen (ceil-div token grid), flux2 (token-COUNT collapse), wan (3-D latent + relational `N_tok`; a14b `dynamic-collapse` has never passed AOTInductor) and ltx (audio-token formula × two-stage × keyframe axis × frame-legality × H100/B200 tier → 82 vs 115 classes) embed family token-math that IS the pgw#669 legality oracle. Their **one-declaration collapse** (fold the file onto the decorator, delete it, prove via the gate) still holds; their class **derivation** does not — forcing a generic deriver would either re-key (gate STOP) or relocate the token-math into the SDK.

## Sequencing (Phase 2, follow-on per-family PRs in inference-endpoints, once this merges)
- Each family: fold `aot_declaration.py`'s `Compile` onto the `@endpoint` decorator (sdxl/z-image use `cfg_image_classes()`; the other 5 keep their family class table), assert `contract_delta == {}` against the standing file in the endpoint's test, then delete the file.
- The registration tightening (make the decorator the single registration; a coexisting standalone a hard error) lands *with/after* the migrations — doing it before would break every un-migrated family whose inline `compile=` is currently thin.

Coordinates with the full-family mint campaign: the gate guarantees no migration changes a compiled artifact or cell key; any migration that *would* re-key is a STOP and a finding.

## Checks
- targeted test green (6 passed), `mypy` clean, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq