### PR TITLE
pgw#1127 S2: boot-adopt asks THIS MACHINE before the hub — a scheme bump now costs a trace, not a mint

### DIFF
--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -5,11 +5,26 @@ pod:
 
 1. **Derive** the ``ck1`` key from code alone — ``boot_key.derive``, process-
    parallel structure-only traces, no weight resident anywhere.
-2. **Ask** the hub by that key — ``cell_resolve.resolve``, ONE artifact or a
+2. **Ask THIS MACHINE first** (pgw#1127 S2, §4.28) — ``local_cell_store.
+   lookup(key)``. The derived key is the local store's own address, so an
+   offline machine holding the exact cell it needs answers here and no hub is
+   asked at all. ONE key, TWO lookup routes, the same CAS.
+3. **Ask the hub** by that key — ``cell_resolve.resolve``, ONE artifact or a
    MISS, never a listing.
-3. **Materialize** a hit through the EXISTING delivery path and hand the
+4. **Materialize** a hit through the EXISTING delivery path and hand the
    caller an admission expectation, so the arm runs the gates the Plan path
    runs and not one gate fewer.
+
+Why the local step is BEFORE the hub and not beside it: §4.28 says *"local
+cell, local repo-CAS… never requested"*. A local-second ordering would ask for
+what the machine already holds, and on a community-cloud pod that is a request
+the hub can only answer by shipping bytes back to the machine that minted them.
+
+Why the derivation now runs with NO hub, which it refused to do before: the old
+gate reasoned that *"deriving a key nobody will answer is pure boot latency"*.
+That is false on exactly the machines §4.28 is about. It survives in the
+honest form — :data:`GATE_REASONS`' ``no_cell_source``, which refuses only when
+BOTH answerers are absent (no hub AND an empty local store).
 
 A MISS returns ``None`` and that is a complete answer: the pod serves eager,
 mints in the background (§4.28: trusted hardware publishes, untrusted keeps it
@@ -55,7 +70,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from . import activity, aot_identity, artifact_meta, boot_key, cell_resolve
+from . import (
+    activity, aot_identity, artifact_meta, boot_key, cell_resolve,
+    local_cell_store,
+)
 from .mint_process import CompileCellSpec, MintSlot
 
 logger = logging.getLogger(__name__)
@@ -69,13 +87,39 @@ GATE_REASONS: Tuple[str, ...] = (
     # The declaration exists but `aot_declaration.cell_plans` will not enumerate
     # it (colliding entry names, no targets).
     "declaration_unreadable",
-    # No hub to ask: no HelloAck base URL yet, or an embedded single-process
-    # worker with neither a local bearer nor a control seam (pgw#1108).
-    "no_hub",
+    # pgw#1127: NOBODY could answer this key — no hub (no HelloAck base URL
+    # yet, or an embedded single-process worker with neither a local bearer nor
+    # a control seam, pgw#1108) AND this machine's own store holds no cell at
+    # all. Only then is deriving pure boot latency. This REPLACES `no_hub`,
+    # which asked about one of the two answerers and refused on behalf of both:
+    # on exactly the machines §4.28 is about, the derived ck1 key IS the local
+    # store's address, so "nobody will answer" was false there.
+    "no_cell_source",
     # The pod's topology forbids arming at all (pgw#775), so a compiled family
     # boots without asking. Correct, and previously indistinguishable from a
     # boot-adopt that asked and was refused.
     "eager_only",
+)
+
+#: Step 1.5 (pgw#1127 S2) — THIS MACHINE's own store, addressed by the DERIVED
+#: key, before the hub is asked at all. §4.28: *"local cell, local repo-CAS,
+#: reused across its own boots — never uploaded, never requested."*
+LOCAL_REASONS: Tuple[str, ...] = (
+    # The machine holds this exact cell. No hub was asked, and on an offline
+    # box no hub COULD be — which is the difference between fully-offline-
+    # capable as a property and as an accident of the arm-token memo.
+    "local_hit",
+    # Derived, asked this machine's own store, and it does not hold this key —
+    # and there is no hub to ask either. The honest successor to a `no_hub`
+    # that used to fire BEFORE the derivation and therefore before the local
+    # store had an address to be asked at.
+    "local_miss_no_hub",
+    # The local store answered with bytes whose recorded graphs are not the
+    # graphs this pod traced (the pgw#1031 floor, applied to route B). NOT a
+    # drop: unlike the memo — which this machine's own mint wrote for this
+    # exact arm token — a derived-key hit is an inference, so it refuses
+    # without destroying a cell some other pipe may legitimately own.
+    "local_graph_witness_mismatch",
 )
 
 #: Step 1 — the derivation. ``boot_key.BootKeyUnavailable.reason`` tokens,
@@ -120,11 +164,18 @@ ASK_REASONS: Tuple[str, ...] = (
 #: from here is a path that can be silent again, so
 #: ``tests/test_boot_adopt_observability_pgw1116.py`` reads the refusal sites
 #: out of the tree and fails on any token this tuple does not carry.
-REASONS: Tuple[str, ...] = GATE_REASONS + DERIVE_REASONS + ASK_REASONS
+REASONS: Tuple[str, ...] = (
+    GATE_REASONS + DERIVE_REASONS + LOCAL_REASONS + ASK_REASONS)
 
-#: The one outcome that armed something. Everything else means "boot as this pod
-#: booted yesterday", and each of those means it for a DIFFERENT reason.
+#: The hub answered and the pod will arm what it named. Everything except this
+#: and :data:`LOCAL_HIT` means "boot as this pod booted yesterday", and each of
+#: those means it for a DIFFERENT reason.
 HIT = "hit"
+
+#: THIS MACHINE answered, by the derived key, with no hub involved (pgw#1127).
+#: The second outcome that leads to a compiled boot — and the only one that
+#: does so on a box with no network at all.
+LOCAL_HIT = "local_hit"
 
 
 @dataclass(frozen=True)
@@ -155,6 +206,15 @@ class BootAdoptOutcome:
     ``adoption`` set means arm it. ``adoption`` None with a ``reason`` means
     boot exactly as this pod booted before the seam existed, and the reason is
     the countable token for why.
+
+    ``local_key`` (pgw#1127) is the one exception to that second sentence, and
+    it is deliberately NOT an ``adoption``: a cell out of THIS MACHINE's own
+    store carries no hub receipt and no publisher org, so it must not ride the
+    ``arm_ordered`` path a hub-resolved cell rides — it arms through
+    ``fleet_cells._arm_exported_cell``, the gate every cell this machine
+    produced for itself passes. What the boot hands the arming brain is the
+    ADDRESS, and the arming brain does the lookup on the same terms it does a
+    memo lookup. Two routes, one CAS, one gate.
     """
 
     adoption: Optional[BootAdoption] = None
@@ -162,6 +222,11 @@ class BootAdoptOutcome:
     detail: str = ""
     derived_key: str = ""
     derive_ms: int = 0
+    #: The ``ck1`` key THIS MACHINE's own store answered on (pgw#1127). "" on
+    #: every other terminus. Equal to ``derived_key`` when set — carried
+    #: separately so a reader never has to infer "and the local store had it"
+    #: from a key that is also present on a miss.
+    local_key: str = ""
     #: Which family and which routable function this decision was about. Carried
     #: on the outcome rather than interpolated at the emit site so a reader of
     #: the event never has to join it back to anything (pgw#1116).
@@ -194,7 +259,7 @@ def report(outcome: BootAdoptOutcome) -> BootAdoptOutcome:
     activity.emit_event(
         activity.KIND_BOOT_ADOPT, detail, phase=outcome.reason or "unreported",
         duration_ms=outcome.derive_ms)
-    if outcome.reason == HIT:
+    if outcome.reason in (HIT, LOCAL_HIT):
         logger.info("boot-adopt[%s]: %s", outcome.reason, detail)
     else:
         # A refusal is a confession, and a pod's own boot log is where an
@@ -251,6 +316,77 @@ def arm_refused(
     ))
 
 
+def no_cell_source(hub_absent: str) -> bool:
+    """True when NOBODY could answer a derived key, so deriving is pure latency.
+
+    The honest form of the gate pgw#1127 §1b found. The old one asked *"is
+    there a hub"* and refused on behalf of both answerers; this asks whether
+    EITHER exists. ``stored_cells`` is a listdir with no digest recomputation
+    (pgw#1096), so the fleet path — whose store is always empty — pays exactly
+    what the old early return paid, and the machines §4.28 is about stop being
+    told there is nobody to ask when they are holding the answer.
+    """
+    if not hub_absent:
+        return False
+    try:
+        return not local_cell_store.stored_cells()
+    except Exception:  # noqa: BLE001 — an unreadable store is an absent one
+        logger.debug("boot-adopt: local store unreadable", exc_info=True)
+        return True
+
+
+def _local_answer(
+    key: str, derived: "boot_key.DerivedKey", *, family: str, fn: str,
+) -> Optional[BootAdoptOutcome]:
+    """This machine's own store, asked by the derived key. ``None`` = ask on.
+
+    A hit is NOT returned as an ``adoption``: a self-minted cell carries no hub
+    receipt and no publisher org, so the ``arm_ordered`` path a hub-resolved
+    cell rides would refuse it ``receipt_gate_unconfigured``. What is returned
+    is the ADDRESS, on ``local_key``, for ``fleet_cells.arm_from_local_store``
+    to arm through the same gate a child's fresh mint passes.
+
+    The pgw#1031 graph-witness floor applies here exactly as it does to a hub
+    hit, and for the same reason: ``ck1`` is an ingress identity, so two
+    endpoints whose declared contracts match can share one key while their
+    bodies differ. It refuses WITHOUT dropping, though — the memo route is
+    written by this machine's own mint for one exact arm token, while a
+    derived-key hit is an inference about which pipe owns the bytes.
+    """
+    try:
+        cell = local_cell_store.lookup(key)
+    except Exception as exc:  # noqa: BLE001 — a cache read is never fatal
+        logger.debug("boot-adopt: local store lookup failed", exc_info=True)
+        logger.warning("boot-adopt: local store unreadable (%s)", exc)
+        return None
+    if cell is None:
+        return None
+    try:
+        meta = artifact_meta.read_metadata(Path(cell.artifact))
+        mismatch = aot_identity.verify_graph_witness(
+            meta, derived.graph_witnesses)
+    except Exception as exc:  # noqa: BLE001 — unreadable IS unproven
+        mismatch = f"unreadable ({type(exc).__name__}: {exc})"
+    if mismatch:
+        return report(BootAdoptOutcome(
+            reason="local_graph_witness_mismatch",
+            detail=(
+                f"this machine's own store holds {key} and its graphs are not "
+                f"this pod's graphs: {mismatch}. The cell is LEFT in place — a "
+                f"derived-key hit is an inference, not the memo this machine "
+                f"wrote for its own arm — and this pod asks the hub instead"),
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
+    return report(BootAdoptOutcome(
+        reason="local_hit",
+        detail=(
+            f"THIS MACHINE minted {key} on an earlier boot and kept it "
+            f"({cell.bytes / 1e6:.1f} MB); it arms from disk with no mint, no "
+            f"hub and no network (§4.28)"),
+        derived_key=key, local_key=key, derive_ms=derived.wall_ms,
+        family=family, function=fn))
+
+
 def attempt(
     *,
     function: str,
@@ -265,16 +401,22 @@ def attempt(
     base_url: str = "",
     bearer: str = "",
     device: int = -1,
+    hub_absent: str = "",
 ) -> BootAdoptOutcome:
-    """Derive, ask, materialize. Never raises — every failure is an outcome.
+    """Derive, ask THIS MACHINE, ask the hub, materialize. Never raises.
 
     ``declared_hint`` is ``len(aot_declaration.cell_plans(decl))`` — it sizes
     the trace pool and nothing else. ``envelope`` is
     ``fleet_cells.declared_envelope_block(cfg)``, i.e. the same extraction the
     publish path recomputes the envelope axis from.
 
+    ``hub_absent`` (pgw#1127) is the caller's own sentence for why there is
+    nobody to ask over the wire, "" when there is. It is a DETAIL, not a
+    decision: the decision is made here, after the local store has been asked,
+    because the derived key is an address this machine can answer at.
+
     Exactly ONE :data:`~gen_worker.activity.KIND_BOOT_ADOPT` event is emitted
-    per call, on every terminus including the hit — see :func:`report`.
+    per call, on every terminus including both hits — see :func:`report`.
     """
     family = str(getattr(cfg, "family", "") or "")
     fn = str(function)
@@ -323,6 +465,25 @@ def attempt(
         "boot-adopt: %s derived %s in %d ms (%d class(es), K=%d, memo=%s)",
         family, key, derived.wall_ms, derived.traced, derived.workers,
         derived.memo)
+
+    # ── §4.28 / pgw#1127: THIS MACHINE, before the wire ────────────────────
+    # The derived key is the local store's own address. A machine that minted
+    # this cell on an earlier boot answers here, and the hub is not asked at
+    # all — which is what "never requested" means and what makes an offline
+    # box arm exactly as well as an online one. Costs one stat on the fleet
+    # path, where the store is always empty.
+    local = _local_answer(key, derived, family=family, fn=fn)
+    if local is not None:
+        return local
+    if hub_absent:
+        # Derived, asked this machine, and there is nobody else. A DIFFERENT
+        # fact from `no_cell_source` (which never derived) and from `miss`
+        # (which asked a hub): this one says the key exists and nothing here
+        # holds it.
+        return report(BootAdoptOutcome(
+            reason="local_miss_no_hub", detail=hub_absent,
+            derived_key=key, derive_ms=derived.wall_ms,
+            family=family, function=fn))
 
     try:
         cell = cell_resolve.resolve(
@@ -412,6 +573,6 @@ def attempt(
 
 __all__ = [
     "ASK_REASONS", "BootAdoptOutcome", "BootAdoption", "DERIVE_REASONS",
-    "GATE_REASONS", "HIT", "REASONS", "arm_refused", "attempt", "refused",
-    "report",
+    "GATE_REASONS", "HIT", "LOCAL_HIT", "LOCAL_REASONS", "REASONS",
+    "arm_refused", "attempt", "no_cell_source", "refused", "report",
 ]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -6886,9 +6886,18 @@ class Executor:
         # RACE the fetch the way §4.27 step 4 asks. It is already off the
         # request path — no dispatch has occurred — and moving it earlier is a
         # restructure of this method's await order, not of the derivation.
+        # pgw#1127 S2: the `ck1` key THIS MACHINE's own store answered on. Not
+        # an `_ArmOrder`: a self-minted cell carries no hub receipt and no
+        # publisher org, so `arm_ordered` would refuse it
+        # `receipt_gate_unconfigured`. It is an ADDRESS, handed to the arming
+        # brain as a second lookup route into the same CAS the arm-token memo
+        # addresses — one key, two routes, and `_arm_exported_cell` is the one
+        # gate at the end of both.
+        boot_local_key = ""
         if arm is None and spec.compile is not None and not eager_only:
             adopt = await asyncio.to_thread(
                 self._boot_adopt, spec, resolved_slots)
+            boot_local_key = adopt.local_key
             if adopt.adoption is not None:
                 got = adopt.adoption
                 compile_selection = _CompileArtifactSelection(
@@ -6997,7 +7006,7 @@ class Executor:
                     snapshots=snapshots,
                     slot_identities=slot_identities,
                     component_paths=component_paths,
-                    arm=arm)
+                    arm=arm, boot_local_key=boot_local_key)
                 rec.shared_keys.extend(inj.shared_keys)
                 # pgw#517: a self-loading (str/Path-slot) endpoint builds its
                 # own pipeline inside setup() and the executor never sees it
@@ -8696,6 +8705,7 @@ class Executor:
         slot_identities: Optional[Dict[str, _ResidencyIdentity]] = None,
         component_paths: Optional[Dict[str, Dict[str, str]]] = None,
         arm: Optional[_ArmOrder] = None,
+        boot_local_key: str = "",
     ) -> "_InjectionResult":
         """Typed injection: each slot receives exactly what its ``setup``
         annotation says — a ``str``/``Path`` local path, or a constructed
@@ -8959,7 +8969,7 @@ class Executor:
                             outcome = await _to_thread_complete(
                                 self._enable_compiled,
                                 pipe, spec.compile_cell(), compile_artifact,
-                                compile_selection, arm,
+                                compile_selection, arm, boot_local_key,
                             )
                         except compile_cache.CompiledExecutionLaneUnavailableError as exc:
                             # Mandatory (w8a8/w4a4) lane: self-mint also hit a
@@ -9896,15 +9906,23 @@ class Executor:
         # action (`cells.resolve`), so the parent supplies base_url + bearer and
         # ignores what the child passes. Mirrors `fleet_cells.CellPublisher`'s
         # own readiness (base_url AND (local bearer OR broker.active())).
+        hub_absent = ""
         if not base_url or (not bearer and not procsplit_broker.active()):
-            # Genuinely nobody to ask: pre-Hello (no base_url yet), or an embedded
-            # single-process worker with no hub and no seam. Deriving a key nobody
-            # will answer is pure boot latency.
+            hub_absent = "nobody to ask: base_url={} bearer={} seam={}".format(
+                base_url or "<unset>", "set" if bearer else "<unset>",
+                "up" if procsplit_broker.active() else "down")
+        # pgw#1127 S2: this used to RETURN here, before the derivation, on the
+        # premise that "deriving a key nobody will answer is pure boot latency".
+        # The premise is false on exactly the machines §4.28 is about: the
+        # derived `ck1` key IS `local_cell_store`'s own address, so an offline
+        # box holding the exact cell it needs was being told there was nobody
+        # to ask. The gate survives in its honest form — refuse only when BOTH
+        # answerers are absent — and `attempt` decides the rest, after the
+        # local store has been asked.
+        if boot_adopt.no_cell_source(hub_absent):
             return boot_adopt.refused(
-                "no_hub",
-                "nobody to ask: base_url={} bearer={} seam={}".format(
-                    base_url or "<unset>", "set" if bearer else "<unset>",
-                    "up" if procsplit_broker.active() else "down"),
+                "no_cell_source",
+                f"{hub_absent}, and this machine's own cell store is empty",
                 family=family, function=fn)
         work_root = Path(
             self.store._cache_dir or Path.home() / ".cache" / "gen-worker"
@@ -9925,12 +9943,14 @@ class Executor:
             cache_dir=self.store._cache_dir,
             base_url=base_url,
             bearer=bearer,
+            hub_absent=hub_absent,
         )
 
     def _enable_compiled(
         self, pipe: Any, cfg: Any, artifact: Optional[Path],
         delivered: Optional["_CompileArtifactSelection"] = None,
         arm: Optional[_ArmOrder] = None,
+        boot_local_key: str = "",
     ) -> "fleet_cells.ArmOutcome":
         """Arm the best available compiled path for a freshly loaded pipeline.
 
@@ -10004,7 +10024,8 @@ class Executor:
                 # when boot-adopt returns a MISS, which is the boot every pod
                 # did before §4.27 existed. The refused cell is not retried: it
                 # is not passed back in.
-                outcome = self._enable_compiled(pipe, cfg, None)
+                outcome = self._enable_compiled(
+                    pipe, cfg, None, boot_local_key=boot_local_key)
                 if outcome.armed or outcome.eager_reason:
                     return outcome
                 return dc_replace(
@@ -10015,6 +10036,10 @@ class Executor:
             publisher=self._cell_publisher(),
             delivered_ref=delivered.ref if delivered else "",
             delivered_digest=delivered.snapshot_digest if delivered else "",
+            # pgw#1127 S2: the boot's own derived `ck1`, when THIS MACHINE's
+            # store answered on it. Empty on the fleet path, where the store is
+            # empty and the lookup is one stat.
+            boot_local_key=boot_local_key,
         )
 
     def _arming_enable(

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1200,6 +1200,7 @@ def enable_compiled(
     delegate: Optional[bool] = None,
     delivered_ref: str = "",
     delivered_digest: str = "",
+    boot_local_key: str = "",
 ) -> ArmOutcome:
     """Fleet arming policy, plus the adoption ledger every exit shares.
 
@@ -1215,7 +1216,7 @@ def enable_compiled(
         pipe, cfg, cache_dir, artifact,
         publisher=publisher, delegate=delegate,
         delivered_ref=delivered_ref, delivered_digest=delivered_digest,
-        adoptions=adoptions,
+        adoptions=adoptions, boot_local_key=boot_local_key,
     )
     if not adoptions:
         return outcome
@@ -1364,6 +1365,7 @@ def _arming_policy(
     delivered_ref: str,
     delivered_digest: str,
     adoptions: List[CellAdoption],
+    boot_local_key: str = "",
 ) -> ArmOutcome:
     """Fleet arming policy (gw#587): delivered cell first, self-mint on miss.
 
@@ -1641,7 +1643,8 @@ def _arming_policy(
     # single missing-file stat on a miss, so the trusted-fleet path — which
     # never stores anything locally — pays a stat and nothing else.
     local_prior = arm_from_local_store(
-        pipe, cfg, cache_dir, bucket, arm_key, family)
+        pipe, cfg, cache_dir, bucket, arm_key, family,
+        boot_local_key=boot_local_key)
     if local_prior is not None:
         return ArmOutcome(
             armed=True, self_mint=local_prior, selection_bug=selection_bug)
@@ -1914,27 +1917,54 @@ def _sweep_superseded_memos_once() -> None:
         logger.debug("fleet-cells: memo sweep failed", exc_info=True)
 
 
+#: pgw#1127: how this machine ADDRESSED the cell it armed. Two routes into one
+#: CAS, and the difference is what a refusal is allowed to do about it.
+ROUTE_MEMO = "memo"
+ROUTE_BOOT_KEY = "boot_key"
+
+
 def arm_from_local_store(
     pipe: Any, cfg: Any, cache_dir: Optional[Path], bucket: int,
-    arm_key: ArmIdentity, family: str,
+    arm_key: ArmIdentity, family: str, boot_local_key: str = "",
 ) -> Optional[SelfMint]:
     """§4.28 step 3: arm from THIS MACHINE's own store, before minting anything.
 
-    Paul's compile-once-run-forever, at the one place a miss is decided. The
-    machine derives its pre-trace identity (milliseconds), the memo names the
-    ``ck1`` key its last mint of that identity produced, the store hands back
-    the digest-verified artifact, and :func:`_arm_exported_cell` — the SAME
-    gate the child's own cell passes — decides. No network is touched on this
-    path at all: a cozy-local box with no hub reachable arms exactly as well as
-    one online, which is what "fully offline-capable" means.
+    Paul's compile-once-run-forever, at the one place a miss is decided. No
+    network is touched on this path at all: a box with no hub reachable arms
+    exactly as well as one online, which is what "fully offline-capable" means.
 
-    ``None`` = no usable local cell; the caller mints, honestly. Every refusal
-    is loud and DROPS the entry, so a corrupted or stale cell costs one re-mint
-    and never two.
+    TWO ROUTES, ONE CAS, ONE GATE (pgw#1127 S2). Both end at
+    :func:`_arm_exported_cell`, the gate a child's fresh mint also passes, so a
+    stored cell is never more trusted than a freshly minted one and never less.
+
+    * :data:`ROUTE_MEMO` — the pre-trace ``ArmIdentity`` (milliseconds), through
+      the memo this machine's own mint wrote for that exact token. The fast
+      path, and the only one before pgw#1127.
+    * :data:`ROUTE_BOOT_KEY` — the ``ck1`` key §4.27's boot derivation produced
+      and ``local_cell_store`` answered on. This is what makes an arm-token
+      SCHEME BUMP cost a trace instead of a mint: `sweep_superseded_memos`
+      deletes the shortcut and leaves the CELLS under their own keys, so after
+      the sweep the memo misses and the derived key still addresses the cell it
+      used to name. On a fleet pod both routes are one stat on an empty store.
+
+    A refusal on the memo route DROPS the entry — this machine wrote that memo
+    for this exact identity, so a cell that will not arm under it is stale.
+    A refusal on the boot-key route does NOT: that hit is an inference about
+    which pipe owns the bytes, and destroying another pipe's cell to punish a
+    wrong guess would turn one honest re-mint into two.
+
+    ``None`` = no usable local cell; the caller mints, honestly.
     """
     _sweep_superseded_memos_once()
+    route = ROUTE_MEMO
     try:
         local = local_cell_store.lookup_for_arm(arm_key.token)
+        if local is None and boot_local_key:
+            # The memo is a SHORTCUT, never an authority (§4.28) — so when it
+            # has nothing to say, the address the boot derived is asked
+            # directly. Same store, same key space, same gate below.
+            route = ROUTE_BOOT_KEY
+            local = local_cell_store.lookup(boot_local_key)
     except Exception as exc:  # noqa: BLE001 — a cache read must never be fatal
         logger.warning("fleet-cells: local cell store unreadable (%s)", exc)
         return None
@@ -1943,21 +1973,36 @@ def arm_from_local_store(
     armed, meta, (reason, detail) = _arm_exported_cell(
         pipe, cfg, cache_dir, bucket, local.artifact, arm_key)
     if not armed:
+        dropped = route == ROUTE_MEMO
         logger.warning(
-            "fleet-cells: the local store's cell for %s (key=%s) did not arm "
-            "(%s%s); dropping it and minting", family, local.key, reason,
-            f": {detail}" if detail else "")
-        local_cell_store.drop(local.key)
+            "fleet-cells: the local store's cell for %s (key=%s, route=%s) did "
+            "not arm (%s%s); %s and minting", family, local.key, route, reason,
+            f": {detail}" if detail else "",
+            "dropping it" if dropped else "leaving it in place")
+        if dropped:
+            local_cell_store.drop(local.key)
         activity_mod.emit_event(
             "local_cell_refused",
-            f"family={family} arm_key={arm_key.token} cell_key={local.key}: "
-            f"this machine's own stored cell did not arm "
-            f"({reason}{': ' + detail if detail else ''}); it has been dropped "
-            f"from the local store and this boot mints a fresh one",
+            f"family={family} arm_key={arm_key.token} cell_key={local.key} "
+            f"route={route}: this machine's own stored cell did not arm "
+            f"({reason}{': ' + detail if detail else ''}); it has been "
+            + ("dropped from the local store" if dropped else
+               "LEFT in the local store — a boot-key hit is an inference "
+               "about which pipe owns the bytes, not a memo this machine "
+               "wrote for this arm")
+            + " and this boot mints a fresh one",
             phase=reason,
         )
         return None
     key = str((meta or {}).get("cell_key") or "").strip() or local.key
+    if route == ROUTE_BOOT_KEY:
+        # The shortcut, REPAIRED. The cell just proved it arms under this arm
+        # token, so the memo the sweep deleted (or that a re-keyed graph left
+        # pointing elsewhere) can be rewritten from evidence instead of from a
+        # mint. This is the whole cost argument for the derived-key route: with
+        # it an arm-scheme bump costs one TRACE per family per machine; without
+        # it, one MINT.
+        local_cell_store.note_memo(arm_key.token, local.key)
     aot_serve.note_aot_key(key)
     minted = SelfMint(
         family=family, cell_key=key,
@@ -1971,13 +2016,17 @@ def arm_from_local_store(
         _FINALIZED[arm_key.token] = minted
     logger.info(
         "fleet-cells: armed %s from THIS MACHINE's local cell store "
-        "(key=%s, %.1f MB) — no mint, no hub, no network (§4.28)",
-        family, key, local.bytes / 1e6)
+        "(key=%s, %.1f MB, route=%s) — no mint, no hub, no network (§4.28)",
+        family, key, local.bytes / 1e6, route)
     activity_mod.emit_event(
         "local_cell_armed",
-        f"family={family} arm_key={arm_key.token} cell_key={key}: this "
-        f"machine minted this cell on an earlier boot and stored it locally; "
-        f"it arms from disk with no mint and no publish route",
+        f"family={family} arm_key={arm_key.token} cell_key={key} "
+        f"route={route}: this machine minted this cell on an earlier boot and "
+        f"stored it locally; it arms from disk with no mint and no publish "
+        f"route"
+        + (" — addressed by the key THIS BOOT derived, so the arm-token memo "
+           "was not needed and has been rewritten from the proven arm"
+           if route == ROUTE_BOOT_KEY else ""),
         phase="local_store_hit",
     )
     return minted

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -286,6 +286,36 @@ def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
     )
 
 
+def note_memo(
+    arm_token: str, key: str, root: Optional[Path] = None,
+) -> bool:
+    """Bind a pre-trace ``arm_token`` to a ``ck1`` key that PROVED it arms.
+
+    pgw#1127. :func:`store` writes this at mint time; this writes it when the
+    cell was found by another route and then passed the arm gate — which is the
+    only other moment the binding is known to be true. It is what makes an
+    arm-token scheme bump (:func:`sweep_superseded_memos`) cost a trace instead
+    of a mint: the sweep deletes the shortcut and leaves the CELLS under their
+    own keys, so the next boot's derived key re-finds the cell and re-writes
+    the shortcut from evidence.
+
+    Never fatal, and never a substitute for the arm: a memo is a shortcut, so
+    failing to write one costs a lookup and nothing else.
+    """
+    if not arm_token or not key:
+        return False
+    try:
+        _write_json_atomic(
+            memo_path(arm_token, root),
+            {"cell_key": key, "noted_at": time.time()})
+        return True
+    except Exception as exc:  # noqa: BLE001 — a shortcut is never load-bearing
+        logger.debug(
+            "local-cell-store: could not memo %s -> %s (%s)",
+            arm_token, key, exc)
+        return False
+
+
 def sweep_superseded_memos(
     scheme: str, root: Optional[Path] = None,
 ) -> int:
@@ -466,6 +496,7 @@ __all__ = [
     "lookup",
     "lookup_for_arm",
     "memo_path",
+    "note_memo",
     "note_refusal",
     "store",
     "store_root",

--- a/tests/test_boot_adopt_credential_pgw1108.py
+++ b/tests/test_boot_adopt_credential_pgw1108.py
@@ -54,6 +54,16 @@ def wired(monkeypatch, tmp_path):
     whether the gate let the derive/resolve leg run — no trace child, no mint."""
     calls: list[Dict[str, Any]] = []
 
+    # pgw#1127: the pre-derive gate now asks whether ANYBODY could answer, and
+    # this machine's own cell store is one of the two answerers. Pin it to an
+    # empty tmp root so the gate under test reads a fact about the test and not
+    # about whatever the developer's `~/.cache/cozy/compile-cells` happens to
+    # hold — the ambient-input class of flake this repo has been bitten by.
+    from gen_worker import local_cell_store
+
+    monkeypatch.setenv(
+        local_cell_store.ENV_STORE_DIR, str(tmp_path / "empty-cells"))
+
     def _attempt(**kw: Any) -> Any:
         calls.append(kw)
         return executor_mod.boot_adopt.BootAdoptOutcome(reason="miss")
@@ -98,17 +108,24 @@ def test_split_child_with_seam_up_resolves_though_it_holds_no_jwt(wired):
 
 
 def test_no_bearer_and_no_seam_degrades_without_deriving(wired):
-    """The gate must STILL protect the genuinely-no-hub case: no local bearer
-    and no seam means nobody to ask, so no derive/resolve, no attempt.
+    """The gate must STILL protect the genuinely-nobody case: no local bearer,
+    no seam AND an empty local cell store means nobody to ask, so no
+    derive/resolve, no attempt.
 
-    pgw#1116: it degrades by NAMING itself (`no_hub`), never by returning a
-    bare None — a refusal that carries no reason is how three pods refused
-    unattributably.
+    pgw#1116: it degrades by NAMING itself, never by returning a bare None — a
+    refusal that carries no reason is how three pods refused unattributably.
+
+    pgw#1127 narrowed the token from `no_hub` to `no_cell_source`, and the
+    narrowing is the point: the hub is only ONE of the two things that can
+    answer a derived ck1 key, and this pod's own store is the other. The
+    tmp-path store this suite runs against is empty, so the fast path is
+    unchanged here — see `test_boot_adopt_local_first_pgw1127` for the case
+    where it is not.
     """
     ex, calls = wired
     # broker._broker is None (fixture); seam is down.
     out = _run_boot_adopt(ex)
-    assert out is not None and out.reason == "no_hub"
+    assert out is not None and out.reason == "no_cell_source"
     assert not out.adopted
     assert calls == []
 

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -1,0 +1,586 @@
+"""pgw#1127 S2 — the boot asks THIS MACHINE before it asks the hub, and can ask nobody.
+
+DESIGN-RULINGS §4.28: *"Untrusted hardware mints for ITSELF: local cell, local
+repo-CAS, reused across its own boots — **never uploaded, never requested**."*
+
+THE DEFECT. ``executor._boot_adopt`` returned ``no_hub`` **before deriving the
+key**, on the premise that *"deriving a key nobody will answer is pure boot
+latency"*. That premise is false on exactly the machines §4.28 is about: the
+derived ``ck1`` key IS ``local_cell_store``'s own address, so an offline box
+holding the exact cell it needs was told there was nobody to ask.
+``boot_adopt.py`` imported ``cell_resolve`` and not ``local_cell_store``; step 2
+of §4.27 was hub-or-nothing.
+
+Reuse still happened — through ``arm_from_local_store``'s arm-token memo — so
+"fully offline-capable" was TRUE BY ACCIDENT of a shortcut rather than by
+design. The sequence is now **derive -> local ``lookup(key)`` -> hub
+``resolve(key)``**, and ``no_hub`` is demoted from a pre-derive gate to two
+honest termini: ``no_cell_source`` (nobody at all, so the derive is skipped) and
+``local_miss_no_hub`` (derived, this machine does not hold it, no hub either).
+
+THE STRONGEST ARGUMENT, and the row that measures it:
+``test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT``. ``sweep_superseded_
+memos`` deletes the shortcut and leaves the CELLS under their own ``ck1`` keys.
+Before S2 that cost one full MINT per family per machine — on a cozy-local box,
+the user's product promise briefly breaking. After S2 the boot addresses the CAS
+directly, finds the cell the memo used to name, and rewrites the shortcut from
+the proven arm. **The next key/scheme bump costs a TRACE instead of a MINT.**
+
+RED before this issue: every row here. `_boot_adopt` refused pre-derive with no
+hub; `local_cell_store` had no reader at boot at all; `boot_local_key` did not
+exist as a route into the store; and `local_hit`/`local_miss_no_hub`/
+`no_cell_source` were not in the pgw#1116 vocabulary, so a fence that reads
+refusal sites out of the tree would have failed on them.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import socket
+import tarfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker import (
+    activity, boot_adopt, boot_key, cell_resolve, fleet_cells, local_cell_store,
+)
+from gen_worker import executor as executor_mod
+from gen_worker.cell_adopt import AdoptOutcome
+
+KEY_A = "ck1-" + "a" * 56
+KEY_B = "ck1-" + "b" * 56
+ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — the machine's own store, and a wire that CANNOT be used
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+@pytest.fixture()
+def events(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    seen: List[Any] = []
+    monkeypatch.setattr(activity, "_sink", seen.append, raising=False)
+    return seen
+
+
+def _adopt_events(seen: List[Any]) -> List[Any]:
+    return [u for u in seen if u.kind == activity.KIND_BOOT_ADOPT]
+
+
+@pytest.fixture()
+def no_wire(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    """The never-request fence, at the SOCKET.
+
+    Not "``cell_resolve.resolve`` was not called" — that is a claim about one
+    function, and the property §4.28 states is about the machine. Any attempt to
+    open any connection, by any layer, records itself and fails.
+    """
+    attempts: List[Any] = []
+    real_connect = socket.socket.connect
+
+    def _connect(self: Any, address: Any) -> None:
+        attempts.append(address)
+        raise OSError(
+            "pgw#1127: this boot must reach the network ZERO times — §4.28's "
+            f"'never requested' — and it tried to reach {address!r}")
+
+    monkeypatch.setattr(socket.socket, "connect", _connect)
+    monkeypatch.setattr(
+        socket, "create_connection",
+        lambda address, *a, **k: _connect(socket.socket(), address))
+    assert real_connect is not None
+    return attempts
+
+
+#: The graphs this pod "traced". Real values in the pgw#1031 sense: the boot's
+#: witnesses and the cell's recorded ones are compared entry by entry, and the
+#: floor is fail-closed in both directions (a silent cell is a refusal too).
+WITNESSES = {"transformer": "9f" * 8}
+
+
+def _cell(
+    tmp_path: Path, *, key: str = KEY_A, name: str = "cell",
+    witnesses: Optional[Dict[str, str]] = None,
+) -> Path:
+    """A cell with a READABLE envelope AND a recorded graph witness.
+
+    `_arm_exported_cell` and the boot's own pgw#1031 floor both read the packed
+    metadata, and a cell that records no witness is refused — correctly — so a
+    fixture without one could only ever test the refusal.
+    """
+    p = tmp_path / name / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({
+        "kind": "aot-inductor", "cell_key": key, "family": "micro-diffusion",
+        "entries": {
+            entry: {"graph_witness": digest}
+            for entry, digest in (
+                WITNESSES if witnesses is None else witnesses).items()
+        },
+    }).encode()
+    with tarfile.open(p, mode="w:gz") as tar:
+        info = tarfile.TarInfo("metadata.json")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return p
+
+
+class _Cfg:
+    family = "micro-diffusion"
+    targets = ("transformer",)
+    shapes = ((64, 64),)
+    text_lens = (8,)
+    guidance_scales = ()
+    lora_bucket = 0
+
+
+class _Spec:
+    name = "generate"
+    module = "micro_diffusion.main"
+    compile = _Cfg()
+
+    def compile_cell(self) -> _Cfg:
+        return _Cfg()
+
+
+class _Pipe:
+    pass
+
+
+class _Arm:
+    def __init__(self, token: str = ARM_A) -> None:
+        self.token = token
+
+    def facts_dict(self) -> Dict[str, str]:
+        return {}
+
+
+def _executor(tmp_path: Path) -> Any:
+    from gen_worker.executor import Executor, ModelStore
+
+    async def _send(msg: Any) -> None:
+        pass
+
+    ex = Executor([], _send, store=ModelStore(_send, cache_dir=tmp_path / "cas"))
+    ex.file_base_url = ""
+    ex.worker_jwt_provider = lambda: ""
+    return ex
+
+
+def _derived(witnesses: Optional[Dict[str, str]] = None) -> Any:
+    """A REAL ``DerivedKey`` — the key is built by ``cell_key.from_axes`` over
+    real axes, so the address the boot hands the store is the address the store
+    is addressed by everywhere else. Only the TRACE is stood in for (there is no
+    card on a CI runner, and `sm` is a key axis)."""
+    from gen_worker import cell_key as ck
+
+    return boot_key.DerivedKey(
+        key=ck.from_axes({
+            "graph": "c0ffee0000000000", "envelope": "e" * 16,
+            "sm": "sm_89", "toolchain": "t" * 16}),
+        class_hashes={"a": "0" * 16}, combined="c0ffee0000000000",
+        workers=2, width_reason="test", traced=1, memo="miss", wall_ms=7,
+        graph_witnesses=dict(WITNESSES if witnesses is None else witnesses))
+
+
+#: The key that derivation actually produces — what the local store must be
+#: addressed by for a boot to find its own cell.
+KEY_DERIVED = _derived().digest
+
+
+@pytest.fixture()
+def declared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The two pre-attempt gates that are NOT under test here."""
+    monkeypatch.setattr(
+        executor_mod.aot_mint, "export_declaration", lambda f: object())
+    monkeypatch.setattr(
+        executor_mod.aot_declaration, "cell_plans", lambda d: [object()])
+    from gen_worker.procsplit import broker
+
+    monkeypatch.setattr(broker, "_broker", None, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. The gate is demoted: nobody-at-all still short-circuits, a machine that
+#    could answer does not
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_store_and_no_hub_still_skips_the_derivation(
+    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The half of the old gate that was RIGHT, kept.
+
+    With no hub AND nothing stored, no route could answer, so paying a
+    structure-only trace would be pure boot latency — the old comment's claim,
+    true in exactly this case and only this case.
+    """
+    monkeypatch.setattr(
+        boot_key, "derive",
+        lambda **kw: pytest.fail("nobody could answer; the derive is latency"))
+
+    out = _executor(tmp_path)._boot_adopt(_Spec(), {})
+
+    assert out.reason == "no_cell_source"
+    assert not out.derived_key
+    assert [u.phase for u in _adopt_events(events)] == ["no_cell_source"]
+
+
+def test_a_machine_holding_cells_DERIVES_even_with_no_hub_at_all(
+    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    no_wire: List[Any], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The half that was WRONG. §4.28's machine has an answerer: itself.
+
+    RED before pgw#1127: `_boot_adopt` returned `no_hub` here without deriving,
+    so the one address that could have been answered was never computed.
+    """
+    local_cell_store.store(
+        _cell(tmp_path), key=KEY_B, family="other", arm_token=ARM_A)
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+
+    out = _executor(tmp_path)._boot_adopt(_Spec(), {})
+
+    assert out.derived_key == KEY_DERIVED, "the key was not derived at all"
+    assert out.reason == "local_miss_no_hub"
+    assert not out.local_key
+    assert not no_wire, f"an offline boot touched the network: {no_wire}"
+    row = _adopt_events(events)[-1]
+    assert row.phase == "local_miss_no_hub"
+    assert "base_url=<unset>" in row.detail
+
+
+# ---------------------------------------------------------------------------
+# 2. THE FENCE (pgw#1127 §4): a populated store + an unreachable hub = ZERO HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
+    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    no_wire: List[Any], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """§4.28's *"never requested"*, enforced rather than described.
+
+    A hub URL is CONFIGURED and points nowhere — the shape that matters, since
+    "no base_url" would make the old gate accidentally right. The boot derives,
+    its own store answers, and no connection is attempted by any layer.
+    """
+    local_cell_store.store(
+        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
+        family="micro-diffusion", arm_token=ARM_A)
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = "http://127.0.0.1:9"   # discard port: nothing listens
+    ex.worker_jwt_provider = lambda: "worker-jwt"
+
+    out = ex._boot_adopt(_Spec(), {})
+
+    assert not no_wire, (
+        "the boot reached for the wire while holding the answer on disk: "
+        f"{no_wire}")
+    assert out.reason == boot_adopt.LOCAL_HIT
+    assert out.local_key == KEY_DERIVED == out.derived_key
+    row = _adopt_events(events)[-1]
+    assert row.phase == "local_hit"
+    assert KEY_DERIVED in row.detail
+
+
+def test_the_local_store_is_asked_BEFORE_a_perfectly_reachable_hub(
+    store: Path, tmp_path: Path, declared: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordering is the promise, not availability. A local-SECOND design would
+    request what the machine already holds — and on a community-cloud pod that
+    is the hub shipping back bytes the pod itself minted."""
+    local_cell_store.store(
+        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
+        family="micro-diffusion", arm_token=ARM_A)
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+    monkeypatch.setattr(
+        cell_resolve, "resolve",
+        lambda *a, **k: pytest.fail("the hub was asked for a resident cell"))
+
+    ex = _executor(tmp_path)
+    ex.file_base_url = "http://hub.local"
+    ex.worker_jwt_provider = lambda: "worker-jwt"
+
+    assert ex._boot_adopt(_Spec(), {}).reason == boot_adopt.LOCAL_HIT
+
+
+def test_a_local_hit_carries_an_ADDRESS_and_never_an_adoption(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-minted cell has no hub receipt and no publisher org, so riding the
+    ``arm_ordered`` path a hub-resolved cell rides would refuse it
+    ``receipt_gate_unconfigured``. The boot hands over the ADDRESS instead, and
+    ``fleet_cells._arm_exported_cell`` — the gate a child's own mint passes —
+    decides."""
+    local_cell_store.store(
+        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
+        family="micro-diffusion", arm_token=ARM_A)
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+
+    out = boot_adopt.attempt(
+        function="generate", modules=("micro_diffusion.main",), cfg=_Cfg(),
+        slots={}, declared_hint=1, envelope={}, work_root=tmp_path,
+        hub_absent="nobody to ask")
+
+    assert out.reason == boot_adopt.LOCAL_HIT
+    assert out.adoption is None and not out.adopted, (
+        "a local cell must not become an `_ArmOrder`: the receipt gate would "
+        "refuse it, and pgw#1122's degrade would spend a whole arm learning it")
+    assert out.local_key == KEY_DERIVED
+
+
+# ---------------------------------------------------------------------------
+# 3. The pgw#1031 graph-witness floor applies to route B — and does not drop
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_cell_whose_graphs_are_not_this_pods_graphs_is_refused(
+    store: Path, tmp_path: Path, events: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ck1` is an INGRESS identity: two endpoints whose declared contracts
+    match can share one key while their bodies differ (`micro-pad32` vs
+    `micro-pad32-branchy`, measured 2026-08-10). Pull-by-key would hand this pod
+    the other endpoint's kernels — locally exactly as much as from the hub."""
+    local_cell_store.store(
+        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
+        family="micro-diffusion", arm_token=ARM_A)
+    # A REAL disagreement, judged by the real `aot_identity.verify_graph_
+    # witness`: the cell records `WITNESSES`, this pod traced something else.
+    # Nothing here is stubbed, so the row cannot pass by agreeing with a stub.
+    monkeypatch.setattr(
+        boot_key, "derive", lambda **kw: _derived({"transformer": "aa" * 8}))
+
+    out = boot_adopt.attempt(
+        function="generate", modules=("m",), cfg=_Cfg(), slots={},
+        declared_hint=1, envelope={}, work_root=tmp_path,
+        hub_absent="nobody to ask")
+
+    assert out.reason == "local_graph_witness_mismatch"
+    assert not out.local_key
+    assert local_cell_store.lookup(KEY_DERIVED) is not None, (
+        "a derived-key hit is an INFERENCE about which pipe owns the bytes; "
+        "dropping the cell to punish a wrong guess turns one honest re-mint "
+        "into two, and the memo route already covers the stale case")
+    assert _adopt_events(events)[-1].phase == "local_graph_witness_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# 4. THE COST ARGUMENT: an arm-scheme bump costs a TRACE, not a MINT
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
+    seen: List[Path] = []
+
+    def _arm(pipe: Any, cfg: Any, cache_dir: Any, artifact: Path,
+             bucket: int, expected: Any = None) -> AdoptOutcome:
+        seen.append(Path(artifact))
+        return AdoptOutcome.hit(KEY_A)
+
+    monkeypatch.setattr(fleet_cells.provision, "arm_aot", _arm)
+    monkeypatch.setattr(
+        fleet_cells.artifact_meta, "read_metadata",
+        lambda p: {"cell_key": KEY_A, "family": "micro-diffusion"})
+    monkeypatch.setattr(fleet_cells, "arm_axis_divergence", lambda key, meta: "")
+    return seen
+
+
+def test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT(
+    store: Path, tmp_path: Path, armable: List[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1127 §5 item 2 — the strongest argument for S2, measured.
+
+    `sweep_superseded_memos` deletes every shortcut written under a superseded
+    arm-token scheme and leaves the CELLS under their own `ck1` keys ("an
+    arm-token change re-derives the shortcut, never the identity"). Before S2
+    the swept memo WAS the only address, so the machine paid a full mint. After
+    S2 the boot-derived key still names the cell.
+
+    On a cozy-local box that is the difference between a user upgrading
+    gen-worker and their next run being instant, and their next run paying a
+    40-minute compile for a cell already on their disk.
+    """
+    local_cell_store.store(
+        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+    # The upgrade: every memo written under the previous scheme is swept.
+    removed = local_cell_store.sweep_superseded_memos("arm99")
+    assert removed == 1
+    assert local_cell_store.lookup_for_arm(ARM_A) is None, "memo not swept"
+    assert local_cell_store.lookup(KEY_A) is not None, "the CELL must survive"
+
+    # WITHOUT the derived key this is a miss, and a miss is a mint.
+    assert fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None
+
+    # WITH it, the same cell arms — and the shortcut is rewritten from the
+    # proven arm, so the boot after this one is a memo hit again.
+    minted = fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion",
+        boot_local_key=KEY_A)
+
+    assert minted is not None and minted.cell_key == KEY_A
+    assert armable and armable[-1] == local_cell_store.cell_dir(KEY_A) / "cell.tar.gz"
+    repaired = local_cell_store.lookup_for_arm(ARM_A)
+    assert repaired is not None and repaired.key == KEY_A, (
+        "the memo must be repaired from the proven arm — otherwise every boot "
+        "after a scheme bump pays the trace again")
+
+
+def test_the_boot_key_route_refuses_WITHOUT_dropping_and_the_memo_route_drops(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two routes, two different things a refusal is allowed to do.
+
+    The memo was written by this machine's own mint for this exact arm token,
+    so a cell that will not arm under it is stale — drop it, one honest
+    re-mint. A boot-key hit is an inference; destroying another pipe's cell to
+    punish a wrong guess costs two.
+    """
+    monkeypatch.setattr(
+        fleet_cells, "_arm_exported_cell",
+        lambda *a, **k: (False, None, ("key_axis_divergence", "sm")))
+
+    local_cell_store.store(
+        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token="")
+    assert fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion",
+        boot_local_key=KEY_A) is None
+    assert local_cell_store.lookup(KEY_A) is not None, "route B must not drop"
+
+    local_cell_store.note_memo(ARM_A, KEY_A)
+    assert fleet_cells.arm_from_local_store(
+        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None
+    assert local_cell_store.lookup(KEY_A) is None, "route A must drop a stale cell"
+
+
+# ---------------------------------------------------------------------------
+# 5. The address actually reaches the arming brain
+# ---------------------------------------------------------------------------
+
+
+def test_the_boot_derived_key_is_threaded_to_the_arming_brain(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A boot that finds its own cell and then cannot say so is the same boot
+    that mints. The address is an explicit parameter the whole way down —
+    `enable_compiled` -> `_arming_policy` -> `arm_from_local_store` — so it is
+    greppable rather than ambient."""
+    seen: Dict[str, Any] = {}
+    monkeypatch.setattr(
+        fleet_cells, "arm_from_local_store",
+        lambda *a, **k: seen.update(k) or None)
+    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+    monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(
+        fleet_cells.cc, "has_compile_target", lambda pipe, cfg: True)
+    monkeypatch.setattr(
+        fleet_cells, "mint_recipe",
+        lambda pipe, cfg, **kw: fleet_cells.RECIPE_AOT)
+    monkeypatch.setattr(fleet_cells, "arm_identity", lambda *a, **k: _Arm())
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell", "nothing delivered"))
+
+    fleet_cells.enable_compiled(
+        _Pipe(), _Cfg(), None, publisher=None, boot_local_key=KEY_A)
+
+    assert seen.get("boot_local_key") == KEY_A
+
+
+# ---------------------------------------------------------------------------
+# 6. The vocabulary — pgw#1116's fence, extended rather than worked around
+# ---------------------------------------------------------------------------
+
+
+def test_every_new_terminus_is_in_the_typed_vocabulary() -> None:
+    """pgw#1116's rule: a path that can produce a token ``REASONS`` does not
+    carry is a path that can be silent again. That telemetry has paid for itself
+    twice in a day; a new gate that skipped it would be the next unattributable
+    pod."""
+    for token in ("local_hit", "local_miss_no_hub",
+                  "local_graph_witness_mismatch"):
+        assert token in boot_adopt.LOCAL_REASONS
+        assert token in boot_adopt.REASONS
+    assert "no_cell_source" in boot_adopt.GATE_REASONS
+    assert "no_hub" not in boot_adopt.REASONS, (
+        "the token that refused on behalf of two answerers is DELETED, not "
+        "aliased — pre-launch hardcut")
+
+
+def test_each_new_terminus_emits_exactly_one_typed_event(
+    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One decision, one event, ``phase`` = the gate's own token. "adopt
+    failed" makes eight different bugs look like one."""
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+    ex = _executor(tmp_path)
+
+    ex._boot_adopt(_Spec(), {})                       # empty store, no hub
+    local_cell_store.store(
+        _cell(tmp_path, name="b"), key=KEY_B, family="other", arm_token="")
+    ex._boot_adopt(_Spec(), {})                       # stored, but not this key
+    local_cell_store.store(
+        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
+        family="micro-diffusion", arm_token=ARM_A)
+    ex._boot_adopt(_Spec(), {})                       # this machine holds it
+
+    phases = [u.phase for u in _adopt_events(events)]
+    assert phases == ["no_cell_source", "local_miss_no_hub", "local_hit"], (
+        f"three different facts must read as three different phases: {phases}")
+
+
+def test_a_key_that_missed_locally_is_distinguishable_from_one_never_derived(
+    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1116's regression box, on the new pair. `derived_key` is what tells
+    "nothing here holds it" apart from "I never computed an address"."""
+    monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+    ex = _executor(tmp_path)
+
+    never = ex._boot_adopt(_Spec(), {})
+    local_cell_store.store(
+        _cell(tmp_path, name="b"), key=KEY_B, family="other", arm_token="")
+    missed = ex._boot_adopt(_Spec(), {})
+
+    assert never.reason == "no_cell_source" and not never.derived_key
+    assert missed.reason == "local_miss_no_hub"
+    assert missed.derived_key == KEY_DERIVED
+    details = {u.phase: u.detail for u in _adopt_events(events)}
+    assert "key=-" in details["no_cell_source"]
+    assert f"key={KEY_DERIVED}" in details["local_miss_no_hub"]
+
+
+def test_boot_adopt_reads_the_local_store_and_says_so_in_its_imports() -> None:
+    """The one-line summary of the defect: ``boot_adopt`` imported
+    ``cell_resolve`` and not ``local_cell_store``, so step 2 of §4.27 was
+    hub-or-nothing. RED before: this import did not exist."""
+    import ast
+
+    tree = ast.parse(Path(boot_adopt.__file__).read_text())
+    imported = {
+        alias.name
+        for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert {"local_cell_store", "cell_resolve"} <= imported, (
+        "one key, two lookup routes — the boot must be able to address BOTH")

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -140,8 +140,17 @@ def test_the_vocabulary_names_the_gates_that_used_to_return_a_bare_none() -> Non
     """The three executor pre-attempt gates are the ones that produced NOTHING
     — not even a discarded reason. They are the reason one pod could not name
     its own refusal."""
-    for token in ("no_export_declaration", "declaration_unreadable", "no_hub"):
+    # pgw#1127 replaced `no_hub` with `no_cell_source`: the gate now refuses
+    # only when BOTH answerers are absent (no hub AND an empty local store),
+    # because the derived ck1 key is `local_cell_store`'s own address.
+    for token in ("no_export_declaration", "declaration_unreadable",
+                  "no_cell_source"):
         assert token in boot_adopt.GATE_REASONS
+    assert "no_hub" not in boot_adopt.REASONS, (
+        "a token nothing can emit is a query nobody can write — pgw#1127 "
+        "split it into `no_cell_source` (pre-derive, nobody at all) and "
+        "`local_miss_no_hub` (derived, this machine does not hold it, and "
+        "there is no hub either)")
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +241,7 @@ def test_each_pre_attempt_gate_names_itself_on_the_wire(
     assert expect in row.detail
 
 
-def test_no_hub_names_which_half_of_the_readiness_was_missing(
+def test_no_cell_source_names_which_half_of_the_readiness_was_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: List[Any],
 ) -> None:
     from gen_worker.procsplit import broker
@@ -248,10 +257,13 @@ def test_no_hub_names_which_half_of_the_readiness_was_missing(
     ex.worker_jwt_provider = lambda: ""
 
     out = ex._boot_adopt(_Spec(), {})
-    assert out.reason == "no_hub"
+    # pgw#1127: the same sentence, under the token that is now true — the
+    # detail is what an operator greps, so it is deliberately unchanged.
+    assert out.reason == "no_cell_source"
     row = _one(events)
-    assert row.phase == "no_hub"
+    assert row.phase == "no_cell_source"
     assert "base_url=<unset>" in row.detail and "seam=down" in row.detail
+    assert "own cell store is empty" in row.detail
 
 
 def test_the_gates_are_pairwise_distinguishable(

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -64,6 +64,21 @@ KEY = "ck1-" + "3f" * 28
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _empty_local_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """pgw#1127: the pre-derive gate asks whether ANYBODY could answer, and this
+    machine's own cell store is one of the two answerers. Pin it to an empty
+    root so every row here reads a fact about the test rather than about
+    whatever `~/.cache/cozy/compile-cells` happens to hold on the box."""
+    from gen_worker import local_cell_store
+
+    monkeypatch.setenv(
+        local_cell_store.ENV_STORE_DIR,
+        str(tmp_path_factory.mktemp("empty-cells")))
+
+
 @pytest.fixture
 def events(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
     seen: List[Any] = []

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -188,7 +188,7 @@ def _seeded_enable(ex, artifact, ref=None, digest=None):
     warmup proof run unchanged."""
     from gen_worker import fleet_cells
 
-    def _enable(pipe, cfg, art, delivered=None, arm=None):
+    def _enable(pipe, cfg, art, delivered=None, arm=None, boot_local_key=""):
         return fleet_cells.enable_compiled(
             pipe, cfg, ex.store._cache_dir, Path(artifact),
             delivered_ref=ref or CACHE_REF,

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -555,7 +555,7 @@ class _Rig:
             pass
         monkeypatch.setattr(
             self.ex, "_enable_compiled",
-            lambda p, cfg, artifact, delivered=None, arm=None:
+            lambda p, cfg, artifact, delivered=None, arm=None, boot_local_key="":
                 fleet_cells.enable_compiled(
                     p, cfg, self.ex.store._cache_dir, artifact,
                     publisher=None))

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -280,7 +280,8 @@ class _Rig:
         for spec in specs:
             monkeypatch.setattr(
                 self.ex, "_enable_compiled",
-                lambda p, cfg, artifact, delivered=None, arm=None:
+                lambda p, cfg, artifact, delivered=None, arm=None,
+                       boot_local_key="":
                     fleet_cells.enable_compiled(
                         p, cfg, self.ex.store._cache_dir, artifact,
                         publisher=None))


### PR DESCRIPTION
## The defect

`executor.py:9907-9915` returned `no_hub` **before deriving the key**:

> *"Genuinely nobody to ask… Deriving a key nobody will answer is pure boot
> latency."*

That is false on exactly the machines DESIGN-RULINGS §4.28 is about. **The
derived `ck1` key IS `local_cell_store`'s own address.** `boot_adopt.py`
imported `cell_resolve` and never `local_cell_store`, so step 2 of §4.27 was
hub-or-nothing and an offline box holding the exact cell it needed was told
there was nobody to ask.

Reuse still happened — via `arm_from_local_store`'s arm-token memo — so
"fully offline-capable" was true **by accident of a shortcut**, not by design.
This makes it a property.

## The sequence is now derive → local `lookup(key)` → hub `resolve(key)`

`no_hub` is **deleted** (pre-launch hardcut, no alias) and split into two
termini that are each individually true:

| token | when |
|---|---|
| `no_cell_source` | pre-derive, and the half of the old gate that was RIGHT: no hub **and** an empty local store, so nothing could answer and the trace really would be pure latency. `stored_cells()` is a listdir with no digest recomputation, so the fleet path pays exactly what the old early return paid. |
| `local_miss_no_hub` | derived, asked this machine, it does not hold the key, and there is no hub either |
| `local_hit` | this machine holds it; the hub is **not asked at all** |
| `local_graph_witness_mismatch` | the pgw#1031 floor applied to the local route — `ck1` is an INGRESS identity, so two endpoints whose declared contracts match can share a key while their bodies differ (`micro-pad32` vs `micro-pad32-branchy`, 112 vs 102 nodes) |

All four ride the **pgw#1116 typed vocabulary**, `phase` = the gate's own token,
so the fence that reads refusal sites out of the source tree stays satisfied and
a future failure here is still a one-query answer. That telemetry has paid for
itself twice in the last day; a new gate that skipped it would be the next
unattributable pod.

## A local hit is an ADDRESS, not an adoption

A self-minted cell carries no hub receipt and no publisher org, so riding the
`arm_ordered` path a hub-resolved cell rides would refuse it
`receipt_gate_unconfigured` — and pgw#1122's degrade would spend a whole arm
learning that. The boot hands the arming brain `boot_local_key` instead,
threaded **explicitly** through `enable_compiled` → `_arming_policy` →
`arm_from_local_store` (greppable, no process-global handoff), where it becomes
a **second lookup route into the same CAS** the arm-token memo addresses.

Both routes end at `_arm_exported_cell` — the gate a child's fresh mint also
passes — so a stored cell is never more trusted than a freshly minted one and
never less. **One key, two lookup routes, one gate.**

Two routes also means two different things a refusal may do. The memo was
written by this machine's own mint for this exact arm token, so a cell that will
not arm under it is stale → dropped, one honest re-mint. A boot-key hit is an
*inference* about which pipe owns the bytes, so it refuses **without dropping**;
destroying another pipe's cell to punish a wrong guess would cost two.

## Why this is worth doing — the strongest argument, and it is measured

`test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT`.

`sweep_superseded_memos` deletes the shortcut and leaves the CELLS under their
own `ck1` keys ("an arm-token change re-derives the shortcut, never the
identity"). **Before S2 the swept memo WAS the only address**, so an arm-scheme
bump cost one full MINT per family per machine — on a cozy-local box, a user
upgrades gen-worker and their next run of a model they have run fifty times pays
a 40-minute compile for a cell already on their disk.

After S2 the boot-derived key still names it, and `local_cell_store.note_memo`
rewrites the shortcut **from the proven arm**. So:

> **the next key/scheme bump costs a TRACE instead of a MINT.**

The memo degrades to what §4.28 calls it: a shortcut.

## The structural fence (pgw#1127 §4)

`_boot_adopt` against a populated local store and an unreachable hub makes
**zero** network attempts — enforced at `socket.connect`, not by asserting that
`cell_resolve.resolve` went uncalled, because the property §4.28 states is about
the *machine* and not about one function. The hub URL is **configured** and
points at the discard port, since "no base_url" would make the old gate
accidentally right.

## RED before

**All 13 rows fail on `origin/master`**, verified by running this file against a
master checkout: `_boot_adopt` refuses pre-derive; `local_cell_store` has no
reader at boot at all; `boot_local_key` does not exist as a route; the new
tokens are not in the vocabulary. The graph-witness row uses the real
`aot_identity.verify_graph_witness` against real recorded witnesses — nothing
stubbed, so it cannot pass by agreeing with a stub.

## Local verification

mypy clean on the changed files; `lint_unreached_surface`, `lint_config_reads`,
`lint_credential_identity`, `lint_settings_writers`, `lint_ambient_census`,
`lint_http_timeouts` all exit 0; ruff clean. Targeted suites:
`test_boot_adopt_local_first_pgw1127`, `test_boot_adopt_observability_pgw1116`,
`test_aot_local_mint_pgw1096`, `test_two_run_reuse_pgw1096`,
`test_import_cycles_pgw981` — 59 passed. No pods, no mints, no GPU.

## Sequencing

Independent of — but complementary to — **#645** (pgw#1127 S1, the cozy-local
re-point). Neither touches the other's call sites; S1 owns `cli/run.py` +
`local_serve.py`, S2 owns `boot_adopt.py` + `executor._boot_adopt`. Both edit
`fleet_cells.py` in disjoint regions. Rebased on `dafe7655`.

Refs pgw#1127 S2 + fence item 4, pgw#1116, pgw#1031, pgw#1096, DESIGN-RULINGS §4.27/§4.28.
