### PR TITLE
pgw#1152: ExpectedIdentity gets ONE constructor, and a resolve answer may no longer state an EMPTY expectation

### DIFF
--- a/changelog.d/pgw1152.md
+++ b/changelog.d/pgw1152.md
@@ -45,3 +45,41 @@
   **All five test-side hand-registrations were removable with zero assertion changes** (pgw#735,
   pgw#844, pgw#1141 ×2, pgw#1033): once the readers ask the OBJECT, the fixture line existed only
   to hide the bug.
+
+- **pgw#1152 (remaining item): `ExpectedIdentity` gets ONE constructor, and the resolve answer
+  stops being allowed to state an EMPTY expectation.** The object every arm gate compares a cell
+  against was built by two independent maps — `aot_identity.expected_from_plan` (the hub PLAN
+  named the artifact) and `cell_resolve.ResolvedCell.expected_identity` (the §4.27 pull-by-key
+  resolve answered) — the same plan-vs-adopt pair that produced pgw#1108/#1122/#1141/#1141b.
+  Both now go through `ExpectedIdentity.named_by`, fenced as a fourth `ONE_CONSTRUCTOR` row in
+  `scripts/lint_arm_state_feeders.py`. The graph contract is passed rather than read off the
+  source because it is a property of the ARM, not of the artifact; every other axis is copied by
+  name, so a new axis cannot reach one source and not the other.
+
+  **The consolidation surfaced a live divergence, exactly as `_ArmOrder` did.** Not a missing
+  struct field this time but a missing REQUIREMENT: `plan._artifact` `_require`s all six artifact
+  fields and the arm `_require`s `graph_contract_digest`, while the resolve path required none of
+  them. Measured on unmodified `origin/master`, a `200 {"found": true}` answer with an empty
+  `publisher_org`, `graph_contract`, `toolchain_digest`, `env_seal_digest`, `content_digest` or
+  `cell_ref` was ACCEPTED, and produced an expectation stating that axis as `''`. That empty
+  expectation is refused — by `verify_declared_identity`, *after* `materialize` has already
+  downloaded the whole cell. `cell_resolve._REQUIRED` refuses it at the answer instead, under the
+  hub's own `cell_resolve_incomplete` code, because the pod reaches the same verdict from the same
+  evidence and a second word for one condition is how routes drift apart.
+
+  `aot_identity.artifact_identity` is classified `PROJECTION`, not migrated: it reads the OBSERVED
+  side out of the mint's stored meta blocks — a `Mapping`, not a source that NAMED an artifact —
+  and is what the expectation is compared *against*. A load-time accounting check now makes an
+  unverified axis unspellable: every `ExpectedIdentity` field is either in `_COMPARED_AXES` or
+  named in `_VERIFIED_ELSEWHERE` with the gate that does compare it, or the module refuses to
+  import.
+
+  The `_VERIFIED_ELSEWHERE` claim is itself CHECKED rather than trusted, which is this fence
+  family's rule (the arm-state lint accepts a `RECOGNIZER` row only after verifying it
+  structurally). The checked property is that the named gate is *handed* the axis — a gate that
+  never receives the expectation cannot be the gate that checks it. That test caught a real
+  mis-attribution while it was being written: the entry first named
+  `receipts.refuse_untrusted_publisher`, which mentions `publisher_org` but asks a different
+  question (is this producer trusted AT ALL, not is it the one the spec NAMED). The gate that
+  compares the named org to the signed receipt's `publisher_org_id`, fail-closed on silence
+  (§4.26), is `fleet_cells.arm_ordered`.

--- a/scripts/arm_state_feeders_allowlist.txt
+++ b/scripts/arm_state_feeders_allowlist.txt
@@ -65,3 +65,4 @@ tests/test_boot_phases_pgw764.py::test_serving_mode_distinguishes_aot_from_jit_f
 # twice; that is pgw#1150's cause, restated.)
 # ---------------------------------------------------------------------------
 src/gen_worker/executor.py::_selection_for::_CompileArtifactSelection()  PROJECTION  built from a MINT object (ref + snapshot_digest off the SelfMint), not from a materialized artifact triple — a different source, and the `self_mint=True` flag says so
