### PR TITLE
pgw#1152: the adopt-path rig becomes the default vehicle, and the fixture that hid four gates becomes unwriteable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,20 @@ jobs:
       - name: pgw#1122 guard - worker-credential reads outside the resolver
         run: uv run python scripts/lint_credential_identity.py
 
+      # GATING (pgw#1152): the ADOPT-PATH half of the same class. Four gates in
+      # a row — pgw#1108, pgw#1122, pgw#1141, pgw#1141b — were one defect: a
+      # rule written against the SELF-MINT path that the boot-adopt path does
+      # not take. `aot_serve._KNOWN_AOT_KEYS` had two feeders, both
+      # self-produced routes, so a cell that resolved, materialized and armed
+      # was scored on the dynamo ledger and thrown away on a real pod. The rule
+      # is structural now (registration happens inside `load_and_wrap`), and
+      # this fence keeps it: a production feeder off the seam is red, a stale
+      # row is red, a SECOND map into a fenced object is red, and a TEST that
+      # hand-feeds one or stubs a lane accessor is red — it drives
+      # tests/harness/adopt_rig.py instead. There is no CONVENTION class.
+      - name: pgw#1152 guard - arm-state feeders and the adopt-path rig
+        run: uv run python scripts/lint_arm_state_feeders.py
+
       # GATING (pgw#1049): the ambient-input census's structural claims —
       # IMPOSED rows exist in DECLARED_ENV, NEUTRALIZED rows are actually
       # scrub-covered, watched env literals in the tree are classified. The

