### PR TITLE
pgw#1153: measure_child reads the `*.mint.json` files the fleet actually commits

### DIFF
--- a/changelog.d/pgw1153.md
+++ b/changelog.d/pgw1153.md
@@ -1,0 +1,40 @@
+- **pgw#1153: `python -m gen_worker.measure_child` reads the `*.mint.json`
+  files the fleet actually commits.** pgw#1134 documented the committed
+  artifact and decoded a different one: every endpoint repo's
+  `aot/*.mint.json` is a flattened DECLARATION payload (`family`, `shapes`,
+  `specialization`, `declaration_module`, `source_ref`) while `MeasureJob`
+  required a runtime `MintRequest`'s input half (`function`, `modules`,
+  `cfg`, resolved `slots`). All 24 committed files in the fleet died on
+  `ValidationError: Object missing required field 'function'` — and the same
+  command sat in PRODUCTION ENDPOINT SOURCE, in ltx-video-2.3's OQ-3
+  `resolves_when`, so following the runbook bought a B200 and exited before
+  touching the card. One decoder now (`load_document`) reads BOTH real
+  documents — the committed payload and a mint work root's `request.json` —
+  and `resolve_job` derives the three things the payload does not spell out
+  from the declaration it NAMES: `modules` from `declaration_module`,
+  `function` from the endpoint declaring `Compile(family=)`, and `targets`
+  from that endpoint's own `Compile(targets=)` (since pgw#1107 no committed
+  payload carries them, and `compile_cache.resolve_targets` returns nothing
+  for an empty tuple — the same defect one step later). `source_ref` binds to
+  the slot that owns those targets, decided from `slot_components` before a
+  checkpoint is opened; `--slot NAME=VALUE[,ref=REF]` names anything else
+  `setup()` requires and `--function` settles a family declared across two
+  classes. Slots resolve OFFLINE and never download — `mint_process` states
+  that rule for the mint child and a measurement of a mint inherits it.
+- **pgw#1153: nothing that cannot start is untyped any more.** Three new
+  `REASONS` tokens (`no_declaration_module`,
+  `declaration_module_unimportable`, `function_underivable`) plus the existing
+  `slots_unresolvable` cover every way the envelope can fail, each naming the
+  missing piece and the flag that supplies it, each written to the report and
+  emitted on `KIND_MEASURE_ONLY`. pgw#1134's structural property is unchanged
+  and re-fenced at the widened door: `MeasureDocument` declares none of
+  `WITHHELD_FIELDS`, so an artifact destination still cannot enter the
+  process.
+- **pgw#1153: the fence that would have caught it.**
+  `tests/test_measure_document_pgw1153.py` drives ALL 24 committed
+  `aot/*.mint.json` (verbatim copies under
+  `tests/fixtures/fleet_mint_requests/`) through the real entry — RED on the
+  pre-fix tree on file one — and runs the documented invocation end to end,
+  through `main(argv)`, against a committed-SHAPE payload on micro-diffusion's
+  real w8a8 tree. inference-endpoints carries the artifact-side half
+  (`scripts/lint_mint_requests.py`).

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -165,6 +165,14 @@ class MintBlocker(msgspec.Struct, frozen=True):
 
         python -m gen_worker.measure_child <request>.mint.json <report>.json
 
+    ``<request>.mint.json`` is the file the endpoint repo COMMITS under
+    ``aot/`` — the declaration payload, read as such since pgw#1153; the
+    function, the compile targets and the target slot's checkpoint are derived
+    from the declaration it names. Run it in the endpoint's own image. Any slot
+    the payload does not name (``setup()`` may require more than one) is
+    refused BY NAME, on the spot, and supplied with
+    ``--slot NAME=/path/to/tree`` — the run never downloads.
+
     It exports (and, unless ``--export-only``, AOT-compiles) the declared class
     set and writes ``export_peak_device_bytes`` /
     ``export_peak_device_reserved_bytes`` and a per-entry outcome. Cite that

