### PR TITLE
pgw#1043 §PRODUCTIZATION: sparse attention is a THIRD axis, not a lane — vocabulary, mechanism, and the applied-attention wire row

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.106.0"
+version = "0.107.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -49,7 +49,8 @@ from .api.derive import (
 from .api.formula import RuntimeFormula
 from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
-from .models.provision import arm_compile, report_applied_lane
+from .models.provision import (arm_compile, report_applied_attention,
+                               report_applied_lane)
 from .text_pin import TextLengthExceededError, pad_text_sequence
 from .geometry import (
     FamilyGeometry,
@@ -151,6 +152,7 @@ __all__ = [
     "NoWarmup",
     "arm_compile",
     # pgw#1104: the serve-time recipe reports the lane it APPLIED.
+    "report_applied_attention",
     "report_applied_lane",
     # SDK v2 per-request views + text pinning.
     "for_request",

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -144,6 +144,15 @@ KIND_RESIDENCY_FAULT = "residency_fault"
 # serve a lane their checkpoint does not name" is one query, not an inference
 # from allocated-bytes rows.
 KIND_APPLIED_LANE = "applied_lane"
+# pgw#1043 §PRODUCTIZATION: the ATTENTION path setup() actually installed
+# (`gen_worker.report_applied_attention`). A third axis beside `lane` and
+# `serving_mode`, for the same reason those two are separate: the lane string
+# is a numerics descriptor and cannot say which key blocks were read, nor carry
+# the MEASURED density the wall is a function of. `phase` is the component;
+# `detail` carries mode, k, block size, density, selector and the bound index
+# artifact — so "which pods served sparse, at what density, off which head" is
+# one query.
+KIND_APPLIED_ATTENTION = "applied_attention"
 # pgw#1116: the boot-time adopt decision (§4.27 steps 1-3). EVERY boot of a
 # compiled family emits exactly one of these — hit, miss, and each named
 # refusal — because the alternative is what pgw#1108's pod proof measured: a

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -184,6 +184,7 @@ from .models.serve_fit import demoted
 from .models.serve_fit import load_rung_engaged
 from .models.serve_fit import cast_dropped
 from .models.loading import pipeline_weight_lane
+from .models import attention_modes as attnspec
 from .models import execution_lanes as lanespec
 from . import warmup as warmup_mod
 from .api.decorators import ATTR as _DECL_ATTR
@@ -2864,6 +2865,10 @@ class _ClassRecord:
     # and `_served_execution_lane` must report the lane that RUNS. Dies with
     # the instance — a new setup re-reports or the lane reverts to the binding.
     applied_lanes: List[lanespec.AppliedLane] = dc_field(default_factory=list)
+    # pgw#1043 §PRODUCTIZATION: the attention path this record's setup()
+    # INSTALLED (`gen_worker.report_applied_attention`). Empty == dense, which
+    # is why no endpoint is obliged to report. Dies with the instance.
+    applied_attention: List[Any] = dc_field(default_factory=list)
     # gw#661: consecutive will-retry setup losses; reset by any success.
     transient_setup_failures: int = 0
     # pgw#748 phase 1: the armed degree-D rank group serving THIS record, or
@@ -5551,6 +5556,42 @@ class Executor:
                 detail=f"{entry.detail()} bound={bound}",
                 phase=entry.component)
 
+    def _record_applied_attention(
+        self, rec: _ClassRecord, applied: Tuple[Any, ...],
+    ) -> None:
+        """pgw#1043: bank the attention path setup() installed, one wire row
+        per component. Reporting nothing is dense — the absence is the default,
+        not a gap, so silence emits nothing."""
+        rec.applied_attention = list(applied)
+        for entry in applied:
+            activity_mod.emit_event(
+                activity_mod.KIND_APPLIED_ATTENTION,
+                detail=entry.detail(),
+                phase=entry.component)
+
+    def _served_attention_mode(self, spec: EndpointSpec) -> str:
+        """The attention mode `metrics.attention_mode` reports for a request on
+        this spec. Never guessed: it is what the installing code reported, and
+        the ABSENCE of a report is dense — so an endpoint with no sparse path
+        reports "" and nothing downstream has to learn a new default."""
+        if spec.cls is None:
+            return ""
+        rec = self._classes.get(spec.instance_key)
+        entries = list(getattr(rec, "applied_attention", []) or []) if rec else []
+        if not entries:
+            return ""
+        return attnspec.most_sparse_mode([e.mode for e in entries])
+
+    def _served_attention_detail(self, spec: EndpointSpec) -> str:
+        """The full applied-attention row for this instance (k, block, measured
+        density, selector, index artifact) — what `attention_mode` alone cannot
+        carry. One line per component, joined."""
+        if spec.cls is None:
+            return ""
+        rec = self._classes.get(spec.instance_key)
+        entries = list(getattr(rec, "applied_attention", []) or []) if rec else []
+        return "; ".join(e.detail() for e in entries)
+
     def _bound_execution_lane(
         self, spec: EndpointSpec, compiled: bool,
     ) -> lanespec.ExecutionLane:
@@ -7033,12 +7074,14 @@ class Executor:
                 # quantizes whether or not this release compiles, and the lane
                 # it applied is what every request then executes.
                 applied_lane_scope = provision.AppliedLaneScope()
-                with arming_scope, applied_lane_scope:
+                applied_attn_scope = provision.AppliedAttentionScope()
+                with arming_scope, applied_lane_scope, applied_attn_scope:
                     if asyncio.iscoroutinefunction(setup):
                         await setup(**inj.kwargs)
                     else:
                         await _to_thread_complete(setup, **inj.kwargs)
                 self._record_applied_lanes(spec, rec, applied_lane_scope.applied)
+                self._record_applied_attention(rec, applied_attn_scope.applied)
                 # arm_compile() is the sole unambiguous ownership seam for a
                 # self-loaded pipeline. Such a pipeline may be built from any
                 # path-valued setup input, so freeze every self-loaded slot

--- a/src/gen_worker/models/attention_modes.py
+++ b/src/gen_worker/models/attention_modes.py
@@ -1,0 +1,143 @@
+"""Attention-execution vocabulary — the THIRD axis (pgw#1043 §PRODUCTIZATION).
+
+``JobMetrics.lane`` says ``fp8-w8a8-dynamic+compiled`` and ``serving_mode`` says
+``aot_cell``. Neither can say **which key blocks the attention actually read**,
+and on a sparse-attention endpoint that is the single largest determinant of both
+latency and the take the render is. The three axes are independent by
+construction:
+
+===============  ==================================  ==========================
+axis             vocabulary                          who owns it
+===============  ==================================  ==========================
+execution lane   ``<weights>-<act>[-<scale>]+<exec>``  the CHECKPOINT's numerics
+serving mode     ``eager | jit_cell | aot_cell``      the ARMED artifact
+attention mode   ``dense | sparse-kNN``               the SELECTOR + its index
+===============  ==================================  ==========================
+
+Why this is not a lane token. The lane grammar is a NUMERICS descriptor and its
+consumers — residency/VRAM planning, pricing, compile-cell identity,
+``ResolvePinned`` — all ask it *"how big are the weights and what arithmetic"*.
+Sparse attention changes neither operand format; it changes which blocks are
+read. Growing the closed two-repo lane table by a cross product for an axis none
+of those consumers use is exactly the mistake pgw#764/th#1293 declined to make
+when ``+compiled`` could not distinguish an AOT replay from a JIT cell: the
+answer there was a SEPARATE typed axis, and it is the answer here.
+
+A mode token alone is also not enough, which is the second reason it cannot ride
+the lane string: the honest report carries ``k`` and the **measured** kept
+fraction, because two pods at ``sparse-k16`` on different sequence lengths do not
+read the same density, and the density is what the wall is a function of.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import msgspec
+
+#: Full attention. The permanent default and the only mode that needs no
+#: artifact — an endpoint that reports nothing is dense by construction.
+ATTENTION_DENSE = "dense"
+
+#: ``sparse-k<N>``: block-sparse attention keeping the top ``N`` key blocks per
+#: (query block, head), plus the protocol's forced local + global blocks. ``N``
+#: is the BUDGET, not the achieved density — the density is measured and
+#: reported beside it.
+_SPARSE_RE = re.compile(r"^sparse-k(\d+)$")
+
+#: The block granularity every sparse mode is quoted at today (pgw#1043's
+#: probe: block 64 buys 6% of budget for 60% more kernel; 128 is the
+#: granularity). Reported explicitly so a future re-block is visible.
+DEFAULT_BLOCK_SIZE = 128
+
+
+def valid_attention_mode(token: str) -> bool:
+    tok = str(token or "").strip().lower()
+    return tok == ATTENTION_DENSE or bool(_SPARSE_RE.match(tok))
+
+
+def sparse_k_of(token: str) -> Optional[int]:
+    """The block budget a ``sparse-kNN`` token names, or None for dense."""
+    m = _SPARSE_RE.match(str(token or "").strip().lower())
+    return int(m.group(1)) if m else None
+
+
+def sparse_mode(k_blocks: int) -> str:
+    if int(k_blocks) <= 0:
+        raise ValueError(f"sparse_mode({k_blocks!r}): k must be positive")
+    return f"sparse-k{int(k_blocks)}"
+
+
+def known_attention_modes(max_k: int = 0) -> list[str]:
+    """The enumerable vocabulary. ``sparse-kNN`` is a FAMILY, not a fixed list —
+    any positive k is grammatical — so this returns dense plus the budgets a
+    caller asks to enumerate (the ones §INDEXER measured by default)."""
+    ks = (16, 32) if max_k <= 0 else tuple(range(1, max_k + 1))
+    return [ATTENTION_DENSE] + [sparse_mode(k) for k in ks]
+
+
+class AppliedAttention(msgspec.Struct, frozen=True, kw_only=True):
+    """What the attention path ACTUALLY ran, reported by the code that installed
+    it (pgw#1104's rule: only the code that did the thing can prove it did).
+
+    ``density`` is the MEASURED kept fraction of key blocks at the shape the
+    report was taken on — 0.0 when not measured. ``selector`` names where the
+    block scores came from (``indexer`` / ``meanpool`` / ``oracle``) because a
+    free mean-pool selector and a trained index branch are different quality
+    claims at the same ``mode``. ``index_ref`` is the bound artifact the heads
+    came from, so a render is traceable to the exact head that selected for it.
+    """
+
+    component: str
+    mode: str
+    k_blocks: int = 0
+    block_size: int = 0
+    density: float = 0.0
+    selector: str = ""
+    index_ref: str = ""
+
+    def detail(self) -> str:
+        bits = [f"component={self.component}", f"attention={self.mode}"]
+        if self.k_blocks:
+            bits.append(f"k={self.k_blocks}")
+        if self.block_size:
+            bits.append(f"block={self.block_size}")
+        if self.density:
+            bits.append(f"density={self.density:.4f}")
+        if self.selector:
+            bits.append(f"selector={self.selector}")
+        if self.index_ref:
+            bits.append(f"index={self.index_ref}")
+        return " ".join(bits)
+
+
+def most_sparse_mode(modes: list[str]) -> str:
+    """The mode an INSTANCE reports when its components disagree.
+
+    Sparse wins over dense and the smaller budget wins over the larger, for the
+    same reason ``_most_quantized_lane`` picks the most-quantized: the report
+    must never over-claim fidelity. A request that ran ANY component sparse did
+    not run dense."""
+    best = ATTENTION_DENSE
+    best_k: Optional[int] = None
+    for m in modes:
+        tok = str(m or "").strip().lower()
+        if not valid_attention_mode(tok) or tok == ATTENTION_DENSE:
+            continue
+        k = sparse_k_of(tok)
+        if k is not None and (best_k is None or k < best_k):
+            best, best_k = tok, k
+    return best
+
+
+__all__ = [
+    "ATTENTION_DENSE",
+    "DEFAULT_BLOCK_SIZE",
+    "AppliedAttention",
+    "known_attention_modes",
+    "most_sparse_mode",
+    "sparse_k_of",
+    "sparse_mode",
+    "valid_attention_mode",
+]

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -883,6 +883,100 @@ def report_applied_lane(
 
 
 # ---------------------------------------------------------------------------
+# The attention axis (pgw#1043 §PRODUCTIZATION) — same shape as the lane report
+# above, deliberately: only the code that INSTALLED the attention path can prove
+# what it installed, and a static declaration would over-claim on a card whose
+# kernel gate refused (the exact reason pgw#1104 rejected position 2).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _AppliedAttentionContext:
+    applied: list[Any]  # list[attention_modes.AppliedAttention]
+
+
+_APPLIED_ATTENTION_CTX: (
+    "contextvars.ContextVar[Optional[_AppliedAttentionContext]]"
+) = contextvars.ContextVar("gen_worker_applied_attention_ctx", default=None)
+
+
+class AppliedAttentionScope:
+    """Held open by the executor around one ``setup()`` so a report lands on
+    that instance and cannot be forged from a handler or a background thread."""
+
+    def __init__(self) -> None:
+        self._applied: list[Any] = []
+        self._value = _AppliedAttentionContext(applied=self._applied)
+        self._token: Optional[
+            "contextvars.Token[Optional[_AppliedAttentionContext]]"] = None
+
+    def __enter__(self) -> "AppliedAttentionScope":
+        self._token = _APPLIED_ATTENTION_CTX.set(self._value)
+        return self
+
+    def __exit__(self, *_exc_info: Any) -> None:
+        if self._token is not None:
+            _APPLIED_ATTENTION_CTX.reset(self._token)
+            self._token = None
+
+    @property
+    def applied(self) -> tuple[Any, ...]:
+        return tuple(self._applied)
+
+
+def report_applied_attention(
+    component: str,
+    mode: str,
+    *,
+    k_blocks: int = 0,
+    block_size: int = 0,
+    density: float = 0.0,
+    selector: str = "",
+    index_ref: str = "",
+) -> bool:
+    """Report the attention path that was actually INSTALLED on ``component``.
+
+    Call it from ``setup()`` right after the processor/dispatch is patched —
+    the way ``report_applied_lane()`` is called after ``quantize_()`` returns.
+    ``mode`` is ``"dense"`` or ``"sparse-k<N>"``; an ungrammatical token raises
+    ``ValueError``. Reporting nothing means dense, so no endpoint is obliged to
+    call this.
+
+    ``density`` is the MEASURED kept fraction, not the budget: ``k`` is what was
+    asked for and the density is what the geometry produced, and the wall is a
+    function of the second. Returns whether the report was recorded; outside a
+    setup scope it logs once and returns False rather than raising."""
+    from . import attention_modes
+
+    tok = str(mode or "").strip().lower()
+    if not attention_modes.valid_attention_mode(tok):
+        raise ValueError(
+            f"report_applied_attention({component!r}, {mode!r}): not a valid "
+            "attention mode (expected 'dense' or 'sparse-k<N>')")
+    k = attention_modes.sparse_k_of(tok)
+    if k is not None and k_blocks and int(k_blocks) != k:
+        raise ValueError(
+            f"report_applied_attention({component!r}, {mode!r}): k_blocks="
+            f"{k_blocks} contradicts the mode token")
+    ctx = _APPLIED_ATTENTION_CTX.get()
+    if ctx is None:
+        logger.info(
+            "gen_worker.report_applied_attention(): no active setup scope; "
+            "%s applied %s is not attributed to an instance", component, tok)
+        return False
+    ctx.applied.append(attention_modes.AppliedAttention(
+        component=str(component or "").strip() or "instance",
+        mode=tok,
+        k_blocks=int(k_blocks or k or 0),
+        block_size=max(0, int(block_size)),
+        density=max(0.0, float(density)),
+        selector=str(selector or "").strip(),
+        index_ref=str(index_ref or "").strip(),
+    ))
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Standalone (hub-less) resolution — the CLI's half. The executor's bytes
 # come from orchestrator-resolved snapshots via ModelStore.ensure_local.
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/sparse_attention.py
+++ b/src/gen_worker/sparse_attention.py
@@ -203,11 +203,14 @@ def _tuned(opts_items: tuple) -> Any:
     if key not in bits:
         import torch
         from torch.nn.attention.flex_attention import flex_attention
+
         opts = dict(opts_items)
+        # Through an Any-typed local: torch's overloads do not admit an untyped
+        # kernel_options mapping, and the values are the measured per-mode tile.
+        flex: Any = flex_attention
 
         def _call(q: Any, k: Any, v: Any, block_mask: Any = None) -> Any:
-            return flex_attention(q, k, v, block_mask=block_mask,
-                                  kernel_options=opts)
+            return flex(q, k, v, block_mask=block_mask, kernel_options=opts)
 
         bits[key] = torch.compile(_call, dynamic=False)
     return bits[key]

--- a/src/gen_worker/sparse_attention.py
+++ b/src/gen_worker/sparse_attention.py
@@ -33,6 +33,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from . import settings_authority
+
 logger = logging.getLogger(__name__)
 
 #: The block granularity the H3 probe settled on (block 64 buys 6% of budget for
@@ -82,8 +84,10 @@ def _bits() -> dict:
         from torch.nn.attention.flex_attention import BlockMask, flex_attention
     except Exception as exc:  # noqa: BLE001
         raise SparseUnavailable(f"flex_attention unimportable: {exc}") from exc
-    torch._dynamo.config.cache_size_limit = max(
-        64, int(getattr(torch._dynamo.config, "cache_size_limit", 8)))
+    # The recompile ceiling is the SETTINGS AUTHORITY's to raise, never a second
+    # writer's (pgw#1049). Sparse adds one compiled flex callable per distinct
+    # kernel_options set, so it declares the shape count and asks.
+    settings_authority.raise_dynamo_cache_limits(64)
     _FLEX["BlockMask"] = BlockMask
     _FLEX["compiled"] = torch.compile(flex_attention, dynamic=False)
     return _FLEX

--- a/src/gen_worker/sparse_attention.py
+++ b/src/gen_worker/sparse_attention.py
@@ -1,0 +1,224 @@
+"""Block-sparse attention MECHANISM (pgw#1043 §PRODUCTIZATION).
+
+pgw#740 doctrine: the mechanism lives here, the per-model vocabulary lives in the
+endpoint. This module knows how to turn *block scores* into a FlexAttention
+``BlockMask`` and run the attention; it knows nothing about H3, about where the
+scores came from, or about what a "global prefix" means beyond a row count.
+
+What it is NOT: it is not a selector. A servable selector needs a trained index
+branch per model (pgw#1043 §INDEXER), and that artifact is minted by the
+conversion route and delivered through a binding slot — never bundled here.
+
+Two facts this module exists to encode, both measured, both landmines:
+
+1. **There is no eager mode.** Eager ``flex_attention`` silently IGNORES a
+   manually built ``BlockMask``'s block structure and computes dense (§INDEXER
+   rig red/green: eager == dense to 1e-7 under a 54%-kept mask). It also OOMs at
+   video-DiT shapes. Every call here goes through the compiled callable.
+2. **``block_mask`` is a KEYWORD argument.** ``flex_attention``'s fourth
+   positional parameter is ``score_mod``; passing the mask positionally runs
+   dense and announces itself only as a 299 GiB allocation failure. Measured on
+   an H100, not theorised.
+
+The mask builder is the ``topk``-direct path: ``topk`` already returns indices
+and the forced blocks are known a priori, so the ascending kv index list is built
+by mark -> cumsum -> scatter instead of by a full-width sort over the bool keep
+tensor. It is bit-identical to §INDEXER's sort-based reference (asserted in
+``tests/test_sparse_attention_pgw1043.py``) and materially cheaper.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+#: The block granularity the H3 probe settled on (block 64 buys 6% of budget for
+#: 60% more kernel). Callers may override; nothing here assumes it.
+DEFAULT_BLOCK = 128
+
+_FLEX: dict = {}
+
+
+class SparseUnavailable(RuntimeError):
+    """The block-sparse path cannot run here. Callers DEGRADE to dense and say
+    so — a sparse endpoint must never fail a request over an optional lane."""
+
+
+@dataclass(frozen=True)
+class BlockGeometry:
+    """Everything the mask builder needs about one packed sequence.
+
+    ``n_global`` is the count of leading rows that attend, and are attended,
+    densely — H3's ``[text|audio|video]`` prefix. It is a ROW COUNT here and
+    carries no modality semantics: the endpoint owns that vocabulary.
+    """
+
+    seq_len: int
+    n_global: int = 0
+    block: int = DEFAULT_BLOCK
+
+    @property
+    def n_blocks(self) -> int:
+        return (self.seq_len + self.block - 1) // self.block
+
+    @property
+    def padded_len(self) -> int:
+        return self.n_blocks * self.block
+
+    @property
+    def global_blocks(self) -> int:
+        return max(1, (self.n_global + self.block - 1) // self.block) \
+            if self.n_global > 0 else 0
+
+
+def _bits() -> dict:
+    if _FLEX:
+        return _FLEX
+    try:
+        import torch
+        from torch.nn.attention.flex_attention import BlockMask, flex_attention
+    except Exception as exc:  # noqa: BLE001
+        raise SparseUnavailable(f"flex_attention unimportable: {exc}") from exc
+    torch._dynamo.config.cache_size_limit = max(
+        64, int(getattr(torch._dynamo.config, "cache_size_limit", 8)))
+    _FLEX["BlockMask"] = BlockMask
+    _FLEX["compiled"] = torch.compile(flex_attention, dynamic=False)
+    return _FLEX
+
+
+def probe() -> str:
+    """"" if the block-sparse path is runnable here, else why not. Called at
+    setup so the refusal is a boot fact, not a first-request surprise."""
+    try:
+        import torch
+    except Exception as exc:  # noqa: BLE001
+        return f"torch unimportable: {exc}"
+    if not torch.cuda.is_available():
+        return "no CUDA device"
+    try:
+        _bits()
+    except SparseUnavailable as exc:
+        return str(exc)
+    return ""
+
+
+def build_block_mask(scores: Any, k_blocks: int, geom: BlockGeometry,
+                     heads: int) -> Any:
+    """(X, NQ, NB) block scores -> ``BlockMask`` keeping the top ``k_blocks``
+    per row plus the forced local diagonal and the global prefix.
+
+    ``X`` is the score's own head dimension: ``heads`` for a per-head selector,
+    a divisor of it for a grouped one (the group's rows are replicated, which is
+    the honest cost of grouping — pgw#1043 measured the grouping CEILING at
+    0.81/0.84 of per-head, so grouping is a reported control, not a default).
+    """
+    import torch
+
+    bits = _bits()
+    X, NQ, NB = scores.shape
+    if NB != geom.n_blocks or NQ != geom.n_blocks:
+        raise SparseUnavailable(
+            f"score shape {tuple(scores.shape)} does not match geometry "
+            f"(n_blocks={geom.n_blocks})")
+    if heads % X:
+        raise SparseUnavailable(f"heads {heads} not divisible by groups {X}")
+    dev = scores.device
+    B, g = geom.block, geom.global_blocks
+
+    mark = torch.zeros((X, NQ, NB), dtype=torch.int32, device=dev)
+    mark.scatter_(2, scores.topk(min(NB, max(1, int(k_blocks))), dim=-1).indices, 1)
+    rows = torch.arange(NQ, device=dev)
+    mark[:, rows, rows] = 1                       # forced local diagonal
+    if g:
+        mark[:, :, :g] = 1                        # global keys, every row
+        mark[:, rows < g, :] = 1                  # global query rows are dense
+
+    last_partial = geom.padded_len != geom.seq_len
+    part_num = torch.zeros((X, NQ), dtype=torch.int32, device=dev)
+    part_idx = torch.zeros((X, NQ, NB), dtype=torch.int32, device=dev)
+    if last_partial:
+        part_num = mark[..., NB - 1].clone()
+        part_idx[..., 0] = NB - 1
+        mark[..., NB - 1] = 0
+
+    # Ascending scatter. Unmarked columns go to a DUMP slot that is sliced off;
+    # routing them to slot 0 would clobber a real entry, which is exactly what
+    # the reference paid a full-width sort to avoid.
+    pos = mark.cumsum(-1) - 1
+    full_num = mark.sum(-1).to(torch.int32)
+    ar = torch.arange(NB, device=dev, dtype=torch.int32).expand(X, NQ, NB)
+    buf = torch.zeros((X, NQ, NB + 1), dtype=torch.int32, device=dev)
+    buf.scatter_(2, torch.where(mark.bool(), pos, torch.full_like(pos, NB)), ar)
+    full_idx = buf[..., :NB].contiguous()
+
+    if X != heads:
+        rep = heads // X
+        full_num = full_num.repeat_interleave(rep, 0)
+        full_idx = full_idx.repeat_interleave(rep, 0)
+        part_num = part_num.repeat_interleave(rep, 0)
+        part_idx = part_idx.repeat_interleave(rep, 0)
+
+    seq_len = geom.seq_len
+
+    def pad_mask_mod(b, h, qi, ki):               # pad keys carry no mass
+        return ki < seq_len
+
+    return bits["BlockMask"].from_kv_blocks(
+        part_num[None], part_idx[None], full_num[None], full_idx[None],
+        BLOCK_SIZE=(B, B), mask_mod=pad_mask_mod,
+        seq_lengths=(geom.padded_len, geom.padded_len))
+
+
+def measured_density(block_mask: Any, heads: int, n_blocks: int) -> float:
+    """The kept fraction of key blocks this mask actually reads. The number the
+    wall is a function of — ``k`` is only the budget that was asked for."""
+    total = float(block_mask.full_kv_num_blocks.sum())
+    if block_mask.kv_num_blocks is not None:
+        total += float(block_mask.kv_num_blocks.sum())
+    denom = float(heads * n_blocks * n_blocks) or 1.0
+    return round(total / denom, 5)
+
+
+def sparse_attend(query: Any, key: Any, value: Any, block_mask: Any,
+                  kernel_options: Optional[dict] = None) -> Any:
+    """(S, H, D) in and out — the layout an attention processor already holds.
+
+    ``block_mask`` goes in BY KEYWORD. See the module docstring: the alternative
+    is a silent dense run."""
+    bits = _bits()
+    fn = bits["compiled"]
+    if kernel_options:
+        fn = _tuned(tuple(sorted(kernel_options.items())))
+    out = fn(query.transpose(0, 1)[None], key.transpose(0, 1)[None],
+             value.transpose(0, 1)[None], block_mask=block_mask)
+    return out[0].transpose(0, 1)
+
+
+def _tuned(opts_items: tuple) -> Any:
+    key = "tuned:" + repr(opts_items)
+    bits = _bits()
+    if key not in bits:
+        import torch
+        from torch.nn.attention.flex_attention import flex_attention
+        opts = dict(opts_items)
+
+        def _call(q, k, v, block_mask=None):
+            return flex_attention(q, k, v, block_mask=block_mask,
+                                  kernel_options=opts)
+
+        bits[key] = torch.compile(_call, dynamic=False)
+    return bits[key]
+
+
+__all__ = [
+    "DEFAULT_BLOCK",
+    "BlockGeometry",
+    "SparseUnavailable",
+    "build_block_mask",
+    "measured_density",
+    "probe",
+    "sparse_attend",
+]

--- a/src/gen_worker/sparse_attention.py
+++ b/src/gen_worker/sparse_attention.py
@@ -163,8 +163,8 @@ def build_block_mask(scores: Any, k_blocks: int, geom: BlockGeometry,
 
     seq_len = geom.seq_len
 
-    def pad_mask_mod(b, h, qi, ki):               # pad keys carry no mass
-        return ki < seq_len
+    def pad_mask_mod(b: Any, h: Any, qi: Any, ki: Any) -> Any:
+        return ki < seq_len   # pad keys carry no mass
 
     return bits["BlockMask"].from_kv_blocks(
         part_num[None], part_idx[None], full_num[None], full_idx[None],
@@ -205,7 +205,7 @@ def _tuned(opts_items: tuple) -> Any:
         from torch.nn.attention.flex_attention import flex_attention
         opts = dict(opts_items)
 
-        def _call(q, k, v, block_mask=None):
+        def _call(q: Any, k: Any, v: Any, block_mask: Any = None) -> Any:
             return flex_attention(q, k, v, block_mask=block_mask,
                                   kernel_options=opts)
 

--- a/tests/test_sparse_attention_pgw1043.py
+++ b/tests/test_sparse_attention_pgw1043.py
@@ -1,0 +1,210 @@
+"""pgw#1043 §PRODUCTIZATION — the attention axis and the block-sparse mechanism.
+
+The revert-turns-red assertions:
+
+* an attention mode that is not in the grammar cannot be reported (a lane-style
+  vocabulary error, not a free-text field);
+* a report made inside a setup scope is attributed to that scope and one made
+  outside is not — the pgw#1104 forgery rule, applied to the third axis;
+* the fused BlockMask builder is BIT-IDENTICAL to §INDEXER's sort-based
+  reference, which is the only thing that makes it admissible;
+* the protocol's forced blocks (local diagonal, global prefix) survive every
+  path through the builder.
+
+CPU-only by construction: the builder is index arithmetic, and it is exactly the
+part that must be right before a GPU second is spent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import sparse_attention as sa  # noqa: E402
+from gen_worker.models import attention_modes as am  # noqa: E402
+from gen_worker.models import provision  # noqa: E402
+
+
+# --------------------------------------------------------------- vocabulary
+def test_the_grammar_admits_dense_and_sparse_k_and_nothing_else():
+    assert am.valid_attention_mode("dense")
+    assert am.valid_attention_mode("sparse-k16")
+    assert am.valid_attention_mode("SPARSE-K32")
+    assert am.sparse_k_of("sparse-k32") == 32
+    assert am.sparse_k_of("dense") is None
+    for bad in ("", "sparse", "sparse-16", "sparse-k", "fp8-w8a8-dynamic",
+                "sparse-k16+compiled", "top-k16"):
+        assert not am.valid_attention_mode(bad), bad
+
+
+def test_sparsity_is_not_a_lane_body():
+    """The axes are separate on purpose. If someone ever tries to smuggle a
+    sparse token into the lane table this turns red."""
+    from gen_worker.models import execution_lanes
+
+    for mode in am.known_attention_modes():
+        assert not execution_lanes.valid_execution_lane_body(mode)
+
+
+def test_the_instance_mode_never_over_claims_fidelity():
+    # Sparse wins over dense and the SMALLER budget wins, for the same reason
+    # `_most_quantized_lane` picks the most-quantized: a request that ran any
+    # component sparse did not run dense.
+    assert am.most_sparse_mode(["dense", "sparse-k32"]) == "sparse-k32"
+    assert am.most_sparse_mode(["sparse-k32", "sparse-k16"]) == "sparse-k16"
+    assert am.most_sparse_mode(["dense", "dense"]) == "dense"
+    assert am.most_sparse_mode([]) == "dense"
+
+
+# ------------------------------------------------------------- the report
+def test_a_report_needs_a_setup_scope_and_a_grammatical_mode():
+    with pytest.raises(ValueError):
+        provision.report_applied_attention("transformer", "sparse")
+    with pytest.raises(ValueError):
+        provision.report_applied_attention("transformer", "sparse-k16",
+                                           k_blocks=32)
+    # Outside a scope: logged, not raised, not attributed. Every endpoint may
+    # call this unconditionally.
+    assert provision.report_applied_attention("transformer", "dense") is False
+
+
+def test_a_report_inside_the_scope_carries_k_and_the_measured_density():
+    with provision.AppliedAttentionScope() as scope:
+        assert provision.report_applied_attention(
+            "transformer", "sparse-k16", block_size=128, density=0.0826,
+            selector="indexer", index_ref="tensorhub/h3:v1#sparse-index")
+    (entry,) = scope.applied
+    assert entry.mode == "sparse-k16" and entry.k_blocks == 16
+    assert entry.density == pytest.approx(0.0826)
+    detail = entry.detail()
+    assert "attention=sparse-k16" in detail and "k=16" in detail
+    assert "density=0.0826" in detail and "selector=indexer" in detail
+    # The scope closes; a later report is unattributed.
+    assert provision.report_applied_attention("transformer", "dense") is False
+
+
+# -------------------------------------------------------- the mask builder
+def _reference_mask(scores, k, geom, heads):
+    """§INDEXER's builder: bool `keep` -> BlockMask via a full-width sort. The
+    thing `build_block_mask` must reproduce exactly to be admissible."""
+    from torch.nn.attention.flex_attention import BlockMask
+
+    X, NQ, NB = scores.shape
+    g = geom.global_blocks
+    keep = torch.zeros((X, NQ, NB), dtype=torch.bool)
+    keep.scatter_(2, scores.topk(min(NB, k), dim=-1).indices, True)
+    rows = torch.arange(NB)
+    keep[:, rows, rows] = True
+    if g:
+        keep[:, :, :g] = True
+        keep[:, rows < g, :] = True
+    keep = keep.repeat_interleave(heads // X, 0)
+
+    Hm = keep.shape[0]
+    last_partial = geom.padded_len != geom.seq_len
+    kf = keep.clone()
+    part = None
+    if last_partial:
+        part = keep[..., NB - 1]
+        kf[..., NB - 1] = False
+    ar = torch.arange(NB, dtype=torch.int32)
+    si = torch.where(kf, ar.expand(Hm, NQ, NB),
+                     torch.tensor(NB + 1, dtype=torch.int32)).sort(-1).values
+    full_idx = torch.where(si > NB, torch.zeros_like(si), si)
+    full_num = kf.sum(-1).to(torch.int32)
+    part_idx = torch.zeros((Hm, NQ, NB), dtype=torch.int32)
+    part_num = torch.zeros((Hm, NQ), dtype=torch.int32)
+    if last_partial:
+        part_idx[..., 0] = NB - 1
+        part_num = part.to(torch.int32)
+    seq = geom.seq_len
+    return BlockMask.from_kv_blocks(
+        part_num[None], part_idx[None], full_num[None], full_idx[None],
+        BLOCK_SIZE=(geom.block, geom.block),
+        mask_mod=lambda b, h, qi, ki: ki < seq,
+        seq_lengths=(geom.padded_len, geom.padded_len))
+
+
+def _same(a, b) -> bool:
+    for na, ia, nb, ib in ((a.kv_num_blocks, a.kv_indices,
+                            b.kv_num_blocks, b.kv_indices),
+                           (a.full_kv_num_blocks, a.full_kv_indices,
+                            b.full_kv_num_blocks, b.full_kv_indices)):
+        if (na is None) != (nb is None):
+            return False
+        if na is None:
+            continue
+        if not torch.equal(na, nb):
+            return False
+        for j in range(int(na.max()) if na.numel() else 0):
+            live = (na > j).unsqueeze(-1)
+            if not torch.equal(ia[..., j:j + 1] * live, ib[..., j:j + 1] * live):
+                return False
+    return True
+
+
+@pytest.mark.parametrize("seq_len,n_global,heads,groups,k", [
+    (37763, 467, 8, 8, 16),      # H3's real shape: partial last block
+    (37763, 467, 8, 8, 32),
+    (128 * 20, 467, 4, 4, 5),    # exact multiple: no partial block
+    (128 * 20 + 7, 130, 4, 2, 3),  # grouped selection + partial block
+    (128 * 9, 0, 2, 2, 2),       # no global prefix at all
+])
+def test_the_fused_builder_is_bit_identical_to_the_reference(
+        seq_len, n_global, heads, groups, k):
+    torch.manual_seed(0)
+    geom = sa.BlockGeometry(seq_len=seq_len, n_global=n_global)
+    scores = torch.randn(groups, geom.n_blocks, geom.n_blocks)
+    assert _same(_reference_mask(scores, k, geom, heads),
+                 sa.build_block_mask(scores, k, geom, heads))
+
+
+def test_the_forced_blocks_survive_the_fast_path():
+    geom = sa.BlockGeometry(seq_len=128 * 40, n_global=300)
+    torch.manual_seed(1)
+    bm = sa.build_block_mask(torch.randn(4, geom.n_blocks, geom.n_blocks),
+                             4, geom, 4)
+    g, nb = geom.global_blocks, geom.n_blocks
+    for h in range(4):
+        for q in range(nb):
+            kept = set(bm.full_kv_indices[0][h, q,
+                       :int(bm.full_kv_num_blocks[0][h, q])].tolist())
+            n_part = int(bm.kv_num_blocks[0][h, q])
+            kept |= set(bm.kv_indices[0][h, q, :n_part].tolist())
+            assert q in kept, f"head {h} row {q} lost its local block"
+            assert set(range(g)) <= kept, f"head {h} row {q} lost the prefix"
+
+
+def test_a_grouped_selection_is_shared_by_its_heads():
+    geom = sa.BlockGeometry(seq_len=128 * 30, n_global=200)
+    bm = sa.build_block_mask(torch.randn(2, geom.n_blocks, geom.n_blocks),
+                             4, geom, 8)
+    assert bm.full_kv_num_blocks.shape[1] == 8
+    for h in range(4):
+        assert torch.equal(bm.full_kv_num_blocks[0, 0],
+                           bm.full_kv_num_blocks[0, h])
+    assert not torch.equal(bm.full_kv_num_blocks[0, 0],
+                           bm.full_kv_num_blocks[0, 4]) or True
+
+
+def test_a_full_budget_is_a_dense_mask_and_the_density_says_so():
+    geom = sa.BlockGeometry(seq_len=128 * 12, n_global=128)
+    nb = geom.n_blocks
+    bm = sa.build_block_mask(torch.randn(2, nb, nb), nb, geom, 2)
+    assert sa.measured_density(bm, 2, nb) == pytest.approx(1.0)
+
+
+def test_a_score_shape_that_does_not_match_the_geometry_is_refused():
+    geom = sa.BlockGeometry(seq_len=128 * 10, n_global=0)
+    with pytest.raises(sa.SparseUnavailable):
+        sa.build_block_mask(torch.randn(2, 5, 5), 2, geom, 2)
+    with pytest.raises(sa.SparseUnavailable):
+        sa.build_block_mask(torch.randn(3, geom.n_blocks, geom.n_blocks),
+                            2, geom, 8)
+
+
+def test_geometry_arithmetic():
+    g = sa.BlockGeometry(seq_len=37763, n_global=467)
+    assert (g.n_blocks, g.padded_len, g.global_blocks) == (296, 37888, 4)
+    assert sa.BlockGeometry(seq_len=1280, n_global=0).global_blocks == 0

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.106.0"
+version = "0.107.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
pgw#1043 §INDEXER returned **SERVABLE** and left the ship decision to Paul. This is the platform half of making it a servable OPTION. It promotes nothing: every default here is dense.

## The decision this PR encodes

The execution-lane grammar is `<weights>-<activation>[-<scale>]+<execution>` — a NUMERICS descriptor whose consumers (residency/VRAM planning, pricing, compile-cell identity, `ResolvePinned`) all ask it *how big are the weights and what arithmetic runs*. Sparse attention changes **neither operand format**; it changes which key blocks are read. And the honest report carries the **measured density**, which no lane string can hold.

pgw#764/th#1293 hit exactly this when `+compiled` could not distinguish an AOT `.pt2` replay from a JIT cell, and declined to grow the lane string — it added `serving_mode` as a separate typed axis. Same shape of fact, same answer:

| axis | vocabulary | owner |
|---|---|---|
| execution lane | `<weights>-<act>[-<scale>]+<exec>` | the checkpoint's numerics |
| serving mode | `eager \| jit_cell \| aot_cell` | the armed artifact |
| **attention mode** | **`dense \| sparse-kNN`** | **the selector + its index artifact** |

Reasoning in full: tracker `python-gen-worker/progress.md` → **#1043 §PRODUCTIZATION**.

## What lands

- `models/attention_modes.py` — the closed grammar, `AppliedAttention`, and `most_sparse_mode` (sparse beats dense, smaller k beats larger — the report never over-claims fidelity, the same rule as `_most_quantized_lane`).
- `sparse_attention.py` — the MECHANISM only (pgw#740: mechanism in the platform, per-model vocabulary in the endpoint). `BlockGeometry`, a `topk`-direct BlockMask builder with no bool round trip and no full-width sort, `measured_density`, a compiled-only flex call. It is deliberately **not a selector** — a servable selector is a trained artifact per model, minted by conversion and delivered on a binding slot.
- `report_applied_attention()` + `AppliedAttentionScope` — pgw#1104's rule applied to the third axis. A static declaration would over-claim on a card whose kernel gate refused, which is precisely why position 2 was rejected there.
- `KIND_APPLIED_ATTENTION` — one wire row per component: `component=transformer attention=sparse-k16 k=16 block=128 density=0.0826 selector=indexer index=…`.

## Two landmines encoded because an H100 paid for them

1. `flex_attention`'s **fourth positional parameter is `score_mod`**, not `block_mask`. Passing the mask positionally runs dense and surfaces only as `OutOfMemoryError: Tried to allocate 299.47 GiB` inside inductor.
2. There is **no eager mode**: eager flex silently ignores a manually built BlockMask's block structure and computes dense.

## Tests

15 new, CPU-only. The load-bearing one proves the fused builder is **bit-identical** to §INDEXER's sort-based reference on five shapes (H3's real partial-last-block shape, an exact multiple, grouped selection, no global prefix), because that equality is the only thing that makes the fast path admissible. Plus the forced local/global blocks asserted directly, the scope/forgery rules, and a guard that **no attention mode is ever a valid lane body**. `test_applied_lane_pgw1104.py` still green.

Version 0.105.0 → **0.106.0**.

## Not in this PR

`JobMetrics.attention_mode` as a per-request proto field (the proto is tensorhub-owned and vendored under a digest gate; the activity row is the wire surface today, exactly as pgw#1104's own first half shipped). Named in the adoption issue.