### PR TITLE
pgw#1123: move the probe image's pin to 0.106.0 — the SDK is fixed, the IMAGE was not

### DIFF
--- a/changelog.d/pgw1123.md
+++ b/changelog.d/pgw1123.md
@@ -1,0 +1,12 @@
+- **pgw#1123 (follow-up): the fleet's probe image is repinned to the wheel that
+  fixed it.** `examples/micro-diffusion` was pinned at `gen-worker==0.97.0` — a
+  wheel whose `models/structure_only` imports `accelerate`, which this family
+  deliberately does not ship. The SDK fix landed in `858a7bcb`, but the BUILT
+  image kept deriving no boot key, issuing no
+  `POST /v1/worker/cells/resolve` and self-minting forever, so the AOT
+  reuse-circle proof would have measured the same silence a third time at real
+  pod cost. Pin moved to `0.106.0` and the lock re-resolved against the
+  published wheel (`sha256:bd1e4558…`). No `accelerate` line was added to the
+  image: `pipeline.py` already uses the SDK's `models.meta_init` seam, and
+  declaring the package here would have fixed one image and left the class in
+  place for every other family.

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -268,15 +268,19 @@ GET /api/v1/repos/tensorhub/micro-diffusion/checkpoints     # model_family stamp
 **ESTIMATE: < 1 min.** No commit to `inference-endpoints` is wanted — this is a
 proof artifact, not a fleet pin.
 
