### PR TITLE
pgw#1099: the compile partition gets its own residual, so `reap_lag_s` stops meaning two things

### DIFF
--- a/changelog.d/pgw1099.md
+++ b/changelog.d/pgw1099.md
@@ -1,0 +1,14 @@
+- **pgw#1099: `reap_lag_s` stopped doubling as the compile partition's catch-all.**
+  `EntryCompilePool._close_entry_partition` closed `compile_s` with three measured members
+  and no residual, so whenever a child reported no epoch — a child too old for the span
+  table (pgw#840), or one that died between writing its report and being reaped — the
+  parent wrote the entire unattributable remainder under a name that means *"the child's
+  exit plus the parent's poll granularity"*. Because `reap_lag_s` was never listed in
+  `RESIDUALS`, `dark_fraction` then reported those entries as **fully attributed**. The
+  outer partition now carries its own declared residual, `parent_other_s`, recorded on
+  every entry (`0.0` when the named members already close the level), so the level
+  reconciles by construction, `check` covers it and unnamed time is loud again — which is
+  pgw#830's whole contract. `SPANS_V` 1 → 2; a v1 table must not be read as a v2 one.
+  **This is why pgw#1099 existed:** pgw#1085 §5c read a 259.6 s median off the residual
+  branch of a 36-entry sdxl mint as real poll lag and filed a compile-acceleration lever
+  against it. There was no lever — there was one span name meaning two things.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -2424,15 +2424,19 @@ class EntryCompilePool:
         """pgw#830: close the outermost partition — the one that spans the
         process boundary and therefore could never be closed inside the child.
 
-        ``compile_s = child_boot_s + child_wall_s + reap_lag_s``, where
-        ``child_boot_s`` is interpreter startup plus this package's import
-        (paid once per ENTRY, because the pool's unit of parallelism is a
-        process that exits) and ``reap_lag_s`` is the child's exit plus the
-        parent's poll granularity.
+        ``compile_s = child_boot_s + child_wall_s + reap_lag_s
+        + parent_other_s``, where ``child_boot_s`` is interpreter startup plus
+        this package's import (paid once per ENTRY, because the pool's unit of
+        parallelism is a process that exits) and ``reap_lag_s`` is the child's
+        exit plus the parent's poll granularity.
 
-        A child that predates this instrumentation reports no epochs; rather
-        than invent a split, the whole wall lands in the residual and the
-        invariant check says so out loud.
+        pgw#1099: ``reap_lag_s`` is a MEASURED span and may never double as
+        the partition's catch-all. When a child reports no epochs the split is
+        unknowable, so the unclaimed remainder lands in ``parent_other_s`` —
+        the declared residual — and ``reap_lag_s`` stays 0. Overloading it
+        cost a real investigation: pgw#1085 §5c read a 259.6 s median off the
+        residual branch as poll lag and pgw#1099 was filed against a lever
+        that did not exist.
         """
         spans = dict(report.spans or {})
         spans["compile_s"] = round(elapsed, 3)
@@ -2447,11 +2451,15 @@ class EntryCompilePool:
                 report.module_import_epoch - row.spawn_epoch, 3)
         if report.report_epoch:
             spans["reap_lag_s"] = round(reap_epoch - report.report_epoch, 3)
-        if "child_boot_s" not in spans or "reap_lag_s" not in spans:
-            spans["child_boot_s"] = spans.get("child_boot_s", 0.0)
-            spans["reap_lag_s"] = round(
-                spans["compile_s"] - spans["child_boot_s"]
-                - float(spans.get("child_wall_s", 0.0)), 3)
+        # The outer partition's residual: recorded on EVERY entry (0.0 when the
+        # named members closed it), so `check` covers it and `dark_fraction`
+        # counts it instead of a measured span silently absorbing the gap.
+        spans["child_boot_s"] = spans.get("child_boot_s", 0.0)
+        spans["reap_lag_s"] = spans.get("reap_lag_s", 0.0)
+        spans["parent_other_s"] = round(
+            spans["compile_s"] - spans["child_boot_s"]
+            - float(spans.get("child_wall_s", 0.0))
+            - spans["reap_lag_s"], 3)
         violations = aot_compile_spans.check(spans)
         if violations:
             # Named, loud, and non-fatal: an attribution defect must never

