### PR TITLE
pgw#1143 §1.33: the layout converter registry, whose admission bar makes re-quantization unregistrable — and the mechanical fence that keeps conversion out of the cell key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,19 @@ jobs:
       - name: pgw#1143 guard - Slot(layouts=) declarations are literals
         run: uv run python scripts/lint_layout_declarations.py
 
+      # GATING (pgw#1143, §1.33 point 5): conversion is UPSTREAM of compute, so
+      # no cell-key axis may read the layout demand or a conversion chain — no
+      # cell re-keys on a conversion, ever. The fenced module set is DERIVED
+      # from who calls a cell-key axis producer, so a new key computation joins
+      # the fence without anyone remembering to add it.
+      - name: pgw#1143 guard - no cell-key axis reads the layout vocabulary
+        run: uv run python scripts/lint_cell_key_layout_fence.py
+
+      # GATING (pgw#740 + pgw#1143): the shipped wheel's registries are bare
+      # by design and a consumer's declarations populate all six.
+      - name: pgw#740 guard - registry contract
+        run: uv run python scripts/check_registry_contract.py
+
       # GATING (pgw#1122): the compute child holds no worker credential BY
       # CONSTRUCTION, so a gate that reads one to answer "who am I?" or "is
       # there a hub?" refuses on every real serving pod (pgw#1108, then

