### PR TITLE
pgw#1118 (th#1773): the pod's OWN warm/compile fault is TYPED, so it stops arriving as the caller's error

### DIFF
--- a/changelog.d/pgw1118.md
+++ b/changelog.d/pgw1118.md
@@ -1,0 +1,31 @@
+- **pgw#1118 (th#1773): a fault in the pod's OWN warm/compile pass is now
+  TYPED, so it stops arriving as the caller's error.** A warm forward runs a
+  payload the worker synthesized from the endpoint's own schema and calls the
+  endpoint's own handler with it; nothing about any request reaches that
+  boundary. Untyped, an exception escaping it left `ensure_setup` verbatim, hit
+  the job path's generic FATAL tail, and the hub booked
+  `error_type='fatal'` with a bare `ValueError` against the paying request that
+  merely woke the pod — measured on request `3d1b9c6a` (minimax-h3 0.4.6),
+  whose own `references[]` were perfectly formed, and which sent an
+  investigation into the hub's dispatch path for hours before th#1771 found the
+  synthesizer. th#1771 removed two TRIGGERS; this removes the MECHANISM. The
+  setup boundary now raises `EndpointSetupFailed(function, phase, cause)`, so
+  the wire carries `EndpointSetupFailed: phase=warmup_forward function=…:
+  ValueError: …` — the same phase token that is already on the
+  `self_mint_compile` activity row, which is what lets the hub route the blame
+  to the RELEASE (th#1773 types it `release_warm_failed`, classifies it
+  execution-scoped at any worker version, and names the phase in the text the
+  caller reads). Three exclusions, each load-bearing: the `load` phase is NOT
+  covered (a caller-routed slot can fail to resolve there, and th#1259's rule is
+  that nothing a payload participates in producing may be labelled
+  release-owned); anything already mapping to a non-FATAL status passes through
+  (a warm-phase OOM is still an OOM a bigger card serves); and anything already
+  a `WorkerError` passes through (`ModelSlotIdentityError` and friends carry
+  their own origin claim, which wrapping would erase). **The label rides the
+  0.105.0 cut** — 0.104.0 was published while this was in review (pgw#1119), so
+  this fragment is the next section's, and no `pyproject` bump belongs on this
+  branch. `EndpointSetupFailed` is deliberately NOT in `gen_worker.__all__`, so
+  the fleet's MAJOR.MINOR `[supported]` allowlist is untouched and no fleet
+  adoption is gated on it; th#1773's hub arm is inert on any worker that cannot
+  emit the label, so the two halves have no train ordering constraint.
+  Cardless, $0, no pod.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -314,6 +314,13 @@ class Activity:
             updated_at_unix_ms=int(time.time() * 1000),
         ))
 
+    @property
+    def phase_name(self) -> str:
+        """The phase this activity is reporting right now (pgw#1118). Read by
+        the setup boundary to name WHICH pass failed, so a warm/compile fault
+        can be typed as the release's instead of the caller's."""
+        return self._phase
+
     def phase(self, phase: str, step: int = 0, total: int = 0) -> None:
         self._phase, self._step, self._total = phase, step, total
         self._finish_counters(keep_phase=phase)

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -198,6 +198,47 @@ class DatasetNotFoundError(PayloadRefError):
         )
 
 
