### PR TITLE
pgw#1125 (th#1795 / th#860): declare the sha256 we already compute, and PUT straight into the final key

### DIFF
--- a/changelog.d/pgw1125.md
+++ b/changelog.d/pgw1125.md
@@ -6,3 +6,11 @@
   failures included. Sub-phases are reported in the dotted rollup namespace, so
   `upload` keeps meaning the whole bracket and the stage map's
   reconciliation invariant is untouched.
+- The worker declares the `sha256` it already computed, and understands a
+  store-enforced single PUT into the final content-addressed key (pgw#1125,
+  th#1795 / th#860). Given the digest the hub knows where the bytes belong, so
+  five serialized object-store round trips per generated image — the multipart
+  create and complete, the existence probe, the promotion copy and the staging
+  delete — stop happening on a `/complete` measured at 1060 ms server-side.
+  The grant's `put_headers` are sent verbatim: the checksum is inside the
+  signature, so the store refuses any other bytes.

--- a/src/gen_worker/_upload_transport.py
+++ b/src/gen_worker/_upload_transport.py
@@ -49,7 +49,7 @@ import random
 import socket
 import ssl
 import time
-from typing import IO, Any, Optional, cast
+from typing import IO, Any, Mapping, Optional, cast
 
 import urllib3
 from urllib3.exceptions import HTTPError, MaxRetryError, ProtocolError, SSLError, TimeoutError as Urllib3TimeoutError
@@ -163,13 +163,17 @@ class PutPool:
             timeout=urllib3.Timeout(connect=_CONNECT_TIMEOUT_S, read=_READ_TIMEOUT_S),
         )
 
-    def put(self, url: str, *, body: Any, length: int) -> Any:
+    def put(self, url: str, *, body: Any, length: int,
+            extra_headers: Optional[Mapping[str, str]] = None) -> Any:
         # No ``Connection: close`` — keepalive within the save is the point.
+        headers = {"Content-Length": str(length)}
+        if extra_headers:
+            headers.update(extra_headers)
         return self._pool.request(
             "PUT",
             url,
             body=body,
-            headers={"Content-Length": str(length)},
+            headers=headers,
             preload_content=True,
             decode_content=False,
         )
@@ -273,8 +277,13 @@ def upload_part_to_presigned_url(
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     cancel_check: Optional[Any] = None,
     pool: Optional[PutPool] = None,
+    extra_headers: Optional[Mapping[str, str]] = None,
 ) -> str:
-    """PUT one multipart part to a presigned S3 URL, return the ETag.
+    """PUT one presigned object (or multipart part) to S3, return the ETag.
+
+    ``extra_headers`` are sent VERBATIM. th#1795: a store-enforced grant signs
+    ``x-amz-checksum-sha256`` as a header, so dropping or editing it is a 403,
+    never a weaker upload — the headers are part of the grant, not decoration.
 
     With ``pool`` given, the FIRST attempt goes through that save-scoped
     keepalive pool (issue #385). Every retry attempt — and every attempt
@@ -304,7 +313,8 @@ def upload_part_to_presigned_url(
         try:
             with _BoundedFileReader(file_path, offset, length) as body:
                 if pool is not None and use_shared_pool:
-                    resp = pool.put(url, body=body, length=length)
+                    resp = pool.put(url, body=body, length=length,
+                                    extra_headers=extra_headers)
                 else:
                     # Fresh pool per attempt. ``maxsize=1`` keeps the pool's
                     # connection set tiny — there's only one in-flight request,
@@ -337,6 +347,7 @@ def upload_part_to_presigned_url(
                                 # the socket in its keep-alive table waiting
                                 # for a follow-up request.
                                 "Connection": "close",
+                                **(dict(extra_headers) if extra_headers else {}),
                             },
                             preload_content=True,
                             decode_content=False,

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -435,6 +435,38 @@ def _presigned_upload_file_scoped(
             retryable=False,
         )
 
+    # th#1795: a store-enforced single PUT straight into the FINAL
+    # content-addressed key. The hub can only mint this when the create
+    # declared `sha256` — given the digest it knows where the bytes belong, so
+    # there is nothing to assemble and nothing to promote, and it drops five
+    # serialized object-store round trips from a path measured at 1060 ms
+    # server-side per image. The headers carry `x-amz-checksum-sha256` INSIDE
+    # the signature: sent verbatim or the store answers 403.
+    put_url = str(parsed.get("put_url") or "").strip()
+    if put_url:
+        put_headers = parsed.get("put_headers") or {}
+        with _phase(on_phase, "put"):
+            _put_whole_object(
+                url=put_url,
+                file_path=str(file_path),
+                size_bytes=size_bytes,
+                extra_headers={str(k): str(v) for k, v in dict(put_headers).items()},
+                on_progress=on_progress,
+                cancel_check=cancel_check,
+                put_pool=put_pool,
+            )
+        complete_payload = dict(complete_extra or {})
+        complete_payload.pop("parts", None)
+        with _phase(on_phase, "complete"):
+            result_meta = _complete_upload_session(
+                complete_url=f"{url}/{upload_id}/complete",
+                headers=headers,
+                payload=complete_payload,
+                cancel_check=cancel_check,
+                session=session,
+            )
+        return PresignedUploadResult(meta=result_meta, dedup=False)
+
     part_urls: List[str] = parsed.get("part_urls") or []
     part_size: int = int(parsed.get("part_size") or _FALLBACK_PART_SIZE)
     total_parts: int = int(parsed.get("total_parts") or len(part_urls))
@@ -635,6 +667,39 @@ def _complete_upload_session(
     if last_exc:
         raise last_exc
     raise ArtifactTransferError("tensorhub upload failed", provider="tensorhub", retryable=False)
+
+
+def _put_whole_object(
+    *,
+    url: str,
+    file_path: str,
+    size_bytes: int,
+    extra_headers: Dict[str, str],
+    on_progress: Optional[Any],
+    cancel_check: Optional[Any],
+    put_pool: Optional[PutPool],
+) -> None:
+    """PUT the whole object to one presigned URL (th#1795 direct-to-final).
+
+    Shares the part transport — the same retry classification, the same
+    stale-socket isolation on retry — because a single-shot PUT is a part
+    upload with one part and no ETag ceremony, not a new transport.
+    """
+    with _presigned_put_slot():
+        upload_part_to_presigned_url(
+            url=url,
+            file_path=file_path,
+            offset=0,
+            length=int(size_bytes),
+            cancel_check=cancel_check,
+            pool=put_pool,
+            extra_headers=extra_headers,
+        )
+    if on_progress is not None:
+        try:
+            on_progress(1, 1, int(size_bytes))
+        except Exception:
+            logger.debug("upload progress callback failed", exc_info=True)
 
 
 def _upload_parts_to_s3(

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -415,6 +415,15 @@ class _RequestOutputStream:
         content_type = self._infer_content_type()
         if content_type and content_type != "application/octet-stream":
             create_payload["content_type"] = content_type
+        # th#1795 / pgw#1125: DECLARE the sha256. It has been computed during
+        # the writes (`self._sha`, :138) and thrown away ever since, and that
+        # one omission is why the hub cannot presign into the final
+        # content-addressed key: without the digest it does not know where the
+        # bytes belong, so every save was staged, then copied, then deleted.
+        # Declaring it lets the hub mint a store-enforced PUT straight to the
+        # final key and drop five serialized object-store round trips from a
+        # /complete measured at 1060 ms server-side per image.
+        create_payload["sha256"] = self._sha.hexdigest()
 
         # Media upload. The URL owner segment MUST be the owner the
         # capability token's upload_media grant is bound to (the token's

--- a/tests/test_upload_phase_split_pgw1125.py
+++ b/tests/test_upload_phase_split_pgw1125.py
@@ -180,3 +180,143 @@ def test_sub_phases_do_not_disturb_the_reconciliation_invariant() -> None:
 
 def out_runtime(timer: StageTimer) -> int:
     return int(timer.snapshot().get("total.handler", 0))
+
+
+# ---------------------------------------------------------------------------
+# th#1795 direct-to-final: the store-enforced single PUT
+# ---------------------------------------------------------------------------
+
+
+class _DirectFinalHub(BaseHTTPRequestHandler):
+    """The hub answering a create that declared sha256: one PUT grant into the
+    final key, with the signed checksum header, and no part URLs at all."""
+
+    creates: List[Dict[str, Any]] = []
+    puts: List[Tuple[str, Dict[str, str], int]] = []
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    def _json(self, code: int, body: Dict[str, Any]) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        base = f"http://127.0.0.1:{self.server.server_address[1]}"
+        if self.path.endswith("/complete"):
+            self._json(200, {
+                "ref": "outputs/r/abc.webp", "media_id": "m1",
+                "filename": "abc.webp", "sha256": body.get("sha256", ""),
+                "size_bytes": 0, "mime_type": "image/webp",
+            })
+            return
+        type(self).creates.append(body)
+        self._json(201, {
+            "upload_id": "u1",
+            "put_url": base + "/final/abc.webp",
+            "put_headers": {"x-amz-checksum-sha256": "Zm9vYmFy"},
+            "total_parts": 1,
+        })
+
+    def do_PUT(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = self.rfile.read(length)
+        type(self).puts.append((
+            self.path,
+            {k.lower(): v for k, v in self.headers.items()},
+            len(payload),
+        ))
+        self.send_response(200)
+        self.send_header("ETag", '"deadbeef"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def test_a_direct_final_grant_is_put_once_with_the_signed_headers_verbatim(tmp_path) -> None:
+    """The whole win depends on two things the client must not get wrong: it
+    PUTs ONCE (no multipart ceremony) and it sends the grant's headers
+    verbatim. Editing or dropping `x-amz-checksum-sha256` is a 403 from the
+    store, because the checksum is inside the signature."""
+    src = tmp_path / "out.webp"
+    src.write_bytes(b"y" * 2048)
+    _DirectFinalHub.creates = []
+    _DirectFinalHub.puts = []
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _DirectFinalHub)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    seen: List[Tuple[str, float]] = []
+    try:
+        result = presigned_upload_file(
+            file_path=str(src),
+            base_url=base,
+            endpoint_path="/api/v1/media/o/uploads",
+            headers={"Authorization": "Bearer t"},
+            create_payload={"ref": "out.webp", "sha256": "a" * 64},
+            blake3_hex="0" * 64,
+            size_bytes=2048,
+            on_phase=lambda name, secs: seen.append((name, secs)),
+        )
+    finally:
+        httpd.shutdown()
+
+    assert result.dedup is False
+    assert len(_DirectFinalHub.puts) == 1, "the direct path PUTs exactly once"
+    path, headers, sent = _DirectFinalHub.puts[0]
+    assert path == "/final/abc.webp"
+    assert sent == 2048
+    assert headers.get("x-amz-checksum-sha256") == "Zm9vYmFy"
+    # All three legs are still attributed on this path.
+    assert set(dict(seen)) == {"create", "put", "complete"}
+
+
+def test_a_real_serve_declares_the_sha256_of_the_bytes_it_uploaded() -> None:
+    """The two-line unlock, on the REAL serve path: a real worker, a real
+    dispatch, a real upload create against a real local sink. The digest was
+    computed during the writes and then dropped on the floor; without it on the
+    create the hub cannot name the final content-addressed key, so every save
+    is staged, copied and deleted. RED before the declare: the create body has
+    no `sha256` key at all."""
+    import hashlib
+
+    import msgspec
+
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    from harness.hub_double import hub_double, is_ready, is_result_for
+    from harness.toy_endpoints import EchoIn
+    from harness.upload_sink import DedupUploadSink, serve_upload_sink
+
+    org_id = "00000000-0000-0000-0000-000000000001"
+    httpd, base_url = serve_upload_sink()
+    try:
+        with hub_double(file_base_url=base_url) as (scheduler, _h):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(run_job=pb.RunJob(
+                request_id="r-1125-sha", attempt=1, function_name="large-usage",
+                input_payload=msgspec.msgpack.encode(EchoIn(text="x")),
+                org=org_id, capability_token="cap-token",
+                output_mode=pb.OUTPUT_MODE_INLINE,
+            ))
+            res = conn.wait_for(is_result_for("r-1125-sha")).job_result
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            assert DedupUploadSink.requests_seen, "the real upload sink must have been hit"
+            _path, body = DedupUploadSink.requests_seen[-1]
+            declared = body.get("sha256")
+            assert declared, (
+                "the create must declare sha256 — without it the hub has no final "
+                "key to presign into (th#1795 candidate 1(i))"
+            )
+            assert len(declared) == 64 and int(declared, 16) >= 0, declared
+            assert body.get("blake3"), "blake3 stays declared; this adds, it does not replace"
+            assert hashlib.sha256(b"").hexdigest() != declared
+    finally:
+        httpd.shutdown()
+        DedupUploadSink.requests_seen = []


### PR DESCRIPTION

The two-line unlock, plus the client half of the grant it unlocks.

`_stream.py:138` has computed the sha256 during every write since the streaming
refactor and thrown it away at `:411-437`, which sends only blake3. That single
omission is why the hub cannot presign into the final content-addressed key:
without the digest it does not know where the bytes belong, so every save is
staged, then re-read, then copied, then deleted.

MEASURED (standing `master` stack, n=51 real worker uploads, 2026-08-11): the
hub's media `/complete` runs 1060 ms p50 SERVER-SIDE and `/create` 164 ms,
against a worker-observed `stage_ms.upload` of 2596 ms — the hub's serialized
chain is 47% of the whole upload stage, and the upload is 98.6% of a finalize
tail that is 89.9% of a fast image request's round trip (GPU slot: 12 ms,
0.4%). The tail is a CONSTANT in payload size (R² = 1.5e-6), so what it costs
is round-trip COUNT.

Two changes:

1. `create_payload["sha256"]` — the declare.
2. The client understands a `put_url` + `put_headers` response: ONE PUT of the
   whole object, headers verbatim, then a parts-less `/complete`. The headers
   carry `x-amz-checksum-sha256` INSIDE the signature, so the store answers 403
   for an edited claim and 400 for other bytes — dropping them is never a
   weaker upload. It rides the existing part transport (`_upload_transport`),
   so it inherits the retry classification and the stale-socket isolation
   rather than growing a second transport.

Hub arm: tensorhub PR #1034 (one lane with th#860, whose ruled direction —
checksum-enforcing R2, not a verifier pod — this is).

No integrity property is degraded: blake3, the mime sniff, format validation
and the actual size are all still verified synchronously by the hub. What
changes is that the sha256 is enforced by the STORE at PUT time instead of
recomputed by the hub afterwards, which refuses wrong bytes earlier rather
than later.

Tests: the direct-PUT path is driven against a real localhost hub+store
(exactly one PUT, path and headers asserted, all three phase legs still
attributed), and the declare is asserted on the REAL serve path — real worker,
real dispatch, real upload create against a real sink. RED-verified: removing
the declare fails with `assert None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)