### PR TITLE
pgw#1149: the declared speed bar and the open mint blockers reach the hub

### DIFF
--- a/changelog.d/pgw1149.md
+++ b/changelog.d/pgw1149.md
@@ -1,0 +1,15 @@
+- **pgw#1149: a family's DECLARED compile-vs-eager speed bar and its open mint blockers now reach
+  the hub.** `Compile` gains `speed_metric` / `min_speedup` — the stage the bar is read off
+  (`stage_ms.<stage>`, never the round trip: th#1795) and the floor the compiled arm must clear —
+  declared beside `numerics_floor` because tensorhub's publish-time validation session (th#1811,
+  ie#664 §6) judges a release against the AUTHOR's bar and holds none of its own. Discovery emits
+  both, plus the OPEN blocker ids from `Compile.blockers` (pgw#1115), onto the manifest's `compile`
+  block, which is where th#1811's ingest already reads them. The bar is refused at declaration on
+  the hub's own rules (a round-trip metric by name, a bar below 1.0 as asking the platform to
+  certify a slowdown, and metric-without-floor or floor-without-metric because the pair IS the
+  declaration), is NOT a `contract_axes()` field — declaring or raising a bar never re-keys a cell
+  — and IS a `derive.OVERRIDE_FACTS` entry, so a declaration migration cannot drop it silently.
+  `export_contract.speed_bar()` is the one readable shape, beside `blocker_rows()`, for the
+  endpoint repo's torch-free lint. Until an endpoint declares a bar, nothing changes: an
+  undeclared bar is ABSENT from the manifest and the hub reports `bar_undeclared` by name rather
+  than defaulting to a number the platform picked.

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -46,7 +46,7 @@ import msgspec
 from .binding import BINDING_TYPES, Binding
 from .export_contract import (
     Arg, Dim, Fork, GraphClass, Input, MintBlocker, open_blockers,
-    validate_contract,
+    validate_contract, validate_speed_bar,
 )
 from .formula import RuntimeFormula
 from .slot import OBJECTIVES, TASKS, Slot
@@ -952,6 +952,19 @@ class Compile(msgspec.Struct, frozen=True):
     # conv-bearing UNet.
     numerics_floor: Optional[float] = None
     numerics_warn: Optional[float] = None
+    # pgw#1149 / th#1811 (ie#664 §6): this family's own compile-vs-eager SPEED
+    # bar — the stage it is read off and the minimum speedup the compiled arm
+    # must clear. Declared here, beside the numerics band, because the hub's
+    # publish-time validation session judges a release against the AUTHOR's bar
+    # and holds none of its own: "responsibility is the author's, verification
+    # is the platform's" is unbuildable if the platform supplies the number it
+    # verifies. Undeclared (the default) resolves `bar_undeclared` at publish —
+    # a named refusal, never a default number. A PAIR: see `validate_speed_bar`.
+    # Deliberately NOT a contract axis — declaring or raising a bar must not
+    # re-key a cell — but it IS a `derive.OVERRIDE_FACTS` entry, so a migration
+    # cannot drop it silently.
+    speed_metric: str = ""
+    min_speedup: Optional[float] = None
     # pgw#1115: DECLARED mint blockers. A family that may not mint yet says so
     # as DATA here — never as a thunk that raises, which the pgw#1107 fold onto
     # this decorator cannot carry (`compile=` takes a Compile, never a
@@ -1028,6 +1041,9 @@ class Compile(msgspec.Struct, frozen=True):
                 f"Compile.numerics_floor ({self.numerics_floor}) must not "
                 f"exceed numerics_warn ({self.numerics_warn}): the floor "
                 f"refuses, the warn only confesses")
+        metric, bar = validate_speed_bar(self.speed_metric, self.min_speedup)
+        force(self, "speed_metric", metric)
+        force(self, "min_speedup", bar)
         validate_contract(self)
 
     @property

--- a/src/gen_worker/api/derive.py
+++ b/src/gen_worker/api/derive.py
@@ -162,10 +162,17 @@ def _repr(value: Any) -> Any:
 
 #: Must-survive facts that are NOT part of ``contract_axes()`` (so a change
 #: does not re-key) but ARE hard-won measured decisions the migration must not
