### PR TITLE
pgw#1031 rig: the declaration registration stops depending on `sys.modules`, closing a recurrent CI flake

### DIFF
--- a/changelog.d/pgw1031.md
+++ b/changelog.d/pgw1031.md
@@ -1,0 +1,19 @@
+- **pgw#1031 rig: the declaration registration stops depending on `sys.modules`, closing a
+  recurrent CI flake.** `test_graph_witness_pgw1031` errored at setup on all five rows —
+  `AttributeError: 'NoneType' object has no attribute 'targets'`, from
+  `export_declaration(family)` returning `None` — on two unrelated PRs (#689, #692), while the
+  SAME commit passed on a plain re-run and a `workflow_dispatch` baseline on master was green.
+  Each hit cost a 17-minute `tests` job for whichever lane drew it.
+
+  **Measured, not guessed:** the rig's registration is an import SIDE EFFECT
+  (`register_export_declaration` at module scope), so the second import of the module is a
+  no-op, and dozens of test modules call `reset_export_declarations()` in their fixtures. Once
+  both have happened in one xdist worker the registry stays empty — `compile_cell()` still
+  returns a cell, it just names a family nothing has declared, and the failure surfaces later
+  and elsewhere. Whether the two land in the same worker is a function of shard split, which is
+  why adding unrelated test rows to a PR could summon it.
+
+  `rig_vehicles._declaration_module` now ASKS THE REGISTRY and reloads when the family is
+  absent, instead of trusting that the import registered. Safe because the declaration modules
+  register with `replace=True`. Same defect class as pgw#1152's fence — a process-global
+  registry fed by a convention the caller has to remember — and the same remedy.

--- a/tests/harness/rig_vehicles.py
+++ b/tests/harness/rig_vehicles.py
@@ -24,6 +24,7 @@ A vehicle answers six questions and nothing else:
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Tuple
@@ -1148,6 +1149,29 @@ MICRO_ESCAPE = Vehicle(
 # ---------------------------------------------------------------------------
 
 
+def _declaration_module(module: str, family: str) -> Any:
+    """Import a family's declaration module AND GUARANTEE the registration.
+
+    The registration is an import SIDE EFFECT (``register_export_declaration``
+    at module scope), so the second import of the same module is a no-op — and
+    dozens of test modules call ``reset_export_declarations()``, which empties
+    the registry that import populated. The two compose into an order-dependent
+    silent failure: ``compile_cell()`` returns a cell whose family nothing has
+    declared, and it surfaces much later and elsewhere as
+    ``export_declaration(family) -> None``.
+
+    Asking the registry instead of trusting the import is what makes it
+    order-free. Re-executing is safe because the declaration modules register
+    with ``replace=True``.
+    """
+    mod = importlib.import_module(module)
+    from gen_worker.api.export_contract import export_declaration
+
+    if export_declaration(family) is None:
+        mod = importlib.reload(mod)
+    return mod
+
+
 def _micro_pad32_cell(family: str = "micro-pad32") -> Any:
     """The cell, AND the declaration registration the parent needs.
 
@@ -1160,15 +1184,15 @@ def _micro_pad32_cell(family: str = "micro-pad32") -> Any:
     """
     from gen_worker.registry import CompileCell
 
-    if family == "micro-pad32-branchy":
-        from micro_diffusion.aot_declaration_pad32_branchy import (
-            COND_LEN, PIXEL_ROWS)
-    else:
-        from micro_diffusion.aot_declaration_pad32 import COND_LEN, PIXEL_ROWS
+    mod = _declaration_module(
+        "micro_diffusion.aot_declaration_pad32_branchy"
+        if family == "micro-pad32-branchy"
+        else "micro_diffusion.aot_declaration_pad32",
+        family)
 
     return CompileCell(
-        shapes=PIXEL_ROWS, targets=("transformer",), family=family,
-        regional=False, text_len=COND_LEN, dynamic=(), lora_bucket=0,
+        shapes=mod.PIXEL_ROWS, targets=("transformer",), family=family,
+        regional=False, text_len=mod.COND_LEN, dynamic=(), lora_bucket=0,
         guidance_scales=(), text_lens=())
 
 

--- a/tests/test_rig_registration_pgw1031.py
+++ b/tests/test_rig_registration_pgw1031.py
@@ -1,0 +1,87 @@
+"""The rig's declaration registration must survive a registry reset.
+
+This closes a RECURRENT CI flake, not a hypothetical. `test_graph_witness_pgw1031`
+errored at setup on all five of its rows — `AttributeError: 'NoneType' object has
+no attribute 'targets'`, from `aot_mint.export_declaration(family)` returning
+`None` — on two unrelated PRs (#689, #692), while the SAME commit passed on a
+plain re-run and a `workflow_dispatch` baseline on master was green. Each hit
+cost a 17-minute `tests` job, for whichever lane happened to draw it.
+
+THE MECHANISM, measured rather than guessed:
+
+    [1] after first compile_cell : True
+    [2] after reset              : False
+    [3] after SECOND compile_cell: False     <- the flake
+
+`rig_vehicles`' declaration registration is an import SIDE EFFECT
+(`register_export_declaration` at module scope), so once the module sits in
+`sys.modules` every later import is a no-op. Dozens of test modules call
+`reset_export_declarations()` in their fixtures. Once both have happened in one
+xdist worker, `compile_cell()` still returns a cell — it just names a family
+nothing has declared any more, and the failure surfaces later and elsewhere.
+Whether the two land in the same worker is a function of shard split, which is
+why adding five unrelated test rows to a PR could summon it.
+
+It is the same defect class the arm-state fence exists for (pgw#1152): a
+process-global registry fed by a convention the caller has to remember. The fix
+is the same shape — ask the registry, do not trust the convention.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gen_worker.api.export_contract import (
+    export_declaration, reset_export_declarations)
+
+# Self-sufficient on purpose: depending on a sibling module to have put this on
+# `sys.path` would make this row order-dependent, which is the exact property
+# it exists to remove.
+MICRO_SRC = Path(__file__).resolve().parent.parent / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+PAIR = ("micro-pad32", "micro-pad32-branchy")
+
+
+@pytest.mark.parametrize("family", PAIR)
+def test_the_rig_re_registers_after_a_reset_wipes_the_registry(family: str) -> None:
+    """RED before the fix at step [3]: the import is a `sys.modules` no-op, so
+    nothing re-registers and the cell names an undeclared family."""
+    from harness import rig_vehicles
+
+    veh = rig_vehicles.vehicle(family)
+
+    assert veh.compile_cell() is not None
+    assert export_declaration(family) is not None, "the first build must register"
+
+    # Exactly what another test module's fixture does between two of ours.
+    reset_export_declarations()
+    assert export_declaration(family) is None, "the reset must really empty it"
+
+    cell = veh.compile_cell()
+    assert export_declaration(family) is not None, (
+        "the rig must RE-register: an import that is a no-op cannot restore a "
+        "registration a reset removed, and the cell it returns would name a "
+        "family nothing has declared")
+    assert cell.family == family
+
+
+def test_the_cell_still_carries_the_declared_contract_after_a_reload() -> None:
+    """The heal must not quietly change what it builds — a reloaded module has
+    to produce a byte-identical cell, or the fix would trade a flake for a
+    silent identity drift (the declaration feeds the cell key)."""
+    from harness import rig_vehicles
+
+    veh = rig_vehicles.vehicle("micro-pad32")
+    before = veh.compile_cell()
+    reset_export_declarations()
+    after = veh.compile_cell()
+
+    assert after.shapes == before.shapes
+    assert after.text_len == before.text_len
+    assert after.targets == before.targets
+    assert after.family == before.family


### PR DESCRIPTION
Closes a flake that has now hit **two unrelated PRs** (#689, #692) and costs a 17-minute `tests` job per occurrence, for whichever lane draws it.

## The symptom

`test_graph_witness_pgw1031` errors at **setup** on all five rows:

```
ERROR at setup of test_the_bodies_now_key_apart
E   AttributeError: 'NoneType' object has no attribute 'targets'
```

`4832 passed, 49 skipped, 5 errors`. The **same commit** passed on a plain re-run both times, and a `workflow_dispatch` baseline on master was green — so it is non-deterministic in worker assignment, not in content.

## The mechanism — measured, not guessed

```
[1] after first compile_cell : True
[2] after reset              : False
[3] after SECOND compile_cell: False     <- the flake
```

The rig's declaration registration is an import **side effect** (`register_export_declaration` at module scope), so the second import of the module is a `sys.modules` no-op. Dozens of test modules call `reset_export_declarations()` in their fixtures. Once both have happened in one xdist worker the registry stays empty — `compile_cell()` still returns a cell, it just names a family nothing has declared, and the failure surfaces later and elsewhere as a `None` deref.

Whether those two land in the same worker is a function of the shard split, which is why **adding five unrelated test rows to a PR could summon it** — that is exactly how #689 hit it.

> Correction to an earlier note of mine: I first recorded that `reset_export_declarations()` had *no caller*. That was wrong — a mis-scoped grep. It has dozens, and that is precisely what makes this reachable.

## The fix

`rig_vehicles._declaration_module` **asks the registry** and reloads when the family is absent, instead of trusting that the import registered. Re-executing is safe because the declaration modules register with `replace=True`.

Same defect class as pgw#1152's arm-state fence — a process-global registry fed by a convention a later caller has to remember — and the same remedy: ask the object, don't trust the convention.

## RED

Three new rows, all failing on unmodified `e2d8a9fb` at the re-registration assertion:

```
E   AssertionError: the rig must RE-register: an import that is a no-op cannot
    restore a registration a reset removed, and the cell it returns would name
    a family nothing has declared
E   assert None is not None
```

One row guards the heal itself: a reloaded module must produce a byte-identical cell, or the fix would trade a flake for silent identity drift (the declaration feeds the cell key). The rows set `sys.path` themselves on purpose — depending on a sibling module to have set it would make them order-dependent, which is the property they exist to remove.

Test-harness only; no production code changes. Local: mypy clean (267 files), ruff clean, arm-state fence green, changelog gate green, 19 tests green across the rig-registration, graph-witness, pad32-codegen and micro-family-registration modules.