--- a/changelog.d/pgw1143.md
+++ b/changelog.d/pgw1143.md
@@ -1,0 +1,34 @@
+- **pgw#1143 (§1.33): the layout CONVERTER registry — and re-quantization cannot
+  enter it.** `gen_worker.convert.layout_converters` is the SDK's sixth registry
+  and the CONVERTIBLE rung of §1.33's ladder (COMPATIBLE → CONVERTIBLE →
+  PRODUCIBLE → INCOMPATIBLE). Edges are keyed `(axis, from → to)` over two
+  independent axes — **topology** (keys/nesting; declared as
+  `convert.repack_spec.RenameRule` passes, executed by a raw byte-range rewrite
+  that never decodes a tensor) and **quant** (what the weights ARE; a streaming
+  same-numerics repack). `register_layout_conversion()` runs the mapping's
+  bit-exactness obligation over its declared corpus *at registration*: key
+  bijection, payload invariance, `A → B → A` content recovery, and — on the
+  quant axis — the target contract's own reference dequant. A cast that drops
+  bits cannot satisfy the round trip, so **the registry structurally cannot hold
+  a re-quantization**; that is `register_layout_production()`'s job, which
+  carries a recipe NAME and a quality gate and no transform at all. The relation
+  itself (`classify_layout`, `plan_layout_conversions`) is membership then
+  reachability, extended only by DATA — the extensibility invariant is gated by
+  a lint that fails on a contract-handle literal reaching it.
+- **The §1.33 point-5 fence is mechanical: no cell re-keys on a conversion.**
+  `scripts/lint_cell_key_layout_fence.py` (new required `fast gates` step)
+  DERIVES the fenced module set from who calls a cell-key axis producer, then
+  fails if any of them reads the layout demand or a conversion chain — by
+  import, by attribute, by stringized annotation or by a deferred
+  `import_module`. `scripts/check_registry_contract.py` also joins the gates,
+  and asserts the sixth registry's bare state and a consumer's edge.
+- **The accepted layout SET is a FILTER; its order carries no preference**
+  (§1.33 pt 2 as amended by th#1803). `Slot(layouts=…)` now canonicalizes the
+  declared handles, so two authors who spell the same set differently publish
+  the same manifest and no reader can recover a ranking from a position that
+  never carried one. Preference keeps exactly one authority: the
+  author-configured ordered ladder of (GPU, lane) pairs.
+- `convert.writer` gains the torch-free safetensors primitives the engine runs
+  on — `rewrite_safetensors_keys` (byte-range rename), `write_safetensors_shard`,
+  `shard_content_digest`, `shard_payload_digests`, `shard_tensor_entries` — and
+  `_read_safetensors_header` is now public as `read_safetensors_header`.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -370,7 +370,7 @@ class Generate:
   (`share_components=` is deleted).
 - **`layouts=` declares WHAT BYTES THIS SLOT'S CODE CAN EXECUTE** (§1.33,
   pgw#1143) — the DEMAND half of the tensor-layout contract, per component
-  path, ordered by preference:
+  path, a SET:
 
   ```python
   from gen_worker.models.tensor_layout_contract import (
@@ -396,6 +396,47 @@ class Generate:
   lands in the build log as `layouts_census_unbacked`, because plenty of
   layouts are decoded natively by `transformers`/`diffusers` with no cozy
   marker.
+
+  **The set is a compatibility FILTER — its order carries no preference**
+  (§1.33 pt 2 as amended by th#1803). Preference has exactly one authority:
+  the owner-configured ordered ladder of (GPU, lane) pairs. The SDK
+  canonicalizes what you write, so spelling the set in a different order is
+  the same declaration, not a different one.
+
+  **When an artifact does not match, §1.33's ladder decides** — COMPATIBLE
+  (in the set) → **CONVERTIBLE** (a registered LOSSLESS mapping reaches an
+  accepted layout) → **PRODUCIBLE** (only a re-quantization from a named
+  higher-precision source does — a priced job, never automatic) →
+  INCOMPATIBLE (refused, both sides named, before any pod). The CONVERTIBLE
+  edge set is `gen_worker.convert.layout_converters`, declared by whoever
+  owns the format:
+
+  ```python
+  from gen_worker.convert import (
+      ConversionCase, CorpusTensor, TopologyConversion,
+      register_layout_conversion)
+  from gen_worker.convert.repack_spec import RenameRule
+
+  register_layout_conversion(TopologyConversion(
+      from_id=TOPOLOGY_COMFY_SPLITFILES,
+      to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+      version=1,
+      rules=(RenameRule(kind="prefix",
+             pairs=(("model.diffusion_model.", "transformer."),)),),
+      inverse_rules=(RenameRule(kind="prefix",
+             pairs=(("transformer.", "model.diffusion_model."),)),),
+      corpus=(ConversionCase(name="dit-block0", tensors={...}),),
+  ))
+  ```
+
+  Registration RUNS the mapping's bit-exactness obligation over its corpus
+  before the edge exists: key bijection, payload invariance, and `A → B → A`
+  content recovery. **A re-quantization cannot pass that round trip, so it
+  cannot be registered as a converter** — it is
+  `register_layout_production()`, which carries a recipe name and a quality
+  gate and no transform. Bump `version` when the mapping changes; the digest
+  moves and every derived artifact gets a new identity, so bytes never
+  silently change under a name.
 
 **Per-family defaults vocabulary**: a typed, versioned,
 JSON-Schema-exportable struct per architecture — the shape tensorhub validates

--- a/scripts/_registry_contract_consumer.py
+++ b/scripts/_registry_contract_consumer.py
@@ -2,7 +2,7 @@
 
 pgw#740: the SDK ships registry MECHANISMS; every vocabulary is declared by the
 endpoint that owns it. This module declares a synthetic family the way a real
-endpoint does, across all five decorator/registration surfaces. The gate
+endpoint does, across all six decorator/registration surfaces. The gate
 (`check_registry_contract.py`) imports it via the documented
 ``load_declaration_module`` path and asserts every registration became visible.
 """
@@ -18,12 +18,21 @@ from gen_worker.api.export_contract import (
 )
 from gen_worker.convert import (
     CIVITAI,
+    ConversionCase,
+    CorpusTensor,
     HintMatch,
     LayoutDeclaration,
+    RenameRule,
     RepackageFamily,
+    TopologyConversion,
     declare_foreign_family_map,
     register_layout,
+    register_layout_conversion,
     register_repackage_family,
+)
+from gen_worker.models.tensor_layout_contract import (
+    TOPOLOGY_COMFY_SPLITFILES,
+    TOPOLOGY_DIFFUSERS_MULTIFILE,
 )
 from gen_worker.families import GenerationDefaults, family
 
@@ -50,6 +59,31 @@ register_layout(
 )
 
 declare_foreign_family_map(CIVITAI, {"ContractCheck 1.0": FAMILY})
+
+# The SIXTH registry (§1.33 / pgw#1143). A topology edge is DATA — declared
+# rename passes plus their inverse — and registration runs the round-trip
+# admission proof over the declared corpus before the edge exists.
+register_layout_conversion(
+    TopologyConversion(
+        from_id=TOPOLOGY_COMFY_SPLITFILES,
+        to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+        version=1,
+        rules=(RenameRule(
+            kind="prefix", pairs=(("model.diffusion_model.", "transformer."),)),),
+        inverse_rules=(RenameRule(
+            kind="prefix", pairs=(("transformer.", "model.diffusion_model."),)),),
+        corpus=(ConversionCase(
+            name="contractcheck-dit",
+            tensors={
+                "model.diffusion_model.blocks.0.attn.to_q.weight":
+                    CorpusTensor(dtype="BF16", shape=(4, 4)),
+                "model.diffusion_model.blocks.0.attn.to_k.weight":
+                    CorpusTensor(dtype="BF16", shape=(4, 4)),
+            },
+        ),),
+        why="the registry-contract gate's representative topology edge",
+    )
+)
 
 register_export_declaration(
     Compile(

--- a/scripts/check_registry_contract.py
+++ b/scripts/check_registry_contract.py
@@ -8,13 +8,13 @@ therefore the WRONG assertion for a bare wheel. The right one — asserted here 
 is the contract:
 
   A. bare import exposes working registry mechanisms in their DOCUMENTED bare
-     state (family/convert/export registries empty, generic component
-     vocabulary present, unknown families refused BY NAME with the fix in the
-     message);
+     state (family/convert/export/layout-conversion registries empty, generic
+     component vocabulary present, unknown families refused BY NAME with the
+     fix in the message);
   B. a representative consumer's declarations, imported via the documented
-     ``load_declaration_module`` path, become visible in ALL five registries
+     ``load_declaration_module`` path, become visible in ALL six registries
      and resolve (aliases, layout hints, foreign-catalog adapter, defaults
-     class, export declaration).
+     class, export declaration, layout conversion edge).
 
 Run with ``--installed`` (the publish workflow does, against the freshly built
 wheel in a clean venv) to also refuse a ``gen_worker`` that resolves from this
@@ -59,6 +59,8 @@ def phase_bare() -> None:
     from gen_worker.component_vocab import component_vocabulary
     from gen_worker.convert import (
         UnknownFamilyError,
+        registered_layout_conversions,
+        registered_layout_productions,
         registered_layouts,
         registered_repackage_families,
         require_repackage_family,
@@ -69,6 +71,12 @@ def phase_bare() -> None:
     _check("repackage", registered_repackage_families() == (), "bare registry empty-by-design")
     _check("layouts", registered_layouts() == (), "bare registry empty-by-design")
     _check("export", registered_export_families() == (), "bare registry empty-by-design")
+    _check(
+        "layout-conversions",
+        registered_layout_conversions() == () and registered_layout_productions() == (),
+        "bare registry empty-by-design (§1.33: edges are declared by whoever "
+        "owns the format, never shipped in the wheel)",
+    )
     vocab = component_vocabulary()
     _check(
         "component_vocab",
@@ -93,6 +101,7 @@ def phase_consumer() -> None:
         civitai_to_family,
         load_declaration_module,
         normalize_family,
+        registered_layout_conversions,
         registered_layouts,
         registered_repackage_families,
     )
@@ -133,6 +142,15 @@ def phase_consumer() -> None:
         "export",
         fam in registered_export_families(),
         "class-bearing Compile declaration registered",
+    )
+    edges = registered_layout_conversions()
+    _check(
+        "layout-conversions",
+        {(e.from_id, e.to_id) for e in edges}
+        == {("comfy.splitfiles@1", "diffusers.multifile@1"),
+            ("diffusers.multifile@1", "comfy.splitfiles@1")},
+        "TopologyConversion registered — BOTH directions, because the "
+        "round-trip admission proof passed on both",
     )
 
 

--- a/scripts/lint_cell_key_layout_fence.py
+++ b/scripts/lint_cell_key_layout_fence.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""pgw#1143 (§1.33 point 5): CONVERSION IS UPSTREAM OF COMPUTE — no cell re-keys.
+
+    Every byte the endpoint's loader/`setup()` observes is in one of the slot's
+    DECLARED accepted layouts. Conversion completes strictly before
+    materialization into the worker's model tree, and the endpoint has no code
+    path that can observe the source layout, the conversion, or its provenance.
+    Therefore the traced graph, `Compile.contract_axes()`, the ck1 cell key and
+    the declared envelope are unchanged by any conversion, and no cell re-keys —
+    ever.
+
+An invariant nobody can execute is a comment, so this script executes it. Two
+fences, both structural:
+
+**FENCE 1 — no cell-key axis reads the layout vocabulary.** The fenced module
+set is DERIVED, not hand-listed: any module that calls a cell-key axis producer
+(`cell_key.from_axes`, `envelope_digest`, `toolchain_axis_digest`,
+`facts_digest`, `from_exported_artifact_metadata`, or constructs `CellKey`) is
+in it, plus `cell_key` itself. A new module that starts computing a key joins
+the fence automatically — the failure mode of a hand-maintained list is that the
+one file that violates the rule is the one nobody added.
+
+Inside the fence, referencing the DEMAND / CONVERSION half of the layout
+vocabulary is red: the `layout_converters` module, `Slot.layouts`, `LayoutId`,
+the planner, the verdict, the provenance. Whether by import, by attribute, or by
+a string naming the module — a deferred `importlib.import_module` is the obvious
+way around an import check, so strings count.
+
+Deliberately NOT banned: `@implements_contract` and `ContractDecoder`. Those are
+the DECODER CENSUS half of the same module — "which decoders does this image
+contain" — which is a property of the wheel that legitimately reaches the
+toolchain closure. The banned set is the demand/conversion half, which is what
+§1.33 point 5 is about.
+
+**FENCE 2 — the compatibility RELATION holds no format knowledge.** §1.33's
+extensibility invariant (`f6f95736`): *"Contract CONTENTS evolve; the
+compatibility RELATION never does."* So the functions that compute the rung
+must contain zero literal contract handles. A handle literal appearing there is
+the first line of a per-format special case, which the ruling forbids; it is
+also the shape a similarity heuristic arrives in.
+
+Run::
+
+    python scripts/lint_cell_key_layout_fence.py
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+SRC = REPO / "src" / "gen_worker"
+
+#: Calling one of these MAKES a module a cell-key axis producer. Narrow on
+#: purpose: `facts_digest` and `subject_digest` are generic canonical-digest
+#: helpers whose callers say so (`contract_facts`: "NOT a key-axis input";
+#: `subject_digest` names a MINT OBLIGATION, never a cell key), so probing on
+#: them would fence modules that compute no key and make the gate noise.
+AXIS_PRODUCERS: Tuple[str, ...] = (
+    "from_axes",
+    "envelope_digest",
+    "toolchain_axis_digest",
+    "from_exported_artifact_metadata",
+    "CellKey",
+)
+
+#: Always fenced, whatever they call: they DEFINE the key or one of its four
+#: axis inputs (graph / envelope / sm / toolchain).
+FENCE_SEED: Tuple[str, ...] = (
+    "cell_key.py",
+    "graph_hash.py",
+    "env_seal.py",
+    "host_isa.py",
+    "guard_closure.py",
+    "compile_cache.py",
+)
+
+#: The DEMAND / CONVERSION half of the layout vocabulary. Names.
+BANNED_NAMES: Tuple[str, ...] = (
+    "LayoutId",
+    "LayoutRung",
+    "LayoutVerdict",
+    "LayoutProduction",
+    "ConversionPlan",
+    "ConversionHop",
+    "ConversionResult",
+    "TopologyConversion",
+    "QuantRepack",
+    "classify_layout",
+    "plan_layout_conversions",
+    "run_layout_conversion",
+    "conversion_provenance",
+    "derived_artifact_identity",
+    "registered_layout_conversions",
+    "registered_layout_productions",
+    "normalize_layout_demand",
+    "validate_layout_handle",
+    "parse_layout_id",
+    "known_contracts",
+    "layouts",
+    "CONVERSION_PROVENANCE_KEY",
+)
+
+#: Module paths that must not be reachable from a fenced module, including via
+#: a string handed to importlib.
+BANNED_MODULES: Tuple[str, ...] = (
+    "gen_worker.convert.layout_converters",
+    "convert.layout_converters",
+    "layout_converters",
+)
+
+#: The functions that COMPUTE the rung. Fence 2 applies to their bodies.
+RELATION_MODULE = SRC / "convert" / "layout_converters.py"
+RELATION_FUNCTIONS: Tuple[str, ...] = (
+    "classify_layout",
+    "plan_layout_conversions",
+    "_shortest_chain",
+    "_axis_satisfied",
+    "_reachable_productions",
+    "_unevaluated",
+)
+
+_HANDLE_LITERAL = re.compile(r"^[a-z0-9]+\.[a-z0-9][a-z0-9._-]*@[1-9][0-9]*$")
+
+
+def _iter_modules() -> List[Path]:
+    return sorted(p for p in SRC.rglob("*.py"))
+
+
+def _called_names(tree: ast.AST) -> Set[str]:
+    """Every callee's last name component in one module."""
+    out: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            out.add(func.attr)
+        elif isinstance(func, ast.Name):
+            out.add(func.id)
+    return out
+
+
+def fenced_modules() -> Dict[Path, str]:
+    """Modules the fence covers, mapped to WHY they are covered."""
+    out: Dict[Path, str] = {}
+    for path in _iter_modules():
+        if path.name in FENCE_SEED and path.parent == SRC:
+            out[path] = "defines the cell key or one of its axis inputs"
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        hits = sorted(_called_names(tree) & set(AXIS_PRODUCERS))
+        if hits:
+            out[path] = f"computes a cell-key axis ({', '.join(hits)})"
+    return out
+
+
+def _docstring_nodes(tree: ast.AST) -> Set[int]:
+    """Every docstring Constant, by id.
+
+    PROSE IS NOT A REFERENCE. A gate that reds on the word appearing in a
+    comment teaches lanes to avoid explaining themselves, and a vocabulary gate
+    that fires on a docstring has already cost this repo a lane-day.
+    """
+    out: Set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef,
+                                 ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", [])
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            out.add(id(body[0].value))
+    return out
+
+
+def _violations(path: Path) -> List[Tuple[int, str]]:
+    """Layout-vocabulary references in one fenced module."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    banned = set(BANNED_NAMES)
+    word = re.compile(r"\b(" + "|".join(re.escape(n) for n in BANNED_NAMES) + r")\b")
+    docstrings = _docstring_nodes(tree)
+    hits: List[Tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in BANNED_MODULES:
+                    hits.append((node.lineno, f"import {alias.name}"))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in BANNED_MODULES or module.endswith(".layout_converters"):
+                hits.append((node.lineno, f"from {module} import ..."))
+            for alias in node.names:
+                if alias.name in banned:
+                    hits.append((node.lineno, f"from {module} import {alias.name}"))
+        elif isinstance(node, ast.Attribute) and node.attr in banned:
+            hits.append((node.lineno, f".{node.attr}"))
+        elif isinstance(node, ast.Name) and node.id in banned:
+            hits.append((node.lineno, node.id))
+        elif (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and id(node) not in docstrings):
+            # Non-docstring strings count: `getattr(slot, "layouts")`, a
+            # deferred `import_module("...layout_converters")` and a stringized
+            # annotation are the three ways around a name/import check.
+            found = word.search(node.value)
+            if node.value in BANNED_MODULES:
+                hits.append((node.lineno, f"string {node.value!r}"))
+            elif found and any(m in node.value for m in BANNED_MODULES):
+                hits.append((node.lineno, f"string {node.value!r}"))
+            elif found:
+                hits.append((node.lineno, f"string names {found.group(1)!r}"))
+    return sorted(set(hits))
+
+
+def _relation_handle_literals() -> List[Tuple[int, str]]:
+    """Contract-handle literals inside the rung computation (fence 2)."""
+    tree = ast.parse(RELATION_MODULE.read_text(encoding="utf-8"))
+    hits: List[Tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in RELATION_FUNCTIONS:
+            continue
+        for inner in ast.walk(node):
+            if (isinstance(inner, ast.Constant)
+                    and isinstance(inner.value, str)
+                    and _HANDLE_LITERAL.match(inner.value)):
+                hits.append((inner.lineno, f"{node.name}: {inner.value!r}"))
+    return sorted(set(hits))
+
+
+def main() -> int:
+    failures: List[str] = []
+
+    fenced = fenced_modules()
+    if not fenced:
+        print("FAIL: the fence covers NO module — the axis-producer probe is "
+              "stale, which makes this gate green for the wrong reason")
+        return 1
+    print(f"fence 1: {len(fenced)} cell-key module(s)")
+    for path, why in sorted(fenced.items()):
+        rel = path.relative_to(REPO)
+        hits = _violations(path)
+        if hits:
+            for line, what in hits:
+                failures.append(f"{rel}:{line}: reads the layout vocabulary ({what})")
+            print(f"  [FAIL] {rel} — {why}")
+        else:
+            print(f"  [ok]   {rel} — {why}")
+
+    literals = _relation_handle_literals()
+    print(f"fence 2: {len(RELATION_FUNCTIONS)} relation function(s)")
+    if literals:
+        for line, what in literals:
+            failures.append(
+                f"{RELATION_MODULE.relative_to(REPO)}:{line}: the compatibility "
+                f"RELATION names a format ({what})")
+        print("  [FAIL] a handle literal reached the relation")
+    else:
+        print("  [ok]   no contract-handle literal in the relation")
+
+    if failures:
+        print(f"\n§1.33 point 5 fence BROKEN ({len(failures)} violation(s)):")
+        for line in failures:
+            print(f"  - {line}")
+        print(
+            "\nConversion is UPSTREAM of compute. If a cell-key axis needs to "
+            "know the layout, the conversion is happening too late — move it "
+            "ahead of materialization instead of widening the key.")
+        return 1
+    print("\n§1.33 point 5 fence holds: no cell re-keys on a conversion")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_cell_key_layout_fence.py
+++ b/scripts/lint_cell_key_layout_fence.py
@@ -46,11 +46,12 @@ Run::
 
 from __future__ import annotations
 
+import argparse
 import ast
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
 SRC = REPO / "src" / "gen_worker"
@@ -127,8 +128,8 @@ RELATION_FUNCTIONS: Tuple[str, ...] = (
 _HANDLE_LITERAL = re.compile(r"^[a-z0-9]+\.[a-z0-9][a-z0-9._-]*@[1-9][0-9]*$")
 
 
-def _iter_modules() -> List[Path]:
-    return sorted(p for p in SRC.rglob("*.py"))
+def _iter_modules(root: Path) -> List[Path]:
+    return sorted(p for p in root.rglob("*.py"))
 
 
 def _called_names(tree: ast.AST) -> Set[str]:
@@ -145,11 +146,11 @@ def _called_names(tree: ast.AST) -> Set[str]:
     return out
 
 
-def fenced_modules() -> Dict[Path, str]:
+def fenced_modules(root: Path = SRC) -> Dict[Path, str]:
     """Modules the fence covers, mapped to WHY they are covered."""
     out: Dict[Path, str] = {}
-    for path in _iter_modules():
-        if path.name in FENCE_SEED and path.parent == SRC:
+    for path in _iter_modules(root):
+        if path.name in FENCE_SEED and path.parent == root:
             out[path] = "defines the cell key or one of its axis inputs"
             continue
         try:
@@ -236,17 +237,24 @@ def _relation_handle_literals() -> List[Tuple[int, str]]:
     return sorted(set(hits))
 
 
-def main() -> int:
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--src", type=Path, default=SRC,
+        help="package root to sweep (default: src/gen_worker). Exists so the "
+             "gate's own RED can be executed against a tree that violates it — "
+             "a fence nobody has watched fail is a fence nobody knows works.")
+    args = parser.parse_args(argv)
     failures: List[str] = []
 
-    fenced = fenced_modules()
+    fenced = fenced_modules(args.src)
     if not fenced:
         print("FAIL: the fence covers NO module — the axis-producer probe is "
               "stale, which makes this gate green for the wrong reason")
         return 1
     print(f"fence 1: {len(fenced)} cell-key module(s)")
     for path, why in sorted(fenced.items()):
-        rel = path.relative_to(REPO)
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
         hits = _violations(path)
         if hits:
             for line, what in hits:

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -127,16 +127,23 @@ class Slot(Generic[D]):
     decoration-time error, never a silent fallback.
 
     ``layouts`` is the slot's per-component DEMAND (§1.33, pgw#1143): a
-    mapping from component path to the ORDERED tuple of tensor-layout
-    contract handles this slot's code can execute. ``"*"`` is the whole-tree
-    default; a component key overrides it for that component only::
+    mapping from component path to the SET of tensor-layout contract handles
+    this slot's code can execute. ``"*"`` is the whole-tree default; a
+    component key overrides it for that component only::
 
         Slot(StableDiffusionXLPipeline, selected_by="model", layouts={
             "*":            (CONTRACT_PLAIN_BF16,),
             "text_encoder": (CONTRACT_HF_FP8_BLOCKWISE, CONTRACT_PLAIN_BF16),
         })
 
-    Order IS preference. The handles are validated here against the SDK's
+    **The set is a compatibility FILTER; its order carries NO preference**
+    (§1.33 point 2 as amended by th#1803). Preference has exactly one
+    authority — the author-configured ordered ladder of (GPU, lane) pairs —
+    so the handles are stored and published in CANONICAL order, not as
+    written. Two authors who spell the same set differently state the same
+    demand, and no downstream reader can mistake a position for a ranking.
+
+    The handles are validated here against the SDK's
     transcribed ``KNOWN_CONTRACTS``; the KEYS are validated at decoration
     against the slot's DERIVED component tree, so a key that would silently
     match nothing is a build error naming the tree. **Absent is UNDECLARED**

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -41,6 +41,29 @@ from .component import Component
 from .dataset import Dataset, write_jsonl_shard
 from .hub import CommitFile, CommitResult, HubClient, HubPublishError
 from .ingest import IngestedSource, ingest_civitai, ingest_huggingface
+from .layout_converters import (
+    ConversionCase,
+    ConversionHop,
+    ConversionIO,
+    ConversionPlan,
+    ConversionProofError,
+    ConversionResult,
+    CorpusTensor,
+    LayoutProduction,
+    LayoutRung,
+    LayoutVerdict,
+    QuantRepack,
+    TopologyConversion,
+    classify_layout,
+    conversion_provenance,
+    derived_artifact_identity,
+    plan_layout_conversions,
+    register_layout_conversion,
+    register_layout_production,
+    registered_layout_conversions,
+    registered_layout_productions,
+    run_layout_conversion,
+)
 from .layout_spec import DirMatch, HintMatch, LayoutDeclaration
 from .loaded_component import LoadedComponent
 from .produced import ProducedFlavor
@@ -156,4 +179,26 @@ __all__ = [
     "registered_repackage_families",
     "repackage_family",
     "require_repackage_family",
+    # §1.33 / pgw#1143: the layout converter registry — the CONVERTIBLE rung.
+    "ConversionCase",
+    "ConversionHop",
+    "ConversionIO",
+    "ConversionPlan",
+    "ConversionProofError",
+    "ConversionResult",
+    "CorpusTensor",
+    "LayoutProduction",
+    "LayoutRung",
+    "LayoutVerdict",
+    "QuantRepack",
+    "TopologyConversion",
+    "classify_layout",
+    "conversion_provenance",
+    "derived_artifact_identity",
+    "plan_layout_conversions",
+    "register_layout_conversion",
+    "register_layout_production",
+    "registered_layout_conversions",
+    "registered_layout_productions",
+    "run_layout_conversion",
 ]

--- a/src/gen_worker/convert/layout_converters.py
+++ b/src/gen_worker/convert/layout_converters.py
@@ -10,35 +10,37 @@ match exactly, §1.33's ladder decides what happens next:
                  reaches one — a priced production JOB, never a converter
     INCOMPATIBLE none of the above; refused, both sides named
 
-This module owns the CONVERTIBLE edge set and the relation over it. Three
+This module owns the CONVERTIBLE edge set and the relation over it. Four
 properties are load-bearing and are enforced by construction rather than by
 review:
 
 **1. Re-quantization is structurally unregistrable.** A registration is a PAIR
-— forward and inverse — and the admission proof runs `A -> B -> A` over the
-declared corpus and requires the recovered shard's content digest to equal the
-source's. A cast that discards bits has no inverse that can satisfy that, so it
-cannot enter this registry at all. It is not a convention that a lossy transform
-stays out; the registry cannot hold one. Re-quantization is
-:class:`LayoutProduction` — a different edge set, a different rung, and it
-carries a recipe NAME, never a transform.
+— forward and inverse — and :func:`prove_layout_conversion` runs `A -> B -> A`
+over the declared corpus at REGISTRATION, requiring the recovered shard's
+content digest to equal the source's. A cast that discards bits has no inverse
+that can satisfy that, so it cannot enter this registry at all. It is not a
+convention that a lossy transform stays out; the registry cannot hold one.
+Re-quantization is :class:`LayoutProduction` — a different edge set, a different
+rung, carrying a recipe NAME and a quality gate, never a transform.
 
-**2. A topology converter cannot touch payload bytes.** It declares a KEY MAP
-(`Callable[[keys], {old: new}]`) and nothing else; the engine does the copy by
-raw byte range (`writer.rewrite_safetensors_keys`), never decoding a tensor. Bit
--losslessness on that axis is therefore a property of the API, not of the
-converter's care.
+**2. A topology converter cannot touch payload bytes.** It declares
+:class:`~gen_worker.convert.repack_spec.RenameRule` passes — the SDK's existing
+key-rewrite vocabulary, reused rather than re-invented — and the engine copies
+each tensor by raw byte range (`writer.rewrite_safetensors_keys`), never
+decoding one. Bit-losslessness on that axis is a property of the API, not of
+the converter's care. It is also DATA, so a topology edge is readable by an AST
+sweep and by the hub, not only by a Python interpreter.
 
 **3. The relation never grows a special case.** Registering a converter adds an
 EDGE. :func:`plan_layout_conversions` and :func:`classify_layout` are fixed
-logic — membership, then reachability — and must never gain a per-format branch,
-a similarity score or a "close enough" fallback (§1.33's extensibility
-invariant, `f6f95736`). `scripts/lint_cell_key_layout_fence.py` fails on a
-handle literal appearing in either function.
+logic — membership, then reachability — and must never gain a per-format
+branch, a similarity score or a "close enough" fallback (§1.33's extensibility
+invariant, `f6f95736`). Neither function contains a literal handle string, and
+`scripts/lint_cell_key_layout_fence.py` fails if one appears.
 
-Preference is NOT here. §1.33 point 2 as amended (th#1803): the accepted set is
-a compatibility FILTER whose order carries no preference, and preference has
-exactly one authority — the author-configured ordered ladder of (GPU, lane)
+**4. Preference is NOT here.** §1.33 point 2 as amended (th#1803): the accepted
+set is a compatibility FILTER whose order carries no preference, and preference
+has exactly one authority — the author-configured ordered ladder of (GPU, lane)
 pairs. So the planner returns EVERY reachable accepted target and orders the
 result deterministically for reproducibility; the caller that owns a ladder
 chooses. A planner that picked "the earliest accepted layout" would be a second
@@ -55,6 +57,8 @@ import hashlib
 import json
 import os
 import struct
+import sys
+import tempfile
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
@@ -71,11 +75,13 @@ from ..models.tensor_layout_contract import (
     LayoutId,
     validate_layout_handle,
 )
-from .repack_spec import DeclarationError
+from .repack_spec import DeclarationError, RenameRule
 from .writer import (
     read_safetensors_header,
     rewrite_safetensors_keys,
     shard_content_digest,
+    shard_payload_digests,
+    shard_tensor_entries,
     write_safetensors_shard,
 )
 
@@ -91,7 +97,6 @@ MAX_CORPUS_PAYLOAD_BYTES = 1 << 20
 #: which the planner says in its refusal rather than silently paying for.
 MAX_PLAN_HOPS_PER_AXIS = 2
 
-KeyMapFn = Callable[[Tuple[str, ...]], Mapping[str, str]]
 RepackFn = Callable[["ConversionIO"], None]
 EquivalenceFn = Callable[[Path, Path], None]
 
@@ -211,8 +216,8 @@ class ConversionIO:
 
     Streaming: payloads are read one tensor at a time and emitted into a spool,
     so a repack never holds a component in memory. Deliberately NOT handed to a
-    topology converter — that axis declares a key map and the engine copies by
-    byte range, which is what makes its bit-losslessness structural.
+    topology converter — that axis declares rename rules and the engine copies
+    by byte range, which is what makes its bit-losslessness structural.
     """
 
     def __init__(self, source: Path, target: Path) -> None:
@@ -239,12 +244,16 @@ class ConversionIO:
 
     def spec(self, key: str) -> CorpusTensor:
         meta = self._entry(key)
+        shape = meta["shape"]
+        assert isinstance(shape, (list, tuple))
         return CorpusTensor(
-            dtype=str(meta["dtype"]), shape=tuple(int(d) for d in meta["shape"]))
+            dtype=str(meta["dtype"]), shape=tuple(int(d) for d in shape))
 
     def read(self, key: str) -> bytes:
         meta = self._entry(key)
-        start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+        offsets = meta["data_offsets"]
+        assert isinstance(offsets, (list, tuple))
+        start, end = int(offsets[0]), int(offsets[1])
         out = bytearray()
         offset = self._base + start
         remaining = end - start
@@ -315,21 +324,42 @@ class ConversionIO:
 # ---------------------------------------------------------------------------
 
 
+def apply_rename_rules(
+    keys: Sequence[str], rules: Sequence[RenameRule],
+) -> Dict[str, str]:
+    """Run the declared rename passes over a key set: ``{old: new}``, total.
+
+    The passes are ``convert.repack_spec.RenameRule`` verbatim — the same
+    prefix / substring / alternation vocabulary the repackage engine already
+    executes. One vocabulary, one semantics; a topology edge that needed a
+    different one would be describing something that is not a rename.
+    """
+    out: Dict[str, str] = {}
+    for key in keys:
+        renamed = key
+        for rule in rules:
+            renamed = rule.apply(renamed)
+        out[key] = renamed
+    return out
+
+
 @dataclass(frozen=True)
 class TopologyConversion:
-    """A TOPOLOGY-axis mapping: a key map, and its inverse.
+    """A TOPOLOGY-axis mapping: declared rename passes, and their inverse.
 
-    The whole declaration is `(keys) -> {old: new}` in both directions. There
-    is no payload API — the engine copies each tensor by raw byte range — so
-    "bit-lossless" is a property of this class rather than a claim a converter
-    makes about itself.
+    The whole declaration is DATA — two tuples of
+    :class:`~gen_worker.convert.repack_spec.RenameRule` — so the engine copies
+    each tensor by raw byte range and "bit-lossless" is a property of this
+    class rather than a claim a converter makes about itself. There is
+    deliberately no payload hook and no callable: a topology edge that wanted
+    to touch bytes is a quant edge that has not admitted it.
     """
 
     from_id: str
     to_id: str
     version: int
-    forward_keys: KeyMapFn
-    inverse_keys: KeyMapFn
+    rules: Tuple[RenameRule, ...]
+    inverse_rules: Tuple[RenameRule, ...]
     corpus: Tuple[ConversionCase, ...]
     why: str = ""
 
@@ -337,16 +367,26 @@ class TopologyConversion:
     proof: str = field(default="key_bijection", init=False)
     needs_torch: bool = field(default=False, init=False)
 
+    def __post_init__(self) -> None:
+        if not self.rules or not self.inverse_rules:
+            raise DeclarationError(
+                f"topology {self.from_id} -> {self.to_id}: both rules= and "
+                "inverse_rules= are required. A lossless mapping is invertible "
+                "by definition, and the inverse is what the admission proof "
+                "runs — an edge with no stated inverse cannot be proven "
+                "lossless, so it cannot be a CONVERTIBLE edge.")
+
 
 @dataclass(frozen=True)
 class QuantRepack:
     """A QUANT-axis SAME-NUMERICS repack: different packing, identical values.
 
-    `equivalence` is the obligation §1.33 names — the target contract's own
-    reference dequant applied to both shards — and it runs over the corpus at
-    registration. It is required, not optional: a quant-axis edge with nothing
-    proving the values survived is exactly the re-quantization this registry
-    must not hold.
+    Unlike topology, this axis genuinely rewrites payload bytes, so the
+    transform is code. `equivalence` is the obligation §1.33 names — the target
+    contract's own reference dequant applied to both shards — and it runs over
+    the corpus at registration alongside the round trip. It is required, not
+    optional: a quant-axis edge with nothing proving the values survived is
+    exactly the re-quantization this registry must not hold.
     """
 
     from_id: str
@@ -429,36 +469,52 @@ class LayoutVerdict:
 _lock = RLock()
 _edges: Dict[Tuple[str, str, str], ConversionHop] = {}
 _specs: Dict[Tuple[str, str, str], LayoutConversion] = {}
-_applies: Dict[Tuple[str, str, str], Union[KeyMapFn, RepackFn]] = {}
+_directions: Dict[Tuple[str, str, str], bool] = {}  # key -> is the spec's forward
 _productions: Dict[Tuple[str, str, str], LayoutProduction] = {}
 
 
-def _apply_module_digest(fn: Callable[..., object]) -> str:
-    """Content identity of the module a converter's code lives in.
+def _module_content_digest(fn: Callable[..., object]) -> str:
+    """Content identity of the module a repack's code lives in.
 
     pgw#990's primitive, reused rather than reinvented: there is ONE
     code-identity mechanism in this SDK and a second one would be a second
-    answer to "did the bytes change".
+    answer to "did the bytes change". Content, not mtime — the digest must be
+    identical on the hub and on a laptop or the derived-artifact identity
+    stops deduping (§1.33 point 4).
     """
-    module = getattr(fn, "__module__", "")
-    path = getattr(__import__("sys").modules.get(module, None), "__file__", None)
+    module = sys.modules.get(getattr(fn, "__module__", ""), None)
+    path = getattr(module, "__file__", None)
     if not path:
         return "unlocatable"
     stat = Path(path).stat()
     return _closure_file_digest(str(path), stat.st_mtime_ns, stat.st_size)
 
 
+def _body_digest(spec: LayoutConversion, *, forward: bool) -> str:
+    """What the edge DOES, as a content address.
+
+    Topology edges are data, so their body IS the declared rename passes —
+    fully deterministic, no code identity needed. Quant edges are code, so
+    their body is the content digest of the module the transform lives in.
+    """
+    if isinstance(spec, TopologyConversion):
+        rules = spec.rules if forward else spec.inverse_rules
+        return hashlib.sha256(json.dumps(
+            [[r.kind, [list(p) for p in r.pairs]] for r in rules],
+            separators=(",", ":"),
+        ).encode()).hexdigest()[:16]
+    return _module_content_digest(spec.forward if forward else spec.inverse)
+
+
 def converter_digest(
-    axis: str, from_id: str, to_id: str, version: int,
-    fn: Callable[..., object],
+    axis: str, from_id: str, to_id: str, version: int, body: str,
 ) -> str:
-    """`sha256(axis ‖ from ‖ to ‖ version ‖ code closure of the apply module)`.
+    """`sha256(axis ‖ from ‖ to ‖ version ‖ body digest)`.
 
     Bumping `version` changes the digest, which changes every derived
     artifact's identity — bytes never silently change under a name.
     """
-    payload = "\x00".join(
-        [axis, from_id, to_id, str(int(version)), _apply_module_digest(fn)])
+    payload = "\x00".join([axis, from_id, to_id, str(int(version)), body])
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
@@ -485,6 +541,10 @@ def register_layout_conversion(
     Refuses, by name: an unknown handle on the axis, a self-edge, a re-declared
     edge with different content, and any mapping whose `A -> B -> A` round trip
     over its own corpus does not recover the source content exactly.
+
+    Both directions are registered because a lossless mapping is invertible and
+    the inverse was proven in the same pass: withholding it would be an edge
+    the platform knows is safe and refuses to use.
     """
     _validate_declaration(spec)
     prove_layout_conversion(spec)
@@ -499,15 +559,15 @@ def register_layout_conversion(
                     f"layout conversion {key[0]} {key[1]} -> {key[2]} is "
                     "already registered with a different declaration; pass "
                     "replace=True only if you own both")
-        for key, fn in ((forward_key, _forward_of(spec)),
-                        (inverse_key, _inverse_of(spec))):
+        for key, is_forward in ((forward_key, True), (inverse_key, False)):
             _specs[key] = spec
-            _applies[key] = fn
+            _directions[key] = is_forward
             _edges[key] = ConversionHop(
                 axis=key[0], from_id=key[1], to_id=key[2],
                 version=spec.version,
-                digest=converter_digest(key[0], key[1], key[2],
-                                        spec.version, fn),
+                digest=converter_digest(
+                    key[0], key[1], key[2], spec.version,
+                    _body_digest(spec, forward=is_forward)),
             )
     return spec
 
@@ -529,6 +589,8 @@ def register_layout_production(
     where = f"LayoutProduction({spec.from_id} -> {spec.to_id})"
     validate_layout_handle(spec.from_id, where=where, axis=spec.axis)
     validate_layout_handle(spec.to_id, where=where, axis=spec.axis)
+    if spec.from_id == spec.to_id:
+        raise DeclarationError(f"{where}: a production to itself is not an edge")
     if not str(spec.recipe or "").strip():
         raise DeclarationError(f"{where}: recipe is empty")
     if not str(spec.quality_gate or "").strip():
@@ -569,18 +631,8 @@ def reset_layout_conversions() -> None:
     with _lock:
         _edges.clear()
         _specs.clear()
-        _applies.clear()
+        _directions.clear()
         _productions.clear()
-
-
-def _forward_of(spec: LayoutConversion) -> Union[KeyMapFn, RepackFn]:
-    return (spec.forward_keys if isinstance(spec, TopologyConversion)
-            else spec.forward)
-
-
-def _inverse_of(spec: LayoutConversion) -> Union[KeyMapFn, RepackFn]:
-    return (spec.inverse_keys if isinstance(spec, TopologyConversion)
-            else spec.inverse)
 
 
 def _validate_declaration(spec: LayoutConversion) -> None:
@@ -622,8 +674,6 @@ def prove_layout_conversion(spec: LayoutConversion) -> Tuple[str, ...]:
     4. **dequant equivalence** (quant) — the declared reference dequant agrees
        across the pair.
     """
-    import tempfile
-
     passed: List[str] = []
     with tempfile.TemporaryDirectory(prefix="cozy-layout-proof-") as tmp:
         root = Path(tmp)
@@ -631,24 +681,13 @@ def prove_layout_conversion(spec: LayoutConversion) -> Tuple[str, ...]:
             source = materialize_case(case, root / f"{case.name}.src.safetensors")
             forward = root / f"{case.name}.fwd.safetensors"
             back = root / f"{case.name}.rt.safetensors"
-            try:
-                _apply_hop(spec, _forward_of(spec), source, forward)
-            except Exception as exc:  # noqa: BLE001 - re-raised typed
-                raise ConversionProofError(
-                    f"{spec.axis} {spec.from_id} -> {spec.to_id}: forward "
-                    f"mapping failed on corpus case {case.name!r}: {exc}"
-                ) from exc
+            _run_hop_or_raise(spec, source, forward, forward=True, case=case)
             _prove_keys(spec, case, source, forward)
+            passed.append(f"{case.name}:key_bijection")
             if isinstance(spec, TopologyConversion):
                 _prove_payload_invariance(spec, case, source, forward)
                 passed.append(f"{case.name}:payload_invariance")
-            try:
-                _apply_hop(spec, _inverse_of(spec), forward, back)
-            except Exception as exc:  # noqa: BLE001 - re-raised typed
-                raise ConversionProofError(
-                    f"{spec.axis} {spec.from_id} -> {spec.to_id}: inverse "
-                    f"mapping failed on corpus case {case.name!r}: {exc}"
-                ) from exc
+            _run_hop_or_raise(spec, forward, back, forward=False, case=case)
             before, after = shard_content_digest(source), shard_content_digest(back)
             if before != after:
                 raise ConversionProofError(
@@ -673,24 +712,34 @@ def prove_layout_conversion(spec: LayoutConversion) -> Tuple[str, ...]:
     return tuple(passed)
 
 
+def _run_hop_or_raise(
+    spec: LayoutConversion, source: Path, target: Path, *,
+    forward: bool, case: ConversionCase,
+) -> None:
+    try:
+        _apply_hop(spec, source, target, forward=forward)
+    except Exception as exc:  # noqa: BLE001 - re-raised typed
+        direction = "forward" if forward else "inverse"
+        raise ConversionProofError(
+            f"{spec.axis} {spec.from_id} -> {spec.to_id}: {direction} mapping "
+            f"failed on corpus case {case.name!r}: {exc}") from exc
+
+
 def _apply_hop(
-    spec: LayoutConversion, fn: Union[KeyMapFn, RepackFn],
-    source: Path, target: Path,
+    spec: LayoutConversion, source: Path, target: Path, *, forward: bool,
 ) -> None:
     """Execute ONE hop. Topology goes through the raw byte-range rewrite and
     never decodes; quant goes through the streaming IO."""
     if isinstance(spec, TopologyConversion):
-        keymap_fn: KeyMapFn = fn  # type: ignore[assignment]
-        with open(source, "rb") as fh:
-            fd = fh.fileno()
-            header, _ = read_safetensors_header(fd)
-        keys = tuple(k for k in header if k != "__metadata__")
-        rewrite_safetensors_keys(source, target, keymap_fn(keys))
+        rules = spec.rules if forward else spec.inverse_rules
+        keys = tuple(name for name, _ in shard_tensor_entries(source))
+        rewrite_safetensors_keys(
+            source, target, apply_rename_rules(keys, rules))
         return
-    repack_fn: RepackFn = fn  # type: ignore[assignment]
+    repack: RepackFn = spec.forward if forward else spec.inverse
     io = ConversionIO(source, target)
     try:
-        repack_fn(io)
+        repack(io)
     finally:
         io.close()
 
@@ -698,17 +747,17 @@ def _apply_hop(
 def _prove_keys(
     spec: LayoutConversion, case: ConversionCase, source: Path, target: Path,
 ) -> None:
-    src_keys = set(_shard_keys(source))
-    dst_keys = list(_shard_keys(target))
+    src_keys = [name for name, _ in shard_tensor_entries(source)]
+    dst_keys = [name for name, _ in shard_tensor_entries(target)]
     if len(dst_keys) != len(set(dst_keys)):
         raise ConversionProofError(
             f"{spec.axis} {spec.from_id} -> {spec.to_id}: corpus case "
             f"{case.name!r} produced a duplicate key — the map is not injective")
-    if len(dst_keys) != len(src_keys):
-        dropped = len(src_keys) - len(dst_keys)
+    if len(dst_keys) != len(set(src_keys)):
+        dropped = len(set(src_keys)) - len(dst_keys)
         raise ConversionProofError(
             f"{spec.axis} {spec.from_id} -> {spec.to_id}: corpus case "
-            f"{case.name!r} has {len(src_keys)} source keys and "
+            f"{case.name!r} has {len(set(src_keys))} source keys and "
             f"{len(dst_keys)} output keys ({dropped:+d}). An unmapped key is a "
             "REFUSAL, never a silent skip, and an invented key is worse.")
 
@@ -716,32 +765,13 @@ def _prove_keys(
 def _prove_payload_invariance(
     spec: TopologyConversion, case: ConversionCase, source: Path, target: Path,
 ) -> None:
-    before = sorted(_payload_digests(source).values())
-    after = sorted(_payload_digests(target).values())
+    before = sorted(shard_payload_digests(source).values())
+    after = sorted(shard_payload_digests(target).values())
     if before != after:
         raise ConversionProofError(
             f"topology {spec.from_id} -> {spec.to_id}: corpus case "
             f"{case.name!r} changed payload bytes. The topology axis is keys "
             "only — 'what the weights ARE' is the quant axis.")
-
-
-def _shard_keys(path: Path) -> Tuple[str, ...]:
-    with open(path, "rb") as fh:
-        header, _ = read_safetensors_header(fh.fileno())
-    return tuple(k for k in header if k != "__metadata__")
-
-
-def _payload_digests(path: Path) -> Dict[str, str]:
-    out: Dict[str, str] = {}
-    with open(path, "rb") as fh:
-        header, base = read_safetensors_header(fh.fileno())
-        for name, meta in header.items():
-            if name == "__metadata__" or not isinstance(meta, dict):
-                continue
-            start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
-            fh.seek(base + start)
-            out[name] = hashlib.sha256(fh.read(end - start)).hexdigest()
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -764,6 +794,12 @@ def _axis_satisfied(demand: Optional[str], supply: Optional[str]) -> bool:
 
 
 def _unevaluated(source: LayoutId, accepts: Sequence[LayoutId]) -> Tuple[str, ...]:
+    """Axes this verdict did NOT decide, because one side never stated them.
+
+    Reported rather than assumed: an unstated axis is UNDECLARED, which is a
+    different fact from "agnostic", and a caller that needs exactness on it
+    must refuse rather than read silence as agreement.
+    """
     return tuple(
         axis for axis in LAYOUT_AXES
         if source.axis(axis) is None
@@ -788,7 +824,7 @@ def _shortest_chain(
         node, chain = queue.popleft()
         if len(chain) >= MAX_PLAN_HOPS_PER_AXIS:
             continue
-        for edge in edges:
+        for edge in sorted(edges, key=lambda e: (e.from_id, e.to_id)):
             if edge.from_id != node or edge.to_id in seen:
                 continue
             extended = chain + (edge,)
@@ -842,8 +878,8 @@ def _reachable_productions(
     for production in productions:
         if source.axis(production.axis) != production.from_id:
             continue
+        candidate = source.with_axis(production.axis, production.to_id)
         for target in accepts:
-            candidate = source.with_axis(production.axis, production.to_id)
             if all(_axis_satisfied(target.axis(a), candidate.axis(a))
                    for a in LAYOUT_AXES):
                 out.append(production)
@@ -907,8 +943,8 @@ def classify_layout(
 #: self-describe, so anyone can re-derive the identity without the hub.
 CONVERSION_PROVENANCE_KEY = "cozy.conversion"
 
-#: `produced_by` value that the publish path REFUSES (§4.28): a conversion done
-#: on untrusted hardware is for that machine's own store, forever.
+#: `produced_by` value the publish path REFUSES (§4.28): a conversion done on
+#: an untrusted machine is for that machine's own store, forever.
 PRODUCED_BY_LOCAL = "local_conversion"
 
 
@@ -941,23 +977,22 @@ def run_layout_conversion(
     if not hops:
         raise DeclarationError("run_layout_conversion: the plan has no hops")
 
-    import tempfile
-
     current = Path(source)
     with tempfile.TemporaryDirectory(
             prefix="cozy-layout-", dir=str(target.parent)) as tmp:
         for index, hop in enumerate(hops):
+            key = (hop.axis, hop.from_id, hop.to_id)
             with _lock:
-                spec = _specs.get((hop.axis, hop.from_id, hop.to_id))
-                fn = _applies.get((hop.axis, hop.from_id, hop.to_id))
-            if spec is None or fn is None:
+                spec = _specs.get(key)
+                forward = _directions.get(key)
+            if spec is None or forward is None:
                 raise DeclarationError(
                     f"no registered converter for {hop.axis} {hop.from_id} -> "
                     f"{hop.to_id}; the plan names an edge this process does "
                     "not hold")
             last = index == len(hops) - 1
             out = target if last else Path(tmp) / f"hop{index}.safetensors"
-            _apply_hop(spec, fn, current, out)
+            _apply_hop(spec, current, out, forward=forward)
             current = out
 
     identity = derived_artifact_identity(source_digest, plan.digests, plan.target)
@@ -1013,10 +1048,12 @@ __all__ = [
     "PRODUCED_BY_LOCAL",
     "QuantRepack",
     "TopologyConversion",
+    "apply_rename_rules",
     "classify_layout",
     "conversion_provenance",
     "converter_digest",
     "derived_artifact_identity",
+    "materialize_case",
     "plan_layout_conversions",
     "prove_layout_conversion",
     "register_layout_conversion",

--- a/src/gen_worker/convert/layout_converters.py
+++ b/src/gen_worker/convert/layout_converters.py
@@ -1,0 +1,1028 @@
+"""pgw#1143 step 4 (§1.33): the layout converter registry — the CONVERTIBLE rung.
+
+The tensor-layout contract is ONE vocabulary with TWO sides: the code side
+DEMANDS (`Slot(layouts=...)`), the artifact side SUPPLIES. When the two do not
+match exactly, §1.33's ladder decides what happens next:
+
+    COMPATIBLE   the supply's LayoutId is in the demand set
+    CONVERTIBLE  a registered LOSSLESS mapping reaches an accepted LayoutId
+    PRODUCIBLE   only a re-quantization from a named higher-precision source
+                 reaches one — a priced production JOB, never a converter
+    INCOMPATIBLE none of the above; refused, both sides named
+
+This module owns the CONVERTIBLE edge set and the relation over it. Three
+properties are load-bearing and are enforced by construction rather than by
+review:
+
+**1. Re-quantization is structurally unregistrable.** A registration is a PAIR
+— forward and inverse — and the admission proof runs `A -> B -> A` over the
+declared corpus and requires the recovered shard's content digest to equal the
+source's. A cast that discards bits has no inverse that can satisfy that, so it
+cannot enter this registry at all. It is not a convention that a lossy transform
+stays out; the registry cannot hold one. Re-quantization is
+:class:`LayoutProduction` — a different edge set, a different rung, and it
+carries a recipe NAME, never a transform.
+
+**2. A topology converter cannot touch payload bytes.** It declares a KEY MAP
+(`Callable[[keys], {old: new}]`) and nothing else; the engine does the copy by
+raw byte range (`writer.rewrite_safetensors_keys`), never decoding a tensor. Bit
+-losslessness on that axis is therefore a property of the API, not of the
+converter's care.
+
+**3. The relation never grows a special case.** Registering a converter adds an
+EDGE. :func:`plan_layout_conversions` and :func:`classify_layout` are fixed
+logic — membership, then reachability — and must never gain a per-format branch,
+a similarity score or a "close enough" fallback (§1.33's extensibility
+invariant, `f6f95736`). `scripts/lint_cell_key_layout_fence.py` fails on a
+handle literal appearing in either function.
+
+Preference is NOT here. §1.33 point 2 as amended (th#1803): the accepted set is
+a compatibility FILTER whose order carries no preference, and preference has
+exactly one authority — the author-configured ordered ladder of (GPU, lane)
+pairs. So the planner returns EVERY reachable accepted target and orders the
+result deterministically for reproducibility; the caller that owns a ladder
+chooses. A planner that picked "the earliest accepted layout" would be a second
+ordering that can disagree with the first.
+
+The wheel ships this registry EMPTY, like the other five (pgw#740): converters
+are declared by the endpoint that owns the format, registered through
+`load_declaration_module`, and asserted bare by `scripts/check_registry_contract.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from threading import RLock
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+from ..compile_cache import _closure_file_digest
+from ..models.tensor_layout_contract import (
+    AXIS_QUANT,
+    AXIS_TOPOLOGY,
+    LAYOUT_AXES,
+    LAYOUT_AXIS_ANY,
+    LayoutId,
+    validate_layout_handle,
+)
+from .repack_spec import DeclarationError
+from .writer import (
+    read_safetensors_header,
+    rewrite_safetensors_keys,
+    shard_content_digest,
+    write_safetensors_shard,
+)
+
+#: A corpus case's synthesized payload budget. The admission proof runs at
+#: REGISTRATION — on a serving pod, at endpoint import — so a corpus that could
+#: cost real I/O would make declaring a converter expensive. Real HEADERS,
+#: synthetic payloads: structure and reversibility are what this proves.
+MAX_CORPUS_PAYLOAD_BYTES = 1 << 20
+
+#: How many rewrites of the weights one plan may cost, per axis. A COST bound,
+#: not a correctness one: lossless∘lossless is lossless at any length, but each
+#: hop is a full weight rewrite, and a 3-hop need means a missing direct edge —
+#: which the planner says in its refusal rather than silently paying for.
+MAX_PLAN_HOPS_PER_AXIS = 2
+
+KeyMapFn = Callable[[Tuple[str, ...]], Mapping[str, str]]
+RepackFn = Callable[["ConversionIO"], None]
+EquivalenceFn = Callable[[Path, Path], None]
+
+_DTYPE_ITEMSIZE: Dict[str, int] = {
+    "BOOL": 1, "U8": 1, "I8": 1, "F8_E4M3": 1, "F8_E5M2": 1,
+    "U16": 2, "I16": 2, "F16": 2, "BF16": 2,
+    "U32": 4, "I32": 4, "F32": 4,
+    "U64": 8, "I64": 8, "F64": 8,
+}
+
+
+class ConversionProofError(DeclarationError):
+    """A converter's bit-exactness obligation did not hold over its corpus.
+
+    Raised at REGISTRATION, never at run time: an unproven converter never
+    enters the registry, so nothing downstream has to ask whether an edge was
+    checked.
+    """
+
+
+class LayoutRung(str, Enum):
+    """§1.33's four-valued ladder. The only verdict vocabulary — do not fork it."""
+
+    COMPATIBLE = "compatible"
+    CONVERTIBLE = "convertible"
+    PRODUCIBLE = "producible"
+    INCOMPATIBLE = "incompatible"
+
+
+# ---------------------------------------------------------------------------
+# The corpus: a REAL artifact header, synthetic payloads
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CorpusTensor:
+    """One tensor as a real artifact's header declares it."""
+
+    dtype: str
+    shape: Tuple[int, ...]
+
+    def nbytes(self) -> int:
+        itemsize = _DTYPE_ITEMSIZE.get(self.dtype)
+        if itemsize is None:
+            raise DeclarationError(
+                f"unknown safetensors dtype {self.dtype!r}; known: "
+                f"{', '.join(sorted(_DTYPE_ITEMSIZE))}")
+        count = 1
+        for dim in self.shape:
+            if int(dim) < 0:
+                raise DeclarationError(f"negative dim in shape {self.shape!r}")
+            count *= int(dim)
+        return count * itemsize
+
+
+@dataclass(frozen=True)
+class ConversionCase:
+    """One corpus case: the KEYS, dtypes and shapes of a real artifact.
+
+    §4.25 / th#1580's corpus method, at header granularity — the part of a real
+    checkpoint a key map and a repack actually act on. Nothing multi-GB touches
+    CI or a developer box; payloads are synthesized deterministically from the
+    case name so a proof is reproducible.
+    """
+
+    name: str
+    tensors: Mapping[str, CorpusTensor]
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not str(self.name or "").strip():
+            raise DeclarationError("ConversionCase.name is empty")
+        if not self.tensors:
+            raise DeclarationError(
+                f"corpus case {self.name!r} declares no tensors; a case that "
+                "acts on nothing proves nothing")
+        total = sum(t.nbytes() for t in self.tensors.values())
+        if total > MAX_CORPUS_PAYLOAD_BYTES:
+            raise DeclarationError(
+                f"corpus case {self.name!r} declares {total} payload bytes, "
+                f"over the {MAX_CORPUS_PAYLOAD_BYTES} budget — the admission "
+                "proof runs at registration, so a case must stay cheap. Use a "
+                "real header with representative KEYS and small shapes.")
+
+
+def _synthetic_payload(case: str, key: str, nbytes: int) -> bytes:
+    """Deterministic bytes for one corpus tensor. Values are irrelevant to a
+    key map and must be irrelevant to a lossless repack; a repack that behaves
+    differently on real values is not value-agnostic and is out of contract."""
+    out = bytearray()
+    seed = f"{case}\x00{key}".encode()
+    counter = 0
+    while len(out) < nbytes:
+        out.extend(hashlib.sha256(seed + str(counter).encode()).digest())
+        counter += 1
+    return bytes(out[:nbytes])
+
+
+def materialize_case(case: ConversionCase, path: Path) -> Path:
+    """Write one corpus case as a real safetensors shard."""
+    tensors = {
+        key: (spec.dtype, tuple(spec.shape),
+              _synthetic_payload(case.name, key, spec.nbytes()))
+        for key, spec in case.tensors.items()
+    }
+    write_safetensors_shard(path, tensors, metadata=dict(case.metadata))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The quant-axis I/O: streaming, torch-free, no network
+# ---------------------------------------------------------------------------
+
+
+class ConversionIO:
+    """One component shard, in and out, for a QUANT-axis repack.
+
+    Streaming: payloads are read one tensor at a time and emitted into a spool,
+    so a repack never holds a component in memory. Deliberately NOT handed to a
+    topology converter — that axis declares a key map and the engine copies by
+    byte range, which is what makes its bit-losslessness structural.
+    """
+
+    def __init__(self, source: Path, target: Path) -> None:
+        self._target = Path(target)
+        self._fd = os.open(str(source), os.O_RDONLY)
+        try:
+            self._header, self._base = read_safetensors_header(self._fd)
+        except BaseException:
+            os.close(self._fd)
+            raise
+        self._spool_path = self._target.parent / f".{self._target.name}.spool"
+        self._spool = open(self._spool_path, "wb")
+        self._emitted: List[Tuple[str, str, Tuple[int, ...], int, int]] = []
+        self._metadata: Dict[str, str] = {
+            str(k): str(v)
+            for k, v in (self._header.get("__metadata__") or {}).items()
+        }
+        self._cursor = 0
+
+    # -- source side --------------------------------------------------------
+
+    def keys(self) -> Tuple[str, ...]:
+        return tuple(k for k in self._header if k != "__metadata__")
+
+    def spec(self, key: str) -> CorpusTensor:
+        meta = self._entry(key)
+        return CorpusTensor(
+            dtype=str(meta["dtype"]), shape=tuple(int(d) for d in meta["shape"]))
+
+    def read(self, key: str) -> bytes:
+        meta = self._entry(key)
+        start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+        out = bytearray()
+        offset = self._base + start
+        remaining = end - start
+        while remaining > 0:
+            chunk = os.pread(self._fd, min(remaining, 8 << 20), offset)
+            if not chunk:
+                raise IOError(f"safetensors: short read on {key!r}")
+            out.extend(chunk)
+            offset += len(chunk)
+            remaining -= len(chunk)
+        return bytes(out)
+
+    def source_metadata(self) -> Mapping[str, str]:
+        return dict(self._metadata)
+
+    # -- target side --------------------------------------------------------
+
+    def emit(self, key: str, *, dtype: str, shape: Sequence[int],
+             payload: bytes) -> None:
+        if not key or key == "__metadata__":
+            raise DeclarationError(f"cannot emit tensor named {key!r}")
+        self._spool.write(payload)
+        self._emitted.append(
+            (key, dtype, tuple(int(d) for d in shape), self._cursor,
+             self._cursor + len(payload)))
+        self._cursor += len(payload)
+
+    def set_metadata(self, key: str, value: str) -> None:
+        self._metadata[str(key)] = str(value)
+
+    def _entry(self, key: str) -> Mapping[str, object]:
+        meta = self._header.get(key)
+        if not isinstance(meta, dict):
+            raise KeyError(f"no tensor {key!r} in this shard")
+        return meta
+
+    def close(self) -> Path:
+        """Finalize the target shard: header, then the spooled payloads."""
+        try:
+            self._spool.close()
+            header: Dict[str, object] = {}
+            if self._metadata:
+                header["__metadata__"] = dict(self._metadata)
+            for key, dtype, shape, start, end in self._emitted:
+                header[key] = {
+                    "dtype": dtype, "shape": list(shape),
+                    "data_offsets": [start, end],
+                }
+            blob = json.dumps(header, separators=(",", ":")).encode("utf-8")
+            tmp = self._target.parent / f".{self._target.name}.writing"
+            with open(tmp, "wb") as out, open(self._spool_path, "rb") as spool:
+                out.write(struct.pack("<Q", len(blob)))
+                out.write(blob)
+                while True:
+                    chunk = spool.read(8 << 20)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            tmp.replace(self._target)
+            return self._target
+        finally:
+            os.close(self._fd)
+            self._spool_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# The declarations
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TopologyConversion:
+    """A TOPOLOGY-axis mapping: a key map, and its inverse.
+
+    The whole declaration is `(keys) -> {old: new}` in both directions. There
+    is no payload API — the engine copies each tensor by raw byte range — so
+    "bit-lossless" is a property of this class rather than a claim a converter
+    makes about itself.
+    """
+
+    from_id: str
+    to_id: str
+    version: int
+    forward_keys: KeyMapFn
+    inverse_keys: KeyMapFn
+    corpus: Tuple[ConversionCase, ...]
+    why: str = ""
+
+    axis: str = field(default=AXIS_TOPOLOGY, init=False)
+    proof: str = field(default="key_bijection", init=False)
+    needs_torch: bool = field(default=False, init=False)
+
+
+@dataclass(frozen=True)
+class QuantRepack:
+    """A QUANT-axis SAME-NUMERICS repack: different packing, identical values.
+
+    `equivalence` is the obligation §1.33 names — the target contract's own
+    reference dequant applied to both shards — and it runs over the corpus at
+    registration. It is required, not optional: a quant-axis edge with nothing
+    proving the values survived is exactly the re-quantization this registry
+    must not hold.
+    """
+
+    from_id: str
+    to_id: str
+    version: int
+    forward: RepackFn
+    inverse: RepackFn
+    equivalence: EquivalenceFn
+    corpus: Tuple[ConversionCase, ...]
+    needs_torch: bool = False
+    why: str = ""
+
+    axis: str = field(default=AXIS_QUANT, init=False)
+    proof: str = field(default="dequant_equivalence", init=False)
+
+
+LayoutConversion = Union[TopologyConversion, QuantRepack]
+
+
+@dataclass(frozen=True)
+class LayoutProduction:
+    """The PRODUCIBLE rung: re-quantization from a named higher-precision source.
+
+    An EDGE DECLARATION and nothing else — no transform lives here. Producing
+    new numerics is a priced job with a quality gate (§4.32, th#1809 T7), and
+    putting an `apply` on this class is how it would quietly become automatic.
+    """
+
+    axis: str
+    from_id: str
+    to_id: str
+    recipe: str
+    quality_gate: str
+    why: str = ""
+
+
+@dataclass(frozen=True)
+class ConversionHop:
+    axis: str
+    from_id: str
+    to_id: str
+    version: int
+    digest: str
+
+
+@dataclass(frozen=True)
+class ConversionPlan:
+    """How to reach ONE accepted LayoutId, per axis."""
+
+    target: LayoutId
+    topology: Tuple[ConversionHop, ...] = ()
+    quant: Tuple[ConversionHop, ...] = ()
+
+    @property
+    def hops(self) -> Tuple[ConversionHop, ...]:
+        return self.topology + self.quant
+
+    @property
+    def digests(self) -> Tuple[str, ...]:
+        return tuple(hop.digest for hop in self.hops)
+
+
+@dataclass(frozen=True)
+class LayoutVerdict:
+    """One rung, plus everything the caller needs to act or to refuse by name."""
+
+    rung: LayoutRung
+    source: LayoutId
+    accepts: Tuple[LayoutId, ...]
+    plans: Tuple[ConversionPlan, ...] = ()
+    productions: Tuple[LayoutProduction, ...] = ()
+    unevaluated_axes: Tuple[str, ...] = ()
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+_lock = RLock()
+_edges: Dict[Tuple[str, str, str], ConversionHop] = {}
+_specs: Dict[Tuple[str, str, str], LayoutConversion] = {}
+_applies: Dict[Tuple[str, str, str], Union[KeyMapFn, RepackFn]] = {}
+_productions: Dict[Tuple[str, str, str], LayoutProduction] = {}
+
+
+def _apply_module_digest(fn: Callable[..., object]) -> str:
+    """Content identity of the module a converter's code lives in.
+
+    pgw#990's primitive, reused rather than reinvented: there is ONE
+    code-identity mechanism in this SDK and a second one would be a second
+    answer to "did the bytes change".
+    """
+    module = getattr(fn, "__module__", "")
+    path = getattr(__import__("sys").modules.get(module, None), "__file__", None)
+    if not path:
+        return "unlocatable"
+    stat = Path(path).stat()
+    return _closure_file_digest(str(path), stat.st_mtime_ns, stat.st_size)
+
+
+def converter_digest(
+    axis: str, from_id: str, to_id: str, version: int,
+    fn: Callable[..., object],
+) -> str:
+    """`sha256(axis ‖ from ‖ to ‖ version ‖ code closure of the apply module)`.
+
+    Bumping `version` changes the digest, which changes every derived
+    artifact's identity — bytes never silently change under a name.
+    """
+    payload = "\x00".join(
+        [axis, from_id, to_id, str(int(version)), _apply_module_digest(fn)])
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def derived_artifact_identity(
+    source_digest: str, chain_digests: Sequence[str], target: LayoutId,
+) -> str:
+    """`sha256(source ‖ ordered converter digests ‖ target LayoutId)`.
+
+    ONE identity function, shipped here and called by every producer of a
+    converted artifact — the hub's convert-once-into-the-CAS and cozy-local's
+    derived store — so a machine that later pulls the hub's copy recognizes it
+    as the same object instead of converting again (§4.28, th#1809 T6).
+    """
+    payload = "\x00".join(
+        [str(source_digest), *[str(d) for d in chain_digests], target.render()])
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def register_layout_conversion(
+    spec: LayoutConversion, *, replace: bool = False,
+) -> LayoutConversion:
+    """Admit ONE lossless mapping — both directions — after proving it.
+
+    Refuses, by name: an unknown handle on the axis, a self-edge, a re-declared
+    edge with different content, and any mapping whose `A -> B -> A` round trip
+    over its own corpus does not recover the source content exactly.
+    """
+    _validate_declaration(spec)
+    prove_layout_conversion(spec)
+
+    forward_key = (spec.axis, spec.from_id, spec.to_id)
+    inverse_key = (spec.axis, spec.to_id, spec.from_id)
+    with _lock:
+        for key in (forward_key, inverse_key):
+            existing = _specs.get(key)
+            if existing is not None and existing != spec and not replace:
+                raise DeclarationError(
+                    f"layout conversion {key[0]} {key[1]} -> {key[2]} is "
+                    "already registered with a different declaration; pass "
+                    "replace=True only if you own both")
+        for key, fn in ((forward_key, _forward_of(spec)),
+                        (inverse_key, _inverse_of(spec))):
+            _specs[key] = spec
+            _applies[key] = fn
+            _edges[key] = ConversionHop(
+                axis=key[0], from_id=key[1], to_id=key[2],
+                version=spec.version,
+                digest=converter_digest(key[0], key[1], key[2],
+                                        spec.version, fn),
+            )
+    return spec
+
+
+def register_layout_production(
+    spec: LayoutProduction, *, replace: bool = False,
+) -> LayoutProduction:
+    """Declare a PRODUCIBLE edge: new numerics from a named source, by recipe.
+
+    Deliberately a different call from :func:`register_layout_conversion`, with
+    no transform and no round-trip obligation, because the two rungs are
+    different things. Anything that would fail the converter registry's
+    admission bar and still needs to exist belongs here — priced, offered, and
+    never automatic.
+    """
+    if spec.axis not in LAYOUT_AXES:
+        raise DeclarationError(
+            f"unknown layout axis {spec.axis!r}; the axes are {list(LAYOUT_AXES)}")
+    where = f"LayoutProduction({spec.from_id} -> {spec.to_id})"
+    validate_layout_handle(spec.from_id, where=where, axis=spec.axis)
+    validate_layout_handle(spec.to_id, where=where, axis=spec.axis)
+    if not str(spec.recipe or "").strip():
+        raise DeclarationError(f"{where}: recipe is empty")
+    if not str(spec.quality_gate or "").strip():
+        raise DeclarationError(
+            f"{where}: quality_gate is empty — producing new numerics without "
+            "naming the gate that will judge them is the decision §4.32 puts "
+            "on the author")
+    key = (spec.axis, spec.from_id, spec.to_id)
+    with _lock:
+        existing = _productions.get(key)
+        if existing is not None and existing != spec and not replace:
+            raise DeclarationError(
+                f"layout production {key} is already registered with a "
+                "different declaration")
+        _productions[key] = spec
+    return spec
+
+
+def registered_layout_conversions() -> Tuple[ConversionHop, ...]:
+    """Every registered EDGE, both directions, in a deterministic order.
+
+    This is the edge table the hub reads to compute the CONVERTIBLE rung
+    (th#1809 T5) — data, never code.
+    """
+    with _lock:
+        return tuple(sorted(
+            _edges.values(), key=lambda e: (e.axis, e.from_id, e.to_id)))
+
+
+def registered_layout_productions() -> Tuple[LayoutProduction, ...]:
+    with _lock:
+        return tuple(sorted(
+            _productions.values(), key=lambda p: (p.axis, p.from_id, p.to_id)))
+
+
+def reset_layout_conversions() -> None:
+    """Drop every registration. Tests only."""
+    with _lock:
+        _edges.clear()
+        _specs.clear()
+        _applies.clear()
+        _productions.clear()
+
+
+def _forward_of(spec: LayoutConversion) -> Union[KeyMapFn, RepackFn]:
+    return (spec.forward_keys if isinstance(spec, TopologyConversion)
+            else spec.forward)
+
+
+def _inverse_of(spec: LayoutConversion) -> Union[KeyMapFn, RepackFn]:
+    return (spec.inverse_keys if isinstance(spec, TopologyConversion)
+            else spec.inverse)
+
+
+def _validate_declaration(spec: LayoutConversion) -> None:
+    where = f"{spec.axis} conversion {spec.from_id} -> {spec.to_id}"
+    validate_layout_handle(spec.from_id, where=where, axis=spec.axis)
+    validate_layout_handle(spec.to_id, where=where, axis=spec.axis)
+    if spec.from_id == spec.to_id:
+        raise DeclarationError(f"{where}: a conversion to itself is not an edge")
+    if int(spec.version) < 1:
+        raise DeclarationError(f"{where}: version must be >= 1")
+    if not spec.corpus:
+        raise DeclarationError(
+            f"{where}: declares no corpus. A mapping ships with at least one "
+            "REAL artifact header (§4.25 / th#1580's corpus method) — that is "
+            "what the bit-exactness obligation runs against.")
+
+
+# ---------------------------------------------------------------------------
+# The admission proof
+# ---------------------------------------------------------------------------
+
+
+def prove_layout_conversion(spec: LayoutConversion) -> Tuple[str, ...]:
+    """Run the mapping's bit-exactness obligation over its own corpus.
+
+    Returns the obligations that passed, so a caller can print them. Raises
+    :class:`ConversionProofError` naming the case and the obligation otherwise.
+
+    The obligations, in the order they catch things:
+
+    1. **key bijection** — the map is total (every source key mapped) and
+       injective (no two keys collide). An unmapped key is a REFUSAL, never a
+       silent skip.
+    2. **payload invariance** (topology) — per-tensor payload sha256 identical
+       before and after. Structural for a key map, and checked anyway because a
+       structural claim nobody executes is a comment.
+    3. **round trip** — `A -> B -> A` recovers the source shard's content
+       digest exactly. This is the obligation re-quantization cannot satisfy.
+    4. **dequant equivalence** (quant) — the declared reference dequant agrees
+       across the pair.
+    """
+    import tempfile
+
+    passed: List[str] = []
+    with tempfile.TemporaryDirectory(prefix="cozy-layout-proof-") as tmp:
+        root = Path(tmp)
+        for case in spec.corpus:
+            source = materialize_case(case, root / f"{case.name}.src.safetensors")
+            forward = root / f"{case.name}.fwd.safetensors"
+            back = root / f"{case.name}.rt.safetensors"
+            try:
+                _apply_hop(spec, _forward_of(spec), source, forward)
+            except Exception as exc:  # noqa: BLE001 - re-raised typed
+                raise ConversionProofError(
+                    f"{spec.axis} {spec.from_id} -> {spec.to_id}: forward "
+                    f"mapping failed on corpus case {case.name!r}: {exc}"
+                ) from exc
+            _prove_keys(spec, case, source, forward)
+            if isinstance(spec, TopologyConversion):
+                _prove_payload_invariance(spec, case, source, forward)
+                passed.append(f"{case.name}:payload_invariance")
+            try:
+                _apply_hop(spec, _inverse_of(spec), forward, back)
+            except Exception as exc:  # noqa: BLE001 - re-raised typed
+                raise ConversionProofError(
+                    f"{spec.axis} {spec.from_id} -> {spec.to_id}: inverse "
+                    f"mapping failed on corpus case {case.name!r}: {exc}"
+                ) from exc
+            before, after = shard_content_digest(source), shard_content_digest(back)
+            if before != after:
+                raise ConversionProofError(
+                    f"{spec.axis} {spec.from_id} -> {spec.to_id}: the round "
+                    f"trip did not recover corpus case {case.name!r} "
+                    f"({before} -> {after}). A CONVERTIBLE mapping is lossless, "
+                    "and lossless means invertible: information the forward "
+                    "mapping dropped cannot come back. A mapping that produces "
+                    "NEW NUMERICS is the PRODUCIBLE rung — declare it with "
+                    "register_layout_production(), which prices it and names "
+                    "its quality gate.")
+            passed.append(f"{case.name}:round_trip")
+            if isinstance(spec, QuantRepack):
+                try:
+                    spec.equivalence(source, forward)
+                except Exception as exc:  # noqa: BLE001 - re-raised typed
+                    raise ConversionProofError(
+                        f"quant {spec.from_id} -> {spec.to_id}: reference "
+                        f"dequant disagreed on corpus case {case.name!r}: {exc}"
+                    ) from exc
+                passed.append(f"{case.name}:dequant_equivalence")
+    return tuple(passed)
+
+
+def _apply_hop(
+    spec: LayoutConversion, fn: Union[KeyMapFn, RepackFn],
+    source: Path, target: Path,
+) -> None:
+    """Execute ONE hop. Topology goes through the raw byte-range rewrite and
+    never decodes; quant goes through the streaming IO."""
+    if isinstance(spec, TopologyConversion):
+        keymap_fn: KeyMapFn = fn  # type: ignore[assignment]
+        with open(source, "rb") as fh:
+            fd = fh.fileno()
+            header, _ = read_safetensors_header(fd)
+        keys = tuple(k for k in header if k != "__metadata__")
+        rewrite_safetensors_keys(source, target, keymap_fn(keys))
+        return
+    repack_fn: RepackFn = fn  # type: ignore[assignment]
+    io = ConversionIO(source, target)
+    try:
+        repack_fn(io)
+    finally:
+        io.close()
+
+
+def _prove_keys(
+    spec: LayoutConversion, case: ConversionCase, source: Path, target: Path,
+) -> None:
+    src_keys = set(_shard_keys(source))
+    dst_keys = list(_shard_keys(target))
+    if len(dst_keys) != len(set(dst_keys)):
+        raise ConversionProofError(
+            f"{spec.axis} {spec.from_id} -> {spec.to_id}: corpus case "
+            f"{case.name!r} produced a duplicate key — the map is not injective")
+    if len(dst_keys) != len(src_keys):
+        dropped = len(src_keys) - len(dst_keys)
+        raise ConversionProofError(
+            f"{spec.axis} {spec.from_id} -> {spec.to_id}: corpus case "
+            f"{case.name!r} has {len(src_keys)} source keys and "
+            f"{len(dst_keys)} output keys ({dropped:+d}). An unmapped key is a "
+            "REFUSAL, never a silent skip, and an invented key is worse.")
+
+
+def _prove_payload_invariance(
+    spec: TopologyConversion, case: ConversionCase, source: Path, target: Path,
+) -> None:
+    before = sorted(_payload_digests(source).values())
+    after = sorted(_payload_digests(target).values())
+    if before != after:
+        raise ConversionProofError(
+            f"topology {spec.from_id} -> {spec.to_id}: corpus case "
+            f"{case.name!r} changed payload bytes. The topology axis is keys "
+            "only — 'what the weights ARE' is the quant axis.")
+
+
+def _shard_keys(path: Path) -> Tuple[str, ...]:
+    with open(path, "rb") as fh:
+        header, _ = read_safetensors_header(fh.fileno())
+    return tuple(k for k in header if k != "__metadata__")
+
+
+def _payload_digests(path: Path) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    with open(path, "rb") as fh:
+        header, base = read_safetensors_header(fh.fileno())
+        for name, meta in header.items():
+            if name == "__metadata__" or not isinstance(meta, dict):
+                continue
+            start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+            fh.seek(base + start)
+            out[name] = hashlib.sha256(fh.read(end - start)).hexdigest()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The relation: membership, then reachability. Never a heuristic.
+# ---------------------------------------------------------------------------
+
+
+def _axis_satisfied(demand: Optional[str], supply: Optional[str]) -> bool:
+    """One axis of the digest-identity comparison.
+
+    Exact equality, with two DECLARED escapes and no inferred ones: a demand
+    that declares itself agnostic accepts anything, and an axis neither side
+    declares is not part of this demand. The SDK compares handles; the hub
+    compares the digests it resolved those handles to at ingest, which is the
+    stricter form of the same relation across registry versions.
+    """
+    if demand is None or demand == LAYOUT_AXIS_ANY:
+        return True
+    return demand == supply
+
+
+def _unevaluated(source: LayoutId, accepts: Sequence[LayoutId]) -> Tuple[str, ...]:
+    return tuple(
+        axis for axis in LAYOUT_AXES
+        if source.axis(axis) is None
+        or all(a.axis(axis) is None for a in accepts)
+    )
+
+
+def _shortest_chain(
+    axis: str, source: Optional[str], target: Optional[str],
+) -> Optional[Tuple[ConversionHop, ...]]:
+    """BFS over the registered edges of ONE axis, capped at
+    :data:`MAX_PLAN_HOPS_PER_AXIS`. ``None`` means unreachable."""
+    if _axis_satisfied(target, source):
+        return ()
+    if source is None or source == LAYOUT_AXIS_ANY or target is None:
+        return None
+    with _lock:
+        edges = [e for e in _edges.values() if e.axis == axis]
+    queue: deque[Tuple[str, Tuple[ConversionHop, ...]]] = deque([(source, ())])
+    seen = {source}
+    while queue:
+        node, chain = queue.popleft()
+        if len(chain) >= MAX_PLAN_HOPS_PER_AXIS:
+            continue
+        for edge in edges:
+            if edge.from_id != node or edge.to_id in seen:
+                continue
+            extended = chain + (edge,)
+            if edge.to_id == target:
+                return extended
+            seen.add(edge.to_id)
+            queue.append((edge.to_id, extended))
+    return None
+
+
+def plan_layout_conversions(
+    source: LayoutId, accepts: Sequence[LayoutId],
+) -> Tuple[ConversionPlan, ...]:
+    """Every accepted LayoutId reachable from ``source`` over LOSSLESS edges.
+
+    Per axis, independently, then paired — which is what makes N+M
+    registrations cover what a composite vocabulary would need N*M for.
+
+    **The result carries no preference.** §1.33 point 2 as amended: the demand
+    is a filter, and the one authority on preference is the (GPU, lane) ladder.
+    The order here is (hop count, rendered target) — determinism so two runs
+    agree, not a ranking. A caller that must pick one and holds no ladder takes
+    the first and is choosing arbitrarily, honestly.
+    """
+    plans: List[ConversionPlan] = []
+    for target in accepts:
+        topology = _shortest_chain(
+            AXIS_TOPOLOGY, source.topology, target.topology)
+        if topology is None:
+            continue
+        quant = _shortest_chain(AXIS_QUANT, source.quant, target.quant)
+        if quant is None:
+            continue
+        if not topology and not quant:
+            continue  # already COMPATIBLE; not a conversion
+        plans.append(ConversionPlan(
+            target=target, topology=topology, quant=quant))
+    return tuple(sorted(
+        plans, key=lambda p: (len(p.hops), p.target.render())))
+
+
+def _reachable_productions(
+    source: LayoutId, accepts: Sequence[LayoutId],
+) -> Tuple[LayoutProduction, ...]:
+    """PRODUCIBLE: one declared recipe edge from the supply to an accepted
+    layout. One hop, deliberately — a chain of re-quantizations is a quality
+    decision nobody made."""
+    with _lock:
+        productions = list(_productions.values())
+    out: List[LayoutProduction] = []
+    for production in productions:
+        if source.axis(production.axis) != production.from_id:
+            continue
+        for target in accepts:
+            candidate = source.with_axis(production.axis, production.to_id)
+            if all(_axis_satisfied(target.axis(a), candidate.axis(a))
+                   for a in LAYOUT_AXES):
+                out.append(production)
+                break
+    return tuple(sorted(out, key=lambda p: (p.axis, p.from_id, p.to_id)))
+
+
+def classify_layout(
+    source: LayoutId, accepts: Sequence[LayoutId],
+) -> LayoutVerdict:
+    """§1.33's ladder for ONE (component, supply, demand): the whole verdict.
+
+    Three relations, all fixed forever, all extended only by DATA: membership,
+    lossless-edge reachability, production-edge reachability. If a new format
+    ever needs this function to change, the descriptor SCHEMA is wrong — version
+    the schema, never the relation.
+    """
+    accepted = tuple(accepts)
+    unevaluated = _unevaluated(source, accepted)
+    if not accepted:
+        return LayoutVerdict(
+            rung=LayoutRung.INCOMPATIBLE, source=source, accepts=(),
+            unevaluated_axes=unevaluated,
+            reason="the demand is UNDECLARED: no accepted layout to match "
+                   "against. An empty demand is not 'accepts everything'.")
+    for target in accepted:
+        if all(_axis_satisfied(target.axis(axis), source.axis(axis))
+               for axis in LAYOUT_AXES):
+            return LayoutVerdict(
+                rung=LayoutRung.COMPATIBLE, source=source, accepts=accepted,
+                unevaluated_axes=unevaluated,
+                reason=f"{source.render()} is in the accepted set")
+    plans = plan_layout_conversions(source, accepted)
+    if plans:
+        return LayoutVerdict(
+            rung=LayoutRung.CONVERTIBLE, source=source, accepts=accepted,
+            plans=plans, unevaluated_axes=unevaluated,
+            reason=f"{len(plans)} lossless plan(s) reach an accepted layout")
+    productions = _reachable_productions(source, accepted)
+    if productions:
+        return LayoutVerdict(
+            rung=LayoutRung.PRODUCIBLE, source=source, accepts=accepted,
+            productions=productions, unevaluated_axes=unevaluated,
+            reason="no lossless mapping; a registered production recipe can "
+                   "make an accepted layout from this source — priced, offered, "
+                   "never automatic")
+    return LayoutVerdict(
+        rung=LayoutRung.INCOMPATIBLE, source=source, accepts=accepted,
+        unevaluated_axes=unevaluated,
+        reason=f"{source.render()} is not accepted, no registered lossless "
+               f"mapping reaches "
+               f"{', '.join(t.render() for t in accepted)}, and no production "
+               f"recipe produces one")
+
+
+# ---------------------------------------------------------------------------
+# The engine
+# ---------------------------------------------------------------------------
+
+#: The `__metadata__` key an artifact's conversion chain rides in. Artifacts
+#: self-describe, so anyone can re-derive the identity without the hub.
+CONVERSION_PROVENANCE_KEY = "cozy.conversion"
+
+#: `produced_by` value that the publish path REFUSES (§4.28): a conversion done
+#: on untrusted hardware is for that machine's own store, forever.
+PRODUCED_BY_LOCAL = "local_conversion"
+
+
+@dataclass(frozen=True)
+class ConversionResult:
+    path: Path
+    target: LayoutId
+    identity: str
+    chain: Tuple[ConversionHop, ...]
+
+
+def run_layout_conversion(
+    plan: ConversionPlan, source: Path, target: Path, *,
+    source_digest: str, produced_by: str,
+) -> ConversionResult:
+    """Execute a plan, hop by hop, and stamp the chain onto the output.
+
+    Upstream of compute, always: this runs before the tree is materialized for
+    `setup()`, so the endpoint observes only its own declared layout and the
+    traced graph — hence the cell key — cannot move (§1.33 point 5).
+    """
+    if not str(produced_by or "").strip():
+        raise DeclarationError(
+            "run_layout_conversion(produced_by=) is required: an artifact that "
+            "cannot say where it was converted cannot be judged by the publish "
+            "fence (§4.28)")
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    hops = plan.hops
+    if not hops:
+        raise DeclarationError("run_layout_conversion: the plan has no hops")
+
+    import tempfile
+
+    current = Path(source)
+    with tempfile.TemporaryDirectory(
+            prefix="cozy-layout-", dir=str(target.parent)) as tmp:
+        for index, hop in enumerate(hops):
+            with _lock:
+                spec = _specs.get((hop.axis, hop.from_id, hop.to_id))
+                fn = _applies.get((hop.axis, hop.from_id, hop.to_id))
+            if spec is None or fn is None:
+                raise DeclarationError(
+                    f"no registered converter for {hop.axis} {hop.from_id} -> "
+                    f"{hop.to_id}; the plan names an edge this process does "
+                    "not hold")
+            last = index == len(hops) - 1
+            out = target if last else Path(tmp) / f"hop{index}.safetensors"
+            _apply_hop(spec, fn, current, out)
+            current = out
+
+    identity = derived_artifact_identity(source_digest, plan.digests, plan.target)
+    _stamp_provenance(target, plan, source_digest, identity, produced_by)
+    return ConversionResult(
+        path=target, target=plan.target, identity=identity, chain=hops)
+
+
+def _stamp_provenance(
+    path: Path, plan: ConversionPlan, source_digest: str, identity: str,
+    produced_by: str,
+) -> None:
+    provenance = json.dumps({
+        "v": 1,
+        "identity": identity,
+        "source_digest": source_digest,
+        "target_layout": plan.target.render(),
+        "produced_by": produced_by,
+        "chain": [
+            {"axis": h.axis, "from": h.from_id, "to": h.to_id,
+             "version": h.version, "converter_digest": h.digest}
+            for h in plan.hops
+        ],
+    }, separators=(",", ":"), sort_keys=True)
+    rewrite_safetensors_keys(
+        path, path, {}, extra_metadata={CONVERSION_PROVENANCE_KEY: provenance})
+
+
+def conversion_provenance(path: Path) -> Optional[Mapping[str, object]]:
+    """The conversion chain an artifact carries, or ``None``."""
+    with open(path, "rb") as fh:
+        header, _ = read_safetensors_header(fh.fileno())
+    raw = (header.get("__metadata__") or {}).get(CONVERSION_PROVENANCE_KEY)
+    if not isinstance(raw, str):
+        return None
+    decoded = json.loads(raw)
+    return decoded if isinstance(decoded, dict) else None
+
+
+__all__ = [
+    "CONVERSION_PROVENANCE_KEY",
+    "ConversionCase",
+    "ConversionHop",
+    "ConversionIO",
+    "ConversionPlan",
+    "ConversionProofError",
+    "ConversionResult",
+    "CorpusTensor",
+    "LayoutConversion",
+    "LayoutProduction",
+    "LayoutRung",
+    "LayoutVerdict",
+    "PRODUCED_BY_LOCAL",
+    "QuantRepack",
+    "TopologyConversion",
+    "classify_layout",
+    "conversion_provenance",
+    "converter_digest",
+    "derived_artifact_identity",
+    "plan_layout_conversions",
+    "prove_layout_conversion",
+    "register_layout_conversion",
+    "register_layout_production",
+    "registered_layout_conversions",
+    "registered_layout_productions",
+    "reset_layout_conversions",
+    "run_layout_conversion",
+]

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -21,6 +21,7 @@ torch/safetensors imports are deferred so importing gen_worker.convert stays che
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -1470,7 +1471,7 @@ _HEADER_LEN_PREFIX = 8
 _RAW_COPY_CHUNK = 8 * 1024 * 1024
 
 
-def _read_safetensors_header(fd: int) -> tuple[dict, int]:
+def read_safetensors_header(fd: int) -> tuple[dict, int]:
 
     os.lseek(fd, 0, os.SEEK_SET)
     prefix = os.read(fd, _HEADER_LEN_PREFIX)
@@ -1486,6 +1487,197 @@ def _read_safetensors_header(fd: int) -> tuple[dict, int]:
     if not isinstance(header, dict):
         raise ValueError("safetensors: header root must be an object")
     return header, _HEADER_LEN_PREFIX + header_len
+
+
+def shard_tensor_entries(path: Path) -> list[tuple[str, dict]]:
+    """Every ``(name, header entry)`` of one shard, in DATA order."""
+    with open(path, "rb") as fh:
+        header, _ = read_safetensors_header(fh.fileno())
+    rows: list[tuple[str, dict]] = []
+    for name, meta in header.items():
+        if name == "__metadata__" or not isinstance(meta, dict):
+            continue
+        offs = meta.get("data_offsets")
+        if not isinstance(offs, list) or len(offs) != 2 or int(offs[1]) < int(offs[0]):
+            raise ValueError(f"safetensors: tensor {name!r} has invalid data_offsets")
+        rows.append((str(name), meta))
+    rows.sort(key=lambda r: int(r[1]["data_offsets"][0]))
+    return rows
+
+
+def shard_metadata(path: Path) -> dict[str, str]:
+    """One shard's ``__metadata__``, as strings."""
+    with open(path, "rb") as fh:
+        header, _ = read_safetensors_header(fh.fileno())
+    md = header.get("__metadata__")
+    return {str(k): str(v) for k, v in md.items()} if isinstance(md, dict) else {}
+
+
+def shard_payload_digests(path: Path) -> dict[str, str]:
+    """Per-tensor payload sha256, keyed by tensor name."""
+    out: dict[str, str] = {}
+    with open(path, "rb") as fh:
+        header, base = read_safetensors_header(fh.fileno())
+        for name, meta in header.items():
+            if name == "__metadata__" or not isinstance(meta, dict):
+                continue
+            start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+            fh.seek(base + start)
+            out[str(name)] = hashlib.sha256(fh.read(end - start)).hexdigest()
+    return out
+
+
+def shard_content_digest(path: Path) -> str:
+    """CONTENT identity of one shard: its tensors' (name, dtype, shape, payload)
+    and its ``__metadata__``, digested in a canonical order.
+
+    Deliberately NOT the file's bytes: tensor ORDER inside the file, header key
+    order and JSON separators are not content, and a rewrite that preserves
+    every tensor exactly must compare equal even when it lays them out
+    differently. That is what makes this digest usable as the round-trip
+    obligation in ``layout_converters`` — it refuses lost information, not
+    reordering.
+    """
+    rows = []
+    with open(path, "rb") as fh:
+        header, base = read_safetensors_header(fh.fileno())
+        for name, meta in sorted(
+            (n, m) for n, m in header.items()
+            if n != "__metadata__" and isinstance(m, dict)
+        ):
+            start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+            fh.seek(base + start)
+            rows.append([
+                str(name), str(meta["dtype"]),
+                [int(d) for d in meta["shape"]],
+                hashlib.sha256(fh.read(end - start)).hexdigest(),
+            ])
+    payload = json.dumps(
+        {"v": 1, "tensors": rows, "metadata": shard_metadata(path)},
+        sort_keys=True, separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def write_safetensors_shard(
+    path: Path,
+    tensors: Mapping[str, tuple[str, Sequence[int], bytes]],
+    *,
+    metadata: Optional[Mapping[str, str]] = None,
+) -> Path:
+    """Write ONE safetensors file from raw ``(dtype, shape, payload)`` triples.
+
+    Torch-free on purpose: the layout-converter corpus materializes real
+    HEADERS with synthetic payloads, and pulling torch in to do that would make
+    a declaration-time proof cost a framework import.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header: dict[str, Any] = {}
+    if metadata:
+        header["__metadata__"] = {str(k): str(v) for k, v in metadata.items()}
+    cursor = 0
+    ordered: list[tuple[str, bytes]] = []
+    for name, (dtype, shape, payload) in tensors.items():
+        if not name or name == "__metadata__":
+            raise ValueError(f"safetensors: cannot write a tensor named {name!r}")
+        header[str(name)] = {
+            "dtype": str(dtype), "shape": [int(d) for d in shape],
+            "data_offsets": [cursor, cursor + len(payload)],
+        }
+        ordered.append((str(name), payload))
+        cursor += len(payload)
+    blob = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    tmp = path.parent / f".{path.name}.writing"
+    with open(tmp, "wb") as out:
+        out.write(len(blob).to_bytes(_HEADER_LEN_PREFIX, "little"))
+        out.write(blob)
+        for _name, payload in ordered:
+            out.write(payload)
+    tmp.replace(path)
+    return path
+
+
+def rewrite_safetensors_keys(
+    source: Path,
+    target: Path,
+    key_map: Mapping[str, str],
+    *,
+    extra_metadata: Optional[Mapping[str, str]] = None,
+) -> Path:
+    """Rename tensors by RAW BYTE-RANGE COPY — no tensor ever enters Python.
+
+    This is the whole topology-axis engine (§1.33: topology is "essentially
+    just different keys"). Because the payloads are copied as opaque ranges,
+    bit-losslessness on that axis is a property of THIS FUNCTION rather than a
+    claim each converter makes about itself.
+
+    ``key_map`` must be total over the shard's tensors — an unmapped key is a
+    refusal, never a silent passthrough — and injective. ``source`` may equal
+    ``target`` (used to stamp provenance in place); the write goes through a
+    temp file and an atomic rename either way.
+    """
+    source, target = Path(source), Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    entries = shard_tensor_entries(source)
+    missing = [name for name, _ in entries if name not in key_map]
+    if missing and key_map:
+        raise ValueError(
+            f"rewrite_safetensors_keys: {len(missing)} key(s) have no mapping "
+            f"({missing[:5]}). An unmapped key is a REFUSAL, never a silent "
+            "skip — a partial rename produces a file that loads as neither "
+            "layout.")
+    renamed = [(key_map.get(name, name), meta) for name, meta in entries]
+    seen: dict[str, str] = {}
+    for (new, _meta), (old, _m) in zip(renamed, entries):
+        if new in seen:
+            raise ValueError(
+                f"rewrite_safetensors_keys: {old!r} and {seen[new]!r} both map "
+                f"to {new!r}; the key map is not injective")
+        seen[new] = old
+
+    metadata = shard_metadata(source)
+    if extra_metadata:
+        metadata.update({str(k): str(v) for k, v in extra_metadata.items()})
+
+    header: dict[str, Any] = {}
+    if metadata:
+        header["__metadata__"] = metadata
+    cursor = 0
+    for new, meta in renamed:
+        start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+        header[new] = {
+            "dtype": meta["dtype"], "shape": list(meta["shape"]),
+            "data_offsets": [cursor, cursor + (end - start)],
+        }
+        cursor += end - start
+    blob = json.dumps(header, separators=(",", ":")).encode("utf-8")
+
+    tmp = target.parent / f".{target.name}.rewriting"
+    src_fd = os.open(str(source), os.O_RDONLY)
+    try:
+        _, base = read_safetensors_header(src_fd)
+        dst = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            os.write(dst, len(blob).to_bytes(_HEADER_LEN_PREFIX, "little"))
+            os.write(dst, blob)
+            for (_new, meta) in renamed:
+                start, end = int(meta["data_offsets"][0]), int(meta["data_offsets"][1])
+                remaining = end - start
+                src_abs = base + start
+                while remaining > 0:
+                    buf = os.pread(src_fd, min(remaining, _RAW_COPY_CHUNK), src_abs)
+                    if not buf:
+                        raise IOError(f"safetensors: short read at {src_abs}")
+                    os.write(dst, buf)
+                    remaining -= len(buf)
+                    src_abs += len(buf)
+        finally:
+            os.close(dst)
+    finally:
+        os.close(src_fd)
+    tmp.replace(target)
+    return target
 
 
 # ---------------------------------------------------------------------------
@@ -1570,7 +1762,7 @@ def merge_safetensors_by_offset(
         for shard in shard_paths:
             fd = os.open(str(shard), os.O_RDONLY)
             fds.append(fd)
-            header, data_base = _read_safetensors_header(fd)
+            header, data_base = read_safetensors_header(fd)
             md = header.get("__metadata__")
             if isinstance(md, dict):
                 for k, v in md.items():

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -168,18 +168,74 @@ def contract_decoders_of(obj: Any) -> tuple[ContractDecoder, ...]:
 #: more specific declaration.
 LAYOUT_KEY_ANY_COMPONENT = "*"
 
+# ── The TWO AXES (§1.33 `d01ed428`; pgw#1143 Q2) ─────────────────────────────
+#
+# TOPOLOGY is SHALLOW — keys/nesting/file layout, "essentially just different
+# keys". It constrains the LOADER, and a conversion between two topologies is
+# pure renaming, bit-lossless. QUANT is DEEP — "what the weights ARE, which
+# requires different runtime code/kernels". It constrains the endpoint's
+# KERNELS.
+#
+# They are two registries with two digests, compared FIELD-WISE and never as
+# one string: a composite handle cannot express "topology differs, quant
+# matches ⇒ CONVERTIBLE", which is the whole ladder.
+AXIS_TOPOLOGY = "topology"
+AXIS_QUANT = "quant"
+LAYOUT_AXES: tuple[str, ...] = (AXIS_TOPOLOGY, AXIS_QUANT)
+
+#: An axis a demand declares itself AGNOSTIC on. A declaration, never an
+#: inference: an axis nobody stated is UNDECLARED (``None``) and is not
+#: evaluated, which is a different fact.
+LAYOUT_AXIS_ANY = "any"
+
+# The topology axis, transcribed from code we already run (pgw#1143 Q2 /
+# th#1809 T3): tensorhub's `catalog/layout_contract.go` (library_name x
+# file_layout) and training-endpoints' `conversion/comfyui.py`
+# `_SPLIT_COMPONENT_MAP`. Same transcription posture as KNOWN_CONTRACTS above —
+# allowed to be stale, CHECKED at the hub's manifest ingest, never authoritative.
+TOPOLOGY_DIFFUSERS_MULTIFILE = "diffusers.multifile@1"
+TOPOLOGY_DIFFUSERS_SINGLEFILE = "diffusers.singlefile@1"
+TOPOLOGY_TRANSFORMERS_NATIVE = "transformers.native@1"
+TOPOLOGY_PEFT_ADAPTER = "peft.adapter@1"
+TOPOLOGY_GGUF_NATIVE = "gguf.native@1"
+TOPOLOGY_COMFY_SPLITFILES = "comfy.splitfiles@1"
+
+KNOWN_TOPOLOGY_CONTRACTS: tuple[str, ...] = (
+    TOPOLOGY_DIFFUSERS_MULTIFILE,
+    TOPOLOGY_DIFFUSERS_SINGLEFILE,
+    TOPOLOGY_TRANSFORMERS_NATIVE,
+    TOPOLOGY_PEFT_ADAPTER,
+    TOPOLOGY_GGUF_NATIVE,
+    TOPOLOGY_COMFY_SPLITFILES,
+)
+
 
 class LayoutDeclarationError(ValueError):
     """A `Slot(layouts=...)` declaration the SDK refuses where it is written."""
 
 
-def validate_layout_handle(handle: object, *, where: str) -> str:
-    """One declared handle, normalized, or a decoration-time refusal.
+def known_contracts(axis: str) -> tuple[str, ...]:
+    """The transcribed handles of ONE axis. Unknown axis is a refusal, not an
+    empty tuple — an empty answer would read as "nothing is registered"."""
+    if axis == AXIS_QUANT:
+        return KNOWN_CONTRACTS
+    if axis == AXIS_TOPOLOGY:
+        return KNOWN_TOPOLOGY_CONTRACTS
+    raise LayoutDeclarationError(
+        f"unknown layout axis {axis!r}; the axes are {list(LAYOUT_AXES)}")
 
-    The quant axis only. §1.33's rendered `"<topology>+<quant>"` pair needs a
-    topology REGISTRY to compare against (th#1809 T3); until that exists a
-    composite is a handle naming a vocabulary the platform cannot resolve, and
-    exact-or-refused means refusing it rather than storing half a pair.
+
+def validate_layout_handle(
+    handle: object, *, where: str, axis: str = AXIS_QUANT,
+) -> str:
+    """One declared handle on ONE axis, normalized, or a refusal.
+
+    `Slot(layouts=...)` declares the QUANT axis alone: §1.33's rendered
+    `"<topology>+<quant>"` pair needs the hub's topology REGISTRY to resolve
+    against (th#1809 T3), and until that exists a composite in the manifest is
+    half a pair stored as if it were exact. The SDK-internal converter registry
+    names the topology axis explicitly (`axis=AXIS_TOPOLOGY`) — that vocabulary
+    is real here and inert hub-side until T3 lands.
     """
     if not isinstance(handle, str):
         raise LayoutDeclarationError(
@@ -187,6 +243,7 @@ def validate_layout_handle(handle: object, *, where: str) -> str:
             f"{type(handle).__name__}"
         )
     text = handle.strip()
+    known = known_contracts(axis)
     if "+" in text:
         raise LayoutDeclarationError(
             f"{where}: {text!r} names a <topology>+<quant> pair. The topology "
@@ -198,12 +255,12 @@ def validate_layout_handle(handle: object, *, where: str) -> str:
         raise LayoutDeclarationError(
             f"{where}: {text!r} is not a contract handle (want ns.name@N)"
         )
-    if text not in KNOWN_CONTRACTS:
+    if text not in known:
         raise LayoutDeclarationError(
-            f"{where}: contract {text!r} is not registered. "
+            f"{where}: {axis} contract {text!r} is not registered. "
             "Contracts are CODE (th#1580 A2): register it in tensorhub's "
             "internal/tensorlayout with a descriptor and a probe set "
-            f"before a slot may demand it. Known: {', '.join(KNOWN_CONTRACTS)}"
+            f"before a slot may demand it. Known: {', '.join(known)}"
         )
     return text
 
@@ -211,12 +268,21 @@ def validate_layout_handle(handle: object, *, where: str) -> str:
 def normalize_layout_demand(
     layouts: object, *, where: str,
 ) -> dict[str, tuple[str, ...]]:
-    """`Slot(layouts=...)` -> `{component_path: ordered handles}`.
+    """`Slot(layouts=...)` -> `{component_path: accepted handle SET}`.
 
-    Ordering IS preference (§1.33 point 2), so the tuple is kept as written
-    and never sorted. Component-path keys are validated against the DERIVED
-    component tree separately, at decoration time, by the registry — this
-    function owns only the shape and the vocabulary.
+    **The set is a compatibility FILTER; its order carries NO preference**
+    (§1.33 point 2 as amended 2026-08-11 by the tag-separability ruling,
+    th#1803). Preference has exactly ONE authority — the author-configured
+    ordered ladder of (GPU, lane) pairs — and "one filter, one order, never two
+    orderings that can disagree" is the property that keeps it that way. So the
+    handles are returned in CANONICAL order, not as written: two authors who
+    declare the same set in different orders state the SAME demand, and no
+    downstream reader can recover a preference from a position that never
+    carried one.
+
+    Component-path keys are validated against the DERIVED component tree
+    separately, at decoration time, by the registry — this function owns only
+    the shape and the vocabulary.
     """
     if not isinstance(layouts, dict):
         raise LayoutDeclarationError(
@@ -241,9 +307,9 @@ def normalize_layout_demand(
         if isinstance(raw_value, (str, bytes)) or not isinstance(
                 raw_value, (tuple, list)):
             raise LayoutDeclarationError(
-                f"{where}: layouts[{key!r}] must be an ORDERED tuple of "
-                f"handles (order is preference), got "
-                f"{type(raw_value).__name__}"
+                f"{where}: layouts[{key!r}] must be a tuple of handles — the "
+                f"SET this component accepts, whose order carries no "
+                f"preference — got {type(raw_value).__name__}"
             )
         if not raw_value:
             raise LayoutDeclarationError(
@@ -258,9 +324,89 @@ def normalize_layout_demand(
                 item, where=f"{where}: layouts[{key!r}]")
             if handle in handles:
                 raise LayoutDeclarationError(
-                    f"{where}: layouts[{key!r}] repeats {handle!r}; the "
-                    "second position is unreachable"
+                    f"{where}: layouts[{key!r}] repeats {handle!r}; a set "
+                    "states each member once"
                 )
             handles.append(handle)
-        out[key] = tuple(handles)
+        out[key] = tuple(sorted(handles))
     return out
+
+
+class LayoutId(msgspec.Struct, frozen=True, kw_only=True):
+    """One side of the two-sided vocabulary, as a PAIR of axes.
+
+    Rendered `"<topology>+<quant>"` and compared FIELD-WISE — never as one
+    string, because a whole-string compare cannot express "topology differs,
+    quant matches", which is the CONVERTIBLE rung.
+
+    Each axis is tri-state: a handle (declared), :data:`LAYOUT_AXIS_ANY`
+    (declared agnostic), or ``None`` (UNDECLARED — not evaluated, and the
+    verdict says so rather than guessing).
+    """
+
+    topology: str | None = None
+    quant: str | None = None
+
+    def render(self) -> str:
+        return f"{self.topology or ''}+{self.quant or ''}"
+
+    def axis(self, name: str) -> str | None:
+        if name == AXIS_TOPOLOGY:
+            return self.topology
+        if name == AXIS_QUANT:
+            return self.quant
+        raise LayoutDeclarationError(
+            f"unknown layout axis {name!r}; the axes are {list(LAYOUT_AXES)}")
+
+    def with_axis(self, name: str, value: str | None) -> "LayoutId":
+        if name == AXIS_TOPOLOGY:
+            return LayoutId(topology=value, quant=self.quant)
+        if name == AXIS_QUANT:
+            return LayoutId(topology=self.topology, quant=value)
+        raise LayoutDeclarationError(
+            f"unknown layout axis {name!r}; the axes are {list(LAYOUT_AXES)}")
+
+
+def parse_layout_id(text: object, *, where: str) -> LayoutId:
+    """`"<topology>+<quant>"`, or a bare handle meaning the QUANT axis alone.
+
+    A bare handle is quant because that is what `Slot(layouts=...)` publishes
+    (th#1809 T3 has not shipped the topology registry), so one spelling has one
+    meaning across the wire and this parser.
+    """
+    if isinstance(text, LayoutId):
+        return text
+    if not isinstance(text, str) or not text.strip():
+        raise LayoutDeclarationError(
+            f"{where}: a layout id is '<topology>+<quant>' or a bare quant "
+            f"handle, got {text!r}")
+    raw = text.strip()
+    if "+" not in raw:
+        return LayoutId(quant=_axis_member(raw, axis=AXIS_QUANT, where=where))
+    topology, _, quant = raw.partition("+")
+    return LayoutId(
+        topology=_axis_member(topology, axis=AXIS_TOPOLOGY, where=where),
+        quant=_axis_member(quant, axis=AXIS_QUANT, where=where),
+    )
+
+
+def _axis_member(text: str, *, axis: str, where: str) -> str | None:
+    """One axis of a layout id: a handle, the explicit agnostic, or UNDECLARED."""
+    value = text.strip()
+    if not value:
+        return None
+    if value == LAYOUT_AXIS_ANY:
+        return LAYOUT_AXIS_ANY
+    if "+" in value:
+        raise LayoutDeclarationError(
+            f"{where}: {value!r} carries a second '+' on the {axis} axis")
+    if not _HANDLE_RE.match(value):
+        raise LayoutDeclarationError(
+            f"{where}: {value!r} is not a contract handle (want ns.name@N)")
+    if value not in known_contracts(axis):
+        raise LayoutDeclarationError(
+            f"{where}: {axis} contract {value!r} is not registered. "
+            "Contracts are CODE (th#1580 A2): register it in tensorhub's "
+            "internal/tensorlayout with a descriptor and a probe set before "
+            f"anything may name it. Known: {', '.join(known_contracts(axis))}")
+    return value

--- a/tests/test_layout_converter_registry_pgw1143.py
+++ b/tests/test_layout_converter_registry_pgw1143.py
@@ -58,7 +58,11 @@ from gen_worker.convert.layout_converters import (
     run_layout_conversion,
 )
 from gen_worker.convert.repack_spec import DeclarationError, RenameRule
-from gen_worker.convert.writer import shard_payload_digests, shard_tensor_entries
+from gen_worker.convert.writer import (
+    rewrite_safetensors_keys,
+    shard_payload_digests,
+    shard_tensor_entries,
+)
 from gen_worker.families.base import GenerationDefaults
 from gen_worker.models.tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
@@ -243,6 +247,30 @@ def test_a_rename_that_collides_two_keys_is_refused() -> None:
                 kind="substring", pairs=(("to_x", "to_q"),)),),
             corpus=(DIT_CASE,),
         ))
+
+
+def test_the_byte_rewriter_refuses_a_non_injective_map(tmp_path: Path) -> None:
+    """`rewrite_safetensors_keys` is the ENGINE, and th#1809 T6 / cozy-local
+    will drive it WITHOUT the registration proof around it. So its own refusals
+    are tested directly — the delete-the-call-site experiment showed the proof's
+    key-count check was masking this one, which would have left the public
+    primitive's only safety check untested.
+    """
+    source = materialize_case(DIT_CASE, tmp_path / "src.safetensors")
+    keys = [name for name, _ in shard_tensor_entries(source)]
+    collide = {k: "one.key.for.all" for k in keys}
+    with pytest.raises(ValueError, match="not injective"):
+        rewrite_safetensors_keys(source, tmp_path / "out.safetensors", collide)
+
+
+def test_the_byte_rewriter_refuses_a_partial_map(tmp_path: Path) -> None:
+    """An unmapped key is a REFUSAL, never a silent passthrough: a partial
+    rename produces a file that loads as neither layout."""
+    source = materialize_case(DIT_CASE, tmp_path / "src.safetensors")
+    keys = [name for name, _ in shard_tensor_entries(source)]
+    partial = {keys[0]: "renamed.only.this"}
+    with pytest.raises(ValueError, match="no mapping"):
+        rewrite_safetensors_keys(source, tmp_path / "out.safetensors", partial)
 
 
 def test_the_conversion_engine_never_touches_a_payload_byte(tmp_path: Path) -> None:
@@ -571,23 +599,77 @@ def test_the_fence_covers_every_module_that_computes_a_cell_key() -> None:
             "aot_serve.py", "compile_cache.py"} <= fenced
 
 
+def _run_fence(*argv: str) -> subprocess.CompletedProcess:
+    """The gate exactly as CI runs it: the script, through its own `main()`."""
+    return subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "lint_cell_key_layout_fence.py"),
+         *argv],
+        capture_output=True, text=True, timeout=180)
+
+
 def test_the_fence_fires_on_a_key_axis_that_reads_the_layout(
     tmp_path: Path,
 ) -> None:
-    """The detector's own RED. A gate whose failure path nobody has executed is
-    a gate nobody knows the shape of."""
-    module = tmp_path / "offender.py"
-    module.write_text(textwrap.dedent(
+    """THE GATE'S OWN RED, through the ENTRY POINT CI invokes.
+
+    Deliberately not a call to `_violations()`. The delete-the-call-site
+    experiment on this very file found that disconnecting the detector from
+    `main()` left every test green — the th#1820 shape, where a function has
+    a dozen tests and its only call site has none. So this drives the SCRIPT
+    against a tree that violates the fence, and a disconnected detector fails
+    here.
+    """
+    (tmp_path / "cell_key.py").write_text(textwrap.dedent(
         """
         from gen_worker.convert.layout_converters import LayoutId
+
 
         def envelope_facts(block, layout: LayoutId):
             return {"v": 1, "layout": layout.render()}
         """
     ), encoding="utf-8")
-    hits = _fence_module()._violations(module)
-    assert hits, "the fence did not see an import of the layout vocabulary"
-    assert any("layout_converters" in what for _line, what in hits)
+    result = _run_fence("--src", str(tmp_path))
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "fence BROKEN" in result.stdout
+    assert "layout_converters" in result.stdout
+    # The refusal must tell the author what to do instead of widening the key.
+    assert "Conversion is UPSTREAM of compute" in result.stdout
+
+
+def test_the_fence_fires_on_a_deferred_import_too(tmp_path: Path) -> None:
+    """A string handed to `import_module` is the obvious way around an import
+    check, so it is checked as a string."""
+    (tmp_path / "cell_key.py").write_text(textwrap.dedent(
+        """
+        import importlib
+
+
+        def envelope_facts(block):
+            mod = importlib.import_module("gen_worker.convert.layout_converters")
+            return {"v": 1, "chain": mod.conversion_provenance}
+        """
+    ), encoding="utf-8")
+    result = _run_fence("--src", str(tmp_path))
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "string 'gen_worker.convert.layout_converters'" in result.stdout
+
+
+def test_the_fence_does_not_fire_on_prose(tmp_path: Path) -> None:
+    """Docstrings are excluded on purpose: a vocabulary gate that reds on the
+    word appearing in an explanation teaches lanes to stop explaining
+    themselves, and has already cost this repo a lane-day."""
+    (tmp_path / "cell_key.py").write_text(textwrap.dedent(
+        '''
+        """The cell key. Deliberately blind to Slot.layouts and to any
+        LayoutId or conversion chain — see classify_layout for why."""
+
+
+        def envelope_facts(block):
+            return {"v": 1}
+        '''
+    ), encoding="utf-8")
+    result = _run_fence("--src", str(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_the_shipped_tree_passes_the_fence() -> None:

--- a/tests/test_layout_converter_registry_pgw1143.py
+++ b/tests/test_layout_converter_registry_pgw1143.py
@@ -1,0 +1,671 @@
+"""pgw#1143 step 4 + 7 (§1.33): the layout converter registry, and the fence
+that keeps conversion out of cell identity.
+
+What is proven here, in the order the ruling puts it:
+
+1. **re-quantization is structurally unregistrable** — the admission proof, run
+   at registration against a REAL safetensors shard, refuses a lossy transform
+   and names the rung it belongs on instead;
+2. a lossless topology edge registers, both directions, and cannot have touched
+   payload bytes;
+3. the ladder's four rungs come out of ONE relation — membership, then lossless
+   reachability, then production reachability — with no format knowledge in it;
+4. the accepted set is a FILTER: neither the planner nor the declaration lets
+   its order become a preference;
+5. the derived-artifact identity is stable across PROCESSES, which is the whole
+   basis of convert-once-into-the-CAS;
+6. **no cell re-keys**: no cell-key axis can read the layout vocabulary
+   (structural, via the shipped gate) and a slot's demand does not move the
+   compile contract (behavioural, through `extract_specs`).
+
+Run: uv run pytest tests/test_layout_converter_registry_pgw1143.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Iterator
+
+import msgspec
+import pytest
+
+from gen_worker import RequestContext, Slot, endpoint
+from gen_worker.api.decorators import Compile
+from gen_worker.api.derive import contract_delta, override_delta
+from gen_worker.api.export_contract import Dim, Fork, GraphClass
+from gen_worker.convert.layout_converters import (
+    ConversionCase,
+    ConversionProofError,
+    CorpusTensor,
+    LayoutProduction,
+    LayoutRung,
+    QuantRepack,
+    TopologyConversion,
+    classify_layout,
+    conversion_provenance,
+    derived_artifact_identity,
+    materialize_case,
+    plan_layout_conversions,
+    register_layout_conversion,
+    register_layout_production,
+    registered_layout_conversions,
+    reset_layout_conversions,
+    run_layout_conversion,
+)
+from gen_worker.convert.repack_spec import DeclarationError, RenameRule
+from gen_worker.convert.writer import shard_payload_digests, shard_tensor_entries
+from gen_worker.families.base import GenerationDefaults
+from gen_worker.models.tensor_layout_contract import (
+    CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_HF_FP8_BLOCKWISE,
+    CONTRACT_PLAIN_BF16,
+    TOPOLOGY_COMFY_SPLITFILES,
+    TOPOLOGY_DIFFUSERS_MULTIFILE,
+    TOPOLOGY_DIFFUSERS_SINGLEFILE,
+    LayoutId,
+    normalize_layout_demand,
+)
+from gen_worker.registry import extract_specs
+
+REPO = Path(__file__).resolve().parents[1]
+
+# A real DiT shard's key shape, at header granularity (§4.25 corpus method).
+DIT_CASE = ConversionCase(
+    name="dit-block0",
+    tensors={
+        "model.diffusion_model.blocks.0.attn.to_q.weight":
+            CorpusTensor(dtype="BF16", shape=(8, 8)),
+        "model.diffusion_model.blocks.0.attn.to_k.weight":
+            CorpusTensor(dtype="BF16", shape=(8, 8)),
+        "model.diffusion_model.blocks.0.ff.net.0.proj.weight":
+            CorpusTensor(dtype="BF16", shape=(16, 8)),
+    },
+    metadata={"format": "pt"},
+)
+
+
+@pytest.fixture(autouse=True)
+def _bare_registry() -> Iterator[None]:
+    """The wheel ships this registry EMPTY (pgw#740); every test declares its
+    own edges the way an endpoint does, and leaves it bare again."""
+    reset_layout_conversions()
+    yield
+    reset_layout_conversions()
+
+
+def _comfy_to_diffusers(version: int = 1) -> TopologyConversion:
+    return TopologyConversion(
+        from_id=TOPOLOGY_COMFY_SPLITFILES,
+        to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+        version=version,
+        rules=(RenameRule(
+            kind="prefix", pairs=(("model.diffusion_model.", "transformer."),)),),
+        inverse_rules=(RenameRule(
+            kind="prefix", pairs=(("transformer.", "model.diffusion_model."),)),),
+        corpus=(DIT_CASE,),
+        why="ComfyUI names the DiT under model.diffusion_model.*",
+    )
+
+
+# ── 1. the admission bar: re-quantization cannot enter this registry ─────────
+
+
+def _bf16_to_fp8(io: object) -> None:
+    """A REAL re-quantization: drop the low byte of every BF16 element.
+
+    Deliberately the cheapest honest one — it is not a good fp8 cast, it is a
+    transform that loses information, which is the property the admission bar
+    is about.
+    """
+    for key in io.keys():  # type: ignore[attr-defined]
+        spec = io.spec(key)  # type: ignore[attr-defined]
+        raw = io.read(key)  # type: ignore[attr-defined]
+        io.emit(  # type: ignore[attr-defined]
+            key, dtype="F8_E4M3", shape=spec.shape, payload=raw[1::2])
+
+
+def _fp8_to_bf16(io: object) -> None:
+    """The inverse anyone would write: widen back, zero-filling what was lost."""
+    for key in io.keys():  # type: ignore[attr-defined]
+        spec = io.spec(key)  # type: ignore[attr-defined]
+        raw = io.read(key)  # type: ignore[attr-defined]
+        widened = bytearray()
+        for byte in raw:
+            widened.extend((0, byte))
+        io.emit(  # type: ignore[attr-defined]
+            key, dtype="BF16", shape=spec.shape, payload=bytes(widened))
+
+
+def _always_equivalent(_a: Path, _b: Path) -> None:
+    """An author's optimistic dequant check — passes unconditionally.
+
+    Present on purpose: the round trip must refuse the cast even when the
+    mapping's OWN equivalence obligation says everything is fine. An admission
+    bar that only refuses what the author already admits is lossy is no bar.
+    """
+
+
+def test_a_re_quantization_cannot_be_registered_as_a_converter() -> None:
+    with pytest.raises(ConversionProofError) as excinfo:
+        register_layout_conversion(QuantRepack(
+            from_id=CONTRACT_PLAIN_BF16,
+            to_id=CONTRACT_COZY_FP8_ROWWISE,
+            version=1,
+            forward=_bf16_to_fp8,
+            inverse=_fp8_to_bf16,
+            equivalence=_always_equivalent,
+            corpus=(DIT_CASE,),
+        ))
+    message = str(excinfo.value)
+    assert "round trip did not recover" in message
+    # The refusal is USEFUL: it names the rung this transform belongs on and
+    # the call that declares it, so the author's next move is written down.
+    assert "PRODUCIBLE" in message
+    assert "register_layout_production()" in message
+    assert registered_layout_conversions() == (), (
+        "a mapping that failed its admission proof must leave NO edge behind — "
+        "the registry cannot hold a lossy transform, which is what makes the "
+        "CONVERTIBLE rung mean something")
+
+
+def test_the_same_transform_is_declarable_as_a_production_and_rung_producible() -> None:
+    """The rung a refused converter belongs on — priced, offered, never a
+    transform: `LayoutProduction` carries a recipe NAME and a quality gate."""
+    register_layout_production(LayoutProduction(
+        axis="quant",
+        from_id=CONTRACT_PLAIN_BF16,
+        to_id=CONTRACT_COZY_FP8_ROWWISE,
+        recipe="quantize-fp8-rowwise",
+        quality_gate="numerics-parity",
+    ))
+    verdict = classify_layout(
+        LayoutId(quant=CONTRACT_PLAIN_BF16),
+        [LayoutId(quant=CONTRACT_COZY_FP8_ROWWISE)],
+    )
+    assert verdict.rung is LayoutRung.PRODUCIBLE
+    assert verdict.productions[0].recipe == "quantize-fp8-rowwise"
+    assert not hasattr(verdict.productions[0], "apply"), (
+        "a production must carry no transform; an `apply` here is how a "
+        "priced quality decision becomes automatic")
+
+
+def test_a_production_must_name_the_gate_that_will_judge_it() -> None:
+    with pytest.raises(DeclarationError, match="quality_gate is empty"):
+        register_layout_production(LayoutProduction(
+            axis="quant", from_id=CONTRACT_PLAIN_BF16,
+            to_id=CONTRACT_COZY_FP8_ROWWISE,
+            recipe="quantize-fp8-rowwise", quality_gate=""))
+
+
+# ── 2. a lossless topology edge: data, both directions, bytes untouched ──────
+
+
+def test_a_topology_rename_registers_both_directions() -> None:
+    register_layout_conversion(_comfy_to_diffusers())
+    edges = {(e.from_id, e.to_id) for e in registered_layout_conversions()}
+    assert edges == {
+        (TOPOLOGY_COMFY_SPLITFILES, TOPOLOGY_DIFFUSERS_MULTIFILE),
+        (TOPOLOGY_DIFFUSERS_MULTIFILE, TOPOLOGY_COMFY_SPLITFILES),
+    }, ("a lossless mapping is invertible and the inverse was proven in the "
+        "same pass; withholding it would be an edge we know is safe and refuse "
+        "to use")
+
+
+def test_a_topology_edge_with_no_inverse_is_refused_at_declaration() -> None:
+    with pytest.raises(DeclarationError, match="inverse_rules="):
+        TopologyConversion(
+            from_id=TOPOLOGY_COMFY_SPLITFILES,
+            to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+            version=1,
+            rules=(RenameRule(kind="prefix", pairs=(("a.", "b."),)),),
+            inverse_rules=(),
+            corpus=(DIT_CASE,),
+        )
+
+
+def test_a_rename_that_collides_two_keys_is_refused() -> None:
+    """An unmapped key is a refusal and an invented key is worse — and a rename
+    that maps two source keys onto one is the silent-data-loss version of both."""
+    with pytest.raises(ConversionProofError, match="not injective|source keys"):
+        register_layout_conversion(TopologyConversion(
+            from_id=TOPOLOGY_COMFY_SPLITFILES,
+            to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+            version=1,
+            rules=(RenameRule(
+                kind="substring", pairs=(("to_q", "to_x"), ("to_k", "to_x"))),),
+            inverse_rules=(RenameRule(
+                kind="substring", pairs=(("to_x", "to_q"),)),),
+            corpus=(DIT_CASE,),
+        ))
+
+
+def test_the_conversion_engine_never_touches_a_payload_byte(tmp_path: Path) -> None:
+    register_layout_conversion(_comfy_to_diffusers())
+    source = materialize_case(DIT_CASE, tmp_path / "src.safetensors")
+    plan = plan_layout_conversions(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)],
+    )[0]
+    result = run_layout_conversion(
+        plan, source, tmp_path / "out.safetensors",
+        source_digest="sha256:source", produced_by="test")
+
+    before = sorted(shard_payload_digests(source).values())
+    after = sorted(shard_payload_digests(result.path).values())
+    assert before == after
+    assert [name for name, _ in shard_tensor_entries(result.path)] == [
+        "transformer.blocks.0.attn.to_q.weight",
+        "transformer.blocks.0.attn.to_k.weight",
+        "transformer.blocks.0.ff.net.0.proj.weight",
+    ]
+
+
+def test_a_converted_artifact_carries_its_own_chain(tmp_path: Path) -> None:
+    """Artifacts self-describe: anyone can re-derive the identity from the file
+    without asking the hub (th#1721 extension 4 stage 3)."""
+    register_layout_conversion(_comfy_to_diffusers())
+    source = materialize_case(DIT_CASE, tmp_path / "src.safetensors")
+    plan = plan_layout_conversions(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)],
+    )[0]
+    result = run_layout_conversion(
+        plan, source, tmp_path / "out.safetensors",
+        source_digest="sha256:source", produced_by="local_conversion")
+
+    chain = conversion_provenance(result.path)
+    assert chain is not None
+    assert chain["identity"] == result.identity
+    assert chain["produced_by"] == "local_conversion"
+    assert [(h["from"], h["to"]) for h in chain["chain"]] == [
+        (TOPOLOGY_COMFY_SPLITFILES, TOPOLOGY_DIFFUSERS_MULTIFILE)]
+    assert derived_artifact_identity(
+        "sha256:source",
+        [h["converter_digest"] for h in chain["chain"]],
+        LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE),
+    ) == result.identity
+
+
+def test_a_conversion_that_cannot_say_where_it_ran_is_refused(
+    tmp_path: Path,
+) -> None:
+    """§4.28's never-upload fence needs `produced_by` to exist on every derived
+    artifact; a conversion that omits it produces bytes the publish path cannot
+    judge."""
+    register_layout_conversion(_comfy_to_diffusers())
+    source = materialize_case(DIT_CASE, tmp_path / "src.safetensors")
+    plan = plan_layout_conversions(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)],
+    )[0]
+    with pytest.raises(DeclarationError, match="produced_by"):
+        run_layout_conversion(
+            plan, source, tmp_path / "out.safetensors",
+            source_digest="sha256:source", produced_by="")
+
+
+# ── 3. the relation: composition, the cost cap, the four rungs ───────────────
+
+
+def _singlefile_edge() -> TopologyConversion:
+    return TopologyConversion(
+        from_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+        to_id=TOPOLOGY_DIFFUSERS_SINGLEFILE,
+        version=1,
+        rules=(RenameRule(kind="prefix", pairs=(("transformer.", "model."),)),),
+        inverse_rules=(RenameRule(kind="prefix", pairs=(("model.", "transformer."),)),),
+        corpus=(ConversionCase(
+            name="multifile-block0",
+            tensors={"transformer.blocks.0.attn.to_q.weight":
+                     CorpusTensor(dtype="BF16", shape=(8, 8))},
+        ),),
+    )
+
+
+def test_two_edges_compose_into_one_plan() -> None:
+    """Composition is what makes N+M registrations cover what a composite
+    vocabulary would need N*M for — and lossless∘lossless is lossless by
+    construction, so it needs no separate proof."""
+    register_layout_conversion(_comfy_to_diffusers())
+    register_layout_conversion(_singlefile_edge())
+    plans = plan_layout_conversions(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_SINGLEFILE)],
+    )
+    assert len(plans) == 1
+    assert [(h.from_id, h.to_id) for h in plans[0].hops] == [
+        (TOPOLOGY_COMFY_SPLITFILES, TOPOLOGY_DIFFUSERS_MULTIFILE),
+        (TOPOLOGY_DIFFUSERS_MULTIFILE, TOPOLOGY_DIFFUSERS_SINGLEFILE),
+    ]
+
+
+def test_a_three_hop_need_is_refused_rather_than_silently_paid_for() -> None:
+    """The cap is a COST bound: each hop is a full weight rewrite, so a 3-hop
+    need means a missing direct edge, which the planner says rather than
+    charging for."""
+    register_layout_conversion(_comfy_to_diffusers())
+    register_layout_conversion(_singlefile_edge())
+    register_layout_conversion(TopologyConversion(
+        from_id=TOPOLOGY_DIFFUSERS_SINGLEFILE,
+        to_id="transformers.native@1",
+        version=1,
+        rules=(RenameRule(kind="prefix", pairs=(("model.", "text_model."),)),),
+        inverse_rules=(RenameRule(kind="prefix", pairs=(("text_model.", "model."),)),),
+        corpus=(ConversionCase(
+            name="singlefile-block0",
+            tensors={"model.blocks.0.attn.to_q.weight":
+                     CorpusTensor(dtype="BF16", shape=(8, 8))},
+        ),),
+    ))
+    verdict = classify_layout(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+        [LayoutId(topology="transformers.native@1")],
+    )
+    assert verdict.rung is LayoutRung.INCOMPATIBLE
+    assert "no registered lossless mapping reaches" in verdict.reason
+
+
+@pytest.mark.parametrize("supply, accepts, rung", [
+    # in the set
+    (LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE),
+     [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)], LayoutRung.COMPATIBLE),
+    # a registered lossless edge reaches the set
+    (LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES),
+     [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)], LayoutRung.CONVERTIBLE),
+    # nothing reaches it
+    (LayoutId(topology="gguf.native@1"),
+     [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)], LayoutRung.INCOMPATIBLE),
+    # an UNDECLARED demand is not "accepts everything"
+    (LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE), [], LayoutRung.INCOMPATIBLE),
+])
+def test_the_ladder(supply: LayoutId, accepts: list, rung: LayoutRung) -> None:
+    register_layout_conversion(_comfy_to_diffusers())
+    assert classify_layout(supply, accepts).rung is rung
+
+
+def test_the_axes_are_compared_field_wise_not_as_one_string() -> None:
+    """A whole-string compare is exact and still cannot express "topology
+    differs, quant matches", which is the CONVERTIBLE rung."""
+    register_layout_conversion(_comfy_to_diffusers())
+    verdict = classify_layout(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES, quant=CONTRACT_PLAIN_BF16),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE, quant=CONTRACT_PLAIN_BF16)],
+    )
+    assert verdict.rung is LayoutRung.CONVERTIBLE
+    # The quant axis needed no hop; only the topology one did.
+    assert verdict.plans[0].quant == ()
+    assert len(verdict.plans[0].topology) == 1
+
+
+def test_a_quant_mismatch_is_not_convertible_on_a_topology_edge() -> None:
+    register_layout_conversion(_comfy_to_diffusers())
+    verdict = classify_layout(
+        LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES, quant=CONTRACT_PLAIN_BF16),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE,
+                  quant=CONTRACT_HF_FP8_BLOCKWISE)],
+    )
+    assert verdict.rung is LayoutRung.INCOMPATIBLE
+
+
+def test_an_axis_neither_side_declares_is_reported_not_assumed() -> None:
+    """UNDECLARED is a different fact from agnostic, and the verdict says which
+    axes it did not decide instead of reading silence as agreement."""
+    verdict = classify_layout(
+        LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE),
+        [LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)],
+    )
+    assert verdict.rung is LayoutRung.COMPATIBLE
+    assert verdict.unevaluated_axes == ("quant",)
+
+
+def test_the_relation_holds_no_handle_literal() -> None:
+    """§1.33's extensibility invariant: contract CONTENTS evolve, the
+    compatibility RELATION never does. Enforced by the shipped gate, asserted
+    here so the invariant has a test and not only a script."""
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "lint_cell_key_layout_fence.py")],
+        capture_output=True, text=True, timeout=180)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "no contract-handle literal in the relation" in proc.stdout
+
+
+# ── 4. the accepted set is a FILTER; its order is not a preference ───────────
+
+
+def test_the_declared_set_is_canonicalized_so_no_reader_can_recover_an_order(
+) -> None:
+    """§1.33 point 2 as AMENDED (th#1803): the set is a compatibility filter and
+    preference has exactly ONE authority — the (GPU, lane) ladder. Two authors
+    who spell the same set differently state the SAME demand, and storing the
+    written order would be a second ordering that can disagree with the first.
+    """
+    first = normalize_layout_demand(
+        {"*": (CONTRACT_HF_FP8_BLOCKWISE, CONTRACT_PLAIN_BF16)}, where="a")
+    second = normalize_layout_demand(
+        {"*": (CONTRACT_PLAIN_BF16, CONTRACT_HF_FP8_BLOCKWISE)}, where="b")
+    assert first == second
+
+
+def test_the_planner_returns_every_reachable_target_and_ranks_none() -> None:
+    register_layout_conversion(_comfy_to_diffusers())
+    register_layout_conversion(_singlefile_edge())
+    supply = LayoutId(topology=TOPOLOGY_COMFY_SPLITFILES)
+    accepts = [LayoutId(topology=TOPOLOGY_DIFFUSERS_SINGLEFILE),
+               LayoutId(topology=TOPOLOGY_DIFFUSERS_MULTIFILE)]
+    forward = plan_layout_conversions(supply, accepts)
+    reversed_ = plan_layout_conversions(supply, list(reversed(accepts)))
+    assert len(forward) == 2
+    assert [p.target for p in forward] == [p.target for p in reversed_], (
+        "the plan order must not follow the demand's order — that is the second "
+        "ordering §1.33 point 2 forbids")
+
+
+# ── 5. one identity function, stable across processes ────────────────────────
+
+
+def test_the_derived_identity_is_identical_in_a_fresh_process(
+    tmp_path: Path,
+) -> None:
+    """Convert-once-into-the-CAS is worth nothing if the hub and a laptop
+    compute different identities for the same conversion — which is exactly
+    what an mtime- or path-dependent code digest would do."""
+    script = tmp_path / "identity.py"
+    script.write_text(textwrap.dedent(
+        """
+        import json
+        from gen_worker.convert.layout_converters import (
+            ConversionCase, CorpusTensor, TopologyConversion,
+            register_layout_conversion, registered_layout_conversions)
+        from gen_worker.convert.repack_spec import RenameRule
+        from gen_worker.models.tensor_layout_contract import (
+            TOPOLOGY_COMFY_SPLITFILES, TOPOLOGY_DIFFUSERS_MULTIFILE)
+
+        register_layout_conversion(TopologyConversion(
+            from_id=TOPOLOGY_COMFY_SPLITFILES,
+            to_id=TOPOLOGY_DIFFUSERS_MULTIFILE,
+            version=1,
+            rules=(RenameRule(kind="prefix",
+                   pairs=(("model.diffusion_model.", "transformer."),)),),
+            inverse_rules=(RenameRule(kind="prefix",
+                   pairs=(("transformer.", "model.diffusion_model."),)),),
+            corpus=(ConversionCase(
+                name="dit-block0",
+                tensors={
+                  "model.diffusion_model.blocks.0.attn.to_q.weight":
+                      CorpusTensor(dtype="BF16", shape=(8, 8)),
+                  "model.diffusion_model.blocks.0.attn.to_k.weight":
+                      CorpusTensor(dtype="BF16", shape=(8, 8)),
+                  "model.diffusion_model.blocks.0.ff.net.0.proj.weight":
+                      CorpusTensor(dtype="BF16", shape=(16, 8)),
+                },
+                metadata={"format": "pt"}),),
+        ))
+        print(json.dumps({
+            (e.from_id + "->" + e.to_id): e.digest
+            for e in registered_layout_conversions()}))
+        """
+    ), encoding="utf-8")
+
+    register_layout_conversion(_comfy_to_diffusers())
+    here = {f"{e.from_id}->{e.to_id}": e.digest
+            for e in registered_layout_conversions()}
+
+    proc = subprocess.run(
+        [sys.executable, str(script)], capture_output=True, text=True,
+        timeout=300, cwd=str(REPO))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert json.loads(proc.stdout.strip()) == here
+
+
+def test_a_version_bump_moves_the_identity(tmp_path: Path) -> None:
+    """Bumping `version` changes the converter digest, which changes every
+    derived artifact's identity — bytes never silently change under a name."""
+    register_layout_conversion(_comfy_to_diffusers(version=1))
+    v1 = {(e.from_id, e.to_id): e.digest for e in registered_layout_conversions()}
+    reset_layout_conversions()
+    register_layout_conversion(_comfy_to_diffusers(version=2))
+    v2 = {(e.from_id, e.to_id): e.digest for e in registered_layout_conversions()}
+    assert set(v1) == set(v2)
+    assert all(v1[k] != v2[k] for k in v1)
+
+
+# ── 6. the §1.33 point-5 fence: conversion is upstream of compute ────────────
+
+
+def _fence_module():
+    spec = importlib.util.spec_from_file_location(
+        "_fence", REPO / "scripts" / "lint_cell_key_layout_fence.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_fence_covers_every_module_that_computes_a_cell_key() -> None:
+    """The fenced set is DERIVED from who calls an axis producer, not
+    hand-listed — the failure mode of a hand-maintained list is that the one
+    file which violates the rule is the one nobody added."""
+    fenced = {p.name for p in _fence_module().fenced_modules()}
+    assert {"cell_key.py", "fleet_cells.py", "boot_key.py", "aot_mint.py",
+            "aot_serve.py", "compile_cache.py"} <= fenced
+
+
+def test_the_fence_fires_on_a_key_axis_that_reads_the_layout(
+    tmp_path: Path,
+) -> None:
+    """The detector's own RED. A gate whose failure path nobody has executed is
+    a gate nobody knows the shape of."""
+    module = tmp_path / "offender.py"
+    module.write_text(textwrap.dedent(
+        """
+        from gen_worker.convert.layout_converters import LayoutId
+
+        def envelope_facts(block, layout: LayoutId):
+            return {"v": 1, "layout": layout.render()}
+        """
+    ), encoding="utf-8")
+    hits = _fence_module()._violations(module)
+    assert hits, "the fence did not see an import of the layout vocabulary"
+    assert any("layout_converters" in what for _line, what in hits)
+
+
+def test_the_shipped_tree_passes_the_fence() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "lint_cell_key_layout_fence.py")],
+        capture_output=True, text=True, timeout=180)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "no cell re-keys on a conversion" in proc.stdout
+
+
+# ── the behavioural half of point 5: a demand does not move the contract ─────
+
+
+class _Vae:
+    pass
+
+
+class _TextEncoder:
+    pass
+
+
+class _Unet:
+    pass
+
+
+class FakePipeline:
+    def __init__(self, vae: _Vae, text_encoder: _TextEncoder, unet: _Unet):
+        self.vae = vae
+        self.text_encoder = text_encoder
+        self.unet = unet
+
+    @classmethod
+    def _get_signature_keys(cls, _obj: object) -> tuple:
+        return {"vae", "text_encoder", "unet"}, set()
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    model: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _Defaults(GenerationDefaults):
+    pass
+
+
+def _compile_declaration() -> Compile:
+    return Compile(
+        family="layoutfence",
+        targets=("unet",),
+        text_len=512,
+        dims=(Dim("H", carried_by=(("hidden_states", 2),), multiple_of=2),
+              Dim("B", carried_by=(("hidden_states", 0),))),
+        forks=(Fork("cfg", served=(False,), unserved=(True,)),),
+        classes=(GraphClass(dims={"H": 90, "B": 1}, fork={"cfg": False}),),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+
+
+def _spec_for(slot: Slot):
+    @endpoint(models={"pipeline": slot}, compile=_compile_declaration())
+    class Endpoint:
+        def setup(self, pipeline: FakePipeline) -> None:
+            self.pipeline = pipeline
+
+        def generate(self, ctx: RequestContext[_Defaults], p: _In) -> _Out:
+            return _Out()
+
+    return extract_specs(Endpoint)[0]
+
+
+def test_declaring_a_layout_demand_does_not_move_the_compile_contract() -> None:
+    """§1.33 point 5, behaviourally: the demand is upstream of compute, so
+    adding it to a slot must not move ANY cell-key input. The compile contract
+    digest is what an endpoint's declaration actually reaches, and this goes RED
+    the moment someone folds `layouts` into `contract_facts()` — which is the
+    placement §1.33 point 5 rules out and the reason the demand lives on `Slot`
+    and not on `Compile`.
+    """
+    bare = _spec_for(Slot(FakePipeline, selected_by="model"))
+    declared = _spec_for(Slot(
+        FakePipeline, selected_by="model",
+        layouts={"*": (CONTRACT_PLAIN_BF16,),
+                 "text_encoder": (CONTRACT_HF_FP8_BLOCKWISE, CONTRACT_PLAIN_BF16)},
+    ))
+    assert declared.slots["pipeline"].layouts is not None, (
+        "the fixture must actually declare something, or this test passes for "
+        "the wrong reason")
+    assert bare.slots["pipeline"].layouts is None
+    assert bare.compile is not None and declared.compile is not None
+    assert declared.compile.contract_axes() == bare.compile.contract_axes()
+    assert contract_delta(bare.compile, declared.compile) == {}
+    assert override_delta(bare.compile, declared.compile) == {}

--- a/tests/test_layout_converter_registry_pgw1143.py
+++ b/tests/test_layout_converter_registry_pgw1143.py
@@ -69,6 +69,7 @@ from gen_worker.models.tensor_layout_contract import (
     TOPOLOGY_DIFFUSERS_SINGLEFILE,
     LayoutId,
     normalize_layout_demand,
+    parse_layout_id,
 )
 from gen_worker.registry import extract_specs
 
@@ -520,6 +521,21 @@ def test_the_derived_identity_is_identical_in_a_fresh_process(
         timeout=300, cwd=str(REPO))
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert json.loads(proc.stdout.strip()) == here
+
+
+@pytest.mark.parametrize("rendered", [
+    "plain.bf16@1",                          # bare handle = the quant axis
+    "+plain.bf16@1",
+    "diffusers.multifile@1+plain.bf16@1",
+    "diffusers.multifile@1+",
+    "any+plain.bf16@1",                      # a DECLARED agnostic, not an inference
+])
+def test_a_layout_id_survives_its_own_rendering(rendered: str) -> None:
+    """`render()` is what `derived_artifact_identity` digests, so a rendering
+    that does not parse back to the same pair would let two different LayoutIds
+    address one CAS object — silently, on the axis nobody printed."""
+    parsed = parse_layout_id(rendered, where="t")
+    assert parse_layout_id(parsed.render(), where="t") == parsed
 
 
 def test_a_version_bump_moves_the_identity(tmp_path: Path) -> None:

--- a/tests/test_one_safetensors_header_bound_pgw973.py
+++ b/tests/test_one_safetensors_header_bound_pgw973.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker.convert.ingest import detect_snapshot_dtype
-from gen_worker.convert.writer import _read_safetensors_header, component_stored_tensor_names
+from gen_worker.convert.writer import read_safetensors_header, component_stored_tensor_names
 from gen_worker.models.loading import safetensors_file_valid
 from gen_worker.models.safetensors_header import MAX_HEADER_BYTES, header_len_ok
 from gen_worker.models.svdq import _read_safetensors_metadata
@@ -105,7 +105,7 @@ def test_every_reader_refuses(tmp_path: Path, declared: int):
     with pytest.raises(ValueError):
         fd = os.open(f, os.O_RDONLY)
         try:
-            _read_safetensors_header(fd)
+            read_safetensors_header(fd)
         finally:
             os.close(fd)
 
@@ -128,7 +128,7 @@ def test_a_legitimate_file_still_parses_everywhere(tmp_path: Path):
     assert w4a4_read_header(f) == _HEADER
     fd = os.open(f, os.O_RDONLY)
     try:
-        header, _ = _read_safetensors_header(fd)
+        header, _ = read_safetensors_header(fd)
     finally:
         os.close(fd)
     assert header == _HEADER
@@ -150,7 +150,7 @@ def test_writer_and_loader_agree_on_the_same_file(tmp_path: Path):
     fd = os.open(f, os.O_RDONLY)
     try:
         with pytest.raises(ValueError, match="implausible header_length"):
-            _read_safetensors_header(fd)
+            read_safetensors_header(fd)
     finally:
         os.close(fd)
 

--- a/tests/test_slot_layout_demand_pgw1143.py
+++ b/tests/test_slot_layout_demand_pgw1143.py
@@ -4,8 +4,9 @@ SDK side.
 What is proven here, in the order the design puts it:
 
 1. a declared slot's demand reaches the PUBLISHED MANIFEST, per component
-   path, in declaration order — that is the whole point, since the manifest is
-   the only thing the hub reads;
+   path, in CANONICAL order — that is the whole point, since the manifest is
+   the only thing the hub reads, and §1.33 pt 2 as amended makes the set a
+   filter whose order carries no preference;
 2. absence is UNDECLARED — no key at all, not an empty one, so the hub cannot
    read it as "accepts everything";
 3. an invalid declaration is refused WHERE IT IS WRITTEN — an unknown handle
@@ -91,7 +92,7 @@ def _components() -> dict:
 # ── 1. the declaration reaches the manifest, ordered, per component ──────────
 
 
-def test_a_declared_slot_publishes_its_demand_per_component_in_order() -> None:
+def test_a_declared_slot_publishes_its_demand_per_component() -> None:
     slot = Slot(
         FakePipeline,
         selected_by="model",
@@ -106,9 +107,27 @@ def test_a_declared_slot_publishes_its_demand_per_component_in_order() -> None:
         "*": ["plain.bf16@1"],
         "text_encoder": ["hf.fp8-blockwise@1", "plain.bf16@1"],
     }
-    # Order IS preference (§1.33 pt 2) — the fp8 encoder is declared FIRST and
-    # must not be sorted into second place by anything on the way out.
-    assert block["layouts"]["text_encoder"][0] == "hf.fp8-blockwise@1"
+
+
+def test_the_published_set_is_canonical_so_no_reader_can_read_a_preference(
+) -> None:
+    """§1.33 pt 2 as AMENDED (th#1803): the accepted set is a compatibility
+    FILTER whose order carries no preference — preference has exactly ONE
+    authority, the (GPU, lane) ladder. So two authors who spell the same set in
+    different orders publish the SAME manifest block. Storing the written order
+    would be a second ordering that can disagree with the first, and the hub
+    stores an ordinal for whatever it is handed."""
+    declared = _slot_to_manifest(
+        "pipeline",
+        Slot(FakePipeline, layouts={
+            "text_encoder": (CONTRACT_HF_FP8_BLOCKWISE, CONTRACT_PLAIN_BF16)}),
+        family="", components=_components())
+    reversed_ = _slot_to_manifest(
+        "pipeline",
+        Slot(FakePipeline, layouts={
+            "text_encoder": (CONTRACT_PLAIN_BF16, CONTRACT_HF_FP8_BLOCKWISE)}),
+        family="", components=_components())
+    assert declared["layouts"] == reversed_["layouts"]
 
 
 def test_an_undeclared_slot_emits_no_layouts_key_at_all() -> None:
@@ -129,7 +148,7 @@ def test_an_undeclared_slot_emits_no_layouts_key_at_all() -> None:
     [
         ({}, "declares nothing"),
         ({"*": ()}, "is empty"),
-        ({"*": "plain.bf16@1"}, "ORDERED tuple"),
+        ({"*": "plain.bf16@1"}, "must be a tuple of handles"),
         ({"*": ("plain.bf16",)}, "not a contract handle"),
         ({"*": ("cozy.not-registered@1",)}, "is not registered"),
         ({"*": ("plain.bf16@1", "plain.bf16@1")}, "repeats"),


### PR DESCRIPTION
Executes **DESIGN-RULINGS §1.33** steps 4 and 7 of pgw#1143 (the SDK half; th#1809 is the hub half). Steps 1-3 (`Slot(layouts=…)`) landed in `b8417357`; this adds the CONVERTIBLE rung and the fence that keeps conversion out of cell identity.

## The converter registry — re-quantization is *structurally* unregistrable

`src/gen_worker/convert/layout_converters.py`: the SDK's **sixth** registry, keyed `(axis, from → to)` over two independent axes.

* **topology** — keys/nesting. Declared as `convert.repack_spec.RenameRule` passes (the SDK's EXISTING key-rewrite vocabulary, not a new one), executed by `writer.rewrite_safetensors_keys`, a raw byte-range copy that never decodes a tensor. Bit-losslessness on that axis is a property of the API, not a claim a converter makes about itself. It is also DATA, so the hub and an AST sweep can both read an edge.
* **quant** — what the weights ARE. A streaming same-numerics repack (`ConversionIO`), plus a required reference-dequant equivalence obligation.

**The admission bar runs at REGISTRATION**, over the mapping's declared corpus (real headers, synthetic payloads, ≤1 MiB — §4.25 / th#1580's corpus method): key bijection → payload invariance (topology) → `A → B → A` content recovery → dequant equivalence (quant). A cast that discards bits cannot satisfy the round trip, so **the registry cannot hold a re-quantization** — it is not a review convention. The refusal names the rung it belongs on and the call that declares it:

```
... the round trip did not recover corpus case 'dit-block0' (… -> …). A CONVERTIBLE
mapping is lossless, and lossless means invertible … A mapping that produces NEW
NUMERICS is the PRODUCIBLE rung — declare it with register_layout_production(),
which prices it and names its quality gate.
```

`LayoutProduction` carries a recipe NAME and a quality gate and **no transform at all** — putting an `apply` there is how a priced quality decision becomes automatic.

**The relation never grows a special case** (§1.33's extensibility invariant): `classify_layout` / `plan_layout_conversions` are membership → lossless-edge reachability → production-edge reachability, extended only by DATA. Per-axis BFS, capped at 2 hops (a COST bound; a 3-hop need means a missing direct edge, which the planner says rather than paying for).

## The set is a FILTER — its order is not a preference

§1.33 pt 2 **as amended by th#1803**. `Slot(layouts=…)` now canonicalizes the declared handles, so two authors who spell the same set differently publish the same manifest and nobody can recover a ranking from a position that never carried one. Preference keeps exactly one authority: the (GPU, lane) ladder. `plan_layout_conversions` returns *every* reachable target and orders by (hop count, rendered target) — determinism, not a ranking.

## The §1.33 point-5 fence, enforced mechanically

`scripts/lint_cell_key_layout_fence.py` — new **required `fast gates`** step. The fenced module set is **DERIVED**, not hand-listed: any module calling a cell-key axis producer (`from_axes`, `envelope_digest`, `toolchain_axis_digest`, `from_exported_artifact_metadata`, `CellKey`) joins it, plus the six that define the key or an axis input. Inside the fence, referencing the layout DEMAND/CONVERSION vocabulary is red — by import, attribute, stringized annotation or deferred `import_module`. Docstrings are excluded on purpose: prose is not a reference.

`scripts/check_registry_contract.py` also joins the gates and asserts the sixth registry's bare state plus a consumer's edge.

## RED before GREEN, on unmodified `origin/master`

1. `tests/test_layout_converter_registry_pgw1143.py` — `ModuleNotFoundError: No module named 'gen_worker.convert.layout_converters'`.
2. The canonicalization test, **behaviourally** (not a collection error): `AssertionError: {'text_encoder': ['hf.fp8-blockwise@1', 'plain.bf16@1']} != {'text_encoder': ['plain.bf16@1', 'hf.fp8-blockwise@1']}`.
3. The fence's own RED, by mutating a real key-axis module: a stringized `LayoutId` annotation on `cell_key.from_axes` → `cell_key.py:223: reads the layout vocabulary (string names 'LayoutId')`; a real `from .convert.layout_converters import LayoutId` inside `envelope_facts` → two violations, exit 1.
4. `check_registry_contract.py` on master prints no `layout-conversions` row.

## Not in scope (blocked, by design)

Step 5 (identify-round-trip fixture, needs the hub's registry), step 6 (real converters, ie/te, needs a published wheel), step 8 (cozy-local derived CAS), step 9 (production spec) — and the topology axis stays SDK-internal until th#1809 T3 ships the hub registry, so `Slot(layouts=)` keeps refusing a `<topology>+<quant>` composite.

**No wheel is cut here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
