### PR TITLE
pgw#1150: ie#664's tier-2 author-CI checklist becomes ONE COMMAND

### DIFF
--- a/changelog.d/pgw1150.md
+++ b/changelog.d/pgw1150.md
@@ -1,0 +1,24 @@
+- **pgw#1150: ie#664's tier-2 author-CI checklist is ONE COMMAND —
+  `python -m gen_worker.author_ci`.** On a pod, in the endpoint's own image, it
+  asserts the fleet line first (`rigcheck`, exiting 90/91 in rigcheck's own
+  vocabulary), arms the endpoint through its real `setup()` (minting, or
+  adopting this machine's cell), takes the parity verdict from the EXISTING
+  mint-parent gate rather than a comparison of its own, measures steady-state
+  compiled-vs-eager in ONE process — compiled arm first, then pgw#1142's
+  eager-only order engaged through its in-process API, N>=5 per arm with the
+  first request of each discarded, median AND p95 read off `stage_ms.<stage>`
+  and never a round trip (th#1795) — and emits the `author-ci.toml` `[proof]`
+  block in exactly the schema `inference-endpoints/scripts/lint_author_ci.py`
+  validates. A family with open `Compile.blockers` reports
+  `blocked-by-declaration`, a legal state, and continues eager-only; a below-bar
+  speedup is recorded as `failed` with its evidence intact, never as a proof.
+  It MEASURES and never gates publish — promotion is the platform's own run on
+  trusted hardware (th#1811, ie#664 §6).
+- **pgw#1150: `Compile.numerics_floor` now actually reaches the gate.**
+  `numerics_ladder.declared_thresholds` has one caller
+  (`numerics_probe.probe_cell`) and its `cfg` is always a `registry.CompileCell`
+  — which carried no `numerics_floor` / `numerics_warn` field, so every gate on
+  every path scored against the SDK default and every `threshold_source` read
+  `sdk-default`, sdxl's declared 0.995/0.999 (pgw#812/#814) included. Both
+  fields are carried now, and deliberately stay out of `contract_facts()`: a
+  numerics band is not a graph axis and must never move a cell key.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -803,3 +803,33 @@ gen-worker prefetch                            # download weights, no GPU
 
 See [local-dev.md](local-dev.md) for the `field=value` payload grammar,
 `--offline`, exit codes, and SIGINT semantics.
+
+## Author CI: proving your compiled path is CORRECT and FASTER (pgw#1150)
+
+Declaring `compile=` claims two things about your own code — that the compiled
+output matches eager, and that it is faster. Both are the AUTHOR's claims to
+prove (DESIGN-RULINGS §4.32, ie#664), because every parity failure caught so far
+was an endpoint code or model config defect. One command, on a pod, in the
+endpoint's own image:
+
+```bash
+python -m gen_worker.author_ci --payload '{"prompt":"a cat"}'   # add --write
+```
+
+It asserts the fleet line first (exits **90** off the line, **91** when the host
+cannot run the wheel — `rigcheck`'s own numbers), arms through your real
+`setup()`, takes the parity verdict from the mint-parent gate, then measures
+steady-state compiled-vs-eager in ONE process: the compiled arm, then the same
+pipeline under pgw#1142's eager-only order. N>=5 per arm, first request of each
+discarded, median and p95 off `stage_ms.<stage>` — never a round trip
+(th#1795). It writes the `[proof]` block of `<endpoint>/author-ci.toml` and
+leaves your `[parity]` / `[speed]` declarations untouched; those are the bar it
+judges against, and `min_speedup` defaults to the fleet's 1.10.
+
+A family with open `Compile.blockers` reports `blocked-by-declaration` — a legal
+state — and runs eager-only. A below-bar speedup is recorded as `failed` with
+its evidence, never as a proof.
+
+**It measures; it never gates publish.** Promotion runs on trusted hardware, on
+the published code (th#1811). The standard and the record schema live in
+`inference-endpoints/AUTHOR-CI.md`.

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -144,6 +144,14 @@ LOCAL-ONLY tests/test_lora_lifted_pgw725.py|set gen_worker_aot_pack_tests=# (pac
 LOCAL-ONLY tests/test_chunk_cas_parallel_th1362.py|multi-gb throughput measurement; set chunk_cas_bench=#
 LOCAL-ONLY tests/test_aot_run_impl_split_pgw811.py|banked pgw#793 wrapper not present
 LOCAL-ONLY tests/test_topology_fuzz_pgw867.py|tensorhub checkout not present
+# pgw#1150. Four rows put the author-CI harness's emitted `author-ci.toml`
+# record through `inference-endpoints/scripts/lint_author_ci.py` ITSELF —
+# that script is the AUTHORITY on the record's schema and must never be
+# re-stated here, so where the sibling repo is absent (every CI runner) the
+# round trip cannot run. The schema half IS measured, in that repo's own
+# `lint_author_ci.py --selftest` (23 cases, red on 20), which its CI gates
+# on. Set AUTHOR_CI_LINT=<path to lint_author_ci.py> to run them anywhere.
+LOCAL-ONLY tests/test_author_ci_harness_pgw1150.py|inference-endpoints is not checked out beside this repo
 # pgw#978. The full local mint cycle: a real child spawn, a real torch.export +
 # AOTInductor compile, a real publish over the wire and a real second-process
 # adopt. It is opt-in EVERYWHERE, CI included — not because CI could run it and

--- a/src/gen_worker/author_ci.py
+++ b/src/gen_worker/author_ci.py
@@ -1,0 +1,752 @@
+"""``python -m gen_worker.author_ci`` — the AUTHOR's compile-vs-eager proof, in
+one command (ie#664 tier 2, DESIGN-RULINGS §4.32).
+
+An endpoint that declares ``compile=`` claims two things about its own code:
+that the compiled output is CORRECT and that it is FASTER. §4.32 makes both the
+AUTHOR's claims to prove, because every parity failure ever caught (a baked
+``conv_out.bias``, timestep dtype scars) was an endpoint code / model config
+defect that no consumer runtime can fix. ie#664 wrote that down as a two-tier
+standard: tier 1 is the torch-free lint in ``inference-endpoints``
+(``scripts/lint_author_ci.py``, every PR), and tier 2 is a pod runbook —
+``AUTHOR-CI.md``'s checklist, executed by hand. This module is that checklist as
+ONE COMMAND, run on a pod in the endpoint's own image::
+
+    python -m gen_worker.author_ci --payload '{"prompt": "a cat"}'
+
+**IT MEASURES; IT NEVER GATES PUBLISH.** The author's run is advisory and always
+will be: it is self-reported (unverifiable card, wheel, honesty). Promotion is
+the PLATFORM's, on trusted hardware, against the published code — th#1811's
+validation session and its promotability gate, per ie#664 §6. Nothing here
+returns a value anything downstream consults, and its exit code is a signal to
+the person who ran it.
+
+WHAT IT ASSEMBLES — every piece already ships; none of them were wired together:
+
+1. ``rigcheck.assert_fleet_line`` first (pgw#1114/#1120). A rig off the fleet's
+   torch/CUDA line has produced no evidence. Exits 90/91 in rigcheck's own
+   vocabulary, so a wrapper script reads one exit table and not two.
+2. The ARM — the endpoint's own ``setup()`` mints (or adopts this machine's
+   cell) through the production path. The parity verdict is the MINT-PARENT
+   GATE's (pgw#1141: ``adopt_delegated_mint`` -> ``arm_aot(verify_numerics=
+   True)`` -> ``provision.gate_cell_numerics``, strict), never a comparison
+   re-implemented here. A family with open ``Compile.blockers`` is a LEGAL
+   state — ``blocked-by-declaration`` — and the run continues eager-only.
+3. SPEED, steady-vs-steady, ONE process, compiled arm first. The eager arm is
+   pgw#1142's operator order engaged through its IN-PROCESS api
+   (``serve_posture.apply_command``) and released in a ``finally`` — never the
+   hub route, because the author's pod may have no hub. N >= 5 per arm with the
+   first request of each arm discarded, median AND p95, read off
+   ``stage_ms.<stage>`` and never a round trip (th#1795: the "10.9x" whose
+   corrected figure was 1.3x).
+4. The RECORD — the ``[proof]`` block of ``<endpoint>/author-ci.toml``, in
+   exactly the schema ``scripts/lint_author_ci.py`` validates. The harness owns
+   ``[proof]`` and nothing else: ``[parity]`` and ``[speed]`` are DECLARATIONS
+   the author made and this command judges itself against, so ``--write``
+   splices and never rewrites them.
+
+A below-bar speedup is recorded as a FAILURE (``status = "failed"``, evidence
+kept), never as a proof. A number that only ever reached a pod's stdout is a
+number we do not have.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import math
+import subprocess
+import sys
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from . import rigcheck, serve_posture, stage_timing
+from .api.export_contract import blocker_refusal, open_blockers
+from .discovery.project import load_project_config
+
+#: Exit codes. 90/91 are rigcheck's, deliberately unchanged: an author who
+#: wraps this command must not have to learn a second table for the same
+#: preflight (0 on the line, 90 off it, 91 when the host cannot run it).
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+EXIT_RIG_OFF_LINE = 90
+EXIT_HOST_UNUSABLE = 91
+
+#: ie#664's fleet default, with its stated rationale: 1.0 ("not slower") is
+#: unfalsifiable on a rented pod because denoise variance sits in the low
+#: single digits, so a bar there is met by noise. A family raises it once it
+#: has a proof to raise it to.
+FLEET_MIN_SPEEDUP = 1.10
+
+#: The standing measurement bar (AUTHOR-CI.md, and `lint_author_ci.py` refuses
+#: a record below it): N >= 5 per arm, steady state, first request discarded.
+MIN_SAMPLES = 5
+
+#: `stage_ms.<stage>` is the only shape a metric may take here. `slot_held_ms`
+#: and `total_round_trip_ms` are hub-side round-trip terms that do not exist in
+#: this process at all, and the second is the one th#1795 named.
+METRIC_PREFIX = "stage_ms."
+
+ARM_MINTED = "minted"
+ARM_ADOPTED = "adopted"
+ARM_BLOCKED = "blocked-by-declaration"
+ARM_EAGER = "eager"
+
+#: `[proof] status` — `lint_author_ci.py`'s closed vocabulary. `failed` is a
+#: FINISHED measurement that did not pass; the lint refuses it (CI stays red)
+#: and keeps the evidence, which is the difference between a failure and the
+#: `never-run` gap it must never be relabelled as.
+STATUS_PROVEN = "proven"
+STATUS_FAILED = "failed"
+STATUS_NEVER_RUN = "never-run"
+
+ARM_COMPILED = "compiled"
+ARM_EAGER_ARM = "eager"
+
+
+class HarnessError(Exception):
+    """A usage / declaration problem, reported to the author by name."""
+
+
+# ---------------------------------------------------------------------------
+# the declared bar
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Bar:
+    """The speed bar this run is judged against, and where it came from."""
+
+    metric: str
+    min_speedup: float
+    source: str
+
+    @property
+    def stage(self) -> str:
+        return self.metric[len(METRIC_PREFIX):]
+
+
+def resolve_bar(declaration: Any, record: Dict[str, Any]) -> Bar:
+    """The DECLARATION first, then the record, then the fleet default.
+
+    pgw#1149 moves the bar onto ``Compile.speed_metric`` / ``min_speedup``
+    (the hub cannot read a repo-side toml at discovery). Those fields do not
+    exist yet, so they are read by ``getattr``: the day that lane lands this
+    resolver follows it with no edit here, and until then there is still only
+    one reader per source.
+    """
+    metric = str(getattr(declaration, "speed_metric", "") or "").strip()
+    declared_speedup = getattr(declaration, "min_speedup", None)
+    if metric and declared_speedup is not None:
+        return Bar(_metric(metric), float(declared_speedup), "declaration")
+
+    speed = record.get("speed")
+    speed = speed if isinstance(speed, dict) else {}
+    metric = str(speed.get("metric") or "").strip()
+    if not metric:
+        raise HarnessError(
+            "no speed metric is declared. `[speed] metric` in author-ci.toml "
+            "names the compute stage this family reads (`stage_ms.denoise`); "
+            "a harness may not guess it, and a bar chosen after seeing the "
+            "number is not a bar. See AUTHOR-CI.md")
+    raw = speed.get("min_speedup")
+    if raw is None:
+        return Bar(_metric(metric), FLEET_MIN_SPEEDUP, "fleet-default")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise HarnessError(f"[speed] min_speedup = {raw!r} is not a number")
+    if float(raw) < 1.0:
+        raise HarnessError(
+            f"[speed] min_speedup = {raw} is below 1.0 — a cell that is not "
+            f"faster than eager has no reason to exist")
+    return Bar(_metric(metric), float(raw), "author-ci.toml")
+
+
+def _metric(metric: str) -> str:
+    """Refuse a round-trip metric BY NAME (th#1795)."""
+    if not metric.startswith(METRIC_PREFIX) or not metric[len(METRIC_PREFIX):]:
+        raise HarnessError(
+            f"[speed] metric = {metric!r} is not readable here. This harness "
+            f"measures IN PROCESS, so the only thing it can honestly report "
+            f"is a compute stage: `{METRIC_PREFIX}<stage>`. A round trip "
+            f"(`total_round_trip_ms`) does not exist in this process and is "
+            f"the term th#1795 named — a sibling lane's '10.9x' corrected to "
+            f"1.3x when it was read off the stage instead")
+    return metric
+
+
+# ---------------------------------------------------------------------------
+# what one arm measured
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Leg:
+    """One arm's steady-state samples, in milliseconds, first ALREADY dropped."""
+
+    name: str
+    samples: Tuple[float, ...]
+    discarded: float
+
+    @property
+    def median(self) -> float:
+        rows = sorted(self.samples)
+        mid = len(rows) // 2
+        if len(rows) % 2:
+            return rows[mid]
+        return (rows[mid - 1] + rows[mid]) / 2.0
+
+    @property
+    def p95(self) -> float:
+        """Nearest-rank p95 — at N=5 that is the max, which is the point: the
+        tail a guard miss produces is exactly what a median hides."""
+        rows = sorted(self.samples)
+        rank = max(1, math.ceil(0.95 * len(rows)))
+        return rows[rank - 1]
+
+    def line(self) -> str:
+        return (f"{self.name:8} n={len(self.samples)} "
+                f"median={self.median:.1f}ms p95={self.p95:.1f}ms "
+                f"(discarded first: {self.discarded:.1f}ms)")
+
+
+@dataclass(frozen=True)
+class Parity:
+    """The MINT-PARENT gate's verdict, carried whole."""
+
+    passed: bool
+    cosine: Optional[float]
+    floor_source: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class Report:
+    """Everything the record and the human verdict are written from."""
+
+    family: str
+    arm: str
+    #: The short citation a `never-run` record's `blocker` carries — a blocker
+    #: id, or the issue that owns the gap. Prose belongs in `arm_detail`.
+    blocker: str
+    arm_detail: str
+    cell_key: str
+    bar: Bar
+    pod: str
+    sm: str
+    commit: str
+    date: str
+    parity: Optional[Parity] = None
+    compiled: Optional[Leg] = None
+    eager: Optional[Leg] = None
+
+    @property
+    def speedup(self) -> Optional[float]:
+        if self.compiled is None or self.eager is None:
+            return None
+        if self.compiled.median <= 0:
+            return None
+        return self.eager.median / self.compiled.median
+
+    @property
+    def status(self) -> str:
+        """`never-run` when no cell served, else proven/failed on the legs.
+
+        A blocked family and a family whose mint refused are the same record
+        state — nothing was measured against a compiled arm — and they differ
+        only in the blocker they cite.
+        """
+        if self.arm in (ARM_BLOCKED, ARM_EAGER):
+            return STATUS_NEVER_RUN
+        speedup = self.speedup
+        if self.parity is None or not self.parity.passed:
+            return STATUS_FAILED
+        if speedup is None or speedup < self.bar.min_speedup:
+            return STATUS_FAILED
+        return STATUS_PROVEN
+
+    # -- the record ---------------------------------------------------------
+
+    def proof_block(self) -> str:
+        """The ``[proof]`` table, in `lint_author_ci.py`'s exact schema."""
+        out = ["[proof]", f'status = "{self.status}"']
+        if self.status == STATUS_NEVER_RUN:
+            out.append(f'blocker = "{_toml_str(self.blocker)}"')
+            out.append(f'note = "{_toml_str(self._never_run_note())}"')
+            return "\n".join(out) + "\n"
+        assert self.compiled is not None and self.eager is not None
+        cosine = self.parity.cosine if self.parity else None
+        out += [
+            f'date = "{self.date}"',
+            f'commit = "{_toml_str(self.commit)}"',
+            f'pod = "{_toml_str(self.pod)}"',
+            f'sm = "{_toml_str(self.sm)}"',
+            f'cell = "{_toml_str(self.cell_key)}"',
+            f"n = {len(self.compiled.samples)}",
+            f"cosine = {cosine if cosine is not None else 0.0:.6f}",
+            f"eager_median_ms = {self.eager.median:.1f}",
+            f"compiled_median_ms = {self.compiled.median:.1f}",
+            f"eager_p95_ms = {self.eager.p95:.1f}",
+            f"compiled_p95_ms = {self.compiled.p95:.1f}",
+            f'note = "{_toml_str(self._proof_note())}"',
+        ]
+        return "\n".join(out) + "\n"
+
+    def _never_run_note(self) -> str:
+        return (f"python -m gen_worker.author_ci on {self.pod or 'this pod'} "
+                f"({self.sm or 'sm unknown'}): no compiled arm to compare — "
+                f"{self.arm}, {self.arm_detail}. The eager arm ran and proves "
+                f"nothing on its own, so no evidence is recorded here")
+
+    def _proof_note(self) -> str:
+        speedup = self.speedup or 0.0
+        head = (f"python -m gen_worker.author_ci, arm={self.arm}, "
+                f"bar={self.bar.min_speedup:g}x from {self.bar.source} on "
+                f"{self.bar.metric}, measured {speedup:.3f}x")
+        if self.status == STATUS_PROVEN:
+            return head
+        if self.parity is not None and not self.parity.passed:
+            return f"{head}. PARITY FAILED: {self.parity.detail}"
+        return (f"{head}. SPEED BELOW THE DECLARED BAR — fix the code or the "
+                f"declaration; do not lower the bar to fit the number")
+
+    # -- the human ----------------------------------------------------------
+
+    def human(self) -> str:
+        verdict = {
+            STATUS_PROVEN: "PROVEN",
+            STATUS_FAILED: "FAILED",
+            STATUS_NEVER_RUN: "NO PROOF",
+        }[self.status]
+        rows = [
+            f"author-ci: {self.family} — {verdict}",
+            f"  rig     {self.pod or '?'} / {self.sm or '?'} @ "
+            f"{self.commit or '?'}",
+            f"  mint    {self.arm}: {self.arm_detail}",
+        ]
+        if self.parity is not None:
+            cosine = ("?" if self.parity.cosine is None
+                      else f"{self.parity.cosine:.5f}")
+            rows.append(
+                f"  parity  {'HEALTHY' if self.parity.passed else 'REFUSED'} "
+                f"cos={cosine} floor={self.parity.floor_source} "
+                f"({self.parity.detail})")
+        if self.compiled is not None:
+            rows.append(f"  speed   {self.compiled.line()}")
+        if self.eager is not None:
+            rows.append(f"  speed   {self.eager.line()}")
+        speedup = self.speedup
+        if speedup is not None:
+            rows.append(
+                f"  speedup {speedup:.3f}x against a declared bar of "
+                f"{self.bar.min_speedup:g}x ({self.bar.source}, "
+                f"{self.bar.metric})")
+        rows.append(
+            "  NOTE    this run is ADVISORY. Publish promotion is the "
+            "platform's own run on trusted hardware (th#1811, ie#664 §6).")
+        return "\n".join(rows)
+
+
+def _toml_str(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', "'").replace("\n", " ")
+
+
+# ---------------------------------------------------------------------------
+# splicing the record — the harness owns [proof] and nothing else
+# ---------------------------------------------------------------------------
+
+def splice_proof(existing: str, block: str) -> str:
+    """Replace the ``[proof]`` table, keeping everything above it VERBATIM.
+
+    ``[parity]`` and ``[speed]`` are the author's declarations and the bar this
+    run was judged against; re-serializing them from a parse would silently
+    drop their comments and their stated reasons.
+    """
+    lines = existing.splitlines(keepends=True)
+    head: List[str] = []
+    for index, line in enumerate(lines):
+        if line.strip() == "[proof]":
+            trailing = [
+                row for row in lines[index + 1:]
+                if row.strip().startswith("[") and row.strip().endswith("]")
+            ]
+            if trailing:
+                raise HarnessError(
+                    f"author-ci.toml has table(s) after [proof] "
+                    f"({[t.strip() for t in trailing]}); this command replaces "
+                    f"[proof] in place and will not reorder an author's file. "
+                    f"Move [proof] last, or drop --write and paste the block")
+            return "".join(head) + block
+        head.append(line)
+    tail = "" if existing.endswith("\n") or not existing else "\n"
+    return existing + tail + "\n" + block
+
+
+# ---------------------------------------------------------------------------
+# the run
+# ---------------------------------------------------------------------------
+
+class _Subject:
+    """The endpoint under measurement: loaded once, invoked many times.
+
+    Everything here routes through ``cli.run`` — the same module loading,
+    function selection, model resolution, ``setup()`` and dispatch the local
+    worker uses. A harness with its own loader would be measuring a program
+    the author does not ship.
+    """
+
+    def __init__(self, args: argparse.Namespace, root: Path) -> None:
+        from .cli import run as run_mod
+
+        self._run = run_mod
+        self.root = root
+        self._args = args
+        self._loaded: Dict[str, Any] = {}
+        self._setup_done = False
+        self.selected: Any = None
+        self.instance: Any = None
+        self.raw_bytes = run_mod._read_payload_bytes(
+            inline=args.payload, path=args.payload_file)
+
+    def load(self) -> None:
+        run_mod = self._run
+        _root, module = run_mod.load_endpoint_module(
+            config_path=self._args.config_path, module=self._args.module)
+        self.selected = run_mod._select_function(
+            run_mod.discover_candidates(module),
+            cls_name=self._args.cls_name,
+            method_name=self._args.method_name,
+            default_name=getattr(module, "__name__", "").split(".", 1)[0])
+        if self._args.execution_lane:
+            self.selected.bindings = run_mod._apply_execution_lane_to_bindings(
+                self.selected.bindings, self._args.execution_lane)
+        self.raw_bytes = run_mod._apply_field_tokens(
+            self.raw_bytes, self._args.fields, self.selected.payload_type)
+        self.instance = run_mod.instantiate_class(self.selected.cls)
+
+    @property
+    def declaration(self) -> Any:
+        """The endpoint's ``Compile``, or None when it declares no compile."""
+        decl = getattr(type(self.instance), "__gen_worker_endpoint__", None)
+        return getattr(decl, "compile", None) if decl is not None else None
+
+    def invoke(self, stage: str) -> float:
+        """One request through the real dispatch; the stage's own ms.
+
+        ``setup()`` runs on the first invocation exactly as ``gen-worker run``
+        does it — which is also where the mint (or the adopt) happens, and it
+        is why the first request of the compiled arm is the discarded one.
+        """
+        run_mod = self._run
+        ctx = run_mod.build_local_context(
+            kind=self.selected.kind, allow_publish=False)
+        ctx._set_execution_lane(run_mod._local_executing_execution_lane(
+            self.selected.bindings, self._args.execution_lane,
+            self.selected.handles))
+        timer = getattr(ctx, "_stages", None)
+        started = time.monotonic()
+        if timer is not None:
+            timer.handler_open()
+        run_mod.dispatch_request(
+            selected=self.selected, instance=self.instance, ctx=ctx,
+            raw_bytes=self.raw_bytes, offline=bool(self._args.offline),
+            emit=run_mod._stderr_emitter,
+            write_event=lambda kind, value: None,
+            on_resolved=self._on_resolved,
+        )
+        if timer is not None:
+            timer.handler_close()
+        runtime_ms = int((time.monotonic() - started) * 1000)
+        stages = stage_timing.stage_ms_for_metrics(timer, runtime_ms)
+        if stage not in stages:
+            raise HarnessError(
+                f"the declared metric names stage {stage!r}, which this "
+                f"handler does not bracket. It recorded "
+                f"{sorted(k for k in stages if '.' not in k)!r} — declare one "
+                f"of those in [speed] metric, or bracket the compute stage "
+                f"with `with ctx.stage({stage!r}):` in the endpoint")
+        return float(stages[stage])
+
+    def _on_resolved(self, resolved: Dict[str, str]) -> None:
+        if self._setup_done:
+            return
+        self._setup_done = True
+        self._loaded = self._run.run_setup(
+            self.instance, resolved,
+            device=str(self._args.device or ""),
+            selected=self.selected, return_loaded=True) or {}
+
+    def armed_pipeline(self) -> Optional[Any]:
+        """The loaded slot currently serving a compiled cell, if any."""
+        from . import aot_serve
+
+        for obj in self._loaded.values():
+            if aot_serve.armed_targets(obj):
+                return obj
+        return None
+
+    def shutdown(self) -> None:
+        fn = getattr(self.instance, "shutdown", None)
+        if callable(fn):
+            try:
+                fn()
+            except Exception:  # noqa: BLE001 — teardown never decides a verdict
+                pass
+
+
+def measure_leg(subject: _Subject, name: str, stage: str, n: int) -> Leg:
+    """``n + 1`` requests; the first is DISCARDED and reported as discarded."""
+    first = subject.invoke(stage)
+    samples = tuple(subject.invoke(stage) for _ in range(n))
+    return Leg(name=name, samples=samples, discarded=first)
+
+
+def read_parity(subject: _Subject, declaration: Any,
+                minted: Optional[Any]) -> Parity:
+    """The mint-parent gate's verdict — read, or (on an ADOPT) taken.
+
+    A cell this process MINTED was already gated strictly on the way to
+    publication (pgw#1141), so its report (``minted``) is simply read back — an
+    armed cell that had failed that gate would not be armed. A cell that came
+    out of this machine's store was gated at ITS mint and adoption runs no
+    quality gate (§4.32 item 3), so there is no verdict to read and this run
+    takes one through the SAME function the mint uses. Never a comparison
+    re-implemented here.
+    """
+    from . import numerics_probe
+    from .models import provision
+
+    pipe = subject.armed_pipeline()
+    if pipe is None:
+        return Parity(False, None, "?", "nothing armed")
+    report = minted
+    if report is None:
+        passed = provision.gate_cell_numerics(pipe, declaration, strict=True)
+        report = numerics_probe.last_report()
+        detail = "taken by this run through the mint's own gate (adopted cell)"
+    else:
+        passed = True
+        detail = "the mint-parent gate's own verdict (pgw#1141)"
+    if report is None:
+        return Parity(False, None, "?",
+                      "the gate ran and produced no report — refusing to call "
+                      "an unmeasurable cell healthy (pgw#868)")
+    comparison = report.comparison()
+    return Parity(
+        passed=bool(passed),
+        cosine=None if comparison is None else float(comparison.cosine),
+        floor_source=report.threshold_source,
+        detail=f"{detail}; {report.context()[:400]}")
+
+
+def preflight(root: Path) -> Dict[str, Any]:
+    """``assert_fleet_line`` first, always. Raises rigcheck's own exceptions."""
+    return rigcheck.assert_fleet_line(
+        "author-ci", start=root, stream=sys.stderr)
+
+
+def _sm(env: Dict[str, Any]) -> str:
+    raw = str(env.get("sm") or "").strip()
+    return f"sm_{raw.replace('.', '')}" if raw else ""
+
+
+def _commit(root: Path, override: str) -> str:
+    if override:
+        return override
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=10.0, check=False)
+    except (OSError, subprocess.SubprocessError):
+        out = None
+    commit = (out.stdout.strip() if out is not None and out.returncode == 0
+              else "")
+    if not commit:
+        raise HarnessError(
+            "cannot read the endpoint commit under measurement (no git here?) "
+            "— pass --commit <sha>. A proof that cannot name WHICH code it "
+            "measured is not re-derivable and the record refuses it")
+    return commit
+
+
+def run(args: argparse.Namespace) -> Tuple[int, Report]:
+    """The whole checklist. Returns ``(exit code, report)``."""
+    # The fleet line is asserted before the endpoint's own code is imported,
+    # let alone loaded: a rig off the line has produced no evidence, so there
+    # is nothing to gain by getting further first.
+    root = (Path.cwd().resolve() if args.module
+            else load_project_config(args.config_path).root)
+    env = preflight(root)
+    subject = _Subject(args, root)
+    record_path = (Path(args.record) if args.record
+                   else subject.root / "author-ci.toml")
+    if not record_path.is_file():
+        raise HarnessError(
+            f"{record_path} does not exist. The DECLARATION half of the record "
+            f"— [parity] floor and [speed] metric/min_speedup — is the "
+            f"author's to write and is what this run is judged against; a "
+            f"harness that invented its own bar would be marking its own "
+            f"homework. Copy the schema from AUTHOR-CI.md")
+    record = tomllib.loads(record_path.read_text(encoding="utf-8"))
+
+    subject.load()
+    declaration = subject.declaration
+    if declaration is None:
+        raise HarnessError(
+            "this endpoint declares no `compile=`, so there is no compiled "
+            "arm to compare against eager and nothing for author CI to prove")
+    bar = resolve_bar(declaration, record)
+    n = max(MIN_SAMPLES, int(args.n))
+    # Asked BEFORE the legs: a pod hour spent producing a proof that cannot
+    # name the code it measured is a pod hour thrown away.
+    commit = _commit(subject.root, args.commit)
+
+    family = str(getattr(declaration, "family", "") or "")
+    blocked = open_blockers(declaration)
+    arm = ARM_EAGER
+    blocker = "ie#664"
+    arm_detail = "no compiled arm"
+    if blocked:
+        # §4.32 / ie#664 §6: a declared block is a LEGAL state, not a failure.
+        # Engaging the order makes the eager-only run STRUCTURAL rather than
+        # hopeful — nothing adopts, mints or arms behind our back.
+        arm = ARM_BLOCKED
+        blocker = ", ".join(b.id for b in blocked)
+        arm_detail = f"{len(blocked)} unresolved Compile.blockers: {blocker}"
+        serve_posture.apply_command(
+            True, actor="author-ci",
+            reason=f"{family} declares open mint blockers: {blocker}")
+        print(blocker_refusal(family, blocked), file=sys.stderr)
+
+    parity: Optional[Parity] = None
+    compiled: Optional[Leg] = None
+    eager: Optional[Leg] = None
+    cell_key = ""
+    try:
+        if arm == ARM_BLOCKED:
+            eager = measure_leg(subject, ARM_EAGER_ARM, bar.stage, n)
+        else:
+            from . import aot_serve, numerics_probe
+
+            # The compiled arm runs FIRST: its discarded request is the one
+            # that runs setup(), and setup() is where the mint happens.
+            # Identity, not presence: the gate's report is a process-wide
+            # record, and reading a PREVIOUS run's would attribute somebody
+            # else's cosine to this cell.
+            before = numerics_probe.last_report()
+            compiled = measure_leg(subject, ARM_COMPILED, bar.stage, n)
+            pipe = subject.armed_pipeline()
+            if pipe is None:
+                arm, compiled = ARM_EAGER, None
+                arm_detail = (
+                    "no cell armed on this pod, so there is nothing to "
+                    "compare — the reason is on the activity wire "
+                    "(self_mint_skipped / self_mint_abort)")
+            else:
+                cell_key = str(aot_serve.armed_metadata(pipe).get("cell_key")
+                               or "")
+                fresh = numerics_probe.last_report()
+                minted = fresh if fresh is not before else None
+                arm = ARM_MINTED if minted is not None else ARM_ADOPTED
+                arm_detail = f"cell {cell_key or '?'}"
+                parity = read_parity(subject, declaration, minted)
+            # pgw#1142 through its IN-PROCESS api: the author's pod may have
+            # no hub, and the order is what makes this the SAME process, the
+            # same weights and the same pipeline answer eager.
+            serve_posture.apply_command(
+                True, actor="author-ci",
+                reason="the eager arm of the §4.32 speed leg")
+            eager = measure_leg(subject, ARM_EAGER_ARM, bar.stage, n)
+    finally:
+        serve_posture.apply_command(
+            False, actor="author-ci", reason="the speed leg is finished")
+        subject.shutdown()
+
+    report = Report(
+        family=family, arm=arm, blocker=blocker, arm_detail=arm_detail,
+        cell_key=cell_key, bar=bar, pod=str(env.get("device") or ""),
+        sm=_sm(env), commit=commit,
+        date=datetime.datetime.now(datetime.timezone.utc).date().isoformat(),
+        parity=parity, compiled=compiled, eager=eager)
+
+    block = report.proof_block()
+    if args.write:
+        record_path.write_text(
+            splice_proof(record_path.read_text(encoding="utf-8"), block),
+            encoding="utf-8")
+        print(f"author-ci: wrote [proof] into {record_path}", file=sys.stderr)
+    else:
+        sys.stdout.write(block)
+    print(report.human(), file=sys.stderr)
+    return (EXIT_OK if report.status == STATUS_PROVEN else EXIT_FAILED), report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m gen_worker.author_ci",
+        description=(
+            "Run ie#664's tier-2 author-CI checklist on THIS pod, in the "
+            "endpoint's own image, and emit the author-ci.toml [proof] "
+            "record. Measures; never gates publish (ie#664 §6)."),
+    )
+    # The selection flags are `gen-worker run`'s, spelled identically: an
+    # author who can invoke their endpoint can measure it.
+    p.add_argument("--class", dest="cls_name", default=None,
+                   help="Class to invoke (inferred when only one exists).")
+    p.add_argument("--method", dest="method_name", default=None,
+                   help="Method to invoke (inferred when only one exists).")
+    p.add_argument("--payload", dest="payload", default=None,
+                   help="Inline JSON payload. One payload, both arms.")
+    p.add_argument("--payload-file", dest="payload_file", default=None,
+                   help="Read the JSON payload from this file.")
+    p.add_argument("--config", dest="config_path", default=None,
+                   help="Path to the endpoint's pyproject.toml.")
+    p.add_argument("--module", dest="module", default=None,
+                   help="Python module to import (overrides [tool.gen_worker]).")
+    p.add_argument("--offline", action="store_true",
+                   help="Use only the local CAS; never fetch weights.")
+    p.add_argument("--device", dest="device", default=None,
+                   help="Override the torch device (e.g. 'cuda:0').")
+    p.add_argument("--lane", dest="execution_lane", default="",
+                   help="Execution lane (th#913 dual-form), as `run` takes it.")
+    p.add_argument("--n", dest="n", type=int, default=MIN_SAMPLES,
+                   help=f"Steady-state requests per arm (>= {MIN_SAMPLES}). "
+                        f"One more is run per arm and discarded.")
+    p.add_argument("--record", dest="record", default=None,
+                   help="The author-ci.toml to judge against (default: the "
+                        "endpoint root's).")
+    p.add_argument("--commit", dest="commit", default="",
+                   help="The endpoint commit measured (default: git HEAD).")
+    p.add_argument("--write", action="store_true",
+                   help="Splice the [proof] block into the record in place. "
+                        "Default: print it on stdout.")
+    p.add_argument("fields", nargs="*", metavar="FIELD=VALUE",
+                   help="Payload args, exactly as `gen-worker run` takes them.")
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """0 proven, 1 measured-and-failed, 2 usage, 90/91 rigcheck's own."""
+    from .cli.run import _UsageError
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        code, _report = run(args)
+        return code
+    except rigcheck.CudaUnusable as exc:
+        print(str(exc), file=sys.stderr, flush=True)
+        return EXIT_HOST_UNUSABLE
+    except (rigcheck.FleetLineMismatch, rigcheck.FleetLineUnknown) as exc:
+        print(str(exc), file=sys.stderr, flush=True)
+        return EXIT_RIG_OFF_LINE
+    except (HarnessError, _UsageError, FileNotFoundError, ValueError) as exc:
+        print(f"author-ci: {exc}", file=sys.stderr, flush=True)
+        return EXIT_USAGE
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -860,6 +860,11 @@ def _load_injected_model(
             lora_bucket=int(getattr(decl, "lora_bucket", 0) or 0),
             guidance_scales=(),
             text_lens=(),
+            # pgw#1150: the declared band travels with the declaration here
+            # too, or a locally minted cell would be gated at the SDK default
+            # while the family declares its own.
+            numerics_floor=compile_cfg.numerics_floor,
+            numerics_warn=compile_cfg.numerics_warn,
         )
     if (
         arm_compile

--- a/src/gen_worker/numerics_probe.py
+++ b/src/gen_worker/numerics_probe.py
@@ -19,14 +19,17 @@ one recorded SEED — and every verdict carries the axis, the thresholds and
 their source with it, the way :class:`~gen_worker.aot_compile_pool.PoolWidth`
 carries its readings.
 
-**Placement: adopt time, deliberately.** A hub-delivered cell never re-enters
-mint, so the arm is the only point EVERY cell passes through, and it is the
-point that decides whether the artifact serves. Mint time is a cheaper early
-catch and worth having second — the mint child holds both forwards in one
-process and owns the device — which is why :func:`measure_axis` takes the two
-callables and a contract rather than a pipeline: the same measurement runs
-there with no new implementation. What must never exist is a mint-only gate,
-which cannot protect the adopting pod whose weights, lane and card differ.
+**Placement: MINT time, and nowhere else** (DESIGN-RULINGS §4.32, landed as
+pgw#1141). This module was written for adopt time and said so — *"what must
+never exist is a mint-only gate"* — and Paul overruled it: every failure it has
+ever caught (a baked ``conv_out.bias``, timestep dtype scars) was an AUTHOR
+defect in endpoint code or config, so re-measuring on every adopter taxes the
+whole fleet forever for one author's one-time mistake. The single caller is
+``provision.arm_aot(verify_numerics=True)``, set by ``adopt_delegated_mint`` on
+the pod that compiled the bytes, before they publish. Adoption materializes,
+arms and serves. That the measurement moved without a new implementation is the
+property :func:`measure_axis`'s signature was built for: it takes the two
+callables and a contract, never a pipeline.
 
 **Parity by construction.** The probe feed comes from
 :func:`gen_worker.aot_inputs.builder_for` — the mint's OWN input builder,
@@ -47,6 +50,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple
@@ -480,11 +484,34 @@ def probe_cell(
         verdicts.append(AxisVerdict(
             axis=axis, comparison=comparison,
             elapsed_ms=int((time.monotonic() - t0) * 1000)))
-    return CellNumerics(
+    report = CellNumerics(
         family=family, cell_key=str(meta.get("cell_key") or ""),
         thresholds=thresholds, threshold_source=source,
         verdicts=tuple(verdicts), axes_total=len(axes),
         elapsed_ms=int((time.monotonic() - started) * 1000))
+    with _LAST_LOCK:
+        global _LAST
+        _LAST = report
+    return report
+
+
+_LAST_LOCK = threading.Lock()
+_LAST: Optional[CellNumerics] = None
+
+
+def last_report() -> Optional[CellNumerics]:
+    """The most recent :func:`probe_cell` report in this process, or None.
+
+    The GATE (``provision.gate_cell_numerics``) answers yes/no and confesses
+    the numbers to the activity wire; a caller in the same process that needs
+    the NUMBER — pgw#1150's author-CI harness, which has to write the measured
+    cosine into an ``author-ci.toml`` ``[proof]`` block — would otherwise have
+    to re-run the probe and record a second measurement of a different moment,
+    or parse the number back out of an event string. Neither is the gate's own
+    verdict. Read-only: nothing here changes what the gate decides.
+    """
+    with _LAST_LOCK:
+        return _LAST
 
 
 __all__ = [
@@ -496,6 +523,7 @@ __all__ = [
     "axes_from_meta",
     "build_feed",
     "eager_view",
+    "last_report",
     "measure_axis",
     "probe_cell",
 ]

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -79,6 +79,16 @@ class CompileCell:
     # their own contracts (two checkpoints = two instances = two cells).
     guidance_scales: tuple
     text_lens: tuple = ()
+    # pgw#1150: the family's DECLARED numerics band, carried through to the
+    # gate. `numerics_ladder.declared_thresholds` has one caller
+    # (`numerics_probe.probe_cell`) and its `cfg` is always this object, so
+    # before these two fields existed `Compile(numerics_floor=…)` was read by
+    # nobody: every gate on every path scored against the SDK default and
+    # every `threshold_source` said `sdk-default`, sdxl's measured 0.995/0.999
+    # (pgw#812/#814) included. Deliberately NOT in `contract_facts()` below —
+    # a numerics band is not a graph axis and must never move a cell key.
+    numerics_floor: Optional[float] = None
+    numerics_warn: Optional[float] = None
 
     def contract_text_lens(self) -> tuple:
         if self.text_lens:
@@ -237,6 +247,8 @@ class EndpointSpec:
                 else warm_guidance_values(self.payload_axes)
             ),
             text_lens=self.text_lens,
+            numerics_floor=cfg.numerics_floor,
+            numerics_warn=cfg.numerics_warn,
         )
 
     @property

--- a/tests/harness/author_ci_endpoints_pgw1150.py
+++ b/tests/harness/author_ci_endpoints_pgw1150.py
@@ -1,0 +1,130 @@
+"""pgw#1150 harness endpoints: compile-declaring families with a real denoise
+stage, at CPU scale.
+
+The author-CI harness measures ``stage_ms.<stage>`` across two arms of ONE
+process, where the arms differ only in pgw#1142's serve posture. So the stage
+here reads that posture exactly the way ``aot_serve``'s wrapper does — an
+ordered-eager call runs the eager body — and the two sleep constants stand in
+for the compiled and eager forwards. No torch, no GPU, no weights, no mint:
+Paul's standing rule is that a compile runs on a pod, and what this file exists
+to exercise is the ORCHESTRATION.
+
+Three families, one property each:
+
+* ``Fast`` — a healthy family: the compiled arm is ~3x, comfortably over the
+  1.10 fleet bar. Its ``family`` is pgw#868's probe family so the real numerics
+  rig can arm a real cell under it.
+* ``Regressed`` — the compiled arm is SLOWER. A speedup below the declared bar
+  is a recorded FAILURE, never a proof, and this is the family that proves it.
+* ``Blocked`` — two unresolved ``Compile.blockers``. A declared block is a
+  LEGAL state (ie#664 §6): the run continues eager-only and the record stays
+  ``never-run`` citing the blocker ids.
+"""
+
+from __future__ import annotations
+
+import time
+
+import msgspec
+
+from gen_worker import (
+    Compile, Dim, GraphClass, Input, MintBlocker, RequestContext, endpoint,
+)
+from gen_worker import serve_posture
+
+#: The stage the records declare (`[speed] metric = "stage_ms.denoise"`).
+STAGE = "denoise"
+
+#: pgw#868's probe family and its declared band, so `test_numerics_gate_pgw868`
+#: can arm a REAL cell for this endpoint's declaration rather than a shape that
+#: only looks like one.
+PROBE_FAMILY = "pgw868-probe"
+FLOOR, WARN = 0.995, 0.999
+
+#: Sleeps, not measurements. Far enough apart that a 5-sample median cannot
+#: cross the bar on scheduler noise, and small enough that the whole file runs
+#: in about a second.
+FAST_COMPILED_S = 0.010
+FAST_EAGER_S = 0.030
+REGRESSED_COMPILED_S = 0.030
+REGRESSED_EAGER_S = 0.010
+
+#: Every call records whether the eager-only order stood when it ran, so a test
+#: can prove the compiled arm ran WITHOUT it and the eager arm WITH it.
+POSTURE_SEEN: list[bool] = []
+
+
+class GenIn(msgspec.Struct):
+    prompt: str = ""
+
+
+class GenOut(msgspec.Struct):
+    ok: bool = True
+
+
+def _denoise(ctx: RequestContext, compiled_s: float, eager_s: float) -> GenOut:
+    """One request, bracketed on the stage the record names.
+
+    Reading ``serve_posture.eager_only()`` here is not a test contrivance: it
+    is the same decision ``aot_serve``'s wrapper makes at the call (pgw#1142's
+    reversibility seam), which is the whole reason the eager arm can be the
+    same process, the same weights and the same pipeline.
+    """
+    ordered_eager = serve_posture.eager_only()
+    POSTURE_SEEN.append(ordered_eager)
+    with ctx.stage(STAGE):
+        time.sleep(eager_s if ordered_eager else compiled_s)
+    return GenOut()
+
+
+@endpoint(compile=Compile(
+    family=PROBE_FAMILY, targets=("denoiser",), shapes=((8, 8), (16, 16)),
+    text_len=0, numerics_floor=FLOOR, numerics_warn=WARN,
+))
+class Fast:
+    def fast_generate(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        return _denoise(ctx, FAST_COMPILED_S, FAST_EAGER_S)
+
+
+@endpoint(compile=Compile(
+    # The same probe family as `Fast`, so its parity leg is HEALTHY and the
+    # only thing this family fails is the SPEED bar. One variable per proof.
+    family=PROBE_FAMILY, targets=("denoiser",), shapes=((8, 8), (16, 16)),
+    text_len=0, numerics_floor=FLOOR, numerics_warn=WARN,
+))
+class Regressed:
+    def regressed_generate(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        return _denoise(ctx, REGRESSED_COMPILED_S, REGRESSED_EAGER_S)
+
+
+BLOCKER_IDS = ("OQ-1-pgw1150-unmeasured", "OQ-2-pgw1150-rank")
+
+BLOCKED_COMPILE = Compile(
+    family="pgw1150-blocked", targets=("denoiser",), shapes=((8, 8),), text_len=0,
+    # `blockers` IS export-contract vocabulary, so this declaration registers
+    # and the classes-and-family invariant applies to it.
+    dims=(Dim("B", carried_by=(("sample", 0),)),),
+    classes=(GraphClass(dims={"B": 1}),),
+    inputs=(Input("sample", shape=("B", 8, 8), dtype="model"),),
+    blockers=(
+        MintBlocker(
+            id=BLOCKER_IDS[0],
+            what="Whole-graph export has never been measured on this lane.",
+            evidence="harness fixture (pgw#1150).",
+            resolves_when="ONE mint-lane measurement at the largest class.",
+        ),
+        MintBlocker(
+            id=BLOCKER_IDS[1],
+            what="The audio timestep is rank-1 on one route and rank-2 on "
+                 "another, and the pytree input spec pins rank.",
+            evidence="harness fixture (pgw#1150).",
+            resolves_when="The endpoint normalizes rank at its boundary.",
+        ),
+    ),
+)
+
+
+@endpoint(compile=BLOCKED_COMPILE)
+class Blocked:
+    def blocked_generate(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        return _denoise(ctx, FAST_COMPILED_S, FAST_EAGER_S)

--- a/tests/test_author_ci_harness_pgw1150.py
+++ b/tests/test_author_ci_harness_pgw1150.py
@@ -1,0 +1,495 @@
+"""pgw#1150 — ie#664's tier-2 checklist as ONE COMMAND.
+
+ie#664 shipped the author-CI standard with its tier-2 leg as a RUNBOOK: a
+checklist a human executes by hand on a rented pod, which is why all 13
+`author-ci.toml` records read `blocker = "ie#664"`. Every primitive it
+assembles already shipped — `rigcheck.assert_fleet_line`, the mint-parent
+parity gate (pgw#1141), `numerics_probe`/`numerics_ladder`, pgw#1142's
+serve-posture eager arm, `stage_ms.*` — and none of them were wired together.
+
+WHAT IS REAL HERE: the endpoint load and function selection (`cli.run`'s own),
+the dispatch, `ctx.stage` -> `stage_ms` timing, the serve-posture order and its
+release, `Compile.blockers` read through `export_contract.open_blockers`, the
+parity gate (`provision.gate_cell_numerics` against pgw#868's real armed cell,
+real ladder, real declared floor), the record's TOML, and — where the sibling
+repo is checked out — `inference-endpoints/scripts/lint_author_ci.py` itself,
+imported and run against what this harness emitted.
+
+WHAT IS FAKED, and why: the COMPILE and the model load. Paul's standing rule
+(2026-08-10) is that no mint, compile or AOTI link runs on the shared dev box.
+So `run_setup` is stubbed to hand back pgw#868's armed probe pipeline — the
+same seam `test_two_run_reuse_pgw1096.py` fakes — and `assert_fleet_line` is
+stubbed in the rows that are not about the preflight (this box HAS a driver and
+no usable CUDA, so the real assertion refuses it, which two rows below assert
+rather than work around). "A real AOTI cell arms on a real card and is faster"
+is a claim only a pod can make; that is the first author's run, and it is owed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tomllib
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import author_ci, rigcheck, serve_posture
+from gen_worker.api.decorators import Compile
+
+import test_numerics_gate_pgw868 as rig  # noqa: E402
+from harness import author_ci_endpoints_pgw1150 as endpoints  # noqa: E402
+
+MODULE = "harness.author_ci_endpoints_pgw1150"
+REPO = Path(__file__).resolve().parents[1]
+
+declared = rig.declared
+
+#: A well-formed DECLARATION half — what tier 1 already refuses a compiling
+#: family for not having. The harness judges itself against it and owns only
+#: `[proof]`.
+RECORD = '''\
+# ie#664 — the AUTHOR's compile-vs-eager test story (DESIGN-RULINGS §4.32).
+[parity]
+floor = "declared"
+
+[speed]
+# Read the compute stage, never total_round_trip_ms (th#1795).
+metric = "stage_ms.denoise"
+min_speedup = 1.10
+
+[proof]
+status = "never-run"
+blocker = "ie#664"
+'''
+
+
+@pytest.fixture(autouse=True)
+def _clean_posture() -> Any:
+    """No row may leak an eager-only order into the next one."""
+    serve_posture.reset()
+    endpoints.POSTURE_SEEN.clear()
+    yield
+    serve_posture.reset()
+
+
+@pytest.fixture
+def on_the_line(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
+    """The preflight, answered. Not the subject of these rows — two others own
+    it — and this box genuinely cannot pass it."""
+    env = {"device": "NVIDIA L4", "sm": "8.9", "torch": "2.13.0+cu130"}
+    monkeypatch.setattr(
+        author_ci.rigcheck, "assert_fleet_line", lambda *a, **k: dict(env))
+    return env
+
+
+def record_file(tmp_path: Path, body: str = RECORD) -> Path:
+    path = tmp_path / "author-ci.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def invoke(record: Path, cls: str, *extra: str) -> Tuple[int, Any]:
+    argv = ["--module", MODULE, "--class", cls, "--payload", '{"prompt": "x"}',
+            "--record", str(record), "--commit", "deadbee", "--write",
+            *extra]
+    args = author_ci.build_parser().parse_args(argv)
+    return author_ci.run(args)
+
+
+def armed_cell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
+               cosine: float, *, verify_numerics: bool) -> Any:
+    """pgw#868's REAL arm, returned as the slot a stubbed `setup()` loads."""
+    packages = {rig.entry_name(h, w): rig.ProbePackage(cosine=cosine)
+                for h, w in rig.ROWS}
+    pipeline, _module, outcome = rig.arm(
+        tmp_path, monkeypatch, decl, packages,
+        verify_numerics=verify_numerics)
+    assert outcome.armed, f"the rig did not arm: {outcome.reason}"
+    monkeypatch.setattr(
+        author_ci._Subject, "_on_resolved",
+        lambda self, resolved: self._loaded.update({"pipeline": pipeline}))
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# 1. the preflight is rigcheck's, exit vocabulary included
+# ---------------------------------------------------------------------------
+
+def test_a_rig_off_the_fleet_line_exits_90_and_a_dead_host_exits_91(
+        tmp_path, monkeypatch):
+    """RED on master: there is no command to exit at all.
+
+    The numbers are rigcheck's own (`python -m gen_worker.rigcheck` exits 0/90/
+    91). An author who wraps this must not have to learn a second table for the
+    same preflight, and a wrapper that mapped both onto 1 would make "your card
+    cannot run this wheel" indistinguishable from "your cell is slow".
+    """
+    record = record_file(tmp_path)
+    base = ["--module", MODULE, "--class", "Fast", "--record", str(record)]
+
+    def refuse(exc: Exception) -> Any:
+        def _raise(*_a: Any, **_k: Any) -> Any:
+            raise exc
+        return _raise
+
+    monkeypatch.setattr(author_ci.rigcheck, "assert_fleet_line",
+                        refuse(rigcheck.FleetLineMismatch("off the line")))
+    assert author_ci.main(base) == author_ci.EXIT_RIG_OFF_LINE == 90
+
+    monkeypatch.setattr(author_ci.rigcheck, "assert_fleet_line",
+                        refuse(rigcheck.FleetLineUnknown("no authority")))
+    assert author_ci.main(base) == 90, "no authority is not permission to measure"
+
+    monkeypatch.setattr(author_ci.rigcheck, "assert_fleet_line",
+                        refuse(rigcheck.CudaUnusable("driver too old")))
+    assert author_ci.main(base) == author_ci.EXIT_HOST_UNUSABLE == 91
+
+
+def test_the_preflight_runs_before_the_endpoint_is_even_imported(
+        tmp_path, monkeypatch):
+    """A rig off the line has produced no evidence, so nothing else may run
+    first — not the load, not the record read, not the git call."""
+    order: List[str] = []
+    monkeypatch.setattr(
+        author_ci.rigcheck, "assert_fleet_line",
+        lambda *a, **k: (order.append("preflight"), {"sm": "8.9"})[1])
+    monkeypatch.setattr(
+        author_ci._Subject, "load",
+        lambda self: order.append("load") or (_ for _ in ()).throw(
+            author_ci.HarnessError("stop here")))
+    author_ci.main(["--module", MODULE, "--class", "Fast",
+                    "--record", str(record_file(tmp_path))])
+    assert order == ["preflight", "load"]
+
+
+# ---------------------------------------------------------------------------
+# 2. a declared block is a LEGAL state (ie#664 §6)
+# ---------------------------------------------------------------------------
+
+def test_a_blocked_family_records_never_run_and_continues_EAGER_ONLY(
+        tmp_path, on_the_line):
+    """`mint: blocked-by-declaration`, and the run does not stop.
+
+    A family with open `Compile.blockers` said WHY it may not mint; repeating
+    the sentence on a rented pod buys nothing. What it must not do is fail as
+    if something broke, or leave the record unable to name the reason.
+    """
+    record = record_file(tmp_path)
+    code, report = invoke(record, "Blocked")
+
+    assert report.arm == author_ci.ARM_BLOCKED
+    assert report.blocker == ", ".join(endpoints.BLOCKER_IDS)
+    assert report.status == author_ci.STATUS_NEVER_RUN
+    assert code == author_ci.EXIT_FAILED, "no proof was produced, and it says so"
+
+    # Eager-only was STRUCTURAL, not hopeful: every request ran under the
+    # order, so nothing could have adopted or minted behind the run's back.
+    assert endpoints.POSTURE_SEEN and all(endpoints.POSTURE_SEEN)
+    assert serve_posture.eager_only() is False, "the order outlived the run"
+
+    proof = tomllib.loads(record.read_text(encoding="utf-8"))["proof"]
+    assert proof["status"] == "never-run"
+    assert proof["blocker"] == ", ".join(endpoints.BLOCKER_IDS)
+    assert not (set(proof) & {"cosine", "eager_median_ms", "n"}), \
+        "a blocked family recorded evidence it does not have"
+
+
+# ---------------------------------------------------------------------------
+# 3. the eager arm is pgw#1142's order, engaged in-process and RELEASED
+# ---------------------------------------------------------------------------
+
+def test_the_compiled_arm_runs_first_then_the_order_engages_and_releases(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """The whole reason the two arms are comparable: ONE process, one set of
+    weights, one pipeline — the arms differ only by the order.
+
+    Engaged through `serve_posture.apply_command`, never the hub route: the
+    author's pod may have no hub at all.
+    """
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    record = record_file(tmp_path)
+    code, report = invoke(record, "Fast")
+
+    n = 5
+    assert len(endpoints.POSTURE_SEEN) == 2 * (n + 1), \
+        "each arm runs n+1 requests — the first is the discarded one"
+    assert endpoints.POSTURE_SEEN[:n + 1] == [False] * (n + 1), \
+        "the compiled arm ran under an eager-only order"
+    assert endpoints.POSTURE_SEEN[n + 1:] == [True] * (n + 1), \
+        "the eager arm ran compiled"
+    assert serve_posture.eager_only() is False
+    assert report.compiled is not None and report.eager is not None
+    assert len(report.compiled.samples) == n == len(report.eager.samples)
+    assert report.compiled.discarded > 0, "the discarded request is recorded"
+    assert code == author_ci.EXIT_OK and report.status == author_ci.STATUS_PROVEN
+
+
+def test_the_order_is_released_even_when_a_leg_raises(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """An abandoned eager-only order would silently un-compile the pod for
+    every later run in the same process."""
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    boom = RuntimeError("the handler died mid-arm")
+    calls: List[int] = []
+
+    def explode(subject: Any, name: str, stage: str, n: int) -> Any:
+        calls.append(1)
+        if len(calls) > 1:
+            raise boom
+        return author_ci.Leg(name=name, samples=(1.0,) * n, discarded=1.0)
+
+    monkeypatch.setattr(author_ci, "measure_leg", explode)
+    with pytest.raises(RuntimeError):
+        invoke(record_file(tmp_path), "Fast")
+    assert serve_posture.eager_only() is False
+
+
+# ---------------------------------------------------------------------------
+# 4. parity is the MINT-PARENT gate's verdict, at the family's DECLARED floor
+# ---------------------------------------------------------------------------
+
+def test_parity_uses_the_familys_own_declared_floor_and_refuses_below_it(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """cos=0.99 is above the SDK default (0.98) and below this family's
+    declared 0.995 — so the floor that decides IS the declaration's, or this
+    row cannot tell the two apart. That is the whole of ie#664's *"the bar is
+    the family's own numerics_floor, never a number typed into a harness"*.
+
+    The cell is armed WITHOUT the mint gate (an adopt), so the harness takes
+    the verdict through the gate itself — the same function, never a
+    comparison re-implemented here.
+    """
+    armed_cell(tmp_path, monkeypatch, declared, 0.99, verify_numerics=False)
+    record = record_file(tmp_path)
+    code, report = invoke(record, "Fast")
+
+    assert report.parity is not None
+    assert report.parity.passed is False
+    assert report.parity.cosine is not None and report.parity.cosine < 0.995
+    assert report.parity.floor_source == "declared", \
+        "the gate scored against the SDK default while the family declared one"
+    assert report.status == author_ci.STATUS_FAILED
+    assert code == author_ci.EXIT_FAILED
+    assert "PARITY FAILED" in record.read_text(encoding="utf-8")
+
+
+def test_a_healthy_cell_records_the_gates_own_cosine(
+        tmp_path, monkeypatch, declared, on_the_line):
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    record = record_file(tmp_path)
+    _code, report = invoke(record, "Fast")
+
+    assert report.parity is not None and report.parity.passed
+    proof = tomllib.loads(record.read_text(encoding="utf-8"))["proof"]
+    assert proof["cosine"] >= 0.999
+    assert proof["cell"] == "cell868", "the record names WHICH cell was measured"
+
+
+def test_the_declared_numerics_floor_reaches_the_gate_at_all(declared):
+    """RED on master, and it is why this issue has a prerequisite.
+
+    `numerics_ladder.declared_thresholds` has exactly ONE caller
+    (`numerics_probe.probe_cell`) and its `cfg` is always a `registry
+    .CompileCell` — which carried no `numerics_floor` field at all. So every
+    gate on every path scored against the SDK default, `threshold_source` said
+    `sdk-default` everywhere, and `Compile.numerics_floor` (pgw#812/#814,
+    sdxl's measured 0.995/0.999) was a declaration nothing read.
+    """
+    from gen_worker import numerics_ladder
+    from gen_worker.registry import extract_specs
+
+    spec = extract_specs(endpoints.Fast)[0]
+    cell = spec.compile_cell()
+    assert cell is not None
+
+    assert cell.numerics_floor == endpoints.FLOOR
+    assert cell.numerics_warn == endpoints.WARN
+    bar = numerics_ladder.declared_thresholds(cell)
+    assert bar.floor == endpoints.FLOOR
+    assert bar != numerics_ladder.DEFAULT_THRESHOLDS
+
+    # A numerics band is not a graph axis: declaring one must never move a
+    # cell key, or every family that states its floor re-mints the fleet.
+    assert "numerics_floor" not in cell.contract_facts()
+    assert "numerics_warn" not in cell.contract_facts()
+
+
+# ---------------------------------------------------------------------------
+# 5. the record — closed vocabulary, and a failure that reads as one
+# ---------------------------------------------------------------------------
+
+def test_a_below_bar_speedup_is_a_FAILURE_and_never_a_proof(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """The `Regressed` family's compiled arm is slower than eager.
+
+    The record keeps the evidence — a number that only reached a pod's stdout
+    is a number we do not have — and says `failed`, which `lint_author_ci.py`
+    refuses. What it must never do is round up to `proven`, and it must never
+    be relabelled `never-run`: that is a measured gap becoming an unmeasured
+    one.
+    """
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    record = record_file(tmp_path)
+    code, report = invoke(record, "Regressed")
+
+    assert report.speedup is not None and report.speedup < 1.10
+    assert report.status == author_ci.STATUS_FAILED
+    assert code == author_ci.EXIT_FAILED
+
+    proof = tomllib.loads(record.read_text(encoding="utf-8"))["proof"]
+    assert proof["status"] == "failed"
+    assert proof["n"] == 5 and proof["compiled_median_ms"] > 0
+    assert proof["eager_median_ms"] > 0 and proof["compiled_p95_ms"] > 0
+    assert "SPEED BELOW THE DECLARED BAR" in proof["note"]
+
+
+def test_a_round_trip_metric_is_refused_by_name(tmp_path, on_the_line):
+    """th#1795: a sibling lane's '10.9x' corrected to 1.3x when it was read
+    off the stage. This harness measures in-process, where a round trip does
+    not exist at all."""
+    for metric in ("total_round_trip_ms", "slot_held_ms", "denoise"):
+        record = record_file(tmp_path, RECORD.replace(
+            '"stage_ms.denoise"', f'"{metric}"'))
+        with pytest.raises(author_ci.HarnessError, match="th#1795"):
+            invoke(record, "Fast")
+
+
+def test_the_bar_comes_from_the_declaration_first_then_the_record(tmp_path):
+    """pgw#1149 moves the bar onto `Compile.speed_metric`/`min_speedup`. Those
+    fields do not exist yet, so the resolver reads them by name — the day that
+    lane lands, this follows it with no edit here and there is still exactly
+    one reader per source."""
+    record = tomllib.loads(RECORD)
+    plain = Compile(family="f", targets=("t",), shapes=((8, 8),), text_len=0)
+    bar = author_ci.resolve_bar(plain, record)
+    assert (bar.metric, bar.min_speedup, bar.source) == (
+        "stage_ms.denoise", 1.10, "author-ci.toml")
+
+    class _Future:
+        family = "f"
+        speed_metric = "stage_ms.transformer"
+        min_speedup = 1.5
+
+    ahead = author_ci.resolve_bar(_Future(), record)
+    assert (ahead.metric, ahead.min_speedup, ahead.source) == (
+        "stage_ms.transformer", 1.5, "declaration")
+
+    # No bar declared anywhere -> ie#664's fleet default, never a guessed
+    # stage: 1.0 is met by denoise noise, and a stage nobody named is not one.
+    del record["speed"]["min_speedup"]
+    assert author_ci.resolve_bar(plain, record).source == "fleet-default"
+    assert author_ci.resolve_bar(plain, record).min_speedup == 1.10
+    record["speed"]["metric"] = ""
+    with pytest.raises(author_ci.HarnessError, match="may not guess"):
+        author_ci.resolve_bar(plain, record)
+
+
+def test_a_metric_the_handler_does_not_bracket_names_what_it_did(
+        tmp_path, on_the_line):
+    record = record_file(tmp_path, RECORD.replace("denoise", "vae_decode"))
+    with pytest.raises(author_ci.HarnessError, match="does not bracket"):
+        invoke(record, "Fast")
+
+
+def test_the_write_keeps_the_authors_declarations_verbatim(tmp_path):
+    """`[parity]` and `[speed]` are the author's DECLARATIONS and the bar the
+    run was judged against. Re-serializing them from a parse would silently
+    drop their stated reasons, which is most of what tier 1 checks."""
+    spliced = author_ci.splice_proof(RECORD, '[proof]\nstatus = "proven"\n')
+    assert spliced.startswith(RECORD.split("[proof]")[0])
+    assert "# Read the compute stage, never total_round_trip_ms" in spliced
+    assert spliced.count("[proof]") == 1
+    assert 'blocker = "ie#664"' not in spliced
+
+    with pytest.raises(author_ci.HarnessError, match="after \\[proof\\]"):
+        author_ci.splice_proof(RECORD + "\n[extra]\nx = 1\n", "[proof]\n")
+
+    # A record with no [proof] table yet gains one rather than being refused.
+    head = RECORD.split("[proof]")[0]
+    assert author_ci.splice_proof(head, "[proof]\n").endswith("[proof]\n")
+
+
+def test_median_and_p95_are_both_reported_and_the_tail_is_not_hidden():
+    """A median alone hides the tail a guard miss produces (`lint_author_ci`
+    requires both). At n=5 the nearest-rank p95 IS the max, deliberately."""
+    leg = author_ci.Leg(name="compiled", samples=(10.0, 11.0, 12.0, 13.0, 90.0),
+                        discarded=400.0)
+    assert leg.median == 12.0
+    assert leg.p95 == 90.0
+    assert "discarded first: 400.0ms" in leg.line()
+
+
+# ---------------------------------------------------------------------------
+# 6. the round trip through the REAL lint — the schema is coordinated, not
+#    forked
+# ---------------------------------------------------------------------------
+
+def _lint() -> Any:
+    """`inference-endpoints/scripts/lint_author_ci.py`, imported for real."""
+    candidates = [os.environ.get("AUTHOR_CI_LINT", "")]
+    candidates += [str(base / "inference-endpoints" / "scripts"
+                       / "lint_author_ci.py")
+                   for base in (REPO.parent, REPO.parents[2], Path.home() / "cozy")
+                   if base is not None]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            spec = importlib.util.spec_from_file_location(
+                "lint_author_ci", candidate)
+            assert spec and spec.loader
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+    pytest.skip("inference-endpoints is not checked out beside this repo")
+
+
+def _through_the_lint(lint: Any, tmp_path: Path, record: Path) -> int:
+    """The emitted record, in the tree shape the real gate reads."""
+    root = lint._tree(tmp_path / "lint", record=record.read_text("utf-8"),
+                      extra=", numerics_floor=0.995")
+    return int(lint.check(root, quiet=True))
+
+
+def test_a_proven_record_passes_the_real_lint(
+        tmp_path, monkeypatch, declared, on_the_line):
+    lint = _lint()
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    record = record_file(tmp_path)
+    _code, report = invoke(record, "Fast")
+    assert report.status == author_ci.STATUS_PROVEN
+    assert _through_the_lint(lint, tmp_path, record) == 0, \
+        "the harness emitted a record its own repo's gate refuses"
+
+
+def test_a_never_run_record_passes_the_real_lint(tmp_path, on_the_line):
+    """A blocked family's record is a LEGAL one — the gap is countable, and
+    CI is green because nothing is claimed."""
+    lint = _lint()
+    record = record_file(tmp_path)
+    invoke(record, "Blocked")
+    assert _through_the_lint(lint, tmp_path, record) == 0
+
+
+def test_a_failed_record_is_REFUSED_by_the_real_lint(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """The point of recording a failure: it stays red until the code (or the
+    declaration) is fixed, and it cannot be skimmed as a proof."""
+    lint = _lint()
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    record = record_file(tmp_path)
+    _code, report = invoke(record, "Regressed")
+    assert report.status == author_ci.STATUS_FAILED
+    assert _through_the_lint(lint, tmp_path, record) == 1
+
+
+def test_the_harness_and_the_lint_agree_on_the_status_vocabulary():
+    """Two spellings of a closed vocabulary is how one of them quietly grows a
+    third word."""
+    lint = _lint()
+    assert set(lint.STATUSES) == {
+        author_ci.STATUS_PROVEN, author_ci.STATUS_FAILED,
+        author_ci.STATUS_NEVER_RUN}
+    assert lint.STATUS_PROVEN == author_ci.STATUS_PROVEN
+    assert lint.STATUS_NEVER_RUN == author_ci.STATUS_NEVER_RUN
+    assert lint.STATUS_FAILED == author_ci.STATUS_FAILED


### PR DESCRIPTION
**ie#664 §5's first open item.** Tier 2 of the author-CI standard is a RUNBOOK — a checklist a human executes by hand on a rented pod. Every primitive it assembles ships in 0.111.0 and none of them were wired together, which is why all 13 `author-ci.toml` records read `blocker = "ie#664"`.

## `python -m gen_worker.author_ci`

```bash
python -m gen_worker.author_ci --payload '{"prompt":"a cat"}' --write
```

1. **`rigcheck.assert_fleet_line` first**, exiting **90**/**91** in rigcheck's own vocabulary — one exit table for one preflight. (Verified live: this dev box exits 91, `driver 570.211.01 / torch CUDA 13.0`.)
2. **The arm** through the endpoint's real `setup()` — mint, or adopt this machine's cell. The parity verdict is the **mint-parent gate's** (pgw#1141), read back; on an ADOPT — where §4.32 deliberately runs no gate — the harness takes one through the SAME `provision.gate_cell_numerics`. Never a comparison re-implemented here.
3. **Speed in ONE process.** Compiled arm first, then pgw#1142's eager-only order engaged through its **in-process API** (`serve_posture.apply_command` — the author's pod may have no hub) and released in a `finally`. N>=5 per arm, first request of each **discarded**, median AND p95 off `stage_ms.<stage>`; a round-trip metric is refused **by name** (th#1795).
4. **The record**, in exactly the schema `lint_author_ci.py` validates. `--write` splices `[proof]` and leaves `[parity]`/`[speed]` byte-identical — those are the author's declarations and the bar the run is judged against.

A family with open `Compile.blockers` reports `blocked-by-declaration`, a **legal** state (ie#664 §6): the order is engaged *before* setup so eager-only is structural, and the record stays `never-run` citing the ids. A below-bar speedup is recorded as `failed` with its evidence intact — never as a proof, and never relabelled `never-run`.

**It measures; it never gates publish.** Promotion is the platform's own run on trusted hardware (th#1811, ie#664 §6).

## Prerequisite, and a real defect: `Compile.numerics_floor` reached NOBODY

`numerics_ladder.declared_thresholds` has exactly one caller (`numerics_probe.probe_cell`) whose `cfg` is always a `registry.CompileCell` — which carried **no `numerics_floor`/`numerics_warn` field at all**. So every gate on every path scored against the SDK default and every `threshold_source` read `sdk-default`, sdxl's declared 0.995/0.999 (pgw#812/#814) included. Both fields are carried now, and stay OUT of `contract_facts()`: a numerics band is not a graph axis and must never move a cell key.

Also `numerics_probe.last_report()` (so the gate's own numbers reach the record without a second measurement), and the module docstring's *"placement: adopt time… what must never exist is a mint-only gate"* corrected to what §4.32/pgw#1141 actually shipped.

## RED, proven by mutation

| mutation | rows that fail |
|---|---|
| `author_ci.py` absent | the whole file is uncollectable (`ImportError`) |
| `CompileCell` drops the two fields | 1 |
| the eager arm never engages the order | 3 |
| a below-bar run reads as `proven` | 2 |
| `open_blockers` ignored | 1 |

18 tests. Four put the **emitted** record through `inference-endpoints/scripts/lint_author_ci.py` **itself** (imported, never re-stated here) — classified `LOCAL-ONLY` in `scripts/skip_census.txt` because no CI runner has the sibling repo; the schema half is gated by that repo's own `--selftest`.

mypy clean (270 files), ruff clean, all ten fast-gate guards green, `test_numerics_gate_pgw868` / `pgw1141` / `pgw1142` / `pgw1096` / `pgw740` unaffected (91 rows).

No release cut — rides the next wheel (pgw#1140 ledger updated on merge). Companion PR in `inference-endpoints` turns AUTHOR-CI.md's tier-2 checklist into "run this" and adds `failed` to the lint's closed vocabulary.

Cross-refs: ie#664, DESIGN-RULINGS §4.31/§4.32, pgw#1141, pgw#1142, pgw#1114/#1120, pgw#868/#812/#814, pgw#1115, th#1795, th#1811, pgw#1149 (the bar's coming move onto the declaration — the resolver already reads it first).