### PR TITLE
pgw#1125 (th#1795 candidate 3): the hub control plane keeps its connection across saves

### DIFF
--- a/changelog.d/pgw1125.md
+++ b/changelog.d/pgw1125.md
@@ -1,0 +1,12 @@
+- **pgw#1125 / th#1795 candidate 3: the hub control plane keeps its connection across saves.** Measured
+  on the standing stack after the hub's own chain collapsed (th#1795 §11, n=18): `upload.create` is
+  589 ms worker-side against a **4.5 ms** hub handler — ~584 ms of pure control-plane network, now the
+  largest attributable slice of the upload tail, and one fresh TCP+TLS handshake through the tunnel
+  (109-155 ms) was paid on every single save because the `requests.Session` died with the save. It is
+  now process-scoped per hub origin, carrying sockets only (cookies refused; auth stays a per-request
+  header). Reuse's new failure mode is answered where it lands: a control-plane POST that fails to
+  connect on a REUSED session evicts it by identity and retries once on a fresh one, while a session
+  the call just built keeps create's old behaviour of not retrying at all — that error is the hub being
+  down, not a stale socket. **The R2 data plane is unchanged and stays SAVE-scoped**; that boundary is
+  the `SSLV3_ALERT_BAD_RECORD_MAC` safety property (issue #13) and both halves are asserted together by
+  connection-count tests against two real servers.

--- a/src/gen_worker/_upload_transport.py
+++ b/src/gen_worker/_upload_transport.py
@@ -31,8 +31,11 @@ presigned part URLs; the worker PUTs bytes directly to those URLs.
      stalled.
 
 The control plane (create / complete / abort POSTs to tensorhub) stays
-on ``requests``, on a per-save ``requests.Session`` owned by
-``presigned_upload.py``.
+on ``requests``, on a PROCESS-scoped ``requests.Session`` per hub origin
+owned by ``presigned_upload.py`` (th#1795 candidate 3 / pgw#1125). That
+wider scope is deliberate and stops at this file's edge: the R2 data
+plane below stays per-save, because the incident this module exists for
+was an R2 edge behaviour and the hub is a different peer.
 
 Public API: ``upload_part_to_presigned_url(url, file_path, offset,
 length, pool=None)`` -> ``etag``, ``PutPool``, and ``backoff_sleep_s`` —

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -23,37 +23,64 @@ and user media (/api/v1/media/:owner/uploads). Repo checkpoints do NOT use
 this client anymore — they publish via the /commits API (gw#471,
 gen_worker.convert.hub).
 
-# HTTP stack (issues #13 / #385)
+# HTTP stack (issues #13 / #385 / pgw#1125)
 
-Connections are scoped to ONE save (``presigned_upload_file`` call) and
-torn down with it — never shared across saves:
+The two planes have DIFFERENT connection scopes, and the boundary is a
+ratified safety property — do not blur it:
 
-  * control plane (create / complete / abort) — one ``requests.Session``
-    per save, so create -> complete reuses the tensorhub connection
-    instead of paying a fresh TCP+TLS handshake per POST (bare
-    ``requests.post`` builds a new Session per call). Auth headers are
-    passed per-request, so worker JWT rotation never forces a new
-    connection.
-  * data plane (part PUTs) — one ``_upload_transport.PutPool`` per save,
-    shared by first attempts so consecutive parts reuse the R2
-    connection. Retry attempts always get a fresh ``urllib3.PoolManager``
-    — the structural guard against the stale-socket
-    ``SSLV3_ALERT_BAD_RECORD_MAC`` R2 incident (see ``_upload_transport``).
+  * control plane (create / complete / abort, worker -> tensorhub) — one
+    PROCESS-scoped ``requests.Session`` per hub origin, reused across
+    saves (th#1795 candidate 3). Measured 2026-08-11 on the standing
+    stack: ``upload.create`` is 589 ms worker-side against a 4.5 ms hub
+    handler, i.e. ~584 ms of pure control-plane network, of which one
+    fresh TCP+TLS handshake through the tunnel is 109-155 ms — paid on
+    every single save because the session used to die with it. Auth
+    headers are passed per-request, so worker JWT rotation never forces a
+    new connection, and the session carries SOCKETS ONLY: cookies are
+    refused so no server state crosses saves.
+    Reuse buys a new failure mode — a socket the peer closed while the
+    pod was denoising — so a control-plane POST that fails to CONNECT on
+    a REUSED session evicts it and retries once on a fresh one. On a
+    session this call just built there is no retry: that error is the hub
+    being down, not staleness, and inventing a retry there would change a
+    behaviour nobody measured.
+  * data plane (part PUTs, worker -> R2) — one
+    ``_upload_transport.PutPool`` per save, torn down with it, NEVER
+    process-scoped. Retry attempts always get a fresh
+    ``urllib3.PoolManager`` — the structural guard against the
+    stale-socket ``SSLV3_ALERT_BAD_RECORD_MAC`` R2 incident (see
+    ``_upload_transport``). That incident is why per-save scoping exists
+    at all; it was an R2 edge behaviour, and the control plane is a
+    different peer with a different failure history.
+
+**What the saving is CONDITIONAL on, so the next pod leg measures the
+right thing.** A handshake is only avoided when the hub (and anything
+between, ngrok included) still holds the socket open across the gap
+between two saves — a gap that is one whole generation long. If the peer
+drops it every time, urllib3's dropped-connection check replaces it
+silently, this costs nothing and buys nothing, and THAT is the finding:
+it would mean create's remaining ~430 ms is one tunnel round trip that
+only topology (th#1795 candidate 6) can remove. Read `upload.create` on
+saves 2..N of a pod's life, never on the first — the first save of a
+process builds the session and pays the handshake exactly as before.
 """
 
 from __future__ import annotations
 
+import http.cookiejar
 import json
 import logging
 import os
 import threading
 import time
+import urllib.parse
 from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import requests
+from requests.adapters import HTTPAdapter
 from blake3 import blake3
 
 from ._upload_transport import (
@@ -144,8 +171,108 @@ __all__ = [
     "STREAM_CHUNK_BYTES",
     "PresignedUploadResult",
     "blake3_hash_file",
+    "control_plane_session",
     "presigned_upload_file",
+    "reset_control_plane_sessions",
 ]
+
+
+# --------------------------------------------------------------------------
+# Control-plane keepalive (th#1795 candidate 3) — see the module docstring for
+# the boundary this must not cross. One session per HUB ORIGIN, not one
+# global: an eviction then drops the poisoned peer's pool and leaves every
+# other peer's connections alone.
+# --------------------------------------------------------------------------
+#: Matches ``_PRESIGNED_PUT_BUDGET``: an endpoint author saving from N threads
+#: can have at most that many control-plane POSTs in flight beside each other.
+_CONTROL_POOL_MAXSIZE = _PRESIGNED_PUT_BUDGET
+#: A worker talks to exactly one hub. The bound only exists so a caller that
+#: rotates base URLs cannot grow this map without limit.
+_MAX_CONTROL_ORIGINS = 8
+
+_control_sessions: Dict[str, requests.Session] = {}
+_control_sessions_lock = threading.Lock()
+
+
+def _control_origin(base_url: str) -> str:
+    parts = urllib.parse.urlsplit(str(base_url or ""))
+    return f"{parts.scheme}://{parts.netloc}"
+
+
+def _new_control_session() -> requests.Session:
+    session = requests.Session()
+    adapter = HTTPAdapter(
+        pool_connections=2,
+        pool_maxsize=_CONTROL_POOL_MAXSIZE,
+        # This module owns retry classification (create: once, on a reused
+        # socket only; complete: `_FINALIZE_RETRY_ATTEMPTS`). A second,
+        # invisible budget inside urllib3 would replay a POST we decided was
+        # terminal.
+        max_retries=0,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    # SOCKETS ONLY, never state. A process-scoped session that accumulated
+    # cookies would carry one save's server state into the next one — auth is
+    # per-request headers and nothing else may persist.
+    session.cookies.set_policy(http.cookiejar.DefaultCookiePolicy(allowed_domains=[]))
+    return session
+
+
+def control_plane_session(base_url: str) -> Tuple[requests.Session, bool]:
+    """The process-scoped hub session for ``base_url``.
+
+    Returns ``(session, fresh)``. ``fresh`` is True when this call built the
+    session — the caller uses it to tell "the hub refused the connection"
+    (fresh) apart from "the pooled socket was dead" (reused), which is the
+    only difference that justifies a retry.
+    """
+    origin = _control_origin(base_url)
+    with _control_sessions_lock:
+        existing = _control_sessions.get(origin)
+        if existing is not None:
+            return existing, False
+        if len(_control_sessions) >= _MAX_CONTROL_ORIGINS:
+            _control_sessions.clear()
+        session = _new_control_session()
+        _control_sessions[origin] = session
+        return session, True
+
+
+def _evict_control_session(base_url: str, session: requests.Session) -> None:
+    """Drop a session whose pooled socket proved dead, by IDENTITY.
+
+    Compare-and-swap: a sibling thread may already have replaced it, and
+    dropping the replacement would make the next save pay a handshake for
+    nothing. The evicted session is NOT closed — another thread may be
+    mid-request on it, and its own connections close when the last reference
+    goes.
+    """
+    origin = _control_origin(base_url)
+    with _control_sessions_lock:
+        if _control_sessions.get(origin) is session:
+            _control_sessions.pop(origin, None)
+
+
+def reset_control_plane_sessions() -> None:
+    """Close and forget every control-plane session (tests, teardown)."""
+    with _control_sessions_lock:
+        sessions = list(_control_sessions.values())
+        _control_sessions.clear()
+    for session in sessions:
+        try:
+            session.close()
+        except Exception:
+            logger.debug("control-plane session close failed", exc_info=True)
+
+
+def _is_connection_error(exc: BaseException) -> bool:
+    """True for "the socket was dead", false for "the hub answered slowly".
+
+    A timeout is deliberately NOT in here: it means the request may be live on
+    the server, and the stale-socket case this covers cannot present as one.
+    """
+    return isinstance(exc, requests.ConnectionError) and not isinstance(exc, requests.Timeout)
 
 
 def _response_body_sample(resp: requests.Response, limit: int = 300) -> str:
@@ -281,9 +408,11 @@ def presigned_upload_file(
             commit body's `provenance` object (worker-addable stamp fields),
             not through this seam.
     """
-    # Per-save connection scope (issue #385): one hub Session + one R2 PUT
-    # pool live exactly as long as this save, then close. Never cross-request.
-    with requests.Session() as session, PutPool() as put_pool:
+    # Two scopes, deliberately different (see the module docstring): the R2
+    # PUT pool lives exactly as long as this save and then closes, while the
+    # hub control-plane session is process-scoped and survives it.
+    session, session_is_fresh = control_plane_session(base_url)
+    with PutPool() as put_pool:
         return _presigned_upload_file_scoped(
             file_path=file_path,
             base_url=base_url,
@@ -297,8 +426,61 @@ def presigned_upload_file(
             complete_extra=complete_extra,
             on_phase=on_phase,
             session=session,
+            session_is_fresh=session_is_fresh,
             put_pool=put_pool,
         )
+
+
+def _post_create(
+    *,
+    session: requests.Session,
+    session_is_fresh: bool,
+    base_url: str,
+    url: str,
+    headers: Dict[str, str],
+    body: str,
+) -> Tuple[requests.Response, requests.Session]:
+    """POST the create leg, retrying ONCE if a REUSED socket was already dead.
+
+    Returns the response and the session it came from — the caller rebinds to
+    it so this save's ``/complete`` reuses the connection create just opened
+    rather than paying a second handshake behind the eviction.
+
+    **Why this retry is safe, i.e. what a duplicate create costs.** The create
+    leg opens an upload session and mints presigns; it writes no media row and
+    publishes nothing — the object only exists once ``/complete`` runs, and
+    this save completes exactly one of the two sessions. A duplicate is an
+    unfinished session the hub GCs, and the direct-final path (th#1795) makes
+    it emptier still: the bytes go straight to the content-addressed key the
+    digest names, so two sessions for the same save even name the same key.
+    The one real charge is the capability grant's budget, which tensorhub
+    debits AT CREATE (`media_presigned.go` `enforceCapabilityGrantBudget(…, 1,
+    size)`): a duplicate spends 1 of the request's `upload_media` `max_count`,
+    minted at 64 (`scheduler_dispatch.go:3003`) against the 1-4 assets a
+    request actually saves. That is what bounds this to ONE retry.
+    ``/complete`` is a different question and is handled where it lives —
+    ``_complete_upload_session`` already retries it, on the hub contract that
+    a finalized session answers the same payload again.
+
+    **Why only on a REUSED session.** Process-scoped keepalive is what
+    introduced the dead-socket case; a session this call just built has no
+    pooled socket to be stale, so a connection error on it is the hub being
+    unreachable. Retrying that would be a behaviour change nobody measured —
+    create had no retry before this, and still has none for that case.
+    """
+    try:
+        return session.post(url, headers=headers, data=body, timeout=_CREATE_TIMEOUT_S), session
+    except requests.RequestException as exc:
+        if session_is_fresh or not _is_connection_error(exc):
+            raise
+        _evict_control_session(base_url, session)
+        logger.info(
+            "control-plane keepalive socket was dead on upload create (%s) — "
+            "retrying once on a fresh connection",
+            type(exc).__name__,
+        )
+    retry_session, _ = control_plane_session(base_url)
+    return retry_session.post(url, headers=headers, data=body, timeout=_CREATE_TIMEOUT_S), retry_session
 
 
 def _presigned_upload_file_scoped(
@@ -316,6 +498,7 @@ def _presigned_upload_file_scoped(
     session: requests.Session,
     put_pool: PutPool,
     on_phase: Optional[Any] = None,
+    session_is_fresh: bool = True,
 ) -> PresignedUploadResult:
     url = f"{base_url}{endpoint_path}"
 
@@ -329,7 +512,14 @@ def _presigned_upload_file_scoped(
 
     try:
         with _phase(on_phase, "create"):
-            resp = session.post(url, headers=create_headers, data=json.dumps(payload), timeout=_CREATE_TIMEOUT_S)
+            resp, session = _post_create(
+                session=session,
+                session_is_fresh=session_is_fresh,
+                base_url=base_url,
+                url=url,
+                headers=create_headers,
+                body=json.dumps(payload),
+            )
     except requests.RequestException as e:
         raise ArtifactTransferError(
             f"tensorhub upload create request failed: {e}",
@@ -582,8 +772,14 @@ def _poll_until_finalized(
                 complete_url, headers=complete_headers, data=json.dumps(payload),
                 timeout=_FINALIZE_TIMEOUT_S,
             )
-        except requests.RequestException:
-            continue  # no answer: the silence window is the only give-up
+        except requests.RequestException as exc:
+            # No answer: the silence window is the only give-up. Drop the
+            # keepalive session first if the socket itself died, so the next
+            # poll does not replay a dead connection.
+            if _is_connection_error(exc):
+                _evict_control_session(complete_url, session)
+                session, _ = control_plane_session(complete_url)
+            continue
         code = resp.status_code
         if code in (401, 403):
             raise AuthError(f"file save unauthorized ({code})")
@@ -631,6 +827,16 @@ def _complete_upload_session(
                 retryable=True,
                 cause_type=type(e).__name__,
             )
+            # pgw#1125: `/complete` was ALREADY retried here on a connection
+            # failure, and the hub contract that makes that safe is unchanged
+            # (a finalized session answers the same success payload again —
+            # `_poll_until_finalized`). What keepalive adds is a pool that can
+            # hand the retry the same dead socket, so evict it by identity and
+            # take a fresh session for the next attempt. No new retry, no new
+            # idempotency assumption.
+            if _is_connection_error(e):
+                _evict_control_session(complete_url, session)
+                session, _ = control_plane_session(complete_url)
         else:
             code = resp.status_code
             if code in (401, 403):

--- a/tests/test_control_plane_keepalive_pgw1125.py
+++ b/tests/test_control_plane_keepalive_pgw1125.py
@@ -1,0 +1,310 @@
+"""pgw#1125 / th#1795 candidate 3: the hub CONTROL plane keeps its connection
+across saves; the R2 DATA plane still does not.
+
+MEASURED, standing `master` stack 2026-08-11 (th#1795 §11, n=18 steady-state
+256x256 webp saves on gen-worker 0.106.0): `upload.create` is **589 ms**
+worker-side against a **4.5 ms** hub handler — ~584 ms of pure control-plane
+network, the largest attributable slice of the whole upload tail once the hub's
+own chain collapsed 1224 -> 292 ms. One fresh TCP+TLS handshake through the
+tunnel is 109-155 ms of that, and it was paid on EVERY save because the
+`requests.Session` died with the save.
+
+The two planes are asserted TOGETHER here on purpose, because the boundary is
+the safety property: the per-save scoping of the R2 pool came from a real
+production incident (`SSLV3_ALERT_BAD_RECORD_MAC`, issue #13) and does not
+move. A change that "fixed" the tail by widening the data plane too would pass
+half of this file and fail the other half.
+
+Connections are counted where they are actually made — the accept loop of two
+separate real servers — not through a mock. Over TLS one accepted TCP
+connection is one handshake, which is the thing being paid for.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import presigned_upload
+from gen_worker.api.errors import ArtifactTransferError
+from gen_worker.presigned_upload import presigned_upload_file, reset_control_plane_sessions
+
+
+class _CountingServer(ThreadingHTTPServer):
+    """Counts ACCEPTED TCP connections — one per handshake a pod would pay."""
+
+    daemon_threads = True
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.connections = 0
+        self.requests_seen: List[str] = []
+        self.cookie_headers: List[Optional[str]] = []
+        self.lock = threading.Lock()
+        # Test-controlled fault injection, read by the handlers below.
+        self.poison_after_response = False
+        self.drop_create_requests = 0
+        self.set_cookie = False
+
+    def get_request(self) -> Any:
+        conn = super().get_request()
+        with self.lock:
+            self.connections += 1
+        return conn
+
+
+class _HubHandler(BaseHTTPRequestHandler):
+    """The three-leg control plane. The PUT leg lives on the other server."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    @property
+    def hub(self) -> _CountingServer:
+        return self.server  # type: ignore[return-value]
+
+    def _json(self, code: int, body: Dict[str, Any]) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        if self.hub.set_cookie:
+            self.send_header("Set-Cookie", "hubstate=1; Path=/")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        leg = "complete" if self.path.endswith("/complete") else "create"
+        with self.hub.lock:
+            self.hub.requests_seen.append(leg)
+            self.hub.cookie_headers.append(self.headers.get("Cookie"))
+            drop = leg == "create" and self.hub.drop_create_requests > 0
+            if drop:
+                self.hub.drop_create_requests -= 1
+        if drop:
+            # The request was READ and then the peer vanished: exactly what a
+            # keepalive socket that died between urllib3's dropped-connection
+            # check and the write looks like from the client (RemoteDisconnected
+            # -> requests.ConnectionError).
+            self.close_connection = True
+            return
+        if leg == "complete":
+            self._json(200, {
+                "ref": "outputs/r/abc.webp",
+                "media_id": "m1",
+                "blake3": "",
+                "sha256": "",
+                "size_bytes": 0,
+                "mime_type": "image/webp",
+            })
+        else:
+            self._json(201, {
+                "upload_id": "u1",
+                "put_url": f"{self.hub.r2_base}/final/abc.webp",  # type: ignore[attr-defined]
+                "put_headers": {"x-amz-checksum-sha256": "AAA="},
+            })
+        if self.hub.poison_after_response:
+            # Answer normally (no `Connection: close`, so the client pools the
+            # socket) and then hang up: the socket is dead before its next use.
+            self.close_connection = True
+
+
+class _R2Handler(BaseHTTPRequestHandler):
+    """The data plane. A separate server so its connections are counted apart."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    def do_PUT(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("ETag", '"deadbeef"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def _serve(handler: Any) -> Tuple[_CountingServer, str]:
+    httpd = _CountingServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+@pytest.fixture()
+def stack(tmp_path):
+    """A hub and an R2, both counting connections, plus a file to save."""
+    reset_control_plane_sessions()
+    hub, hub_base = _serve(_HubHandler)
+    r2, r2_base = _serve(_R2Handler)
+    hub.r2_base = r2_base  # type: ignore[attr-defined]
+    src = tmp_path / "out.webp"
+    src.write_bytes(b"x" * 4096)
+
+    def save() -> Any:
+        return presigned_upload_file(
+            file_path=str(src),
+            base_url=hub_base,
+            endpoint_path="/api/v1/media/o/uploads",
+            headers={"Authorization": "Bearer t"},
+            create_payload={"ref": "out.webp", "sha256": "0" * 64},
+            blake3_hex="0" * 64,
+            size_bytes=4096,
+        )
+
+    try:
+        yield hub, r2, hub_base, save
+    finally:
+        reset_control_plane_sessions()
+        hub.shutdown()
+        r2.shutdown()
+
+
+def test_saves_share_one_hub_connection_and_never_share_the_r2_pool(stack) -> None:
+    """The whole point, and its guardrail, in one assertion pair.
+
+    RED before this change: a fresh `requests.Session()` per save made the hub
+    count 3 connections for 3 saves — one TCP+TLS handshake per image, 109-155
+    ms of the measured 589 ms `upload.create` on the tunnelled stack.
+    """
+    hub, r2, _base, save = stack
+    for _ in range(3):
+        assert save().dedup is False
+
+    assert hub.requests_seen.count("create") == 3
+    assert hub.requests_seen.count("complete") == 3
+    assert hub.connections == 1, (
+        f"control plane opened {hub.connections} connections for 3 saves — "
+        "the process-scoped session is not being reused"
+    )
+    assert r2.connections == 3, (
+        f"data plane opened {r2.connections} connections for 3 saves — the R2 "
+        "pool must stay SAVE-scoped (issue #13, SSLV3_ALERT_BAD_RECORD_MAC)"
+    )
+
+
+def test_a_dead_keepalive_socket_retries_once_instead_of_failing_the_save(stack) -> None:
+    """The failure mode reuse buys: the money path must survive it.
+
+    The hub reads the second save's create and hangs up without answering —
+    a pooled socket that passed urllib3's dropped-connection check and died
+    anyway (that check is check-then-use, not a guarantee). Without the
+    retry this raises `ArtifactTransferError(phase="create")` and the whole
+    generated image is thrown away after the GPU work is already paid for.
+    """
+    hub, _r2, _base, save = stack
+    assert save().dedup is False  # save 1 establishes the keepalive socket
+
+    hub.drop_create_requests = 1
+    assert save().dedup is False  # save 2 survives it
+
+    assert hub.requests_seen.count("create") == 3  # 1 + (dropped + retried)
+    assert hub.connections == 2  # the poisoned one, then the replacement
+
+
+def test_a_hub_that_hangs_up_after_answering_costs_one_reconnect_not_a_failure(stack) -> None:
+    """The realistic shape of staleness: the peer FINs an idle socket while
+    the pod denoises. Every save must still succeed.
+
+    Honest about what this proves: it passes WITHOUT the retry too, because
+    urllib3 selects on a pooled socket before reusing it and quietly replaces
+    a FINed one. That is why the retry above is scoped to the case urllib3
+    cannot see — the socket that dies after that check. This test is the
+    regression guard on the common case, not the RED one.
+    """
+    hub, _r2, _base, save = stack
+    hub.poison_after_response = True
+    for _ in range(3):
+        assert save().dedup is False
+    assert hub.requests_seen.count("create") == 3
+    assert hub.requests_seen.count("complete") == 3
+
+
+def test_a_fresh_session_does_not_invent_a_retry_create_never_had(stack) -> None:
+    """The retry is scoped to STALENESS, not to "the hub is down".
+
+    A session this call just built has no pooled socket, so a connection
+    failure on it is the hub — and create's pre-keepalive behaviour (raise,
+    no retry) is preserved exactly. Only the reused case retries.
+    """
+    hub, _r2, _base, save = stack
+    hub.drop_create_requests = 99  # every create dies unanswered
+
+    with pytest.raises(ArtifactTransferError) as first:
+        save()
+    assert first.value.phase == "create"
+    assert hub.requests_seen.count("create") == 1, "a fresh session must not retry"
+
+    with pytest.raises(ArtifactTransferError):
+        save()
+    assert hub.requests_seen.count("create") == 3, "a reused session retries exactly once"
+
+
+def test_the_keepalive_session_carries_sockets_only_never_server_state(stack) -> None:
+    """A process-scoped session that accumulated cookies would leak one
+    save's server state into the next request's identity. Auth is the
+    per-request header and nothing else persists."""
+    hub, _r2, _base, save = stack
+    hub.set_cookie = True
+    save()
+    save()
+    assert all(c is None for c in hub.cookie_headers), hub.cookie_headers
+
+
+def test_eviction_is_by_identity_so_a_sibling_replacement_survives() -> None:
+    """Two threads can fail on the same socket at once. Whoever evicts second
+    must not throw away the replacement the first one already installed —
+    that would make the next save pay a handshake for nothing."""
+    reset_control_plane_sessions()
+    try:
+        first, fresh = presigned_upload.control_plane_session("http://127.0.0.1:9/x")
+        assert fresh is True
+        again, fresh_again = presigned_upload.control_plane_session("http://127.0.0.1:9/y")
+        assert again is first and fresh_again is False
+
+        presigned_upload._evict_control_session("http://127.0.0.1:9/x", first)
+        replacement, _ = presigned_upload.control_plane_session("http://127.0.0.1:9/x")
+        assert replacement is not first
+
+        presigned_upload._evict_control_session("http://127.0.0.1:9/x", first)  # late, stale
+        still, _ = presigned_upload.control_plane_session("http://127.0.0.1:9/x")
+        assert still is replacement
+    finally:
+        reset_control_plane_sessions()
+
+
+def test_sessions_are_per_origin_so_one_dead_hub_does_not_evict_another() -> None:
+    reset_control_plane_sessions()
+    try:
+        a, _ = presigned_upload.control_plane_session("http://hub-a:3867/api")
+        b, _ = presigned_upload.control_plane_session("http://hub-b:3867/api")
+        assert a is not b
+        presigned_upload._evict_control_session("http://hub-a:3867/api", a)
+        assert presigned_upload.control_plane_session("http://hub-b:3867/api")[0] is b
+    finally:
+        reset_control_plane_sessions()
+
+
+def test_reuse_does_not_slow_the_second_save(stack) -> None:
+    """Sanity, not a benchmark: the reused-socket save must not be SLOWER
+    than the first. On a pod the difference is a real handshake; on loopback
+    it is microseconds, so this only catches a reuse path that accidentally
+    reconnects (or worse, serializes)."""
+    _hub, _r2, _base, save = stack
+    t0 = time.monotonic()
+    save()
+    first = time.monotonic() - t0
+    t1 = time.monotonic()
+    save()
+    second = time.monotonic() - t1
+    assert second <= first + 0.25


### PR DESCRIPTION
**Re-priced, not re-argued.** th#1795 §10 deferred the control-plane keepalive at *4-6% of a 2596 ms stage*. Candidate 1(i) then landed on the hub (`14e26055`, five object-store round trips deleted) and §11 measured the result on a real pod leg: hub server time fell to **292 of 1955 ms**, `/create`'s handler is **4.5 ms**, and the worker's own split reads `upload.create` **589 ms p50** (n=18). That leaves **~584 ms of pure control-plane network per save**, one fresh TCP+TLS handshake of it (109-155 ms through the tunnel) paid on every single image because the `requests.Session` died with the save. The deferral was priced against a denominator that no longer exists.

### What changed
- The hub control-plane session is **process-scoped per origin**, carrying **sockets only** — cookies refused, auth still a per-request header, urllib3 retries still off (this module owns retry classification).
- **The R2 data plane does not move.** Its per-save `PutPool` came from the `SSLV3_ALERT_BAD_RECORD_MAC` incident (issue #13) and is a safety property. The two scopes are now stated as a boundary in both module docstrings.
- **Honest failure handling for the socket reuse buys.** A control-plane POST that fails to CONNECT on a **reused** session evicts it *by identity* (a sibling thread's replacement survives) and retries once on a fresh one, and the save continues on that session so `/complete` doesn't pay a second handshake. A session the call just built does **not** retry — that error is the hub being down, and create had no retry before this.
- **Idempotency checked against the hub, not assumed.** Create writes no media row; a duplicate is an unfinished session the hub GCs, costing 1 of the request's `upload_media` `max_count` of 64 (`scheduler_dispatch.go:3003`) — which is what bounds it to one retry. `/complete` was already retried here, on the contract that a finalized session returns the same payload again (`media_presigned.go:796`); keepalive adds no new retry and no new assumption there, only session eviction so a retry can't replay a dead socket.

### Evidence (no pods — connection counts, in the accept loop of two real servers)
| test | on master |
|---|---|
| 3 saves ⇒ hub **1** connection, R2 **3** | **RED** (hub opened 3) |
| a socket that dies after urllib3's dropped-connection check ⇒ save survives | RED without the retry |
| a fresh session does not invent a retry create never had | RED without the scoping |
| eviction by identity / per-origin isolation / no cookie crosses a save | new |

`fast gates` locally: ruff (pinned 0.15.21) clean, mypy clean on both touched files, every lint guard OK, `assemble_changelog --check` OK.

### Owed number (th#1795 §7)
`upload.create` p50 on saves **2..N** of a pod's life, against the **589 ms** baseline. Expect ~430-470 ms *if* the tunnel holds the socket across a generation-long gap. If it does not move, that is the answer rather than a null result: create's remainder is then one tunnel round trip that only topology (candidate 6) can remove.

No release cut here — this rides the next batch.