--- a/src/gen_worker/aot_compile_spans.py
+++ b/src/gen_worker/aot_compile_spans.py
@@ -24,7 +24,7 @@ total by construction and a newly-introduced phase shows up as the residual
 growing rather than as time silently vanishing::
 
     compile_s (parent Popen -> reap)
-      = child_boot_s + child_wall_s + reap_lag_s
+      = child_boot_s + child_wall_s + reap_lag_s + parent_other_s
 
     child_wall_s (child module import -> report written)
       = child_seal_s + child_torch_import_s + child_devlock_s
@@ -67,7 +67,13 @@ import time
 from typing import Dict, Iterator, List, Mapping, Tuple
 
 #: Bump when the partition changes shape, so a reader never mixes two ledgers.
-SPANS_V = 1
+#: v2 (pgw#1099): the outer partition grew its own residual, ``parent_other_s``.
+#: Before it, an unclosable outer split was written into ``reap_lag_s``, so one
+#: NAME meant two things — "the child's exit plus the parent's poll
+#: granularity" on a reporting child, and "everything nobody could attribute"
+#: on a silent one. A reader could not tell which, and one did not: pgw#1085
+#: §5c read the residual branch as poll lag on a 36-entry sdxl mint.
+SPANS_V = 2
 
 #: Disjoint ``compilation_time_metrics`` leaves. These partition the inside of
 #: ``aot_compile`` together with the ``compile_other_s`` residual.
