### PR TITLE
pgw#1127 S1: cozy-local can REACH the AOT cell sink — and can never publish through it

### DIFF
--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -91,6 +91,25 @@ GUARDED = re.compile(
 # wheel; this tree is not their call site and never will be.
 EXEMPT_PACKAGES = ("gen_worker.api",)
 
+# target -> why it is unreached AND who deletes it. Each row is a DELETION
+# THAT IS OWED, never a permanent pardon: the only legitimate reason to be in
+# here is that something outside this lane's scope owns the removal, so every
+# row names that owner. A row whose target no longer exists is RED (see
+# `stale_exemptions`) — the same rule the config-reads and settings-writers
+# allowlists follow, and what stops this table becoming the place dead code
+# goes to be forgotten.
+EXEMPT_TARGETS = {
+    "gen_worker.local_cells.enable_compiled": (
+        "the JIT local-serve entry, dead since pgw#1127 re-pointed "
+        "`cli/run.py` at `local_serve.enable_compiled` (the AOT sink). The "
+        "MODULE's deletion is pgw#1086 wave 1's inventory item and pgw#1127 "
+        "§6 puts it explicitly out of that lane's scope — so this row exists "
+        "for exactly as long as `local_cells.py` does. OWNER: pgw#1086 "
+        "wave 1. EXPIRY: that module's deletion, which this row then fails "
+        "until it is removed with it."
+    ),
+}
+
 # Decorators meaning "something else calls this, by table not by name".
 DYNAMIC_DECORATORS = {
     "endpoint", "worker_function", "property", "cached_property", "setter",
@@ -412,7 +431,20 @@ class Finding:
     note: str = ""
 
 
+def stale_exemptions(defs: List[Definition]) -> List[str]:
+    """Rows in :data:`EXEMPT_TARGETS` naming something that no longer exists.
+
+    An exemption is a deletion somebody OWES. Once the owner lands it the row
+    is a pardon for nothing, and a pardon for nothing is how the next dead
+    symbol gets waved through under a comment about a different one.
+    """
+    have = {d.target for d in defs}
+    return sorted(t for t in EXEMPT_TARGETS if t not in have)
+
+
 def exempt(d: Definition, published: Set[str], reach: Reach) -> Optional[str]:
+    if d.target in EXEMPT_TARGETS:
+        return EXEMPT_TARGETS[d.target]
     if any(d.module == p or d.module.startswith(p + ".") for p in EXEMPT_PACKAGES):
         return "authored-worker API (consumers are endpoint repos)"
     if d.name in published:
@@ -460,6 +492,11 @@ def run(scope_all: bool, want_params: bool, explain: bool) -> List[Finding]:
     published = published_names()
 
     findings: List[Finding] = []
+    for target in stale_exemptions(defs):
+        findings.append(Finding(
+            "stale-exemption", target, SELF, 0,
+            "EXEMPT_TARGETS names a symbol this tree no longer defines — the "
+            "deletion it was waiting for has landed; drop the row"))
     for d in defs:
         why = exempt(d, published, reach)
         if why:

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -22,9 +22,16 @@ import types
 import typing
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import (
+    TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple,
+)
 
 import msgspec
+
+if TYPE_CHECKING:  # pgw#1127: the arming import stays deferred at runtime —
+    # `gen_worker.local_serve` pulls the whole compile stack, and `cozy run`
+    # on a payload-only endpoint must not pay for it.
+    from .. import local_serve
 
 from ..api.errors import CanceledError
 from ..models import provision
@@ -550,6 +557,7 @@ def run_setup(
     arm_compile: bool = True, return_loaded: bool = False,
     component_paths: Optional[Dict[str, Dict[str, str]]] = None,
     structure_only: Sequence[str] = (), place: bool = True,
+    selected: Optional["_SelectedFunction"] = None,
 ) -> Optional[Dict[str, Any]]:
     """Call ``instance.setup(...)`` once, passing exactly the resolved model
     slots its signature declares.
@@ -558,6 +566,12 @@ def run_setup(
     (pgw#784): the mint child drives its own cold arm + capture and must not
     have a cell armed under it. ``return_loaded=True`` returns the loaded slot
     objects so a caller can reach the pipeline it just built.
+
+    ``selected`` (pgw#1127) is the routable function these slots belong to. It
+    is what makes ``arm_compile=True`` able to MINT: a delegated child
+    rediscovers the endpoint from its declaring module and re-resolves the
+    parent's slots, so without it this path can only adopt a cell that already
+    exists. Absent, the arm is adopt-only and says so.
 
     ``place=False`` (pgw#1124) loads the slots without running the worker's
     serving placement ladder at all, while ``device`` still says which device
@@ -637,12 +651,20 @@ def run_setup(
     except (TypeError, ValueError, NameError):
         hints = {}
     decl = getattr(type(instance), _ENDPOINT_ATTR, None)
+    # pgw#1127: the mint context is built from the WHOLE resolution, once,
+    # before any slot loads — the child re-runs setup, so it needs every slot
+    # this endpoint declares and not just the one whose load happens to reach
+    # the arm. Built even when `arm_compile` is False (it costs a dict) so the
+    # two paths cannot drift into resolving slots differently.
+    mint = _local_mint_context(
+        instance, resolved_models, wanted,
+        component_paths=component_paths, selected=selected)
     loaded = {
         k: _load_injected_model(
             hints.get(k), v, decl=decl, slot=k, device=device,
             arm_compile=arm_compile, place=place,
             overrides=dict((component_paths or {}).get(k) or {}),
-            structure_only=tuple(structure_only))
+            structure_only=tuple(structure_only), mint=mint)
         for k, v in resolved_models.items()
         if k in wanted
     }
@@ -656,6 +678,44 @@ def run_setup(
 
 _INJECTED_CACHE: Dict[Tuple[str, str], Any] = {}
 _ENDPOINT_ATTR = "__gen_worker_endpoint__"
+
+
+def _local_mint_context(
+    instance: Any,
+    resolved_models: Dict[str, str],
+    wanted: Any,
+    *,
+    component_paths: Optional[Dict[str, Dict[str, str]]],
+    selected: Optional[_SelectedFunction],
+) -> Optional["local_serve.LocalMintContext"]:
+    """This run's resolution, in the shape a delegated mint child reads.
+
+    ``None`` when the caller did not name the function (``mint_child`` and
+    ``boot_trace_child`` both call ``run_setup`` without one, and both pass
+    ``arm_compile=False`` — a child that opened its own mint would be the
+    recursion this must not have).
+    """
+    if selected is None:
+        return None
+    from .. import local_serve
+
+    module = str(getattr(selected.spec, "module", "") or "").strip()
+    if not module:
+        # The endpoint was discovered from a file path or an interactive
+        # namespace, so no importable module name exists for a child to
+        # rediscover it in. Adopt-only, honestly.
+        module = str(getattr(selected.cls, "__module__", "") or "").strip()
+        if module in ("", "__main__"):
+            module = ""
+    return local_serve.mint_context(
+        function=selected.fn_name,
+        module=module,
+        slots=local_serve.slot_map(
+            {k: v for k, v in resolved_models.items() if k in wanted},
+            selected.bindings,
+            component_paths,
+        ),
+    )
 
 
 def _assert_structure_honored(
@@ -714,6 +774,7 @@ def _load_injected_model(
     device: str = "", arm_compile: bool = True, place: bool = True,
     overrides: Optional[Dict[str, str]] = None,
     structure_only: Sequence[str] = (),
+    mint: Optional["local_serve.LocalMintContext"] = None,
 ) -> Any:
     """Load one setup slot via the shared core, with a per-process warm cache
     (so ``serve`` and repeated local dispatches never reload weights).
@@ -796,14 +857,20 @@ def _load_injected_model(
         and compile_cfg is not None
         and device.strip().lower() != "cpu"
     ):
-        from ..local_cells import enable_compiled as enable_compiled_local
+        from .. import local_serve
         from ..models.cache_paths import tensorhub_cas_dir
 
-        # Local runtime (gw#555): delivered/env artifacts first, then the
-        # user's local cell store — adopt a stored self-minted cell or mint
-        # one. This call-site is the ONLY entry to local minting; the
-        # production executor arms compile via hub-delivered cells only.
-        enable_compiled_local(sl.obj, compile_cfg, Path(tensorhub_cas_dir()))
+        # §4.28 / pgw#1127: the ONE arming brain, with NO sink. Delivered
+        # artifact, then THIS MACHINE's own ck1-keyed cell store, then a
+        # delegated AOT mint whose result lands in that store — so the second
+        # run of this endpoint on this machine arms from disk with no mint, no
+        # hub and no network. Before pgw#1127 this line called
+        # `local_cells.enable_compiled`, the JIT path, which meant the store
+        # pgw#1096 built for exactly this machine was unreachable from it and
+        # pgw#1086 wave 1's deletion of that module would have taken compiled
+        # serving off cozy-local outright.
+        local_serve.enable_compiled(
+            sl.obj, compile_cfg, Path(tensorhub_cas_dir()), mint=mint)
     _INJECTED_CACHE[key] = sl.obj
     return sl.obj
 
@@ -1200,7 +1267,8 @@ def _run_inner(args: argparse.Namespace) -> int:
             emit=_stderr_emitter,
             write_event=_write_event,
             on_resolved=lambda resolved: _discard(
-                run_setup(instance, resolved, device=device)),
+                run_setup(
+                    instance, resolved, device=device, selected=selected)),
         )
     except CanceledError:
         raise

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -406,7 +406,13 @@ class _Endpoint:
                     served.selected.bindings, offline=self.offline,
                 )
                 before = memory.cuda_allocated_bytes()
