### PR TITLE
pgw#1150 (second pass): `threshold_source` stops lying, and a declaration reaches a cell through ONE constructor

### DIFF
--- a/changelog.d/pgw1150.md
+++ b/changelog.d/pgw1150.md
@@ -22,3 +22,21 @@
   `sdk-default`, sdxl's declared 0.995/0.999 (pgw#812/#814) included. Both
   fields are carried now, and deliberately stay out of `contract_facts()`: a
   numerics band is not a graph axis and must never move a cell key.
+- **pgw#1150 (second pass): `threshold_source` cannot lie about which band
+  decided, and the declaration reaches a cell through ONE constructor.** The
+  band's provenance was answered twice — `numerics_probe.probe_cell` re-derived
+  it from `cfg.numerics_floor` alone while `declared_thresholds` resolved the
+  band from `floor` **or** `warn` — so a family declaring only `numerics_warn`
+  was judged at its DECLARED band while the wire row, the `author-ci.toml`
+  `[proof]` record and `Parity.floor_source` all reported `sdk-default`.
+  `declared_thresholds` is now the one authority and stamps `Thresholds.source`
+  (`declared` / `sdk-default`); nobody re-derives it. The two `Compile` ->
+  `CompileCell` construction sites (the registry's `compile_cell()` and
+  `cli.run`'s §4.28 desktop arm) collapse onto
+  `CompileCell.from_declaration`, so a must-survive field can no longer reach
+  one path and not the other — which is how the band reached no gate at all.
+  New `tests/test_declared_floor_at_every_gate_pgw1150.py` drives the real
+  `arm_aot(verify_numerics=True)` / `gate_cell_numerics` paths against all
+  three cfg objects a gate is actually handed in production, because every
+  pre-existing gate row passes a raw `Compile` — a type no fleet path uses,
+  which is precisely why the original defect survived a green suite.

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -850,22 +850,12 @@ def _load_injected_model(
         # is self-consistent.
         from ..registry import CompileCell
 
-        compile_cfg = CompileCell(
-            shapes=tuple(compile_cfg.shapes),
-            targets=tuple(compile_cfg.targets),
-            family=str(compile_cfg.family or ""),
-            regional=bool(compile_cfg.regional),
-            text_len=compile_cfg.text_len,
-            dynamic=tuple(compile_cfg.dynamic),
-            lora_bucket=int(getattr(decl, "lora_bucket", 0) or 0),
-            guidance_scales=(),
-            text_lens=(),
-            # pgw#1150: the declared band travels with the declaration here
-            # too, or a locally minted cell would be gated at the SDK default
-            # while the family declares its own.
-            numerics_floor=compile_cfg.numerics_floor,
-            numerics_warn=compile_cfg.numerics_warn,
-        )
+        # ONE constructor with the registry's path (pgw#1150): a must-survive
+        # field this site forgot to copy — the declared numerics band was
+        # exactly that — silently judges every locally minted cell at a default
+        # nobody chose.
+        compile_cfg = CompileCell.from_declaration(
+            compile_cfg, lora_bucket=int(getattr(decl, "lora_bucket", 0) or 0))
     if (
         arm_compile
         and compile_cfg is not None

--- a/src/gen_worker/numerics_ladder.py
+++ b/src/gen_worker/numerics_ladder.py
@@ -93,6 +93,18 @@ class Thresholds:
     #: Where these numbers came from. Carried into every refusal so the
     #: reader can argue with the calibration instead of guessing at it.
     label: str = ""
+    #: The PROVENANCE of the band, in the closed vocabulary below, set by
+    #: whoever resolved it — :data:`SOURCE_DECLARED` when a family's own
+    #: declaration supplied a number, :data:`SOURCE_SDK_DEFAULT` when it did
+    #: not. It rides the object rather than being re-derived at the reader,
+    #: because a second reader of the declaration is exactly the defect this
+    #: field closes: `numerics_probe` used to answer the question again from
+    #: `cfg.numerics_floor` alone, so a family declaring only `numerics_warn`
+    #: was judged at its DECLARED band while every wire row, every
+    #: `author-ci.toml` `[proof]` record and `Parity.floor_source` said
+    #: `sdk-default`. "" for populations that are not family-declared at all
+    #: (the pgw#800 adapter ladder).
+    source: str = ""
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.floor <= self.warn <= 1.0:
@@ -417,10 +429,18 @@ NUMERICS_WARN = 0.999
 #: retention outside [0.95, 1.0526] is at least DEGRADED.
 NUMERICS_RETENTION_FLOOR = 0.95
 
+#: :attr:`Thresholds.source` when a family's own declaration supplied at least
+#: one of the two bounds.
+SOURCE_DECLARED = "declared"
+#: :attr:`Thresholds.source` when the family declared neither bound and the
+#: measured SDK band above decided.
+SOURCE_SDK_DEFAULT = "sdk-default"
+
 DEFAULT_THRESHOLDS = Thresholds(
     floor=NUMERICS_FLOOR, warn=NUMERICS_WARN,
     retention_floor=NUMERICS_RETENTION_FLOOR,
-    label="assembled-vs-eager (pgw#814 §VERDICT)")
+    label="assembled-vs-eager (pgw#814 §VERDICT)",
+    source=SOURCE_SDK_DEFAULT)
 
 
 def declared_thresholds(cfg: Any) -> Thresholds:
@@ -431,6 +451,16 @@ def declared_thresholds(cfg: Any) -> Thresholds:
     a 25-block fp8 DiT and a conv-bearing UNet. A family that declares
     nothing gets :data:`DEFAULT_THRESHOLDS`, whose derivation is the measured
     band above — a default with evidence, not a guess.
+
+    THE ONE PLACE that decides declared-vs-default, and it stamps its own
+    answer onto :attr:`Thresholds.source`. Nobody may re-derive it: the whole
+    class of defect here is a declaration read by a second party that drifts
+    from the authority, which is how ``Compile.numerics_floor`` spent its
+    first 300 commits reaching no gate at all (pgw#1150).
+
+    ``cfg`` is duck-typed on purpose — it is a raw ``Compile`` on the author-CI
+    path and a ``registry.CompileCell`` on every fleet path, and both carry the
+    two fields (``CompileCell.from_declaration`` is what keeps that true).
     """
     floor = getattr(cfg, "numerics_floor", None)
     warn = getattr(cfg, "numerics_warn", None)
@@ -440,13 +470,15 @@ def declared_thresholds(cfg: Any) -> Thresholds:
         floor=float(NUMERICS_FLOOR if floor is None else floor),
         warn=float(NUMERICS_WARN if warn is None else warn),
         retention_floor=NUMERICS_RETENTION_FLOOR,
-        label=f"assembled-vs-eager (declared by {getattr(cfg, 'family', '?')})")
+        label=f"assembled-vs-eager (declared by {getattr(cfg, 'family', '?')})",
+        source=SOURCE_DECLARED)
 
 
 __all__ = [
     "DEFAULT_THRESHOLDS",
     "NUMERICS_FLOOR", "NUMERICS_RETENTION_FLOOR", "NUMERICS_WARN",
     "PHASE_ARMED_UNDISPATCHED", "PHASE_DEGRADED", "PHASE_REFUSED",
+    "SOURCE_DECLARED", "SOURCE_SDK_DEFAULT",
     "VERDICT_DEGRADED", "VERDICT_DESTROYED", "VERDICT_HEALTHY",
     "Comparison", "RowStat", "Thresholds",
     "compare_outputs", "declared_thresholds", "flatten_outputs", "gate",

--- a/src/gen_worker/numerics_probe.py
+++ b/src/gen_worker/numerics_probe.py
@@ -433,8 +433,12 @@ def probe_cell(
 
     family = str(getattr(cfg, "family", "") or meta.get("family") or "")
     thresholds = numerics_ladder.declared_thresholds(cfg)
-    source = ("declared" if getattr(cfg, "numerics_floor", None) is not None
-              else "sdk-default")
+    # READ, never re-derive. This used to ask `cfg.numerics_floor` again and
+    # so could disagree with the band it was reporting on: a family declaring
+    # only `numerics_warn` was judged at its DECLARED band while this said
+    # `sdk-default`. `declared_thresholds` is the one authority and stamps its
+    # own answer (pgw#1150).
+    source = thresholds.source
     targets = aot_serve.armed_targets(pipeline)
     if not targets:
         raise ProbeUnavailable(

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -90,6 +90,37 @@ class CompileCell:
     numerics_floor: Optional[float] = None
     numerics_warn: Optional[float] = None
 
+    @classmethod
+    def from_declaration(
+        cls, cfg: Any, *, lora_bucket: int = 0, text_len: Optional[int] = None,
+        guidance_scales: tuple = (), text_lens: tuple = (),
+    ) -> "CompileCell":
+        """THE ``Compile`` -> ``CompileCell`` map, in one place.
+
+        Two call sites build this object — the registry's per-spec
+        :meth:`EndpointSpec.compile_cell` and the local CLI's §4.28 desktop arm
+        — and they differ only in the four enrichments above, which are
+        spec-scoped facts the raw declaration cannot know. Everything else is a
+        straight carry, so a field ADDED to ``Compile`` that one site copied and
+        the other forgot is a whole path silently judged at a default nobody
+        chose. That is not hypothetical: it is exactly what
+        ``numerics_floor``/``numerics_warn`` were before pgw#1150, and one
+        constructor is the fence that keeps the next one from repeating it.
+        """
+        return cls(
+            shapes=tuple(cfg.shapes),
+            targets=tuple(cfg.targets),
+            family=str(cfg.family or ""),
+            regional=bool(cfg.regional),
+            text_len=text_len if text_len is not None else cfg.text_len,
+            dynamic=tuple(cfg.dynamic),
+            lora_bucket=int(lora_bucket or 0),
+            guidance_scales=guidance_scales,
+            text_lens=text_lens,
+            numerics_floor=cfg.numerics_floor,
+            numerics_warn=cfg.numerics_warn,
+        )
+
     def contract_text_lens(self) -> tuple:
         if self.text_lens:
             return tuple(sorted({int(v) for v in self.text_lens}))
@@ -232,23 +263,16 @@ class EndpointSpec:
         if cfg is None:
             return None
 
-        effective_text_len = self.text_len if self.text_len is not None else cfg.text_len
-        return CompileCell(
-            shapes=tuple(cfg.shapes),
-            targets=tuple(cfg.targets),
-            family=str(cfg.family or ""),
-            regional=bool(cfg.regional),
-            text_len=effective_text_len,
-            dynamic=tuple(cfg.dynamic),
+        return CompileCell.from_declaration(
+            cfg,
             lora_bucket=int(self.lora_bucket or 0),
+            text_len=self.text_len,
             guidance_scales=(
                 self.guidance_union
                 if self.guidance_union
                 else warm_guidance_values(self.payload_axes)
             ),
             text_lens=self.text_lens,
-            numerics_floor=cfg.numerics_floor,
-            numerics_warn=cfg.numerics_warn,
         )
 
     @property

--- a/tests/test_declared_floor_at_every_gate_pgw1150.py
+++ b/tests/test_declared_floor_at_every_gate_pgw1150.py
@@ -1,0 +1,312 @@
+"""pgw#1150 (second pass) — the DECLARED numerics band reaches every gate that
+judges parity, and ``threshold_source`` never lies about which band decided.
+
+## What the first pass fixed, and the hole it left
+
+`25f1f190` closed the headline: `registry.CompileCell` gained
+`numerics_floor`/`numerics_warn`, so the object the FLEET mint parent hands the
+gate finally carries the family's declaration. Verified on `88af2c9b`: a
+`spec.compile_cell()` driven through `provision.arm_aot(verify_numerics=True)`
+is judged at 0.995, not 0.98.
+
+What it did NOT close is that the PROVENANCE was answered twice.
+`numerics_probe.probe_cell` re-derived `threshold_source` from
+`cfg.numerics_floor` alone while `numerics_ladder.declared_thresholds` decided
+the band from `floor` **or** `warn` — so a family declaring only
+`numerics_warn` was judged at its DECLARED band while every wire row, every
+`author-ci.toml` `[proof]` record and `Parity.floor_source` reported
+`sdk-default`. A `threshold_source` that can be false about the number beside
+it is the same defect as a floor nobody reads, one level in: the measurement
+is right and the record of it is wrong, and the record is what anyone acts on.
+`declared_thresholds` is now the ONE authority and stamps `Thresholds.source`.
+
+## Why this file exists as well as `test_numerics_gate_pgw868.py`
+
+pgw#868's rows drive the real arm — and every one of them passes a raw
+`Compile`, which is a type NO fleet path ever hands the gate. That single
+substitution is why `Compile.numerics_floor` reached nobody for 300+ commits
+with a green suite the whole time: deleting the two `numerics_floor=` lines
+from `registry.py` leaves every pre-existing test green.
+
+So the rows below are parametrized over the cfg objects the gate ACTUALLY
+receives in production — the raw `Compile` (author CI), the registry's
+`CompileCell` (fleet mint parent), and the local CLI's `CompileCell` (§4.28
+desktop) — and each drives the real path rather than `declared_thresholds` in
+isolation. The pgw#868 rig is reused verbatim: real `arm_aot`, real
+`aot_serve.enable`, real ladder, real packed artifact, real torch tensors.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import numerics_ladder, numerics_probe
+from gen_worker.api import derive
+from gen_worker.registry import CompileCell, extract_specs
+
+import test_numerics_gate_pgw868 as rig  # noqa: E402
+from harness import author_ci_endpoints_pgw1150 as endpoints  # noqa: E402
+
+declared = rig.declared
+events = rig.events
+
+#: Between the SDK default floor (0.98) and the declared one (0.995). The whole
+#: file turns on this number: a cell here is DEGRADED against the default and
+#: DESTROYED against the declaration, so the two bands produce different
+#: verdicts, different wire phases and different outcomes on one measurement.
+BETWEEN = 0.99
+
+
+# ---------------------------------------------------------------------------
+# the three cfg objects a gate can actually be handed, built the production way
+# ---------------------------------------------------------------------------
+
+def _registry_cell() -> CompileCell:
+    """The FLEET mint parent's object: `pending.cfg` is the `spec.compile_cell()`
+    the executor opened its `ArmingScope` with."""
+    cell = extract_specs(endpoints.Fast)[0].compile_cell()
+    assert cell is not None
+    return cell
+
+
+def _local_cell() -> CompileCell:
+    """The §4.28 desktop object `cli.run` builds for `local_serve`.
+
+    Spelled out field by field rather than through
+    :meth:`CompileCell.from_declaration`, deliberately: this row has to stay
+    RED-able about the BAND on any revision, and a fixture that called the
+    helper this change introduces would fail on the older tree for the wrong
+    reason (no such attribute) and prove nothing about which floor decided.
+    The helper has its own structural row below.
+    """
+    decl = rig.declaration()
+    return CompileCell(
+        shapes=tuple(decl.shapes), targets=tuple(decl.targets),
+        family=str(decl.family or ""), regional=bool(decl.regional),
+        text_len=decl.text_len, dynamic=tuple(decl.dynamic),
+        lora_bucket=0, guidance_scales=(), text_lens=(),
+        numerics_floor=decl.numerics_floor, numerics_warn=decl.numerics_warn)
+
+
+def _raw_compile() -> Any:
+    """Author CI's: `_Subject.declaration` is the endpoint's raw `Compile`."""
+    return rig.declaration()
+
+
+CFGS = {
+    "author-ci/raw-Compile": _raw_compile,
+    "fleet-mint-parent/registry.CompileCell": _registry_cell,
+    "local-serve/cli.CompileCell": _local_cell,
+}
+
+
+def _undeclare(cfg: Any) -> Any:
+    """The same cfg with the band removed — the negative control."""
+    if isinstance(cfg, CompileCell):
+        return dataclasses.replace(cfg, numerics_floor=None, numerics_warn=None)
+    return rig.declaration(floor=None, warn=None)
+
+
+def _arm(tmp_path, monkeypatch, cfg: Any, cosine: float,
+         *, verify_numerics: bool) -> Any:
+    packages = {rig.entry_name(h, w): rig.ProbePackage(cosine=cosine)
+                for h, w in rig.ROWS}
+    _pipe, _module, outcome = rig.arm(
+        tmp_path, monkeypatch, cfg, packages,
+        verify_numerics=verify_numerics)
+    return outcome
+
+
+def _phases(said: List[Tuple[str, str, str]]) -> List[str]:
+    return [phase for _detail, phase in rig.numerics_rows(said)]
+
+
+# ---------------------------------------------------------------------------
+# 1. THE MINT-PARENT PUBLISH GATE — every cfg type, the declaration decides
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(CFGS))
+def test_the_mint_parent_gate_judges_at_the_familys_declared_floor(
+        name, tmp_path, monkeypatch, declared, events):
+    """`adopt_delegated_mint` -> `arm_aot(verify_numerics=True)`, §4.32.
+
+    cos=0.99 is DESTROYED against the declared 0.995 and merely DEGRADED
+    against the SDK default 0.98, so the band that decided is legible from the
+    wire phase alone — not inferred from a number this test also chose.
+    """
+    outcome = _arm(tmp_path, monkeypatch, CFGS[name](), BETWEEN,
+                   verify_numerics=True)
+
+    assert outcome.armed is False
+    assert outcome.reason == "numerics_refused"
+    assert numerics_ladder.PHASE_REFUSED in _phases(events), (
+        "the cell was DEGRADED, not DESTROYED — the gate scored it against "
+        "the SDK default 0.98 while this family declares 0.995")
+
+    report = numerics_probe.last_report()
+    assert report is not None
+    assert report.thresholds.floor == endpoints.FLOOR
+    assert report.thresholds.warn == endpoints.WARN
+    assert report.threshold_source == "declared"
+
+
+@pytest.mark.parametrize("name", sorted(CFGS))
+def test_an_undeclared_family_still_gets_the_sdk_default_and_says_so(
+        name, tmp_path, monkeypatch, declared, events):
+    """The negative. A family that declares nothing must NOT silently inherit
+    some other family's band, and must report the default as the default —
+    `threshold_source` is what tells an operator which of the two happened."""
+    outcome = _arm(tmp_path, monkeypatch, _undeclare(CFGS[name]()), BETWEEN,
+                   verify_numerics=True)
+
+    # Still refused — §4.32 is strict, and the gray band does not publish —
+    # but for a DIFFERENT reason, and the wire says which.
+    assert outcome.armed is False
+    assert numerics_ladder.PHASE_DEGRADED in _phases(events)
+    assert numerics_ladder.PHASE_REFUSED not in _phases(events)
+
+    report = numerics_probe.last_report()
+    assert report is not None
+    assert report.thresholds == numerics_ladder.DEFAULT_THRESHOLDS
+    assert report.threshold_source == "sdk-default"
+
+
+# ---------------------------------------------------------------------------
+# 2. `provision.gate_cell_numerics` — the function the author-CI adopt leg calls
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(CFGS))
+def test_gate_cell_numerics_refuses_on_the_declared_floor_alone(
+        name, tmp_path, monkeypatch, declared, events):
+    """Called directly, non-strict, so the FLOOR is the only thing separating
+    the two answers: 0.99 is below the declared 0.995 (refuse) and inside the
+    default's gray band (serve, confess). One measurement, two verdicts,
+    decided by the declaration and nothing else.
+
+    `author_ci.read_parity` reaches this exact call for an ADOPTED cell.
+    """
+    from gen_worker.models import provision
+
+    cfg = CFGS[name]()
+    packages = {rig.entry_name(h, w): rig.ProbePackage(cosine=BETWEEN)
+                for h, w in rig.ROWS}
+    pipe, _module, outcome = rig.arm(
+        tmp_path, monkeypatch, cfg, packages, verify_numerics=False)
+    assert outcome.armed, "the rig did not arm without the gate"
+
+    assert provision.gate_cell_numerics(pipe, cfg, strict=False) is False
+    assert numerics_probe.last_report().threshold_source == \
+        "declared"
+
+    assert provision.gate_cell_numerics(
+        pipe, _undeclare(cfg), strict=False) is True
+    assert numerics_probe.last_report().threshold_source == \
+        "sdk-default"
+
+
+# ---------------------------------------------------------------------------
+# 3. `threshold_source` IS TRUE — RED on 88af2c9b
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(CFGS))
+def test_a_warn_only_declaration_is_reported_as_DECLARED(
+        name, tmp_path, monkeypatch, declared, events):
+    """RED on `88af2c9b`: `sdk-default` while a declared band decided.
+
+    `Compile(numerics_warn=…)` with no floor is a legal declaration — the floor
+    refuses, the warn only confesses, and a family may reasonably tighten just
+    the confession band. `declared_thresholds` honours it (the returned band is
+    NOT `DEFAULT_THRESHOLDS`), but `probe_cell` used to answer the provenance
+    question a SECOND time from `cfg.numerics_floor` alone and got `sdk-default`
+    — the one field whose whole job is to say which band decided, saying the
+    wrong one. Nobody re-derives it now.
+    """
+    cfg = CFGS[name]()
+    if isinstance(cfg, CompileCell):
+        cfg = dataclasses.replace(cfg, numerics_floor=None, numerics_warn=0.9999)
+    else:
+        cfg = rig.declaration(floor=None, warn=0.9999)
+
+    from gen_worker.models import provision
+
+    band = numerics_ladder.declared_thresholds(cfg)
+    assert band != numerics_ladder.DEFAULT_THRESHOLDS
+    assert band.warn == 0.9999
+
+    # Armed without the gate, then gated explicitly, so the report read below
+    # is THIS row's and never a stale one from the process.
+    packages = {rig.entry_name(h, w): rig.ProbePackage(cosine=0.9995)
+                for h, w in rig.ROWS}
+    pipe, _module, outcome = rig.arm(
+        tmp_path, monkeypatch, cfg, packages, verify_numerics=False)
+    assert outcome.armed
+    # 0.9995 sits under the declared 0.9999 warn and over the default 0.999:
+    # the confession itself is the declaration's, not the SDK's.
+    assert provision.gate_cell_numerics(pipe, cfg, strict=True) is False
+    report = numerics_probe.last_report()
+    assert report is not None
+    assert report.thresholds.warn == 0.9999, \
+        "the gate did not use the declared warn band"
+    assert report.threshold_source == "declared", \
+        "the gate scored against a DECLARED band and reported `sdk-default`"
+
+
+def test_the_provenance_is_decided_in_exactly_one_place():
+    """The structural half of the row above: `Thresholds` carries its own
+    source, so a reader cannot disagree with the band it is reporting on."""
+    assert numerics_ladder.DEFAULT_THRESHOLDS.source == \
+        "sdk-default"
+    for name, build in CFGS.items():
+        cfg = build()
+        assert numerics_ladder.declared_thresholds(cfg).source == \
+            "declared", name
+        assert numerics_ladder.declared_thresholds(_undeclare(cfg)).source == \
+            "sdk-default", name
+
+
+# ---------------------------------------------------------------------------
+# 4. the fences: ONE constructor, no re-key, and the band survives a migration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(CFGS))
+def test_declaring_a_band_never_moves_a_cell_key(name):
+    """A numerics band is a GATE, not a graph axis. If declaring one re-keyed,
+    every family that states its floor would re-mint the whole fleet — which is
+    the cost that makes "just leave it at the default" tempting."""
+    cfg = CFGS[name]()
+    bare = _undeclare(cfg)
+
+    if isinstance(cfg, CompileCell):
+        assert "numerics_floor" not in cfg.contract_facts()
+        assert "numerics_warn" not in cfg.contract_facts()
+        assert cfg.contract_digest() == bare.contract_digest()
+    else:
+        assert "numerics_floor" not in cfg.contract_axes()
+        assert "numerics_warn" not in cfg.contract_axes()
+        assert cfg.contract_axes() == bare.contract_axes()
+        # ...and BECAUSE it does not re-key, `contract_delta` alone would wave a
+        # dropped band through. That is what OVERRIDE_FACTS is for.
+        assert derive.contract_delta(cfg, bare) == {}
+        assert set(derive.override_delta(cfg, bare)) == {
+            "numerics_floor", "numerics_warn"}
+
+
+def test_one_constructor_maps_a_declaration_onto_a_cell():
+    """Both production sites go through `CompileCell.from_declaration`, so a
+    must-survive field cannot reach one path and not the other — which is
+    precisely how the band reached no gate at all."""
+    decl = rig.declaration()
+    for name, build in CFGS.items():
+        cell = build()
+        if not isinstance(cell, CompileCell):
+            continue
+        assert cell.numerics_floor == decl.numerics_floor, name
+        assert cell.numerics_warn == decl.numerics_warn, name
+
+    every: Dict[str, Any] = dataclasses.asdict(
+        CompileCell.from_declaration(decl, lora_bucket=0))
+    assert every["numerics_floor"] == rig.FLOOR
+    assert every["numerics_warn"] == rig.WARN