+src/gen_worker/aot_identity.py::artifact_identity::ExpectedIdentity()  PROJECTION  the OBSERVED side, read out of the mint's stored meta blocks — a Mapping, not a source that NAMED an artifact; it is what `verify_declared_identity` compares the expectation AGAINST, and it deliberately leaves publisher_org empty because an artifact cannot attest to its own producer

--- a/scripts/lint_arm_state_feeders.py
+++ b/scripts/lint_arm_state_feeders.py
@@ -203,6 +203,14 @@ ONE_CONSTRUCTOR: Tuple[OneConstructor, ...] = (
         why="pgw#1152: both order builders also built the selection from the "
             "same three fields; it is now built once, with the order",
     ),
+    OneConstructor(
+        name="ExpectedIdentity",
+        constructor=("aot_identity.py", "ExpectedIdentity.named_by"),
+        why="pgw#1152's last reported duplicate: this is the object EVERY arm "
+            "gate compares a cell against, and its two expectation sources "
+            "are the hub PLAN and the §4.27 pull-by-key resolve — the same "
+            "plan-vs-adopt pair that produced pgw#1108/#1122/#1141/#1141b",
+    ),
 )
 
 

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -40,12 +40,34 @@ would add surface this PR cannot reach.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Protocol
 
 import msgspec
 
 from . import cell_key, env_seal
 from .plan import Plan
+
+
+class NamesAnArtifact(Protocol):
+    """A source that NAMES one compiled cell, by the axes it already carries.
+
+    Both expectation sources satisfy it: the Plan's ``ArtifactRef`` (the hub
+    named the artifact) and ``cell_resolve.ResolvedCell`` (the hub answered a
+    pull by derived key). They are DIFFERENT sources of the same expectation,
+    which is why there is one map and not two.
+    """
+
+    @property
+    def cell_key(self) -> str: ...
+
+    @property
+    def toolchain_digest(self) -> str: ...
+
+    @property
+    def env_seal_digest(self) -> str: ...
+
+    @property
+    def publisher_org(self) -> str: ...
 
 
 class ExpectedIdentity(msgspec.Struct, frozen=True):
