### PR TITLE
pgw#1108: boot-adopt must not gate on the compute child holding a worker JWT — the AOT reuse circle stayed open

### DIFF
--- a/changelog.d/pgw1108.md
+++ b/changelog.d/pgw1108.md
@@ -1,0 +1,16 @@
+- **pgw#1108: boot-adopt now fires under the split — the AOT reuse circle closes.**
+  `_boot_adopt` gated on the executor's OWN process holding a worker JWT
+  (`if not base_url or not bearer: return None`). But the executor runs in the
+  compute child (pgw#783, the only execution model), which holds no credential by
+  construction — `child.py`'s `current_worker_jwt` returns `""` (pgw#763 delta 1).
+  So the gate tripped on EVERY real serving pod: `boot_key.derive` never ran, no
+  `POST /v1/worker/cells/resolve` ever reached the hub, and the pod fell straight
+  through to a self-mint — measured on the 2026-08-11 cross-pod run (POD B
+  re-minted POD A's already-published, entitled cell; zero resolve calls; no
+  `trace_for_key`/`key_fold` events). The resolve is a parent-mediated action
+  (`cells.resolve`); the parent supplies base_url + bearer. The gate now mirrors
+  `fleet_cells.CellPublisher`'s readiness — base_url AND (a local bearer OR the
+  control seam being up, `broker.active()`) — so a serving worker derives its key
+  and pulls by key before self-minting (§4.27/§4.29 pull-by-key), while the
+  genuinely-no-hub case (pre-Hello, embedded single-process with no seam) still
+  degrades to the pre-existing eager/self-mint boot.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -38,6 +38,7 @@ from . import boot_adopt
 from . import boot_phases as boot_mod
 from . import cell_adopt
 from . import dispatch
