### PR TITLE
pgw#1114: a rig proves it is on the fleet's torch/CUDA line before it may measure anything

### DIFF
--- a/changelog.d/pgw1114.md
+++ b/changelog.d/pgw1114.md
@@ -1,0 +1,26 @@
+- **pgw#1114: `gen_worker.rigcheck` — a measurement rig now proves it is on the
+  fleet's torch/CUDA line before it is allowed to measure anything.** Two false
+  verdicts came from the same mechanism: a rig built by copying an older rig's
+  `setup.sh` forward, running `torch 2.9.1+cu129` while every deployed endpoint
+  had been on `2.13.0+cu130` since 2026-07-13. The B200 re-cell paid $11.3 for
+  it; pgw#1081 §R2 used it to close SageAttention-2 as "not integrable", which
+  was a statement about software nobody runs. The rule against this was written
+  down the day before the second occurrence, which is the point: a rule a human
+  has to remember is not a control. `assert_fleet_line()` is the first statement
+  of every rig entrypoint (`python3 -m gen_worker.rigcheck` pod-side, exit 90) —
+  it resolves torch, the CUDA build, driver, device and the endpoint-relevant
+  wheels, raises a typed `FleetLineMismatch` when the environment is below the
+  line, and PRINTS the resolved environment table on success so every report
+  carries the stack it was measured on. There is no override env and no warn
+  mode: a missing wheel for the fleet line is the finding to report, never
+  permission to measure on an old one. **The expected values are READ, never
+  hardcoded** — a constant copied out of the fleet's declaration is the same
+  failure one layer down, going stale the next time the fleet moves. It reads
+  `endpoint.toml [[build.profiles]]` (the declaration tensorhub's builder
+  resolves the managed base image from, and the only one that names CUDA),
+  `fleet-floors.toml [floors]`, and installed distribution metadata; every
+  authority reachable is compared and the strictest floor wins, and *no*
+  authority reachable is also an abort, because nothing to compare against is
+  not permission to measure. The canonical environment, including the pod-side
+  install that actually produces torch 2.13/cu130 on the fleet base, is
+  `cozy-creator-tracker/research/RIG-ENV.md`.

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -120,6 +120,7 @@ src/gen_worker/aot_wrapper_split.py::GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF LIBRARY G
 # ---------------------------------------------------------------------------
 # STANDALONE — CLI / convert paths that load no app config.
 # ---------------------------------------------------------------------------
+src/gen_worker/rigcheck.py::GEN_WORKER_FLEET_LINE_FILE STANDALONE GEN_WORKER_FLEET_LINE_FILE (pgw#1114), a PATH to the fleet-line authority (an endpoint.toml or fleet-floors.toml) for a measurement rig. Never runs in the worker pipeline - a rig process has no Settings and no config sources - so there is nothing to thread it through. It is a config VALUE, not a logic flag: it changes WHERE the expectation is read from, never WHETHER the assertion runs, and there is no value of it that turns the abort into a warning.
 src/gen_worker/cli/local_context.py::GEN_WORKER_LOCAL_OUTPUT_DIR STANDALONE GEN_WORKER_LOCAL_OUTPUT_DIR, local-run output dir.
 src/gen_worker/cli/local_context.py::USER STANDALONE USER, for the local-dev owner label.
 src/gen_worker/convert/clone.py::COZY_CONVERT_SCRATCH_TTL_S STANDALONE COZY_CONVERT_SCRATCH_TTL_S, convert-tool scratch TTL.

--- a/scripts/rig_gauntlet.py
+++ b/scripts/rig_gauntlet.py
@@ -194,6 +194,24 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--json", type=Path, default=None)
     args = parser.parse_args(list(argv) if argv is not None else None)
 
+    # pgw#1114: carry the resolved environment, but do NOT assert the fleet line
+    # here. This gauntlet's product is a plumbing verdict (did the machinery
+    # agree with its expectation), never a number, and the box cannot run a
+    # cu130 build against its card at all — `scripts/rig_gpu_env.sh` builds the
+    # fleet's torch on cu126 deliberately. Any rig that produces a NUMBER calls
+    # `assert_fleet_line()` instead and aborts; see research/RIG-ENV.md §3b.
+    from gen_worker import rigcheck
+
+    try:
+        env = rigcheck.resolve_environment()
+        print(rigcheck.format_report(env, rigcheck.resolve_fleet_line()),
+              file=sys.stderr, flush=True)
+    except rigcheck.FleetLineUnknown as exc:
+        print(f"rig_gauntlet: fleet line unresolved ({exc})", file=sys.stderr)
+    print("rig_gauntlet: PLUMBING VERDICT ONLY — these variants report machinery "
+          "agreement, not measurements. No number from this rig is quotable.",
+          file=sys.stderr, flush=True)
+
     from harness import rig_vehicles
 
     names = [n.strip() for n in args.only.split(",") if n.strip()] or list(ORDER)

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -170,6 +170,9 @@ _OWNED_NON_SETTINGS: frozenset[str] = frozenset(REFUSED_KEY_MATERIAL) | frozense
     "COZY_CONVERT_SCRATCH_TTL_S",
     "COZY_CLONE_DOWNLOAD_ATTEMPTS",
     "COZY_CIVITAI_DOWNLOAD_ATTEMPTS",
+    # pgw#1114: rig-side only. A path to the fleet-line authority; a worker
+    # process never reads it and it has no Settings field by design.
+    "GEN_WORKER_FLEET_LINE_FILE",
 })
 
 

