### PR TITLE
pgw#1111: the entry pool carries a WEIGHT-FREE program, so a mint stops being serial

### DIFF
--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -53,6 +53,10 @@ from .aot_compile_pool import (
 )
 from . import aot_device_lock
 from . import aot_shape_hints
+# pgw#1111's META round-trip. Imports no torch of its own (measured 0.21 s,
+# `torch` absent from sys.modules afterwards), so `child_torch_import_s` still
+# measures only the child's own torch import.
+from .models import structure_only
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +146,41 @@ def _device_fields() -> dict:
             "peak_device_reserved_bytes": reserved}
 
 
+def load_program(job: EntryJob) -> Any:
+    """The child's half of the pool's process boundary: ``torch.export.load``
+    plus the two repairs the round trip needs before anything reads a shape.
+
+    A named function because both repairs are silent when skipped — the
+    artifact still builds, under the same cell key, and is wrong. A test can
+    reach this without an inductor compile; the compile itself cannot be a
+    cheap test.
+    """
+    import torch
+
+    program = torch.export.load(job.program)
+    # pgw#1111: the inverse of the parent's `as_meta_for_save`. A weight-free
+    # program crossed as META (fake tensors have no storage to serialize);
+    # re-virtualize META -> FAKE inside the mode the load rebuilt the example
+    # inputs in, so `aot_compile`'s one-fake-mode precondition holds and
+    # `compile_entry_files` reads `weightless=True` off the program exactly as
+    # the serial path does. A real-weight program carries no meta: a no-op.
+    if structure_only.has_meta_params(program):
+        if structure_only.revirtualize_from_meta(program) is None:
+            # The mode is read off the example inputs; with none there is
+            # nothing to re-virtualize INTO, and compiling a meta-param program
+            # selects the WEIGHT-BEARING inductor config for a weight-free
+            # graph — a different artifact under an unmoved key. Refuse.
+            raise RuntimeError(
+                "pgw#1111: the program crossed as META but its example inputs "
+                "name no fake mode to re-virtualize into")
+    # pgw#998: the round trip drops the ShapeEnv's symbol VALUES (it rebuilds
+    # the map keyed by size expressions), which makes any extent that is not
+    # literally one of those keys unlowerable. Restored from the parent's own
+    # env — the one authority for them — before anything reads a shape.
+    aot_shape_hints.restore_symbol_values(program, job.symbol_values)
+    return program
+
+
 def run(job: EntryJob) -> int:
     from . import aot_mint, env_seal
 
@@ -188,13 +227,7 @@ def run(job: EntryJob) -> int:
         # matching `load`). Named because "serialization across the pool's
         # process boundary" was a prime suspect for the dark 44 %.
         with ledger.span("child_program_load_s"):
