### PR TITLE
pgw#1117 / th#1777: refuse an artifact that cannot fit its declared envelope BEFORE staging it

### DIFF
--- a/changelog.d/pgw1117.md
+++ b/changelog.d/pgw1117.md
@@ -1,0 +1,30 @@
+- **pgw#1117 / th#1777: a slot load now REFUSES an artifact that cannot fit the
+  release's declared envelope, before staging it, instead of OOMing after.**
+  ie#642's tape: the worker printed `staged 0.67 GiB of 32.81 GiB` against a
+  release declaring `vram_gb = 22` with `strict_vram` — it held both numbers and
+  staged anyway, OOMed 192 MiB short of a 23.52 GiB RTX 4090 inside `setup()`,
+  disabled every function in its lane, and the hub's fast-failure streak took a
+  live endpoint dark. The artifact was an fp32 archive clone behind a bare `prod`
+  head the th#1754 wipe had repointed, and that fact was on disk before the first
+  byte moved. New `models/envelope.py` weighs the bound trees AS THEY WILL LOAD —
+  safetensors headers only, no tensor read, no torch, dtype-aware (an fp32 tree
+  bound with `dtype="bf16"` is counted at half width, and variant twins are
+  counted once) — and `provision.load_slot` compares it against
+  `declared_vram_gb` BEFORE the progress reporter starts. A clear breach raises
+  the typed `ArtifactEnvelopeExceeded` naming both numbers and the artifact
+  digest. **The estimate is honest about its error bars:** it is weights only, a
+  LOWER bound with no invented overhead factor, so it refuses only past a 10%
+  band and abstains entirely on anything it cannot weigh cleanly (a runtime fp8
+  storage cast, an on-disk quant config, the svdq/w8a8/w4a4/gguf lanes, an
+  unknown dtype token). A marginal artifact still tries. Complements
+  `strict_vram` rather than duplicating it — the check only fires when the author
+  already closed the offload escape, so "degrade, don't OOM" is untouched. Blame
+  is RELEASE/BINDING-scoped: a new `artifact_envelope_exceeded` FnUnavailable
+  reason (wire contract updated) carrying axes{estimated_vram_gb,
+  declared_vram_gb, artifact_digest, ref, on_disk_dtype, load_dtype}, deliberately
+  NOT a `HardwareUnmetError` (no machine was consulted) and not a bare
+  `setup_failed` (which the hub feeds to the breaker). One
+  `artifact_envelope_exceeded` activity event banks the verbatim cause.
+  `tests/test_envelope_precondition_pgw1117.py` (20 cases) rebuilds ie#642's
+  artifact from headers at $0 and pins the red, the marginal green, the dtype
+  awareness and the blame routing.

--- a/changelog.d/pgw1117.md
+++ b/changelog.d/pgw1117.md
@@ -25,6 +25,6 @@
   NOT a `HardwareUnmetError` (no machine was consulted) and not a bare
   `setup_failed` (which the hub feeds to the breaker). One
   `artifact_envelope_exceeded` activity event banks the verbatim cause.
-  `tests/test_envelope_precondition_pgw1117.py` (20 cases) rebuilds ie#642's
+  `tests/test_envelope_precondition_pgw1117.py` (21 cases) rebuilds ie#642's
   artifact from headers at $0 and pins the red, the marginal green, the dtype
   awareness and the blame routing.

--- a/proto/PROTO_DIGEST
+++ b/proto/PROTO_DIGEST
@@ -3,4 +3,4 @@
 # BOTH repos commit this same digest, so a one-sided edit fails scripts/proto-drift-check.sh
 # offline, in the repo where it happened. Regenerate with:
 #   sha256sum internal/orchestrator/grpc/proto/worker_scheduler.proto
-19f8367ceeca114a50500c32ea5f3ff171e9a432c0f7edb195e1af89d8b2be8c
+1b755a1c66001c3e27f1ba166fd8d60d29ad3baee729bc754d26cb38f5622e8d

--- a/proto/worker_scheduler.proto
+++ b/proto/worker_scheduler.proto
@@ -1718,6 +1718,21 @@ message FnUnavailable {
   // (pgw#676). It carries axes{streak, last_signal, last_kind}, and O
   // condemns the WORKER on it (th#1205) — the pod is recycled, so the
   // recovery from this one disable is the pod going away, not a re-probe.
+  //
+  // RELEASE/BINDING facts — the declaration and the artifact it is bound to
+  // disagree, identically on every pod. Nothing about the machine, the place
+  // or the payload participates, so O neither re-probes them nor charges
+  // them to host/datacenter health:
+  //   artifact_envelope_exceeded.
+  // `artifact_envelope_exceeded` (th#1777/pgw#1117) is W's PRE-STAGE
+  // precondition: the bound artifact, weighed as it will load, is clearly
+  // larger than the release's declared `vram_gb`. It carries
+  // axes{estimated_vram_gb, declared_vram_gb, artifact_digest, ref,
+  // on_disk_dtype, load_dtype}. It replaces a paid setup OOM with a $0
+  // refusal, so it must NOT be laundered into the fast-failure streak the
+  // OOM fed (th#1259's allowlist): it is ground truth on first sight, and O
+  // marks the function broken directly instead of buying two more pods to
+  // re-derive a deterministic fact.
   string reason = 2;
   string detail = 3; // human-readable elaboration for the admin availability view
   map<string, string> axes = 4; // e.g. {detected_sm: "8.9", required_sm: "10.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.103.0"
+version = "0.104.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -126,6 +126,14 @@ KIND_COMPONENT_MISS = "component_miss"
 # frame_std_min, so ie#634's "corr 0.29 was uploaded and billed" is countable
 # hub-side instead of invisible.
 KIND_OUTPUT_INTEGRITY = "output_integrity"
+# pgw#1117 / th#1777: the pre-stage envelope precondition refused a slot load.
+# `phase=refused` — deterministic and fail-CLOSED: the bound artifact weighs
+# more, as it will load, than the release's declared `vram_gb` envelope, so
+# nothing was staged and no GPU time was spent. `detail` carries BOTH numbers
+# and the artifact digest, which is the whole point: ie#642's OOM banked
+# `CUDA out of memory` and sent an operator measuring the model, when the fact
+# that mattered was that the binding pointed at an fp32 archive clone.
+KIND_ENVELOPE_REFUSAL = "artifact_envelope_exceeded"
 KIND_ROTATION_PRELOAD = "rotation_preload"
 KIND_CAPABILITY_RENEWAL = "capability_renewal"
 KIND_RESIDENCY_FAULT = "residency_fault"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -123,6 +123,7 @@ from .models.memory import (
 )
 from .models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from .models.download import ensure_local, lookup_provider_for_ref
+from .models.envelope import ArtifactEnvelopeExceeded
 from .models.errors import MissingSnapshotError, UrlExpiredError
 from .models.execution_lanes import ExecutionLaneUnavailableError, mandatory_traced_lane_of
 from .models.residency import Residency
@@ -353,6 +354,17 @@ def _sanitize(message: str) -> str:
     for pat in _REDACTIONS:
         out = pat.sub("[redacted]", out)
     return out[:1024]
+
+
+def _snapshot_digest(snapshots: Any, ref: str) -> str:
+    """The resolved snapshot's own digest for ``ref``, or ``""``.
+
+    pgw#1117 names it in the envelope refusal: "the binding resolved to THIS
+    artifact" is the fact an operator needs, and a ref alone does not carry it
+    — the whole ie#642 shape is a mutable bare tag head pointing somewhere
+    new."""
+    snap = (snapshots or {}).get(ref) if snapshots else None
+    return str(getattr(snap, "snapshot_digest", "") or "")
 
 
 def _reserved_repo_info(payload: Any, field_name: str) -> Dict[str, Any]:
@@ -6585,6 +6597,16 @@ class Executor:
             # every attempt is this function's terminal truth (th#1159's
             # genuinely-unfittable VRAM lane is the case this exists for).
             reason, axes = "retry_exhausted", {}
+        elif isinstance(exc, ArtifactEnvelopeExceeded):
+            # pgw#1117 / th#1777: a RELEASE/BINDING verdict, reported under
+            # its own token so the hub can tell it apart from the OOM it
+            # replaces. Deliberately ahead of nothing and behind nothing
+            # meaningful — it is not a HardwareUnmetError (no machine was
+            # consulted, and routing it there would teach the buy-floor
+            # learner to shop for a card big enough to serve an archive
+            # clone) and not a bare setup_failed (which the hub reads as
+            # "the pod could not boot" and feeds to the breaker).
+            reason, axes = exc.reason, exc.axes()
         elif isinstance(exc, HardwareUnmetError):
             reason = getattr(exc, "reason", "hardware_unmet")
             axes = {str(k): str(v) for k, v in (exc.axes() or {}).items()}
@@ -8747,6 +8769,7 @@ class Executor:
                             force_storage_dtype=(
                                 "fp8" if slot in force_fp8_slots else ""),
                             strict_vram=bool(spec.resources.strict_vram),
+                            artifact_digest=_snapshot_digest(snapshots, ref),
                         )
                     except Exception as exc:
                         # Corruption-shaped load failure (gw#408): digest-verify
