### PR TITLE
pgw#1151: a declared range is a CONTRACT, not a strict dynamo constraint — H3's "inductor int32 guard" is ours, not the compiler's

### DIFF
--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2665,6 +2665,24 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
     extent outside the declared range is a typed :class:`DeclaredRangeExceeded`
     — the declaration is wrong and the endpoint must fix it — never a
     dynamo-internal error nobody can attribute.
+
+    pgw#1151: the declared range is enforced HERE and is not forwarded into
+    ``mark_dynamic``. Passing ``min=``/``max=`` makes dynamo build a
+    ``StrictMinMaxConstraint`` (``_dynamo/variables/builder.py``), and a
+    strict constraint turns any range NARROWING the compiler performs into a
+    ``ConstraintViolationError`` — a permanent eager degrade — even when the
+    narrowing carries no correctness content. Inductor's index-dtype choice is
+    exactly such a narrowing: ``can_use_32bit_indexing`` elects int32 from the
+    FIRST call's size hint and then installs ``check_leq(numel, INT32_MAX)``
+    (``_inductor/codegen/simd.py``), so on minimax-h3 the 5 s cold call
+    (38,015 rows x a 28,672 inner dim) pinned int32 and its guard,
+    ``sequence <= 74,898``, contradicted the declared max. Every width above
+    that took a hard refusal, which is why 11-15 s served 100% eager.
+    Marking without bounds yields a ``RelaxedUnspecConstraint`` instead: the
+    axis still may not specialize to a constant (the pgw#1082 failure this
+    function exists to prevent), but the compiler may split the range, so the
+    wide call simply RECOMPILES with int64 indexing. Two graphs, each
+    optimally indexed, no degrade.
     """
 
     import torch
@@ -2703,8 +2721,9 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
                 for dim in range(t.dim()):
                     if int(t.shape[dim]) != extent:
                         continue
-                    torch._dynamo.mark_dynamic(
-                        t, dim, min=int(d.min), max=int(d.max))
+                    # No min=/max=: see the docstring. The range is a CONTRACT
+                    # checked above, never a strict dynamo constraint.
+                    torch._dynamo.mark_dynamic(t, dim)
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/tests/test_declared_range_is_not_a_dynamo_constraint_pgw1151.py
+++ b/tests/test_declared_range_is_not_a_dynamo_constraint_pgw1151.py
@@ -71,8 +71,13 @@ def _args(seq: int):
 
 @pytest.fixture(autouse=True)
 def _isolated_dynamo():
+    # `graph_audit` reads the PROCESS-WIDE dynamo counters, which `reset()` does
+    # not clear — a worker that ran other files first carries their graphs in.
+    from torch._dynamo.utils import counters
+
     gc.collect()
     torch._dynamo.reset()
+    counters.clear()
     yield
     gc.collect()
     torch._dynamo.reset()

--- a/tests/test_declared_range_is_not_a_dynamo_constraint_pgw1151.py
+++ b/tests/test_declared_range_is_not_a_dynamo_constraint_pgw1151.py
@@ -1,0 +1,129 @@
+"""pgw#1151: a declared range is a CONTRACT, not a strict dynamo constraint.
+
+``_with_declared_marks`` used to forward the declaration into
+``mark_dynamic(t, dim, min=, max=)``. Dynamo turns explicit bounds into a
+``StrictMinMaxConstraint`` (``_dynamo/variables/builder.py``), and a strict
+constraint makes any range NARROWING the compiler performs a hard
+``ConstraintViolationError`` — which ``_guarded_regional`` can only answer by
+degrading the target to eager for the life of the pod.
+
+Compilers narrow ranges for reasons that carry no correctness content. The one
+that cost us a product: inductor elects int32 indexing from the FIRST call's
+size hint and then installs ``check_leq(numel, INT32_MAX)``
+(``_inductor/codegen/simd.py::can_use_32bit_indexing``). On minimax-h3 the
+DiT's largest planned buffer has a 28,672-element inner dim, so a cold 5 s
+request (38,015 packed rows) pinned int32 and its guard —
+``sequence <= 74,898`` — contradicted the declared max. Every width above that
+took the refusal, which is the whole reason 11-15 s clips served 100% eager.
+Nothing about wide sequences is uncompilable: with no strict upper bound
+inductor simply picks int64 for the wide graph.
+
+Marking without bounds yields a ``RelaxedUnspecConstraint`` instead: still no
+specialization to a constant (the pgw#1082 failure ``_with_declared_marks``
+exists to prevent), but the compiler may split the range and the wide call
+RECOMPILES. Both tests below are RED on the pre-pgw#1151 code.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+import torch
+
+from gen_worker import compile_cache as cc
+
+
+class _Dim:
+    def __init__(self, dim: str, mn: int, mx: int) -> None:
+        self.dim, self.min, self.max = dim, mn, mx
+
+
+# A compiler that narrows the marked axis, in miniature: the branch installs a
+# `sequence <= 1000` guard on the first (narrow) call, exactly the shape of
+# inductor's `28672*sequence <= 2**31-1`.
+_BLOCK_SRC = """
+class _Block(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(8, 8)
+
+    def forward(self, hidden, index, rotary):
+        cos, sin = rotary
+        out = self.lin(hidden)
+        if hidden.shape[1] <= 1000:
+            out = out * 2.0
+        scale = cos.index_select(0, index)
+        return out * (1.0 + scale) + sin.index_select(0, index)
+"""
+
+_NARROWING_BOUND = 1000
+_DECLARED_MAX = 4096
+
+
+def _args(seq: int):
+    return (
+        torch.randn(1, seq, 8),
+        torch.arange(seq),
+        (torch.randn(seq, 8), torch.randn(seq, 8)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_dynamo():
+    gc.collect()
+    torch._dynamo.reset()
+    yield
+    gc.collect()
+    torch._dynamo.reset()
+
+
+def _marked_block(dims):
+    torch._dynamo.reset()
+    ns = {"torch": torch}
+    exec(_BLOCK_SRC, ns)
+    block = ns["_Block"]().eval()
+    block.compile(dynamic=None, fullgraph=True)
+    block._compiled_call_impl = cc._with_declared_marks(
+        block._compiled_call_impl, dims)
+    return block
+
+
+def test_a_compiler_narrowing_the_axis_recompiles_instead_of_degrading():
+    """THE fix. RED before: the narrow call pinned a `sequence <= 1000` guard,
+    the strict constraint from `max=4096` made that a
+    ``ConstraintViolationError``, and the target degraded to eager. H3's
+    real one was inductor's int32 index guard at 74,898 rows against a
+    declared 116,126."""
+    block = _marked_block((_Dim("sequence", 2, _DECLARED_MAX),))
+    with torch.no_grad():
+        block(*_args(96))                       # narrow: installs the guard
+        out = block(*_args(_NARROWING_BOUND * 2))  # wide: must RECOMPILE
+    assert out.shape == (1, _NARROWING_BOUND * 2, 8)
+    audit = cc.graph_audit()
+    assert audit.unique_graphs == 2, audit.summary()
+    assert audit.graph_breaks == 0, audit.summary()
+
+
+def test_the_declared_range_is_still_enforced_by_the_sdk_not_by_dynamo():
+    """The guardrail. Dropping the bounds from ``mark_dynamic`` must not drop
+    the CONTRACT: an out-of-range extent is still the typed, named refusal the
+    executor turns into ``declared_range_exceeded``, and the marks dynamo
+    receives must carry no bounds (that is what makes the constraint
+    RELAXED — see ``_dynamo/variables/builder.py``)."""
+    marks: list[dict] = []
+    original = torch._dynamo.mark_dynamic
+    torch._dynamo.mark_dynamic = lambda t, dim, **kw: marks.append(kw)
+    try:
+        wrapped = cc._with_declared_marks(
+            lambda *a, **k: None, (_Dim("sequence", 2, _DECLARED_MAX),))
+        wrapped(*_args(96))
+    finally:
+        torch._dynamo.mark_dynamic = original
+    assert marks, "the declared axis must still be marked"
+    assert all(kw == {} for kw in marks), marks
+
+    block = _marked_block((_Dim("sequence", 2, _DECLARED_MAX),))
+    with pytest.raises(cc.DeclaredRangeExceeded, match="sequence"):
+        with torch.no_grad():
+            block(*_args(_DECLARED_MAX + 1))


### PR DESCRIPTION
## What this is

`compile_cache._with_declared_marks` forwarded the endpoint's declared range into `torch._dynamo.mark_dynamic(t, dim, min=, max=)`. Dynamo turns explicit bounds into a **`StrictMinMaxConstraint`** (`_dynamo/variables/builder.py`), and a strict constraint promotes any range **narrowing** the compiler performs into a hard `ConstraintViolationError` — which `_guarded_regional` can only answer by degrading the target to eager for the life of the pod.

This PR marks the axis **without bounds** and keeps enforcing the declared range where it was already enforced: in `_mark`, as the typed `DeclaredRangeExceeded`.

## Why it matters

Inductor elects int32 indexing from the **first call's size hint** and then installs `check_leq(numel, INT32_MAX)` (`_inductor/codegen/simd.py::can_use_32bit_indexing`). minimax-h3's DiT plans a buffer with a 28,672-element inner dim, so a cold 5 s request (38,015 packed rows) pinned int32 and its guard, `sequence <= 74,898`, contradicted the declared max.

That 74,898 has been carried in the tracker and in `minimax-h3/src/minimax_h3/main.py` (`_INDUCTOR_INT32_SEQ_MAX`, `_presets_over_compile_guard`, the `_max_packed_sequence` clamp) as a **hard compiler ceiling**, and it is the sole reason H3's 11–15 s cells serve 100% eager — including the 15 s cell at 109,062 rows, where ~28% of the step is non-attention eager overhead.

**It is not a ceiling.** `can_use_32bit_indexing` returning False is not an error path — `select_index_dtype` returns `torch.int64` and compiles. Corroboration already in hand: pgw#1130 §ACTIVATION compiled **88,781 rows** — above the "ceiling" — with no refusal, because that rig compiles statically and never marks the axis, so inductor saw a concrete numel over INT32_MAX and picked int64.

With a relaxed constraint the narrow call gets int32 and the wide call simply **recompiles** with int64. Two graphs, each optimally indexed, no degrade.

## Tests

`tests/test_declared_range_is_not_a_dynamo_constraint_pgw1151.py`, both **verified RED on the parent commit**:

- `test_a_compiler_narrowing_the_axis_recompiles_instead_of_degrading` — a CPU miniature of the failure (a branch that installs a `sequence <= 1000` guard); asserts two graphs, zero graph breaks, instead of a violation.
- `test_the_declared_range_is_still_enforced_by_the_sdk_not_by_dynamo` — the guardrail: marks carry no kwargs (that is what makes the constraint relaxed) **and** an out-of-range extent is still the typed refusal.

`tests/test_regional_marks_pgw1082.py`, `test_regional_dynamic_refusal_pgw746.py`, `test_graph_hash_pgw716.py`, `test_guard_closure_pgw691.py`: 38 passed.

## Follow-on

ie#674 widens minimax-h3's declaration to the honest preset worst case and deletes the clamp, once a release carrying this lands and the fleet pin moves.