### PR DESCRIPTION
## Verified first: `25f1f190` really did fix the headline

The ranked note in `progress.md` still carries pgw#1150's finding as OPEN — *"`Compile.numerics_floor` REACHES NOBODY"*. It is **stale**. On `88af2c9b`:

- `registry.CompileCell` carries `numerics_floor`/`numerics_warn` (`registry.py:90-91`), populated by `EndpointSpec.compile_cell()` (`registry.py:250-251`);
- `cli/run.py:853` carries them onto the §4.28 desktop object;
- author CI never needed the fix — `_Subject.declaration` (`author_ci.py:428`) hands the gate the **raw `Compile`**.

Driven through the real mint-parent path (`arm_aot(verify_numerics=True)` → `gate_cell_numerics` → `probe_cell`), a `spec.compile_cell()` is judged at the declared **0.995** with `threshold_source="declared"` and refuses a 0.99 cell the SDK default would only have DEGRADED. **12 of the 17 rows added here are green on master** and record that.

## What was still open

**The band's provenance was answered twice.** `numerics_probe.probe_cell` re-derived `threshold_source` from `cfg.numerics_floor` alone, while `numerics_ladder.declared_thresholds` resolves the band from `floor` **or** `warn`. So a family declaring only `numerics_warn` is judged at its **declared** band while the wire row, the `author-ci.toml` `[proof]` record and `Parity.floor_source` all report `sdk-default`.