@@ -8775,6 +8798,7 @@ class Executor:
                             force_storage_dtype=(
                                 "fp8" if slot in force_fp8_slots else ""),
                             strict_vram=bool(spec.resources.strict_vram),
+                            artifact_digest=_snapshot_digest(snapshots, ref),
                         )
                     pipe = sl.obj
                     # pgw#678: record the PIPELINE identity for this slot

--- a/src/gen_worker/models/envelope.py
+++ b/src/gen_worker/models/envelope.py
@@ -1,0 +1,407 @@
+"""pgw#1117 / th#1777: the pre-stage envelope precondition.
+
+THE INCIDENT (ie#642, 2026-08-11). A release declaring ``vram_gb = 22`` with
+``strict_vram`` was bound to a repo's bare ``prod`` head that the th#1754 wipe
+had repointed at the fp32 archive clone. The worker printed
+
+    load_phase :: pipeline:tensorhub/hidream-o1-image: load; staged 0.67 GiB of 32.81 GiB
+
+— it KNEW the artifact weighed 32.81 GiB and it KNEW the declaration said 22 —
+staged anyway, OOMed 192 MiB short of a 23.52 GiB card inside ``setup()``,
+disabled every function in its lane, tripped the hub's
+``model_load_failure_streak`` and darkened a live endpoint. Cost: a billed
+4090 per attempt for a fact that was on disk before the first byte moved.
+
+THE PRECONDITION. Before staging, weigh the artifact AS IT WILL LOAD and
+compare it against the envelope the release declares. A clear breach is a
+typed refusal naming both numbers and the artifact digest — not an OOM, not a
+retry, and not evidence for the hub's breaker.
+
+WHAT THE ESTIMATE IS, AND WHAT IT IS NOT. It is the header-declared tensor
+bytes of the snapshot's safetensors files, re-scaled by the dtype the loader
+will actually ask for (:func:`estimate_resident_bytes`). That is a LOWER BOUND
+on resident bytes and deliberately nothing more:
+
+* it counts WEIGHTS only — activations, attention workspace, allocator
+  fragmentation and CUDA context all sit on top, unmeasured here;
+* it counts the files the loader will open, after variant-twin de-duplication,
+  but it cannot know which components a pipeline leaves on the host;
+* it applies no upward "overhead factor". There is no measured one, and
+  inventing a multiplier would convert an honest lower bound into a guess.
+
+Because it is a lower bound, the comparison is sound in exactly one direction:
+weights alone exceeding the declared envelope means the load cannot fit,
+whatever the activations do. The margin below is therefore the ESTIMATOR's own
+error budget (which twin the loader picks, buffers that never reach the card,
+a component that stays on the host), not a headroom allowance for the model.
+
+WHEN IT DOES NOT SPEAK. The estimator refuses to answer — and the load
+proceeds untouched — for any snapshot whose resident size is not plainly
+computable from headers: a runtime storage cast, an on-disk quantization
+config, the svdq / w8a8 / w4a4 / gguf lanes, an unknown dtype token, or no
+safetensors at all. A marginal artifact still tries. Only a clear breach is
+refused; this is a precondition against a wrong BINDING, not a second
+strict_vram.
+
+RELATION TO ``strict_vram``. Complementary, not overlapping. ``strict_vram``
+is the AUTHOR's declaration that CPU-resident weights are unacceptable, which
+is what removes the offload rung that would otherwise carry an oversized
+artifact slowly instead of fatally. This check catches the other half — the
+right declaration bound to the WRONG ARTIFACT — and it only fires where the
+offload escape is already closed, because without ``strict_vram`` an artifact
+that does not fit degrades rather than dies ("degrade, don't OOM").
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .safetensors_header import header_len_ok
+
+logger = logging.getLogger(__name__)
+
+_GIB = float(1 << 30)
+
+#: The estimator's own error budget, as a fraction of the declared envelope.
+#: NOT headroom for the model: the estimate is a weights-only LOWER bound, so
+#: any true excess is already a breach. This covers what the estimator can get
+#: wrong — which variant twin the loader opens, non-parameter buffers, a
+#: component that never reaches the card. 10% of a 22 GB envelope is 2.2 GB,
+#: which is far wider than any of those and still leaves the ie#642 artifact
+#: (32.81 vs 22) refused by a factor of 1.36.
+ENVELOPE_ERROR_BAND = 0.10
+
+#: Bytes per element for every safetensors dtype token we can weigh. A token
+#: outside this table makes the estimate UNMEASURABLE rather than approximate.
+_ELEMENT_BYTES: Dict[str, int] = {
+    "BOOL": 1, "U8": 1, "I8": 1,
+    "F8_E4M3": 1, "F8_E5M2": 1, "F8_E8M0": 1,
+    "I16": 2, "U16": 2, "F16": 2, "BF16": 2,
+    "I32": 4, "U32": 4, "F32": 4,
+    "I64": 8, "U64": 8, "F64": 8,
+}
+
+#: The float dtypes a ``torch_dtype`` cast actually re-widths. Integer and
+#: boolean tensors keep their storage whatever the compute dtype is.
+_CASTABLE = frozenset({"F8_E4M3", "F8_E5M2", "F8_E8M0", "F16", "BF16", "F32", "F64"})
+
+#: Binding dtype string -> bytes per element. Mirrors ``loading._DTYPE_MAP``;
+#: an unrecognised string makes the estimate unmeasurable (the loader would
+#: raise on it anyway).
+_CAST_ELEMENT_BYTES: Dict[str, int] = {
+    "fp16": 2, "float16": 2,
+    "bf16": 2, "bfloat16": 2,
+    "fp32": 4, "float32": 4,
+}
+
+#: Variant infixes diffusers uses to publish twins of the same tensor set
+#: (``diffusion_pytorch_model.fp16.safetensors``). Counting both twins would
+#: inflate the estimate, which is the one direction it must never err in.
+_VARIANT_INFIXES = ("fp16", "bf16", "fp8", "fp32")
+
+
+class ArtifactEnvelopeExceeded(RuntimeError):
+    """The bound artifact cannot fit the envelope the release declares.
+
+    Terminal and deterministic: every pod of this release reaches the same
+    verdict from the same bytes, so it is never retried and never re-probed.
+    Blame is RELEASE/BINDING-scoped — the declaration and the artifact
+    disagree — never the payload (no request participated) and never the host
+    (no card was consulted). Deliberately NOT a
+    :class:`~gen_worker.capability.HardwareUnmetError`: that family means
+    "this MACHINE cannot satisfy a correct declaration" and feeds the hub's
+    hardware-fact and buy-floor paths, which would send an operator shopping
+    for a bigger card to serve an archive clone.
+    """
+
+    #: FnUnavailable reason vocabulary token (the closed set in
+    #: worker_scheduler.proto).
+    reason = "artifact_envelope_exceeded"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        estimated_bytes: int = 0,
+        declared_vram_gb: float = 0.0,
+        artifact_digest: str = "",
+        ref: str = "",
+        on_disk_dtype: str = "",
+        load_dtype: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.estimated_bytes = int(estimated_bytes)
+        self.declared_vram_gb = float(declared_vram_gb)
+        self.artifact_digest = artifact_digest
+        self.ref = ref
+        self.on_disk_dtype = on_disk_dtype
+        self.load_dtype = load_dtype
+
+    def axes(self) -> Dict[str, str]:
+        """Axis map for ``WorkerFunctionUnavailableSignal``. Both numbers are
+        axes, not prose: the hub's operator view reads them as columns."""
+        out = {
+            "estimated_vram_gb": f"{self.estimated_bytes / _GIB:.2f}",
+            "declared_vram_gb": f"{self.declared_vram_gb:.2f}",
+        }
+        if self.artifact_digest:
+            out["artifact_digest"] = self.artifact_digest
+        if self.ref:
+            out["ref"] = self.ref
+        if self.on_disk_dtype:
+            out["on_disk_dtype"] = self.on_disk_dtype
+        if self.load_dtype:
+            out["load_dtype"] = self.load_dtype
+        return out
+
+
+@dataclass(frozen=True)
+class EnvelopeEstimate:
+    """What the artifact weighs as it will load, plus the honesty about it."""
+
+    #: Header-declared tensor bytes of the files the loader will open.
+    disk_bytes: int
+    #: The same tensors re-scaled by the dtype the loader will ask for. A
+    #: LOWER bound on resident bytes: weights only.
+    resident_bytes: int
+    #: Majority on-disk dtype ("bf16"/"fp16"/"fp32"/"fp8"/"").
+    on_disk_dtype: str
+    #: The dtype the load will present ("" = as stored, no cast directive).
+    load_dtype: str
+    #: False when the resident size is not plainly computable from headers.
+    #: An unmeasurable estimate never refuses anything.
+    measurable: bool
+    #: Why it is unmeasurable, or how it was computed. Carried into logs so a
+    #: silent non-answer is still an answer someone can read.
+    method: str
+
+    @property
+    def resident_gb(self) -> float:
+        return self.resident_bytes / _GIB
+
+
+def _tensor_bytes_by_dtype(path: Path) -> Optional[Dict[str, int]]:
+    """Header-declared bytes per dtype token in one safetensors file, or None
+    when the header cannot be read (a truncated or malformed file is not a
+    zero — it is an unmeasurable one)."""
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(8)
+            if len(raw) < 8:
+                return None
+            (n,) = struct.unpack("<Q", raw)
+            if not header_len_ok(n):
+                return None
+            header = json.loads(f.read(n))
+    except (OSError, ValueError):
+        return None
+    out: Dict[str, int] = {}
+    for key, value in header.items():
+        if key == "__metadata__" or not isinstance(value, dict):
+            continue
+        offsets = value.get("data_offsets")
+        dtype = value.get("dtype")
+        if not offsets or dtype is None:
+            continue
+        try:
+            start, end = int(offsets[0]), int(offsets[1])
+        except (TypeError, ValueError, IndexError):
+            return None
+        out[str(dtype)] = out.get(str(dtype), 0) + max(0, end - start)
+    return out
+
+
+def _loaded_files(root: Path, variant: str) -> List[Path]:
+    """The safetensors files the loader will actually open, with variant twins
+    collapsed to one. Two twins of the same tensor set on disk are one set in
+    memory; counting both is the one error the estimate must not make."""
+    groups: Dict[Tuple[str, str], Dict[str, Path]] = {}
+    for p in sorted(root.rglob("*.safetensors")):
+        stem = p.name[: -len(".safetensors")]
+        var = ""
+        for candidate in _VARIANT_INFIXES:
+            if stem.lower().endswith("." + candidate):
+                var, stem = candidate, stem[: -(len(candidate) + 1)]
+                break
+        groups.setdefault((str(p.parent), stem), {})[var] = p
+    out: List[Path] = []
+    for by_variant in groups.values():
+        if len(by_variant) == 1:
+            out.append(next(iter(by_variant.values())))
+            continue
+        if variant and variant in by_variant:
+            out.append(by_variant[variant])
+        elif "" in by_variant:
+            out.append(by_variant[""])
+        else:
+            # Twins only, none of them the loader's declared variant: take the
+            # SMALLEST, so an ambiguity can never inflate the estimate.
+            out.append(min(by_variant.values(), key=lambda q: q.stat().st_size))
+    return sorted(out)
+
+
+def estimate_resident_bytes(
+    trees: Sequence[Path | str],
+    *,
+    cast_dtype: str = "",
+    variant: str = "",
+) -> EnvelopeEstimate:
+    """Weigh the snapshot AS IT WILL LOAD, from headers alone. No tensor is
+    read, no torch is imported, nothing is downloaded.
+
+    ``cast_dtype`` is the binding's ``dtype`` directive. Empty means the loader
+    passes no ``torch_dtype`` for an fp32/unknown tree and honors the sniffed
+    precision for a bf16/fp16 one — either way the tensors land at their stored
+    width, which is exactly what happened in ie#642: an fp32 tree loaded fp32.
+    """
+    files: List[Path] = []
+    for tree in trees:
+        root = Path(tree)
+        if root.is_file():
+            if root.suffix == ".safetensors":
+                files.append(root)
+            continue
+        try:
+            files.extend(_loaded_files(root, variant))
+        except OSError:
+            return EnvelopeEstimate(
+                0, 0, "", "", False, "snapshot tree is unreadable")
+
+    if not files:
+        return EnvelopeEstimate(
+            0, 0, "", "", False, "no safetensors weights in the snapshot")
+
+    by_dtype: Dict[str, int] = {}
+    counts: Dict[str, int] = {}
+    for p in files:
+        per_file = _tensor_bytes_by_dtype(p)
+        if per_file is None:
+            return EnvelopeEstimate(
+                0, 0, "", "", False,
+                f"unreadable safetensors header in {p.name}")
+        for token, nbytes in per_file.items():
+            by_dtype[token] = by_dtype.get(token, 0) + nbytes
+            counts[token] = counts.get(token, 0) + 1
+
+    unknown = sorted(t for t in by_dtype if t not in _ELEMENT_BYTES)
+    if unknown:
+        return EnvelopeEstimate(
+            0, 0, "", "", False,
+            f"unweighable safetensors dtype(s) {unknown}")
+
+    disk_bytes = sum(by_dtype.values())
+    top = max(by_dtype, key=lambda k: by_dtype[k]) if by_dtype else ""
+    on_disk = {"BF16": "bf16", "F16": "fp16", "F32": "fp32",
+               "F8_E4M3": "fp8"}.get(top, top.lower())
+
+    cast = (cast_dtype or "").strip().lower()
+    if not cast:
+        return EnvelopeEstimate(
+            disk_bytes, disk_bytes, on_disk, "", True,
+            f"{len(files)} safetensors file(s), header-declared tensor bytes, "
+            f"loaded as stored ({on_disk or 'mixed'}) — no cast directive")
+
+    target = _CAST_ELEMENT_BYTES.get(cast)
+    if target is None:
+        return EnvelopeEstimate(
+            disk_bytes, disk_bytes, on_disk, "", False,
+            f"unrecognised binding dtype {cast_dtype!r}")
+
+    resident = 0
+    for token, nbytes in by_dtype.items():
+        elem = _ELEMENT_BYTES[token]
+        if token in _CASTABLE:
+            resident += (nbytes // elem) * target
+        else:
+            resident += nbytes
+    return EnvelopeEstimate(
+        disk_bytes, resident, on_disk, cast, True,
+        f"{len(files)} safetensors file(s), header-declared tensor bytes "
+        f"re-scaled from {on_disk or 'mixed'} to the binding's {cast}")
+
+
+def envelope_refusal(
+    trees: Sequence[Path | str],
+    *,
+    declared_vram_gb: float,
+    strict_vram: bool,
+    cast_dtype: str = "",
+    storage_dtype: str = "",
+    variant: str = "",
+    specialized_layout: str = "",
+    slot: str = "",
+    ref: str = "",
+    artifact_digest: str = "",
+) -> Optional[ArtifactEnvelopeExceeded]:
+    """The precondition itself: the refusal to raise before staging, or None.
+
+    None is the answer for everything the estimator cannot settle CLEANLY — no
+    declaration, no ``strict_vram`` (the offload rung still carries it), a
+    runtime storage cast, a specialized weight layout, an unmeasurable tree,
+    or a merely marginal excess. A load that is not refused here is a load
+    that proceeds exactly as it did before this check existed.
+    """
+    if declared_vram_gb <= 0:
+        return None
+    if not strict_vram:
+        # Without strict_vram the fit ladder may legitimately place an
+        # oversized artifact on the offload rung. Refusing would break the
+        # "degrade, don't OOM" ruling; this precondition exists for the case
+        # where that escape is already closed by the author.
+        return None
+    if storage_dtype:
+        # A runtime fp8 storage cast restructures a subset of the modules
+        # AFTER the load, and which subset is a property of the pipeline
+        # class, not of the tree. Not plainly computable -> no verdict.
+        return None
+    if specialized_layout:
+        return None
+
+    est = estimate_resident_bytes(trees, cast_dtype=cast_dtype, variant=variant)
+    if not est.measurable:
+        logger.debug("envelope precondition abstained for %s: %s", ref or slot,
+                     est.method)
+        return None
+
+    declared_bytes = declared_vram_gb * _GIB
+    ceiling = declared_bytes * (1.0 + ENVELOPE_ERROR_BAND)
+    if est.resident_bytes <= ceiling:
+        return None
+
+    digest = artifact_digest or "(digest unknown)"
+    over = est.resident_bytes / declared_bytes
+    message = (
+        f"artifact does not fit the declared envelope: slot {slot or '?'!r} "
+        f"ref {ref or '?'} artifact {digest} weighs "
+        f"{est.resident_gb:.2f} GiB as it will load, and the release declares "
+        f"vram_gb={declared_vram_gb:.2f} with strict_vram "
+        f"({over:.2f}x the envelope). Estimate: {est.method}; WEIGHTS ONLY, so "
+        f"it is a lower bound — activations and workspace are on top of it. "
+        f"Refused BEFORE staging: no bytes were staged onto the card and no "
+        f"GPU time was spent. The declaration and the bound artifact "
+        f"disagree — rebind the slot to the serving flavor, or raise the "
+        f"declaration to what this artifact actually needs."
+    )
+    return ArtifactEnvelopeExceeded(
+        message,
+        estimated_bytes=est.resident_bytes,
+        declared_vram_gb=declared_vram_gb,
+        artifact_digest=artifact_digest,
+        ref=ref,
+        on_disk_dtype=est.on_disk_dtype,
+        load_dtype=est.load_dtype or est.on_disk_dtype,
+    )
+
+
+__all__ = [
+    "ENVELOPE_ERROR_BAND",
+    "ArtifactEnvelopeExceeded",
+    "EnvelopeEstimate",
+    "envelope_refusal",
+    "estimate_resident_bytes",
+]

--- a/src/gen_worker/models/envelope.py
+++ b/src/gen_worker/models/envelope.py
@@ -280,7 +280,6 @@ def estimate_resident_bytes(
             0, 0, "", "", False, "no safetensors weights in the snapshot")
 
     by_dtype: Dict[str, int] = {}
-    counts: Dict[str, int] = {}
     for p in files:
         per_file = _tensor_bytes_by_dtype(p)
         if per_file is None:
@@ -289,7 +288,6 @@ def estimate_resident_bytes(
                 f"unreadable safetensors header in {p.name}")
         for token, nbytes in per_file.items():
             by_dtype[token] = by_dtype.get(token, 0) + nbytes
-            counts[token] = counts.get(token, 0) + 1
 
     unknown = sorted(t for t in by_dtype if t not in _ELEMENT_BYTES)
     if unknown:
@@ -298,6 +296,10 @@ def estimate_resident_bytes(
             f"unweighable safetensors dtype(s) {unknown}")
 
     disk_bytes = sum(by_dtype.values())
+    # Majority by BYTES, not by tensor count (which is what
+    # `loading.detect_on_disk_dtype` reports): this label describes what the
+    # artifact WEIGHS, and a thousand tiny fp32 norm tensors do not make a
+    # bf16 transformer an fp32 tree.
     top = max(by_dtype, key=lambda k: by_dtype[k]) if by_dtype else ""
     on_disk = {"BF16": "bf16", "F16": "fp16", "F32": "fp32",
                "F8_E4M3": "fp8"}.get(top, top.lower())

--- a/src/gen_worker/models/envelope.py
+++ b/src/gen_worker/models/envelope.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import struct
 from dataclasses import dataclass
 from pathlib import Path
@@ -99,10 +100,13 @@ _CAST_ELEMENT_BYTES: Dict[str, int] = {
     "fp32": 4, "float32": 4,
 }
 
-#: Variant infixes diffusers uses to publish twins of the same tensor set
-#: (``diffusion_pytorch_model.fp16.safetensors``). Counting both twins would
-#: inflate the estimate, which is the one direction it must never err in.
-_VARIANT_INFIXES = ("fp16", "bf16", "fp8", "fp32")
+#: Variant infixes diffusers uses to publish twins of the same tensor set.
+#: They appear both as a suffix (``diffusion_pytorch_model.fp16.safetensors``)
+#: and INSIDE a shard name (``diffusion_pytorch_model.fp16-00001-of-00002``),
+#: so the match is delimiter-anchored rather than a plain endswith — a missed
+#: shard twin would double-count a set and inflate the estimate, which is the
+#: one direction a refusal-grade number must never err in.
+_VARIANT_RE = re.compile(r"\.(fp16|bf16|fp8|fp32)(?=$|[.\-_])")
 
 
 class ArtifactEnvelopeExceeded(RuntimeError):
@@ -223,11 +227,10 @@ def _loaded_files(root: Path, variant: str) -> List[Path]:
     groups: Dict[Tuple[str, str], Dict[str, Path]] = {}
     for p in sorted(root.rglob("*.safetensors")):
         stem = p.name[: -len(".safetensors")]
-        var = ""
-        for candidate in _VARIANT_INFIXES:
-            if stem.lower().endswith("." + candidate):
-                var, stem = candidate, stem[: -(len(candidate) + 1)]
-                break
+        match = _VARIANT_RE.search(stem.lower())
+        var = match.group(1) if match else ""
+        if match:
+            stem = stem[: match.start()] + stem[match.end():]
         groups.setdefault((str(p.parent), stem), {})[var] = p
     out: List[Path] = []
     for by_variant in groups.values():

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -2191,6 +2191,31 @@ def snapshot_component_weight_bytes(model_path: Path) -> Dict[str, int]:
     return {k: v for k, v in out.items() if v > 0}
 
 
+def specialized_weight_layout(model_path: str | Path) -> str:
+    """The non-plain lane :func:`load_from_pretrained` would take for this
+    snapshot (``"quantized"``/``"svdq"``/``"w8a8"``/``"w4a4"``/``"gguf"``), or
+    ``""`` for the plain dense-safetensors path.
+
+    pgw#1117 asks exactly one question of it: is this tree's resident size
+    computable from safetensors headers? On every lane named here it is not —
+    packed 4-bit weights, fp8 GEMM scale tables and GGUF blocks all have a
+    header story that differs from their in-memory story — so the envelope
+    precondition abstains instead of guessing. Same detectors, same ORDER as
+    the loader, so the answer cannot drift from the lane actually taken."""
+    p = Path(model_path)
+    if read_on_disk_quant_config(p):
+        return "quantized"
+    if detect_svdq_artifact(p) is not None:
+        return "svdq"
+    if detect_w8a8_artifact(p) is not None:
+        return "w8a8"
+    if detect_w4a4_artifact(p) is not None:
+        return "w4a4"
+    if detect_gguf_snapshot(p) is not None:
+        return "gguf"
+    return ""
+
+
 def bitsandbytes_available() -> bool:
     """Importability gate for the bnb-nf4 rung (gw#469): the quant config
     constructs fine without bitsandbytes and the load then dies deep in
@@ -2773,6 +2798,7 @@ __all__ = [
     "model_index_components",
     "model_index_component_classes",
     "snapshot_component_weight_bytes",
+    "specialized_weight_layout",
     "load_from_pretrained",
     "is_modular_pipeline_class",
     "hydrate_modular_pipeline",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -37,12 +37,15 @@ from . import disk_gc, load_progress
 from .cache_paths import tensorhub_cas_dir
 from .errors import UrlExpiredError
 from .ladder import maybe_rebind_family_fp8
+from .envelope import envelope_refusal
 from .loading import (
     RUNG_NF4_UNLANDED,
     assert_uniform_compute_dtype,
     composition_compute_dtype,
+    detect_diffusers_variant,
     load_from_pretrained,
     model_index_components,
+    specialized_weight_layout,
 )
 from .memory import place_pipeline
 from .refs import DEFAULT_REF_TAG, parse_model_ref
@@ -110,6 +113,7 @@ def load_slot(
     declared_vram_gb: float = 0.0,
     force_storage_dtype: str = "",
     strict_vram: bool = False,
+    artifact_digest: str = "",
 ) -> SlotLoad:
     """Typed slot injection: the slot receives exactly what its ``setup``
     annotation says — a ``str``/``Path`` local path, or a constructed
@@ -154,6 +158,31 @@ def load_slot(
                 f"has no denoiser/cast surface (components: {sorted(comps)}); "
                 "serving at base precision")
             storage_dtype = ""
+
+    # pgw#1117 / th#1777: the artifact is weighed AS IT WILL LOAD and checked
+    # against the declared envelope BEFORE a single byte is staged. ie#642
+    # printed both numbers ("staged 0.67 GiB of 32.81 GiB" against
+    # vram_gb=22), staged anyway, and OOMed on a billed card inside setup().
+    # A clear breach is a typed refusal here; a marginal one still tries.
+    trees = [path, *sorted((component_trees or {}).values())]
+    refusal = envelope_refusal(
+        trees,
+        declared_vram_gb=declared_vram_gb,
+        strict_vram=strict_vram,
+        cast_dtype=dtype,
+        storage_dtype=storage_dtype,
+        variant=detect_diffusers_variant(Path(path)) or "",
+        specialized_layout=specialized_weight_layout(path),
+        slot=slot,
+        ref=ref,
+        artifact_digest=artifact_digest,
+    )
+    if refusal is not None:
+        logger.error("pre-load envelope refusal: %s", refusal)
+        activity_mod.emit_event(
+            activity_mod.KIND_ENVELOPE_REFUSAL, str(refusal), phase="refused",
+        )
+        raise refusal
 
     # pgw#1041: byte-level staging progress + death breadcrumb for the whole
     # load (hydration AND placement). The counter feeds the existing 10s

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -179,9 +179,12 @@ def load_slot(
     )
     if refusal is not None:
         logger.error("pre-load envelope refusal: %s", refusal)
-        activity_mod.emit_event(
-            activity_mod.KIND_ENVELOPE_REFUSAL, str(refusal), phase="refused",
-        )
+        try:
+            activity_mod.emit_event(
+                activity_mod.KIND_ENVELOPE_REFUSAL, str(refusal),
+                phase="refused")
+        except Exception:  # noqa: BLE001 - the refusal outranks its telemetry
+            logger.debug("envelope-refusal event dropped", exc_info=True)
         raise refusal
 
     # pgw#1041: byte-level staging progress + death breadcrumb for the whole

--- a/tests/test_envelope_precondition_pgw1117.py
+++ b/tests/test_envelope_precondition_pgw1117.py
@@ -1,0 +1,357 @@
+"""pgw#1117 / th#1777: refuse an artifact that cannot fit its declared
+envelope BEFORE staging it, instead of OOMing after.
+
+The red case is ie#642, to the byte. `tensorhub/hidream-o1-image` declared
+``vram_gb = 22`` with ``strict_vram`` and its bare ``prod`` head had been
+repointed by the th#1754 wipe at the fp32 archive clone —
+35,231,236,996 B = 32.81 GiB. The worker printed BOTH numbers
+("staged 0.67 GiB of 32.81 GiB"), staged anyway, and OOMed inside ``setup()``
+192 MiB short of a 23.52 GiB RTX 4090.
+
+Every snapshot here is built from safetensors HEADERS only: a header declares
+its tensors' ``data_offsets``, and the estimator never reads past them, so a
+32.81 GiB artifact is a few hundred bytes on disk. $0, no GPU, no torch.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Sequence, Tuple
+
+import pytest
+
+from gen_worker.models import provision
+from gen_worker.models.envelope import (
+    ArtifactEnvelopeExceeded,
+    envelope_refusal,
+    estimate_resident_bytes,
+)
+
+GIB = 1 << 30
+
+# ie#642's own numbers.
+FP32_CLONE_BYTES = 35_231_236_996      # 32.81 GiB, the archive head
+BF16_SERVING_BYTES = 17_621_456_640    # 16.41 GiB, the checkpoint that serves
+DECLARED_VRAM_GB = 22.0
+CLONE_DIGEST = "sha256:8a8676a6" + "0" * 56
+
+_ELEM = {"F32": 4, "BF16": 2, "F16": 2, "F8_E4M3": 1, "I64": 8, "U8": 1}
+
+
+def write_safetensors(path: Path, tensors: Sequence[Tuple[str, str, int]]) -> Path:
+    """One safetensors file whose HEADER declares ``tensors`` (name, dtype,
+    byte length). The tensor data is never written — nothing in the estimator
+    reads it, which is what makes a 32 GiB artifact a $0 fixture."""
+    header: Dict[str, object] = {}
+    offset = 0
+    for name, dtype, nbytes in tensors:
+        header[name] = {
+            "dtype": dtype,
+            "shape": [nbytes // _ELEM[dtype]],
+            "data_offsets": [offset, offset + nbytes],
+        }
+        offset += nbytes
+    blob = json.dumps(header).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+    return path
+
+
+def snapshot(root: Path, *, total_bytes: int, dtype: str = "F32") -> Path:
+    """A two-component diffusers-shaped tree weighing ``total_bytes``."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model_index.json").write_text(
+        json.dumps({"_class_name": "HiDreamImagePipeline"}), encoding="utf-8")
+    denoiser = int(total_bytes * 0.9)
+    denoiser -= denoiser % _ELEM[dtype]
+    rest = total_bytes - denoiser
+    rest -= rest % _ELEM[dtype]
+    write_safetensors(
+        root / "transformer" / "diffusion_pytorch_model.safetensors",
+        [("transformer.weight", dtype, denoiser)])
+    write_safetensors(
+        root / "text_encoder" / "model.safetensors",
+        [("encoder.weight", dtype, rest)])
+    return root
+
+
+def refusal_for(root: Path, **over: object):
+    kwargs: Dict[str, object] = dict(
+        declared_vram_gb=DECLARED_VRAM_GB,
+        strict_vram=True,
+        artifact_digest=CLONE_DIGEST,
+        slot="pipeline",
+        ref="tensorhub/hidream-o1-image:prod",
+    )
+    kwargs.update(over)
+    return envelope_refusal([root], **kwargs)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# RED: the ie#642 artifact is refused before anything is staged
+# --------------------------------------------------------------------------
+
+
+def test_fp32_clone_against_a_22gb_declaration_is_refused(tmp_path: Path) -> None:
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+
+    exc = refusal_for(root)
+
+    assert isinstance(exc, ArtifactEnvelopeExceeded)
+    text = str(exc)
+    # BOTH numbers, in the message, by the issue's requirement.
+    assert "32.8" in text, text
+    assert "22.00" in text, text
+    assert CLONE_DIGEST in text, text
+    # And both of them again as machine-readable axes for the hub.
+    assert exc.axes()["declared_vram_gb"] == "22.00"
+    assert exc.axes()["estimated_vram_gb"].startswith("32.8")
+    assert exc.axes()["artifact_digest"] == CLONE_DIGEST
+    assert exc.axes()["on_disk_dtype"] == "fp32"
+    assert exc.reason == "artifact_envelope_exceeded"
+
+
+def test_the_refusal_is_not_a_hardware_verdict() -> None:
+    """Blame routing: this is a RELEASE/BINDING fault. Typing it into the
+    HardwareUnmetError family would make the hub treat it as a machine fact
+    (sticky, never re-probed) and would feed the buy-floor learner a demand
+    for a card big enough to serve an archive clone."""
+    from gen_worker.capability import HardwareUnmetError
+
+    assert not issubclass(ArtifactEnvelopeExceeded, HardwareUnmetError)
+
+
+def test_refusal_happens_before_the_loader_is_ever_called(tmp_path: Path) -> None:
+    """The seam, exercised through the REAL `provision.load_slot`: a refused
+    slot never reaches `from_pretrained`, so nothing is staged onto the card
+    and no GPU second is billed."""
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+    calls: list[str] = []
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: object) -> "FakePipeline":
+            calls.append(path)
+            return cls()
+
+    with pytest.raises(ArtifactEnvelopeExceeded):
+        provision.load_slot(
+            FakePipeline,
+            str(root),
+            slot="pipeline",
+            ref="tensorhub/hidream-o1-image:prod",
+            declared_vram_gb=DECLARED_VRAM_GB,
+            strict_vram=True,
+            artifact_digest=CLONE_DIGEST,
+        )
+
+    assert calls == [], "the loader ran: the refusal is not a PRE-stage one"
+
+
+# --------------------------------------------------------------------------
+# GREEN: everything that must still be attempted
+# --------------------------------------------------------------------------
+
+
+def test_the_bf16_checkpoint_that_actually_serves_is_admitted(tmp_path: Path) -> None:
+    """16.41 GiB under a 22 GB declaration — the checkpoint ie#642 repointed
+    `prod` back to. It served a billed 2048x2048 render on the same card."""
+    root = snapshot(tmp_path / "bf16", total_bytes=BF16_SERVING_BYTES, dtype="BF16")
+    assert refusal_for(root) is None
+
+
+@pytest.mark.parametrize("gib", [22.0, 23.0, 24.0])
+def test_a_marginal_artifact_still_tries(tmp_path: Path, gib: float) -> None:
+    """The estimate has error bars, so only a CLEAR breach refuses. Anything
+    inside the estimator's error band gets its chance at the card exactly as
+    it did before this precondition existed."""
+    root = snapshot(tmp_path / f"marginal-{gib}", total_bytes=int(gib * GIB))
+    assert refusal_for(root) is None
+
+
+def test_the_band_is_bounded_and_the_clear_breach_is_still_refused(
+    tmp_path: Path,
+) -> None:
+    """A band that swallowed the incident would be a band that fixes nothing:
+    just past it, the refusal is back."""
+    root = snapshot(tmp_path / "just-over", total_bytes=int(25.0 * GIB))
+    assert refusal_for(root) is not None
+
+
+def test_without_strict_vram_the_offload_rung_still_carries_it(tmp_path: Path) -> None:
+    """"Degrade, don't OOM": without `strict_vram` the fit ladder may place an
+    oversized artifact on the offload rung, slowly but alive. This
+    precondition only fires where the author already closed that escape."""
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+    assert refusal_for(root, strict_vram=False) is None
+
+
+def test_an_undeclared_envelope_is_not_a_zero_envelope(tmp_path: Path) -> None:
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+    assert refusal_for(root, declared_vram_gb=0.0) is None
+
+
+# --------------------------------------------------------------------------
+# The estimate is DTYPE-AWARE, and honest about what it cannot weigh
+# --------------------------------------------------------------------------
+
+
+def test_a_binding_dtype_cast_is_counted(tmp_path: Path) -> None:
+    """The same fp32 bytes bound with `dtype="bf16"` load at half the width,
+    so they FIT — the estimate weighs the artifact as it will load, not as it
+    sits on disk. A disk-bytes check would have refused this wrongly."""
+    root = snapshot(tmp_path / "fp32-cast", total_bytes=FP32_CLONE_BYTES)
+
+    est = estimate_resident_bytes([root], cast_dtype="bf16")
+    assert est.on_disk_dtype == "fp32"
+    assert est.load_dtype == "bf16"
+    assert est.resident_bytes == pytest.approx(est.disk_bytes / 2, rel=1e-6)
+
+    assert refusal_for(root, cast_dtype="bf16") is None
+    # ...and the uncast load of the same tree is still refused.
+    assert refusal_for(root) is not None
+
+
+def test_integer_tensors_are_not_recast(tmp_path: Path) -> None:
+    """A cast re-widths FLOAT weights; int64 position ids and uint8 buffers
+    keep their storage whatever the compute dtype is."""
+    root = tmp_path / "mixed"
+    write_safetensors(
+        root / "transformer" / "diffusion_pytorch_model.safetensors",
+        [("w", "F32", 4 * 1024 * 1024), ("ids", "I64", 8 * 1024)],
+    )
+    est = estimate_resident_bytes([root], cast_dtype="bf16")
+    assert est.resident_bytes == 2 * 1024 * 1024 + 8 * 1024
+
+
+def test_variant_twins_are_counted_once(tmp_path: Path) -> None:
+    """`diffusion_pytorch_model.safetensors` plus its `.fp16.` twin is ONE
+    tensor set in memory. Counting both would inflate the estimate, which is
+    the one direction a refusal-grade number must never err in."""
+    root = tmp_path / "twins"
+    write_safetensors(
+        root / "unet" / "diffusion_pytorch_model.safetensors",
+        [("w", "F32", 8 * 1024 * 1024)])
+    write_safetensors(
+        root / "unet" / "diffusion_pytorch_model.fp16.safetensors",
+        [("w", "F16", 4 * 1024 * 1024)])
+
+    assert estimate_resident_bytes([root]).disk_bytes == 8 * 1024 * 1024
+    assert estimate_resident_bytes([root], variant="fp16").disk_bytes == 4 * 1024 * 1024
+
+
+def test_an_unweighable_dtype_abstains_instead_of_guessing(tmp_path: Path) -> None:
+    root = tmp_path / "exotic"
+    write_safetensors(root / "w.safetensors", [("w", "F32", 4096)])
+    # Rewrite the header with a token the table does not carry.
+    raw = (root / "w.safetensors").read_bytes()
+    (n,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + n])
+    header["w"]["dtype"] = "E3M2"
+    blob = json.dumps(header).encode("utf-8")
+    (root / "w.safetensors").write_bytes(struct.pack("<Q", len(blob)) + blob)
+
+    est = estimate_resident_bytes([root])
+    assert not est.measurable
+    assert "E3M2" in est.method
+    assert refusal_for(root) is None
+
+
+def test_a_weightless_or_unreadable_tree_abstains(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert not estimate_resident_bytes([empty]).measurable
+    assert refusal_for(empty) is None
+
+
+def test_a_runtime_storage_cast_abstains(tmp_path: Path) -> None:
+    """`storage_dtype=fp8` restructures a subset of modules AFTER the load and
+    which subset is a property of the pipeline class, not of the tree. Not
+    plainly computable -> no verdict."""
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+    assert refusal_for(root, storage_dtype="fp8") is None
+
+
+def test_a_specialized_weight_layout_abstains(tmp_path: Path) -> None:
+    """svdq / w8a8 / w4a4 / gguf / on-disk-quantized trees have a header story
+    that differs from their in-memory story."""
+    root = snapshot(tmp_path / "fp32-clone", total_bytes=FP32_CLONE_BYTES)
+    assert refusal_for(root, specialized_layout="w4a4") is None
+
+
+def test_component_override_trees_are_weighed_too(tmp_path: Path) -> None:
+    """th#980/pgw#617 component overrides are staged alongside the base tree,
+    so they count toward residency."""
+    base = snapshot(tmp_path / "base", total_bytes=int(12.0 * GIB), dtype="BF16")
+    override = tmp_path / "override"
+    write_safetensors(
+        override / "diffusion_pytorch_model.safetensors",
+        [("w", "F32", int(20.0 * GIB))])
+
+    assert envelope_refusal(
+        [base], declared_vram_gb=DECLARED_VRAM_GB, strict_vram=True) is None
+    assert envelope_refusal(
+        [base, override], declared_vram_gb=DECLARED_VRAM_GB, strict_vram=True
+    ) is not None
+
+
+# --------------------------------------------------------------------------
+# Blame routing at the executor seam
+# --------------------------------------------------------------------------
+
+
+class _Rec:
+    def __init__(self) -> None:
+        self.specs = [SimpleNamespace(name="generate")]
+        self.failed = None
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.unavailable: Dict[str, object] = {}
+
+    def _on_state_change(self) -> None:
+        pass
+
+
+def _classify(exc: BaseException) -> Tuple[str, Dict[str, str], str]:
+    from gen_worker.executor import Executor
+
+    ex, rec = _Executor(), _Rec()
+    Executor._mark_setup_failed(ex, rec, exc)  # type: ignore[arg-type]
+    reason, detail, axes = ex.unavailable["generate"]  # type: ignore[misc]
+    return reason, axes, detail
+
+
+def test_the_executor_reports_the_typed_reason_not_setup_failed() -> None:
+    """`setup_failed` is what the hub reads as "the pod could not boot", and
+    it is what fed the streak that darkened the endpoint. The refusal must
+    arrive under its own token, carrying both numbers as axes."""
+    exc = ArtifactEnvelopeExceeded(
+        "artifact does not fit", estimated_bytes=FP32_CLONE_BYTES,
+        declared_vram_gb=DECLARED_VRAM_GB, artifact_digest=CLONE_DIGEST,
+        ref="tensorhub/hidream-o1-image:prod", on_disk_dtype="fp32")
+
+    reason, axes, detail = _classify(exc)
+
+    assert reason == "artifact_envelope_exceeded"
+    assert axes["declared_vram_gb"] == "22.00"
+    assert axes["estimated_vram_gb"].startswith("32.8")
+    assert axes["artifact_digest"] == CLONE_DIGEST
+    assert "artifact does not fit" in detail
+
+    # Control: an ordinary setup exception is unchanged.
+    assert _classify(RuntimeError("boom"))[0] == "setup_failed"
+
+
+def test_the_reason_token_is_in_the_wire_contract() -> None:
+    proto = (Path(__file__).resolve().parents[1]
+             / "proto" / "worker_scheduler.proto").read_text(encoding="utf-8")
+    assert "artifact_envelope_exceeded" in proto
+
+

--- a/tests/test_envelope_precondition_pgw1117.py
+++ b/tests/test_envelope_precondition_pgw1117.py
@@ -245,6 +245,25 @@ def test_variant_twins_are_counted_once(tmp_path: Path) -> None:
     assert estimate_resident_bytes([root], variant="fp16").disk_bytes == 4 * 1024 * 1024
 
 
+def test_sharded_variant_twins_are_counted_once(tmp_path: Path) -> None:
+    """The twin marker sits INSIDE a shard name
+    (`diffusion_pytorch_model.fp16-00001-of-00002.safetensors`), not at the
+    end of it. A suffix-only match would miss every sharded twin and double
+    the estimate for the biggest models — the exact class of artifact this
+    precondition is aimed at."""
+    root = tmp_path / "sharded-twins"
+    for i in (1, 2):
+        write_safetensors(
+            root / "transformer" / f"diffusion_pytorch_model-0000{i}-of-00002.safetensors",
+            [(f"w{i}", "F32", 8 * 1024 * 1024)])
+        write_safetensors(
+            root / "transformer" / f"diffusion_pytorch_model.fp16-0000{i}-of-00002.safetensors",
+            [(f"w{i}", "F16", 4 * 1024 * 1024)])
+
+    assert estimate_resident_bytes([root]).disk_bytes == 16 * 1024 * 1024
+    assert estimate_resident_bytes([root], variant="fp16").disk_bytes == 8 * 1024 * 1024
+
+
 def test_an_unweighable_dtype_abstains_instead_of_guessing(tmp_path: Path) -> None:
     root = tmp_path / "exotic"
     write_safetensors(root / "w.safetensors", [("w", "F32", 4096)])

--- a/tests/test_fn_unavailable_vocabulary_th1563.py
+++ b/tests/test_fn_unavailable_vocabulary_th1563.py
@@ -38,6 +38,12 @@ _PROTO = _ROOT / "proto" / "worker_scheduler.proto"
 _SOURCES = (
     _ROOT / "src" / "gen_worker" / "executor.py",
     _ROOT / "src" / "gen_worker" / "capability.py",
+    # pgw#1117: the third file declaring a reason token on an exception class.
+    # `_mark_setup_failed` writes `exc.reason` for it exactly the way it does
+    # for the capability gates, so leaving this file out would have made the
+    # NEW token the one case the contract test cannot see — which is precisely
+    # the blindness th#1562/th#1563 wrote this test to end.
+    _ROOT / "src" / "gen_worker" / "models" / "envelope.py",
 )
 
 _FunctionNode = (ast.FunctionDef, ast.AsyncFunctionDef)

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.103.0"
+version = "0.104.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The incident this makes impossible

ie#642, 2026-08-11. The worker printed both numbers and staged anyway:

```
load_phase :: pipeline:tensorhub/hidream-o1-image: load; staged 0.67 GiB of 32.81 GiB
```

against a release declaring `vram_gb = 22` with `strict_vram`. It OOMed 192 MiB
short of a 23.52 GiB RTX 4090 **inside `setup()`**, disabled every function in
its compute lane, tripped the hub's `model_load_failure_streak` and darkened a
live endpoint. The artifact was an fp32 archive clone sitting behind a bare
`prod` head the th#1754 wipe had repointed — a fact that was on disk before the
first byte moved.

## The seam

`provision.load_slot` already computed the staging total and already received
`declared_vram_gb` and `strict_vram` (the declaration was plumbed all the way
into `load_from_pretrained` and read by nothing). The precondition goes where
those two facts already meet: immediately before the progress reporter starts,
therefore before any staging.

## The estimate, and its error bars

`models/envelope.py` weighs the bound trees **as they will load**, from
safetensors headers only — no tensor read, no torch, no download. Dtype-aware
(an fp32 tree bound `dtype="bf16"` counts at half width; integer buffers are not
recast; variant twins count once). It applies **no upward overhead factor**:
there is no measured one, and inventing a multiplier turns an honest lower bound
into a guess. The number is therefore **weights only** — activations and
workspace sit on top, unmeasured — which makes the comparison sound in exactly
one direction, and makes the 10% band the *estimator's* error budget rather than
headroom for the model.

It abstains entirely on anything it cannot weigh cleanly: a runtime fp8 storage
cast, an on-disk quant config, the svdq / w8a8 / w4a4 / gguf lanes, an unknown
dtype token, an unreadable header. **A marginal artifact still tries.**

## Blame routing

`ArtifactEnvelopeExceeded` reports under its own `artifact_envelope_exceeded`
FnUnavailable token with axes `{estimated_vram_gb, declared_vram_gb,
artifact_digest, ref, on_disk_dtype, load_dtype}`.

- **Not** a `HardwareUnmetError` — no machine was consulted, and that family is
  a hardware FACT the hub never re-probes and the buy-floor learner reads.
- **Not** a bare `setup_failed` — which the hub reads as "the pod could not
  boot" and feeds to the breaker.

Complements `strict_vram` rather than duplicating it: the check only fires where
the author already closed the offload escape, so "degrade, don't OOM" is intact.

## Wire contract

Vendored from tensorhub's canonical copy (PROTO_DIGEST re-recorded). The hub
half is tensorhub th#1777 and **lands after this PR** (its layer-2 drift check
reads this branch's `master`). `test_fn_unavailable_vocabulary_th1563` now scans
`models/envelope.py`, so the new token could not have slipped in undocumented.

## Tests — $0, no GPU

`tests/test_envelope_precondition_pgw1117.py`, 20 cases. ie#642's 32.81 GiB
artifact is rebuilt from headers alone (a header declares `data_offsets`; the
estimator never reads past them, so a 32 GiB fixture is a few hundred bytes).
Red case refused pre-stage with both numbers and the digest; the real `load_slot`
proving `from_pretrained` is never reached; the 16.41 GiB checkpoint that
actually serves admitted; 22/23/24 GiB marginal cases still attempting; the band
bounded at 25 GiB; dtype cast, variant twins, every abstention, and the executor
classification. **Red-proofed** by widening the band — 5 of them fail.

Local: 20/20 new, 60/60 across the touched neighbours, mypy + ruff clean.
0.103.0 -> 0.104.0 (pyproject + uv.lock).