+class EndpointSetupFailed(WorkerError):
+    """The pod's OWN warm / compile pass failed. No request participates.
+
+    pgw#1118 / th#1773. A warm forward runs a payload the WORKER synthesized
+    from the endpoint's own schema and calls the endpoint's own handler with
+    it; the same is true of the trace and inductor passes. Nothing about any
+    caller reaches those boundaries — which is exactly what the untyped
+    version of this failure hid.
+
+    Measured (th#1771's tape, request 3d1b9c6a on minimax-h3 0.4.6): the
+    synthesizer raised a bare ``ValueError`` about ``references[]`` 3 ms into
+    ``self_mint_compile phase=warmup_forward``, the setup boundary re-raised it
+    verbatim, the job path mapped it through the generic FATAL tail, and the
+    hub booked ``error_type='fatal'`` with that exception against the paying
+    request that happened to wake the pod — whose own ``references[]`` were
+    perfectly formed. It read as a payload verdict to every human and every
+    machine downstream and cost hours of investigation in the dispatch path.
+
+    The label is the whole point: it is the worker's ORIGIN claim, made at the
+    boundary that knows it, so the hub can route the blame to the RELEASE at
+    any hub version instead of guessing from an exception class it cannot
+    attribute. The ``phase=`` token is the same one on the activity row, so
+    ``worker_activity_events`` and the request row read one vocabulary.
+
+    Deliberately NOT raised for the LOAD phase (a caller-routed slot can fail
+    there), for anything already typed (``WorkerError`` and its subclasses
+    carry their own origin), or for anything that maps to a non-FATAL status
+    (a warm-phase OOM is still an OOM).
+    """
+
+    def __init__(self, function: str, phase: str, cause: BaseException) -> None:
+        self.function = str(function or "")
+        self.phase = str(phase or "")
+        self.cause = cause
+        detail = str(cause).splitlines()[0] if str(cause) else ""
+        super().__init__(
+            f"phase={self.phase} function={self.function}: "
+            f"{type(cause).__name__}: {detail}".rstrip(": ")
+        )
+
+
 class ModelSlotIdentityError(WorkerError):
     """Dispatched model slot's repo differs from the function's declared ref
     (gw#583, the ie#518 silence).

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -71,11 +71,13 @@ from .api.errors import (
     ArtifactTransferError,
     CanceledError,
     ComponentSubstitutionError,
+    EndpointSetupFailed,
     GpuSlotUnreachable,
     IllegalCombination,
     ModelSlotIdentityError,
     RetryableError,
     ValidationError,
+    WorkerError,
 )
 from .api.streaming import (
     BatchItemDelta,
@@ -548,6 +550,44 @@ def _map_exception(exc: BaseException) -> Tuple["pb.JobStatus", str]:
     detail = _sanitize(str(exc).splitlines()[0] if str(exc) else "")
     label = type(exc).__name__
     return pb.JOB_STATUS_FATAL, f"{label}: {detail}"[:512] if detail else label
+
+
+#: Setup phases in which the worker drives its OWN synthetic forwards. No
+#: request payload reaches any of them — that is the entry condition, and the
+#: reason a fault raised here is the RELEASE's whoever reads it. ``load`` is
+#: deliberately absent: a caller-routed slot can fail to resolve there, and
+#: th#1259's rule is that nothing a payload participates in producing may be
+#: labelled release-owned.
+_WORKER_OWNED_SETUP_PHASES = frozenset({
+    activity_mod.PHASE_TRACE_GRAPH,
+    activity_mod.PHASE_INDUCTOR_COMPILE,
+    activity_mod.PHASE_WARMUP_FORWARD,
+})
+
+
+def _typed_setup_fault(
+    function: str, phase: str, exc: BaseException,
+) -> "Optional[EndpointSetupFailed]":
+    """pgw#1118/th#1773 -> the typed release fault, or None to re-raise as-is.
+
+    Three exclusions, each load-bearing:
+
+    * a phase outside ``_WORKER_OWNED_SETUP_PHASES`` — a payload may
+      participate there, so the origin is not ours to claim;
+    * an exception that already maps to a non-FATAL status — a warm-phase OOM
+      is still an OOM, and re-typing it would fatal a job a bigger card serves;
+    * anything already a ``WorkerError`` — those carry their own origin claim
+      (``ModelSlotIdentityError``, ``ComponentSubstitutionError``, ... are
+      exactly the labels the hub routes on), and wrapping would erase it.
+    """
+    if phase not in _WORKER_OWNED_SETUP_PHASES:
+        return None
+    if isinstance(exc, WorkerError) or not isinstance(exc, Exception):
+        return None
+    status, _ = _map_exception(exc)
+    if status != pb.JOB_STATUS_FATAL:
+        return None
+    return EndpointSetupFailed(function, phase, exc)
 
 
 def _runtime_term_values(
@@ -5959,6 +5999,12 @@ class Executor:
                     self._mark_compile_setup_unavailable(rec, spec, str(exc))
                     self._on_state_change()
                 self._mark_setup_failed(rec, exc, exhausted=exhausted)
+                # pgw#1118/th#1773: name the pod's OWN warm/compile fault
+                # before it leaves this boundary — the job path cannot tell
+                # afterwards, and untyped it becomes the caller's `fatal`.
+                typed = _typed_setup_fault(spec.name, act.phase_name, exc)
+                if typed is not None:
+                    raise typed from exc
                 raise
             if rec.failed is not None:
                 # Recovery (desired-state retry succeeded): lift the

--- a/tests/test_warm_fault_typed_pgw1118.py
+++ b/tests/test_warm_fault_typed_pgw1118.py
@@ -1,0 +1,144 @@
+"""pgw#1118 / th#1773: the pod's OWN warm pass must not fail as the caller's.
+
+th#1771 removed two TRIGGERS of the incident (the one-of synthesizer, the
+integrity gate judging warm frames). It did not touch the MECHANISM: any other
+exception escaping the warm pass still left the setup boundary untyped, hit the
+job path's generic FATAL tail, and became `error_type='fatal'` with a bare
+`ValueError` on the request that happened to wake the pod.
+
+A warm forward runs a payload the WORKER synthesized and calls the endpoint's
+own handler with it. No caller participates, so the origin is not in doubt —
+it just was not stated. These tests pin the statement and its three exclusions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import msgspec
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker.api import Resources, endpoint
+from gen_worker.api.errors import (
+    EndpointSetupFailed,
+    ModelSlotIdentityError,
+    RetryableError,
+)
+from gen_worker.executor import Executor, _map_exception, _typed_setup_fault
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+
+class _In(msgspec.Struct):
+    prompt: str = "x"
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+# The incident's exception, verbatim.
+_REFS_REFUSAL = (
+    "each references[] entry carries exactly one of image / video / audio, got none"
+)
+
+
+def test_warm_forward_fault_leaves_setup_typed() -> None:
+    """The integration: a real `ensure_setup`, a real synthesized warm pass."""
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    @endpoint(resources=Resources(vram_gb_hint=8))
+    class Ep:
+        def setup(self) -> None:
+            return None
+
+        def generate(self, ctx, payload: _In) -> _Out:
+            # What the handler does on the WARM payload the worker built for
+            # itself. The caller's own payload never reaches this run.
+            raise ValueError(_REFS_REFUSAL)
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _send)
+
+    with pytest.raises(EndpointSetupFailed) as caught:
+        asyncio.run(ex.ensure_setup(specs[0]))
+
+    fault = caught.value
+    assert fault.phase == activity_mod.PHASE_WARMUP_FORWARD, (
+        f"the fault must name the pass it happened in, got phase={fault.phase!r}"
+    )
+    assert isinstance(fault.cause, ValueError)
+    assert _REFS_REFUSAL in str(fault), "the worker's verbatim error must survive"
+
+    # And this is what the hub reads off the wire: a label it can route on,
+    # with the phase in the detail.
+    status, message = _map_exception(fault)
+    assert status == pb.JOB_STATUS_FATAL
+    assert message.startswith("EndpointSetupFailed: phase=warmup_forward function=")
+    assert _REFS_REFUSAL in message
+
+
+def test_load_phase_fault_is_not_claimed_as_the_release_s() -> None:
+    """LOAD is out of scope: a caller-ROUTED slot can fail to resolve there,
+    and th#1259's rule is that nothing a payload participates in producing may
+    be labelled release-owned."""
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    @endpoint(resources=Resources(vram_gb_hint=8))
+    class Ep:
+        def setup(self) -> None:
+            raise ValueError("load blew up")
+
+        def generate(self, ctx, payload: _In) -> _Out:
+            return _Out(y="ok")
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _send)
+
+    with pytest.raises(ValueError) as caught:
+        asyncio.run(ex.ensure_setup(specs[0]))
+    assert not isinstance(caught.value, EndpointSetupFailed), (
+        "a LOAD-phase failure was claimed as a warm/compile fault"
+    )
+
+
+def test_typed_setup_fault_exclusions() -> None:
+    warm = activity_mod.PHASE_WARMUP_FORWARD
+
+    # The case it exists for.
+    typed = _typed_setup_fault("reference-to-video", warm, ValueError(_REFS_REFUSAL))
+    assert isinstance(typed, EndpointSetupFailed)
+    assert str(typed).startswith("phase=warmup_forward function=reference-to-video: ")
+
+    # Compile passes are the worker's own forwards too.
+    assert _typed_setup_fault(
+        "f", activity_mod.PHASE_INDUCTOR_COMPILE, RuntimeError("x")
+    ) is not None
+    assert _typed_setup_fault(
+        "f", activity_mod.PHASE_TRACE_GRAPH, RuntimeError("x")
+    ) is not None
+
+    # Exclusion 1 — a phase a payload can participate in.
+    assert _typed_setup_fault("f", activity_mod.PHASE_LOAD, ValueError("x")) is None
+
+    # Exclusion 2 — already non-FATAL. A warm-phase OOM is still an OOM, and a
+    # bigger/idler card serves it; re-typing would fatal a retryable job.
+    assert _typed_setup_fault(
+        "f", warm, RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
+    ) is None
+    assert _typed_setup_fault("f", warm, RetryableError("try again")) is None
+
+    # Exclusion 3 — already typed. Those labels are the hub's routing keys and
+    # wrapping them would erase the origin the worker already claimed.
+    assert _typed_setup_fault(
+        "f", warm,
+        ModelSlotIdentityError("f", "pipeline", declared_ref="a", dispatched_ref="b"),
+    ) is None


