### PR TITLE
pgw#1113: the obligation names its SUBJECT, the memo names what it traced, the advertisement names what ARMED (closes pgw#819)

### DIFF
--- a/changelog.d/pgw1113.md
+++ b/changelog.d/pgw1113.md
@@ -1,0 +1,54 @@
+- **pgw#1113: the obligation names its SUBJECT, the memo names what it traced,
+  the advertisement names what ARMED — and the key finally names placement.**
+  pgw#1031 made the *cell key* sound; nothing else in the path moved with it.
+  The unifying rule, now stated in the code: **the CELL KEY is the computation
+  and must not OVER-split (the membership axiom); the ARM TOKEN is a mint
+  obligation and a cache lookup and must not UNDER-split.** Over-splitting an
+  obligation costs one re-mint; under-splitting one binds a pipeline to a cell
+  nobody proved is its computation. Five changes, one change:
+  - `fleet_cells.arm_identity` gains the compile SUBJECT — which slot, resolved
+    to which checkpoint refs (base + pgw#617 component overrides) and snapshot
+    digest — plus the `targets`/`dynamic`/`regional` the token could not see.
+    The executor stamps the resolution on the pipeline beside the execution
+    lane (`fleet_cells.stamp_arm_subject`). qwen's two slots, flux.2-klein's two
+    `@endpoint` classes and z-image's two slots each get their own obligation
+    instead of dedupping into one pending, one child and one memo row.
+    `ARM_FACTS` splits into `ARM_ENVIRONMENT_FACTS` (compared at the handback
+    seam, as before) and `ARM_SUBJECT_FACTS` (deliberately not: a cell records
+    no checkpoint and must not — one cell legally serves every checkpoint whose
+    graph it is).
+  - **`boot_key.closure_digest` now folds the resolved slot identity.** This is
+    the priority fix: a memo HIT skips the traces and returns the MEMO's own
+    witnesses, which `boot_adopt` verifies the pulled cell against — so on a
+    checkpoint-blind memo pgw#1031's witness floor could only agree with itself
+    and was structurally unable to fire on the adopt path. It can fail now.
+  - **The "sharers" fiction is deleted.** `_advertise_minted_cells` binds
+    `active_compile_ref` only for the pipe that ACTUALLY armed the bytes (one
+    per delegated mint, by construction); the unarmed holders get a typed
+    `self_mint_unarmed_holder` event instead of an advertisement only
+    `_bind_compile_guard`'s incidental `False` kept off the wire. The gw#612
+    publish-coverage rule now reads the obligation, not pid membership. The
+    `_FINALIZED` re-arm branch — the one path that armed a sibling pipe while
+    skipping `arm_axis_divergence` — goes through `_arm_exported_cell` like
+    every other self-produced cell.
+  - **`placement` keying fact (closes pgw#819).** A program whose own device map
+    spans several cards has that placement baked into its kernels, and the
+    canonical graph form scrubs the device INDEX by deliberate design — so a
+    2-card cell published under a key byte-identical to the 1-card one, in both
+    directions. `aot_mint.keying_block` now records the distinct devices
+    (`graph_hash.device_placement`) and `aot_serve.class_hash` folds them **only
+    when non-trivial**, on the `excluded`/`param`/`overlay` precedent. The graph
+    hash is untouched.
+  - **The eager-only gate is a topology rule, not a mode allowlist**:
+    `degree > 1`, full stop. `parallel="internal"` was the measured hole and
+    `cfg` (`topology.PARALLEL_CFG`) would have inherited it the day it got a
+    serve-side implementation.
+  - **NO LIVE CELL RE-KEYS** — checked, not asserted: every new keying fact is
+    omitted at the value every published cell holds, and
+    `tests/test_identity_soundness_pgw1113.py` recomputes the pre-change formula
+    to prove it. **MEMO INVALIDATION IS EXPECTED and typed**: the arm-token
+    scheme is its fact set (`arm1` -> `arm2`) and `boot_key` memo v3 -> v4, so a
+    predecessor row is unaddressable rather than misreadable;
+    `local_cell_store.sweep_superseded_memos` drops the stale entries once per
+    process and counts them. Cost: **one re-mint per family per machine, once**,
+    on volume-backed pods and cozy-local boxes. Cells keep their `ck1` keys.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -3434,6 +3434,15 @@ def keying_block(
         "graph": entry_graph_block(program, spec),
         "graph_witness": graph_hash.graph_hash(program),
     }
+    placement = graph_hash.device_placement(program)
+    if len(placement) > 1:
+        # pgw#1113 / pgw#819: the program's own device map put its modules on
+        # more than one card, and inductor bakes that placement into the
+        # artifact. Recorded — and keyed, in `aot_serve.class_hash` — ONLY
+        # here, on the `excluded_inputs` precedent above: a single-device
+        # program states nothing, so no published cell's block moves and no
+        # published cell re-keys.
+        block["placement"] = list(placement)
     if adapter_arm(spec.fork) is False:
         # pgw#790: the NEGATIVE half of this class's contract. Without it the
         # branchless entry silently ADMITS an adapter-bearing call (a

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -578,6 +578,9 @@ def class_hash(
     entry is body-blind rather than unhashable; production entries always
     carry it (``keying_block``), and such stale cells are refused by the
     envelope/structure gates and the witness backstop regardless.
+
+    ``placement`` (pgw#1113) folds in only when the entry states MORE THAN ONE
+    distinct device — see the comment at the fold.
     """
     facts = {
         "v": 3,
@@ -591,6 +594,19 @@ def class_hash(
         "strict": bool(strict),
         "lora_bucket": int(lora_bucket or 0),
     }
+    placement = sorted({str(d) for d in (entry.get("placement") or ()) if d})
+    if len(placement) > 1:
+        # pgw#1113, closing pgw#819 at the key: a program whose own device map
+        # spans several cards has that placement baked into its kernels, and
+        # the canonical graph form scrubs the device INDEX by deliberate
+        # design (`graph_hash._render_scalar`) so it cannot ride `graph`.
+        # Keyed only when non-trivial — the `excluded` / `param` / `overlay`
+        # precedent — because a single-device placement is what every cell the
+        # fleet has published states, and a field that says "unchanged" would
+        # strand all of them. No `v` bump for the same reason: the fact is
+        # absent from every existing entry and its absence must stay the
+        # canonical form.
+        facts["placement"] = placement
     blob = json.dumps(facts, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()[:16]
 

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -93,7 +93,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 import msgspec
 
 from . import aot_serve, boot_phases, cell_key, compile_cache as cc, env_seal
-from .mint_process import CompileCellSpec, MintSlot
+from .mint_process import CompileCellSpec, MintSlot, slot_subjects
 from .postmortem import cpu_quota_cores, effective_cpu_count
 
 logger = logging.getLogger(__name__)
@@ -308,11 +308,22 @@ def trace_workers(classes: int, *, limit: int = 0) -> PoolWidth:
 #: has none — which the adopt-side floor reads as "this pod cannot state its
 #: own graph" and refuses. Bumped so a stale memo is a re-trace rather than a
 #: refusal nobody can explain.
-MEMO_VERSION = 3
+#: v4 (pgw#1113): the digest a row is filed under now names the RESOLVED SLOTS
+#: as well as the code and the declaration. A v3 row was filed under a
+#: checkpoint-blind digest, so it answers a strictly different question and
+#: must not be read as an answer to this one. The version rides the digest
+#: input as well as the file header, so a stale row is unaddressable AND the
+#: file it lives in is discarded whole — two independent reasons it cannot be
+#: misread, which is what "typed invalidation" has to mean for a cache whose
+#: wrong answer is a wrong cell.
+MEMO_VERSION = 4
 MEMO_FILENAME = "boot-key-graphs.json"
 
 
-def closure_digest(family: str, cfg: CompileCellSpec, *, function: str = "") -> str:
+def closure_digest(
+    family: str, cfg: CompileCellSpec, *, function: str = "",
+    slots: Optional[Mapping[str, MintSlot]] = None,
+) -> str:
     """The memo's key: what a per-class graph hash is a pure function OF.
 
     ``cc.content_keys()`` is the SDK+endpoint code content (pgw#990 demoted it
@@ -320,9 +331,23 @@ def closure_digest(family: str, cfg: CompileCellSpec, *, function: str = "") -> 
     declaration facts are the other half — two boots of the same code that
     declare different shape ladders trace different graphs.
 
+    ``slots`` is the third half, and it is the one this memo went without for
+    two issues (pgw#1113). The traced graph is a function of the CHECKPOINT's
+    own config: ``zero_cond_t`` exists on ``Qwen-Image-Edit-2511`` and not on
+    ``Qwen-Image``, and block counts, head counts and quantization ops are the
+    general case. Without it, a redeploy that rebinds a slot to a different
+    checkpoint answered from the PREVIOUS checkpoint's row — and because a
+    memo hit skips the traces and returns the memo's own witnesses, the
+    pgw#1031 witness floor that ``boot_adopt`` runs against those witnesses
+    could only ever agree with itself. Folding the slots in is what makes that
+    check capable of failing. Cost: one memo miss and one trace on the first
+    boot after a rebinding, which is what correctness costs here.
+
     Deliberately NOT included: sm, toolchain, env seal. They are key AXES and
     they re-derive every boot in milliseconds; folding them in here would make
     the memo miss on facts whose whole point is that they are cheap to restate.
+    Nor the slots' local PATHS — see ``mint_process.slot_subjects``: where the
+    bytes landed on this disk is not what was traced.
     """
     facts = {
         "v": MEMO_VERSION,
@@ -336,6 +361,7 @@ def closure_digest(family: str, cfg: CompileCellSpec, *, function: str = "") -> 
             "guidance": sorted(float(v) for v in cfg.guidance_scales),
             "lora_bucket": int(cfg.lora_bucket or 0),
         },
+        "subject": cell_key.subject_facts(slot_subjects(dict(slots or {}))),
     }
     blob = json.dumps(facts, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()[:32]
@@ -723,7 +749,7 @@ def derive(
             f"family {family!r} declares no graph classes; a cell with no "
             f"class set has no identity (pgw#716/#758)")
 
-    digest = closure_digest(family, cfg, function=function)
+    digest = closure_digest(family, cfg, function=function, slots=slots)
     memoized = read_memo(memo_dir, digest) if trust_memo else {}
     memo_state = "miss"
 

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -98,7 +98,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Iterable, Mapping, Tuple
 
 # pgw#958 (DESIGN-RULINGS §1.27(g)) and pgw#1059 amendment 1: the counter
 # stays at 1 — Paul 2026-08-09: "stick with version-1 for now since we're
@@ -271,6 +271,69 @@ def envelope_digest(block: Mapping[str, Any]) -> str:
     return facts_digest(envelope_facts(block))
 
 
+# --- the SUBJECT: what an obligation is FOR (pgw#1113) ---------------------
+#
+# THE ASYMMETRY, stated once, here, because both consumers below depend on it:
+#
+#   The CELL KEY is the computation and must not OVER-split (the membership
+#   axiom at the top of this module).  The ARM TOKEN and the boot-key memo are
+#   an OBLIGATION and a CACHE LOOKUP, and must not UNDER-split.  Over-splitting
+#   an obligation costs one re-mint; under-splitting one binds a pipeline to a
+#   cell nobody proved is its computation.
+#
+# So the subject is deliberately NOT a key axis and must never become one: one
+# cell legally serves every checkpoint whose graph it is (weight VALUES are
+# never hashed — see graph_hash's module docstring), and keying on the
+# checkpoint would put every fine-tune in its own key space.  What the subject
+# does is stop two DIFFERENT checkpoints sharing one pending mint, one
+# local-store memo entry or one boot-key memo row on the strength of an
+# assumption nothing checked.
+
+
+@dataclass(frozen=True)
+class SlotSubject:
+    """WHICH checkpoint one setup slot resolved to.
+
+    ``refs`` is the base wire ref plus every pgw#617 component-override ref,
+    in the order ``api.binding.binding_wire_refs`` produces them;
+    ``snapshot_digest`` is the materialized tree's content digest when the
+    resolver stated one (it is "" for a slot resolved without one, which is a
+    narrower statement, never a different subject).
+    """
+
+    slot: str
+    refs: Tuple[str, ...] = ()
+    snapshot_digest: str = ""
+
+
+def subject_facts(subjects: Iterable[SlotSubject]) -> Dict[str, Any]:
+    """The canonical SUBJECT block for one arm/trace — sorted by slot, so two
+    callers that resolved the same slots in different orders state one fact."""
+    return {
+        "v": 1,
+        "slots": [
+            [sub.slot, list(sub.refs), sub.snapshot_digest]
+            for sub in sorted(tuple(subjects), key=lambda s: s.slot)
+        ],
+    }
+
+
+def subject_digest(subjects: Iterable[SlotSubject]) -> str:
+    """16-hex digest of the resolved subject, or ``""`` when the caller could
+    state none.
+
+    ``""`` is the honest answer for a pipeline whose slot resolution this
+    process never saw (an endpoint that builds its own pipeline out of a
+    path-valued slot, reached through ``arm_compile()``); it is exactly the
+    pre-pgw#1113 posture for that path and it under-splits, so every caller
+    that CAN state a subject states one.
+    """
+    subs = tuple(subjects)
+    if not subs:
+        return ""
+    return facts_digest(subject_facts(subs))
+
+
 def from_exported_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     """The key an EXPORTED (``aot-inductor``) cell's OWN recorded facts
     describe — THE single implementation of the cell key: ``aot_mint``
@@ -348,6 +411,9 @@ __all__ = [
     "EXPORT_ENVELOPE_KEY",
     "CellKey",
     "CellKeyError",
+    "SlotSubject",
+    "subject_digest",
+    "subject_facts",
     "envelope_digest",
     "envelope_facts",
     "facts_digest",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -65,7 +65,8 @@ from .api.binding import (
     wire_ref,
 )
 from .convert.hub import HubPublishError
-from .mint_process import MintSlot
+from . import cell_key
+from .mint_process import MintSlot, slot_subjects
 from .api.errors import (
     ArtifactTransferError,
     CanceledError,
@@ -5163,14 +5164,34 @@ class Executor:
         only at degree>1" is therefore enforced by construction: no compile
         selection is fetched, no arming scope opens, no targets install, no
         cell adopts. This is the code the a08a3bd commit message claimed.
+
+        pgw#1113/pgw#819: the condition is ``degree > 1``, FULL STOP — it used
+        to be ``degree > 1 and parallel == "sequence"``, an allowlist by mode
+        NAME, and every mode not on the list inherited a hole. ``internal``
+        was the measured one (a model that spans its cards by its own device
+        map bakes that placement into its kernels, so its cell keyed
+        byte-identically to the single-GPU one, in both directions), and
+        ``cfg`` — the platform's next declared sharding mode
+        (``topology.PARALLEL_CFG``) — would have inherited the same hole the
+        day it got a serve-side implementation. A gate that has to be widened
+        once per new mode is not a rule; ``degree > 1`` is.
+
+        This costs nothing today (no ``internal``-parallel release compiles)
+        and it is SUPERSEDED, not contradicted, by the ``placement`` keying
+        fact (``aot_serve.class_hash``): once a cell can state which cards it
+        was baked for, cells at degree>1 become servable and this gate can
+        narrow again to the modes whose collectives genuinely forbid an
+        ungated forward.
         """
         topo = self.topology
-        if topo.degree > 1 and topo.parallel == "sequence":
+        if topo.degree > 1:
             return (
                 f"eager only at {topo}: compile/hot-swap/self-mint are "
-                "disabled under context parallelism (pgw#775) — any forward "
-                "outside the sequence gate would hang the degree-"
-                f"{topo.degree} group"
+                f"disabled at degree>1 (pgw#775/pgw#819) — under "
+                f"{topo.parallel or 'internal placement'} a compile cell "
+                f"cannot state the {topo.degree}-card placement it would be "
+                f"baked for, and under platform sharding any forward outside "
+                f"the parallelism gate would hang the group"
             )
         return ""
 
@@ -6904,7 +6925,12 @@ class Executor:
                     # on a context-parallel pod.
                     None if eager_only else spec.compile_cell(),
                     self.store._cache_dir, compile_artifact,
-                    enable=self._arming_enable,
+                    enable=functools.partial(
+                        self._arming_enable,
+                        subject=slot_subjects(
+                            resolved_slots,
+                            {name: ident[0]
+                             for name, ident in slot_identities.items()})),
                 )
                 # pgw#1104: NOT gated on spec.compile — a serve-time recipe
                 # quantizes whether or not this release compiles, and the lane
@@ -8812,6 +8838,16 @@ class Executor:
                         # read the ONE serveability brain
                         # (compile_cache.mandatory_serving) instead of the
                         # weight-lane prefix. Never overwritten once set.
+                        # pgw#1113: and stamp WHAT this pipe was resolved
+                        # from, for the same reason and at the same seam. The
+                        # arm token is an obligation, and an obligation that
+                        # cannot name its subject dedups two checkpoints into
+                        # one pending, one child and one memo row.
+                        if binding is not None:
+                            fleet_cells.stamp_arm_subject(
+                                pipe, slot, binding_wire_refs(binding),
+                                (slot_identities or {}).get(slot, ("", 0))[0],
+                            )
                         exec_execution_lane, lane_pinned = (
                             self._execution_lane_pick_for_ref(ref))
                         if exec_execution_lane and not getattr(
@@ -9508,6 +9544,12 @@ class Executor:
         next capability projection — and pgw#622 stays alive for post-mint
         novel shapes. Shared by the in-process and delegated routes (pgw#784):
         the artifact SOURCE differs, what it means to advertise one does not.
+
+        pgw#1113: ``finalized`` holds exactly the pipes that ARMED the cell.
+        The caller no longer expands it across every pid that happened to hold
+        the same pending — an advertisement is a claim about what a target
+        serves, and a pipe that never had the bytes installed serves eager
+        whatever this map says.
         """
 
         act.phase(activity_mod.PHASE_FINALIZE)
@@ -9560,21 +9602,35 @@ class Executor:
         """
 
         spec = bg.spec
-        # One child per DISTINCT pending: sibling pipes of one record whose
-        # axes compute the same key share ONE cell (the qwen edit shape), and
-        # the child mints their union exactly once.
-        sharers: Dict[int, List[int]] = {}
+        # One child per DISTINCT pending. Pipes whose obligation identity is
+        # the same token share one pending and therefore one child mint —
+        # since pgw#1113 that identity names the SUBJECT (which slot, resolved
+        # to which checkpoint), so a shared pending means one thing to
+        # compile rather than one family on one card.
+        holders: Dict[int, List[int]] = {}
         for pid, pending in bg.pendings.items():
-            sharers.setdefault(id(pending), []).append(pid)
-        if not sharers:
+            holders.setdefault(id(pending), []).append(pid)
+        if not holders:
             raise RuntimeError("delegated mint has no pending cell to build")
 
+        #: id(pipeline) -> the cell its OWN pipeline armed. pgw#1113 deleted
+        #: the "sharers" fiction that used to fill this for every pid holding
+        #: the pending: exactly one pipe is handed to `build_cell` and exactly
+        #: one pipe is passed to `adopt_delegated_mint`, so exactly one pipe
+        #: ever had those bytes installed on it. Advertising the other pids'
+        #: targets as compiled was a wire lie that only
+        #: `_bind_compile_guard`'s incidental `False` ("advertising eager")
+        #: stopped from reaching the hub.
         finalized: Dict[int, Any] = {}
+        #: id(pending) -> the cell that discharged it. The publish-coverage
+        #: rule (gw#612) is about the OBLIGATION, not about how many pipes
+        #: hold it, so it reads this rather than `finalized`.
+        discharged: Dict[int, Any] = {}
         declined: Optional[_MintDeclined] = None
         # pgw#999: every classified refusal this run saw, so the terminal
         # RuntimeError names them instead of restating "no advertisable cell".
         declined_reasons: List[str] = []
-        for pids in sharers.values():
+        for pids in holders.values():
             pending = bg.pendings[pids[0]]
             pipe = bg.pipes[pids[0]]
             result = await mint_delegate.build_cell(
@@ -9623,8 +9679,23 @@ class Executor:
                 )
                 declined_reasons.append(result.reason or result.status)
                 continue
-            for pid in pids:
-                finalized[pid] = minted
+            # pgw#1113: the ARMED pipe, and only it. `build_cell` handed the
+            # child this one pipeline and `adopt_delegated_mint` installed the
+            # cell on this one pipeline; the other pids holding this pending
+            # were never armed with these bytes and must not advertise them.
+            finalized[pids[0]] = minted
+            discharged[id(pending)] = minted
+            if len(pids) > 1:
+                activity_mod.emit_event(
+                    "self_mint_unarmed_holder",
+                    f"family={pending.family} key={pending.arm_token}: "
+                    f"{len(pids) - 1} further compile object(s) hold this "
+                    f"obligation and were NOT armed with its cell — one pipe "
+                    f"is armed per delegated mint, so they serve eager until "
+                    f"their own arm. They are not advertised as compiled "
+                    f"(pgw#1113)",
+                    phase="unarmed_obligation_holder",
+                )
             compile_cache.record_cell_proven(str(minted.ref))
 
         if not finalized:
@@ -9636,17 +9707,19 @@ class Executor:
                 + (f" (refused: {', '.join(sorted(set(declined_reasons)))})"
                    if declined_reasons else ""))
 
-        # Publish per shared cell on gw#612's rule: a family cell ships only
-        # when EVERY sharer is covered by it — a partial pack bricks every
-        # adopting boot at the gw#607 per-object proof.
-        for pids in sharers.values():
+        # Publish per OBLIGATION on gw#612's rule: a cell ships only when the
+        # obligation it was built for was actually discharged — a partial pack
+        # bricks every adopting boot at the gw#607 per-object proof. pgw#1113
+        # re-aims the rule from the sharers map (pid membership, which said
+        # nothing about what armed) to the pending itself, which is the thing
+        # the child was given and the thing it either produced a cell for or
+        # did not.
+        for pids in holders.values():
             pending = bg.pendings[pids[0]]
-            gap = [pid for pid in pids if pid not in finalized]
-            if gap:
+            if id(pending) not in discharged:
                 fleet_cells_mod.withhold_self_mint_publish(
                     pending,
-                    f"{len(gap)}/{len(pids)} cell-sharing compile object(s) "
-                    "were not covered by the delegated mint")
+                    "the delegated mint produced no cell for this obligation")
             else:
                 fleet_cells_mod.publish_self_mint(pending)
 
@@ -9794,12 +9867,23 @@ class Executor:
     def _arming_enable(
         self, pipe: Any, cfg: Any, cache_dir: Optional[Path],
         artifact: Optional[Path],
+        subject: Tuple[cell_key.SlotSubject, ...] = (),
     ) -> "fleet_cells.ArmOutcome":
         """ArmingScope adapter: a self-loaded pipeline's ``arm_compile()``
         gets the same fleet policy (delivered cell first, self-mint on miss)
         as a worker-loaded slot. ``cache_dir`` comes from the scope, which
-        the executor constructed with its own store cache dir."""
+        the executor constructed with its own store cache dir.
 
+        pgw#1113: this pipeline was built by the ENDPOINT, out of path-valued
+        slots, so nothing here can say which of them it read. The obligation
+        therefore names EVERY slot this setup resolved. That over-splits when
+        the endpoint used only one of them — which costs one re-mint — and
+        the alternative under-splits, which binds a pipeline to a cell nobody
+        proved is its computation.
+        """
+        for sub in subject:
+            fleet_cells.stamp_arm_subject(
+                pipe, sub.slot, sub.refs, sub.snapshot_digest)
         return fleet_cells.enable_compiled(
             pipe, cfg, cache_dir, artifact,
             publisher=self._cell_publisher(),

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -56,7 +56,8 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import (
+    Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple)
 
 
 from . import activity as activity_mod
@@ -117,7 +118,14 @@ class SelfMint:
 #: arm token must never pass ``cell_key.is_key`` / the hub's
 #: ``compilecache.IsCellKey``, because it is NOT a cell key — see
 #: :class:`ArmIdentity`.
-ARM_SCHEME = "arm1"
+#:
+#: The digit is the token's FACT-SET SCHEMA, and it is the memo-invalidation
+#: mechanism (pgw#1113): ``arm2`` states the compile SUBJECT, ``arm1`` did
+#: not, so an ``arm1-`` memo answers a question no ``arm2`` reader is asking.
+#: A stale-schema entry is therefore unaddressable by construction rather
+#: than misreadable, and :func:`arm_from_local_store` sweeps the predecessor
+#: files once per process instead of leaving them to accumulate silently.
+ARM_SCHEME = "arm2"
 
 
 @dataclass(frozen=True)
@@ -156,17 +164,76 @@ class ArmIdentity:
         return f"{ARM_SCHEME}-{digest[:56]}"
 
 
-#: The facts an :class:`ArmIdentity` states, in report order. ``envelope``
-#: and ``toolchain`` use the exported key's own derivations
+#: The ENVIRONMENT half of an :class:`ArmIdentity` — the facts a delegated
+#: child re-derives in its own process and RECORDS on the cell it hands back.
+#: ``envelope`` and ``toolchain`` use the exported key's own derivations
 #: (``cell_key.envelope_digest`` / ``cell_key.facts_digest``), ``lane`` the
-#: one lane label (``cc.execution_lane_label``) — the pgw#1042 divergence
-#: check compares exactly these, so an axis that fails to survive the
-#: parent->child boundary is refused BY NAME at the handback seam.
+#: one lane label (``cc.execution_lane_label``) — :func:`arm_axis_divergence`
+#: compares exactly these, so an axis that fails to survive the parent->child
+#: boundary is refused BY NAME at the handback seam.
 #: ``graph`` is deliberately absent: it exists only after the export, and
 #: comparing a declared-facts stand-in against the traced fact is the
 #: phantom divergence this type retires.
-ARM_FACTS = ("family", "format", "lane", "sm", "envelope", "env_seal",
-             "toolchain")
+ARM_ENVIRONMENT_FACTS = ("family", "format", "lane", "sm", "envelope",
+                         "env_seal", "toolchain")
+
+#: The SUBJECT half (pgw#1113): WHAT this obligation compiles, as opposed to
+#: what runtime it compiles on. ``subject`` is the resolved slot identity
+#: (:func:`cell_key.subject_digest` — which slot, which checkpoint refs,
+#: which snapshot digest); ``targets``/``dynamic``/``regional`` are the rest
+#: of ``cc.declared_compile_facts`` the token could not previously see.
+#:
+#: These are NOT compared at the handback seam, and that is the asymmetry
+#: this issue is about rather than an omission: a cell records no subject and
+#: must not, because one cell legally serves every checkpoint whose graph it
+#: is. The subject splits the OBLIGATION — which pipe owes which mint, which
+#: pending they may share, which memo row answers them — and the cell's own
+#: key, which is the traced computation, is what says the computation matches.
+ARM_SUBJECT_FACTS = ("subject", "targets", "dynamic", "regional")
+
+#: Every fact in the token, in report order.
+ARM_FACTS = ARM_ENVIRONMENT_FACTS + ARM_SUBJECT_FACTS
+
+#: The pipeline attribute carrying the resolved :class:`cell_key.SlotSubject`
+#: set the executor built this object from (pgw#1113). Stamped beside the
+#: execution lane, read here for the same reason the lane is read here rather
+#: than threaded through six call sites: the pipe is the one handle every arm
+#: site holds. A pipeline the worker did not resolve carries none, and
+#: :func:`cell_key.subject_digest` answers "" for it — honestly narrower, not
+#: silently equal to some other subject.
+ARM_SUBJECT_ATTR = "_cozy_arm_subject"
+
+
+def stamp_arm_subject(
+    pipe: Any, slot: str, refs: Sequence[str], snapshot_digest: str = "",
+) -> None:
+    """Record that ``pipe`` was resolved from ``slot`` at ``refs``.
+
+    Additive per slot: a shared-component pipeline serving two slots ends up
+    stating both. Best effort — a pipeline object that refuses attributes
+    leaves the subject unstated, which is the pre-pgw#1113 posture and never
+    an exception on a serving path.
+    """
+    subject = cell_key.SlotSubject(
+        slot=str(slot or ""),
+        refs=tuple(str(ref) for ref in refs if str(ref or "")),
+        snapshot_digest=str(snapshot_digest or ""),
+    )
+    known = {sub.slot: sub for sub in pipeline_arm_subject(pipe)}
+    known[subject.slot] = subject
+    try:
+        setattr(pipe, ARM_SUBJECT_ATTR,
+                tuple(sorted(known.values(), key=lambda s: s.slot)))
+    except Exception:  # noqa: BLE001 — a stamp is never worth a failed boot
+        logger.debug("fleet-cells: pipeline refused the arm subject stamp",
+                     exc_info=True)
+
+
+def pipeline_arm_subject(pipe: Any) -> Tuple[cell_key.SlotSubject, ...]:
+    """The resolved subject stamped on ``pipe``, or ``()``."""
+    stamped = getattr(pipe, ARM_SUBJECT_ATTR, None) or ()
+    return tuple(
+        sub for sub in stamped if isinstance(sub, cell_key.SlotSubject))
 
 
 def declared_envelope_block(cfg: Any) -> Dict[str, Any]:
@@ -188,8 +255,18 @@ def declared_envelope_block(cfg: Any) -> Dict[str, Any]:
     }
 
 
-def arm_identity(family: str, weight_lane: str, lora_bucket: int, cfg: Any) -> ArmIdentity:
-    """This runtime's :class:`ArmIdentity` for one owed (family, lane) mint.
+def arm_identity(
+    family: str, weight_lane: str, lora_bucket: int, cfg: Any,
+    subject: Iterable[cell_key.SlotSubject] = (),
+) -> ArmIdentity:
+    """This runtime's :class:`ArmIdentity` for one owed mint.
+
+    ``subject`` is WHAT is being compiled (pgw#1113): the resolved slots of
+    the pipeline this obligation is for. Without it the token named a
+    (family, lane) pair and nothing else, so two `@endpoint` classes sharing
+    one ``Compile``, or two slots of one class bound to different
+    checkpoints, computed ONE token — one pending, one child, one local-store
+    memo row — and the first of them to arm handed its cell to the others.
 
     Raises :class:`ValueError` when the runtime cannot state a fact (no
     CUDA => no ``sm``): a worker that cannot state its obligation identity
@@ -200,6 +277,14 @@ def arm_identity(family: str, weight_lane: str, lora_bucket: int, cfg: Any) -> A
         raise ValueError(
             "cannot state the compute capability (sm) of this runtime; no "
             "mint obligation can be opened without it")
+    # ONE derivation of the declaration's facts (``cc.declared_compile_facts``
+    # is the canonical form the cozy-local store verdict and the JIT semantic
+    # tag already read), so the obligation and the contract cannot disagree
+    # about what was declared. ``targets`` keeps DECLARATION ORDER: the child
+    # picks its compile target first-match (``mint_child.pick_compile_target``),
+    # so the order is meaning, not presentation.
+    declared = cc.declared_compile_facts(
+        cfg, lora_bucket_override=int(lora_bucket or 0))
     facts = {
         "family": str(family or ""),
         "format": str(cc.ARTIFACT_FORMAT),
@@ -209,6 +294,11 @@ def arm_identity(family: str, weight_lane: str, lora_bucket: int, cfg: Any) -> A
         "envelope": cell_key.envelope_digest(declared_envelope_block(cfg)),
         "env_seal": env_seal.seal_digest(env_seal.effective_seal()),
         "toolchain": cell_key.facts_digest(dict(cc.toolchain_digest())),
+        "subject": cell_key.subject_digest(subject),
+        "targets": ",".join(str(t) for t in declared["targets"]),
+        "dynamic": json.dumps(
+            declared["dynamic"], sort_keys=True, separators=(",", ":")),
+        "regional": "1" if declared["regional"] else "0",
     }
     return ArmIdentity(facts=tuple(sorted(facts.items())))
 
@@ -223,9 +313,11 @@ class PendingSelfMint:
     delivered-cell path once the child's cell earns adoption.
 
     One instance may be SHARED by several pipelines of one record whose
-    facts compute the same obligation identity (the qwen edit shape: two
-    lanes, one family cell). ``_state`` memoizes the adopt outcome so
-    sibling candidates converge on one publish.
+    facts compute the same obligation identity — which since pgw#1113
+    includes the SUBJECT (which slot, resolved to which checkpoint), so
+    sharing means "provably the same thing to compile", not "the same family
+    on the same card". ``_state`` memoizes the adopt outcome so sibling
+    candidates converge on one publish.
 
     pgw#1010: a DYNAMO miss no longer builds one of these. The JIT recipe
     keeps its serving role (intake, ``compile_cache.arm_jit_intake``) and
@@ -1440,7 +1532,8 @@ def _arming_policy(
 
     try:
         arm_key = arm_identity(
-            family, loading.pipeline_weight_lane(pipe), bucket, cfg)
+            family, loading.pipeline_weight_lane(pipe), bucket, cfg,
+            subject=pipeline_arm_subject(pipe))
         key = arm_key.token
     except Exception as exc:  # noqa: BLE001 — obligation facts must be statable
         logger.warning("fleet-cells: self-mint identity computation failed (%s)", exc)
@@ -1505,9 +1598,26 @@ def _arming_policy(
         # This process already minted and ADOPTED this exact cell — re-arm
         # the same artifact through the same AOT gates instead of paying a
         # second export for bytes that are already on this disk.
+        #
+        # pgw#1113: through `_arm_exported_cell`, which is THE gate every cell
+        # this machine produced for itself passes, and not the bare
+        # `provision.arm_aot` that stood here. This was the one branch that
+        # armed a pipe from another pipe's artifact while skipping
+        # `arm_axis_divergence` entirely — and since the arm token is what
+        # decides "this exact cell", a token that could not name its subject
+        # made "another pipe" and "this pipe" the same sentence. The token now
+        # names the subject, so the branch is reached far less often; when it
+        # is reached it now earns the arm the same way every other
+        # self-produced cell does.
         try:
-            armed_ready = bool(provision.arm_aot(
-                pipe, cfg, cache_dir, Path(finalized_prior.artifact), bucket))
+            armed_ready, _meta, refusal = _arm_exported_cell(
+                pipe, cfg, cache_dir, bucket,
+                Path(finalized_prior.artifact), arm_key)
+            if not armed_ready:
+                logger.warning(
+                    "fleet-cells: the in-process finalized cell for key=%s "
+                    "did not re-arm (%s%s); falling through to a fresh mint",
+                    key, refusal[0], f": {refusal[1]}" if refusal[1] else "")
         except Exception as exc:  # noqa: BLE001 — fall back to a fresh mint
             logger.warning(
                 "fleet-cells: re-arm from the in-process finalized cell "
@@ -1535,9 +1645,13 @@ def _arming_policy(
         return ArmOutcome(
             armed=True, self_mint=local_prior, selection_bug=selection_bug)
 
-    # Sibling pipes of one record whose axes compute the SAME key share one
-    # child mint (the qwen edit shape: two lanes, one family cell) — the
-    # first arm registers the pending and every sharer adopts its cell.
+    # Pipes whose obligation identity is the SAME token share one child mint:
+    # same runtime, same declaration AND same subject — the same slot resolved
+    # to the same checkpoint — so there is one computation to buy and one
+    # pending to open. pgw#1113 deleted the premise this comment used to
+    # state ("the qwen edit shape: two lanes, one family cell"): two lanes are
+    # one cell only when the graph says so, and the graph does not exist yet
+    # here. The obligation names its subject instead of assuming one.
     with _PENDING_LOCK:
         existing = _PENDING.get(key)
     if existing is not None:
@@ -1598,8 +1712,8 @@ def arm_axis_divergence(
     arm_key: ArmIdentity, meta: Mapping[str, Any],
 ) -> str:
     """'' when the child's cell-metadata states the parent's obligation
-    identity on every pre-trace fact (:data:`ARM_FACTS`), else the FIRST
-    diverging fact with both values (pgw#1042).
+    identity on every ENVIRONMENT fact (:data:`ARM_ENVIRONMENT_FACTS`), else
+    the FIRST diverging fact with both values (pgw#1042).
 
     A delegated child re-derives every environment-shaped fact in its own
     process, so a fact that fails to survive the boundary (the measured
@@ -1610,6 +1724,14 @@ def arm_axis_divergence(
     it exists only post-trace, and comparing a declared-facts stand-in
     against the traced fact was the attempt-28 phantom divergence
     (pgw#1059). Every compared fact uses the SAME derivation on both sides.
+
+    :data:`ARM_SUBJECT_FACTS` are equally deliberately NOT compared
+    (pgw#1113). A cell records no subject and must not: the key is the traced
+    computation, so one cell legally serves every checkpoint whose graph it
+    is, and demanding the cell restate the checkpoint it was minted from
+    would refuse exactly the reuse the membership axiom exists to allow. The
+    subject splits the obligation on THIS side of the boundary; what crosses
+    it is compared here.
     """
     envelope_block = meta.get(cell_key.EXPORT_ENVELOPE_KEY)
     child: Dict[str, str] = {
@@ -1627,7 +1749,7 @@ def arm_axis_divergence(
         "toolchain": cell_key.facts_digest(dict(meta.get("toolchain") or {})),
     }
     parent = arm_key.facts_dict()
-    for fact in ARM_FACTS:
+    for fact in ARM_ENVIRONMENT_FACTS:
         if parent.get(fact, "") != child.get(fact, ""):
             return (f"{fact}: child cell states {child.get(fact, '')!r}, "
                     f"this runtime computed {parent.get(fact, '')!r}")
@@ -1694,7 +1816,8 @@ def _arm_exported_cell(
     Two checks, in this order:
 
     1. **key-axis divergence** (pgw#1042) — the cell's recorded metadata must
-       state THIS runtime on every pre-trace axis (:data:`ARM_FACTS`), refused
+       state THIS runtime on every pre-trace environment axis
+       (:data:`ARM_ENVIRONMENT_FACTS`), refused
        by fact name. This is what makes a toolchain/sm/envelope move an honest
        refusal instead of a wrong arm;
     2. **the AOT arm** (pgw#805) — ``provision.arm_aot``: lifted-binding
@@ -1765,6 +1888,31 @@ def _arm_exported_cell(
     return False, meta, refusal
 
 
+#: One sweep per process: the store is this machine's, the predecessor
+#: entries are finite, and re-listing a directory on every arm buys nothing.
+_MEMO_SWEPT = False
+
+
+def _sweep_superseded_memos_once() -> None:
+    """Discard memo rows written under a superseded arm-token schema.
+
+    pgw#1113 states the cost up front: the subject facts change every token,
+    so every machine with a local store pays ONE re-mint per family, once.
+    That cost is the point — an entry keyed by a token that could not state
+    what it was compiling is exactly the row that could hand this pipeline
+    another checkpoint's cell — but it must be spent EXPLICITLY, in a counted
+    line, not discovered later as a store full of unreadable files.
+    """
+    global _MEMO_SWEPT
+    if _MEMO_SWEPT:
+        return
+    _MEMO_SWEPT = True
+    try:
+        local_cell_store.sweep_superseded_memos(ARM_SCHEME)
+    except Exception:  # noqa: BLE001 — a cache sweep is never fatal
+        logger.debug("fleet-cells: memo sweep failed", exc_info=True)
+
+
 def arm_from_local_store(
     pipe: Any, cfg: Any, cache_dir: Optional[Path], bucket: int,
     arm_key: ArmIdentity, family: str,
@@ -1783,6 +1931,7 @@ def arm_from_local_store(
     is loud and DROPS the entry, so a corrupted or stale cell costs one re-mint
     and never two.
     """
+    _sweep_superseded_memos_once()
     try:
         local = local_cell_store.lookup_for_arm(arm_key.token)
     except Exception as exc:  # noqa: BLE001 — a cache read must never be fatal

--- a/src/gen_worker/graph_hash.py
+++ b/src/gen_worker/graph_hash.py
@@ -355,6 +355,63 @@ def graph_hash(obj: Any) -> str:
     return digest_lines(canonical_lines(obj))
 
 
+def device_placement(obj: Any) -> Tuple[str, ...]:
+    """The distinct devices — WITH index — the traced program touches.
+
+    A SEPARATE observation, deliberately outside the canonical form (pgw#1113,
+    the pgw#819 remedy). The canonical form scrubs the device INDEX by design
+    (``_render_scalar``, *"cuda:1 -> cuda"*) and that stays: a graph is the
+    same graph wherever it runs, and un-scrubbing it would re-key every
+    published cell to record a fact all of them state trivially.
+
+    What was missing is the OTHER half of that sentence — a model whose own
+    device map splits its modules across ``cuda:0``/``cuda:1`` has inductor
+    bake that placement into the compiled artifact, and pgw#819 measured that
+    such a cell publishes under a key byte-identical to the single-GPU one, in
+    both directions. So the placement is observed here, recorded on the keying
+    block, and folded into ``aot_serve.class_hash`` ONLY when it is
+    non-trivial (more than one distinct device). Every cell the fleet has
+    published is single-device, so every one of them keeps its key.
+
+    Returns sorted distinct ``"<type>:<index>"`` strings ("cuda:0"), or ``()``
+    when the program states no device at all.
+    """
+    import torch
+
+    seen: set = set()
+
+    def _note(value: Any) -> None:
+        if isinstance(value, torch.device):
+            index = value.index
+            seen.add(
+                f"{value.type}:{index}" if index is not None else value.type)
+        elif isinstance(value, torch.Tensor):
+            _note(value.device)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                _note(item)
+        elif isinstance(value, dict):
+            for item in value.values():
+                _note(item)
+
+    if isinstance(obj, torch.export.ExportedProgram):
+        graph = obj.graph_module.graph
+    else:
+        graph = getattr(obj, "graph", None) if not isinstance(
+            obj, torch.fx.Graph) else obj
+    if graph is None or not hasattr(graph, "nodes"):
+        raise GraphHashError(
+            f"{type(obj).__module__}.{type(obj).__qualname__} is not a graph IR "
+            "(want torch.fx.GraphModule or torch.export.ExportedProgram)")
+    for node in graph.nodes:
+        present, raw_val = _node_val(node)
+        if present:
+            _note(raw_val)
+        _note(node.args)
+        _note(node.kwargs)
+    return tuple(sorted(seen))
+
+
 def digest_lines(lines: Iterable[str]) -> str:
     """Digest an already-canonical line sequence."""
     payload = "\n".join(lines).encode()
@@ -374,6 +431,7 @@ __all__ = [
     "SPEC_PREFIX",
     "SYM_PREFIX",
     "canonical_lines",
+    "device_placement",
     "digest_lines",
     "graph_hash",
 ]

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -286,6 +286,46 @@ def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
     )
 
 
+def sweep_superseded_memos(
+    scheme: str, root: Optional[Path] = None,
+) -> int:
+    """Delete every memo entry written under a SUPERSEDED token scheme.
+
+    pgw#1113: the arm token's scheme digit is its fact-set schema, so when
+    the fact set gains an axis (``arm1`` -> ``arm2``, which added the compile
+    SUBJECT) every stored ``arm1-`` row becomes an answer to a question
+    nothing asks any more. That is already safe — no reader can address them
+    — but "safe because unreachable" is how a store accumulates files whose
+    meaning nobody can reconstruct, so the invalidation is EXPLICIT and
+    counted rather than implicit and silent.
+
+    Only the memo is swept. The CELLS keep their ``ck1`` keys, which did not
+    move: an arm-token change re-derives the shortcut, never the identity.
+    Returns the number of entries removed.
+    """
+    prefix = str(scheme or "").strip() + "-"
+    memo_dir = cells_root(root) / MEMO_DIRNAME
+    if len(prefix) < 2 or not memo_dir.is_dir():
+        return 0
+    removed = 0
+    for entry in sorted(memo_dir.glob("*.json")):
+        if entry.name.startswith(prefix):
+            continue
+        try:
+            entry.unlink()
+            removed += 1
+        except OSError:
+            logger.debug("local-cell-store: could not drop %s", entry,
+                         exc_info=True)
+    if removed:
+        logger.info(
+            "local-cell-store: dropped %d memo entry/entries written under a "
+            "superseded arm-token schema (current %s) — this machine re-mints "
+            "each affected family ONCE and memoizes the answer again",
+            removed, prefix.rstrip("-"))
+    return removed
+
+
 def lookup_for_arm(
     arm_token: str, root: Optional[Path] = None,
 ) -> Optional[LocalCell]:
@@ -430,5 +470,6 @@ __all__ = [
     "store",
     "store_root",
     "stored_cells",
+    "sweep_superseded_memos",
     "trust_class",
 ]

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -70,7 +70,8 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
-from .api.binding import ModelRef, wire_ref
+from . import cell_key
+from .api.binding import ModelRef, binding_wire_refs, wire_ref
 from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
@@ -208,6 +209,30 @@ class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
             raise ValueError(
                 f"a resolved slot must name the tree its bytes are in; got an "
                 f"empty path for {wire_ref(self.ref)!r}")
+
+
+def slot_subjects(
+    slots: Mapping[str, MintSlot],
+    digests: Optional[Mapping[str, str]] = None,
+) -> Tuple[cell_key.SlotSubject, ...]:
+    """The resolved SUBJECT of one arm or one boot trace (pgw#1113).
+
+    THE single derivation, so the arm token, the local-store memo and the
+    boot-key memo cannot disagree about which checkpoint a pipeline is bound
+    to. ``path`` is deliberately excluded — where the bytes were materialized
+    is a location on this machine, never an identity — and so is
+    ``component_paths``, whose identity half is already in the ref's
+    ``component_overrides`` (``binding_wire_refs``).
+    """
+    have = dict(digests or {})
+    return tuple(
+        cell_key.SlotSubject(
+            slot=str(name),
+            refs=tuple(binding_wire_refs(slot.ref)),
+            snapshot_digest=str(have.get(str(name), "") or ""),
+        )
+        for name, slot in sorted(slots.items())
+    )
 
 
 class MintRequest(msgspec.Struct, frozen=True, kw_only=True):

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -35,8 +35,10 @@ from gen_worker.cell_adopt import AdoptOutcome
 
 KEY_A = "ck1-" + "a" * 56
 KEY_B = "ck1-" + "b" * 56
-ARM_A = "arm1-" + "1" * 56
-ARM_B = "arm1-" + "2" * 56
+# pgw#1113: spelled in the CURRENT token scheme — a predecessor-scheme memo
+# is swept by `fleet_cells._sweep_superseded_memos_once`, which is the point.
+ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
+ARM_B = fleet_cells.ARM_SCHEME + "-" + "2" * 56
 
 
 @pytest.fixture()

--- a/tests/test_cell_key_pgw1059.py
+++ b/tests/test_cell_key_pgw1059.py
@@ -371,7 +371,11 @@ def test_arm_token_never_passes_is_key(monkeypatch):
         fleet_cells.cc, "toolchain_digest", lambda: (("torch", "x" * 16),))
     identity = fleet_cells.arm_identity("fam", "", 0, _Cfg())
     token = identity.token
-    assert token.startswith("arm1-")
+    # pgw#1113: the scheme digit is the token's FACT SET, and the fact set
+    # gained the compile SUBJECT — so the prefix moved with it, which is what
+    # makes a predecessor memo row unaddressable rather than misreadable.
+    assert token.startswith(fleet_cells.ARM_SCHEME + "-")
+    assert not token.startswith("ck")
     assert not cell_key.is_key(token)
     # the compared facts are exactly the pre-trace set — graph is absent
     assert set(identity.facts_dict()) == set(fleet_cells.ARM_FACTS)

--- a/tests/test_identity_soundness_pgw1113.py
+++ b/tests/test_identity_soundness_pgw1113.py
@@ -1,0 +1,458 @@
+"""pgw#1113 — the obligation names its subject, the memo names what it traced,
+the advertisement names what armed, and the key names the placement.
+
+THE GOVERNING PRINCIPLE, which is why these five changes are one change:
+
+    The CELL KEY is the computation and must not OVER-split (the membership
+    axiom, ``cell_key.py``).  The ARM TOKEN is a mint obligation and a cache
+    lookup and must not UNDER-split.  Over-splitting an obligation costs one
+    re-mint; under-splitting one binds a pipeline to a cell nobody proved is
+    its computation.
+
+The tree applied the first axiom to both, so every key downstream of the cell
+key named a (family, lane, runtime) triple and nothing about WHAT was being
+compiled. Each test below is red on the parent commit.
+
+Nothing here needs a card, a pod or a mint: every claim in this issue is about
+what a digest is a function of, and that is answerable on a CPU in
+milliseconds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+import pytest
+
+from gen_worker import boot_key, cell_key, fleet_cells, local_cell_store
+from gen_worker import mint_process as mp
+from gen_worker.api.binding import Hub
+from gen_worker.mint_process import CompileCellSpec
+
+# --------------------------------------------------------------------------
+# fixtures — two checkpoints of one family, and one declaration over them
+# --------------------------------------------------------------------------
+
+BASE = Hub("qwen/qwen-image")
+EDIT = Hub("qwen/qwen-image-edit-2511")
+
+
+class _Cfg:
+    """A ``registry.CompileCell`` duck — the declaration both slots share."""
+
+    family = "qwen-image"
+    targets = ("transformer",)
+    shapes = ((1024, 1024),)
+    text_lens = (77,)
+    guidance_scales = (4.0,)
+    dynamic = ()
+    regional = False
+    lora_bucket = 0
+
+
+class _Pipe:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _stable_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One fixed runtime, so every token difference below is a SUBJECT
+    difference and cannot be an environment one."""
+    monkeypatch.setattr(
+        fleet_cells.cc, "runtime_key",
+        lambda: {"sm": "sm_89", "sku": "l4", "torch": "t", "triton": "",
+                 "cuda": "", "image_digest": ""})
+    monkeypatch.setattr(
+        fleet_cells.cc, "toolchain_digest", lambda: (("torch", "x" * 16),))
+    monkeypatch.setattr(
+        fleet_cells.env_seal, "effective_seal", lambda: {"v": 4})
+
+
+def _token(pipe: Any, cfg: Any = None) -> str:
+    return fleet_cells.arm_identity(
+        "qwen-image", "", 0, cfg or _Cfg(),
+        subject=fleet_cells.pipeline_arm_subject(pipe)).token
+
+
+# --------------------------------------------------------------------------
+# 1. the arm token gains the SUBJECT
+# --------------------------------------------------------------------------
+
+
+def test_two_slots_bound_to_two_checkpoints_owe_two_mints() -> None:
+    """The qwen edit shape. Two slots of ONE class, one ``Compile``, two
+    checkpoints — and ``zero_cond_t`` (present on Edit-2511, absent on
+    Qwen-Image) makes the two graphs structurally different forever.
+
+    Before pgw#1113 both computed ONE token: one pending, one child, one
+    local-store memo row, and the first slot to arm handed its cell to the
+    other — "correct by backstop, not by design", the backstop being
+    ``_bind_compile_guard`` returning False on an unarmed pipe.
+    """
+    t2i, edit = _Pipe(), _Pipe()
+    fleet_cells.stamp_arm_subject(t2i, "pipeline", ["qwen/qwen-image"])
+    fleet_cells.stamp_arm_subject(edit, "edit", ["qwen/qwen-image-edit-2511"])
+    assert _token(t2i) != _token(edit)
+
+
+def test_two_endpoint_classes_sharing_one_compile_owe_two_mints() -> None:
+    """The flux.2-klein-4b shape: ``Generate`` and ``GenerateTurbo``, each
+    with its own root ``pipeline`` slot bound to a DIFFERENT checkpoint at
+    deploy, both passing the same ``_KLEIN_COMPILE``.
+
+    Benign today only because the two checkpoints happen to share an
+    architecture — which nothing checks. Cross-checkpoint sharing must be
+    EARNED by the graph, never ASSUMED by the obligation token.
+    """
+    base, turbo = _Pipe(), _Pipe()
+    fleet_cells.stamp_arm_subject(base, "pipeline", ["flux2/klein-4b"])
+    fleet_cells.stamp_arm_subject(turbo, "pipeline", ["flux2/klein-4b-turbo"])
+    assert _token(base) != _token(turbo)
+
+
+def test_the_same_slot_at_the_same_checkpoint_still_shares_one_mint() -> None:
+    """The other half, and the reason the subject is not simply "the pipe":
+    two pipelines that ARE the same thing to compile must still buy one
+    compile. Over-splitting is cheap, not free."""
+    one, two = _Pipe(), _Pipe()
+    for pipe in (one, two):
+        fleet_cells.stamp_arm_subject(
+            pipe, "pipeline", ["qwen/qwen-image"], "sha256:aa")
+    assert _token(one) == _token(two)
+
+
+def test_a_component_override_is_part_of_the_subject() -> None:
+    """pgw#617 rebinds a single component. The composition it produces is a
+    different set of bytes and can be a different graph, so it is a different
+    obligation."""
+    plain, overridden = _Pipe(), _Pipe()
+    fleet_cells.stamp_arm_subject(plain, "pipeline", ["qwen/qwen-image"])
+    fleet_cells.stamp_arm_subject(
+        overridden, "pipeline", ["qwen/qwen-image", "qwen/other-vae"])
+    assert _token(plain) != _token(overridden)
+
+
+def test_a_snapshot_digest_move_is_a_different_obligation() -> None:
+    old, new = _Pipe(), _Pipe()
+    fleet_cells.stamp_arm_subject(old, "pipeline", ["q/img"], "sha256:aa")
+    fleet_cells.stamp_arm_subject(new, "pipeline", ["q/img"], "sha256:bb")
+    assert _token(old) != _token(new)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("targets", ("transformer", "vae.decode")),
+    ("dynamic", (type("D", (), {"dim": 1, "min": 1, "max": 4})(),)),
+    ("regional", True),
+])
+def test_the_token_states_the_declaration_facts_it_could_not_see(
+    field: str, value: Any,
+) -> None:
+    """``declared_compile_facts`` has all four (targets/dynamic/regional plus
+    the shapes the envelope already carried) and the token saw none of the
+    three. Two declarations that compile different programs must not share one
+    obligation."""
+    pipe = _Pipe()
+    fleet_cells.stamp_arm_subject(pipe, "pipeline", ["q/img"])
+    other = type("_Other", (_Cfg,), {field: value})
+    assert _token(pipe) != _token(pipe, other())
+
+
+def test_an_unstamped_pipeline_states_no_subject_and_says_so() -> None:
+    """An endpoint that builds its own pipeline out of a path-valued slot and
+    calls ``arm_compile()`` — nothing in this process saw a resolution for it.
+    ``""`` is the honest answer and it UNDER-splits, which is why the executor
+    stamps every subject it can (including, for that path, all of them)."""
+    assert fleet_cells.pipeline_arm_subject(_Pipe()) == ()
+    assert cell_key.subject_digest(()) == ""
+    facts = fleet_cells.arm_identity("f", "", 0, _Cfg()).facts_dict()
+    assert facts["subject"] == ""
+
+
+def test_the_stamp_accumulates_and_is_order_free() -> None:
+    a, b = _Pipe(), _Pipe()
+    fleet_cells.stamp_arm_subject(a, "pipeline", ["r1"])
+    fleet_cells.stamp_arm_subject(a, "refiner", ["r2"])
+    fleet_cells.stamp_arm_subject(b, "refiner", ["r2"])
+    fleet_cells.stamp_arm_subject(b, "pipeline", ["r1"])
+    assert _token(a) == _token(b)
+
+
+def test_the_arm_facts_split_into_environment_and_subject() -> None:
+    """The two halves are different axioms, so they are different tuples.
+
+    ``ARM_ENVIRONMENT_FACTS`` is what a delegated child RECORDS on the cell it
+    hands back, and is therefore comparable across the process boundary.
+    ``ARM_SUBJECT_FACTS`` is not on the cell and must not be: the key is the
+    computation, so one cell legally serves every checkpoint whose graph it
+    is. Demanding the cell restate its minting checkpoint would refuse exactly
+    the reuse the membership axiom exists to allow.
+    """
+    assert set(fleet_cells.ARM_FACTS) == (
+        set(fleet_cells.ARM_ENVIRONMENT_FACTS)
+        | set(fleet_cells.ARM_SUBJECT_FACTS))
+    assert not (set(fleet_cells.ARM_ENVIRONMENT_FACTS)
+                & set(fleet_cells.ARM_SUBJECT_FACTS))
+    identity = fleet_cells.arm_identity("f", "", 0, _Cfg())
+    assert set(identity.facts_dict()) == set(fleet_cells.ARM_FACTS)
+    assert "graph" not in identity.facts_dict()
+
+
+def test_a_subject_difference_is_not_a_handback_divergence() -> None:
+    """A cell records no subject, so the handback seam must not ask for one —
+    otherwise every delegated mint would refuse itself."""
+    pipe = _Pipe()
+    fleet_cells.stamp_arm_subject(pipe, "pipeline", ["q/img"], "sha256:aa")
+    arm = fleet_cells.arm_identity(
+        "qwen-image", "", 0, _Cfg(),
+        subject=fleet_cells.pipeline_arm_subject(pipe))
+    facts = arm.facts_dict()
+    meta: Dict[str, Any] = {
+        "family": facts["family"],
+        "format": facts["format"],
+        "weight_lane": "",
+        "lora_bucket": 0,
+        "sm": facts["sm"],
+        cell_key.EXPORT_ENVELOPE_KEY: fleet_cells.declared_envelope_block(
+            _Cfg()),
+        "toolchain": dict(fleet_cells.cc.toolchain_digest()),
+    }
+    meta[fleet_cells.env_seal.SEAL_KEY] = fleet_cells.env_seal.effective_seal()
+    assert fleet_cells.arm_axis_divergence(arm, meta) == ""
+
+
+# --------------------------------------------------------------------------
+# 2. the boot-key memo is no longer checkpoint-blind
+# --------------------------------------------------------------------------
+
+
+def _spec() -> CompileCellSpec:
+    return CompileCellSpec(
+        family="qwen-image", targets=("transformer",),
+        shapes=((1024, 1024),), text_lens=(77,), guidance_scales=(4.0,))
+
+
+def _slots(ref: Any, path: str = "/cas/a") -> Dict[str, mp.MintSlot]:
+    return {"pipeline": mp.MintSlot(ref=ref, path=path)}
+
+
+def test_a_rebinding_forces_a_memo_MISS() -> None:
+    """THE finding this issue most wants read.
+
+    ``closure_digest`` folded the SDK+endpoint code content and the
+    declaration — and not the resolved slot refs the traces are actually run
+    against. A memo HIT skips the traces and returns the MEMO's own witnesses
+    (``graph_witnesses_of(memoized)``), which ``boot_adopt`` then verifies the
+    pulled cell against. On that path pgw#1031's graph-witness floor — the
+    fail-closed backstop for a wrong cell by key — was comparing a cell
+    against a stale record of a DIFFERENT checkpoint's graph, so it could only
+    agree. It was structurally unable to fire on the one path that most needs
+    it.
+
+    Folding the slots in is what makes that check capable of failing.
+    """
+    cfg = _spec()
+    base = boot_key.closure_digest(
+        "qwen-image", cfg, function="generate", slots=_slots(BASE))
+    edit = boot_key.closure_digest(
+        "qwen-image", cfg, function="generate", slots=_slots(EDIT))
+    assert base != edit
+
+
+def test_the_memo_row_of_one_checkpoint_does_not_answer_for_another(
+    tmp_path: Path,
+) -> None:
+    """The same claim at the memo, which is where the wrong answer is served:
+    one host with a volume, one family, unchanged code and declaration, and a
+    redeploy that rebinds the slot."""
+    cfg = _spec()
+    was = boot_key.closure_digest("q", cfg, function="fn", slots=_slots(BASE))
+    boot_key.write_memo(tmp_path, was, {
+        "a": {"class_hash": "1" * 16, "graph_witness": "w" * 16}})
+    assert boot_key.read_memo(tmp_path, was), "the memo must answer itself"
+
+    now = boot_key.closure_digest("q", cfg, function="fn", slots=_slots(EDIT))
+    assert boot_key.read_memo(tmp_path, now) == {}, (
+        "a rebound slot must MISS — a hit here returns the previous "
+        "checkpoint's witnesses and the witness floor can only agree with them")
+
+
+def test_the_slot_PATH_is_not_part_of_the_memo_key() -> None:
+    """Where the bytes were materialized is a location on this machine, never
+    an identity. Folding it in would miss the memo on every fresh tmpdir,
+    which is how a correctness fix turns into "the memo never hits"."""
+    cfg = _spec()
+    here = boot_key.closure_digest("q", cfg, slots=_slots(BASE, "/cas/a"))
+    there = boot_key.closure_digest("q", cfg, slots=_slots(BASE, "/tmp/b"))
+    assert here == there
+
+
+def test_a_memo_file_from_the_previous_schema_is_discarded_whole(
+    tmp_path: Path,
+) -> None:
+    """Memo invalidation is EXPECTED here (one re-trace per host after a
+    rebinding) and it must be typed: a v3 row was filed under a
+    checkpoint-blind digest, so it answers a different question and is never
+    read as an answer to this one."""
+    path = tmp_path / boot_key.MEMO_FILENAME
+    path.write_text(json.dumps({
+        "v": boot_key.MEMO_VERSION - 1,
+        "closures": {"whatever": {"blocks": {"a": "{}"}}},
+    }))
+    assert boot_key.read_memo(tmp_path, "whatever") == {}
+    assert boot_key.MEMO_VERSION >= 4
+
+
+# --------------------------------------------------------------------------
+# 3. the local-store memo: superseded arm tokens are swept, not left to rot
+# --------------------------------------------------------------------------
+
+
+def test_the_arm_token_scheme_is_its_fact_set(tmp_path: Path) -> None:
+    """The scheme digit IS the schema. ``arm1`` could not state a subject, so
+    an ``arm1-`` memo row is an answer to a question no reader asks — and the
+    cost of that, one re-mint per family per machine, is spent explicitly and
+    counted rather than discovered later as a store of unreadable files."""
+    memo_dir = local_cell_store.cells_root(tmp_path) / local_cell_store.MEMO_DIRNAME
+    memo_dir.mkdir(parents=True)
+    stale = memo_dir / ("arm1-" + "a" * 56 + ".json")
+    current = memo_dir / (fleet_cells.ARM_SCHEME + "-" + "b" * 56 + ".json")
+    for entry in (stale, current):
+        entry.write_text(json.dumps({"cell_key": "ck1-" + "c" * 56}))
+
+    dropped = local_cell_store.sweep_superseded_memos(
+        fleet_cells.ARM_SCHEME, tmp_path)
+    assert dropped == 1
+    assert not stale.exists() and current.exists()
+    assert fleet_cells.ARM_SCHEME != "arm1"
+
+
+# --------------------------------------------------------------------------
+# 4. the placement keying fact — and the NO-RE-KEY proof
+# --------------------------------------------------------------------------
+
+
+def _class_hash_before_pgw1113(
+    entry: Mapping[str, Any], *, strict: bool, lora_bucket: int,
+) -> str:
+    """``aot_serve.class_hash`` VERBATIM as of the parent commit.
+
+    Kept as a literal second implementation on purpose — the only way to prove
+    a keying change re-keys nothing is to compute both keys, and the honest
+    "before" is the old formula, not the new one with the new field left out.
+    """
+    facts = {
+        "v": 3,
+        "target": str(entry.get("target") or ""),
+        "fork": [[str(n), v] for n, v in (entry.get("fork") or [])],
+        "class_dims": [
+            [str(n), int(v)] for n, v in (entry.get("class_dims") or [])],
+        "range_digest": str(entry.get("range_digest") or ""),
+        "graph": dict(entry.get("graph") or {}),
+        "graph_witness": str(entry.get("graph_witness") or ""),
+        "strict": bool(strict),
+        "lora_bucket": int(lora_bucket or 0),
+    }
+    blob = json.dumps(facts, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _entry(**extra: Any) -> Dict[str, Any]:
+    block: Dict[str, Any] = {
+        "target": "transformer",
+        "fork": [["adapter", False]],
+        "class_dims": [["height", 1024], ["width", 1024]],
+        "range_digest": "d" * 32,
+        "graph": {"specialization": {"strict": True, "lora_bucket": 0}},
+        "graph_witness": "e" * 16,
+    }
+    block.update(extra)
+    return block
+
+
+@pytest.mark.parametrize("extra", [
+    {},                                    # every cell published to date
+    {"placement": ["cuda:0"]},             # a single-device cell that states it
+    {"placement": []},                     # stated, and empty
+])
+def test_no_live_cell_re_keys(extra: Dict[str, Any]) -> None:
+    """pgw#1113 claims NOTHING re-keys a live cell, as a deliberate property
+    rather than luck: every new fact is omitted at the value every published
+    cell holds. This is that claim, checked rather than asserted.
+
+    A single-device placement is TRIVIAL, so the canonical form is
+    byte-identical to the form with no placement at all — the ``excluded`` /
+    ``param`` / ``overlay`` precedent, and the reason ``v`` does not move.
+    """
+    from gen_worker import aot_serve
+
+    entry = _entry(**extra)
+    assert aot_serve.class_hash(entry, strict=True, lora_bucket=0) == (
+        _class_hash_before_pgw1113(entry, strict=True, lora_bucket=0))
+
+
+def test_a_multi_device_placement_keys_APART() -> None:
+    """pgw#819: a cell minted on a ``gpu_count=2, parallel="internal"`` pod —
+    where the pipeline's own device map split the modules across
+    ``cuda:0``/``cuda:1`` and inductor baked that placement into the graph —
+    published under a key byte-identical to the single-GPU one, in BOTH
+    directions, and the hub deduped them."""
+    from gen_worker import aot_serve
+
+    narrow = aot_serve.class_hash(_entry(), strict=True, lora_bucket=0)
+    wide = aot_serve.class_hash(
+        _entry(placement=["cuda:0", "cuda:1"]), strict=True, lora_bucket=0)
+    assert narrow != wide
+    # …and the order it was observed in is not information.
+    assert wide == aot_serve.class_hash(
+        _entry(placement=["cuda:1", "cuda:0"]), strict=True, lora_bucket=0)
+
+
+def test_the_graph_hash_still_scrubs_the_device_index() -> None:
+    """The placement rides its OWN fact precisely so the canonical graph form
+    does not have to change. Un-scrubbing the index there would re-key every
+    published cell to record a fact all of them state trivially — and it is
+    scrubbed by deliberate design (*"placement is the sm axis, not graph
+    identity"*)."""
+    import inspect
+
+    from gen_worker import graph_hash
+
+    body = inspect.getsource(graph_hash._render_scalar)
+    assert 'text.split(":", 1)[0]' in body
+
+
+def _fx_module(torch: Any, first: str, second: str) -> Any:
+    """A two-node graph whose nodes name two devices. No allocation, no CUDA
+    context, no card — ``torch.device("cuda:1")`` is just a value."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    a = graph.call_function(
+        torch.zeros, (2,), {"device": torch.device(first)})
+    b = graph.call_function(
+        torch.zeros, (2,), {"device": torch.device(second)})
+    graph.output((x, a, b))
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def test_device_placement_reads_exactly_what_the_graph_hash_scrubs() -> None:
+    """pgw#819, demonstrated on a CPU in milliseconds.
+
+    The two graphs differ ONLY in the device index of one node — a 1-card
+    program and a 2-card one. Their canonical graph forms are byte-identical
+    (the index is scrubbed by design), which is why no key axis could tell
+    them apart and both directions of the adoption were silent. The placement
+    observer sees the difference the canonical form deliberately does not.
+    """
+    torch = pytest.importorskip("torch")
+
+    from gen_worker import graph_hash
+
+    narrow = _fx_module(torch, "cuda:0", "cuda:0")
+    wide = _fx_module(torch, "cuda:0", "cuda:1")
+
+    assert graph_hash.graph_hash(narrow) == graph_hash.graph_hash(wide)
+    assert graph_hash.device_placement(narrow) == ("cuda:0",)
+    assert graph_hash.device_placement(wide) == ("cuda:0", "cuda:1")

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -270,11 +270,20 @@ def test_the_delegated_route_mints_in_a_child_adopts_and_advertises(
     assert "finalize" in act.phases
 
 
-def test_shared_sharers_mint_one_cell_between_them(
+def test_shared_holders_mint_one_cell_between_them(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Two pipes, one pending, ONE child — and both objects advertise it.
-    A per-pipe child would compile the same cell twice on one card."""
+    """Two pipes, one pending, ONE child — and only the ARMED pipe advertises.
+
+    pgw#1113 flips the second half of this assertion. One child is still the
+    point and still holds: a per-pipe child would compile the same cell twice
+    on one card. But `build_cell` is handed ONE pipeline and
+    `adopt_delegated_mint` installs the cell on that ONE pipeline, so the
+    sibling target never had those bytes — advertising a compiled ref for it
+    was a claim about what it serves that was false at the moment it was made,
+    and only `_bind_compile_guard`'s incidental `False` ("advertising eager")
+    kept it off the wire.
+    """
     spawns: List[Any] = []
     real = mint_delegate.build_cell
 
@@ -295,8 +304,17 @@ def test_shared_sharers_mint_one_cell_between_them(
 
     asyncio.run(ex._delegated_mint_run(rec, bg, _Act()))
     assert len(spawns) == 1, "one shared cell must mean one child process"
-    assert all(
-        t.active_compile_ref == "r" for t in rec.compile_targets.values())
+    armed_pipe = spawns[0].pipe
+    advertised = {
+        name: t.active_compile_ref for name, t in rec.compile_targets.items()}
+    assert [
+        ref for name, ref in advertised.items()
+        if rec.compile_targets[name].pipeline is armed_pipe] == ["r"]
+    assert [
+        ref for name, ref in advertised.items()
+        if rec.compile_targets[name].pipeline is not armed_pipe] == [""], (
+        "a pipe the mint never armed must advertise nothing: the cell was "
+        "installed on one pipeline and only that pipeline serves it")
 
 
 def test_a_decline_raises_MintDeclined_so_the_tier_stays_eager(

--- a/tests/test_sp_eager_only_pgw775.py
+++ b/tests/test_sp_eager_only_pgw775.py
@@ -137,8 +137,33 @@ def test_degree_one_is_unchanged() -> None:
     assert _executor_at(dp)._eager_only_reason() == ""
 
 
-def test_internal_parallelism_is_not_context_parallelism() -> None:
-    # `parallel="internal"` means the MODEL spans the cards by its own
-    # arrangement — no CP hooks, so compile is still legal.
-    topo = ExecutionTopology(gpu_count=2, gpus_per_execution_group=2, parallel="internal")
-    assert _executor_at(topo)._eager_only_reason() == ""
+def test_every_degree_above_one_is_eager_only() -> None:
+    """pgw#1113/pgw#819 FLIPS this assertion, deliberately.
+
+    It used to read: *"`parallel="internal"` means the MODEL spans the cards
+    by its own arrangement — no CP hooks, so compile is still legal."* The
+    premise is true and the conclusion did not follow. "No CP hooks" answers
+    the HANG question (nothing forwards outside a collective gate) and says
+    nothing about the IDENTITY question: a model whose own device map splits
+    its modules across `cuda:0`/`cuda:1` has inductor bake that placement into
+    the artifact, while the cell key scrubs the device index by design — so
+    the 2-card cell and the 1-card cell published under one key and each pod
+    adopted the other's, silently, in both directions (pgw#819, measured).
+
+    The gate was an allowlist by mode NAME, so `cfg` — declared at
+    `topology.PARALLEL_CFG` and platform-installed like `sequence` — was
+    uncovered too, latent only because it has no serve-side implementation
+    yet. The rule is `degree > 1`; a gate that must be widened once per new
+    mode is not a rule.
+    """
+    # `parallel=""` is not in this list because it cannot be: a group wider
+    # than one card with no parallel mechanism is refused by the topology
+    # decoder itself (`topology_parallel_required`), so `degree > 1` and "some
+    # mode is declared" are the same statement.
+    for parallel in ("internal", "sequence", "cfg"):
+        topo = ExecutionTopology(
+            gpu_count=2, gpus_per_execution_group=2, parallel=parallel)
+        assert topo.degree == 2
+        assert _executor_at(topo)._eager_only_reason(), (
+            f"degree-2 pod with parallel={parallel!r} must refuse to arm a "
+            "compile cell: no cell can state the placement it was baked for")

--- a/tests/test_two_run_reuse_pgw1096.py
+++ b/tests/test_two_run_reuse_pgw1096.py
@@ -50,7 +50,7 @@ from gen_worker.cell_adopt import AdoptOutcome
 
 MODE = sys.argv[1]
 KEY = "ck1-" + "c" * 56
-ARM = "arm1-" + "9" * 56
+ARM = fleet_cells.ARM_SCHEME + "-" + "9" * 56
 FAMILY = "micro-diffusion"
 
 


### PR DESCRIPTION
Implements [pgw#1113](https://github.com/cozy-creator/cozy-creator-tracker/blob/master/python-gen-worker/progress.md) in full, and closes **pgw#819** against it.

## The governing principle

> **The CELL KEY is the computation and must not OVER-split** (the membership axiom, `cell_key.py`).
> **The ARM TOKEN is a mint obligation and a cache lookup and must not UNDER-split.**
> Over-splitting an obligation costs one re-mint; under-splitting one binds a pipeline to a cell nobody proved is its computation.

pgw#1031 made the *cell key* sound. Nothing else in the path moved with it, because the tree applied the first axiom to both: the arm identity (a mint obligation), the boot-key memo (a trace shortcut) and the advertise binding (which target claims which cell) each named a `(family, lane, runtime)` triple and nothing about WHAT was being compiled. Each of them could hand one pipeline the cell of a different one.

## The five changes

**1. `arm_identity` gains the SUBJECT.** Which slot, resolved to which checkpoint refs (base + pgw#617 component overrides) and snapshot digest — plus the `targets`/`dynamic`/`regional` of `declared_compile_facts` the token could not previously see. The executor stamps the resolution onto the pipeline beside the execution lane (`fleet_cells.stamp_arm_subject`), which is the one handle every arm site holds. qwen's two slots, flux.2-klein's two `@endpoint` classes and z-image's two slots now each get their own obligation instead of dedupping into one pending, one child and one local-store memo row.

`ARM_FACTS` splits into `ARM_ENVIRONMENT_FACTS` (compared at the handback seam exactly as before) and `ARM_SUBJECT_FACTS` (**deliberately not compared**). That asymmetry is the point, not an omission: a cell records no checkpoint and must not, because one cell legally serves every checkpoint whose graph it is. The subject splits the OBLIGATION; the cell's own key — the traced computation — is what says the computation matches.

**2. `boot_key.closure_digest` folds the resolved slot identity.** *The priority change.* A memo HIT skips the traces and returns the MEMO's own witnesses (`graph_witnesses_of(memoized)`), which `boot_adopt.attempt` then verifies the pulled cell against. On a checkpoint-blind memo, pgw#1031's graph-witness floor — installed precisely for wrong-cell-by-key — was comparing a cell against a stale record of a *different* checkpoint's graph, so **it could only agree**. It was structurally unable to fire on the one path that most needs it. It can fail now. Cost: one memo miss and one trace on the first boot after a rebinding.

**3. The "sharers" fiction is deleted.** `_advertise_minted_cells` binds `active_compile_ref` only for the pipe that ACTUALLY armed the bytes — `build_cell` is handed one pipeline and `adopt_delegated_mint` installs on that one pipeline, so exactly one pipe ever had the bytes. The other holders now get a typed `self_mint_unarmed_holder` event instead of an advertisement that only `_bind_compile_guard`'s incidental `False` ("advertising eager") kept off the wire. gw#612's publish-coverage rule is re-aimed from pid membership to the obligation. And the `_FINALIZED` re-arm branch — the one path that armed a sibling pipe while skipping `arm_axis_divergence` entirely — now goes through `_arm_exported_cell` like every other self-produced cell.

**4. `placement` keying fact (closes pgw#819).** A model whose own device map spans several cards has that placement baked into its kernels, while the canonical graph form scrubs the device INDEX by deliberate design — so a 2-card cell published under a key byte-identical to the 1-card one, in both directions, and the hub deduped them. `aot_mint.keying_block` now records the distinct devices (`graph_hash.device_placement`, a separate observation) and `aot_serve.class_hash` folds them **only when non-trivial**, on the `excluded`/`param`/`overlay` precedent. **`graph_hash`'s scrub is untouched** — un-scrubbing it would re-key every published cell to record a fact all of them state trivially, and there is a test pinning that it stays scrubbed.

**5. The eager-only gate becomes a topology rule.** `degree > 1`, full stop, instead of an allowlist by mode NAME. `internal` was the measured hole; `cfg` (`topology.PARALLEL_CFG`) would have inherited the same hole the day it got a serve-side implementation. Free today, and superseded rather than contradicted by (4) when cells at degree>1 become real.

### Why one test assertion was WRONG and is flipped

`tests/test_sp_eager_only_pgw775.py` asserted the defect by name: *"`parallel="internal"` means the MODEL spans the cards by its own arrangement — no CP hooks, so compile is still legal."* The premise is true and the conclusion does not follow. "No CP hooks" answers the **hang** question (nothing forwards outside a collective gate) and says nothing about the **identity** question, which pgw#819 measured: the 2-card cell and the 1-card cell key identically and each pod silently adopts the other's. The row now asserts the refusal across `internal`/`sequence`/`cfg`.

`test_mint_wiring_pgw784::test_shared_sharers_mint_one_cell_between_them` is flipped for the same reason: one child is still the point and still holds, but *"and both objects advertise it"* was a claim about what a target serves that was false at the moment it was made.

## Re-key impact — verified, not assumed

**Nothing re-keys a live cell.** Every new keying fact is omitted at the value every published cell holds (all single-device, all trivial), which is a deliberate property rather than luck. `test_no_live_cell_re_keys` recomputes the **pre-change `class_hash` formula verbatim** and asserts identity for the shapes live cells have. Verified red-capable: making the placement fold unconditional reds all three rows.

## Memo invalidation — expected, and typed

The arm-token scheme IS its fact set: `arm1` → `arm2`, and the boot-key memo goes v3 → v4 (the version rides the digest input as well as the file header). A predecessor row is therefore **unaddressable by construction rather than misreadable**, and `local_cell_store.sweep_superseded_memos` drops the stale entries once per process and counts them, so the cost is spent explicitly instead of leaving a store of files nobody can reconstruct. **Cost: one re-mint per family per machine, once**, on volume-backed pods and cozy-local boxes. Cells keep their `ck1` keys — an arm-token change re-derives the shortcut, never the identity.

## Verification

- `tests/test_identity_soundness_pgw1113.py` — 23 rows, **19 verified RED against `73ada335`**; the other 4 are the no-re-key and anti-regression guards (red-capability of the no-re-key rows demonstrated separately, above).
- 890 rows green across every impacted test file (2 workers, `nice -n 19`).
- mypy clean (256 files); ruff clean on `src/gen_worker`; all seven fast-gate lint guards + the changelog-name check pass locally.
- **Cardless and podless throughout** — every claim in this issue is about what a digest is a function of, which is answerable on a CPU in milliseconds. No mint, no compile, no GPU.

## Sequencing

- Rebased on `73ada335` (PR #625, which touched `mint_child.py`).
- SDK-side: needs a wheel (0.104.0, which also carries #625) plus endpoint image rebuilds to take effect. **Not cut here** — that is a separate owner action, and pgw#1113 asks for it to land between z-image campaign legs, not inside one.
- **qwen's own remedy stays owed** (pgw#1112 item 2, endpoint-side): a non-root slot still cannot own a compile target at all. Change 1 makes the shape SAFE; only the split makes the edit arm SERVABLE.
- pgw#1113's item 6 (settle z-image's premise by comparing the two slots' derived graph witnesses) is now buyable for free and still owed.
