### PR TITLE
pgw#1080 inc3: fail closed on a weight-free-buildable target that isn't honored (z-image ~40 GiB export hole)

### DIFF
--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -660,17 +660,19 @@ def _assert_structure_honored(
     unexpected keyword — ``**kwargs`` swallows it and the class loads the
     checkpoint itself. That failure is SILENT and it is the exact failure this
     slice cannot tolerate: the mint would hold every weight and still report a
-    weightless child. So it is checked, on the object that came back, and the
-    caller decides what to do about a refusal (the mint child falls back to a
-    real-weight load and records why).
+    weightless child. So it is checked, on the object that came back, and a
+    miss raises ``StructureNotHonored`` — a DISTINCT type from the buildable
+    strand, because the component WAS built weight-free and the pipeline threw
+    it away. The mint child FAILS CLOSED on it (it does not fall back to a
+    real-weight export, which is how z-image OOM'd ~40 GiB as `retryable`).
     """
-    from ..models.structure_only import STAMP, StructureOnlyUnsupported
+    from ..models.structure_only import STAMP, StructureNotHonored
 
     for component, module in sorted(injected.items()):
         got = getattr(pipe, component, None)
         if got is module or getattr(got, STAMP, False):
             continue
-        raise StructureOnlyUnsupported(
+        raise StructureNotHonored(
             component=component,
             cls_name=type(pipe).__name__,
             lacks=(

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -870,7 +870,8 @@ def mint(request: MintRequest) -> MintReport:
         endpoint instance, its compile-target pipeline, and that pipeline's
         export spec."""
         from . import fleet_cells
-        from .models.structure_only import StructureOnlyUnsupported
+        from .models.structure_only import (
+            StructureNotHonored, StructureOnlyUnsupported)
 
         obj = spec.cls()
         try:
@@ -878,6 +879,18 @@ def mint(request: MintRequest) -> MintReport:
                 obj, dict(paths), arm_compile=False,
                 return_loaded=True, component_paths=overrides,
                 structure_only=structure_targets) or {}
+        except StructureNotHonored as exc:
+            # pgw#1080 z-image tail: the target WAS built weight-free and the
+            # pipeline discarded it and rebuilt from the checkpoint. Falling
+            # back here (below) would export ~weight-scale REAL tensors while
+            # the child reports weightless — the silent 40 GiB `retryable` OOM
+            # (ie#638). This is buildable-but-not-honored, NOT a stranded
+            # family, so it FAILS CLOSED with the authoring cause named rather
+            # than degrading to a real-weight export the meta gate never sees.
+            raise MintChildRefused(
+                f"structure-only was requested for {mint_identity(request)} "
+                f"and the target built weight-free, but the composed pipeline "
+                f"did not carry it: {exc}") from exc
         except StructureOnlyUnsupported as exc:
             structure_refusals.append(str(exc))
             frame(phase="load", note=f"structure-only declined: {exc}")

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -104,6 +104,23 @@ class StructureOnlyUnsupported(WorkerError):
         )
 
 
+class StructureNotHonored(StructureOnlyUnsupported):
+    """A component that WAS built weight-free was not carried by the pipeline.
+
+    Distinct from its parent on purpose. ``StructureOnlyUnsupported`` means the
+    component could not be built from code+config at all (a genuinely stranded
+    family: no config surface, a quantized artifact lane, an unnamed class) —
+    for which loading real weights is the CORRECT outcome and the mint child
+    legitimately falls back. This subclass means the opposite: ``build_component``
+    SUCCEEDED (the module's parameters are fake, zero storage) and the composed
+    pipeline then IGNORED the injected module and rebuilt the target from the
+    checkpoint. Falling back there would export ~weight-scale REAL tensors while
+    still reporting a weightless child — the exact silent failure this slice
+    exists to prevent (measured on z-image: a ~40 GiB `torch.export` OOM
+    misclassified `retryable`, ie#638). So it must FAIL CLOSED, not fall back.
+    """
+
+
 @dataclass(frozen=True)
 class StructureFacts:
     """What one structure-only component costs, and what it did NOT cost."""
