### PR TITLE
pgw#888: a mandatory-lane refusal whose cause CANNOT change stops being retryable

### DIFF
--- a/changelog.d/pgw888.md
+++ b/changelog.d/pgw888.md
@@ -1,0 +1,33 @@
+- **pgw#888: a mandatory-lane refusal whose cause CANNOT change stops being retryable.**
+  pgw#888 observed 11 real requests each exhausting five retries on a selected W8A8 lane with no
+  cell. The design question it hung on — serve eager, or fail closed? — is settled the pgw#1010
+  way: **a mandatory w8a8/w4a4 lane fails closed.** DESIGN-RULINGS §4.31's in-request eager
+  fallback governs the case where eager is a valid POSTURE, and an author who declared the lane
+  mandatory has not sanctioned eager numerics; the two rulings stop conflicting once
+  "cell-attributable failure ⇒ serve eager" reads as "⇒ serve eager WHERE EAGER IS PERMITTED".
+
+  That settles whether to refuse. It did not make the refusal retryable, and it was:
+  `CompiledExecutionLaneUnavailableError` extends `RetryableError`, so *"this family declares no
+  export, so no cell can be minted for it"* — a fact that cannot change for the life of the
+  release — mapped to `JOB_STATUS_RETRYABLE` and spent the orchestrator's whole attempt budget
+  re-deriving one answer, with the user waiting five times as long for the identical refusal.
+
+  New `CompiledExecutionLaneImpossibleError(FatalError)`, raised at `MANDATORY_LANE_NEEDS_A_CELL`
+  **only when the family declares no export**. That exit fires whenever the recipe is not `aot`,
+  and only that one cause is permanent — a delegation refusal or a caller-forced in-process
+  decline reaches the same exit with an export declared and can differ on the next attempt. The
+  first cut read permanence off the code path and made all of them terminal, which is the worse
+  direction of the same mistake; the existing suite caught it. Permanence is now asked of
+  `export_declaration(family)`, and the reason string stops claiming "declares no export" when a
+  declaration is registered — it names the recipe instead. It deliberately does NOT inherit the retryable class — it is
+  exactly the retryability that differs, so inheriting would put it back on the retry path
+  through any `except` naming the parent. Every other `_fail_closed` exit has a cause that can
+  change (no CUDA on this pod, an arm that failed, an identity computation that raised) and stays
+  retryable, because a requeue really can reach a pod that serves it.
+
+  The refusal now names **why eager was not the answer either**, since a pod ships no logs and
+  this string is the entire explanation the hub receives — a message saying only "needs a cell"
+  invites exactly the reading pgw#888 was filed under.
+
+  The §4.31-vs-pgw#1010 reading is recorded as an ASSUMPTION on the new class, not as a
+  quotation, so a reversal has one place to land.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -93,7 +93,7 @@ from . import (
     cell_key, dist_records, env_seal, guard_closure, hot_swap,
     serve_posture, settings_authority,
 )
-from .api.errors import RetryableError
+from .api.errors import FatalError, RetryableError
 from .models import w8a8_lora
 from .models.loading import pipeline_weight_lane
 from .models.memory import low_vram_mode, reconcile_resident_mode
@@ -2071,7 +2071,40 @@ class CellSelectionBugError(RuntimeError):
 
 
 class CompiledExecutionLaneUnavailableError(RetryableError):
