### PR TITLE
th#1779: the in-call stall gate was a 300 s wall clock wearing a progress counter's name

### DIFF
--- a/changelog.d/th1779.md
+++ b/changelog.d/th1779.md
@@ -1,0 +1,32 @@
+- **th#1779: the in-call stall gate now reads WORK, not how chatty the endpoint
+  is.** `_execute`'s docstring promises there is no wall deadline,
+  "deliberately", and that the abort authority is `progress.self_diagnosis()`.
+  But the only counter a serving request ever opened was `infer:steps`, which
+  `_make_ctx_emitter` advances once per ctx event — so an endpoint whose render
+  is one long silent library call froze it at the opening `ctx.log` and the
+  `infer` family's 300 s window condemned a perfectly healthy render. Measured
+  on the standing stack: minimax-h3 `reference-to-video` ended
+  `request.requeued reason=worker_retryable` at **exactly 300 s** after its
+  first log line, four attempts running, with `timeout_ms: 2400000` on the
+  request moving none of it; `generate` on the SAME endpoint and the SAME
+  silence completed only because it fits (compute_ms 126926-228918). Every
+  serving handler now opens `evidence:handler` for the life of the call, fed by
+  the same process CPU + disk I/O sampler `activity.watchdog` has trusted for
+  wire-silent compiles since gw#621. A silent-but-working handler proves it is
+  working; a wedged one advances neither counter and still confesses on fact.
+  `self_diagnosis()` stays registry-wide, as pgw#894 pinned it
+  (`tests/test_serving_stall_evidence_th1779.py`).
+- **th#1779: the stuck-handler reaper watched the wrong object and had never
+  fired.** `_reap_stuck_thread` awaited `shield(job.exec_task)` — the task its
+  own caller CANCELS one line earlier — so the shield re-raised that
+  cancellation immediately and the `except BaseException: pass` arm recorded it
+  as "thread finished (with error) — no recycle needed". A sync handler cannot
+  be killed, so the abandoned thread kept running on the GPU while the hub
+  re-dispatched the same request onto the same pod: measured across four
+  attempts on one H100, reserved VRAM ratcheted 59.0 -> 75.1 -> 75.8 -> 76.7 GiB
+  as renders stacked. The reaper now waits on `_Job.handler_thread_done`, set by
+  the handler thread itself in `_call_sync` / `_pump_sync_gen`, which is the
+  only object that can answer the question it asks.
+- `activity.default_evidence` and `activity.EVIDENCE_EPS` are public — the
+  serving path samples the same signal the watchdog does, and it should not
+  reach into a private to do it.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -179,7 +179,7 @@ HEARTBEAT_INTERVAL_S = 60.0
 # Minimum evidence advance (process CPU seconds) per interval for a heartbeat:
 # a hung (blocked/deadlocked) call stops accruing CPU and the beat stops with
 # it, which is exactly the silence the hub enforces on.
-_EVIDENCE_EPS = 0.05
+EVIDENCE_EPS = 0.05
 
 _lock = threading.Lock()
 _seq = 0
@@ -616,7 +616,7 @@ def _process_io_evidence() -> float:
     return (io.read_bytes + io.write_bytes) / (1 << 20)
 
 
-def _default_evidence() -> float:
+def default_evidence() -> float:
     """Combined default watchdog evidence: process+live-children CPU
     seconds PLUS process disk I/O megabytes. Either source alone advancing
     proves genuine life: a network download followed by on-disk model load
@@ -635,7 +635,7 @@ class watchdog:
     hub's stall rule takes it from there.
 
     Default evidence is process+children CPU seconds plus process disk I/O
-    (see _default_evidence); pass a monotonic callable (e.g.
+    (see default_evidence); pass a monotonic callable (e.g.
     compile-wall-seconds) for calls with a better signal."""
 
     def __init__(
@@ -647,7 +647,7 @@ class watchdog:
     ) -> None:
         self._act = act
         self._interval = interval_s
-        self._evidence = evidence or _default_evidence
+        self._evidence = evidence or default_evidence
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=self._run, name="activity-watchdog", daemon=True,
@@ -663,7 +663,7 @@ class watchdog:
                 now = self._evidence()
             except Exception:
                 continue