@@ -97,7 +103,9 @@ OVERLAY_KEYS: Dict[str, Tuple[str, ...]] = {
 #: The three-level partition, as {total: members}. ``check`` walks this, so
 #: adding a member in one place is enough for the invariant to cover it.
 PARTITIONS: Dict[str, Tuple[str, ...]] = {
-    "compile_s": ("child_boot_s", "child_wall_s", "reap_lag_s"),
+    "compile_s": (
+        "child_boot_s", "child_wall_s", "reap_lag_s", "parent_other_s",
+    ),
     "child_wall_s": (
         "child_seal_s", "child_torch_import_s", "child_devlock_s",
         "child_program_load_s", "compile_wall_s", "child_other_s",
@@ -110,14 +118,20 @@ PARTITIONS: Dict[str, Tuple[str, ...]] = {
 
 #: Residual member of each partition — the one that absorbs whatever the named
 #: members did not claim. Named so the invariant can say WHICH bucket grew.
-RESIDUALS = ("child_other_s", "compile_other_s")
+#: Every level has exactly one, and no MEASURED span is ever used as another
+#: level's residual (pgw#1099): a name that means "what I measured" on one
+#: entry and "what nobody could measure" on the next is unreadable, and a
+#: reader who sums it across entries is measuring the instrument.
+RESIDUALS = ("parent_other_s", "child_other_s", "compile_other_s")
 
 #: Recorded alongside the partition but NOT a member of it: each is a split of
 #: a member above it, kept because it is the number that decides a fix.
 #: ``child_interp_s`` is the part of ``child_boot_s`` a persistent pool worker
 #: would delete; ``triton_s`` / ``device_lock_wait_s`` nest inside
 #: ``compile_wall_s``. Anything listed here must be excluded by a reader
-#: summing the table.
+#: summing the table. NOTE the two ``parent_*`` entries here are OUTSIDE
+#: ``compile_s`` (parent work that overlaps other children); ``parent_other_s``
+#: is not one of them — it is the residual INSIDE ``compile_s``.
 SUBSPANS = ("child_interp_s", "triton_s", "autotune_s", "device_lock_wait_s",
             "inductor_total_s", "parent_stage_s", "parent_spawn_s")
 

--- a/tests/test_compile_attribution_pgw830.py
+++ b/tests/test_compile_attribution_pgw830.py
@@ -208,7 +208,10 @@ def test_check_names_the_partition_that_broke() -> None:
     the same defect this issue is closing."""
     good = {
         "compile_s": 10.0, "child_boot_s": 1.0, "child_wall_s": 8.5,
-        "reap_lag_s": 0.5,
+        # pgw#1099: the outer partition has its own residual now, so a
+        # measured span never doubles as the catch-all. Zero here because the
+        # named members already close the level — which is the normal case.
+        "reap_lag_s": 0.5, "parent_other_s": 0.0,
         "child_seal_s": 0.1, "child_torch_import_s": 1.5,
         "child_devlock_s": 0.0, "child_program_load_s": 0.4,
         "compile_wall_s": 6.0, "child_other_s": 0.5,

--- a/tests/test_reap_lag_residual_pgw1099.py
+++ b/tests/test_reap_lag_residual_pgw1099.py
@@ -1,0 +1,226 @@
+"""pgw#1099: ``reap_lag_s`` is a MEASURED span, never the outer partition's
+catch-all.
+
+The defect
+----------
+``EntryCompilePool._close_entry_partition`` closed ``compile_s`` with three
+members. When a child reported no ``report_epoch`` — pgw#840's case: a child
+too old for the span table, or one that died between writing its report and
+being reaped — the parent computed
+
+    reap_lag_s = compile_s - child_boot_s - child_wall_s
+
+and wrote the whole unattributable remainder under a name that means "the
+child's exit plus the parent's poll granularity". ``aot_compile_pool``'s own
+``EntryReport.code_digest`` comment already said this happened ("the parent
+absorbed its whole compile into ``reap_lag_s``"), and ``RESIDUALS`` never
+listed ``reap_lag_s``, so ``dark_fraction`` reported those entries as **fully
+attributed**.
+
+What it cost, measured
+----------------------
+pgw#1085 §5c's 36-entry sdxl-on-L40S mint recorded a ``reap_lag_s`` median of
+259.6 s (max 403.4 s) summing to 164.5 min. pgw#1099 was filed on that number
+as "the single largest unclaimed block of time in the run, and no pgw#1051
+lever addresses it". Both halves of the reading were wrong, and this file pins
+both corrections:
+
+1. ``reap_lag_s`` is a SUB-SPAN of ``compile_s``, so summing it over entries
+   compiled at K=3 and comparing that to the pool's wall is a category error —
+   ``compile_s`` itself sums to 3.35x the same wall.
+2. A 259.6 s median with a 403.4 s max is the signature of the residual branch
+   firing, not of poll granularity.
+
+The fix is a declared residual of its own, ``parent_other_s``, recorded on
+every entry so ``check`` covers it and ``dark_fraction`` counts it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from gen_worker import aot_compile_spans as spans
+from gen_worker.aot_compile_pool import EntryCompilePool, EntryReport, _Running
+
+
+def _running(entry: str = "unet", *, spawn_epoch: float = 1000.0) -> _Running:
+    row = _Running(
+        entry=entry,
+        proc=None,  # type: ignore[arg-type]  # never touched by this seam
+        job=None,  # type: ignore[arg-type]
+        program_path=Path("/nonexistent/program.pt2"),
+        started=0.0,
+        stderr_path=Path("/nonexistent/stderr.log"),
+    )
+    row.spawn_epoch = spawn_epoch
+    return row
+
+
+def _close(
+    report: EntryReport, *, elapsed: float, reap_epoch: float,
+) -> Dict[str, float]:
+    """Drive the REAL `_close_entry_partition`. Nothing about the partition
+    arithmetic touches the pool's construction, so the seam is entered
+    directly rather than through a pool double that could disagree with it."""
+    pool = EntryCompilePool.__new__(EntryCompilePool)
+    pool.entry_stage_seconds = {}
+    pool.entry_spawn_seconds = {}
+    return pool._close_entry_partition(
+        _running(), report, elapsed=elapsed, reap_epoch=reap_epoch)
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_the_outer_partition_declares_its_OWN_residual() -> None:
+    """RED before pgw#1099: ``compile_s``'s members were the three measured
+    spans, so the level had no residual and the arithmetic had to go
+    somewhere. It went into a measured member."""
+    assert spans.PARTITIONS["compile_s"] == (
+        "child_boot_s", "child_wall_s", "reap_lag_s", "parent_other_s")
+    assert "parent_other_s" in spans.RESIDUALS
+
+
+def test_no_MEASURED_span_is_any_levels_residual() -> None:
+    """The invariant that makes the table readable: every level's residual is
+    a name that means *only* "unclaimed". If a measured span is also a
+    residual, one number means two things and no reader can tell which."""
+    measured = {
+        member
+        for members in spans.PARTITIONS.values()
+        for member in members
+        if member not in spans.RESIDUALS
+    }
+    assert measured.isdisjoint(spans.RESIDUALS)
+    # exactly one residual per level, and every level has one
+    for total, members in spans.PARTITIONS.items():
+        got = [m for m in members if m in spans.RESIDUALS]
+        assert len(got) == 1, f"{total} has residual members {got!r}"
+
+
+def test_the_ledger_version_moved_with_the_partition_shape() -> None:
+    """A reader must never mix a v1 table (where ``reap_lag_s`` could mean
+    'unattributed') with a v2 one."""
+    assert spans.SPANS_V >= 2
+
+
+# ---------------------------------------------------------------------------
+# The pool, on the two real branches
+# ---------------------------------------------------------------------------
+
+
+def test_a_reporting_child_measures_reap_lag_and_leaves_the_residual_empty(
+) -> None:
+    """The good branch is unchanged: an epoch-reporting child's poll lag is
+    still measured and named, and nothing lands in the residual."""
+    report = EntryReport(
+        entry="unet",
+        spans={"child_wall_s": 8.6},
+        run_start_epoch=1001.0,
+        module_import_epoch=1000.5,
+        report_epoch=1009.6,
+    )
+    table = _close(report, elapsed=10.0, reap_epoch=1010.0)
+
+    assert table["child_boot_s"] == pytest.approx(1.0)
+    assert table["reap_lag_s"] == pytest.approx(0.4)
+    assert table["parent_other_s"] == pytest.approx(0.0)
+    assert spans.check(table) == []
+
+
+def test_a_SILENT_child_puts_the_gap_in_the_residual_not_in_reap_lag() -> None:
+    """THE ROW THIS ISSUE EXISTS FOR. A child that reports no epochs — the
+    pgw#840 case ``EntryReport.code_digest`` documents — must not have its
+    unattributable time written under a measured span's name.
+
+    RED on master: ``reap_lag_s`` came back as the full 259.6 s remainder,
+    exactly the shape pgw#1085 §5c misread as poll lag.
+    """
+    report = EntryReport(entry="unet", spans={}, run_start_epoch=0.0, report_epoch=0.0)
+    table = _close(report, elapsed=259.6, reap_epoch=1259.6)
+
+    assert table["reap_lag_s"] == 0.0, (
+        "the parent cannot know the poll lag of a child that reported no "
+        "epoch, and must not claim a number for it")
+    assert table["parent_other_s"] == pytest.approx(259.6)
+
+    # And it stays LOUD. A child this silent recorded no `child_wall_s`
+    # either, and `check` must keep naming that — the residual holding the
+    # seconds is the honest bookkeeping, not an excuse to stop complaining.
+    problems = spans.check(table)
+    assert any("child_wall_s" in p for p in problems), problems
+
+
+def test_the_silent_child_is_now_visible_to_dark_fraction() -> None:
+    """The second half of the defect: because ``reap_lag_s`` was never in
+    ``RESIDUALS``, an entry whose ENTIRE compile was unattributed reported
+    ``dark_fraction == 0.0`` — fully attributed. pgw#830's whole contract is
+    that unnamed time is loud."""
+    report = EntryReport(entry="unet", spans={}, run_start_epoch=0.0, report_epoch=0.0)
+    table = _close(report, elapsed=259.6, reap_epoch=1259.6)
+
+    assert spans.dark_fraction(table) == pytest.approx(1.0)
+
+
+def test_a_partial_report_keeps_what_it_measured_and_banks_only_the_gap(
+) -> None:
+    """A child that wrote its report epoch but whose inner ledger is missing
+    must keep its real poll lag; only the genuinely unclaimed seconds move."""
+    report = EntryReport(
+        entry="unet",
+        spans={"child_wall_s": 200.0},
+        run_start_epoch=1002.0,
+        report_epoch=1250.0,
+    )
+    table = _close(report, elapsed=259.6, reap_epoch=1250.5)
+
+    assert table["child_boot_s"] == pytest.approx(2.0)
+    assert table["reap_lag_s"] == pytest.approx(0.5)
+    assert table["parent_other_s"] == pytest.approx(57.1)
+    assert spans.check(table) == []
+
+
+def test_every_entry_records_the_residual_so_check_can_see_it() -> None:
+    """``check`` reports a partition member that was never recorded. If
+    ``parent_other_s`` were written only on the silent branch, every healthy
+    entry would trip that rule — which is why it is recorded always, as 0.0
+    when the named members already close the level."""
+    report = EntryReport(
+        entry="unet",
+        spans={"child_wall_s": 9.0},
+        run_start_epoch=1000.5,
+        report_epoch=1009.9,
+    )
+    table = _close(report, elapsed=10.0, reap_epoch=1010.0)
+
+    assert "parent_other_s" in table
+    assert spans.check(table) == []
+
+
+# ---------------------------------------------------------------------------
+# The arithmetic that refutes the filing
+# ---------------------------------------------------------------------------
+
+
+def test_a_subspan_sum_across_entries_is_not_comparable_to_the_pool_wall(
+) -> None:
+    """pgw#1099's headline — "``reap_lag_s`` sums to 164.5 min on a 92-min
+    wall" — is not evidence of anything. ``reap_lag_s`` is INSIDE
+    ``compile_s``, and at K entries in flight the per-entry totals sum to
+    roughly K times the wall by construction. On the same row-7 table
+    ``compile_s`` sums to 308.1 min against the same 92.0-minute wall.
+    """
+    wall_min = 92.0
+    compile_s_sum_min = 308.1          # pgw#1085 §5c, row 7, 36 entries, K=3
+    reap_lag_sum_min = 164.5
+
+    assert "reap_lag_s" in spans.PARTITIONS["compile_s"]
+    assert compile_s_sum_min > wall_min, (
+        "the containing span already exceeds the wall, so its member doing so "
+        "carries no information")
+    assert reap_lag_sum_min < compile_s_sum_min


### PR DESCRIPTION
Closes the pgw#1099 investigation the way its own acceptance box allowed for: **as an instrument defect**, with the defect fixed rather than merely noted.

## The defect

`EntryCompilePool._close_entry_partition` closed the `compile_s` partition with three **measured** members and no residual:

```
compile_s = child_boot_s + child_wall_s + reap_lag_s
```

When a child reported no `report_epoch` — pgw#840's case (a child too old for the span table), or one that died between writing its report and being reaped — the parent computed `reap_lag_s = compile_s - child_boot_s - child_wall_s` and wrote the whole unattributable remainder under a name that means *"the child's exit plus the parent's poll granularity"*.

`aot_compile_pool`'s own `EntryReport.code_digest` comment already recorded that this happened ("the parent absorbed its whole compile into `reap_lag_s`"). Nothing acted on it. And because `reap_lag_s` was never listed in `aot_compile_spans.RESIDUALS`, `dark_fraction` reported those entries as **fully attributed** — the exact inverse of pgw#830's contract, which is that unnamed time is loud.

## The fix

The outer partition declares its own residual, `parent_other_s`, recorded on **every** entry (`0.0` when the named members already close the level). So:

* a reporting child's poll lag is still measured and named, and the level now reconciles *by construction* instead of tripping `check`'s delta warning;
* a silent child's seconds land in a bucket whose name means only "unclaimed", and `dark_fraction` sees them;
* **no measured span is any level's residual** — asserted directly, so a third instance of this shape cannot be written.

`SPANS_V` 1 → 2, because a reader must never mix a v1 table (where `reap_lag_s` could mean "unattributed") with a v2 one.

## Why the issue existed

pgw#1085 §5c's 36-entry sdxl-on-L40S mint recorded a `reap_lag_s` median of 259.6 s (max 403.4 s) summing to 164.5 min, and pgw#1099 was filed on that as *"the single largest unclaimed block of time in the run, and no pgw#1051 lever addresses it"*. Both halves of the reading are wrong:

1. `reap_lag_s` is a **sub-span of `compile_s`**, so summing it across entries compiled at K=3 and comparing that total to the pool's 92-min wall is a category error — `compile_s` itself sums to **308.1 min** against the same wall.
2. A 259.6 s median with a 403.4 s max is the signature of the **residual branch firing**, not of poll granularity.

There was no missing lever. There was one span name meaning two things.

## RED-first

`tests/test_reap_lag_residual_pgw1099.py` drives the **real** `_close_entry_partition` with real `EntryReport` / `_Running` values — not a pool double, which could disagree with the seam under test. **8 of 9 rows fail on `origin/master`**, verified by running the file against a clean `git archive origin/master` export rather than by reasoning. The 9th row states the arithmetic that refutes the filing and is deliberately green on both trees.

Locally: 9 passed + the pgw#830 and pgw#840 attribution suites green; all nine hard `fast gates` lint scripts green. (mypy/ruff could not run on this box — `--extra dev` fails on an unrelated torch wheel-hash mismatch in the lockfile — so CI is the gate for those two.)

**\$0** — no pods, no GPU, no mint, no compile. Cardless telemetry arithmetic only. Unreleased; rides the next cut (pgw#1140).