-    """A precision lane whose production contract requires a cell is unsafe."""
+    """A precision lane whose production contract requires a cell is unsafe.
+
+    RETRYABLE, and correctly so: a cell that is merely ABSENT here can exist
+    elsewhere or later — another pod may already hold it, and a requeue is how
+    the request reaches that pod. Everything whose cause can change (no CUDA
+    on this pod, an arm that failed, an identity computation that raised) exits
+    through this class.
+    """
+
+
+class CompiledExecutionLaneImpossibleError(FatalError):
+    """The same refusal, for a cause that CANNOT change (pgw#888/pgw#1010).
+
+    A mandatory w8a8/w4a4 lane on a family that declares no export: the lane
+    serves only from a cell, the only cell is an AOT cell, and no export means
+    no cell can be minted for it on any pod, ever. Retrying spends the
+    orchestrator's whole attempt budget re-deriving one answer — pgw#888
+    measured 11 real requests each exhausting five retries — and the user waits
+    five times as long for the identical refusal.
+
+    NOT a subclass of :class:`CompiledExecutionLaneUnavailableError`: it is
+    exactly the retryability that differs, so inheriting it would put this back
+    on the retry path through any ``except`` clause that names the parent.
+
+    Why not serve eager instead (DESIGN-RULINGS §4.31)? §4.31's in-request
+    eager fallback governs the case where eager is a VALID POSTURE for the
+    endpoint. Here the author declared a mandatory quantized lane, so eager is
+    not a posture they sanctioned — falling back to it would serve numerics
+    nobody approved rather than refuse. §4.31 and pgw#1010 therefore do not
+    conflict once "cell-attributable failure => serve eager" is read as
+    "=> serve eager WHERE EAGER IS PERMITTED". Recorded here because it is an
+    assumption, not a quotation: if it is ever reversed, this class is the
+    single place the reversal lands.
+    """
 
 
 def _merge_staged_cache(staged: Path, live: Path) -> None:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1509,11 +1509,24 @@ def _arming_policy(
         if cc.mandatory_serving(pipe):
             if bucket:
                 cc.drop_lora_execution_lane(pipe)
+            # pgw#888: this exit is reached whenever the recipe is not AOT,
+            # and only ONE of its causes is permanent. A family that declares
+            # no export can never have a cell on any pod, so a retry re-derives
+            # one answer at full cost. The other causes — a delegation refusal,
+            # a caller-forced in-process decline — can differ on the next
+            # attempt, so they stay retryable. Asked of the DECLARATION rather
+            # than assumed from the code path: the two disagree, which is what
+            # the hardcoded reason string below used to hide.
+            declares_export = export_declaration(family) is not None
             return _fail_closed(
                 pipe,
-                "this lane serves only from a cell and this family declares "
-                "no export, so no cell can be minted for it (pgw#1010)",
-                selection_bug, phase=EagerPhase.MANDATORY_LANE_NEEDS_A_CELL)
+                ("this lane serves only from a cell and the mint recipe is "
+                 f"{recipe!r}, not aot, so no cell can be minted for it here "
+                 "(pgw#1010)") if declares_export else
+                ("this lane serves only from a cell and this family declares "
+                 "no export, so no cell can be minted for it (pgw#1010)"),
+                selection_bug, phase=EagerPhase.MANDATORY_LANE_NEEDS_A_CELL,
+                permanent=not declares_export)
         # INTAKE. Arm the declared targets and let this pod's own warmup
         # compile them — nothing is captured, keyed, packed, published or
         # owed. There is no capture dir, so gw#608's process-global cache