-            program = torch.export.load(job.program)
-            # pgw#998: the round trip drops the ShapeEnv's symbol VALUES (it
-            # rebuilds the map keyed by size expressions), which makes any
-            # extent that is not literally one of those keys unlowerable.
-            # Restored from the parent's own env — the one authority for them
-            # — before anything reads a shape.
-            aot_shape_hints.restore_symbol_values(program, job.symbol_values)
+            program = load_program(job)
     except Exception as exc:  # noqa: BLE001
         _write(report_path, EntryReport(
             entry=job.entry, status=REFUSED,

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -1351,14 +1351,8 @@ class EntryCompilePool:
         inductor_configs: Optional[Mapping[str, Any]] = None,
         cache_dir: str = "",
         python: str = "",
-        nice_children: bool = False,
     ) -> None:
         self.workdir = Path(workdir)
-        #: pgw#1111 / §4.30: on the untrusted tier (cozy-local — the user's own
-        #: machine, hub-asserted, never an env flag) the compile children run
-        #: niced so a background mint never saturates the machine the user is
-        #: also serving on. A dedicated serving pod leaves it False (aggressive).
-        self.nice_children = bool(nice_children)
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.width = width
         #: pgw#842/th#1359: the width facts as last EMITTED, so a re-emit
@@ -1453,6 +1447,10 @@ class EntryCompilePool:
         # other children run, so summing it into the compile total would
         # invent seconds nobody spent compiling.
         self.entry_stage_seconds: Dict[str, float] = {}
+        #: pgw#1111: how many entries crossed the process boundary as META
+        #: (a weight-free mint). A pool that ran a structure-only cell and
+        #: reports 0 here staged real weights and the round-trip never fired.
+        self.meta_staged_entries = 0
         self.entry_spawn_seconds: Dict[str, float] = {}
         self.entry_overlays: Dict[str, Dict[str, float]] = {}
         self.entry_metrics_raw: Dict[str, Dict[str, float]] = {}
@@ -1470,12 +1468,17 @@ class EntryCompilePool:
         slot.mkdir(parents=True, exist_ok=True)
         program_path = slot / "program.pt2"
         t0 = time.monotonic()
-        # pgw#1111: a weight-free program's params are FAKE (no storage to
-        # serialize). Re-cast them to META so the save succeeds; the child
-        # re-virtualizes META -> FAKE after load. Real-weight programs (and the
-        # example inputs of both) are untouched — a no-op returning 0.
-        meta_params = structure_only.to_meta_for_save(program)
-        torch.export.save(program, program_path)
+        # pgw#1111: a weight-free program's params are FAKE, and a fake tensor
+        # has no storage to serialize — the child died deserializing it, which
+        # is why every structure-only mint ran SERIALLY. META tensors carry the
+        # same shape/dtype and DO serialize, so the save crosses the process
+        # boundary on metadata and `aot_compile_child` re-virtualizes
+        # META -> FAKE inside the load's own mode. Real-weight programs are
+        # untouched (the cast moves nothing and the context is a no-op).
+        with structure_only.as_meta_for_save(program) as meta_params:
+            torch.export.save(program, program_path)
+        if meta_params:
+            self.meta_staged_entries += 1
         self.entry_stage_seconds[entry] = round(time.monotonic() - t0, 3)
         self.ledger.stage_total_s = round(
             self.ledger.stage_total_s + self.entry_stage_seconds[entry], 3)
@@ -1496,38 +1499,17 @@ class EntryCompilePool:
         job_path.write_bytes(msgspec.json.encode(job))
         return job, job_path
 
-    def _child_preexec(self) -> Optional[Callable[[], None]]:
-        """pgw#1111 / §4.30: on the untrusted tier, drop each child to the
-        lowest scheduling priority so a background mint yields to the user's own
-        work. ``start_new_session`` already runs here, so the two compose in one
-        ``preexec_fn``. Returns ``None`` on a trusted pod — aggressive, unniced.
-        """
-        if not self.nice_children:
-            return None
-
-        def _pre() -> None:
-            os.setsid()
-            try:
-                os.nice(19)
-            except OSError:
-                pass
-        return _pre
-
     def _spawn(self, job: EntryJob, job_path: Path, program_path: Path) -> _Running:
         stderr_path = job_path.parent / "stderr.log"
         handle = stderr_path.open("wb")
         t0 = time.monotonic()
-        preexec = self._child_preexec()
         try:
             proc = subprocess.Popen(
                 child_argv(job_path, python=self.python),
                 stdout=subprocess.DEVNULL,
                 stderr=handle,
                 env=child_env(self.cache_dir, seal_memo=self.seal_memo),
-                # `start_new_session` and the nice drop compose in preexec when
-                # the pod is untrusted; otherwise the flag gives the own group.
-                start_new_session=preexec is None,   # own group -> reaping
-                preexec_fn=preexec,
+                start_new_session=True,   # own group -> group-wide reaping
             )
         finally:
             handle.close()

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -1351,8 +1351,14 @@ class EntryCompilePool:
         inductor_configs: Optional[Mapping[str, Any]] = None,
         cache_dir: str = "",
         python: str = "",
+        nice_children: bool = False,
     ) -> None:
         self.workdir = Path(workdir)
+        #: pgw#1111 / §4.30: on the untrusted tier (cozy-local — the user's own
+        #: machine, hub-asserted, never an env flag) the compile children run
+        #: niced so a background mint never saturates the machine the user is
+        #: also serving on. A dedicated serving pod leaves it False (aggressive).
+        self.nice_children = bool(nice_children)
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.width = width
         #: pgw#842/th#1359: the width facts as last EMITTED, so a re-emit
@@ -1458,10 +1464,17 @@ class EntryCompilePool:
     def _stage(self, entry: str, program: Any, index: int) -> Tuple[EntryJob, Path]:
         import torch
 
+        from .models import structure_only
+
         slot = self.workdir / f"entry-{index:03d}"
         slot.mkdir(parents=True, exist_ok=True)
         program_path = slot / "program.pt2"
         t0 = time.monotonic()