-            if now - last >= _EVIDENCE_EPS:
+            if now - last >= EVIDENCE_EPS:
                 last = now
                 # gw#621: evidence advance is ALSO a registry counter, so the
                 # 10s beat reports it and the hub sees a moving number

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -261,6 +261,12 @@ EVENT_CONTENT_TYPE = "application/x-request-event+json"
 # `progress.STALL_WINDOW_S`).
 _STALL_POLL_S = 5.0
 _STUCK_THREAD_RECYCLE_S = 30.0
+# How often the reaper re-asks whether the abandoned handler thread has ended.
+_STUCK_THREAD_POLL_S = 0.5
+# th#1779: how often the request's evidence sampler re-reads process CPU+I/O.
+# Same cadence as the stall poll, so the freshest sample is never older than
+# one poll when the diagnosis is taken.
+_HANDLER_EVIDENCE_INTERVAL_S = _STALL_POLL_S
 # pgw#687: a cancel that never unwinds. Cancellation of a SYNC handler is
 # cooperative — the thread cannot be killed — so a handler that never polls
 # ctx.cancelled (observed: a modelopt calibration loop) keeps the GPU permit
@@ -3049,6 +3055,11 @@ class _Job:
     # where the resolved payload is in scope; 0 means "not applicable"
     # (non-spatial function), never "zero".
     shape: Tuple[int, int, int] = (0, 0, 0)
+    # th#1779: set by the handler THREAD itself when it returns. A sync
+    # handler cannot be killed and its asyncio wrapper task says nothing about
+    # it once cancelled, so this event is the only truthful answer to "is the
+    # abandoned handler still on the card".
+    handler_thread_done: threading.Event = dc_field(default_factory=threading.Event)
     admitted_at: float = dc_field(default_factory=time.monotonic)
     # One JobProgress seq space per job, shared by stream chunks and ctx
     # events so interleaved sends stay monotonic. itertools.count.__next__
@@ -12163,10 +12174,26 @@ class Executor:
         ``progress.self_diagnosis()`` — non-None only when even the FRESHEST
         open counter is stale past its own per-phase window, the same typed
         ``self_stalled`` confession the activity beat reports to the hub.
