### PR TITLE
pgw#1158: a declared target that NO `Input` row reaches is refused

### DIFF
--- a/changelog.d/pgw1158.md
+++ b/changelog.d/pgw1158.md
@@ -24,3 +24,23 @@
   forks carried prose `why=` and no machine `reason=` — precisely the prose-doing-a-machine's-job
   failure the pair was invented for). The severance experiment is kept as a test row and run
   against these guards: a validator that never fires is the defect being fixed.
+
+- **pgw#1158 (the unambiguous half of the target-scoping finding): a declared target that NO
+  `Input` row reaches is refused.** `target_inputs` scopes by
+  `not inp.targets or target in inp.targets`, so a target every row scopes AWAY from still got a
+  mint plan — one with no declared inputs at all, whose trace has nothing to feed. Measured on
+  unmodified `c9fb5d4a` with two targets and every row scoped to the first: the declaration was
+  ACCEPTED, `vae.decode` reported **0 declared inputs**, and `cell_plans` minted a plan for it
+  anyway. The cost is a wasted mint entry, not merely a confusing declaration.
+
+  **Deliberately independent of the open question.** Whether an UNTARGETED row should fan out to
+  every declared target is a defaulting semantic with real cost attached — one of two leading
+  candidates for sdxl's 36-vs-18 entry discrepancy — and it is a design call, escalated rather
+  than guessed. No defaulting anyone would choose makes an input-less target correct, so this
+  refusal cannot freeze that question either way, and a test pins today's untargeted-row
+  behaviour as untouched so the guard cannot be read as having decided it.
+
+  The refusal names the starved target, what every row scoped itself to, and all three ways out.
+  `test_a_target_with_no_class_row_is_refused_by_name`'s fixture gains the `vae.decode` input it
+  was silently missing — its subject is the absent CLASS, and a fixture missing an input too
+  would have stopped measuring that.

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -1065,6 +1065,21 @@ def validate_contract(compile_decl: Any) -> None:
                 raise DeclarationError(
                     f"Input {inp.name!r} is declared twice for target {target!r}")
             names.add(inp.name)
+        # pgw#1158: ...and a declared target must end up with AT LEAST ONE.
+        # `target_inputs` scopes by `not inp.targets or target in inp.targets`,
+        # so a target every row scopes AWAY from mints a plan with no declared
+        # inputs at all — the trace has nothing to feed. This is refused
+        # independently of how the untargeted-row default is later ruled: no
+        # defaulting semantic anyone would choose makes an input-less target
+        # correct, so the refusal cannot freeze that question either way.
+        if inputs and not names:
+            row_scopes = sorted({t for inp in inputs for t in inp.targets})
+            raise DeclarationError(
+                f"target {target!r} is declared but NO Input row reaches it — "
+                f"every row scopes itself to {row_scopes!r}, so this target would "
+                f"mint a plan with no declared inputs and the trace would have "
+                f"nothing to feed. Scope a row to {target!r}, drop the target, "
+                f"or leave the rows it needs untargeted")
 
     # A binding may belong to any target's inputs; refuse only when NO
     # declared row knows the name at all.

--- a/tests/test_input_less_target_pgw1158.py
+++ b/tests/test_input_less_target_pgw1158.py
@@ -1,0 +1,114 @@
+"""pgw#1158: a declared target that NO Input row reaches is refused.
+
+The unambiguous half of the target-scoping finding. `target_inputs` scopes by
+``not inp.targets or target in inp.targets``, so a target that every row scopes
+AWAY from still gets a mint plan — one with no declared inputs at all, whose
+trace has nothing to feed.
+
+Measured on unmodified `origin/master` (c9fb5d4a), two declared targets with
+every Input row scoped to the first:
+
+    origin/master: declaration ACCEPTED
+       target 'transformer': 1 declared input(s)
+       target 'vae.decode': 0 declared input(s)
+       plans minted: ['transformer', 'vae.decode']
+
+So the cost is not merely a confusing declaration: a whole plan is minted for a
+target the author gave nothing to trace.
+
+WHY THIS ONE AND NOT THE OTHER HALF. Whether an UNTARGETED row should fan out
+to every declared target is a defaulting semantic with real cost attached (it
+is one of two leading candidates for sdxl's 36-vs-18 entry discrepancy), and it
+is a design call. This refusal is deliberately independent of it: no defaulting
+anyone would choose makes an input-less target correct, so refusing it cannot
+freeze that question in either direction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.api.decorators import Compile
+from gen_worker.api.export_contract import (
+    DeclarationError, Dim, GraphClass, Input)
+
+
+def _decl(**over) -> Compile:
+    base = dict(
+        family="fam", text_len=512,
+        dims=(Dim("B", carried_by=(("hidden_states", 0),)),),
+        classes=(GraphClass(dims={"B": 1}),),
+        shape_strategy="static-rows", warm_changes_key=False)
+    base.update(over)
+    return Compile(**base)  # type: ignore[arg-type]
+
+
+def test_a_target_no_input_row_reaches_is_REFUSED() -> None:
+    """RED on master: ACCEPTED, and it mints a plan for the starved target."""
+    with pytest.raises(DeclarationError, match="NO Input row reaches it"):
+        _decl(
+            targets=("transformer", "vae.decode"),
+            inputs=(Input("hidden_states", shape=("B", 4), dtype="model",
+                          targets=("transformer",)),))
+
+
+def test_the_refusal_names_the_TARGET_and_where_the_rows_went() -> None:
+    """An author reading it must be able to act without re-deriving the scope
+    map: the starved target by name, and what every row scoped itself to."""
+    with pytest.raises(DeclarationError) as err:
+        _decl(
+            targets=("transformer", "vae.decode"),
+            inputs=(Input("hidden_states", shape=("B", 4), dtype="model",
+                          targets=("transformer",)),))
+    detail = str(err.value)
+    assert "'vae.decode'" in detail, detail
+    assert "['transformer']" in detail, detail
+    # ...and all three ways out, because a refusal with one exit gets routed
+    # around by whichever exit the author thought of first.
+    assert "Scope a row" in detail and "drop the target" in detail, detail
+    assert "untargeted" in detail, detail
+
+
+# ---------------------------------------------------------------------------
+# It must not widen: the shapes below are legitimate and stay constructible
+# ---------------------------------------------------------------------------
+
+
+def test_an_UNTARGETED_row_reaching_every_target_is_untouched() -> None:
+    """Today's defaulting — the half that is NOT ruled here. Whatever it
+    becomes, this row must keep constructing until that ruling lands, or this
+    guard would have decided the open question by refusing one side of it."""
+    decl = _decl(
+        targets=("transformer", "vae.decode"),
+        inputs=(Input("hidden_states", shape=("B", 4), dtype="model"),))
+    assert decl.targets == ("transformer", "vae.decode")
+
+
+def test_a_declaration_with_NO_inputs_at_all_is_a_different_case() -> None:
+    """`inputs=()` is a declaration that states no ingress anywhere — already
+    handled elsewhere and legal here. The guard asks "did the rows MISS this
+    target", which is only a question when rows exist."""
+    assert _decl(targets=("transformer",), inputs=()).inputs == ()
+
+
+def test_every_target_scoped_explicitly_is_fine() -> None:
+    """The shape the guard exists to require."""
+    decl = _decl(
+        targets=("transformer", "vae.decode"),
+        inputs=(Input("hidden_states", shape=("B", 4), dtype="model",
+                      targets=("transformer",)),
+                Input("latent", shape=("B", 4), dtype="model",
+                      targets=("vae.decode",))))
+    assert len(decl.inputs) == 2
+
+
+def test_the_guard_FIRES_on_the_shape_master_accepted() -> None:
+    """The severance experiment, run on this guard: master accepted the
+    construction below and minted a plan for the starved target. If this stops
+    raising, the guard has been severed."""
+    with pytest.raises(DeclarationError):
+        _decl(
+            targets=("transformer", "vae.decode"),
+            inputs=(Input("hidden_states", shape=("B", 4), dtype="model",
+                          targets=("transformer",)),))
+        pytest.fail("the guard did not fire — it has been severed")