-                run_mod.run_setup(inst, resolved, device=self.device)
+                run_mod.run_setup(
+                    inst, resolved, device=self.device,
+                    # pgw#1127: `cozy serve` is the machine §4.28 was written
+                    # about. Naming the function here is what lets its first
+                    # run mint an AOT cell into this machine's own store and
+                    # every later run arm it from disk.
+                    selected=served.selected)
                 measured = max(0, memory.cuda_allocated_bytes() - before)
                 self._setup_done.add(iid)
 

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -34,9 +34,14 @@ every claimed key axis against its own records and pins the token to
 exactly this cell key; the endpoint-scoped ``cell_store`` row is stamped
 hub-side from the token claim, never from anything this module sends.
 
-cozy-local NEVER uses this module (its self-mint stays local-store-only in
-the cozy-local cell store module — user-controlled hardware is untrusted tier by
-definition); the local CLI path does not construct a publisher.
+cozy-local USES this module since pgw#1127, through ``local_serve``, with
+``publisher=None`` — one arming brain, two sinks. What it never has is a
+PUBLISHER: user-controlled hardware is untrusted tier by definition, so its
+cells land in ``local_cell_store`` (``local_keep_reason`` -> ``no_publish_sink``)
+and its obligation ends at :func:`keep_self_mint_local`. That absence is
+pinned structurally by ``tests/test_local_serve_no_publisher_pgw1127.py``,
+not by this paragraph: before pgw#1127 the local CLI armed JIT through
+``local_cells`` and never reached the local store at all.
 
 Mint failures keep the pre-self-mint miss policy: plain lanes serve eager,
 quantized (w8a8/w4a4) lanes keep their typed fail-closed refusal.
@@ -2178,8 +2183,11 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
         # Runtime assertion (gw#587): every fleet cell miss must produce a
         # publish attempt. A fleet worker minting with no usable sink is a
         # wiring defect (file_base_url/worker JWT absent at arming time),
-        # not a policy choice — loud, greppable, alarm-adjacent. (cozy-local
-        # legitimately has no publisher, but it never enters this module.)
+        # not a policy choice — loud, greppable, alarm-adjacent. cozy-local
+        # DOES enter this module since pgw#1127, and it must never enter
+        # HERE: it ends its obligation at :func:`keep_self_mint_local`, whose
+        # whole point is that a machine with no sink by design is not a
+        # machine that lost its sink by accident.
         logger.warning(
             "fleet-cells: SELF_MINT_WITHOUT_PUBLISH_SINK family=%s — cell "
             "stays local to this pod; the fleet store gains nothing",
@@ -2196,6 +2204,55 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
         )
         mark_terminus(pending, TERMINUS_WITHHELD)
         shutil.rmtree(pending.mint_root, ignore_errors=True)