+
+        th#1779: the gate is given a source of evidence the handler cannot
+        silence by saying nothing.
+        Before, the only counter a serving request opened was ``infer:steps``,
+        which advances only when the handler emits a ctx event — so an endpoint
+        whose render is one long silent library call had a counter frozen at
+        its opening log line, and the "no magic timeouts" gate degenerated into
+        exactly the 300 s wall clock this docstring disclaims. Measured:
+        minimax-h3 `reference-to-video` died `worker_retryable` at exactly
+        300 s on four consecutive attempts while `generate` (126-229 s)
+        squeaked under the same window. ``_HandlerEvidence`` samples the same
+        process CPU + disk I/O signal ``activity.watchdog`` already trusts for
+        wire-silent compiles, so a silent-but-working handler PROVES it is
+        working and a genuinely wedged one still confesses on fact. The
+        diagnosis itself stays registry-wide, as pgw#894 pinned it.
         """
         bound = spec.method if instance is None else getattr(instance, spec.attr_name)
         call_kwargs = {spec.ctx_param: ctx, spec.payload_param: payload, **kwargs}
 
+        owner = f"request:{job.request_id}"
         loop = asyncio.get_running_loop()
         if spec.is_async_gen:
             coro = self._pump_async_gen(job, bound(**call_kwargs))
@@ -12175,30 +12202,34 @@ class Executor:
         elif spec.output_mode == "stream":
             coro = asyncio.to_thread(self._pump_sync_gen, job, bound, call_kwargs, gpu_index, loop)
         else:
-            coro = asyncio.to_thread(self._call_sync, bound, call_kwargs, gpu_index)
+            coro = asyncio.to_thread(self._call_sync, job, bound, call_kwargs, gpu_index)
 
         job.exec_task = asyncio.ensure_future(coro)
         # th#1111: the handler window stage_ms reconciles against (the same
         # interval runtime_ms measures).
         ctx._stages.handler_open()
         try:
-            while True:
-                try:
-                    return await asyncio.wait_for(
-                        asyncio.shield(job.exec_task), _STALL_POLL_S)
-                except asyncio.TimeoutError:
-                    stalled = progress_mod.self_diagnosis()
-                    if stalled is None:
-                        continue  # advancing (or evidence-free): keep waiting
-                    ctx._cancel()
-                    job.exec_task.cancel()
-                    if not spec.is_async:
-                        self._reap_stuck_thread(job)
-                    raise _ExecutionStalled(
-                        f"self_stalled: counter {stalled.name!r} "
-                        f"({stalled.unit}) has not advanced for "
-                        f"{stalled.age_s:.0f}s (window {stalled.window_s:.0f}s)"
-                    ) from None
+            with _HandlerEvidence(owner):
+                while True:
+                    try:
+                        return await asyncio.wait_for(
+                            asyncio.shield(job.exec_task), _STALL_POLL_S)
+                    except asyncio.TimeoutError:
+                        # pgw#894 pins this UNSCOPED on purpose: the loop's
+                        # question is "is this process wedged", and many
+                        # handlers register no counter of their own.
+                        stalled = progress_mod.self_diagnosis()
+                        if stalled is None:
+                            continue  # advancing (or evidence-free): keep waiting
+                        ctx._cancel()
+                        job.exec_task.cancel()
+                        if not spec.is_async:
+                            self._reap_stuck_thread(job)
+                        raise _ExecutionStalled(
+                            f"self_stalled: counter {stalled.name!r} "
+                            f"({stalled.unit}) has not advanced for "
+                            f"{stalled.age_s:.0f}s (window {stalled.window_s:.0f}s)"
+                        ) from None
         except asyncio.CancelledError:
             # CancelJob path: the exec task was cancelled underneath us.
             raise CanceledError("canceled")
@@ -12206,30 +12237,49 @@ class Executor:
             ctx._stages.handler_close()
 
     @staticmethod
-    def _call_sync(bound: Callable[..., Any], call_kwargs: Dict[str, Any], gpu_index: int) -> Any:
+    def _call_sync(
+        job: _Job, bound: Callable[..., Any], call_kwargs: Dict[str, Any], gpu_index: int,
+    ) -> Any:
         if torch is not None and torch.cuda.is_available():
             try:
                 torch.cuda.set_device(gpu_index)
             except Exception:
                 pass
-        return bound(**call_kwargs)
+        try:
+            return bound(**call_kwargs)
+        finally:
+            # th#1779: the ONLY honest report that the handler THREAD is gone.
+            job.handler_thread_done.set()
 
     def _reap_stuck_thread(self, job: _Job) -> None:
         """Deadline fired but the sync handler thread may not die. If it's
-        still running after the recycle grace, exit so the pod is recycled."""
+        still running after the recycle grace, exit so the pod is recycled.
+
+        th#1779: this watched ``job.exec_task`` — the task the caller had just
+        CANCELLED one line earlier — so ``shield(...)`` re-raised that
+        cancellation immediately, the ``except BaseException`` arm read it as
+        "thread finished" and the reaper never fired once. A sync handler
+        cannot be killed, so the abandoned thread kept denoising on the card
+        while the hub re-dispatched the same request onto the same pod:
+        measured across four attempts on one H100, reserved VRAM ratcheted
+        59.0 -> 75.1 -> 75.8 -> 76.7 GiB with concurrent renders stacking up.
+        The thread's own completion event is the only thing that can answer
+        the question the reaper asks.
+        """
 
         async def _watch() -> None:
-            assert job.exec_task is not None
-            try:
-                await asyncio.wait_for(asyncio.shield(job.exec_task), _STUCK_THREAD_RECYCLE_S)
-            except asyncio.TimeoutError:
-                logger.critical(
-                    "handler thread for %s ignored deadline+cancel for %.0fs; "
-                    "recycling worker process", job.request_id, _STUCK_THREAD_RECYCLE_S,
-                )
-                self._process_exit(70)
-            except BaseException:
-                pass  # thread finished (with error) — no recycle needed
+            done = job.handler_thread_done
+            deadline = time.monotonic() + _STUCK_THREAD_RECYCLE_S
+            while not done.is_set():
+                if time.monotonic() >= deadline:
+                    logger.critical(
+                        "handler thread for %s ignored deadline+cancel for %.0fs; "
+                        "recycling worker process", job.request_id, _STUCK_THREAD_RECYCLE_S,
+                    )
+                    self._process_exit(70)
+                    return
+                await asyncio.sleep(_STUCK_THREAD_POLL_S)
+            # Thread finished (with error or otherwise) — no recycle needed.
 
         asyncio.create_task(_watch(), name=f"reap-{job.request_id}")
 