-#: drop: the numerics ADOPT band (pgw#812/#814). ``shape_strategy``,
-#: ``warm_changes_key`` and ``eager`` are already contract axes and covered by
-#: :func:`contract_delta`; these two are the gap.
-OVERRIDE_FACTS: Tuple[str, ...] = ("numerics_floor", "numerics_warn")
+#: drop: the numerics ADOPT band (pgw#812/#814) and the compile-vs-eager SPEED
+#: bar the hub's publish-time validation gate judges against (pgw#1149 /
+#: th#1811). ``shape_strategy``, ``warm_changes_key`` and ``eager`` are already
+#: contract axes and covered by :func:`contract_delta`; these four are the gap.
+#:
+#: The speed pair is here for the same reason the floor is: dropping it loosens
+#: a gate without re-keying anything, so :func:`contract_delta` alone waves it
+#: through — and a release that arrives at the hub with no bar is not refused,
+#: it is judged `bar_undeclared` and simply stops being promotable.
+OVERRIDE_FACTS: Tuple[str, ...] = (
+    "numerics_floor", "numerics_warn", "speed_metric", "min_speedup")
 
 
 def override_delta(standing: Compile, migrated: Compile) -> Dict[str, Tuple[Any, Any]]:

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -258,6 +258,67 @@ def blocker_refusal(family: str, blockers: Sequence[MintBlocker]) -> str:
         f"what settled it (pgw#1115).")
 
 
+#: The stage vocabulary a speed bar may name (th#1795). A bar declared against
+#: `total_round_trip_ms` measures the network and the queue and calls it the
+#: model — that is the "10.9x" which corrected to 1.3x.
+SPEED_STAGE_PREFIX = "stage_ms."
+
+
+def validate_speed_bar(metric: str, min_speedup: Optional[float]) -> Tuple[str, Optional[float]]:
+    """Normalize + refuse the family's declared compile-vs-eager bar (pgw#1149).
+
+    Called from ``Compile.__post_init__`` so the refusal lands at endpoint
+    import. The rules are the hub's own (th#1811 `parseManifestCompileBlock`):
+    the metric names a STAGE, the bar is ``>= 1.0``, and the two are a PAIR —
+    the hub's ``Bar.Declared`` is ``metric != "" and min_speedup >= 1.0``, so
+    half a declaration is ``bar_undeclared`` with extra steps.
+    """
+    name = str(metric or "").strip()
+    if name:
+        if (name.lower() == "total_round_trip_ms"
+                or name.lower().endswith(".total_round_trip_ms")):
+            raise DeclarationError(
+                f"Compile.speed_metric {name!r} is the round trip, not a "
+                f"stage — declare {SPEED_STAGE_PREFIX}<stage> (th#1795)")
+        if not name.startswith(SPEED_STAGE_PREFIX) or name == SPEED_STAGE_PREFIX:
+            raise DeclarationError(
+                f"Compile.speed_metric {name!r} must name a worker stage as "
+                f"{SPEED_STAGE_PREFIX}<stage> — the compute stage the family "
+                f"reads, never the round trip (th#1795)")
+    bar: Optional[float] = None
+    if min_speedup is not None:
+        bar = float(min_speedup)
+        if bar != bar or bar in (float("inf"), float("-inf")) or bar < 1.0:
+            raise DeclarationError(
+                f"Compile.min_speedup must be a finite value >= 1.0 (a bar "
+                f"below 1.0 asks the platform to certify a slowdown), got "
+                f"{min_speedup!r}")
+    if bool(name) != (bar is not None):
+        raise DeclarationError(
+            f"Compile.speed_metric and min_speedup: a bar is a PAIR "
+            f"(got metric={name!r}, min_speedup={min_speedup!r}). A stage with "
+            f"no floor judges nothing and a floor with no stage names nothing; "
+            f"the publish-time validation session reads both or neither "
+            f"(th#1811 `bar_undeclared`)")
+    return name, bar
+
+
+def speed_bar(decl: Any) -> Optional[Dict[str, Any]]:
+    """The declaration's speed bar as a JSON-able row, or ``None`` when the
+    family declares none (pgw#1149).
+
+    The counterpart of :func:`blocker_rows`: ONE readable shape, so the endpoint
+    repo's torch-free ``scripts/lint_author_ci.py`` reads the author's bar off
+    the declaration the hub reads instead of re-deriving it from a second file.
+    """
+    metric = str(getattr(decl, "speed_metric", "") or "").strip()
+    bar = getattr(decl, "min_speedup", None)
+    if not metric or bar is None:
+        return None
+    return {"family": str(getattr(decl, "family", "") or ""),
+            "metric": metric, "min_speedup": float(bar)}
+
+
 def _identifier(kind: str, name: Any) -> str:
     text = str(name or "").strip()
     if not text or not text.replace(".", "_").isidentifier():