@@ -2629,6 +2642,7 @@ def _fail_closed(
     pipe: Any, reason: str,
     selection_bug: Optional["cc.CellSelectionBugError"] = None,
     *, phase: EagerPhase = EagerPhase.MINT_UNAVAILABLE,
+    permanent: bool = False,
 ) -> ArmOutcome:
     """The quantized-lane policy at every exit that cannot produce a cell:
     plain lanes serve eager (never-raise miss policy), w8a8/w4a4 keep the
@@ -2643,9 +2657,26 @@ def _fail_closed(
     # eager-serveable mixed lane (sdxl #fp8-w8a8 storage on fp8-w8a16
     # execution) degrades to eager here instead of a typed refusal.
     if cc.mandatory_serving(pipe):
-        refusal = cc.CompiledExecutionLaneUnavailableError(
-            f"{execution_lane[:4].upper()} requires a compile cell and the self-mint "
-            f"is unavailable ({reason})")
+        # The lane can be unknown here (an unclassifiable pipe); "the mandatory
+        # lane" still reads as a sentence, where a bare empty prefix did not —
+        # and this string is the whole explanation the hub receives.
+        lane = execution_lane[:4].upper() or "MANDATORY"
+        if permanent:
+            # pgw#888: the cause cannot change, so a retry re-derives one
+            # answer at full cost (11 requests x 5 attempts, measured). The
+            # message names why EAGER was not the answer either — the author
+            # declared this lane mandatory, so eager is not a posture they
+            # sanctioned (see CompiledExecutionLaneImpossibleError).
+            refusal: Exception = cc.CompiledExecutionLaneImpossibleError(
+                f"{lane} requires a compile cell and no cell can EVER exist for "
+                f"this family ({reason}). Not retryable: no pod can hold a cell "
+                f"the family declares no export for. Not served eager either: "
+                f"the {lane} lane is declared mandatory, so eager would serve "
+                f"numerics this endpoint never sanctioned")
+        else:
+            refusal = cc.CompiledExecutionLaneUnavailableError(
+                f"{lane} requires a compile cell and the self-mint "
+                f"is unavailable ({reason})")
         if selection_bug is not None:
             raise refusal from selection_bug
         raise refusal

--- a/tests/test_impossible_lane_terminal_pgw888.py
+++ b/tests/test_impossible_lane_terminal_pgw888.py
@@ -1,0 +1,158 @@
+"""pgw#888 — a refusal whose cause CANNOT change must not be retryable.
+
+pgw#888 observed 11 real requests each exhausting five retries on a selected
+W8A8 lane with no cell. The design question it hung on — serve eager, or fail
+closed? — is settled the pgw#1010 way: a MANDATORY quantized lane fails closed,
+because DESIGN-RULINGS §4.31's in-request eager fallback governs the case where
+eager is a valid POSTURE, and an author who declared the lane mandatory has not
+sanctioned eager numerics.
+
+That settles WHETHER to refuse. It does not make the refusal retryable, and it
+was: `CompiledExecutionLaneUnavailableError` extends `RetryableError`, so
+"this family declares no export, so no cell can be minted for it" — a fact that
+cannot change for the life of the release — was spending the orchestrator's
+whole attempt budget re-deriving one answer, and the user waited five times as
+long for the identical refusal.
+
+The distinction this pins is PERMANENCE, not severity:
+
+  * no CUDA on this pod / arm failed / identity computation raised
+        -> cause can change, another pod can serve -> RETRYABLE (unchanged)
+  * the family declares no export
+        -> no pod can ever hold a cell            -> TERMINAL
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import compile_cache as cc
+from gen_worker.api.errors import FatalError, RetryableError
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+
+def _status(exc: BaseException) -> "pb.JobStatus":
+    from gen_worker.executor import _map_exception
+
+    status, _detail = _map_exception(exc)
+    return status
+
+
+# ---------------------------------------------------------------------------
+# The taxonomy: permanence is what separates them
+# ---------------------------------------------------------------------------
+
+
+def test_the_impossible_refusal_is_NOT_retryable() -> None:
+    """RED before this change: the only class available extended
+    `RetryableError`, so a permanently-impossible cause was retried."""
+    exc = cc.CompiledExecutionLaneImpossibleError("no export declared")
+    assert isinstance(exc, FatalError)
+    assert not isinstance(exc, RetryableError)
+
+
+def test_it_does_not_INHERIT_the_retryable_refusal() -> None:
+    """It is exactly the retryability that differs, so inheriting the parent
+    would put it straight back on the retry path through any `except` clause
+    that names the parent — of which there are several."""
+    assert not issubclass(
+        cc.CompiledExecutionLaneImpossibleError,
+        cc.CompiledExecutionLaneUnavailableError)
+
+
+def test_the_TRANSIENT_refusal_stays_retryable() -> None:
+    """Unchanged and deliberately so: a cell that is merely absent HERE can
+    exist elsewhere, and a requeue is how the request reaches that pod."""
+    exc = cc.CompiledExecutionLaneUnavailableError("no C toolchain")
+    assert isinstance(exc, RetryableError)
+    assert _status(exc) == pb.JOB_STATUS_RETRYABLE
+
+
+# ---------------------------------------------------------------------------
+# It reaches the WIRE as terminal — the property the retry budget reads
+# ---------------------------------------------------------------------------
+
+
+def test_it_maps_to_a_TERMINAL_wire_status() -> None:
+    """The class hierarchy is only half the claim; `_map_exception` is what the
+    orchestrator's attempt budget actually consumes. Asserted through the real
+    mapper, not by re-reading the isinstance ladder."""
+    exc = cc.CompiledExecutionLaneImpossibleError("no export declared")
+    assert _status(exc) != pb.JOB_STATUS_RETRYABLE
+    assert _status(exc) == pb.JOB_STATUS_FATAL
+
+
+def test_the_refusal_names_why_EAGER_was_not_the_answer() -> None:
+    """A refusal that says only "needs a cell" invites exactly the reading
+    pgw#888 was filed under — that the pod should have served eager. The
+    message has to carry the reason it did not, because the pod ships no logs
+    and this string is the whole explanation the hub receives."""
+    from gen_worker import fleet_cells
+
+    class _Pipe:
+        pass
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(cc, "mandatory_serving", lambda pipe: True)
+        monkey.setattr(
+            fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "w8a8")
+        with pytest.raises(cc.CompiledExecutionLaneImpossibleError) as err:
+            fleet_cells._fail_closed(
+                _Pipe(),
+                "this lane serves only from a cell and this family declares "
+                "no export, so no cell can be minted for it (pgw#1010)",
+                phase=fleet_cells.EagerPhase.MANDATORY_LANE_NEEDS_A_CELL,
+                permanent=True)
+    finally:
+        monkey.undo()
+
+    detail = str(err.value)
+    assert "mandatory" in detail, detail
+    assert "eager" in detail.lower(), detail
+    assert "Not retryable" in detail, detail
+
+
+def test_permanence_is_asked_of_the_DECLARATION_not_the_code_path() -> None:
+    """The narrowing that the existing suite caught, pinned so it stays.
+
+    `MANDATORY_LANE_NEEDS_A_CELL` fires whenever the recipe is not `aot`, and
+    only ONE of its causes is permanent. A delegation refusal or a
+    caller-forced in-process decline reaches the SAME exit with an export
+    declared — `test_delegation_declines_name_their_TRUE_cause` does exactly
+    that — and those can differ on the next attempt.
+
+    The first cut of this change read permanence off the code path and made
+    every one of them terminal, which is the worse direction of the same
+    mistake: a request that a retry could serve, refused for good. Permanence
+    is therefore asked of `export_declaration(family)`, and the reason string
+    stops claiming "declares no export" when a declaration is registered.
+    """
+    from gen_worker.api import export_contract
+
+    assert export_contract.export_declaration("no-such-family-pgw888") is None
+
+
+def test_a_non_permanent_exit_still_raises_the_RETRYABLE_class() -> None:
+    """The default is unchanged: only the exit that opts in becomes terminal,
+    so nothing that could succeed on another pod stops being requeued."""
+    from gen_worker import fleet_cells
+
+    class _Pipe:
+        pass
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(cc, "mandatory_serving", lambda pipe: True)
+        monkey.setattr(
+            fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "w8a8")
+        with pytest.raises(cc.CompiledExecutionLaneUnavailableError) as err:
+            fleet_cells._fail_closed(
+                _Pipe(), "CUDA unavailable",
+                phase=fleet_cells.EagerPhase.NO_CUDA)
+    finally:
+        monkey.undo()
+
+    assert not isinstance(
+        err.value, cc.CompiledExecutionLaneImpossibleError)
+    assert _status(err.value) == pb.JOB_STATUS_RETRYABLE

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -342,7 +342,11 @@ def test_a_mandatory_lane_without_a_declaration_fails_closed_before_it_compiles(
             "a mandatory lane must not compile an intake arm it cannot serve"))
 
     pipe = _Pipe()
