### PR TITLE
pgw#891 (th#1457 item 2, worker half): a graph contract belongs to the ARTIFACT, so a non-cell arm carries none

### DIFF
--- a/changelog.d/891-arm-graph-contract.md
+++ b/changelog.d/891-arm-graph-contract.md
@@ -1,0 +1,7 @@
+- `ExecutionSpec.arm.graph_contract_digest` now follows the artifact: required on an
+  `aot_cell` arm (pgw#903's pre-dlopen fence compares it), refused on `dynamo` and
+  `eager_only` arms. A non-cell arm has no traced graph the hub could name ahead of
+  dispatch, and `aot_identity.expected_from_plan` already returns `None` there — so the
+  old unconditional requirement made every non-cell dispatch unbuildable hub-side while
+  the value it demanded had no reader. Paired with tensorhub `1457-arm-graph-contract`;
+  both halves must ship together.

--- a/src/gen_worker/plan.py
+++ b/src/gen_worker/plan.py
@@ -163,6 +163,14 @@ class ArmRef(msgspec.Struct, frozen=True):
     arm instead of being recovered from the adapter list. ``artifact`` is set
     iff ``backend == "aot_cell"``: since pgw#1010 dynamo cells are neither
     sealed nor published, so DYNAMO has no artifact to name.
+
+    ``graph_contract_digest`` follows the artifact exactly: it is the
+    ``combined_graph_hash`` of a compiled cell, so it is non-empty iff the arm
+    names one, and empty otherwise. An ``eager_only`` arm traces nothing and a
+    ``dynamo`` arm compiles at serve time, so neither has a graph contract the
+    hub could name ahead of dispatch — and :func:`aot_identity.expected_from_plan`
+    already returns ``None`` for both, so nothing on this side ever reads it
+    there.
     """
 
     graph_contract_digest: str
@@ -507,9 +515,22 @@ def _arm(spec: Any) -> ArmRef:
     elif backend == "aot_cell":
         raise PlanRefusal(
             "spec.arm.artifact", "exactly one ArtifactIdentity on an aot_cell arm", "absent")
+    graph_contract = str(arm.graph_contract_digest or "").strip()
+    # Required on the arm that has an artifact (pgw#903's pre-dlopen fence
+    # compares exactly this value), refused on every other — symmetrically with
+    # ``artifact`` above. A graph contract on an arm that names no cell is a
+    # value the hub cannot produce and this worker never verifies, riding inside
+    # the execution digest.
+    if artifact is not None:
+        graph_contract = _require(graph_contract, "spec.arm.graph_contract_digest")
+    elif graph_contract:
+        raise PlanRefusal(
+            "spec.arm.graph_contract_digest",
+            "absent unless backend is aot_cell",
+            f"present with backend {backend}",
+        )
     return ArmRef(
-        graph_contract_digest=_require(
-            arm.graph_contract_digest, "spec.arm.graph_contract_digest"),
+        graph_contract_digest=graph_contract,
         shape=shape,
         adapter_rank_bucket=bucket,
         backend=backend,

--- a/tests/test_artifact_identity_pgw903.py
+++ b/tests/test_artifact_identity_pgw903.py
@@ -173,11 +173,13 @@ def test_identity_is_never_confirmed_by_comparing_bytes() -> None:
 
 def _plan(backend: int = pb.STEADY_BACKEND_AOT_CELL) -> Any:
     arm = pb.Arm(
-        graph_contract_digest="gc_01",
         shape=pb.ARM_SHAPE_BRANCHLESS,
         backend=backend,
     )
     if backend == pb.STEADY_BACKEND_AOT_CELL:
+        # The graph contract follows the artifact — an arm that names no cell
+        # carries neither.
+        arm.graph_contract_digest = "gc_01"
         arm.artifact.CopyFrom(pb.ArtifactIdentity(
             cell_ref="cozy/cells-micro#k1",
             content_digest="sha256:" + "c" * 64,

--- a/tests/test_plan_pgw902.py
+++ b/tests/test_plan_pgw902.py
@@ -269,13 +269,53 @@ def test_a_non_aot_arm_carrying_an_artifact_refuses() -> None:
     assert "dynamo" in exc.value.have
 
 
-def test_an_eager_only_arm_is_a_valid_plan_with_no_artifact() -> None:
-    p = _plan(arm=pb.Arm(
-        graph_contract_digest="gc_01",
-        shape=pb.ARM_SHAPE_BRANCHLESS,
-        backend=pb.STEADY_BACKEND_EAGER_ONLY))
-    assert p.arm.backend == "eager_only"
+@pytest.mark.parametrize(
+    "backend,token",
+    [
+        (pb.STEADY_BACKEND_EAGER_ONLY, "eager_only"),
+        (pb.STEADY_BACKEND_DYNAMO, "dynamo"),
+    ],
+)
+def test_a_non_cell_arm_is_a_valid_plan_with_no_artifact_and_no_graph_contract(
+    backend: int, token: str,
+) -> None:
+    """The shape most of the fleet's declared lanes need. `svdq-fp4-w4a4+eager`
+    is execution-eager-only in tensorhub's lane table — a lane that cannot be
+    compiled at all — so an EAGER_ONLY arm can never name a graph contract; a
+    DYNAMO arm compiles at serve time, so the hub cannot name one ahead of
+    dispatch either."""
+    p = _plan(arm=pb.Arm(shape=pb.ARM_SHAPE_BRANCHLESS, backend=backend))
+    assert p.arm.backend == token
     assert p.arm.artifact is None
+    assert p.arm.graph_contract_digest == ""
+
+
+@pytest.mark.parametrize(
+    "backend", [pb.STEADY_BACKEND_EAGER_ONLY, pb.STEADY_BACKEND_DYNAMO])
+def test_a_graph_contract_on_a_non_cell_arm_refuses(backend: int) -> None:
+    """Symmetric with the artifact rule: a graph contract on an arm that names
+    no cell is a value the hub cannot produce and this worker never verifies
+    (`aot_identity.expected_from_plan` returns None there), riding inside the
+    execution digest."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=pb.Arm(
+            graph_contract_digest="gc_01",
+            shape=pb.ARM_SHAPE_BRANCHLESS,
+            backend=backend))
+    assert exc.value.field == "spec.arm.graph_contract_digest"
+
+
+def test_an_aot_cell_arm_without_a_graph_contract_refuses() -> None:
+    """pgw#903's pre-dlopen fence compares exactly this value, so the arm that
+    HAS an artifact must still name it."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=pb.Arm(
+            shape=pb.ARM_SHAPE_BRANCHLESS,
+            backend=pb.STEADY_BACKEND_AOT_CELL,
+            artifact=pb.ArtifactIdentity(
+                cell_ref="r", content_digest="d", cell_key="k",
+                publisher_org="o", toolchain_digest="t", env_seal_digest="e")))
+    assert exc.value.field == "spec.arm.graph_contract_digest"
 
 
 def test_an_artifact_with_no_publisher_refuses() -> None:

--- a/tests/test_run_attempt_cutover_pgw904.py
+++ b/tests/test_run_attempt_cutover_pgw904.py
@@ -81,7 +81,7 @@ def _spec(
     spec.release.image_digest = "sha256:" + "1" * 64
     spec.release.code_closure_id = "cc-1"
     spec.numerical_lane.weights = pb.WEIGHT_LANE_BF16
-    spec.arm.graph_contract_digest = "gc-1"
+    # No graph contract: an eager arm names no cell, so it has none.
     spec.arm.shape = pb.ARM_SHAPE_BRANCHLESS
     spec.arm.backend = pb.STEADY_BACKEND_EAGER_ONLY
     spec.topology.accelerator = "none"


### PR DESCRIPTION
> **DRAFT AND HELD — do not merge without the cutover decision.** Opened so the branch is
> recorded rather than left anonymous after a session interruption. See "Why this is held".

## What it does

`ExecutionSpec.arm.graph_contract_digest` now follows the artifact exactly:
**required** on an `aot_cell` arm (pgw#903's pre-dlopen fence compares exactly this value),
**refused** on `dynamo` and `eager_only` arms — symmetrically with `arm.artifact` immediately
above it in `_arm`.

A non-cell arm has no traced graph the hub could name ahead of dispatch, and
`aot_identity.expected_from_plan` already returns `None` there, so under the old
unconditional `_require` the value had **no producer and no reader** while still riding
inside the execution digest.

## Why this is held

This is one half of a coordinated cross-repo pair:

- the tensorhub half is `cozy-creator/tensorhub#984` (branch `1457-arm-graph-contract`),
  which is **closed, not merged**, and whose own body reads *"DRAFT AND HELD. Do not merge
  without the cutover decision — this is one half of a coordinated pair and the other half
  is a python-gen-worker wheel."*
- the pairing therefore needs a **wheel cut**, and the next cut carries pgw#1050's one-time
  fleet re-mint (the toolchain narrowing re-keys every ck1 cell). That has to be announced
  by whoever cuts it — it is not a side effect of merging a PR.

So the decision this is waiting on is not a review question, it is a cutover question.

## Direction of the change, for whoever takes the decision

The worker half alone is **loosening** in the case that matters: it stops `_require`-ing a
value the hub cannot produce for a non-cell arm, which is what made every non-cell dispatch
structurally unbuildable hub-side. The refusal it adds (a graph contract present on a
non-cell arm) is a shape the hub has no source for — `ArmFromVerifiedCell` is its only
producer — so worker-first is the safe ordering for the pair, if the cutover is taken.

Rebased onto `8829e991`; 66 tests green across `test_plan_pgw902`, `test_artifact_identity_pgw903`
and `test_run_attempt_cutover_pgw904`.