### PR TITLE
pgw#1050: the `toolchain` cell-key axis is the COMPILER, not the model libraries — THE CORPUS RE-KEYS

### DIFF
--- a/changelog.d/pgw1050.md
+++ b/changelog.d/pgw1050.md
@@ -1,0 +1,32 @@
+- **pgw#1050: the `toolchain` cell-key axis is the COMPILER, not the model
+  libraries — `diffusers`/`transformers`/`peft` are evicted. THE CORPUS
+  RE-KEYS.** ⚠️ **Whoever cuts the wheel carrying this must know: every ck1 key
+  in the fleet changes.** The three libraries' RECORD digests were folded into
+  `compile_cache.toolchain_digest`, so a `diffusers` patch release re-keyed
+  every cell in the fleet — a full re-mint bought by a bump that changed no
+  graph. Their whole effect on a cell arrives through the traced computation
+  (ops, literal args, tensor meta, symbolic ranges, the graph signature and
+  both pytree specs), which the `graph` axis hashes node-for-node since
+  pgw#1031; the two channels that could route around it are closed by
+  CONSTRUCTION and not by this axis — weight/constant VALUES cannot reach the
+  artifact (the B1 code-only gate + the pgw#1097 folding fence, both declared
+  and refused pre-download by `aot_serve.verify_declared`), and torch settings
+  a library mutates behind our back trip `env_seal.assert_seal_unchanged`
+  pre-trace and are refused by name. So a model-library bump either moves the
+  graph, and re-keys through the axis that honestly owns it, or cannot change
+  the artifact at all.
+  MEMBERSHIP is the only thing that narrows: identification of everything that
+  stays is still the CONTENT digest of the installed wheel's RECORD, never a
+  version string. `cell_key.toolchain_facts` / `toolchain_axis_digest` is the
+  ONE statement of membership, applied by the producer and by every reader that
+  restates the axis from a recorded block (publish recompute, boot key, arm
+  handback, the `ArtifactIdentity` wire fact) — a deny-list, so a component
+  nobody has classified keys by default. The pre-trace surfaces that cannot see
+  a graph stay pessimistic and are deliberately untouched: `compile_cache.verify`
+  still refuses a local JIT cell on a `libs` drift.
+  **Consequence, stated rather than discovered:** published cells carry
+  pre-narrowing keys and pre-narrowing `toolchain_digest` wire facts, so no pod
+  running this wheel will ever ask for one. The corpus is purged and the fleet
+  re-mints once — the pgw#1059/pgw#868 precedent, at a corpus of ~15 ck1 cells,
+  and `KEY_SCHEME` correctly stays `ck1` (§1.27(g), pre-launch). Bought once,
+  every subsequent `diffusers`/`transformers`/`peft` bump costs zero re-mints.

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -76,6 +76,16 @@ boot/pre-trace GATES unchanged). `kind`/`format` are single-valued metadata,
 (pgw#1059 amendment 6: "don't key on parameters that don't require us to
 recompile") is enforced by `tests/test_cell_key_pgw1059.py`.
 
+`toolchain` is the COMPILER — torch/Inductor, triton, ptxas, the CUDA runtime
+wheels, the settings declaration, the boot-frozen native manifest. It is **not**
+`diffusers`/`transformers`/`peft` (pgw#1050): those are pure python, run at
+trace time only, and everything they do to a cell arrives as the traced graph,
+which the `graph` axis hashes node-for-node since pgw#1031. Folding them
+re-keyed every cell in the fleet on every model-library patch release for a
+computation that had not moved. Their versions stay recorded for forensics.
+`tests/test_toolchain_membership_pgw1050.py` holds both halves: an evicted
+library moves no key, a compiler component still does.
+
 Compile wins 15-34% warm latency on flux-class models but costs 20-46s per
 (model, shape) and needs a C toolchain prod worker images don't ship. The
 split:

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -120,7 +120,8 @@ def artifact_identity(meta: Mapping[str, Any]) -> ExpectedIdentity:
     return ExpectedIdentity(
         cell_key=str(meta.get("cell_key") or ""),
         toolchain_digest=(
-            cell_key.facts_digest(dict(toolchain)) if isinstance(toolchain, dict) else ""),
+            cell_key.toolchain_axis_digest(dict(toolchain))
+            if isinstance(toolchain, dict) else ""),
         env_seal_digest=(
             env_seal.seal_digest(dict(seal)) if isinstance(seal, dict) else ""),
         graph_contract_digest=str(meta.get("combined_graph_hash") or ""),

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -50,7 +50,11 @@ test admits four axes and no more:
                   RECORDs + bundled ptxas/nvdisasm binaries) PLUS the
                   settings DECLARATION digest (pgw#1049 seal v4) and the
                   boot-frozen loaded-library digest. Content, never version
-                  strings.
+                  strings. MEMBERSHIP is the COMPILER, not the model
+                  libraries (pgw#1050) — ONE derivation:
+                  :func:`toolchain_axis_digest` over the recorded
+                  ``toolchain`` block, which is what
+                  :func:`toolchain_facts` says the axis is.
 
 Axes deliberately NOT in the key, each because it fails the axiom:
 
@@ -76,6 +80,22 @@ Axes deliberately NOT in the key, each because it fails the axiom:
 * ``code_closure`` — pgw#990: a memo, never identity.
 * ``sku`` / ``cuda_driver`` / version strings / ``image_digest`` —
   observability (pgw#691, gw#577, pgw#700).
+* the MODEL LIBRARIES — ``diffusers`` / ``transformers`` / ``peft``
+  (pgw#1050). They ran inside ``toolchain`` until 2026-08-11, and that was
+  the axiom's other failure mode: an OVER-split. They are pure-python and
+  run at TRACE time only, so everything they can do to a cell arrives as
+  the traced computation — ops, literal args, tensor meta, symbolic ranges,
+  the graph signature and both pytree specs, all of which the ``graph``
+  axis hashes node-for-node since pgw#1031. The two channels that could
+  route around the graph are both closed by construction, not by this
+  axis: weight/constant VALUES cannot reach the artifact (the B1 code-only
+  gate and the pgw#1097 folding fence, both DECLARED and refused
+  pre-download by ``aot_serve.verify_declared``), and torch settings a
+  library mutates behind our back trip ``env_seal.assert_seal_unchanged``
+  pre-trace and are refused by name. So a model-library bump either moves
+  the graph — and re-keys through ``graph``, which is the honest axis — or
+  cannot change the artifact at all. Keeping them double-counted the first
+  case and re-minted the whole fleet for the second.
 
 There is no pre-trace ("arm") cell key any more. The pgw#1033/#1042
 two-digest-space design — a COMPUTED ``kind="inductor"`` key from declared
@@ -271,6 +291,45 @@ def envelope_digest(block: Mapping[str, Any]) -> str:
     return facts_digest(envelope_facts(block))
 
 
+#: Components a recorded ``toolchain`` block may carry that are NOT the
+#: ``toolchain`` axis (pgw#1050). The eviction is a MEMBERSHIP change and
+#: only that: identification of everything that stays is still the CONTENT
+#: digest of the installed wheel's RECORD, never a version string (the
+#: pgw#1050 amendment's own constraint — in a pinned-PyPI fleet versions and
+#: content change at the same rate, so version strings would buy no churn
+#: reduction and would accept the rebuilt/patched-wheel divergences content
+#: catches).
+#:
+#: Read the module docstring for WHY these three are not members. Deny-list
+#: rather than allow-list on purpose: a component nobody has classified must
+#: stay IN the key, because the axiom's expensive failure is the over-split
+#: and the axiom's UNSAFE failure is the under-split.
+_NOT_TOOLCHAIN: Tuple[str, ...] = ("diffusers", "transformers", "peft")
+
+
+def toolchain_facts(block: Mapping[str, Any]) -> Dict[str, str]:
+    """The canonical form of one recorded TOOLCHAIN block — the single
+    statement of what the ``toolchain`` axis IS.
+
+    Applied at BOTH ends, exactly as :func:`envelope_facts` is: the producer
+    (``compile_cache.toolchain_digest``) collects the components, and every
+    reader that restates the axis from an artifact's recorded block
+    (the publish recompute, the boot key, the arm handback, the wire
+    identity) reads membership from here. Two ends that decide membership
+    separately are two derivations of one axis, which is the failure
+    ``test_cell_key_pgw1059``'s fence exists to prevent.
+    """
+    return {
+        str(name): str(value) for name, value in block.items()
+        if str(name) not in _NOT_TOOLCHAIN
+    }
+
+
+def toolchain_axis_digest(block: Mapping[str, Any]) -> str:
+    """The ``toolchain`` key-axis value for one recorded toolchain block."""
+    return facts_digest(toolchain_facts(block))
+
+
 # --- the SUBJECT: what an obligation is FOR (pgw#1113) ---------------------
 #
 # THE ASYMMETRY, stated once, here, because both consumers below depend on it:
@@ -401,7 +460,7 @@ def from_exported_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
         "graph": combined,
         "envelope": envelope_digest(envelope),
         "sm": sm,
-        "toolchain": facts_digest(toolchain),
+        "toolchain": toolchain_axis_digest(toolchain),
     })
 
 
@@ -417,6 +476,8 @@ __all__ = [
     "envelope_digest",
     "envelope_facts",
     "facts_digest",
+    "toolchain_axis_digest",
+    "toolchain_facts",
     "from_exported_artifact_metadata",
     "from_axes",
     "is_key",

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -37,6 +37,12 @@ by a different gen-worker, or traced under different low-VRAM flags, can
 pass every other key yet miss inductor's FX-graph cache at trace time,
 serving eager while reporting adopted). ``source_ref`` records which family member the producer
 compiled from — informational, never part of the match.
+
+This paragraph is about the LOCAL/JIT recipe above, which is a PRE-TRACE facts
+comparison and must not UNDER-split: it cannot see a graph, so ``diffusers``
+stands in for one and stays. The exported lane's ck1 key is the opposite side
+of that asymmetry — it HAS the traced graph, so the model libraries are not in
+its ``toolchain`` axis (pgw#1050, :func:`toolchain_digest`).
 """
 
 from __future__ import annotations
@@ -938,8 +944,10 @@ def _static_imports(path: Path, module_name: str) -> set[str]:
 def static_code_closure() -> Tuple[Tuple[str, str], ...]:
     """The recipe's code identity: sorted (module path, content digest) of
     every source file statically reachable from the compile entrypoints.
-    Restricted to the gen_worker package; torch/diffusers/transformers content
-    rides the ``toolchain`` axis at package granularity instead. Deterministic:
+    Restricted to the gen_worker package; torch/triton content rides the
+    ``toolchain`` axis at package granularity, and the model libraries ride
+    the ``graph`` axis (pgw#1050 — their code IS the traced computation, and
+    nothing else about them reaches a cell). Deterministic:
     module-derived relative paths, sorted, content digests — never absolute
     paths, never bytecode.
 
@@ -979,6 +987,20 @@ def toolchain_digest() -> Tuple[Tuple[str, str], ...]:
     """pgw#710/pgw#1059: CONTENT identity of "the compiler stack AS WE
     CONFIGURE IT", per component — the ``toolchain`` key axis's whole input.
 
+    THE COMPILER, and not the model libraries (pgw#1050): ``diffusers`` /
+    ``transformers`` / ``peft`` rode this axis until 2026-08-11 and were
+    evicted because their whole effect on a cell arrives through the traced
+    graph, which the ``graph`` axis hashes node-for-node since pgw#1031 —
+    see ``cell_key``'s module docstring for the channel-by-channel argument
+    and for the two fences (B1 code-only + the pgw#1097 folding fence;
+    ``env_seal.assert_seal_unchanged``) that close the routes around it.
+    Folded here, every model-library patch release re-keyed every cell in
+    the fleet for a graph that had not moved. ``cell_key.toolchain_facts``
+    is the READER of the same membership, and the pair is what keeps one
+    axis one derivation. Their versions stay RECORDED for forensics
+    (:func:`_lib_versions`, ``artifact_metadata``'s ``libs`` block) — an
+    observability fact, exactly like ``sku``.
+
     The binary half (pgw#710) is the equivalence precondition that lets
     ``image_digest`` be relaxed (pgw#700) without degrading the compile
     stack's identity to version strings (the ccache ``compiler_check=mtime``
@@ -1016,7 +1038,7 @@ def toolchain_digest() -> Tuple[Tuple[str, str], ...]:
     # per-FILE digests and this axis's per-PACKAGE digests are two readings of
     # the same manifests, and reading them twice is how two surfaces start
     # disagreeing about what is installed.
-    wanted = ("torch", "triton", "diffusers", "transformers", "peft")
+    wanted = ("torch", "triton")
     for name, record in dist_records.record_texts().items():
         if name in wanted or name.startswith("nvidia-"):
             out[name] = hashlib.sha256(record.encode()).hexdigest()[:16]

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -300,7 +300,7 @@ def arm_identity(
         "sm": sm,
         "envelope": cell_key.envelope_digest(declared_envelope_block(cfg)),
         "env_seal": env_seal.seal_digest(env_seal.effective_seal()),
-        "toolchain": cell_key.facts_digest(dict(cc.toolchain_digest())),
+        "toolchain": cell_key.toolchain_axis_digest(dict(cc.toolchain_digest())),
         "subject": cell_key.subject_digest(subject),
         "targets": ",".join(str(t) for t in declared["targets"]),
         "dynamic": json.dumps(
@@ -1760,7 +1760,8 @@ def arm_axis_divergence(
             if isinstance(envelope_block, dict) and envelope_block else ""),
         "env_seal": env_seal.seal_digest(
             dict(meta.get(env_seal.SEAL_KEY) or {})),
-        "toolchain": cell_key.facts_digest(dict(meta.get("toolchain") or {})),
+        "toolchain": cell_key.toolchain_axis_digest(
+            dict(meta.get("toolchain") or {})),
     }
     parent = arm_key.facts_dict()
     for fact in ARM_ENVIRONMENT_FACTS:

--- a/tests/test_cell_key_pgw1059.py
+++ b/tests/test_cell_key_pgw1059.py
@@ -124,6 +124,16 @@ _DERIVATION_ALLOWLIST = {
         "fleet_cells.py",  # arm_identity + arm_axis_divergence (same derivation
                            # both sides of the handback seam — the pgw#1042 check)
     },
+    # the toolchain-axis digest, i.e. its MEMBERSHIP (pgw#1050). The producer
+    # (`compile_cache.toolchain_digest`) collects components; this is the one
+    # place that says which of them ARE the axis, and every reader that
+    # restates the axis from a recorded block must come through it or the
+    # two ends can disagree about membership.
+    "toolchain_axis_digest(": {
+        "cell_key.py",     # def (+ toolchain_facts)
+        "fleet_cells.py",  # arm_identity + arm_axis_divergence
+        "aot_identity.py",  # artifact_identity (the wire fact)
+    },
 }
 
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -141,10 +141,17 @@ def test_metadata_roundtrips_the_recipe_key(pinned_runtime: None) -> None:
     assert ck.from_exported_artifact_metadata(retooled).digest != want.digest
 
 
-def test_toolchain_covers_the_model_libraries() -> None:
+def test_toolchain_covers_the_compiler_and_not_the_model_libraries() -> None:
+    """pgw#1050 INVERTS this test. It used to demand ``diffusers`` and
+    ``transformers`` in the axis; their whole effect on a cell arrives through
+    the traced ``graph`` axis, so folding them here re-keyed the fleet on every
+    model-library bump for a computation that had not moved. Membership is the
+    compiler — see ``tests/test_toolchain_membership_pgw1050.py``."""
     toolchain = dict(cc.toolchain_digest())
-    for pkg in ("torch", "triton", "diffusers", "transformers"):
+    for pkg in ("torch", "triton"):
         assert pkg in toolchain, pkg
+    for pkg in ("diffusers", "transformers", "peft"):
+        assert pkg not in toolchain, pkg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_toolchain_membership_pgw1050.py
+++ b/tests/test_toolchain_membership_pgw1050.py
@@ -1,0 +1,193 @@
+"""pgw#1050 — the ``toolchain`` axis's MEMBERSHIP: the compiler, not the
+model libraries.
+
+The membership axiom (pgw#1059 amendment 6) has two failure modes and this
+file pins the expensive one. The key must not UNDER-split — that is the arm
+token's and the local-store verdict's problem, and both stay pessimistic. The
+key must also not OVER-split, and it did: ``diffusers``/``transformers``/
+``peft`` rode the ``toolchain`` axis while everything they can do to a cell
+already arrives through the traced ``graph`` axis (pgw#1031 folded the
+node-level witness, so the axis is the COMPUTATION and not the ingress). Every
+model-library patch release therefore re-keyed every cell in the fleet for a
+graph that had not moved.
+
+The two tests that matter are a matched pair, and neither is meaningful
+without the other:
+
+* an evicted component moves NO key (the over-split, fixed here) — RED on
+  `origin/master`, where each of the three moved the key;
+* a genuine compiler component still moves the key (the under-split, which
+  must never happen) — GREEN on both sides, and it is what makes the first
+  test a narrowing rather than a deletion.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import aot_identity, cell_key, compile_cache as cc, dist_records
+
+from harness.cell_meta import exported_cell_meta
+
+#: A recorded ``toolchain`` block of the shape a real mint records: the
+#: compiler proper (content digests of the wheels' RECORDs + the bundled CUDA
+#: tool binaries), the settings declaration, the boot-frozen native manifest —
+#: and, on a pre-pgw#1050 cell, the three model libraries.
+TOOLCHAIN: Dict[str, str] = {
+    "settings_declaration": "5" * 16,
+    "loaded_libs": "6" * 16,
+    "torch": "7" * 16,
+    "triton": "8" * 16,
+    "nvidia-cuda-nvrtc-cu13": "9" * 16,
+    "bin:ptxas": "a" * 16,
+    "diffusers": "b" * 16,
+    "transformers": "c" * 16,
+    "peft": "d" * 16,
+}
+
+#: What the axis IS. Every other component of a recorded block is not.
+COMPILER_COMPONENTS = (
+    "settings_declaration", "loaded_libs", "torch", "triton",
+    "nvidia-cuda-nvrtc-cu13", "bin:ptxas",
+)
+
+MODEL_LIBRARIES = ("diffusers", "transformers", "peft")
+
+
+def _bumped(component: str) -> Dict[str, str]:
+    """The same toolchain block with exactly one component's CONTENT moved —
+    a wheel bump, identified the way the amendment requires (the RECORD's
+    content digest), never a version string."""
+    block = dict(TOOLCHAIN)
+    block[component] = "f" * 16
+    return block
+
+
+def _key(block: Dict[str, str]) -> str:
+    """The ck1 key of a cell whose graph, envelope and sm are held fixed and
+    whose toolchain block is ``block``."""
+    return str(exported_cell_meta(toolchain=block)["cell_key"])
+
+
+# ---------------------------------------------------------------------------
+# The over-split — RED on origin/master, for each of the three
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("library", MODEL_LIBRARIES)
+def test_a_model_library_bump_does_not_rekey(library: str) -> None:
+    """Two cells identical in graph x envelope x sm, differing ONLY in a model
+    library's content, are ONE cell and must carry ONE key.
+
+    RED on `origin/master`: the axis folded the library's RECORD digest, so
+    the bump moved the key and the whole fleet re-minted for a computation
+    that had not changed.
+    """
+    assert _key(_bumped(library)) == _key(dict(TOOLCHAIN))
+
+
+@pytest.mark.parametrize("library", MODEL_LIBRARIES)
+def test_the_axis_ignores_the_library_even_when_a_cell_records_it(
+    library: str,
+) -> None:
+    """Membership is a property of the AXIS, not of whichever producer wrote
+    the block: a recorded block that carries the component digests the same as
+    one that does not."""
+    without = {k: v for k, v in TOOLCHAIN.items() if k not in MODEL_LIBRARIES}
+    with_one = dict(without)
+    with_one[library] = TOOLCHAIN[library]
+    assert (cell_key.toolchain_axis_digest(with_one)
+            == cell_key.toolchain_axis_digest(without))
+    assert library not in cell_key.toolchain_facts(TOOLCHAIN)
+
+
+# ---------------------------------------------------------------------------
+# The under-split — must stay GREEN on both sides of the change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("component", COMPILER_COMPONENTS)
+def test_a_genuine_toolchain_bump_still_splits(component: str) -> None:
+    """torch, triton, the CUDA runtime wheels, the bundled ptxas, the settings
+    declaration and the boot-frozen native manifest are the compiler. A cell is
+    a ``dlopen``-ed ELF linking torch's AOTI runtime: an ABI mismatch is a
+    segfault or silent numerics, never slowness. Each of them moves the key."""
+    assert _key(_bumped(component)) != _key(dict(TOOLCHAIN))
+
+
+def test_an_unclassified_component_stays_in_the_key() -> None:
+    """The eviction is a DENY-list, not an allow-list. A component nobody has
+    classified — a new ``nvidia-*`` runtime wheel, a new bundled tool — keys
+    by default, because the axiom's expensive failure is the over-split and
+    its UNSAFE failure is the under-split."""
+    block = dict(TOOLCHAIN)
+    block["nvidia-cublas-cu14"] = "e" * 16
+    assert _key(block) != _key(dict(TOOLCHAIN))
+
+
+# ---------------------------------------------------------------------------
+# The producer collects the same membership the reader states
+# ---------------------------------------------------------------------------
+
+
+def test_the_producer_does_not_collect_the_model_libraries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED on `origin/master`: ``toolchain_digest`` hashed the three RECORDs
+    alongside torch/triton/nvidia.
+
+    Driven off a synthetic env rather than this box's site-packages, so the
+    test cannot go falsely green on a machine that simply has no diffusers
+    installed.
+    """
+    env = {
+        "torch": "torch RECORD", "triton": "triton RECORD",
+        "nvidia-cuda-nvrtc-cu13": "nvrtc RECORD",
+        "diffusers": "diffusers RECORD", "transformers": "transformers RECORD",
+        "peft": "peft RECORD", "requests": "requests RECORD",
+    }
+    monkeypatch.setattr(dist_records, "record_texts", lambda: env)
+    cc.toolchain_digest.cache_clear()
+    try:
+        collected = dict(cc.toolchain_digest())
+    finally:
+        cc.toolchain_digest.cache_clear()
+    for library in MODEL_LIBRARIES:
+        assert library not in collected, library
+    # ...and it still collects the compiler, so the test is not passing by
+    # collecting nothing.
+    for component in ("torch", "triton", "nvidia-cuda-nvrtc-cu13"):
+        assert component in collected, component
+    # A distribution that is neither is not swept in by the narrowing.
+    assert "requests" not in collected
+
+
+def test_producer_and_reader_agree_on_membership() -> None:
+    """One axis, one membership: whatever the producer collects survives the
+    reader's canonical form untouched."""
+    collected = dict(cc.toolchain_digest())
+    assert cell_key.toolchain_facts(collected) == {
+        str(k): str(v) for k, v in collected.items()}
+
+
+# ---------------------------------------------------------------------------
+# The wire fact follows the key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("library", MODEL_LIBRARIES)
+def test_the_published_toolchain_wire_fact_follows_the_key(
+    library: str,
+) -> None:
+    """``ArtifactIdentity.toolchain_digest`` is compared fail-closed at adopt
+    time. If it kept the old membership while the key narrowed, every adoption
+    of a correctly-keyed cell would refuse on an axis that is a consequence of
+    the key — so it narrows with it."""
+    def _wire(block: Dict[str, Any]) -> str:
+        return aot_identity.artifact_identity(
+            exported_cell_meta(toolchain=block)).toolchain_digest
+
+    assert _wire(_bumped(library)) == _wire(dict(TOOLCHAIN))
+    assert _wire(_bumped("torch")) != _wire(dict(TOOLCHAIN))


### PR DESCRIPTION
## ⚠️ THE CORPUS RE-KEYS. Whoever cuts the wheel carrying this must know.

Narrowing a key axis changes every key derived from it. Published cells carry
**pre-narrowing `cell_key` values and pre-narrowing `toolchain_digest` wire
facts**, so no pod running this code will ever ask for one. **The corpus is
purged and the fleet re-mints once** — the pgw#1059/pgw#868 precedent, at a
corpus of ~15 ck1 cells across five sm. `KEY_SCHEME` correctly stays `ck1`
(§1.27(g), pre-launch): the axis's semantics are unchanged, its membership
narrowed. Bought once; **every subsequent `diffusers`/`transformers`/`peft`
bump then costs zero re-mints**, where today each one costs a full fleet.

## The defect

`compile_cache.toolchain_digest` folded the `diffusers`/`transformers`/`peft`
RECORD digests alongside torch/triton/nvidia, so a model-library patch release
re-keyed every cell in the fleet — a full re-mint bought by a bump that changed
no graph. That is the membership axiom's other failure mode: the key must not
OVER-split (pgw#1059 amendment 6). Over-splitting costs re-mints; only the arm
token and the local-store verdict have to worry about under-splitting, and both
are deliberately untouched here.

## The verdict, per library: all three OUT, and why

All three are **pure python** — no native extension in either wheel, so none can
reach `loaded_libs` (which enumerates only the torch/triton/nvidia package roots)
either. They run at **trace time only**. Everything they can do to a cell
therefore arrives as the traced computation, which the `graph` axis hashes
node-for-node since pgw#1031: ops, targets, connectivity, literal args (floats by
exact hex), per-node tensor meta, symbolic-dim RANGES, the graph signature and
both in/out pytree specs.

The channels that could route around the graph were checked one by one, and both
of the real ones are closed by CONSTRUCTION, not by this axis:

| channel | verdict |
|---|---|
| codegen / lowering / ops emitted / kernel selection | torch + inductor + triton + ptxas only. These libraries do not participate after `torch.export` returns. **Stays in the axis; that is the axis.** |
| serialization format of the exported program | torch's `.pt2`, versioned by torch. Not theirs. |
| **constant / weight VALUES baked into the artifact** | The one channel `graph_hash` deliberately does not cover (tensors render dtype/shape only, so a fine-tune shares a cell). **Structurally fenced:** B1 code-only (`package_constants_in_so=False`, proven by `aot_package.code_only_violations`) plus the pgw#1097 folding fence (`use_runtime_constant_folding=True`), both DECLARED on every cell and refused pre-download by `aot_serve.verify_declared`. §4.32(3)(b) rests on the same fence. |
| **torch settings mutated at import by a library** | `env_seal.assert_seal_unchanged` re-reads the live settings (including the full portable inductor config digest) pre-trace and refuses BY NAME. Gated, never silently keyed. |
| pytree registration (`ModelOutput` / `BaseOutput`), attention implementation, config flags | all move the graph — signature, specs, ops. Captured. |
| opaque python custom ops (`diffusers` attention dispatch, `transformers_msa::sparse_atten`, the moe op) | the generated `.so` calls them **by name through the dispatcher**; the implementation is resolved at load and is not in the artifact. The compiled artifact is unchanged, so the axiom does not admit it — and the fleet already accepts this for its own `kernel_path` custom op, which is opaque to inductor and whose producing `gen_worker` version is not a key axis at all. |

So a model-library bump either moves the graph — and re-keys through the axis
that honestly owns it — or cannot change the artifact at all. Keeping them
double-counted the first case and re-minted the whole fleet for the second.

## What actually changed

**MEMBERSHIP only.** Identification of everything that stays is still the
CONTENT digest of the installed wheel's RECORD, never a version string (the
amendment's own constraint, and the no-version-strings ruling).

`cell_key.toolchain_facts` / `toolchain_axis_digest` is the ONE statement of
membership — the `envelope_facts` pattern — applied by the producer and by every
reader that restates the axis from a recorded block (publish recompute, boot key,
arm handback, the `ArtifactIdentity` wire fact). The pgw#1059 single-derivation
fence now pins its call sites, so the two ends cannot drift apart about what the
axis is. It is a **DENY-list, not an allow-list**: a component nobody has
classified keys by default, because the axiom's expensive failure is the
over-split and its UNSAFE failure is the under-split.

`compile_cache.verify` (the local/JIT lane) still refuses a local cell on a
`libs` drift and is deliberately untouched: it is a PRE-TRACE facts comparison
with no graph to stand behind, so `diffusers` legitimately stands in for one
there. That asymmetry is now stated in the module docstring.

Their versions stay RECORDED for forensics (`_lib_versions`, the `libs` block) —
observability, exactly like `sku`.

## RED evidence

Against a clean `git archive` export of `origin/master` (not the working tree),
`tests/test_toolchain_membership_pgw1050.py` is **11 failed / 7 passed**:

- RED — `test_a_model_library_bump_does_not_rekey[diffusers|transformers|peft]`:
  each moved the ck1 key.
- RED — `test_the_published_toolchain_wire_fact_follows_the_key[…]`: each moved
  `ArtifactIdentity.toolchain_digest`, which is compared fail-closed at adopt.
- RED — `test_the_producer_does_not_collect_the_model_libraries`: driven off a
  SYNTHETIC dist env, so it cannot go falsely green on a box with no diffusers
  installed.
- RED — `test_the_axis_ignores_the_library_even_when_a_cell_records_it[…]` and
  `test_producer_and_reader_agree_on_membership` (no membership canonicalizer
  existed).
- **GREEN on both sides — the matched negative**, which is what makes this a
  narrowing and not a deletion:
  `test_a_genuine_toolchain_bump_still_splits[torch|triton|nvidia-cuda-nvrtc-cu13|bin:ptxas|settings_declaration|loaded_libs]`
  plus `test_an_unclassified_component_stays_in_the_key`.

After the change: 18 passed. `tests/test_recipe_identity.py`'s
`test_toolchain_covers_the_model_libraries` is INVERTED in place (it demanded
the old behaviour) rather than deleted.

## Verification

- `mypy src/gen_worker` clean (266 files), `ruff check src/gen_worker` clean.
- All nine `fast gates` lint scripts pass; `assemble_changelog.py --check` passes.
- 922 passed / 5 skipped across every test file touching `toolchain`,
  `artifact_identity` or `arm_axis_divergence` (67 files), plus 148 passed on the
  core identity files after rebasing onto `origin/master` (which had moved 5
  commits, including pgw#1092's forge deletion).
- No pods, no GPU, no mint, no compile. $0.

## Not in scope

pgw#1050's OTHER half — AOTInductor ABI-compatible mode + the shim-symbol
NEED-SET vs EXPORT-SET load gate, which would narrow the axis further to
`{shim ABI, CUDA major, sm}` — is untouched and stays open. This PR discharges
the membership-narrowing amendment only.