--- a/changelog.d/pgw1152.md
+++ b/changelog.d/pgw1152.md
@@ -1,0 +1,47 @@
+- **pgw#1152: the ADOPT-PATH rig, and a fence that makes the fixture which hid four gates
+  unwriteable.** Four of the six reuse-circle gates — pgw#1108, pgw#1122, pgw#1141, pgw#1141b —
+  were ONE defect wearing different clothes: the boot-adopt path structurally differs from the
+  self-mint path (it arms BEFORE setup, its compute child holds no JWT, and it is fed by
+  `fleet_cells.arm_ordered` rather than by the self-produced routes), and every gate was written
+  and validated against self-mint. RED-first caught all four *after* they shipped and prevented
+  none, because their fixtures simulated an adoption using self-mint machinery — thirteen rows
+  called `aot_serve.note_aot_key(key)` BY HAND, which is production's single missing line.
+
+  **The rig.** `tests/harness/adopt_rig.py` is the vehicle pgw#1141b built, promoted out of one
+  test file and made the default for anything arming-adjacent: real `ensure_setup` → real
+  `_enable_compiled` → a real `_ArmOrder(adopt=…)` → real `arm_ordered` → the real receipt gate
+  against a real RSA-signed receipt from a real HTTP hub → `provision.arm_aot` → `load_and_wrap`
+  on a real packed cell → real warmup, proof pass and target install. It constructs nothing
+  production constructs differently: outcomes are forced by REMOVING or BREAKING a real input (a
+  hub that serves no receipt, a packaged entry that really raises, a subject that really
+  diverges), never by supplying a fact. `harness/exported_cell.py` and `harness/receipt_hub.py`
+  are the two pieces it stands on, promoted out of `test_numerics_gate_pgw868.py` and
+  `test_receipts_pgw709.py` (already imported as rigs by five other modules).
+
+  **It re-finds a bug we already fixed.** `reintroduce(monkeypatch, "pgw1141b")` deletes both
+  halves of `f3ab710e` and the rig reproduces POD PROOF #4's chain verbatim —
+  `target_applicability_incomplete functions=()` → `armed_target_unresolved` → `serve_degrade`.
+  A rig that cannot re-find a known bug proves nothing.
+
+  **The fence.** `scripts/lint_arm_state_feeders.py` classifies every writer of arming/serving
+  process-global state by enclosing function (pgw#1122's `lint_credential_identity.py` shape):
+  unclassified is red, stale is red, a SEAM that stops feeding is red, and a **SECOND MAP** into a
+  fenced production object is red. There is deliberately no `CONVENTION` class and no `RELAY` —
+  a feeder called because a docstring asked the caller to remember is the bug itself. Tests get
+  exactly one label, `RECOGNIZER`, and the lint **checks the claim**: it is accepted only when the
+  enclosing function drives no arm and the module replaces no arm driver, so a fixture standing in
+  for an adoption still has nothing to write down.
+
+  **What the sweep changed.** `note_aot_key`'s two remaining production feeders
+  (`fleet_cells.arm_from_local_store`, `adopt_delegated_mint`) are DELETED, not moved — both ran
+  after their own arm had already passed the wrap, and a redundant copy of a structural fact is
+  how the convention survived long enough for `arm_ordered` not to keep it. `_ArmOrder` +
+  `_CompileArtifactSelection` gain ONE constructor, `_ArmOrder.for_artifact`: the §4.27 boot-adopt
+  order and the hub PLAN order were built independently and are field-for-field identical except
+  `adopt`, which is pgw#1150's duplicated-mapping cause on the object at the centre of this class.
+  The rig also hands the arm the type production hands it — a `CompileCell`, observed at the call
+  — and `production_cfgs()` parametrises a row over both real `Compile`→`CompileCell` call sites.
+
+  **All five test-side hand-registrations were removable with zero assertion changes** (pgw#735,
+  pgw#844, pgw#1141 ×2, pgw#1033): once the readers ask the OBJECT, the fixture line existed only
+  to hide the bug.

--- a/scripts/arm_state_feeders_allowlist.txt
+++ b/scripts/arm_state_feeders_allowlist.txt
@@ -1,0 +1,67 @@
+# pgw#1152 — every writer of arming/serving process-global state, classified.
+# Enforced by scripts/lint_arm_state_feeders.py: an unclassified feed is red, a
+# row matching nothing is red, and a SEAM that stops feeding is red. Keyed
+# <path>::<scope>::<name>, never a line.
+#
+# WHY THIS FILE EXISTS. `aot_serve._KNOWN_AOT_KEYS` decides which failure
+# detector applies to a serving object — the DYNAMO lane's cache-hit ledger,
+# which an AOTI artifact can never move, or §4.31's serve-first rule. pgw#1033
+# wrote its feeding rule as a CONVENTION ("whoever reads a cell_key off an
+# aot-inductor envelope registers it") with two feeders, BOTH self-produced
+# routes. `arm_ordered` — every hub Plan arm and every §4.27 boot-adopt — kept
+# nothing, so on a real pod (pgw#1141b, POD PROOF #4) a cell that resolved,
+# materialized and armed was scored on the dynamo ledger, disarmed, and the pod
+# served eager for life. That was the FOURTH gate in a row with the same shape:
+# a rule written against the self-mint path, and an adopt path that does not
+# take it.
+#
+# THE SEAM. `aot_serve.load_and_wrap` registers the key at the wrap — the one
+# function every arm route passes, and the moment the fact becomes true. It is
+# never written here; the lint asserts the call still exists.
+#
+# THERE IS NO `CONVENTION` CLASSIFICATION, AND NO `RELAY`. A feeder called
+# because a docstring asked the caller to remember is the bug itself, twice
+# over. Move it to the seam, or delete it and ask the OBJECT
+# (`aot_serve.holds_exported_cell`, pgw#1141b).
+#
+#   VERDICT     the site records a decision only this frame can know, and sits
+#               AT that decision. No seam can derive it: a proof pass concluding
+#               a cell served its own graph is not a fact about the wrap.
+#   OWNER       the module that owns the state writing it from its own primary
+#               write path.
+#   RECOGNIZER  TESTS ONLY, and the lint CHECKS the claim: the enclosing
+#               function must drive no arm and the module must replace no arm
+#               driver. A fixture standing in for an adoption cannot qualify.
+
+# ---------------------------------------------------------------------------
+# VERDICT — a decision, recorded where the decision is made.
+# ---------------------------------------------------------------------------
+src/gen_worker/executor.py::Executor._setup_locked_inner::compile_cache.record_cell_proven  VERDICT  the boot proof pass concluding this object served its OWN warmup graph (gw#587); no seam observes a proof
+src/gen_worker/executor.py::Executor._setup_locked_inner::compile_cache.record_cell_quarantined  VERDICT  the same pass concluding the opposite — pgw#672's churn-loop stop, written at the disarm
+src/gen_worker/executor.py::Executor._compile_guard_failed::compile_cache.record_cell_quarantined  VERDICT  a serve-time cell-attributable fault; the guard is the only frame that saw it
+src/gen_worker/executor.py::Executor._delegated_mint_run::compile_cache.record_cell_proven  VERDICT  the delegated mint's own finalize proof, same fact from the other producer
+src/gen_worker/fleet_cells.py::arm_from_local_store::local_cell_store.note_memo  VERDICT  §4.28's memo REWRITTEN FROM EVIDENCE — the cell just proved it arms under this arm token, which no wrap can know
+
+# ---------------------------------------------------------------------------
+# OWNER — the producer putting its own bytes in its own store.
+# ---------------------------------------------------------------------------
+src/gen_worker/fleet_cells.py::adopt_delegated_mint::local_cell_store.store  OWNER  §4.28: this machine minted these bytes; the mint's own finalize is the store's primary write path
+src/gen_worker/fleet_cells.py::_publish_async.run::local_cell_store.store  OWNER  th#1643 SUNK: the hub refused the publish, so the producer keeps what it made rather than rmtree-ing it
+
+# ---------------------------------------------------------------------------
+# RECOGNIZER (tests) — the registry/classifier IS the subject. Each row's claim
+# is verified structurally: no arm driven in the function, none replaced in the
+# module. Anything that arms goes through tests/harness/adopt_rig.py.
+# ---------------------------------------------------------------------------
+tests/test_aot_serve_pgw721.py::test_an_aot_ref_is_recognized_only_by_a_REGISTERED_stamped_key::aot_serve.note_aot_key  RECOGNIZER  the recognizer's own unit row — pgw#1035's deleted label sniff, asserted directly on is_aot_ref
+tests/test_compile_proof_pgw637.py::test_proven_cell_registry_roundtrip::compile_cache.record_cell_proven  RECOGNIZER  the proven-cell registry's own roundtrip; no pipeline exists in this row
+tests/test_compile_proof_pgw637.py::test_inmemory_probe_reports_dynamo_truth_not_the_registry::compile_cache.record_cell_proven  RECOGNIZER  pgw#637's point exactly: the registry alone must NOT certify, and the row proves it by feeding it and getting False
+tests/test_eager_only_command_pgw1142.py::test_a_suppressed_request_is_not_reported_as_compiled::aot_serve.note_aot_key  RECOGNIZER  a serving_mode.resolve dimension row — a ref and a posture, no object and no arm
+tests/test_boot_phases_pgw764.py::test_serving_mode_distinguishes_aot_from_jit_from_eager::aot_serve.is_aot_ref  RECOGNIZER  classify_mode's discrimination asserted over bare refs; nothing is armed anywhere in the row
+
+# ---------------------------------------------------------------------------
+# PROJECTION — builds the object from a DIFFERENT source shape, so it is not a
+# second copy of the fenced map. (There is no label for writing the same map
+# twice; that is pgw#1150's cause, restated.)
+# ---------------------------------------------------------------------------
+src/gen_worker/executor.py::_selection_for::_CompileArtifactSelection()  PROJECTION  built from a MINT object (ref + snapshot_digest off the SelfMint), not from a materialized artifact triple — a different source, and the `self_mint=True` flag says so

--- a/scripts/lint_arm_state_feeders.py
+++ b/scripts/lint_arm_state_feeders.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""pgw#1152: a process-global fact about an ARMED cell is fed at a SEAM, never
+by a caller who remembered — and a TEST may not feed one at all.
+
+THE DEFECT CLASS. ``aot_serve._KNOWN_AOT_KEYS`` decides which failure detector
+applies to a serving object: the DYNAMO lane's per-class cache-hit ledger (which
+an AOTI artifact can never move, so it reads every honest adoption as a disproof)
+or §4.31's serve-first rule. pgw#1033 wrote its feeding rule as a CONVENTION —
+*"whoever reads a `cell_key` off an aot-inductor envelope registers it"* — and it
+had exactly two feeders, ``fleet_cells.arm_from_local_store`` and
+``adopt_delegated_mint``, **both SELF-PRODUCED routes**. ``arm_ordered`` (every
+hub Plan arm and every §4.27 boot-adopt) fed it nothing. Measured on a real pod
+(pgw#1141b, POD PROOF #4): a cell that resolved, materialized and armed was
+scored on the dynamo ledger, disarmed, and the pod served eager for life.
+
+That was the FOURTH gate in a row with the same shape (pgw#1108, pgw#1122,
+pgw#1141, pgw#1141b): a rule written against the self-mint path, and an adopt
+path that does not take it. So the rule is now structural — the registration
+happens inside ``aot_serve.load_and_wrap``, the one function every arm route
+passes — and this script keeps it that way.
+
+TWO SCOPES, TWO RULES.
+
+**src/gen_worker** — every call to a listed feeder must be either the declared
+SEAM itself, or a row in ``scripts/arm_state_feeders_allowlist.txt`` under one of
+the classifications below. Unclassified is red; a stale row is red; and a SEAM
+that stops calling its feeder is red (the registration is an asserted fact, not
+a habit).
+
+    SEAM      the one function every route passes; declared in FEEDERS below and
+              exempt because it IS the structure. Never written in the allowlist.
+    VERDICT   the site records a decision only this frame can know, and it sits
+              AT that decision — no seam can derive it (a proof pass concluding
+              a cell served its own graph; a disarm concluding one did not).
+    OWNER     the module that owns the state, writing it from its own primary
+              write path (a mint finalize putting its own bytes in its own
+              store).
+
+**There is deliberately NO ``CONVENTION`` classification, and no ``RELAY``.**
+A feeder called because a docstring asked the caller to remember is exactly the
+bug, twice. It has no label to write down: move the call to the seam, or delete
+it and ask the OBJECT instead (``aot_serve.holds_exported_cell``, pgw#1141b).
+
+**tests/** — a hand-feed is RED, and so is stubbing a lane ACCESSOR. pgw#1141
+shipped thirteen green rows whose fleet-policy stand-ins called
+``aot_serve.note_aot_key(key)`` BY HAND — production's single missing line — and
+another suite stubbed ``is_aot_ref`` outright. Those fixtures answered the
+question the gate was supposed to ask, so the tests entered one gate east of the
+bug and RED-first prevented nothing. A test that needs an armed, boot-adopted
+object drives ``tests/harness/adopt_rig.py``, which arms a real packed cell
+through the real ordered path.
+
+There is exactly ONE test classification, ``RECOGNIZER``, and **the lint checks
+the claim instead of trusting it**: the row is accepted only when the enclosing
+function DRIVES no arm and the module REPLACES no arm driver. A unit test of the
+recognizer itself (no pipeline anywhere, the classifier is the subject) qualifies
+structurally; a fixture standing in for an adoption cannot, whatever it writes in
+the file. So a simulated arm still has no label to write down.
+
+Same enforcement shape as ``lint_credential_identity.py`` (pgw#1122),
+``lint_settings_writers.py`` (pgw#1049) and ``lint_config_reads.py`` (§1.18).
+Sites are keyed ``<path>::<enclosing scope>::<name>``, never by line number: a
+line is a fact other people change (pgw#931).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+
+CLASSIFICATIONS = {"VERDICT", "OWNER", "RECOGNIZER", "PROJECTION"}
+
+#: Calling one of these means this frame ARMS something. A test that both arms
+#: and hand-feeds is standing in for an adoption, which is the bug class.
+ARM_DRIVERS = frozenset({
+    "ensure_setup", "arm_aot", "arm_ordered", "enable_compiled",
+    "_enable_compiled", "load_and_wrap", "adopt_delegated_mint",
+    "arm_from_local_store", "self_mint",
+})
+
+
+@dataclass(frozen=True)
+class Feeder:
+    """One production-owned writer of arming/serving process state."""
+
+    #: dotted spelling as other modules call it, e.g. ``aot_serve.note_aot_key``
+    dotted: str
+    #: the module that owns it, so a bare call inside that file counts too
+    owner: str
+    #: the state it feeds, for the message
+    state: str
+    #: ``(file, function)`` that is the structural seam, or None when the fact
+    #: is a verdict no seam can derive
+    seam: Optional[Tuple[str, str]] = None
+    #: does a hand-feed in a TEST simulate an ARM? those are unwriteable
+    arm_simulating: bool = True
+    #: is the bare name distinctive enough to match on ANY receiver?
+    distinctive: bool = True
+    #: when it is not, the receiver spellings that count
+    receivers: Tuple[str, ...] = ()
+
+
+FEEDERS: Tuple[Feeder, ...] = (
+    Feeder(
+        dotted="aot_serve.note_aot_key", owner="aot_serve.py",
+        state="aot_serve._KNOWN_AOT_KEYS (which lane a cell ref is on)",
+        seam=("aot_serve.py", "load_and_wrap"),
+    ),
+    Feeder(
+        dotted="compile_cache.record_cell_proven", owner="compile_cache.py",
+        state="compile_cache._PROVEN_CELLS (this process served this cell)",
+        seam=None,
+    ),
+    Feeder(
+        dotted="compile_cache.record_cell_quarantined", owner="compile_cache.py",
+        state="compile_cache._QUARANTINED_CELLS (this identity failed here)",
+        seam=None, arm_simulating=False,
+    ),
+    Feeder(
+        dotted="local_cell_store.store", owner="local_cell_store.py",
+        state="this machine's own cell store (§4.28)",
+        seam=None, arm_simulating=False,
+        distinctive=False, receivers=("local_cell_store", "store"),
+    ),
+    Feeder(
+        dotted="local_cell_store.note_memo", owner="local_cell_store.py",
+        state="the pre-trace arm-token -> ck1 memo (§4.28)",
+        seam=None, arm_simulating=False,
+    ),
+)
+
+#: Reading these is how a frame asks WHICH LANE an object serves on. A test that
+#: replaces one has answered the gate's question for it — the pgw#1141 fixture
+#: sin, in its second form.
+#: Scoped to the LANE-IDENTITY question — "is this the exported lane, and has
+#: this process served this cell?" — not to the broader "is anything armed"
+#: (``is_armed`` / ``is_compile_armed``), which is a different and much older
+#: pattern this issue makes no claim about.
+ACCESSORS: Dict[str, Tuple[str, ...]] = {
+    "aot_serve": ("is_aot_ref", "holds_exported_cell", "proven_since"),
+    "aot": ("is_aot_ref", "holds_exported_cell", "proven_since"),
+    "compile_cache": ("cell_proven_in_process", "cell_quarantined_in_process"),
+    "cc": ("cell_proven_in_process", "cell_quarantined_in_process"),
+}
+
+RIG = "tests/harness/adopt_rig.py"
+
+
+@dataclass(frozen=True)
+class OneConstructor:
+    """A production object that must have exactly ONE map into it.
+
+    THE THIRD VARIANT of the same bug class (pgw#1150, second pass). Two sites
+    mapped a ``Compile`` onto a ``CompileCell`` — the registry's
+    ``compile_cell()`` and ``cli.run``'s §4.28 desktop arm — and the
+    ``numerics_floor``/``numerics_warn`` fields reached one and not the other,
+    so a whole serving path was judged at an SDK default nobody chose while
+    every record said ``declared``. The instance was a missing field; the CAUSE
+    is that the same object had two independent constructors. Any place two
+    constructors build one production object is a latent divergence of exactly
+    that kind — and on the arming path the two constructors are usually "the
+    self-mint/plan route" and "the adopt route", which is how four gates
+    shipped.
+    """
+
+    #: the type name as it is CALLED
+    name: str
+    #: ``<file>::<scope>`` of the one constructor, which is exempt
+    constructor: Tuple[str, str]
+    #: only constructions passing one of these keywords are fenced; empty =
+    #: every construction. (``_ArmOrder(backend=…)`` with no artifact is a
+    #: complete answer for a dynamo/eager plan and maps nothing.)
+    when_kwargs: Tuple[str, ...] = ()
+    why: str = ""
+
+
+ONE_CONSTRUCTOR: Tuple[OneConstructor, ...] = (
+    OneConstructor(
+        name="CompileCell",
+        constructor=("registry.py", "CompileCell.from_declaration"),
+        why="pgw#1150: a Compile field that reaches one map and not the other "
+            "judges a whole path at a default nobody chose",
+    ),
+    OneConstructor(
+        name="_ArmOrder",
+        constructor=("executor.py", "_ArmOrder.for_artifact"),
+        when_kwargs=("selection",),
+        why="pgw#1152: the §4.27 boot-adopt order and the hub PLAN order were "
+            "built independently and are field-for-field identical except "
+            "`adopt` — the exact adopt-vs-plan asymmetry that produced "
+            "pgw#1108/#1122/#1141/#1141b",
+    ),
+    OneConstructor(
+        name="_CompileArtifactSelection",
+        constructor=("executor.py", "_ArmOrder.for_artifact"),
+        when_kwargs=(),
+        why="pgw#1152: both order builders also built the selection from the "
+            "same three fields; it is now built once, with the order",
+    ),
+)
+
+
+def _dotted(node: ast.AST) -> str:
+    parts: List[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+class _Calls(ast.NodeVisitor):
+    """Every feeder call and every accessor stub in one module, scoped."""
+
+    def __init__(self, owner_file: str) -> None:
+        self.owner_file = owner_file
+        self.feeds: List[Tuple[int, str, Feeder]] = []
+        self.stubs: List[Tuple[int, str, str]] = []
+        self.builds: List[Tuple[int, str, OneConstructor]] = []
+        #: every function/class scope defined in this module, dotted
+        #: enclosing scopes that call an arm driver
+        self.arming_scopes: set = set()
+        #: True when this module REPLACES an arm driver (a fixture standing in
+        #: for the arm, which is how every one of these fixtures was built)
+        self.replaces_arm = False
+        self.defined_scopes: set = set()
+        self._scope: List[str] = []
+
+    def _where(self) -> str:
+        return ".".join(self._scope) or "<module>"
+
+    def _push(self, node: ast.AST, name: str) -> None:
+        self._scope.append(name)
+        self.defined_scopes.add(self._where())
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._push(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._push(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._push(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        path = _dotted(node.func)
+        tail = path.rpartition(".")[2]
+        for feeder in FEEDERS:
+            bare = feeder.dotted.split(".")[-1]
+            # Deliberately by NAME rather than by resolved receiver, except
+            # where the name is too generic to be one: the receiver is
+            # `aot_serve`, `aot`, `cc`, `fleet_cells.aot_serve` or a module
+            # alias at different sites, and a fence that only catches the
+            # spellings we thought of is not a fence (pgw#1122's rule).
+            if tail != bare:
+                continue
+            receiver = path.rpartition(".")[0].rpartition(".")[2]
+            if not receiver:
+                if self.owner_file != feeder.owner:
+                    continue
+            elif not feeder.distinctive and receiver not in feeder.receivers:
+                continue
+            self.feeds.append((node.lineno, self._where(), feeder))
+        if tail in ARM_DRIVERS:
+            self.arming_scopes.add(self._where())
+        for one in ONE_CONSTRUCTOR:
+            if tail != one.name:
+                continue
+            if one.when_kwargs and not any(
+                kw.arg in one.when_kwargs for kw in node.keywords
+            ):
+                continue
+            self.builds.append((node.lineno, self._where(), one))
+        self._note_stub(node, path)
+        self.generic_visit(node)
+
+    def _note_stub(self, node: ast.Call, path: str) -> None:
+        if not path.endswith("setattr") or len(node.args) < 2:
+            return
+        owner = _dotted(node.args[0]).split(".")[-1]
+        name = node.args[1]
+        if not isinstance(name, ast.Constant) or not isinstance(name.value, str):
+            return
+        if name.value in ARM_DRIVERS:
+            self.replaces_arm = True
+        if name.value in ACCESSORS.get(owner, ()):
+            self.stubs.append(
+                (node.lineno, self._where(), f"{owner}.{name.value}"))
+
+
+def _iter_modules(root: Path) -> List[Path]:
+    return [p for p in sorted(root.rglob("*.py")) if "__pycache__" not in p.parts]
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO))
+    except ValueError:
+        return str(path)
+
+
+def scan_src(root: Path) -> Tuple[Dict[Tuple[str, str], int], List[str]]:
+    """Feeder sites outside the declared seams, plus seam-integrity problems."""
+    sites: Dict[Tuple[str, str], int] = {}
+    problems: List[str] = []
+    seams_seen = {f.seam: False for f in FEEDERS if f.seam}
+    constructors_seen = {o.name: False for o in ONE_CONSTRUCTOR}
+    for path in _iter_modules(root):
+        calls = _Calls(path.name)
+        calls.visit(ast.parse(path.read_text(encoding="utf-8")))
+        rel = _rel(path)
+        for lineno, scope, feeder in calls.feeds:
+            if feeder.seam and (path.name, scope) == feeder.seam:
+                seams_seen[feeder.seam] = True
+                continue
+            sites.setdefault((rel, f"{scope}::{feeder.dotted}"), lineno)
+        for one in ONE_CONSTRUCTOR:
+            if one.constructor[0] == path.name and (
+                one.constructor[1] in calls.defined_scopes
+            ):
+                constructors_seen[one.name] = True
+        for lineno, scope, one in calls.builds:
+            if (path.name, scope) == one.constructor:
+                continue
+            sites.setdefault((rel, f"{scope}::{one.name}()"), lineno)
+    for name, seen in constructors_seen.items():
+        where = dict((o.name, o.constructor) for o in ONE_CONSTRUCTOR)[name]
+        # Only demanded when the owning module is in the scanned tree at all,
+        # so the rule can be exercised over a synthetic tree.
+        if not seen and (root / where[0]).is_file():
+            problems.append(
+                f"ONE-CONSTRUCTOR MISSING: {where[0]}::{where[1]} — the one "
+                f"map into {name} — does not exist. That map IS the fence; if "
+                "it moved, move it in ONE_CONSTRUCTOR here too.")
+    for seam, seen in seams_seen.items():
+        if seen:
+            continue
+        feeder = next(f for f in FEEDERS if f.seam == seam)
+        problems.append(
+            f"SEAM BROKEN: {seam[0]}::{seam[1]} no longer calls "
+            f"{feeder.dotted}. That call is what feeds {feeder.state} for "
+            "EVERY arm route — with it gone, a new route is one forgotten "
+            "convention away from pgw#1141b (a resolved, materialized, armed "
+            "cell scored on the dynamo ledger and thrown away on a real pod). "
+            "Put it back, or move the seam and update FEEDERS here.")
+    return sites, problems
+
+
+def scan_tests(
+    root: Path, allowed: Dict[Tuple[str, str], str],
+) -> Tuple[Dict[Tuple[str, str], int], List[str]]:
+    """A test may not feed a production registry, nor stub a lane accessor.
+
+    The one escape, ``RECOGNIZER``, is CHECKED rather than trusted: the row is
+    accepted only when the enclosing function drives no arm and the module
+    replaces no arm driver. A fixture standing in for an adoption fails that
+    test whatever it writes in the allowlist.
+    """
+    sites: Dict[Tuple[str, str], int] = {}
+    problems: List[str] = []
+    for path in _iter_modules(root):
+        if _rel(path) == RIG:
+            # The rig is the sanctioned vehicle; it is fenced by
+            # `test_adopt_rig_pgw1152.py::test_the_rig_itself_registers_nothing`,
+            # which reads its source and refuses a registration.
+            continue
+        calls = _Calls(path.name)
+        calls.visit(ast.parse(path.read_text(encoding="utf-8")))
+        rel = _rel(path)
+
+        def _recognizer_ok(scope: str) -> Optional[str]:
+            """None when the RECOGNIZER claim holds, else why it does not."""
+            if calls.replaces_arm:
+                return ("this module REPLACES an arm driver, so it is standing "
+                        "in for the arm — the claim is refused")
+            if scope in calls.arming_scopes:
+                return f"{scope} drives an arm itself — the claim is refused"
+            return None
+
+        def _judge(lineno: int, scope: str, name: str, complaint: str) -> None:
+            key = (rel, f"{scope}::{name}")
+            label = allowed.get(key)
+            if label == "RECOGNIZER":
+                refusal = _recognizer_ok(scope)
+                if refusal is None:
+                    sites[key] = lineno
+                    return
+                problems.append(
+                    f"{rel}:{lineno}: RECOGNIZER claimed for {scope}::{name}, "
+                    f"but {refusal}. Drive {RIG}.")
+                return
+            if label is not None:
+                problems.append(
+                    f"{rel}:{lineno}: {label} is not a TEST classification for "
+                    f"{scope}::{name} — the only one is RECOGNIZER.")
+                return
+            problems.append(f"{rel}:{lineno}: {complaint}")
+
+        for lineno, scope, feeder in calls.feeds:
+            if not feeder.arm_simulating:
+                continue
+            _judge(
+                lineno, scope, feeder.dotted,
+                f"a TEST hand-feeds {feeder.dotted} in {scope} — that writes "
+                f"{feeder.state}, which is exactly the fact production writes "
+                "at its seam. pgw#1141 shipped 13 green rows whose stand-ins "
+                "did this; they entered one gate east of the bug. Drive "
+                f"{RIG} instead.")
+        for lineno, scope, name in calls.stubs:
+            _judge(
+                lineno, scope, name,
+                f"a TEST STUBBED the lane accessor {name} in {scope} — the "
+                "gate under test then answers from the fixture rather than "
+                f"from the object. Drive {RIG} and let a real arm make the "
+                "answer true.")
+    return sites, problems
+
+
+def load_allowlist(path: Path) -> Tuple[Dict[Tuple[str, str], str], List[str]]:
+    """Parse ``<path>::<scope>::<name>  <CLASSIFICATION>  <reason>`` lines."""
+    allowed: Dict[Tuple[str, str], str] = {}
+    errors: List[str] = []
+    if not path.is_file():
+        return allowed, [f"{path} is missing"]
+    for num, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            errors.append(
+                f"{path.name}:{num}: need '<path>::<scope>::<name> "
+                f"<CLASSIFICATION> <reason>', got {line!r}")
+            continue
+        key, classification = parts[0], parts[1]
+        if "::" not in key:
+            errors.append(f"{path.name}:{num}: site key {key!r} lacks '::'")
+            continue
+        if classification not in CLASSIFICATIONS:
+            errors.append(
+                f"{path.name}:{num}: unknown classification "
+                f"{classification!r} (want one of {sorted(CLASSIFICATIONS)}). "
+                "There is no CONVENTION class and no RELAY class: a feeder "
+                "called because the caller was asked to remember is the bug "
+                "itself (pgw#1033 -> pgw#1141b). Move it to the seam, or "
+                "delete it and ask the object.")
+            continue
+        file_part, name = key.split("::", 1)
+        allowed[(file_part, name)] = classification
+    return allowed, errors
+
+
+def check(
+    sites: Dict[Tuple[str, str], int],
+    allowed: Dict[Tuple[str, str], str],
+    seen: Optional[Dict[Tuple[str, str], int]] = None,
+) -> List[str]:
+    problems: List[str] = []
+    for (rel, name), lineno in sorted(sites.items()):
+        if allowed.get((rel, name)) == "RECOGNIZER":
+            problems.append(
+                f"{rel}:{lineno}: RECOGNIZER is a TEST classification and this "
+                "is production code — a src feeder is SEAM, VERDICT or OWNER.")
+            continue
+        if name.endswith("()"):
+            if (rel, name) in allowed:
+                continue
+            one = next(o for o in ONE_CONSTRUCTOR if o.name == name.rpartition("::")[2][:-2])
+            problems.append(
+                f"{rel}:{lineno}: SECOND MAP into {one.name} at {name} — "
+                f"{one.constructor[0]}::{one.constructor[1]} is the one "
+                f"constructor. {one.why}. Call it, or — if this builds the "
+                "object from a DIFFERENT source shape and is therefore not a "
+                "second copy of the same map — classify it PROJECTION in "
+                "scripts/arm_state_feeders_allowlist.txt. There is no label "
+                "for writing the same map twice.")
+            continue
+        if (rel, name) not in allowed:
+            problems.append(
+                f"{rel}:{lineno}: UNCLASSIFIED arm-state feed: {name} — this "
+                "writes a process-global fact about an armed cell from "
+                "somewhere that is not the seam every arm route passes. That "
+                "is pgw#1033's convention, and the route that did not keep it "
+                "cost four pods and four gates (pgw#1141b). Move it to the "
+                "seam, delete it in favour of asking the object, or classify "
+                "it in scripts/arm_state_feeders_allowlist.txt")
+    matched = set(sites) | set(seen or {})
+    for key in sorted(set(allowed) - matched):
+        problems.append(
+            f"stale allowlist row {key[0]}::{key[1]} matches no feed site — "
+            "delete it (a row matching nothing is a boundary that lies)")
+    return problems
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", type=Path, default=REPO / "src" / "gen_worker")
+    ap.add_argument("--tests", type=Path, default=REPO / "tests")
+    ap.add_argument(
+        "--allowlist", type=Path,
+        default=REPO / "scripts" / "arm_state_feeders_allowlist.txt")
+    args = ap.parse_args(argv)
+
+    sites, seam_problems = scan_src(args.src)
+    allowed, errors = load_allowlist(args.allowlist)
+    test_sites, test_problems = scan_tests(args.tests, allowed)
+    problems = (seam_problems + errors
+                + check(sites, allowed, seen=test_sites) + test_problems)
+    if problems:
+        print("\n".join(problems), file=sys.stderr)
+        return 1
+    print(f"arm-state fence: {len(sites)} classified production feed(s), "
+          f"{len([f for f in FEEDERS if f.seam])} structural seam(s) intact, "
+          f"{len(test_sites)} RECOGNIZER row(s); no test simulates an arm")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -11,9 +11,9 @@ nobody else. The out-of-process producer this module was designed around —
 training-endpoints ``produce-inductor-cache`` — was DELETED by te#179 (it
 minted ``kind="torch-inductor-cache"``, and th#1788 made ``aot-inductor`` the
 only class the hub adopts, so its publishes were refused before entering the
-store), and DESIGN-RULINGS §4.28/§4.30 make that permanent: there is no forge,
-no mint request and no compile fleet, and compilation runs on the machine that
-will USE the cell. A family too large to self-mint beside its own server is a
+store), and DESIGN-RULINGS §4.28/§4.30 make that permanent: there is no
+central compile service, no mint request and no compile fleet, and compilation
+runs on the machine that will USE the cell. A family too large to self-mint beside its own server is a
 PLACEMENT question — boot its serving pod on a card that fits, per §4.28's
 "pre-warming a release/SKU = boot an ordinary serving pod there" — and
 :meth:`~gen_worker.mint_budget.MintBudget.card_bytes` is the number that

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2651,6 +2651,40 @@ class _ArmOrder:
     publisher_org: str = ""
     adopt: Optional["boot_adopt.BootAdoptOutcome"] = None
 
+    @classmethod
+    def for_artifact(
+        cls,
+        *,
+        path: Path,
+        ref: str,
+        snapshot_digest: str,
+        expected: Optional["aot_identity.ExpectedIdentity"],
+        publisher_org: str,
+        adopt: Optional["boot_adopt.BootAdoptOutcome"] = None,
+    ) -> "_ArmOrder":
+        """THE artifact -> arming-order map, in one place (pgw#1152).
+
+        TWO routes build this object and they are field-for-field identical
+        except for ``adopt``: ``_setup_locked_inner``'s §4.27 BOOT-ADOPT order,
+        and ``_materialize_arm``'s hub PLAN order. That is the same duplicated
+        mapping pgw#1150 found between ``compile_cell()`` and ``cli.run`` — a
+        field ADDED here that one site sets and the other forgets silently
+        diverges the two arm routes, which is this repo's most expensive defect
+        shape: pgw#1108, pgw#1122, pgw#1141 and pgw#1141b were all "a rule the
+        self-mint/plan path keeps and the adopt path does not".
+
+        The selection is built here too, because the two sites also built THAT
+        independently from the same three fields.
+        """
+        return cls(
+            backend="aot_cell",
+            selection=_CompileArtifactSelection(
+                path=path, ref=ref, snapshot_digest=snapshot_digest),
+            expected=expected,
+            publisher_org=publisher_org,
+            adopt=adopt,
+        )
+
 
 @dataclass(frozen=True)
 class _JobOrder:
@@ -7016,16 +7050,15 @@ class Executor:
             boot_local_key = adopt.local_key
             if adopt.adoption is not None:
                 got = adopt.adoption
-                compile_selection = _CompileArtifactSelection(
-                    path=got.artifact, ref=got.ref,
-                    snapshot_digest=got.snapshot_digest)
                 compile_artifact = got.artifact
-                arm = _ArmOrder(
-                    backend="aot_cell", selection=compile_selection,
+                arm = _ArmOrder.for_artifact(
+                    path=got.artifact, ref=got.ref,
+                    snapshot_digest=got.snapshot_digest,
                     expected=got.expected,
                     publisher_org=got.cell.publisher_org,
                     # pgw#1122: this order is the POD's, not the hub's.
                     adopt=adopt)
+                compile_selection = arm.selection
         elif arm is None and spec.compile is not None:
             # pgw#1116: a compiled family that boots WITHOUT asking is a fact
             # somebody has to be able to read. This is the only branch where
@@ -11069,13 +11102,10 @@ class Executor:
             cache_dir=self.store._cache_dir,
             what=what,
         )
-        return _ArmOrder(
-            backend="aot_cell",
-            selection=_CompileArtifactSelection(
-                path=path,
-                ref=artifact.cell_ref,
-                snapshot_digest=artifact.content_digest,
-            ),
+        return _ArmOrder.for_artifact(
+            path=path,
+            ref=artifact.cell_ref,
+            snapshot_digest=artifact.content_digest,
             expected=expected,
             publisher_org=artifact.publisher_org,
         )

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -2024,7 +2024,12 @@ def arm_from_local_store(
         # it an arm-scheme bump costs one TRACE per family per machine; without
         # it, one MINT.
         local_cell_store.note_memo(arm_key.token, local.key)
-    aot_serve.note_aot_key(key)
+    # pgw#1152: the `note_aot_key(key)` that stood here is GONE, not moved. The
+    # arm above already went through `aot_serve.load_and_wrap`, which registers
+    # the key at the wrap (pgw#1141b) — this line was one of the two
+    # SELF-PRODUCED routes that kept pgw#1033's convention, and keeping a
+    # redundant copy of a structural fact is how the convention survived long
+    # enough for `arm_ordered` to not keep it.
     minted = SelfMint(
         family=family, cell_key=key,
         ref=f"{cc.system_repo(family)}#{key}",
@@ -2155,13 +2160,12 @@ def adopt_delegated_mint(
     )
     state["minted"] = minted
     state["meta"] = dict(meta)
-    # pgw#1033: this process has now READ a stamped `aot-inductor` key off a
-    # packed envelope, which is the one event that teaches a runtime that a
-    # key-flavored ref names an EXPORTED cell (the delivered-arm path
-    # registers its keys the same way; a SELF-MINTED cell was the
-    # unregistered half, so the executor's #734/#735 kind dispatch scored this
-    # pod's own `.pt2` by FX cache hits it can never produce).
-    aot_serve.note_aot_key(minted.cell_key)
+    # pgw#1152: pgw#1033's registration stood here and is GONE, not moved.
+    # `_arm_exported_cell` above already wrapped these bytes onto the pipe, and
+    # `aot_serve.load_and_wrap` registers the key AT the wrap (pgw#1141b) — the
+    # one seam every arm route passes. This was the second of pgw#1033's two
+    # SELF-PRODUCED feeders; both are deleted, so the registry has exactly one
+    # writer and no route can inherit the convention that killed `arm_ordered`.
     # th#1355: the mint cost, banked at the moment the cell becomes real.
     state["mint_duration_ms"] = max(
         0, int((time.monotonic() - pending.armed_at) * 1000))

--- a/tests/harness/adopt_rig.py
+++ b/tests/harness/adopt_rig.py
@@ -1,0 +1,563 @@
+"""THE BOOT-ADOPT VEHICLE — the default rig for anything arming-adjacent.
+
+WHY THIS EXISTS (pgw#1152). Four of the six gates the reuse circle hit —
+pgw#1108, pgw#1122, pgw#1141, pgw#1141b — were ONE defect wearing different
+clothes: **the boot-adopt path structurally differs from the self-mint path**.
+It arms BEFORE setup, the compute child holds no JWT, and it is fed by
+``fleet_cells.arm_ordered`` rather than by the self-produced routes
+(``arm_from_local_store`` / ``adopt_delegated_mint``). Every one of those gates
+was written and validated against self-mint.
+
+And the TESTS could not see it. Their fixtures simulated an adoption using
+self-mint machinery: thirteen rows called ``aot_serve.note_aot_key(key)`` BY
+HAND — production's single missing line — another stubbed an accessor to raise,
+another hand-set a marker production never writes. RED-first caught all six
+*after* they shipped and prevented none, because a mutation proves your
+assertion can fail, not that your fixture resembles production.
+
+So: **a test may not construct anything production constructs differently.** No
+hand-registration, no stubbed accessor, no hand-set marker. Where a test needs
+to force an outcome it does so by REMOVING or BREAKING a real input — a hub that
+serves no receipt, a package whose entry raises, a cell whose subject really
+diverges — never by supplying a fact.
+
+WHAT RUNS FOR REAL. The whole chain from the ordered arm to the target install::
+
+    Executor.ensure_setup
+      -> _injection_kwargs -> _enable_compiled with a real _ArmOrder(adopt=…)
+      -> fleet_cells.arm_ordered
+      -> the real receipt gate, against a real RSA-signed receipt from a real
+         HTTP hub (harness.receipt_hub)
+      -> provision.arm_aot -> aot_serve.load_and_wrap on a real packed cell
+         (harness.exported_cell) whose ck1 key is restatable from its own
+         recorded facts
+      -> the real boot warmup, the real per-object proof pass, the real
+         _install_compile_targets and _assert_armed_targets_installed
+
+Nothing about applicability, the lane split, the proof pass, the arm decision
+or the target install is stubbed — those are the code under test.
+
+THREE SEAMS, all WEST of everything this rig is used to measure, all named:
+
+* ``Executor._boot_adopt`` returns a constructed HIT. Its derive+resolve half is
+  driven end to end for real by ``test_boot_adopt_observability_pgw1116.py``
+  against ``examples/micro-diffusion`` and a real hub; repeating it here would
+  measure that, not this.
+* ``provision.load_slot`` returns the probe pipeline instead of reading weights
+  off disk — the class-annotated slot shape micro-diffusion uses,
+  ``Slot(MicroPipeline, selected_by="model")``, which is what routes the arm
+  order to ``_enable_compiled`` at all.
+* ``aot_serve._load_package``: an AOTI ``.so`` needs a GPU. pgw#868's rig owns
+  this substitution and it is the only piece deferred to a pod.
+
+Usage::
+
+    def test_something(tmp_path, monkeypatch, hub):
+        boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+        assert boot.serves_compiled()
+
+``hub`` is :mod:`harness.receipt_hub`'s fixture; import it into your module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import msgspec
+import pytest
+import torch
+
+from gen_worker import (
+    RequestContext, Resources, Slot, activity, aot_identity, aot_serve,
+    boot_adopt, boot_key, cell_key, cell_resolve, endpoint, env_seal, receipts,
+    worker_function,
+)
+from gen_worker import executor as ex_mod
+from gen_worker.executor import Executor
+from gen_worker.models import provision
+from gen_worker.models.refs import normalize_model_ref
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+from harness import exported_cell as cell868
+from harness.exported_cell import (
+    ROWS, RUNTIME, ProbeDenoiser, ProbePackage, ProbePipeline, declaration,
+    entry_name,
+)
+
+#: The publishing org. PLATFORM tier by default, so the trust rule needs no
+#: viewer identity — the identity half is pgw#1122's and is fenced there.
+ORG = "11111111-2222-3333-4444-555555555555"
+
+FAMILY = cell868.FAMILY
+MODEL_REF = "acme/micro-probe:prod"
+
+#: Everything the endpoint instance (constructed by the executor, not by the
+#: test) and the load seam hand each other for one boot.
+RIG: Dict[str, Any] = {}
+
+
+class GenIn(msgspec.Struct):
+    prompt: str = "warm"
+
+
+class Out(msgspec.Struct):
+    y: str = "ok"
+
+
+#: pgw#868's declaration with the one field an ``@endpoint`` lint requires that
+#: a bare ``provision.arm_aot`` rig never needed: the probe denoiser is
+#: unconditioned, so the text axis is explicitly absent (ie#544).
+CELL = msgspec.structs.replace(declaration(), text_len=0)
+
+
+class AdoptedPipeline(ProbePipeline):
+    """A WORKER-LOADED slot class — the annotation shape that routes the arm
+    order into ``_enable_compiled``. ``from_pretrained`` is what the executor
+    tests for; the load itself is the named seam (``provision.load_slot``)."""
+
+    def __init__(self) -> None:
+        super().__init__(ProbeDenoiser())
+
+    @classmethod
+    def from_pretrained(cls, *_a: Any, **_k: Any) -> "AdoptedPipeline":
+        raise AssertionError("provision.load_slot is the seam, not this")
+
+
+@endpoint(
+    models={"pipeline": Slot(AdoptedPipeline)},
+    resources=Resources(gpu=True),
+    compile=CELL,
+)
+class AdoptedFamily:
+    """A CLASS-annotated slot, which is micro-diffusion's shape and the reason
+    the arm order reaches ``_enable_compiled`` at all: the arming-scope path a
+    ``Slot(str)`` endpoint takes never sees an ``_ArmOrder``."""
+
+    def setup(self, pipeline: AdoptedPipeline) -> None:
+        self.pipe = pipeline
+
+    @worker_function()
+    def generate(self, ctx: RequestContext, p: GenIn) -> Out:
+        """The pod's default shape: the boot warmup runs and its payload lands
+        on NO packaged entry of the adopted cell, so the artifact's own counter
+        does not move.
+
+        With ``warm_dispatches`` the handler really calls the wrapped forward
+        at a DECLARED shape row — a genuine dispatch through the cell, which is
+        what moves ``aot_serve.execution_count``. Nothing here writes a counter.
+        """
+        for _ in range(int(RIG.get("warm_dispatches", 0))):
+            h, w = ROWS[0]
+            self.pipe.denoiser(torch.zeros(h, w), torch.tensor(1.0))
+        return Out()
+
+
+# ---------------------------------------------------------------------------
+# the cell: a real packed artifact with a real, fully-stated identity
+# ---------------------------------------------------------------------------
+
+
+def cell_metadata() -> Dict[str, Any]:
+    """pgw#868's envelope plus the two identity blocks an ADOPTED cell must
+    carry: ``verify_declared_identity`` compares four axes and refuses a cell
+    that is SILENT on any of them."""
+    meta = cell868.metadata()
+    meta["toolchain"] = {"torch": RUNTIME["torch"], "cuda": RUNTIME["cuda"],
+                         "triton": "3.6.0"}
+    meta[env_seal.SEAL_KEY] = {"PYTHONHASHSEED": "0", "TORCH_COMPILE_DEBUG": ""}
+    meta[cell_key.EXPORT_ENVELOPE_KEY] = {
+        "shapes": [list(row) for row in ROWS], "text_len": 0,
+        "shape_strategy": "static-rows",
+    }
+    # The REAL key, restated from the artifact's own recorded facts — the same
+    # recomputation admission runs (pgw#1059), so nothing here is a stamp the
+    # bytes cannot back up.
+    meta["cell_key"] = cell_key.from_exported_artifact_metadata(meta).digest
+    return meta
+
+
+def resolved_cell(
+    meta: Dict[str, Any], *, publisher_tier: str = "platform",
+    publisher_org: str = ORG,
+) -> cell_resolve.ResolvedCell:
+    """The hub's answer, stating exactly the identity the mint stamped."""
+    have = aot_identity.artifact_identity(meta)
+    return cell_resolve.ResolvedCell(
+        family=FAMILY, cell_key=have.cell_key,
+        cell_ref=f"root/family-{FAMILY}#{have.cell_key}",
+        checkpoint_id="", content_digest="sha256:" + "ab" * 32,
+        artifact_path="cell.tar.gz", size_bytes=0,
+        publisher_org=publisher_org, publisher_tier=publisher_tier,
+        graph_contract=have.graph_contract_digest,
+        toolchain_digest=have.toolchain_digest,
+        env_seal_digest=have.env_seal_digest,
+        identity_axes={}, sm=RUNTIME["sm"], sku=RUNTIME["sku"], lane="",
+        receipt="",
+        transport=cell_resolve.Transport(
+            snapshot_digest="blake3:" + "cd" * 32, files=()),
+    )
+
+
+def production_cfgs() -> Dict[str, Any]:
+    """Every cfg object a PRODUCTION path hands the compile machinery.
+
+    pgw#1150 (second pass): raw ``Compile`` never travels past the registry, and
+    a suite that only ever passes one is testing a shape no fleet path builds —
+    deleting ``registry.py``'s two ``numerics_floor=`` lines left that suite
+    green. Both entries below come from a real production call site:
+
+    * ``registry`` — ``EndpointSpec.compile_cell()``, what the executor hands
+      ``_enable_compiled`` on every serving pod;
+    * ``cli`` — ``cli.run``'s §4.28 desktop arm, the other call site.
+
+    Both now route through ``CompileCell.from_declaration``, so a row
+    parametrised over this dict proves the map is genuinely one map. Use it
+    wherever a gate takes a cfg::
+
+        @pytest.mark.parametrize("cfg", production_cfgs().values(), ids=...)
+    """
+    from gen_worker.registry import CompileCell
+
+    spec = next(s for s in extract_specs(AdoptedFamily) if s.name == "generate")
+    return {
+        "registry": spec.compile_cell(),
+        "cli": CompileCell.from_declaration(CELL),
+    }
+
+
+def _derived(digest: str) -> boot_key.DerivedKey:
+    return boot_key.DerivedKey(
+        key=cell_key.CellKey(axes=(("adopted", digest),)),
+        class_hashes={}, combined="", workers=1, width_reason="rig",
+        traced=len(ROWS), memo="miss", wall_ms=10_291,
+    )
+
+
+# ---------------------------------------------------------------------------
+# what a boot produced, read back through production's own accessors
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdoptedBoot:
+    """One completed ``ensure_setup`` over a boot-adopted cell.
+
+    Every reader below asks PRODUCTION for the answer (``aot_serve.is_armed``,
+    the class record's own compile targets, ``Executor._served_execution_lane``)
+    rather than restating what the rig believes it did.
+    """
+
+    executor: Executor
+    spec: Any
+    pipeline: AdoptedPipeline
+    cell: cell_resolve.ResolvedCell
+    artifact: Path
+    meta: Dict[str, Any]
+    packages: Dict[str, ProbePackage]
+    events: List[Tuple[str, str, str]] = field(default_factory=list)
+
+    # -- the wire ---------------------------------------------------------
+    def phases(self, kind: str) -> List[str]:
+        return [phase for k, phase, _d in self.events if k == kind]
+
+    def details(self, kind: str) -> List[str]:
+        return [detail for k, _p, detail in self.events if k == kind]
+
+    def adopted(self) -> bool:
+        return "hit" in self.phases(activity.KIND_BOOT_ADOPT)
+
+    # -- the object -------------------------------------------------------
+    @property
+    def record(self) -> Any:
+        return self.executor._classes[self.spec.instance_key]
+
+    def is_armed(self) -> bool:
+        return aot_serve.is_armed(self.pipeline)
+
+    def holds_cell(self) -> bool:
+        return aot_serve.holds_exported_cell(self.pipeline)
+
+    def compile_target(self) -> Any:
+        targets = self.record.compile_targets
+        return next(iter(targets.values())) if targets else None
+
+    def serves_compiled(self) -> bool:
+        return self.executor._served_execution_lane(self.spec).endswith(
+            "+compiled")
+
+    @property
+    def armed_cfg(self) -> Any:
+        """The cfg object PRODUCTION handed ``provision.arm_aot`` on this boot —
+        observed at the call, never constructed here."""
+        return RIG.get("armed_cfg")
+
+
+# ---------------------------------------------------------------------------
+# the rig
+# ---------------------------------------------------------------------------
+
+
+class AdoptRig:
+    """Build and drive ONE boot-adopt.
+
+    Every keyword forces an outcome by removing or breaking a REAL input:
+
+    ``cosine``          the packaged subject really diverges from eager by that
+                        much (adoption runs no quality gate — §4.32 — so this
+                        must NOT refuse; it is here so a test can prove that).
+    ``package_raises``  the packaged entry really raises when dispatched, which
+                        is how a cell revokes itself for real.
+    ``serve_receipt``   False = the hub answers 404 for these bytes, so the real
+                        receipt gate refuses on a missing input.
+    ``publisher_tier``  what the RECEIPT says, verbatim. ``"org"`` needs a
+                        viewer identity this process does not hold (pgw#1122).
+    ``warm_dispatches`` the handler really calls the wrapped forward N times.
+    ``after_arm``       called with the pipeline immediately after the real
+                        ``load_and_wrap`` returns — an observation point at the
+                        exact moment production has one, for driving real
+                        dispatches before setup's proof snapshot. It may not
+                        write state the arm did not.
+    """
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        hub: Any,
+        *,
+        cosine: float = 1.0,
+        package_raises: str = "",
+        serve_receipt: bool = True,
+        publisher_tier: str = "platform",
+        publisher_org: str = ORG,
+        owning_endpoint: str = "",
+        warm_dispatches: int = 0,
+        after_arm: Optional[Callable[[Any], None]] = None,
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+        self.hub = hub
+        self.cosine = cosine
+        self.package_raises = package_raises
+        self.serve_receipt = serve_receipt
+        self.publisher_tier = publisher_tier
+        self.publisher_org = publisher_org
+        self.owning_endpoint = owning_endpoint
+        self.warm_dispatches = warm_dispatches
+        self.after_arm = after_arm
+        self.events: List[Tuple[str, str, str]] = []
+
+    # -- assembly ---------------------------------------------------------
+
+    def _install_event_spy(self) -> None:
+        """Capture at the ONE sink the hub's ``worker_activity_events`` table
+        is built from, and still let the real emitter run."""
+        said = self.events
+        real = activity.emit_event
+
+        def _spy(kind: str, detail: str = "", **kw: Any) -> Any:
+            said.append((kind, str(kw.get("phase", "")), detail))
+            try:
+                return real(kind, detail, **kw)
+            except Exception:
+                return None
+
+        self.monkeypatch.setattr(activity, "emit_event", _spy)
+        self.monkeypatch.setattr(ex_mod.activity_mod, "emit_event", _spy)
+
+    def _forget_keys(self) -> None:
+        """``_KNOWN_AOT_KEYS`` is PROCESS-global, so a sibling test file that
+        armed the same key would answer this boot's question for it. Every boot
+        starts with a runtime that has been told nothing.
+
+        This REMOVES an input; it never supplies one. It is the only legitimate
+        contact any test has with that set.
+        """
+        self.monkeypatch.setattr(aot_serve, "_KNOWN_AOT_KEYS", set())
+
+    def _packages(self) -> Dict[str, ProbePackage]:
+        return {
+            entry_name(h, w): ProbePackage(
+                cosine=self.cosine, raises=self.package_raises)
+            for h, w in ROWS
+        }
+
+    def _install_seams(self, packages: Dict[str, ProbePackage]) -> None:
+        mp = self.monkeypatch
+        # SEAM 3 (GPU) + the runtime axes a cardless box cannot state —
+        # pgw#868's substitutions, verbatim.
+        mp.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME))
+        mp.setattr(aot_serve, "_entry_admission_drift", lambda *a, **k: None)
+        mp.setattr(
+            aot_serve, "_load_package",
+            lambda path, entry="model": packages[entry])
+
+        # SEAM 2: the class-annotated slot's weights load. `_inject_models`
+        # arms whatever this returns, through the real ordered path.
+        def _load_slot(annotation: Any, path: str, **_kw: Any) -> provision.SlotLoad:
+            pipe = AdoptedPipeline()
+            RIG["pipe"] = pipe
+            return provision.SlotLoad(obj=pipe, is_pipeline=True, ran="bf16")
+
+        mp.setattr(provision, "load_slot", _load_slot)
+        mp.setattr(ex_mod.provision, "load_slot", _load_slot)
+
+        # OBSERVE, never construct: what cfg object did production actually
+        # hand the arm? pgw#1150's third variant is a fixture passing a TYPE no
+        # fleet path builds, so the rig records the real one and
+        # `AdoptedBoot.armed_cfg` exposes it for assertion.
+        real_arm = provision.arm_aot
+
+        def _record_cfg(pipeline: Any, cfg: Any, *a: Any, **k: Any) -> Any:
+            RIG["armed_cfg"] = cfg
+            return real_arm(pipeline, cfg, *a, **k)
+
+        mp.setattr(provision, "arm_aot", _record_cfg)
+
+        if self.after_arm is not None:
+            real_wrap = aot_serve.load_and_wrap
+            hook = self.after_arm
+
+            def _wrap_then_observe(pipeline: Any, *a: Any, **k: Any) -> Any:
+                meta = real_wrap(pipeline, *a, **k)
+                hook(pipeline)
+                return meta
+
+            mp.setattr(aot_serve, "load_and_wrap", _wrap_then_observe)
+
+    def _install_boot_adopt(
+        self, cell: cell_resolve.ResolvedCell, artifact: Path,
+    ) -> None:
+        """SEAM 1: the derive+resolve half, whose own coverage is pgw#1116's."""
+
+        def _adopt(_self: Any, spec: Any, slots: Any) -> boot_adopt.BootAdoptOutcome:
+            return boot_adopt.report(boot_adopt.BootAdoptOutcome(
+                adoption=boot_adopt.BootAdoption(
+                    derived=_derived(cell.cell_key), cell=cell,
+                    artifact=artifact),
+                reason=boot_adopt.HIT, derived_key=cell.cell_key,
+                derive_ms=10_291, family=FAMILY, function="generate"))
+
+        self.monkeypatch.setattr(Executor, "_boot_adopt", _adopt)
+
+    # -- the drive --------------------------------------------------------
+
+    def boot(self) -> AdoptedBoot:
+        RIG.clear()
+        RIG["warm_dispatches"] = self.warm_dispatches
+        self._install_event_spy()
+        self._forget_keys()
+
+        meta = cell_metadata()
+        artifact = cell868.artifact(self.tmp_path, meta)
+        cell = resolved_cell(
+            meta, publisher_tier=self.publisher_tier,
+            publisher_org=self.publisher_org)
+
+        if self.serve_receipt:
+            # The hub countersigns these EXACT bytes.
+            self.hub.serve_receipt_for(
+                artifact, cell_key=cell.cell_key, family=FAMILY,
+                publisher_tier=self.publisher_tier,
+                publisher_org_id=self.publisher_org,
+                owning_endpoint_id=self.owning_endpoint)
+        receipts.configure(base_url=self.hub.base_url, worker_jwt=lambda: "")
+
+        packages = self._packages()
+        self._install_seams(packages)
+        self._install_boot_adopt(cell, artifact)
+
+        executor, spec = self._ensure_setup()
+        return AdoptedBoot(
+            executor=executor, spec=spec, pipeline=RIG["pipe"], cell=cell,
+            artifact=artifact, meta=meta, packages=packages,
+            events=self.events)
+
+    def _ensure_setup(self) -> Tuple[Executor, Any]:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        ex = Executor(extract_specs(AdoptedFamily), _send)
+        ex.store._cache_dir = self.tmp_path / "cas"
+
+        async def _fake_download(target: str, **_kw: Any) -> Path:
+            p = self.tmp_path / target.replace("/", "_").replace(":", "_")
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+
+        self.monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+
+        from gen_worker import dispatch as dispatch_mod
+
+        spec = ex.specs["generate"]
+        eff = ex._dispatched_spec(
+            spec,
+            {"pipeline": dispatch_mod.SlotOrder(ref=MODEL_REF, components=())})
+        snaps = {normalize_model_ref(MODEL_REF): pb.Snapshot(
+            digest="d1" * 16,
+            files=[pb.SnapshotFile(
+                path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+                url="http://r2.invalid/presigned")])}
+        asyncio.run(ex.ensure_setup(eff, snaps))
+        return ex, eff
+
+
+# ---------------------------------------------------------------------------
+# the historical-defect bank — a rig that cannot re-find a bug we already fixed
+# proves nothing
+# ---------------------------------------------------------------------------
+
+
+def _revert_pgw1141b(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put the tree back where ``f3ab710e`` found it, both halves.
+
+    1. ``load_and_wrap`` stops registering the key it just armed, so
+       ``_KNOWN_AOT_KEYS`` goes back to being fed only by the two SELF-PRODUCED
+       routes — which the ordered/boot-adopt arm is not one of.
+    2. ``executor._exported_arm`` goes back to asking the REF STRING through
+       ``is_aot_ref`` instead of asking the object.
+
+    Both are DELETIONS of the fix, not additions of a fault: this is master
+    before the fix, reached by removing what the fix added.
+    """
+    real_wrap = aot_serve.load_and_wrap
+    real_note = aot_serve.note_aot_key
+
+    def _wrap_without_registering(pipeline: Any, *a: Any, **k: Any) -> Any:
+        aot_serve.note_aot_key = lambda _key: None  # type: ignore[assignment]
+        try:
+            return real_wrap(pipeline, *a, **k)
+        finally:
+            aot_serve.note_aot_key = real_note  # type: ignore[assignment]
+
+    monkeypatch.setattr(aot_serve, "load_and_wrap", _wrap_without_registering)
+    monkeypatch.setattr(
+        ex_mod, "_exported_arm",
+        lambda pipeline, ref="": bool(ref) and aot_serve.is_aot_ref(ref))
+
+
+#: name -> the deletion that puts the tree back where the fix found it.
+HISTORICAL_DEFECTS: Dict[str, Callable[[pytest.MonkeyPatch], None]] = {
+    "pgw1141b": _revert_pgw1141b,
+}
+
+
+def reintroduce(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Remove a landed fix so the rig can be asked to re-find its bug.
+
+    A rig is only worth what it can catch, and the only honest evidence of that
+    is a bug we ALREADY know the shape of. Every entry here is a deletion of
+    production code, never an injected fault.
+    """
+    try:
+        HISTORICAL_DEFECTS[name](monkeypatch)
+    except KeyError:
+        raise AssertionError(
+            f"no historical defect named {name!r}; "
+            f"have {sorted(HISTORICAL_DEFECTS)}") from None

--- a/tests/harness/exported_cell.py
+++ b/tests/harness/exported_cell.py
@@ -1,0 +1,273 @@
+"""A REAL packed exported cell: real declaration, real envelope, real tensors.
+
+Promoted out of ``test_numerics_gate_pgw868.py`` by pgw#1152, unchanged. It was
+already a harness in everything but location — three other modules imported it
+as ``rig868`` — and the adopt-path rig (:mod:`harness.adopt_rig`) needs the same
+artifact, so the shared thing now lives where shared things live.
+
+What is REAL here: the ``Compile`` declaration, the packed ``cell.tar.gz`` with
+its recorded entry blocks, the class/range digests, the constants manifest, and
+a genuine ``nn.Module`` whose eager output the compiled subject is compared
+against. The ONE substitution is :class:`ProbePackage`, which stands in for an
+entry's ``AOTICompiledModel`` — an AOTI ``.so`` needs a GPU, and it is the only
+piece deferred to a pod. It reproduces the eager maths from the constants it was
+BOUND with, so the comparison is genuinely compiled-vs-eager on identical
+weights, then rotates the result to an exactly declared cosine.
+
+No number produced here may be cited as evidence about a real cell's numerics.
+"""
+
+from __future__ import annotations
+
+import math
+import platform
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+import torch
+
+from gen_worker import aot_serve as aot
+from gen_worker.api.decorators import Compile
+from gen_worker.api.export_contract import (
+    Dim, GraphClass, Input, register_export_declaration,
+    reset_export_declarations,
+)
+
+FAMILY = "pgw868-probe"
+RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130", "cuda": "13.0"}
+TARGET = "denoiser"
+#: Two declared shape rows -> two packaged entries. The second row is what
+#: makes "one shape row" a real axis rather than a word in a docstring.
+ROWS = ((8, 8), (16, 16))
+#: sdxl's declared band, used verbatim: pgw#868 was a measurement plus wiring,
+#: never a re-design of what "good" means.
+FLOOR, WARN = 0.995, 0.999
+
+
+# ---------------------------------------------------------------------------
+# the subject — a calibrated blend, so a test can NAME the rung it aims at
+# ---------------------------------------------------------------------------
+
+
+def blend(reference: torch.Tensor, cosine: float) -> torch.Tensor:
+    """``reference`` rotated to EXACTLY ``cosine``, at unchanged magnitude.
+
+    Gram-Schmidt against a fixed ramp: the perturbation is deterministic and
+    the resulting cosine is analytic, so a threshold test asserts the ladder's
+    boundary rather than a tuned fudge factor.
+    """
+    flat = reference.reshape(-1).to(torch.float64)
+    ramp = torch.linspace(-1.0, 1.0, flat.numel(), dtype=torch.float64)
+    ramp = ramp - flat * (torch.dot(ramp, flat) / torch.dot(flat, flat))
+    ramp = ramp / ramp.norm() * flat.norm()
+    sin = math.sqrt(max(0.0, 1.0 - cosine * cosine))
+    out = cosine * flat + sin * ramp
+    return out.reshape(reference.shape).to(reference.dtype)
+
+
+class ProbeDenoiser(torch.nn.Module):
+    """The eager reference. Deterministic, tiny, and REAL: a genuine
+    `nn.Module` whose signature the declaration is positionalized against."""
+
+    def __init__(self, width: int = 16) -> None:
+        super().__init__()
+        # Built without the global RNG on purpose: the probe must be provable
+        # not to disturb the serving generator, and a fixture that seeded it
+        # would hide exactly that.
+        self.weight = torch.nn.Parameter(
+            torch.linspace(0.1, 3.0, width * width).reshape(width, width).sin())
+
+    def forward(self, sample: torch.Tensor, timestep: torch.Tensor) -> torch.Tensor:
+        return (sample @ self.weight[: sample.shape[-1], : sample.shape[-1]]) * timestep
+
+
+class ProbePipeline:
+    def __init__(self, module: torch.nn.Module) -> None:
+        self.denoiser = module
+
+
+class ProbePackage:
+    """Stands in for one entry's `AOTICompiledModel` — the ONE deferred piece.
+
+    Reproduces the eager maths from the constants it was BOUND with (so the
+    comparison is genuinely compiled-vs-eager on identical weights) and then
+    rotates the result to a declared cosine.
+    """
+
+    def __init__(self, cosine: float = 1.0, *, raises: str = "",
+                 drop_output: bool = False) -> None:
+        self.cosine = float(cosine)
+        self.raises = raises
+        self.drop_output = drop_output
+        self.loaded: Dict[str, Any] = {}
+        self.invocations = 0
+
+    def get_constant_fqns(self) -> List[str]:
+        return ["weight"]
+
+    def load_constants(self, values: Dict[str, Any], check_full_update: bool = False,
+                       **_kw: Any) -> None:
+        self.loaded = dict(values)
+
+    def __call__(self, sample: torch.Tensor, timestep: torch.Tensor) -> Any:
+        self.invocations += 1
+        if self.raises:
+            raise RuntimeError(self.raises)
+        w = self.loaded["weight"]
+        out = (sample @ w[: sample.shape[-1], : sample.shape[-1]]) * timestep
+        if self.drop_output:
+            return (out, out)
+        return out if self.cosine >= 1.0 else blend(out, self.cosine)
+
+
+# ---------------------------------------------------------------------------
+# the declaration + the artifact — both real
+# ---------------------------------------------------------------------------
+
+
+def declaration(floor: float = FLOOR, warn: float = WARN) -> Compile:
+    return Compile(
+        family=FAMILY,
+        targets=(TARGET,),
+        dims=(Dim(name="h", carried_by=(("sample", 0),)),
+              Dim(name="w", carried_by=(("sample", 1),))),
+        classes=tuple(GraphClass(dims={"h": h, "w": w}) for h, w in ROWS),
+        inputs=(Input(name="sample", shape=("h", "w"), dtype="float32"),
+                Input(name="timestep", shape=(), dtype="float32", value=1.0)),
+        shape_strategy="static-rows",
+        numerics_floor=floor,
+        numerics_warn=warn,
+    )
+
+
+def entry_name(h: int, w: int) -> str:
+    return f"{TARGET}/h={h},w={w}"
+
+
+def _entry(h: int, w: int) -> Dict[str, Any]:
+    block = {
+        "target": TARGET,
+        "fork": [],
+        "class_dims": [["h", h], ["w", w]],
+        "inputs": [
+            {"name": "sample", "position": 0, "dtype": "float32",
+             "shape": [h, w]},
+            {"name": "timestep", "position": 1, "dtype": "float32",
+             "shape": []},
+        ],
+        "symbols": {},
+        "constants": [{"fqn": "weight", "source": aot.SOURCE_STATE_DICT,
+                       "dtype": "float32", "shape": [16, 16]}],
+        "graph": {},
+    }
+    block["range_digest"] = aot.range_digest(block)
+    block["class_hash"] = aot.class_hash(block, strict=True, lora_bucket=0)
+    return block
+
+
+def metadata(rows: Tuple[Tuple[int, int], ...] = ROWS) -> Dict[str, Any]:
+    entries = {entry_name(h, w): _entry(h, w) for h, w in rows}
+    meta = {
+        "format": aot.ARTIFACT_FORMAT, "kind": aot.ARTIFACT_KIND, **RUNTIME,
+        "family": FAMILY, "precision": "w8a8", "cell_key": "cell868",
+        "entries": entries, "strict_export": True, "lora_bucket": 0,
+        "package_constants_in_so": False, "constant_folding_fenced": True,
+        "source_ref": "", "source_digest": "",
+        # pgw#950: every mint stamps a host-ISA requirement, and a cell that
+        # stamps none is refused rather than sniffed from the .pt2. Satisfiable
+        # anywhere: this host's machine, no ISA level.
+        "host_isa": {"machine": platform.machine(), "march": "", "simdlen": 0,
+                     "level": ""},
+    }
+    meta["combined_graph_hash"] = aot.combined_graph_hash(
+        b["class_hash"] for b in entries.values())
+    return meta
+
+
+def artifact(tmp_path: Path, meta: Dict[str, Any] | None = None) -> Path:
+    work = tmp_path / "work"
+    work.mkdir(exist_ok=True)
+    (work / aot.PACKAGE_NAME).write_bytes(b"\x00not-a-real-pt2")
+    return aot.pack(work, tmp_path / "cell.tar.gz", meta or metadata())
+
+
+@pytest.fixture
+def declared() -> Any:
+    reset_export_declarations()
+    decl = declaration()
+    register_export_declaration(decl, family=FAMILY, replace=True)
+    yield decl
+    reset_export_declarations()
+
+
+@pytest.fixture
+def events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
+    import gen_worker.activity as activity_mod
+
+    said: List[Tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: said.append(
+            (kind, detail, str(kw.get("phase", "")))))
+    return said
+
+
+def cell_cfg(decl: Any, **enrichments: Any) -> Any:
+    """The object the FLEET hands the compile machinery, built its own way.
+
+    pgw#1150 (second pass) / pgw#1152: **raw ``Compile`` never travels past the
+    registry** — every production path hands a ``CompileCell``, and it is built
+    by exactly one map, ``CompileCell.from_declaration``. A test that passes the
+    raw declaration is testing a TYPE no fleet path constructs, which is the
+    third variant of this repo's fixture defect class: deleting the two
+    ``numerics_floor=`` lines from ``registry.py`` left the old gate suite green
+    because every one of its rows passed a shape production never passes.
+    """
+    from gen_worker.registry import CompileCell
+
+    return CompileCell.from_declaration(decl, **enrichments)
+
+
+def arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
+        packages: Dict[str, ProbePackage],
+        meta: Dict[str, Any] | None = None,
+        verify_numerics: bool = True,
+        cfg: Any = None) -> Tuple[Any, Any, Any]:
+    """Drive the REAL arm path and return ``(pipeline, module, outcome)``.
+
+    ``cfg`` defaults to :func:`cell_cfg` — the ``CompileCell`` production
+    builds. Pass one of :func:`harness.adopt_rig.production_cfgs`' values to
+    parametrise a row over every production call site.
+
+    ``verify_numerics=True`` is the MINT arm (pgw#1141 / DESIGN-RULINGS §4.32):
+    the gate runs on the pod that minted the bytes, before it publishes them,
+    and nowhere else. Adoption passes False and runs no gate — that direction
+    belongs to :mod:`harness.adopt_rig`, which enters through the executor.
+
+    pgw#923: the arm returns a typed :class:`AdoptOutcome` rather than a bool,
+    so its verdict — armed, or refused with the classified reason — is a value
+    the caller can assert on and the executor can put on the wire. It stays
+    truthy/falsy, so `assert outcome` reads exactly as `assert armed` did.
+    """
+    from gen_worker.models import provision
+
+    monkeypatch.setattr(aot, "runtime_key", lambda: dict(RUNTIME))
+    monkeypatch.setattr(
+        aot, "_entry_admission_drift", lambda *a, **k: None)
+    monkeypatch.setattr(
+        aot, "_load_package", lambda path, entry="model": packages[entry])
+    module = ProbeDenoiser()
+    pipeline = ProbePipeline(module)
+    outcome = provision.arm_aot(
+        pipeline, cell_cfg(decl) if cfg is None else cfg,
+        tmp_path / "cache", artifact(tmp_path, meta), 0,
+        verify_numerics=verify_numerics)
+    return pipeline, module, outcome
+
+
+def numerics_rows(said: List[Tuple[str, str, str]]) -> List[Tuple[str, str]]:
+    import gen_worker.activity as activity_mod
+
+    return [(detail, phase) for kind, detail, phase in said
+            if kind == activity_mod.KIND_CELL_NUMERICS]

--- a/tests/harness/receipt_hub.py
+++ b/tests/harness/receipt_hub.py
@@ -1,0 +1,269 @@
+"""A REAL cell-receipt hub: real RSA keys, real JWS, real HTTP on localhost.
+
+Promoted out of ``test_receipts_pgw709.py`` by pgw#1152, unchanged. The signer
+mirrors the hub's production format byte-for-byte (RS256 PKCS1v15/SHA256
+compact JWS, kid header, ``cell-receipt-v1+jws`` typ, ``cell-receipt-v2``
+claims); the hub half's Go tests pin the same format from the signing side.
+:class:`HubStub` serves the three real routes the worker calls — JWKS, receipt
+lookup, revocations — on a real socket.
+
+It is here rather than in a test module because the receipt gate is on the ARM
+path: :mod:`harness.adopt_rig` drives a boot-adopt through it, and pgw#1122's
+identity seam drives it from the other side. A shared vehicle belongs where
+shared vehicles live.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import tarfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from gen_worker import receipts, worker_credential, worker_identity
+
+KID = "test-kid-1"
+FAMILY = "sdxl"
+CELL_KEY = "ck1-0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+SNAPSHOT = "snapdigest-abc123"
+# th#1657: the endpoint the test pod serves, and the one every fixture receipt
+# is minted FOR unless a test deliberately mints it for someone else. Keeping
+# the default a matching ORG-tier pair means the publisher gate is live in every
+# case below, not just the ones that name it.
+SELF_ENDPOINT = "3e0f8f7a-1111-2222-3333-444455556666"
+OTHER_ENDPOINT = "9c1d2e3f-9999-8888-7777-666655554444"
+SELF_ORG = "11111111-2222-3333-4444-555555555555"
+B3_HEX = "ab12cd34" * 8
+SHA_HEX = "12ab34cd" * 8
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def sign_receipt(
+    key: rsa.RSAPrivateKey,
+    claims: Dict[str, Any],
+    *,
+    kid: str = KID,
+    alg: str = "RS256",
+) -> str:
+    header = {"alg": alg, "kid": kid, "typ": "cell-receipt-v1+jws"}
+    signing_input = (
+        _b64url(json.dumps(header).encode()) + "." + _b64url(json.dumps(claims).encode())
+    )
+    sig = key.sign(signing_input.encode("ascii"), padding.PKCS1v15(), hashes.SHA256())
+    return signing_input + "." + _b64url(sig)
+
+
+def make_claims(
+    artifact_digest: str,
+    size_bytes: int,
+    *,
+    legacy_blake3_only: bool = False,
+    **overrides: Any,
+) -> Dict[str, Any]:
+    """Build receipt claims binding an ALGORITHM-TAGGED artifact digest.
+
+    ``legacy_blake3_only`` reproduces a receipt minted before pgw#807: the
+    bare-hex ``blake3`` claim and no ``digest`` at all. It exists so the tests
+    can prove that shape is now REFUSED — the v1 protocol that minted it is
+    gone from this SDK, so a cell it names is re-minted, never armed.
+    """
+    algo, _, hex_part = artifact_digest.partition(":")
+    artifact: Dict[str, Any] = {"path": "cell.tar.gz", "size_bytes": size_bytes}
+    if legacy_blake3_only:
+        assert algo == "blake3", "legacy receipts only ever carried blake3"
+        artifact["blake3"] = hex_part
+    else:
+        artifact["digest"] = artifact_digest
+    claims: Dict[str, Any] = {
+        "crv": "cell-receipt-v2",
+        "family": FAMILY,
+        "cell_key": CELL_KEY,
+        "axes": {"sku": "rtx-4090", "image_digest": "sha256:feed", "gen_worker": "0.75.1"},
+        "owning_endpoint_id": SELF_ENDPOINT,
+        "publisher": "selfmint:worker=w1:pod=p1:release=r1",
+        # th#1657 publisher trust, inside the signature.
+        "publisher_tier": "org",
+        "publisher_org_id": SELF_ORG,
+        "snapshot_digest": SNAPSHOT,
+        "artifact": artifact,
+        "manifest_digest": "sha256:aa",
+        "fingerprint_digest": "sha256:bb",
+        "iat": 1_700_000_000,
+    }
+    claims.update(overrides)
+    return claims
+
+
+@pytest.fixture()
+def rsa_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture()
+def pub_map(rsa_key: rsa.RSAPrivateKey) -> Dict[str, rsa.RSAPublicKey]:
+    return {KID: rsa_key.public_key()}
+
+
+def make_artifact(tmp_path: Path, *, cell_key: str = CELL_KEY, family: str = FAMILY) -> Path:
+    meta = {"cell_key": cell_key, "family": family, "format": "cozy-compile-cache/v1"}
+    target = tmp_path / "cell.tar.gz"
+    with tarfile.open(target, "w:gz") as tar:
+        raw = json.dumps(meta).encode()
+        ti = tarfile.TarInfo("metadata.json")
+        ti.size = len(raw)
+        tar.addfile(ti, io.BytesIO(raw))
+        payload = b"fake-inductor-entry" * 64
+        ti = tarfile.TarInfo("inductor/aa/entry.py")
+        ti.size = len(payload)
+        tar.addfile(ti, io.BytesIO(payload))
+    return target
+
+
+class HubStub:
+    """A real HTTP server speaking the hub's three receipt surfaces."""
+
+    def __init__(self, key: rsa.RSAPrivateKey) -> None:
+        self.key = key
+        self.receipts: Dict[Tuple[str, str], str] = {}
+        self.last_query: Tuple[List[str], str] = ([], "")
+        self.revoked: List[Dict[str, str]] = []
+        self.receipt_status: Optional[int] = None  # force an error status
+        pub = key.public_key().public_numbers()
+
+        def b64_int(v: int) -> str:
+            raw = v.to_bytes((v.bit_length() + 7) // 8, "big")
+            return _b64url(raw)
+
+        self.jwks = {"keys": [{"kty": "RSA", "kid": KID, "use": "sig", "alg": "RS256",
+                               "n": b64_int(pub.n), "e": b64_int(pub.e)}]}
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # noqa: N802
+                pass
+
+            def do_GET(self) -> None:  # noqa: N802
+                parsed = urlparse(self.path)
+                if parsed.path == receipts.JWKS_PATH:
+                    self._json(200, stub.jwks)
+                elif parsed.path == receipts.RECEIPT_PATH:
+                    if stub.receipt_status is not None:
+                        self._json(stub.receipt_status, {"error": "forced"})
+                        return
+                    q = parse_qs(parsed.query)
+                    cell_key = q.get("cell_key", [""])[0]
+                    # The real route matches on the SET of tagged digests the
+                    # worker offers. pgw#807 deleted the bare-hex `blake3`
+                    # param with the protocol that needed it.
+                    offered = list(q.get("artifact_digest", []))
+                    stub.last_query = (offered, cell_key)
+                    jws = None
+                    for ref in offered:
+                        jws = stub.receipts.get((ref, cell_key))
+                        if jws is not None:
+                            break
+                    if jws is None:
+                        self._json(404, {"error": "cell_receipt_not_found"})
+                    else:
+                        self._json(200, {"receipt": jws, "snapshot_digest": SNAPSHOT})
+                elif parsed.path == receipts.REVOCATIONS_PATH:
+                    self._json(200, {"revoked": stub.revoked})
+                else:
+                    self._json(404, {"error": "unknown route"})
+
+            def _json(self, status: int, body: Dict[str, Any]) -> None:
+                raw = json.dumps(body).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+    def serve_receipt_for(
+        self, artifact: Path, *, algo: str = "sha256", **claim_overrides: Any
+    ) -> str:
+        """Publish a receipt for ``artifact`` bound with ``algo``; returns the ref."""
+        assert algo == "sha256"
+        ref = receipts.artifact_digest(artifact)
+        size = artifact.stat().st_size
+        claims = make_claims(ref, size, **claim_overrides)
+        self.receipts[(ref, str(claims["cell_key"]))] = sign_receipt(self.key, claims)
+        return ref
+
+
+@pytest.fixture()
+def hub(rsa_key: rsa.RSAPrivateKey) -> Iterator[HubStub]:
+    stub = HubStub(rsa_key)
+    yield stub
+    stub.close()
+    receipts.reset()
+    # pgw#1122: identity is a PROCESS fact now, so the fixture must unwind it
+    # too or the next test inherits this one's pod.
+    worker_identity.reset()
+    worker_credential.reset()
+
+
+def worker_jwt_for(endpoint_id: str, org_id: str = "") -> str:
+    """A hub-shaped worker credential naming the endpoint this pod serves.
+
+    th#1657: the pod's own identity comes from the `cell_read_endpoint_id` the
+    hub stamps on the cell-read grant (th#1335), so the test builds the same
+    thing. The signature is never checked — this is our OWN bearer token, not an
+    input — so an unsigned third segment is faithful to what the gate reads.
+    """
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    claims = {"sub": "worker-1", "cell_read_endpoint_id": endpoint_id}
+    # th#1680: the org rides the same grant. Omitted when empty, exactly as a
+    # pre-th#1680 hub (or one that could not resolve the org) leaves it out.
+    if org_id:
+        claims["cell_read_org_id"] = org_id
+    payload = _b64url(json.dumps(claims).encode())
+    return header + "." + payload + ".not-checked-here"
+
+
+def _identify(token: str) -> None:
+    """Give this process the credential a single-process worker holds.
+
+    pgw#1122: the gate no longer decodes its OWN bearer for identity — the
+    compute child holds none by construction, so the process-wide credential
+    (``worker_credential``, pgw#848's single source) is what
+    ``worker_identity.viewer`` reads, exactly as production does after the
+    transport installs a rotation. Installing it here is what production
+    writes; passing a token to ``receipts.configure`` was only ever a bearer.
+    """
+    worker_identity.reset()
+    worker_credential.reset()
+    if token:
+        worker_credential.install(token)
+
+
+def _configure(stub: HubStub, *, endpoint_id: str = SELF_ENDPOINT) -> None:
+    token = worker_jwt_for(endpoint_id)
+    _identify(token)
+    receipts.configure(base_url=stub.base_url, worker_jwt=lambda: token)
+

--- a/tests/test_adopt_rig_pgw1152.py
+++ b/tests/test_adopt_rig_pgw1152.py
@@ -1,0 +1,457 @@
+"""pgw#1152: the adopt-path rig re-finds a bug we already fixed, and the fence
+makes the fixture that hid it unwriteable.
+
+THE BUG CLASS, stated once. Four of the six reuse-circle gates — pgw#1108,
+pgw#1122, pgw#1141, pgw#1141b — were ONE defect: the boot-adopt path
+structurally differs from the self-mint path (it arms BEFORE setup, its compute
+child holds no JWT, and it is fed by ``arm_ordered`` rather than by the
+self-produced routes), and every gate was written and validated against
+self-mint. The tests could not see it because their fixtures SIMULATED an
+adoption using self-mint machinery: thirteen rows called
+``aot_serve.note_aot_key(key)`` by hand — production's single missing line.
+
+Two things close that class, and both are asserted here:
+
+1. :mod:`harness.adopt_rig` — the real vehicle, promoted out of
+   ``test_adopted_arm_lane_pgw1141b.py``. This file proves it by making it
+   RE-FIND pgw#1141b: delete the landed fix and the rig reproduces POD PROOF
+   #4's four-row chain verbatim. A rig that cannot re-find a bug we already
+   fixed proves nothing.
+2. ``scripts/lint_arm_state_feeders.py`` — the fence. Every production feeder of
+   arming/serving process-global state is classified by enclosing function
+   (pgw#1122's ``lint_credential_identity.py`` shape), unclassified is red,
+   stale is red, and a TEST that hand-feeds one is red with no label to write
+   down. The rows below drive the lint over synthetic trees, so proving it goes
+   red never requires writing the bug into this repo.
+
+Run: uv run pytest tests/test_adopt_rig_pgw1152.py -q
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker import activity, aot_serve, cell_adopt
+from gen_worker import executor as ex_mod
+
+from harness import exported_cell as cell868
+from harness.adopt_rig import AdoptRig, production_cfgs, reintroduce
+# The REAL receipt gate: a real RSA key, a real JWKS/receipt HTTP hub.
+from harness.receipt_hub import HubStub, hub, pub_map, rsa_key  # noqa: F401
+
+REPO = Path(__file__).resolve().parents[1]
+LINT = REPO / "scripts" / "lint_arm_state_feeders.py"
+
+
+# ===========================================================================
+# 1. THE RIG RE-FINDS pgw#1141b
+# ===========================================================================
+
+
+def test_the_rig_serves_a_boot_adopted_cell_COMPILED(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """The control. With the tree as it stands, a boot-adopted cell that the
+    warmup never dispatched through keeps its arm, gets its target, and serves
+    compiled — §4.31 + §4.32 + pgw#1141b, end to end, off-pod."""
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+
+    assert boot.adopted(), "the boot did not adopt at all"
+    assert boot.is_armed() is True
+    assert boot.holds_cell() is True
+    target = boot.compile_target()
+    assert target is not None, "armed and still no installed compile target"
+    assert "generate" in target.function_names
+    assert target.active_compile_ref == boot.cell.cell_ref
+    assert boot.record.eager_posture == ""
+    assert boot.serves_compiled()
+    assert not boot.phases(activity.KIND_SERVE_DEGRADE)
+
+
+def test_the_rig_RE_FINDS_pgw1141b_when_its_fix_is_deleted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """THE PROOF THE RIG IS WORTH ANYTHING.
+
+    ``reintroduce(monkeypatch, "pgw1141b")`` deletes both halves of ``f3ab710e``
+    — the registration inside ``load_and_wrap``, and the object-first lane
+    reader — putting the tree back where the fix found it. The rig must then
+    reproduce POD PROOF #4 (RTX A4500, sm_86, gen-worker 0.111.0) verbatim::
+
+        seq 13  serve_eager_posture  target_applicability_incomplete
+                  functions=() … owned_slots=['pipeline']
+        seq 14  serve_eager_posture  armed_target_unresolved
+        seq 15  serve_degrade        armed_target_unresolved
+
+    If this row ever goes green, the rig has stopped entering through the
+    boot-adopt path and is measuring the self-mint one again — which is the
+    whole reason six gates shipped broken.
+    """
+    reintroduce(monkeypatch, "pgw1141b")
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+
+    assert boot.adopted(), "the boot did not adopt at all"
+    postures = boot.phases("serve_eager_posture")
+    assert "target_applicability_incomplete" in postures, (
+        "the rig did NOT re-find pgw#1141b — with the fix deleted, a "
+        "boot-adopted cell must be scored on the dynamo ledger and disarmed")
+    assert cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value in postures
+    assert boot.phases(activity.KIND_SERVE_DEGRADE)
+    assert boot.compile_target() is None
+    assert not boot.serves_compiled()
+
+    # …and the locus itself, named: the process armed these exact bytes and
+    # still did not recognize their ref as an exported cell.
+    assert not aot_serve.is_aot_ref(boot.cell.cell_ref)
+
+
+def test_the_registration_is_what_the_re_find_turns_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """One variable moved. The fix's first half alone (the wrap registers the
+    key) is enough to keep the arm, which is what makes the deletion above a
+    bisection rather than a vibe."""
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+    assert aot_serve.is_aot_ref(boot.cell.cell_ref)
+    assert aot_serve.is_aot_ref(boot.cell.cell_ref, boot.cell.family)
+
+    # The structural half: with the registry deliberately emptied AFTER the
+    # wrap, the readers must still put this object on the exported lane.
+    monkeypatch.setattr(aot_serve, "_KNOWN_AOT_KEYS", set())
+    assert not aot_serve.is_aot_ref(boot.cell.cell_ref)
+    assert aot_serve.holds_exported_cell(boot.pipeline) is True
+    assert ex_mod._exported_arm(boot.pipeline, boot.cell.cell_ref) is True
+
+
+# ===========================================================================
+# 1b. THE THIRD VARIANT — the rig hands the arm the TYPE production hands it
+# ===========================================================================
+
+
+def test_the_arm_receives_the_type_PRODUCTION_builds_not_a_declaration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """pgw#1150's second pass, folded in. Raw ``Compile`` never travels past
+    the registry, so a suite that only ever passes one is measuring a shape no
+    fleet path constructs — which is why deleting ``registry.py``'s two
+    ``numerics_floor=`` lines left the old gate suite green.
+
+    The rig does not assert this by construction: it OBSERVES what production
+    handed ``provision.arm_aot`` on a real boot.
+    """
+    from gen_worker.api.decorators import Compile
+    from gen_worker.registry import CompileCell
+
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+
+    assert isinstance(boot.armed_cfg, CompileCell), type(boot.armed_cfg)
+    assert not isinstance(boot.armed_cfg, Compile)
+    # …and the declared band really reaches the gate through it (pgw#1150).
+    assert boot.armed_cfg.numerics_floor == cell868.FLOOR
+    assert boot.armed_cfg.numerics_warn == cell868.WARN
+
+
+def test_both_production_call_sites_build_the_SAME_cell_object() -> None:
+    """The one-constructor claim, asserted on the two real call sites rather
+    than on the constructor's own docstring. ``EndpointSpec.compile_cell()`` and
+    ``cli.run``'s §4.28 desktop arm differ only in the four spec-scoped
+    enrichments a raw declaration cannot know; every other field is a straight
+    carry, and a field that reaches one and not the other silently judges a
+    whole serving path at a default nobody chose."""
+    import dataclasses
+
+    cfgs = production_cfgs()
+    registry_cfg, cli_cfg = cfgs["registry"], cfgs["cli"]
+    enrichments = {"lora_bucket", "text_len", "guidance_scales", "text_lens"}
+    for field in dataclasses.fields(type(registry_cfg)):
+        if field.name in enrichments:
+            continue
+        assert getattr(registry_cfg, field.name) == getattr(cli_cfg, field.name), (
+            f"{field.name} reaches one Compile->CompileCell map and not the "
+            "other — that is pgw#1150's cause, not its instance")
+
+
+@pytest.mark.parametrize("origin", ["registry", "cli"])
+def test_the_declared_band_survives_EVERY_production_route(origin: str) -> None:
+    """Parametrised over the cfg objects the fleet actually hands a gate, not
+    over the convenient one. This is the pattern that would have caught
+    pgw#1150 before it shipped."""
+    cfg = production_cfgs()[origin]
+    assert cfg.numerics_floor == cell868.FLOOR
+    assert cfg.numerics_warn == cell868.WARN
+
+
+# ===========================================================================
+# 2. THE RIG FORCES OUTCOMES BY BREAKING REAL INPUTS
+# ===========================================================================
+
+
+def test_a_cell_whose_ENTRY_RAISES_revokes_itself_and_installs_no_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """The de-arm still has teeth, forced the honest way: the packaged entry
+    really raises when the arm dispatches through it, so the artifact revokes
+    ITSELF. Nothing here sets ``failed`` by hand.
+
+    A fix that made a cell undisarmable would be worse than the bug — an object
+    whose every call runs eager must never advertise ``serving_mode=aot_cell``.
+    """
+    boot = AdoptRig(
+        tmp_path, monkeypatch, hub,
+        package_raises="dlopen: undefined symbol", warm_dispatches=1,
+    ).boot()
+
+    assert boot.is_armed() is False
+    assert boot.holds_cell() is True, (
+        "a revoked cell stopped being recognizable as an exported one, which "
+        "would route it back onto the dynamo lane's ledger")
+    assert boot.compile_target() is None
+    assert boot.record.eager_posture
+
+
+def test_a_hub_that_serves_NO_RECEIPT_refuses_the_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """Forcing by REMOVING an input, not by supplying one: the hub simply has
+    no receipt for these bytes, so the real gate refuses on a 404 and the pod
+    serves eager rather than the cell it resolved."""
+    boot = AdoptRig(tmp_path, monkeypatch, hub, serve_receipt=False).boot()
+
+    assert boot.adopted()
+    assert boot.is_armed() is False
+    assert boot.holds_cell() is False, (
+        "an unreceipted cell was wrapped onto the pipeline anyway")
+    # pgw#1122: an ordered arm this pod ordered ITSELF degrades to eager rather
+    # than failing the function, so the boot falls through to the ordinary
+    # policy — a target is still registered (active-less, advertising the key
+    # for peer adoption), and it must name NO artifact.
+    target = boot.compile_target()
+    assert target is not None
+    assert target.active_compile_ref == "", (
+        "a refused cell is still advertised as the served artifact")
+    assert not boot.serves_compiled()
+
+
+def test_a_WARM_DISPATCH_moves_the_artifacts_own_counter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
+) -> None:
+    """The other arm of the proof pass, and it is a REAL dispatch: the handler
+    calls the wrapped forward at a declared shape row, so the packaged entry's
+    own invocation count moves. pgw#1141's rig moved a counter by hand."""
+    boot = AdoptRig(tmp_path, monkeypatch, hub, warm_dispatches=1).boot()
+
+    assert boot.is_armed() is True
+    assert aot_serve.execution_count(boot.pipeline) > 0, (
+        "the handler dispatched through the cell and its counter did not move")
+    served = [p.invocations for p in boot.packages.values()]
+    assert sum(served) > 0, served
+    assert boot.serves_compiled()
+
+
+# ===========================================================================
+# 3. THE FENCE — a hand-feed has no label to write down
+# ===========================================================================
+
+
+def _run_lint(src: Path, tests: Path, allowlist: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(LINT), "--src", str(src), "--tests", str(tests),
+         "--allowlist", str(allowlist)],
+        capture_output=True, text=True)
+
+
+def _tree(root: Path, files: Dict[str, str]) -> None:
+    for name, body in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+
+SEAM = '''
+def load_and_wrap(pipeline, *a, **k):
+    meta = {}
+    note_aot_key(str(meta.get("cell_key") or ""))
+    return meta
+'''
+
+
+def test_the_fence_passes_when_the_only_feeder_is_the_seam(tmp_path: Path) -> None:
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {"aot_serve.py": SEAM})
+    tests.mkdir()
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("# nothing to classify\n")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 0, got.stderr
+
+
+def test_the_fence_goes_RED_on_a_production_feeder_off_the_seam(
+    tmp_path: Path,
+) -> None:
+    """pgw#1141b's actual shape: a second arm route feeds the registry by
+    convention. There is no classification that makes this legal."""
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {
+        "aot_serve.py": SEAM,
+        "fleet_cells.py": (
+            "from . import aot_serve\n\n\n"
+            "def arm_ordered(pipe, order):\n"
+            "    aot_serve.note_aot_key(order.cell_key)\n"),
+    })
+    tests.mkdir()
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "UNCLASSIFIED" in got.stderr
+    assert "arm_ordered::aot_serve.note_aot_key" in got.stderr
+
+
+def test_the_fence_goes_RED_on_a_HAND_REGISTRATION_IN_A_TEST(
+    tmp_path: Path,
+) -> None:
+    """THE ROW THIS ISSUE EXISTS FOR. ``_fake_adopt_arm`` called
+    ``note_aot_key`` by hand and thirteen green rows entered one gate east of
+    the bug. A test may not feed a production registry — it goes through
+    ``harness.adopt_rig``. There is deliberately no label for this."""
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {"aot_serve.py": SEAM})
+    _tree(tests, {"test_adopt.py": (
+        "from gen_worker import aot_serve\n\n\n"
+        "def _fake_adopt_arm(key):\n"
+        "    aot_serve.note_aot_key(key)\n")})
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "harness/adopt_rig.py" in got.stderr
+    assert "_fake_adopt_arm" in got.stderr
+
+
+def test_the_fence_goes_RED_on_a_STUBBED_LANE_ACCESSOR_IN_A_TEST(
+    tmp_path: Path,
+) -> None:
+    """The second fixture sin, same class: pgw#1141's suite stubbed an accessor
+    so the gate under test answered from the fixture rather than the object."""
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {"aot_serve.py": SEAM})
+    _tree(tests, {"test_lanes.py": (
+        "from gen_worker import aot_serve\n\n\n"
+        "def test_x(monkeypatch):\n"
+        '    monkeypatch.setattr(aot_serve, "is_aot_ref", lambda r: True)\n')})
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "STUBBED" in got.stderr
+
+
+def test_the_fence_goes_RED_when_the_SEAM_STOPS_FEEDING(tmp_path: Path) -> None:
+    """The registration lives at the wrap because that is the one function every
+    arm route passes. Delete it and a new route is one convention away from
+    pgw#1141b again — so the seam's own call is an asserted fact, not a habit.
+    """
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {"aot_serve.py": "def load_and_wrap(pipeline, *a, **k):\n    return {}\n"})
+    tests.mkdir()
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "SEAM" in got.stderr
+
+
+def test_the_fence_goes_RED_on_a_STALE_ALLOWLIST_ROW(tmp_path: Path) -> None:
+    """A row matching nothing is a boundary that lies (pgw#1122's rule)."""
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {"aot_serve.py": SEAM})
+    tests.mkdir()
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text(
+        "src/gone.py::vanished::aot_serve.note_aot_key  VERDICT  gone\n")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "stale allowlist row" in got.stderr
+
+
+def test_there_is_no_CONVENTION_classification(tmp_path: Path) -> None:
+    """The pgw#1122 rule, transplanted: the third instance of this bug has no
+    label to write down. ``CONVENTION`` names exactly what went wrong twice, so
+    it may not be spellable."""
+    src, tests = tmp_path / "src", tmp_path / "tests"
+    _tree(src, {
+        "aot_serve.py": SEAM,
+        "fleet_cells.py": (
+            "from . import aot_serve\n\n\n"
+            "def arm_ordered(pipe, order):\n"
+            "    aot_serve.note_aot_key(order.cell_key)\n"),
+    })
+    tests.mkdir()
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text(
+        "src/fleet_cells.py::arm_ordered::aot_serve.note_aot_key  "
+        "CONVENTION  whoever reads a key off an envelope registers it\n")
+
+    got = _run_lint(src, tests, allowlist)
+    assert got.returncode == 1
+    assert "unknown classification" in got.stderr
+
+
+# ===========================================================================
+# 4. THE FENCE RUNS ON THIS REPO
+# ===========================================================================
+
+
+def test_the_fence_is_green_on_the_tree() -> None:
+    """The allowlist is a live inventory, not a document: every production
+    feeder of arming/serving process state is classified right now."""
+    got = subprocess.run(
+        [sys.executable, str(LINT)], capture_output=True, text=True, cwd=REPO)
+    assert got.returncode == 0, got.stdout + got.stderr
+
+
+def test_no_test_module_hand_feeds_the_arm_registries() -> None:
+    """Stated separately so a failure names the right thing: if this goes red,
+    somebody re-simulated an adoption instead of driving ``harness.adopt_rig``.
+    """
+    got = subprocess.run(
+        [sys.executable, str(LINT)], capture_output=True, text=True, cwd=REPO)
+    offenders: List[str] = [
+        line for line in (got.stderr or "").splitlines()
+        if line.startswith("tests/")]
+    assert not offenders, "\n".join(offenders)
+
+
+def test_the_rig_itself_registers_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rig is the thing every other test is sent to, so it is the one place
+    a hand-feed would be invisible. It touches ``_KNOWN_AOT_KEYS`` exactly once,
+    to EMPTY it — removing an input is legal, supplying one is not."""
+    import ast
+    import inspect
+
+    from harness import adopt_rig
+
+    source = inspect.getsource(adopt_rig)
+    calls = [
+        node for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and (getattr(node.func, "attr", None) or getattr(node.func, "id", None))
+        == "note_aot_key"
+    ]
+    assert not calls, (
+        "the rig hand-registers a cell key — the exact fixture sin it exists "
+        f"to replace (line {[c.lineno for c in calls]})")
+    # …and it touches the registry exactly once, to EMPTY it. Removing an
+    # input is legal; supplying one is not.
+    assert source.count('setattr(aot_serve, "_KNOWN_AOT_KEYS", set())') == 1

--- a/tests/test_adopted_arm_lane_pgw1141b.py
+++ b/tests/test_adopted_arm_lane_pgw1141b.py
@@ -78,262 +78,22 @@ Run: uv run pytest tests/test_adopted_arm_lane_pgw1141b.py -q
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
-import msgspec
 import pytest
 
-from gen_worker import (
-    RequestContext, Resources, Slot, activity, aot_identity, aot_serve,
-    boot_adopt, cell_adopt, cell_key, cell_resolve, endpoint,
-    env_seal, receipts, worker_function,
-)
+from gen_worker import activity, aot_serve, cell_adopt
 from gen_worker import executor as ex_mod
-from gen_worker.executor import Executor
-from gen_worker.models import provision
-from gen_worker.models.refs import normalize_model_ref
-from gen_worker.pb import worker_scheduler_pb2 as pb
-from gen_worker.registry import extract_specs
 
-# The REAL artifact/arm rig: a real packed cell, a real declaration, real
-# torch tensors. Its ONE substitution is the AOTI `.so`.
-import test_numerics_gate_pgw868 as rig868  # noqa: E402
-from test_numerics_gate_pgw868 import (  # noqa: E402
-    FAMILY, ROWS, RUNTIME, ProbeDenoiser, ProbePackage, ProbePipeline,
-    declaration, entry_name,
-)
-# The REAL receipt gate: a real RSA key, a real JWKS/receipt HTTP hub.
-from test_receipts_pgw709 import (  # noqa: F401,E402 — fixtures come with it
-    HubStub, hub, pub_map, rsa_key,
-)
-
-#: The publishing org. Platform tier, so the trust rule needs no viewer
-#: identity — the identity half is pgw#1122's, fenced there.
-ORG = "11111111-2222-3333-4444-555555555555"
-
-MODEL_REF = "acme/micro-probe:prod"
-
-#: Everything the endpoint instance and the load seam hand each other.
-RIG: Dict[str, Any] = {}
-
-
-class GenIn(msgspec.Struct):
-    prompt: str = "warm"
-
-
-class Out(msgspec.Struct):
-    y: str = "ok"
-
-
-#: pgw#868's declaration with the one field a `@endpoint` lint requires that a
-#: bare `provision.arm_aot` rig never needed: the probe denoiser is
-#: unconditioned, so the text axis is explicitly absent (ie#544).
-CELL = msgspec.structs.replace(declaration(), text_len=0)
-
-
-class AdoptedPipeline(ProbePipeline):
-    """A WORKER-LOADED slot class — the annotation shape that routes the arm
-    order into ``_enable_compiled``. ``from_pretrained`` is what the executor
-    tests for; the load itself is the named seam (``provision.load_slot``)."""
-
-    def __init__(self) -> None:
-        super().__init__(ProbeDenoiser())
-
-    @classmethod
-    def from_pretrained(cls, *_a: Any, **_k: Any) -> "AdoptedPipeline":
-        raise AssertionError("provision.load_slot is the seam, not this")
-
-
-@endpoint(
-    models={"pipeline": Slot(AdoptedPipeline)},
-    resources=Resources(gpu=True),
-    compile=CELL,
-)
-class AdoptedFamily:
-    """A CLASS-annotated slot, which is micro-diffusion's shape and the reason
-    the arm order reaches ``_enable_compiled`` at all: the arming-scope path a
-    ``Slot(str)`` endpoint takes never sees an ``_ArmOrder``."""
-
-    def setup(self, pipeline: AdoptedPipeline) -> None:
-        self.pipe = pipeline
-
-    @worker_function()
-    def generate(self, ctx: RequestContext, p: GenIn) -> Out:
-        # The pod's shape: the boot warmup runs and lands on no packaged entry
-        # of the adopted cell, so the artifact's own counter does not move.
-        return Out()
-
-
-# ---------------------------------------------------------------------------
-# the cell: a real packed artifact with a real, fully-stated identity
-# ---------------------------------------------------------------------------
-
-
-def _metadata() -> Dict[str, Any]:
-    """pgw#868's envelope plus the two identity blocks an ADOPTED cell must
-    carry: ``verify_declared_identity`` compares four axes and refuses a cell
-    that is SILENT on any of them."""
-    meta = rig868.metadata()
-    meta["toolchain"] = {"torch": RUNTIME["torch"], "cuda": RUNTIME["cuda"],
-                         "triton": "3.6.0"}
-    meta[env_seal.SEAL_KEY] = {"PYTHONHASHSEED": "0", "TORCH_COMPILE_DEBUG": ""}
-    meta[cell_key.EXPORT_ENVELOPE_KEY] = {
-        "shapes": [list(row) for row in ROWS], "text_len": 0,
-        "shape_strategy": "static-rows",
-    }
-    # The REAL key, restated from the artifact's own recorded facts — the same
-    # recomputation admission runs (pgw#1059), so nothing here is a stamp the
-    # bytes cannot back up.
-    meta["cell_key"] = cell_key.from_exported_artifact_metadata(meta).digest
-    return meta
-
-
-def _resolved(meta: Dict[str, Any]) -> cell_resolve.ResolvedCell:
-    """The hub's answer, stating exactly the identity the mint stamped."""
-    have = aot_identity.artifact_identity(meta)
-    return cell_resolve.ResolvedCell(
-        family=FAMILY, cell_key=have.cell_key,
-        cell_ref=f"root/family-{FAMILY}#{have.cell_key}",
-        checkpoint_id="", content_digest="sha256:" + "ab" * 32,
-        artifact_path="cell.tar.gz", size_bytes=0,
-        publisher_org=ORG, publisher_tier="platform",
-        graph_contract=have.graph_contract_digest,
-        toolchain_digest=have.toolchain_digest,
-        env_seal_digest=have.env_seal_digest,
-        identity_axes={}, sm=RUNTIME["sm"], sku=RUNTIME["sku"], lane="",
-        receipt="",
-        transport=cell_resolve.Transport(
-            snapshot_digest="blake3:" + "cd" * 32, files=()),
-    )
-
-
-def _derived(digest: str) -> Any:
-    from gen_worker import boot_key
-
-    return boot_key.DerivedKey(
-        key=cell_key.CellKey(axes=(("adopted", digest),)),
-        class_hashes={}, combined="", workers=1, width_reason="test",
-        traced=len(ROWS), memo="miss", wall_ms=10_291,
-    )
-
-
-# ---------------------------------------------------------------------------
-# the rig
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
-    """The typed rows, captured at the ONE sink the hub's
-    ``worker_activity_events`` table is built from."""
-    said: List[Tuple[str, str, str]] = []
-    real = activity.emit_event
-
-    def _spy(kind: str, detail: str = "", **kw: Any) -> Any:
-        said.append((kind, str(kw.get("phase", "")), detail))
-        try:
-            return real(kind, detail, **kw)
-        except Exception:
-            return None
-
-    monkeypatch.setattr(activity, "emit_event", _spy)
-    monkeypatch.setattr(ex_mod.activity_mod, "emit_event", _spy)
-    return said
-
-
-def phases(said: List[Tuple[str, str, str]], kind: str) -> List[str]:
-    return [phase for k, phase, _d in said if k == kind]
-
-
-@pytest.fixture
-def forget_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``note_aot_key`` learns into a PROCESS-global set, so a sibling file
-    that armed the same key would answer this file's question for it. Every
-    row here starts with a runtime that has been told nothing."""
-    monkeypatch.setattr(aot_serve, "_KNOWN_AOT_KEYS", set())
-
-
-@pytest.fixture
-def adopted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
-    forget_keys: None,
-) -> Dict[str, Any]:
-    """A boot that RESOLVED a cell by its own derived key and is about to arm
-    it — everything from the ``_ArmOrder`` down runs for real."""
-    RIG.clear()
-    meta = _metadata()
-    artifact = rig868.artifact(tmp_path, meta)
-    cell = _resolved(meta)
-
-    # The hub countersigns these exact bytes. Platform tier: adoptable by any
-    # pod, so the arm asks nobody who it is (pgw#1122 owns that direction).
-    hub.serve_receipt_for(
-        artifact, cell_key=cell.cell_key, family=FAMILY,
-        publisher_tier="platform", publisher_org_id=ORG,
-        owning_endpoint_id="")
-    receipts.configure(base_url=hub.base_url, worker_jwt=lambda: "")
-
-    # The one deferred piece (GPU) and the runtime axes a cardless box cannot
-    # state — pgw#868's substitutions, verbatim.
-    monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME))
-    monkeypatch.setattr(aot_serve, "_entry_admission_drift",
-                        lambda *a, **k: None)
-    packages = {entry_name(h, w): ProbePackage() for h, w in ROWS}
-    monkeypatch.setattr(
-        aot_serve, "_load_package", lambda path, entry="model": packages[entry])
-
-    # The class-annotated slot's weights load. `_inject_models` arms whatever
-    # this returns, through the real ordered path.
-    def _load_slot(annotation: Any, path: str, **_kw: Any) -> provision.SlotLoad:
-        pipe = AdoptedPipeline()
-        RIG["pipe"] = pipe
-        return provision.SlotLoad(obj=pipe, is_pipeline=True, ran="bf16")
-
-    monkeypatch.setattr(provision, "load_slot", _load_slot)
-    monkeypatch.setattr(ex_mod.provision, "load_slot", _load_slot)
-
-    def _adopt(self: Any, spec: Any, slots: Any) -> boot_adopt.BootAdoptOutcome:
-        return boot_adopt.report(boot_adopt.BootAdoptOutcome(
-            adoption=boot_adopt.BootAdoption(
-                derived=_derived(cell.cell_key), cell=cell, artifact=artifact),
-            reason=boot_adopt.HIT, derived_key=cell.cell_key, derive_ms=10_291,
-            family=FAMILY, function="generate"))
-
-    monkeypatch.setattr(Executor, "_boot_adopt", _adopt)
-    RIG["meta"], RIG["cell"], RIG["artifact"] = meta, cell, artifact
-    return RIG
-
-
-def _boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Tuple[Executor, Any]:
-    sent: List[pb.WorkerMessage] = []
-
-    async def _send(msg: pb.WorkerMessage) -> None:
-        sent.append(msg)
-
-    ex = Executor(extract_specs(AdoptedFamily), _send)
-    ex.store._cache_dir = tmp_path / "cas"
-
-    async def _fake_download(target: str, **_kw: Any) -> Path:
-        p = tmp_path / target.replace("/", "_").replace(":", "_")
-        p.mkdir(parents=True, exist_ok=True)
-        return p
-
-    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
-
-    from gen_worker import dispatch as dispatch_mod
-
-    spec = ex.specs["generate"]
-    eff = ex._dispatched_spec(
-        spec, {"pipeline": dispatch_mod.SlotOrder(ref=MODEL_REF, components=())})
-    snaps = {normalize_model_ref(MODEL_REF): pb.Snapshot(
-        digest="d1" * 16,
-        files=[pb.SnapshotFile(
-            path="model.safetensors", size_bytes=5, blake3="cd" * 32,
-            url="http://r2.invalid/presigned")])}
-    asyncio.run(ex.ensure_setup(eff, snaps))
-    return ex, eff
+# pgw#1152: the vehicle this file built is now `tests/harness/adopt_rig.py`,
+# the DEFAULT rig for anything arming-adjacent. It is the same chain, verbatim
+# — real `ensure_setup` -> real `_enable_compiled` -> a real `_ArmOrder(adopt=…)`
+# -> real `arm_ordered` -> the real receipt gate against a real RSA-signed
+# receipt from a real HTTP hub -> `provision.arm_aot` -> `load_and_wrap` on a
+# real packed cell -> real warmup, proof pass and target install.
+from harness.adopt_rig import FAMILY, AdoptRig  # noqa: F401
+from harness.receipt_hub import HubStub, hub, pub_map, rsa_key  # noqa: F401
 
 
 # ===========================================================================
@@ -342,90 +102,89 @@ def _boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Tuple[Executor, An
 
 
 def test_a_boot_adopted_cell_is_NOT_scored_on_the_dynamo_ledger(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
-    events: List[Tuple[str, str, str]],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
-    """THE RED. On master this reproduces POD PROOF #4's chain exactly:
-    ``target_applicability_incomplete functions=()`` then
-    ``armed_target_unresolved`` then ``serve_degrade``, and the pod serves
-    eager for life having thrown away the cell it just materialized.
+    """THE RED. On the tree before ``f3ab710e`` this reproduces POD PROOF #4's
+    chain exactly: ``target_applicability_incomplete functions=()`` then
+    ``armed_target_unresolved`` then ``serve_degrade``, and the pod serves eager
+    for life having thrown away the cell it just materialized. That deletion is
+    now a first-class row of its own —
+    ``test_adopt_rig_pgw1152::test_the_rig_RE_FINDS_pgw1141b_when_its_fix_is_deleted``.
 
-    The four assertions below are the four rows the pod emitted, in order.
+    The assertions below are the four rows the pod emitted, in order.
     """
-    ex, eff = _boot(tmp_path, monkeypatch)
-    pipe = RIG["pipe"]
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
 
-    assert "hit" in phases(events, activity.KIND_BOOT_ADOPT), (
+    assert boot.adopted(), (
         "the boot did not adopt at all — this row is testing the wrong thing")
 
     # seq 13: the object's applicability. `functions=()` is where the pod died.
-    assert "target_applicability_incomplete" not in phases(
-        events, "serve_eager_posture"), (
+    assert "target_applicability_incomplete" not in boot.phases(
+        "serve_eager_posture"), (
         "the boot-adopted cell computed EMPTY applicability — the ordered arm "
         "route never taught `is_aot_ref` its key, so the exported cell was "
         "scored on the dynamo lane's cache-hit ledger and disarmed")
     # seq 14 + 15: the orphan report and the degrade.
-    assert cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value not in phases(
-        events, "serve_eager_posture")
-    assert not [k for k, _p, _d in events if k == activity.KIND_SERVE_DEGRADE], (
+    assert cell_adopt.EagerPhase.ARMED_TARGET_UNRESOLVED.value not in \
+        boot.phases("serve_eager_posture")
+    assert not boot.phases(activity.KIND_SERVE_DEGRADE), (
         "a cell that materialized, armed and was never dispatched through "
         "degraded the whole record")
 
     # ...and the positive statement of the same fact: it SERVES.
-    assert aot_serve.is_armed(pipe) is True
-    rec = ex._classes[eff.instance_key]
-    assert rec.compile_targets, "armed and still no installed compile target"
-    target = next(iter(rec.compile_targets.values()))
+    assert boot.is_armed() is True
+    target = boot.compile_target()
+    assert target is not None, "armed and still no installed compile target"
     assert "generate" in target.function_names
-    assert target.active_compile_ref == RIG["cell"].cell_ref
-    assert rec.eager_posture == ""
-    assert ex._served_execution_lane(eff).endswith("+compiled")
+    assert target.active_compile_ref == boot.cell.cell_ref
+    assert boot.record.eager_posture == ""
+    assert boot.serves_compiled()
 
 
 def test_the_ordered_arm_teaches_the_recognizer_its_key(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """THE LOCUS, stated as one fact. ``note_aot_key`` had two feeders and both
-    were self-produced routes; the ordered arm — every hub Plan and every
-    §4.27 boot-adopt — fed it nothing, so an adopted cell's own ref answered
-    "not an AOT cell" on the pod that was serving it.
-    """
-    _boot(tmp_path, monkeypatch)
+    were self-produced routes; the ordered arm — every hub Plan and every §4.27
+    boot-adopt — fed it nothing, so an adopted cell's own ref answered "not an
+    AOT cell" on the pod that was serving it.
 
-    ref = RIG["cell"].cell_ref
-    assert aot_serve.is_aot_ref(ref), (
+    pgw#1152 then DELETED both of those feeders: the wrap is now the registry's
+    only writer, so this fact has exactly one producer.
+    """
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+
+    assert aot_serve.is_aot_ref(boot.cell.cell_ref), (
         "the process armed this exact artifact and still does not recognize "
         "its ref as an exported cell")
-    assert aot_serve.is_aot_ref(ref, FAMILY)
+    assert aot_serve.is_aot_ref(boot.cell.cell_ref, FAMILY)
 
 
 def test_the_lane_is_read_off_the_OBJECT_not_a_registry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """The structural half. Registering the key is a convention a future arm
     route can forget again — twice now a disarm authority has survived one gate
     east of its fix. With the registry deliberately emptied AFTER the wrap, the
     readers must still put this object on the exported lane."""
-    ex, eff = _boot(tmp_path, monkeypatch)
-    pipe = RIG["pipe"]
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
 
     monkeypatch.setattr(aot_serve, "_KNOWN_AOT_KEYS", set())
-    assert not aot_serve.is_aot_ref(RIG["cell"].cell_ref)
-    assert aot_serve.holds_exported_cell(pipe) is True
-    assert ex_mod._exported_arm(pipe, RIG["cell"].cell_ref) is True
+    assert not aot_serve.is_aot_ref(boot.cell.cell_ref)
+    assert aot_serve.holds_exported_cell(boot.pipeline) is True
+    assert ex_mod._exported_arm(boot.pipeline, boot.cell.cell_ref) is True
 
 
 def test_the_posture_row_names_the_adoption_not_the_dynamo_lane(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
-    events: List[Tuple[str, str, str]],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """seq 12 on the pod carried §4.31's new sentence, which is why the leg
     read as "pgw#1141 works". It did — but the reason under it was the DYNAMO
     lane's ("this boot holds no evidence either way"), because the cell had
     been sorted onto that lane. An adopted cell's row must say what it is."""
-    _boot(tmp_path, monkeypatch)
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
 
-    rows = [d for k, _p, d in events if k == activity.KIND_CELL_NUMERICS]
+    rows = boot.details(activity.KIND_CELL_NUMERICS)
     assert len(rows) == 1, rows
     assert "STAYS ARMED" in rows[0]
     assert "adoption runs no quality gate" in rows[0], (
@@ -439,37 +198,32 @@ def test_the_posture_row_names_the_adoption_not_the_dynamo_lane(
 
 
 def test_a_REVOKED_cell_still_de_arms_and_installs_no_target(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
-    events: List[Tuple[str, str, str]],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """§4.31's sticky de-arm, unchanged. The artifact ran and failed before any
     guard was bound, so nothing may advertise ``serving_mode=aot_cell`` for it.
-    A fix that made a cell undisarmable would be worse than the bug."""
-    real_wrap = aot_serve.load_and_wrap
+    A fix that made a cell undisarmable would be worse than the bug.
 
-    def _wrap_then_revoke(pipeline: Any, *a: Any, **k: Any) -> Any:
-        meta = real_wrap(pipeline, *a, **k)
-        for state in aot_serve._marker_states(pipeline):
-            state["failed"] = True
-        return meta
+    pgw#1152: the revocation is forced by BREAKING a real input — the packaged
+    entry raises when the arm dispatches through it — rather than by setting
+    ``failed`` on a marker the test wrote itself.
+    """
+    boot = AdoptRig(
+        tmp_path, monkeypatch, hub,
+        package_raises="dlopen: undefined symbol", warm_dispatches=1,
+    ).boot()
 
-    monkeypatch.setattr(aot_serve, "load_and_wrap", _wrap_then_revoke)
-
-    ex, eff = _boot(tmp_path, monkeypatch)
-    pipe = RIG["pipe"]
-
-    assert aot_serve.is_armed(pipe) is False
-    rec = ex._classes[eff.instance_key]
-    assert not rec.compile_targets, (
+    assert boot.is_armed() is False
+    assert boot.compile_target() is None, (
         "a revoked cell kept an installed target, so the wire would say "
         "aot_cell on a pipeline whose every call runs eager")
-    assert cell_adopt.EagerPhase.COMPILED_DEGRADED.value in phases(
-        events, "serve_eager_posture")
-    assert rec.eager_posture
+    assert cell_adopt.EagerPhase.COMPILED_DEGRADED.value in boot.phases(
+        "serve_eager_posture")
+    assert boot.record.eager_posture
 
 
 def test_an_operator_eager_only_order_still_wins(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """§4.32 item 4: the consumer can always opt out of compiled serving. The
     exported-lane recognition must not route around the operator's order."""
@@ -477,15 +231,14 @@ def test_an_operator_eager_only_order_still_wins(
 
     serve_posture.apply_command(True, actor="operator", reason="pgw#1141b row")
     try:
-        ex, eff = _boot(tmp_path, monkeypatch)
-        rec = ex._classes[eff.instance_key]
+        boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
         # Nothing armed and nothing adopted: the order is obeyed at the
         # arming brain, before the lane question is ever asked.
-        assert aot_serve.is_armed(RIG["pipe"]) is False
-        assert aot_serve.holds_exported_cell(RIG["pipe"]) is False
-        assert rec.eager_posture == cell_adopt.EagerPhase.OPERATOR_EAGER_ONLY
-        assert ex.serving_tiers()["generate"] == "eager"
-        assert not ex._served_execution_lane(eff).endswith("+compiled")
+        assert boot.is_armed() is False
+        assert boot.holds_cell() is False
+        assert boot.record.eager_posture == cell_adopt.EagerPhase.OPERATOR_EAGER_ONLY
+        assert boot.executor.serving_tiers()["generate"] == "eager"
+        assert not boot.serves_compiled()
     finally:
         serve_posture.reset()
 
@@ -500,7 +253,12 @@ def test_the_registration_lives_at_the_wrap_not_at_the_call_sites() -> None:
     ("whoever reads a cell_key off an aot-inductor envelope registers it") and
     the ordered arm simply did not keep it. Registration now happens inside
     ``load_and_wrap``, the one function every arm route passes, so a new route
-    inherits it instead of having to remember it."""
+    inherits it instead of having to remember it.
+
+    pgw#1152 made this a repo-wide lint (``scripts/lint_arm_state_feeders.py``)
+    rather than one file's assertion; this row stays because it names the fact
+    at the place a reader of THIS issue looks for it.
+    """
     import inspect
 
     body = inspect.getsource(aot_serve.load_and_wrap)
@@ -510,13 +268,13 @@ def test_the_registration_lives_at_the_wrap_not_at_the_call_sites() -> None:
 
 
 def test_a_wrapped_object_answers_the_lane_question_itself(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, adopted: Dict[str, Any],
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, hub: HubStub,  # noqa: F811
 ) -> None:
     """``holds_exported_cell`` is deliberately NOT ``is_armed``: the install
     path must tell a REVOKED exported cell (never advertise it) apart from an
     object carrying no cell at all (an ordinary dynamo/eager object)."""
-    _boot(tmp_path, monkeypatch)
-    pipe = RIG["pipe"]
+    boot = AdoptRig(tmp_path, monkeypatch, hub).boot()
+    pipe = boot.pipeline
 
     assert aot_serve.holds_exported_cell(pipe) is True
     for state in aot_serve._marker_states(pipe):

--- a/tests/test_adopted_cell_warm_proof_pgw1141.py
+++ b/tests/test_adopted_cell_warm_proof_pgw1141.py
@@ -334,7 +334,12 @@ def _fake_adopt_arm(key: str, ref: str, *, revoke: bool = False):
         marker = {"module": unet, "state": state, "meta": {"cell_key": key}}
         setattr(unet, aot_serve._MARKER_ATTR, marker)
         setattr(pipe, aot_serve._MARKER_ATTR, marker)
-        aot_serve.note_aot_key(key)
+        # pgw#1152: an `aot_serve.note_aot_key(key)` stood here — the ONE line no
+        # production arm route ever called, which is why these rows were green
+        # while the pod served eager (pgw#1141b). It is DELETED, not moved: the
+        # marker set above is what `load_and_wrap` publishes, so
+        # `holds_exported_cell` answers the lane question off the OBJECT.
+        # A fixture that needs a REAL boot-adopt drives tests/harness/adopt_rig.py.
         if revoke:
             state["failed"] = True
         adopted = fleet_cells.SelfMint(

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -116,7 +116,12 @@ def _fake_arm(key: str, ref: str):
         marker = {"module": unet, "state": state, "meta": {}}
         setattr(unet, aot_serve._MARKER_ATTR, marker)
         setattr(pipe, aot_serve._MARKER_ATTR, marker)
-        aot_serve.note_aot_key(key)
+        # pgw#1152: an `aot_serve.note_aot_key(key)` stood here — the ONE line no
+        # production arm route ever called, which is why these rows were green
+        # while the pod served eager (pgw#1141b). It is DELETED, not moved: the
+        # marker set above is what `load_and_wrap` publishes, so
+        # `holds_exported_cell` answers the lane question off the OBJECT.
+        # A fixture that needs a REAL boot-adopt drives tests/harness/adopt_rig.py.
         adopted = fleet_cells.SelfMint(
             family=FAMILY, cell_key=key, ref=ref,
             snapshot_digest="blake3:" + "ab" * 32,

--- a/tests/test_cell_key_space_pgw1033.py
+++ b/tests/test_cell_key_space_pgw1033.py
@@ -290,14 +290,24 @@ def test_a_quarantined_ARM_ref_still_declines_the_next_arm(
 # ---------------------------------------------------------------------------
 
 
-def test_a_self_minted_cell_is_registered_as_an_AOT_ref(
+def test_an_ARM_TOKEN_is_never_classified_as_an_exported_ref(
     _miss: None, _events: List[Tuple[str, str, str]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """RED at HEAD: ``note_aot_key`` had one caller — discovery. The one
-    artifact this process is CERTAIN is exported, because it just built it,
-    was the one ref ``is_aot_ref`` did not recognize; the executor then scored
-    it by FX cache hits an AOTI package cannot produce and disproved it."""
+    """The KEY-SPACE half, which is this file's subject: an owed mint's
+    computed ref names an obligation, never an artifact, and no adopt may make
+    it read as one. The cell's STAMPED key is a different space entirely.
+
+    pgw#1152 moved the other half out. ``note_aot_key`` used to be called by
+    this finalize — one of pgw#1033's two SELF-PRODUCED feeders, and the
+    convention the ordered/boot-adopt arm did not keep (pgw#1141b, measured on
+    a pod). Registration is now a property of ``aot_serve.load_and_wrap``, so
+    "an exported cell's ref is recognized" is a fact about the WRAP and is
+    asserted where a real wrap happens:
+    ``test_adopted_arm_lane_pgw1141b::test_the_ordered_arm_teaches_the_recognizer_its_key``.
+    This fixture deliberately stubs ``arm_aot`` — nothing is wrapped here, and
+    nothing may therefore be recognized.
+    """
     pending = _arm().self_mint
     assert pending is not None
     assert not aot_serve.is_aot_ref(pending.ref), (
@@ -306,14 +316,13 @@ def test_a_self_minted_cell_is_registered_as_an_AOT_ref(
 
     minted = _adopt(monkeypatch, pending)
     assert minted is not None
-
-    assert aot_serve.is_aot_ref(minted.ref), (
-        "this pod's own exported cell reads as a dynamo ref, so the boot "
-        "proof scores it by FX cache hits and fails it closed")
-    assert aot_serve.is_aot_ref(minted.ref, FAMILY)
-    # The registry is the STAMPED key's, not the arm's: an arm key names no
-    # artifact and must never be classified as one.
+    assert minted.cell_key == STAMPED_KEY, (
+        "the finalized cell carries the ARM token as its identity; the stamped "
+        "key is the only thing that addresses the bytes")
     assert not aot_serve.is_aot_ref(pending.ref)
+    assert not aot_serve.is_aot_ref(minted.ref), (
+        "this fixture never reached the wrap, so nothing armed these bytes — "
+        "a ref recognized here would be a registration nobody earned")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -29,237 +29,26 @@ pod, and no test here may be cited as evidence about a real cell's numerics.
 
 from __future__ import annotations
 
-import math
-import platform
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, List
 
 import pytest
 import torch
 
 from gen_worker import aot_serve as aot
 from gen_worker import numerics_probe
-from gen_worker.api.decorators import Compile
-from gen_worker.api.export_contract import (
-    Dim, GraphClass, Input, register_export_declaration,
-    reset_export_declarations,
+from gen_worker.api.export_contract import reset_export_declarations
+
+# pgw#1152: the rig this file grew moved to `tests/harness/exported_cell.py`.
+# Three other modules already imported it from here as `rig868`, and the
+# adopt-path rig needs the same packed artifact — a shared vehicle belongs
+# where shared vehicles live. Nothing about it changed; the names below are
+# the same objects.
+from harness.exported_cell import (  # noqa: F401 — `declared`/`events` are fixtures
+    FAMILY, FLOOR, ROWS, RUNTIME, TARGET, WARN,
+    ProbeDenoiser, ProbePackage, ProbePipeline,
+    arm, artifact, blend, declaration, declared, entry_name, events,
+    metadata, numerics_rows,
 )
-
-FAMILY = "pgw868-probe"
-RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130", "cuda": "13.0"}
-TARGET = "denoiser"
-#: Two declared shape rows -> two packaged entries. The second row is what
-#: makes "one shape row" a real axis rather than a word in a docstring.
-ROWS = ((8, 8), (16, 16))
-#: sdxl's declared band, used verbatim: this issue is a measurement plus
-#: wiring, never a re-design of what "good" means.
-FLOOR, WARN = 0.995, 0.999
-
-
-# ---------------------------------------------------------------------------
-# the subject — a calibrated blend, so a test can NAME the rung it aims at
-# ---------------------------------------------------------------------------
-
-
-def blend(reference: torch.Tensor, cosine: float) -> torch.Tensor:
-    """``reference`` rotated to EXACTLY ``cosine``, at unchanged magnitude.
-
-    Gram-Schmidt against a fixed ramp: the perturbation is deterministic and
-    the resulting cosine is analytic, so a threshold test asserts the ladder's
-    boundary rather than a tuned fudge factor.
-    """
-    flat = reference.reshape(-1).to(torch.float64)
-    ramp = torch.linspace(-1.0, 1.0, flat.numel(), dtype=torch.float64)
-    ramp = ramp - flat * (torch.dot(ramp, flat) / torch.dot(flat, flat))
-    ramp = ramp / ramp.norm() * flat.norm()
-    sin = math.sqrt(max(0.0, 1.0 - cosine * cosine))
-    out = cosine * flat + sin * ramp
-    return out.reshape(reference.shape).to(reference.dtype)
-
-
-class ProbeDenoiser(torch.nn.Module):
-    """The eager reference. Deterministic, tiny, and REAL: a genuine
-    `nn.Module` whose signature the declaration is positionalized against."""
-
-    def __init__(self, width: int = 16) -> None:
-        super().__init__()
-        # Built without the global RNG on purpose: the probe must be provable
-        # not to disturb the serving generator, and a fixture that seeded it
-        # would hide exactly that.
-        self.weight = torch.nn.Parameter(
-            torch.linspace(0.1, 3.0, width * width).reshape(width, width).sin())
-
-    def forward(self, sample: torch.Tensor, timestep: torch.Tensor) -> torch.Tensor:
-        return (sample @ self.weight[: sample.shape[-1], : sample.shape[-1]]) * timestep
-
-
-class ProbePipeline:
-    def __init__(self, module: torch.nn.Module) -> None:
-        self.denoiser = module
-
-
-class ProbePackage:
-    """Stands in for one entry's `AOTICompiledModel` — the ONE deferred piece.
-
-    Reproduces the eager maths from the constants it was BOUND with (so the
-    comparison is genuinely compiled-vs-eager on identical weights) and then
-    rotates the result to a declared cosine.
-    """
-
-    def __init__(self, cosine: float = 1.0, *, raises: str = "",
-                 drop_output: bool = False) -> None:
-        self.cosine = float(cosine)
-        self.raises = raises
-        self.drop_output = drop_output
-        self.loaded: Dict[str, Any] = {}
-        self.invocations = 0
-
-    def get_constant_fqns(self) -> List[str]:
-        return ["weight"]
-
-    def load_constants(self, values: Dict[str, Any], check_full_update: bool = False,
-                       **_kw: Any) -> None:
-        self.loaded = dict(values)
-
-    def __call__(self, sample: torch.Tensor, timestep: torch.Tensor) -> Any:
-        self.invocations += 1
-        if self.raises:
-            raise RuntimeError(self.raises)
-        w = self.loaded["weight"]
-        out = (sample @ w[: sample.shape[-1], : sample.shape[-1]]) * timestep
-        if self.drop_output:
-            return (out, out)
-        return out if self.cosine >= 1.0 else blend(out, self.cosine)
-
-
-# ---------------------------------------------------------------------------
-# the declaration + the artifact — both real
-# ---------------------------------------------------------------------------
-
-
-def declaration(floor: float = FLOOR, warn: float = WARN) -> Compile:
-    return Compile(
-        family=FAMILY,
-        targets=(TARGET,),
-        dims=(Dim(name="h", carried_by=(("sample", 0),)),
-              Dim(name="w", carried_by=(("sample", 1),))),
-        classes=tuple(GraphClass(dims={"h": h, "w": w}) for h, w in ROWS),
-        inputs=(Input(name="sample", shape=("h", "w"), dtype="float32"),
-                Input(name="timestep", shape=(), dtype="float32", value=1.0)),
-        shape_strategy="static-rows",
-        numerics_floor=floor,
-        numerics_warn=warn,
-    )
-
-
-def entry_name(h: int, w: int) -> str:
-    return f"{TARGET}/h={h},w={w}"
-
-
-def _entry(h: int, w: int) -> Dict[str, Any]:
-    block = {
-        "target": TARGET,
-        "fork": [],
-        "class_dims": [["h", h], ["w", w]],
-        "inputs": [
-            {"name": "sample", "position": 0, "dtype": "float32",
-             "shape": [h, w]},
-            {"name": "timestep", "position": 1, "dtype": "float32",
-             "shape": []},
-        ],
-        "symbols": {},
-        "constants": [{"fqn": "weight", "source": aot.SOURCE_STATE_DICT,
-                       "dtype": "float32", "shape": [16, 16]}],
-        "graph": {},
-    }
-    block["range_digest"] = aot.range_digest(block)
-    block["class_hash"] = aot.class_hash(block, strict=True, lora_bucket=0)
-    return block
-
-
-def metadata(rows: Tuple[Tuple[int, int], ...] = ROWS) -> Dict[str, Any]:
-    entries = {entry_name(h, w): _entry(h, w) for h, w in rows}
-    meta = {
-        "format": aot.ARTIFACT_FORMAT, "kind": aot.ARTIFACT_KIND, **RUNTIME,
-        "family": FAMILY, "precision": "w8a8", "cell_key": "cell868",
-        "entries": entries, "strict_export": True, "lora_bucket": 0,
-        "package_constants_in_so": False, "constant_folding_fenced": True,
-        "source_ref": "", "source_digest": "",
-        # pgw#950: every mint stamps a host-ISA requirement, and a cell that
-        # stamps none is refused rather than sniffed from the .pt2. Satisfiable
-        # anywhere: this host's machine, no ISA level.
-        "host_isa": {"machine": platform.machine(), "march": "", "simdlen": 0,
-                     "level": ""},
-    }
-    meta["combined_graph_hash"] = aot.combined_graph_hash(
-        b["class_hash"] for b in entries.values())
-    return meta
-
-
-def artifact(tmp_path: Path, meta: Dict[str, Any] | None = None) -> Path:
-    work = tmp_path / "work"
-    work.mkdir(exist_ok=True)
-    (work / aot.PACKAGE_NAME).write_bytes(b"\x00not-a-real-pt2")
-    return aot.pack(work, tmp_path / "cell.tar.gz", meta or metadata())
-
-
-@pytest.fixture
-def declared() -> Any:
-    reset_export_declarations()
-    decl = declaration()
-    register_export_declaration(decl, family=FAMILY, replace=True)
-    yield decl
-    reset_export_declarations()
-
-
-@pytest.fixture
-def events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
-    import gen_worker.activity as activity_mod
-
-    said: List[Tuple[str, str, str]] = []
-    monkeypatch.setattr(
-        activity_mod, "emit_event",
-        lambda kind, detail, **kw: said.append(
-            (kind, detail, str(kw.get("phase", "")))))
-    return said
-
-
-def arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
-        packages: Dict[str, ProbePackage],
-        meta: Dict[str, Any] | None = None,
-        verify_numerics: bool = True) -> Tuple[Any, Any, Any]:
-    """Drive the REAL arm path and return ``(pipeline, module, outcome)``.
-
-    ``verify_numerics=True`` is the MINT arm (pgw#1141 / DESIGN-RULINGS §4.32):
-    since this issue the gate runs on the pod that minted the bytes, before it
-    publishes them, and nowhere else. Adoption passes False and runs no gate —
-    `test_adopted_cell_warm_proof_pgw1141.py` owns that direction.
-
-    pgw#923: the arm returns a typed :class:`AdoptOutcome` rather than a bool,
-    so its verdict — armed, or refused with the classified reason — is a value
-    the caller can assert on and the executor can put on the wire. It stays
-    truthy/falsy, so `assert outcome` reads exactly as `assert armed` did.
-    """
-    from gen_worker.models import provision
-
-    monkeypatch.setattr(aot, "runtime_key", lambda: dict(RUNTIME))
-    monkeypatch.setattr(
-        aot, "_entry_admission_drift", lambda *a, **k: None)
-    monkeypatch.setattr(
-        aot, "_load_package", lambda path, entry="model": packages[entry])
-    module = ProbeDenoiser()
-    pipeline = ProbePipeline(module)
-    outcome = provision.arm_aot(
-        pipeline, decl, tmp_path / "cache", artifact(tmp_path, meta), 0,
-        verify_numerics=verify_numerics)
-    return pipeline, module, outcome
-
-
-def numerics_rows(said: List[Tuple[str, str, str]]) -> List[Tuple[str, str]]:
-    import gen_worker.activity as activity_mod
-
-    return [(detail, phase) for kind, detail, phase in said
-            if kind == activity_mod.KIND_CELL_NUMERICS]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_partial_shape_coverage_pgw844.py
+++ b/tests/test_partial_shape_coverage_pgw844.py
@@ -322,13 +322,14 @@ def _boot(
         executor_mod.activity_mod, "emit_event",
         lambda kind, detail, phase="", duration_ms=0: events.append(
             (kind, phase, detail)))
-    if exported:
-        # The exported lane is identified by the ref the hub delivers; a
-        # stamped cell key is only computable on CUDA, so this process is TOLD
-        # the flavor is an AOT cell exactly as a Plan's `Arm.artifact` tells a
-        # pod (pgw#904). Everything downstream of that is production code.
-        aot_serve.note_aot_key(FLAVOR)
-
+    # pgw#1152: an `aot_serve.note_aot_key(FLAVOR)` stood here, with a comment
+    # arguing this process is "TOLD the flavor is an AOT cell exactly as a
+    # Plan's `Arm.artifact` tells a pod". Production is told no such thing — it
+    # LEARNS at the wrap (`load_and_wrap`, pgw#1141b), and the route that
+    # believed the convention instead is what cost four pods. The line is
+    # deleted rather than moved: `_arm` below publishes the pipeline-level
+    # marker `load_and_wrap` publishes, so `holds_exported_cell` answers the
+    # lane question off the OBJECT and the registry is not consulted at all.
     artifact = _cell_snapshot(tmp_path)
     model_dir = tmp_path / "sdxl-model"
     model_dir.mkdir()

--- a/tests/test_receipts_pgw709.py
+++ b/tests/test_receipts_pgw709.py
@@ -8,121 +8,26 @@ are the red verification: each one asserts the gate actually REFUSES.
 
 from __future__ import annotations
 
-import base64
 import hashlib
-import io
 import json
 import tarfile
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
-from urllib.parse import parse_qs, urlparse
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from gen_worker import receipts, worker_credential, worker_identity
 
-KID = "test-kid-1"
-FAMILY = "sdxl"
-CELL_KEY = "ck1-0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-SNAPSHOT = "snapdigest-abc123"
-# th#1657: the endpoint the test pod serves, and the one every fixture receipt
-# is minted FOR unless a test deliberately mints it for someone else. Keeping
-# the default a matching ORG-tier pair means the publisher gate is live in every
-# case below, not just the ones that name it.
-SELF_ENDPOINT = "3e0f8f7a-1111-2222-3333-444455556666"
-OTHER_ENDPOINT = "9c1d2e3f-9999-8888-7777-666655554444"
-SELF_ORG = "11111111-2222-3333-4444-555555555555"
-B3_HEX = "ab12cd34" * 8
-SHA_HEX = "12ab34cd" * 8
-
-
-def _b64url(raw: bytes) -> str:
-    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
-
-
-def sign_receipt(
-    key: rsa.RSAPrivateKey,
-    claims: Dict[str, Any],
-    *,
-    kid: str = KID,
-    alg: str = "RS256",
-) -> str:
-    header = {"alg": alg, "kid": kid, "typ": "cell-receipt-v1+jws"}
-    signing_input = (
-        _b64url(json.dumps(header).encode()) + "." + _b64url(json.dumps(claims).encode())
-    )
-    sig = key.sign(signing_input.encode("ascii"), padding.PKCS1v15(), hashes.SHA256())
-    return signing_input + "." + _b64url(sig)
-
-
-def make_claims(
-    artifact_digest: str,
-    size_bytes: int,
-    *,
-    legacy_blake3_only: bool = False,
-    **overrides: Any,
-) -> Dict[str, Any]:
-    """Build receipt claims binding an ALGORITHM-TAGGED artifact digest.
-
-    ``legacy_blake3_only`` reproduces a receipt minted before pgw#807: the
-    bare-hex ``blake3`` claim and no ``digest`` at all. It exists so the tests
-    can prove that shape is now REFUSED — the v1 protocol that minted it is
-    gone from this SDK, so a cell it names is re-minted, never armed.
-    """
-    algo, _, hex_part = artifact_digest.partition(":")
-    artifact: Dict[str, Any] = {"path": "cell.tar.gz", "size_bytes": size_bytes}
-    if legacy_blake3_only:
-        assert algo == "blake3", "legacy receipts only ever carried blake3"
-        artifact["blake3"] = hex_part
-    else:
-        artifact["digest"] = artifact_digest
-    claims: Dict[str, Any] = {
-        "crv": "cell-receipt-v2",
-        "family": FAMILY,
-        "cell_key": CELL_KEY,
-        "axes": {"sku": "rtx-4090", "image_digest": "sha256:feed", "gen_worker": "0.75.1"},
-        "owning_endpoint_id": SELF_ENDPOINT,
-        "publisher": "selfmint:worker=w1:pod=p1:release=r1",
-        # th#1657 publisher trust, inside the signature.
-        "publisher_tier": "org",
-        "publisher_org_id": SELF_ORG,
-        "snapshot_digest": SNAPSHOT,
-        "artifact": artifact,
-        "manifest_digest": "sha256:aa",
-        "fingerprint_digest": "sha256:bb",
-        "iat": 1_700_000_000,
-    }
-    claims.update(overrides)
-    return claims
-
-
-@pytest.fixture()
-def rsa_key() -> rsa.RSAPrivateKey:
-    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
-
-
-@pytest.fixture()
-def pub_map(rsa_key: rsa.RSAPrivateKey) -> Dict[str, rsa.RSAPublicKey]:
-    return {KID: rsa_key.public_key()}
-
-
-def make_artifact(tmp_path: Path, *, cell_key: str = CELL_KEY, family: str = FAMILY) -> Path:
-    meta = {"cell_key": cell_key, "family": family, "format": "cozy-compile-cache/v1"}
-    target = tmp_path / "cell.tar.gz"
-    with tarfile.open(target, "w:gz") as tar:
-        raw = json.dumps(meta).encode()
-        ti = tarfile.TarInfo("metadata.json")
-        ti.size = len(raw)
-        tar.addfile(ti, io.BytesIO(raw))
-        payload = b"fake-inductor-entry" * 64
-        ti = tarfile.TarInfo("inductor/aa/entry.py")
-        ti.size = len(payload)
-        tar.addfile(ti, io.BytesIO(payload))
-    return target
+# pgw#1152: the signer + the live hub moved to `tests/harness/receipt_hub.py`.
+# pgw#1122's identity seam already imported them from here, and the adopt-path
+# rig needs the same real receipt gate. Same objects, one home.
+from harness.receipt_hub import (  # noqa: F401 — fixtures come with it
+    B3_HEX, CELL_KEY, FAMILY, KID, OTHER_ENDPOINT, SELF_ENDPOINT, SELF_ORG,
+    SHA_HEX, SNAPSHOT,
+    HubStub, _b64url, _configure, _identify, hub, make_artifact, make_claims,
+    pub_map, rsa_key, sign_receipt, worker_jwt_for,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -193,142 +98,6 @@ class TestVerifyReceiptJWS:
 # ---------------------------------------------------------------------------
 # End-to-end gate over real HTTP (a live hub stub on localhost)
 # ---------------------------------------------------------------------------
-
-
-class HubStub:
-    """A real HTTP server speaking the hub's three receipt surfaces."""
-
-    def __init__(self, key: rsa.RSAPrivateKey) -> None:
-        self.key = key
-        self.receipts: Dict[Tuple[str, str], str] = {}
-        self.last_query: Tuple[List[str], str] = ([], "")
-        self.revoked: List[Dict[str, str]] = []
-        self.receipt_status: Optional[int] = None  # force an error status
-        pub = key.public_key().public_numbers()
-
-        def b64_int(v: int) -> str:
-            raw = v.to_bytes((v.bit_length() + 7) // 8, "big")
-            return _b64url(raw)
-
-        self.jwks = {"keys": [{"kty": "RSA", "kid": KID, "use": "sig", "alg": "RS256",
-                               "n": b64_int(pub.n), "e": b64_int(pub.e)}]}
-        stub = self
-
-        class Handler(BaseHTTPRequestHandler):
-            def log_message(self, *args: Any) -> None:  # noqa: N802
-                pass
-
-            def do_GET(self) -> None:  # noqa: N802
-                parsed = urlparse(self.path)
-                if parsed.path == receipts.JWKS_PATH:
-                    self._json(200, stub.jwks)
-                elif parsed.path == receipts.RECEIPT_PATH:
-                    if stub.receipt_status is not None:
-                        self._json(stub.receipt_status, {"error": "forced"})
-                        return
-                    q = parse_qs(parsed.query)
-                    cell_key = q.get("cell_key", [""])[0]
-                    # The real route matches on the SET of tagged digests the
-                    # worker offers. pgw#807 deleted the bare-hex `blake3`
-                    # param with the protocol that needed it.
-                    offered = list(q.get("artifact_digest", []))
-                    stub.last_query = (offered, cell_key)
-                    jws = None
-                    for ref in offered:
-                        jws = stub.receipts.get((ref, cell_key))
-                        if jws is not None:
-                            break
-                    if jws is None:
-                        self._json(404, {"error": "cell_receipt_not_found"})
-                    else:
-                        self._json(200, {"receipt": jws, "snapshot_digest": SNAPSHOT})
-                elif parsed.path == receipts.REVOCATIONS_PATH:
-                    self._json(200, {"revoked": stub.revoked})
-                else:
-                    self._json(404, {"error": "unknown route"})
-
-            def _json(self, status: int, body: Dict[str, Any]) -> None:
-                raw = json.dumps(body).encode()
-                self.send_response(status)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(raw)))
-                self.end_headers()
-                self.wfile.write(raw)
-
-        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
-        self.thread.start()
-
-    @property
-    def base_url(self) -> str:
-        return f"http://127.0.0.1:{self.server.server_port}"
-
-    def close(self) -> None:
-        self.server.shutdown()
-        self.server.server_close()
-
-    def serve_receipt_for(
-        self, artifact: Path, *, algo: str = "sha256", **claim_overrides: Any
-    ) -> str:
-        """Publish a receipt for ``artifact`` bound with ``algo``; returns the ref."""
-        assert algo == "sha256"
-        ref = receipts.artifact_digest(artifact)
-        size = artifact.stat().st_size
-        claims = make_claims(ref, size, **claim_overrides)
-        self.receipts[(ref, str(claims["cell_key"]))] = sign_receipt(self.key, claims)
-        return ref
-
-
-@pytest.fixture()
-def hub(rsa_key: rsa.RSAPrivateKey) -> Iterator[HubStub]:
-    stub = HubStub(rsa_key)
-    yield stub
-    stub.close()
-    receipts.reset()
-    # pgw#1122: identity is a PROCESS fact now, so the fixture must unwind it
-    # too or the next test inherits this one's pod.
-    worker_identity.reset()
-    worker_credential.reset()
-
-
-def worker_jwt_for(endpoint_id: str, org_id: str = "") -> str:
-    """A hub-shaped worker credential naming the endpoint this pod serves.
-
-    th#1657: the pod's own identity comes from the `cell_read_endpoint_id` the
-    hub stamps on the cell-read grant (th#1335), so the test builds the same
-    thing. The signature is never checked — this is our OWN bearer token, not an
-    input — so an unsigned third segment is faithful to what the gate reads.
-    """
-    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
-    claims = {"sub": "worker-1", "cell_read_endpoint_id": endpoint_id}
-    # th#1680: the org rides the same grant. Omitted when empty, exactly as a
-    # pre-th#1680 hub (or one that could not resolve the org) leaves it out.
-    if org_id:
-        claims["cell_read_org_id"] = org_id
-    payload = _b64url(json.dumps(claims).encode())
-    return header + "." + payload + ".not-checked-here"
-
-
-def _identify(token: str) -> None:
-    """Give this process the credential a single-process worker holds.
-
-    pgw#1122: the gate no longer decodes its OWN bearer for identity — the
-    compute child holds none by construction, so the process-wide credential
-    (``worker_credential``, pgw#848's single source) is what
-    ``worker_identity.viewer`` reads, exactly as production does after the
-    transport installs a rotation. Installing it here is what production
-    writes; passing a token to ``receipts.configure`` was only ever a bearer.
-    """
-    worker_identity.reset()
-    worker_credential.reset()
-    if token:
-        worker_credential.install(token)
-
-
-def _configure(stub: HubStub, *, endpoint_id: str = SELF_ENDPOINT) -> None:
-    token = worker_jwt_for(endpoint_id)
-    _identify(token)
-    receipts.configure(base_url=stub.base_url, worker_jwt=lambda: token)
 
 
 class TestGateDeliveredArtifact:


### PR DESCRIPTION
## The bug class, not a bug

Four of the six reuse-circle gates — **pgw#1108, pgw#1122, pgw#1141, pgw#1141b** — were ONE defect wearing different clothes. The **boot-adopt path structurally differs from the self-mint path**: it arms BEFORE setup, the compute child holds no JWT, and it is fed by `fleet_cells.arm_ordered` rather than by the self-produced routes (`arm_from_local_store` / `adopt_delegated_mint`). Every one of those gates was written and validated against self-mint.

And the TESTS could not see it. Their fixtures simulated an adoption using self-mint machinery: **thirteen rows called `aot_serve.note_aot_key(key)` BY HAND** — production's single missing line — another stubbed an accessor to raise, another hand-set a marker production never writes. RED-first caught all four *after* they shipped and prevented none, because a mutation proves your assertion can fail, not that your fixture resembles production.

## 1. The rig — `tests/harness/adopt_rig.py`

Promoted out of `test_adopted_arm_lane_pgw1141b.py` and made the default vehicle. The whole chain runs for real:

```
Executor.ensure_setup -> _enable_compiled with a real _ArmOrder(adopt=…)
  -> fleet_cells.arm_ordered
  -> the real receipt gate, against a real RSA-signed receipt from a real HTTP hub
  -> provision.arm_aot -> aot_serve.load_and_wrap on a real packed cell
  -> the real boot warmup, proof pass, _install_compile_targets and
     _assert_armed_targets_installed
```

**It constructs nothing production constructs differently.** Outcomes are forced by REMOVING or BREAKING a real input — a hub that serves no receipt (404), a packaged entry that really raises when dispatched, a subject that really diverges — never by supplying a fact. The one contact with `_KNOWN_AOT_KEYS` EMPTIES it; a row asserts the rig itself never registers a key (AST, not substring).

Three named seams, all WEST of anything it measures: `Executor._boot_adopt` (its derive+resolve half is pgw#1116's coverage), `provision.load_slot`, and `aot_serve._load_package` (an AOTI `.so` needs a GPU — the only piece deferred to a pod).

It stands on two more promotions, both already imported as rigs by five other modules: `harness/exported_cell.py` (out of `test_numerics_gate_pgw868.py`) and `harness/receipt_hub.py` (out of `test_receipts_pgw709.py`).

## 2. It re-finds a bug we already fixed

`reintroduce(monkeypatch, "pgw1141b")` **deletes** both halves of `f3ab710e` — the registration inside `load_and_wrap`, and the object-first lane reader — putting the tree back where the fix found it. The rig then reproduces POD PROOF #4 (RTX A4500, sm_86, 0.111.0) verbatim:

```
serve_eager_posture  target_applicability_incomplete   functions=() … owned_slots=['pipeline']
serve_eager_posture  armed_target_unresolved
serve_degrade        armed_target_unresolved
```

A rig that cannot re-find a bug we already know the shape of proves nothing.

## 3. The fence — `scripts/lint_arm_state_feeders.py`

pgw#1122's `lint_credential_identity.py` shape, transplanted. Keyed `<path>::<scope>::<name>`, never a line.

**src/gen_worker** — a feeder call is the declared SEAM or a classified row. `SEAM` (auto), `VERDICT` (a decision only this frame can know, sitting AT that decision), `OWNER` (the module writing its own store from its own primary write path). Unclassified red, stale red, and a **SEAM that stops feeding is red** — the registration is an asserted fact, not a habit.

**tests/** — a hand-feed is red, and so is stubbing a lane-identity accessor. There is exactly ONE test label, `RECOGNIZER`, and **the lint checks the claim instead of trusting it**: accepted only when the enclosing function drives no arm and the module replaces no arm driver. A fixture standing in for an adoption cannot qualify, whatever it writes in the file.

**There is deliberately no `CONVENTION` class and no `RELAY`.** A feeder called because a docstring asked the caller to remember is exactly the bug, twice over.

Nine RED rows drive the lint over synthetic trees, so proving it goes red never requires writing the bug into this repo. Wired into CI's `fast gates`.

## 4. The third variant, folded in (numerics-floor lane, `5620f596`)

A fixture may also construct a **TYPE production never constructs** — raw `Compile` where the fleet hands `CompileCell`. Two answers:

- The rig **observes** what production handed `provision.arm_aot` and exposes it (`AdoptedBoot.armed_cfg`); a row asserts it is a `CompileCell`, carrying the declared band.
- `production_cfgs()` returns both real `Compile`→`CompileCell` call sites (`EndpointSpec.compile_cell()`, `cli.run`'s §4.28 desktop arm) for parametrising a row over the shapes production actually builds. `harness/exported_cell.arm()` now defaults to the production type.
- The fence gains a **SECOND MAP** rule: a fenced production object must have ONE constructor.

## 5. What the sweep changed

- **`note_aot_key`'s two remaining production feeders are DELETED, not moved.** `arm_from_local_store` and `adopt_delegated_mint` both ran *after* their own arm had already passed the wrap. A redundant copy of a structural fact is how the convention survived long enough for `arm_ordered` not to keep it. The registry now has exactly one writer.
- **`_ArmOrder` + `_CompileArtifactSelection` get ONE constructor, `_ArmOrder.for_artifact`.** The §4.27 boot-adopt order (`_setup_locked_inner`) and the hub PLAN order (`_materialize_arm`) were built independently and are field-for-field identical except `adopt` — pgw#1150's duplicated-mapping cause, on the object at the centre of this bug class. Both also built the selection separately from the same three fields.
- **All five test-side hand-registrations were removable with ZERO assertion changes** (pgw#735, pgw#844, pgw#1141 ×2, pgw#1033). Once the readers ask the OBJECT, the fixture line existed only to hide the bug — which is the cleanest evidence available that pgw#1141b's fix is structural.

## The convention-fed inventory (the deliverable, including where nothing changed)

| state | fed by | verdict |
|---|---|---|
| `aot_serve._KNOWN_AOT_KEYS` | `load_and_wrap` (seam) | **FIXED** — two convention feeders deleted; one writer, fenced |
| `compile_cache._PROVEN_CELLS` | 3 executor sites | VERDICT — the proof pass is the only frame that knows; classified |
| `compile_cache._QUARANTINED_CELLS` | 3 executor sites | VERDICT — attributed disarms; a seam would quarantine honest unwraps |
| `compile_cache._ARMED_PIPELINES` | inside `compile_cache.arm` | STRUCTURAL — set with the marker; scopes `torch._dynamo.reset()` only, so the AOTI lane's absence is correct |
| `local_cell_store` (store + memo) | 3 fleet_cells sites, all self-produced | **§4.28 CHARTER, not a gap** — the local store is the *untrusted machine mints for ITSELF* store; a boot-adopt's bytes are already CAS-cached. Classified OWNER/VERDICT so nobody "fixes" it with a third convention feeder |
| `fleet_cells._PENDING`/`_FINALIZED` | the self-mint routes, keyed by ARM TOKEN | SCOPED — a boot-adopt computes no arm token, so the key does not exist on that route. Not a seventh gate; noted as a residual second index |
| `fleet_cells._IN_FLIGHT`/`_PUBLISHED`/`_REFUSED`/`_DURABLE_*` | inside `_publish_async` | STRUCTURAL — fed by the publish itself |
| `executor` `inj.active_compile_artifacts` | 2 injection-loop sites, route-independent | STRUCTURAL |
| `serve_posture._ORDER`, `receipts._CONFIG`, `hot_swap._WORKER`, `compile_cache._PROCESS_COMPILES_DISABLED` | explicit config/operator latches | NOT REGISTRIES |
| **duplicated mappings** | `_ArmOrder` ×2, `_CompileArtifactSelection` ×3 | **FIXED** — one constructor. `ExpectedIdentity` ×3 across 2 modules is the next candidate and is reported, not changed |

## Tests

`tests/test_adopt_rig_pgw1152.py` (20 rows): the control, the re-find, the bisection, the type-shape rows, the break-a-real-input rows, and nine fence rows over synthetic trees plus two over this repo. Green; the rewritten `test_adopted_arm_lane_pgw1141b.py` (8/8) now consumes the harness rather than defining its own vehicle.

`mypy src/gen_worker` clean, `ruff check src/gen_worker` clean, fence green (8 classified production feeds, 1 seam intact, 5 RECOGNIZER rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)