--- a/tests/test_target_scoped_classes_pgw967.py
+++ b/tests/test_target_scoped_classes_pgw967.py
@@ -187,7 +187,12 @@ def test_a_target_with_no_class_row_is_refused_by_name() -> None:
         shapes=((1024, 1024),),
         dims=(Dim("B", carried_by=(("sample", 0),)),),
         classes=(GraphClass(dims={"B": 2}, targets=("unet",)),),
-        inputs=(Input("sample", shape=("B", 4, 128, 128), targets=("unet",), dtype="model"),),
+        inputs=(Input("sample", shape=("B", 4, 128, 128), targets=("unet",), dtype="model"),
+                # pgw#1158: vae.decode needs a row of its own, or the
+                # DECLARATION is refused first and this row would stop
+                # measuring the missing CLASS it is named for.
+                Input("z", shape=("B", 4, 128, 128), targets=("vae.decode",),
+                      dtype="model"),),
         shape_strategy="static-rows",
         warm_changes_key=False,
     )


### PR DESCRIPTION
The **unambiguous half** of the target-scoping finding. The ambiguous half is escalated, not guessed — see below.

## The defect

`target_inputs` scopes by `not inp.targets or target in inp.targets`, so a target that every row scopes **away from** still gets a mint plan — one with no declared inputs at all, whose trace has nothing to feed.

## RED, on unmodified `c9fb5d4a`

Two declared targets, every `Input` row scoped to the first:

```
origin/master: declaration ACCEPTED
   target 'transformer': 1 declared input(s)
   target 'vae.decode': 0 declared input(s)
   plans minted: ['transformer', 'vae.decode']
```

So the cost is a **wasted mint entry**, not merely a confusing declaration. 3 of 6 new rows fail on master; the 3 that pass on both are the legitimate shapes the guard must not refuse. The severance experiment is a kept row.

Now:

```
target 'vae.decode' is declared but NO Input row reaches it — every row scopes
itself to ['transformer'], so this target would mint a plan with no declared
inputs and the trace would have nothing to feed. Scope a row to 'vae.decode',
drop the target, or leave the rows it needs untargeted
```

## Why this half and not the other

Whether an **untargeted** row should fan out to every declared target is a defaulting semantic with real cost attached — one of two leading candidates for sdxl's **36-vs-18** entry discrepancy — and it is a design call.

This refusal is deliberately independent of it: **no defaulting anyone would choose makes an input-less target correct**, so it cannot freeze that question in either direction. `test_an_UNTARGETED_row_reaching_every_target_is_untouched` pins today's behaviour explicitly, so this guard cannot be read as having decided one side of the question it is waiting on.

## One fixture was hiding a second defect

`test_a_target_with_no_class_row_is_refused_by_name` (pgw#967) builds a declaration whose `vae.decode` has no class row **and** no input row. Its subject is the absent **class** — so once the declaration is refused earlier for the missing input, that row stops measuring what it is named for. Fixture gains the `vae.decode` input it was silently missing, rather than the guard being loosened around it.

Local: mypy clean (267 files), ruff clean, all 11 fast-gate lints green, changelog gate green, registry-contract gate green, 111+ tests green across the declaration suites (`pgw967`, `pgw739` ×2, `pgw1158` ×2, `pgw740`, `pgw758`, `pgw1107`).