Under §4.32 the gate is the publish decision and that record is what it is argued from, so a field whose entire job is to say which band decided, saying the wrong one, is the same defect as a floor nobody reads — one level in.

`declared_thresholds` is now the one authority and stamps `Thresholds.source` (`declared` / `sdk-default`). Nobody re-derives it.

**And the structural cause, not just the instance.** Two sites map a `Compile` onto a `CompileCell` — the registry's `compile_cell()` and `cli.run`'s desktop arm — and a must-survive field reaching one but not the other silently judges a whole path at a default nobody chose. That is precisely what the numerics band was. Both collapse onto `CompileCell.from_declaration`, field-for-field identical to what each built before.

## Why the original defect survived a green suite

Every pre-existing gate row passes a raw `Compile` — **a type no fleet path ever hands the gate**. Deleting the two `numerics_floor=` lines from `registry.py` today leaves the whole suite green.

`tests/test_declared_floor_at_every_gate_pgw1150.py` (17 rows) parametrizes the real `arm_aot(verify_numerics=True)` and `provision.gate_cell_numerics` paths over **all three cfg objects a gate is actually handed in production** — author-CI raw `Compile`, fleet `registry.CompileCell`, local CLI `CompileCell`. The two bands are discriminated by **wire phase on one measurement**: cos=0.99 is DESTROYED against 0.995 and merely DEGRADED against 0.98, so nothing is inferred from a number the test also chose. Plus the negative control (an undeclared family still gets 0.98 and reports `sdk-default`) and the no-re-key fences (`contract_axes`/`contract_facts` exclude the band; `derive.OVERRIDE_FACTS` still catches a migration dropping it).