-> ⚠️ **Pin at 0.100.0 (current), never below the 0.97.0 fleet floor.** This
-> family declares a container input with a plain input after it — the shape
-> pgw#994 (`2165c2d5`, 0.93.4) fixed; below it the cell mints and seals and then
-> **refuses at ingress on its first served call**, burning a pod to rediscover a
-> fixed defect. 0.97.0 is the fleet floor (pgw#1084, four-axis `ck1`); 0.100.0
-> additionally carries the AOT re-key — boot-derived cell key (pgw#1089/1090),
-> the folding fence (pgw#1097) and AOT-local mint (pgw#1096). Keep this pin on
-> the SAME wheel the fleet serves (the example's `pyproject.toml` pin is the
-> source of truth) so the gauntlet stays a usable probe.
+> ⚠️ **Pin at 0.106.0 (current), never below it on THIS family.** Below
+> 0.106.0 the boot-key derivation refuses outright: `models/structure_only`
+> imported `accelerate`, which this image deliberately does not ship, so no key
+> exists, no `/v1/worker/cells/resolve` is ever issued and the pod self-mints
+> forever — measured on `ykwoaiqub6ktt3` and `3o09rf9ehnc4ym`, and it is what
+> silenced the first paid reuse-circle proof (pgw#1123). Older floors still
+> apply and are all below it: pgw#994 (`2165c2d5`, 0.93.4) for the container
+> input followed by a plain input — below it the cell mints and seals and then
+> **refuses at ingress on its first served call**; 0.97.0 for pgw#1084's
+> four-axis `ck1`; 0.100.0 for the AOT re-key (pgw#1089/1090), the folding fence
+> (pgw#1097) and AOT-local mint (pgw#1096). Keep this pin on the SAME wheel the
+> fleet serves (the example's `pyproject.toml` pin is the source of truth) so
+> the gauntlet stays a usable probe.
 
 ### 2. Publish the release
 

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -13,14 +13,12 @@ dependencies = [
     # cell MINTS and SEALS and then refuses at ingress on its first served
     # call. Never pin below that.
     #
-    # 0.97.0 (pgw#1084): the fleet hardcut to it in `inference-endpoints`
-    # `2440905` (ie#639/PR ie#298 — 28 pins, floor, and `[supported]` all moved,
-    # 0.96 DELETED with no transition window). This example is outside that
-    # train, so it is repinned here by hand to keep the micro gauntlet on the
-    # SAME wheel the fleet serves — which is the whole reason the gauntlet is a
-    # usable probe. 0.97.0 also carries pgw#1059's four-axis `ck1`, so every
-    # cell minted from this pin is a live-scheme cell.
-    "gen-worker==0.97.0",
+    # This example is outside the `inference-endpoints` relock train, so the pin
+    # is moved here by hand at each cut to keep the micro gauntlet on the SAME
+    # wheel the fleet serves — which is the whole reason the gauntlet is a
+    # usable probe. Floor facts still in force: pgw#1059's four-axis `ck1`
+    # (0.97.0), so every cell minted from this pin is a live-scheme cell.
+    "gen-worker==0.106.0",
     "msgspec>=0.18",
     "safetensors>=0.4",
     "pillow",
@@ -30,14 +28,14 @@ dependencies = [
 # is that its image is small and its boot is short; a dependency it does not
 # use would cost both on every cycle.
 #
-# ⚠️ THE PIN ABOVE MUST MOVE TO >=0.106.0 AT THE NEXT RELOCK (pgw#1123).
-# On 0.97.0-0.105.0 `models/structure_only` imports `accelerate`, so on THIS
-# image the boot-key derivation refuses and the pod self-mints forever —
-# measured on pods `ykwoaiqub6ktt3` and `3o09rf9ehnc4ym`, and it is what
-# silenced the first paid reuse-circle proof. 0.106.0 owns the meta-init
-# (`gen_worker.models.meta_init`), which `pipeline.py` now uses; adding
-# `accelerate` here instead would fix this one image and leave the SDK defect
-# in place for every other family, which is why it is deliberately NOT here.
+# The pin is 0.106.0 BECAUSE of pgw#1123: on 0.97.0-0.105.0
+# `models/structure_only` imported `accelerate`, so on THIS image the boot-key
+# derivation refused, no `/v1/worker/cells/resolve` was ever issued, and the pod
+# self-minted forever — measured on pods `ykwoaiqub6ktt3` and `3o09rf9ehnc4ym`,
+# and it is what silenced the first paid reuse-circle proof. 0.106.0 owns the
+# meta-init (`gen_worker.models.meta_init`), which `pipeline.py` uses. Adding
+# `accelerate` here instead would have fixed this one image and left the SDK
+# defect in place for every other family, which is why it is NOT here.
 
 [dependency-groups]
 local = [

--- a/examples/micro-diffusion/uv.lock
+++ b/examples/micro-diffusion/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.97.0"
+version = "0.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -350,9 +350,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/16/d9f70aa67fce5240cd418bbe06993f15e9c0d2814a84b6629c7a50abfb84/gen_worker-0.97.0.tar.gz", hash = "sha256:585d1efeb7e6e2d5e3efa50c9c913387ed242935e3de11dd8090a69627186ec1", size = 1740831, upload-time = "2026-08-10T14:23:44.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/44/06a42492077d62db9d90052515d767b56762ecb8b39e21f6745a701320c3/gen_worker-0.106.0.tar.gz", hash = "sha256:b7a1d16c744c88fe0fdbb90f38a6fb377a9bfb980f16e73fdbb11c4a9967efce", size = 1932696, upload-time = "2026-08-11T17:05:52.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/32/6f565d35d324bb77ee0db0d5d1d32b0143bdf0cfcad6ae2a73b83f2713ac/gen_worker-0.97.0-py3-none-any.whl", hash = "sha256:cd0adea043f40a93db57fd9dd51b04dfc07ca145fdde4210278522108312266d", size = 1901447, upload-time = "2026-08-10T14:23:42.427Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ab/ce2578a11d5c7fa1e4c545c32bde0c9d032535cb2ced0e5b8c5f606b13b4/gen_worker-0.106.0-py3-none-any.whl", hash = "sha256:bd1e4558cc00b1a0d060e7066f747144ef736b2b50413458606a18029262c6be", size = 2107003, upload-time = "2026-08-11T17:05:50.092Z" },
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ local = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gen-worker", specifier = "==0.97.0" },
+    { name = "gen-worker", specifier = "==0.106.0" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pillow" },
     { name = "safetensors", specifier = ">=0.4" },


### PR DESCRIPTION
`examples/micro-diffusion` was pinned at `gen-worker==0.97.0`. Every wheel 0.97.0–0.105.0 has `models/structure_only` importing `accelerate`, which this family deliberately does not ship — so on the built image the boot key never derived, no `POST /v1/worker/cells/resolve` was ever issued, and the pod self-minted forever (pods `ykwoaiqub6ktt3`, `3o09rf9ehnc4ym`). That is what silenced the first paid reuse-circle proof.

`858a7bcb` fixed the SDK; **0.106.0** (tag `v0.106.0`, commit `5548da2a`, wheel `sha256:bd1e4558…`) is the first wheel carrying it, so the pin could not move until now.

**Verified by parsing the lock, not by uv's exit code** (ie#635 anima trap): `uv.lock` resolves gen-worker 0.106.0 from `https://pypi.org/simple` with wheel hash `sha256:bd1e4558cc00b1a0d060e7066f747144ef736b2b50413458606a18029262c6be`, identical to what the simple index serves. Note for the next lane: `uv lock --refresh-package gen-worker` reported the requirement *unsatisfiable* (stale index cache); plain `uv lock --refresh` resolved it.

**No `accelerate` line added** to the Dockerfile or dependencies — `pipeline.py` uses the SDK's `models.meta_init` seam as of `858a7bcb`. Adding it would fix one image and leave the SDK defect in place for every other family.