### PR TITLE
pgw#1107: an export declaration is a Compile, and the gate asks INTENT — retire `_Thunk`, aim the registration tightening at the author's decision

### DIFF
--- a/changelog.d/pgw1107.md
+++ b/changelog.d/pgw1107.md
@@ -1,0 +1,16 @@
+- Export declarations register on INTENT, and `_Thunk` is gone (pgw#1107). With
+  every family folded onto `@endpoint(compile=)` and zero `aot_declaration.py`
+  left in the fleet, `register_export_declaration` takes a `Compile` and
+  nothing else; a callable is refused and pointed at `Compile(blockers=...)`
+  (pgw#1115), which is the form a fold can carry. The decorator's registration
+  gate stopped asking "does this carry classes" — which silently dropped a
+  declaration that named dims/inputs and forgot its class rows, leaving a
+  family reading on a pod exactly like one that never declared AOT — and asks
+  instead whether the author reached for the export vocabulary at all. A
+  class-less `compile=` is a dynamo-lane decision (six inference endpoints ship
+  one) and registers nothing; anything using `classes`/`dims`/`forks`/`inputs`/
+  `args`/`blockers`/`shape_strategy`/`warm_changes_key` must carry classes and
+  a family or it is refused where it is written. `export_declaration` is now a
+  registry read that cannot raise, so the `declaration_refused` boot-adopt gate
+  and the mint gate's exception branch — reachable only from a thunk — go with
+  it.

--- a/src/gen_worker/aot_preconditions.py
+++ b/src/gen_worker/aot_preconditions.py
@@ -23,12 +23,10 @@ Four verdicts, and the difference between the last three is the whole point:
 
 ``ok``         the precondition holds on this image.
 ``refused``    it does not, and nothing on a pod can fix it — FAIL THE BUILD.
-``blocked``    the declaration refused: either it carries unresolved
-               ``Compile.blockers`` (pgw#1115 — the declared form) or it
-               raised typed ``MintRefused`` (pgw#853's thunk, which the
-               pgw#1107 fold retires). The family said why; it is a DECLARED
-               block, not a broken image, and it does not need a pod to
-               repeat the sentence.
+``blocked``    the declaration carries unresolved ``Compile.blockers``
+               (pgw#1115). The family said why; it is a DECLARED block, not a
+               broken image, and it does not need a pod to repeat the
+               sentence.
 ``abstained``  this environment cannot decide (a torch-less manifest build).
                Recorded, never silent — an unrecorded abstention is how a gate
                becomes decorative.
@@ -177,31 +175,9 @@ def static_mint_preconditions(
                          verdict=ABSTAINED, detail=detail, family=f)
             for f in families)
 
-    from .aot_contract import MintRefused
-
     aot_declaring: list[str] = []
     for family in families:
-        try:
-            decl = export_declaration(family)
-        except MintRefused as exc:
-            # The family REFUSED, in the vocabulary built for refusing. That
-            # is a declared block (ltx-2.3's open MINT_BLOCKERS), not a broken
-            # image — and it is now said at build time instead of being
-            # rediscovered by every pod that rents a GPU to hear it.
-            rows.append(Precondition(
-                check=CHECK_DECLARATION_EVALUATES, verdict=BLOCKED,
-                family=family, detail=str(exc)))
-            continue
-        except Exception as exc:  # noqa: BLE001 — everything else is a defect
-            rows.append(Precondition(
-                check=CHECK_DECLARATION_EVALUATES, verdict=REFUSED,
-                family=family, detail=(
-                    f"the export declaration raised "
-                    f"{type(exc).__name__}: {exc}. A family that cannot mint "
-                    f"YET says so with MintRefused and carries its blockers; "
-                    f"any other exception is a broken declaration, and every "
-                    f"pod running this image would pay to rediscover it")))
-            continue
+        decl = export_declaration(family)
         if decl is None:
             rows.append(Precondition(
                 check=CHECK_DECLARATION_EVALUATES, verdict=REFUSED,
@@ -209,10 +185,8 @@ def static_mint_preconditions(
                     "the registered export declaration evaluated to None — "
                     "there is no Compile to derive graph classes from")))
             continue
-        # pgw#1115: the SAME declared block, read as DATA. The `MintRefused`
-        # branch above is the thunk saying it; a folded declaration says it
-        # with `blockers=`, and the build gate must recognise both or the
-        # pgw#1107 fold turns a build-time `blocked` verdict into silence.
+        # pgw#1115: the declared block, read as DATA — the one form since
+        # pgw#1107 retired the thunk that used to say it by raising.
         blocked = open_blockers(decl)
         if blocked:
             rows.append(Precondition(

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -1735,13 +1735,27 @@ def endpoint(
             "unconditioned model, or a dynamic range via "
             "Compile(dynamic=(DynamicDim('sequence', min=.., max=..),))."
         )
-    if compile is not None and compile.classes and compile.family:
-        # pgw#739: a class-bearing declaration is the family's export
-        # contract; registering at decoration is what lets the mint derive
-        # export inputs with zero per-family SDK code.
-        from .export_contract import register_export_declaration
+    if compile is not None:
+        # pgw#739: an export declaration is the family's export contract;
+        # registering at decoration is what lets the mint derive export inputs
+        # with zero per-family SDK code.
+        #
+        # pgw#1107: the gate asks about INTENT, not about the payload. It used
+        # to read `compile.classes and compile.family`, so a declaration that
+        # named dims/forks/inputs and forgot its classes (or its family) was
+        # dropped on the floor — registered nothing, minted nothing, and on a
+        # pod was indistinguishable from an endpoint that never declared AOT.
+        # Flipping it to "classes required for every compile=" was the other
+        # wrong answer: six endpoints ship a thin class-less `compile=` for the
+        # dynamo lane only and declare no export contract at all. So the
+        # question is whether the author reached for the export vocabulary; if
+        # they did, `register_export_declaration` holds them to it.
+        from .export_contract import (
+            declares_export_contract, register_export_declaration,
+        )
 
-        register_export_declaration(compile)
+        if declares_export_contract(compile):
+            register_export_declaration(compile)
     bucket = int(lora_bucket or 0)
     if bucket:
         from ..models.w8a8_lora import RANK_BUCKETS

--- a/src/gen_worker/api/derive.py
+++ b/src/gen_worker/api/derive.py
@@ -33,10 +33,10 @@ so they run anywhere including this box:
 
 3. :func:`blocker_delta` / :func:`assert_blockers` — the REFUSAL half of that
    gate (pgw#1115). The one fact a fold can drop that neither of the above
-   sees is a family's declared mint blockers, because the family that has them
-   keeps them outside its ``Compile`` today (a module-level table read by a
-   refusing thunk). Dropping one does not re-key anything; it simply starts
-   minting against an open design question.
+   sees is a family's declared mint blockers, because before the fold the
+   family that had them kept them OUTSIDE its ``Compile`` (a module-level
+   table read by a refusing thunk, retired in pgw#1107). Dropping one does not
+   re-key anything; it simply starts minting against an open design question.
 """
 
 from __future__ import annotations
@@ -205,9 +205,9 @@ def assert_blockers(
 
     :func:`blocker_delta` can only compare two declarations, so it is blind
     where the standing declaration kept its blockers OUTSIDE the ``Compile``
-    (a module-level table read by a refusing thunk — ltx-video-2.3's shape,
-    and precisely the shape the fold has to carry across). This states the
-    expectation in the family's OWN test instead, so the assertion survives
+    (a module-level table read by a refusing thunk — ltx-video-2.3's pre-fold
+    shape, and precisely the shape the fold had to carry across). This states
+    the expectation in the family's OWN test instead, so the assertion survives
     the file the blockers used to live in.
 
     ``ids=()`` asserts the family is mintable, and is just as load-bearing:

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -975,73 +975,40 @@ _declared: Dict[str, Any] = {}
 _import_failures: List[Tuple[str, str]] = []
 
 
-class _Thunk:
-    """A registered declaration that has not been built yet (pgw#853).
+#: The export-contract vocabulary (pgw#1107). A ``Compile`` that carries ANY of
+#: these fields is DECLARING AN AOT EXPORT CONTRACT and is registered as one; a
+#: ``Compile`` that carries NONE of them is a dynamo-lane compile block and
+#: declares no export intent at all. That distinction is the tightening: the
+#: gate used to filter on `classes` alone, which silently swallowed a
+#: declaration that named dims/forks/inputs and simply FORGOT its classes —
+#: registered nothing, minted nothing, and read on a pod exactly like an
+#: endpoint that never declared AOT. Six inference endpoints (`ernie`,
+#: `flux.1-dev`, `flux.1-schnell`, `krea-2`, `minimax-h3`, `sd15`) legitimately
+#: ship a thin class-less `compile=`; a classes-required invariant over every
+#: `compile=` would red-line all six, so intent — not the payload — is what
+#: decides.
+EXPORT_CONTRACT_FIELDS: Tuple[str, ...] = (
+    "classes", "dims", "forks", "inputs", "args", "blockers",
+    "shape_strategy", "warm_changes_key",
+)
 
-    A family whose declaration REFUSES TO MINT (open blockers, an unresolved
-    config width, a shape it cannot legally export) used to express that by
-    raising at module scope — which made registering it equivalent to taking
-    the endpoint down at boot. A refusal to mint and a refusal to import are
-    different events with different blast radii; conflating them is the bug.
-    The thunk moves the evaluation to :func:`export_declaration`, i.e. to the
-    moment the MINT asks, where ``fleet_cells.mint_recipe`` already turns a
-    refusal into a typed ``self_mint_skipped`` carrying the blocker text.
+
+def declares_export_contract(decl: Any) -> bool:
+    """Whether this ``Compile`` declares an AOT export contract (pgw#1107).
+
+    False for a dynamo-only `compile=` block (shapes/targets/text_len/dynamic/
+    regional and nothing else) — legitimate, and registered nowhere. True the
+    moment the author reaches for the pgw#739 export vocabulary, which is when
+    :func:`register_export_declaration`'s classes-and-family invariant applies.
     """
-
-    __slots__ = ("family", "factory", "_built")
-
-    def __init__(self, family: str, factory: Any) -> None:
-        self.family = family
-        self.factory = factory
-        self._built: Any = None
-
-    def build(self) -> Any:
-        """Evaluate (once on success) and validate. Lets the factory's own
-        exception out — the blocker text IS the diagnostic."""
-        if self._built is not None:
-            return self._built
-        decl = self.factory()
-        got = str(getattr(decl, "family", "") or "").strip()
-        if got != self.family:
-            raise DeclarationError(
-                f"export declaration thunk registered for family "
-                f"{self.family!r} built a Compile for {got!r}")
-        if not getattr(decl, "classes", ()):
-            raise DeclarationError(
-                f"export declaration for {self.family!r} carries no graph "
-                f"classes — there is nothing to derive from")
-        self._built = decl
-        return decl
-
-    def _identity(self) -> Tuple[Any, ...]:
-        """SOURCE identity, deliberately not object identity.
-
-        A ``Compile`` re-registered from a second execution of the same file
-        is VALUE-equal (msgspec Struct), so registration was idempotent. Two
-        thunks are two distinct function objects, so a naive ``==`` made it
-        NOT idempotent — and that regression was not academic: the endpoint
-        walker (``discovery/walk.py``) imports EVERY submodule of an endpoint
-        package, so a declaration module reachable under two module names
-        registered twice, the second raised ``DeclarationError``, and the
-        walk died with ``EndpointImportError``. I.e. the compile feature broke
-        serving again, through a different door. Measured on qwen-image.
-
-        Same function, same source file => same declaration, whatever module
-        name it was loaded under. A genuinely different declaration still
-        conflicts by name.
-        """
-        fn = self.factory
-        code = getattr(fn, "__code__", None)
-        if code is None:  # a callable object, not a function
-            return (self.family, id(fn))
-        return (self.family, getattr(fn, "__qualname__", ""),
-                getattr(code, "co_filename", ""))
-
-    def __eq__(self, other: Any) -> bool:
-        return isinstance(other, _Thunk) and other._identity() == self._identity()
-
-    def __hash__(self) -> int:
-        return hash(self._identity())
+    if decl is None:
+        return False
+    for name in EXPORT_CONTRACT_FIELDS:
+        value = getattr(decl, name, None)
+        if value is None or value == () or value == "":
+            continue
+        return True
+    return False
 
 
 def register_export_declaration(
@@ -1049,35 +1016,39 @@ def register_export_declaration(
 ) -> Any:
     """Register one family's export declaration.
 
-    ``compile_decl`` is either a ``Compile`` carrying classes, or a ZERO-ARG
-    CALLABLE returning one (pgw#853), in which case ``family=`` is required
-    because there is nothing to read the name off yet. Idempotent for an
-    identical declaration; refuses a conflicting one by name.
+    ``compile_decl`` is a ``Compile`` carrying graph classes, and nothing
+    else. Idempotent for an identical declaration (msgspec Structs are
+    value-equal); refuses a conflicting one by name.
 
-    Prefer the callable form for any family that can REFUSE — the refusal
-    then reaches the mint gate as a typed event instead of killing the import
-    that registers it.
+    pgw#1107 retired the CALLABLE form (pgw#853's thunk). Its job — letting a
+    family that may not mint yet say so without taking the endpoint down at
+    import — is done by ``Compile(blockers=...)`` (pgw#1115), which the
+    ``@endpoint(compile=)`` fold can actually carry. A callable cannot survive
+    that fold at all, so it is refused here rather than silently dropped.
     """
     if callable(compile_decl) and not hasattr(compile_decl, "classes"):
-        fam = str(family or "").strip()
-        if not fam:
-            raise DeclarationError(
-                "a callable export declaration must be registered with an "
-                "explicit family= (the Compile does not exist yet)")
-        entry: Any = _Thunk(fam, compile_decl)
-    else:
-        fam = str(getattr(compile_decl, "family", "") or "").strip()
-        if not fam:
-            raise DeclarationError(
-                "cannot register an export declaration with no Compile.family")
-        if family is not None and str(family).strip() != fam:
-            raise DeclarationError(
-                f"family= {family!r} does not match Compile.family {fam!r}")
-        if not getattr(compile_decl, "classes", ()):
-            raise DeclarationError(
-                f"export declaration for {fam!r} carries no graph classes — "
-                f"there is nothing to derive from")
-        entry = compile_decl
+        raise DeclarationError(
+            "an export declaration is a Compile, never a callable (pgw#1107 "
+            "retired the pgw#853 thunk). A family that may not mint yet "
+            "declares that as DATA — `Compile(blockers=(MintBlocker(...),))` "
+            "— which `@endpoint(compile=)` can carry and a factory cannot")
+    fam = str(getattr(compile_decl, "family", "") or "").strip()
+    if not fam:
+        raise DeclarationError(
+            "cannot register an export declaration with no Compile.family")
+    if family is not None and str(family).strip() != fam:
+        raise DeclarationError(
+            f"family= {family!r} does not match Compile.family {fam!r}")
+    # THE INVARIANT CARRIED OVER FROM `_Thunk.build()` (pgw#1107): a
+    # declaration in the export vocabulary that names no graph classes has
+    # nothing to derive from. Before the tightening this could not fire from
+    # the decorator at all — the gate filtered on `classes` and dropped such a
+    # declaration on the floor — so it was reachable only through a thunk.
+    if not getattr(compile_decl, "classes", ()):
+        raise DeclarationError(
+            f"export declaration for {fam!r} carries no graph classes — "
+            f"there is nothing to derive from")
+    entry: Any = compile_decl
     with _lock:
         existing = _declared.get(fam)
         if existing is not None and existing != entry and not replace:
@@ -1091,15 +1062,13 @@ def register_export_declaration(
 def export_declaration(family: str) -> Optional[Any]:
     """The family's ``Compile``, or ``None`` if none is registered.
 
-    pgw#853: a THUNK registration is evaluated HERE, and its exception is let
-    out HERE — this is "the mint asking", and every caller on the mint path
-    turns that into a typed refusal that keeps the blocker text. Callers that
-    only need to know whether a declaration EXISTS must use
-    :func:`has_export_declaration`, which never evaluates anything.
+    A plain registry read since pgw#1107 retired the thunk: nothing is
+    evaluated here and nothing raises. A family that refuses to mint says so
+    in the returned value (``Compile.open_blockers``), so every caller reads
+    the refusal instead of catching it.
     """
     with _lock:
-        entry = _declared.get(str(family or "").strip())
-    return entry.build() if isinstance(entry, _Thunk) else entry
+        return _declared.get(str(family or "").strip())
 
 
 def weak_arms(decl: Any) -> Tuple[Any, ...]:
@@ -1121,16 +1090,13 @@ def weak_arms(decl: Any) -> Tuple[Any, ...]:
 def weak_arms_by_family() -> Dict[str, Tuple[Any, ...]]:
     """:func:`weak_arms` across every registered family, for a fleet sweep.
 
-    Skips families whose declaration REFUSES (a blocked family is not a
-    silent one — its refusal is the pgw#853 typed event, and it should not
-    take a fleet query down).
+    A BLOCKED family still answers (pgw#1107): its refusal is data on the
+    declaration, not an exception thrown by reading it, so a fleet query no
+    longer has to choose between skipping the family and falling over.
     """
     out: Dict[str, Tuple[Any, ...]] = {}
     for family in registered_export_families():
-        try:
-            decl = export_declaration(family)
-        except Exception:  # noqa: BLE001 — a blocked family is not a query error
-            continue
+        decl = export_declaration(family)
         if decl is None:
             continue
         arms = weak_arms(decl)
@@ -1140,18 +1106,19 @@ def weak_arms_by_family() -> Dict[str, Tuple[Any, ...]]:
 
 
 def registered_entry(family: str) -> Optional[Any]:
-    """The RAW registry entry — a ``Compile`` or an unevaluated thunk.
+    """The registry entry as stored — a ``Compile`` or ``None``.
 
-    For callers that need registration IDENTITY (has this exact declaration
-    already been registered?) without triggering a blocked family's refusal.
+    Identical to :func:`export_declaration` since pgw#1107 retired the thunk;
+    kept as the name for callers asking about registration IDENTITY (has this
+    exact declaration already been registered?) rather than about content.
     """
     with _lock:
         return _declared.get(str(family or "").strip())
 
 
 def has_export_declaration(family: str) -> bool:
-    """Whether a declaration is registered — never evaluates a thunk, so a
-    blocked family still reads as DECLARED (it is; it just refuses to mint)."""
+    """Whether a declaration is registered. A blocked family reads as
+    DECLARED (it is; it just refuses to mint)."""
     with _lock:
         return str(family or "").strip() in _declared
 
@@ -1187,9 +1154,10 @@ def import_export_declaration(
     """Import a module whose only job is to register a declaration, and NEVER
     let its failure past this call (pgw#853, backstop (3)).
 
-    ``register_export_declaration``'s thunk form fixes declarations that opt
-    into it; any other module-scope work in a declaration file can still
-    throw. A compile feature must never be able to break serving, so this
+    ``Compile(blockers=...)`` covers a family that refuses to MINT; any other
+    module-scope work in a declaration file can still throw at IMPORT, and the
+    two have different blast radii. A compile feature must never be able to
+    break serving, so this
     reports the failure as a typed ``aot_declaration_import_failed`` activity
     event carrying the exception and returns ``False`` — the pod serves
     eager, uncompiled, and says why.
@@ -1239,7 +1207,9 @@ __all__ = [
     "WEAK_FORK_REASONS",
     "blocker_refusal",
     "blocker_rows",
+    "EXPORT_CONTRACT_FIELDS",
     "declaration_import_failures",
+    "declares_export_contract",
     "export_declaration",
     "has_export_declaration",
     "registered_entry",

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -66,9 +66,6 @@ GATE_REASONS: Tuple[str, ...] = (
     # `aot_mint.export_declaration(family)` answered None: this family ships no
     # export declaration, so no key can name its class set.
     "no_export_declaration",
-    # A pgw#853 THUNK declaration REFUSED to build (open mint blockers). It used
-    # to escape `_boot_adopt` uncaught and take the whole model setup down.
-    "declaration_refused",
     # The declaration exists but `aot_declaration.cell_plans` will not enumerate
     # it (colliding entry names, no targets).
     "declaration_unreadable",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -9864,18 +9864,11 @@ class Executor:
         cfg = spec.compile_cell()
         family = str(getattr(cfg, "family", "") or "")
         fn = str(spec.name or "")
-        try:
-            decl = aot_mint.export_declaration(family)
-        except Exception as exc:  # noqa: BLE001
-            # pgw#853: a THUNK declaration is EVALUATED by this accessor and
-            # its exception is let out here. Uncaught, it left `_boot_adopt`,
-            # left `asyncio.to_thread`, and failed the model setup — a blocked
-            # family's mint refusal taking serving down, which is the exact
-            # blast radius pgw#853 exists to prevent.
-            return boot_adopt.refused(
-                "declaration_refused",
-                f"family {family!r} declares a mint refusal: "
-                f"{type(exc).__name__}: {exc}", family=family, function=fn)
+        # pgw#1107: a registry read, not an evaluation. The pgw#853 thunk that
+        # could raise out of here (and, uncaught, failed the whole model setup)
+        # is retired; a blocked family carries its refusal as
+        # `Compile.blockers` and the mint gate reads it.
+        decl = aot_mint.export_declaration(family)
         if decl is None:
             return boot_adopt.refused(
                 "no_export_declaration",

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -2375,31 +2375,13 @@ def mint_recipe(
                 "out-of-process minting is unavailable and an AOTI export "
                 "has no eager tier to serve from while it compiles"))
 
-    # pgw#853: THIS is where a declaration is allowed to refuse. A family with
-    # open mint blockers (ltx/qwen/z-image) registers a THUNK, so its refusal
-    # arrives here — as a typed `self_mint_skipped` carrying every word of the
-    # blocker text — instead of as an ImportError that takes the endpoint
-    # down at boot. A refusal to MINT is not a refusal to IMPORT.
-    #
-    # pgw#996: the STATIC half of this refusal (unresolved MINT_BLOCKERS) is
-    # already recorded by the build gate, so no pod discovers it for the first
-    # time. The branch survives because the other half is genuinely a pod
-    # fact: ltx-2.3's thunk reads `LTX_SERVING_TIER` off the environment, and
-    # an unknown tier there is a MintRefused the image could not have known.
-    try:
-        decl = export_declaration(family)
-    except Exception as exc:  # noqa: BLE001 — serving outranks compiling
-        # Deliberately `Exception`, not `BaseException`: this runs INSIDE the
-        # serving process, where swallowing a KeyboardInterrupt/cancellation
-        # would be its own defect. Every refusal shape the declarations
-        # actually raise (MintRefused, DeclarationError, ImportError) is an
-        # Exception. The import boundary is the other way round — see
-        # `import_export_declaration`, which runs at BOOT and catches
-        # everything, because there nothing outranks the endpoint coming up.
-        return _decline(
-            "declaration_refused",
-            f"family {family!r}'s export declaration refuses to mint "
-            f"({type(exc).__name__}): {exc}")
+    # pgw#853 put the refusal HERE rather than at import, because a refusal to
+    # MINT is not a refusal to IMPORT. pgw#1107 retired the thunk that carried
+    # it: the accessor is now a registry read that cannot raise, and the
+    # refusal arrives below as DATA (`open_blockers`) under its own phase. The
+    # `try/except` that used to wrap this call went with it — a gate that can
+    # no longer fire is a decorative one.
+    decl = export_declaration(family)
 
     if decl is None:
         return _decline(
@@ -2408,11 +2390,11 @@ def mint_recipe(
             f"`compile=` block carrying graph classes, pgw#739/#758) — the "
             f"class set a multi-graph cell covers is undeclared")
 
-    # pgw#1115: the same refusal, now as DATA. A `Compile` carrying unresolved
-    # `blockers=` declines here under its own phase, naming the ids — the
-    # thunk's raise (above) and this branch are the same event said two ways,
-    # and the fold onto `@endpoint(compile=)` can only carry the second.
-    # Serving is untouched: this pod serves eager exactly as it did.
+    # pgw#1115: the refusal, as DATA. A `Compile` carrying unresolved
+    # `blockers=` declines here under its own phase, naming the ids — the one
+    # form the fold onto `@endpoint(compile=)` can carry, and since pgw#1107
+    # the only one. Serving is untouched: this pod serves eager exactly as it
+    # did.
     blocked = open_blockers(decl)
     if blocked:
         return _decline("declaration_blocked", blocker_refusal(family, blocked))

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -32,7 +32,9 @@ from .warmup import validate_class_warmup
 import dataclasses
 from .api.compile_axis import warm_guidance_values
 from .cell_key import facts_digest
-from .api.export_contract import register_export_declaration, registered_entry
+from .api.export_contract import (
+    declares_export_contract, register_export_declaration, registered_entry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -701,7 +703,7 @@ def _apply_class_unions(specs: List[EndpointSpec]) -> List[EndpointSpec]:
 
 
 def register_declared_exports(specs: Sequence[EndpointSpec]) -> Tuple[str, ...]:
-    """pgw#805: a ``compile=`` block that carries graph CLASSES *is* its
+    """pgw#805: a ``compile=`` block that declares an EXPORT CONTRACT *is* its
     family's export declaration — register it at collection time.
 
     Without this, ``export_declaration(family)`` resolves only when somebody
@@ -728,12 +730,12 @@ def register_declared_exports(specs: Sequence[EndpointSpec]) -> Tuple[str, ...]:
             continue
         seen.add(id(compile_decl))
         family = str(getattr(compile_decl, "family", "") or "").strip()
-        if not family or not getattr(compile_decl, "classes", ()):
+        # pgw#1107: the same INTENT question the decorator asks — a dynamo-only
+        # `compile=` block declares no export contract and is registered
+        # nowhere; anything reaching for the export vocabulary is held to
+        # carrying classes by `register_export_declaration`.
+        if not family or not declares_export_contract(compile_decl):
             continue
-        # pgw#853: `registered_entry`, NOT `export_declaration` — reading the
-        # registry back through the evaluating accessor would detonate a
-        # blocked family's thunk inside endpoint COLLECTION, which is the
-        # exact blast radius this issue exists to remove.
         if registered_entry(family) is compile_decl:
             continue
         try:

--- a/tests/harness/blocked_declaration_endpoints.py
+++ b/tests/harness/blocked_declaration_endpoints.py
@@ -1,12 +1,13 @@
 """An endpoint that carries a REFUSING export declaration and serves anyway.
 
-pgw#853's invariant, as an endpoint module: this is what the five unwired
-families must be able to look like. Two mechanisms, both exercised here:
+pgw#853's invariant, as an endpoint module. Two mechanisms, both exercised:
 
-- ``register_export_declaration(thunk, family=...)`` — the blockers evaluate
-  when the MINT asks, not when python imports;
-- ``import_export_declaration(...)`` — the backstop, for module-scope work
-  that raises anyway (``harness.blocked_declaration`` does exactly that).
+- ``Compile(blockers=...)`` — the family declares WHY it may not mint yet, as
+  data the mint gate reads (pgw#1115; it replaced pgw#853's thunk, which
+  pgw#1107 retired because ``@endpoint(compile=)`` cannot carry a callable);
+- ``import_export_declaration(...)`` — the backstop, for module-scope work in
+  a declaration file that raises anyway (``harness.blocked_declaration`` does
+  exactly that).
 
 If either one leaked, importing this module would raise and the worker would
 never collect an endpoint — no serving, for a compile feature.
@@ -22,24 +23,18 @@ from gen_worker import (
 )
 from gen_worker.families.base import GenerationDefaults, family as family_vocab
 
-#: (3) the belt-and-braces backstop: this import RAISES, and must not escape.
+from .blocked_declaration_parts import BLOCKER, build_declaration
+
+#: (2) the belt-and-braces backstop: this import RAISES, and must not escape.
 DECLARATION_IMPORTED = import_export_declaration(
     "harness.blocked_declaration")
 
-#: (1) the primary fix: a thunk whose blockers evaluate at mint time.
-THUNK_FAMILY = "harness-thunk-family"
+#: (1) the primary fix: a declaration whose blockers are VALUES.
+BLOCKED_FAMILY = "harness-blocked-declared"
+BLOCKED_DECLARATION = build_declaration(
+    family=BLOCKED_FAMILY, blockers=(BLOCKER,))
 
-
-def _blocked_thunk():
-    from gen_worker.aot_mint import MintRefused
-
-    from .blocked_declaration_parts import BLOCKER_TEXT
-
-    raise MintRefused(BLOCKER_TEXT)
-
-
-register_export_declaration(_blocked_thunk, family=THUNK_FAMILY)
-
+register_export_declaration(BLOCKED_DECLARATION)
 
 @family_vocab("harness-blocked-family")
 class _BlockedDefaults(GenerationDefaults, frozen=True):

--- a/tests/harness/blocked_declaration_parts.py
+++ b/tests/harness/blocked_declaration_parts.py
@@ -1,29 +1,44 @@
 """The declaration a blocked family owns — importable WITHOUT detonating.
 
 Split from :mod:`harness.blocked_declaration` (which raises at module scope,
-the way ltx/qwen/z-image do today) so tests can build the same real
-declaration to prove the family is BLOCKED, not malformed.
+the shape a declaration FILE could still fail in) so tests can build the same
+real declaration to prove the family is BLOCKED, not malformed.
 """
 
 from __future__ import annotations
 
-from gen_worker import Compile, Dim, GraphClass, Input
+from typing import Tuple
+
+from gen_worker import Compile, Dim, GraphClass, Input, MintBlocker
 
 FAMILY = "harness-blocked-family"
 
-#: The exact sentence that must survive from the blocker to the typed event.
+#: The blocker every refusal on this family must reproduce, verbatim.
+BLOCKER = MintBlocker(
+    id="B1-harness",
+    what="the traced module's list container is not pytree-representable",
+    evidence="harness fixture standing in for a real boundary-shape blocker.",
+    resolves_when="the boundary is shrunk to tensors",
+)
+
+#: The sentence a declaration MODULE that refuses at import raises with. Only
+#: :mod:`harness.blocked_declaration` uses it — a MINT refusal is data now
+#: (:data:`BLOCKER`), and this is the other, still-real failure: a declaration
+#: file whose module scope throws for any reason at all.
 BLOCKER_TEXT = (
     f"family {FAMILY!r} has 1 UNRESOLVED mint blocker(s); the declaration is "
     f"complete and validated but refuses to mint:\n"
-    f"  - B1-harness: the traced module's list container is not pytree-"
-    f"representable\n    RESOLVES WHEN: the boundary is shrunk to tensors"
+    f"  - {BLOCKER.id}: {BLOCKER.what}\n    RESOLVES WHEN: "
+    f"{BLOCKER.resolves_when}"
 )
 
 
-def build_declaration() -> Compile:
+def build_declaration(
+    *, family: str = FAMILY, blockers: Tuple[MintBlocker, ...] = (),
+) -> Compile:
     """A real, valid declaration in the pgw#739 vocabulary."""
     return Compile(
-        family=FAMILY,
+        family=family,
         targets=("transformer",),
         text_len=77,
         shapes=((1024, 1024),),
@@ -33,4 +48,5 @@ def build_declaration() -> Compile:
                       dtype="bfloat16"),),
         shape_strategy="static-rows",
         warm_changes_key=False,
+        blockers=blockers,
     )

--- a/tests/harness/blocked_pkg/aot_declaration.py
+++ b/tests/harness/blocked_pkg/aot_declaration.py
@@ -1,27 +1,18 @@
-"""A PACKAGE-resident declaration that refuses — the shape ltx/qwen/z-image
-now ship. The endpoint walker imports every submodule of an endpoint package,
-so this module is imported whether or not ``main`` asks for it.
+"""A PACKAGE-resident declaration that refuses to MINT.
+
+The endpoint walker imports every submodule of an endpoint package, so this
+module is imported whether or not ``main`` asks for it — which is why the
+refusal must be data (``Compile.blockers``, pgw#1115) and not an exception.
 """
 
 from __future__ import annotations
 
-from gen_worker import Compile, register_export_declaration
-from gen_worker.aot_mint import MintRefused
+from gen_worker import register_export_declaration
 
-from ..blocked_declaration_parts import BLOCKER_TEXT, FAMILY, build_declaration
+from ..blocked_declaration_parts import BLOCKER, FAMILY, build_declaration
 
 _FAMILY = FAMILY
 
+DECLARATION = build_declaration(blockers=(BLOCKER,))
 
-def _refuse_if_blocked() -> None:
-    raise MintRefused(BLOCKER_TEXT)
-
-
-def _declaration() -> Compile:
-    """Mirrors the endpoints' own shape exactly: build, then blocker-check."""
-    decl = build_declaration()
-    _refuse_if_blocked()
-    return decl
-
-
-register_export_declaration(_declaration, family=_FAMILY)
+register_export_declaration(DECLARATION)

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -172,10 +172,6 @@ def _executor(tmp_path: Path) -> Any:
     return ex
 
 
-class _Blocked:
-    """A pgw#853 thunk-shaped declaration that REFUSES when asked."""
-
-
 @pytest.mark.parametrize(
     "gate,wire,expect",
     [
@@ -185,13 +181,12 @@ class _Blocked:
                 executor_mod.aot_mint, "export_declaration", lambda f: None),
             "no registered export declaration",
         ),
-        (
-            "declaration_refused",
-            lambda mp: mp.setattr(
-                executor_mod.aot_mint, "export_declaration",
-                _raise(RuntimeError("OQ-2 audio_timestep rank unresolved"))),
-            "audio_timestep",
-        ),
+        # pgw#1107: there is no `declaration_refused` row any more. The gate
+        # existed because a pgw#853 THUNK could raise out of
+        # `export_declaration`; the accessor is a registry read now, so the
+        # gate could only ever have fired for a stubbed function — and a gate
+        # only its own test can trigger proves nothing. A blocked family is
+        # `Compile.blockers`, refused at the mint gate (pgw#1115).
         (
             "declaration_unreadable",
             lambda mp: mp.setattr(

--- a/tests/test_declaration_cannot_break_serving_pgw853.py
+++ b/tests/test_declaration_cannot_break_serving_pgw853.py
@@ -3,44 +3,47 @@
 The defect, found by pgw#834: the ONLY mechanism the platform has for making
 an export declaration visible to a pod is importing a module that calls
 ``register_export_declaration`` at module scope — and ltx-2.3, qwen-image and
-z-image express their mint blockers by RAISING ``MintRefused`` at that same
+z-image expressed their mint blockers by RAISING ``MintRefused`` at that same
 module scope. So wiring those three to the AOT lane the way sdxl is wired
 would take the endpoint DOWN AT BOOT. A refusal to MINT was being expressed
 as a refusal to IMPORT; the two have different blast radii, and conflating
 them is the bug.
 
 The invariant this file exists to establish, and the reason it boots a real
-worker rather than asserting on a function: a declaration that raises must
+worker rather than asserting on a function: a declaration that refuses must
 cost the AOT lane and NOTHING ELSE. It is written so a FUTURE declaration
 that raises at import cannot take an endpoint down.
 
-Deliberately real: ``harness.blocked_declaration`` raises exactly the way
-z-image's file does, ``harness.blocked_declaration_endpoints`` imports it the
-way an endpoint must, and the serving proof is a real job dispatched over the
-hub-double's gRPC wire into a real ``Worker``. Nothing about the raise is
-simulated.
+pgw#1107 retired the mechanism, not the invariant. The refusal used to be a
+THUNK evaluated when the mint asked; every family is now folded onto
+``@endpoint(compile=)``, which takes a ``Compile`` and never a callable, so
+the refusal is DATA (``Compile.blockers``, pgw#1115) and the registry accessor
+cannot raise at all. What survives from the thunk is its construction check —
+an export declaration that names no graph classes has nothing to derive from —
+and that check is asserted here, on the path the decorator actually walks.
+
+Deliberately real: ``harness.blocked_declaration`` still raises at module
+scope (the OTHER failure, a declaration file that throws for any reason),
+``harness.blocked_declaration_endpoints`` imports it the way an endpoint must,
+and the serving proof is a real job dispatched over the hub-double's gRPC wire
+into a real ``Worker``. Nothing about the raise is simulated.
 """
 
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import msgspec
 import pytest
 
-from gen_worker import fleet_cells
 from gen_worker.aot_mint import MintRefused
 from gen_worker.api.export_contract import (
     DeclarationError, export_declaration, has_export_declaration,
     import_export_declaration, register_export_declaration,
     registered_export_families, reset_export_declarations,
 )
-from gen_worker import config as gw_config
 from gen_worker.pb import worker_scheduler_pb2 as pb
-from gen_worker.cell_adopt import AdoptOutcome
 
 from harness.hub_double import hub_double, is_ready, is_result_for
 
@@ -109,24 +112,26 @@ def test_the_guarded_import_reports_the_failure_instead_of_raising() -> None:
     assert BLOCKED_MODULE in detail
 
 
-def test_endpoint_collection_registers_the_thunk_without_evaluating_it() -> None:
-    """The blocked family is DECLARED — it just refuses to mint. Reading the
-    registry must not detonate it (pgw#853: `register_declared_exports` used
-    to read it back with `export_declaration`)."""
+def test_endpoint_collection_registers_the_blocked_declaration() -> None:
+    """The blocked family is DECLARED — it just refuses to mint. Collection
+    must register it and read it back without detonating (pgw#853:
+    `register_declared_exports` used to read it back through an accessor that
+    evaluated a thunk)."""
     from gen_worker.registry import collect_endpoints
 
     reset_export_declarations()
     try:
-        importlib.import_module(ENDPOINT_MODULE)
         mod = importlib.import_module(ENDPOINT_MODULE)
-        register_export_declaration(
-            mod._blocked_thunk, family=mod.THUNK_FAMILY, replace=True)
+        register_export_declaration(mod.BLOCKED_DECLARATION, replace=True)
 
         specs = collect_endpoints([ENDPOINT_MODULE])
 
         assert specs, "collection produced no endpoint"
-        assert mod.THUNK_FAMILY in registered_export_families()
-        assert has_export_declaration(mod.THUNK_FAMILY)
+        assert mod.BLOCKED_FAMILY in registered_export_families()
+        assert has_export_declaration(mod.BLOCKED_FAMILY)
+        decl = export_declaration(mod.BLOCKED_FAMILY)
+        assert decl is not None
+        assert [b.id for b in decl.open_blockers] == ["B1-harness"]
     finally:
         reset_export_declarations()
 
@@ -136,243 +141,92 @@ def test_endpoint_collection_registers_the_thunk_without_evaluating_it() -> None
 # ---------------------------------------------------------------------------
 
 
-def test_a_thunk_refuses_where_the_mint_asks_not_where_python_imports() -> None:
+def test_a_blocked_family_refuses_at_the_MINT_not_at_the_registry_read() -> None:
+    """The refusal is readable, typed, and costs the read nothing."""
+    from harness.blocked_declaration_parts import BLOCKER, build_declaration
+
     reset_export_declarations()
     try:
-        register_export_declaration(_raising_thunk, family="harness-blocked")
+        register_export_declaration(
+            build_declaration(family="harness-blocked", blockers=(BLOCKER,)))
         assert has_export_declaration("harness-blocked")
-        with pytest.raises(MintRefused) as excinfo:
-            export_declaration("harness-blocked")
-        assert "B1-harness" in str(excinfo.value)
+
+        decl = export_declaration("harness-blocked")
+
+        assert decl is not None, "reading a blocked declaration returned None"
+        assert [b.id for b in decl.open_blockers] == ["B1-harness"]
+        assert "not pytree-representable" in decl.open_blockers[0].what
     finally:
         reset_export_declarations()
 
 
-def test_a_callable_registration_requires_an_explicit_family() -> None:
-    reset_export_declarations()
-    try:
-        with pytest.raises(DeclarationError):
-            register_export_declaration(_raising_thunk)
-    finally:
-        reset_export_declarations()
-
-
-def test_a_thunk_that_builds_the_wrong_family_is_refused_by_name() -> None:
+def test_a_CALLABLE_declaration_is_refused_and_says_what_to_use_instead() -> None:
+    """pgw#1107 deleted the thunk. A callable must not be accepted-and-ignored
+    (the fold onto `@endpoint(compile=)` cannot carry one), and the refusal has
+    to name the replacement or the author has nowhere to go."""
     from harness.blocked_declaration_parts import build_declaration
 
     reset_export_declarations()
     try:
-        register_export_declaration(build_declaration, family="not-that-one")
         with pytest.raises(DeclarationError) as excinfo:
-            export_declaration("not-that-one")
+            register_export_declaration(build_declaration, family="harness-x")
+        assert "blockers" in str(excinfo.value)
+        assert not has_export_declaration("harness-x")
+    finally:
+        reset_export_declarations()
+
+
+def test_a_declaration_whose_family_does_not_match_is_refused_by_name() -> None:
+    from harness.blocked_declaration_parts import build_declaration
+
+    reset_export_declarations()
+    try:
+        with pytest.raises(DeclarationError) as excinfo:
+            register_export_declaration(
+                build_declaration(), family="not-that-one")
         assert "not-that-one" in str(excinfo.value)
     finally:
         reset_export_declarations()
 
 
-def test_a_thunk_that_builds_is_evaluated_once_and_memoized() -> None:
-    calls = {"n": 0}
-
-    def _once():
-        from harness.blocked_declaration_parts import build_declaration
-
-        calls["n"] += 1
-        return build_declaration()
+def test_the_thunks_classes_check_survives_the_thunks_deletion() -> None:
+    """`_Thunk.build()` refused a declaration that named no graph classes.
+    That check is the one behaviour the deletion had to carry forward — it is
+    now the registration invariant, and it is REACHABLE, which it was not
+    while the decorator gate filtered class-less declarations out."""
+    from gen_worker import Compile, Dim, Input
 
     reset_export_declarations()
     try:
-        register_export_declaration(_once, family="harness-blocked-family")
-        first = export_declaration("harness-blocked-family")
-        second = export_declaration("harness-blocked-family")
-        assert first is second
-        assert calls["n"] == 1
+        with pytest.raises(DeclarationError) as excinfo:
+            register_export_declaration(Compile(
+                family="harness-classless", targets=("transformer",),
+                text_len=77, shapes=((1024, 1024),),
+                dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
+                inputs=(Input("hidden_states", shape=("B", 4, 128, 128),
+                              dtype="bfloat16"),),
+                shape_strategy="static-rows"))
+        assert "no graph classes" in str(excinfo.value)
     finally:
         reset_export_declarations()
 
 
 # ---------------------------------------------------------------------------
-# 3. THE MINT GATE — a thunk refusal lands as a TYPED event, text intact.
+# 3. THE MINT GATE and the REGISTRATION-IDEMPOTENCE regression both moved on.
+#
+#    §3 used to prove a thunk refusal lands as a typed `self_mint_skipped`
+#    with its text intact; that is now `test_declared_blockers_pgw1115.py`
+#    (`test_the_recipe_gate_declines_a_blocked_family_and_names_the_ids` +
+#    `test_the_blocked_pod_keeps_serving`), which asserts the same event under
+#    the `declaration_blocked` phase on the declared form. §4 proved a THUNK
+#    re-registered from the same source file was idempotent — a `Compile` is a
+#    frozen msgspec Struct and value-equal, which is what made two thunks the
+#    hard case; the value-equality half is covered by
+#    `test_export_contract_pgw739.py`. Neither is repeated here.
 # ---------------------------------------------------------------------------
 
 
 FAMILY = "harness-blocked-family"
-
-
-class _Pipe:
-    pass
-
-
-@dataclass
-class _Cfg:
-    family: str = FAMILY
-    lora_bucket: int = 64
-    shapes: Tuple[Tuple[int, int], ...] = ((1024, 1024),)
-    targets: Tuple[str, ...] = ("transformer",)
-    text_lens: Tuple[int, ...] = (77,)
-    guidance_scales: Tuple[float, ...] = (1.0, 5.0)
-    regional: bool = False
-
-
-class _Publisher:
-    base_url = "http://hub.invalid"
-
-    def enabled(self) -> bool:
-        return True
-
-    def worker_jwt(self) -> str:
-        return "jwt"
-
-
-def _raising_thunk():
-    from harness.blocked_declaration_parts import BLOCKER_TEXT
-
-    raise MintRefused(BLOCKER_TEXT)
-
-
-@pytest.fixture()
-def _events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
-    seen: List[Tuple[str, str, str]] = []
-    monkeypatch.setattr(
-        fleet_cells.activity_mod, "emit_event",
-        lambda kind, detail, phase="", duration_ms=0: seen.append(
-            (kind, phase, detail)))
-    return seen
-
-
-@pytest.fixture()
-def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
-    """A real AOT discovery miss on an otherwise mint-capable pod."""
-    gw_config.reload_for_test()
-    monkeypatch.setattr(
-        fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
-    monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
-    monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
-    monkeypatch.setattr(fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
-    monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
-    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
-    monkeypatch.setattr(fleet_cells, "_PENDING", {})
-    monkeypatch.setattr(
-        fleet_cells, "arm_identity",
-        lambda *a, **k: type("_A", (), {
-            "token": "arm1-" + "a" * 56,
-            "facts_dict": lambda self: {}})())
-    monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda p: False)
-    monkeypatch.setattr(
-        fleet_cells.cc, "arm_jit_intake", lambda p, c: None)
-    monkeypatch.setattr(
-        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "w8a8")
-    reset_export_declarations()
-    yield
-    reset_export_declarations()
-    gw_config.reload_for_test()
-
-
-def test_the_mint_gate_declines_typed_and_keeps_the_blocker_text(
-    _miss: Any, _events: List[Tuple[str, str, str]],
-) -> None:
-    """The whole point of moving the refusal: it must still be SAID, with
-    its evidence, on the wire — not swallowed by a try/except."""
-    register_export_declaration(_raising_thunk, family=FAMILY)
-
-    outcome = fleet_cells.enable_compiled(
-        _Pipe(), _Cfg(), publisher=_Publisher(), delegate=True)  # type: ignore[arg-type]
-
-    # pgw#1010: an AOT cell cannot be minted for a blocked family, and there
-    # is no second artifact to fall back to — the pod serves JIT intake and
-    # owes nothing. The refusal is still SAID, which is this test's subject.
-    assert outcome.self_mint is None
-    skipped = [(p, d) for k, p, d in _events if k == "self_mint_skipped"]
-    assert skipped, _events
-    phases = [p for p, _ in skipped]
-    assert "declaration_refused" in phases, phases
-    detail = next(d for p, d in skipped if p == "declaration_refused")
-    assert "B1-harness" in detail, detail
-    assert "RESOLVES WHEN" in detail, detail
-
-
-def test_the_pod_serves_eager_rather_than_failing_the_arm(
-    _miss: Any, _events: List[Tuple[str, str, str]],
-) -> None:
-    register_export_declaration(_raising_thunk, family=FAMILY)
-
-    outcome = fleet_cells.enable_compiled(
-        _Pipe(), _Cfg(), publisher=_Publisher(), delegate=True)  # type: ignore[arg-type]
-
-    # pgw#1010: "serves eager rather than failing the arm" is now "serves JIT
-    # INTAKE rather than failing the arm" — the pod compiles its own graphs
-    # and keeps serving; what it does not do is mint or publish anything.
-    assert outcome.armed is True
-    assert outcome.self_mint is None
-    assert not [k for k, _p, _d in _events if k == "self_mint_started"]
-
-
-# ---------------------------------------------------------------------------
-# 4. THE REGRESSION THIS FIX ALMOST SHIPPED WITH — registering a thunk twice
-#    from the same source file must be IDEMPOTENT.
-# ---------------------------------------------------------------------------
-
-
-def test_the_same_declaration_file_registered_twice_is_idempotent() -> None:
-    """Measured on qwen-image, and it is the same defect class this whole
-    file exists to kill, entering through a different door.
-
-    `discovery/walk.py` imports EVERY submodule of an endpoint package, so an
-    in-wheel declaration module is reachable under more than one module name.
-    A `Compile` re-registered from a second execution is VALUE-equal (msgspec
-    Struct) so it was always idempotent; two THUNKS are two distinct function
-    objects, so the naive `==` raised `DeclarationError` on the second
-    registration and the walk died with `EndpointImportError` — a pod that
-    does not boot, for a compile feature.
-    """
-    import importlib.util
-    from pathlib import Path
-
-    src = Path(__file__).resolve().parent / "harness" / "blocked_declaration_parts.py"
-
-    def _exec_under(name: str):
-        spec = importlib.util.spec_from_file_location(name, src)
-        assert spec is not None and spec.loader is not None
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-
-    reset_export_declarations()
-    try:
-        first = _exec_under("parts_alias_one")
-        second = _exec_under("parts_alias_two")
-        assert first.build_declaration is not second.build_declaration, (
-            "the two module objects must really be distinct, or this test "
-            "proves nothing")
-
-        register_export_declaration(first.build_declaration, family=FAMILY)
-        # Must NOT raise: same function, same source file, same declaration.
-        register_export_declaration(second.build_declaration, family=FAMILY)
-
-        assert registered_export_families() == (FAMILY,)
-        assert export_declaration(FAMILY).family == FAMILY
-    finally:
-        reset_export_declarations()
-
-
-def test_a_genuinely_different_thunk_still_conflicts_by_name() -> None:
-    """Source identity must not be so loose that two real declarations for
-    one family register over each other silently."""
-    reset_export_declarations()
-    try:
-        register_export_declaration(_raising_thunk, family=FAMILY)
-        with pytest.raises(DeclarationError):
-            register_export_declaration(_other_thunk, family=FAMILY)
-        # ...and the owner can still say so explicitly.
-        register_export_declaration(_other_thunk, family=FAMILY, replace=True)
-    finally:
-        reset_export_declarations()
-
-
-def _other_thunk():
-    from harness.blocked_declaration_parts import build_declaration
-
-    return build_declaration()
 
 
 # ---------------------------------------------------------------------------
@@ -387,9 +241,9 @@ def test_a_package_whose_declaration_submodule_refuses_still_serves() -> None:
     `discovery/walk.py` imports EVERY submodule of an endpoint package and
     raises `EndpointImportError` on any failure. So for an in-wheel
     declaration the walker imports it DIRECTLY — `main.py`'s guarded import is
-    not on that path at all, and the thunk is what actually makes these
-    families safe. Proven the only way that means anything: a real worker, a
-    real package, a real job over the wire.
+    not on that path at all, so the declaration itself has to be import-safe,
+    which is what `Compile(blockers=...)` buys. Proven the only way that means
+    anything: a real worker, a real package, a real job over the wire.
     """
     with hub_double(modules=("harness.blocked_pkg",)) as (scheduler, _harness):
         conn = scheduler.wait_connection(0)
@@ -403,24 +257,24 @@ def test_a_package_whose_declaration_submodule_refuses_still_serves() -> None:
     assert msgspec.msgpack.decode(res.inline)["response"] == "pkg-served:marco"
 
 
-def test_the_walker_registers_the_blocked_family_and_it_refuses_at_the_mint() -> None:
+def test_the_walker_registers_the_blocked_family_and_it_still_refuses() -> None:
     """Registered by the walk, and still refusing — both halves, one pass."""
     from gen_worker.registry import collect_endpoints
 
     # The module may already be in sys.modules from a sibling test, and a
     # cached module does not re-run its registration. Re-assert it so this
-    # test states one thing (collection does not detonate the thunk) rather
+    # test states one thing (collection registers the blocked family) rather
     # than accidentally testing import order.
     mod = importlib.import_module("harness.blocked_pkg.aot_declaration")
     reset_export_declarations()
-    register_export_declaration(mod._declaration, family=FAMILY)
+    register_export_declaration(mod.DECLARATION)
     try:
         specs = collect_endpoints(["harness.blocked_pkg"])
 
         assert specs, "the package collected no endpoint"
         assert FAMILY in registered_export_families()
-        with pytest.raises(MintRefused) as excinfo:
-            export_declaration(FAMILY)
-        assert "B1-harness" in str(excinfo.value)
+        decl = export_declaration(FAMILY)
+        assert decl is not None
+        assert [b.id for b in decl.open_blockers] == ["B1-harness"]
     finally:
         reset_export_declarations()

--- a/tests/test_fork_reason_kind_pgw853.py
+++ b/tests/test_fork_reason_kind_pgw853.py
@@ -41,10 +41,11 @@ from gen_worker.api.export_contract import (
 )
 
 
-def _decl(*forks: Fork, family: str = "harness-fork-family") -> Compile:
+def _decl(*forks: Fork, family: str = "harness-fork-family",
+          blockers: tuple = ()) -> Compile:
     fork_names = {f.name for f in forks}
     return Compile(
-        family=family, targets=("transformer",), text_len=0,
+        family=family, targets=("transformer",), text_len=0, blockers=blockers,
         shapes=((64, 64),),
         dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
         forks=forks,
@@ -129,30 +130,38 @@ def test_a_served_only_fork_is_never_weak() -> None:
     assert weak_arms(decl) == ()
 
 
-def test_the_fleet_query_skips_a_family_whose_declaration_REFUSES() -> None:
-    """A blocked family (ltx/qwen/z-image register thunks that raise) must not
-    take a fleet-wide query down — pgw#853's whole point is that a refusal to
-    MINT is not a refusal to everything else."""
-    from gen_worker.aot_mint import MintRefused
+def test_the_fleet_query_ANSWERS_for_a_family_whose_declaration_REFUSES() -> None:
+    """A blocked family must not take a fleet-wide query down — pgw#853's
+    whole point is that a refusal to MINT is not a refusal to everything else.
 
-    def _blocked():
-        raise MintRefused("family 'harness-blocked' has 1 UNRESOLVED blocker")
+    pgw#1107 makes that strictly better than "skipped": the refusal is DATA on
+    the declaration, so a blocked family's weak arms are still readable. A
+    sweep asking "which families are one payload field from an unserved arm?"
+    used to answer with a hole exactly where the answer mattered most.
+    """
+    from gen_worker.api.export_contract import MintBlocker
+
+    blocker = MintBlocker(
+        id="B1-harness", what="one open question",
+        evidence="harness fixture", resolves_when="it is measured")
 
     reset_export_declarations()
     try:
-        register_export_declaration(_blocked, family="harness-blocked")
+        register_export_declaration(_decl(
+            Fork("cfg", served=(False,), unserved=(True,),
+                 reason="default_value"),
+            family="harness-blocked", blockers=(blocker,)))
         register_export_declaration(_decl(
             Fork("cfg", served=(False,), unserved=(True,),
                  reason="default_value"), family="harness-weak"))
 
         found = weak_arms_by_family()
 
-        assert "harness-weak" in found
         assert [f.name for f in found["harness-weak"]] == ["cfg"]
-        assert "harness-blocked" not in found
-        # ...and the blocked family still refuses when asked directly.
-        with pytest.raises(MintRefused):
-            export_declaration("harness-blocked")
+        assert [f.name for f in found["harness-blocked"]] == ["cfg"]
+        decl = export_declaration("harness-blocked")
+        assert decl is not None
+        assert [b.id for b in decl.open_blockers] == ["B1-harness"]
     finally:
         reset_export_declarations()
 

--- a/tests/test_mint_preconditions_pgw996.py
+++ b/tests/test_mint_preconditions_pgw996.py
@@ -277,54 +277,18 @@ def test_an_endpoint_that_declares_NO_export_owes_the_AOT_lane_nothing(
 # ---------------------------------------------------------------------------
 
 
-def test_a_declared_MintRefused_is_a_BLOCKED_family_not_a_broken_build(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
-) -> None:
-    """ltx-2.3's shape: a THUNK with open MINT_BLOCKERS. The family refused in
-    the vocabulary built for refusing, so the image is fine and the sentence
-    is said HERE — instead of on every pod that rents a GPU to hear it."""
-    monkeypatch.syspath_prepend(str(tmp_path))
-
-    manifest, result = _build(tmp_path, "ep996_blocked", """
-        from gen_worker import Compile, register_export_declaration
-        from gen_worker.aot_contract import MintRefused
-
-        def _thunk() -> Compile:
-            raise MintRefused("2 UNRESOLVED mint blocker(s): OQ-2, OQ-4")
-
-        register_export_declaration(_thunk, family="ep996")
-    """)
-
-    assert result.ok is True, result.errors
-    (warn,) = [w for w in result.warnings if "blocked" in w]
-    assert "UNRESOLVED mint blocker" in warn
-    (row,) = manifest["aot_preconditions"]
-    assert row["verdict"] == pre.BLOCKED and row["family"] == "ep996"
-    # A blocked family never runs an AOTI export, so the image owes no
-    # toolchain — the gate must not manufacture a second refusal from it.
-    assert row["check"] == pre.CHECK_DECLARATION_EVALUATES
-
-
-def test_any_OTHER_declaration_exception_is_a_broken_build(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
-) -> None:
-    """The distinction is the whole point: MintRefused is a family SAYING no;
-    a TypeError is a declaration nobody has run since it was written."""
-    monkeypatch.syspath_prepend(str(tmp_path))
-
-    _manifest, result = _build(tmp_path, "ep996_broken", """
-        from gen_worker import Compile, register_export_declaration
-
-        def _thunk() -> Compile:
-            raise TypeError("Dim() got an unexpected keyword 'carried'")
-
-        register_export_declaration(_thunk, family="ep996")
-    """)
-
-    assert result.ok is False
-    (err,) = [e for e in result.errors
-              if pre.CHECK_DECLARATION_EVALUATES in e]
-    assert "TypeError" in err and "MintRefused" in err
+# pgw#1107 retired the thunk, and with it the two cases that lived here:
+#
+# * a declaration that says "blocked" — a THUNK raising `MintRefused` became
+#   `Compile(blockers=...)`, and the BLOCKED verdict off that declared form is
+#   `test_declared_blockers_pgw1115.py`
+#   (`test_the_image_BUILD_says_a_family_is_blocked_without_renting_a_pod`);
+# * a declaration that is simply BROKEN — with no factory to evaluate, a
+#   declaration module that throws fails at IMPORT, which is
+#   `test_a_declaration_module_that_cannot_IMPORT_fails_the_build` above.
+#
+# `static_mint_preconditions` no longer catches anything around the registry
+# read, because the read cannot raise.
 
 
 def test_a_torchless_discovery_ABSTAINS_out_loud(clean_registry) -> None:

--- a/tests/test_registration_tightening_pgw1107.py
+++ b/tests/test_registration_tightening_pgw1107.py
@@ -1,0 +1,285 @@
+"""pgw#1107 §"exactly one declaration" — the REGISTRATION tightening.
+
+The dual-declaration hazard is gone: every family in every endpoint repo now
+declares on ``@endpoint(compile=)`` and no ``aot_declaration.py`` survives. The
+gate that made the dual world safe (``decorators.py``: register only if
+``compile.classes and compile.family``) outlived it, and it has a defect the
+dual world hid — a declaration in the export vocabulary that FORGETS its
+classes, or its family, is dropped silently. Nothing registers, nothing mints,
+and on a pod that is indistinguishable from an endpoint which never declared
+AOT at all. Exactly the shape of every silent-coverage defect this codebase
+has paid for.
+
+The naive fix — "a ``compile=`` block must carry classes" — is the other wrong
+answer, and it is the one this file exists to keep out. SIX inference
+endpoints ship a thin, class-less ``compile=`` for the DYNAMO lane and declare
+no export contract at all: ``ernie``, ``flux.1-dev``, ``flux.1-schnell``,
+``krea-2``, ``minimax-h3`` and ``sd15`` (``flux.1-schnell`` and ``sd15``
+declare two families each). Every one would fail a classes-required invariant
+at import. A class-less compile is a DECISION, not an omission.
+
+So the gate asks about INTENT instead: a ``Compile`` that reaches for the
+pgw#739 export vocabulary (``classes``/``dims``/``forks``/``inputs``/``args``/
+``blockers``/``shape_strategy``/``warm_changes_key``) is declaring an export
+contract and is held to carrying classes and a family; a ``Compile`` that
+carries none of it is a dynamo-lane block and is registered nowhere.
+
+RED on origin/master, both directions:
+  * the malformed-declaration tests pass silently on master (the gate drops
+    the declaration, so nothing raises and nothing registers);
+  * the six-endpoint tests are what goes red under the naive flip.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import (
+    Arg, Compile, Dim, DynamicDim, Fork, GraphClass, Input, MintBlocker,
+    RequestContext, endpoint,
+)
+from gen_worker.api.export_contract import (
+    DeclarationError, EXPORT_CONTRACT_FIELDS, declares_export_contract,
+    export_declaration, has_export_declaration, registered_export_families,
+    reset_export_declarations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+class _In(msgspec.Struct):
+    text: str = ""
+
+
+class _Out(msgspec.Struct):
+    response: str
+
+
+def _decorate(compile_decl: Compile) -> type:
+    """Decorate a real endpoint class — the production registration path."""
+
+    @endpoint(compile=compile_decl)
+    class _Ep:
+        def go(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(response=data.text)
+
+    return _Ep
+
+
+# ---------------------------------------------------------------------------
+# 1. THE SIX CLASS-LESS DYNAMO ENDPOINTS — verified against
+#    inference-endpoints master (6c5b1330), and the reason the gate is not a
+#    one-line flip. A tightening that red-lines a working endpoint is a
+#    regression wearing an invariant's clothes.
+# ---------------------------------------------------------------------------
+
+
+#: The declaration SHAPES the six ship, transcribed from their `main.py`. Not
+#: the endpoints themselves (this repo cannot import them) — the shapes, which
+#: is what the gate actually sees.
+CLASS_LESS_DYNAMO: Tuple[Tuple[str, Compile], ...] = (
+    ("ernie", Compile(
+        family="ernie", shapes=((1024, 1024), (1152, 896)), text_len=512)),
+    ("flux.1-dev", Compile(
+        family="flux1-dev", shapes=((1024, 1024),), text_len=512)),
+    ("flux.1-schnell", Compile(
+        family="flux1-schnell", shapes=((1024, 1024),), text_len=256)),
+    ("flux.1-schnell (2nd family)", Compile(
+        family="flux1-schnell-redux", shapes=((1024, 1024),), text_len=256)),
+    ("krea-2", Compile(
+        family="krea-2", shapes=((1024, 1024),), targets=("transformer",),
+        text_len=512)),
+    # pgw#1107 finding: the prior lane's list said FIVE. minimax-h3 is the
+    # sixth, and the one with the most export-adjacent-LOOKING declaration —
+    # `regional=True` plus a declared dynamic sequence range, and still no
+    # export contract. An intent test that mistook either for export intent
+    # would take it down.
+    ("minimax-h3", Compile(
+        family="minimax-h3", shapes=((1024, 1024),), targets=("transformer",),
+        regional=True,
+        dynamic=(DynamicDim("sequence", min=2, max=8192),))),
+    ("sd15", Compile(
+        family="sd15", shapes=((512, 512),), targets=("unet",), text_len=77)),
+    ("sd15 (2nd family)", Compile(
+        family="sd15-inpaint", shapes=((512, 512),), targets=("unet",),
+        text_len=77)),
+)
+
+
+@pytest.mark.parametrize(
+    "name,decl", CLASS_LESS_DYNAMO, ids=[n for n, _ in CLASS_LESS_DYNAMO])
+def test_a_class_less_dynamo_endpoint_decorates_and_registers_nothing(
+    name: str, decl: Compile,
+) -> None:
+    """The load-bearing half of the tightening. These six are correct as
+    written: they compile under dynamo and declare no AOT export contract, so
+    the classes-required invariant must not reach them."""
+    assert declares_export_contract(decl) is False, (
+        f"{name} was read as declaring an export contract; the intent test is "
+        f"too broad and would red-line a working endpoint")
+
+    _decorate(decl)  # must not raise
+
+    assert registered_export_families() == (), (
+        f"{name} registered an export declaration it never made — the mint "
+        f"would then ask it for graph classes it does not have")
+    assert has_export_declaration(decl.family) is False
+
+
+def test_the_six_are_the_whole_dynamo_only_shape_and_nothing_else_is() -> None:
+    """The complement: every field in the export vocabulary flips intent on.
+
+    Written as a sweep over :data:`EXPORT_CONTRACT_FIELDS` so a field ADDED to
+    the vocabulary without being added to the gate fails here rather than
+    silently reopening the drop-on-the-floor hole.
+    """
+    base = dict(family="sweep", shapes=((64, 64),), targets=("transformer",),
+                text_len=0)
+    values = {
+        "classes": (GraphClass(dims={"B": 1}),),
+        "dims": (Dim("B", carried_by=(("x", 0),)),),
+        "forks": (Fork("cfg", served=(False,), unserved=(True,),
+                       reason="default_value"),),
+        "inputs": (Input("x", shape=("B", 4), dtype="model"),),
+        "args": (Arg("n", value=1),),
+        "blockers": (MintBlocker(
+            id="B1", what="w", evidence="e", resolves_when="r"),),
+        "shape_strategy": "static-rows",
+        "warm_changes_key": False,
+    }
+    assert set(values) == set(EXPORT_CONTRACT_FIELDS), (
+        "the export-contract vocabulary changed; add the new field to this "
+        "sweep AND to EXPORT_CONTRACT_FIELDS, or the gate silently stops "
+        "seeing declarations that use it")
+
+    assert declares_export_contract(Compile(**base)) is False
+    # `classes` and `dims` require each other at construction (rows are
+    # coordinates over named dims), so they are the one pair tested together;
+    # every other field stands alone.
+    pairs = {"classes": "dims", "dims": "classes"}
+    for field, value in values.items():
+        partner = pairs.get(field)
+        extra = {partner: values[partner]} if partner else {}
+        decl = Compile(**base, **{field: value}, **extra)  # type: ignore[arg-type]
+        assert declares_export_contract(decl) is True, field
+
+
+# ---------------------------------------------------------------------------
+# 2. THE HOLE THE TIGHTENING CLOSES — a declaration that MEANT to export and
+#    is malformed. RED on master: the gate drops it, so `_decorate` returns
+#    happily and `registered_export_families()` is empty either way.
+# ---------------------------------------------------------------------------
+
+
+def test_an_export_declaration_that_forgets_its_classes_is_REFUSED() -> None:
+    """dims, inputs, a shape strategy — every word of an export contract
+    except the coordinate rows. On master this registered NOTHING and said
+    NOTHING; the family then read on a pod as "never declared AOT", which is
+    the same sentence a deliberately dynamo-only endpoint produces.
+
+    This is `_Thunk.build()`'s classes check, on the path that now reaches it.
+    """
+    with pytest.raises(DeclarationError) as excinfo:
+        _decorate(Compile(
+            family="malformed-noclasses", shapes=((1024, 1024),),
+            targets=("transformer",), text_len=77,
+            dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
+            inputs=(Input("hidden_states", shape=("B", 4, 128, 128),
+                          dtype="bfloat16"),),
+            shape_strategy="static-rows", warm_changes_key=False,
+            classes=()))
+
+    assert "no graph classes" in str(excinfo.value)
+    assert "malformed-noclasses" in str(excinfo.value)
+    assert registered_export_families() == ()
+
+
+def test_an_export_declaration_that_forgets_its_FAMILY_is_REFUSED() -> None:
+    """The other half of the old gate's `and`. A family-less export
+    declaration has no name to register under and no name to mint for — and
+    on master it, too, was dropped without a word."""
+    with pytest.raises(DeclarationError) as excinfo:
+        _decorate(Compile(
+            family="", shapes=((1024, 1024),), targets=("transformer",),
+            text_len=77,
+            dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
+            classes=(GraphClass(dims={"B": 1}),),
+            inputs=(Input("hidden_states", shape=("B", 4, 128, 128),
+                          dtype="bfloat16"),),
+            shape_strategy="static-rows", warm_changes_key=False))
+
+    assert "no Compile.family" in str(excinfo.value)
+    assert registered_export_families() == ()
+
+
+def test_a_BLOCKED_declaration_still_has_to_carry_its_classes() -> None:
+    """pgw#1115's blockers say "not yet", never "and therefore incomplete".
+    ltx-video-2.3 folded 82 graph classes AND three open blockers; a blocked
+    family that also dropped its class table would look identical to a
+    correctly blocked one."""
+    with pytest.raises(DeclarationError):
+        _decorate(Compile(
+            family="blocked-noclasses", shapes=((1024, 1024),),
+            targets=("transformer",), text_len=77,
+            blockers=(MintBlocker(id="B1", what="w", evidence="e",
+                                  resolves_when="r"),)))
+
+
+# ---------------------------------------------------------------------------
+# 3. THE WELL-FORMED DECLARATION STILL REGISTERS — the gate re-aimed, not
+#    removed. Includes the blocked-but-complete shape (ltx's).
+# ---------------------------------------------------------------------------
+
+
+def _well_formed(family: str, **over: Any) -> Compile:
+    return Compile(
+        family=family, shapes=((1024, 1024),), targets=("transformer",),
+        text_len=77,
+        dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
+        classes=(GraphClass(dims={"B": 1}),),
+        inputs=(Input("hidden_states", shape=("B", 4, 128, 128),
+                      dtype="bfloat16"),),
+        shape_strategy="static-rows", warm_changes_key=False, **over)
+
+
+def test_a_well_formed_export_declaration_registers_at_decoration() -> None:
+    _decorate(_well_formed("well-formed"))
+
+    assert registered_export_families() == ("well-formed",)
+    decl = export_declaration("well-formed")
+    assert decl is not None and decl.classes
+
+
+def test_a_complete_but_BLOCKED_declaration_registers_and_carries_its_ids() -> None:
+    _decorate(_well_formed("blocked-complete", blockers=(MintBlocker(
+        id="OQ-2", what="w", evidence="e", resolves_when="r"),)))
+
+    decl = export_declaration("blocked-complete")
+    assert decl is not None
+    assert [b.id for b in decl.open_blockers] == ["OQ-2"]
+
+
+def test_collection_applies_the_same_intent_test_as_the_decorator() -> None:
+    """`registry.register_declared_exports` is the SECOND gate — it re-reads
+    every collected spec's `compile=`. Two gates asking different questions is
+    how the dual-declaration hazard got in; they ask one question now."""
+    from gen_worker.registry import register_declared_exports
+
+    class _Spec:
+        def __init__(self, compile_decl: Any) -> None:
+            self.compile = compile_decl
+
+    dynamo = Compile(family="dyn-only", shapes=((64, 64),), text_len=0)
+    assert register_declared_exports([_Spec(dynamo)]) == ()  # type: ignore[arg-type]
+    assert registered_export_families() == ()
+
+    assert register_declared_exports(
+        [_Spec(_well_formed("collected"))]) == ("collected",)  # type: ignore[arg-type]


### PR DESCRIPTION
The two SDK rows pgw#1107 sequenced LAST, behind the fleet-wide fold. Zero `aot_declaration.py` remain in `inference-endpoints`, `private-inference-endpoints` or `training-endpoints`, so both are unblocked.

## 1. `_Thunk` is dead code — deleted

Swept all three endpoint repos: **not one call site passes a callable to `register_export_declaration`**. There are no call sites at all outside `@endpoint`, which passes a literal `Compile`. What the thunk existed for — a family that may not mint yet saying so without taking the endpoint down at import — is `Compile(blockers=...)` since pgw#1115, and it is the only form a fold onto a decorator can carry. A callable is now refused by name and pointed at the replacement.

**The invariant carried forward:** `_Thunk.build()` refused a declaration carrying no graph classes ("there is nothing to derive from"). It survives as the registration invariant — and is now REACHABLE, which is row 2's point. On master it could fire only through a thunk, because the decorator gate filtered class-less declarations out before registration ever saw them.

## 2. The registration tightening, and the trap

`decorators.py:1738` gated on `compile.classes and compile.family`. A declaration that named dims, inputs and a shape strategy and simply FORGOT its class rows was **dropped on the floor**: nothing registered, nothing minted, and on a pod that family was indistinguishable from one that never declared AOT.

But the naive flip red-lines six working endpoints. **Verified against `inference-endpoints` master `6c5b1330` by AST scan of every `Compile(...)` in every endpoint:** `ernie`, `flux.1-dev`, `flux.1-schnell` (×2 families), `krea-2`, **`minimax-h3`**, `sd15` (×2 families) — eight declarations. The prior lane's list of five **missed `minimax-h3`**, which is also the one whose declaration looks most export-adjacent (`regional=True` + a declared dynamic sequence range) and still declares no export contract.

So the gate asks about **intent**, not payload: a `Compile` reaching for `classes`/`dims`/`forks`/`inputs`/`args`/`blockers`/`shape_strategy`/`warm_changes_key` is declaring an export contract and must carry classes and a family; one carrying none of it is a dynamo block and registers nowhere. Both gates — the decorator's and `registry.register_declared_exports`' — now ask that single question.

**This is narrower than "exactly one declaration, gate removed"**, and deliberately so: the gate cannot be removed, only re-aimed. A class-less compile is a decision, not an omission.

## Dead branches that went with the thunk

`export_declaration` is a registry read that cannot raise, so `fleet_cells.mint_recipe`'s try/except, `executor._boot_adopt`'s, the `declaration_refused` gate token, and `aot_preconditions`' `MintRefused`/generic-exception branches are all unreachable and deleted. The `declaration_refused` row in `test_boot_adopt_observability_pgw1116` fired only because the test **stubbed the accessor to raise** — a gate only its own test can trigger proves nothing. `BLOCKED` still comes from `open_blockers`, covered by `test_declared_blockers_pgw1115::test_the_image_BUILD_says_a_family_is_blocked_without_renting_a_pod`.

## RED first, both directions

Proven on a detached `origin/master` worktree:

- **Four behavioural assertions FAIL on master, pass here** — a class-less export declaration, a family-less one, a blocked-but-class-less one, and a callable registration are all accepted silently on master.
- **With the naive flip applied to master, all eight class-less dynamo declarations fail at decoration.** That is the test this design exists to keep green (`test_a_class_less_dynamo_endpoint_decorates_and_registers_nothing`, 8 params).
- `test_the_six_are_the_whole_dynamo_only_shape_and_nothing_else_is` sweeps `EXPORT_CONTRACT_FIELDS` so a field added to the vocabulary without being added to the gate fails here instead of silently reopening the hole.

## Coverage moved, not dropped

`test_declaration_cannot_break_serving_pgw853` keeps its serving invariants (real worker, real job over the hub-double wire, the raising-at-import backstop) on the blockers path. Its §3 (mint-gate refusal text) and §4 (thunk source-identity idempotence) are superseded by `test_declared_blockers_pgw1115` and `test_export_contract_pgw739` respectively, with a pointer left in place.

## Verification

- 207 + 187 targeted tests green (`nice -n 19`, 2 workers).
- `mypy src/gen_worker` clean (260 files); `ruff check` clean.
- `scripts/lint_unreached_surface.py` and `scripts/check_registry_contract.py` green.

## Follow-up (endpoint repo, not this PR)

`inference-endpoints/scripts/lint_declarations.py` keeps its own thunk handling and `--selftest thunk` red case. Neither breaks on this SDK (the fixture raises at module scope, it never registers a callable), but both are now describing a retired mechanism and can be dropped when the repo picks up the wheel.