### PR TITLE
pgw#1125 (th#1795): split `stage_ms.upload` into create / put / complete

### DIFF
--- a/changelog.d/pgw1125.md
+++ b/changelog.d/pgw1125.md
@@ -1,0 +1,8 @@
+- `stage_ms.upload` splits into `upload.create` / `upload.put` / `upload.complete`
+  (pgw#1125, th#1795). The upload is 98.6% of a fast request's finalize tail and
+  90% of its whole round trip, and it was one opaque number — the split across
+  the three legs of the presigned protocol was inference. `presigned_upload_file`
+  takes an `on_phase(name, seconds)` callback that fires as each leg finishes,
+  failures included. Sub-phases are reported in the dotted rollup namespace, so
+  `upload` keeps meaning the whole bracket and the stage map's
+  reconciliation invariant is untouched.

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -213,6 +213,27 @@ def blake3_hash_file(path: str | Path, chunk_size: int = STREAM_CHUNK_BYTES) -> 
     return h.hexdigest()
 
 
+@contextmanager
+def _phase(on_phase: Optional[Any], name: str) -> Iterator[None]:
+    """Time one leg of the three-leg protocol and hand it to ``on_phase``.
+
+    pgw#1125 / th#1795: ``stage_ms.upload`` is ONE bracket around create ->
+    PUT -> complete, and it is 98.6% of a fast request's finalize tail. The
+    split across the three legs decides which fix is worth building, so it has
+    to be measured rather than budgeted. The callback fires on the way out of
+    the leg, failure included — a leg that raised still cost its time.
+    """
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        if on_phase is not None:
+            try:
+                on_phase(name, max(0.0, time.monotonic() - started))
+            except Exception:  # a metric may never break an upload
+                logger.debug("upload phase callback failed for %s", name, exc_info=True)
+
+
 class PresignedUploadResult:
     """Result of a presigned upload."""
 
@@ -235,6 +256,7 @@ def presigned_upload_file(
     on_progress: Optional[Any] = None,
     cancel_check: Optional[Any] = None,
     complete_extra: Optional[Dict[str, Any]] = None,
+    on_phase: Optional[Any] = None,
 ) -> PresignedUploadResult:
     """Upload a file to TensorHub.
 
@@ -248,6 +270,10 @@ def presigned_upload_file(
         size_bytes: File size in bytes.
         on_progress: Optional callback(parts_done, total_parts, bytes_uploaded).
         cancel_check: Optional callable that returns True if canceled.
+        on_phase: Optional callback(phase_name, seconds) invoked as each leg
+            of the protocol finishes — "create", "put", "complete". th#1795:
+            without it ``stage_ms.upload`` is one opaque number and every
+            attribution inside it is a guess.
         complete_extra: Optional extra fields merged into the /complete POST
             body (after the `parts` array). NOTE (gw#401/th#606): tensorhub's
             per-file /complete is parts-only and does NOT persist lineage
@@ -269,6 +295,7 @@ def presigned_upload_file(
             on_progress=on_progress,
             cancel_check=cancel_check,
             complete_extra=complete_extra,
+            on_phase=on_phase,
             session=session,
             put_pool=put_pool,
         )
@@ -288,6 +315,7 @@ def _presigned_upload_file_scoped(
     complete_extra: Optional[Dict[str, Any]],
     session: requests.Session,
     put_pool: PutPool,
+    on_phase: Optional[Any] = None,
 ) -> PresignedUploadResult:
     url = f"{base_url}{endpoint_path}"
 
@@ -300,7 +328,8 @@ def _presigned_upload_file_scoped(
     create_headers["Content-Type"] = "application/json"
 
     try:
-        resp = session.post(url, headers=create_headers, data=json.dumps(payload), timeout=_CREATE_TIMEOUT_S)
+        with _phase(on_phase, "create"):
+            resp = session.post(url, headers=create_headers, data=json.dumps(payload), timeout=_CREATE_TIMEOUT_S)
     except requests.RequestException as e:
         raise ArtifactTransferError(
             f"tensorhub upload create request failed: {e}",
@@ -366,13 +395,14 @@ def _presigned_upload_file_scoped(
         from .s3_transfer import S3TransferGrant, upload_file_with_grant
 
         grant = S3TransferGrant.from_mapping(transfer_grant)
-        sdk_result = upload_file_with_grant(
-            file_path=file_path,
-            grant=grant,
-            blake3_hex=blake3_hex,
-            size_bytes=size_bytes,
-            on_progress=on_progress,
-        )
+        with _phase(on_phase, "put"):
+            sdk_result = upload_file_with_grant(
+                file_path=file_path,
+                grant=grant,
+                blake3_hex=blake3_hex,
+                size_bytes=size_bytes,
+                on_progress=on_progress,
+            )
         complete_payload: Dict[str, Any] = {
             "transfer": {
                 "mode": "s3_sdk",
@@ -387,13 +417,14 @@ def _presigned_upload_file_scoped(
             for k, v in complete_extra.items():
                 if v is not None and k != "transfer":
                     complete_payload[k] = v
-        result_meta = _complete_upload_session(
-            complete_url=f"{url}/{upload_id}/complete",
-            headers=headers,
-            payload=complete_payload,
-            cancel_check=cancel_check,
-            session=session,
-        )
+        with _phase(on_phase, "complete"):
+            result_meta = _complete_upload_session(
+                complete_url=f"{url}/{upload_id}/complete",
+                headers=headers,
+                payload=complete_payload,
+                cancel_check=cancel_check,
+                session=session,
+            )
         return PresignedUploadResult(meta=result_meta, dedup=False)
 
     if _is_tensorhub_model_weight_upload(endpoint_path):
@@ -421,15 +452,16 @@ def _presigned_upload_file_scoped(
     abort_url = f"{url}/{session_id}"
 
     try:
-        etags = _upload_parts_to_s3(
-            file_path=str(file_path),
-            part_urls=part_urls,
-            part_size=part_size,
-            total_parts=total_parts,
-            on_progress=on_progress,
-            cancel_check=cancel_check,
-            put_pool=put_pool,
-        )
+        with _phase(on_phase, "put"):
+            etags = _upload_parts_to_s3(
+                file_path=str(file_path),
+                part_urls=part_urls,
+                part_size=part_size,
+                total_parts=total_parts,
+                on_progress=on_progress,
+                cancel_check=cancel_check,
+                put_pool=put_pool,
+            )
     except BaseException:
         # Abort the multipart upload on failure.
         try:
@@ -452,13 +484,14 @@ def _presigned_upload_file_scoped(
             if k == "parts":
                 continue
             complete_payload[k] = v
-    result_meta = _complete_upload_session(
-        complete_url=complete_url,
-        headers=headers,
-        payload=complete_payload,
-        cancel_check=cancel_check,
-        session=session,
-    )
+    with _phase(on_phase, "complete"):
+        result_meta = _complete_upload_session(
+            complete_url=complete_url,
+            headers=headers,
+            payload=complete_payload,
+            cancel_check=cancel_check,
+            session=session,
+        )
     return PresignedUploadResult(meta=result_meta, dedup=False)
 
 

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 from ..api.errors import CanceledError
 from ..api.types import Asset, Tensors
-from ..stage_timing import stage_of
+from ..stage_timing import record_phase_of, stage_of
 from ._helpers import _enforce_output_file_size_limit, _infer_mime_type, _infer_tensors_format, _normalize_output_ref
 
 if TYPE_CHECKING:
@@ -442,6 +442,12 @@ class _RequestOutputStream:
                 self._chunks_uploaded = parts_done
             self._maybe_emit_progress(stage="stream_upload")
 
+        def _phase_cb(phase: str, seconds: float) -> None:
+            # th#1795: `upload` is one bracket around create -> PUT ->
+            # complete and it is 98.6% of the finalize tail. Report the legs
+            # separately so the fix is aimed by measurement.
+            record_phase_of(self._ctx, "upload", phase, seconds)
+
         result = presigned_upload_file(
             file_path=self._tmp_path,
             base_url=base,
@@ -453,6 +459,7 @@ class _RequestOutputStream:
             on_progress=_progress_cb,
             cancel_check=lambda: self._ctx.cancelled,
             complete_extra=None,
+            on_phase=_phase_cb,
         )
 
         # Issue #269: sample peak RSS to verify the streaming refactor is

--- a/src/gen_worker/stage_timing.py
+++ b/src/gen_worker/stage_timing.py
@@ -93,7 +93,7 @@ class StageTimer:
     """
 
     __slots__ = (
-        "_lock", "_local", "_totals", "_intervals", "_pre",
+        "_lock", "_local", "_totals", "_intervals", "_pre", "_phases",
         "_steps", "_handler_start", "_handler_end", "_truncated",
     )
 
@@ -103,6 +103,9 @@ class StageTimer:
         self._totals: Dict[str, float] = {}
         self._intervals: List[Tuple[str, float, float]] = []
         self._pre: Dict[str, float] = {}
+        # (stage, phase) -> seconds. Reported as `stage.phase`, NEVER part of
+        # the exclusive-accounting sum — see :meth:`record_phase`.
+        self._phases: Dict[Tuple[str, str], float] = {}
         # stage name -> [(step_index, monotonic_at_step_end), ...]
         self._steps: Dict[str, List[Tuple[int, float]]] = {}
         self._handler_start: Optional[float] = None
@@ -128,6 +131,31 @@ class StageTimer:
             return
         with self._lock:
             self._pre[name] = self._pre.get(name, 0.0) + float(seconds)
+
+    def record_phase(self, stage: str, phase: str, seconds: float) -> None:
+        """Record a SUB-PHASE of ``stage``, reported as ``stage.phase``.
+
+        pgw#1125 / th#1795: ``upload`` is one bracket around a three-leg
+        protocol (create session -> PUT parts to the object store -> complete),
+        and it is the largest measured term in a fast request's round trip
+        (2587 ms of a 2623 ms finalize tail). Which leg owns it decides which
+        fix is worth building, and today that split is inference.
+
+        Sub-phases are reported in the DOTTED namespace deliberately. Stage
+        totals are exclusive and reconcile against ``total.handler``; nesting
+        real stages inside ``upload`` would keep that invariant but would also
+        redefine ``upload`` itself to mean "upload minus its legs", silently
+        breaking continuity with every number already measured against it.
+        A dotted key is a rollup like ``denoise.step_mean``: reported, never
+        summed, and skipped by :func:`reconciliation`.
+        """
+        stage = _stage_name(stage)
+        phase = _stage_name(phase)
+        if not stage or not phase or seconds <= 0:
+            return
+        key = (stage, phase)
+        with self._lock:
+            self._phases[key] = self._phases.get(key, 0.0) + float(seconds)
 
     @contextmanager
     def stage(self, name: str) -> Iterator[None]:
@@ -185,6 +213,7 @@ class StageTimer:
             totals = dict(self._totals)
             intervals = list(self._intervals)
             pre = dict(self._pre)
+            phases = dict(self._phases)
             steps = {k: list(v) for k, v in self._steps.items()}
             start = handler_start if handler_start is not None else self._handler_start
             end = handler_end if handler_end is not None else self._handler_end
@@ -193,6 +222,8 @@ class StageTimer:
         out: Dict[str, int] = {}
         for name, seconds in pre.items():
             out[name] = _ms(seconds)
+        for (stage, phase), seconds in phases.items():
+            out[stage + "." + phase] = _ms(seconds)
         if start is None:
             return out
         if end is None:
@@ -368,6 +399,15 @@ def stage_of(ctx: object, name: str) -> Iterator[None]:
         yield
 
 
+def record_phase_of(ctx: object, stage: str, phase: str, seconds: float) -> None:
+    """Record a sub-phase on ``ctx``'s timer; a no-op for contexts that carry
+    none (CLI dispatch, endpoint unit tests with a stub context)."""
+    timer = getattr(ctx, "_stages", None)
+    if not isinstance(timer, StageTimer):
+        return
+    timer.record_phase(stage, phase, seconds)
+
+
 def _stage_name(name: str) -> str:
     """Endpoint-supplied stage names share one flat map with the derived
     rollups, so ``.`` (the namespace separator for ``total.``/``class.``/
@@ -382,6 +422,7 @@ def _ms(seconds: float) -> int:
 __all__ = [
     "StageTimer",
     "stage_of",
+    "record_phase_of",
     "stage_ms_for_metrics",
     "reconciliation",
     "PRE_HANDLER_STAGES",

--- a/tests/test_upload_phase_split_pgw1125.py
+++ b/tests/test_upload_phase_split_pgw1125.py
@@ -1,0 +1,182 @@
+"""pgw#1125 / th#1795: `stage_ms.upload` splits into its three real legs.
+
+MEASURED on the standing `master` stack (2026-08-11): a fast image request
+waits 2917 ms, of which the GPU slot is held 12 ms (0.4%) and `finalize` is
+2623 ms (89.9%) — 98.6% of that being `upload`. The upload does NOT scale with
+payload size (n=88 spanning 46 KB -> 13 MB: intercept 2971 ms, slope
+0.72 ms/MB, R² = 1.5e-6), so it is round-trip count, not bandwidth. Which of
+the three legs owns the round trips decides which fix is worth building, and
+the whole 2587 ms was reported under ONE key.
+
+The test drives the REAL client (`presigned_upload_file`: real
+`requests.Session`, real `PutPool`, real part PUTs) against a real localhost
+server that implements all three legs. Each leg is given a distinct, disjoint
+artificial delay, so a callback that attributed time to the wrong leg cannot
+pass: the assertion is per-leg and the bands do not overlap.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Tuple
+
+from gen_worker.presigned_upload import presigned_upload_file
+from gen_worker.stage_timing import StageTimer, reconciliation, stage_ms_for_metrics
+
+CREATE_DELAY_S = 0.30
+PUT_DELAY_S = 0.60
+COMPLETE_DELAY_S = 0.90
+
+
+class _ThreeLegHub(BaseHTTPRequestHandler):
+    """create -> PUT part -> complete, each leg deliberately slow."""
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    def _json(self, code: int, body: Dict[str, Any]) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        base = f"http://127.0.0.1:{self.server.server_address[1]}"
+        if self.path.endswith("/complete"):
+            time.sleep(COMPLETE_DELAY_S)
+            self._json(200, {
+                "ref": "outputs/r/abc.bin", "media_id": "m1",
+                "filename": "abc.bin", "blake3": "", "sha256": "",
+                "size_bytes": 0, "mime_type": "application/octet-stream",
+            })
+            return
+        time.sleep(CREATE_DELAY_S)
+        self._json(201, {
+            "upload_id": "u1",
+            "part_urls": [base + "/put/1"],
+            "part_size": 8 << 20,
+            "total_parts": 1,
+        })
+
+    def do_PUT(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        time.sleep(PUT_DELAY_S)
+        self.send_response(200)
+        self.send_header("ETag", '"deadbeef"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def _serve() -> Tuple[ThreadingHTTPServer, str]:
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _ThreeLegHub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+def test_the_three_legs_are_attributed_separately(tmp_path) -> None:
+    src = tmp_path / "out.webp"
+    src.write_bytes(b"x" * 4096)
+
+    httpd, base = _serve()
+    seen: List[Tuple[str, float]] = []
+    try:
+        result = presigned_upload_file(
+            file_path=str(src),
+            base_url=base,
+            endpoint_path="/api/v1/media/o/uploads",
+            headers={"Authorization": "Bearer t"},
+            create_payload={"ref": "out.webp"},
+            blake3_hex="0" * 64,
+            size_bytes=4096,
+            on_phase=lambda name, secs: seen.append((name, secs)),
+        )
+    finally:
+        httpd.shutdown()
+
+    assert result.dedup is False
+    phases = dict(seen)
+    assert set(phases) == {"create", "put", "complete"}
+    # Disjoint bands: an off-by-one-leg attribution cannot satisfy all three.
+    assert CREATE_DELAY_S <= phases["create"] < PUT_DELAY_S
+    assert PUT_DELAY_S <= phases["put"] < COMPLETE_DELAY_S
+    assert COMPLETE_DELAY_S <= phases["complete"] < COMPLETE_DELAY_S + PUT_DELAY_S
+
+
+def test_a_failed_leg_still_reports_its_cost(tmp_path) -> None:
+    """A leg that raised still spent its time; a callback that only fires on
+    success would make the slow failure mode invisible — exactly the case an
+    operator is looking at when the tail blows up."""
+    src = tmp_path / "out.webp"
+    src.write_bytes(b"x" * 16)
+
+    class _RefuseComplete(_ThreeLegHub):
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path.endswith("/complete"):
+                length = int(self.headers.get("Content-Length", "0"))
+                _ = self.rfile.read(length)
+                time.sleep(COMPLETE_DELAY_S)
+                self._json(400, {"error": {"code": "bad_request"}})
+                return
+            super().do_POST()
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _RefuseComplete)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    seen: List[Tuple[str, float]] = []
+    try:
+        try:
+            presigned_upload_file(
+                file_path=str(src),
+                base_url=base,
+                endpoint_path="/api/v1/media/o/uploads",
+                headers={"Authorization": "Bearer t"},
+                create_payload={"ref": "out.webp"},
+                blake3_hex="0" * 64,
+                size_bytes=16,
+                on_phase=lambda name, secs: seen.append((name, secs)),
+            )
+        except Exception:
+            pass
+    finally:
+        httpd.shutdown()
+
+    phases = dict(seen)
+    assert "complete" in phases
+    assert phases["complete"] >= COMPLETE_DELAY_S
+
+
+def test_sub_phases_do_not_disturb_the_reconciliation_invariant() -> None:
+    """The stage map's headline property is that measured stages plus
+    `resid.unattributed` equal `total.runtime`. Sub-phases are a rollup like
+    `denoise.step_mean`: reported, never summed. If they were charged as
+    stages, `upload` would silently start meaning "upload minus its legs" and
+    every number already measured against it would stop comparing."""
+    timer = StageTimer()
+    timer.handler_open()
+    with timer.stage("upload"):
+        time.sleep(0.02)
+    timer.record_phase("upload", "create", 0.005)
+    timer.record_phase("upload", "put", 0.004)
+    timer.record_phase("upload", "complete", 0.008)
+    timer.handler_close()
+
+    out = stage_ms_for_metrics(timer, runtime_ms=out_runtime(timer))
+    assert out["upload.create"] == 5
+    assert out["upload.put"] == 4
+    assert out["upload.complete"] == 8
+    # `upload` still means the whole bracket, unchanged.
+    assert out["upload"] >= 20
+    attributed, total = reconciliation(out)
+    assert attributed == total
+
+
+def out_runtime(timer: StageTimer) -> int:
+    return int(timer.snapshot().get("total.handler", 0))


### PR DESCRIPTION

MEASURED, standing `master` stack, 2026-08-11: a fast image request costs the
user 2917 ms, of which the GPU slot is held **12 ms (0.4%)** and
`finalize_wall_ms` is **2623 ms (89.9%)** — 98.6% of that being `upload`. The
upload does not scale with payload: over n=88 uploads spanning 46 KB -> 13 MB
the regression is intercept 2971 ms, slope 0.72 ms/MB, **R² = 1.5e-6**. It is
round-trip count, not bandwidth.

Which of the three legs (create session -> PUT to the object store -> complete)
owns those round trips decides which fix is worth building — hub-chain collapse
or control-plane keepalive — and th#1795 says explicitly that the split was
INFERRED. This makes it measured. It saves 0 ms and it gates everything else.

`presigned_upload_file` gains an `on_phase(name, seconds)` callback that fires
on the way OUT of each leg, failures included: a leg that raised still cost its
time, and that is exactly the case an operator is looking at when a tail blows
up. `_stream.py` forwards it to the request's `StageTimer`.

Sub-phases live in the DOTTED rollup namespace (`upload.create`, like
`denoise.step_mean`), not as nested stages. Nesting would preserve the
exclusive-accounting invariant but would redefine `upload` itself to mean
"upload minus its legs", silently breaking continuity with every number already
measured against it. Dotted keys are reported, never summed, and skipped by
`reconciliation()`.

Tests drive the REAL client (real `requests.Session`, real `PutPool`, real part
PUTs) against a real localhost three-leg server, each leg given a disjoint
artificial delay so an off-by-one-leg attribution cannot pass. RED-verified:
mislabelling the PUT leg as `create` fails the band assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)