### PR DESCRIPTION
Paired with tensorhub th#1773 (the hub arm, separate PR). Either half is useful alone; together they end the tape.

## The tape

Request `3d1b9c6a-a82c-4dee-b68d-579fbddbba86`, master stack, minimax-h3 0.4.6. A paying request woke a pod. The pod's own boot pass ran `self_mint_compile phase=warmup_forward`, whose synthetic payload builder raised `ValueError` 3 ms in. `ensure_setup` re-raised it verbatim, the job path mapped it through `_map_exception`'s generic FATAL tail, and the hub wrote `request_state.error_type='fatal'` with that bare exception as `error_message_safe` — on a request whose own `references[]` were perfectly formed and are still in the row. It read as "the caller sent something the endpoint refused" to every human and every machine downstream.

th#1771 removed two TRIGGERS (the one-of synthesizer at `warmup._struct_factory`, the integrity floor judging warm frames). It did not touch the MECHANISM, so the next exception out of the warm pass does the same thing.

## The change

`executor.ensure_setup`'s failure boundary — the one place that knows both that this was SETUP and which pass it was in — raises `EndpointSetupFailed(function, phase, cause)`. On the wire:

```
EndpointSetupFailed: phase=warmup_forward function=reference-to-video: ValueError: each references[] entry carries exactly one of image / video / audio, got none
```