@@ -12331,17 +12381,20 @@ class Executor:
             except Exception:
                 pass
         acc = StreamAccumulator()
-        for item in bound(**call_kwargs):
-            if job.ctx is not None:
-                job.ctx.raise_if_cancelled()
-            enc = self._encode_chunk(item)
-            if enc is None:
-                break
-            acc.add(item)
-            fut = asyncio.run_coroutine_threadsafe(
-                self._emit_progress(job, next(job.seq), enc[0], enc[1]), loop
-            )
-            fut.result()  # backpressure: block the producer on queue overflow
+        try:
+            for item in bound(**call_kwargs):
+                if job.ctx is not None:
+                    job.ctx.raise_if_cancelled()
+                enc = self._encode_chunk(item)
+                if enc is None:
+                    break
+                acc.add(item)
+                fut = asyncio.run_coroutine_threadsafe(
+                    self._emit_progress(job, next(job.seq), enc[0], enc[1]), loop
+                )
+                fut.result()  # backpressure: block the producer on queue overflow
+        finally:
+            job.handler_thread_done.set()  # th#1779, same contract as _call_sync
         return acc.result()
 
     # ---- results -----------------------------------------------------------
@@ -12549,6 +12602,76 @@ class Executor:
         if not self.in_flight_keys():
             self._idle.set()
             self._bg_quiet.set()
