### PR TITLE
pgw#1156: the shipped fp8 lane stops LOSING to bf16 on narrow projections — the activation quantize is fused

### DIFF
--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -344,11 +344,92 @@ def w8a8_gemm_mode() -> str:
     return _choose_gemm_mode(major * 10 + minor)
 
 
+def _build_quantizer(torch: Any) -> Any:
+    """The dynamic activation quantize, and the reason it must not run op-by-op.
+
+    Eager, the chain is six full passes over the [M, K] activation (abs, amax,
+    reciprocal, mul, clamp, cast). Its cost scales with M*K while the GEMM
+    scales with M*K*N, so the overhead fraction goes as 1/N and on a thin-N
+    projection it eats the entire fp8 win. Measured on H100 at H3's shapes
+    (pgw#1156): `attn.to_out.0` and `ff.net.2` served 0.82-0.93x bf16 — the fp8
+    lane LOSING to the precision it replaces, at every duration — while their
+    bare GEMMs won 1.48x and 1.30x. One inductor-fused kernel pair closes it
+    (0.82x -> 1.21x, within 0.1% of the fully-compiled arm) and helps the wide
+    classes too.
+
+    Inside a compiled region the enclosing graph already fuses this, so the
+    helper hands back the eager source and nests nothing. Where inductor is
+    unavailable it degrades to the eager chain once, loudly, and keeps serving:
+    the lane stays correct, only slow."""
+
+    def _quant_src(x2: Any, pertensor: bool, static: Any) -> tuple:
+        if static is not None:
+            # Static scales are per-tensor scalars already — the pertensor GEMM
+            # consumes [1,1] directly.
+            sa = (static if pertensor
+                  else static.expand(x2.shape[0], 1).contiguous())
+        elif pertensor:
+            sa = (x2.abs().amax().float()
+                  / _FP8_MAX).clamp(min=1e-12).reshape(1, 1)
+        else:
+            sa = (x2.abs().amax(dim=-1, keepdim=True).float()
+                  / _FP8_MAX).clamp(min=1e-12)
+        # Quantize in the COMPUTE dtype (reciprocal multiply) — fp32
+        # intermediates here doubled the eager activation traffic and made eager
+        # w8a8 as slow as the cast hooks it replaces (H100 measured; bf16
+        # mantissa loss is irrelevant next to the fp8 target).
+        xq = (x2 * (1.0 / sa).to(x2.dtype)).clamp(
+            -_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+        return xq, sa
+
+    state: dict[str, Any] = {"fused": None, "off": False}
+
+    def quantize(x2: Any, pertensor: bool, static: Any) -> tuple:
+        if state["off"] or torch.compiler.is_compiling():
+            return _quant_src(x2, pertensor, static)
+        fused = state["fused"]
+        if fused is None:
+            try:
+                fused = torch.compile(_quant_src, dynamic=False, fullgraph=True)
+            except Exception as exc:  # noqa: BLE001 — no inductor => eager, not a refusal
+                _quant_degrade(exc)
+                state["off"] = True
+                return _quant_src(x2, pertensor, static)
+            state["fused"] = fused
+        try:
+            return fused(x2, pertensor, static)
+        except Exception as exc:  # noqa: BLE001
+            _quant_degrade(exc)
+            state["off"] = True
+            return _quant_src(x2, pertensor, static)
+
+    quantize.eager_source = _quant_src  # type: ignore[attr-defined]
+    return quantize
+
+
+def _quant_degrade(exc: BaseException) -> None:
+    """Once per process. A pod that quantizes op-by-op keeps the fp8 memory
+    saving and loses most of the speed — and on the thin-N classes it is slower
+    than bf16 — so it must not be silent (the pgw#824 shape)."""
+    logger.warning(
+        "w8a8: the fused activation-quantize did not build (%s); this process "
+        "quantizes op-by-op", exc)
+    activity_mod.emit_event(
+        activity_mod.KIND_SERVE_DEGRADE,
+        f"the fp8 activation quantize could not be fused ({type(exc).__name__}: "
+        f"{exc}), so it runs as six separate passes over every activation — on "
+        f"narrow-output projections that is SLOWER than bf16 (pgw#1156)",
+        phase="w8a8_quant_unfused",
+    )
+
+
 def _build_module_class() -> type:
     """Define the nn.Module lazily so importing this module never needs
     torch (discovery/CPU tools)."""
     import torch
     import torch.nn as nn
+
+    quantize = _build_quantizer(torch)
 
     class _Fp8ScaledLinear(nn.Module):
         """fp8 weights RESIDENT; y = scaled_mm(quant(x), W^T) + bias.
@@ -442,23 +523,7 @@ def _build_module_class() -> type:
             shape = x.shape
             x2 = x.reshape(-1, self.in_features).contiguous()
             pertensor = self.gemm_mode == "pertensor"
-            if self.input_scale is not None:
-                # Static scales are per-tensor scalars already — the
-                # pertensor GEMM consumes [1,1] directly.
-                sa = (self.input_scale if pertensor else
-                      self.input_scale.expand(x2.shape[0], 1).contiguous())
-            elif pertensor:
-                sa = (x2.abs().amax().float()
-                      / _FP8_MAX).clamp(min=1e-12).reshape(1, 1)
-            else:
-                sa = (x2.abs().amax(dim=-1, keepdim=True).float()
-                      / _FP8_MAX).clamp(min=1e-12)
-            # Quantize in the COMPUTE dtype (reciprocal multiply) — fp32
-            # intermediates here doubled the eager activation traffic and made
-            # eager w8a8 as slow as the cast hooks it replaces (H100 measured;
-            # bf16 mantissa loss is irrelevant next to the fp8 target).
-            xq = (x2 * (1.0 / sa).to(x2.dtype)).clamp(
-                -_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+            xq, sa = quantize(x2, pertensor, self.input_scale)
             scaled_mm: Any = torch._scaled_mm
             if pertensor:
                 # Scalar-scaled GEMM (cuBLASLt's Ada fast path, gw#564); the

--- a/tests/test_w8a8_fused_quant_pgw1156.py
+++ b/tests/test_w8a8_fused_quant_pgw1156.py
@@ -1,0 +1,148 @@
+"""pgw#1156: the fp8 activation quantize is FUSED, and its failure is loud.
+
+Measured on H100 at H3's real shapes: the eager op-by-op quantize costs six full
+passes over the [M, K] activation while the GEMM scales with M*K*N, so on the
+thin-N projections (`attn.to_out.0`, `ff.net.2`) the shipped fp8 forward ran
+**0.82-0.93x bf16** — slower than the precision it replaces — at every duration.
+Fusing the chain takes those classes to 1.21-1.39x.
+
+Two halves, both CPU-only:
+
+1. the fused path must compute EXACTLY what the pre-fix inline expression
+   computed, on all three scale branches (rowwise dynamic / pertensor dynamic /
+   static). The reference here is written out longhand rather than imported, so
+   a semantic drift in the refactor is RED.
+2. a host where the fusion cannot build must keep serving AND say so — an
+   unfused pod keeps the fp8 memory saving and loses the speed, which is the
+   pgw#824 silent-lane shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import activity  # noqa: E402
+from gen_worker.models import w8a8  # noqa: E402
+
+FP8_MAX = 448.0
+
+
+@pytest.fixture()
+def events(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    captured: List[Any] = []
+    monkeypatch.setattr(activity, "_emit", captured.append)
+    return captured
+
+
+def _reference(x2: Any, pertensor: bool, static: Any) -> tuple:
+    """The expression the module carried BEFORE the fusion landed, verbatim."""
+    if static is not None:
+        sa = (static if pertensor
+              else static.expand(x2.shape[0], 1).contiguous())
+    elif pertensor:
+        sa = (x2.abs().amax().float() / FP8_MAX).clamp(min=1e-12).reshape(1, 1)
+    else:
+        sa = (x2.abs().amax(dim=-1, keepdim=True).float()
+              / FP8_MAX).clamp(min=1e-12)
+    xq = (x2 * (1.0 / sa).to(x2.dtype)).clamp(
+        -FP8_MAX, FP8_MAX).to(torch.float8_e4m3fn)
+    return xq, sa
+
+
+CASES = [
+    ("rowwise_dynamic", False, False),
+    ("pertensor_dynamic", True, False),
+    ("rowwise_static", False, True),
+    ("pertensor_static", True, True),
+]
+
+
+def _faithfulness(xq: Any, sa: Any, x2: Any) -> float:
+    """Relative error of the quantized activation against the bf16 original."""
+    deq = xq.float() * sa.float()
+    return float((deq - x2.float()).norm() / x2.float().norm())
+
+
+@pytest.mark.parametrize("name,pertensor,use_static", CASES)
+def test_fused_quantize_is_the_same_recipe_and_no_less_faithful(
+    name: str, pertensor: bool, use_static: bool,
+) -> None:
+    """NOT bitwise: fusing the chain lets inductor hold the reciprocal-multiply in
+    fp32 instead of rounding it to bf16 between ops, so a handful of codes land one
+    fp8 step away. That is the SAME divergence the compiled arm has always had
+    against the eager one — the fix makes the two agree, it does not open a new
+    gap — and it moves in the accurate direction. What must not drift is the
+    recipe: the scale is a pure reduction and stays bit-exact, and the codes stay
+    overwhelmingly identical."""
+    torch.manual_seed(1156)
+    x2 = torch.randn(64, 128, dtype=torch.bfloat16) * 7.5
+    static = torch.tensor([[0.013]], dtype=torch.float32) if use_static else None
+
+    quantize = w8a8._build_quantizer(torch)
+    xq, sa = quantize(x2, pertensor, static)
+    rq, rs = _reference(x2, pertensor, static)
+
+    assert xq.dtype == torch.float8_e4m3fn
+    # the GEMM's scale-shape contract: rowwise wants [M,1], pertensor wants [1,1]
+    assert tuple(sa.shape) == ((1, 1) if pertensor else (x2.shape[0], 1))
+    assert torch.equal(sa, rs), f"{name}: the scale recipe drifted"
+
+    same = (xq.view(torch.uint8) == rq.view(torch.uint8)).float().mean().item()
+    assert same > 0.95, f"{name}: {1 - same:.4f} of codes differ — not a rounding gap"
+    # every disagreement is at most ONE representable e4m3 step (3 mantissa bits)
+    f, r = xq.float() * sa, rq.float() * rs
+    step = 2.0 ** -3 * 1.01
+    assert int(((f - r).abs() > step * torch.maximum(f.abs(), r.abs())).sum()) == 0, name
+    assert _faithfulness(xq, sa, x2) <= _faithfulness(rq, rs, x2) + 1e-6, name
+
+
+def test_a_host_that_cannot_fuse_still_serves_and_confesses(
+    events: List[Any], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_inductor(*_a: Any, **_k: Any) -> Any:
+        raise RuntimeError("inductor exploded")
+
+    monkeypatch.setattr(torch, "compile", _no_inductor)
+    torch.manual_seed(1156)
+    x2 = torch.randn(32, 64, dtype=torch.bfloat16)
+
+    quantize = w8a8._build_quantizer(torch)
+    xq, sa = quantize(x2, False, None)
+    rq, rs = _reference(x2, False, None)
+
+    # BEHAVIOR unchanged — the lane is correct, only slow
+    assert torch.equal(xq.view(torch.uint8), rq.view(torch.uint8))
+    assert torch.equal(sa, rs)
+
+    got = [e for e in events if e.kind == activity.KIND_SERVE_DEGRADE]
+    assert [e.phase for e in got] == ["w8a8_quant_unfused"]
+    assert "inductor exploded" in got[0].detail
+
+    # and it degrades ONCE, not on every activation
+    quantize(x2, False, None)
+    quantize(x2, False, None)
+    assert len([e for e in events
+                if e.kind == activity.KIND_SERVE_DEGRADE]) == 1
+
+
+def test_inside_a_compiled_region_the_helper_nests_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The enclosing graph already fuses the chain; building a second inductor
+    graph inside it is pure cost (and, under AOT export, a hazard)."""
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("torch.compile must not be called while compiling")
+
+    monkeypatch.setattr(torch, "compile", _boom)
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+
+    x2 = torch.randn(16, 32, dtype=torch.bfloat16)
+    quantize = w8a8._build_quantizer(torch)
+    xq, sa = quantize(x2, False, None)
+    rq, rs = _reference(x2, False, None)
+    assert torch.equal(xq.view(torch.uint8), rq.view(torch.uint8))
+    assert torch.equal(sa, rs)


### PR DESCRIPTION
## What the issue said, and what the card said

pgw#1156 was filed from the B200 probe as *"the fp8-w8a8 speed edge collapses at 15 s sequence shapes — 1.408x → 1.098x, NEGATIVE on `attn.to_qkv` and `ff.net.0.proj`"*, hypothesis: per-call dynamic-quantize overhead scaling with M.

Profiled on the fleet card (one H100 SXM, torch 2.13.0+cu130, H3's real shapes), **both halves of that are wrong, and the truth is worse.**

1. The B200 rig's fp8 arm pre-quantized its activations and passed unit scales — it measured a **bare `torch._scaled_mm`** and contained no quantize at all. Its 15 s inversion is an sm_100 GEMM effect (the only two cells that lose are the only two whose output crosses `M*N = 2^31`, and their fp8 TFLOPS drop to exactly the bf16 rate). **It does not reproduce on H100**: bare fp8 holds 1.27-1.59x flat at every shape, and a fine M sweep across `2^31/N` is flat to ±2%.
2. The real defect is in the **shipped forward**, it is on the OTHER two classes, and it is present at **every** duration including 5 s.

## The defect

`Fp8ScaledLinear.forward` ran the dynamic activation quantize as six full passes over the `[M, K]` activation — `abs`, `amax`, `reciprocal`, `mul`, `clamp`, `cast`. That cost scales with `M*K`; the GEMM scales with `M*K*N`. So the overhead fraction goes as **1/N**, and on a narrow-output projection it is the entire win.

Profiler, 15 s, `ff.net.2` (K=14336, N=5376), per call:

| | ms |
|---|---:|
| `aten::_scaled_mm` | 15.99 |
| `aten::mul` | 4.44 |
| `aten::abs` | 2.06 |
| `aten::clamp` | 2.06 |
| `aten::amax` | 1.54 |
| `aten::copy_` | 1.52 |
| **total** | **27.61** |
| bf16 `nn.Linear` | **23.71** |

**11.62 ms of elementwise traffic around a 16.0 ms GEMM.** The bare GEMM wins 1.30x; the forward loses.

fp8 forward ÷ bf16 `nn.Linear`, before:

| class | 5 s | 10 s | 15 s |
|---|---:|---:|---:|
| attn.to_qkv | 1.243 | 1.211 | 1.252 |
| **attn.to_out.0** | **0.807** | **0.875** | **0.930** |
| ff.net.0.proj | 1.177 | 1.278 | 1.274 |
| **ff.net.2** | **0.899** | **0.886** | **0.821** |

## The fix

One inductor-fused kernel pair behind the quantize. After:

| class | 5 s | 10 s | 15 s |
|---|---:|---:|---:|
| attn.to_qkv | 1.395 | 1.421 | 1.419 |
| **attn.to_out.0** | **1.273** | **1.315** | **1.394** |
| ff.net.0.proj | 1.299 | 1.401 | 1.374 |
| **ff.net.2** | **1.356** | **1.297** | **1.208** |

Within 0.1% of the fully-compiled arm at every cell (15 s `ff.net.2`: fused 1.208 vs compiled 1.209) — **the fix hands the EAGER serving arm the rate compilation was already giving the other one.** Summed over the four classes the linear block goes `1.077 / 1.110 / 1.109x` → `1.336 / 1.376 / 1.353x` at 5/10/15 s.

- Inside a compiled region `torch.compiler.is_compiling()` returns the eager source — the enclosing graph fuses it anyway, and nesting a second inductor graph inside an AOT export is a hazard.
- A host where inductor cannot build degrades to the op-by-op chain **once** and emits `w8a8_quant_unfused`. An unfused pod keeps the memory saving, loses the speed, and on the narrow classes is slower than bf16 — the pgw#824 silent-lane shape.

## Numerics

**Not bitwise identical.** Fusion lets the reciprocal-multiply stay in fp32 instead of rounding to bf16 between ops, so ~1.7% of codes land one e4m3 step away — in the accurate direction (rel error vs an fp32 reference: fused **0.015677** / eager 0.015792, measured on all four classes). That is the same divergence the compiled arm has always had against the eager one; this makes them agree rather than opening a new gap. The scale is a pure reduction and stays bit-exact.

## Tests

`tests/test_w8a8_fused_quant_pgw1156.py`, CPU-only, 6 cases:
- the recipe does not drift on any of the four scale branches (rowwise/pertensor × dynamic/static): scale bit-exact, >95% of codes identical, every disagreement at most one e4m3 step, faithfulness no worse;
- a host that cannot fuse still serves correct values, confesses via `serve_degrade`, and confesses **once**;
- inside a compiled region no second `torch.compile` is issued.

The RED proof for the *performance* claim is the measurement, not a unit test.

## Evidence

`~/cozy/samples/pgw1156-fp8-decay-20260812/` — pod `yymjdpzd30qwlz`, 1× H100 80GB HBM3, 17 min, ~$0.93, `DELETE 204` + `GET 404`-verified. Fleet line asserted on the pod: torch 2.13.0+cu130 / cuDNN 9.20.0 / driver 580.126.09 / sm_90, read from `endpoint.toml [[build.profiles]]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)