### PR TITLE
pgw#1121: the clone disk preflight READS the source's storage width instead of guessing it (0.105.0)

### DIFF
--- a/changelog.d/pgw1121.md
+++ b/changelog.d/pgw1121.md
@@ -1,0 +1,29 @@
+- **pgw#1121: the clone disk preflight READS the source's storage width instead
+  of guessing it, so an untagged fp32 upstream is castable again.** `_preflight_disk`
+  sized a materialized output from the source dtype, and the dtype came from the
+  plan-time classifier, which can only read one off a filename VARIANT TAG
+  (`model.fp16.safetensors`). Upstream diffusers repos carry no tag —
+  `Wan-AI/Wan2.2-T2V-A14B-Diffusers` ships plain
+  `transformer_2/diffusion_pytorch_model-00001-of-00012.safetensors` — so the
+  untagged case fell to a 4-bit default and modelled a 53.2 GiB **fp32** tree as
+  packed 4-bit. A bf16 cast was then budgeted at 4x the source and refused before
+  a byte moved: `CloneDiskSpaceError: need ~268.1 GiB free … have 199.9 GiB`
+  against a true need of ~82 GiB (live request
+  `3190bc31-8091-440f-ae0e-413c522d2d8d`, ie#632). Every dense fp32 upstream was
+  un-castable at ingest — the whole class the platform most wants to downcast.
+  `plan_huggingface` now range-reads the selected weight set's safetensors
+  HEADERS (`parse_safetensors_file_metadata`, up to 3 of the largest files — the
+  header, never tensor data), stamps the byte-dominant dtype when the tag
+  heuristic came up empty (which also makes `dtype: "source"` honest BEFORE the
+  transfer rather than after it), and carries measured **bits per stored
+  parameter** on the plan. An output tree is `params × out_bits / 8`, so scaling
+  the source bytes by `out_bits / bits_per_param` is exact even for a mixed-dtype
+  tree, where naming a single dtype would not be. The unreadable-header fallback
+  moved from 4 bits to **32**, the widest dense width, and the refusal now says
+  so: the two ways to be wrong do not cost the same — too narrow REFUSES a job
+  that fits, permanently and before anything runs, on a conversion surface with
+  one pod shape; too wide can hit a late, loud, retryable ENOSPC. Narrowing casts
+  keep the old "no bigger than the source" bound whenever the width was guessed
+  rather than measured. `tests/convert/test_clone_preflight_dtype_pgw1121.py`
+  pins the live request's own numbers red-to-green, plus the mixed tree, the
+  unreadable header and the tag-still-wins case.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.104.0"
+version = "0.105.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -395,6 +395,24 @@ _DTYPE_STORAGE_BITS = {
     "q3_k_m": 3, "q3_k_s": 3,
     "q2_k": 2,
 }
+# pgw#1121. The source's dtype is READ at plan time from the safetensors
+# headers (`ingest.stamp_plan_source_dtype`), so this fires only when no
+# header could be read at all. It is 32 — the widest DENSE width — and the
+# choice is deliberate, because the two ways to be wrong do not cost the same:
+#
+#   * too NARROW (the old default, 4) makes the estimate 4-8x the truth and
+#     REFUSES the job at plan time, before a byte moves. Nothing recovers
+#     that: the conversion surface has one pod shape, and you cannot rent
+#     268 GiB for an 82 GiB clone. It also fired on essentially every real
+#     source, since a genuinely packed 4-bit tree is always tagged, gguf, or
+#     routed through a quant strategy — never an unreadable dense header.
+#   * too WIDE under-estimates the output and can hit ENOSPC mid-clone. That
+#     costs one pod-hour, says exactly what happened, and is retryable on a
+#     bigger disk.
+#
+# A loud, late, recoverable failure on the rare unreadable source beats a
+# silent, early, permanent refusal on the common one.
+_UNRESOLVED_SOURCE_BITS = 32
 
 
 def _plan_has_no_repackager(plan: Any) -> bool:
@@ -417,6 +435,22 @@ def _plan_has_no_repackager(plan: Any) -> bool:
         declared = repackage_family(canonical_model_family_from_variant(variant))
         return declared is None or not declared.supports_singlefile_to_diffusers
     return False