+
+
+def keep_self_mint_local(pending: "PendingSelfMint") -> None:
+    """§4.28 terminus for a machine that has NO sink by design (cozy-local).
+
+    The cell is already in this machine's own store — ``adopt_delegated_mint``
+    put it there under its stamped ``ck1`` key before any publish could be
+    attempted — so all that is left is to END the obligation (pgw#815: a
+    pending that reaches the end of a boot carrying no terminus VANISHED) and
+    drop the capture directory.
+
+    Deliberately NOT :func:`publish_self_mint`. That function's sinkless branch
+    is a WIRING ALARM — a fleet pod whose ``file_base_url``/JWT went missing —
+    and firing it on cozy-local would make the one machine §4.28 was written
+    about permanently indistinguishable from a broken pod. It also takes a
+    publisher, and this one cannot: the local serve entry's never-publish
+    property is pinned structurally by
+    ``tests/test_local_serve_no_publisher_pgw1127.py``, and a terminus that
+    accepted a sink would be the hole that fence exists to close.
+    """
+    state = pending._state
+    if state.get("publish_resolved"):
+        return
+    state["publish_resolved"] = True
+    if state.get("minted") is None:
+        activity_mod.emit_event(
+            "self_mint_publish_withheld",
+            f"family={pending.family} key={pending.arm_token}: this machine "
+            f"has no publish sink and nothing was packed for this pending, so "
+            f"there is no cell to keep either",
+            phase="nothing_to_publish",
+        )
+        mark_terminus(pending, TERMINUS_ABANDONED)
+        shutil.rmtree(pending.mint_root, ignore_errors=True)
+        return
+    logger.info(
+        "fleet-cells: %s stays on THIS MACHINE (key=%s) — it has no publish "
+        "sink by design, and its own store is where every later run finds it "
+        "(§4.28)", pending.family, pending.arm_token)
+    activity_mod.emit_event(
+        "self_mint_publish_withheld",
+        f"family={pending.family} key={pending.arm_token}: this machine mints "
+        f"for ITSELF (§4.28) — the cell is in its own store, addressed by the "
+        f"same ck1 key the hub store would use, and no publish was attempted "
+        f"because no sink exists to attempt one against",
+        phase=KEEP_NO_PUBLISHER,
+    )
+    mark_terminus(pending, TERMINUS_WITHHELD)
+    shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
 def withhold_self_mint_publish(pending: "PendingSelfMint", reason: str) -> None:

--- a/src/gen_worker/local_serve.py
+++ b/src/gen_worker/local_serve.py
@@ -1,0 +1,243 @@
+"""pgw#1127 / §4.28 — the cozy-local serve entry: the fleet arming brain, no sink.
+
+DESIGN-RULINGS §4.28 (Paul, 2026-08-10): *"Untrusted hardware (community
+cloud, cozy-local) mints for ITSELF: local cell, local repo-CAS, reused
+across its own boots — never uploaded, never requested."*
+
+pgw#1096 built the store that clause needs (``local_cell_store``) and wired it
+into ``fleet_cells._arming_policy``, local-first, before any mint is opened.
+It left ONE thing owed, and the omission made the whole build unreachable from
+the machine it was written for: ``cli/run.py`` still armed through
+``local_cells`` — the JIT path — so ``_arming_policy`` was never entered from
+``cozy serve`` and cozy-local got compile-once-run-forever on JIT only, on the
+recipe pgw#1086 wave 1 deletes.
+
+This module is that re-point, and it is deliberately a MODULE rather than a
+line in ``cli/run.py``: the never-publish property has to be structural.
+
+WHAT IS STRUCTURAL HERE, and what merely happens to be true
+-----------------------------------------------------------
+``publisher=None`` at one call site is a convention. What pins the property is
+that this module — the ONLY arming entry the local CLI has — contains no
+``CellPublisher`` construction, no publish call and no transport import at all,
+and ``tests/test_local_serve_no_publisher_pgw1127.py`` reads that out of the
+source tree. The obligation's terminus is ``fleet_cells.keep_self_mint_local``,
+which takes no publisher and therefore cannot grow into one.
+
+WHAT THIS DOES NOT ADD
+----------------------
+No mint code (the delegated ``mint_delegate`` -> ``mint_process`` ->
+``mint_child`` chain is used unchanged, weight-free since pgw#1080), no second
+key scheme, no coordinator, no mint-request in any address form, no trust
+self-declaration, and no env behaviour switch. A cozy-local box learns it keeps
+its own cells from ``local_keep_reason``'s ``no_publish_sink`` — a fact about
+the SINK, never a claim about itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from . import activity as activity_mod
+from . import compile_cache as cc
+from . import fleet_cells, mint_delegate
+from .mint_process import MintSlot
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LocalMintContext:
+    """Everything a mint child needs that the local serve process knows.
+
+    The same three facts the executor hands ``mint_delegate.MintTask``: WHICH
+    routable function, WHICH modules to rediscover it in, and the parent's own
+    resolution of every setup slot (identity + bytes + pgw#617 composition, as
+    one value — see ``mint_process.MintSlot``). A context with no function or
+    no modules cannot be minted from and is declared ``incomplete``: the child
+    re-runs discovery, so a module list it cannot import is a silent
+    "compiles nothing, forever".
+    """
+
+    function: str = ""
+    modules: Tuple[str, ...] = ()
+    slots: Mapping[str, MintSlot] = field(default_factory=dict)
+    device: Optional[int] = None
+
+    @property
+    def incomplete(self) -> str:
+        if not self.function:
+            return "no routable function name"
+        if not self.modules:
+            return "no declaring module for the child to rediscover"
+        return ""
+
+
+def enable_compiled(
+    pipe: Any,
+    cfg: Any,
+    cache_dir: Optional[Path] = None,
+    *,
+    mint: Optional[LocalMintContext] = None,
+) -> bool:
+    """Arm ``pipe`` from this machine's own cells, minting one if it has none.
+
+    The ordering is ``fleet_cells``' and is not restated here: delivered
+    artifact -> in-process ledgers -> **this machine's local store** ->
+    delegated mint. On a local-store hit no network is touched and no mint is
+    opened, which is the whole of compile-once-run-forever.
+
+    Returns True when this pipeline is now serving compiled. False is never an
+    error: a machine with no CUDA, a family with no export declaration, or a
+    mint that could not fit on the card all serve eager, exactly as they did
+    before — except on a mandatory (w8a8/w4a4) lane, whose typed refusal
+    ``fleet_cells`` raises and this function deliberately does not catch.
+    """
+    outcome = fleet_cells.enable_compiled(
+        pipe, cfg, cache_dir,
+        # §4.28, and the reason this module exists: user hardware is untrusted
+        # tier by definition, so there is no sink to pass and never will be.
+        publisher=None,
+    )
+    if outcome.armed:
+        return True
+    pending = outcome.self_mint
+    if not isinstance(pending, fleet_cells.PendingSelfMint):
+        # An eager exit with a classified reason (`no_toolchain`, a declined
+        # family, a quarantined identity). `fleet_cells` already named it.
+        return False
+    if mint is None or mint.incomplete:
+        # A pending nobody can drive is the pgw#815 shape: an obligation with
+        # no terminus. End it here rather than leaving the capture dir and the
+        # ledger entry behind for a run that will never come.
+        fleet_cells.abandon_self_mint(pending)
+        logger.warning(
+            "local-serve: %s opened a mint this process cannot drive (%s); "
+            "serving eager", pending.family,
+            mint.incomplete if mint is not None else "no mint context")
+        return False
+    return _mint_here(pipe, pending, mint)
+
+
+def _mint_here(
+    pipe: Any, pending: "fleet_cells.PendingSelfMint", mint: LocalMintContext,
+) -> bool:
+    """Run the delegated child mint on THIS machine and keep what it produces.
+
+    Identical to the executor's ``_delegated_mint_run`` in everything that
+    decides correctness — same ``build_cell``, same child, same
+    ``adopt_delegated_mint`` gate — and different in the two things a desktop
+    does not have: there is no serving loop to keep beating (this call is the
+    boot, and it blocks), and there is nowhere to publish, so the obligation
+    ends at ``keep_self_mint_local`` instead of at the publish gate.
+    """
+    result: Optional[mint_delegate.DelegatedResult] = None
+    with activity_mod.running(activity_mod.KIND_SELF_MINT_COMPILE) as act:
+        try:
+            result = _drive(mint_delegate.build_cell(
+                mint_delegate.MintTask(
+                    pending=pending,
+                    pipe=pipe,
+                    function=mint.function,
+                    modules=mint.modules,
+                    slots=dict(mint.slots),
+                    # Cell IDENTITY's lane, the same probe the mint's own
+                    # `stamp_lane` memoizes — so what this machine looks up on
+                    # its next boot is what this mint stamps (pgw#686).
+                    weight_lane=cc.cell_base_execution_lane(pipe),
+                    device=mint.device,
+                ),
+                act=act))
+        except Exception as exc:  # noqa: BLE001 — a mint must never kill a serve
+            logger.warning(
+                "local-serve: the mint for %s failed (%s: %s); serving eager "
+                "and keeping nothing", pending.family, type(exc).__name__, exc)
+    if result is not None and result.ok:
+        # The cell is ALREADY in this machine's store — `adopt_delegated_mint`
+        # put it there before any publish could be attempted, which is what
+        # makes a process killed here cost nothing (th#1643's SUNK case).
+        fleet_cells.keep_self_mint_local(pending)
+        return True
+    if not fleet_cells.terminus_of(pending):
+        # pgw#815: every obligation ends somewhere nameable. `build_cell`
+        # abandons its own failures; a DECLINED one (no room on the card) it
+        # deliberately leaves open for a caller that might have another.
+        fleet_cells.abandon_self_mint(pending)
+    logger.info(
+        "local-serve: %s has no cell on this machine yet (%s); serving eager",
+        pending.family,
+        (result.detail or result.status) if result is not None else "mint failed")
+    return False
+
+
+def _drive(coro: Any) -> Any:
+    """Run one coroutine to completion from this synchronous serve path.
+
+    ``cozy run`` and ``cozy serve`` both call ``run_setup`` off any event loop
+    — the CLI's own async dispatch runs inside ``asyncio.run`` per request,
+    never around setup — so this is the ordinary case. It is asserted rather
+    than assumed: a loop already running here would mean the mint is being
+    driven from inside a request, which is the one place a 40-minute compile
+    must not be.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    coro.close()
+    raise RuntimeError(
+        "local-serve: a delegated mint was driven from inside a running event "
+        "loop — the local serve path arms at setup, never on the request path")
+
+
+def mint_context(
+    *, function: str, module: str, slots: Mapping[str, MintSlot],
+    device: Optional[int] = None,
+) -> LocalMintContext:
+    """Build a :class:`LocalMintContext` from what the local CLI holds.
+
+    ``module`` is the endpoint's own declaring module, which is exactly what
+    ``executor._mint_modules`` hands a fleet mint: ``registry`` walks it and
+    its submodules, so the child rediscovers this class AND its class-scoped
+    siblings without the parent serializing anything live.
+    """
+    named = str(module or "").strip()
+    return LocalMintContext(
+        function=str(function or ""),
+        modules=(named,) if named else (),
+        slots=dict(slots),
+        device=device,
+    )
+
+
+def slot_map(
+    paths: Mapping[str, str],
+    bindings: Mapping[str, Any],
+    component_paths: Optional[Mapping[str, Mapping[str, str]]] = None,
+) -> Dict[str, MintSlot]:
+    """The parent's resolution of every setup slot, as the child reads it.
+
+    A slot the local run did not resolve is ABSENT, never a present entry with
+    a hole in it — ``MintSlot`` refuses to be constructed without both halves,
+    and ``mint_child.assert_slots_resolvable`` refuses a declared,
+    non-optional slot that never arrived.
+    """
+    out: Dict[str, MintSlot] = {}
+    for slot, path in paths.items():
+        binding = bindings.get(slot)
+        if binding is None or not str(path or ""):
+            continue
+        out[slot] = MintSlot(
+            ref=binding, path=str(path),
+            component_paths=dict((component_paths or {}).get(slot) or {}),
+        )
+    return out
+
+
+__all__ = [
+    "LocalMintContext", "enable_compiled", "mint_context", "slot_map",
+]

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -480,11 +480,15 @@ def test_local_cells_has_no_publish_path():
         assert not bad, f"local_cells code references {bad}"
 
 