--- a/src/gen_worker/rigcheck.py
+++ b/src/gen_worker/rigcheck.py
@@ -1,0 +1,504 @@
+"""Fleet-line preflight for measurement rigs (pgw#1114).
+
+A rig measures a rig. When the rig's torch/CUDA line drifts off the fleet's, its
+verdict is about software nobody runs — and it reads as a verdict about
+production. pgw#1081 §R2 closed SageAttention-2 as "not integrable" from a pod on
+``torch 2.9.1+cu129`` while every deployed endpoint had been on ``2.13.0+cu130``
+since 2026-07-13. That was the second occurrence (the B200 re-cell was the first),
+so the rule stops being remembered and becomes mechanical: **every rig calls
+:func:`assert_fleet_line` as its first act, and a rig that has not asserted the
+fleet line has produced no evidence.**
+
+THE EXPECTED VALUES ARE READ, NEVER HARDCODED. A constant copied into this module
+is the same failure one layer down — it would go stale the next time the fleet
+moves and nobody would notice. Authorities, all of them files production itself
+reads, best-first:
+
+1. ``endpoint.toml`` ``[[build.profiles]]`` — ``torch`` + ``cuda``. This is the
+   exact declaration tensorhub's builder resolves the managed base image from
+   (``internal/builder/baseimage.go``), so it is what the endpoint's production
+   image literally runs. It ships inside the endpoint sdist, so a rig that has the
+   endpoint source — which every rig must, since the rig imports the endpoint's
+   own code — has this file. The only authority that declares CUDA.
+2. ``fleet-floors.toml`` ``[floors] torch`` — the fleet-wide floor CI enforces
+   against every endpoint's lock. Fleet-scoped, torch only.
+3. Installed distribution metadata — the endpoint dist's own ``torch>=…``
+   requirement, else ``gen-worker[torch]``'s. Always available wherever the code
+   under measurement is installed; torch only.
+
+Every authority found is compared and the STRICTEST floor wins, so a rig sitting
+between two of them fails rather than picking the lenient one. **No authority
+found is also an abort**: nothing to compare against is not permission to
+measure.
+
+There is deliberately no override and no "warn" mode. A missing wheel for the
+fleet line is a FINDING to report, never permission to measure on an old one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+__all__ = [
+    "FleetLine",
+    "FleetLineMismatch",
+    "FleetLineUnknown",
+    "assert_fleet_line",
+    "format_report",
+    "resolve_environment",
+    "resolve_fleet_line",
+]
+
+#: Config value (a path), not a logic flag: point the resolver at the authority
+#: when the rig's layout hides it. It changes WHERE the expectation is read from,
+#: never WHETHER the assertion runs.
+FLEET_LINE_FILE_ENV = "GEN_WORKER_FLEET_LINE_FILE"
+
+#: Wheels whose version decides whether a kernel/quantization result is about the
+#: fleet's stack or about the rig's. Reported on every run; absence is reported,
+#: not raised — an unbuildable wheel is the finding.
+REPORTED_PACKAGES = (
+    "gen-worker",
+    "torch",
+    "torchvision",
+    "torchaudio",
+    "triton",
+    "transformers",
+    "diffusers",
+    "accelerate",
+    "torchao",
+    "sageattention",
+    "flash-attn",
+    "flashinfer-python",
+    "nvidia-cudnn-cu13",
+    "nvidia-cudnn-cu12",
+)
+
+_MAX_WALK_UP = 8
+
+
+class FleetLineMismatch(RuntimeError):
+    """The rig is not on the fleet's torch/CUDA line. Measuring is forbidden."""
+
+
+class FleetLineUnknown(RuntimeError):
+    """No authority declared a fleet line. Nothing to assert against."""
+
+
+@dataclass(frozen=True)
+class Authority:
+    """One declaration of the fleet line, and where it was read from."""
+
+    torch: Optional[tuple[int, ...]]
+    cuda: Optional[tuple[int, ...]]
+    source: str
+    origin: str
+
+
+@dataclass(frozen=True)
+class FleetLine:
+    """The strictest floor across every authority that could be read."""
+
+    torch: tuple[int, ...]
+    cuda: Optional[tuple[int, ...]]
+    authorities: tuple[Authority, ...] = field(default=())
+
+    @property
+    def torch_text(self) -> str:
+        return ".".join(str(p) for p in self.torch)
+
+    @property
+    def cuda_text(self) -> str:
+        return ".".join(str(p) for p in self.cuda) if self.cuda else "undeclared"
+
+
+# --------------------------------------------------------------------------- #
+# version parsing
+# --------------------------------------------------------------------------- #
+
+
+def _version(text: object, parts: int = 3) -> Optional[tuple[int, ...]]:
+    """``'2.13.0+cu130'`` -> ``(2, 13, 0)``. None when nothing numeric is there."""
+    if text is None:
+        return None
+    head = str(text).strip().split("+")[0].split(" ")[0]
+    out: list[int] = []
+    for token in head.split("."):
+        digits = re.match(r"\d+", token)
+        if not digits:
+            break
+        out.append(int(digits.group()))
+        if len(out) == parts:
+            break
+    if not out:
+        return None
+    return tuple(out)
+
+
+def _pad(v: Sequence[int], n: int) -> tuple[int, ...]:
+    return tuple(list(v)[:n] + [0] * (n - len(v)))
+
+
+def _below(found: Optional[Sequence[int]], floor: Sequence[int]) -> bool:
+    if found is None:
+        return True
+    n = max(len(found), len(floor))
+    return _pad(found, n) < _pad(floor, n)
+
+
+def _requirement_floor(requirement: str, name: str) -> Optional[tuple[int, ...]]:
+    """Lowest version ``name`` may take under one PEP 508 requirement string."""
+    req = requirement.split(";")[0].strip()
+    head = re.match(r"^([A-Za-z0-9._-]+)", req)
+    if not head or head.group(1).lower().replace("_", "-") != name:
+        return None
+    best: Optional[tuple[int, ...]] = None
+    for op, ver in re.findall(r"(>=|==|~=|>)\s*([0-9][0-9A-Za-z.*+!-]*)", req):
+        parsed = _version(ver.replace("*", "0"))
+        if parsed and (best is None or parsed > best):
+            best = parsed
+    return best
+
+
+# --------------------------------------------------------------------------- #
+# authorities
+# --------------------------------------------------------------------------- #
+
+
+def _walk_up(start: Path, name: str) -> Iterable[Path]:
+    here = start if start.is_dir() else start.parent
+    for _ in range(_MAX_WALK_UP):
+        candidate = here / name
+        if candidate.is_file():
+            yield candidate
+        if here.parent == here:
+            break
+        here = here.parent
+
+
+def _search_roots(start: Optional[Path]) -> list[Path]:
+    roots: list[Path] = []
+    for p in (start, Path.cwd(), Path("/src"), Path("/rig")):
+        if p and p.exists() and p not in roots:
+            roots.append(p)
+    return roots
+
+
+def _candidate_files(name: str, start: Optional[Path]) -> list[Path]:
+    found: list[Path] = []
+    for root in _search_roots(start):
+        for hit in _walk_up(root, name):
+            if hit not in found:
+                found.append(hit)
+        if root.is_dir():
+            # One level down covers the pod layout `/src/<endpoint>/endpoint.toml`.
+            for child in sorted(root.iterdir()):
+                hit = child / name
+                if child.is_dir() and hit.is_file() and hit not in found:
+                    found.append(hit)
+    return found
+
+
+def _endpoint_toml_authority(path: Path) -> Optional[Authority]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    profiles = (data.get("build") or {}).get("profiles") or []
+    if not isinstance(profiles, list):
+        return None
+    chosen: Optional[Mapping[str, Any]] = None
+    for profile in profiles:
+        if not isinstance(profile, Mapping):
+            continue
+        if str(profile.get("accelerator", "")).lower() == "cuda":
+            chosen = profile
+            break
+        chosen = chosen or profile
+    if chosen is None:
+        return None
+    torch = _version(chosen.get("torch"))
+    cuda = _version(chosen.get("cuda"), parts=2)
+    if torch is None and cuda is None:
+        return None
+    return Authority(
+        torch=torch,
+        cuda=cuda,
+        source="endpoint.toml [[build.profiles]]",
+        origin=f"{path} (profile {chosen.get('name', '?')})",
+    )
+
+
+def _fleet_floors_authority(path: Path) -> Optional[Authority]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    torch = _version((data.get("floors") or {}).get("torch"))
+    if torch is None:
+        return None
+    return Authority(
+        torch=torch,
+        cuda=None,
+        source="fleet-floors.toml [floors]",
+        origin=str(path),
+    )
+
+
+def _metadata_authority(dist: str, extra_hint: str = "") -> Optional[Authority]:
+    from importlib import metadata
+
+    try:
+        requirements = metadata.requires(dist) or []
+    except metadata.PackageNotFoundError:
+        return None
+    best: Optional[tuple[int, ...]] = None
+    for requirement in requirements:
+        floor = _requirement_floor(requirement, "torch")
+        if floor and (best is None or floor > best):
+            best = floor
+    if best is None:
+        return None
+    return Authority(
+        torch=best,
+        cuda=None,
+        source=f"{dist} distribution metadata{extra_hint}",
+        origin=f"importlib.metadata.requires({dist!r}) -> torch>={'.'.join(map(str, best))}",
+    )
+
+
+def _collect_authorities(
+    start: Optional[Path], endpoint_dists: Sequence[str]
+) -> list[Authority]:
+    explicit = os.environ.get(FLEET_LINE_FILE_ENV, "").strip()
+    if explicit:
+        path = Path(explicit)
+        found = _endpoint_toml_authority(path) or _fleet_floors_authority(path)
+        if found is None:
+            raise FleetLineUnknown(
+                f"{FLEET_LINE_FILE_ENV}={explicit} declares no fleet line "
+                "(expected an endpoint.toml [[build.profiles]] or a "
+                "fleet-floors.toml [floors] torch)"
+            )
+        return [found]
+
+    authorities: list[Authority] = []
+    for path in _candidate_files("endpoint.toml", start):
+        found = _endpoint_toml_authority(path)
+        if found:
+            authorities.append(found)
+    for path in _candidate_files("fleet-floors.toml", start):
+        found = _fleet_floors_authority(path)
+        if found:
+            authorities.append(found)
+    for dist in list(endpoint_dists) + ["gen-worker"]:
+        found = _metadata_authority(dist)
+        if found:
+            authorities.append(found)
+    return authorities
+
+
+def resolve_fleet_line(
+    *,
+    start: Optional[os.PathLike[str] | str] = None,
+    endpoint_dists: Sequence[str] = (),
+) -> FleetLine:
+    """Read every reachable authority and return the STRICTEST floor.
+
+    Raises :class:`FleetLineUnknown` when nothing declares a line.
+    """
+    root = Path(start).resolve() if start else None
+    authorities = _collect_authorities(root, endpoint_dists)
+    torch_floors = [a.torch for a in authorities if a.torch]
+    if not torch_floors:
+        raise FleetLineUnknown(
+            "no fleet-line authority is reachable from "
+            f"{[str(p) for p in _search_roots(root)]}. A rig with nothing to "
+            "compare against has produced no evidence: ship the endpoint's "
+            f"endpoint.toml next to the rig, or set {FLEET_LINE_FILE_ENV} to it."
+        )
+    cuda_floors = [a.cuda for a in authorities if a.cuda]
+    return FleetLine(
+        torch=max(torch_floors),
+        cuda=max(cuda_floors) if cuda_floors else None,
+        authorities=tuple(authorities),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolved environment
+# --------------------------------------------------------------------------- #
+
+
+def _driver_version() -> Optional[str]:
+    import shutil
+    import subprocess
+
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return None
+    try:
+        out = subprocess.run(
+            [smi, "--query-gpu=driver_version", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    line = out.stdout.strip().splitlines()
+    return line[0].strip() if line else None
+
+
+def _package_versions() -> dict[str, str]:
+    from importlib import metadata
+
+    out: dict[str, str] = {}
+    for name in REPORTED_PACKAGES:
+        try:
+            out[name] = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            continue
+    return out
+
+
+def resolve_environment() -> dict[str, Any]:
+    """torch / CUDA / driver / device / wheel versions, as actually installed."""
+    env: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "platform": sys.platform,
+        "packages": _package_versions(),
+    }
+    try:
+        import torch  # noqa: PLC0415 — heavy, and torch is a capability (pgw#788)
+    except Exception as exc:  # noqa: BLE001 — an unimportable torch IS the report
+        env["torch"] = None
+        env["torch_import_error"] = f"{type(exc).__name__}: {exc}"[:400]
+        env["cuda"] = None
+        return env
+
+    env["torch"] = getattr(torch, "__version__", None)
+    env["cuda"] = getattr(getattr(torch, "version", None), "cuda", None)
+    try:
+        env["cudnn"] = torch.backends.cudnn.version()
+    except Exception:  # noqa: BLE001
+        env["cudnn"] = None
+    try:
+        env["cuda_available"] = bool(torch.cuda.is_available())
+    except Exception:  # noqa: BLE001
+        env["cuda_available"] = False
+    if env["cuda_available"]:
+        try:
+            props = torch.cuda.get_device_properties(0)
+            env["device"] = props.name
+            env["sm"] = f"{props.major}.{props.minor}"
+            env["vram_gib"] = round(props.total_memory / 2**30, 2)
+        except Exception:  # noqa: BLE001
+            pass
+    env["driver"] = _driver_version()
+    return env
+
+
+def format_report(env: Mapping[str, Any], line: FleetLine) -> str:
+    """The environment table every rig report must carry."""
+    rows: list[tuple[str, str]] = [
+        ("torch", f"{env.get('torch')}  (fleet floor {line.torch_text})"),
+        ("torch CUDA", f"{env.get('cuda')}  (fleet floor {line.cuda_text})"),
+        ("cudnn", str(env.get("cudnn"))),
+        ("driver", str(env.get("driver"))),
+        ("device", f"{env.get('device', 'none')}  sm{env.get('sm', '-')}  "
+                   f"{env.get('vram_gib', '-')} GiB"),
+        ("python", str(env.get("python"))),
+    ]
+    for name, version in (env.get("packages") or {}).items():
+        if name != "torch":
+            rows.append((name, version))
+    width = max(len(k) for k, _ in rows)
+    body = "\n".join(f"  {k.ljust(width)}  {v}" for k, v in rows)
+    provenance = "\n".join(
+        f"  - {a.source}: torch>={'.'.join(map(str, a.torch)) if a.torch else '-'}"
+        f"{', cuda>=' + '.'.join(map(str, a.cuda)) if a.cuda else ''}\n"
+        f"      {a.origin}"
+        for a in line.authorities
+    )
+    return (
+        "FLEET LINE — resolved environment\n"
+        f"{body}\n"
+        "read from:\n"
+        f"{provenance}"
+    )
+
+
+def assert_fleet_line(
+    what: str = "rig",
+    *,
+    start: Optional[os.PathLike[str] | str] = None,
+    endpoint_dists: Sequence[str] = (),
+    stream: Any = None,
+) -> dict[str, Any]:
+    """Abort unless this interpreter is on the fleet's torch/CUDA line.
+
+    Call it as the FIRST act of any rig, harness, probe or scoring script. On
+    success it prints the resolved environment table (so every report carries
+    it) and returns that environment as a dict. On mismatch it raises
+    :class:`FleetLineMismatch`; when no authority is reachable it raises
+    :class:`FleetLineUnknown`. Both are fatal by design — there is no override.
+    """
+    out = stream if stream is not None else sys.stderr
+    line = resolve_fleet_line(start=start, endpoint_dists=endpoint_dists)
+    env = resolve_environment()
+    report = format_report(env, line)
+
+    problems: list[str] = []
+    if env.get("torch") is None:
+        problems.append(
+            f"torch does not import: {env.get('torch_import_error', 'unknown')}"
+        )
+    elif _below(_version(env["torch"]), line.torch):
+        problems.append(
+            f"torch {env['torch']} is below the fleet line {line.torch_text}"
+        )
+    if line.cuda is not None:
+        found = _version(env.get("cuda"), parts=2)
+        if _below(found, line.cuda):
+            problems.append(
+                f"torch CUDA build {env.get('cuda')} is below the fleet line "
+                f"{line.cuda_text}"
+            )
+
+    if problems:
+        raise FleetLineMismatch(
+            f"{what}: REFUSING TO MEASURE — this environment is not the fleet's.\n"
+            + "\n".join(f"  * {p}" for p in problems)
+            + "\n\n"
+            + report
+            + "\n\nA rig off the fleet line produces no evidence (pgw#1114). Rebuild "
+            "the environment per RIG-ENV.md; a missing wheel for the fleet line is "
+            "the finding to report, not permission to measure on an old one."
+        )
+
+    print(f"{what}: on the fleet line.\n{report}", file=out, flush=True)
+    return env
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """``python -m gen_worker.rigcheck`` — exit 0 on the line, 90 off it."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    start = args[0] if args else None
+    try:
+        assert_fleet_line("rigcheck", start=start, stream=sys.stdout)
+    except (FleetLineMismatch, FleetLineUnknown) as exc:
+        print(str(exc), file=sys.stderr, flush=True)
+        return 90
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_rigcheck_pgw1114.py
+++ b/tests/test_rigcheck_pgw1114.py
@@ -1,0 +1,262 @@
+"""pgw#1114 — the fleet-line preflight's own red/green.
+
+The assertion is the thing standing between a stale rig and a false verdict, so
+it is tested the way a rig exercises it: real authority FILES on disk (the same
+``endpoint.toml`` / ``fleet-floors.toml`` shapes production reads), a real
+resolved-environment dict, and the abort path proven to be typed and loud rather
+than a log line.
+
+No torch import is faked into ``sys.modules``: :func:`resolve_environment` is the
+only torch toucher and the assertion consumes its output as data, so the version
+axes are driven by substituting that reader. Everything else — parsing, authority
+discovery, strictest-floor selection, the printed table — runs for real.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gen_worker import rigcheck
+
+ENDPOINT_TOML = textwrap.dedent(
+    """
+    schema_version = 1
+    main = "demo.main"
+
+    [runtime]
+    language = "python"
+
+    [[build.profiles]]
+    name = "default"
+    accelerator = "cuda"
+    cuda = "13.0"
+    python = "3.12"
+    torch = "2.13.0"
+    """
+)
+
+FLEET_FLOORS_TOML = textwrap.dedent(
+    """
+    [floors]
+    gen-worker = "0.102.0"
+    torch = "2.13.0"
+    transformers = "5.13"
+    """
+)
+
+
+def _env(torch: str | None, cuda: str | None) -> dict:
+    return {
+        "python": "3.12.8",
+        "platform": "linux",
+        "packages": {"gen-worker": "0.104.0", "torch": torch or "absent"},
+        "torch": torch,
+        "cuda": cuda,
+        "cudnn": 91002,
+        "cuda_available": True,
+        "device": "NVIDIA H100 80GB HBM3",
+        "sm": "9.0",
+        "vram_gib": 79.19,
+        "driver": "580.65.06",
+    }
+
+
+@pytest.fixture
+def rig(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A pod-shaped layout: `/src/<endpoint>/endpoint.toml` next to a rig dir."""
+    src = tmp_path / "src" / "demo-endpoint"
+    src.mkdir(parents=True)
+    (src / "endpoint.toml").write_text(ENDPOINT_TOML, encoding="utf-8")
+    rig_dir = tmp_path / "src" / "rig"
+    rig_dir.mkdir()
+    monkeypatch.delenv(rigcheck.FLEET_LINE_FILE_ENV, raising=False)
+    monkeypatch.chdir(tmp_path / "src")
+    return rig_dir
+
+
+def _use_env(monkeypatch: pytest.MonkeyPatch, torch: str | None, cuda: str | None):
+    monkeypatch.setattr(rigcheck, "resolve_environment", lambda: _env(torch, cuda))
+
+
+# --------------------------------------------------------------------------- #
+# the expectation is READ, not hardcoded
+# --------------------------------------------------------------------------- #
+
+
+def test_reads_the_line_from_endpoint_toml(rig: Path) -> None:
+    line = rigcheck.resolve_fleet_line(start=rig)
+    assert line.torch == (2, 13, 0)
+    assert line.cuda == (13, 0)
+    assert any("endpoint.toml" in a.source for a in line.authorities)
+
+
+def test_the_line_moves_when_the_authority_moves(rig: Path) -> None:
+    """No constant in the module: edit the file, the floor follows."""
+    toml = rig.parent / "demo-endpoint" / "endpoint.toml"
+    toml.write_text(
+        ENDPOINT_TOML.replace('torch = "2.13.0"', 'torch = "2.15.2"').replace(
+            'cuda = "13.0"', 'cuda = "14.1"'
+        ),
+        encoding="utf-8",
+    )
+    line = rigcheck.resolve_fleet_line(start=rig)
+    assert line.torch == (2, 15, 2)
+    assert line.cuda == (14, 1)
+
+
+def test_fleet_floors_is_an_authority_too(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv(rigcheck.FLEET_LINE_FILE_ENV, raising=False)
+    (tmp_path / "fleet-floors.toml").write_text(FLEET_FLOORS_TOML, encoding="utf-8")
+    line = rigcheck.resolve_fleet_line(start=tmp_path)
+    assert line.torch == (2, 13, 0)
+    assert line.cuda is None  # only endpoint.toml declares CUDA
+    assert any("fleet-floors.toml" in a.source for a in line.authorities)
+
+
+def test_strictest_authority_wins(rig: Path) -> None:
+    """Two authorities disagreeing must not let the lenient one through."""
+    (rig.parent / "fleet-floors.toml").write_text(
+        FLEET_FLOORS_TOML.replace('torch = "2.13.0"', 'torch = "2.14.0"'),
+        encoding="utf-8",
+    )
+    assert rigcheck.resolve_fleet_line(start=rig).torch == (2, 14, 0)
+
+
+def test_explicit_authority_path_env(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "elsewhere.toml"
+    path.write_text(ENDPOINT_TOML, encoding="utf-8")
+    monkeypatch.setenv(rigcheck.FLEET_LINE_FILE_ENV, str(path))
+    line = rigcheck.resolve_fleet_line(start=tmp_path)
+    assert (line.torch, line.cuda) == ((2, 13, 0), (13, 0))
+
+
+def test_gen_worker_metadata_is_the_last_resort() -> None:
+    """gen-worker declares `torch>=…` in its own `torch` extra; that is readable."""
+    authority = rigcheck._metadata_authority("gen-worker")
+    assert authority is not None, "gen-worker must declare a torch floor"
+    assert authority.torch is not None and authority.torch >= (2, 13, 0)
+
+
+# --------------------------------------------------------------------------- #
+# RED — a stale rig aborts
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_torch_aborts(rig: Path, monkeypatch) -> None:
+    """pgw#1081 §R2 verbatim: torch 2.9.1+cu129 against a 2.13/cu13 fleet."""
+    _use_env(monkeypatch, "2.9.1+cu129", "12.9")
+    with pytest.raises(rigcheck.FleetLineMismatch) as excinfo:
+        rigcheck.assert_fleet_line("pgw1081-r2", start=rig)
+    message = str(excinfo.value)
+    assert "REFUSING TO MEASURE" in message
+    assert "torch 2.9.1+cu129 is below the fleet line 2.13.0" in message
+    assert "CUDA build 12.9 is below the fleet line 13.0" in message
+    assert "endpoint.toml" in message  # the report names its own authority
+
+
+def test_right_torch_wrong_cuda_aborts(rig: Path, monkeypatch) -> None:
+    """The rig_gpu_env.sh shape: correct torch, cu126 build. Still not the fleet."""
+    _use_env(monkeypatch, "2.13.0+cu126", "12.6")
+    with pytest.raises(rigcheck.FleetLineMismatch) as excinfo:
+        rigcheck.assert_fleet_line(start=rig)
+    assert "CUDA build 12.6 is below" in str(excinfo.value)
+    assert "torch 2.13.0+cu126 is below" not in str(excinfo.value)
+
+
+def test_torchless_environment_aborts(rig: Path, monkeypatch) -> None:
+    env = _env(None, None)
+    env["torch_import_error"] = "ImportError: no module named torch"
+    monkeypatch.setattr(rigcheck, "resolve_environment", lambda: env)
+    with pytest.raises(rigcheck.FleetLineMismatch, match="torch does not import"):
+        rigcheck.assert_fleet_line(start=rig)
+
+
+def test_no_authority_aborts(tmp_path: Path, monkeypatch) -> None:
+    """Nothing to compare against is not permission to measure."""
+    monkeypatch.delenv(rigcheck.FLEET_LINE_FILE_ENV, raising=False)
+    monkeypatch.setattr(rigcheck, "_collect_authorities", lambda *a, **k: [])
+    with pytest.raises(rigcheck.FleetLineUnknown, match="no evidence"):
+        rigcheck.assert_fleet_line(start=tmp_path)
+
+
+def test_there_is_no_override(rig: Path, monkeypatch) -> None:
+    """No env, argument or config turns a mismatch into a warning."""
+    for name in ("GEN_WORKER_RIGCHECK", "GEN_WORKER_SKIP_RIGCHECK",
+                 "GEN_WORKER_RIGCHECK_FORCE", "RIGCHECK_ALLOW_STALE"):
+        monkeypatch.setenv(name, "1")
+    _use_env(monkeypatch, "2.9.1+cu129", "12.9")
+    with pytest.raises(rigcheck.FleetLineMismatch):
+        rigcheck.assert_fleet_line(start=rig)
+
+
+# --------------------------------------------------------------------------- #
+# GREEN — an on-line rig passes and PRINTS the table
+# --------------------------------------------------------------------------- #
+
+
+def test_on_the_line_passes_and_prints(rig: Path, monkeypatch, capsys) -> None:
+    _use_env(monkeypatch, "2.13.0+cu130", "13.0")
+    env = rigcheck.assert_fleet_line("h3-rig", start=rig, stream=None)
+    printed = capsys.readouterr().err
+    assert env["torch"] == "2.13.0+cu130"
+    assert "h3-rig: on the fleet line." in printed
+    for expected in ("torch", "2.13.0+cu130", "fleet floor 2.13.0", "driver",
+                     "580.65.06", "NVIDIA H100 80GB HBM3", "endpoint.toml"):
+        assert expected in printed, expected
+
+
+def test_newer_than_the_floor_passes(rig: Path, monkeypatch) -> None:
+    _use_env(monkeypatch, "2.14.0+cu131", "13.1")
+    assert rigcheck.assert_fleet_line(start=rig)["torch"] == "2.14.0+cu131"
+
+
+def test_cli_exit_codes(rig: Path, monkeypatch) -> None:
+    _use_env(monkeypatch, "2.13.0+cu130", "13.0")
+    assert rigcheck.main([str(rig)]) == 0
+    _use_env(monkeypatch, "2.9.1+cu129", "12.9")
+    assert rigcheck.main([str(rig)]) == 90
+
+
+# --------------------------------------------------------------------------- #
+# parsing edges that decide a verdict
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("2.13.0+cu130", (2, 13, 0)),
+        ("2.9.1+cu129", (2, 9, 1)),
+        ("2.13.0a0+git1234", (2, 13, 0)),
+        ("13.0", (13, 0)),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_version_parsing(text, expected) -> None:
+    assert rigcheck._version(text) == expected
+
+
+def test_two_component_comparison_is_not_lexical() -> None:
+    """`2.9` must not read as newer than `2.13`."""
+    assert rigcheck._below((2, 9, 1), (2, 13, 0))
+    assert not rigcheck._below((2, 13, 0), (2, 13, 0))
+    assert not rigcheck._below((2, 13), (2, 13, 0))
+
+
+@pytest.mark.parametrize(
+    "requirement,expected",
+    [
+        ("torch>=2.13.0", (2, 13, 0)),
+        ("torch>=2.13.0; extra == 'torch'", (2, 13, 0)),
+        ("torch==2.12.1", (2, 12, 1)),
+        ("torch~=2.13.0", (2, 13, 0)),
+        ("torchvision>=0.28.0", None),
+        ("torchaudio>=2.8,<3", None),
+    ],
+)
+def test_requirement_floor(requirement, expected) -> None:
+    assert rigcheck._requirement_floor(requirement, "torch") == expected


### PR DESCRIPTION
Paul, 2026-08-11, second telling: *"STOP THE PROBE RIGS FROM RUNNING AN OLD PYTORCH FOR GOD'S SAKE! We went over this before! Use pytorch 2.13 + CUDA 13.0 already."*

The rule was banked 2026-08-10 after the B200 re-cell ($11.3) and violated the next day: pgw#1081 §R2 ran `torch 2.9.1+cu129` — the RunPod image every H3 rig copied forward — while every deployed endpoint had been on `2.13.0+cu130` since 2026-07-13, and closed SageAttention-2 as "not integrable". A false verdict that shut the only untried full-fp8 route for a day. **A rule a human has to remember is not a control.**

## The mechanism

`gen_worker.rigcheck.assert_fleet_line()` — first statement of every rig entrypoint; `python3 -m gen_worker.rigcheck` pod-side (exit 90).

- Resolves torch / CUDA build / cuDNN / driver / device / endpoint-relevant wheels.
- Raises typed `FleetLineMismatch` below the line. **No override env, no warn mode** — a missing wheel for the fleet line is the finding to report, never permission to measure on an old one.
- **Prints the resolved environment table on success**, so every report carries the stack it was measured on.

## The expected values are READ, never hardcoded

A constant copied out of the fleet's declaration is the same failure one layer down. Three authorities, all files production itself reads; strictest floor wins; **no authority reachable is also an abort**.

| # | Authority | Declares | Why authoritative |
|---|---|---|---|
| 1 | `endpoint.toml [[build.profiles]]` | torch + cuda | What tensorhub's `internal/builder/baseimage.go` resolves the managed base image from. Ships in the endpoint sdist. Only source that names CUDA. |
| 2 | `fleet-floors.toml [floors] torch` | torch | The fleet-wide floor CI enforces against every lock. |
| 3 | Installed dist metadata | torch | Endpoint's own `torch>=`, else `gen-worker[torch]`'s. |

Run against the real tree with a `torch 2.9.1+cu129` interpreter — the verbatim pgw#1081 §R2 environment:

```
rigcheck: REFUSING TO MEASURE — this environment is not the fleet's.
  * torch 2.9.1+cu129 is below the fleet line 2.13.0
  * torch CUDA build 12.9 is below the fleet line 13.0
...
read from:
  - endpoint.toml [[build.profiles]]: torch>=2.13.0, cuda>=13.0
      inference-endpoints/minimax-h3/endpoint.toml (profile default)
  - fleet-floors.toml [floors]: torch>=2.13.0
  - gen-worker distribution metadata: torch>=2.13.0
exit=90
```

## Tests — 27, `tests/test_rigcheck_pgw1114.py`

**Red:** the verbatim pgw#1081 §R2 environment aborts; right-torch/wrong-cuda (the `rig_gpu_env.sh` cu126 shape) aborts; a torchless interpreter aborts; no-authority aborts; four plausible override envs do nothing.
**Green:** on-line rig passes and prints the table; newer-than-floor passes; CLI 0/90.
**The one that matters for staleness:** edit the authority file, the floor follows with no code change.

## In this repo

- `src/gen_worker/rigcheck.py` — the module.
- `scripts/rig_gauntlet.py` — the ONE non-asserting caller. Its product is a plumbing verdict (did each mint variant match its declared expectation), never a number, and this box's 570.211.01 driver cannot run cu130 against the card at all. It prints the table via the non-asserting API and says no number from it is quotable. Bounded, and written into RIG-ENV.md §3b.
- `GEN_WORKER_FLEET_LINE_FILE` is a PATH — `STANDALONE` in the config-read census, added to `_OWNED_NON_SETTINGS`. It changes *where* the expectation is read from, never *whether* the assertion runs.
- **No version bump.** master is `0.103.0` = PyPI latest and this repo bumps at the cut (a lane bump also fails `uv sync --locked`, docs/releasing.md §1). New public helper -> rides the **0.104.0** train with pgw#1080.

## Outside this PR

**Tracker (pushed to master):** `research/RIG-ENV.md` (the canonical rig-env spec — gate, authority table, the pod-side install that actually produces torch 2.13/cu130 on the fleet base, the declared-exception case, what a report must carry); `WORKSPACE-GIT-POLICY.md` §Local inference — *a rig that has not asserted the fleet line has produced no evidence*; `research/INDEX.md`; issue #1114.

**`~/cozy/samples` sweep (untracked working state):**

| | count |
|---|---|
| rig-dir py measurement entrypoints gated | 136 |
| rig-dir shell scripts gated (after installs) | 79 |
| flat-layout (pre-`rig/`) entrypoints gated | 27 |
| lifecycle/transport files deliberately EXEMPT, reason written in | 95 |
| stale pins annotated in place (record preserved, copy-forward dead) | 37 |
| rig READMEs bannered | 11 |

**23 of 23 pod-launching rigs booted the same stale image**, `runpod/pytorch:1.1.0-rc.154-cu1290-torch291-ubuntu2404` = torch 2.9.1+cu129. That is the copy-forward vector itself.

`deadman*`, `pull*`, `poll*`, `podctl*`, `pod_fetch*`, `mkmanifest*` are exempt on purpose: a deadman that refuses to arm is an uncapped billing run, and a puller that refuses is evidence we never get. `pgw1081-r2retry`'s local `fleet_line.py` (which carried its own `REQUIRED_TORCH = (2, 13)`) is now a shim over this module, and its `setup.sh` installs gen-worker before gating instead of gating at step 0 with nothing installed.

`SERVE-RECIPE.md` got two in-place corrections where a fact about the RIG's torch had been written down as a fleet constraint: §2 *"torchao … fail to load on torch 2.9"* (pin kept — it still stands on 2.13 for the ie#632 granularity reason — reason corrected) and §6 `PYTORCH_CUDA_ALLOC_CONF` (the fleet line uses `PYTORCH_ALLOC_CONF`; verified against the installed 2.13.0+cu130).

Local: `mypy src/gen_worker` clean (257 files), ruff clean, config-read guard OK, 48 targeted tests green.