+        # pgw#1111: a weight-free program's params are FAKE (no storage to
+        # serialize). Re-cast them to META so the save succeeds; the child
+        # re-virtualizes META -> FAKE after load. Real-weight programs (and the
+        # example inputs of both) are untouched — a no-op returning 0.
+        meta_params = structure_only.to_meta_for_save(program)
         torch.export.save(program, program_path)
         self.entry_stage_seconds[entry] = round(time.monotonic() - t0, 3)
         self.ledger.stage_total_s = round(
@@ -1483,17 +1496,38 @@ class EntryCompilePool:
         job_path.write_bytes(msgspec.json.encode(job))
         return job, job_path
 
+    def _child_preexec(self) -> Optional[Callable[[], None]]:
+        """pgw#1111 / §4.30: on the untrusted tier, drop each child to the
+        lowest scheduling priority so a background mint yields to the user's own
+        work. ``start_new_session`` already runs here, so the two compose in one
+        ``preexec_fn``. Returns ``None`` on a trusted pod — aggressive, unniced.
+        """
+        if not self.nice_children:
+            return None
+
+        def _pre() -> None:
+            os.setsid()
+            try:
+                os.nice(19)
+            except OSError:
+                pass
+        return _pre
+
     def _spawn(self, job: EntryJob, job_path: Path, program_path: Path) -> _Running:
         stderr_path = job_path.parent / "stderr.log"
         handle = stderr_path.open("wb")
         t0 = time.monotonic()
+        preexec = self._child_preexec()
         try:
             proc = subprocess.Popen(
                 child_argv(job_path, python=self.python),
                 stdout=subprocess.DEVNULL,
                 stderr=handle,
                 env=child_env(self.cache_dir, seal_memo=self.seal_memo),
-                start_new_session=True,   # own group -> group-wide reaping
+                # `start_new_session` and the nice drop compose in preexec when
+                # the pod is untrusted; otherwise the flag gives the own group.
+                start_new_session=preexec is None,   # own group -> reaping
+                preexec_fn=preexec,
             )
         finally:
             handle.close()

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2163,25 +2163,20 @@ def _mint_cell(
         # has run and `per_entry_rss_basis` said "default" forever. 0 keeps
         # the constant, and keeps saying so.
         peak_rss_bytes=int(entry_peak_rss_bytes or 0))
+    # pgw#1111: a structure-only mint used to DISCARD this width and run K=1.
+    # `fc77b923` made every production mint weight-free, so that override made
+    # the pool dead code fleet-wide — and because `progress.width` is recorded
+    # below either way, the hub's `pool` row went on reporting the width that
+    # was thrown away. That is how the sdxl A40 mint (release
+    # 6ee9b4d4df2697a53da6f43a, pod bgmdxhazxsugmk) came to be read as
+    # "entry_workers=3" when it ran serially: its `pool` block carries the
+    # width facts and NO ledger, and export_s + compile_s summed to within
+    # 0.6 % of total_s, which is what zero overlap looks like.
+    # The pool now carries a weight-free program as META
+    # (`structure_only.as_meta_for_save` in the parent's stage,
+    # `revirtualize_from_meta` in `aot_compile_child.load_program`), so the
+    # width this pod computed is the width it runs.
     parallel = width.workers > 1
-    if parallel and structure_only.is_structure_only(pipeline):
-        # pgw#1080, MEASURED on the micro-lora gauntlet member: the pool hands
-        # each entry to a compile CHILD by saving the ExportedProgram to
-        # `program.pt2`. A program whose parameters are fake tensors has no
-        # storage to serialize, and the child dies deserializing it
-        # ("We ran into an error when deserializing the saved file"). So a
-        # weightless mint compiles SERIALLY, in this process, which is the
-        # pre-pgw#809 path and is correct — just narrower.
-        #
-        # OWED, not hidden (pgw#1080 follow-up): the pool could carry a
-        # weightless program by saving it with META parameters and
-        # re-virtualizing them onto the device inside the child. That is a
-        # real change to the pool's contract and it is not this slice.
-        logger.warning(
-            "aot-mint: structure-only mint compiles SERIALLY — the entry pool "
-            "serializes the exported program and a fake-parameter program "
-            "cannot round-trip (pgw#1080). Width %d discarded.", width.workers)
-        parallel = False
     logger.info("aot-mint: entry compile width — %s", width.reason)
     if width.underwidth:
         # pgw#842: a pool narrower than the cell could use is a COST, and it

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -643,6 +643,124 @@ def under(mode: Optional[Any]) -> Iterator[None]:
 
 
 # ---------------------------------------------------------------------------
+# pgw#1111: the META round-trip that lets a weight-free program cross the
+# entry-compile pool's process boundary
+# ---------------------------------------------------------------------------
+#
+# The parallel entry pool hands each ExportedProgram to a compile CHILD by
+# ``torch.export.save`` in the parent and ``torch.export.load`` in the child
+# (pgw#809). A structure-only program's PARAMETERS are FAKE tensors, and a fake
+# tensor has no storage to serialize — the child dies deserializing it
+# ("We ran into an error when deserializing the saved file"). So before
+# ``fc77b923`` a weight-free mint could only compile SERIALLY, in the parent,
+# which is K=1 (pgw#1051 regression).
+#
+# The round-trip: on the way OUT, re-cast the fake params to META — meta
+# tensors carry shape/dtype and serialize (they, too, hold no storage, but the
+# serializer records them as metadata rather than reaching for bytes). On the
+# way IN, re-virtualize META -> FAKE inside the load's OWN fake mode and on the
+# real device, both read off the program's example inputs (which are fake in
+# that mode already, exactly as a real-weight program's are). aot_compile then
+# sees params and inputs sharing ONE fake mode — its precondition — and the
+# graph is byte-identical to the serial path, so the cell key does not move.
+
+
+def _program_tensor_tables(program: Any) -> Iterator[Tuple[Any, str, Any]]:
+    """``(table, name, tensor)`` over a program's state_dict and constants."""
+    for holder in ("state_dict", "constants"):
+        table = getattr(program, holder, None)
+        if not isinstance(table, dict):
+            continue
+        for name, tensor in list(table.items()):
+            if tensor is not None:
+                yield table, name, tensor
+
+
+def to_meta_for_save(program: Any) -> int:
+    """Re-cast a weight-free program's FAKE params/constants to META, in place.
+
+    Only fake tensors move; real buffers (config-derived tables, the literals a
+    family ships inside the cell) stay real and serialize as they always have.
+    Returns the number of tensors converted — 0 means this was not a weight-free
+    program and nothing changed. The example inputs are left untouched: they are
+    fake on a real device and torch.export already serialises them as metadata
+    (a real-weight program round-trips with fake example inputs today).
+    """
+    import torch
+
+    moved = 0
+    for table, name, tensor in _program_tensor_tables(program):
+        if not mi.is_virtual(tensor):
+            continue
+        if str(getattr(getattr(tensor, "device", None), "type", "")) == "meta":
+            continue
+        meta = torch.empty(tuple(tensor.shape), dtype=tensor.dtype,
+                           device="meta")
+        if isinstance(tensor, torch.nn.Parameter):
+            meta = torch.nn.Parameter(meta, requires_grad=False)
+        table[name] = meta
+        moved += 1
+    return moved
+
+
+def has_meta_params(program: Any) -> bool:
+    """Whether this loaded program carries META params — the signal that it was
+    saved by :func:`to_meta_for_save` and must be re-virtualized before compile.
+    """
+    for _table, _name, tensor in _program_tensor_tables(program):
+        if str(getattr(getattr(tensor, "device", None), "type", "")) == "meta":
+            return True
+    return False
+
+
+def _load_mode_and_device(program: Any) -> Tuple[Optional[Any], Optional[Any]]:
+    """The fake mode and real device the load rebuilt this program's example
+    inputs in. aot_compile requires params and inputs to share ONE mode, so the
+    re-virtualized params must join THIS mode on THIS device — never a fresh one.
+    """
+    example = getattr(program, "example_inputs", None)
+    if not example:
+        return None, None
+    args, kwargs = example if isinstance(example, tuple) and len(example) == 2 \
+        else (example, {})
+    tensors: List[Any] = []
+    for value in list(args or ()) + list((kwargs or {}).values()):
+        if hasattr(value, "fake_mode") or hasattr(value, "device"):
+            tensors.append(value)
+    for tensor in tensors:
+        mode = getattr(tensor, "fake_mode", None)
+        if mode is not None:
+            return mode, getattr(tensor, "device", None)
+    return None, None
+
+
+def revirtualize_from_meta(program: Any) -> Optional[Any]:
+    """META params -> FAKE, inside the load's own mode and on the real device.
+
+    The inverse of :func:`to_meta_for_save`, run in the compile child after
+    ``torch.export.load``. Returns the fake mode the program now belongs to
+    (``None`` when there was nothing to do). After this call
+    :func:`fake_mode_of_program` finds that mode via the state dict, so
+    :func:`compiling_under` installs it and the export's ShapeEnv exactly as the
+    in-process serial path did — the compile is byte-identical.
+    """
+    import torch
+
+    mode, device = _load_mode_and_device(program)
+    if mode is None or device is None:
+        return None
+    for table, name, tensor in _program_tensor_tables(program):
+        if str(getattr(getattr(tensor, "device", None), "type", "")) != "meta":
+            continue
+        with mode, torch.device(str(device)):
+            fake = torch.empty(tuple(tensor.shape), dtype=tensor.dtype)
+        if isinstance(tensor, torch.nn.Parameter):
+            fake = torch.nn.Parameter(fake, requires_grad=False)
+        table[name] = fake
+    return mode
+
+
+# ---------------------------------------------------------------------------
 # The pgw#984 warm proof runs on RANDOM values (coordinator ruling, 2026-08-10)
 # ---------------------------------------------------------------------------
 
@@ -752,14 +870,17 @@ __all__ = [
     "facts_of",
     "fake_mode_of",
     "fake_mode_of_program",
+    "has_meta_params",
     "is_structure_only",
     "materialize_random",
     "modules_of",
     "program_shape_env",
     "refusal_token",
     "restore_virtual",
+    "revirtualize_from_meta",
     "stray_real_tensors",
     "structure_only_components",
+    "to_meta_for_save",
     "virtualize",
     "under",
 ]

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -703,6 +703,33 @@ def to_meta_for_save(program: Any) -> int:
     return moved
 
 
+@contextlib.contextmanager
+def as_meta_for_save(program: Any) -> Iterator[int]:
+    """:func:`to_meta_for_save` for the duration of a save, then EXACTLY the
+    original tensor objects back.
+
+    The parent keeps using its programs after staging them (class
+    canonicalization, the resident release's weight aliases), so the cast must
+    not outlive the ``torch.export.save`` it exists for. Restoring the original
+    objects — not equivalent new fakes — keeps tensor IDENTITY, which is what
+    an alias map compares.
+    """
+    before: List[Tuple[Any, Dict[str, Any]]] = []
+    seen: List[int] = []
+    for table, _name, _tensor in _program_tensor_tables(program):
+        if id(table) not in seen:
+            seen.append(id(table))
+            before.append((table, dict(table)))
+    moved = to_meta_for_save(program)
+    try:
+        yield moved
+    finally:
+        if moved:
+            for table, original in before:
+                table.clear()
+                table.update(original)
+
+
 def has_meta_params(program: Any) -> bool:
     """Whether this loaded program carries META params — the signal that it was
     saved by :func:`to_meta_for_save` and must be re-virtualized before compile.

--- a/tests/test_meta_roundtrip_pgw1111.py
+++ b/tests/test_meta_roundtrip_pgw1111.py
@@ -1,0 +1,305 @@
+"""pgw#1111: the META round-trip that lets a WEIGHT-FREE program cross the
+entry-compile pool's process boundary.
+
+Why this exists, measured rather than asserted
+----------------------------------------------
+``fc77b923`` (pgw#1080) made every production mint weight-free, and
+``aot_mint`` then FORCED ``parallel = False`` for exactly those mints because a
+fake-parameter ``ExportedProgram`` could not survive ``torch.export.save`` ->
+``load``. So the entry pool became dead code fleet-wide and every mint ran K=1,
+in-process, with export and compile strictly sequential.
+
+The cost is on the record, hub-side: the sdxl A40 mint
+(release ``6ee9b4d4df2697a53da6f43a``, pod ``bgmdxhazxsugmk``, gen-worker
+0.112.0) reported ``export_s`` 1378.52 + ``compile_s`` 2065.36 = 3443.88 s
+against ``total_s`` 3463.84 s — **0.6 % apart**, which is what "no overlap at
+all" looks like. Its ``pool`` row said ``entry_workers=3`` and carried NO
+ledger (no ``pool_wall_s``, no ``pool_efficiency``, no ``peak_concurrency``),
+because ``progress.width`` is recorded whether or not the width is used: the
+3 was the width the override threw away.
+
+The tests below prove the premise the override rested on is fixable, not that
+it was imaginary — ``test_a_FAKE_param_program_CANNOT_round_trip`` reproduces
+the original ``RuntimeError`` verbatim, and is the RED half of every other test
+in this file.
+
+Everything here exports only. No inductor, no autotune, no card.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("accelerate")
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+from gen_worker import aot_mint  # noqa: E402
+from gen_worker.models import structure_only as so  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from micro_diffusion.weights import SEED, materialize
+
+    root = tmp_path_factory.mktemp("micro-tree")
+    return materialize(root, seed=SEED)
+
+
+def _weightless_program(tree: Path):
+    """A real structure-only export through the real seams — the same
+    ``build_component`` -> ``export_program`` pair the mint runs."""
+    module, _facts = so.build_component(tree, "decoder", device="cpu")
+    mode = so.fake_mode_of(module)
+    assert mode is not None
+    with so.under(mode):
+        latent = torch.randn(1, 8, 16)
+        program = aot_mint.export_program(module, (latent,), {})
+    return program
+
+
+@contextlib.contextmanager
+def _quiet_serde() -> Iterator[None]:
+    """torch's deserializer logs ``"...type %s after initial failure: %s"``
+    with ONE argument, so emitting it raises ``TypeError`` — and pytest's
+    capture handler re-raises formatting errors instead of swallowing them.
+    It fires on any program whose EXAMPLE INPUTS are fake, which is every
+    exported program, weight-free or not; a real-weight mint has taken this
+    same path through the pool since pgw#809. Upstream's bug, muted here so
+    the assertions below are about this change.
+    """
+    log = logging.getLogger("torch._export.serde.serialize")
+    was, log.disabled = log.disabled, True
+    try:
+        yield
+    finally:
+        log.disabled = was
+
+
+def _load(path: Path):
+    with _quiet_serde():
+        return torch.export.load(str(path))
+
+
+def _graph_text(program) -> str:
+    return str(program.graph_module.graph)
+
+
+def _modes(program):
+    """``(state-dict modes, example-input modes)`` as identity sets."""
+    tables = list(program.state_dict.values())
+    tables += list(getattr(program, "constants", {}).values())
+    sd = {id(m) for m in (getattr(t, "fake_mode", None) for t in tables)
+          if m is not None}
+    args = program.example_inputs[0] or ()
+    ins = {id(m) for m in (getattr(t, "fake_mode", None) for t in args)
+           if m is not None}
+    return sd, ins
+
+
+# ---------------------------------------------------------------------------
+# RED: the premise the serial override rested on
+# ---------------------------------------------------------------------------
+
+
+def test_a_FAKE_param_program_CANNOT_round_trip(tree: Path, tmp_path: Path) -> None:
+    """The original failure, reproduced verbatim on the pin. Every other test
+    in this file is only interesting because this one holds."""
+    program = _weightless_program(tree)
+    path = tmp_path / "fake.pt2"
+    torch.export.save(program, str(path))
+    with pytest.raises(RuntimeError) as caught, _quiet_serde():
+        torch.export.load(str(path))
+    assert "deserializing the saved file" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# GREEN: META crosses, and crosses IDENTICALLY
+# ---------------------------------------------------------------------------
+
+
+def test_the_META_round_trip_preserves_the_GRAPH(tree: Path, tmp_path: Path) -> None:
+    """Parallelism is time-only. A round-tripped program whose graph differed
+    from the serial one would publish a DIFFERENT artifact under the SAME cell
+    key (the key digests the traced graph, sm, toolchain and env seal — none of
+    which move here), which is this codebase's worst failure class."""
+    program = _weightless_program(tree)
+    before = _graph_text(program)
+
+    path = tmp_path / "meta.pt2"
+    with so.as_meta_for_save(program) as moved:
+        assert moved > 0, "a weight-free program must have fake params to move"
+        torch.export.save(program, str(path))
+    loaded = _load(path)
+
+    assert so.has_meta_params(loaded)
+    assert so.revirtualize_from_meta(loaded) is not None
+    assert not so.has_meta_params(loaded)
+    assert _graph_text(loaded) == before
+
+
+def test_the_round_tripped_program_shares_ONE_fake_mode(
+    tree: Path, tmp_path: Path,
+) -> None:
+    """``aot_compile`` asserts every input belongs to one mode, and
+    ``compile_entry_files`` reads that mode off the program itself. Params
+    re-virtualized into a mode of their own would fail that assertion — or
+    worse, pass it while ``fake_mode_of_program`` returned None."""
+    program = _weightless_program(tree)
+    path = tmp_path / "meta.pt2"
+    with so.as_meta_for_save(program):
+        torch.export.save(program, str(path))
+    loaded = _load(path)
+    so.revirtualize_from_meta(loaded)
+
+    sd, ins = _modes(loaded)
+    assert sd and ins, "neither side may be mode-less"
+    assert sd == ins, "params and example inputs must share ONE fake mode"
+    assert so.fake_mode_of_program(loaded) is not None
+
+
+def test_a_meta_program_that_was_NOT_revirtualized_flips_the_INDUCTOR_CONFIG(
+    tree: Path, tmp_path: Path,
+) -> None:
+    """The severance that says why the child's call site is load-bearing.
+
+    ``compile_entry_files`` selects its inductor options with
+    ``weightless=fake_mode_of_program(program) is not None``. A program left on
+    META answers None, so skipping the re-virtualization does not merely fail —
+    it compiles the *weight-bearing* config for a weight-free graph and
+    publishes it under the weight-free cell key. Silent, and wrong.
+    """
+    program = _weightless_program(tree)
+    path = tmp_path / "meta.pt2"
+    with so.as_meta_for_save(program):
+        torch.export.save(program, str(path))
+
+    loaded = _load(path)
+    assert so.fake_mode_of_program(loaded) is None, (
+        "un-revirtualized: the config selector would read `weightless=False`")
+
+    so.revirtualize_from_meta(loaded)
+    assert so.fake_mode_of_program(loaded) is not None, (
+        "revirtualized: the selector reads `weightless=True`, as the serial "
+        "path does")
+
+
+# ---------------------------------------------------------------------------
+# The PRODUCTION call sites — the pool's stage and the child's load
+# ---------------------------------------------------------------------------
+
+
+def test_the_POOLS_OWN_STAGE_writes_a_program_the_CHILDS_OWN_LOAD_can_read(
+    tree: Path, tmp_path: Path,
+) -> None:
+    """End to end across the process boundary, through the real
+    ``EntryCompilePool._stage`` and the real ``aot_compile_child.load_program``
+    — no re-implementation of either. Everything short of the inductor compile,
+    which is not a cheap test on any machine.
+
+    Delete either call site and this goes red: without ``as_meta_for_save`` the
+    stage's own ``torch.export.save``/child load raises the deserialize error;
+    without ``revirtualize_from_meta`` the loaded program answers
+    ``fake_mode_of_program() is None`` and the last assertion fails.
+    """
+    from gen_worker import aot_compile_child, aot_compile_pool
+
+    program = _weightless_program(tree)
+    expected = _graph_text(program)
+    original = dict(program.state_dict)
+
+    width = aot_compile_pool.entry_workers(
+        1, available_bytes=1 << 36, free_vram_bytes=0, vcpus=8,
+        device_lock=True)
+    pool = aot_compile_pool.EntryCompilePool(tmp_path / "pool", width=width)
+    job, _job_path = pool._stage("decoder", program, 0)
+
+    assert pool.meta_staged_entries == 1, "the stage must have cast to META"
+    assert Path(job.program).exists()
+    # The parent's copy survives the cast, objects and all.
+    for name, tensor in original.items():
+        assert program.state_dict[name] is tensor
+
+    with _quiet_serde():
+        loaded = aot_compile_child.load_program(job)
+
+    assert not so.has_meta_params(loaded)
+    assert _graph_text(loaded) == expected
+    assert so.fake_mode_of_program(loaded) is not None, (
+        "the child must hand `compile_entry_files` a program whose own fake "
+        "mode it can find — that is what selects the weight-free config")
+
+
+# ---------------------------------------------------------------------------
+# The cast must not outlive the save
+# ---------------------------------------------------------------------------
+
+
+def test_the_save_cast_gives_back_the_EXACT_original_tensors(
+    tree: Path, tmp_path: Path,
+) -> None:
+    """The parent keeps using its programs after staging them (dispatch-class
+    canonicalization, the resident release's weight aliases). Restoring
+    equivalent new fakes would satisfy every value check and still break an
+    identity comparison, so the contract is object identity."""
+    program = _weightless_program(tree)
+    original = dict(program.state_dict)
+    assert original, "the fixture must have a state dict to protect"
+
+    with so.as_meta_for_save(program):
+        assert all(str(t.device) == "meta" for t in program.state_dict.values())
+        torch.export.save(program, str(tmp_path / "meta.pt2"))
+
+    assert list(program.state_dict) == list(original)
+    for name, tensor in original.items():
+        assert program.state_dict[name] is tensor, f"{name} was not the original"
+
+
+def test_a_REAL_weight_program_is_untouched_by_the_cast() -> None:
+    """The context is a no-op on the path it does not own. `moved == 0` is the
+    fence: a real-weight mint must serialize exactly as it always has."""
+
+    class Tiny(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(4, 4)
+
+        def forward(self, x: "torch.Tensor") -> "torch.Tensor":
+            return self.lin(x)
+
+    program = torch.export.export(Tiny(), (torch.randn(2, 4),))
+    before = dict(program.state_dict)
+    with so.as_meta_for_save(program) as moved:
+        assert moved == 0
+        assert all(str(t.device) != "meta" for t in program.state_dict.values())
+    assert dict(program.state_dict) == before
+
+
+# ---------------------------------------------------------------------------
+# The override is gone: a weight-free mint may now run the width it computed
+# ---------------------------------------------------------------------------
+
+
+def test_aot_mint_no_longer_FORCES_a_structure_only_mint_serial() -> None:
+    """Severance-style: the deleted branch was ``if parallel and
+    is_structure_only(pipeline): parallel = False``. Nothing else in the module
+    may reintroduce a structure-only test on the width decision — if it does,
+    every weight-free mint silently returns to K=1 and no test in the tree
+    noticed the first time (there was none).
+    """
+    source = (REPO / "src" / "gen_worker" / "aot_mint.py").read_text()
+    head, _, _ = source.partition("    minted = progress.minted")
+    _, _, decision = head.rpartition("    parallel = width.workers > 1")
+    assert "is_structure_only" not in decision, (
+        "the width decision must not re-acquire a structure-only override")
+    assert "compiles SERIALLY" not in source


### PR DESCRIPTION
## The defect

Since `fc77b923` every production mint is weight-free, and `aot_mint` FORCED `parallel = False` for exactly those, because a fake-parameter `ExportedProgram` could not survive `torch.export.save` -> `load`. So the pgw#809 entry pool has been **dead code fleet-wide** and every mint has run K=1, in-process, with export and compile strictly sequential. **No test asserted the override**, so nothing noticed.

## Measured, hub-side

Release `6ee9b4d4df2697a53da6f43a`, pod `bgmdxhazxsugmk`, A40, gen-worker 0.112.0, 16 of sdxl's 36 entries:

| fact | value |
|---|---|
| `export_s` (sum) | 1378.52 s |
| `compile_s` (sum) | 2065.36 s |
| sum of the two | **3443.88 s** |
| `total_s` | **3463.84 s** |

**0.6 % apart** — which is what zero export/compile overlap looks like. pgw#1052 exists precisely so those two do *not* add.

The same mint's `pool` row reported `entry_workers=3, underwidth=5, binding=vram, device_lock=True` **and carried no ledger** (no `pool_wall_s`, no `pool_efficiency`, no `peak_concurrency` — compare a real pool's row on `ykwoaiqub6ktt3`). `progress.width` is recorded whether or not the width is used, so the 3 was the width the override discarded. th#1822 read that row as a pool that ran; it did not. Deleting the override removes the misreport too.

Also from that row, and it reframes the levers: the compile is **CPU-bound**, not GPU-bound — `codegen_s` 643 s, `host_compile_s` 315 s, `lowering_s` 249 s, `graph_passes_s` 185 s, against `autotune_s` **28 s** and `triton_s` 17 s. The pool's cross-process GPU benchmark lock is therefore not a meaningful serializer of a wide pool.

## The fix

META tensors carry shape+dtype and serialize where fake tensors have no storage to reach for.

- Parent stages under `structure_only.as_meta_for_save` — a **context**, so the cast never outlives the save. The parent keeps using its programs (dispatch-class canonicalization, the resident release's weight aliases) and gets the **exact original tensor objects** back, not equivalent new fakes.
- `aot_compile_child.load_program` re-virtualizes META -> FAKE inside the mode the load rebuilt the example inputs in.

Result-neutral by construction and by test: identical graph, params and example inputs share **one** fake mode, and `fake_mode_of_program` still answers — which is what selects `weightless=True` in `compile_entry_files`. A program left on META answers `None` and would compile the **weight-bearing** config for a weight-free graph, under an unmoved cell key. The child refuses by name rather than let that happen silently.

## Proof

RED first: `test_a_FAKE_param_program_CANNOT_round_trip` reproduces the original `RuntimeError` on the real micro tree, through the real `build_component` -> `export_program` seams — not a stub.

Delete-the-call-site, all three severed, each turns a test red:

| severed | red test |
|---|---|
| pool stage's `as_meta_for_save` | `test_the_POOLS_OWN_STAGE_writes_a_program_the_CHILDS_OWN_LOAD_can_read` |
| child's `revirtualize_from_meta` | same |
| the restored `parallel=False` override | `test_aot_mint_no_longer_FORCES_a_structure_only_mint_serial` |

`test_the_POOLS_OWN_STAGE...` drives the real `EntryCompilePool._stage` and the real `aot_compile_child.load_program` across the actual save/load boundary — everything short of the inductor compile.

Local: 8 passed in the new file; 47 passed across `test_structure_only_pgw1080` / `test_aot_compile_pool_pgw809` / `test_pool_sizing_pgw842`; 62 passed across `test_compile_politeness_pgw1137` / `test_pool_rewiden_pgw868_a4` / `test_pool_simultaneity_pgw992`; `mypy` clean; `ruff` clean.

## Expected effect, stated with its comparison arm

Producer/consumer arithmetic from the same measured row: export is ~86 s/entry **serial in the parent**, compile ~129 s/entry in children. At K=3 the pool consumes at 43 s/entry, so the mint becomes **export-bound** and the wall collapses toward `export_all_s` + one compile tail: **~3444 s -> ~1500 s for those 16 entries**, and sdxl's full 36 from the on-course ~2.2 h toward **~55 min**. That is a *prediction from the measured per-entry costs*, not a measurement — the pod A/B is owed and is the acceptance item below.

## Scope deliberately NOT taken

pgw#1051 owed **(b)/(c)** — unclamping the device leg and raising `MAX_ENTRY_WORKERS` — are not here. With the pool restored the serial export in the parent is the producer bound at K>=2, so K past 3 buys **nothing** on this workload; and a weight-free child's device floor is unmeasured on a big family, where guessing it wrong is an OOM on paid work. Owed **(d)** is already done by pgw#1137, so this branch's `nice_children` / `preexec_fn` half is **dropped, not resumed** (its AST fence refuses `preexec_fn`, and a serial mint spawns no children for it to nice anyway).

- [x] meta round-trip, both call sites, RED-proven and severed
- [x] the discarded-width misreport goes away with the override
- [ ] pod A/B: the next sdxl mint's `pool` row must carry a **ledger** (`pool_wall_s`, `peak_concurrency` > 1) and `export_s + compile_s` must exceed `total_s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)