### PR TITLE
th#1800: a self-mint decline names the CARD CLASS that would admit it

### DIFF
--- a/changelog.d/th1800.md
+++ b/changelog.d/th1800.md
@@ -1,0 +1,13 @@
+- **th#1800: a self-mint decline now names the CARD CLASS that would admit the mint.**
+  `MintBudget.card_bytes` (the server's own resident set plus the child's whole ask) rides
+  the `self_mint_skipped` line as `card>=<N>GiB`. Everything the line carried before was a
+  fact about the card the mint did NOT fit on, and §4.28 leaves exactly one way to get a
+  cell for a family that does not fit — *"pre-warming a release/SKU = boot an ordinary
+  serving pod there"* — which is booked by SKU, not by shortfall. wan-2.2-t2v-a14b's
+  `headroom=37.68GiB needed~=72.54GiB resident=40.65GiB` is **113.19 GiB of card**, i.e.
+  H200-class; that number had to be re-derived by hand from a log line before anyone could
+  say so, and the hand-derivation is why the issue was filed as *"no path to a compile
+  cell"* rather than as a placement fact. Also corrects `compile_cache`'s module docstring
+  and `docs/compile-cache.md`, both of which still named training-endpoints'
+  `produce-inductor-cache` as the producer — te#179 deleted it and §4.28/§4.30 make its
+  absence permanent.

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -77,15 +77,22 @@ boot/pre-trace GATES unchanged). `kind`/`format` are single-valued metadata,
 recompile") is enforced by `tests/test_cell_key_pgw1059.py`.
 
 Compile wins 15-34% warm latency on flux-class models but costs 20-46s per
-(model, shape) and needs a C toolchain prod worker images don't ship. The
-split:
+(model, shape). The split:
 
-- **Producer** — the platform's first-party compile job (training-endpoints
-  `produce-inductor-cache`) runs on the target GPU SKU with a toolchain,
-  compiles the declared shape set, and publishes the captured
+- **Producer** — the SERVING WORKER itself, on the card it will serve from. It
+  compiles the declared shape set in a mint child and publishes the captured
   `TORCHINDUCTOR_CACHE_DIR` + `TRITON_CACHE_DIR` as ONE deterministic
   `.tar.gz` flavor `#inductor-<sku>-torch<maj.min>` of the family system repo
   `root/family-<family>`.
