### PR TITLE
pgw#1115: a mint REFUSAL is DATA on the declaration, and it fails closed

### DIFF
--- a/changelog.d/pgw1115.md
+++ b/changelog.d/pgw1115.md
@@ -1,0 +1,20 @@
+- **pgw#1115: a mint REFUSAL is now DATA on the declaration, and it fails
+  closed.** `Compile(blockers=(MintBlocker(id=…, what=…, evidence=…,
+  resolves_when=…),))` — SDK vocabulary plus literals, nothing callable,
+  nothing to evaluate. Until now the only way a family could say "complete
+  declaration, may not mint yet" was to register a THUNK that raises
+  `MintRefused` when the mint asks (pgw#853), and pgw#1107 folds every
+  declaration onto `@endpoint(compile=)`, which takes a `Compile` and never a
+  callable: folding ltx-video-2.3 verbatim would have SILENTLY DELETED a live
+  refusal standing on three open design questions and let the family mint
+  against them. While any blocker is unresolved the mint fails closed and names
+  the ids — `fleet_cells.mint_recipe` declines under its own
+  `declaration_blocked` phase, `mint_child` refuses with `MintChildRefused`
+  before a weight is read, and the image build records the existing `blocked`
+  verdict (pgw#996) — while SERVING is untouched, exactly as it is today.
+  Closing a blocker requires a `resolution=` citation, so an unblock is a
+  reviewable edit rather than a bool flip. Blockers are deliberately NOT a
+  contract axis: resolving one re-keys nothing. `assert_faithful` now STOPS a
+  fold that drops a blocker, and `assert_blockers(decl, ids=…)` is the
+  per-family guard for the family whose blockers live outside its `Compile`
+  today. Cardless, $0, no pod.

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -33,11 +33,13 @@ from .api.export_contract import (
     Fork,
     GraphClass,
     Input,
+    MintBlocker,
     import_export_declaration,
     register_export_declaration,
 )
 from .api.derive import (
     DeclarationMismatch,
+    assert_blockers,
     assert_faithful,
     cfg_image_classes,
     class_set_delta,
@@ -134,8 +136,11 @@ __all__ = [
     "GraphClass",
     "Input",
     "Arg",
+    # pgw#1115: a mint refusal is DATA on the declaration.
+    "MintBlocker",
     "register_export_declaration",
     "DeclarationMismatch",
+    "assert_blockers",
     "assert_faithful",
     "cfg_image_classes",
     "class_set_delta",

--- a/src/gen_worker/aot_preconditions.py
+++ b/src/gen_worker/aot_preconditions.py
@@ -23,10 +23,12 @@ Four verdicts, and the difference between the last three is the whole point:
 
 ``ok``         the precondition holds on this image.
 ``refused``    it does not, and nothing on a pod can fix it — FAIL THE BUILD.
-``blocked``    the declaration itself refused, in typed ``MintRefused``
-               vocabulary (ltx-2.3's open ``MINT_BLOCKERS``). The family said
-               why; it is a DECLARED block, not a broken image, and it does
-               not need a pod to repeat the sentence.
+``blocked``    the declaration refused: either it carries unresolved
+               ``Compile.blockers`` (pgw#1115 — the declared form) or it
+               raised typed ``MintRefused`` (pgw#853's thunk, which the
+               pgw#1107 fold retires). The family said why; it is a DECLARED
+               block, not a broken image, and it does not need a pod to
+               repeat the sentence.
 ``abstained``  this environment cannot decide (a torch-less manifest build).
                Recorded, never silent — an unrecorded abstention is how a gate
                becomes decorative.
@@ -39,9 +41,11 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 from .api.export_contract import (
+    blocker_refusal,
     declaration_import_failures,
     export_declaration,
     has_export_declaration,
+    open_blockers,
 )
 
 # Every heavier import in this module is DEFERRED into the function that needs
@@ -204,6 +208,16 @@ def static_mint_preconditions(
                 family=family, detail=(
                     "the registered export declaration evaluated to None — "
                     "there is no Compile to derive graph classes from")))
+            continue
+        # pgw#1115: the SAME declared block, read as DATA. The `MintRefused`
+        # branch above is the thunk saying it; a folded declaration says it
+        # with `blockers=`, and the build gate must recognise both or the
+        # pgw#1107 fold turns a build-time `blocked` verdict into silence.
+        blocked = open_blockers(decl)
+        if blocked:
+            rows.append(Precondition(
+                check=CHECK_DECLARATION_EVALUATES, verdict=BLOCKED,
+                family=family, detail=blocker_refusal(family, blocked)))
             continue
         rows.append(Precondition(
             check=CHECK_DECLARATION_EVALUATES, verdict=OK, family=family,

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -44,7 +44,10 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Type
 import msgspec
 
 from .binding import BINDING_TYPES, Binding
-from .export_contract import Arg, Dim, Fork, GraphClass, Input, validate_contract
+from .export_contract import (
+    Arg, Dim, Fork, GraphClass, Input, MintBlocker, open_blockers,
+    validate_contract,
+)
 from .formula import RuntimeFormula
 from .slot import OBJECTIVES, TASKS, Slot
 from ..models import execution_lanes as lanespec
@@ -949,6 +952,14 @@ class Compile(msgspec.Struct, frozen=True):
     # conv-bearing UNet.
     numerics_floor: Optional[float] = None
     numerics_warn: Optional[float] = None
+    # pgw#1115: DECLARED mint blockers. A family that may not mint yet says so
+    # as DATA here — never as a thunk that raises, which the pgw#1107 fold onto
+    # this decorator cannot carry (`compile=` takes a Compile, never a
+    # callable, so a folded refusal would simply vanish). While any blocker is
+    # unresolved the mint fails CLOSED and names the ids; serving is untouched.
+    # Deliberately NOT a contract axis (`contract_axes()`): resolving a blocker
+    # must not re-key a cell.
+    blockers: tuple[MintBlocker, ...] = ()
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -991,7 +1002,7 @@ class Compile(msgspec.Struct, frozen=True):
         # (`compile_cache._mark_regional_blocks`).
         for name, typ in (("dims", Dim), ("forks", Fork),
                           ("classes", GraphClass), ("inputs", Input),
-                          ("args", Arg)):
+                          ("args", Arg), ("blockers", MintBlocker)):
             rows = tuple(getattr(self, name))
             if any(not isinstance(r, typ) for r in rows):
                 raise TypeError(
@@ -1018,6 +1029,12 @@ class Compile(msgspec.Struct, frozen=True):
                 f"exceed numerics_warn ({self.numerics_warn}): the floor "
                 f"refuses, the warn only confesses")
         validate_contract(self)
+
+    @property
+    def open_blockers(self) -> tuple[MintBlocker, ...]:
+        """The UNRESOLVED blockers (pgw#1115). Non-empty ⟹ this family refuses
+        to mint, by declaration, and every mint site fails closed on it."""
+        return open_blockers(self)
 
     @property
     def sequence_dynamic(self) -> Optional[DynamicDim]:

--- a/src/gen_worker/api/derive.py
+++ b/src/gen_worker/api/derive.py
@@ -30,6 +30,13 @@ so they run anywhere including this box:
    iff the two declarations' contract axes match. A non-empty delta is a STOP,
    not a merge: it is the surprise re-key (or the silently-lost hard-won fact)
    the gate exists to catch before a family being minted RIGHT NOW is disturbed.
+
+3. :func:`blocker_delta` / :func:`assert_blockers` — the REFUSAL half of that
+   gate (pgw#1115). The one fact a fold can drop that neither of the above
+   sees is a family's declared mint blockers, because the family that has them
+   keeps them outside its ``Compile`` today (a module-level table read by a
+   refusing thunk). Dropping one does not re-key anything; it simply starts
+   minting against an open design question.
 """
 
 from __future__ import annotations
@@ -38,11 +45,13 @@ import json
 from typing import Any, Dict, List, Sequence, Tuple
 
 from .decorators import Compile
-from .export_contract import GraphClass
+from .export_contract import GraphClass, open_blockers
 
 __all__ = [
     "DeclarationMismatch",
+    "assert_blockers",
     "assert_faithful",
+    "blocker_delta",
     "cfg_image_classes",
     "class_set_delta",
     "contract_delta",
@@ -172,6 +181,59 @@ def override_delta(standing: Compile, migrated: Compile) -> Dict[str, Tuple[Any,
     return delta
 
 
+def blocker_delta(standing: Compile, migrated: Compile) -> Tuple[str, ...]:
+    """The OPEN blocker ids the standing declaration carries and the migrated
+    one does not (pgw#1115). ``()`` iff no refusal was lost.
+
+    Deliberately DIRECTIONAL, unlike every other delta here. A fold may ADD a
+    blocker — that is a family recording a question it had not written down —
+    but it may never drop one, because a dropped blocker is a family that
+    starts minting against an open design question and says nothing. A
+    RESOLVED-in-the-migrated-declaration id counts as dropped: resolving is a
+    reviewable edit to the standing declaration, not a side effect of a move.
+    """
+    before = {b.id for b in open_blockers(standing)}
+    after = {b.id for b in open_blockers(migrated)}
+    return tuple(sorted(before - after))
+
+
+def assert_blockers(
+    decl: Compile, *, ids: Sequence[str], family: str = "",
+) -> None:
+    """Raise :class:`DeclarationMismatch` unless ``decl``'s OPEN blocker ids
+    are EXACTLY ``ids`` (pgw#1115) — the per-family testable guard.
+
+    :func:`blocker_delta` can only compare two declarations, so it is blind
+    where the standing declaration kept its blockers OUTSIDE the ``Compile``
+    (a module-level table read by a refusing thunk — ltx-video-2.3's shape,
+    and precisely the shape the fold has to carry across). This states the
+    expectation in the family's OWN test instead, so the assertion survives
+    the file the blockers used to live in.
+
+    ``ids=()`` asserts the family is mintable, and is just as load-bearing:
+    it goes red the day somebody adds a blocker without telling the family's
+    tests.
+    """
+    want = tuple(sorted(str(i).strip() for i in ids))
+    got = tuple(sorted(b.id for b in open_blockers(decl)))
+    if want == got:
+        return
+    who = f" for {family!r}" if family else ""
+    missing = sorted(set(want) - set(got))
+    extra = sorted(set(got) - set(want))
+    lines = [f"declared mint blockers{who} are not the asserted set:"]
+    if missing:
+        lines.append(
+            f"  MISSING (the declaration no longer refuses on): {missing} — a "
+            f"refusal that disappeared without being resolved lets this family "
+            f"mint against an open design question")
+    if extra:
+        lines.append(
+            f"  UNEXPECTED (the declaration now refuses on): {extra} — the "
+            f"family's tests have not been told")
+    raise DeclarationMismatch("\n".join(lines))
+
+
 def class_set_delta(
     standing: Sequence[GraphClass], migrated: Sequence[GraphClass],
 ) -> Dict[str, Any]:
@@ -207,10 +269,16 @@ def assert_faithful(
     """
     cdelta = contract_delta(standing, migrated)
     odelta = override_delta(standing, migrated)
-    if not cdelta and not odelta:
+    bdelta = blocker_delta(standing, migrated)
+    if not cdelta and not odelta and not bdelta:
         return
     who = f" for {family!r}" if family else ""
     lines = [f"migrated declaration{who} is not faithful to the standing one:"]
+    if bdelta:
+        lines.append(
+            f"  mint REFUSAL dropped ({len(bdelta)} blocker(s)): {list(bdelta)} "
+            f"— the migrated declaration would mint against open design "
+            f"question(s) the standing one refuses on (pgw#1115)")
     if cdelta:
         lines.append(
             f"  cell-key contract re-keys ({len(cdelta)} axis(es) differ):")

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -126,6 +126,124 @@ class DeclarationError(ValueError):
     import / ``Compile`` construction), never at mint time."""
 
 
+class MintBlocker(msgspec.Struct, frozen=True):
+    """A named, evidence-carrying reason this family may not MINT yet
+    (pgw#1115).
+
+    A refusal is DATA on the declaration, not code that raises. Before this,
+    a family with open questions expressed them by registering a THUNK that
+    raised ``MintRefused`` when the mint asked (pgw#853) — which the pgw#1107
+    fold cannot carry: ``@endpoint(compile=)`` takes a ``Compile``, never a
+    callable, so folding a refusing thunk onto the decorator would silently
+    DELETE the refusal and let the family mint against its own open questions.
+
+    So the refusal moves into the vocabulary. Every field is a literal; there
+    is no callable, no torch, no runtime state and nothing to evaluate — which
+    is what lets the endpoint repo's torch-free declaration lint READ a
+    family's open blockers out of an AST-extracted ``compile=`` expression
+    without a GPU, a pod or a mint.
+
+    * ``what`` — the claim the declaration cannot yet make.
+    * ``evidence`` — the citations. A blocker with no evidence is an opinion.
+    * ``resolves_when`` — the EXIT criterion, so the block is a question with
+      an answer rather than a permanent stall.
+    * ``resolved`` + ``resolution`` — an open blocker closes by a REVIEWABLE
+      edit that cites what settled it (a measurement, a merged change). The
+      citation is required, not conventional: a bare bool flip is exactly the
+      silent unblock this vocabulary exists to prevent. Deleting the row
+      outright is equally valid once nobody needs the record.
+
+    Blockers gate MINTING ONLY. A blocked family serves eagerly, exactly as it
+    does today, and blockers are deliberately NOT a contract axis — resolving
+    one must not re-key a cell.
+    """
+
+    id: str
+    what: str
+    evidence: str
+    resolves_when: str
+    resolved: bool = False
+    resolution: str = ""
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        ident = str(self.id or "").strip()
+        if not ident or ident.split() != [ident]:
+            raise DeclarationError(
+                f"MintBlocker id {self.id!r} must be a single whitespace-free "
+                f"token — it is printed in the refusal's id list and is how a "
+                f"human names the blocker they are resolving")
+        force(self, "id", ident)
+        for field in ("what", "evidence", "resolves_when"):
+            text = str(getattr(self, field) or "").strip()
+            if not text:
+                raise DeclarationError(
+                    f"MintBlocker {ident!r} states no {field} — a blocker "
+                    f"carries the claim it blocks, the evidence for it and "
+                    f"the exit criterion, or it is not reviewable")
+            force(self, field, text)
+        force(self, "resolved", bool(self.resolved))
+        resolution = str(self.resolution or "").strip()
+        if self.resolved and not resolution:
+            raise DeclarationError(
+                f"MintBlocker {ident!r} is marked resolved with no resolution "
+                f"citation — closing a blocker is a reviewable edit that must "
+                f"name what settled it (a measurement, a merged change); a "
+                f"bare bool flip is a silent unblock. Delete the row instead "
+                f"if nobody needs the record")
+        force(self, "resolution", resolution)
+
+    def as_row(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "what": self.what,
+            "evidence": self.evidence,
+            "resolves_when": self.resolves_when,
+            "resolved": self.resolved,
+            "resolution": self.resolution,
+        }
+
+
+def open_blockers(decl: Any) -> Tuple[MintBlocker, ...]:
+    """Every UNRESOLVED :class:`MintBlocker` a declaration carries.
+
+    Takes any object with a ``blockers`` attribute (a ``Compile``), so the
+    mint path, the build gate and the endpoint repo's lint all read the same
+    answer. Empty for a declaration that carries none — the normal case, and
+    the only state in which a family mints.
+    """
+    return tuple(
+        b for b in getattr(decl, "blockers", ()) if not getattr(b, "resolved", False))
+
+
+def blocker_rows(decl: Any) -> List[Dict[str, Any]]:
+    """The declaration's blockers as JSON-able rows, for a lint or a manifest.
+
+    The endpoint repo's ``scripts/lint_declarations.py`` evaluates a family's
+    ``compile=`` expression in an SDK-only namespace with no torch installed
+    and reports what it finds; this is the one shape it reads, so the report
+    cannot drift from the vocabulary.
+    """
+    return [b.as_row() for b in getattr(decl, "blockers", ())]
+
+
+def blocker_refusal(family: str, blockers: Sequence[MintBlocker]) -> str:
+    """The ONE refusal sentence, so every site that fails closed on an open
+    blocker says the same thing and names the same ids."""
+    ids = ", ".join(b.id for b in blockers)
+    detail = "\n".join(
+        f"  - {b.id}: {b.what}\n    EVIDENCE: {b.evidence}"
+        f"\n    RESOLVES WHEN: {b.resolves_when}"
+        for b in blockers)
+    return (
+        f"family {family!r} declares {len(blockers)} UNRESOLVED mint "
+        f"blocker(s) [{ids}] and REFUSES TO MINT. The declaration is otherwise "
+        f"complete — this is a declared gate, not a malformed declaration, and "
+        f"the family serves eagerly meanwhile:\n{detail}\n"
+        f"Resolving one is a reviewable edit to the declaration that cites "
+        f"what settled it (pgw#1115).")
+
+
 def _identifier(kind: str, name: Any) -> str:
     text = str(name or "").strip()
     if not text or not text.replace(".", "_").isidentifier():
@@ -775,6 +893,13 @@ def validate_contract(compile_decl: Any) -> None:
                     f"graph class #{i}: fork {name}={value!r} is not a "
                     f"declared arm (served: {sorted(map(repr, served_by_fork.get(name, set())))})")
 
+    blockers: Tuple[MintBlocker, ...] = compile_decl.blockers
+    blocker_ids = [b.id for b in blockers]
+    if len(set(blocker_ids)) != len(blocker_ids):
+        raise DeclarationError(
+            "Compile.blockers repeats a blocker id — an id is how a refusal "
+            "is named, cited and resolved")
+
     strategy = str(compile_decl.shape_strategy or "")
     if strategy and strategy not in SHAPE_STRATEGIES:
         raise DeclarationError(
@@ -1107,15 +1232,19 @@ __all__ = [
     "ForkValue",
     "GraphClass",
     "Input",
+    "MintBlocker",
     "SHAPE_STRATEGIES",
     "STATIC_ROWS",
     "FORK_REASONS",
     "WEAK_FORK_REASONS",
+    "blocker_refusal",
+    "blocker_rows",
     "declaration_import_failures",
     "export_declaration",
     "has_export_declaration",
     "registered_entry",
     "import_export_declaration",
+    "open_blockers",
     "register_export_declaration",
     "registered_export_families",
     "reset_export_declarations",

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -72,7 +72,8 @@ from .procsplit import broker
 from .models import loading, provision
 from .request_context._helpers import _decode_unverified_jwt_claims
 from .convert.hub import HubPublishError
-from .api.export_contract import export_declaration
+from .api.export_contract import (
+    blocker_refusal, export_declaration, open_blockers)
 from .models import lora_lifted
 
 logger = logging.getLogger(__name__)
@@ -2257,6 +2258,15 @@ def mint_recipe(
             f"family {family!r} registered no export declaration (a "
             f"`compile=` block carrying graph classes, pgw#739/#758) — the "
             f"class set a multi-graph cell covers is undeclared")
+
+    # pgw#1115: the same refusal, now as DATA. A `Compile` carrying unresolved
+    # `blockers=` declines here under its own phase, naming the ids — the
+    # thunk's raise (above) and this branch are the same event said two ways,
+    # and the fold onto `@endpoint(compile=)` can only carry the second.
+    # Serving is untouched: this pod serves eager exactly as it did.
+    blocked = open_blockers(decl)
+    if blocked:
+        return _decline("declaration_blocked", blocker_refusal(family, blocked))
 
     # CYCLE: aot_mint imports CellPublisher from this module at module scope,
     # so this direction of the pair must stay deferred.

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -71,6 +71,8 @@ import msgspec
 
 from . import warm_spans, worker_goals
 from .api.errors import ValidationError
+from .api.export_contract import (
+    blocker_refusal, export_declaration, open_blockers)
 from .config import load_settings
 from .mint_process import (
     EXIT_BAD_REQUEST,
@@ -107,6 +109,31 @@ class MintChildRefused(RuntimeError):
     ) -> None:
         super().__init__(*args)
         self.mint_phases: Dict[str, Any] = dict(mint_phases or {})
+
+
+def _assert_family_mintable(family: str) -> None:
+    """Refuse the mint outright while the family declares an open blocker
+    (pgw#1115).
+
+    The pattern is pgw#1080's: split the refusal by TYPE and fail closed
+    rather than degrading. A blocked family has exactly one legal outcome —
+    it serves eager and mints nothing — so there is no fallback to take, and
+    a mint that started anyway would publish a cell for a class set the
+    declaration says it cannot yet claim.
+    """
+    if not family:
+        return
+    try:
+        decl = export_declaration(family)
+    except Exception as exc:  # noqa: BLE001 — a refusing declaration is a refusal
+        raise MintChildRefused(
+            f"family {family!r}'s export declaration refuses to build "
+            f"({type(exc).__name__}): {exc}") from exc
+    if decl is None:
+        return
+    blocked = open_blockers(decl)
+    if blocked:
+        raise MintChildRefused(blocker_refusal(family, blocked))
 
 
 def _declaration_refusal(exc: ValidationError) -> MintChildRefused:
@@ -851,6 +878,15 @@ def mint(request: MintRequest) -> MintReport:
     # declared facts by name (family, targets, shapes, text_lens, guidance,
     # lora_bucket) and the spec carries exactly those.
     cfg = request.cfg
+
+    # pgw#1115: FAIL CLOSED on a declared mint blocker, here — after discovery
+    # has registered the declaration and before one weight is read. The parent
+    # declines a blocked family in `fleet_cells.mint_recipe`, so a request that
+    # reaches a child came from somewhere else (an operator CLI, a delegated
+    # request built against a stale declaration). Serving a blocked family
+    # eagerly is the declared outcome; minting it is not available at all, and
+    # a refusal that only one of the two paths honours is not a refusal.
+    _assert_family_mintable(str(getattr(cfg, "family", "") or ""))
 
     frame(phase="load", note=(
         f"setup {spec.cls.__name__}"

--- a/tests/harness/blocked_endpoint_pgw1115.py
+++ b/tests/harness/blocked_endpoint_pgw1115.py
@@ -1,0 +1,132 @@
+"""The POST-FOLD shape of a family that may not mint yet (pgw#1115).
+
+ltx-video-2.3 is the family this fixture is drawn from. Its declaration is
+COMPLETE — 82 graph classes on H100, 115 on B200 — and it still may not mint,
+because three design questions are open (audio_timestep rank, whole-graph OOM
+never measured on the served w8a8 lane, live coverage gaps that predate AOT).
+Today it says so by registering a THUNK that raises ``MintRefused``
+(pgw#853); pgw#1107 folds every declaration onto ``@endpoint(compile=)``,
+which takes a ``Compile`` and never a callable, so the refusal has to become
+DATA or it disappears in the move.
+
+This module is what that looks like: one endpoint class, one ``Compile``, two
+unresolved ``MintBlocker`` rows and one resolved one. Nothing here raises,
+nothing here is callable, and the module imports without torch — which is the
+whole property the fold needs.
+
+Deliberately isolated (the ``toy_endpoints_slot_only`` precedent): the mint
+child walks ``request.modules`` and re-runs discovery over it, so what else
+lives beside it is part of the test.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import (
+    Compile, Dim, GraphClass, Hub, Input, MintBlocker, RequestContext,
+    Resources, Slot, endpoint,
+)
+from gen_worker.families.base import GenerationDefaults, family
+
+FAMILY = "harness-pgw1115-blocked"
+DECLARED_PIPELINE = Hub("harness/pgw1115-blocked", tag="prod")
+
+#: The two ids every refusal on this family must name.
+OPEN_IDS = ("OQ-2-audio_timestep-rank", "OQ-3-whole-graph-OOM-unmeasured")
+
+BLOCKERS = (
+    MintBlocker(
+        id=OPEN_IDS[0],
+        what="`audio_timestep` is RANK-1 on generate and RANK-2 on edit, and "
+             "the pytree input spec pins rank — so the declared T_at dim is "
+             "only valid once the audio side is normalized at the endpoint "
+             "boundary.",
+        evidence="harness fixture standing in for ltx-video-2.3's OQ-2 "
+                 "(pipeline_ltx2_audio.py:292 vs pipeline_ltx2_edit.py:294).",
+        resolves_when="The endpoint builds (B, 1) instead of (B,) on "
+                      "generate/extend/a2v; ONE equivalence test proves it.",
+    ),
+    MintBlocker(
+        id=OPEN_IDS[1],
+        what="This declaration assumes WHOLE-transformer export, and the "
+             "OOM rationale behind the alternative was measured on a lane "
+             "this endpoint no longer serves.",
+        evidence="harness fixture standing in for ltx-video-2.3's OQ-3.",
+        resolves_when="ONE mint-lane measurement of whole-graph export at the "
+                      "largest declared classes.",
+    ),
+    MintBlocker(
+        id="OQ-9-already-settled",
+        what="A blocker that has been answered and is kept for the record.",
+        evidence="harness fixture: the RESOLVED half of the vocabulary.",
+        resolves_when="Measured on the mint lane.",
+        resolved=True,
+        resolution="Measured 2026-08-11 on the w8a8 lane; the graph is one "
+                   "class, not two (this citation is what makes the flip "
+                   "reviewable).",
+    ),
+)
+
+BLOCKED_COMPILE = Compile(
+    family=FAMILY,
+    targets=("transformer",),
+    text_len=128,
+    shapes=((64, 64),),
+    shape_strategy="static-rows",
+    warm_changes_key=False,
+    dims=(
+        Dim("B", carried_by=(("hidden_states", 0),)),
+        Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+    ),
+    classes=(GraphClass(dims={"B": 1, "T_txt": 128}),),
+    inputs=(
+        Input("hidden_states", shape=("B", 4, 8, 8), dtype="model"),
+        Input("encoder_hidden_states", shape=("B", "T_txt", 16), dtype="model"),
+    ),
+    blockers=BLOCKERS,
+)
+
+
+class BlockedPipeline:
+    """A worker-LOADED slot, so the endpoint is a real compile shape (a
+    self-loading `str` slot is refused at discovery for a `compile=` class)."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.transformer = object()
+
+    @classmethod
+    def from_pretrained(cls, path: str, **_kw: object) -> "BlockedPipeline":
+        return cls(path)
+
+    def to(self, device: str) -> "BlockedPipeline":
+        return self
+
+
+@family(FAMILY)
+class _Defaults(GenerationDefaults, frozen=True):
+    steps: int = 3
+
+
+class EchoIn(msgspec.Struct):
+    text: str = ""
+
+
+class EchoOut(msgspec.Struct):
+    response: str
+
+
+@endpoint(
+    models={"pipeline": Slot(BlockedPipeline, default_checkpoint=DECLARED_PIPELINE)},
+    compile=BLOCKED_COMPILE,
+    resources=Resources(gpu=True),
+)
+class BlockedFamilyEndpoint:
+    def setup(self, pipeline: BlockedPipeline) -> None:
+        self.pipeline = pipeline
+
+    def blocked_echo(
+        self, ctx: RequestContext[_Defaults], data: EchoIn,
+    ) -> EchoOut:
+        return EchoOut(response=f"served:{data.text}")

--- a/tests/test_declared_blockers_pgw1115.py
+++ b/tests/test_declared_blockers_pgw1115.py
@@ -1,0 +1,515 @@
+"""pgw#1115 — a mint REFUSAL is DATA on the declaration, and it fails CLOSED.
+
+The defect this file exists to prevent, found by the pgw#1107 fold lane: three
+families express "this family may not mint yet" by registering a THUNK that
+raises ``MintRefused`` (pgw#853), and ltx-video-2.3's thunk genuinely refuses
+today on three open design questions. ``@endpoint(compile=)`` accepts a
+``Compile`` and never a callable, so folding that family verbatim onto its
+decorator — which is exactly what pgw#1107 does to all seven — would SILENTLY
+DELETE a live mint refusal and let it mint against three unanswered questions.
+
+So the refusal becomes vocabulary: ``Compile(blockers=(MintBlocker(...),))``.
+Four properties, one section each:
+
+1. it is DATA — SDK vocabulary plus literals, nothing callable, nothing to
+   evaluate, and NOT a contract axis (resolving a blocker must not re-key);
+2. the endpoint repo's TORCH-FREE declaration lint can read it out of an
+   AST-extracted ``compile=`` expression, which is the constraint that decides
+   the shape (a design the lint cannot read is the wrong design);
+3. minting FAILS CLOSED while any blocker is unresolved — in the serving
+   parent's recipe gate AND in the mint child, each naming the ids — and a
+   family with none mints normally;
+4. serving is UNAFFECTED, and a fold cannot lose a refusal.
+
+Cardless: no GPU, no pod, no mint, no weights.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import Compile, MintBlocker, fleet_cells
+from gen_worker import mint_child, mint_delegate
+from gen_worker import mint_process as mp
+from gen_worker import config as gw_config
+from gen_worker.api.derive import (
+    DeclarationMismatch, assert_blockers, assert_faithful, blocker_delta,
+    contract_delta,
+)
+from gen_worker.api.export_contract import (
+    DeclarationError, open_blockers, reset_export_declarations,
+)
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.registry import CompileCell
+
+from harness import blocked_endpoint_pgw1115 as blocked
+
+HARNESS_MODULE = "harness.blocked_endpoint_pgw1115"
+FAMILY = blocked.FAMILY
+GIB = 1 << 30
+
+
+def _clean(**over: Any) -> Compile:
+    """The same declaration with NO open blockers — the mintable control."""
+    over.setdefault("blockers", ())
+    return msgspec.structs.replace(blocked.BLOCKED_COMPILE, **over)
+
+
+# ---------------------------------------------------------------------------
+# 1. The refusal is DATA
+# ---------------------------------------------------------------------------
+
+
+def test_a_declaration_carries_its_open_blockers_as_values() -> None:
+    decl = blocked.BLOCKED_COMPILE
+    assert [b.id for b in decl.open_blockers] == list(blocked.OPEN_IDS)
+    # The resolved row is still carried — it is a record, not a hole.
+    assert len(decl.blockers) == len(blocked.OPEN_IDS) + 1
+    assert open_blockers(_clean()) == ()
+
+
+@pytest.mark.parametrize("hole", ["what", "evidence", "resolves_when"])
+def test_a_blocker_missing_its_claim_evidence_or_exit_is_refused(hole: str) -> None:
+    """A blocker that cannot be reviewed is not a blocker: without evidence it
+    is an opinion, and without an exit criterion it is a permanent stall."""
+    kwargs = {"id": "OQ-x", "what": "w", "evidence": "e", "resolves_when": "r"}
+    kwargs[hole] = "   "
+    with pytest.raises(DeclarationError) as exc:
+        MintBlocker(**kwargs)  # type: ignore[arg-type]
+    assert hole in str(exc.value)
+
+
+def test_resolving_a_blocker_requires_a_CITATION_not_a_bool_flip() -> None:
+    """The unblock has to be reviewable. A bare ``resolved=True`` is exactly
+    the silent unblock this vocabulary exists to prevent."""
+    with pytest.raises(DeclarationError) as exc:
+        MintBlocker(id="OQ-x", what="w", evidence="e", resolves_when="r",
+                    resolved=True)
+    assert "resolution" in str(exc.value)
+    ok = MintBlocker(id="OQ-x", what="w", evidence="e", resolves_when="r",
+                     resolved=True, resolution="measured 2026-08-11 on the "
+                                               "w8a8 lane")
+    assert open_blockers(SimpleNamespace(blockers=(ok,))) == ()
+
+
+def test_an_id_is_a_single_token_because_the_refusal_prints_a_list() -> None:
+    with pytest.raises(DeclarationError):
+        MintBlocker(id="OQ 2 audio rank", what="w", evidence="e",
+                    resolves_when="r")
+
+
+def test_a_repeated_blocker_id_is_refused_at_declaration_time() -> None:
+    row = blocked.BLOCKERS[0]
+    with pytest.raises(DeclarationError) as exc:
+        _clean(blockers=(row, row))
+    assert "repeats a blocker id" in str(exc.value)
+
+
+def test_a_callable_is_not_a_blocker() -> None:
+    """No thunks, at any level: the whole point is that nothing evaluates."""
+    with pytest.raises(TypeError):
+        _clean(blockers=(lambda: None,))  # type: ignore[arg-type]
+
+
+def test_blockers_are_NOT_a_contract_axis_so_resolving_one_never_re_keys() -> None:
+    """A blocked family has no published cell to re-key, but a family that
+    RESOLVES its last blocker must not find its first mint keyed differently
+    from the declaration it was reviewed against."""
+    assert contract_delta(blocked.BLOCKED_COMPILE, _clean()) == {}
+    assert "blockers" not in blocked.BLOCKED_COMPILE.contract_axes()
+
+
+# ---------------------------------------------------------------------------
+# 2. The TORCH-FREE lint can read them
+#
+#    `inference-endpoints/scripts/lint_declarations.py` AST-extracts a family's
+#    `compile=` expression and evaluates it in an SDK-only namespace with no
+#    torch installed. This section is that reader, run against the harness
+#    endpoint with torch BLOCKED at the import system — so a design that needed
+#    torch, a callable or a runtime value to state its blockers fails here.
+# ---------------------------------------------------------------------------
+
+
+def _extract(module_path: Path) -> Tuple[List[str], str]:
+    """``(prelude, compile_expression)``, read statically — the fold lane's
+    reader, kept in step with it deliberately."""
+    tree = ast.parse(module_path.read_text(encoding="utf-8"), str(module_path))
+    prelude: List[str] = []
+    expr = ""
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] == "gen_worker" and not node.level:
+                prelude.append(ast.unparse(node))
+        elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.ClassDef,
+                               ast.FunctionDef)):
+            prelude.append(ast.unparse(node))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for deco in node.decorator_list:
+            if not isinstance(deco, ast.Call):
+                continue
+            name = (deco.func.id if isinstance(deco.func, ast.Name)
+                    else getattr(deco.func, "attr", ""))
+            if name == "endpoint":
+                for kw in deco.keywords:
+                    if kw.arg == "compile":
+                        expr = ast.unparse(kw.value)
+    return prelude, expr
+
+
+_TORCH_FREE_PROBE = '''
+import json, sys
+
+class _NoTorch:
+    """Anything the fleet's pinned wheel does NOT install alongside the SDK."""
+    BANNED = ("torch", "diffusers", "transformers", "triton", "torchvision")
+
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in self.BANNED:
+            raise ModuleNotFoundError(f"{name} is not installed (lint env)")
+        return None
+
+sys.meta_path.insert(0, _NoTorch())
+
+from gen_worker.api.export_contract import blocker_rows
+
+ns = {"__name__": "declaration", "__builtins__": __builtins__}
+for stmt in PRELUDE:
+    try:
+        exec(compile(stmt, "<prelude>", "exec"), ns)
+    except Exception:
+        pass
+decl = eval(compile(EXPR, "<declaration>", "eval"), ns)
+print(json.dumps({
+    "family": decl.family,
+    "blockers": blocker_rows(decl),
+    "torch_imported": "torch" in sys.modules,
+}))
+'''
+
+
+def test_the_torch_free_lint_reads_and_reports_the_open_blockers(
+    tmp_path: Path,
+) -> None:
+    """THE CONSTRAINT. A declaration the lint cannot read is the wrong design:
+    the lint is the only automated feedback on a declaration that does not cost
+    a rented pod (ie#631), and after the fold it is also the only place a
+    family's refusal is visible without one."""
+    prelude, expr = _extract(Path(blocked.__file__))
+    assert expr, "the reader found no compile= on the @endpoint decorator"
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        f"PRELUDE = {prelude!r}\nEXPR = {expr!r}\n" + _TORCH_FREE_PROBE)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(Path(__file__).resolve().parent), env.get("PYTHONPATH", "")])
+    proc = subprocess.run([sys.executable, str(probe)], env=env,
+                          capture_output=True, text=True, timeout=300)
+    assert proc.returncode == 0, proc.stderr[-3000:]
+    out = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    assert out["torch_imported"] is False, "reading a declaration imported torch"
+    assert out["family"] == FAMILY
+    open_ids = [r["id"] for r in out["blockers"] if not r["resolved"]]
+    assert open_ids == list(blocked.OPEN_IDS)
+    # A reported blocker carries its exit criterion, or the report tells a
+    # reader a family is stuck without telling them how it gets unstuck.
+    for row in out["blockers"]:
+        assert row["resolves_when"] and row["evidence"]
+    resolved = [r for r in out["blockers"] if r["resolved"]]
+    assert resolved and all(r["resolution"] for r in resolved)
+
+
+# ---------------------------------------------------------------------------
+# 3. Minting FAILS CLOSED — in the parent's recipe gate and in the child
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = FAMILY
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((64, 64),)
+    targets: Tuple[str, ...] = ("transformer",)
+    text_lens: Tuple[int, ...] = (128,)
+    guidance_scales: Tuple[float, ...] = ()
+    regional: bool = False
+
+
+class _Publisher:
+    base_url = "http://hub.invalid"
+
+    def enabled(self) -> bool:
+        return True
+
+    def worker_jwt(self) -> str:
+        return "jwt"
+
+
+@pytest.fixture()
+def _miss(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A real AOT discovery miss on an otherwise mint-capable pod (the
+    pgw#853 fixture, which is the production shape of this decision)."""
+    gw_config.reload_for_test()
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
+    monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
+    monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
+    monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
+    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+    monkeypatch.setattr(fleet_cells, "_PENDING", {})
+    monkeypatch.setattr(
+        fleet_cells, "arm_identity",
+        lambda *a, **k: type("_A", (), {
+            "token": "arm1-" + "a" * 56,
+            "facts_dict": lambda self: {}})())
+    monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda p: False)
+    monkeypatch.setattr(fleet_cells.cc, "arm_jit_intake", lambda p, c: None)
+    monkeypatch.setattr(
+        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "w8a8")
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+    gw_config.reload_for_test()
+
+
+@pytest.fixture()
+def _events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
+    seen: List[Tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        fleet_cells.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: seen.append(
+            (kind, phase, detail)))
+    return seen
+
+
+def _enable(decl: Compile, events: List[Tuple[str, str, str]]) -> Any:
+    from gen_worker.api.export_contract import register_export_declaration
+
+    register_export_declaration(decl, replace=True)
+    return fleet_cells.enable_compiled(
+        _Pipe(), _Cfg(), publisher=_Publisher(), delegate=True)  # type: ignore[arg-type]
+
+
+def test_the_recipe_gate_declines_a_blocked_family_and_names_the_ids(
+    _miss: Any, _events: List[Tuple[str, str, str]],
+) -> None:
+    """The refusal must still be SAID, typed and groupable, with its evidence
+    — not swallowed, and not a quieter string than the thunk's was."""
+    outcome = _enable(blocked.BLOCKED_COMPILE, _events)
+
+    assert outcome.self_mint is None, "a blocked family started a mint"
+    skipped = [(p, d) for k, p, d in _events if k == "self_mint_skipped"]
+    phases = [p for p, _ in skipped]
+    assert "declaration_blocked" in phases, phases
+    detail = next(d for p, d in skipped if p == "declaration_blocked")
+    for ident in blocked.OPEN_IDS:
+        assert ident in detail, detail
+    assert "RESOLVES WHEN" in detail
+    assert "OQ-9-already-settled" not in detail, "a RESOLVED blocker still gates"
+
+
+def test_the_blocked_pod_keeps_serving(
+    _miss: Any, _events: List[Tuple[str, str, str]],
+) -> None:
+    """Blockers gate MINTING only. The arm is not failed, and nothing about
+    the request path changes — this is the property that makes recording a
+    refusal cheap enough to be honest about."""
+    outcome = _enable(blocked.BLOCKED_COMPILE, _events)
+
+    assert outcome.armed is True
+    assert not [k for k, _p, _d in _events if k == "self_mint_started"]
+
+
+def test_a_family_with_no_open_blockers_is_not_blocked(
+    _miss: Any, _events: List[Tuple[str, str, str]],
+) -> None:
+    """The control, and it is load-bearing: a gate that blocks everything is
+    indistinguishable from one that works. The clean declaration declines
+    later, for a reason that is about the composed pipeline, never about
+    blockers."""
+    _enable(_clean(), _events)
+
+    phases = [p for k, p, _d in _events if k == "self_mint_skipped"]
+    assert "declaration_blocked" not in phases, phases
+
+
+def _blocked_request(tmp_path: Path) -> mp.MintRequest:
+    """A mint request for the blocked family, built through the REAL parent
+    chain and round-tripped through msgspec — the boundary IS a file."""
+    tree = tmp_path / "weights"
+    tree.mkdir(parents=True, exist_ok=True)
+    pending = SimpleNamespace(
+        family=FAMILY, arm_token="ck1-blocked", recipe="aot",
+        cfg=CompileCell(shapes=((64, 64),), targets=("transformer",),
+                        family=FAMILY, regional=False, text_len=128,
+                        dynamic=(), lora_bucket=0, guidance_scales=(),
+                        text_lens=()),
+        target=tmp_path / "cell.tar.gz", mint_root=tmp_path)
+    task = mint_delegate.MintTask(
+        pending=pending, pipe=object(), function="blocked-echo",
+        modules=(HARNESS_MODULE,),
+        slots={"pipeline": mp.MintSlot(
+            ref=blocked.DECLARED_PIPELINE, path=str(tree))},
+        execution_lane="w8a8", device=-1)
+    request = mint_delegate.build_request(
+        task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
+    return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
+
+
+def test_the_mint_child_refuses_a_blocked_family_before_it_reads_a_weight(
+    tmp_path: Path,
+) -> None:
+    """The FAIL-CLOSED half, on the real entrypoint: ``python -m
+    gen_worker.mint_child request.json``, spawned by the parent's real
+    supervisor. The parent declines a blocked family in ``mint_recipe``, so a
+    request that reaches a child came from somewhere else — an operator CLI, a
+    delegated request built against a stale declaration — and a refusal only
+    one of the two paths honours is not a refusal (pgw#1080's lesson: split by
+    type and fail closed; never degrade).
+    """
+    request = _blocked_request(tmp_path)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(Path(__file__).resolve().parent), env.get("PYTHONPATH", "")])
+    outcome = asyncio.run(mp.run_mint(
+        request, workdir=tmp_path / "w", python=sys.executable, env=env))
+
+    assert outcome.status == mp.REFUSED, (
+        f"{outcome.status}: {outcome.detail or outcome.stderr_tail}")
+    assert outcome.exit_code == mp.EXIT_REFUSED, "a refusal must be TERMINAL"
+    report = outcome.report
+    assert report is not None and report.status == "refused"
+    for ident in blocked.OPEN_IDS:
+        assert ident in report.detail, report.detail
+    # Before any side effect the child could have: no artifact, no weights.
+    assert not Path(request.target).exists()
+    assert "warmup_forward" not in report.phases, report.phases
+
+
+def test_the_mint_child_mints_a_family_whose_blockers_are_all_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control for the child gate — in-process, because the point is the
+    gate and not the export: a declaration with no open blocker passes it
+    silently, and one with an open blocker does not."""
+    reset_export_declarations()
+    try:
+        from gen_worker.api.export_contract import register_export_declaration
+
+        register_export_declaration(_clean(), replace=True)
+        mint_child._assert_family_mintable(FAMILY)  # no raise
+
+        register_export_declaration(blocked.BLOCKED_COMPILE, replace=True)
+        with pytest.raises(mint_child.MintChildRefused) as exc:
+            mint_child._assert_family_mintable(FAMILY)
+        assert all(i in str(exc.value) for i in blocked.OPEN_IDS)
+    finally:
+        reset_export_declarations()
+
+
+def test_the_image_BUILD_says_a_family_is_blocked_without_renting_a_pod() -> None:
+    """pgw#996's property, preserved across the fold: the static gate already
+    recorded a thunk's ``MintRefused`` as a ``blocked`` verdict, and it must
+    recognise the declared form too — otherwise folding a family turns a
+    build-time sentence into silence."""
+    from gen_worker import aot_preconditions as pre
+    from gen_worker.api.export_contract import register_export_declaration
+
+    reset_export_declarations()
+    try:
+        register_export_declaration(blocked.BLOCKED_COMPILE, replace=True)
+        rows = pre.static_mint_preconditions({FAMILY: 0}, torch_available=True,
+                                             torch_version="2.13.0+cu130")
+        verdicts = {r.check: r for r in rows}
+        row = verdicts[pre.CHECK_DECLARATION_EVALUATES]
+        assert row.verdict == pre.BLOCKED, [r.manifest_row() for r in rows]
+        assert all(i in row.detail for i in blocked.OPEN_IDS)
+        # A family that will never mint owes this image no toolchain row.
+        assert pre.CHECK_CXX_TOOLCHAIN not in verdicts
+
+        register_export_declaration(_clean(), replace=True)
+        rows = pre.static_mint_preconditions({FAMILY: 0}, torch_available=True,
+                                             torch_version="2.13.0+cu130")
+        assert {r.check: r.verdict for r in rows}[
+            pre.CHECK_DECLARATION_EVALUATES] == pre.OK
+    finally:
+        reset_export_declarations()
+
+
+# ---------------------------------------------------------------------------
+# 4. A fold cannot LOSE a refusal
+# ---------------------------------------------------------------------------
+
+
+def test_the_migration_gate_stops_a_fold_that_drops_a_blocker() -> None:
+    """pgw#1107's per-family gate is ``assert_faithful(standing, migrated)``.
+    A dropped blocker re-keys nothing and loosens nothing, so neither
+    ``contract_delta`` nor ``override_delta`` sees it — it just starts minting
+    against an open design question."""
+    standing = blocked.BLOCKED_COMPILE
+    migrated = _clean()
+    assert contract_delta(standing, migrated) == {}
+    assert blocker_delta(standing, migrated) == blocked.OPEN_IDS
+
+    with pytest.raises(DeclarationMismatch) as exc:
+        assert_faithful(standing, migrated, family=FAMILY)
+    assert "REFUSAL dropped" in str(exc.value)
+    for ident in blocked.OPEN_IDS:
+        assert ident in str(exc.value)
+
+
+def test_a_fold_that_ADDS_a_blocker_is_faithful() -> None:
+    """Directional on purpose. ltx-video-2.3's blockers live OUTSIDE its
+    Compile today (a module table read by a refusing thunk), so its fold
+    ADDS them to the declaration — and that is the fold working, not a
+    mismatch."""
+    assert blocker_delta(_clean(), blocked.BLOCKED_COMPILE) == ()
+    assert_faithful(_clean(), blocked.BLOCKED_COMPILE, family=FAMILY)
+
+
+def test_resolving_a_blocker_in_the_MIGRATED_half_counts_as_dropping_it() -> None:
+    """Resolving is a reviewable edit to the standing declaration, never a
+    side effect of a move."""
+    rows = tuple(
+        msgspec.structs.replace(b, resolved=True, resolution="in the fold")
+        for b in blocked.BLOCKED_COMPILE.blockers)
+    assert blocker_delta(
+        blocked.BLOCKED_COMPILE, _clean(blockers=rows)) == blocked.OPEN_IDS
+
+
+def test_assert_blockers_is_the_per_family_guard() -> None:
+    """The gate above can only compare two Compiles, and the family that most
+    needs the guard keeps its blockers outside its Compile today — so the
+    expectation is stated in the family's OWN test, where it survives the file
+    the blockers used to live in."""
+    assert_blockers(blocked.BLOCKED_COMPILE, ids=blocked.OPEN_IDS, family=FAMILY)
+    assert_blockers(_clean(), ids=(), family=FAMILY)
+
+    with pytest.raises(DeclarationMismatch) as exc:
+        assert_blockers(_clean(), ids=blocked.OPEN_IDS, family=FAMILY)
+    assert "MISSING" in str(exc.value)
+
+    with pytest.raises(DeclarationMismatch) as exc:
+        assert_blockers(blocked.BLOCKED_COMPILE, ids=(), family=FAMILY)
+    assert "UNEXPECTED" in str(exc.value)


### PR DESCRIPTION
## The defect (found by the pgw#1107 fold lane, verified against the tree)

pgw#1107 puts every family's compile declaration on `@endpoint(compile=Compile(...))` and deletes `aot_declaration.py`. `compile=` accepts a `Compile` and **never a callable** — but three families register a THUNK (`ltx-video-2.3`, `qwen-image`, `z-image`), and ltx's thunk genuinely **refuses to build a `Compile` at all**: it stands on three unresolved mint blockers (OQ-2 audio_timestep rank, OQ-3 whole-graph OOM never measured on the served w8a8 lane, OQ-8 live coverage gaps that predate AOT). Folding it verbatim would have **silently deleted a live mint refusal** and let the family mint against three open design questions. (qwen's and z-image's blockers are all `resolved=True`, so those two fold with nothing to lose — ltx is the only live refusal in the fleet.)

## The ruling implemented: refusal becomes DATA

```python
@endpoint(compile=Compile(
    family="ltx-2.3", ...,
    blockers=(
        MintBlocker(
            id="OQ-2-audio_timestep-rank",
            what="`audio_timestep` is RANK-1 on generate and RANK-2 on edit ...",
            evidence="pipeline_ltx2_audio.py:292 vs pipeline_ltx2_edit.py:294 ...",
            resolves_when="The endpoint builds (B, 1) instead of (B,) ...",
        ),
    ),
))
```

SDK vocabulary plus literals — nothing callable, no torch, no runtime state, nothing to evaluate. That is what lets the endpoint repo's **torch-free** declaration lint read a family's open blockers out of an AST-extracted `compile=` expression instead of renting a pod to hear the sentence.

## Fails CLOSED, everywhere a mint can start, naming the ids

| site | behaviour |
|---|---|
| `fleet_cells.mint_recipe` | declines under its own `declaration_blocked` phase (typed `self_mint_skipped`, blocker text intact) |
| `mint_child.mint` | `MintChildRefused` after discovery, **before a weight is read** — pgw#1080's pattern: split by type, fail closed, never degrade |
| `aot_preconditions` (image build) | keeps recording the existing `blocked` verdict (pgw#996), which the fold would otherwise have turned into silence |

**Serving is untouched**: a blocked family serves eager exactly as today; boot-adopt is not consulted. Blockers are deliberately **not** a contract axis — resolving one re-keys nothing.

## A fold cannot lose a refusal

- closing a blocker requires a `resolution=` citation, so an unblock is a reviewable edit rather than a bool flip;
- `assert_faithful` now STOPs on a **dropped** blocker (directional: ADDING one is the fold working, which is exactly ltx's shape);
- `assert_blockers(decl, ids=...)` states the expectation in the family's **own** test — the only guard that survives the file ltx's blockers live in today.

## Tests — `tests/test_declared_blockers_pgw1115.py`, 20 passed, cardless ($0, no pod, no GPU, no weights)

RED-first, verified by reverting each production hunk in place: 5 rows go red (recipe gate, serving-unaffected, build gate, migration gate, callable-rejection), and the child row goes red on its own (`crashed`/exit 1 instead of a terminal `EXIT_REFUSED`).

- the child half runs the **real** entrypoint — `python -m gen_worker.mint_child request.json` through the parent's real supervisor;
- the torch-free half evaluates the AST-extracted declaration in a subprocess with `torch`, `diffusers`, `transformers`, `triton` and `torchvision` blocked at the import system, and asserts `torch not in sys.modules`.

mypy clean (256 files), ruff clean, every fast-gate lint green.

Tracker: pgw#1115. Blocks: ie#645's ltx row (the fold lane is holding it on this).