## RED evidence

Against a clean `git archive` export of `88af2c9b`, **5 of 17 red**:

| row | red because |
|---|---|
| `test_a_warn_only_declaration_is_reported_as_DECLARED[author-ci/raw-Compile]` | `assert 'sdk-default' == 'declared'` |
| `…[fleet-mint-parent/registry.CompileCell]` | `assert 'sdk-default' == 'declared'` |
| `…[local-serve/cli.CompileCell]` | `assert 'sdk-default' == 'declared'` |
| `test_the_provenance_is_decided_in_exactly_one_place` | `Thresholds` has no attribute `source` |
| `test_one_constructor_maps_a_declaration_onto_a_cell` | `CompileCell` has no attribute `from_declaration` |

The three behavioural rows assert the wire vocabulary as **literals**, deliberately — a row that goes red with an `AttributeError` on the new API proves nothing about which floor decided.

## Verification

- `tests/test_{numerics_ladder,numerics_gate_pgw868,author_ci_harness_pgw1150,declared_floor_at_every_gate_pgw1150}.py` — 53 passed
- registry/`CompileCell` consumers (`sdk_v2_pgw647`, `lora_cells`, `arm_compile_pgw517`, `vocabulary_train_pgw654`, `aot_derive_pgw1107`, `compile_cache`, `measure_only_pgw1134`) — 161 passed
- mint/adopt paths (`adopted_cell_warm_proof_pgw1141`, `aot_selfmint_pgw805`, `aot_local_mint_pgw1096`, `two_run_reuse_pgw1096`, `delegated_adopt_reason_pgw999`, `abandoned_mint_telemetry_pgw848`, `graph_witness_pgw1031`, `executor_adopt`) — 138 passed
- mypy clean on the four touched modules; ruff clean; `lint_http_timeouts.py` and `assemble_changelog.py --check` pass

No pods, no mint, no GPU, no compile. **No release cut** — this rides the next wheel; the waiting consumer is the mint-time publish gate (a cell published under the wrong floor is the cost).