+
+
+def _output_tree_bytes(
+    spec: OutputSpec, source_bytes: int, source_bits: int, measured_bits: int,
+) -> int:
+    """How big one materialized output tree will be, in bytes.
+
+    A NARROWING cast is only known to shrink when the source width was
+    measured; on a guessed width the old, deliberately loose bound stands —
+    an output tree is never bigger than the source it was cast from."""
+    out_bits = _DTYPE_STORAGE_BITS.get(spec.dtype)
+    if out_bits is None:  # "source", or a container we cannot size
+        return source_bytes
+    if not measured_bits and out_bits <= source_bits:
+        return source_bytes
+    return (source_bytes * out_bits + source_bits - 1) // source_bits
 
 
 def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
@@ -491,14 +525,15 @@ def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
             if m:
                 shard_groups[m.group("group")] = shard_groups.get(m.group("group"), 0) + size
         deshard_bytes = len(passthrough) * max(shard_groups.values(), default=0)
-        # Untagged safetensors may still be a packed 4-bit tree. Mirrors do
-        # not use this estimate; explicit widening conversions do.
-        source_bits = _DTYPE_STORAGE_BITS.get(source_dtype, 4)
+        # pgw#1121: bits per stored parameter, MEASURED at plan time off the
+        # source's safetensors headers. An output tree is
+        # ``params * out_bits / 8``, so scaling the source bytes by
+        # ``out_bits / measured_bits`` is exact even for a mixed-dtype tree.
+        measured_bits = int(getattr(plan, "source_storage_bits", 0) or 0)
+        source_bits = measured_bits or _DTYPE_STORAGE_BITS.get(
+            source_dtype, _UNRESOLVED_SOURCE_BITS)
         output_sizes = [
-            source_bytes if _DTYPE_STORAGE_BITS.get(spec.dtype, source_bits) <= source_bits
-            else (
-                source_bytes * _DTYPE_STORAGE_BITS[spec.dtype] + source_bits - 1
-            ) // source_bits
+            _output_tree_bytes(spec, source_bytes, source_bits, measured_bits)
             for spec in materialized
         ]
         gguf_intermediate = max(
@@ -533,6 +568,11 @@ def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
             parts.append("one intermediate F16 GGUF tree")
         if repack:
             parts.append("one layout-repack tree")
+        if (materialized and not measured_bits
+                and source_dtype not in _DTYPE_STORAGE_BITS):
+            parts.append(
+                "source dtype unreadable, assumed "
+                f"{_UNRESOLVED_SOURCE_BITS}-bit")
         operation = ", ".join(parts) or "source tree"
 
     free = shutil.disk_usage(workdir).free

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -14,7 +14,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable, NoReturn, Optional, Sequence
+from typing import Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence
 
 import hashlib
 import re
@@ -79,6 +79,68 @@ _SAFETENSORS_DTYPE_NAMES = {
     "F32": "fp32", "F16": "fp16", "BF16": "bf16",
     "F8_E4M3": "fp8", "F8_E5M2": "fp8:e5m2",
 }
+# pgw#1121: bits per stored element, for weighing a mixed header by BYTES.
+_SAFETENSORS_DTYPE_BITS = {
+    "F64": 64, "I64": 64, "U64": 64,
+    "F32": 32, "I32": 32, "U32": 32,
+    "F16": 16, "BF16": 16, "I16": 16, "U16": 16,
+    "F8_E4M3": 8, "F8_E5M2": 8, "I8": 8, "U8": 8, "BOOL": 8,
+}
+# pgw#1121: how many of the selected weight files' headers we range-read to
+# resolve an untagged source's real dtype. Shards of one set share a dtype,
+# so the largest few are representative; the cap keeps a 100-shard listing
+# from turning plan time into 100 round-trips.
+_MAX_DTYPE_HEADER_READS = 3
+
+
+def _remote_safetensors_width(
+    repo_id: str,
+    revision: str | None,
+    filenames: Sequence[str],
+    hf_token: str | None,
+) -> tuple[str, int]:
+    """``(dominant dtype, bits per stored parameter)`` of a REMOTE safetensors
+    set, read from the files' HEADERS (pgw#1121). ``("", 0)`` when no header
+    could be read.
+
+    ``parse_safetensors_file_metadata`` range-reads the header and nothing
+    else — no tensor data — so this is a plan-time metadata call like every
+    other one on this path, not a download.
+
+    Both numbers are BYTE-weighted, because the caller is sizing a disk budget
+    and a tree's scale factor is set by where its bytes are. Bits-per-parameter
+    is the exact conversion factor even for a MIXED tree: an output tree's size
+    is ``params * out_bits / 8``, so ``source_bytes * out_bits / bits_per_param``
+    holds whatever the mix is — where "the source is fp32" would be a lie that
+    happens to be close.
+    """
+    api = hf().HfApi(token=(hf_token or None))
+    bytes_by_dtype: dict[str, int] = {}
+    total_params = 0
+    read = 0
+    for name in filenames:
+        if read >= _MAX_DTYPE_HEADER_READS:
+            break
+        try:
+            meta = api.parse_safetensors_file_metadata(
+                repo_id, name, revision=revision)
+        except Exception:  # noqa: BLE001 — any unreadable header just abstains
+            continue
+        read += 1
+        for raw_dtype, params in (getattr(meta, "parameter_count", None) or {}).items():
+            bits = _SAFETENSORS_DTYPE_BITS.get(str(raw_dtype).upper())
+            if not bits:
+                continue
+            key = str(raw_dtype).upper()
+            bytes_by_dtype[key] = bytes_by_dtype.get(key, 0) + bits * int(params)
+            total_params += int(params)
+    if not bytes_by_dtype or total_params <= 0:
+        return "", 0
+    top = max(bytes_by_dtype, key=lambda k: bytes_by_dtype[k])
+    # Floor: a narrower assumed width over-provisions, which is the harmless
+    # direction for a rounding error.
+    bits_per_param = max(1, sum(bytes_by_dtype.values()) // total_params)
+    return _SAFETENSORS_DTYPE_NAMES.get(top, ""), bits_per_param
 
 
 def _detect_snapshot_dtype(root: Path) -> str:
@@ -243,6 +305,11 @@ class HFSourcePlan:
     side: dict[str, Any]
     classification: RepoClassification
     content_ids: dict[str, str]        # path -> "sha256:<hex>" | "git:<oid>"
+    # pgw#1121: MEASURED bits per stored parameter, off the selected weight
+    # set's safetensors headers. 0 when no header could be read. Lives on the
+    # plan, not in ``classification.attrs``, because it is a sizing fact for
+    # the disk preflight — not a checkpoint attribute anyone publishes.
+    source_storage_bits: int = 0
 
     @property
     def provider(self) -> str:
@@ -340,10 +407,57 @@ def plan_huggingface(
         dtype_pref=tuple(dtype_preference or ("bf16", "fp16", "fp32")),
         gguf_quant=gguf_quant,
     )
+    bits = resolve_plan_source_width(classification, repo_id, rev, sizes, hf_token)
     return HFSourcePlan(
         repo_id=repo_id, revision=sha, paths=paths, sizes=sizes, side=side,
         classification=classification, content_ids=content_ids,
+        source_storage_bits=bits,
     )
+
+
+def resolve_plan_source_width(
+    classification: RepoClassification,
+    repo_id: str,
+    revision: str | None,
+    sizes: Mapping[str, int],
+    hf_token: str | None,
+) -> int:
+    """Read the selected weight set's real storage width off its safetensors
+    headers; stamp the dtype when the filename heuristic came up empty, and
+    return bits-per-parameter for the disk estimate (pgw#1121). 0 = unreadable.
+
+    The variant-tag heuristic can only read a dtype off a FILENAME
+    (``model.fp16.safetensors``), and upstream diffusers repos are untagged —
+    ``Wan-AI/Wan2.2-T2V-A14B-Diffusers`` ships plain
+    ``transformer_2/diffusion_pytorch_model-00001-of-00012.safetensors``. It
+    answered ``""``, and everything downstream had to guess: the clone disk
+    preflight modelled a 53.2 GiB fp32 tree as packed 4-bit and refused a bf16
+    cast that needed 82 GiB by asking for 268.1 GiB.
+
+    The width is IN the file — every tensor's dtype sits in the safetensors
+    header, which is a range read, not a download. Reading it here also makes
+    ``dtype: "source"`` honest BEFORE the transfer rather than after it
+    (``_detect_snapshot_dtype`` only runs post-ingest).
+
+    The dtype stamp defers to a tag that already resolved (a variant suffix is
+    the publisher's own declaration); the WIDTH does not, because it is a
+    measurement and the estimate wants the measured one.
+    """
+    selected = sorted(
+        (p for p in classification.allow_patterns
+         if p.lower().endswith(".safetensors")),
+        key=lambda p: int(sizes.get(p, 0)), reverse=True,
+    )
+    if not selected:
+        return 0
+    try:
+        dtype, bits = _remote_safetensors_width(
+            repo_id, revision, selected, hf_token)
+    except Exception:  # noqa: BLE001 — an unresolvable width is not a refusal
+        return 0
+    if dtype and not str(classification.attrs.get("dtype") or "").strip():
+        classification.attrs["dtype"] = dtype
+    return bits
 
 
 def plan_civitai(

--- a/tests/convert/test_clone_preflight_dtype_pgw1121.py
+++ b/tests/convert/test_clone_preflight_dtype_pgw1121.py
@@ -1,0 +1,271 @@
+"""pgw#1121: the clone disk preflight sizes an UNTAGGED source by reading it.
+
+`_preflight_disk` sized a materialized output from the source's storage width,
+and the width came from the PLAN-time classification — which could only read a
+dtype off a filename VARIANT TAG (`model.fp16.safetensors`). Upstream diffusers
+repos carry no tag: `Wan-AI/Wan2.2-T2V-A14B-Diffusers` ships plain
+`transformer_2/diffusion_pytorch_model-00001-of-00012.safetensors`. So the
+untagged case fell to a 4-bit default and modelled a 53.2 GiB **fp32** tree as
+packed 4-bit — a bf16 cast was budgeted at 4x the source and refused before a
+byte moved:
+
+    CloneDiskSpaceError: not enough disk for clone: need ~268.1 GiB free
+    (source 53.2 GiB; 1 materialized output tree(s); 2 GiB margin),
+    have 199.9 GiB
+
+Live on master 2026-08-11, request `3190bc31-8091-440f-ae0e-413c522d2d8d`. The
+true need is 53.2 + 26.6 + 2 = ~82 GiB, which fits the 200 GB conversion pod
+2.4x over. Every dense fp32 upstream was un-castable at ingest.
+
+The numbers below are that request's: 57,154,175,562 B of transformer_2 across
+12 shards, 199.9 GiB free.
+
+    pytest tests/convert/test_clone_preflight_dtype_pgw1121.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from gen_worker.convert.clone import (
+    CloneDiskSpaceError,
+    OutputSpec,
+    _preflight_disk,
+)
+from gen_worker.convert.ingest import plan_huggingface
+
+GIB = 1024 ** 3
+# The live request's own numbers.
+TRANSFORMER_2_BYTES = 57_154_175_562
+SHARDS = 12
+POD_FREE_BYTES = int(199.9 * GIB)
+
+
+_WIDTH = {"F32": 4, "BF16": 2, "F16": 2}
+
+
+def _safetensors_bytes(*tensors: tuple[str, int]) -> bytes:
+    """A real (tiny) safetensors file — the header is what gets read.
+    Each `(dtype, params)` pair becomes one tensor."""
+    header: dict[str, Any] = {}
+    offset = 0
+    for i, (dtype, params) in enumerate(tensors):
+        end = offset + params * _WIDTH[dtype]
+        header[f"blocks.{i}.weight"] = {
+            "dtype": dtype, "shape": [params], "data_offsets": [offset, end]}
+        offset = end
+    blob = json.dumps(header).encode("utf-8")
+    return struct.pack("<Q", len(blob)) + blob + b"\x00" * offset
+
+
+def _wan22_remote(tmp_path: Path, dtype: str = "F32") -> Path:
+    """The Wan2.2-T2V-A14B-Diffusers shape: a diffusers tree whose weight
+    files carry NO dtype variant tag."""
+    remote = tmp_path / "remote"
+    (remote / "transformer_2").mkdir(parents=True)
+    (remote / "model_index.json").write_text(json.dumps({
+        "_class_name": "WanPipeline",
+        "transformer_2": ["diffusers", "WanTransformer3DModel"],
+    }), encoding="utf-8")
+    (remote / "transformer_2" / "config.json").write_text(
+        json.dumps({"_class_name": "WanTransformer3DModel"}), encoding="utf-8")
+    for i in range(1, SHARDS + 1):
+        name = f"diffusion_pytorch_model-{i:05d}-of-{SHARDS:05d}.safetensors"
+        (remote / "transformer_2" / name).write_bytes(
+            _safetensors_bytes((dtype, 4)))
+    return remote
+
+
+def _fake_hf(remote: Path, *, headers_readable: bool = True) -> Any:
+    """The huggingface_hub surface `gen_worker.convert.ingest` uses. Reported
+    SIZES are the production ones; the bytes on disk are tiny, because weights
+    never transit a dev box and the plan never reads them."""
+
+    def _files() -> list[Path]:
+        return sorted(p for p in remote.rglob("*") if p.is_file())
+
+    def _reported_size(rel: str, real: int) -> int:
+        if rel.startswith("transformer_2/") and rel.endswith(".safetensors"):
+            return TRANSFORMER_2_BYTES // SHARDS
+        return real
+
+    class _Api:
+        def __init__(self, token: str | None = None) -> None:
+            self.token = token
+
+        def repo_info(self, repo_id: str, revision: str | None = None) -> Any:
+            return SimpleNamespace(sha="5be7df96" + "0" * 32)
+
+        def list_repo_tree(self, repo_id: str, revision: str | None = None,
+                           recursive: bool = False) -> Any:
+            for p in _files():
+                rel = p.relative_to(remote).as_posix()
+                yield SimpleNamespace(
+                    path=rel, size=_reported_size(rel, p.stat().st_size),
+                    lfs=SimpleNamespace(sha256=f"{abs(hash(rel)):064x}"[:64]),
+                    blob_id="")
+
+        def parse_safetensors_file_metadata(
+            self, repo_id: str, filename: str, *, revision: str | None = None,
+            repo_type: str | None = None, token: str | None = None,
+        ) -> Any:
+            """The real range-read call, served off the local header bytes."""
+            if not headers_readable:
+                raise OSError("header unreadable")
+            raw = (remote / filename).read_bytes()
+            (n,) = struct.unpack("<Q", raw[:8])
+            header = json.loads(raw[8:8 + n])
+            counts: dict[str, int] = {}
+            for value in header.values():
+                if not isinstance(value, dict) or "dtype" not in value:
+                    continue
+                params = 1
+                for dim in value.get("shape") or []:
+                    params *= int(dim)
+                counts[str(value["dtype"])] = (
+                    counts.get(str(value["dtype"]), 0) + params)
+            return SimpleNamespace(parameter_count=counts, metadata={})
+
+    def _download(repo_id: str, filename: str, revision: str | None = None,
+                  token: str | None = None) -> str:
+        return str(remote / filename)
+
+    return SimpleNamespace(
+        HfApi=_Api, hf_hub_download=_download,
+        snapshot_download=lambda *a, **k: "")
+
+
+def _plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **kw: Any) -> Any:
+    remote = _wan22_remote(tmp_path, dtype=kw.pop("dtype", "F32"))
+    monkeypatch.setattr("gen_worker.convert.ingest.hf",
+                        lambda: _fake_hf(remote, **kw))
+    return plan_huggingface(
+        "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        source_include=["model_index.json", "transformer_2/*"],
+    )
+
+
+def _with_free(monkeypatch: pytest.MonkeyPatch, free: int) -> None:
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _p: shutil._ntuple_diskusage(  # type: ignore[attr-defined]
+            total=free * 2, used=free, free=free))
+
+
+BF16 = OutputSpec(dtype="bf16", file_layout="diffusers", file_type="safetensors")
+
+
+def test_untagged_fp32_source_resolves_its_dtype_at_plan_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No filename says fp32 — the safetensors HEADER does, and the plan
+    reads it. This also makes `dtype: "source"` honest before the transfer."""
+    plan = _plan(tmp_path, monkeypatch)
+
+    assert plan.classification.attrs["dtype"] == "fp32"
+
+
+def test_bf16_cast_of_the_live_wan22_leg_is_not_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Request 3190bc31: 53.2 GiB of untagged fp32 -> bf16 on a 200 GB pod.
+
+    Revert-turns-red: restore the 4-bit default in `_preflight_disk` (or drop
+    the `resolve_plan_source_width` call in `plan_huggingface`) and this asks
+    for 268.1 GiB again."""
+    plan = _plan(tmp_path, monkeypatch)
+    _with_free(monkeypatch, POD_FREE_BYTES)
+
+    _preflight_disk(tmp_path, plan, [BF16])  # must not raise
+
+
+def test_the_estimate_is_source_plus_half_plus_margin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bracket the bound: a bf16 output of an fp32 source is HALF the source,
+    so ~82 GiB is required and ~81 GiB is not enough. Asserting only "does
+    not raise at 199.9 GiB" would also pass on an estimate that is far too
+    small."""
+    plan = _plan(tmp_path, monkeypatch)
+    source_bytes = sum(size for _, size, _ in plan.bank_files())
+    required = source_bytes + -(-source_bytes // 2) + 2 * GIB
+    assert 81 * GIB < required < 82 * GIB  # the tracker's ~82 GiB
+
+    _with_free(monkeypatch, required)
+    _preflight_disk(tmp_path, plan, [BF16])
+
+    _with_free(monkeypatch, required - 1)
+    with pytest.raises(CloneDiskSpaceError) as excinfo:
+        _preflight_disk(tmp_path, plan, [BF16])
+    assert "need ~81.8 GiB" in str(excinfo.value)
+
+
+def test_an_unreadable_header_assumes_the_widest_dense_width_and_says_so(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no header can be read the preflight still has to guess, and the
+    guess is 32 bits — the direction whose failure is a late, loud, retryable
+    ENOSPC rather than an early, permanent refusal of a job that fits. The
+    refusal names the assumption so the reader is not left deriving it."""
+    plan = _plan(tmp_path, monkeypatch, headers_readable=False)
+    assert not plan.classification.attrs.get("dtype")
+
+    _with_free(monkeypatch, POD_FREE_BYTES)
+    _preflight_disk(tmp_path, plan, [BF16])  # 82 GiB, not 268 GiB
+
+    _with_free(monkeypatch, 40 * GIB)
+    with pytest.raises(CloneDiskSpaceError) as excinfo:
+        _preflight_disk(tmp_path, plan, [BF16])
+    assert "source dtype unreadable, assumed 32-bit" in str(excinfo.value)
+
+
+def test_a_mixed_dtype_tree_is_sized_by_bits_per_parameter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Half fp32, half fp16 by BYTES. Naming one dtype would be a lie either
+    way; bits-per-parameter is exact — 8 bytes of source hold 3 parameters, so
+    a bf16 output of it is 0.75x the source, and that is what the estimate
+    says."""
+    remote = _wan22_remote(tmp_path)
+    for p in sorted((remote / "transformer_2").glob("*.safetensors")):
+        p.write_bytes(_safetensors_bytes(("F32", 4), ("F16", 8)))
+    monkeypatch.setattr("gen_worker.convert.ingest.hf", lambda: _fake_hf(remote))
+
+    plan = plan_huggingface(
+        "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        source_include=["model_index.json", "transformer_2/*"],
+    )
+    assert plan.source_storage_bits == 21  # floor(8 * 8 / 3)
+
+    source_bytes = sum(size for _, size, _ in plan.bank_files())
+    _with_free(monkeypatch, int(source_bytes * 1.77) + 2 * GIB)
+    _preflight_disk(tmp_path, plan, [BF16])
+
+    _with_free(monkeypatch, int(source_bytes * 1.7) + 2 * GIB)
+    with pytest.raises(CloneDiskSpaceError):
+        _preflight_disk(tmp_path, plan, [BF16])
+
+
+def test_a_tagged_source_still_wins_over_the_header_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stamp only fills a GAP: a source the variant-tag heuristic already
+    resolved is untouched, so no existing classification changes shape."""
+    remote = _wan22_remote(tmp_path, dtype="BF16")
+    for p in sorted((remote / "transformer_2").glob("*.safetensors")):
+        p.rename(p.with_name(p.name.replace(".safetensors", ".fp16.safetensors")))
+    monkeypatch.setattr("gen_worker.convert.ingest.hf", lambda: _fake_hf(remote))
+
+    plan = plan_huggingface(
+        "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        source_include=["model_index.json", "transformer_2/*"],
+    )
+
+    assert plan.classification.attrs["dtype"] == "fp16"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.104.0"
+version = "0.105.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The defect

`_preflight_disk` (`convert/clone.py`) sized a materialized output from the source's storage width:

```python
source_bits = _DTYPE_STORAGE_BITS.get(source_dtype, 4)
```

`source_dtype` comes from the PLAN-time classification, and the classifier can only read a dtype off a filename **variant tag** (`model.fp16.safetensors`). Upstream diffusers repos are untagged — `Wan-AI/Wan2.2-T2V-A14B-Diffusers` ships `transformer_2/diffusion_pytorch_model-00001-of-00012.safetensors` — so the default fired and the estimator modelled a **fp32 tree as packed 4-bit**:

> `CloneDiskSpaceError: not enough disk for clone: need ~268.1 GiB free (source 53.2 GiB; 1 materialized output tree(s); 2 GiB margin), have 199.9 GiB`

Live on master 2026-08-11, request `3190bc31-8091-440f-ae0e-413c522d2d8d`. The true need is 53.2 + 26.6 + 2 = **~82 GiB** — it fits the 200 GB conversion pod 2.4x over. Every dense fp32 upstream was un-castable at ingest, which is the whole class the platform most wants to downcast.

## The fix: read it, do not guess it

`plan_huggingface` range-reads the selected weight set's safetensors **headers** (`HfApi.parse_safetensors_file_metadata`, capped at the 3 largest files — the header only, never tensor data, so it is a metadata call like every other one on this path) and:

* **stamps the byte-dominant dtype** on `RepoClassification.attrs["dtype"]` when the variant-tag heuristic came up empty. This also makes `dtype: "source"` honest BEFORE the transfer instead of after it — `_detect_snapshot_dtype` only runs post-ingest.
* carries **measured bits per stored parameter** as `HFSourcePlan.source_storage_bits`. It lives on the plan, not in `attrs`, because it is a sizing fact for the preflight and not a checkpoint attribute anyone publishes.

Bits-per-parameter, not a dtype name, is what the estimate actually wants: an output tree is `params × out_bits / 8`, so `source_bytes × out_bits / bits_per_param` is **exact even for a mixed-dtype tree**, where "the source is fp32" would be a lie that happens to be close.

## The fallback direction, and why

The unreadable-header default moves from **4 bits to 32** — the widest DENSE width — and the refusal names the assumption. The two ways to be wrong do not cost the same:

* **too NARROW** (the old 4) inflates the estimate 4-8x and **REFUSES the job at plan time**, before a byte moves. Nothing recovers that: the conversion surface has one pod shape, and you cannot rent 268 GiB for an 82 GiB clone. It also fired on essentially every real source, since a genuinely packed 4-bit tree is always tagged, gguf, or routed through a quant strategy — never an unreadable dense header.
* **too WIDE** under-estimates and can hit ENOSPC mid-clone: one pod-hour, a message that says exactly what happened, retryable on a bigger disk.

A loud, late, recoverable failure on the rare unreadable source beats a silent, early, permanent refusal on the common one. Narrowing casts keep the old "an output is never bigger than the source it was cast from" bound whenever the width was **guessed** rather than measured.

## Tests

`tests/convert/test_clone_preflight_dtype_pgw1121.py` — 6 cases driving the real `plan_huggingface` against a local stand-in for the provider, with the live request's own numbers (57,154,175,562 B across 12 untagged shards, 199.9 GiB free):

* the untagged fp32 source resolves its dtype at plan time
* the live wan-2.2 bf16 leg is not refused
* the estimate is bracketed at source + half + margin (~81.8 GiB), not merely "does not raise"
* a mixed fp32/fp16 tree is sized by bits-per-parameter
* an unreadable header assumes 32 bits and says so in the refusal
* a tagged source still wins over the header read (the stamp only fills a gap)

**Revert-turns-red, verified:** with the 4-bit default and the width resolution removed, 4 of the 6 fail with the verbatim production message `need ~268.1 GiB free (source 53.2 GiB; ...), have 199.9 GiB`.

Full `tests/convert` suite: 100 passed, 2 skipped, 1 xfailed. mypy/ruff/every lint gate green locally.

Version 0.104.0 → **0.105.0** in `pyproject.toml` and `uv.lock`, same commit.

Closes pgw#1121. Unblocks te#179 / ie#632's wan-2.2 bf16 leg.