`phase=` is the same token already on the activity row, so `worker_activity_events` and the request row read one vocabulary. The label is the worker's ORIGIN claim, made at the boundary that knows it (th#1288's doctrine), which is what lets the hub classify at any version instead of guessing from an exception class it cannot attribute.

### Three exclusions, each load-bearing

| excluded | why |
|---|---|
| the `load` phase | a caller-ROUTED slot can fail to resolve there. th#1259: never label something a payload participates in producing. A warm forward has no payload at all — that is what makes it the clean case. |
| anything mapping to a non-FATAL status | a warm-phase OOM is still an OOM, and a bigger/idler card serves it. Re-typing would fatal a retryable job. |
| anything already a `WorkerError` | `ModelSlotIdentityError`, `ComponentSubstitutionError`, `CompiledExecutionLaneUnavailableError` … already claim their own origin, and those labels are the hub's routing keys. Wrapping erases them. |

## Tests

`tests/test_warm_fault_typed_pgw1118.py` — integration-grade over a real `Executor` and a real `ensure_setup` + synthesized warm pass, no GPU, no mocks of the seam under test:

* a handler that raises in the warm pass leaves setup as `EndpointSetupFailed`, phase `warmup_forward`, worker text intact, and `_map_exception` renders the labeled FATAL the hub matches on;
* a `setup()` failure (LOAD phase) is NOT claimed;
* the three exclusions, pinned individually.

RED without the change: the bare `ValueError` escapes verbatim, which is exactly the incident. Adjacent suites re-run green (`test_warmup_oneof_invariant_th1771`, `test_output_integrity_warm_exempt_th1771`, `test_cancelled_setup_leak_gw624`, `test_activity_gw601`, `test_retry_activity_gw661`, `test_fn_unavailable_vocabulary_th1563`, `test_warmup_kind_collision_pgw1067`, `test_eager_first_boot_pgw671`, `test_executor_adopt` — 93 passed).

## Versions

No `pyproject` bump: this repo bumps at publish (one artifact per number), same as pgw#1113/#1115/#1116. `EndpointSetupFailed` is not added to `gen_worker.__all__`, so the fleet's MAJOR.MINOR `[supported]` allowlist is untouched. Ships in the next cut; the hub arm is inert on workers that cannot emit the label, so there is no ordering constraint on the train.

$0 — cardless, no pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)