### PR TITLE
pgw#660: `Resources` gets back the HARD VRAM floor SDK v2 dropped — `min_vram_gb`

### DIFF
--- a/changelog.d/pgw660.md
+++ b/changelog.d/pgw660.md
@@ -1,0 +1,37 @@
+- **pgw#660: `Resources` gets back the HARD VRAM floor SDK v2 dropped — `min_vram_gb`.**
+  v2 deleted `Resources.vram_gb` and `Resources.compute_capability` on purpose (pgw#647),
+  on the reasoning that th#683's prove-and-profile would MEASURE the real requirement. That
+  reasoning is right about how much VRAM a function WANTS and wrong about the card it cannot
+  run on AT ALL, and only the second question has an answer before a first build exists.
+
+  The builder maps requirements out of the manifest's `resources{}` **by name**, so after v2
+  the intersection it could still gate on was `gpu` + `libraries` + `vcpus`. A per-function
+  `min_vram_gb: 80` simply stopped being emitted, `req.VRAMGB` fell back to the RELEASE-level
+  envelope (7 GB for conversion), and the floor left the selection path with **no error, no
+  lint and no build failure**. The SM twin of the same hole was confirmed live six times in ten
+  minutes (th#1155: `modelopt-quantization`, which needs `torch._scaled_mm` at sm_89+, placed on
+  sm_80 A100s), and again on te#125. The SM half shipped as `compute_capability` at 0.75.0;
+  this is its VRAM twin, and it completes the pair Paul ruled ("restore it as a declared,
+  scheduler-enforced requirement").
+
+  **No tensorhub change is required, and that is why the field is spelled this way.**
+  `function_requirements.go` already folds `min_vram_gb` into `requirement_payload_json`, whence
+  it reaches `req.VRAMGB` → `MinVRAMGB` → the GPU candidate filter. The hub has read the key all
+  along; nothing was emitting it. The builder's `vram_gb` → `min_vram_gb` fallback applies only
+  when the explicit key is absent, so this can never be shadowed by a v1 remap.
+
+  **It is deliberately not `vram_gb_hint` promoted.** The hint's contract — "never a gate" — is
+  what pgw#647 froze, and gating on a value declared as advisory would silently turn every
+  existing hint in the fleet into a hard refusal. A floor is a different statement, so it is a
+  different field, named `min_` for what it is (a floor the hub may exceed, never a cap — the
+  same reading as `min_disk_gb`). Declaring it implies `gpu=True`; a `vram_gb_hint` BELOW the
+  floor is a self-contradicting declaration and costs a `ValueError` rather than a build.
+
+  **It is a PLACEMENT gate only.** It deliberately does not reach `models/serve_fit.py`, which by
+  contract "never refuses on the recommended-VRAM hint alone" and whose sole author opt-out is
+  `strict_vram`. A floor that also became a runtime refusal would turn a scheduling statement into
+  a serving one and could refuse requests a pod can answer — a separate decision.
+
+  The v1 spellings `vram_gb`/`ram_gb` stay deleted, and `sdk_shape.DELETED_FIELDS` now says why:
+  one word for two questions is how the hint got declared where the gate was meant, so its
+  redirect names both survivors instead of pointing an author who needs a floor at the hint.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -540,7 +540,8 @@ Resources(gpu=True, libraries=("nunchaku",))
 Fields: `gpu`, `gpu_count`, `max_gpu_count`,
 `max_gpus_per_execution_group`, `parallel`, `libraries`, `strict_vram`
 (bindings that cannot tolerate CPU-resident weights), `vcpus`,
-`compute_capability`, and the two hints `vram_gb_hint` / `ram_gb_hint`.
+the two hard floors `compute_capability` / `min_vram_gb`, and the two hints
+`vram_gb_hint` / `ram_gb_hint`.
 `max_gpus_per_execution_group` / `parallel` are the multi-GPU axis — see
 [multi-gpu.md](multi-gpu.md).
 
@@ -551,24 +552,44 @@ th#683 profiling measurements exist; `ram_gb_hint` (pgw#670) is its
 host-side twin and does not imply `gpu=True`. Both are allocation-time
 asks the platform may miss: never a gate, ceiling, or reservation.
 
-`compute_capability` (pgw#660) is the opposite — a HARD GPU-architecture
-floor the scheduler filters offers on and refuses to rent below. Declare
-the dotted capability the way NVIDIA writes it (`8.9`, `"8.9"`, or
-`"sm_89"`, never the bare SM code `89`); it implies `gpu=True`.
+`compute_capability` and `min_vram_gb` (both pgw#660) are the opposite —
+HARD floors the scheduler filters offers on and refuses to rent below.
+`compute_capability` is the GPU-architecture floor: declare the dotted
+capability the way NVIDIA writes it (`8.9`, `"8.9"`, or `"sm_89"`, never the
+bare SM code `89`). `min_vram_gb` is the VRAM floor, named `min_` for what it
+is — a floor the hub may exceed, never a cap. Both imply `gpu=True`.
 
 ```python
-# scaled_mm is sm_89+ or nothing — an incapability, not a slow rung.
-Resources(gpu=True, compute_capability=8.9, libraries=("modelopt",))
+# scaled_mm is sm_89+ or nothing, and 80 GB is the card it cannot run below —
+# both are incapabilities, not slow rungs.
+Resources(gpu=True, compute_capability=8.9, min_vram_gb=80,
+          libraries=("modelopt",))
 ```
 
-Declare it ONLY for genuine incapability. A function that merely runs
-*better* on newer silicon declares nothing and lets the fit ladder choose;
-over-declaring shrinks the rentable pool for no reason. Omitting it is
-always safe — no key, no gate, today's behaviour.
+**`vram_gb_hint` is not a smaller `min_vram_gb`.** The hint is never read as
+a gate by the builder, so a function that declares only the hint has *no*
+VRAM floor on the placement path — that is the exact v2 regression pgw#660
+closes, and it is silent (no error, no lint, no build failure). If your
+function cannot run below a size, say `min_vram_gb`. Where both are declared
+the hint may not sit below the floor; that contradiction is a declaration-time
+`ValueError`.
 
-`vram_gb` and `ram_gb` remain deleted from SDK v2 (measured requirements
-belong to the profiler; host RAM is an opportunistic tier), as does v1's
-`min_compute_capability` spelling — the hub rejects that key outright.
+Declare either ONLY for genuine incapability. A function that merely runs
+*better* on newer or larger silicon declares nothing and lets the fit ladder
+choose; over-declaring shrinks the rentable pool for no reason. Omitting them
+is always safe — no key, no gate, today's behaviour.
+
+Note the split of duties: `min_vram_gb` is a PLACEMENT gate only. The
+worker-side fit ladder never refuses on a declared VRAM number — `strict_vram`
+is the sole author opt-out of the CPU-touching rungs.
+
+The v1 spellings `vram_gb` and `ram_gb` remain deleted from SDK v2 — what a
+function WANTS per lane and shape is the profiler's measurement, not an
+authored guess. What it CANNOT RUN BELOW came back under explicit names
+(`min_vram_gb`, `compute_capability`), which is why the old words stay gone
+rather than being restored: one word for two questions is how the hint got
+declared where the gate was meant. v1's `min_compute_capability` spelling is
+also still dead — the hub rejects that key outright.
 
 ## Kinds
 

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -128,6 +128,35 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     exist. It is never a gate, never a runtime ceiling, and never a
     per-load reservation. Declaring it implies ``gpu=True``.
 
+    ``min_vram_gb`` (pgw#660) is the HARD VRAM floor, and it is the exact
+    twin of ``compute_capability`` above: the v2 cut deleted ``vram_gb`` on
+    the reasoning that th#683 would MEASURE the real requirement, and that
+    reasoning is right about how much VRAM a function wants and wrong about
+    the card it cannot run on at all. The two are not the same question, and
+    only one of them has an answer before the first build exists.
+
+    It is deliberately NOT ``vram_gb_hint`` promoted. The hint's contract —
+    "never a gate" — is what pgw#647 froze, and teaching the scheduler to
+    gate on a value declared as advisory would silently turn every existing
+    hint into a hard refusal. A floor is a different statement, so it gets a
+    different field, named ``min_`` for what it is: a floor the hub may
+    exceed, never a cap (the same reading as ``min_disk_gb``). Declare it
+    ONLY for a genuine incapability — a function that merely runs BETTER
+    with more VRAM declares nothing and lets the fit ladder choose.
+
+    Declaring it implies ``gpu=True``. Where both are present the floor must
+    not exceed the hint: a hint BELOW the floor is a contradiction (the
+    first-build placement would land under the value the function says it
+    cannot run below), and it is refused here rather than shipped.
+
+    It is a PLACEMENT gate and nothing else. It deliberately does not reach
+    the worker-side fit ladder (``models/serve_fit.py``), which by contract
+    "never refuses on the recommended-VRAM hint alone" and whose sole author
+    opt-out is ``strict_vram``. A floor that also became a runtime refusal
+    would turn a scheduling statement into a serving one and could refuse
+    requests a pod can answer — a separate decision, not a consequence of
+    this one.
+
     ``ram_gb_hint`` (pgw#670) is its HOST-side twin, restored after the v2
     cut deleted ``ram_gb`` on the reasoning that host RAM is an
     opportunistic latency tier. For ltx-video-2.3 it was neither
@@ -221,6 +250,7 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     strict_vram: bool = False
     vcpus: int | None = None
     vram_gb_hint: float | None = None
+    min_vram_gb: float | None = None
     ram_gb_hint: float | None = None
     min_disk_gb: float | None = None
     compute_capability: float | str | None = None
@@ -241,6 +271,17 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
         ``min_disk_gb`` (pgw#732) needs no remap either — it is already the
         key the hub reads as an additional disk floor
         (``mergeRequestDiskIntoSupply``), the same spelling on both sides.
+
+        ``min_vram_gb`` (pgw#660) needs no remap either, and that is the whole
+        reason the floor is spelled this way: it is already the key
+        ``function_requirements.go`` folds into ``requirement_payload_json``
+        (``for _, key := range []string{"min_vram_gb", "vram_multiplier"}``),
+        from which it reaches ``req.VRAMGB`` → ``MinVRAMGB`` → the GPU
+        candidate filter. The hub reads it as the floor ALREADY — v2 simply
+        stopped emitting anything that landed there, so the gate vanished with
+        no error and no build failure. Note the builder's own fallback,
+        ``vram_gb`` → ``min_vram_gb`` *when the explicit key is absent*: the
+        explicit key wins, so this field can never be shadowed by a v1 remap.
 
         ``compute_capability`` needs no remap: it is already the key
         ``internal/builder/function_requirements.go`` parses (scalar or
@@ -271,10 +312,24 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
             if v <= 0:
                 raise ValueError(f"vram_gb_hint must be positive, got {v}")
             force(self, "vram_gb_hint", v)
+        if self.min_vram_gb is not None:
+            f = float(self.min_vram_gb)
+            if f <= 0:
+                raise ValueError(f"min_vram_gb must be positive, got {f}")
+            force(self, "min_vram_gb", f)
+            # A hint below the floor would place the first build under the
+            # value the function says it cannot run below — the declaration
+            # contradicts itself, so it costs a ValueError, not a build.
+            if self.vram_gb_hint is not None and self.vram_gb_hint < f:
+                raise ValueError(
+                    f"vram_gb_hint {self.vram_gb_hint} is below min_vram_gb {f}: "
+                    "the hint places the first build, and placing it under the "
+                    "hard floor cannot be what was meant")
         if self.compute_capability is not None:
             force(self, "compute_capability",
                   _normalize_compute_capability(self.compute_capability))
         if (n_gpu > 1 or self.vram_gb_hint is not None
+                or self.min_vram_gb is not None
                 or self.compute_capability is not None):
             force(self, "gpu", True)
         if self.ram_gb_hint is not None:

--- a/src/gen_worker/api/sdk_shape.py
+++ b/src/gen_worker/api/sdk_shape.py
@@ -54,9 +54,12 @@ DELETED_FIELDS: Tuple[DeletedField, ...] = (
         name="vram_gb",
         deleted_at="0.60.0",
         reason=(
-            "th#683 prove-and-profile MEASURES the real VRAM requirement per lane "
-            "and shape; an authored floor is a placement gate over a guess. The "
-            "survivor is the optional first-build hint `vram_gb_hint`."
+            "th#683 prove-and-profile MEASURES how much VRAM a function WANTS per "
+            "lane and shape, so the gate-shaped v1 spelling does not come back. It "
+            "split in two: `vram_gb_hint` is the optional first-build hint and is "
+            "NEVER a gate, and `min_vram_gb` (pgw#660) is the hard floor the "
+            "scheduler filters offers on. Declaring the hint when you meant the "
+            "floor is the v2 regression this row now exists to prevent."
         ),
     ),
     DeletedField(

--- a/tests/test_vram_floor_pgw660.py
+++ b/tests/test_vram_floor_pgw660.py
@@ -1,0 +1,150 @@
+"""pgw#660 — SDK v2 dropped every endpoint's hard VRAM floor; this restores it.
+
+v2 deleted `Resources.vram_gb` and `Resources.compute_capability` on purpose
+(pgw#647), on the reasoning that th#683's prove-and-profile would MEASURE the
+real requirement. That reasoning is right about how much VRAM a function
+WANTS and wrong about the card it cannot run on AT ALL — and only the second
+question has an answer before a first build exists.
+
+The consequence was not theoretical. The builder maps requirements out of the
+manifest's `resources{}` by NAME, and after v2 the intersection it could still
+gate on was `gpu` + `libraries` + `vcpus`. So `min_vram_gb: 80` simply stopped
+being emitted, `req.VRAMGB` fell back to the RELEASE-level envelope (7 GB for
+conversion), and the per-function floor left the selection path with no error,
+no lint and no build failure. The SM twin of this hole was confirmed live six
+times in ten minutes (th#1155: `modelopt-quantization`, which needs
+`torch._scaled_mm` at sm_89+, placed on sm_80 A100s).
+
+The SM half shipped as `Resources.compute_capability`. This is its VRAM twin,
+and the tests below are written against the SAME hub keys the builder already
+reads, so a hub-side rename reds here rather than on a rented pod.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.api.decorators import Resources
+
+
+# ---------------------------------------------------------------------------
+# The emitter, under the key the hub already gates on
+# ---------------------------------------------------------------------------
+
+
+def test_the_floor_projects_under_the_HUBS_OWN_key_with_no_remap() -> None:
+    """`function_requirements.go` folds `min_vram_gb` straight into
+    `requirement_payload_json`, whence `req.VRAMGB` -> `MinVRAMGB` -> the GPU
+    candidate filter. The hub has read this key all along; v2 stopped emitting
+    anything that landed there. Same word on both sides, deliberately — the
+    one remap in this projection (`ram_gb_hint` -> `ram_gb`) is the exception
+    that had to be written down."""
+    assert Resources(min_vram_gb=80).manifest_dict() == {
+        "gpu": True, "min_vram_gb": 80.0}
+
+
+def test_an_undeclared_floor_emits_NOTHING() -> None:
+    """`omit_defaults`, so every release written before this field has a
+    byte-identical payload. "No floor" is spelled by not declaring one."""
+    assert Resources().manifest_dict() == {}
+    assert "min_vram_gb" not in Resources(vcpus=4).manifest_dict()
+    assert Resources().min_vram_gb is None
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION ITSELF: a hint is not a gate, and never becomes one
+# ---------------------------------------------------------------------------
+
+
+def test_the_hint_ALONE_still_emits_no_gate_which_IS_the_defect() -> None:
+    """This is the v2 hole, stated as an assertion rather than a story.
+
+    `image_lora_finetuner 0.6.6` declares `Resources(vram_gb_hint=48)` and
+    believes it has a 48 GB floor. It does not: the builder never reads
+    `vram_gb_hint`, so nothing in the projection reaches the candidate filter.
+    The row is here so that "the hint is not a gate" can never quietly stop
+    being true — if some later change taught the hint to emit a floor, every
+    existing advisory declaration in the fleet would silently become a hard
+    refusal, which is precisely what pgw#647's freeze forbids."""
+    projected = Resources(vram_gb_hint=48).manifest_dict()
+    assert projected == {"gpu": True, "vram_gb_hint": 48.0}
+    assert "min_vram_gb" not in projected
+    assert "vram_gb" not in projected
+
+
+def test_the_floor_and_the_hint_are_INDEPENDENT_axes() -> None:
+    """Declaring a floor does not silently populate the hint, nor the reverse.
+    They answer different questions and the payload carries both words."""
+    both = Resources(min_vram_gb=80, vram_gb_hint=96).manifest_dict()
+    assert both == {"gpu": True, "vram_gb_hint": 96.0, "min_vram_gb": 80.0}
+
+
+def test_the_conversion_case_that_filed_this_issue_now_emits_its_floor() -> None:
+    """te#113: conversion's `modelopt-quantization` declared `min_vram_gb: 80`
+    + `compute_capability 8.9` under v1 and emitted NEITHER under v2, so an
+    80 GB/sm_89 producer became placeable against a 7 GB release envelope.
+    Both halves now ride the same declaration."""
+    payload = Resources(
+        gpu=True, vcpus=16, libraries=("modelopt",),
+        min_vram_gb=80, compute_capability="sm_89",
+    ).manifest_dict()
+    assert payload["min_vram_gb"] == 80.0
+    assert payload["compute_capability"] == 8.9
+    assert payload["vcpus"] == 16
+
+
+# ---------------------------------------------------------------------------
+# It is a FLOOR, and the name says so
+# ---------------------------------------------------------------------------
+
+
+def test_there_is_no_second_spelling_for_an_author_to_reach_for() -> None:
+    """v1's `vram_gb` must not come back as an alias: two words for one axis
+    is how an author declares the advisory one and believes it is the gate.
+    (The builder still maps `vram_gb` -> `min_vram_gb` as a FALLBACK for
+    hand-written manifests, and its explicit key wins, so this SDK emitting
+    only the explicit key can never be shadowed.)"""
+    assert not hasattr(Resources(), "vram_gb")
+    assert "vram_gb" not in Resources(min_vram_gb=80).manifest_dict()
+
+
+def test_declaring_a_floor_implies_gpu() -> None:
+    """Unlike `min_disk_gb`/`ram_gb_hint` (host-side allocation asks that must
+    not rent a card), a VRAM floor is a statement about a GPU — same posture as
+    `vram_gb_hint` and `compute_capability`. The builder's accelerator fold
+    reads `gpu`, so without this a floor-only declaration would land with no
+    accelerator resolved."""
+    assert Resources(min_vram_gb=24).gpu is True
+    assert Resources(min_vram_gb=24).manifest_dict()["gpu"] is True
+
+
+# ---------------------------------------------------------------------------
+# Contradictions cost a ValueError, never a build
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5])
+def test_a_nonpositive_floor_is_a_DECLARATION_time_error(bad: float) -> None:
+    with pytest.raises(ValueError, match="min_vram_gb must be positive"):
+        Resources(min_vram_gb=bad)
+
+
+def test_a_hint_BELOW_the_floor_is_refused() -> None:
+    """The hint places the FIRST build. Placing it under the value the
+    function says it cannot run below is a declaration that contradicts
+    itself, and it is refused where it is written rather than shipped."""
+    with pytest.raises(ValueError, match="below min_vram_gb"):
+        Resources(min_vram_gb=80, vram_gb_hint=24)
+
+
+def test_a_hint_at_or_above_the_floor_is_fine() -> None:
+    """The hint may legitimately exceed the floor — "cannot run below 24, and
+    place me on 80 for the first build" is coherent."""
+    assert Resources(min_vram_gb=24, vram_gb_hint=80).min_vram_gb == 24.0
+    assert Resources(min_vram_gb=24, vram_gb_hint=24).vram_gb_hint == 24.0
+
+
+def test_an_int_floor_is_normalized_to_float_like_every_other_axis() -> None:
+    """One numeric type on the wire; `80` and `80.0` must not be two payloads."""
+    assert Resources(min_vram_gb=80).manifest_dict()["min_vram_gb"] == 80.0
+    assert isinstance(Resources(min_vram_gb=80).min_vram_gb, float)


### PR DESCRIPTION
Closes the VRAM half of pgw#660. The SM half shipped as `compute_capability` at 0.75.0; this is its twin, and it completes the pair Paul ruled ("restore it as a declared, scheduler-enforced requirement").

## The hole

SDK v2 deleted `Resources.vram_gb` on purpose (pgw#647), on the reasoning that th#683's prove-and-profile would MEASURE the real requirement. That is right about how much VRAM a function **wants** per lane and shape, and wrong about the card it **cannot run on at all** — and only the second question has an answer before a first build exists.

The builder maps requirements out of the manifest's `resources{}` **by name**, so after v2 the intersection it could still gate on was `gpu` + `libraries` + `vcpus`. A per-function `min_vram_gb: 80` stopped being emitted, `req.VRAMGB` fell back to the RELEASE-level envelope (7 GB for conversion), and the floor left the selection path with **no error, no lint, no build failure**.

## RED, measured on unmodified `origin/master` (`484ffb67`)

The te#113 conversion `modelopt-quantization` declaration, as v2 allows it today:

```
origin/master projection: {'gpu': True, 'libraries': ('modelopt',), 'vcpus': 16,
                           'vram_gb_hint': 80.0, 'compute_capability': 8.9}

  keys the hub GATES on   : ['compute_capability', 'gpu', 'libraries', 'vcpus']
  hard VRAM floor emitted : False

declaring a floor on master -> TypeError Unexpected keyword argument 'min_vram_gb'
```

The SM twin of this hole was confirmed live six times in ten minutes (th#1155: `modelopt-quantization`, which needs `torch._scaled_mm` at sm_89+, placed on sm_80 A100s) and again on te#125.

New test file: **13 of 14 rows fail on master, 14/14 pass here.** The one that passes on both is deliberate — `test_the_hint_ALONE_still_emits_no_gate_which_IS_the_defect` is a guard rail asserting the hint never becomes a gate, which must be true on both sides.

## No tensorhub change is required — and that is why the field is spelled this way

`internal/builder/function_requirements.go:228` already folds `min_vram_gb` into `requirement_payload_json`:

```go
for _, key := range []string{"min_vram_gb", "vram_multiplier"} { ... }
// gen-worker `vram_gb` → scheduler `min_vram_gb` (explicit min_vram_gb wins).
```

whence it reaches `req.VRAMGB` → `MinVRAMGB` → the GPU candidate filter. The hub has read the key all along; nothing was emitting it. The `vram_gb` fallback applies only when the explicit key is absent, so this can never be shadowed by a v1 remap. I verified the only typed key rejection in that file is `min_compute_capability` (th#1015), which is unrelated.

## It is deliberately NOT `vram_gb_hint` promoted

"Never a gate" is the contract pgw#647 froze. Teaching the scheduler to gate on a value declared as advisory would silently turn **every existing hint in the fleet** into a hard refusal — `image_lora_finetuner 0.6.6` declares `vram_gb_hint=48` today. A floor is a different statement, so it gets a different field, named `min_` for what it is: a floor the hub may exceed, never a cap (the same reading as `min_disk_gb`, whose docstring already said "exactly like `min_vram_gb`" before the field existed).

- Declaring it implies `gpu=True` (the builder's accelerator fold reads `gpu`).
- A `vram_gb_hint` **below** the floor is self-contradicting — the hint places the first build — and costs a `ValueError`, not a build.
- `omit_defaults`, so every release written before this field has a byte-identical payload.

## Scope boundary, stated rather than left to look forgotten

`min_vram_gb` is a **placement gate only**. It does not reach `models/serve_fit.py`, which by contract "never refuses on the recommended-VRAM hint alone" and whose sole author opt-out is `strict_vram`. A floor that also became a runtime refusal would turn a scheduling statement into a serving one and could refuse requests a pod can answer — a separate decision needing its own measurement.

`sdk_shape.DELETED_FIELDS` keeps `vram_gb` deleted (v1's gate-shaped spelling does not come back) but its redirect changed: it used to send authors to `vram_gb_hint`, i.e. point someone who needs a gate at the advisory field, which is the mis-declaration this issue is about.

Local: mypy clean (266 files), ruff clean, 55 tests green across `test_vram_floor_pgw660`, `test_compute_capability_pgw660`, `test_ram_floor_pgw670`, `test_disk_floor_pgw732`, `test_testing_recorder_pgw942`, `test_mandatory_lane_th1059`.