+  **There is no out-of-process producer, and there must not be one** (th#1800):
+  training-endpoints' `produce-inductor-cache` was deleted by te#179 and
+  DESIGN-RULINGS §4.28/§4.30 make its absence permanent — no forge, no mint
+  request, no compile fleet, and compilation runs on the machine that will USE
+  the cell. A family whose mint does not fit beside its own server is a
+  PLACEMENT question, not a missing-producer question: §4.28's answer is "boot
+  an ordinary serving pod on a card that fits", and the decline line's
+  `card>=<N>GiB` (`mint_budget.MintBudget.card_bytes`) is the number that
+  names which card.
 - **Consumer** — an endpoint opts in with
   `@endpoint(compile=Compile(family="flux2-klein-4b", shapes=((768,768),(1024,1024)), text_len=512))`.
   Every `compile=` endpoint MUST state `text_len` (ie#544): a positive value

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1,12 +1,23 @@
 """Per-SKU torch.compile cache artifacts (#384).
 
 torch.compile wins 15-34% warm latency on flux-class models but costs 20-46s
-of compile per (model, resolution) and needs a C toolchain the prod worker
-images don't ship. The split: a platform compile job (training-endpoints
-``produce-inductor-cache``) compiles once per GPU SKU and publishes the
-inductor+triton cache dirs as a repo flavor; workers that opt in via
+of compile per (model, resolution). The artifact is the inductor+triton cache
+dirs, published as a repo flavor; workers that opt in via
 ``@endpoint(compile=Compile(...))`` seed those dirs before load and hit the
 cache with no compiler and no stall.
+
+**Who produces one, as of 2026-08-11 (th#1800).** The worker itself, and
+nobody else. The out-of-process producer this module was designed around —
+training-endpoints ``produce-inductor-cache`` — was DELETED by te#179 (it
+minted ``kind="torch-inductor-cache"``, and th#1788 made ``aot-inductor`` the
+only class the hub adopts, so its publishes were refused before entering the
+store), and DESIGN-RULINGS §4.28/§4.30 make that permanent: there is no forge,
+no mint request and no compile fleet, and compilation runs on the machine that
+will USE the cell. A family too large to self-mint beside its own server is a
+PLACEMENT question — boot its serving pod on a card that fits, per §4.28's
+"pre-warming a release/SKU = boot an ordinary serving pod there" — and
+:meth:`~gen_worker.mint_budget.MintBudget.card_bytes` is the number that
+question is answered with.
 
 Policy: cache miss / key mismatch / no artifact leaves ordinary lanes eager,
 never causing a boot stall or a runtime compile attempt in prod. A declared
@@ -18,7 +29,8 @@ Artifacts are FAMILY-keyed (settled 2026-07-06): torch.compile caches key on
 the traced graph + shapes, not the weights, so one artifact serves every
 fine-tune of a model family. They live in a system-owned repo per family
 (``root/family-<family>``), one flavor per (SKU, torch) cell — and they
-are CODE: only the platform's first-party compile job publishes shared ones.
+are CODE: only a TRUSTED-hardware worker publishes shared ones (§4.28;
+untrusted hardware mints for itself and never uploads).
 
 Artifact = deterministic ``.tar.gz``::
 

--- a/src/gen_worker/mint_budget.py
+++ b/src/gen_worker/mint_budget.py
@@ -108,6 +108,27 @@ class MintBudget:
     #: 21.48 GiB free.
     cap_bytes: int = 0
 
+    @property
+    def card_bytes(self) -> int:
+        """th#1800: the TOTAL device memory a card must carry to admit this
+        mint at all — the server's own resident set plus the child's whole ask.
+
+        A decline that says only "not here" cannot be acted on; §4.28 leaves
+        exactly one way to get a cell for a family that does not fit
+        (*"pre-warming a release/SKU = boot an ordinary serving pod there"*),
+        and acting on that needs a card CLASS, not a shortfall. wan-2.2-t2v-a14b
+        declined at ``resident=40.65 need~=72.54`` on an 80 GiB H100 — the H200
+        that admits it is a fact of THIS number (113.19 GiB), and it had to be
+        re-derived by hand from a log line before it could be stated.
+
+        ``resident_bytes`` is added because the server's weights are already
+        allocated and therefore already outside ``free_bytes``: the card must
+        hold both processes, not just the child.
+        """
+        if not self.probed:
+            return 0
+        return self.resident_bytes + self.need_bytes
+
     def line(self, event: str, reason: str) -> str:
         """The one structured line a decline logs and puts on the wire."""
         if not self.probed:
@@ -119,6 +140,7 @@ class MintBudget:
             f"activation={_gib(self.activation_bytes)}"
             f"({'measured' if self.measured else 'estimated'}) "
             f"cap={_gib(self.cap_bytes)} "
+            f"card>={_gib(self.card_bytes)} "
             f"cache_slack={_gib(self.cache_slack_bytes)}"
         )
 

--- a/tests/test_mint_card_class_th1800.py
+++ b/tests/test_mint_card_class_th1800.py
@@ -1,0 +1,91 @@
+"""th#1800: a self-mint decline must name the CARD CLASS that would admit it.
+
+The wall this covers is real and measured (ie#655, wan-2.2-t2v-a14b on an
+80 GiB H100)::
+
+    self_mint_skipped reason=insufficient_vram headroom=37.68GiB
+                      needed~=72.54GiB resident=40.65GiB activation=26.89GiB
+
+Everything in that line is about the card the mint did NOT fit on. Nothing in
+it answers the only question a §4.28 platform can act on — *which card does?*
+— because the mint path §4.28 leaves is "boot an ordinary serving pod there",
+and a pod is booked by SKU, not by shortfall. That number had to be
+re-derived by hand (40.65 + 72.54 = 113.19 GiB, i.e. H200-class) before
+anybody could say so, and the hand-derivation is exactly why the issue was
+filed as "no path to a compile cell" rather than as a placement fact.
+
+The arithmetic is deliberately the server's resident set PLUS the child's
+whole ask: the server's weights are already allocated and therefore already
+outside ``free_bytes``, so a card that carries only ``need_bytes`` carries the
+child and evicts the tenant.
+"""
+
+from __future__ import annotations
+
+from gen_worker import mint_budget
+
+_GIB = 1 << 30
+
+
+def _wan22_decline() -> mint_budget.MintBudget:
+    """The ie#655 reading, verbatim, as a budget value."""
+    return mint_budget.MintBudget(
+        fits=False,
+        probed=True,
+        measured=True,
+        free_bytes=int(37.68 * _GIB),
+        need_bytes=int(72.54 * _GIB),
+        resident_bytes=int(40.65 * _GIB),
+        activation_bytes=int(26.89 * _GIB),
+        cap_bytes=int(72.54 * _GIB),
+    )
+
+
+def test_card_bytes_is_the_placement_fact() -> None:
+    """RED before th#1800: ``card_bytes`` did not exist, so the H200 verdict
+    lived only in a tracker paragraph."""
+    budget = _wan22_decline()
+    assert budget.card_bytes == budget.resident_bytes + budget.need_bytes
+    gib = budget.card_bytes / _GIB
+    assert 113.0 < gib < 113.5, gib
+
+    # The verdict the number carries, stated as the two catalog facts it
+    # decides between (runpod-go-sdk gpu_catalog.go): an 80 GiB H100 cannot
+    # admit this mint and a 141 GB H200 can. Both are sm_90, so the cell the
+    # H200 mints is key-identical for the H100 fleet.
+    assert budget.card_bytes > 80 * _GIB
+    assert budget.card_bytes < 131 * _GIB
+
+
+def test_decline_line_names_the_card() -> None:
+    """The fact has to be ON THE WIRE, not merely computable: the decline is
+    an activity event the hub stores, and a fact nobody transmits is a fact
+    the next lane re-derives."""
+    line = _wan22_decline().line("self_mint_skipped", "insufficient_vram")
+    assert "card>=113.19GiB" in line, line
+    # ...beside, not instead of, everything the line already carried.
+    for token in ("reason=insufficient_vram", "headroom=", "needed~=",
+                  "resident=", "activation=", "cap=", "cache_slack="):
+        assert token in line, (token, line)
+
+
+def test_unprobeable_states_nothing() -> None:
+    """A card that cannot be read decides no placement. ``card_bytes`` is 0
+    and the line is unchanged — this module never guesses a SKU."""
+    blind = mint_budget.MintBudget(fits=True, probed=False)
+    assert blind.card_bytes == 0
+    assert blind.line("self_mint_skipped", "x") == (
+        "self_mint_skipped reason=x headroom=unprobeable")
+
+
+def test_a_fitting_budget_also_states_its_card() -> None:
+    """Not a decline-only field. A mint that fits still records what it took,
+    so the fleet can learn a family's mint card from a SUCCESS as well as
+    from a refusal."""
+    ok = mint_budget.MintBudget(
+        fits=True, probed=True, measured=True,
+        free_bytes=40 * _GIB, need_bytes=12 * _GIB,
+        resident_bytes=8 * _GIB, activation_bytes=2 * _GIB,
+        cap_bytes=38 * _GIB)
+    assert ok.card_bytes == 20 * _GIB
+    assert "card>=20.00GiB" in ok.line("self_mint", "ok")


### PR DESCRIPTION
## The gap

`self_mint_skipped` told the fleet what did not fit and never what would:

```
self_mint_skipped reason=insufficient_vram headroom=37.68GiB needed~=72.54GiB
                  resident=40.65GiB activation=26.89GiB
```

Every term there is a fact about the card the mint was refused on. DESIGN-RULINGS §4.28 leaves exactly one way to get a cell for a family that does not fit on its serving card — *"pre-warming a release/SKU = boot an ordinary serving pod there"* — and a pod is booked by **SKU**, not by shortfall. So the one number the platform can act on was the one the line did not carry.

## The change

`MintBudget.card_bytes` = `resident_bytes + need_bytes` (the server's weights are already allocated and therefore already outside `free_bytes`, so the card must hold both processes). It rides the line as `card>=<N>GiB`.

For wan-2.2-t2v-a14b that is **113.19 GiB** — H200-class. `runpod-go-sdk/gpu_catalog.go` says H200 is 141 GB at **SMCapability 90**, identical to the H100 fleet, so the cell an H200 pod mints is key-identical (`cell_key`'s `sm` axis is `sm_90` for both) for every H100 pod that adopts it. B200 is sm_100 and would mint a cell no H100 can use. That verdict had to be re-derived by hand off a log line in ie#655 before anyone could state it, which is why th#1800 was filed as *"large models have no path to a compile cell"* rather than as a placement fact.

Also corrects two docs that still named a deleted producer: `compile_cache`'s module docstring and `docs/compile-cache.md` both pointed at training-endpoints `produce-inductor-cache`, which te#179 deleted and which §4.28/§4.30 make permanently absent (no forge, no mint request, no compile fleet; compilation runs on the machine that will USE the cell).

## Proof

- **RED:** all four rows of `tests/test_mint_card_class_th1800.py` fail against `origin/master`'s tree — `AttributeError: 'MintBudget' object has no attribute 'card_bytes'` — and pass here.
- `mypy src/gen_worker` clean (270 files); `ruff check src/gen_worker` clean; `lint_http_timeouts` / `lint_unreached_surface` / `lint_unbounded_reads` / `assemble_changelog --check` green.
- 109 rows green across every mint-budget-adjacent suite (`pgw737`, `pgw848` ×2, `pgw784` ×3, `pgw930`, `pgw877`, `pgw992`).
- **$0** — no pods, no mints, no GPU, no compile. Unreleased; rides the next cut (pgw#1140).