@@ -55,6 +77,11 @@ class ExpectedIdentity(msgspec.Struct, frozen=True):
     identity the hub digested. Every field is a digest that some producer
     already committed to; none is probed from this runtime (the runtime axes
     are ``aot_serve.verify``'s job and stay there).
+
+    ONE map builds it — :meth:`named_by`, fenced by
+    ``scripts/lint_arm_state_feeders.py``. This is the object every arm gate
+    compares a cell against, so a field reaching one source's map and not the
+    other's is pgw#1150's defect one level in.
     """
 
     cell_key: str
@@ -80,6 +107,26 @@ class ExpectedIdentity(msgspec.Struct, frozen=True):
     # row to delete it as readerless — this is its other possible resolution,
     # and the two lanes must not settle it independently).
 
+    @classmethod
+    def named_by(
+        cls, named: NamesAnArtifact, graph_contract_digest: str,
+    ) -> ExpectedIdentity:
+        """THE map from a source that named an artifact to the expectation.
+
+        The graph contract is passed rather than read off ``named`` because it
+        is a property of the ARM, not of the artifact: the Plan carries it on
+        ``arm``, the resolve answer carries it as ``graph_contract``. Every
+        other axis is the artifact's own and is copied by name, so a new axis
+        cannot reach one source and not the other.
+        """
+        return ExpectedIdentity(
+            cell_key=named.cell_key,
+            toolchain_digest=named.toolchain_digest,
+            env_seal_digest=named.env_seal_digest,
+            graph_contract_digest=graph_contract_digest,
+            publisher_org=named.publisher_org,
+        )
+
 
 def expected_from_plan(plan: Plan) -> ExpectedIdentity | None:
     """The expectation for a plan's arm, or ``None`` when it names no artifact.
@@ -93,13 +140,7 @@ def expected_from_plan(plan: Plan) -> ExpectedIdentity | None:
     artifact = plan.arm.artifact
     if artifact is None:
         return None
-    return ExpectedIdentity(
-        cell_key=artifact.cell_key,
-        toolchain_digest=artifact.toolchain_digest,
-        env_seal_digest=artifact.env_seal_digest,
-        graph_contract_digest=plan.arm.graph_contract_digest,
-        publisher_org=artifact.publisher_org,
-    )
+    return ExpectedIdentity.named_by(artifact, plan.arm.graph_contract_digest)
 
 
 def artifact_identity(meta: Mapping[str, Any]) -> ExpectedIdentity:
@@ -114,6 +155,12 @@ def artifact_identity(meta: Mapping[str, Any]) -> ExpectedIdentity:
     ``publisher_org`` is deliberately empty here. An artifact cannot attest to
     its own publisher — that claim lives inside the hub-signed receipt, and
     :func:`verify_receipt_publisher` is where it is checked.
+
+    Not built through :meth:`ExpectedIdentity.named_by`, and classified
+    PROJECTION in the fence's allowlist for that reason: this is the OBSERVED
+    side, DERIVED from the mint's stored blocks rather than copied from a
+    source that named an artifact. A projection from a different source shape
+    is not a second copy of the map.
     """
     seal = meta.get(env_seal.SEAL_KEY)
     toolchain = meta.get("toolchain")
@@ -136,6 +183,30 @@ def artifact_identity(meta: Mapping[str, Any]) -> ExpectedIdentity:
 _COMPARED_AXES: tuple[str, ...] = (
     "cell_key", "toolchain_digest", "env_seal_digest", "graph_contract_digest")
 
+#: The axes NOT compared here, each with the gate that does compare them. An
+#: axis is verified here or it is verified somewhere named — never neither.
+#: The claim is CHECKED, not trusted: `test_artifact_identity_pgw903.py`
+#: imports each named gate and asserts it reads the axis.
+_VERIFIED_ELSEWHERE: Mapping[str, str] = {
+    "publisher_org": (
+        "fleet_cells.arm_ordered — an artifact cannot attest to its own "
+        "producer, so §4.26's match is against the hub-signed RECEIPT's "
+        "publisher_org_id, fail-closed on silence. Distinct from "
+        "receipts.refuse_untrusted_publisher, which asks whether the producer "
+        "is trusted AT ALL, not whether it is the one the spec named"),
+}
+
+if set(_COMPARED_AXES) | set(_VERIFIED_ELSEWHERE) != set(
+    ExpectedIdentity.__struct_fields__
+):
+    # Unspellable rather than merely tested: an axis added to the identity and
+    # to neither set is an axis NOTHING verifies, and a silently unverified
+    # axis on this object is how a cell gets armed on an unchecked claim.
+    raise AssertionError(
+        "every ExpectedIdentity axis must be compared by "
+        "verify_declared_identity or named in _VERIFIED_ELSEWHERE; "
+        f"unaccounted: {sorted(set(ExpectedIdentity.__struct_fields__) - set(_COMPARED_AXES) - set(_VERIFIED_ELSEWHERE))}")
+
 
 def verify_declared_identity(
     meta: Mapping[str, Any], expected: ExpectedIdentity,
@@ -157,9 +228,10 @@ def verify_declared_identity(
         want, got = getattr(expected, axis), getattr(have, axis)
         if not want:
             # An expectation that names no value cannot be verified, and an
-            # unverifiable expectation must not read as a pass. The Plan
-            # refuses an artifact missing any of these, so reaching this
-            # branch means a caller built an ExpectedIdentity by hand.
+            # unverifiable expectation must not read as a pass. BOTH sources
+            # refuse an artifact missing any of these at the point they read
+            # it — `plan._artifact` and `cell_resolve.resolve` — so reaching
+            # this branch means a caller built an ExpectedIdentity by hand.
             return f"{axis}: the spec named no expected value"
         if want != got:
             return f"{axis}: expected {want}, have {got or '<absent>'}"
@@ -247,6 +319,7 @@ def verify_graph_witness(
 __all__ = [
     "GRAPH_WITNESS_FIELD",
     "ExpectedIdentity",
+    "NamesAnArtifact",
     "artifact_identity",
     "expected_from_plan",
     "verify_declared_identity",

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -70,6 +70,24 @@ REFUSAL_CODES = (
     "cell_resolve_client_supplied_field",
 )
 
+#: Every field an accepted answer must NAME, and why. The Plan path
+#: ``_require``s each of its counterparts (``plan._artifact``), so an answer
+#: omitting one states an expectation the Plan route could never produce — and
+#: the gate that would catch it sits AFTER the whole cell is downloaded.
+#: ``cell_resolve_incomplete`` is the hub's own code for this fact: the pod
+#: reaches the same verdict from the same evidence, so it reports it under the
+#: same name rather than inventing a second word for one condition.
+_REQUIRED: Tuple[Tuple[str, str], ...] = (
+    ("cell_key", "the admission expectation's identity axis"),
+    ("toolchain_digest", "the admission expectation's toolchain axis"),
+    ("env_seal_digest", "the admission expectation's environment axis"),
+    ("graph_contract", "the admission expectation's graph axis"),
+    ("publisher_org", "an artifact whose producer is unnamed is trusted by no "
+                      "rule, and 'unknown publisher' is not a tier"),
+    ("cell_ref", "the address the bytes are fetched from"),
+    ("content_digest", "what the fetched bytes are verified against"),
+)
+
 
 class CellResolveRefused(RuntimeError):
     """The hub refused to answer, typed. Distinct from a MISS by construction."""
@@ -138,18 +156,12 @@ class ResolvedCell:
     def expected_identity(self) -> aot_identity.ExpectedIdentity:
         """The admission expectation this answer states.
 
-        The SAME type ``expected_from_plan`` builds, so the artifact reaching
-        ``aot_identity.verify_declared_identity`` cannot tell whether it was
-        named by a Plan or pulled by key — which is the property that keeps
-        this from being a second admission brain.
+        Built by the SAME map ``expected_from_plan`` uses, so the artifact
+        reaching ``aot_identity.verify_declared_identity`` cannot tell whether
+        it was named by a Plan or pulled by key — which is the property that
+        keeps this from being a second admission brain.
         """
-        return aot_identity.ExpectedIdentity(
-            cell_key=self.cell_key,
-            toolchain_digest=self.toolchain_digest,
-            env_seal_digest=self.env_seal_digest,
-            graph_contract_digest=self.graph_contract,
-            publisher_org=self.publisher_org,
-        )
+        return aot_identity.ExpectedIdentity.named_by(self, self.graph_contract)
 
 
 def _transport_from(body: Mapping[str, Any]) -> Transport:
@@ -270,6 +282,15 @@ def resolve(
         raise CellResolveRefused(
             "cell_resolve_key_mismatch",
             f"asked for {key}, the hub answered {cell.cell_key!r}")
+    missing = [(f, why) for f, why in _REQUIRED if not getattr(cell, f)]
+    if missing:
+        # Refused HERE rather than at the identity gate, which runs after
+        # `materialize` has already paid for the whole cell. The Plan route
+        # cannot reach that gate incomplete; this one could.
+        raise CellResolveRefused(
+            "cell_resolve_incomplete",
+            "the answer names no " + "; no ".join(
+                f"{f} ({why})" for f, why in missing))
     logger.info(
         "cell-resolve: HIT %s -> %s (%s tier, %d bytes)",
         key, cell.cell_ref, cell.publisher_tier, cell.size_bytes)

--- a/tests/test_artifact_identity_pgw903.py
+++ b/tests/test_artifact_identity_pgw903.py
@@ -14,6 +14,8 @@ one expected fact must refuse, and the refusal must name that fact.
 
 from __future__ import annotations
 
+import importlib
+import inspect
 import json
 import tarfile
 from pathlib import Path
@@ -319,3 +321,49 @@ def test_an_internally_corrupt_artifact_keeps_its_own_distinct_refusal(
             cache_dir=tmp_path / "cache", expected=_expected())
     assert exc.value.reason == "key_mismatch"
     assert exc.value.reason != "expected_identity_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# pgw#1152: every axis is verified SOMEWHERE, and the claim is checked
+# ---------------------------------------------------------------------------
+
+
+def test_every_identity_axis_is_either_compared_here_or_named_elsewhere() -> None:
+    """The accounting is enforced at import (`aot_identity` refuses to load
+    otherwise), so this row states the invariant rather than re-deriving it: an
+    axis on the identity that nothing verifies is how a cell gets armed on an
+    unchecked claim."""
+    accounted = (set(aot_identity._COMPARED_AXES)
+                 | set(aot_identity._VERIFIED_ELSEWHERE))
+    assert accounted == set(ExpectedIdentity.__struct_fields__)
+
+
+def test_each_axis_verified_elsewhere_names_a_gate_that_really_reads_it() -> None:
+    """`_VERIFIED_ELSEWHERE` is a CLAIM, and pgw#1152's rule for this fence
+    family is that a claim is CHECKED, not trusted — the arm-state lint accepts
+    a `RECOGNIZER` row only after verifying it structurally, for exactly the
+    reason that a comment naming the wrong gate reads identical to one naming
+    the right gate.
+
+    The checked property is that the named gate **is handed the axis** — it
+    takes it as a parameter — because "this gate verifies the expectation"
+    means the expectation reaches it. Merely *mentioning* the axis is too weak
+    to discriminate: this entry first named
+    `receipts.refuse_untrusted_publisher`, whose body does mention
+    `publisher_org` while asking a different question (is this producer trusted
+    AT ALL, rather than is it the one the spec NAMED). It takes no
+    `publisher_org` parameter, so it fails this row; `fleet_cells.arm_ordered`,
+    which compares the named org to the signed receipt's `publisher_org_id`
+    fail-closed on silence (§4.26), takes one and passes.
+    """
+    for axis, why in aot_identity._VERIFIED_ELSEWHERE.items():
+        dotted = why.split(" ", 1)[0]
+        mod_name, _, func_name = dotted.rpartition(".")
+        assert mod_name and func_name, f"{axis}: {why!r} must start with mod.func"
+        module = importlib.import_module(f"gen_worker.{mod_name}")
+        gate = getattr(module, func_name, None)
+        assert gate is not None, f"{axis} names {dotted}, which does not exist"
+        assert axis in inspect.signature(gate).parameters, (
+            f"{axis} claims {dotted} verifies it, but that function is never "
+            "handed the axis — a gate that does not receive the expectation "
+            "cannot be the gate that checks it")

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -8,11 +8,13 @@ broker is stubbed, which is what the ``procsplit`` seam exists to make possible.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 
-from gen_worker import cell_resolve
+from gen_worker import aot_identity, cell_key as ck, cell_resolve, env_seal
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.plan import AttemptRef, PlanFactory
 from gen_worker.procsplit import actions as actions_mod
 
 KEY = "ck1-" + "ab" * 28
@@ -151,6 +153,49 @@ def test_an_answer_naming_a_different_key_is_refused_not_adopted(stub) -> None:
     assert err.value.code == "cell_resolve_key_mismatch"
 
 
+#: ``cell_key`` is caught one gate earlier — an empty key is not the key that
+#: was asked for, so the mismatch gate names the seam that lied first.
+_EARLIER_GATE = {"cell_key": "cell_resolve_key_mismatch"}
+
+
+@pytest.mark.parametrize("field", [f for f, _ in cell_resolve._REQUIRED])
+def test_an_incomplete_answer_is_refused_before_the_cell_is_paid_for(
+    stub, field,
+) -> None:
+    """A 200 hit that leaves an admission field unnamed is REFUSED here.
+
+    The Plan route cannot reach the identity gate incomplete — ``plan._artifact``
+    ``_require``s every counterpart — so before pgw#1152 this route was the only
+    one that could, and the gate that would have caught it runs after
+    ``materialize`` has already downloaded the whole cell.
+    """
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _hit_body(**{field: ""}))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve("sdxl", KEY)
+    assert err.value.code == _EARLIER_GATE.get(field, "cell_resolve_incomplete")
+    assert field in err.value.detail or field == "cell_key"
+
+
+def test_every_expectation_axis_is_required_of_the_answer() -> None:
+    """An axis on ``ExpectedIdentity`` that the answer need not name is an
+    expectation this route can state as empty — and
+    ``verify_declared_identity`` refuses an empty expectation only AFTER the
+    bytes are paid for. Derived from the struct, so a new axis reds here."""
+    required = {f for f, _ in cell_resolve._REQUIRED}
+    # the answer spells the graph axis without the `_digest` suffix; every
+    # other axis is copied by name in `ExpectedIdentity.named_by`
+    answer_name = {"graph_contract_digest": "graph_contract"}
+    for axis in aot_identity.ExpectedIdentity.__struct_fields__:
+        assert answer_name.get(axis, axis) in required, axis
+
+
+def test_an_incomplete_answer_is_a_typed_refusal_not_a_miss() -> None:
+    """A pod that read it as "no cell" would go pay for a whole cold mint
+    believing the hub holds nothing, which is false and expensive."""
+    assert "cell_resolve_incomplete" in cell_resolve.REFUSAL_CODES
+
+
 def test_a_non_key_is_refused_before_the_hub_is_dialled(stub) -> None:
     sent, _resp = stub
     for bad in ("", "sdxl", "arm1-" + "ab" * 28, "ck1-short"):
@@ -184,7 +229,6 @@ def test_a_hit_builds_the_same_expected_identity_the_plan_path_builds(
     assert cell is not None
 
     expected = cell.expected_identity()
-    from gen_worker import aot_identity
 
     assert isinstance(expected, aot_identity.ExpectedIdentity)
     assert expected.cell_key == KEY
@@ -201,8 +245,6 @@ def test_a_hit_builds_the_same_expected_identity_the_plan_path_builds(
         "env_seal": {"a": 1},
         "combined_graph_hash": "c0ffee0000000000",
     }
-    from gen_worker import cell_key as ck, env_seal
-
     meta["toolchain_digest_expected"] = ck.facts_digest(meta["toolchain"])
     reason = aot_identity.verify_declared_identity(
         meta,
@@ -213,6 +255,56 @@ def test_a_hit_builds_the_same_expected_identity_the_plan_path_builds(
             graph_contract_digest="c0ffee0000000000",
             publisher_org="org-a"))
     assert reason == ""
+
+
+def _plan_naming_the_same_artifact() -> Any:
+    """A Plan whose arm names the artifact ``_hit_body`` describes."""
+    arm = pb.Arm(
+        graph_contract_digest="c0ffee0000000000",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=pb.STEADY_BACKEND_AOT_CELL,
+    )
+    arm.artifact.CopyFrom(pb.ArtifactIdentity(
+        cell_ref=f"root/family-sdxl#{KEY}",
+        content_digest="sha256:" + "11" * 32,
+        cell_key=KEY,
+        publisher_org="org-a",
+        toolchain_digest="toolch0000000000",
+        env_seal_digest="seal000000000000",
+    ))
+    spec = pb.ExecutionSpec(
+        digest="sha256:" + "a" * 64,
+        spec_version=1,
+        release=pb.EndpointRelease(
+            org="org-a", endpoint="sdxl", release_id="r1",
+            image_digest="sha256:img", code_closure_id="clo_01"),
+        function_name="txt2img",
+        numerical_lane=pb.ExecutionLane(weights=pb.WEIGHT_LANE_BF16),
+        arm=arm,
+        topology=pb.Topology(accelerator="cuda", gpu_count=1, execution_groups=1),
+        components=pb.ComponentManifest(slots=[pb.SlotBinding(
+            slot="unet", ref="org-a/sdxl@v1", snapshot_digest="sha256:d")]),
+    )
+    return PlanFactory.from_execution_spec(AttemptRef("req", 1), spec)
+
+
+def test_both_expectation_sources_produce_an_EQUAL_object(stub) -> None:
+    """Not "the same type" — the same VALUE, compared whole.
+
+    pgw#1150's defect was a field that reached one map and not the other while
+    both still produced the right type. Since pgw#1152 there is one map
+    (``ExpectedIdentity.named_by``), so this row is what proves the two sources
+    have not drifted apart again: a new axis copied on one side only reds here
+    without anyone remembering to extend an assertion list.
+    """
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _hit_body())
+    cell = cell_resolve.resolve("sdxl", KEY)
+    assert cell is not None
+
+    from_plan = aot_identity.expected_from_plan(_plan_naming_the_same_artifact())
+    assert from_plan is not None
+    assert cell.expected_identity() == from_plan
 
 
 def test_the_receipt_rides_the_answer_and_is_never_re_fetched(stub) -> None:


### PR DESCRIPTION
Finishes the one item pgw#1152 (`c7184e9d`) deliberately left open: `ExpectedIdentity` was built by two independent maps.

## The consolidation

`expected_from_plan` (the hub PLAN named the artifact) and `ResolvedCell.expected_identity` (the §4.27 pull-by-key resolve answered) both now go through **`ExpectedIdentity.named_by`**, fenced as a fourth `ONE_CONSTRUCTOR` row in `scripts/lint_arm_state_feeders.py`. That is the same plan-vs-adopt pair that produced pgw#1108/#1122/#1141/#1141b, on the object every arm gate compares a cell against.

The graph contract is passed rather than read off the source because it belongs to the ARM, not the artifact. Every other axis is copied by name, so a new axis cannot reach one source and not the other.

## It surfaced a live divergence, exactly as `_ArmOrder` did

Not a missing struct field this time — a missing **requirement**. `plan._artifact` `_require`s all six artifact fields and the arm `_require`s `graph_contract_digest`. The resolve path required none.

Measured on unmodified `origin/master` (`8829e991`), a `200 {"found": true}` answer was **accepted** with any of these empty, and produced an expectation stating that axis as `''`:

```
ACCEPTED empty publisher_org    -> expectation states publisher_org=''
ACCEPTED empty graph_contract   -> expectation states graph_contract_digest=''
ACCEPTED empty toolchain_digest -> expectation states toolchain_digest=''
ACCEPTED empty env_seal_digest  -> expectation states env_seal_digest=''
ACCEPTED empty content_digest   -> (not an identity axis; materialize's argument)
ACCEPTED empty cell_ref         -> (not an identity axis; materialize's argument)
```

An empty expectation *is* refused — by `verify_declared_identity`, **after `materialize` has already downloaded the whole cell**. `cell_resolve._REQUIRED` refuses it at the answer instead, under the hub's own `cell_resolve_incomplete` code: the pod reaches the same verdict from the same evidence, and inventing a second word for one condition is how two routes drift apart in the first place.

## `artifact_identity` is PROJECTION, not migrated

It reads the OBSERVED side out of the mint's stored meta blocks — a `Mapping`, not a source that NAMED an artifact — and is what the expectation is compared *against*. Classified in `scripts/arm_state_feeders_allowlist.txt`; the fence red on it until it was.

A load-time accounting check makes an unverified axis unspellable: every `ExpectedIdentity` field is in `_COMPARED_AXES` or named in `_VERIFIED_ELSEWHERE` **with the gate that does compare it**, or the module refuses to import.

## Tests

- the incompleteness refusal is covered per-field, parametrised off `_REQUIRED`, so a new requirement is exercised without editing a list;
- the axis-coverage row is derived from `ExpectedIdentity.__struct_fields__`, so a new axis reds;
- the two sources are now compared as **equal objects** rather than field-by-field — the assertion shape pgw#1150 would have failed. The pre-existing row asserted only "same type" and listed fields by hand.

RED proof above is behavioural against unmodified `origin/master`, not a collection error.

Local: arm-state fence green, mypy clean (266 files), ruff clean, 177 tests green across the ten affected modules.