### PR TITLE
pgw#1108: move the probe image's pin to 0.111.0 — the circle's five fixes are all in this wheel

### DIFF
--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -268,7 +268,12 @@ GET /api/v1/repos/tensorhub/micro-diffusion/checkpoints     # model_family stamp
 **ESTIMATE: < 1 min.** No commit to `inference-endpoints` is wanted — this is a
 proof artifact, not a fleet pin.
 
-> ⚠️ **Pin at 0.106.0 (current), never below it on THIS family.** Below
+> ⚠️ **Pin at 0.111.0 (current), never below it on THIS family.** Below
+> 0.111.0 the reuse circle cannot close: pgw#1141 (`0dbf68e5`) deletes the setup
+> warmup barrier that DISARMED every boot-adopted cell — measured twice,
+> identically, in POD PROOF #3 — and pgw#1132 (`8867baac`) arms the lifted
+> forward in the boot-key loop so a `lora_bucket`-bearing family can derive a key
+> at all. Below
 > 0.106.0 the boot-key derivation refuses outright: `models/structure_only`
 > imported `accelerate`, which this image deliberately does not ship, so no key
 > exists, no `/v1/worker/cells/resolve` is ever issued and the pod self-mints

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # wheel the fleet serves — which is the whole reason the gauntlet is a
     # usable probe. Floor facts still in force: pgw#1059's four-axis `ck1`
     # (0.97.0), so every cell minted from this pin is a live-scheme cell.
-    "gen-worker==0.106.0",
+    "gen-worker==0.111.0",
     "msgspec>=0.18",
     "safetensors>=0.4",
     "pillow",
@@ -28,7 +28,7 @@ dependencies = [
 # is that its image is small and its boot is short; a dependency it does not
 # use would cost both on every cycle.
 #
-# The pin is 0.106.0 BECAUSE of pgw#1123: on 0.97.0-0.105.0
+# The FLOOR is 0.106.0 BECAUSE of pgw#1123: on 0.97.0-0.105.0
 # `models/structure_only` imported `accelerate`, so on THIS image the boot-key
 # derivation refused, no `/v1/worker/cells/resolve` was ever issued, and the pod
 # self-minted forever — measured on pods `ykwoaiqub6ktt3` and `3o09rf9ehnc4ym`,
@@ -36,6 +36,12 @@ dependencies = [
 # meta-init (`gen_worker.models.meta_init`), which `pipeline.py` uses. Adding
 # `accelerate` here instead would have fixed this one image and left the SDK
 # defect in place for every other family, which is why it is NOT here.
+#
+# The pin is 0.111.0 because the reuse circle cannot close below it: pgw#1141
+# (`0dbf68e5`) deletes the warmup barrier that DISARMED every boot-adopted cell
+# on 0.106.0 (POD PROOF #3, twice, identically), and pgw#1132 (`8867baac`) arms
+# the lifted forward in the boot-key loop. Below 0.111.0 an adopting pod resolves,
+# materializes and then throws the cell away.
 
 [dependency-groups]
 local = [

--- a/examples/micro-diffusion/uv.lock
+++ b/examples/micro-diffusion/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.106.0"
+version = "0.111.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -350,9 +350,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/44/06a42492077d62db9d90052515d767b56762ecb8b39e21f6745a701320c3/gen_worker-0.106.0.tar.gz", hash = "sha256:b7a1d16c744c88fe0fdbb90f38a6fb377a9bfb980f16e73fdbb11c4a9967efce", size = 1932696, upload-time = "2026-08-11T17:05:52.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/d3/0514a30623a8fc1641d99557c9bb95270987834d28cfee0a501d91502782/gen_worker-0.111.0.tar.gz", hash = "sha256:1b19a64422208c1f60bc1172201bf568d23bbdcc7952425e6704be0161ddab45", size = 1987331, upload-time = "2026-08-11T22:14:34.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ab/ce2578a11d5c7fa1e4c545c32bde0c9d032535cb2ced0e5b8c5f606b13b4/gen_worker-0.106.0-py3-none-any.whl", hash = "sha256:bd1e4558cc00b1a0d060e7066f747144ef736b2b50413458606a18029262c6be", size = 2107003, upload-time = "2026-08-11T17:05:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/00/5ad052fec7feb93005553627119ac4497737eba45855a471a7e948f3bb2d/gen_worker-0.111.0-py3-none-any.whl", hash = "sha256:d9ce8a9a72bcb249a7bd354a1c806701694bf00207fde5d5633071360948f3c2", size = 2167554, upload-time = "2026-08-11T22:14:31.959Z" },
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ local = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gen-worker", specifier = "==0.106.0" },
+    { name = "gen-worker", specifier = "==0.111.0" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pillow" },
     { name = "safetensors", specifier = ">=0.4" },


### PR DESCRIPTION
Pin move only. `examples/micro-diffusion` was on `gen-worker==0.106.0`; the reuse-circle proof lane (attempt four) needs an image that resolves **0.111.0**, the first published wheel carrying all five circle fixes:

- pgw#1116 `3a775746` — a boot-adopt refusal names its own gate
- pgw#1122 `f71875a0` — receipt identity
- pgw#1124 `55ad6b7a` — trace-child placement
- pgw#1132 `8867baac` — the boot-key loop arms the LIFTED forward
- pgw#1141 `0dbf68e5` — serve-first adoption (warmup barrier deleted)

On 0.106.0 a boot-adopted cell is resolved, materialized, verified `cos=1.00000` on 3/3 axes and then **DISARMED** — POD PROOF #3, twice, identically. That is the thing this pin unblocks measuring.

`uv lock` resolves `gen_worker-0.111.0-py3-none-any.whl` `sha256:d9ce8a9a72bcb249a7bd354a1c806701694bf00207fde5d5633071360948f3c2`. No source change; the README's pin-floor box moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)