### PR TITLE
pgw#1123: own the meta-init, so a boot key stops depending on a package nothing declared

### DIFF
--- a/changelog.d/pgw1123.md
+++ b/changelog.d/pgw1123.md
@@ -1,0 +1,25 @@
+- **pgw#1123 — the boot key no longer needs a package nothing declared, and a
+  broken image no longer looks like a pod that chose to self-mint.**
+  `models/structure_only` imported `accelerate` for its meta-init. Nothing
+  declared it, and `examples/micro-diffusion` — the fleet's cheapest AOT probe
+  vehicle — deliberately ships no diffusers stack, so on two real pods
+  (`ykwoaiqub6ktt3`, `3o09rf9ehnc4ym`, 0.104.0) the derivation refused with
+  ``` `accelerate` is not importable ```, no key existed, no
+  `POST /v1/worker/cells/resolve` was ever issued, and the pod self-minted
+  forever. That silence is what wasted the first paid reuse-circle proof.
+  - `gen_worker.models.meta_init` now OWNS the context manager (parameters on
+    meta, buffers real) and proves the invariant on the process before using
+    it, so the boot-key path depends on torch and nothing else. `accelerate` is
+    declared in the `torch` extra for the real-weight quantized loaders
+    (`w8a8` / `w4a4` / `svdq_native`) that still build skeletons with it — not
+    in `dependencies`, because it hard-requires torch and the base wheel
+    deliberately carries none.
+  - Second, distinct token: `structure_capability_missing`. A stranded FAMILY
+    (permanent and correct on the quantized artifact lanes) and an IMAGE that
+    cannot meta-instantiate at all were both `structure_unsupported`, so the
+    second read as the first. The new token names the missing capability, is
+    fenced by `boot_adopt.REASONS`, and is logged at ERROR by the trace child
+    and the mint child.
+  - `examples/micro-diffusion`'s micro-rope pipeline uses the SDK seam instead
+    of importing `accelerate` itself; its `gen-worker` pin must move to
+    `>=0.106.0` at the next relock for the built image to carry any of this.

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -27,7 +27,7 @@ src/micro_diffusion/
                       three L values whose pads are 0, 16 and 28
   *_pad32_branchy.py  micro-pad32-branchy: the RED twin — branches on the pad, so
                       the declared-range gate must REFUSE it (pgw#1079)
-  FAMILIES            the six families discovery finds here — half of the
+  FAMILIES            the seven families discovery finds here — half of the
                       cross-repo fence below
 ```
 
@@ -211,7 +211,7 @@ Two things that are easy to get wrong:
   Without it the gate fails closed on `binding_incompatible`: *"slot declares
   family … but the artifact's family is undeterminable"*.
 
-One checkpoint serves **all six** families: every variant either
+One checkpoint serves **all seven** families: every variant either
 `load_state_dict(base.transformer.state_dict(), strict=True)` or (micro-conv)
 derives its weights from the same tree's declared seed, and all of them root to
 `micro-diffusion` in tensorhub's `rootOverrides` — so the seed-997 tree

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -29,6 +29,15 @@ dependencies = [
 # NO diffusers, NO transformers, NO accelerate. The whole point of this family
 # is that its image is small and its boot is short; a dependency it does not
 # use would cost both on every cycle.
+#
+# ⚠️ THE PIN ABOVE MUST MOVE TO >=0.106.0 AT THE NEXT RELOCK (pgw#1123).
+# On 0.97.0-0.105.0 `models/structure_only` imports `accelerate`, so on THIS
+# image the boot-key derivation refuses and the pod self-mints forever —
+# measured on pods `ykwoaiqub6ktt3` and `3o09rf9ehnc4ym`, and it is what
+# silenced the first paid reuse-circle proof. 0.106.0 owns the meta-init
+# (`gen_worker.models.meta_init`), which `pipeline.py` now uses; adding
+# `accelerate` here instead would fix this one image and leave the SDK defect
+# in place for every other family, which is why it is deliberately NOT here.
 
 [dependency-groups]
 local = [

--- a/examples/micro-diffusion/src/micro_diffusion/pipeline.py
+++ b/examples/micro-diffusion/src/micro_diffusion/pipeline.py
@@ -305,7 +305,11 @@ class MicroRopePipeline(MicroPipeline):
             # Rebuilding it structure-only — instead of loading the
             # checkpoint into a real one — is the authoring answer to that,
             # and it keeps the mint weightless (pgw#1080).
-            from accelerate import init_empty_weights
+            # The SDK's own meta-init seam, not `accelerate`: this family
+            # ships no diffusers stack, and importing one here would put the
+            # boot-key derivation back behind a dependency the image does not
+            # have (pgw#1123 — it is what silenced two paid pods).
+            from gen_worker.models.meta_init import init_empty_weights
 
             with init_empty_weights():
                 pinned = MicroRopeDenoiser(base.config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ torch = [
     "safetensors>=0.8.0",
     # Emergency nf4 fit rung (gw#420) — automatic on CUDA hosts, needs bnb.
     "bitsandbytes>=0.45.0; sys_platform == 'linux' or sys_platform == 'win32'",
+    # pgw#1123: the real-weight quantized loaders (models/w8a8, models/w4a4,
+    # models/svdq_native) build their skeletons with
+    # `accelerate.init_empty_weights`. It was an undeclared import on those
+    # paths; declared here and NOT in `dependencies`, because accelerate
+    # hard-requires torch>=2.0.0 and the base wheel deliberately carries none.
+    # The BOOT-KEY path no longer imports it at all — `models/meta_init` owns
+    # that context manager, so a family without accelerate still derives a key.
+    "accelerate>=1.9",
 ]
 vision = [
     "torchvision>=0.28.0",

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -88,6 +88,13 @@ DERIVE_REASONS: Tuple[str, ...] = (
     "no_classes", "code_drift", "class_set_disagreement", "class_set_gap",
     "trace_failed", "bad_report", "child_died", "refused", "child_error",
     "slots_unresolvable", "structure_unsupported", "no_compile_target",
+    # pgw#1123 — the OPPOSITE finding to `structure_unsupported`, and until
+    # this token existed they were the same word. `structure_unsupported` says
+    # ONE FAMILY is stranded (permanent and correct on the quantized artifact
+    # lanes); this says THIS IMAGE cannot meta-instantiate at all, so every
+    # family it serves derives no key, asks for no cell, and self-mints
+    # forever — which is what two paid pods spent an evening looking like.
+    "structure_capability_missing",
     "structure_not_honored", "no_declaration", "trace_refused", "empty_share",
     # pgw#1124: the child's composition put REAL tensors off the host, so it
     # would be competing for VRAM with the parent that spawned it.

--- a/src/gen_worker/boot_trace_child.py
+++ b/src/gen_worker/boot_trace_child.py
@@ -168,8 +168,13 @@ def run(job: TraceJob) -> int:
             place=False,
             structure_only=tuple(cfg.targets)) or {}
     except structure_only.StructureOnlyUnsupported as exc:
-        # NOT a fallback — see the module docstring.
-        return _fail(report_path, "structure_unsupported", str(exc))
+        # NOT a fallback — see the module docstring. Two tokens, because a
+        # stranded FAMILY and an image that cannot meta-instantiate AT ALL are
+        # opposite findings that were reported identically (pgw#1123).
+        token = structure_only.refusal_token(exc)
+        if token == structure_only.TOKEN_CAPABILITY_MISSING:
+            logger.error("boot key cannot be derived in this image: %s", exc)
+        return _fail(report_path, token, str(exc))
 
     try:
         _slot, pipeline = pick_compile_target(loaded, cfg)

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -906,8 +906,10 @@ def mint(request: MintRequest) -> MintReport:
         endpoint instance, its compile-target pipeline, and that pipeline's
         export spec."""
         from . import fleet_cells
+        from .models import structure_only
         from .models.structure_only import (
-            StructureNotHonored, StructureOnlyUnsupported)
+            StructureCapabilityMissing, StructureNotHonored,
+            StructureOnlyUnsupported)
 
         obj = spec.cls()
         try:
@@ -929,7 +931,18 @@ def mint(request: MintRequest) -> MintReport:
                 f"did not carry it: {exc}") from exc
         except StructureOnlyUnsupported as exc:
             structure_refusals.append(str(exc))
-            frame(phase="load", note=f"structure-only declined: {exc}")
+            # pgw#1123: still never fatal — a real-weight mint is a correct,
+            # more expensive mint. But a CAPABILITY refusal is not this
+            # family declining, it is this image being unable to, and the two
+            # were one note. Say which, and say it at ERROR: the same image
+            # derives no boot key either, so every pod running it re-mints.
+            if isinstance(exc, StructureCapabilityMissing):
+                logger.error(
+                    "the weight-free mint is unavailable in this image, so "
+                    "this mint loads real weights and every boot in it will "
+                    "self-mint: %s", exc)
+            frame(phase="load", note=(
+                f"structure-only {structure_only.refusal_token(exc)}: {exc}"))
             obj = spec.cls()
             got = run_setup(
                 obj, dict(paths), arm_compile=False,

--- a/src/gen_worker/models/meta_init.py
+++ b/src/gen_worker/models/meta_init.py
@@ -1,0 +1,153 @@
+"""pgw#1123: the ONE meta-instantiation seam, owned and proven in-process.
+
+Weight-free instantiation is not an optimization any more — it is step 1 of
+every boot-time adopt (§4.27) and of the zero-download forge (pgw#1080). The
+key a pod derives, and therefore whether it can ASK the hub for a cell at all,
+begins with building a compile target from code + config alone.
+
+WHY THIS IS NOT ``accelerate.init_empty_weights``
+-------------------------------------------------
+It was, and the cost was measured on two real pods (`ykwoaiqub6ktt3`,
+`3o09rf9ehnc4ym`, 2026-08-11): ``structure_only`` imported ``accelerate``
+without anything declaring it, so ``examples/micro-diffusion`` — the fleet's
+cheapest AOT probe vehicle, which deliberately ships no diffusers stack — could
+not derive a key, never issued a resolve, and self-minted forever. Three
+campaigns measured "the worker never asks" without being able to say why.
+
+Declaring the dependency instead was considered and rejected on two facts:
+
+* ``accelerate`` hard-requires ``torch>=2.0.0``, and this package's base wheel
+  deliberately carries no torch ("the base wheel stays lean for plain-Python
+  (API-proxy) endpoints", ``pyproject.toml``). A core dependency would put a
+  multi-GB torch behind ``pip install gen-worker``, and into the exported
+  requirement set every endpoint Dockerfile installs over its base image's own
+  torch. Putting it in the ``torch`` extra costs nothing but reaches nobody:
+  no fleet family requests that extra.
+* What we actually need is ~20 lines with a contract this tree already states
+  as a REQUIREMENT — parameters on meta, **buffers real** — and the upstream
+  version of it reads ``ACCELERATE_INIT_INCLUDE_BUFFERS`` from the ambient
+  environment. An ambient third-party env var that can flip a structure
+  invariant a cell key is derived from is not a dependency, it is a hazard.
+
+``accelerate`` remains declared in the ``torch`` extra for the real-weight
+quantized loaders (:mod:`.w8a8`, :mod:`.w4a4`, :mod:`.svdq_native`) that build
+their skeletons with it. Those run only on artifacts that only exist in
+families which ship it; the boot-key path no longer depends on any of that.
+
+WHY THE CAPABILITY IS PROVEN AND NOT ASSUMED
+--------------------------------------------
+:func:`require_meta_init` builds a probe module and checks the invariant on the
+result. A meta-init that silently stopped moving parameters would trace real
+weights; one that started moving BUFFERS would make ``aot_package``'s literal
+constants unpackable, much later and much less legibly. Either way the answer
+is a typed :class:`MetaInitUnavailable` naming the capability, which
+``structure_only`` turns into a refusal a boot-adopt event can distinguish from
+a family that is genuinely stranded.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterator
+
+from ..api.errors import WorkerError
+
+#: The capability this module provides, named so a refusal can say what is
+#: missing rather than that "something" is.
+CAPABILITY = "meta-instantiation (parameters on meta, buffers real)"
+
+
+class MetaInitUnavailable(WorkerError):
+    """This PROCESS cannot meta-instantiate — a broken image, never normal.
+
+    Distinct in kind from "this family has no structure-only build": that is a
+    correct, permanent property of some trees, while this is an install that
+    cannot do what every install is expected to do.
+    """
+
+    def __init__(self, *, capability: str, lacks: str) -> None:
+        self.capability = str(capability or CAPABILITY)
+        self.lacks = str(lacks or "")
+        super().__init__(
+            f"this process cannot provide {self.capability}: {self.lacks}. "
+            f"Weight-free instantiation is how a compile target is built from "
+            f"CODE + CONFIG, so without it no boot key can be derived, no "
+            f"cell can be asked for, and this pod will self-mint on every "
+            f"boot")
+
+
+@contextlib.contextmanager
+def init_empty_weights() -> Iterator[None]:
+    """Instantiate modules with their PARAMETERS on ``meta`` and no storage.
+
+    Buffers are left alone on purpose — they are config-derived, KB-to-MB
+    scale, and they are what a literal-bearing cell packs.
+    """
+    import torch
+    from torch import nn
+
+    original = nn.Module.register_parameter
+    meta = torch.device("meta")
+
+    def register_empty_parameter(
+        module: Any, name: str, param: Any,
+    ) -> None:
+        original(module, name, param)
+        held = module._parameters.get(name)
+        if held is None:
+            return
+        cls = type(held)
+        kwargs = dict(held.__dict__)
+        kwargs["requires_grad"] = held.requires_grad
+        module._parameters[name] = cls(held.to(meta), **kwargs)
+
+    setattr(nn.Module, "register_parameter", register_empty_parameter)
+    try:
+        yield
+    finally:
+        setattr(nn.Module, "register_parameter", original)
+
+
+def require_meta_init() -> None:
+    """Prove the capability on THIS process, or refuse naming it."""
+    try:
+        import torch
+        from torch import nn
+    except Exception as exc:  # noqa: BLE001
+        raise MetaInitUnavailable(
+            capability=CAPABILITY,
+            lacks=f"`torch` is not importable ({exc})") from exc
+
+    class _Probe(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(2, 2))
+            self.register_buffer("table", torch.zeros(2))
+
+    try:
+        with init_empty_weights():
+            probe = _Probe()
+    except Exception as exc:  # noqa: BLE001
+        raise MetaInitUnavailable(
+            capability=CAPABILITY,
+            lacks=f"building a probe module refused ({exc!r})") from exc
+
+    if probe.weight.device.type != "meta":
+        raise MetaInitUnavailable(
+            capability=CAPABILITY,
+            lacks=(f"a parameter built under the context manager landed on "
+                   f"{probe.weight.device!r}, not on meta — this build would "
+                   f"hold real weights"))
+    buffer = probe.get_buffer("table")
+    if buffer.device.type == "meta":
+        raise MetaInitUnavailable(
+            capability=CAPABILITY,
+            lacks=("a BUFFER built under the context manager landed on meta; "
+                   "buffers are config-derived values a literal-bearing cell "
+                   "packs, and a fake one makes the package unbuildable"))
+
+
+__all__ = [
+    "CAPABILITY", "MetaInitUnavailable", "init_empty_weights",
+    "require_meta_init",
+]

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -16,7 +16,10 @@ refuses or copies real data in). The pattern that actually skips the state dict
 is ``init_empty_weights()`` + ``from_config`` — which is a per-CLASS capability
 (diffusers' ``ConfigMixin``), and which every quantized loader in this tree
 already uses to build its denoiser (:mod:`.w8a8` , :mod:`.w4a4`,
-:mod:`.svdq_native`). A PIPELINE's config is its component CLASS MAP
+:mod:`.svdq_native`). The context manager itself is :mod:`.meta_init`, owned
+here rather than imported from ``accelerate``: see that module for the pods
+that measured what an undeclared import on this path costs (pgw#1123). A
+PIPELINE's config is its component CLASS MAP
 (``model_index.json``), not a weights layout, so ``from_config`` on a pipeline
 builds nothing the export traces. Hence: build the COMPONENT, inject it through
 the ``components=`` seam the loader already has, and let the pipeline class
@@ -55,12 +58,15 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from ..api.errors import WorkerError
 from .. import meta_instantiation as mi
+
+logger = logging.getLogger(__name__)
 
 #: Stamped on a structure-only module and on the pipeline composed around it.
 STAMP = "_cozy_structure_only"
@@ -91,17 +97,73 @@ class StructureOnlyUnsupported(WorkerError):
         self.cls_name = str(cls_name or "")
         self.lacks = str(lacks or "")
         self.tree = str(tree or "")
-        super().__init__(
+        super().__init__(self._sentence())
+
+    def _sentence(self) -> str:
+        return (
             f"structure-only build of component {self.component!r} "
             f"({self.cls_name or 'unknown class'}) is not possible: "
             f"{self.lacks}. The zero-download forge instantiates a compile "
             f"target from CODE + CONFIG (`load_config` + `from_config` under "
-            f"`accelerate.init_empty_weights()` — the shape "
+            f"`meta_init.init_empty_weights()` — the shape "
             f"`models/w8a8.py` already uses), so a class without that surface "
             f"has no structure-only path and this family is stranded on the "
             f"real-weight mint until it grows one"
             + (f" (tree: {self.tree})" if self.tree else "")
         )
+
+
+class StructureCapabilityMissing(StructureOnlyUnsupported):
+    """The PROCESS cannot meta-instantiate — nothing about this family is wrong.
+
+    A subclass so every existing ``except StructureOnlyUnsupported`` keeps its
+    never-fatal degradation, and a distinct type because the two mean opposite
+    things to whoever reads the boot-adopt event. Its parent is a permanent,
+    correct property of some trees (a quantized artifact lane has no
+    config-only structure and never will); this one is a broken install, is
+    never normal, and strands EVERY family in the image rather than one — which
+    is exactly how it went unnoticed on two paid pods (pgw#1123).
+    """
+
+    def __init__(self, *, component: str, cls_name: str, lacks: str,
+                 capability: str, tree: str = "") -> None:
+        self.capability = str(capability or "")
+        super().__init__(component=component, cls_name=cls_name, lacks=lacks,
+                         tree=tree)
+
+    def _sentence(self) -> str:
+        return (
+            f"structure-only build of component {self.component!r} is "
+            f"impossible in THIS PROCESS, for every family it serves: "
+            f"{self.lacks}. Missing capability: {self.capability}. This is an "
+            f"IMAGE defect, not an authoring one — no boot key can be derived "
+            f"here, so this pod can never ask the hub for a cell and will "
+            f"self-mint on every boot"
+            + (f" (tree: {self.tree})" if self.tree else "")
+        )
+
+
+#: The ``boot_adopt`` phase token for each kind of structure-only refusal.
+#: Read out of this source by
+#: ``tests/test_boot_adopt_observability_pgw1116.py``'s vocabulary fence.
+TOKEN_UNSUPPORTED = "structure_unsupported"
+TOKEN_CAPABILITY_MISSING = "structure_capability_missing"
+
+
+def refusal_token(exc: StructureOnlyUnsupported) -> str:
+    """Which boot-adopt token a structure-only refusal reports under.
+
+    The distinction is the whole of pgw#1123: ``structure_unsupported`` is a
+    family that is stranded (correct, expected forever on the quantized
+    artifact lanes, and a reason to look at the FAMILY);
+    ``structure_capability_missing`` is an image that cannot do the thing at
+    all (a reason to look at the IMAGE). Reported under one token they are
+    indistinguishable, and the second one looks exactly like a pod that chose
+    to self-mint.
+    """
+    return (TOKEN_CAPABILITY_MISSING
+            if isinstance(exc, StructureCapabilityMissing)
+            else TOKEN_UNSUPPORTED)
 
 
 class StructureNotHonored(StructureOnlyUnsupported):
@@ -239,16 +301,26 @@ def _refuse_artifact_lanes(root: Path, component: str, cls: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _init_empty_weights() -> Any:
+def _init_empty_weights(component: str = "") -> Any:
+    """The meta-init seam, PROVEN on this process before it is used.
+
+    pgw#1123: this used to import ``accelerate`` — undeclared, absent from the
+    fleet's own probe image, and refusing under the same token a stranded
+    family refuses under. Both halves are fixed: the mechanism is owned
+    (:mod:`.meta_init`), and if it is ever unavailable anyway the refusal names
+    the missing CAPABILITY under its own token.
+    """
+    from . import meta_init
+
     try:
-        from accelerate import init_empty_weights
-    except Exception as exc:  # noqa: BLE001
-        raise StructureOnlyUnsupported(
-            component="", cls_name="", lacks=(
-                f"`accelerate` is not importable ({exc}), and "
-                f"`init_empty_weights` is the mechanism that skips the state "
-                f"dict")) from exc
-    return init_empty_weights
+        meta_init.require_meta_init()
+    except meta_init.MetaInitUnavailable as exc:
+        logger.error(
+            "structure-only build is impossible in this process: %s", exc)
+        raise StructureCapabilityMissing(
+            component=component, cls_name="", capability=exc.capability,
+            lacks=exc.lacks) from exc
+    return meta_init.init_empty_weights
 
 
 def build_component(
@@ -263,6 +335,12 @@ def build_component(
     """
     import torch
 
+    # FIRST, before anything about this family is inspected: a process that
+    # cannot meta-instantiate refuses about ITSELF, not about the tree it was
+    # handed (pgw#1123 — the pod message named component '' and 'unknown
+    # class', which read as a family problem and was an image problem).
+    init_empty_weights = _init_empty_weights(component)
+
     root = Path(tree)
     cls = _component_class(root, component)
     _refuse_artifact_lanes(root, component, cls)
@@ -275,7 +353,6 @@ def build_component(
     # refuse (pgw#689 defect 1).
     config.pop("quantization_config", None)
 
-    init_empty_weights = _init_empty_weights()
     with mi.observe(f"structure:{component}") as census:
         with init_empty_weights():
             module = cls.from_config(config)
@@ -664,6 +741,9 @@ __all__ = [
     "RANDOM_SEED",
     "RANDOM_STD",
     "STAMP",
+    "TOKEN_CAPABILITY_MISSING",
+    "TOKEN_UNSUPPORTED",
+    "StructureCapabilityMissing",
     "StructureFacts",
     "StructureNotHonored",
     "StructureOnlyUnsupported",
@@ -676,6 +756,7 @@ __all__ = [
     "materialize_random",
     "modules_of",
     "program_shape_env",
+    "refusal_token",
     "restore_virtual",
     "stray_real_tensors",
     "structure_only_components",

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -119,6 +119,13 @@ def test_every_refusal_token_in_the_tree_is_in_the_vocabulary() -> None:
         src / "boot_adopt.py", r"reason=\"([a-z_]+)\"",
     ):
         found[token] = "boot_adopt.attempt"
+    # pgw#1123: `boot_trace_child` now reports the structure-only refusal under
+    # whichever of these two `structure_only.refusal_token` picks, so the
+    # tokens themselves live there and must still be read out of the tree.
+    for token in _tokens(
+        src / "models" / "structure_only.py", r"TOKEN_[A-Z_]+ = \"([a-z_]+)\"",
+    ):
+        found[token] = "structure_only.refusal_token"
 
     assert found, "the scan found no refusal sites at all — the patterns rotted"
     missing = sorted(
@@ -442,7 +449,8 @@ def hub() -> Iterator[Any]:
 @pytest.fixture(scope="module")
 def micro_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
     pytest.importorskip("torch")
-    pytest.importorskip("accelerate")
+    # No `importorskip("accelerate")`: pgw#1123 removed it from this path, and
+    # the row below proves the derivation completes when it is unimportable.
     if str(MICRO_SRC) not in sys.path:
         sys.path.insert(0, str(MICRO_SRC))
     from micro_diffusion.weights import SEED, materialize
@@ -545,3 +553,62 @@ def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
     assert row.duration_ms > 0, (
         "the derivation was measured and the measurement must reach the hub — "
         "otherwise 'the boot derive costs seconds' stays an anecdote")
+
+
+def test_the_same_boot_derives_a_key_with_accelerate_UNIMPORTABLE(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
+    hub: Any, micro_tree: Path, micro_declaration: None, sm_runtime: None,
+) -> None:
+    """pgw#1123, end to end on the vehicle the pods ran.
+
+    The row above with ONE difference: the trace children run with
+    ``accelerate`` shadowed by a module that refuses to import — which is what
+    ``examples/micro-diffusion``'s image is, and what a family shading the
+    package would be. On 0.104.0 all three children died
+    ``structure_unsupported``, no key existed and the hub was never called;
+    the pods' GIN log counted zero resolves and nothing said why.
+
+    The shading is in the ENVIRONMENT, not in the code under test: every seam
+    from ``_boot_adopt`` down to the child's structure build is the real one.
+    """
+    from gen_worker.api.binding import ModelRef
+    from gen_worker.mint_process import MintSlot
+    from gen_worker.procsplit import broker
+    from gen_worker.registry import collect_endpoints
+
+    shade = tmp_path / "shade"
+    (shade / "accelerate").mkdir(parents=True)
+    (shade / "accelerate" / "__init__.py").write_text(
+        "raise ImportError(\"No module named 'accelerate'\")\n")
+
+    if str(MICRO_SRC) not in sys.path:
+        sys.path.insert(0, str(MICRO_SRC))
+    monkeypatch.syspath_prepend(str(REPO / "tests"))
+    monkeypatch.setenv(
+        "PYTHONPATH", ":".join([
+            str(shade), str(REPO / "src"), str(REPO / "tests"),
+            str(MICRO_SRC)]))
+    monkeypatch.setattr(broker, "_broker", None, raising=False)
+
+    specs = collect_endpoints(["harness.rig_runtime", "micro_diffusion.main"])
+    spec = next(s for s in specs if s.name == "generate")
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = f"http://127.0.0.1:{hub.server_address[1]}"
+    slots = {"pipeline": MintSlot(
+        ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
+                     tag="prod"),
+        path=str(micro_tree))}
+
+    out = ex._boot_adopt(spec, slots)
+
+    assert out.reason != "structure_unsupported", (
+        "the trace children still cannot build a structure without "
+        f"`accelerate`: {out.detail}")
+    assert out.reason == "miss", out.detail
+    assert out.derived_key.startswith("ck1-")
+    resolves = [c for c in hub.calls if c[0] == cell_resolve.RESOLVE_PATH]
+    assert len(resolves) == 1, (
+        "an image without `accelerate` must still ASK — this is the pgw#1123 "
+        f"pod defect, reproduced off-pod. Hub saw: {hub.calls}")
+    assert _one(events).phase == "miss"

--- a/tests/test_meta_init_capability_pgw1123.py
+++ b/tests/test_meta_init_capability_pgw1123.py
@@ -1,0 +1,224 @@
+"""pgw#1123: an image that cannot meta-instantiate must SAY SO, distinguishably.
+
+The measured defect (pods ``ykwoaiqub6ktt3`` / ``3o09rf9ehnc4ym``, gen-worker
+0.104.0, ``examples/micro-diffusion`` as the repo ships it):
+
+    boot_adopt[structure_unsupported]: family=micro-diffusion function=generate
+      key=- — 3 of 3 boot-trace child(ren) produced no class hashes:
+      structure-only build of component '' (unknown class) is not possible:
+      `accelerate` is not importable (No module named 'accelerate')
+
+Two independent failures in one line, and this file holds one row for each:
+
+1. ``structure_only`` imported ``accelerate``, which nothing declared and which
+   the fleet's own probe family deliberately does not ship. No key, no resolve,
+   self-mint forever. Fixed by OWNING the context manager
+   (:mod:`gen_worker.models.meta_init`), not by adding a dependency that
+   hard-requires torch to a base wheel that carries none.
+2. It refused under ``structure_unsupported`` — the SAME token a family that is
+   genuinely stranded reports, which is a correct and permanent state for the
+   quantized artifact lanes. So "this image is broken for everything" and "this
+   tree has no config-only structure" were one word, and the first looked
+   exactly like a pod that chose to self-mint. Belt and braces after the fix:
+   a stripped image or a shading family gets its own token,
+   ``structure_capability_missing``, with the capability named.
+
+Everything here drives the REAL seams — the real ``structure_only.build_component``
+over micro-diffusion's real generated tree, the real refusal classifier the
+trace child calls, the real ``boot_adopt`` vocabulary and the real activity
+sink. Nothing stubs the function whose brokenness is the subject: the capability
+is removed from the ENVIRONMENT, which is what a stripped image does.
+
+No pod, no GPU, no mint, no compile — meta instantiation only.
+"""
+
+from __future__ import annotations
+
+import builtins
+import contextlib
+import sys
+from pathlib import Path
+from typing import Any, Iterator, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import activity, boot_adopt  # noqa: E402
+from gen_worker.models import meta_init, structure_only as so  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+
+
+@contextlib.contextmanager
+def _unimportable(name: str) -> Iterator[None]:
+    """Make ``name`` unimportable, exactly as an image that lacks it is.
+
+    Not a monkeypatch of the code under test: the code under test is what
+    happens WHEN the package is absent, and this is the only honest way to
+    produce that on a box where the package is installed.
+    """
+    real_import = builtins.__import__
+    saved = {k: v for k, v in sys.modules.items()
+             if k == name or k.startswith(name + ".")}
+
+    def blocked(mod: str, *args: Any, **kwargs: Any) -> Any:
+        if mod == name or mod.startswith(name + "."):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(mod, *args, **kwargs)
+
+    for key in saved:
+        del sys.modules[key]
+    builtins.__import__ = blocked
+    try:
+        yield
+    finally:
+        builtins.__import__ = real_import
+        sys.modules.update(saved)
+
+
+@pytest.fixture(scope="module")
+def micro_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    if str(MICRO_SRC) not in sys.path:
+        sys.path.insert(0, str(MICRO_SRC))
+    from micro_diffusion.weights import SEED, materialize
+
+    return materialize(tmp_path_factory.mktemp("micro-tree"), seed=SEED)
+
+
+# ---------------------------------------------------------------------------
+# 1. The defect itself: the derivation must not need a package the probe
+#    family does not ship.
+# ---------------------------------------------------------------------------
+
+
+def test_a_structure_only_build_needs_no_accelerate(micro_tree: Path) -> None:
+    """RED on 0.105.0 with the verbatim pod message.
+
+    The real builder, the real tree, `accelerate` absent from the process
+    exactly as it is absent from the image the two pods ran.
+    """
+    with _unimportable("accelerate"):
+        module, facts = so.build_component(micro_tree, "transformer",
+                                           device="cpu")
+
+    from gen_worker import meta_instantiation as mi
+
+    assert facts.cls_name == "MicroDenoiser"
+    assert facts.parameters > 0
+    assert facts.virtual_param_bytes > 0
+    assert all(mi.is_virtual(p) for _n, p in module.named_parameters())
+
+
+def test_the_seam_keeps_the_invariant_the_key_depends_on() -> None:
+    """Parameters on meta, buffers REAL — the property ``aot_package``'s
+    literal constants and the folding fence both rest on. Upstream's version of
+    this context manager reads ``ACCELERATE_INIT_INCLUDE_BUFFERS`` from the
+    ambient environment and would move the buffers too; owning it is what makes
+    that unreachable."""
+    from torch import nn
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = nn.Linear(4, 4)
+            self.register_buffer("table", torch.arange(4.0))
+
+    with meta_init.init_empty_weights():
+        tiny = _Tiny()
+
+    assert tiny.lin.weight.device.type == "meta"
+    assert tiny.get_buffer("table").device.type != "meta"
+    # And the patch is undone: a module built afterwards is ordinary.
+    assert _Tiny().lin.weight.device.type != "meta"
+
+
+def test_the_capability_is_proven_not_assumed() -> None:
+    """``require_meta_init`` builds a probe and checks the result, so a torch
+    (or a shading family) that silently stopped moving parameters is caught
+    here rather than by tracing real weights."""
+    meta_init.require_meta_init()  # the box has torch: this must not raise
+
+    with _unimportable("torch"):
+        with pytest.raises(meta_init.MetaInitUnavailable) as caught:
+            meta_init.require_meta_init()
+    assert "torch" in str(caught.value)
+    assert caught.value.capability == meta_init.CAPABILITY
+
+
+# ---------------------------------------------------------------------------
+# 2. The louder half: the two refusals are not the same word.
+# ---------------------------------------------------------------------------
+
+
+def test_a_broken_image_and_a_stranded_family_get_DIFFERENT_tokens(
+    micro_tree: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The heart of pgw#1123. Both exceptions below are raised by the REAL
+    ``structure_only`` seams; only their tokens are asserted."""
+    # (a) a genuinely stranded tree — a class with no ConfigMixin surface.
+    stranded = so.StructureOnlyUnsupported(
+        component="transformer", cls_name="MicroDenoiser",
+        lacks="it exposes no `from_config`")
+
+    # (b) a process that cannot meta-instantiate, produced by the real builder.
+    with _unimportable("torch"):
+        with pytest.raises(so.StructureCapabilityMissing) as caught:
+            so._init_empty_weights("transformer")
+    broken = caught.value
+
+    assert so.refusal_token(stranded) == "structure_unsupported"
+    assert so.refusal_token(broken) == "structure_capability_missing"
+    assert so.refusal_token(stranded) != so.refusal_token(broken)
+
+    # It is still a StructureOnlyUnsupported, so every existing never-fatal
+    # `except` keeps degrading rather than killing a boot.
+    assert isinstance(broken, so.StructureOnlyUnsupported)
+    # And it names the capability instead of blaming the family.
+    assert meta_init.CAPABILITY in str(broken)
+    assert "IMAGE defect" in str(broken)
+    assert broken.capability == meta_init.CAPABILITY
+
+
+def test_the_new_token_is_in_the_boot_adopt_vocabulary() -> None:
+    """An event nobody can enumerate, count or alert on is the next silent
+    one — which is the whole of pgw#1116's fence."""
+    assert "structure_capability_missing" in boot_adopt.DERIVE_REASONS
+    assert "structure_capability_missing" in boot_adopt.REASONS
+    assert so.TOKEN_CAPABILITY_MISSING in boot_adopt.REASONS
+    assert so.TOKEN_UNSUPPORTED in boot_adopt.REASONS
+
+
+def test_the_trace_child_reports_the_capability_token_loudly() -> None:
+    """The real classification site: ``boot_trace_child.run``'s ``except``
+    clause routes through ``structure_only.refusal_token`` and logs the
+    capability refusal at ERROR. Read out of the source so a future edit that
+    collapses the two back into one token fails here."""
+    src = (REPO / "src" / "gen_worker" / "boot_trace_child.py").read_text()
+    assert "structure_only.refusal_token(exc)" in src
+    assert "TOKEN_CAPABILITY_MISSING" in src
+    assert 'logger.error("boot key cannot be derived in this image' in src
+
+
+def test_the_refusal_reaches_the_hub_as_its_own_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End of the wire: the token a trace child reports is the ``phase`` of the
+    typed ``boot_adopt`` event, through the real emitter and the real sink the
+    hub's ``worker_activity_events`` row is built from."""
+    seen: List[Any] = []
+    monkeypatch.setattr(activity, "_sink", seen.append, raising=False)
+
+    outcome = boot_adopt.refused(
+        so.TOKEN_CAPABILITY_MISSING,
+        f"3 of 3 boot-trace child(ren) produced no class hashes: "
+        f"{meta_init.CAPABILITY} is unavailable",
+        family="micro-diffusion", function="generate")
+
+    rows = [u for u in seen if u.kind == activity.KIND_BOOT_ADOPT]
+    assert len(rows) == 1
+    assert rows[0].phase == "structure_capability_missing"
+    assert rows[0].phase != "structure_unsupported"
+    assert meta_init.CAPABILITY in rows[0].detail
+    assert outcome.reason == "structure_capability_missing"

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,7 @@ signing = [
     { name = "c2pa-python" },
 ]
 torch = [
+    { name = "accelerate" },
     { name = "bitsandbytes", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "safetensors" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -655,6 +656,7 @@ vision = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'dev'", specifier = ">=1.9" },
+    { name = "accelerate", marker = "extra == 'torch'", specifier = ">=1.9" },
     { name = "av", marker = "extra == 'dev'", specifier = ">=12" },
     { name = "av", marker = "extra == 'video'", specifier = ">=12" },
     { name = "bitsandbytes", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=0.45.0" },


### PR DESCRIPTION
## The defect

`models/structure_only` imported `accelerate` for the context manager that makes a compile
target weight-free. **Nothing declared it**, and `examples/micro-diffusion` — the fleet's
cheapest AOT probe vehicle — deliberately ships no diffusers stack. Measured on pods
`ykwoaiqub6ktt3` / `3o09rf9ehnc4ym` (0.104.0):

```
boot_adopt[structure_unsupported]: family=micro-diffusion function=generate key=-
  — 3 of 3 boot-trace child(ren) produced no class hashes: structure-only build of
    component '' (unknown class) is not possible: `accelerate` is not importable
```

No key, no `POST /v1/worker/cells/resolve`, self-mint forever — and indistinguishable
from a pod that chose to self-mint. It is what the first paid reuse-circle proof bought.

## Depend vs vendor — the evidence

`accelerate` 1.14.0 is 389 KB, but it **hard-requires `torch>=2.0.0`**, and this package's
base wheel deliberately carries none ("the base wheel stays lean for plain-Python
(API-proxy) endpoints"). A core dependency would put a multi-GB torch behind
`pip install gen-worker` and into the exported requirement set every endpoint Dockerfile
installs `--no-deps` over its base image's own torch. The `torch` extra costs nothing and
**reaches nobody**: 29 of 29 `inference-endpoints` families request no such extra.

So the mechanism is owned: `gen_worker.models.meta_init` (parameters on meta, buffers
real), which additionally **proves the invariant on the process** before using it.
Upstream's version reads `ACCELERATE_INIT_INCLUDE_BUFFERS` from the ambient environment —
an env var that can move BUFFERS to meta can silently change a structure a cell key is
derived from. `accelerate>=1.9` is declared in the `torch` extra anyway, for `w8a8` /
`w4a4` / `svdq_native`, which build real-weight skeletons with it and had it undeclared.

## The louder half, which outlives the dependency

A stranded FAMILY (permanent and correct on the quantized artifact lanes) and an IMAGE
that cannot meta-instantiate at all were the same word. Now: `StructureCapabilityMissing`
→ **`structure_capability_missing`**, naming the missing capability, in
`boot_adopt.REASONS`, read out of the tree by pgw#1116's vocabulary fence, and logged at
ERROR by both the trace child and the mint child.

## Fleet census (the issue's third task)

19 of 29 `inference-endpoints` families declare `accelerate`; `anima` has it transitively;
**every one of the remaining nine ships no `compile=`** and so never enters this path. The
only broken vehicle was the probe family itself.

## RED-first, real path

New end-to-end row in `tests/test_boot_adopt_observability_pgw1116.py`: real
`Executor._boot_adopt` → real `boot_key.derive` → three real trace children → real HTTP
hub, with `accelerate` shadowed by an unimportable module **in the children's
environment** (never stubbed in the code under test). On `55ad6b7a` it fails with the
pod's line verbatim; on this branch the key derives and the resolve is issued.
`tests/test_meta_init_capability_pgw1123.py` adds 7 rows, all RED on master.

## Not papered over

No `accelerate` line in the example's Dockerfile — a previous lane refused that
deliberately and was right. The micro-rope pipeline uses the SDK seam instead of importing
`accelerate` itself, and **its `gen-worker` pin must move to `>=0.106.0` at the next
relock** for the built image to carry any of this (recorded in its `pyproject.toml`).
README says seven families, which it has been since `fc77b923`.

## Tests

77 passed (boot-adopt / structure-only / boot-key / trace-child) + 273 (mint-child,
micro-family, identity-soundness, cell-key). mypy clean (261 files), ruff clean, all eight
`fast gates` lint scripts and the changelog check green. No pod, no GPU, no mint, no
compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