+from .procsplit import broker as procsplit_broker
 from .plan import (
     InputAssetRef,
     Plan,
@@ -9692,9 +9693,21 @@ class Executor:
             return None
         base_url = str(self.file_base_url or "")
         bearer = str(self.worker_jwt_provider() or "")
-        if not base_url or not bearer:
-            # Pre-Hello, or an embedded worker with no hub. There is nobody to
-            # ask, and deriving a key nobody will answer is pure boot latency.
+        # pgw#1108: the credential lives in the PARENT under the split (pgw#783),
+        # which is the only execution model. This executor runs in the compute
+        # child, whose `worker_jwt_provider` returns "" BY CONSTRUCTION (it holds
+        # no credential — pgw#763 delta 1), so a `not bearer` gate here refused
+        # boot-adopt on EVERY real serving pod: derive never ran, resolve never
+        # fired, and the pod fell straight through to self-mint — the whole reuse
+        # circle stayed open. The seam being up (`broker.active()`) is the child's
+        # honest "there is somebody to ask": the resolve is a parent-mediated
+        # action (`cells.resolve`), so the parent supplies base_url + bearer and
+        # ignores what the child passes. Mirrors `fleet_cells.CellPublisher`'s
+        # own readiness (base_url AND (local bearer OR broker.active())).
+        if not base_url or (not bearer and not procsplit_broker.active()):
+            # Genuinely nobody to ask: pre-Hello (no base_url yet), or an embedded
+            # single-process worker with no hub and no seam. Deriving a key nobody
+            # will answer is pure boot latency.
             return None
         work_root = Path(
             self.store._cache_dir or Path.home() / ".cache" / "gen-worker"

--- a/tests/test_boot_adopt_credential_pgw1108.py
+++ b/tests/test_boot_adopt_credential_pgw1108.py
@@ -1,0 +1,115 @@
+"""pgw#1108: boot-adopt must not gate on the CHILD holding a worker JWT.
+
+The executor runs in the compute child (pgw#783, the only execution model).
+That child holds NO credential by construction — ``worker_jwt_provider()``
+returns ``""`` (pgw#763 delta 1, ``child.py``'s ``current_worker_jwt``). The
+resolve is a PARENT-mediated action (``cells.resolve``): the parent supplies the
+credential and the base URL. So a ``not bearer`` gate in ``_boot_adopt`` refused
+boot-adopt on every real serving pod — derive never ran, ``/v1/worker/cells/
+resolve`` never fired, the pod fell straight through to self-mint, and the whole
+compile-once-reuse-forever circle stayed open (measured on the 2026-08-11 2-pod
+run: POD B re-minted, ZERO resolve calls, no ``trace_for_key``/``key_fold``).
+
+The readiness that IS correct mirrors ``fleet_cells.CellPublisher``: a base URL
+AND (a local bearer OR the control seam being up, ``broker.active()``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gen_worker import executor as executor_mod
+from gen_worker.procsplit import broker
+
+
+@dataclass
+class _Cfg:
+    family: str = "micro-diffusion"
+
+
+class _Spec:
+    name = "generate"
+
+    def compile_cell(self) -> _Cfg:
+        return _Cfg()
+
+
+def _executor(tmp_path: Path) -> Any:
+    from gen_worker.executor import Executor, ModelStore
+
+    async def _send(msg: Any) -> None:
+        pass
+
+    return Executor([], _send, store=ModelStore(_send, cache_dir=tmp_path / "cas"))
+
+
+@pytest.fixture
+def wired(monkeypatch, tmp_path):
+    """An executor whose ``_boot_adopt`` reaches the credential gate, with
+    ``boot_adopt.attempt`` replaced by a recorder so the test observes ONLY
+    whether the gate let the derive/resolve leg run — no trace child, no mint."""
+    calls: list[Dict[str, Any]] = []
+
+    def _attempt(**kw: Any) -> Any:
+        calls.append(kw)
+        return executor_mod.boot_adopt.BootAdoptOutcome(reason="miss")
+
+    # Everything before the gate: a declaration exists and sizes one class.
+    monkeypatch.setattr(executor_mod.aot_mint, "export_declaration",
+                        lambda family: object())
+    monkeypatch.setattr(executor_mod.aot_declaration, "cell_plans",
+                        lambda decl: [object()])
+    monkeypatch.setattr(executor_mod, "_mint_modules", lambda spec: ("m",))
+    monkeypatch.setattr(executor_mod.fleet_cells, "declared_envelope_block",
+                        lambda cfg: {})
+    monkeypatch.setattr(executor_mod.boot_adopt, "attempt", _attempt)
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = "http://hub.local"
+    # The compute child's honest answer: it holds no credential.
+    ex.worker_jwt_provider = lambda: ""
+
+    # Isolate the process-global broker seam for this test.
+    monkeypatch.setattr(broker, "_broker", None, raising=False)
+    return ex, calls
+
+
+def _run_boot_adopt(ex: Any) -> Optional[Any]:
+    return ex._boot_adopt(_Spec(), {})
+
+
+def test_split_child_with_seam_up_resolves_though_it_holds_no_jwt(wired):
+    """THE regression: bearer is "" (compute child) but the control seam is up,
+    so the parent can answer. boot-adopt MUST proceed to derive+resolve."""
+    ex, calls = wired
+    broker.install(object())  # seam up: broker.active() is True
+    try:
+        _run_boot_adopt(ex)
+    finally:
+        broker.install(None)
+    assert len(calls) == 1, (
+        "boot-adopt refused to even attempt derive/resolve on a split pod whose "
+        "seam is up — the pod would self-mint instead of adopting")
+    assert calls[0]["cfg"].family == "micro-diffusion"
+
+
+def test_no_bearer_and_no_seam_degrades_without_deriving(wired):
+    """The gate must STILL protect the genuinely-no-hub case: no local bearer
+    and no seam means nobody to ask, so no derive/resolve, no attempt."""
+    ex, calls = wired
+    # broker._broker is None (fixture); seam is down.
+    assert _run_boot_adopt(ex) is None
+    assert calls == []
+
+
+def test_single_process_bearer_still_resolves_with_no_seam(wired):
+    """Embedded/single-process: broker is None but the executor holds a real
+    JWT locally. Unchanged — boot-adopt proceeds."""
+    ex, calls = wired
+    ex.worker_jwt_provider = lambda: "real-jwt"
+    assert _run_boot_adopt(ex) is not None or calls  # attempt ran
+    assert len(calls) == 1


### PR DESCRIPTION
## The bug (one call site)

`executor._boot_adopt` (the §4.27/§4.29 boot-time pull-by-key) gated on the
executor's **own process** holding a worker JWT:

```python
base_url = str(self.file_base_url or "")
bearer = str(self.worker_jwt_provider() or "")
if not base_url or not bearer:      # <-- the bug
    return None
```

But the executor runs in the **compute child** (pgw#783 — the only execution
model), which holds **no credential by construction**: `procsplit/child.py`'s
`current_worker_jwt` returns `""` (pgw#763 delta 1 — "an empty string is the
honest answer: this process has no credential"). `file_base_url` IS set in the
child (the parent relays the full HelloAck), but `bearer` is **always** `""`, so
the `not bearer` half tripped on **every real serving pod**:

- `boot_key.derive` never ran (no `trace_for_key`/`key_fold` events)
- no `POST /v1/worker/cells/resolve` ever reached the hub
- the pod fell straight through to a background self-mint

This is exactly what the 2026-08-11 cross-pod pod-proof run measured (pgw#868):
POD B re-minted POD A's already-published, servable, entitled cell; **zero
resolve calls**; publish calls WERE logged (they go through the parent broker,
which supplies the credential). Cross-pod key determinism worked (identical
`ck1-cef44056…`), but automatic **reuse** — compile-once-reuse-forever, the whole
point — did not. The reuse circle stayed open.

## The fix

The resolve is a **parent-mediated action** (`cells.resolve`, already allowlisted
in `procsplit/actions.py`): under the split the parent supplies base_url + bearer
and **ignores what the child passes** (`broker.request`). So the child's own
empty bearer is irrelevant; the correct readiness signal is the **control seam
being up**. The gate now mirrors `fleet_cells.CellPublisher`'s own readiness —
`base_url AND (local bearer OR broker.active())`:

```python
if not base_url or (not bearer and not procsplit_broker.active()):
    return None
```

A serving worker that derives its key and finds no hub-delivered cell now
resolves by key **before** self-minting (§4.27/§4.29 pull-by-key). The
genuinely-no-hub case (pre-Hello / embedded single-process with no seam) still
degrades to the pre-existing eager/self-mint boot.

Worker-side only — the resolve route is live hub-side (th#1750, HTTP 401 to an
unauthenticated probe). Rides the next wheel cut; **not tagged** (coordinator-gated).

## RED proof

`tests/test_boot_adopt_credential_pgw1108.py`:
- **`test_split_child_with_seam_up_resolves_though_it_holds_no_jwt`** — the
  regression: bearer `""` + `broker.active()` True now attempts derive+resolve.
  Fails against the original guard (`assert 0 == 1`, attempt never called),
  passes with the fix.
- `test_no_bearer_and_no_seam_degrades_without_deriving` — the gate still
  protects the genuinely-no-hub case.
- `test_single_process_bearer_still_resolves_with_no_seam` — embedded path
  unchanged.

24 passed (3 new + 21 existing pgw#1090 resolve-client tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq1cH316f4RNSovRm3B6dq