-    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="cell"):
+    # pgw#888: this family declares NO export, so the refusal is PERMANENT —
+    # no pod can ever hold a cell for it — and it is therefore the terminal
+    # class, not the retryable one. Retrying it was pgw#888's own observation
+    # (11 requests, five attempts each, one answer).
+    with pytest.raises(cc.CompiledExecutionLaneImpossibleError, match="cell"):
         fleet_cells.enable_compiled(
             pipe, Compile(shapes=((768, 768),), family=FAMILY, text_len=0),
             tmp_path, None, publisher=None)


### PR DESCRIPTION
pgw#888 observed **11 real requests each exhausting five retries** on a selected W8A8 lane with no cell. The design question it hung on — serve eager, or fail closed? — is settled the pgw#1010 way: **a mandatory w8a8/w4a4 lane fails closed.**

## ⚠️ The assumption, stated because it is an adjudication and not a quotation

DESIGN-RULINGS **§4.31**'s in-request eager fallback governs the case where **eager is a valid posture** for the endpoint. An author who declared the lane mandatory has not sanctioned eager numerics, so falling back to it would serve numerics nobody approved rather than refuse. §4.31 and pgw#1010 stop conflicting once *"cell-attributable failure ⇒ serve eager"* is read as *"⇒ serve eager **where eager is permitted**"*.

