### PR TITLE
pgw#1116: a boot-adopt refusal names its own gate, on the wire

### DIFF
--- a/changelog.d/pgw1116.md
+++ b/changelog.d/pgw1116.md
@@ -1,0 +1,37 @@
+- **pgw#1116: a boot-adopt refusal now names its own gate on the wire — the
+  reason existed and nothing could read it.** `BootAdoptOutcome.reason`,
+  `.detail`, `.derived_key` and `.derive_ms` had **zero readers outside
+  `boot_adopt.py`**: the executor consumed only `.adoption`, and its own three
+  pre-attempt gates returned a bare `None` that built no outcome at all. So all
+  of `boot_adopt`'s documented refusals — plus three gates that produced
+  literally nothing — presented identically as "a pod that quietly self-minted".
+  That is why a merged fix (pgw#1108) and a published wheel (0.103.0) both
+  shipped over a boot-adopt that called `POST /v1/worker/cells/resolve` **zero
+  times** on three real pods: hub-spawned pods expose no stdout (pgw#760), so a
+  `logger.info` is not observability, and localising the refusal needed an
+  event, not another pod.
+
+  Every terminus now emits exactly ONE typed `boot_adopt` activity event
+  (`activity.KIND_BOOT_ADOPT`) whose `phase` is the gate's own token —
+  `no_export_declaration`, `declaration_refused`, `declaration_unreadable`,
+  `no_hub`, `eager_only`, `structure_unsupported`, `child_died`,
+  `derive_failed`, the hub's typed `cell_resolve_*` codes, `miss`,
+  `materialize_failed`, `witness_unreadable`, `graph_witness_mismatch`, `hit` —
+  with `detail` carrying family, function, derived key and the sentence, and
+  `duration_ms` carrying the derivation's measured wall as a numeric column.
+  "adopt failed" is not an answer this module is able to give. The complete
+  vocabulary is `boot_adopt.REASONS`, and a test reads the refusal sites out of
+  `boot_trace_child`, `boot_key`, `boot_adopt` and `executor` and fails on any
+  token it does not carry, so a new refusal cannot become the next silent one.
+
+  Two behaviour changes ride with it. `Executor._boot_adopt` returns a
+  `BootAdoptOutcome` **always**, never `None`. And a pgw#853 THUNK declaration
+  that REFUSES (open mint blockers) no longer escapes uncaught: it used to
+  leave `_boot_adopt`, leave `asyncio.to_thread` and fail the model setup —
+  a blocked family's mint refusal taking serving down, which is the exact blast
+  radius pgw#853 exists to prevent. It is now a `declaration_refused` outcome
+  and the pod serves.
+
+  A pod that derived a key and got a MISS is now distinguishable from a pod
+  that never derived one, which is the fact the reuse-circle proof needed and
+  did not have.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -136,6 +136,15 @@ KIND_RESIDENCY_FAULT = "residency_fault"
 # serve a lane their checkpoint does not name" is one query, not an inference
 # from allocated-bytes rows.
 KIND_APPLIED_LANE = "applied_lane"
+# pgw#1116: the boot-time adopt decision (§4.27 steps 1-3). EVERY boot of a
+# compiled family emits exactly one of these — hit, miss, and each named
+# refusal — because the alternative is what pgw#1108's pod proof measured: a
+# merged fix and a published wheel both sailed past a boot-adopt that never
+# called the hub, since all of `BootAdoptOutcome`'s eight refusals presented
+# identically as "a pod that quietly self-minted". `phase` is the gate token
+# (`boot_adopt.REASONS`, countable hub-side); `detail` names family, function,
+# derived key and the sentence; `duration_ms` is the derivation's own wall.
+KIND_BOOT_ADOPT = "boot_adopt"
 # th#1322: JIT (dynamo/inductor) compile duration, as a typed numeric event.
 # It used to be `logger.info("compiled %s in %.0fs")` and nothing else, so on a
 # hub-spawned pod (no stdout, pgw#760) the one number an AOT-vs-JIT comparison

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -29,6 +29,23 @@ branch is how the reason ends up being `logger.debug`.
 
 **Never fatal.** A cold boot that cannot adopt is the boot every pod did before
 this existed. The one thing this must never do is prevent a pod from serving.
+
+Never SILENT either (pgw#1116)
+------------------------------
+"Never fatal" was implemented as "never observed". ``reason``/``detail``/
+``derived_key``/``derive_ms`` had zero readers outside this module — the
+executor consumed only ``adoption`` — and the executor's own pre-attempt gates
+returned a bare ``None`` that carried no reason at all. So all of the refusals
+above, plus three gates that never even built an outcome, presented identically
+as "a pod that quietly self-minted". A merged fix (pgw#1108) and a published
+wheel (0.103.0) both shipped over a boot-adopt that called the hub ZERO times
+on three real pods, because off-pod there was nothing to read: hub-spawned pods
+expose no stdout (pgw#760), so a `logger.info` is not observability.
+
+Every terminus therefore emits ONE typed :data:`~gen_worker.activity.
+KIND_BOOT_ADOPT` event whose ``phase`` is the gate's own token — see
+:data:`REASONS`, which is exhaustive and fenced by test. "adopt failed" is not
+an answer this module is able to give.
 """
 
 from __future__ import annotations
@@ -36,12 +53,64 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from . import aot_identity, artifact_meta, boot_key, cell_resolve
+from . import activity, aot_identity, artifact_meta, boot_key, cell_resolve
 from .mint_process import CompileCellSpec, MintSlot
 
 logger = logging.getLogger(__name__)
+
+#: Gates that refuse BEFORE :func:`attempt` is entered — the executor's own
+#: preconditions. These are the ones that used to be a bare ``return None``.
+GATE_REASONS: Tuple[str, ...] = (
+    # `aot_mint.export_declaration(family)` answered None: this family ships no
+    # export declaration, so no key can name its class set.
+    "no_export_declaration",
+    # A pgw#853 THUNK declaration REFUSED to build (open mint blockers). It used
+    # to escape `_boot_adopt` uncaught and take the whole model setup down.
+    "declaration_refused",
+    # The declaration exists but `aot_declaration.cell_plans` will not enumerate
+    # it (colliding entry names, no targets).
+    "declaration_unreadable",
+    # No hub to ask: no HelloAck base URL yet, or an embedded single-process
+    # worker with neither a local bearer nor a control seam (pgw#1108).
+    "no_hub",
+    # The pod's topology forbids arming at all (pgw#775), so a compiled family
+    # boots without asking. Correct, and previously indistinguishable from a
+    # boot-adopt that asked and was refused.
+    "eager_only",
+)
+
+#: Step 1 — the derivation. ``boot_key.BootKeyUnavailable.reason`` tokens,
+#: including the ones a trace child names in its own report
+#: (``boot_trace_child._fail``), which ``boot_key.derive`` re-raises verbatim.
+DERIVE_REASONS: Tuple[str, ...] = (
+    "no_classes", "code_drift", "class_set_disagreement", "class_set_gap",
+    "trace_failed", "bad_report", "child_died", "refused", "child_error",
+    "slots_unresolvable", "structure_unsupported", "no_compile_target",
+    "structure_not_honored", "no_declaration", "trace_refused", "empty_share",
+    # The derivation raised something that is not a typed BootKeyUnavailable.
+    "derive_failed",
+)
+
+#: Steps 2-3 — asking the hub, materializing, and the pgw#1031 witness floor.
+#: The hub's own typed refusal codes ride through verbatim, which is the point
+#: of them being typed.
+ASK_REASONS: Tuple[str, ...] = (
+    "invalid_request", "cell_resolve_key_mismatch", "resolve_unreachable",
+    "miss", "materialize_failed", "witness_unreadable",
+    "graph_witness_mismatch", "hit",
+) + tuple(cell_resolve.REFUSAL_CODES)
+
+#: The COMPLETE boot-adopt vocabulary. A path that can produce a token missing
+#: from here is a path that can be silent again, so
+#: ``tests/test_boot_adopt_observability_pgw1116.py`` reads the refusal sites
+#: out of the tree and fails on any token this tuple does not carry.
+REASONS: Tuple[str, ...] = GATE_REASONS + DERIVE_REASONS + ASK_REASONS
+
+#: The one outcome that armed something. Everything else means "boot as this pod
+#: booted yesterday", and each of those means it for a DIFFERENT reason.
+HIT = "hit"
 
 
 @dataclass(frozen=True)
@@ -79,10 +148,60 @@ class BootAdoptOutcome:
     detail: str = ""
     derived_key: str = ""
     derive_ms: int = 0
+    #: Which family and which routable function this decision was about. Carried
+    #: on the outcome rather than interpolated at the emit site so a reader of
+    #: the event never has to join it back to anything (pgw#1116).
+    family: str = ""
+    function: str = ""
 
     @property
     def adopted(self) -> bool:
         return self.adoption is not None
+
+
+def report(outcome: BootAdoptOutcome) -> BootAdoptOutcome:
+    """Emit this decision as ONE typed event, and return it unchanged.
+
+    The whole of pgw#1116: on a hub-spawned pod stdout goes nowhere, so a
+    boot-adopt outcome that is only logged is a boot-adopt outcome nobody can
+    read. ``phase`` is the gate token — never a summary — because the question
+    the fleet asks is *which* gate, and "adopt failed" makes eight different
+    bugs look like one.
+
+    Returns the outcome so every terminus can be ``return report(...)`` and the
+    "exactly one event per decision" property is structural rather than
+    remembered.
+    """
+    detail = (
+        f"family={outcome.family or '?'} function={outcome.function or '?'} "
+        f"key={outcome.derived_key or '-'}"
+        + (f" — {outcome.detail}" if outcome.detail else "")
+    )
+    activity.emit_event(
+        activity.KIND_BOOT_ADOPT, detail, phase=outcome.reason or "unreported",
+        duration_ms=outcome.derive_ms)
+    if outcome.reason == HIT:
+        logger.info("boot-adopt[%s]: %s", outcome.reason, detail)
+    else:
+        # A refusal is a confession, and a pod's own boot log is where an
+        # operator with a shell reads it. The EVENT is what everyone else reads.
+        logger.warning("boot-adopt[%s]: %s", outcome.reason, detail)
+    return outcome
+
+
+def refused(
+    reason: str, detail: str, *, family: str = "", function: str = "",
+) -> BootAdoptOutcome:
+    """A gate that refuses BEFORE :func:`attempt` — reported, never a bare None.
+
+    The executor's three pre-attempt gates used to ``return None``, which is
+    the one shape that cannot say anything: no reason, no detail, no event, and
+    a caller that could not tell "this pod had nobody to ask" from "this pod
+    asked and was told no".
+    """
+    return report(BootAdoptOutcome(
+        reason=str(reason), detail=str(detail),
+        family=str(family), function=str(function)))
 
 
 def attempt(
@@ -106,8 +225,12 @@ def attempt(
     the trace pool and nothing else. ``envelope`` is
     ``fleet_cells.declared_envelope_block(cfg)``, i.e. the same extraction the
     publish path recomputes the envelope axis from.
+
+    Exactly ONE :data:`~gen_worker.activity.KIND_BOOT_ADOPT` event is emitted
+    per call, on every terminus including the hit — see :func:`report`.
     """
     family = str(getattr(cfg, "family", "") or "")
+    fn = str(function)
     spec = CompileCellSpec(
         shapes=tuple(
             tuple(int(v) for v in row)
@@ -134,14 +257,19 @@ def attempt(
             device=int(device),
         )
     except boot_key.BootKeyUnavailable as exc:
-        logger.info(
-            "boot-adopt: no derived key for %s (%s) — this pod adopts nothing "
-            "and mints the ordinary way: %s", family, exc.reason, exc.detail)
-        return BootAdoptOutcome(reason=exc.reason, detail=exc.detail)
+        # The reason is a trace child's own token when a child refused
+        # (`boot_trace_child._fail`) — `structure_unsupported` and
+        # `slots_unresolvable` are the two that name a family the boot path
+        # cannot key at all, and they are the whole point of not collapsing
+        # this to "derive failed".
+        return report(BootAdoptOutcome(
+            reason=exc.reason, detail=exc.detail,
+            family=family, function=fn))
     except Exception as exc:  # noqa: BLE001 — never fatal, see the docstring
-        logger.warning("boot-adopt: key derivation failed", exc_info=True)
-        return BootAdoptOutcome(
-            reason="derive_failed", detail=f"{type(exc).__name__}: {exc}")
+        logger.debug("boot-adopt: key derivation failed", exc_info=True)
+        return report(BootAdoptOutcome(
+            reason="derive_failed", detail=f"{type(exc).__name__}: {exc}",
+            family=family, function=fn))
 
     key = derived.digest
     logger.info(
@@ -157,32 +285,37 @@ def attempt(
         # a full cold mint believing the hub holds nothing, which is false and
         # expensive. It still degrades to the old boot; it is the SENTENCE
         # that differs, and that sentence is what gets the hub fixed.
-        logger.warning(
-            "boot-adopt: the hub REFUSED to resolve %s: %s", key, exc)
-        return BootAdoptOutcome(
-            reason=exc.code, detail=exc.detail,
-            derived_key=key, derive_ms=derived.wall_ms)
+        return report(BootAdoptOutcome(
+            reason=exc.code or "resolve_unreachable", detail=exc.detail,
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
     except Exception as exc:  # noqa: BLE001
-        logger.warning("boot-adopt: resolve call failed", exc_info=True)
-        return BootAdoptOutcome(
+        logger.debug("boot-adopt: resolve call failed", exc_info=True)
+        return report(BootAdoptOutcome(
             reason="resolve_unreachable", detail=f"{type(exc).__name__}: {exc}",
-            derived_key=key, derive_ms=derived.wall_ms)
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
 
     if cell is None:
-        return BootAdoptOutcome(
+        # A pod that DERIVED a key and was told MISS is a different fact from a
+        # pod that never derived one — `derived_key` is what tells them apart,
+        # and it is on the event.
+        return report(BootAdoptOutcome(
             reason="miss",
             detail=f"the hub holds no entitled cell for {key}",
-            derived_key=key, derive_ms=derived.wall_ms)
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
 
     try:
         artifact = cell_resolve.materialize(
             cell, cache_dir=Path(cache_dir) if cache_dir else None,
             what=f"boot adopt of {key} (family {family})")
     except Exception as exc:  # noqa: BLE001
-        logger.warning("boot-adopt: materialize failed", exc_info=True)
-        return BootAdoptOutcome(
+        logger.debug("boot-adopt: materialize failed", exc_info=True)
+        return report(BootAdoptOutcome(
             reason="materialize_failed", detail=f"{type(exc).__name__}: {exc}",
-            derived_key=key, derive_ms=derived.wall_ms)
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
 
     # pgw#1031, THE GRAPH-WITNESS FLOOR. Everything above this line agreed on
     # the KEY, and the key is an ingress identity: two endpoints whose declared
@@ -199,32 +332,38 @@ def attempt(
         # only one of them.
         meta = artifact_meta.read_metadata(Path(artifact))
     except Exception as exc:  # noqa: BLE001 — unreadable IS unproven
-        logger.warning("boot-adopt: metadata unreadable", exc_info=True)
-        return BootAdoptOutcome(
+        logger.debug("boot-adopt: metadata unreadable", exc_info=True)
+        return report(BootAdoptOutcome(
             reason="witness_unreadable",
             detail=(
                 f"the materialized cell for {key} would not state its "
                 f"metadata ({type(exc).__name__}: {exc}), so its graphs cannot "
                 f"be shown to be this pod's graphs"),
-            derived_key=key, derive_ms=derived.wall_ms)
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
     mismatch = aot_identity.verify_graph_witness(
         meta, derived.graph_witnesses)
     if mismatch:
-        logger.error(
-            "boot-adopt: REFUSING %s (%s) — the key matched and the graph did "
-            "not: %s. This pod serves eager and mints its own.",
-            key, cell.cell_ref, mismatch)
-        return BootAdoptOutcome(
-            reason="graph_witness_mismatch", detail=mismatch,
-            derived_key=key, derive_ms=derived.wall_ms)
+        return report(BootAdoptOutcome(
+            reason="graph_witness_mismatch",
+            detail=(
+                f"the key matched {cell.cell_ref} and the graph did not: "
+                f"{mismatch}. This pod serves eager and mints its own."),
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
 
-    logger.info(
-        "boot-adopt: %s resolved to %s (%s tier) and materialized at %s — "
-        "arming with ZERO dispatches having occurred",
-        key, cell.cell_ref, cell.publisher_tier, artifact)
-    return BootAdoptOutcome(
+    return report(BootAdoptOutcome(
         adoption=BootAdoption(derived=derived, cell=cell, artifact=artifact),
-        reason="hit", derived_key=key, derive_ms=derived.wall_ms)
+        reason=HIT,
+        detail=(
+            f"resolved to {cell.cell_ref} ({cell.publisher_tier} tier), "
+            f"materialized at {artifact} — arming with ZERO dispatches having "
+            f"occurred"),
+        derived_key=key, derive_ms=derived.wall_ms,
+        family=family, function=fn))
 
 
-__all__ = ["BootAdoptOutcome", "BootAdoption", "attempt"]
+__all__ = [
+    "ASK_REASONS", "BootAdoptOutcome", "BootAdoption", "DERIVE_REASONS",
+    "GATE_REASONS", "HIT", "REASONS", "attempt", "refused", "report",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -6813,7 +6813,7 @@ class Executor:
         if arm is None and spec.compile is not None and not eager_only:
             adopt = await asyncio.to_thread(
                 self._boot_adopt, spec, resolved_slots)
-            if adopt is not None and adopt.adoption is not None:
+            if adopt.adoption is not None:
                 got = adopt.adoption
                 compile_selection = _CompileArtifactSelection(
                     path=got.artifact, ref=got.ref,
@@ -6823,6 +6823,16 @@ class Executor:
                     backend="aot_cell", selection=compile_selection,
                     expected=got.expected,
                     publisher_org=got.cell.publisher_org)
+        elif arm is None and spec.compile is not None:
+            # pgw#1116: a compiled family that boots WITHOUT asking is a fact
+            # somebody has to be able to read. This is the only branch where
+            # that is correct by design (pgw#775 forbids arming here at all) —
+            # so it says so, rather than being the ninth way to look like a pod
+            # that quietly self-minted.
+            boot_adopt.refused(
+                "eager_only", eager_only,
+                family=str(getattr(spec.compile, "family", "") or ""),
+                function=str(spec.name or ""))
         # pgw#947: the serving-kernel lane comes from the CELL, and it has to
         # be pinned BEFORE setup() — the linears are swapped at model load, so
         # a verdict read afterwards would arrive one whole pipeline too late.
@@ -9757,24 +9767,49 @@ class Executor:
 
     def _boot_adopt(
         self, spec: EndpointSpec, slots: Dict[str, MintSlot],
-    ) -> "Optional[boot_adopt.BootAdoptOutcome]":
+    ) -> "boot_adopt.BootAdoptOutcome":
         """§4.27 steps 1-3 for one boot, off the event loop.
 
-        Returns ``None`` when this pod cannot even ATTEMPT the derivation (no
-        declaration for the family, no hub credential yet) — which is not a
-        failure, it is the state every pod was in before this seam existed.
-        Everything past that point is a :class:`BootAdoptOutcome`, and every
-        one of its non-hit outcomes means "boot as this pod booted yesterday".
+        ALWAYS an outcome, never ``None`` (pgw#1116). The three gates below
+        used to return a bare ``None`` — "this pod cannot even attempt the
+        derivation" — which is a true statement that names nothing: no family,
+        no gate, no event, and a caller unable to tell it from a pod that asked
+        the hub and was told no. Three real pods on 0.103.0 called
+        ``/v1/worker/cells/resolve`` ZERO times and no artifact anywhere said
+        which of these gates did it. Each one now names itself and emits.
+
+        None of them is fatal, and none of them is new behaviour: every non-hit
+        outcome still means "boot as this pod booted yesterday".
         """
         cfg = spec.compile_cell()
         family = str(getattr(cfg, "family", "") or "")
-        decl = aot_mint.export_declaration(family)
+        fn = str(spec.name or "")
+        try:
+            decl = aot_mint.export_declaration(family)
+        except Exception as exc:  # noqa: BLE001
+            # pgw#853: a THUNK declaration is EVALUATED by this accessor and
+            # its exception is let out here. Uncaught, it left `_boot_adopt`,
+            # left `asyncio.to_thread`, and failed the model setup — a blocked
+            # family's mint refusal taking serving down, which is the exact
+            # blast radius pgw#853 exists to prevent.
+            return boot_adopt.refused(
+                "declaration_refused",
+                f"family {family!r} declares a mint refusal: "
+                f"{type(exc).__name__}: {exc}", family=family, function=fn)
         if decl is None:
-            return None
+            return boot_adopt.refused(
+                "no_export_declaration",
+                f"family {family!r} has no registered export declaration, so "
+                f"this boot cannot state the class set a cell key names",
+                family=family, function=fn)
         try:
             declared_hint = len(list(aot_declaration.cell_plans(decl)))
-        except Exception:  # noqa: BLE001 — never fatal
-            return None
+        except Exception as exc:  # noqa: BLE001 — never fatal
+            return boot_adopt.refused(
+                "declaration_unreadable",
+                f"family {family!r} has a declaration this boot cannot "
+                f"enumerate: {type(exc).__name__}: {exc}",
+                family=family, function=fn)
         base_url = str(self.file_base_url or "")
         bearer = str(self.worker_jwt_provider() or "")
         # pgw#1108: the credential lives in the PARENT under the split (pgw#783),
@@ -9792,7 +9827,12 @@ class Executor:
             # Genuinely nobody to ask: pre-Hello (no base_url yet), or an embedded
             # single-process worker with no hub and no seam. Deriving a key nobody
             # will answer is pure boot latency.
-            return None
+            return boot_adopt.refused(
+                "no_hub",
+                "nobody to ask: base_url={} bearer={} seam={}".format(
+                    base_url or "<unset>", "set" if bearer else "<unset>",
+                    "up" if procsplit_broker.active() else "down"),
+                family=family, function=fn)
         work_root = Path(
             self.store._cache_dir or Path.home() / ".cache" / "gen-worker"
         ) / "boot-key" / (spec.name or "endpoint")

--- a/tests/test_boot_adopt_credential_pgw1108.py
+++ b/tests/test_boot_adopt_credential_pgw1108.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 
@@ -78,7 +78,7 @@ def wired(monkeypatch, tmp_path):
     return ex, calls
 
 
-def _run_boot_adopt(ex: Any) -> Optional[Any]:
+def _run_boot_adopt(ex: Any) -> Any:
     return ex._boot_adopt(_Spec(), {})
 
 
@@ -99,10 +99,17 @@ def test_split_child_with_seam_up_resolves_though_it_holds_no_jwt(wired):
 
 def test_no_bearer_and_no_seam_degrades_without_deriving(wired):
     """The gate must STILL protect the genuinely-no-hub case: no local bearer
-    and no seam means nobody to ask, so no derive/resolve, no attempt."""
+    and no seam means nobody to ask, so no derive/resolve, no attempt.
+
+    pgw#1116: it degrades by NAMING itself (`no_hub`), never by returning a
+    bare None — a refusal that carries no reason is how three pods refused
+    unattributably.
+    """
     ex, calls = wired
     # broker._broker is None (fixture); seam is down.
-    assert _run_boot_adopt(ex) is None
+    out = _run_boot_adopt(ex)
+    assert out is not None and out.reason == "no_hub"
+    assert not out.adopted
     assert calls == []
 
 
@@ -111,5 +118,8 @@ def test_single_process_bearer_still_resolves_with_no_seam(wired):
     JWT locally. Unchanged — boot-adopt proceeds."""
     ex, calls = wired
     ex.worker_jwt_provider = lambda: "real-jwt"
-    assert _run_boot_adopt(ex) is not None or calls  # attempt ran
-    assert len(calls) == 1
+    out = _run_boot_adopt(ex)
+    # NOT `x is not None or calls` — that disjunction could never fail on the
+    # old code either, which is the tautology class pgw#1113 is fixing.
+    assert len(calls) == 1, "boot-adopt did not attempt derive/resolve"
+    assert out.reason == "miss"

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -1,0 +1,547 @@
+"""pgw#1116: a boot-adopt refusal must NAME ITS GATE, on the wire.
+
+The measured defect (pgw#1108's POD PROOF, three real pods on 0.103.0):
+``/v1/worker/cells/resolve`` was called **zero** times, every pod self-minted,
+and nothing off-pod could say why — ``BootAdoptOutcome.reason``/``.detail``/
+``.derived_key``/``.derive_ms`` had zero readers outside ``boot_adopt.py`` (the
+executor consumed only ``.adoption``), and the executor's own three pre-attempt
+gates returned a bare ``None`` that built no outcome at all. So a merged fix and
+a published wheel both sailed past a completely broken adopt path.
+
+What is proved here:
+
+1. **Every gate is individually distinguishable on the wire.** One typed
+   ``boot_adopt`` activity event per decision, ``phase`` = the gate's own token.
+   Parametrized over every terminus — the four executor pre-attempt gates, the
+   eager-only non-entry, each ``attempt`` refusal, the miss and the hit.
+2. **The vocabulary is exhaustive.** Every refusal token any path in the tree
+   can produce is in ``boot_adopt.REASONS``; a new refusal that forgets to name
+   itself fails here rather than becoming the next silent one.
+3. **A pod that DERIVED a key and missed is distinguishable from a pod that
+   never derived one** (the issue's regression box).
+4. **A boot with no local cell and a reachable hub actually issues the resolve
+   call** — driven end to end through the real ``Executor._boot_adopt``, the
+   real ``boot_key.derive`` (three structure-only trace children, fake tensors,
+   no compile anywhere) and a real HTTP hub, against ``examples/micro-diffusion``
+   — the exact vehicle the three pods ran.
+
+None of this traces a real checkpoint, links a ``.so`` or mints: the derivation
+is fake-tensor tracing, which is what the "mints run on remote machines only"
+rule explicitly permits.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Dict, Iterator, List
+
+import pytest
+
+from gen_worker import activity, boot_adopt, boot_key, cell_resolve
+from gen_worker import executor as executor_mod
+
+
+def _raise(exc: BaseException) -> Any:
+    def _f(*_a: Any, **_k: Any) -> Any:
+        raise exc
+
+    return _f
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+
+KEY = "ck1-" + "3f" * 28
+
+
+# ---------------------------------------------------------------------------
+# Capture: the REAL sink, so the assertions read the same ActivityUpdate the
+# hub's worker_activity_events row is built from.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def events(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    seen: List[Any] = []
+    monkeypatch.setattr(activity, "_sink", seen.append, raising=False)
+    return seen
+
+
+def _adopt_events(seen: List[Any]) -> List[Any]:
+    return [u for u in seen if u.kind == activity.KIND_BOOT_ADOPT]
+
+
+def _one(seen: List[Any]) -> Any:
+    rows = _adopt_events(seen)
+    assert len(rows) == 1, (
+        "a boot-adopt decision must emit EXACTLY one typed event — got "
+        f"{[(u.kind, u.phase) for u in seen]}")
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. The vocabulary is exhaustive — read out of the tree, not restated
+# ---------------------------------------------------------------------------
+
+
+def _tokens(path: Path, pattern: str) -> List[str]:
+    return re.findall(pattern, path.read_text())
+
+
+def test_every_refusal_token_in_the_tree_is_in_the_vocabulary() -> None:
+    """A refusal path that names a token ``REASONS`` does not carry is a path
+    whose event nobody can enumerate, count or alert on — i.e. the next silent
+    one. Read the sites out of the source so adding a refusal without adding
+    its name fails HERE."""
+    src = REPO / "src" / "gen_worker"
+    found: Dict[str, str] = {}
+    for token in _tokens(
+        src / "boot_trace_child.py", r"_fail\(\s*report_path,\s*\"([a-z_]+)\"",
+    ):
+        found[token] = "boot_trace_child._fail"
+    for token in _tokens(
+        src / "boot_key.py", r"BootKeyUnavailable\(\s*\n?\s*\"([a-z_]+)\"",
+    ):
+        found[token] = "boot_key.BootKeyUnavailable"
+    for token in _tokens(
+        src / "boot_key.py", r"reason=\"([a-z_]+)\"",
+    ):
+        found[token] = "boot_key trace report"
+    for token in _tokens(
+        src / "executor.py", r"boot_adopt\.refused\(\s*\n?\s*\"([a-z_]+)\"",
+    ):
+        found[token] = "executor gate"
+    for token in _tokens(
+        src / "boot_adopt.py", r"reason=\"([a-z_]+)\"",
+    ):
+        found[token] = "boot_adopt.attempt"
+
+    assert found, "the scan found no refusal sites at all — the patterns rotted"
+    missing = sorted(
+        f"{token} ({where})" for token, where in found.items()
+        if token not in boot_adopt.REASONS)
+    assert not missing, (
+        "these refusal paths can produce a token boot_adopt.REASONS does not "
+        f"carry, so their events are unenumerable: {missing}")
+
+
+def test_the_vocabulary_names_the_gates_that_used_to_return_a_bare_none() -> None:
+    """The three executor pre-attempt gates are the ones that produced NOTHING
+    — not even a discarded reason. They are the reason one pod could not name
+    its own refusal."""
+    for token in ("no_export_declaration", "declaration_unreadable", "no_hub"):
+        assert token in boot_adopt.GATE_REASONS
+
+
+# ---------------------------------------------------------------------------
+# 2. The executor's pre-attempt gates: each names itself, and none returns None
+# ---------------------------------------------------------------------------
+
+
+class _Cfg:
+    family = "micro-diffusion"
+    targets = ("transformer",)
+    shapes = ((64, 64),)
+    text_lens = (8,)
+    guidance_scales = ()
+    lora_bucket = 0
+
+
+class _Spec:
+    name = "generate"
+    module = "micro_diffusion.main"
+    compile = _Cfg()
+
+    def compile_cell(self) -> _Cfg:
+        return _Cfg()
+
+
+def _executor(tmp_path: Path) -> Any:
+    from gen_worker.executor import Executor, ModelStore
+
+    async def _send(msg: Any) -> None:
+        pass
+
+    ex = Executor([], _send, store=ModelStore(_send, cache_dir=tmp_path / "cas"))
+    ex.file_base_url = "http://hub.local"
+    ex.worker_jwt_provider = lambda: "worker-jwt"
+    return ex
+
+
+class _Blocked:
+    """A pgw#853 thunk-shaped declaration that REFUSES when asked."""
+
+
+@pytest.mark.parametrize(
+    "gate,wire,expect",
+    [
+        (
+            "no_export_declaration",
+            lambda mp: mp.setattr(
+                executor_mod.aot_mint, "export_declaration", lambda f: None),
+            "no registered export declaration",
+        ),
+        (
+            "declaration_refused",
+            lambda mp: mp.setattr(
+                executor_mod.aot_mint, "export_declaration",
+                _raise(RuntimeError("OQ-2 audio_timestep rank unresolved"))),
+            "audio_timestep",
+        ),
+        (
+            "declaration_unreadable",
+            lambda mp: mp.setattr(
+                executor_mod.aot_declaration, "cell_plans",
+                _raise(ValueError("two mint plans share entry name"))),
+            "share entry name",
+        ),
+    ],
+)
+def test_each_pre_attempt_gate_names_itself_on_the_wire(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+    gate: str, wire: Any, expect: str,
+) -> None:
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: object())
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", lambda d: [object()])
+    monkeypatch.setattr(
+        executor_mod.boot_adopt, "attempt",
+        _raise(AssertionError("attempt must not be reached past this gate")))
+    wire(monkeypatch)
+
+    out = _executor(tmp_path)._boot_adopt(_Spec(), {})
+
+    assert out is not None, (
+        "a gate that returns a bare None carries no reason, no family and no "
+        "event — which is exactly how three pods refused unattributably")
+    assert out.reason == gate
+    assert not out.adopted
+    row = _one(events)
+    assert row.phase == gate, (
+        "the event's phase must be the GATE's own token — 'adopt failed' makes "
+        "eight different bugs look like one")
+    assert "family=micro-diffusion" in row.detail
+    assert "function=generate" in row.detail
+    assert expect in row.detail
+
+
+def test_no_hub_names_which_half_of_the_readiness_was_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+) -> None:
+    from gen_worker.procsplit import broker
+
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: object())
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", lambda d: [object()])
+    monkeypatch.setattr(broker, "_broker", None, raising=False)
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = ""
+    ex.worker_jwt_provider = lambda: ""
+
+    out = ex._boot_adopt(_Spec(), {})
+    assert out.reason == "no_hub"
+    row = _one(events)
+    assert row.phase == "no_hub"
+    assert "base_url=<unset>" in row.detail and "seam=down" in row.detail
+
+
+def test_the_gates_are_pairwise_distinguishable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The property the pod proof needed and did not have: knowing an adopt did
+    not happen is worth nothing unless the phases differ."""
+    seen: List[str] = []
+    monkeypatch.setattr(
+        activity, "_sink",
+        lambda u: seen.append(u.phase) if u.kind == activity.KIND_BOOT_ADOPT
+        else None, raising=False)
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", lambda d: [object()])
+
+    ex = _executor(tmp_path)
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: None)
+    ex._boot_adopt(_Spec(), {})
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: object())
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", _raise(ValueError("nope")))
+    ex._boot_adopt(_Spec(), {})
+    ex.file_base_url = ""
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", lambda d: [object()])
+    ex._boot_adopt(_Spec(), {})
+
+    assert len(seen) == len(set(seen)) == 3, (
+        f"three different refusals must read as three different phases: {seen}")
+
+
+# ---------------------------------------------------------------------------
+# 3. Every terminus inside `attempt` emits, hit included
+# ---------------------------------------------------------------------------
+
+
+def _derived(wall_ms: int = 1234) -> Any:
+    from gen_worker import cell_key as ck
+
+    return boot_key.DerivedKey(
+        key=ck.from_axes({
+            "graph": "c0ffee0000000000", "envelope": "e" * 16,
+            "sm": "sm_89", "toolchain": "t" * 16}),
+        class_hashes={"a": "0" * 16}, combined="c0ffee0000000000",
+        workers=2, width_reason="test", traced=1, memo="miss",
+        wall_ms=wall_ms)
+
+
+class _Cell:
+    publisher_org = "org-a"
+    publisher_tier = "platform"
+    cell_ref = "root/family-micro-diffusion#" + KEY
+    content_digest = "sha256:" + "ab" * 32
+
+
+def _attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **wires: Any) -> Any:
+    if "derive" in wires:
+        monkeypatch.setattr(boot_key, "derive", wires["derive"])
+    if "resolve" in wires:
+        monkeypatch.setattr(cell_resolve, "resolve", wires["resolve"])
+    if "materialize" in wires:
+        monkeypatch.setattr(cell_resolve, "materialize", wires["materialize"])
+    return boot_adopt.attempt(
+        function="generate", modules=("micro_diffusion.main",), cfg=_Cfg(),
+        slots={}, declared_hint=3,
+        envelope={"shapes": [[64, 64]], "text_lens": [8], "guidance": []},
+        work_root=tmp_path)
+
+
+def _refuse_hub(code: str) -> Any:
+    return _raise(cell_resolve.CellResolveRefused(code, "the hub said so", status=409))
+
+
+@pytest.mark.parametrize(
+    "phase,wires",
+    [
+        # Step 1 — the derivation. `structure_unsupported` is the one that
+        # names a family whose structure-only build does not exist; collapsing
+        # it into "derive failed" loses the only signal that says which family
+        # to build next.
+        ("structure_unsupported", {"derive": _raise(boot_key.BootKeyUnavailable(
+            "structure_unsupported",
+            "MicroEscapeDenoiser has no from_config"))}),
+        ("child_died", {"derive": _raise(boot_key.BootKeyUnavailable(
+            "child_died", "trace child exited 1 without a report"))}),
+        ("derive_failed", {"derive": _raise(MemoryError("no headroom"))}),
+        # Step 2 — the ask. A typed hub refusal is NOT a miss.
+        ("cell_resolve_ambiguous",
+         {"derive": lambda **_k: _derived(), "resolve": _refuse_hub(
+             "cell_resolve_ambiguous")}),
+        ("resolve_unreachable",
+         {"derive": lambda **_k: _derived(),
+          "resolve": _raise(OSError("connection reset"))}),
+        ("miss", {"derive": lambda **_k: _derived(),
+                  "resolve": lambda *_a, **_k: None}),
+        # Step 3 — materialize + the pgw#1031 witness floor.
+        ("materialize_failed",
+         {"derive": lambda **_k: _derived(),
+          "resolve": lambda *_a, **_k: _Cell(),
+          "materialize": _raise(RuntimeError("content_digest_mismatch"))}),
+    ],
+)
+def test_every_attempt_terminus_emits_its_own_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+    phase: str, wires: Dict[str, Any],
+) -> None:
+    out = _attempt(monkeypatch, tmp_path, **wires)
+    assert out.reason == phase
+    row = _one(events)
+    assert row.phase == phase
+    assert row.phase in boot_adopt.REASONS
+    assert "family=micro-diffusion" in row.detail
+
+
+def test_the_derive_wall_rides_the_event_as_a_number(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+) -> None:
+    """``duration_ms`` is a numeric column hub-side. A derivation timed by the
+    pod and then interpolated into free text cannot be grouped or percentiled,
+    which is how "the derive is slow" stayed an anecdote."""
+    _attempt(monkeypatch, tmp_path, derive=lambda **_k: _derived(8350),
+             resolve=lambda *_a, **_k: None)
+    assert _one(events).duration_ms == 8350
+
+
+def test_a_pod_that_derived_and_missed_is_not_a_pod_that_never_derived(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+) -> None:
+    """The issue's regression box, verbatim. Both pods self-mint; only one of
+    them proves the hub was asked and answered."""
+    _attempt(monkeypatch, tmp_path, derive=lambda **_k: _derived(),
+             resolve=lambda *_a, **_k: None)
+    missed = _one(events)
+    events.clear()
+
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: None)
+    _executor(tmp_path)._boot_adopt(_Spec(), {})
+    never = _one(events)
+
+    assert missed.phase == "miss" and never.phase == "no_export_declaration"
+    assert "key=ck1-" in missed.detail, (
+        "a MISS must carry the key that missed — it is the whole difference "
+        "between 'the hub holds nothing for me' and 'I never asked'")
+    assert "key=-" in never.detail
+
+
+# ---------------------------------------------------------------------------
+# 4. END TO END: a boot with no local cell and a reachable hub ASKS
+# ---------------------------------------------------------------------------
+
+
+class _ResolveHub(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802
+        raw = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        body = json.loads(raw or b"{}")
+        self.server.calls.append((self.path, body))  # type: ignore[attr-defined]
+        # th#1788: the live hub withholds every self-minted cell from a resolve,
+        # so a MISS is what a correct worker gets today. The property under test
+        # is that it ASKED.
+        out = json.dumps({"found": False}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+
+@pytest.fixture
+def hub() -> Iterator[Any]:
+    srv = HTTPServer(("127.0.0.1", 0), _ResolveHub)
+    srv.calls = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(scope="module")
+def micro_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    pytest.importorskip("torch")
+    pytest.importorskip("accelerate")
+    if str(MICRO_SRC) not in sys.path:
+        sys.path.insert(0, str(MICRO_SRC))
+    from micro_diffusion.weights import SEED, materialize
+
+    return materialize(tmp_path_factory.mktemp("micro-tree"), seed=SEED)
+
+
+@pytest.fixture
+def micro_declaration(micro_tree: Path) -> None:
+    """Restore micro-diffusion's export declaration before the run.
+
+    On a pod the import IS the registration (`micro_diffusion/main.py` imports
+    `.aot_declaration`, which registers at module scope). In a SUITE that is not
+    enough: several files call `export_contract.reset_export_declarations()`,
+    which empties the process-global registry, and by then
+    `micro_diffusion.main` is already in `sys.modules` — so `collect_endpoints`
+    re-imports nothing and re-registers nothing. Measured on CI run
+    31475315256 (`-n 4 --dist loadfile`, worker gw2): this row reported
+    `no_export_declaration` while passing in isolation. Restated here rather
+    than depended on, because the property under test is the RESOLVE, not
+    whichever file happened to share the worker.
+    """
+    from gen_worker.api import export_contract as ec
+
+    import micro_diffusion.aot_declaration as decl
+
+    ec.register_export_declaration(decl.DECLARATION, replace=True)
+
+
+@pytest.fixture
+def sm_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sm`` is a KEY AXIS, so a cardless box cannot state a key at all — which
+    is correct behaviour, not something to test around. Patch only the PROBES;
+    every value is a real fact of a real runtime and nothing about how they are
+    combined into a key is faked."""
+    import torch
+
+    from gen_worker import aot_serve, compile_cache
+
+    full = {
+        "sku": "l4", "sm": "sm_89", "torch": str(torch.__version__),
+        "triton": "3.6.0", "cuda": "13.0",
+        "image_digest": "sha256:" + "ab" * 32,
+    }
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: dict(full))
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: {
+        k: full[k] for k in ("sku", "sm", "torch", "cuda")})
+
+
+def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+    hub: Any, micro_tree: Path, micro_declaration: None, sm_runtime: None,
+) -> None:
+    """THE end-to-end property, on the vehicle the three pods ran.
+
+    Real ``Executor._boot_adopt`` -> real ``boot_key.derive`` (structure-only
+    trace children on fake tensors, no compile) -> real ``cell_resolve.resolve``
+    -> a real HTTP hub. What the pods' GIN log counted zero of is counted here,
+    and the decision is READABLE afterwards, which is the half that was missing.
+    """
+    from gen_worker.api.binding import ModelRef
+    from gen_worker.mint_process import MintSlot
+    from gen_worker.procsplit import broker
+    from gen_worker.registry import collect_endpoints
+
+    if str(MICRO_SRC) not in sys.path:
+        sys.path.insert(0, str(MICRO_SRC))
+    monkeypatch.syspath_prepend(str(REPO / "tests"))
+    monkeypatch.setenv(
+        "PYTHONPATH", ":".join([
+            str(REPO / "src"), str(REPO / "tests"), str(MICRO_SRC)]))
+    # Single-process posture: no seam, a local bearer. `broker.request` then
+    # makes the same POST the parent makes on a split pod.
+    monkeypatch.setattr(broker, "_broker", None, raising=False)
+
+    specs = collect_endpoints(["harness.rig_runtime", "micro_diffusion.main"])
+    spec = next(s for s in specs if s.name == "generate")
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = f"http://127.0.0.1:{hub.server_address[1]}"
+    slots = {"pipeline": MintSlot(
+        ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
+                     tag="prod"),
+        path=str(micro_tree))}
+
+    out = ex._boot_adopt(spec, slots)
+
+    resolves = [c for c in hub.calls if c[0] == cell_resolve.RESOLVE_PATH]
+    assert len(resolves) == 1, (
+        "the worker did not ask the hub by its derived key — this is the pod "
+        f"defect, reproduced off-pod. Hub saw: {hub.calls}")
+    assert resolves[0][1] == {
+        "family": "micro-diffusion", "cell_key": out.derived_key}
+    assert out.derived_key.startswith("ck1-")
+    assert out.reason == "miss"
+
+    row = _one(events)
+    assert row.phase == "miss"
+    assert out.derived_key in row.detail
+    assert row.duration_ms > 0, (
+        "the derivation was measured and the measurement must reach the hub — "
+        "otherwise 'the boot derive costs seconds' stays an anecdote")


### PR DESCRIPTION
Closes pgw#1116.

## The defect

`BootAdoptOutcome.reason` / `.detail` / `.derived_key` / `.derive_ms` had **zero readers outside `boot_adopt.py`** — the executor consumed only `.adoption` — and `Executor._boot_adopt`'s own three pre-attempt gates returned a bare `None` that built no outcome at all. So every documented refusal, plus three gates that produced literally nothing, presented identically as *"a pod that quietly self-minted"*.

That is how a merged fix (pgw#1108) and a published wheel (0.103.0) both shipped over a boot-adopt that called `POST /v1/worker/cells/resolve` **zero times** on three real pods. Hub-spawned pods expose no stdout (pgw#760), so a `logger.info` is not observability: localising the refusal needed an event, not another pod.

## What changed

* **One typed event per decision.** `activity.KIND_BOOT_ADOPT` (`boot_adopt`), `phase` = the gate's own token, `detail` = family / function / derived key / the sentence, `duration_ms` = the derivation's measured wall as a numeric column. Emitted on every terminus including the hit, through a single `boot_adopt.report()` so "exactly one event per decision" is structural.
* **The vocabulary is exhaustive and fenced.** `boot_adopt.REASONS` (34 tokens across `GATE_REASONS` / `DERIVE_REASONS` / `ASK_REASONS`). A test reads the refusal sites out of `boot_trace_child.py`, `boot_key.py`, `boot_adopt.py` and `executor.py` and fails on any token `REASONS` does not carry — a new refusal cannot become the next silent one.
* **`Executor._boot_adopt` returns an outcome ALWAYS, never `None`.** The three silent gates are now `no_export_declaration`, `declaration_unreadable`, `no_hub`; the eager-only non-entry (pgw#775) is `eager_only`.
* **A pgw#853 THUNK declaration that REFUSES no longer escapes uncaught.** `export_declaration()` evaluates the thunk and lets its exception out; uncaught it left `_boot_adopt`, left `asyncio.to_thread`, and failed the model setup — a blocked family's mint refusal taking serving down, the exact blast radius pgw#853 exists to prevent. Now `declaration_refused`, and the pod serves.

## RED proof

All **17 rows fail on `origin/master`** (`c938aa11`); 17 pass here. They include:

* every pre-attempt gate emitting its own distinguishable `phase`, and a row asserting three different refusals read as three different phases;
* every `attempt` terminus (`structure_unsupported`, `child_died`, `derive_failed`, `cell_resolve_ambiguous`, `resolve_unreachable`, `miss`, `materialize_failed`);
* the issue's regression box — a pod that derived a key and MISSED carries `key=ck1-…`, a pod that never derived one carries `key=-`;
* **end to end**: real `Executor._boot_adopt` → real `boot_key.derive` (three structure-only trace children on fake tensors, no compile anywhere) → real `cell_resolve.resolve` → a real HTTP hub, against `examples/micro-diffusion` — the exact vehicle the three pods ran — asserting **exactly one `POST /v1/worker/cells/resolve`** carrying the derived key, and that the decision is readable afterwards.

## What that end-to-end run also establishes

On the pods' own vehicle the worker-side path is **sound end to end**: it derives `ck1-…` in ~8.4 s and issues exactly one resolve. So the pod-side refusal is one of the gates that until this PR produced no artifact at all — which is precisely why one pod could not name it. With this merged, the next pod names it in one `worker_activity_events` query.

## Scope notes

* Hub half is th#1788 (`COALESCE(cs.axes->>'kind','')`); a correct worker still gets a MISS until that lands. The success criterion here is that the worker ASKS and its outcome is observable, not that adoption succeeds.
* Also fixes a tautological assertion in `test_boot_adopt_credential_pgw1108.py` (`assert x is not None or calls` could never fail) — the class pgw#1113 is fixing.
* `mypy src/gen_worker` clean; ruff + every `fast gates` lint script green locally. No local mint, no compile, no GPU, no pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)