-def test_local_cli_is_the_only_mint_caller():
-    # The mint entry is the local CLI only: the production executor and
-    # lifecycle must never import or call local_cells (fetch-only stays
-    # fetch-only). AST-level: imports plus any code identifier naming the
-    # module count; prose mentions in docstrings do not.
+def test_nothing_calls_this_module_any_more():
+    # pgw#1127: the local CLI was this module's LAST reader, and it is gone —
+    # `cli/run.py` arms through `local_serve` (the AOT sink) since S1. So the
+    # assertion flips from "exactly the local CLI" to "nobody", and that is the
+    # whole safety argument for pgw#1086 wave 1's deletion of it: no serve path
+    # can break, because no serve path reaches it.
+    #
+    # AST-level: imports plus any code identifier naming the module count;
+    # prose mentions in docstrings do not.
     root = Path(lc.__file__).parent
     callers = set()
     for p in root.rglob("*.py"):
@@ -504,10 +508,12 @@ def test_local_cli_is_the_only_mint_caller():
                 callers.add(p)
             elif isinstance(node, ast.Attribute) and "local_cells" in node.attr:
                 callers.add(p)
-    # pgw#1096: `aot_resume` (pgw#848 item 5) used to reach in here for
-    # `store_root()` — the PRODUCTION resume bank routed through a module
-    # pgw#1086 wave 1 deletes (pgw#1092 §4 landmine 1). The accessor moved to
-    # `local_cell_store` with its value unchanged, so this module is now
-    # reached from the local CLI and NOTHING else, and its deletion breaks no
-    # serve path. `test_aot_local_mint_pgw1096` holds the other half.
-    assert {p.relative_to(root).as_posix() for p in callers} == {"cli/run.py"}
+    # pgw#1096 moved `aot_resume`'s bank accessor out of here (landmine 1);
+    # pgw#1127 re-pointed the local CLI (landmine 2, and the live defect). Both
+    # readers are gone, so this module is dead code awaiting its owner's
+    # deletion — pgw#1086 wave 1, which `scripts/lint_unreached_surface.py`
+    # names as the owner of the one `EXEMPT_TARGETS` row keeping the
+    # unreached-surface guard green until then.
+    assert {p.relative_to(root).as_posix() for p in callers} == set(), (
+        "the JIT local-cell module must have no readers left — a new one puts "
+        "cozy-local back on pgw#1086 wave 1's critical path")

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -1,0 +1,515 @@
+"""pgw#1127 S1 — cozy-local can REACH the sink pgw#1096 built, and can never publish.
+
+Two things are proven here, and they are different in kind.
+
+**Reachability** (the live defect). pgw#1096 built ``local_cell_store``, keyed it
+by ``ck1``, and wired it into ``fleet_cells._arming_policy`` local-first. It left
+``cli/run.py`` pointing at ``local_cells.enable_compiled`` — the JIT path — so
+``_arming_policy`` was never entered from ``cozy serve`` and the machine §4.28 was
+written about got none of it. RED before this issue on every test in section 1:
+the arming import in ``gen_worker.cli`` was ``..local_cells``, and
+``gen_worker.local_serve`` did not exist.
+
+**Never-publish, STRUCTURALLY** (§4.28's *"never uploaded"*). Before S1 that
+property held because the local CLI could not reach the publishing module at
+all. After S1 it runs ``fleet_cells``, which imports ``CellPublisher`` — so
+"cozy-local never publishes" would rest on one keyword argument at one call
+site. Section 2 is the fence that replaces the convention: the local serve entry
+names no publisher, constructs none, and reaches no publish call, read out of
+the source tree rather than asserted about a run. Each of those is RED-provable
+by deleting ``publisher=None`` or adding a ``CellPublisher(...)`` — which is the
+only reason to prefer it to a mock.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import subprocess
+import sys
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import fleet_cells, local_cell_store, local_serve, mint_delegate
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.cli import run as cli_run
+from gen_worker.mint_process import MintSlot
+
+KEY_A = "ck1-" + "a" * 56
+ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
+
+SRC = Path(fleet_cells.__file__).parent
+
+#: The local serve ENTRY: every file a `cozy serve` / `cozy run` arm passes
+#: through on its way to the arming brain. The fence in section 2 reads all of
+#: them, because a publisher constructed one frame up the stack is a publisher.
+LOCAL_SERVE_ENTRY = (
+    SRC / "local_serve.py",
+    SRC / "cli" / "run.py",
+    SRC / "cli" / "serve.py",
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+class _Pipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = "micro-diffusion"
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((64, 64),)
+    targets: Tuple[str, ...] = ("transformer",)
+    text_lens: Tuple[int, ...] = (16,)
+    guidance_scales: Tuple[float, ...] = (1.0,)
+    regional: bool = False
+
+
+class _Arm:
+    def __init__(self, token: str = ARM_A) -> None:
+        self.token = token
+
+    def facts_dict(self) -> Dict[str, str]:
+        return {}
+
+
+def _armable_artifact(tmp_path: Path, *, key: str = KEY_A) -> Path:
+    """A cell with a READABLE envelope — `_arm_exported_cell` refuses an
+    unreadable one before every other gate (pgw#1098), local store included."""
+    p = tmp_path / "mint" / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {"kind": "aot-inductor", "cell_key": key, "family": "micro-diffusion"}
+    ).encode()
+    with tarfile.open(p, mode="w:gz") as tar:
+        info = tarfile.TarInfo("metadata.json")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return p
+
+
+@pytest.fixture()
+def machine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The FACTS about this box that a CPU runner cannot supply: a card, a C
+    toolchain, a resolvable compile target, a family that declares an export.
+
+    Deliberately only facts. Nothing in the decision under test —  the store
+    consult, its ordering against the pending, the sink choice, the arm gate —
+    is stubbed, because a test that stubs the thing it is measuring proves the
+    stub.
+    """
+    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+    monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(
+        fleet_cells.cc, "has_compile_target", lambda pipe, cfg: True)
+    monkeypatch.setattr(
+        fleet_cells, "mint_recipe",
+        lambda pipe, cfg, **kw: fleet_cells.RECIPE_AOT)
+    monkeypatch.setattr(
+        fleet_cells, "arm_identity", lambda *a, **k: _Arm())
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda pipe, cfg, cache_dir=None, artifact=None: AdoptOutcome.miss(
+            "no_cell", "no artifact was delivered to this machine"))
+
+
+@pytest.fixture()
+def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
+    """`provision.arm_aot` succeeds; record WHICH artifact it was handed."""
+    seen: List[Path] = []
+
+    def _arm(pipe: Any, cfg: Any, cache_dir: Any, artifact: Path,
+             bucket: int, expected: Any = None) -> AdoptOutcome:
+        seen.append(Path(artifact))
+        return AdoptOutcome.hit(KEY_A)
+
+    monkeypatch.setattr(fleet_cells.provision, "arm_aot", _arm)
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "read_metadata",
+        lambda p: {"cell_key": KEY_A, "family": "micro-diffusion"})
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "try_read_metadata",
+        lambda p: {"cell_key": KEY_A, "family": "micro-diffusion"})
+    monkeypatch.setattr(fleet_cells, "arm_axis_divergence", lambda key, meta: "")
+    return seen
+
+
+def _ctx() -> local_serve.LocalMintContext:
+    return local_serve.mint_context(
+        function="generate", module="micro_diffusion.endpoint",
+        slots={"pipeline": MintSlot(ref="cozy/micro#1", path="/tmp/micro")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. REACHABILITY — the local CLI arms through the AOT sink, not the JIT one
+# ---------------------------------------------------------------------------
+
+
+def _arming_import(module_file: Path) -> str:
+    """The module `_load_injected_model` imports its arming entry from."""
+    tree = ast.parse(module_file.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_load_injected_model")
+    names: List[str] = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.ImportFrom):
+            # `from .. import local_serve` carries the name on the ALIAS, not
+            # on `.module` (which is None at level 2) — so both are read, or
+            # the fence answers "" for exactly the form this issue introduced.
+            names.append(node.module or "")
+            names += [alias.name for alias in node.names]
+        elif isinstance(node, ast.Import):
+            names += [alias.name for alias in node.names]
+    return ";".join(names)
+
+
+def test_the_local_cli_arms_through_the_AOT_sink_and_never_the_JIT_one() -> None:
+    """§4.28's second clause, at the ONE call site that decides whether cozy-local
+    has it at all.
+
+    RED before pgw#1127: this read ``..local_cells`` — the JIT path, which
+    imports ``compile_cache`` and nothing that mints AOT. ``_arming_policy``,
+    and therefore the entire local store, was unreachable from ``cozy serve``.
+    """
+    imported = _arming_import(SRC / "cli" / "run.py")
+    assert "local_serve" in imported, (
+        "the local serve entry must arm through `local_serve` — the fleet "
+        "arming brain with no sink — so a `cozy serve` miss consults THIS "
+        "MACHINE's ck1 store before it mints anything")
+    assert "local_cells" not in imported, (
+        "the JIT local-serve path is what pgw#1086 wave 1 deletes; arming "
+        "through it is how cozy-local loses compiled serving outright")
+
+
+def test_nothing_under_the_cli_imports_the_JIT_local_cell_module() -> None:
+    """Reachability has to be a property of the PACKAGE, not of one function.
+
+    A sibling module re-importing `local_cells` would restore the coupling this
+    issue exists to cut, and would put `cozy` back on pgw#1086 wave 1's
+    critical path.
+    """
+    offenders: List[str] = []
+    for path in sorted((SRC / "cli").rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and "local_cells" in (
+                    node.module or ""):
+                offenders.append(f"{path.name}:{node.lineno}")
+            elif isinstance(node, ast.ImportFrom) and any(
+                    a.name == "local_cells" for a in node.names):
+                offenders.append(f"{path.name}:{node.lineno}")
+    assert not offenders, f"cli still reaches the JIT local store: {offenders}"
+
+
+def test_a_second_run_on_this_machine_arms_from_its_own_store_and_never_mints(
+    store: Path, tmp_path: Path, machine: None, armable: List[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compile-once-run-forever, through the entry `cozy serve` actually calls.
+
+    The whole ordering runs for real: delivered-artifact miss -> in-process
+    ledgers -> **this machine's store** -> (never reached) the pending. A mint
+    opened here would mean the machine recompiled what it already had, so the
+    delegated mint is wired to FAIL the test rather than to be counted.
+
+    RED before pgw#1127: `gen_worker.local_serve` did not exist, and the entry
+    that did exist could not address a ck1-keyed cell at all.
+    """
+    monkeypatch.setattr(
+        mint_delegate, "build_cell",
+        lambda *a, **k: pytest.fail("a machine holding its own cell re-minted"))
+    local_cell_store.store(
+        _armable_artifact(tmp_path), key=KEY_A, family="micro-diffusion",
+        arm_token=ARM_A)
+
+    armed = local_serve.enable_compiled(_Pipe(), _Cfg(), None, mint=_ctx())
+
+    assert armed is True
+    assert armable and armable[0] == store / "aot-cells" / KEY_A / "cell.tar.gz"
+
+
+def test_the_local_entry_hands_the_arming_brain_no_sink_at_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """§4.28 at the seam: ``publisher=None`` is what makes ``local_keep_reason``
+    answer ``no_publish_sink``, which is what makes the mint's own cell land in
+    this machine's store instead of being rmtree'd behind a failed publish."""
+    seen: Dict[str, Any] = {}
+
+    def _enable(pipe: Any, cfg: Any, cache_dir: Any = None, artifact: Any = None,
+                **kw: Any) -> fleet_cells.ArmOutcome:
+        seen.update(kw)
+        return fleet_cells.ArmOutcome(armed=True)
+
+    monkeypatch.setattr(fleet_cells, "enable_compiled", _enable)
+    assert local_serve.enable_compiled(_Pipe(), _Cfg(), None, mint=_ctx())
+    assert "publisher" in seen and seen["publisher"] is None
+    assert fleet_cells.local_keep_reason(seen["publisher"]) == (
+        fleet_cells.KEEP_NO_PUBLISHER)
+
+
+# ---------------------------------------------------------------------------
+# 2. THE FENCE — never-publish is STRUCTURAL, not a keyword argument
+# ---------------------------------------------------------------------------
+
+
+def test_the_local_serve_entry_constructs_no_publisher(
+) -> None:
+    """The fence pgw#1127 §4 says is owed.
+
+    RED-provable in one edit: add ``CellPublisher(...)`` anywhere on the local
+    serve entry and this fails. That is the difference between a property and a
+    habit — ``publisher=None`` at one call site is a habit, and after S1 the
+    module the local CLI now runs is one that CAN publish.
+    """
+    banned = {"CellPublisher", "publish_self_mint", "_publish_async",
+              "publish_intent", "presign", "put_object", "upload"}
+    offenders: List[str] = []
+    for path in LOCAL_SERVE_ENTRY:
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            name = (
+                node.id if isinstance(node, ast.Name)
+                else node.attr if isinstance(node, ast.Attribute)
+                else "")
+            if name in banned:
+                offenders.append(f"{path.name}:{node.lineno} {name}")
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    if alias.name in banned:
+                        offenders.append(
+                            f"{path.name}:{node.lineno} import {alias.name}")
+    assert not offenders, (
+        "§4.28: the local serve entry must never name a publish route — "
+        f"{offenders}")
+
+
+def test_the_sinkless_call_is_a_LITERAL_none_and_not_a_variable() -> None:
+    """A ``publisher=publisher`` that is None today is a sink tomorrow.
+
+    The keyword is pinned to the literal so that wiring one in is an EDIT to
+    this line, seen in review, rather than a value that changes upstream.
+    """
+    tree = ast.parse((SRC / "local_serve.py").read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "enable_compiled")
+    passed = [
+        kw for call in ast.walk(fn)
+        if isinstance(call, ast.Call)
+        for kw in call.keywords if kw.arg == "publisher"
+    ]
+    assert passed, "the local entry must state its sink, not inherit a default"
+    for kw in passed:
+        assert isinstance(kw.value, ast.Constant) and kw.value.value is None, (
+            "publisher= must be the literal None on the local serve entry")
+
+
+def test_the_obligation_ends_at_a_terminus_that_cannot_publish(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A driven local mint ends at ``keep_self_mint_local`` — pgw#815's rule
+    (every obligation ends somewhere nameable) met by a function that takes no
+    publisher and therefore cannot grow into one.
+
+    ``publish_self_mint`` would also have "worked": its sinkless branch is a
+    WIRING ALARM for a fleet pod that lost its `file_base_url`, and firing it on
+    the one machine §4.28 was written about would make correct and broken
+    indistinguishable forever.
+    """
+    monkeypatch.setattr(
+        fleet_cells, "publish_self_mint",
+        lambda pending: pytest.fail("cozy-local reached the publish gate"))
+    pending = fleet_cells.PendingSelfMint(
+        family="micro-diffusion", arm_token=ARM_A, ref="repo#x", cfg=_Cfg(),
+        target=tmp_path / "cell.tar.gz", mint_root=tmp_path / "mint",
+        publisher=None, cache_dir=None, arm_key=_Arm(),
+    )
+    (tmp_path / "mint").mkdir(exist_ok=True)
+    pending._state["minted"] = object()
+
+    fleet_cells.keep_self_mint_local(pending)
+
+    assert fleet_cells.terminus_of(pending) == fleet_cells.TERMINUS_WITHHELD
+    assert not (tmp_path / "mint").exists(), "the capture dir must be cleaned"
+
+
+def test_a_pending_this_process_cannot_drive_is_ended_not_dropped(
+    store: Path, tmp_path: Path, machine: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#815, on the local path: a mint context that names no importable
+    module cannot be handed to a child, and the obligation it would have
+    discharged must not simply be forgotten."""
+    monkeypatch.setattr(
+        mint_delegate, "build_cell",
+        lambda *a, **k: pytest.fail("an undrivable pending spawned a child"))
+    monkeypatch.setattr(
+        fleet_cells.provision, "arm_aot",
+        lambda *a, **k: pytest.fail("nothing is armed on a miss (pgw#784)"))
+
+    armed = local_serve.enable_compiled(
+        _Pipe(), _Cfg(), None,
+        mint=local_serve.mint_context(function="f", module="", slots={}))
+
+    assert armed is False
+    pending = fleet_cells._PENDING.get(ARM_A)
+    assert pending is None or fleet_cells.terminus_of(pending)
+
+
+def test_storing_a_cell_imports_no_transport_at_all(tmp_path: Path) -> None:
+    """§4.28's *"never uploaded"*, proven by ABSENCE in a real interpreter.
+
+    The AST fence in ``test_aot_local_mint_pgw1096`` proves the module names no
+    transport. This proves the RUN does not: a cell enters the store in a fresh
+    process and no HTTP client, no CAS client and no upload module is resident
+    afterwards. A store that reached transport lazily — the one shape an AST
+    scan of the module cannot see — fails here.
+    """
+    root = tmp_path / "store"
+    artifact = tmp_path / "cell.tar.gz"
+    artifact.write_bytes(b"packed")
+    program = f"""
+import os, sys
+os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = {str(root)!r}
+from gen_worker import local_cell_store
+cell = local_cell_store.store(
+    {str(artifact)!r}, key={KEY_A!r}, family="micro-diffusion",
+    arm_token={ARM_A!r})
+assert cell is not None, "the store refused a well-formed cell"
+assert local_cell_store.lookup({KEY_A!r}) is not None
+banned = [
+    m for m in sys.modules
+    if m in ("httpx", "requests", "urllib3", "boto3", "aiohttp")
+    or m.startswith(("gen_worker.convert", "gen_worker.presigned_upload",
+                     "gen_worker._upload_transport", "gen_worker.transport"))
+]
+print(",".join(sorted(banned)))
+"""
+    out = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True,
+        timeout=300)
+    assert out.returncode == 0, out.stderr
+    resident = out.stdout.strip()
+    assert not resident, (
+        "storing a cell pulled transport into the process: " + resident)
+
+
+def _store_artifact(tmp_path: Path) -> Path:
+    p = tmp_path / "cell.tar.gz"
+    p.write_bytes(b"packed")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 3. The mint context — what a child needs, resolved once, or declared absent
+# ---------------------------------------------------------------------------
+
+
+def test_a_mint_context_missing_its_module_is_INCOMPLETE_not_silently_empty(
+) -> None:
+    """A module list a child cannot import is a machine that compiles nothing,
+    forever, and says nothing about it."""
+    assert local_serve.mint_context(
+        function="f", module="pkg.mod", slots={}).incomplete == ""
+    assert local_serve.mint_context(
+        function="f", module="", slots={}).incomplete
+    assert local_serve.mint_context(
+        function="", module="pkg.mod", slots={}).incomplete
+
+
+def test_a_slot_with_bytes_and_no_identity_is_ABSENT_never_half_present(
+) -> None:
+    """``MintSlot``'s rule (pgw#974), enforced where the local CLI builds them:
+    ``{"pipeline": "/tmp/x"}`` with no binding decoded, type-checked and looked
+    complete, and the child died 0.0 s into ``warmup_forward``."""
+    slots = local_serve.slot_map(
+        {"pipeline": "/tmp/a", "refiner": "/tmp/b", "empty": ""},
+        {"pipeline": "cozy/x#1", "empty": "cozy/z#1"},
+    )
+    assert set(slots) == {"pipeline"}
+    assert slots["pipeline"].path == "/tmp/a"
+
+
+def test_the_local_run_resolves_the_WHOLE_setup_not_one_slot_at_a_time(
+) -> None:
+    """The child re-runs ``setup()``, so it needs every slot the endpoint
+    declares — a context built inside the per-slot loader would carry whichever
+    slot happened to reach the arm first."""
+    tree = ast.parse((SRC / "cli" / "run.py").read_text())
+    loader = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_load_injected_model")
+    built_in_loader = [
+        c for c in ast.walk(loader)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+        and c.func.id == "_local_mint_context"
+    ]
+    assert not built_in_loader, (
+        "the mint context must be built once from the whole resolution, above "
+        "the per-slot loader")
+    assert any(
+        isinstance(n, ast.FunctionDef) and n.name == "run_setup"
+        and any(
+            isinstance(c, ast.Call) and isinstance(c.func, ast.Name)
+            and c.func.id == "_local_mint_context" for c in ast.walk(n))
+        for n in ast.walk(tree)), "run_setup must build it"
+
+
+def test_the_mint_child_path_never_opens_a_mint_of_its_own() -> None:
+    """``mint_child`` and ``boot_trace_child`` both call ``run_setup``. Neither
+    may arm — a child that opened its own mint is the recursion this must not
+    have — and neither names a function, so the context is None by
+    construction as well as by ``arm_compile=False``."""
+    for module in ("mint_child.py", "boot_trace_child.py"):
+        tree = ast.parse((SRC / module).read_text())
+        for call in ast.walk(tree):
+            if not (isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "run_setup"):
+                continue
+            kwargs = {kw.arg: kw.value for kw in call.keywords}
+            assert "arm_compile" in kwargs, f"{module}: run_setup must be explicit"
+            value = kwargs["arm_compile"]
+            assert isinstance(value, ast.Constant) and value.value is False, (
+                f"{module}: a mint/trace child must never arm a cell under itself")
+            assert "selected" not in kwargs, (
+                f"{module}: a child must not be able to open a mint")
+
+
+def test_the_cli_serve_path_names_the_function_so_it_can_mint() -> None:
+    """The reachability half's other end: without ``selected=`` the local entry
+    can only ADOPT, so a machine with an empty store would stay eager forever
+    and §4.28's *"compile ONCE"* would never happen at all."""
+    tree = ast.parse((SRC / "cli" / "serve.py").read_text())
+    calls = [
+        c for c in ast.walk(tree)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+        and c.func.attr == "run_setup"
+    ]
+    assert calls, "cli/serve.py must still be the serve path"
+    for call in calls:
+        assert any(kw.arg == "selected" for kw in call.keywords), (
+            "`cozy serve` must name the function it is arming, or it can "
+            "never mint the first cell")
+
+
+def test_run_setup_signature_carries_the_selected_function() -> None:
+    """Cheap, and it is the thing every other test in section 1 rests on."""
+    import inspect
+
+    params = inspect.signature(cli_run.run_setup).parameters
+    assert "selected" in params and params["selected"].default is None