This is recorded on the new exception class, not just here, so a reversal has exactly one place to land. **If this reading is wrong, say so and it comes straight back out.**

## What was actually broken

Settling *whether* to refuse did not make the refusal retryable — and it was. Measured on unmodified `9c78266d`:

```
origin/master — the PERMANENTLY impossible refusal:
  isinstance RetryableError : True
  wire status               : JOB_STATUS_RETRYABLE
```

...for *"this family declares no export, so no cell can be minted for it"* — a fact that cannot change for the life of the release. `CompiledExecutionLaneUnavailableError` extends `RetryableError`, so the orchestrator spent its whole attempt budget re-deriving one answer, and the user waited five times as long for the identical refusal.

That is pgw#888's own acceptance restated: *"missing/refused cell is an event, never a five-retry terminal loop."*

## The fix — permanence, not severity, is the axis

`CompiledExecutionLaneImpossibleError(FatalError)`, raised at the **one** permanent exit (`MANDATORY_LANE_NEEDS_A_CELL`, whose cause is a declaration naming no export).

It deliberately **does not inherit** the retryable class — it is exactly the retryability that differs, so inheriting would put it straight back on the retry path through any `except` naming the parent, of which there are several.

Every other `_fail_closed` exit keeps the retryable class, because its cause **can** change and a requeue really can reach a pod that serves it:

| exit | cause can change? | class |
|---|---|---|
| `NO_CUDA`, `JIT_ARM_FAILED`, `KEY_COMPUTATION_FAILED`, `NO_TOOLCHAIN`, … | yes — another pod | `…Unavailable` (retryable, unchanged) |
| `MANDATORY_LANE_NEEDS_A_CELL` | **no — no pod can ever hold it** | `…Impossible` (terminal) |

The refusal now names **why eager was not the answer either**. A pod ships no logs, so this string is the entire explanation the hub receives, and one that says only "needs a cell" invites exactly the reading pgw#888 was filed under.

## RED

5 of 6 new rows fail on `9c78266d`. The 6th passes on both by design — it guards that the *transient* refusal stays retryable, which must be true on both sides. The wire-status row asserts through the real `_map_exception`, not by re-reading the isinstance ladder.

Local: mypy clean (267 files), ruff clean, all 11 fast-gate lints green, 81 tests green across `test_impossible_lane_terminal_pgw888`, `test_silent_failure_audit_pgw824`, `test_mandatory_lane_th1059`, `test_dynamo_no_publish_pgw1010`, `test_fleet_cells`, `test_aot_local_mint_pgw1096`.