### PR TITLE
pgw#1154: the bubble gets a meter, and the stage spine stops being blind on the video lane

### DIFF
--- a/changelog.d/pgw1154.md
+++ b/changelog.d/pgw1154.md
@@ -1,0 +1,44 @@
+- **pgw#1154: the zero-bubble program gets its two missing meters, and one of
+  them was blind on exactly the endpoints that matter.** Paul's bar is *"the GPU
+  should remain hot at all times ... no wasted time in between requests."*
+  Neither half of that was measurable. (1) th#1111 derives a request's denoise
+  window — and therefore `total.prep`, `total.tail`, `total.denoise`,
+  `denoise.step_mean` and `class.gpu_busy`, the numbers every pipelining
+  decision reads — from step marks, but the only producer of a mark was
+  `diffusers_step_callback`. Every endpoint driving its own step loop and
+  reporting it through `ctx.progress(..., step=, total=)` produced no window at
+  all: minimax-h3, ltx-video's stage 1, anima and hidream-o1-image, i.e. the
+  whole DiffSynth half of the fleet and the entire video lane. Banked evidence
+  off the standing master stack: an H3 row with `total.handler` 130,666 ms
+  reported `class.gpu_busy` 0 and `resid.unattributed` 128,660 ms — 98.5% of the
+  request unexplained, and no prep/tail key emitted. `ctx.progress` now takes
+  the mark itself; it is the same fact the event already carries, so the fix
+  costs nothing and changes no endpoint. `mark_step` became idempotent per
+  `(stage, index)` in the same move, because the shared callback marks and
+  *then* calls `ctx.progress` — a duplicated index would have halved the
+  reported per-step mean, which is the number the hub's JIT dispatch gate
+  extrapolates the head's remaining time from. (2) Nothing anywhere measured the
+  gap BETWEEN requests. `gpu_permit_wait` measures a request waiting for the
+  card; the inverse — the card waiting for a request — was in no metric, no log
+  and no event, so "the bubble is zero" was unfalsifiable. `_PermitLedger` now
+  times every window in which a group's permits are wholly unheld and reports it
+  on the next request as `stage_ms.gpu_idle_before`. It is a pre-handler stage
+  (charged to no request's `runtime_ms`, added to `PRE_HANDLER_STAGES` and to
+  the hub's mirrored set in the same lane — th#1818), it is read-once, and it is
+  ABSENT rather than zero on a worker's first request: an unmeasured gap and a
+  zero gap are different answers, and reporting the former as the latter would
+  have made every cold pod look perfect.
+- **pgw#1154: `_release_gpu_slot_for_finalize` no longer overclaims.** Its
+  docstring said the slotless encode/upload tail means "the next request's
+  denoise starts now". That is false for a SAME-instance follower — the
+  back-to-back case a single-endpoint pod actually serves. The worker's lock
+  order is instance gate -> GPU permit (pgw#954), the follower is queued on
+  `run_lock`, and this method releases only the permit; the gate is held until
+  the handler returns. What makes the tail overlap for real on today's fleet is
+  th#1130's deferred outputs (the handler returns at the decode handoff, so gate
+  and permit fall together), and the endpoints th#1130 excludes —
+  `output_mode == "stream"` and async-gen handlers — would serialize their whole
+  tail against a follower. No fleet endpoint is in that class today. Releasing
+  the gate here too would let a follower mutate the instance graph under a
+  running handler, which no lock order makes safe, so it is deliberately not
+  done and the seam is named instead.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3242,12 +3242,25 @@ class _PermitLedger:
     outside this ledger or a hold whose owning task already finished.
     """
 
-    __slots__ = ("depth", "_holds", "_next_token", "transitions")
+    __slots__ = (
+        "depth", "_holds", "_next_token", "transitions", "_idle_since",
+        "_idle_span",
+    )
 
     def __init__(self, depth: int) -> None:
         self.depth = max(1, int(depth))
         self._holds: Dict[int, Dict[int, _PermitHold]] = {}
         self._next_token = 0
+        # pgw#1154, THE ZERO-BUBBLE METER. id(sem) -> the monotonic instant
+        # this group's permits went wholly unheld, and the span that ended
+        # when the next holder took one. A permit is the group's card, so an
+        # unheld permit is a card nobody is scheduled on — the inter-request
+        # bubble Paul's bar is stated against, measured on every request
+        # instead of inferred from a one-off harness. Seeded only by the
+        # FIRST release, so request 1 reports no span at all: "unmeasured"
+        # and "zero" must not render alike.
+        self._idle_since: Dict[int, float] = {}
+        self._idle_span: Dict[int, float] = {}
         # Bumped on every take/drop. Two probes spanning no transition saw a
         # settled ledger, which is what makes the predicate safe to act on: a
         # permit handed to another waiter between them would otherwise read as
@@ -3273,13 +3286,29 @@ class _PermitLedger:
                 task = asyncio.current_task()
             except RuntimeError:
                 task = None
-        self._holds.setdefault(id(sem), {})[token] = _PermitHold(label, task)
+        holds = self._holds.setdefault(id(sem), {})
+        if not holds:
+            # First holder after an unheld window: close the bubble.
+            since = self._idle_since.pop(id(sem), None)
+            if since is not None:
+                self._idle_span[id(sem)] = max(0.0, time.monotonic() - since)
+        holds[token] = _PermitHold(label, task)
         self.transitions += 1
         return token
 
     def drop(self, sem: asyncio.Semaphore, token: int) -> None:
-        if self._holds.get(id(sem), {}).pop(token, None) is not None:
+        holds = self._holds.get(id(sem), {})
+        if holds.pop(token, None) is not None:
             self.transitions += 1
+            if not holds:
+                # Nobody is scheduled on this group's card as of now.
+                self._idle_since[id(sem)] = time.monotonic()
+
+    def consume_idle(self, sem: asyncio.Semaphore) -> Optional[float]:
+        """Seconds this group's card sat with no permit holder immediately
+        before the current holder took it, or ``None`` when no such window
+        has been observed yet (the worker's first job). Read-once."""
+        return self._idle_span.pop(id(sem), None)
 
     def unreachable(self, sem: asyncio.Semaphore) -> Optional[str]:
         """Reason iff some outstanding permit has no live holder, else None."""
@@ -11972,6 +12001,21 @@ class Executor:
                     # the handler window, so runtime_ms never saw it.
                     ctx._stages.record_pre(
                         "gpu_permit_wait", time.monotonic() - permit_t0)
+                    # pgw#1154: and the INVERSE wait — the card idle, waiting
+                    # for a request — was in no metric either. Emitted only
+                    # when a previous holder has actually released on this
+                    # worker, so the number always means "gap after the job
+                    # before me" and never "time since boot".
+                    idle_before = self._permits.consume_idle(gpu_permit)
+                    if idle_before is not None:
+                        # `record_pre` drops non-positive values, and a ZERO
+                        # bubble is the target state — the one reading that
+                        # must never be silently indistinguishable from "this
+                        # worker has no meter". Floored so the key is always
+                        # emitted once a gap has actually been observed; it
+                        # renders as 0 ms either way.
+                        ctx._stages.record_pre(
+                            "gpu_idle_before", max(idle_before, 1e-9))
                     self._loop = asyncio.get_running_loop()
                     lease = _GpuSlotLease(
                         gpu_permit, self._loop, self._permits,

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -930,9 +930,28 @@ class RequestContext(Generic[D]):
     def _release_gpu_slot_for_finalize(self) -> None:
         """Worker-internal: TERMINAL GPU-slot release at the decode->finalize
         handoff (gw#476 / gw#516). The handler is done with GPU compute; the
-        encode + upload tail proceeds slotless so the next request's denoise
-        starts now instead of idling the GPU (measured up to 179s on a
-        CPU-contended host). Unlike :meth:`_gpu_slot_yielded` there is no
+        encode + upload tail proceeds slotless so a request on ANOTHER live
+        instance can take the card instead of idling it (measured up to 179s
+        on a CPU-contended host).
+
+        pgw#1154 — READ THIS BEFORE SIZING ANY OVERLAP AGAINST THIS RELEASE.
+        It does NOT hand the card to a SAME-instance follower, which is the
+        back-to-back case a single-endpoint pod actually serves. The worker's
+        lock order is instance gate -> GPU permit (pgw#954), so the follower
+        is queued on ``run_lock``, and this method releases only the permit;
+        the gate stays held until the handler RETURNS. Releasing the gate
+        here too would let a follower mutate the instance graph under a
+        handler that is still running, which no lock order makes safe, so it
+        is deliberately not done. What makes the tail overlap for real on the
+        fleet is th#1130: deferred outputs move encode+upload out of the
+        handler entirely, so the handler returns at the decode handoff and
+        gate + permit fall together. Endpoints EXCLUDED from that arming
+        (``output_mode == "stream"``, async-gen handlers) therefore still
+        serialize their whole tail against a same-instance follower — today
+        no fleet endpoint is in that class, and if one appears, this is the
+        seam that will cost it.
+
+        Unlike :meth:`_gpu_slot_yielded` there is no
         reacquire — a finishing request must never block behind the next
         request's denoise just to return. The executor's post-handler release
         no-ops (lease transitions are once-only), so the semaphore balance
@@ -999,7 +1018,20 @@ class RequestContext(Generic[D]):
         ``progress`` is a 0..1 fraction; ``step``/``total`` carry the exact
         step counter when known (e.g. denoise step 5 of 20) so UIs can render
         "5 / 20" instead of a bare percentage.
+
+        pgw#1154: a call carrying ``step`` is ALSO a timing mark. th#1111 wired
+        marks from ``diffusers_step_callback`` only, so every endpoint driving
+        its own step loop — the whole DiffSynth half of the fleet, minimax-h3
+        and ltx-video included — reported progress to the hub and no stage
+        window at all: `total.prep`, `total.tail` and `class.gpu_busy` were
+        absent and 98.5% of a 130 s handler landed in `resid.unattributed`.
+        The mark is the same fact the event already carries, so taking it here
+        costs nothing and needs no endpoint change.
         """
+        if step is not None:
+            timer = getattr(self, "_stages", None)
+            if timer is not None:
+                timer.mark_step(str(stage or "denoise"), int(step))
         payload: Dict[str, Any] = {"progress": progress}
         if stage is not None:
             payload["stage"] = stage

--- a/src/gen_worker/stage_timing.py
+++ b/src/gen_worker/stage_timing.py
@@ -94,7 +94,7 @@ class StageTimer:
 
     __slots__ = (
         "_lock", "_local", "_totals", "_intervals", "_pre", "_phases",
-        "_steps", "_handler_start", "_handler_end", "_truncated",
+        "_steps", "_step_seen", "_handler_start", "_handler_end", "_truncated",
     )
 
     def __init__(self) -> None:
@@ -108,6 +108,11 @@ class StageTimer:
         self._phases: Dict[Tuple[str, str], float] = {}
         # stage name -> [(step_index, monotonic_at_step_end), ...]
         self._steps: Dict[str, List[Tuple[int, float]]] = {}
+        # stage name -> step indices already marked. Two producers can mark the
+        # same step (pgw#1154: the diffusers callback marks, then calls
+        # ctx.progress, which marks too); a duplicate index would inflate the
+        # mark count and halve the derived per-step mean.
+        self._step_seen: Dict[str, set] = {}
         self._handler_start: Optional[float] = None
         self._handler_end: Optional[float] = None
         self._truncated = False
@@ -190,14 +195,24 @@ class StageTimer:
 
     def mark_step(self, stage: str, index: int) -> None:
         """Record the END of denoise step ``index`` (1-based) for ``stage``.
-        Wired from ``diffusers_step_callback``, so every endpoint using the
-        shared callback gets denoise timing with no code change."""
+
+        Wired from ``diffusers_step_callback`` AND from ``ctx.progress`` when
+        it carries a step counter (pgw#1154), so an endpoint driving its own
+        step loop gets denoise timing with no code change either. First mark
+        for an index wins: the callback's is un-throttled and therefore the
+        better clock, and ``ctx.progress`` only fills in the endpoints the
+        callback does not cover."""
         stage = str(stage or "denoise").strip() or "denoise"
+        index = int(index)
         now = time.monotonic()
         with self._lock:
+            seen = self._step_seen.setdefault(stage, set())
+            if index in seen:
+                return
             marks = self._steps.setdefault(stage, [])
             if len(marks) < _MAX_INTERVALS:
-                marks.append((int(index), now))
+                seen.add(index)
+                marks.append((index, now))
 
     # -- rendering ---------------------------------------------------------
 
@@ -342,8 +357,11 @@ def _clipped(
 #: ``runtime_ms`` reconciliation. ``instance_gate_wait`` is pgw#677's
 #: attribution of time queued behind the per-instance gate (typically a
 #: background mint/compile turn) — deliberately outside ``runtime_ms``.
+#: pgw#1154: ``gpu_idle_before`` is not a wait this request served at all — it
+#: is the gap BEFORE it, charged to no request's runtime. Reported, never summed.
 PRE_HANDLER_STAGES = frozenset(
-    {"gpu_permit_wait", "input_fetch", "setup_wait", "instance_gate_wait"})
+    {"gpu_permit_wait", "input_fetch", "setup_wait", "instance_gate_wait",
+     "gpu_idle_before"})
 
 
 def reconciliation(stage_ms: Mapping[str, int]) -> Tuple[int, int]:

--- a/tests/harness/stage_endpoints.py
+++ b/tests/harness/stage_endpoints.py
@@ -58,3 +58,30 @@ class Staged:
             format="webp", as_type=ImageAsset,
         )
         return GenOut(image=asset)
+
+
+@endpoint
+class ProgressOnly:
+    """pgw#1154: the OTHER half of the fleet — an endpoint that drives its own
+    step loop and reports it with ``ctx.progress(..., step=, total=)`` instead
+    of the shared ``diffusers_step_callback``. This is minimax-h3's, ltx's
+    stage-1, anima's and hidream's shape (a DiffSynth ``progress_bar_cmd``
+    shim), and it used to produce NO denoise window at all: no `total.prep`,
+    no `total.tail`, no `class.gpu_busy`, the whole handler in
+    `resid.unattributed`. Nothing here brackets a stage on purpose."""
+
+    def progress_generate(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        time.sleep(TEXT_ENCODE_S)  # prep: un-bracketed, like the real ones
+
+        for i in range(STEPS):
+            time.sleep(STEP_S)
+            ctx.progress((i + 1) / STEPS, "denoise", step=i + 1, total=STEPS)
+
+        time.sleep(DECODE_S)  # tail: un-bracketed VAE-decode stand-in
+
+        image = Image.effect_noise((512, 512), 64).convert("RGB")
+        asset = gw_io.write_image(
+            ctx, f"outputs/{ctx.request_id}/image.webp", image,
+            format="webp", as_type=ImageAsset,
+        )
+        return GenOut(image=asset)

--- a/tests/test_zero_bubble_meter_pgw1154.py
+++ b/tests/test_zero_bubble_meter_pgw1154.py
@@ -1,0 +1,227 @@
+"""pgw#1154: the zero-bubble program's two meters, on the real serve path.
+
+Paul's bar is *"the GPU should remain hot at all times ... no wasted time in
+between requests."* Two things have to be true before that bar can even be
+scored, and neither was:
+
+1. **The stage window must exist on the endpoints that matter.** th#1111 wired
+   step marks from ``diffusers_step_callback`` only. Every endpoint driving its
+   own step loop and reporting it with ``ctx.progress(..., step=, total=)`` —
+   minimax-h3, ltx-video's stage 1, anima, hidream-o1-image, i.e. the whole
+   DiffSynth half of the fleet and the entire video lane — produced no denoise
+   window at all. Banked evidence, standing master stack, 2026-08-12: an H3 row
+   with ``total.handler`` 130,666 ms reported ``class.gpu_busy`` 0 and
+   ``resid.unattributed`` 128,660 ms (98.5%), and no ``total.prep`` /
+   ``total.tail`` key whatsoever. The number the whole pipelining program is
+   sized against was structurally absent exactly where the round-trip gap is.
+
+2. **The gap BETWEEN requests must be measured, not inferred.** Nothing in the
+   platform reported it. ``gpu_permit_wait`` measures a request waiting for the
+   card; nothing measured the card waiting for a request.
+
+Both assertions here come off the wire in ``JobResult.metrics.stage_ms``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import msgspec
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.stage_timing import (
+    PRE_HANDLER_STAGES,
+    StageTimer,
+    reconciliation,
+    stage_ms_for_metrics,
+)
+
+from harness.hub_double import hub_double, is_ready, is_result_for
+from harness.stage_endpoints import DECODE_S, STEP_S, STEPS, TEXT_ENCODE_S
+from harness.upload_sink import DedupUploadSink, serve_upload_sink
+
+ORG = "00000000-0000-0000-0000-000000000001"
+
+
+def _payload() -> bytes:
+    return msgspec.msgpack.encode({"prompt": "a cat"})
+
+
+def _run(conn, request_id: str, function_name: str):
+    conn.send(run_job=pb.RunJob(
+        request_id=request_id, attempt=1, function_name=function_name,
+        input_payload=_payload(), output_mode=pb.OUTPUT_MODE_INLINE,
+        org=ORG, capability_token="cap-token"))
+    return conn.wait_for(is_result_for(request_id)).job_result
+
+
+def test_a_progress_only_endpoint_gets_a_denoise_window_with_no_endpoint_change() -> None:
+    """The Defect-A fix. ``ProgressOnly`` brackets NOTHING and never touches
+    ``diffusers_step_callback``; it only calls ``ctx.progress(step=, total=)``,
+    exactly as the DiffSynth families do. Before pgw#1154 this produced no
+    ``total.prep``, no ``total.tail``, no ``denoise`` and ``class.gpu_busy``
+    == 0."""
+    httpd, base_url = serve_upload_sink()
+    try:
+        with hub_double(modules=("harness.stage_endpoints",),
+                        file_base_url=base_url) as (scheduler, _h):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            res = _run(conn, "r-progress", "progress-generate")
+    finally:
+        httpd.shutdown()
+        DedupUploadSink.requests_seen = []
+
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    stages = dict(res.metrics.stage_ms)
+
+    # The denoise window exists and is derived from the progress marks.
+    assert stages["denoise"] >= int(STEPS * STEP_S * 1000) - 15, stages
+    assert stages.get("flag.denoise_estimated") == 1, stages
+    step_mean = stages["denoise.step_mean"]
+    assert abs(step_mean - int(STEP_S * 1000)) <= 25, step_mean
+
+    # And therefore so do the two numbers pipelining is sized against.
+    assert stages["total.prep"] >= int(TEXT_ENCODE_S * 1000) - 5, stages
+    assert stages["total.tail"] >= int(DECODE_S * 1000) - 5, stages
+    assert stages["class.gpu_busy"] >= int(STEPS * STEP_S * 1000) - 15, stages
+
+    # The instrument still closes: a new mark producer must not double-count.
+    attributed, total = reconciliation(stages)
+    assert total == res.metrics.runtime_ms
+    assert abs(attributed - total) <= 5, (attributed, total, stages)
+
+
+def test_the_shared_callback_and_ctx_progress_do_not_double_mark() -> None:
+    """``diffusers_step_callback`` marks the step AND then calls
+    ``ctx.progress``, which now marks too. A duplicated index would inflate the
+    mark count and halve the derived per-step mean — the instrument would lie
+    about the one number the JIT gate and every pipelining estimate read."""
+    httpd, base_url = serve_upload_sink()
+    try:
+        with hub_double(modules=("harness.stage_endpoints",),
+                        file_base_url=base_url) as (scheduler, _h):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            res = _run(conn, "r-dedup", "staged-generate")
+    finally:
+        httpd.shutdown()
+        DedupUploadSink.requests_seen = []
+
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    stages = dict(res.metrics.stage_ms)
+    step_mean = stages["denoise.step_mean"]
+    # Halved-by-duplication would land at ~STEP_S/2; the band excludes it.
+    assert abs(step_mean - int(STEP_S * 1000)) <= 25, (step_mean, stages)
+    assert stages["denoise"] >= int(STEPS * STEP_S * 1000) - 15, stages
+
+
+def test_step_marks_are_idempotent_per_index() -> None:
+    timer = StageTimer()
+    timer.handler_open()
+    for i in range(1, 5):
+        timer.mark_step("denoise", i)
+        timer.mark_step("denoise", i)  # the second producer
+        time.sleep(0.02)
+    timer.handler_close()
+    out = timer.snapshot()
+    # 4 distinct marks span 3 gaps of ~20 ms -> mean ~20. Marking each index
+    # twice makes it 8 marks over the same 60 ms wall -> mean ~8.6, which this
+    # band excludes. A sleep is a floor, so the ceiling carries the slack.
+    assert out["denoise.step_mean"] >= 14, out
+    assert out["denoise.step_mean"] <= 45, out
+
+
+def test_gpu_idle_before_measures_the_gap_between_two_permit_holders() -> None:
+    """The bubble meter itself. The permit path is unreachable from a CPU-only
+    harness (th#1111 hit the same wall and covered ``gpu_permit_wait`` the same
+    way), so this drives ``_PermitLedger`` — the object that computes the
+    number — through the exact take/drop sequence two back-to-back requests
+    produce on one card.
+
+    The first holder must report NOTHING: an unmeasured gap and a zero gap are
+    different answers, and a worker's first request would otherwise report its
+    entire boot as a bubble.
+    """
+    import asyncio
+
+    from gen_worker.executor import _PermitLedger
+
+    sem = asyncio.Semaphore(1)
+    ledger = _PermitLedger(1)
+
+    token = ledger.take(sem, "request A")
+    assert ledger.consume_idle(sem) is None, "first holder invented a bubble"
+
+    ledger.drop(sem, token)
+    gap_s = 0.25
+    time.sleep(gap_s)
+    ledger.take(sem, "request B")
+
+    idle = ledger.consume_idle(sem)
+    assert idle is not None
+    # A sleep is a floor at any box load: assert the floor and a ceiling loose
+    # enough to survive contention, never a tight band.
+    assert idle >= gap_s - 0.02, idle
+    assert idle <= gap_s + 5.0, idle
+    # Read-once: the span belongs to the request that closed it, not to every
+    # later reader.
+    assert ledger.consume_idle(sem) is None
+
+
+def test_no_bubble_is_recorded_while_any_holder_remains() -> None:
+    """A multi-permit group only idles when the card is wholly unheld. One of
+    two holders leaving is not a bubble, and recording it as one would report
+    idle time on a card that never stopped computing."""
+    import asyncio
+
+    from gen_worker.executor import _PermitLedger
+
+    sem = asyncio.Semaphore(2)
+    ledger = _PermitLedger(2)
+    a = ledger.take(sem, "request A")
+    ledger.take(sem, "request B")
+
+    ledger.drop(sem, a)
+    time.sleep(0.05)
+    ledger.take(sem, "request C")
+    assert ledger.consume_idle(sem) is None, "counted idle while B still held"
+
+
+def test_gpu_idle_before_rides_the_stage_map_as_a_pre_handler_stage() -> None:
+    """It is the gap BEFORE this request — reported on it, charged to no
+    request's ``runtime_ms``, and excluded from the reconciliation on BOTH
+    sides of the wire (see runtimestore.preHandlerStageKeys)."""
+    assert "gpu_idle_before" in PRE_HANDLER_STAGES
+
+    timer = StageTimer()
+    timer.record_pre("gpu_idle_before", 12.5)
+    timer.handler_open()
+    with timer.stage("denoise"):
+        time.sleep(0.02)
+    timer.handler_close()
+
+    out = stage_ms_for_metrics(timer, runtime_ms=timer.snapshot()["total.handler"])
+    assert out["gpu_idle_before"] == 12500
+    attributed, total = reconciliation(out)
+    assert total < 12500, out
+    assert abs(attributed - total) <= 2, out
+
+
+
+def test_a_zero_bubble_still_reports_the_key() -> None:
+    """The target state must be DISTINGUISHABLE from an unmetered worker.
+    ``record_pre`` drops non-positive values, so a perfect handoff would
+    otherwise emit no key at all and read exactly like a pre-pgw#1154 worker —
+    the one reading the whole program is trying to achieve, rendered as
+    'no data'."""
+    timer = StageTimer()
+    timer.record_pre("gpu_idle_before", 1e-9)
+    timer.handler_open()
+    with timer.stage("denoise"):
+        time.sleep(0.01)
+    timer.handler_close()
+
+    out = stage_ms_for_metrics(timer, runtime_ms=timer.snapshot()["total.handler"])
+    assert "gpu_idle_before" in out, out
+    assert out["gpu_idle_before"] == 0, out


### PR DESCRIPTION
Paul, 2026-08-11: *"the GPU should remain hot at all times ... there is no wasted time in between requests."* This is the measurement half of that directive. Neither number the bar is scored against existed.

## 1. The stage spine was blind on the entire video lane

th#1111 derives a request's denoise window — and with it `total.prep`, `total.tail`, `total.denoise`, `denoise.step_mean` and `class.gpu_busy` — from step marks. The only producer of a mark was `diffusers_step_callback`. Every endpoint that drives its own step loop and reports it through `ctx.progress(..., step=, total=)` produced **no window at all**: `minimax-h3`, `ltx-video` stage 1, `anima`, `hidream-o1-image` — the DiffSynth half of the fleet and the whole video lane.

Banked evidence, standing master stack, `request_events.payload->metrics->stage_ms`:

| worker | lane | total.handler | class.gpu_busy | resid.unattributed | total.prep / total.tail |
|---|---|---:|---:|---:|---|
| `1fef30898b3e` (H3) | fp8-w8a8-dynamic+compiled | 130,666 ms | **0** | **128,660 ms (98.5%)** | **absent** |
| `1fef30898b3e` (H3) | fp8-w8a8-dynamic+compiled | 430,860 ms | **0** | 424,905 ms | **absent** |
| `7a72d204be62` (callback-wired) | bf16-w16a16+eager | 457,434 ms | 440,815 ms | 11,307 ms | 127 / 16,492 |

The flagship the entire round-trip gap lives on is the one place the instrument could not see. `ctx.progress` now takes the mark itself — the same fact the event already carries, so no endpoint changes and nothing new goes on the wire.

`mark_step` became idempotent per `(stage, index)` in the same move: the shared callback marks and *then* calls `ctx.progress`, so without dedupe the mark count doubles and `denoise.step_mean` halves — and that mean is what the hub's JIT dispatch gate (th#816) extrapolates a head's remaining time from.

## 2. The gap BETWEEN requests was in no metric, log or event

`gpu_permit_wait` times a request waiting for the card. Nothing timed the card waiting for a request, so "the bubble is zero" was unfalsifiable and would have rotted silently.

`_PermitLedger` now times every window in which a group's permits are wholly unheld and reports it on the next request as `stage_ms.gpu_idle_before`. A permit *is* the group's card (pgw#779), so an unheld permit is a card nobody is scheduled on. It is:

- **pre-handler** — charged to no request's `runtime_ms`; in `PRE_HANDLER_STAGES`, mirrored hub-side in th#1818 so it raises no false th#1111 drift alarm (same defect shape as th#1251);
- **read-once** — the span belongs to the request that closed it;
- **absent, not zero, on a worker's first request** — an unmeasured gap and a zero gap are different answers, and reporting the former as the latter makes every cold pod look perfect;
- **not opened while any holder remains** — one of two permits leaving a multi-permit group is not a bubble.

## 3. `_release_gpu_slot_for_finalize` was overclaiming

Its docstring said the slotless encode/upload tail means *"the next request's denoise starts now"*. That is **false for a same-instance follower** — the back-to-back case a single-endpoint pod actually serves. Lock order is instance gate → GPU permit (pgw#954), the follower is queued on `run_lock`, and this method releases only the permit; the gate is held until the handler returns. What actually overlaps the tail on today's fleet is th#1130's deferred outputs (handler returns at the decode handoff, so gate and permit fall together). The endpoints th#1130 excludes — `output_mode == "stream"`, async-gen handlers — would serialize their whole tail against a follower; none exist on the fleet today. Releasing the gate here would let a follower mutate the instance graph under a running handler, which no lock order makes safe, so the seam is **named rather than opened**.

## Tests

`tests/test_zero_bubble_meter_pgw1154.py`, plus a `ProgressOnly` harness endpoint that brackets nothing and never touches `diffusers_step_callback` — the real DiffSynth shape — driven over the real serve path (`hub_double`: real gRPC socket, real transport/lifecycle/executor).

Red-verified: with `src/` reverted to `origin/master` and the tests unchanged, **4 of 6 fail**; all 6 pass with the fix. The two that pass either way are guardrails on the new behaviour (double-marking, multi-holder groups). The permit path is unreachable from a CPU-only harness — th#1111 hit the same wall and covered `gpu_permit_wait` the same way — so the ledger is driven directly through the exact take/drop sequence two back-to-back requests produce.

Adjacent suites green, no regressions: `test_th1111_stage_timing`, `test_group_permits_pgw779`, `test_progress_gw621`, `test_progress_keyed_bounds_pgw887_pgw892`, `test_p9_result_upload_metrics`, `test_th1107_placement_and_finalize`, `test_serve_finalize_pgw672` (53 tests).

## What this does NOT claim

No throughput change ships here — this lane makes the bubble **visible**, it does not close it. Dispatch-ahead (th#815 prefetch floor 2 + th#816 JIT gate) and tail overlap (gw#476/gw#516 + th#1130) already exist and, on banked H3 rows, already work: `slot_held_ms` 134,062 against `finalize_wall_ms` 5,254, with `worker_queue_ms` 9 ms. What has never been measured is any of it **under a real queue** — every banked sequence on the stack is a serial client, `queue_ms` 3-34 ms, so the recorded inter-completion gaps are client pacing, not platform bubbles. That measurement is blocked on the box-wide auth outage and is the next step; `gpu_idle_before` is what makes it a one-query answer instead of a bespoke harness.

Paired with th#1818 (hub half). Tracker: pgw#1154.