### PR DESCRIPTION
## The defect

**pgw#1096 built the AOT local cell sink. `cozy serve` could not reach it.**

`src/gen_worker/local_cell_store.py` exists, is `ck1`-keyed, digest-verified,
record-written-last, and is consulted local-first in
`fleet_cells._arming_policy` **before** a `PendingSelfMint` is opened. All of
that is good and none of it changes here.

What was broken is that `cli/run.py:799-806` still armed through
`local_cells.enable_compiled` — the JIT path (`local_cells.py:61` imports
`compile_cache`). `_arming_policy` was therefore **never entered from
`cozy serve`**, so cozy-local — the machine DESIGN-RULINGS §4.28 was written
about — got compile-once-run-forever on JIT only, on the recipe pgw#1086
wave 1 deletes. pgw#1096 explicitly left this re-point owed; it never happened.

## Ordering against pgw#1086 wave 1

**Checked before starting, and re-checked before opening this PR: there is no
active pgw#1086 lane** — no worktree, no branch (`git ls-remote --heads
origin`), no open PR, and pgw#1086 is a PROGRAM whose wave 1 requires
coordinator GO on four green triggers. So the hazard is latent, not live, and
this PR is the correct side of it.

After this merges the ordering constraint is **discharged**:
`scripts/lint_unreached_surface.py` reports `local_cells.enable_compiled` as
unreached, and `tests/test_local_cells.py` now asserts the module has **zero**
readers anywhere in the tree. Wave 1 can delete it without breaking a serve
path, because no serve path reaches it.

pgw#1127 §6 puts that module's DELETION out of this lane's scope, so the guard
grows one `EXEMPT_TARGETS` row — with the owner (pgw#1086 wave 1) and an
expiry that enforces itself: `stale_exemptions()` fails the guard the moment
the target stops existing, so the row cannot outlive the deletion it is
waiting for.

## What this adds

| | |
|---|---|
| `src/gen_worker/local_serve.py` | the local serve entry: `fleet_cells.enable_compiled(..., publisher=None)`, and on a miss it DRIVES the ordinary `mint_delegate.build_cell` -> `mint_process` -> `mint_child` chain (weight-free since pgw#1080). The cell lands in `local_cell_store` at adopt time. |
| `cli/run.py`, `cli/serve.py` | re-pointed; `run_setup` now takes the routable function it is arming. Without it the path can only ADOPT — a child re-runs discovery and re-resolves the parent's slots, so a mint needs the declaring module and the WHOLE slot resolution, not one slot at a time. |
| `fleet_cells.keep_self_mint_local` | the §4.28 terminus (pgw#815: every obligation ends somewhere nameable). |

**Verified, not assumed:** `publisher=None` -> `local_keep_reason` returns
`no_publish_sink` -> `adopt_delegated_mint` stores the cell locally *before*
any publish could be attempted. That is the claim pgw#1127 S1 rests on and it
holds at `fleet_cells.py:2098-2106`.

`keep_self_mint_local` is deliberately **not** `publish_self_mint`. That
function's sinkless branch is a WIRING ALARM — a fleet pod whose
`file_base_url`/JWT went missing — and firing it on cozy-local would make the
one machine §4.28 is about permanently indistinguishable from a broken pod. It
also takes a publisher, and this terminus cannot.

## What this does NOT add

No mint code, no second key scheme, no coordinator, no mint-request in any
address form, no obligation ledger, no worker-side trust self-declaration, no
env behaviour switch. The posture stays learned from the SINK, never claimed.

## The structural fence (pgw#1127 §4)

Before S1, "cozy-local never publishes" was true because it could not reach the
publishing module. After S1 it runs `fleet_cells`, which imports
`CellPublisher` — so the property would rest on one keyword at one call site.
That is the convention-not-structure shape this repo keeps getting bitten by.

`tests/test_local_serve_no_publisher_pgw1127.py` replaces the convention:

* an AST fence over the whole local serve entry (`local_serve.py`,
  `cli/run.py`, `cli/serve.py`) refusing any `CellPublisher`, publish
  identifier or transport import;
* `publisher=` pinned to the **literal** `None` (a `publisher=publisher` that
  is None today is a sink tomorrow);
* a RUNTIME assertion, in a fresh interpreter, that a cell enters the store
  with no HTTP/CAS/upload module resident — the lazy-import shape an AST scan
  of the store module alone cannot see.

**Both AST fences were proven to fire** by reintroducing
`publisher=fleet_cells.CellPublisher()` and re-running: 2 failed. A fence that
cannot go red proves nothing.

## RED before

Run against `origin/master`'s source tree: **13 of 15 rows fail.** The wiring
row reads `..local_cells`; the end-to-end reuse row cannot address a
`ck1`-keyed cell at all; the fences have no subject. The 2 that pass are
regression fences for properties pgw#1096 already holds.

## Local verification

`fast gates` equivalents all green (mypy clean on the changed files — the 50 remaining
errors are pre-existing 3.13-vs-3.12 env drift, identical on master;
`lint_unreached_surface`, `lint_config_reads`, `lint_credential_identity`,
`lint_settings_writers`, `lint_ambient_census` exit 0). Targeted suites:
`test_local_serve_no_publisher_pgw1127`, `test_aot_local_mint_pgw1096`,
`test_local_cells`, `test_mint_resume_pgw848`, `test_plan_pgw902` — 90 passed.
No pods, no mints, no GPU.

Refs pgw#1127 S1 + fence item 2, pgw#1096, pgw#1086 wave 1, DESIGN-RULINGS §4.28.