--- a/src/gen_worker/measure_child.py
+++ b/src/gen_worker/measure_child.py
@@ -1,11 +1,52 @@
 """pgw#1134: the MEASURE-ONLY child — ``python -m gen_worker.measure_child``.
 
-    python -m gen_worker.measure_child <request.json> [<report.json>]
+    python -m gen_worker.measure_child <request>.mint.json [<report>.json]
 
 It runs the mint's own load and the mint's own export loop — optionally with
 the INDUCTOR compile — against ONE declared class set, records what the run
 cost on the card, and produces **nothing else**. No cell, no artifact, no
 package, no hub call, no advertisement.
+
+What ``<request>.mint.json`` actually IS (pgw#1153)
+--------------------------------------------------
+The file an operator holds is the one an endpoint repo COMMITS — e.g.
+``ltx-video-2.3/aot/transformer-b200-tv261120-ta126-tat1.mint.json``. That is a
+DECLARATION payload: a flattened compile contract (``family``, ``shapes``,
+``text_lens``, ``specialization``, ``declaration_module``, ``source_ref``)
+generated from the ``@endpoint(compile=...)`` block. It is NOT a runtime
+``MintRequest``, which the hub-driven parent builds in a work root and which
+additionally carries ``function``, ``modules`` and RESOLVED ``slots``.
+
+pgw#1134 documented the committed file and decoded the runtime one, so the
+documented command — quoted in ltx's OQ-3 ``resolves_when``, i.e. in production
+endpoint source — died on ``ValidationError: Object missing required field
+'function'`` in the first millisecond of a bought B200. This module now reads
+the committed shape, because that is the artifact that exists:
+
+* ``modules``   <- the payload's ``declaration_module``;
+* ``function``  <- the endpoint whose ``Compile(family=)`` IS the payload's
+  ``family`` (``--function`` overrides, and is required only when that is
+  ambiguous across classes);
+* ``targets``   <- the chosen endpoint's own ``Compile(targets=)`` when the
+  payload names none, which since pgw#1107 is every committed file;
+* ``slots``     <- the payload's ``source_ref``, bound to the slot that owns
+  the declared targets, plus ``--slot NAME=...`` for anything else the
+  endpoint's ``setup()`` requires.
+
+Both shapes decode through :func:`load_document` -> :func:`resolve_job`, so
+there is ONE decoder and no second opinion about what a request file is. Every
+piece the payload cannot supply is refused BY NAME, before a weight is read,
+naming the flag that supplies it — the failure this issue exists for is a
+command that could not start, and a typed refusal on a laptop is worth a rented
+hour.
+
+**Slots resolve OFFLINE.** A ref named by the payload or a flag is looked up in
+this machine's local store and never downloaded: ``mint_process`` states the
+rule for the mint child (*"the child never touches the network: a mint is
+compute, and a mint process that could download is one that can stall on a
+lemon host"*) and a measurement of a mint inherits it. On a pod the serving
+process has already materialized every slot; ``--slot NAME=/path`` names a tree
+directly.
 
 Why a second child exists at all
 --------------------------------
@@ -95,6 +136,17 @@ REASONS: Tuple[str, ...] = (
     # A declared slot the request cannot resolve — refused by name, before a
     # weight is read.
     "slots_unresolvable",
+    # pgw#1153. The request file parsed, but it is not a request: it names no
+    # `declaration_module` and no `modules`, so there is no image to collect
+    # endpoints from and nothing to measure.
+    "no_declaration_module",
+    # pgw#1153. `declaration_module` named a module this image cannot import.
+    # The commonest shape of it is running the command outside the endpoint's
+    # own image, which is the one thing the runbook line says not to do.
+    "declaration_module_unimportable",
+    # pgw#1153. The payload's `family` selects no endpoint function, or selects
+    # several that do not share an instance — `--function` says which.
+    "function_underivable",
     # The endpoint's own `setup()` raised. Never re-classified here: a load
     # that fails under measurement fails under a mint too.
     "load_failed",
@@ -137,6 +189,58 @@ class MeasureJob(msgspec.Struct, frozen=True, kw_only=True):
     slots: Dict[str, MintSlot] = {}
     device: int = -1
     execution_lane: str = ""
+
+
+class MeasureDocument(msgspec.Struct, frozen=True, kw_only=True):
+    """pgw#1153: what a ``*.mint.json`` FILE may carry, either shape.
+
+    There are exactly two request documents in the fleet and this decodes both,
+    because a tool that decodes one of them is the defect this struct closes:
+
+    * an endpoint repo's committed ``aot/*.mint.json`` — a flattened
+      declaration payload. ``family`` / ``declaration_module`` / ``source_ref``
+      are top-level and there is no ``cfg``, no ``function``, no ``slots``;
+    * a mint work root's ``request.json`` — the runtime ``MintRequest``, whose
+      input half is ``function`` / ``modules`` / ``cfg`` / ``slots``.
+
+    Every field is optional and every field is INPUT-SIDE. :data:`WITHHELD_FIELDS`
+    still holds here for the same structural reason it holds on
+    :class:`MeasureJob`: msgspec drops what a struct does not declare, so an
+    artifact destination cannot enter this process through the widened door
+    either.
+    """
+
+    # The runtime envelope's input half.
+    function: str = ""
+    modules: Tuple[str, ...] = ()
+    cfg: Optional[CompileCellSpec] = None
+    slots: Dict[str, MintSlot] = {}
+    device: int = -1
+    execution_lane: str = ""
+    # The committed declaration payload's half. `family` is common to both.
+    family: str = ""
+    #: The module whose IMPORT registers the family's export declaration
+    #: (pgw#1107). Committed by every endpoint repo and fenced by their own
+    #: declaration suites, which is what makes it a safe default for `modules`.
+    declaration_module: str = ""
+    #: The compile target's checkpoint, as the endpoint repo records it. Bound
+    #: to the slot that owns the declared targets — see :func:`resolve_job`.
+    source_ref: str = ""
+
+
+class MeasureRefused(Exception):
+    """A typed refusal raised while BUILDING the job (pgw#1153).
+
+    It carries a :data:`REASONS` token so that a request that cannot start is
+    reported in the same vocabulary as a run that started and stopped. The
+    whole point of this issue is that "the command did not work" must be a row
+    somebody can count, not a stack trace on a pod.
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        super().__init__(detail)
+        self.reason = reason
+        self.detail = detail
 
 
 class EntryMeasurement(msgspec.Struct, frozen=True, kw_only=True):
@@ -262,6 +366,238 @@ def _discard(files: Sequence[str]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# The envelope (pgw#1153): a committed declaration payload -> a MeasureJob.
+#
+# Nothing here decides anything about the measurement. It answers the four
+# questions the payload does not spell out — which image, which function,
+# which targets, which checkpoints — from the declaration the payload NAMES,
+# and refuses by name when it cannot.
+# ---------------------------------------------------------------------------
+
+
+def load_document(raw: bytes) -> Tuple[MeasureDocument, CompileCellSpec]:
+    """Decode one request file into ``(document, flattened compile spec)``.
+
+    The committed payload IS a ``CompileCellSpec`` at top level, so the same
+    bytes are read twice against two structs rather than sniffed for a
+    discriminator: msgspec drops what each struct does not declare, and a
+    document that carries neither half decodes to two empty structs and is
+    refused by :func:`resolve_job` with its emptiness named.
+
+    THE one decoder. ``main`` had a second (``type=MeasureJob``) and that is
+    the whole of pgw#1153: it accepted a shape nothing in the fleet commits.
+    """
+    return (
+        msgspec.json.decode(raw, type=MeasureDocument),
+        msgspec.json.decode(raw, type=CompileCellSpec),
+    )
+
+
+def _parse_slot_flag(raw: str) -> Tuple[str, str, str]:
+    """``NAME=VALUE[,ref=REF]`` -> ``(name, value, ref)``.
+
+    ``VALUE`` is a local tree when it exists on this filesystem and a model ref
+    otherwise, so an operator on a pod can name either the bytes or the
+    catalog row without a second flag to remember.
+    """
+    name, sep, rest = raw.partition("=")
+    name = name.strip()
+    if not sep or not name or not rest.strip():
+        raise MeasureRefused(
+            "slots_unresolvable",
+            f"--slot {raw!r} is not NAME=VALUE[,ref=REF]")
+    value, _, tail = rest.partition(",ref=")
+    return name, value.strip(), tail.strip()
+
+
+def _slot_from_value(name: str, value: str, ref_text: str) -> MintSlot:
+    """One resolved slot from ``VALUE`` — a local tree, or a ref already here.
+
+    A ref with no provider prefix is read as a tensorhub ref, which is what a
+    pod serves from. Nothing here guesses harder than that: a miss is a typed
+    refusal naming the flag that settles it, and a wrong guess would be a
+    measurement of the wrong checkpoint.
+
+    Identity is deliberately weak on the path form. No cell key, digest or
+    artifact leaves this process (:class:`MeasureReport` carries none of the
+    three), so a slot's ``ref`` exists only to satisfy ``ctx.slots``; it is the
+    operator's when ``,ref=`` gives one and a slot-shaped placeholder when not.
+    """
+    from .api.binding import ModelRef
+    from .models.provision import resolve_local_path
+
+    if Path(value).is_dir():
+        return MintSlot(
+            ref=ModelRef(source="tensorhub", path=ref_text or f"local/{name}"),
+            path=str(Path(value)))
+    ref = ModelRef(source="tensorhub", path=value)
+    try:
+        path = resolve_local_path(
+            ref=value, provider="tensorhub", offline=True, emit=lambda _e: None)
+    except Exception as exc:  # noqa: BLE001 — every miss is one refusal
+        raise MeasureRefused(
+            "slots_unresolvable",
+            f"slot {name!r}: {value!r} is neither a directory on this machine "
+            f"nor a tensorhub ref already materialized in its local store "
+            f"({type(exc).__name__}: {exc}). A measure run never downloads — "
+            f"it is compute, exactly as a mint is — so name a tree this pod "
+            f"already fetched: --slot {name}=/path/to/tree") from exc
+    return MintSlot(ref=ref, path=str(path))
+
+
+def _target_owner(spec: Any, targets: Sequence[str]) -> str:
+    """The ONE declared slot that owns every compile target, or ``""``.
+
+    Read off the declaration alone (``slot_components``, derived at decoration
+    from each slot's pipeline class), because this runs BEFORE the load: the
+    question "which checkpoint does `source_ref` name" has to be answered
+    before a checkpoint is opened.
+    """
+    roots = {str(t).split(".", 1)[0] for t in targets if str(t)}
+    owners = [
+        name for name, tree in (getattr(spec, "slot_components", {}) or {}).items()
+        if roots and roots.issubset(set(tree))
+    ]
+    if len(owners) != 1:
+        family = str(getattr(getattr(spec, "compile", None), "family", "") or "")
+        owners = [
+            name for name, fam in (getattr(spec, "slot_family", {}) or {}).items()
+            if family and str(fam) == family
+        ]
+    return owners[0] if len(owners) == 1 else ""
+
+
+def _declares(specs: Sequence[Any], family: str) -> bool:
+    return any(
+        str(getattr(getattr(s, "compile", None), "family", "") or "") == family
+        for s in specs)
+
+
+def _function_for_family(specs: Sequence[Any], family: str) -> str:
+    """The endpoint function the payload's ``family`` names.
+
+    A committed payload names a FAMILY because that is what a cell is scoped to
+    (pgw#758: one mint -> one cell for the family's whole declared class set);
+    it does not name a function, and it should not have to. Functions sharing a
+    class are interchangeable here — ``select_specs`` pulls the whole sibling
+    set from any of them — so ambiguity is only real when the candidates span
+    classes, and then it is `--function`'s to settle.
+    """
+    candidates = [
+        s for s in specs
+        if str(getattr(getattr(s, "compile", None), "family", "") or "") == family
+    ]
+    if not candidates:
+        declared = sorted({
+            str(getattr(getattr(s, "compile", None), "family", "") or "")
+            for s in specs} - {""})
+        raise MeasureRefused(
+            "function_underivable",
+            f"no endpoint in this image declares Compile(family={family!r}) — "
+            f"this image declares {declared or '(no compiling family)'}. Either "
+            f"the request belongs to a different endpoint or the payload's "
+            f"family is stale; --function names one explicitly.")
+    classes = {id(s.cls) for s in candidates}
+    if len(classes) > 1:
+        raise MeasureRefused(
+            "function_underivable",
+            f"family {family!r} is declared by functions on more than one "
+            f"class ({sorted(s.name for s in candidates)}), which are "
+            f"different instances and therefore different loads — name one "
+            f"with --function")
+    return sorted(s.name for s in candidates)[0]
+
+
+def resolve_job(
+    doc: MeasureDocument, flat: CompileCellSpec, *,
+    function: str = "", slot_flags: Sequence[str] = (),
+) -> MeasureJob:
+    """Build the job the run needs from whichever document arrived.
+
+    Imports the endpoint's declaring module — the same walk ``mint_child`` and
+    ``boot_trace_child`` do — because the three answers the committed payload
+    omits all live on the declaration, and reading them from anywhere else
+    would be a second declaration.
+    """
+    from .mint_child import MintChildRefused, select_specs
+    from .registry import collect_endpoints
+
+    modules = tuple(str(m) for m in doc.modules if str(m).strip())
+    if not modules and doc.declaration_module.strip():
+        modules = (doc.declaration_module.strip(),)
+    if not modules:
+        raise MeasureRefused(
+            "no_declaration_module",
+            "the request names neither `modules` nor `declaration_module`, so "
+            "there is no image to collect endpoints from. Every committed "
+            "aot/*.mint.json carries `declaration_module` (pgw#1107); a file "
+            "without one is not a request this child can measure.")
+
+    cfg = doc.cfg if doc.cfg is not None else flat
+    family = (doc.family or cfg.family).strip()
+    if not family:
+        raise MeasureRefused(
+            "no_declaration_module",
+            "the request names no `family`, so nothing selects a declaration "
+            "or a class set")
+
+    def _collect(names: Sequence[str]) -> List[Any]:
+        try:
+            return list(collect_endpoints(list(names)))
+        except BaseException as exc:  # noqa: BLE001 — an unimportable image is one
+            raise MeasureRefused(
+                "declaration_module_unimportable",
+                f"cannot import {list(names)} ({type(exc).__name__}: {exc}). "
+                f"Run this in the ENDPOINT'S OWN IMAGE, where the module that "
+                f"registers the declaration is on sys.path.") from exc
+
+    specs = _collect(modules)
+    if not _declares(specs, family) and len(modules) == 1 and "." in modules[0]:
+        # sdxl's shape: `declaration_module` names a declaration-ONLY module
+        # (`sdxl.aot_declaration`), which registers the export declaration and
+        # decorates nothing. `find_endpoints` walks submodules, never parents,
+        # so the family's functions live one level up. Widen ONCE, to the
+        # package that module belongs to — the same tree the pod imports.
+        package = modules[0].split(".", 1)[0]
+        widened = _collect((package,))
+        if _declares(widened, family):
+            modules, specs = (package,), widened
+
+    name = (function or doc.function).strip() or _function_for_family(
+        specs, family)
+    try:
+        chosen, _siblings = select_specs(specs, name)
+    except MintChildRefused as exc:
+        raise MeasureRefused("function_underivable", str(exc)) from exc
+
+    if not cfg.targets:
+        # pgw#1107: targets DERIVE from the declaration, so no committed
+        # payload carries them — and `compile_cache.resolve_targets` returns
+        # nothing for an empty tuple, which is the same defect one step later.
+        declared = tuple(
+            str(t) for t in
+            (getattr(getattr(chosen, "compile", None), "targets", ()) or ()))
+        cfg = msgspec.structs.replace(cfg, targets=declared)
+    if not cfg.family:
+        cfg = msgspec.structs.replace(cfg, family=family)
+
+    # Flags FIRST, then the payload's own ref for whatever they left unnamed —
+    # a `--slot` that names the target slot must not have to survive an
+    # eager refusal from the ref it was passed to replace.
+    slots: Dict[str, MintSlot] = dict(doc.slots)
+    for raw in slot_flags:
+        slot_name, value, ref_text = _parse_slot_flag(str(raw))
+        slots[slot_name] = _slot_from_value(slot_name, value, ref_text)
+    owner = _target_owner(chosen, cfg.targets)
+    if doc.source_ref.strip() and owner and owner not in slots:
+        slots[owner] = _slot_from_value(owner, doc.source_ref.strip(), "")
+
+    return MeasureJob(
+        function=chosen.name, modules=modules, cfg=cfg, family=family,
+        slots=slots, device=int(doc.device), execution_lane=doc.execution_lane)
+
+
+# ---------------------------------------------------------------------------
 # The run
 # ---------------------------------------------------------------------------
 
@@ -316,7 +652,11 @@ def run(
         chosen, siblings = select_specs(specs, job.function)
         bind_slots(siblings, job.slots)
         assert_slots_resolvable(
-            siblings, job.slots, what=f"measure-only run of {job.function!r}")
+            siblings, job.slots,
+            what=f"measure-only run of {job.function!r} — a committed "
+                 f"aot/*.mint.json names ONE checkpoint (`source_ref`), so "
+                 f"every other slot the endpoint's setup() requires is named "
+                 f"with `--slot NAME=/path/to/tree`")
     except MintChildRefused as exc:
         return _fail(report_path, "slots_unresolvable", str(exc),
                      partial=partial)
@@ -488,24 +828,42 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         description=(
             "Export (and compile) one family's declared graph classes and "
             "report what it cost on the card. Publishes nothing, ever."))
-    parser.add_argument("request", help="a mint request JSON; its output-side "
-                                        "fields are ignored by construction")
+    parser.add_argument(
+        "request",
+        help="an endpoint repo's committed aot/*.mint.json (a declaration "
+             "payload) or a mint work root's request.json; either way the "
+             "output-side fields are dropped by construction")
     parser.add_argument("report", nargs="?", default="",
                         help="where to write the typed measurement "
                              "(default: <request>.measure.json)")
     parser.add_argument(
         "--export-only", action="store_true",
         help="skip the inductor compile — cheaper, and a weaker answer")
+    parser.add_argument(
+        "--function", default="",
+        help="the endpoint function to measure. Derived from the payload's "
+             "Compile(family=) unless that is ambiguous across classes")
+    parser.add_argument(
+        "--slot", action="append", default=[], metavar="NAME=VALUE[,ref=REF]",
+        help="a setup slot the payload does not name: VALUE is a local tree, "
+             "or a ref already materialized in this machine's store (a "
+             "measure run never downloads). Repeatable")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     request = Path(args.request)
     report_path = Path(args.report) if args.report else request.with_suffix(
         request.suffix + ".measure.json")
     try:
-        job = msgspec.json.decode(request.read_bytes(), type=MeasureJob)
+        doc, flat = load_document(request.read_bytes())
     except (OSError, msgspec.DecodeError, msgspec.ValidationError) as exc:
         sys.stderr.write(f"measure: unreadable request {request}: {exc}\n")
         return EXIT_BAD_JOB
+    try:
+        job = resolve_job(
+            doc, flat, function=str(args.function),
+            slot_flags=[str(s) for s in args.slot])
+    except MeasureRefused as exc:
+        return _fail(report_path, exc.reason, exc.detail)
     try:
         return run(job, report_path, compile_entries=not args.export_only)
     except BaseException as exc:  # noqa: BLE001 — every terminus is reported
@@ -517,5 +875,6 @@ if __name__ == "__main__":  # pragma: no cover — process entrypoint
     raise SystemExit(main())
 
 
-__all__ = ["EntryMeasurement", "MeasureJob", "MeasureReport", "REASONS",
-           "WITHHELD_FIELDS", "main", "run"]
+__all__ = ["EntryMeasurement", "MeasureDocument", "MeasureJob",
+           "MeasureRefused", "MeasureReport", "REASONS", "WITHHELD_FIELDS",
+           "load_document", "main", "resolve_job", "run"]

--- a/tests/fixtures/fleet_mint_requests/flux.2-klein-4b/transformer-4b.mint.json
+++ b/tests/fixtures/fleet_mint_requests/flux.2-klein-4b/transformer-4b.mint.json
@@ -1,0 +1,120 @@
+{
+  "_declaration": "flux.2-klein-4b/src/flux2_klein_4b/main.py \u2014 the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; src/flux2_klein_4b/aot_declaration.py and the aot/declaration.py shim are DELETED. static-rows by pgw#852.",
+  "_status": "READY — declaration registers cleanly; no open mint blockers. shape_strategy=static-rows, 9 entries (pgw#852).",
+  "_notes": [
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused); `fork` states the minted class's arm values. flux2's `kv_cache` fork has NO source binding — it is a call-argument fact, not a composed pipeline/module field — so the mint keys it but cannot assert it from composition.",
+    "⚠ SUPERSEDED BY pgw#852 — THIS IS NOT ONE ARTIFACT ANY MORE, AND IT NEVER COULD HAVE BEEN. shape_strategy is now `static-rows` and the declaration carries the GENERATE lane's 9 real coordinates (T_img = 4056 4070 4089 4096 4116 7744 8160 14400 16384), deriving 9 entries with no free symbol on any of them. Measured on H100 pod dykztnghs4k8pc: under dynamic-collapse torch.export SUCCEEDED (47.07 s) and AOTInductor then REFUSED — `InductorError: CantSplit: 12288*s11 + 6291456 not divisible by s11 + 512`, where s11 is the collapsed token symbol and s11+512 is T_img+T_txt at _TEXT_LEN. Inductor's split/tiling pass cannot prove divisibility across a free symbol. #728's node count is an EXPORT-stage measurement (upstream of inductor) and pgw#812's 0.0% is the DYNAMO backend; neither was evidence about AOTInductor. pgw#846 forbids dynamic collapse on served cells regardless. The EDIT lane is declared OUT and serves EAGER (qwen-image's own call): its token count is base + a multiset of 1..4 reference buckets — 617 coordinates — not a shape table.",
+    "T_img is bound to hidden_states[1] AND img_ids[1]. A binding naming only hidden_states would let img_ids specialize and silently pin the artifact to the generate lane — the edit concat grows both.",
+    "#728 measured flux2 static->dynamic at 2758 -> 2760 nodes (+2, rc=1) — a TORCH.EXPORT-stage node count, which is exactly why it did not predict the AOTInductor refusal (pgw#852). Exports clean strict and non-strict, all four modes; that remains true and is not the gate.",
+    "#730's conv rationale still does not hold this lane (transformer_flux2.py has ZERO nn.Conv layers), but per pgw#852 that is no longer the binding constraint: AOTInductor refuses the free symbol outright, conv or not. Kept for the record, not as a licence to collapse.",
+    "CAVEAT for the mint operator: `aot_mint.lane_admitted` still hard-refuses every non-PARITY lane (PARITY_LANES = w8a8, w8a8-rowwise) with a message citing #730, even though #730 is closed and explicitly UNHELD for DiTs. A plain-bf16 flux2 mint is legitimate on the evidence but would need --allow-regressed-lanes to get past a stale gate. Flagged to the coordinator (ie#571 gap F).",
+    "WEIGHT LANE IS A DEPLOY-TIME DECISION HERE, NOT A FAMILY FACT. Unlike z-image/qwen (which pin fp8-w8a8), this endpoint pins NO flavor — th#546's automatic fit ladder picks the rung per card at load time (main.py:27-30). Mint the lane the TARGET SKU will actually serve; w8a8 is set below because it is the PARITY lane that mints without an override, not because the endpoint guarantees it.",
+    "CFG IS NOT A GRAPH CLASS HERE, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_flux2_klein.py:848-875 runs CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 on every served path and there is no cfg fork. (Same misstatement in qwen-image's endpoint; z-image is the one family where CFG really does batch — #728.)",
+    "DORMANT HAZARD 1 — kv_cache. Declared as a fork with served=(False,), unserved=(True,). KV caching lives exclusively in Flux2KleinKVPipeline, which the endpoint does not import; the editing path uses plain token concatenation instead. Flux2KVCache is not pytree-representable and the forward mutates it in place (transformer_flux2.py:1303/1348), so that lane would need a boundary-shrink before it could export. Real but UNREACHED — a declared gate, not a blocker.",
+    "DORMANT HAZARD 2 — num_ref_tokens / ref_fixed_timestep are SPECIALIZING PYTHON SCALARS: a nonzero value bakes a different graph. Both are 0 on every served path, and are pinned as explicit Args in the declaration so the traced call states them outright rather than inheriting a default that could move.",
+    "warm_changes_key=false: transformer_flux2.py has ZERO data-dependent tensor ops (#728 counted them across all five surveyed denoisers) and no lazily-built rope state, so a forward pass before export cannot change the graph. The opposite of z-image's measured True.",
+    "source_ref is left EMPTY deliberately: ie#524/th#980 made the base/turbo checkpoint refs deploy-time slot bindings rather than code constants. Fill it, and source_digest, from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "flux2-klein-4b",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 0,
+  "shapes": [
+    [
+      1024,
+      1024
+    ],
+    [
+      1184,
+      880
+    ],
+    [
+      880,
+      1184
+    ],
+    [
+      1248,
+      832
+    ],
+    [
+      832,
+      1248
+    ],
+    [
+      1392,
+      752
+    ],
+    [
+      752,
+      1392
+    ],
+    [
+      1568,
+      672
+    ],
+    [
+      672,
+      1568
+    ],
+    [
+      1408,
+      1408
+    ],
+    [
+      1920,
+      1088
+    ],
+    [
+      1088,
+      1920
+    ],
+    [
+      2048,
+      2048
+    ],
+    [
+      2560,
+      1440
+    ],
+    [
+      1440,
+      2560
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "kv_cache": false
+  },
+  "declaration_module": "flux2_klein_4b.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "kv_cache": null,
+    "kv_cache_mode": null,
+    "num_ref_tokens": 0,
+    "ref_fixed_timestep": 0.0,
+    "patch_size": 1,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "max_reference_images": 4,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "Flux2KleinPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 30.0
+}

--- a/tests/fixtures/fleet_mint_requests/flux.2-klein-9b/transformer-9b.mint.json
+++ b/tests/fixtures/fleet_mint_requests/flux.2-klein-9b/transformer-9b.mint.json
@@ -1,0 +1,122 @@
+{
+  "_declaration": "flux.2-klein-9b/src/flux2_klein_9b/main.py \u2014 the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; src/flux2_klein_9b/aot_declaration.py and the aot/declaration.py shim are DELETED. static-rows by pgw#852.",
+  "_status": "READY — declaration registers cleanly; no open mint blockers. shape_strategy=static-rows, 9 entries (pgw#852).",
+  "_notes": [
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused); `fork` states the minted class's arm values. flux2's `kv_cache` fork has NO source binding — it is a call-argument fact, not a composed pipeline/module field — so the mint keys it but cannot assert it from composition.",
+    "⚠ SUPERSEDED BY pgw#852 — THIS IS NOT ONE ARTIFACT ANY MORE, AND IT NEVER COULD HAVE BEEN. shape_strategy is now `static-rows` and the declaration carries the GENERATE lane's 9 real coordinates (T_img = 4056 4070 4089 4096 4116 7744 8160 14400 16384), deriving 9 entries with no free symbol on any of them. Measured on H100 pod dykztnghs4k8pc: under dynamic-collapse torch.export SUCCEEDED (47.07 s) and AOTInductor then REFUSED — `InductorError: CantSplit: 12288*s11 + 6291456 not divisible by s11 + 512`, where s11 is the collapsed token symbol and s11+512 is T_img+T_txt at _TEXT_LEN. Inductor's split/tiling pass cannot prove divisibility across a free symbol. #728's node count is an EXPORT-stage measurement (upstream of inductor) and pgw#812's 0.0% is the DYNAMO backend; neither was evidence about AOTInductor. pgw#846 forbids dynamic collapse on served cells regardless. The EDIT lane is declared OUT and serves EAGER (qwen-image's own call): its token count is base + a multiset of 1..4 reference buckets — 617 coordinates — not a shape table.",
+    "T_img is bound to hidden_states[1] AND img_ids[1]. A binding naming only hidden_states would let img_ids specialize and silently pin the artifact to the generate lane — the edit concat grows both.",
+    "#728 measured flux2 static->dynamic at 2758 -> 2760 nodes (+2, rc=1) — a TORCH.EXPORT-stage node count, which is exactly why it did not predict the AOTInductor refusal (pgw#852). Exports clean strict and non-strict, all four modes; that remains true and is not the gate.",
+    "#730's conv rationale still does not hold this lane (transformer_flux2.py has ZERO nn.Conv layers), but per pgw#852 that is no longer the binding constraint: AOTInductor refuses the free symbol outright, conv or not. Kept for the record, not as a licence to collapse.",
+    "CAVEAT for the mint operator: `aot_mint.lane_admitted` still hard-refuses every non-PARITY lane (PARITY_LANES = w8a8, w8a8-rowwise) with a message citing #730, even though #730 is closed and explicitly UNHELD for DiTs. A plain-bf16 flux2 mint is legitimate on the evidence but would need --allow-regressed-lanes to get past a stale gate. Flagged to the coordinator (ie#571 gap F).",
+    "WEIGHT LANE IS A DEPLOY-TIME DECISION HERE, NOT A FAMILY FACT. Unlike z-image/qwen (which pin fp8-w8a8), this endpoint pins NO flavor — th#546's automatic fit ladder picks the rung per card at load time (main.py:27-30). Mint the lane the TARGET SKU will actually serve; w8a8 is set below because it is the PARITY lane that mints without an override, not because the endpoint guarantees it.",
+    "CFG IS NOT A GRAPH CLASS HERE, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_flux2_klein.py:848-875 runs CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 on every served path and there is no cfg fork. (Same misstatement in qwen-image's endpoint; z-image is the one family where CFG really does batch — #728.)",
+    "DORMANT HAZARD 1 — kv_cache. Declared as a fork with served=(False,), unserved=(True,). KV caching lives exclusively in Flux2KleinKVPipeline, which the endpoint does not import; the editing path uses plain token concatenation instead. Flux2KVCache is not pytree-representable and the forward mutates it in place (transformer_flux2.py:1303/1348), so that lane would need a boundary-shrink before it could export. Real but UNREACHED — a declared gate, not a blocker.",
+    "DORMANT HAZARD 2 — num_ref_tokens / ref_fixed_timestep are SPECIALIZING PYTHON SCALARS: a nonzero value bakes a different graph. Both are 0 on every served path, and are pinned as explicit Args in the declaration so the traced call states them outright rather than inheriting a default that could move.",
+    "warm_changes_key=false: transformer_flux2.py has ZERO data-dependent tensor ops (#728 counted them across all five surveyed denoisers) and no lazily-built rope state, so a forward pass before export cannot change the graph. The opposite of z-image's measured True.",
+    "source_ref is left EMPTY deliberately: ie#524/th#980 made the base/turbo checkpoint refs deploy-time slot bindings rather than code constants. Fill it, and source_digest, from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's.",
+    "9b WAS SURVEY-BLOCKED IN #728: black-forest-labs/FLUX.2-klein-9B is a gated repo and its transformer config was not cached, so no export was ever traced for it. Its structure is INFERRED from 4b — same Flux2Transformer2DModel class, byte-identical aspect tables, larger num_layers — and that inference is GUARDED rather than assumed: every width comes from ('config', field), which raises MintRefused BY NAME if the resolved module's config does not carry it. A config surprise therefore fails loudly at mint instead of tracing a wrong graph. Closing the survey gap costs one cached 1 KB config file.",
+    "ENDPOINT DIVERGENCE FOUND (ie#571): flux.2-klein-9b/src/flux2_klein_9b/main.py's Compile OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode'), while 4b states ('transformer',). It also omits guidance_scales and both @endpoint blocks omit warmup=. This declaration compiles the transformer only, matching 4b; the 9b Compile should be made explicit in the endpoint lane."
+  ],
+  "family": "flux2-klein-9b",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 0,
+  "shapes": [
+    [
+      1024,
+      1024
+    ],
+    [
+      1184,
+      880
+    ],
+    [
+      880,
+      1184
+    ],
+    [
+      1248,
+      832
+    ],
+    [
+      832,
+      1248
+    ],
+    [
+      1392,
+      752
+    ],
+    [
+      752,
+      1392
+    ],
+    [
+      1568,
+      672
+    ],
+    [
+      672,
+      1568
+    ],
+    [
+      1408,
+      1408
+    ],
+    [
+      1920,
+      1088
+    ],
+    [
+      1088,
+      1920
+    ],
+    [
+      2048,
+      2048
+    ],
+    [
+      2560,
+      1440
+    ],
+    [
+      1440,
+      2560
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "kv_cache": false
+  },
+  "declaration_module": "flux2_klein_9b.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "kv_cache": null,
+    "kv_cache_mode": null,
+    "num_ref_tokens": 0,
+    "ref_fixed_timestep": 0.0,
+    "patch_size": 1,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "max_reference_images": 4,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "Flux2KleinPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 44.0
+}

--- a/tests/fixtures/fleet_mint_requests/ltx-video-2.3/transformer-b200-tv261120-ta126-tat1.mint.json
+++ b/tests/fixtures/fleet_mint_requests/ltx-video-2.3/transformer-b200-tv261120-ta126-tat1.mint.json
@@ -1,0 +1,83 @@
+{
+  "_declaration": "ltx-video-2.3/src/ltx_video_23/main.py \u2014 the @endpoint(compile=...) block (ie#571, folded by ie#645/pgw#1107)",
+  "_generated_by": "ltx-video-2.3/aot/make_mint_requests.py",
+  "_status": "READY BUT BLOCKED \u2014 see Compile(blockers=MINT_BLOCKERS) in src/ltx_video_23/main.py (OQ-2 / OQ-3 / OQ-8).",
+  "_tier": "b200",
+  "_lane": "generate/extend/a2v",
+  "_row": "T_v=261120 video tokens, T_a=126 audio tokens, T_at=1 (generate/extend/a2v)",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED. The declaration carries three UNRESOLVED `Compile(blockers=...)` rows (pgw#1115) and the MINT fails closed on them: OQ-2 (audio_timestep rank), OQ-3 (whole-graph OOM unmeasured on the w8a8 lane) and OQ-8 (live coverage gaps). Those are LTX-AOT-DESIGN.md's mint-gating open questions, recorded as declared blockers rather than guessed. Do not hand-edit around them.",
+    "pgw#739: `dynamic` derives from the declaration's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 82/115 rows sit at the SINGLE served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "BUCKET-ENUM FIRST (LTX-AOT-DESIGN OQ-4): one artifact per declared class \u2014 parity with today's dynamo behaviour, never a regression. The T_v/T_a dynamic collapse is a SEPARATE, MEASURED change, and ltx is the family where it is most likely FREE: #728 measured static->dynamic at 30,877 -> 30,878 nodes (+1, one range constraint), and #730's mechanism is conv-specific while transformer_ltx2.py has ZERO nn.Conv layers. If the collapse lands, T_v collapses per lane and the artifact set falls by an order of magnitude. Measure it early rather than deferring by analogy to sdxl, because the analogy is now known NOT to hold.",
+    "THE SHAPE TABLE IS WRONG IN BOTH DIRECTIONS, which is why class_dims and not shapes identifies this artifact. It OVER-counts by transposition (num_frames/height/width/fps are DEAD inside the forward \u2014 the pipeline always precomputes video_coords \u2014 so the graph is a function of T_v alone and 704x1280 == 1280x704: 10 of the 30 H100 rows are duplicates) and UNDER-counts by ~4x on T_a, T_at and T_kf, which have no slot in a 3-tuple.",
+    "T_a IS AN AXIS THE ROW CANNOT CARRY. T_a = round(frames / native_fps * 25) and the row carries num_frames but NOT frame_rate, so two admissible requests share a row and need different artifacts. It enumerates to exactly four values {126, 251, 376, 501}; rows at 241f and 481f carry TWO T_a and therefore DOUBLE. The endpoint's own comment \u2014 'frame_rate does not change the DiT graph; only num_frames does' (main.py:465) \u2014 is FALSE for the audio stream and must be corrected with this declaration.",
+    "T_kf IS BINARY, NOT OPEN-ENDED. _validate_image_roles admits first_frame and last_frame at most once each and rejects reference. first_frame OVERWRITES tokens (no growth); last_frame sits at a non-zero latent index so prepare_latents APPENDS one latent frame of patches. So T_kf in {0, H_lat*W_lat}, folded into T_v, and it applies to generate only.",
+    "EDIT IS PERMANENTLY ITS OWN ARTIFACT SET (OQ-9). T_at is 1 on generate/extend/a2v and T_a on edit, and {1, T_a} cannot fuse into one dynamic dim: torch specializes 0 and 1 unconditionally and the SDK encodes that as DynamicDim.min >= 2 (ie#543). Normalizing the rank (OQ-2) buys honesty and keyability, NOT artifacts. Edit contributes 28 (H100) / 39 (B200) classes nothing else shares \u2014 worth pricing before minting them.",
+    "STG IS UNREACHABLE ON EVERY SERVED PATH, and the stg fork makes that deliberate. LTX has exactly 2 data-dependent tensor ops, both torch.all(perturbation_mask == 0) \u2014 the only ones across all five denoisers #728 surveyed, and a genuine export blocker. Both sites are guarded by `perturbation_mask is not None`, a python-None check export erases at trace time, and all four served call sites pass both spatio_temporal_guidance_blocks and perturbation_mask as literal None.",
+    "isolate_modalities IS DECLARED UNSERVED. It drops both AV cross-attentions (transformer_ltx2.py:1587-1588/1616-1617) \u2014 measured 1276 vs 1708 nodes at 2 layers (ie#571) and 20,509 vs 30,877 at full depth (#728). Reachable only through pipeline_ltx2_audio.text_to_audio, which no worker_function calls (ie#383 phase 2). Declared so the phase-2 wiring cannot silently mint into the wrong class. NOTE for that day: strict dead-code-eliminates the unused AV cross-attention weights (19,261/2,960 placeholders strict vs 20,509/4,208 non-strict \u2014 a 1,248-parameter difference, i.e. a DIFFERENT WEIGHT CONTRACT), so export mode becomes load-bearing for pgw#698's expected-FQN set.",
+    "compile_mode='whole': the AOT lane exports the WHOLE transformer (design \u00a73.2), gated on OQ-3 \u2014 and since pgw#846 the AOT mint is whole-graph UNCONDITIONALLY and ignores `Compile.regional`, which on the one folded declaration carries its DYNAMO/JIT meaning (ie#645, regional=True). The published dynamo cell (compile_mode='regional') and these AOT cells (compile_mode='whole') therefore coexist and artifact_drift actively refuses a cross-mode adoption; the 20-row dynamo cell keeps serving unmodified. If OQ-3's re-measure shows whole-graph still OOMs, take the DESIGNED fallback \u2014 ONE exported repeated block \u2014 never regional-as-is, which yields N hashes and no whole-graph identity.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached transformer config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 1708 nodes in ALL FOUR arms. The opposite of z-image's measured True.",
+    "strict=true per pgw#723 S1. The mode is already keyed (strict_mode_drift in aot_package.py), so the isolate_modalities interaction above is a recording obligation, not a build one.",
+    "sigma IS REQUIRED IN PRACTICE despite defaulting to None: cross_attn_mod=true on this checkpoint makes prompt_modulation True, which calls sigma.flatten() unconditionally.",
+    "encoder_hidden_states MUST arrive at cross_attention_dim=4096 (audio at 2048), NOT the docstring's caption_channels=3840: use_prompt_embeddings is false on this checkpoint so caption_projection does not exist and the connector output arrives already projected. Passing 3840 fails with 'Attempting to broadcast a dimension of length 4096 at -1'.",
+    "THE CLASS SET IS PER-SKU and this request is tier-specific. H100 admits 82 classes, B200 115, because _frames_legal is tier-aware (ie#461): B200 adds the 4K family and 241f ultrawide. The SKU is already a cell-key axis, so this needs no new concept \u2014 but minting a b200 request on an h100 pod (or vice versa) is a category error.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting."
+  ],
+  "family": "ltx-2.3",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 0,
+  "shapes": [],
+  "text_lens": [
+    1024
+  ],
+  "guidance_scales": [
+    1.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "cfg": false,
+    "isolate_modalities": false,
+    "stg": false
+  },
+  "class_dims": {
+    "B": 1,
+    "T_a": 126,
+    "T_at": 1,
+    "T_txt": 1024,
+    "T_v": 261120
+  },
+  "declaration_module": "ltx_video_23.main",
+  "specialization": {
+    "return_dict": false,
+    "isolate_modalities": false,
+    "spatio_temporal_guidance_blocks": null,
+    "perturbation_mask": null,
+    "use_cross_timestep": false,
+    "regional": false,
+    "compile_mode": "whole",
+    "in_channels": 128,
+    "audio_in_channels": 128,
+    "cross_attention_dim": 4096,
+    "audio_cross_attention_dim": 2048,
+    "vae_scale_factors": [
+      8,
+      32,
+      32
+    ],
+    "audio_tokens_per_second": 25.0,
+    "serving_tier": "b200"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/ltx-2.3-distilled:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "LTX2ConditionPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 140.0
+}

--- a/tests/fixtures/fleet_mint_requests/ltx-video-2.3/transformer-b200-tv261120-ta251-tat1.mint.json
+++ b/tests/fixtures/fleet_mint_requests/ltx-video-2.3/transformer-b200-tv261120-ta251-tat1.mint.json
@@ -1,0 +1,83 @@
+{
+  "_declaration": "ltx-video-2.3/src/ltx_video_23/main.py \u2014 the @endpoint(compile=...) block (ie#571, folded by ie#645/pgw#1107)",
+  "_generated_by": "ltx-video-2.3/aot/make_mint_requests.py",
+  "_status": "READY BUT BLOCKED \u2014 see Compile(blockers=MINT_BLOCKERS) in src/ltx_video_23/main.py (OQ-2 / OQ-3 / OQ-8).",
+  "_tier": "b200",
+  "_lane": "generate/extend/a2v",
+  "_row": "T_v=261120 video tokens, T_a=251 audio tokens, T_at=1 (generate/extend/a2v)",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED. The declaration carries three UNRESOLVED `Compile(blockers=...)` rows (pgw#1115) and the MINT fails closed on them: OQ-2 (audio_timestep rank), OQ-3 (whole-graph OOM unmeasured on the w8a8 lane) and OQ-8 (live coverage gaps). Those are LTX-AOT-DESIGN.md's mint-gating open questions, recorded as declared blockers rather than guessed. Do not hand-edit around them.",
+    "pgw#739: `dynamic` derives from the declaration's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 82/115 rows sit at the SINGLE served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "BUCKET-ENUM FIRST (LTX-AOT-DESIGN OQ-4): one artifact per declared class \u2014 parity with today's dynamo behaviour, never a regression. The T_v/T_a dynamic collapse is a SEPARATE, MEASURED change, and ltx is the family where it is most likely FREE: #728 measured static->dynamic at 30,877 -> 30,878 nodes (+1, one range constraint), and #730's mechanism is conv-specific while transformer_ltx2.py has ZERO nn.Conv layers. If the collapse lands, T_v collapses per lane and the artifact set falls by an order of magnitude. Measure it early rather than deferring by analogy to sdxl, because the analogy is now known NOT to hold.",
+    "THE SHAPE TABLE IS WRONG IN BOTH DIRECTIONS, which is why class_dims and not shapes identifies this artifact. It OVER-counts by transposition (num_frames/height/width/fps are DEAD inside the forward \u2014 the pipeline always precomputes video_coords \u2014 so the graph is a function of T_v alone and 704x1280 == 1280x704: 10 of the 30 H100 rows are duplicates) and UNDER-counts by ~4x on T_a, T_at and T_kf, which have no slot in a 3-tuple.",
+    "T_a IS AN AXIS THE ROW CANNOT CARRY. T_a = round(frames / native_fps * 25) and the row carries num_frames but NOT frame_rate, so two admissible requests share a row and need different artifacts. It enumerates to exactly four values {126, 251, 376, 501}; rows at 241f and 481f carry TWO T_a and therefore DOUBLE. The endpoint's own comment \u2014 'frame_rate does not change the DiT graph; only num_frames does' (main.py:465) \u2014 is FALSE for the audio stream and must be corrected with this declaration.",
+    "T_kf IS BINARY, NOT OPEN-ENDED. _validate_image_roles admits first_frame and last_frame at most once each and rejects reference. first_frame OVERWRITES tokens (no growth); last_frame sits at a non-zero latent index so prepare_latents APPENDS one latent frame of patches. So T_kf in {0, H_lat*W_lat}, folded into T_v, and it applies to generate only.",
+    "EDIT IS PERMANENTLY ITS OWN ARTIFACT SET (OQ-9). T_at is 1 on generate/extend/a2v and T_a on edit, and {1, T_a} cannot fuse into one dynamic dim: torch specializes 0 and 1 unconditionally and the SDK encodes that as DynamicDim.min >= 2 (ie#543). Normalizing the rank (OQ-2) buys honesty and keyability, NOT artifacts. Edit contributes 28 (H100) / 39 (B200) classes nothing else shares \u2014 worth pricing before minting them.",
+    "STG IS UNREACHABLE ON EVERY SERVED PATH, and the stg fork makes that deliberate. LTX has exactly 2 data-dependent tensor ops, both torch.all(perturbation_mask == 0) \u2014 the only ones across all five denoisers #728 surveyed, and a genuine export blocker. Both sites are guarded by `perturbation_mask is not None`, a python-None check export erases at trace time, and all four served call sites pass both spatio_temporal_guidance_blocks and perturbation_mask as literal None.",
+    "isolate_modalities IS DECLARED UNSERVED. It drops both AV cross-attentions (transformer_ltx2.py:1587-1588/1616-1617) \u2014 measured 1276 vs 1708 nodes at 2 layers (ie#571) and 20,509 vs 30,877 at full depth (#728). Reachable only through pipeline_ltx2_audio.text_to_audio, which no worker_function calls (ie#383 phase 2). Declared so the phase-2 wiring cannot silently mint into the wrong class. NOTE for that day: strict dead-code-eliminates the unused AV cross-attention weights (19,261/2,960 placeholders strict vs 20,509/4,208 non-strict \u2014 a 1,248-parameter difference, i.e. a DIFFERENT WEIGHT CONTRACT), so export mode becomes load-bearing for pgw#698's expected-FQN set.",
+    "compile_mode='whole': the AOT lane exports the WHOLE transformer (design \u00a73.2), gated on OQ-3 \u2014 and since pgw#846 the AOT mint is whole-graph UNCONDITIONALLY and ignores `Compile.regional`, which on the one folded declaration carries its DYNAMO/JIT meaning (ie#645, regional=True). The published dynamo cell (compile_mode='regional') and these AOT cells (compile_mode='whole') therefore coexist and artifact_drift actively refuses a cross-mode adoption; the 20-row dynamo cell keeps serving unmodified. If OQ-3's re-measure shows whole-graph still OOMs, take the DESIGNED fallback \u2014 ONE exported repeated block \u2014 never regional-as-is, which yields N hashes and no whole-graph identity.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached transformer config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 1708 nodes in ALL FOUR arms. The opposite of z-image's measured True.",
+    "strict=true per pgw#723 S1. The mode is already keyed (strict_mode_drift in aot_package.py), so the isolate_modalities interaction above is a recording obligation, not a build one.",
+    "sigma IS REQUIRED IN PRACTICE despite defaulting to None: cross_attn_mod=true on this checkpoint makes prompt_modulation True, which calls sigma.flatten() unconditionally.",
+    "encoder_hidden_states MUST arrive at cross_attention_dim=4096 (audio at 2048), NOT the docstring's caption_channels=3840: use_prompt_embeddings is false on this checkpoint so caption_projection does not exist and the connector output arrives already projected. Passing 3840 fails with 'Attempting to broadcast a dimension of length 4096 at -1'.",
+    "THE CLASS SET IS PER-SKU and this request is tier-specific. H100 admits 82 classes, B200 115, because _frames_legal is tier-aware (ie#461): B200 adds the 4K family and 241f ultrawide. The SKU is already a cell-key axis, so this needs no new concept \u2014 but minting a b200 request on an h100 pod (or vice versa) is a category error.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting."
+  ],
+  "family": "ltx-2.3",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 0,
+  "shapes": [],
+  "text_lens": [
+    1024
+  ],
+  "guidance_scales": [
+    1.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "cfg": false,
+    "isolate_modalities": false,
+    "stg": false
+  },
+  "class_dims": {
+    "B": 1,
+    "T_a": 251,
+    "T_at": 1,
+    "T_txt": 1024,
+    "T_v": 261120
+  },
+  "declaration_module": "ltx_video_23.main",
+  "specialization": {
+    "return_dict": false,
+    "isolate_modalities": false,
+    "spatio_temporal_guidance_blocks": null,
+    "perturbation_mask": null,
+    "use_cross_timestep": false,
+    "regional": false,
+    "compile_mode": "whole",
+    "in_channels": 128,
+    "audio_in_channels": 128,
+    "cross_attention_dim": 4096,
+    "audio_cross_attention_dim": 2048,
+    "vae_scale_factors": [
+      8,
+      32,
+      32
+    ],
+    "audio_tokens_per_second": 25.0,
+    "serving_tier": "b200"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/ltx-2.3-distilled:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "LTX2ConditionPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 140.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1024x1024.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1024x1024.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1024x1024 (1mp tier) -> patch grid 64x64 = 4096 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1024,
+      1024
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 4096,
+    "H_pat": 64,
+    "W_pat": 64,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          64,
+          64
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1056x1584.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1056x1584.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1056x1584 (2mp tier) -> patch grid 99x66 = 6534 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1056,
+      1584
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6534,
+    "H_pat": 99,
+    "W_pat": 66,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          99,
+          66
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1104x1472.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1104x1472.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1104x1472 (2mp tier) -> patch grid 92x69 = 6348 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1104,
+      1472
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6348,
+    "H_pat": 92,
+    "W_pat": 69,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          92,
+          69
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1152x864.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1152x864.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1152x864 (1mp tier) -> patch grid 54x72 = 3888 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1152,
+      864
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 3888,
+    "H_pat": 54,
+    "W_pat": 72,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          54,
+          72
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1248x832.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1248x832.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1248x832 (1mp tier) -> patch grid 52x78 = 4056 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1248,
+      832
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 4056,
+    "H_pat": 52,
+    "W_pat": 78,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          52,
+          78
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1280x720.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1280x720.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1280x720 (1mp tier) -> patch grid 45x80 = 3600 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1280,
+      720
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 3600,
+    "H_pat": 45,
+    "W_pat": 80,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          45,
+          80
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1328x1328.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1328x1328.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1328x1328 (2mp tier) -> patch grid 83x83 = 6889 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1328,
+      1328
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6889,
+    "H_pat": 83,
+    "W_pat": 83,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          83,
+          83
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1472x1104.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1472x1104.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1472x1104 (2mp tier) -> patch grid 69x92 = 6348 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1472,
+      1104
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6348,
+    "H_pat": 69,
+    "W_pat": 92,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          69,
+          92
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1584x1056.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1584x1056.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1584x1056 (2mp tier) -> patch grid 66x99 = 6534 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1584,
+      1056
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6534,
+    "H_pat": 66,
+    "W_pat": 99,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          66,
+          99
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1664x928.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-1664x928.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "1664x928 (2mp tier) -> patch grid 58x104 = 6032 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1664,
+      928
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6032,
+    "H_pat": 58,
+    "W_pat": 104,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          58,
+          104
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-720x1280.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-720x1280.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "720x1280 (1mp tier) -> patch grid 80x45 = 3600 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      720,
+      1280
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 3600,
+    "H_pat": 80,
+    "W_pat": 45,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          80,
+          45
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-832x1248.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-832x1248.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "832x1248 (1mp tier) -> patch grid 78x52 = 4056 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      832,
+      1248
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 4056,
+    "H_pat": 78,
+    "W_pat": 52,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          78,
+          52
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-864x1152.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-864x1152.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "864x1152 (1mp tier) -> patch grid 72x54 = 3888 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      864,
+      1152
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 3888,
+    "H_pat": 72,
+    "W_pat": 54,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          72,
+          54
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 1,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/qwen-image/transformer-928x1664.mint.json
+++ b/tests/fixtures/fleet_mint_requests/qwen-image/transformer-928x1664.mint.json
@@ -1,0 +1,82 @@
+{
+  "_declaration": "qwen-image/src/qwen_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/qwen_image/aot_declaration.py are DELETED.",
+  "_status": "READY BUT BLOCKED \u2014 see B1/B2 in declaration.py MINT_BLOCKERS.",
+  "_row": "928x1664 (2mp tier) -> patch grid 104x58 = 6032 image tokens",
+  "_notes": [
+    "STATUS: READY BUT BLOCKED \u2014 declaration.py raises MintRefused at import until B1 (img_shapes is inexpressible in the #739 vocabulary) and B2 (the edit lane's class set is unbounded) clear. Do not hand-edit around it: the blockers are precisely why a hand-written request would be wrong.",
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused). Under static-rows the request must NAME its row via `class_dims` \u2014 14 declared rows sit at the single served fork coordinate, so the coordinate alone does not identify an artifact.",
+    "SHAPE STRATEGY IS static-rows, AND IT IS FORCED BY A MEASURED REFUSAL, NOT BY #730. Declared-dynamic export is refused verbatim: 'Constraints violated (img_tok)! - You marked img_tok as dynamic but your code specialized it to be a constant (6889).' Root cause: img_shapes carries the token count as PYTHON INTS ([[(1, H//16, W//16)]], pipeline_qwenimage.py:648) and pos_embed computes seq_lens = frame*height*width from them and slices rope to that length (transformer_qwenimage.py:925). The count enters the graph twice \u2014 once as a symbolic tensor dim, once as a baked constant \u2014 and the constant wins.",
+    "#730 does NOT hold this lane. transformer_qwenimage.py has ZERO nn.Conv layers (counted 2026-07-28) and #730 S4 names qwen's class in the UNHELD set. static-rows here is img_shapes' doing.",
+    "TRANSPOSED ROWS DO NOT DEDUPE ON QWEN, unlike flux2 and ltx. There the rope coordinates arrive as TENSOR inputs so the graph is a function of token count alone; here the patch grid is BAKED from img_shapes' python ints, so (1,69,92) and (1,92,69) bake different rope constants at the same 6348 tokens. 14 declared rows yield only 8 distinct token counts but 14 distinct artifacts \u2014 which is why H_pat and W_pat are separate declared dims.",
+    "THE ESCAPE IS MEASURED AND WOULD COLLAPSE 14 ARTIFACTS TO 1. Lifting image_rotary_emb out of the exported region and passing it as graph inputs: 'static EXPORT OK nodes=501 / DYNAMIC img_tok EXPORT OK nodes=502 range_constraints=1' \u2014 it works and costs +1 node. Not taken in ie#571 because it is an ENDPOINT CODE CHANGE (wrapper module + frozen pos_embed, ~30 lines, 2-3d), not a declaration change. CAVEAT for whoever takes it: the rope tensors are complex64 ((6889,64) and (512,64)) and complex graph inputs through AOTI are unproven; if Inductor balks, pass real/imag as two real tensors.",
+    "warm_changes_key=false \u2014 MEASURED (ie#571, 2026-07-28, meta device from the cached Qwen/Qwen-Image config, depth-truncated): exported cold and pre-warmed, strict and non-strict, 521 nodes in ALL FOUR arms. Consistent with structure \u2014 QwenEmbedRope builds pos_freqs/neg_freqs eagerly in __init__ and its device cache is explicitly @lru_cache_unless_export, so there is no lazy state for a pre-warm to populate. The opposite of z-image's measured True.",
+    "CFG IS NOT A GRAPH CLASS, and the endpoint's Compile comment is wrong. diffusers 0.39 pipeline_qwenimage.py:697-725 runs true-CFG as TWO SEQUENTIAL BATCH-1 forwards under cache_context('cond')/('uncond'), differing only in which encoder_hidden_states is passed. The guidance axis changes call COUNT, not traced shape, so batch is 1 and guidance_scales is NOT a fork. (Same misstatement in flux2's endpoint; z-image is the one family where CFG really does batch \u2014 #728.)",
+    "THE EDIT LANE IS DECLARED UNSERVED (fork condition_images: served=(0,), unserved=(1,2,3)). QwenImageEditPlusPipeline concatenates condition-image latents onto the token axis and grows img_shapes' LENGTH, and each condition image is sized by calculate_dimensions(VAE_IMAGE_SIZE, user_ratio) which snaps to multiples of 32 at the USER'S OWN aspect ratio \u2014 not a payload bucket \u2014 so its class set is not a finite row set. Edit serves EAGER, deliberately. Declaring it unserved is what stops it silently minting into the t2i class.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128) (gw#561/ie#501): the branch-bearing w8a8-lora128 graph family, with turbo's Lightning attach a buffer copy rather than a recompile.",
+    "NOTE (general hazard, same class as #728's z-image finding): QwenEmbedRope's pos_freqs/neg_freqs are plain tensor attributes rather than registered buffers, so under a code-only .pt2 they have no CAS provenance. Unlike z-image's they are deterministic from config, so baking them is at least reproducible \u2014 but pgw#723 B1's rule is about provenance, not reproducibility. Worth confirming against the loadable-constants set before minting.",
+    "targets is ('transformer',) here. The endpoint's _QWEN_COMPILE OMITS `targets` and therefore silently inherits the SDK default ('transformer', 'vae.decode') \u2014 recorded for the endpoint lane (ie#571). The survey measured the DiT only; declaring a vae.decode export contract nobody traced would be guessing.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's."
+  ],
+  "family": "qwen-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      928,
+      1664
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    1.0,
+    4.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "condition_images": 0
+  },
+  "class_dims": {
+    "B": 1,
+    "T_img": 6032,
+    "H_pat": 104,
+    "W_pat": 58,
+    "T_txt": 512
+  },
+  "declaration_module": "qwen_image.main",
+  "specialization": {
+    "return_dict": false,
+    "guidance": null,
+    "guidance_embeds": false,
+    "img_shapes": [
+      [
+        [
+          1,
+          104,
+          58
+        ]
+      ]
+    ],
+    "in_channels": 64,
+    "joint_attention_dim": 3584,
+    "patch_size": 2,
+    "vae_scale_factor": 8,
+    "token_divisor": 16,
+    "megapixels_tier": 2,
+    "cfg_batching": "two sequential batch-1 forwards (call count, not shape)"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/qwen-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "QwenImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 72.0
+}

--- a/tests/fixtures/fleet_mint_requests/sdxl/sdxl.mint.json
+++ b/tests/fixtures/fleet_mint_requests/sdxl/sdxl.mint.json
@@ -1,0 +1,42 @@
+{
+  "_declaration": "sdxl/src/sdxl/aot_declaration.py (pgw#739); one-cell shape per pgw#758. Moved into the WHEEL by pgw#805 — a serving pod that mints in the background needs the declaration registered by its own endpoint import, not by a mint request.",
+  "_notes": [
+    "pgw#758 (Paul's ruling): 'generate and generate_turbo are separate functions, they have separate graphs, but they are COMBINED TOGETHER INTO ONE FILE.' One mint -> ONE cell carrying all 18 declared classes (9 aspect rows x cfg/no-cfg) as named entries — the pilot runbook's one-artifact-per-pod serving ceiling is gone; a single resident cell serves every declared aspect and both CFG arms.",
+    "The SDXL-AOT-PILOT minted 4 of these classes as 4 separate format-1 cells; those are RETIRED by the format-2 envelope + v2 contract facts (ck5 exact identity: recipe change strands old cells, correct and expected).",
+    "weight_lane w8a8 is the migration's first lane (pgw#704: latency PARITY with dynamo, 276.2 vs 274.6 ms). lora_bucket=64 with pgw#725 option-2 input-lifting — the SDK scopes the bucket to branch-capable denoisers (the unet; setup() swaps the VAE post-arming, so no vae entry exists in the declaration).",
+    "source_ref is the family BASE (graph identity is family-scoped: fine-tunes share cells, so any family member composes the same graphs). source_digest is a DEPLOY-TIME fact — fill from the serving release before minting.",
+    "warm_changes_key=False is sdxl's measured canon (a pre-export forward produced the same key as a cold mint) — the mint runs no warm ceremony here; z-image's True is the family where the executed warm canon matters."
+  ],
+  "family": "sdxl",
+  "weight_lane": "w8a8",
+  "precision": "w8a8",
+  "batch": 0,
+  "lora_bucket": 64,
+  "shapes": [
+    [1536, 640],
+    [1344, 768],
+    [1216, 832],
+    [1152, 896],
+    [1024, 1024],
+    [896, 1152],
+    [832, 1216],
+    [768, 1344],
+    [640, 1536]
+  ],
+  "text_lens": [77],
+  "guidance_scales": [1.0, 5.0],
+  "declaration_module": "sdxl.aot_declaration",
+  "specialization": {
+    "return_dict": false
+  },
+  "lora_fqns": [],
+  "lifted_inputs": ["lora_a", "lora_b"],
+  "strict": true,
+  "source_ref": "stabilityai/stable-diffusion-xl-base-1.0",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "StableDiffusionXLPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "w8a8",
+  "declared_vram_gb": 24.0
+}

--- a/tests/fixtures/fleet_mint_requests/sdxl/sdxl.mint.json
+++ b/tests/fixtures/fleet_mint_requests/sdxl/sdxl.mint.json
@@ -1,5 +1,5 @@
 {
-  "_declaration": "sdxl/src/sdxl/aot_declaration.py (pgw#739); one-cell shape per pgw#758. Moved into the WHEEL by pgw#805 — a serving pod that mints in the background needs the declaration registered by its own endpoint import, not by a mint request.",
+  "_declaration": "sdxl/src/sdxl/main.py — the @endpoint(compile=...) block (pgw#739; folded onto the decorator by ie#645/pgw#1107, which DELETED aot_declaration.py). One-cell shape per pgw#758. A serving pod that mints in the background needs the declaration registered by its own endpoint import, not by a mint request.",
   "_notes": [
     "pgw#758 (Paul's ruling): 'generate and generate_turbo are separate functions, they have separate graphs, but they are COMBINED TOGETHER INTO ONE FILE.' One mint -> ONE cell carrying all 18 declared classes (9 aspect rows x cfg/no-cfg) as named entries — the pilot runbook's one-artifact-per-pod serving ceiling is gone; a single resident cell serves every declared aspect and both CFG arms.",
     "The SDXL-AOT-PILOT minted 4 of these classes as 4 separate format-1 cells; those are RETIRED by the format-2 envelope + v2 contract facts (ck5 exact identity: recipe change strands old cells, correct and expected).",
@@ -25,7 +25,7 @@
   ],
   "text_lens": [77],
   "guidance_scales": [1.0, 5.0],
-  "declaration_module": "sdxl.aot_declaration",
+  "declaration_module": "sdxl.main",
   "specialization": {
     "return_dict": false
   },

--- a/tests/fixtures/fleet_mint_requests/wan-2.2/i2v-a14b.mint.json
+++ b/tests/fixtures/fleet_mint_requests/wan-2.2/i2v-a14b.mint.json
@@ -1,0 +1,36 @@
+{
+  "_declaration": "wan-2.2/src/wan_2_2/main.py \u2014 the @endpoint(compile=...) blocks. pgw#1107: ONE declaration per family, on the class decorators; aot/declaration.py and src/wan_2_2/aot_declaration.py are DELETED.",
+  "_notes": [
+    "pgw#758: ONE cell for the family's whole declared class set — the former i2v-a14b-{transformer,transformer_2,vae-decode}.mint.json trio collapsed here and ie#574 dropped the decoder entry; targets/forks/class rows derive from declaration.py.",
+    "I2V conditions by CHANNEL CONCATENATION (in_channels=36 = 16 noisy + 4 mask + 16 cond, read off the module's own config by the declaration's ('config','in_channels') axis) — no request vocabulary needed.",
+    "ie#574: the decoder is NOT a target and not in this cell (compiling it is a measured 0.46x); lora_bucket scopes to branch-capable denoisers by composed truth. See t2v-a14b.mint.json notes for lane/bucket/deploy-time caveats — identical here."
+  ],
+  "family": "wan-2.2-i2v-a14b",
+  "weight_lane": "",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 64,
+  "shapes": [
+    [1280, 720, 81],
+    [720, 1280, 81]
+  ],
+  "text_lens": [512],
+  "guidance_scales": [1.0],
+  "declaration_module": "wan_2_2.main",
+  "specialization": {
+    "return_dict": false,
+    "text_dim": 4096,
+    "timestep_kind": "scalar_per_batch",
+    "conditioning": "channel_concat_36 = 16 noisy + 4 mask + 16 cond"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/wan22-i2v-a14b:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "WanPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 80.0
+}

--- a/tests/fixtures/fleet_mint_requests/wan-2.2/t2v-a14b.mint.json
+++ b/tests/fixtures/fleet_mint_requests/wan-2.2/t2v-a14b.mint.json
@@ -1,0 +1,40 @@
+{
+  "_declaration": "wan-2.2/src/wan_2_2/main.py \u2014 the @endpoint(compile=...) blocks. pgw#1107: ONE declaration per family, on the class decorators; aot/declaration.py and src/wan_2_2/aot_declaration.py are DELETED.",
+  "_notes": [
+    "pgw#758 (Paul's ruling): ONE mint invocation -> ONE cell for the family's whole declared class set. The former t2v-a14b-{transformer,transformer_2,vae-decode}.mint.json trio collapsed into this file, and ie#574 then dropped the decoder entry entirely; targets/forks/class rows all derive from declaration.py — a request naming target/fork/class_dims/dynamic is refused by name.",
+    "ie#574: THE DECODER IS NOT IN THIS CELL. Compiling AutoencoderKLWan is a measured 0.46x (10.305 s vs 4.413 s eager, 686 s compile, 75.36 GiB peak, two rigs), so the cell covers the two denoisers only and decode serves eager by declaration. 'precision' below is the CELL label; lora_bucket applies per target by COMPOSED truth (branch-capable denoisers).",
+    "batch is DECLARED 1 in the class rows (ie#566 G2): diffusers runs Wan CFG as TWO SEQUENTIAL BATCH-1 forwards, so guidance changes call COUNT, not traced shape. guidance_scales stays [1.0] as the honest CFG-class label.",
+    "weight_lane is '' (plain bf16) because that is what wan-2.2 actually serves. aot_mint.lane_admitted REFUSES this lane without --allow-regressed-lanes (pgw#730); the ~7% AOTI regression was measured on the conv-dominated sdxl UNet and may not transfer to a pure DiT.",
+    "lora_bucket=128 matches the endpoint's @endpoint declaration (armed unconditionally at boot). Under AOT it needs pgw#725's input-lifted adapter on the denoisers, sequenced AFTER wan by pgw#722.",
+    "source_digest and declared_vram_gb are DEPLOY-TIME facts: fill source_digest from the release before minting; declared_vram_gb must be the SERVING release's envelope, not the mint pod's.",
+    "specialization here carries only CELL-SHARED frozen facts; per-entry fork arms and shape_strategy are stamped by the mint. The old per-target blocks (in_channels=36 channel-concat on i2v, z_dim/frames_baked on the VAE) are declaration/config truths the mint reads off the composed modules."
+  ],
+  "family": "wan-2.2-t2v-a14b",
+  "weight_lane": "",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [1280, 720, 81],
+    [720, 1280, 81]
+  ],
+  "text_lens": [512],
+  "guidance_scales": [1.0],
+  "declaration_module": "wan_2_2.main",
+  "specialization": {
+    "return_dict": false,
+    "text_dim": 4096,
+    "timestep_kind": "scalar_per_batch",
+    "conditioning": "text_only"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/wan22-t2v-a14b:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "WanPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 80.0
+}

--- a/tests/fixtures/fleet_mint_requests/wan-2.2/ti2v-5b.mint.json
+++ b/tests/fixtures/fleet_mint_requests/wan-2.2/ti2v-5b.mint.json
@@ -1,0 +1,35 @@
+{
+  "_declaration": "wan-2.2/src/wan_2_2/main.py \u2014 the @endpoint(compile=...) blocks. pgw#1107: ONE declaration per family, on the class decorators; aot/declaration.py and src/wan_2_2/aot_declaration.py are DELETED.",
+  "_notes": [
+    "pgw#758: ONE cell for the family's whole declared class set — the former ti2v-5b-{transformer,vae-decode}.mint.json pair collapsed here and ie#574 dropped the decoder entry; targets/forks/class rows derive from declaration.py (transformer GC-3 per-token timestep, expand_timesteps=true).",
+    "Every future duration bucket is a new GRAPH CLASS ROW in declaration.py, which under pgw#758 lands as another named entry in this same cell. (The old note about the frame axis never being symbolic on vae.decode is moot: ie#574 removed that target.)",
+    "ie#574: the ~21k-node decode graph is NOT exported — compiling this VAE is a measured 0.46x, and it was the whole compile budget. lora_bucket=0: this family's endpoint declares no adapter bucket.",
+    "source_digest and declared_vram_gb are DEPLOY-TIME facts — fill from the serving release before minting."
+  ],
+  "family": "wan-2.2-ti2v-5b",
+  "weight_lane": "",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 0,
+  "shapes": [
+    [1280, 704, 121]
+  ],
+  "text_lens": [512],
+  "guidance_scales": [1.0],
+  "declaration_module": "wan_2_2.main",
+  "specialization": {
+    "return_dict": false,
+    "text_dim": 4096,
+    "timestep_kind": "per_token_float32"
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/wan22-ti2v-5b:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "WanPipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 24.0
+}

--- a/tests/fixtures/fleet_mint_requests/z-image/transformer-cfg-off.mint.json
+++ b/tests/fixtures/fleet_mint_requests/z-image/transformer-cfg-off.mint.json
@@ -1,0 +1,97 @@
+{
+  "_declaration": "z-image/src/z_image/main.py \u2014 the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/z_image/aot_declaration.py are DELETED.",
+  "_status": "READY. All three mint blockers (B1/B2/B3) are resolved, so the declaration no longer refuses at import or at mint.",
+  "_notes": [
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused); `fork` states the minted class's arm values. z-image's `cfg` fork has NO source binding \u2014 the CFG regime is a request-time fact (the guidance scale), not a composed pipeline/module field, so the mint keys it but cannot assert it from composition.",
+    "THE NO-CFG ARM: guidance 0.0 takes the batch-1 branch (`apply_cfg = do_classifier_free_guidance and current_guidance_scale > 0`, pipeline_z_image.py:513). BOTH turbo lanes (the PAI 2603 8-step LoRA distill at adapter weight 0.8, and the official Turbo DMD 9-step checkpoint) pin guidance 0.0 and therefore SHARE this arity-1 graph \u2014 fuse-once LoRA is a pure parameter update, same graph. Measured 4327 nodes at N=1 vs 4373 at N=2.",
+    "shape_strategy is dynamic-collapse (#730 ratified for DiTs), so the 10 declared aspect rows collapse to ONE artifact per CFG arm. The derived latent hull is [90, 240] multiple-of-2 on both x[2] and x[3] \u2014 DERIVED by the SDK from the class rows, never hand-written here.",
+    "#730 DOES NOT HOLD THIS LANE. The 6.9-7.0% AOTI gap was root-caused as inductor's channels-last layout opt bailing when a CONVOLUTION operand carries a free symbol; #730 S4 states the scope outright \u2014 HOLD = conv-bearing sdxl-UNet-class lanes, UNHELD = DiTs, naming z-image. `transformer_z_image.py` has ZERO nn.Conv layers (counted 2026-07-28), so `decide_layout_opt` bails at nconv==0 in BOTH arms and there is nothing to lose.",
+    "CAVEAT for the mint operator: `aot_mint.lane_admitted` still hard-refuses every non-PARITY lane with a message citing #730, even though #730 is closed and explicitly UNHELD for DiTs. weight_lane 'w8a8' is a PARITY lane so this request is unaffected \u2014 but a plain-bf16 z-image mint would be refused by a stale gate. Flagged to the coordinator (ie#571 gap F).",
+    "strict=true is CONDITIONAL ON THE PRE-WARM (blocker B2). Measured: strict export FAILS COLD \u2014 'Unsupported context manager ... Dynamo does not know how to enter a device context manager' \u2014 because ZImageRopeEmbedder.__call__ builds its rope tables lazily inside `with torch.device(\"cpu\"):` (transformer_z_image.py:328). One call to populate freqs_cis before export fixes it (4285 nodes). Until the mint path performs that pre-warm in an ORDERED way, this request cannot be honestly run.",
+    "warm_changes_key=true is z-image's headline fact and the opposite of sdxl's False: the pre-warm is NOT neutral. Cold non-strict export traces the rope-table construction INTO the graph (4327 nodes); pre-warmed export bakes the finished tables as constants (4285, -42). Same model, same inputs, two artifacts \u2014 a mint-order dependence that lands on pgw#699's double-mint determinism gate.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128): base is armed with canonical zeroed rank-128 branches so bare and runtime-overlay requests share one compiled graph without recompilation or state leakage.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately \u2014 fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope (Resources(vram_gb=40.0) is the endpoint's declared floor), not the mint pod's."
+  ],
+  "family": "z-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 1,
+  "lora_bucket": 128,
+  "shapes": [
+    [
+      1024,
+      1024
+    ],
+    [
+      1152,
+      864
+    ],
+    [
+      864,
+      1152
+    ],
+    [
+      1248,
+      832
+    ],
+    [
+      832,
+      1248
+    ],
+    [
+      1280,
+      720
+    ],
+    [
+      720,
+      1280
+    ],
+    [
+      1408,
+      1408
+    ],
+    [
+      1920,
+      1088
+    ],
+    [
+      1088,
+      1920
+    ]
+  ],
+  "text_lens": [
+    512
+  ],
+  "guidance_scales": [
+    0.0
+  ],
+  "dynamic": [],
+  "fork": {
+    "cfg": false
+  },
+  "declaration_module": "z_image.main",
+  "specialization": {
+    "return_dict": false,
+    "patch_size": 2,
+    "f_patch_size": 1,
+    "in_channels": 16,
+    "cap_feat_dim": 2560,
+    "dim": 3840,
+    "n_layers": 30,
+    "vae_scale_factor": 8,
+    "cfg_batching": "no CFG \u2014 batch-1 graph (arity N=1), shared by BOTH turbo lanes",
+    "cfg_normalization": false,
+    "cfg_truncation": 1.0
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/z-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "ZImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 40.0
+}

--- a/tests/fixtures/fleet_mint_requests/z-image/transformer-cfg-on.mint.json
+++ b/tests/fixtures/fleet_mint_requests/z-image/transformer-cfg-on.mint.json
@@ -1,0 +1,63 @@
+{
+  "_declaration": "z-image/src/z_image/main.py — the @endpoint(compile=...) block. pgw#1107: ONE declaration, on the class decorator; aot/declaration.py and src/z_image/aot_declaration.py are DELETED.",
+  "_status": "READY. All three mint blockers (B1/B2/B3) are resolved, so the declaration no longer refuses at import or at mint.",
+  "_notes": [
+    "pgw#739: `dynamic` derives from declaration.py's class rows (hand rows are refused); `fork` states the minted class's arm values. z-image's `cfg` fork has NO source binding — the CFG regime is a request-time fact (the guidance scale), not a composed pipeline/module field, so the mint keys it but cannot assert it from composition.",
+    "THE CFG ARM: z-image is the ONE family in the pgw#728 survey whose CFG genuinely changes traced shape. pipeline_z_image.py:513-518 batches CFG into ONE forward — `latents.repeat(2,1,1,1)` plus a LIST CONCATENATION `prompt_embeds + negative_prompt_embeds` — so the pytree ARITY doubles to N=2. Measured: N=1 is 4327 nodes, N=2 is 4373. Two graphs, not one graph at two sizes. (Contrast flux2 and qwen, whose diffusers 0.39 pipelines run CFG as two SEQUENTIAL batch-1 forwards under cache_context('cond')/('uncond') — there the guidance axis changes call COUNT, not traced shape, and their endpoints' 'batch-2 graph' comments are wrong.)",
+    "shape_strategy is dynamic-collapse (#730 ratified for DiTs), so the 10 declared aspect rows collapse to ONE artifact per CFG arm. The derived latent hull is [90, 240] multiple-of-2 on both x[2] and x[3] — DERIVED by the SDK from the class rows, never hand-written here.",
+    "#730 DOES NOT HOLD THIS LANE. The 6.9-7.0% AOTI gap was root-caused as inductor's channels-last layout opt bailing when a CONVOLUTION operand carries a free symbol; #730 S4 states the scope outright — HOLD = conv-bearing sdxl-UNet-class lanes, UNHELD = DiTs, naming z-image. `transformer_z_image.py` has ZERO nn.Conv layers (counted 2026-07-28), so `decide_layout_opt` bails at nconv==0 in BOTH arms and there is nothing to lose.",
+    "CAVEAT for the mint operator: `aot_mint.lane_admitted` still hard-refuses every non-PARITY lane with a message citing #730, even though #730 is closed and explicitly UNHELD for DiTs. weight_lane 'w8a8' is a PARITY lane so this request is unaffected — but a plain-bf16 z-image mint would be refused by a stale gate. Flagged to the coordinator (ie#571 gap F).",
+    "strict=true is CONDITIONAL ON THE PRE-WARM (blocker B2). Measured: strict export FAILS COLD — 'Unsupported context manager ... Dynamo does not know how to enter a device context manager' — because ZImageRopeEmbedder.__call__ builds its rope tables lazily inside `with torch.device(\"cpu\"):` (transformer_z_image.py:328). One call to populate freqs_cis before export fixes it (4285 nodes). Until the mint path performs that pre-warm in an ORDERED way, this request cannot be honestly run.",
+    "warm_changes_key=true is z-image's headline fact and the opposite of sdxl's False: the pre-warm is NOT neutral. Cold non-strict export traces the rope-table construction INTO the graph (4327 nodes); pre-warmed export bakes the finished tables as constants (4285, -42). Same model, same inputs, two artifacts — a mint-order dependence that lands on pgw#699's double-mint determinism gate.",
+    "lora_bucket=128 mirrors the endpoint's Compile(lora_bucket=128): base is armed with canonical zeroed rank-128 branches so bare and runtime-overlay requests share one compiled graph without recompilation or state leakage.",
+    "source_digest, declared_vram_gb and the serving image digest are DEPLOY-TIME facts. source_digest is left empty deliberately — fill it from the release before minting; declared_vram_gb must be the SERVING release's envelope (Resources(vram_gb=40.0) is the endpoint's declared floor), not the mint pod's."
+  ],
+  "family": "z-image",
+  "target": "transformer",
+  "weight_lane": "w8a8",
+  "precision": "bf16",
+  "batch": 2,
+  "lora_bucket": 128,
+  "shapes": [
+    [1024, 1024],
+    [1152, 864],
+    [864, 1152],
+    [1248, 832],
+    [832, 1248],
+    [1280, 720],
+    [720, 1280],
+    [1408, 1408],
+    [1920, 1088],
+    [1088, 1920]
+  ],
+  "text_lens": [512],
+  "guidance_scales": [4.0],
+  "dynamic": [],
+  "fork": {
+    "cfg": true
+  },
+  "declaration_module": "z_image.main",
+  "specialization": {
+    "return_dict": false,
+    "patch_size": 2,
+    "f_patch_size": 1,
+    "in_channels": 16,
+    "cap_feat_dim": 2560,
+    "dim": 3840,
+    "n_layers": 30,
+    "vae_scale_factor": 8,
+    "cfg_batching": "one batch-2 forward (arity N=2 over the list inputs)",
+    "cfg_normalization": false,
+    "cfg_truncation": 1.0
+  },
+  "lora_fqns": [],
+  "lifted_inputs": [],
+  "strict": true,
+  "source_ref": "tensorhub/z-image:prod",
+  "source_digest": "",
+  "closure_roots": [],
+  "pipeline_class": "ZImagePipeline",
+  "dtype": "bf16",
+  "storage_dtype": "",
+  "declared_vram_gb": 40.0
+}

--- a/tests/test_measure_document_pgw1153.py
+++ b/tests/test_measure_document_pgw1153.py
@@ -1,0 +1,410 @@
+"""pgw#1153 — the documented command must work on the artifacts that exist.
+
+pgw#1134 shipped ``python -m gen_worker.measure_child <request>.mint.json``,
+wrote that line into ltx-video-2.3's OQ-3 ``resolves_when`` (production endpoint
+source) and into this SDK's own ``MintBlocker`` docstring — and decoded the file
+as a runtime ``MintRequest``. Every ``aot/*.mint.json`` an endpoint repo commits
+is a flattened DECLARATION payload instead, so the documented invocation died on
+``ValidationError: Object missing required field 'function'`` in the first
+millisecond of a rented B200. A documented command that had never been executed
+end to end against a real committed file.
+
+This file is the fence that makes that impossible to reintroduce:
+
+1. **Every committed ``aot/*.mint.json`` in the fleet parses through the real
+   entry** — the corpus under ``tests/fixtures/fleet_mint_requests/`` is a
+   verbatim copy of all 24 of them (inference-endpoints ``dfc6e2bc``), and each
+   one is driven through :func:`measure_child.load_document`, which is the ONE
+   decoder ``main()`` uses. On the pre-fix tree the same corpus raises
+   ``ValidationError`` on file one.
+2. **The derivation is exercised, not asserted** — the three answers a committed
+   payload does not spell out (which function, which targets, which checkpoint)
+   are taken from the declaration the payload NAMES, on a real endpoint with a
+   real ``@endpoint(compile=...)`` block.
+3. **The documented invocation runs a real measurement end to end** — a
+   committed-SHAPE payload for micro-diffusion, through ``main(argv)``, through
+   the real loader and the real export loop, to a real ``MeasureReport``.
+4. **Nothing the widened door admits can publish** — the new document type is
+   input-side only, exactly as :class:`measure_child.MeasureJob` is.
+
+Cardless: CPU throughout, inductor faked at the one seam it is exercised at, no
+GPU, no mint, no pod, no network (slot resolution is offline by construction).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import measure_child
+from gen_worker.mint_process import CompileCellSpec, MintRequest
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+FLEET = REPO / "tests" / "fixtures" / "fleet_mint_requests"
+FAMILY = "micro-diffusion"
+
+#: Every committed request in the fleet at the time this fence was written.
+#: A count, so that a fixture quietly disappearing fails here rather than
+#: shrinking the corpus in silence.
+FLEET_COUNT = 24
+
+#: The committed files that name no checkpoint at all (``source_ref: ""``).
+#: SHRINK-ONLY, and each one costs an operator a `--slot` flag they have to
+#: source themselves — which is the reason to fill them, not a reason to widen
+#: this. inference-endpoints' own `scripts/lint_mint_requests.py` holds the
+#: same inventory on the artifact side.
+NO_SOURCE_REF = frozenset({
+    "flux.2-klein-4b/transformer-4b.mint.json",
+    "flux.2-klein-9b/transformer-9b.mint.json",
+})
+
+
+def _committed() -> List[Path]:
+    return sorted(FLEET.rglob("*.mint.json"))
+
+
+# ---------------------------------------------------------------------------
+# 1. THE FENCE: every committed file, through the real entry.
+# ---------------------------------------------------------------------------
+
+
+def test_the_corpus_is_the_whole_fleet() -> None:
+    files = _committed()
+    assert len(files) == FLEET_COUNT, (
+        f"the corpus is {len(files)} files, not {FLEET_COUNT} — a fence that "
+        f"shrinks silently is not a fence")
+    assert len({p.parent.name for p in files}) == 7
+
+
+@pytest.mark.parametrize(
+    "path", _committed(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_every_committed_mint_request_parses_through_the_documented_entry(
+    path: Path,
+) -> None:
+    """RED on the pre-fix tree, on file one.
+
+    ``load_document`` is the decoder ``main()`` calls, so this is the actual
+    first instruction of the documented command — not a re-implementation of
+    it, which is the mistake that let the two shapes drift apart.
+    """
+    doc, flat = measure_child.load_document(path.read_bytes())
+
+    body = json.loads(path.read_text())
+    family = (doc.family or flat.family).strip()
+
+    assert family, f"{path}: names no family, so nothing selects a declaration"
+    assert family == body["family"]
+    assert doc.declaration_module.strip(), (
+        f"{path}: names no `declaration_module`, so the documented command has "
+        f"no image to collect endpoints from (pgw#1107)")
+    if f"{path.parent.name}/{path.name}" in NO_SOURCE_REF:
+        assert not doc.source_ref.strip(), (
+            f"{path}: names a source_ref now — take it OUT of NO_SOURCE_REF, "
+            f"which is shrink-only")
+    else:
+        assert doc.source_ref.strip(), (
+            f"{path}: names no `source_ref`, so nothing binds the slot that "
+            f"owns the compile targets and every invocation of the documented "
+            f"command needs a --slot flag. Fill it, or record it in "
+            f"NO_SOURCE_REF with the cost stated")
+    # The committed payload is the DECLARATION half: it carries none of the
+    # runtime envelope, which is exactly why decoding it as one could not work.
+    assert not doc.function and not doc.modules and doc.cfg is None
+    assert not doc.slots
+
+
+@pytest.mark.parametrize(
+    "path", _committed(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_no_committed_request_can_carry_an_output_destination(
+    path: Path,
+) -> None:
+    """pgw#1134's structural property, held at the WIDENED door.
+
+    The reason a measure run cannot publish is that the destination never
+    enters the process. Widening what the file may say is exactly the change
+    that could have undone it.
+    """
+    doc, _flat = measure_child.load_document(path.read_bytes())
+    for field in measure_child.WITHHELD_FIELDS:
+        assert not hasattr(doc, field), field
+
+
+def test_the_document_type_is_input_side_only() -> None:
+    fields = set(measure_child.MeasureDocument.__struct_fields__)
+    assert fields.isdisjoint(measure_child.WITHHELD_FIELDS)
+    assert set(measure_child.WITHHELD_FIELDS) <= set(
+        MintRequest.__struct_fields__), (
+        "the withheld list must name fields a MintRequest actually carries")
+    # Everything the runtime envelope contributes is still a MintRequest field;
+    # the two additions are the committed payload's own, and both are inputs.
+    assert fields - set(MintRequest.__struct_fields__) == {
+        "declaration_module", "source_ref"}
+
+
+def test_a_runtime_mint_request_still_decodes_through_the_same_door(
+    tmp_path: Path,
+) -> None:
+    """The OTHER real artifact — a mint work root's ``request.json`` — has to
+    keep working, and through the SAME decoder. Two decoders is the defect."""
+    cfg = CompileCellSpec(family=FAMILY, targets=("transformer",))
+    request = MintRequest(
+        function="generate-w8a8", modules=("micro_diffusion.main_w8a8",),
+        family=FAMILY, arm_token="arm1-deadbeef",
+        target=str(tmp_path / "cell.tar.gz"), work_root=str(tmp_path / "work"),
+        report=str(tmp_path / "mint.json"), resume=str(tmp_path / "bank"),
+        cfg=cfg)
+    raw = msgspec.json.encode(request)
+    assert b"cell.tar.gz" in raw
+
+    doc, _flat = measure_child.load_document(raw)
+
+    assert doc.function == "generate-w8a8" and doc.cfg is not None
+    assert doc.cfg.family == FAMILY and doc.cfg.targets == ("transformer",)
+    for field in measure_child.WITHHELD_FIELDS:
+        assert not hasattr(doc, field), field
+
+
+# ---------------------------------------------------------------------------
+# 2. THE DERIVATION, on a real declaration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def micro_src() -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("diffusers")
+    if str(MICRO_SRC) not in sys.path:
+        sys.path.insert(0, str(MICRO_SRC))
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(
+    micro_src: None, tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    from micro_diffusion.weights import SEED, materialize_w8a8
+
+    return materialize_w8a8(
+        tmp_path_factory.mktemp("micro-1153") / "w8a8", seed=SEED)
+
+
+MODULES = ("harness.rig_runtime", "micro_diffusion.main_w8a8")
+
+
+def _committed_shape(**over: Any) -> Dict[str, Any]:
+    """A committed ``aot/*.mint.json`` for micro-diffusion, in the shape the
+    fleet actually commits — flattened, declaration-named, no envelope."""
+    body: Dict[str, Any] = {
+        "_declaration": "micro_diffusion/main_w8a8.py — the @endpoint block",
+        "family": FAMILY,
+        "declaration_module": "micro_diffusion.main_w8a8",
+        "weight_lane": "w8a8",
+        "precision": "w8a8",
+        "batch": 1,
+        "lora_bucket": 0,
+        "text_lens": [],
+        "guidance_scales": [],
+        "strict": True,
+        "source_ref": "cozy/micro-diffusion:prod",
+        "source_digest": "",
+        "declared_vram_gb": 8.0,
+    }
+    body.update(over)
+    return body
+
+
+@pytest.fixture
+def on_path(monkeypatch: pytest.MonkeyPatch, micro_src: None) -> None:
+    monkeypatch.syspath_prepend(str(REPO / "tests"))
+    monkeypatch.setenv("PYTHONPATH", ":".join(
+        [str(REPO / "src"), str(REPO / "tests"), str(MICRO_SRC)]))
+
+
+def _resolve(body: Dict[str, Any], **kw: Any) -> measure_child.MeasureJob:
+    raw = json.dumps(body).encode()
+    doc, flat = measure_child.load_document(raw)
+    return measure_child.resolve_job(doc, flat, **kw)
+
+
+def test_the_three_answers_the_payload_omits_come_off_the_declaration(
+    on_path: None, w8a8_tree: Path,
+) -> None:
+    """A committed payload names a FAMILY and a MODULE. The function, the
+    compile targets and the target slot's checkpoint are all derived — which
+    is the whole of the fix, and each one of them is separately load-bearing.
+    """
+    job = _resolve(
+        _committed_shape(), slot_flags=[f"pipeline={w8a8_tree}"])
+
+    # (a) modules <- declaration_module.
+    assert job.modules == ("micro_diffusion.main_w8a8",)
+    # (b) function <- the endpoint declaring Compile(family=).
+    assert job.function == "generate-w8a8"
+    assert job.family == FAMILY and job.cfg.family == FAMILY
+    # (c) targets <- that endpoint's own Compile(targets=). Since pgw#1107 no
+    # committed payload carries them, and `compile_cache.resolve_targets`
+    # returns NOTHING for an empty tuple — the same defect one step later.
+    assert job.cfg.targets == ("transformer", "decoder")
+    assert job.slots["pipeline"].path == str(w8a8_tree)
+
+
+def test_source_ref_binds_to_the_slot_that_owns_the_targets(
+    on_path: None, tmp_path: Path,
+) -> None:
+    """The payload's one checkpoint goes to the one slot the declared targets
+    live on, decided from the declaration alone — the question has to be
+    answered BEFORE a checkpoint is opened."""
+    from gen_worker.registry import collect_endpoints
+
+    specs = collect_endpoints(list(MODULES))
+    spec = next(s for s in specs if s.name == "generate-w8a8")
+    assert measure_child._target_owner(spec, ("transformer", "decoder")) == (
+        "pipeline")
+
+    # And when the operator names it, the flag wins over the payload — without
+    # the payload's ref being resolved first and refusing on the way past.
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    job = _resolve(_committed_shape(), slot_flags=[f"pipeline={tree}"])
+    assert job.slots["pipeline"].path == str(tree)
+
+
+def test_an_explicit_function_overrides_the_derivation(
+    on_path: None, tmp_path: Path,
+) -> None:
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    job = _resolve(
+        _committed_shape(), function="generate-w8a8-turbo",
+        slot_flags=[f"pipeline={tree}"])
+    assert job.function == "generate-w8a8-turbo"
+
+
+# ---------------------------------------------------------------------------
+# 3. EVERY REFUSAL NAMES ITSELF, and none of them is a ValidationError.
+# ---------------------------------------------------------------------------
+
+
+def _refusal(body: Dict[str, Any], **kw: Any) -> measure_child.MeasureRefused:
+    with pytest.raises(measure_child.MeasureRefused) as caught:
+        _resolve(body, **kw)
+    assert caught.value.reason in measure_child.REASONS, caught.value.reason
+    return caught.value
+
+
+def test_a_payload_naming_no_module_refuses_by_name() -> None:
+    body = _committed_shape()
+    body.pop("declaration_module")
+    assert _refusal(body).reason == "no_declaration_module"
+
+
+def test_a_module_this_image_cannot_import_refuses_by_name() -> None:
+    body = _committed_shape(declaration_module="not_in_this_image.main")
+    refusal = _refusal(body)
+    assert refusal.reason == "declaration_module_unimportable"
+    assert "ENDPOINT'S OWN IMAGE" in refusal.detail
+
+
+def test_a_family_no_endpoint_declares_refuses_by_name(on_path: None) -> None:
+    refusal = _refusal(_committed_shape(family="not-a-family"))
+    assert refusal.reason == "function_underivable"
+    assert FAMILY in refusal.detail, (
+        "the refusal must say what this image DOES declare, or the operator "
+        "cannot tell a stale payload from the wrong pod")
+
+
+def test_a_ref_the_local_store_does_not_hold_refuses_without_downloading(
+    on_path: None,
+) -> None:
+    """A measure run never downloads. ``mint_process`` states the rule for the
+    mint child and a measurement of a mint inherits it — so a slot that is not
+    already on this machine is a refusal, not a 40 GiB fetch."""
+    refusal = _refusal(_committed_shape())
+    assert refusal.reason == "slots_unresolvable"
+    assert "never downloads" in refusal.detail
+    assert "--slot pipeline=" in refusal.detail
+
+
+def test_a_malformed_slot_flag_refuses_by_name(on_path: None) -> None:
+    assert _refusal(
+        _committed_shape(), slot_flags=["pipeline"]).reason == (
+        "slots_unresolvable")
+
+
+# ---------------------------------------------------------------------------
+# 4. THE DOCUMENTED INVOCATION, end to end, on a committed-shape file.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def faked_inductor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The compile half, cardless. The export is REAL; only the AOTInductor
+    call is stood in for, at the one seam pgw#1134's own suite fakes it."""
+    from gen_worker import aot_mint
+
+    real = aot_mint._export_entry
+
+    def _fake(*a: Any, **kw: Any) -> Any:
+        kw = dict(kw)
+        kw["compile_now"] = False
+        return real(*a, **kw)
+
+    monkeypatch.setattr(aot_mint, "_export_entry", _fake, raising=True)
+
+
+def test_the_documented_command_measures_a_committed_shape_file(
+    tmp_path: Path, w8a8_tree: Path, on_path: None,
+) -> None:
+    """THE acceptance, executed: a file in the shape endpoint repos commit,
+    the exact ``main()`` an operator invokes, a real load, a real export loop
+    and a real typed report — with no hand-written wire struct anywhere.
+    """
+    request = tmp_path / "transformer.mint.json"
+    request.write_text(json.dumps(_committed_shape()))
+    report_path = tmp_path / "measure.json"
+
+    rc = measure_child.main([
+        str(request), str(report_path), "--export-only",
+        f"--slot=pipeline={w8a8_tree}",
+    ])
+
+    report = msgspec.json.decode(
+        report_path.read_bytes(), type=measure_child.MeasureReport)
+    assert rc == measure_child.EXIT_OK, f"{report.reason}: {report.detail[:600]}"
+    assert report.ok and report.family == FAMILY
+    assert report.function == "generate-w8a8"
+    assert report.declared_classes == 3 and len(report.entries) == 3
+    assert all(e.ok and e.nodes > 0 for e in report.entries), report.entries
+    assert report.weights == "real"
+
+
+def test_a_file_that_is_not_a_request_at_all_exits_bad_job(
+    tmp_path: Path,
+) -> None:
+    request = tmp_path / "x.mint.json"
+    request.write_text("not json")
+    assert measure_child.main(
+        [str(request), str(tmp_path / "r.json")]) == measure_child.EXIT_BAD_JOB
+
+
+def test_every_committed_file_reaches_the_declaration_walk(
+    tmp_path: Path,
+) -> None:
+    """The end of the cardless road for the REAL fleet files: each one gets
+    past the decode and refuses only because this machine is not the
+    endpoint's image. On the pre-fix tree not one of them got that far.
+    """
+    seen = set()
+    for path in _committed():
+        doc, flat = measure_child.load_document(path.read_bytes())
+        with pytest.raises(measure_child.MeasureRefused) as caught:
+            measure_child.resolve_job(doc, flat)
+        seen.add(caught.value.reason)
+        assert caught.value.reason == "declaration_module_unimportable", (
+            f"{path}: {caught.value.reason}: {caught.value.detail[:300]}")
+    assert seen == {"declaration_module_unimportable"}

--- a/tests/test_measure_document_pgw1153.py
+++ b/tests/test_measure_document_pgw1153.py
@@ -13,10 +13,13 @@ This file is the fence that makes that impossible to reintroduce:
 
 1. **Every committed ``aot/*.mint.json`` in the fleet parses through the real
    entry** — the corpus under ``tests/fixtures/fleet_mint_requests/`` is a
-   verbatim copy of all 24 of them (inference-endpoints ``dfc6e2bc``), and each
+   verbatim copy of all 24 of them, and each
    one is driven through :func:`measure_child.load_document`, which is the ONE
    decoder ``main()`` uses. On the pre-fix tree the same corpus raises
-   ``ValidationError`` on file one.
+   ``ValidationError`` on file one. The corpus is a SNAPSHOT
+   (inference-endpoints ``dd41755``); the half that cannot go stale is that
+   repo's own ``scripts/lint_mint_requests.py``, which reads the real tree on
+   every PR — and which found sdxl naming a module ie#645 had deleted.
 2. **The derivation is exercised, not asserted** — the three answers a committed
    payload does not spell out (which function, which targets, which checkpoint)
    are taken from the declaration the payload NAMES, on a real endpoint with a


### PR DESCRIPTION
## The defect

`python -m gen_worker.measure_child <request>.mint.json` — the invocation pgw#1134 documented, and which sits verbatim in **production endpoint source** at `ltx-video-2.3/src/ltx_video_23/main.py` (OQ-3's `resolves_when`) — could not decode a single committed file. All **24 of 24** `aot/*.mint.json` in the fleet raise `ValidationError: Object missing required field 'function'`.

An operator following the runbook rents a B200 (~$5-6/hr) and exits `EXIT_BAD_JOB` in the first millisecond. That is the exact class of waste pgw#1134 was built to prevent, reintroduced by the instrument itself.

## Which side was wrong, and why

**The tool.** The committed payload is the canonical artifact operators hold, it is generated from the declaration and already fenced by the endpoint repos' own suites — and the three pieces `MeasureJob` wanted are pod-local facts a repo *cannot* commit: `slots` are paths on a rented machine, `function` is redundant with `family`, and `source_digest` is already left deliberately empty for exactly that reason. Making the files carry the runtime shape would be committing a lie.

## What shipped

ONE decoder — `load_document` — reads both documents that really exist (the committed declaration payload, and a mint work root's `request.json`). `resolve_job` derives what the payload does not spell out from the declaration it NAMES:

| piece | source |
|---|---|
| `modules` | the payload's `declaration_module` (widened once to the top-level package for sdxl's declaration-only module) |
| `function` | the endpoint declaring `Compile(family=)` — `--function` settles a family declared across two classes |
| `targets` | that endpoint's own `Compile(targets=)`. Since pgw#1107 **no** committed payload carries them, and `compile_cache.resolve_targets` returns nothing for an empty tuple — the same defect one step later |
| `slots` | `source_ref`, bound to the slot that owns those targets (decided from `slot_components`, before a checkpoint is opened), plus `--slot NAME=VALUE[,ref=REF]` |

**Slots resolve OFFLINE and never download.** `mint_process` states that rule for the mint child (*"a mint is compute, and a mint process that could download is one that can stall on a lemon host"*) and a measurement of a mint inherits it.

Three new `REASONS` tokens (`no_declaration_module`, `declaration_module_unimportable`, `function_underivable`) mean nothing that cannot start is untyped: each refusal names the missing piece and the flag that supplies it, is written to the report, and rides `KIND_MEASURE_ONLY`. pgw#1134's structural property is re-fenced at the widened door — `MeasureDocument` declares none of `WITHHELD_FIELDS`, so an artifact destination still cannot enter the process.

## The fence

`tests/test_measure_document_pgw1153.py` — 62 rows:

- **every committed `aot/*.mint.json` in the fleet**, verbatim copies under `tests/fixtures/fleet_mint_requests/` (inference-endpoints `dfc6e2bc`), driven through the real entry. **RED on the pre-fix tree: 24/24 `ValidationError`.**
- the documented invocation **end to end** through `main(argv)` against a committed-SHAPE payload, on micro-diffusion's real w8a8 tree, through the real loader and the real export loop.
- every refusal, by token; the input-side-only property of the new document type; a runtime `MintRequest` still decoding through the same door.

inference-endpoints carries the artifact-side half (`scripts/lint_mint_requests.py`) so a NEW committed file with a missing `declaration_module`/`family` is red there too.

## Cardless proof

The exact documented command, against a real committed file, on a machine with no CUDA:

```
$ cd inference-endpoints/wan-2.2
$ python -m gen_worker.measure_child aot/t2v-a14b.mint.json /tmp/wan.measure.json --slot pipeline=<tree>
INFO ... measure_only load_failed family=wan-2.2-t2v-a14b function=text-to-video
    OSError: Error no file named model_index.json found in directory <tree>
```

It decodes the committed file, derives the function from the family, derives the targets from the decorator, and runs the endpoint's OWN `setup()` through the real diffusers loader — stopping only on bytes this laptop does not have. With no `--slot` at all it gets as far as the payload's `source_ref` and refuses typed (`slots_unresolvable`) naming the flag.

No pods, no GPU, no mint, no compile, no downloads.

## Gates

`mypy src/gen_worker` clean (266 files), `ruff check src/gen_worker` clean, all nine fast-gate lint guards green, `assemble_changelog --check` green. Existing `tests/test_measure_only_pgw1134.py` 12/12 unchanged.

Unreleased — rides the next wheel per the pgw#1140 ledger.