@@ -1216,6 +1277,7 @@ __all__ = [
     "Input",
     "MintBlocker",
     "SHAPE_STRATEGIES",
+    "SPEED_STAGE_PREFIX",
     "STATIC_ROWS",
     "FORK_REASONS",
     "WEAK_FORK_REASONS",
@@ -1232,7 +1294,9 @@ __all__ = [
     "register_export_declaration",
     "registered_export_families",
     "reset_export_declarations",
+    "speed_bar",
     "validate_contract",
+    "validate_speed_bar",
     "weak_arms",
     "weak_arms_by_family",
 ]

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -889,6 +889,24 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             # SDK v2: declared at the decorator (`@endpoint(lora_bucket=)`).
             if es.lora_bucket:
                 fn["compile"]["lora_bucket"] = int(es.lora_bucket)
+            # pgw#1149 / th#1811 (ie#664 §6): the AUTHOR's declared bar and
+            # refusals, so the hub's publish-time validation session judges a
+            # release against a DECLARATION instead of a number the platform
+            # picked. Absent when undeclared — the hub reports `bar_undeclared`
+            # by name, and a default emitted here would make the SDK the author
+            # of the bar the platform verifies.
+            if es.compile.speed_metric:
+                fn["compile"]["speed_metric"] = es.compile.speed_metric
+            if es.compile.min_speedup is not None:
+                fn["compile"]["min_speedup"] = float(es.compile.min_speedup)
+            # OPEN blockers only (pgw#1115): the hub reads a non-empty list as
+            # "the author refuses to mint" and marks the mint check
+            # blocked-by-declaration, so a RESOLVED id would park the family in
+            # that state forever. Ids, not prose — open-vs-resolved is the
+            # whole of what the hub decides on.
+            open_ids = [b.id for b in es.compile.open_blockers]
+            if open_ids:
+                fn["compile"]["blockers"] = open_ids
         out.append(fn)
 
     return out

--- a/tests/test_declared_speed_bar_pgw1149.py
+++ b/tests/test_declared_speed_bar_pgw1149.py
@@ -1,0 +1,239 @@
+"""pgw#1149 — the family's DECLARED compile-vs-eager bar reaches the hub.
+
+th#1811 built the publish-time validation session and the promotability gate:
+at initial publish the hub boots one pod, drives real inferences compiled and
+eager, and judges the steady-state medians *against the family's own declared
+bar*. Its hub-side ingest for `compile.speed_metric` / `min_speedup` /
+`blockers` landed with it — and **discovery emitted none of them**, so every
+compile-declaring release resolved `bar_undeclared` and enforcement had to ship
+defaulted to observe.
+
+The bar therefore lives on the DECLARATION (`Compile`), beside `numerics_floor`
+whose precedent it copies field for field — not in the endpoint repo's
+`author-ci.toml`, which the wheel cannot see at discovery and which would be a
+second file feeding the manifest (the drift pgw#1107 spent a campaign deleting).
+
+What this file pins:
+
+1. the bar is validated where it is DECLARED, with the hub's own rules — a
+   stage name never the round trip, `>= 1.0`, and metric+bar as a PAIR
+   (the hub's `Bar.Declared` is `metric != "" && min_speedup >= 1.0`);
+2. it is NOT a contract axis — declaring or raising a bar must never re-key a
+   cell — but it IS an OVERRIDE_FACT, so a migration cannot silently drop it;
+3. discovery emits all three onto `fn["compile"]`, blockers as the OPEN ids
+   only: the hub reads `len(blockers) > 0` as "the author refuses to mint", so
+   a resolved id would park the family in `blocked-by-declaration` forever;
+4. one readable shape (`speed_bar`) beside `blocker_rows`, so the endpoint
+   repo's torch-free lint reads the bar from the SDK and never re-implements it.
+
+Cardless: no GPU, no pod, no mint, no weights.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import Compile
+from gen_worker.api.derive import (
+    OVERRIDE_FACTS, contract_delta, override_delta,
+)
+from gen_worker.api.export_contract import DeclarationError, speed_bar
+
+BAR = {"speed_metric": "stage_ms.denoise", "min_speedup": 1.10}
+
+
+@pytest.fixture()
+def tmp_pkg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return tmp_path
+
+
+def _write(pkg: Path, main_src: str) -> None:
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent(main_src))
+
+
+def _compile_block(tmp_pkg: Path, name: str, decl_src: str) -> Dict[str, Any]:
+    """The `compile` block discovery emits for a one-function endpoint whose
+    `@endpoint(compile=)` is ``decl_src``. Real discovery, no fixture manifest."""
+    from gen_worker.discovery.discover import discover_functions
+
+    _write(tmp_pkg / name, f"""
+        import msgspec
+        from gen_worker import (
+            Compile, Dim, GraphClass, Input, MintBlocker, RequestContext,
+            endpoint,
+        )
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(compile={decl_src})
+        class Gen:
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="x")
+    """)
+    fns = {f["name"]: f
+           for f in discover_functions(tmp_pkg, main_module=f"{name}.main")}
+    return dict(fns["generate"]["compile"])
+
+
+# ---------------------------------------------------------------------------
+# 1. the bar is declared, and validated where it is declared
+# ---------------------------------------------------------------------------
+
+def test_a_declaration_carries_the_family_s_own_bar() -> None:
+    decl = Compile(family="probe", shapes=((1024, 1024),), **BAR)
+    assert decl.speed_metric == "stage_ms.denoise"
+    assert decl.min_speedup == pytest.approx(1.10)
+
+
+def test_a_bar_below_1_0_is_refused_at_DECLARATION_time() -> None:
+    # The hub refuses it at publish as "asking the platform to certify a
+    # slowdown"; refusing it here means no such manifest is ever built.
+    with pytest.raises(ValueError, match="certify a slowdown"):
+        Compile(family="probe", shapes=((1024, 1024),),
+                speed_metric="stage_ms.denoise", min_speedup=0.9)
+
+
+@pytest.mark.parametrize("metric", [
+    "total_round_trip_ms", "stage_ms.total_round_trip_ms"])
+def test_the_round_trip_is_refused_BY_NAME(metric: str) -> None:
+    # th#1795: a bar declared against the round trip measures the network and
+    # the queue and calls it the model — the "10.9x" that corrected to 1.3x.
+    with pytest.raises(ValueError, match="round trip"):
+        Compile(family="probe", shapes=((1024, 1024),),
+                speed_metric=metric, min_speedup=1.1)
+
+
+def test_a_metric_that_names_no_stage_is_refused() -> None:
+    with pytest.raises(ValueError, match="stage_ms"):
+        Compile(family="probe", shapes=((1024, 1024),),
+                speed_metric="denoise", min_speedup=1.1)
+
+
+@pytest.mark.parametrize("half", [
+    {"speed_metric": "stage_ms.denoise"}, {"min_speedup": 1.2}])
+def test_the_bar_is_a_PAIR_and_half_of_one_is_refused(half: Dict[str, Any]) -> None:
+    # The hub's `Bar.Declared` is `metric != "" && min_speedup >= 1.0`, so half
+    # a bar is `bar_undeclared` with extra steps: refuse it at the source.
+    with pytest.raises(ValueError, match="a bar is a PAIR"):
+        Compile(family="probe", shapes=((1024, 1024),), **half)
+
+
+# ---------------------------------------------------------------------------
+# 2. not a contract axis; IS a must-survive override fact
+# ---------------------------------------------------------------------------
+
+def test_declaring_a_bar_NEVER_re_keys_a_cell() -> None:
+    bare = Compile(family="probe", shapes=((1024, 1024),))
+    barred = Compile(family="probe", shapes=((1024, 1024),), **BAR)
+    assert contract_delta(bare, barred) == {}
+    assert "min_speedup" not in barred.contract_axes()
+    assert "speed_metric" not in barred.contract_axes()
+
+
+def test_a_migration_that_DROPS_the_declared_bar_is_caught() -> None:
+    # numerics_floor's precedent exactly: outside contract_axes(), so
+    # contract_delta alone would wave the loss through.
+    standing = Compile(family="probe", shapes=((1024, 1024),), **BAR)
+    migrated = Compile(family="probe", shapes=((1024, 1024),))
+    assert contract_delta(standing, migrated) == {}
+    assert override_delta(standing, migrated) == {
+        "speed_metric": ("stage_ms.denoise", ""),
+        "min_speedup": (1.10, None),
+    }
+    assert {"speed_metric", "min_speedup"} <= set(OVERRIDE_FACTS)
+
+
+def test_a_migration_that_LOWERS_the_declared_bar_is_caught() -> None:
+    standing = Compile(family="probe", shapes=((1024, 1024),), **BAR)
+    lowered = Compile(family="probe", shapes=((1024, 1024),),
+                      speed_metric="stage_ms.denoise", min_speedup=1.0)
+    assert override_delta(standing, lowered) == {"min_speedup": (1.10, 1.0)}
+
+
+# ---------------------------------------------------------------------------
+# 3. discovery EMITS it — the whole point of this issue
+# ---------------------------------------------------------------------------
+
+def test_the_manifest_carries_the_declared_bar(tmp_pkg: Path) -> None:
+    block = _compile_block(
+        tmp_pkg, "ep_bar",
+        'Compile(family="probe", shapes=((1024, 1024),), text_len=77, '
+        'speed_metric="stage_ms.denoise", min_speedup=1.10)')
+    assert block["speed_metric"] == "stage_ms.denoise"
+    assert block["min_speedup"] == pytest.approx(1.10)
+
+
+def test_an_undeclared_bar_is_ABSENT_never_defaulted(tmp_pkg: Path) -> None:
+    # The hub reports `bar_undeclared` by name. A default emitted here would
+    # make the SDK the author of the bar the platform verifies.
+    block = _compile_block(
+        tmp_pkg, "ep_nobar",
+        'Compile(family="probe", shapes=((1024, 1024),), text_len=77)')
+    assert "speed_metric" not in block
+    assert "min_speedup" not in block
+    assert "blockers" not in block
+
+
+#: `blockers=` is export-contract vocabulary (EXPORT_CONTRACT_FIELDS), so a
+#: declaration carrying one must name its graph classes like any other — the
+#: minimum shape that registers.
+_BLOCKED_DECL = (
+    'Compile(family="{family}", targets=("transformer",), text_len=128, '
+    'shapes=((64, 64),), shape_strategy="static-rows", warm_changes_key=False, '
+    'dims=(Dim("B", carried_by=(("hidden_states", 0),)),), '
+    'classes=(GraphClass(dims={{"B": 1}}),), '
+    'inputs=(Input("hidden_states", shape=("B", 4, 8, 8), dtype="model"),), '
+    'blockers=({blockers}))')
+
+_OPEN = ('MintBlocker(id="open-q", what="w", evidence="e", '
+         'resolves_when="r"),')
+_RESOLVED = ('MintBlocker(id="settled", what="w", evidence="e", '
+             'resolves_when="r", resolved=True, resolution="pgw#1149"),')
+
+
+def test_the_manifest_carries_the_OPEN_blockers_only(tmp_pkg: Path) -> None:
+    # The hub reads `len(blockers) > 0` as "the author refuses to mint" and
+    # marks the mint check blocked-by-declaration. A RESOLVED id emitted here
+    # would park the family in that state forever, so open-vs-resolved is the
+    # whole content of this field — the prose stays in the declaration.
+    block = _compile_block(tmp_pkg, "ep_blocked", _BLOCKED_DECL.format(
+        family="probe-blocked", blockers=_OPEN + _RESOLVED))
+    assert block["blockers"] == ["open-q"]
+
+
+def test_a_family_whose_blockers_are_ALL_resolved_emits_none(tmp_pkg: Path) -> None:
+    block = _compile_block(tmp_pkg, "ep_unblocked", _BLOCKED_DECL.format(
+        family="probe-unblocked", blockers=_RESOLVED))
+    assert "blockers" not in block
+
+
+# ---------------------------------------------------------------------------
+# 4. one readable shape, for the endpoint repo's torch-free lint
+# ---------------------------------------------------------------------------
+
+def test_speed_bar_is_the_one_readable_shape() -> None:
+    decl = Compile(family="probe", shapes=((1024, 1024),), **BAR)
+    assert speed_bar(decl) == {"family": "probe",
+                               "metric": "stage_ms.denoise",
+                               "min_speedup": 1.10}
+    assert speed_bar(Compile(family="probe", shapes=((1024, 1024),))) is None
+    # Reads any object carrying the attributes, like `blocker_rows` — the lint
+    # evaluates an AST-extracted declaration, not an imported endpoint.
+    assert speed_bar(None) is None
+
+
+def test_a_bar_that_is_not_a_bar_is_refused() -> None:
+    with pytest.raises((ValueError, TypeError, DeclarationError)):
+        Compile(family="probe", shapes=((1024, 1024),),
+                speed_metric="stage_ms.denoise", min_speedup=float("inf"))


### PR DESCRIPTION
**th#1811's owed SDK half — ie#664 §6's stated "concrete next step".**

tensorhub's publish-time validation session (`9700e894`) judges a release's SPEED against the family's DECLARED bar and honours declared BLOCKERS. Its ingest for `compile.speed_metric` / `min_speedup` / `blockers` landed with it. **Discovery emitted none of them**, so every compile-declaring release resolved `bar_undeclared`, the speed check refused by name, and `publish_validation.enforce` shipped defaulted to observe.

## The (a)/(b) decision

The bar lives on the **declaration**, not in `author-ci.toml`. ie#664 put `min_speedup` in the repo-side toml, which is not wheel-visible at discovery; a second file feeding the manifest is exactly the dual-declaration drift pgw#1107 deleted. `Compile.speed_metric` / `Compile.min_speedup` are one more author-declared fact beside `numerics_floor`, lint-readable, and they ride the manifest naturally.

## What landed

- `Compile.speed_metric` / `min_speedup`, validated in `__post_init__` via `export_contract.validate_speed_bar` with the hub's own rules: a stage name never the round trip (th#1795), `>= 1.0`, and the two as a PAIR (the hub's `Bar.Declared` is `metric != "" && min_speedup >= 1.0`).
- **Not** a `contract_axes()` field — declaring or raising a bar must never re-key a cell. **Is** a `derive.OVERRIDE_FACTS` entry, following `numerics_floor` exactly: a migration must not silently drop a declared bar.
- Discovery emits `speed_metric`, `min_speedup` and the **OPEN** blocker ids onto `fn["compile"]`. Open only: the hub reads a non-empty list as "the author refuses to mint", so a resolved id would park the family in `blocked-by-declaration` forever. Undeclared → absent, never defaulted.
- `export_contract.speed_bar()` — one readable shape beside `blocker_rows()`, for the endpoint repo's torch-free lint.

## RED evidence

With the discovery hunk and the two `OVERRIDE_FACTS` rows reverted, 4 of 16 cases fail and 12 stay green:

```
FAILED test_the_manifest_carries_the_declared_bar
FAILED test_the_manifest_carries_the_OPEN_blockers_only        KeyError: 'blockers'
FAILED test_a_migration_that_DROPS_the_declared_bar_is_caught
FAILED test_a_migration_that_LOWERS_the_declared_bar_is_caught
```

Adjacent suites green (`test_declared_blockers_pgw1115`, `test_aot_derive_pgw1107`, `test_objectives_pgw654`, `test_numerics_ladder`, `test_p5_discovery_lock` — 74 passed); mypy + ruff clean; every `fast gates` lint run locally.

## What this does NOT do

No endpoint declares a bar yet, so nothing changes on the fleet: an undeclared bar is absent and the hub still says `bar_undeclared`. Moving the bar out of `author-ci.toml` into the 13 declarations (and rewriting `scripts/lint_author_ci.py` to derive it) can only land with the fleet repin onto the wheel that carries these fields — filed as ie#664 §6's remaining half. No release here; this rides the next wheel (pgw#1140 ledger updated, naming th#1811 enforcement as the waiting consumer).