@@ -648,6 +665,7 @@ __all__ = [
     "RANDOM_STD",
     "STAMP",
     "StructureFacts",
+    "StructureNotHonored",
     "StructureOnlyUnsupported",
     "build_component",
     "compiling_under",

--- a/tests/test_structure_only_pgw1080.py
+++ b/tests/test_structure_only_pgw1080.py
@@ -196,11 +196,65 @@ def test_a_pipeline_that_IGNORES_the_injection_is_refused_not_trusted(
     class Ignores:
         transformer = "a real module, loaded from the checkpoint"
 
-    with pytest.raises(so.StructureOnlyUnsupported) as caught:
+    with pytest.raises(so.StructureNotHonored) as caught:
         run_mod._assert_structure_honored(
             Ignores(), {"transformer": object()}, slot="pipeline")
     assert "does not carry the injected structure-only module" in str(
         caught.value)
+
+
+def test_not_honored_is_a_DISTINCT_type_from_the_buildable_strand() -> None:
+    """pgw#1080 z-image tail — the two refusals must NOT be conflated.
+
+    A buildable strand (no config surface, an artifact lane) raises
+    ``StructureOnlyUnsupported`` and the mint child CORRECTLY falls back to a
+    real-weight mint. A composition that discarded a target that DID build
+    weight-free raises ``StructureNotHonored``; falling back there would export
+    ~weight-scale real tensors while reporting weightless — the silent z-image
+    40 GiB `retryable` OOM (ie#638). The mint child tells them apart by TYPE, so
+    the subclass relationship (broad ``except`` still sees "unsupported") must
+    hold WHILE the concrete type stays distinguishable."""
+    assert issubclass(so.StructureNotHonored, so.StructureOnlyUnsupported)
+    assert so.StructureNotHonored is not so.StructureOnlyUnsupported
+    # A plain buildable strand is NOT a not-honored miss.
+    strand = so.StructureOnlyUnsupported(
+        component="transformer", cls_name="Fp8Denoiser",
+        lacks="this tree is a w8a8 artifact")
+    assert not isinstance(strand, so.StructureNotHonored)
+
+
+def test_the_real_load_seam_raises_NOT_HONORED_on_a_swallowed_injection(
+    tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production seam the mint child fails closed on. ``build_component``
+    succeeds (the micro transformer builds weight-free), then the composed
+    pipeline drops the injection and carries a real module — so
+    ``_load_injected_model`` raises ``StructureNotHonored`` (NOT the buildable
+    strand). The mint child's three-line handler turns exactly this type into a
+    ``MintChildRefused`` so the real-weight export never starts; conflating it
+    with the strand is what let z-image OOM ~40 GiB as `retryable` (ie#638)."""
+    from gen_worker.cli import run as run_mod
+    from gen_worker.models import provision
+
+    class _Rebuilt:
+        transformer = "reloaded from the checkpoint, not the injected fake"
+
+    def _swallows(annotation: object, path: object, **_k: object
+                  ) -> provision.SlotLoad:
+        return provision.SlotLoad(obj=_Rebuilt(), is_pipeline=True)
+
+    monkeypatch.setattr(provision, "load_slot", _swallows)
+    monkeypatch.setattr(run_mod.provision, "load_slot", _swallows)
+
+    cls = so._component_class(tree, "transformer")
+    with pytest.raises(so.StructureNotHonored) as caught:
+        run_mod._load_injected_model(
+            cls, str(tree), slot="pipeline", device="cpu",
+            arm_compile=False, structure_only=("transformer",))
+    assert "does not carry the injected structure-only module" in str(
+        caught.value)
+    # And it must NOT be swallowed as a buildable strand.
+    assert isinstance(caught.value, so.StructureOnlyUnsupported)
 
 
 def test_the_micro_tree_names_its_component_classes(tree: Path) -> None:


### PR DESCRIPTION
## What

The pgw#868 A2 pod lane measured z-image's self-mint reaching export and OOMing — `torch.export(strict=True) for ZImageTransformer2DModel` holding **~40.01 GiB of REAL device memory** in the mint child, classified `retryable` (the ie#638 signature).

**Root cause is NOT the component builder.** Proven cardless ($0, no pod): `structure_only.build_component` + `init_empty_weights()` + `from_config` on the real SDK path against diffusers 0.39.0's `ZImageTransformer2DModel` (endpoint ie#630 rope fix active) builds it **fully weight-free — 0 real param bytes, all params fake**. Increment 2 already generalizes to z-image by construction.

The defect is a **gate hole + a silent fallback**:

1. `meta_instantiation.guard` is installed around the export **only when `fake_mode is not None`** (`aot_mint.py:1333`) — a real-weight export runs UNGUARDED, so a 40 GiB real `torch.export` yields no typed refusal, just an OOM misread as `retryable`.
2. `mint_child._load` swallowed `_assert_structure_honored`'s refusal into the **same fallback** as a genuinely stranded family. So a composition that discarded a target that DID build weight-free degraded to a real-weight export instead of failing. `boot_trace_child` already fails closed here (`structure_not_honored`); `mint_child` did not — the inconsistency is the hole.

## Fix

Split the refusal by TYPE:
- `_assert_structure_honored` now raises **`StructureNotHonored`** (subclass of `StructureOnlyUnsupported`).
- `mint_child._load` catches it FIRST and **fails closed (`MintChildRefused`)** — the real-weight export never starts, with the authoring/composition cause named.
- A genuinely stranded family (no config surface, w8a8/w4a4/svdq/gguf artifact lane, unnamed class) still raises the plain parent and still falls back correctly.

Net: a weight-free-capable family can never again silently hold ~40 GiB and be misclassified `retryable`.

## Tests / gates

- `tests/test_structure_only_pgw1080.py` **13/13 green** (3 new: distinct-type, real-load-seam raises `StructureNotHonored`, and the ignored-injection test tightened to the new type).
- `mypy src/gen_worker` clean (256 files).
- Cardless, CPU-only (fake/meta), $0, no pod.

## Gated (not in this PR)

The exact decline z-image hits on the real tree (composition leak vs. a clean-child weight-scale warm proof) needs the real Qwen text_encoder composition — unreproducible cardless — and the peak-MB-not-GB pod confirmation is the family-campaign re-run, blocked on th#1771 (bf16 warm-forward). The fix is correct under both readings.

Tracker: pgw#1080 increment 3.