+
+
+class _HandlerEvidence:
+    """th#1779: loop-independent proof that a SERVING handler is working.
+
+    ``activity.watchdog`` has done exactly this for wire-silent load/compile
+    phases since gw#621; a serving request had no equivalent, so the only
+    counter open under it was ``infer:steps`` — which advances on ctx events
+    and therefore measures how CHATTY the endpoint is, not whether it is
+    working. An endpoint whose render is one long silent library call froze
+    that counter at its opening log line and was condemned at the family's
+    300 s window: measured, minimax-h3 `reference-to-video` died
+    `worker_retryable` at exactly 300 s on four consecutive attempts, while
+    `generate` (126-229 s of the same silence) fit under the window and
+    passed. That is a wall clock wearing a progress counter's name.
+
+    The evidence is process+children CPU seconds plus process disk I/O MB —
+    ``activity_mod.default_evidence``, unchanged. A GPU render burns CPU issuing
+    and synchronising kernels; a deadlocked or wedged process burns neither,
+    which is the distinction the gate is supposed to make. Registered under
+    the REQUEST's scope so ``self_diagnosis(owner)`` answers about this
+    request, so the counter dies with the handler (pgw#962) and cannot answer
+    for work it is not doing (pgw#894). The in-call diagnosis stays
+    registry-wide, which pgw#894 pinned deliberately.
+    """
+
+    def __init__(
+        self,
+        owner: str,
+        *,
+        interval_s: float = _HANDLER_EVIDENCE_INTERVAL_S,
+        evidence: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._owner = owner
+        self._interval = interval_s
+        self._evidence = evidence or activity_mod.default_evidence
+        self._stop = threading.Event()
+        self._counter: Optional[progress_mod.Counter] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def _run(self) -> None:
+        try:
+            base = last = self._evidence()
+        except Exception:
+            base = last = 0.0
+        while not self._stop.wait(self._interval):
+            try:
+                now = self._evidence()
+            except Exception:
+                continue
+            if now - last >= activity_mod.EVIDENCE_EPS and self._counter is not None:
+                last = now
+                self._counter.set_done(now - base)
+
+    def __enter__(self) -> "_HandlerEvidence":
+        self._counter = progress_mod.counter(
+            "evidence:handler", progress_mod.UNIT_EVIDENCE, owner=self._owner)
+        self._thread = threading.Thread(
+            target=self._run, name="handler-evidence", daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        if self._counter is not None:
+            # A counter left open after its producer stopped is the min-age
+            # counter of work nobody is doing (pgw#962).
+            self._counter.finish()
 
 
 class _ExecutionStalled(Exception):

--- a/tests/test_serving_stall_evidence_th1779.py
+++ b/tests/test_serving_stall_evidence_th1779.py
@@ -1,0 +1,226 @@
+"""th#1779 — the in-call stall gate was a wall clock wearing a counter's name.
+
+`_execute`'s docstring promises there is no wall deadline, "deliberately", and
+that the abort authority is `progress.self_diagnosis()`. But the ONLY counter a
+serving request opened was `infer:steps`, which `_make_ctx_emitter` advances
+once per ctx event — so the number the gate read measured how CHATTY the
+endpoint is, not whether it was working. An endpoint whose render is one long
+silent library call froze the counter at its opening `ctx.log` and the `infer`
+family's 300 s window condemned it mid-render.
+
+Measured in production, request `790f6145-5f38-4f1a-b4b7-48836c34f3c4`
+(minimax-h3 0.4.10, four attempts on pod `ptndxsdsy5ws1u`): `job.log` at
+05:40:41.173 -> `request.requeued reason=worker_retryable` at 05:45:41.112;
+05:45:45.161 -> 05:50:45.320; 05:50:49.154 -> 05:55:49.358. Exactly 300 s,
+three times, and `timeout_ms: 2400000` on the request moved none of it.
+`generate` on the SAME endpoint completed with compute_ms 126926 / 188730 /
+207588 / 208320 / 212132 / 219639 / 228918 — the identical silence, just short
+enough to fit.
+
+Two defects, one incident:
+
+1. the gate had no evidence but the endpoint's chatter -> `_HandlerEvidence`
+2. `_reap_stuck_thread` watched the task the caller had just CANCELLED, so it
+   read that cancellation as "thread finished" and never fired once. The
+   abandoned handler kept denoising while the hub re-dispatched onto the same
+   pod: reserved VRAM 59.0 -> 75.1 -> 75.8 -> 76.7 GiB across those attempts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import executor as executor_mod
+from gen_worker import progress as progress_mod
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> Any:
+    progress_mod.reset()
+    yield
+    progress_mod.reset()
+
+
+@pytest.fixture()
+def clock(monkeypatch: pytest.MonkeyPatch) -> Dict[str, float]:
+    t = {"t": 0.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: t["t"])
+    return t
+
+
+OWNER = "request:790f6145-5f38-4f1a-b4b7-48836c34f3c4"
+
+
+# ---------------------------------------------------------------------------
+# 1. the verdict a silent-but-working render gets
+# ---------------------------------------------------------------------------
+
+
+def test_a_silent_but_working_handler_is_condemned_without_evidence(
+    clock: Dict[str, float],
+) -> None:
+    """The production shape, reproduced: one ctx event, then real work.
+
+    This is the RED assertion — it documents what the gate DID, and the fix
+    below is what stops it deciding on this evidence alone."""
+    steps = progress_mod.counter(
+        "infer:steps", progress_mod.UNIT_STEPS, owner=OWNER)
+    steps.add(1)  # the endpoint's opening ctx.log, and the last thing it says
+
+    clock["t"] = 299.0
+    assert progress_mod.self_diagnosis() is None
+    clock["t"] = 300.1
+    verdict = progress_mod.self_diagnosis()  # the call `_execute` makes
+    assert verdict is not None and verdict.name == "infer:steps"
+
+
+def test_handler_evidence_keeps_a_silent_render_alive(clock: Dict[str, float]) -> None:
+    """With the request's own evidence counter open and advancing, the same
+    silent render is NOT stalled — five minutes in or fifty."""
+    steps = progress_mod.counter(
+        "infer:steps", progress_mod.UNIT_STEPS, owner=OWNER)
+    steps.add(1)
+
+    cpu = {"v": 0.0}
+    ev = executor_mod._HandlerEvidence(
+        OWNER, interval_s=0.01, evidence=lambda: cpu["v"])
+    with ev:
+        for elapsed in (300.1, 600.1, 3000.1):
+            clock["t"] = elapsed - 1.0
+            cpu["v"] += 10.0  # the render burns real CPU issuing kernels
+            _wait_until(lambda: _age(OWNER, "evidence:handler") == 0.0)
+            clock["t"] = elapsed
+            assert progress_mod.self_diagnosis() is None, (
+                f"condemned a working handler at t={elapsed}")
+
+
+def test_handler_evidence_still_confesses_a_wedged_process(
+    clock: Dict[str, float],
+) -> None:
+    """The gate must keep its teeth: neither counter advancing IS a stall."""
+    progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS, owner=OWNER).add(1)
+    cpu = {"v": 0.0}  # a deadlocked process burns no CPU and moves no bytes
+    with executor_mod._HandlerEvidence(
+        OWNER, interval_s=0.01, evidence=lambda: cpu["v"]
+    ):
+        clock["t"] = 301.0
+        verdict = progress_mod.self_diagnosis()
+    assert verdict is not None
+    assert verdict.age_s > verdict.window_s
+
+
+def test_evidence_is_scoped_to_the_request_and_closed_after(
+    clock: Dict[str, float],
+) -> None:
+    """pgw#894's rule, applied to the in-call loop it left registry-wide: a
+    neighbour's counter can neither save nor condemn this request, and the
+    counter dies with the handler (pgw#962)."""
+    other = progress_mod.counter("infer:steps", progress_mod.UNIT_STEPS, owner="request:other")
+    other.add(1)
+    with executor_mod._HandlerEvidence(OWNER, interval_s=0.01, evidence=lambda: 0.0):
+        names = {s.name for s in progress_mod.snapshot(OWNER)}
+        assert names == {"evidence:handler"}
+    assert progress_mod.snapshot(OWNER) == []
+
+
+def test_the_default_evidence_source_is_the_one_watchdog_already_trusts() -> None:
+    ev = executor_mod._HandlerEvidence(OWNER)
+    assert ev._evidence is activity_mod.default_evidence
+
+
+# ---------------------------------------------------------------------------
+# 2. the reaper that never fired
+# ---------------------------------------------------------------------------
+
+
+def _job() -> Any:
+    return executor_mod._Job(request_id="rid-th1779", attempt=1, spec=None)
+
+
+def test_reaper_recycles_when_the_handler_thread_outlives_the_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED before the fix: the reaper watched `job.exec_task`, which the caller
+    cancels one line before arming it, so `shield()` raised CancelledError
+    immediately and the `except BaseException: pass` arm concluded the thread
+    had finished. It never once fired, and the abandoned handler kept the
+    card while the next attempt landed on the same pod."""
+    monkeypatch.setattr(executor_mod, "_STUCK_THREAD_RECYCLE_S", 0.05)
+    monkeypatch.setattr(executor_mod, "_STUCK_THREAD_POLL_S", 0.01)
+    exits: list[int] = []
+
+    async def _drive() -> None:
+        ex = executor_mod.Executor.__new__(executor_mod.Executor)
+        monkeypatch.setattr(ex, "_process_exit", exits.append, raising=False)
+        job = _job()
+        # Exactly the state `_execute` arms the reaper in: the task cancelled,
+        # the THREAD still running.
+        job.exec_task = asyncio.ensure_future(asyncio.sleep(60))
+        job.exec_task.cancel()
+        ex._reap_stuck_thread(job)
+        await asyncio.sleep(0.3)
+
+    asyncio.run(_drive())
+    assert exits == [70], "the abandoned handler thread was never reaped"
+
+
+def test_reaper_stands_down_when_the_thread_really_ended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(executor_mod, "_STUCK_THREAD_RECYCLE_S", 0.2)
+    monkeypatch.setattr(executor_mod, "_STUCK_THREAD_POLL_S", 0.01)
+    exits: list[int] = []
+
+    async def _drive() -> None:
+        ex = executor_mod.Executor.__new__(executor_mod.Executor)
+        monkeypatch.setattr(ex, "_process_exit", exits.append, raising=False)
+        job = _job()
+        job.exec_task = asyncio.ensure_future(asyncio.sleep(60))
+        job.exec_task.cancel()
+        job.handler_thread_done.set()  # what `_call_sync`'s finally does
+        ex._reap_stuck_thread(job)
+        await asyncio.sleep(0.4)
+
+    asyncio.run(_drive())
+    assert exits == []
+
+
+def test_call_sync_reports_the_thread_ending_on_both_paths() -> None:
+    job = _job()
+    executor_mod.Executor._call_sync(job, lambda: "out", {}, 0)
+    assert job.handler_thread_done.is_set()
+
+    job2 = _job()
+
+    def _boom() -> None:
+        raise RuntimeError("handler exploded")
+
+    with pytest.raises(RuntimeError):
+        executor_mod.Executor._call_sync(job2, _boom, {}, 0)
+    assert job2.handler_thread_done.is_set()
+
+
+# ---------------------------------------------------------------------------
+
+
+def _age(owner: str, name: str) -> float:
+    for s in progress_mod.snapshot(owner):
+        if s.name == name:
+            return s.age_s
+    return float("inf")
+
+
+def _wait_until(pred: Any, timeout_s: float = 2.0) -> None:
+    deadline = threading.Event()
+    waited = 0.0
+    while waited < timeout_s:
+        if pred():
+            return
+        deadline.wait(0.01)
+        waited += 0.01
+    raise AssertionError("condition never held")


### PR DESCRIPTION
Measured on the standing stack, request `790f6145-5f38-4f1a-b4b7-48836c34f3c4` (minimax-h3 0.4.10, four attempts on pod `ptndxsdsy5ws1u`):

```
job.log 05:40:41.173  ->  requeued worker_retryable 05:45:41.112
job.log 05:45:45.161  ->  requeued worker_retryable 05:50:45.320
job.log 05:50:49.154  ->  requeued worker_retryable 05:55:49.358
```

Exactly 300 s, every time, nothing banked, and `timeout_ms: 2400000` on the request moved none of it. `generate` on the SAME endpoint with the SAME silence completed — compute_ms 126926 / 188730 / 207588 / 208320 / 212132 / 219639 / 228918, every one under the window.

### 1. The gate had no evidence but the endpoint's chatter

`_execute` promises there is no wall deadline, "deliberately", because *"a clock cannot distinguish a slow-but-advancing handler from a wedged one"*. True — and the only counter a serving request opened was `infer:steps`, advanced once per ctx event by `_make_ctx_emitter`. That measures how talkative the endpoint is. A render that is one silent `pipeline(...)` call froze it at the opening `ctx.log`, and `STALL_WINDOW_S["infer"] = 300.0` did the rest. The disclaimed clock came back in through the choice of evidence.

`_HandlerEvidence` opens `evidence:handler` for the life of the call, sampling `activity.default_evidence` — process+children CPU seconds plus disk I/O MB, the signal `activity.watchdog` has trusted for wire-silent compiles since gw#621. A GPU render burns CPU issuing and synchronising kernels; a deadlocked process burns neither.

`self_diagnosis()` stays **registry-wide** — pgw#894 pinned that on purpose and its reasoning ("many handlers never register a counter") is this issue from the other side.

### 2. The reaper watched the task it had just cancelled

`_reap_stuck_thread` awaited `shield(job.exec_task)`, and `_execute` cancels that task on the line before arming it — the shield re-raised CancelledError immediately and `except BaseException: pass` logged it as "thread finished". It never fired once. A sync handler cannot be killed, so the abandoned thread kept denoising while the hub re-dispatched the same request onto the same pod: **reserved VRAM 59.0 → 75.1 → 75.8 → 76.7 GiB** across those four attempts on an 80 GB H100. It now waits on `_Job.handler_thread_done`, set by the handler thread itself in `_call_sync` / `_pump_sync_gen`'s `finally`.

### Tests

`tests/test_serving_stall_evidence_th1779.py` — RED first on both: the production verdict on a one-event handler, and the reaper driven in exactly the state `_execute` arms it in (task cancelled, thread alive), where the old body recorded zero `_process_exit` calls.

Siblings: inference-endpoints [#319](https://github.com/cozy-creator/inference-endpoints/pull/319) (minimax-h3 0.4.12 emits per-step progress), and th#1779's tensorhub PR (a `worker_retryable` requeue must bank the cause the worker already sent — that silence is why this took three investigations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHywnqnYgUUFKJ7zagNUJ1