### PR TITLE
pgw#1163: the source-only import audit reports on THE WALK, not on its caller

### DIFF
--- a/changelog.d/pgw1163.md
+++ b/changelog.d/pgw1163.md
@@ -1,0 +1,24 @@
+- **pgw#1163: the source-only import audit reports on THE WALK, not on its caller — and stops
+  advising readers to ship their test suite.** Cause C of ie#690. `_audit_source_only_imports`
+  scanned all of `sys.modules` for top-level modules under the project root that the installed
+  wheel does not provide. Run from inside pytest, that set includes the RUNNER's own modules;
+  ernie's census run named exactly three — `conftest`, `test_aot_declaration`,
+  `test_ernie_functions` — every one a file pytest injected and **a pod never imports**. The three
+  affected endpoints had nothing wrong with their packaging.
+
+  `discover_functions` now snapshots `sys.modules` BEFORE the walk and the audit considers only
+  what the walk ADDED. Excluding by already-loaded rather than by name keeps the scan free of any
+  knowledge of the test runner — one that had to recognise pytest would have to recognise the next
+  tool too — and a test asserts the CODE names no runner (the docstring may, since explaining the
+  motivating caller is what it is for).
+
+  **The message was the worse half.** It advised *"include the module in the built package (e.g.
+  hatch only-include)"*, so following it would package `conftest.py` and the whole test suite into
+  the shipped wheel — strictly worse than the failure it claimed to fix, and it would have looked
+  like a successful fix. It now leads with DROP THE IMPORT, says a test/conftest/dev script must
+  never be packaged to satisfy the gate, and makes the packaging advice conditional on the module
+  genuinely running on the pod. Pinned by a test, including the ordering.
+
+  The guard itself is unweakened and pinned: wan-2.2 1.6.0's `src/cozy_finish.py` — absent from
+  the wheel, imported BY the walk — still fails the bake, because trading this false positive for
+  a boot-time `ModuleNotFoundError` on every pod a release staffs would be the worse bargain.

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -539,6 +539,13 @@ def discover_functions(
         sys.path.insert(0, src_str)
 
     top_level = main_module.split(".", 1)[0]
+    # pgw#1163: the audit below is about what THE WALK imported, so the set it
+    # compares against has to be taken before the walk runs. Scanning all of
+    # `sys.modules` instead attributes the CALLER's imports to discovery — and
+    # when the caller is pytest, that is its own `conftest` and test modules,
+    # which live under `root` and are not in the wheel, so they read as
+    # offenders. A pod never imports them.
+    preloaded = frozenset(sys.modules)
     with stub_missing_heavy_deps(extra_heavy_deps):
         try:
             found = find_endpoints([top_level])
@@ -567,7 +574,8 @@ def discover_functions(
 
     _assert_unique_function_names(functions)
     _validate_variant_targets(functions)
-    _audit_source_only_imports(root=root, top_level=top_level)
+    _audit_source_only_imports(
+        root=root, top_level=top_level, preloaded=preloaded)
     return functions
 
 
@@ -586,7 +594,9 @@ class SourceOnlyModuleError(ValueError):
     """
 
 
-def _audit_source_only_imports(*, root: Path, top_level: str) -> None:
+def _audit_source_only_imports(
+    *, root: Path, top_level: str, preloaded: frozenset = frozenset(),
+) -> None:
     """Fail the bake when the walk leaned on source-tree-only modules.
 
     Applies only when the walked project is INSTALLED (its top-level package
@@ -596,6 +606,15 @@ def _audit_source_only_imports(*, root: Path, top_level: str) -> None:
     from under ``root`` must also resolve from the installed environment;
     ``cwd`` is deliberately not honoured (the worker's import set must not
     depend on the directory it happens to start in).
+
+    ``preloaded`` is ``sys.modules`` as it stood BEFORE the walk, and the scan
+    considers only what the walk ADDED (pgw#1163). Without it the audit reports
+    on its CALLER's imports: run from inside pytest it flagged the runner's own
+    ``conftest`` and test modules, which sit under ``root``, are absent from the
+    wheel, and are imported by no pod that ever exists. Excluding by
+    already-loaded rather than by name keeps this free of any knowledge of the
+    test runner — a scan that has to recognise pytest would have to recognise
+    the next tool too.
     """
 
     root_str = str(root)
@@ -631,6 +650,8 @@ def _audit_source_only_imports(*, root: Path, top_level: str) -> None:
 
     offenders: List[str] = []
     for name, mod in list(sys.modules.items()):
+        if name in preloaded:
+            continue  # the caller's import, not the walk's (pgw#1163)
         if "." in name:
             continue  # submodules resolve with their package
         filename = getattr(mod, "__file__", None)
@@ -647,9 +668,13 @@ def _audit_source_only_imports(*, root: Path, top_level: str) -> None:
             "them and every pod of this release will die at boot with "
             "ModuleNotFoundError (pgw#833):\n  "
             + "\n  ".join(sorted(offenders))
-            + "\nFix: include the module in the built package (e.g. hatch "
-            "[tool.hatch.build.targets.wheel] only-include / py-modules), or "
-            "drop the import."
+            + "\nFix: DROP THE IMPORT if the module is not runtime code — a "
+            "test, a conftest, a dev script and anything else a pod never "
+            "imports must not be reachable from the endpoint's import graph, "
+            "and must NEVER be packaged to satisfy this gate. Only if the "
+            "module genuinely runs on the pod, add it to the built package "
+            "(e.g. hatch [tool.hatch.build.targets.wheel] only-include / "
+            "py-modules)."
         )
 
 

--- a/tests/test_discovery_offender_scope_pgw1163.py
+++ b/tests/test_discovery_offender_scope_pgw1163.py
@@ -1,0 +1,158 @@
+"""pgw#1163 — the source-only audit reports on THE WALK, not on its caller.
+
+Cause C of ie#690. The audit walked all of `sys.modules` looking for top-level
+modules under the project root that the installed wheel does not provide. Run
+from inside pytest, that set includes the RUNNER's own modules — ernie's census
+run named exactly three:
+
+    conftest             (imported from ernie/conftest.py)
+    test_aot_declaration (imported from ernie/tests/test_aot_declaration.py)
+    test_ernie_functions (imported from ernie/tests/test_ernie_functions.py)
+
+Every one is a file pytest injected and a pod never imports. The three named
+endpoints have nothing wrong with their packaging.
+
+THE MESSAGE WAS THE WORSE HALF. It advised *"include the module in the built
+package (e.g. hatch only-include)"* — following it would package `conftest.py`
+and the whole test suite into the shipped wheel, which is strictly worse than
+the failure it claims to fix AND would look like a successful fix. An error
+that misdirects a competent reader into shipping tests to production pods is
+its own defect, so the message is fixed here too and pinned by a test.
+
+The scope fix is deliberately NOT "detect pytest": excluding by
+already-loaded-before-the-walk requires no knowledge of the test runner, and a
+scan that has to recognise pytest would have to recognise the next tool too.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from gen_worker.discovery import discover as disc
+
+
+def _fake_module(name: str, filename: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__file__ = filename
+    return mod
+
+
+@pytest.fixture
+def installed_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project root whose top-level package resolves as INSTALLED.
+
+    The audit no-ops unless the walked project is installed, so the fixture
+    forces that arm — otherwise every row below would pass for the wrong
+    reason (the dev-tree early return), which is the failure shape this repo
+    keeps finding.
+    """
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+
+    real = disc.importlib.machinery.PathFinder.find_spec
+
+    def _find_spec(name, path=None, target=None):
+        if name == "mypkg":
+            spec = types.SimpleNamespace(origin="/installed/site-packages/mypkg/__init__.py")
+            return spec
+        return real(name, path, target)
+
+    monkeypatch.setattr(
+        disc.importlib.machinery.PathFinder, "find_spec", staticmethod(_find_spec))
+    return root
+
+
+def test_a_module_the_CALLER_already_imported_is_not_an_offender(
+    installed_project: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED on master: reported as an offender and the bake failed.
+
+    This is the ernie shape exactly — pytest's `conftest`, loaded from under
+    the project root before discovery ever ran."""
+    root = installed_project
+    conftest = _fake_module("conftest", str(root / "conftest.py"))
+    monkeypatch.setitem(sys.modules, "conftest", conftest)
+
+    preloaded = frozenset(sys.modules)  # as discover_functions takes it
+
+    disc._audit_source_only_imports(
+        root=root, top_level="mypkg", preloaded=preloaded)
+
+
+def test_a_module_THE_WALK_imported_is_still_an_offender(
+    installed_project: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard must keep firing on what it exists for: wan-2.2 1.6.0's
+    `src/cozy_finish.py`, absent from the wheel, imported BY the walk. A fix
+    that silenced this too would trade a false positive for the boot-time
+    `ModuleNotFoundError` on every pod the release staffs."""
+    root = installed_project
+    preloaded = frozenset(sys.modules)  # snapshot BEFORE the "walk"
+
+    leaked = _fake_module("cozy_finish", str(root / "src" / "cozy_finish.py"))
+    monkeypatch.setitem(sys.modules, "cozy_finish", leaked)
+
+    with pytest.raises(disc.SourceOnlyModuleError, match="cozy_finish"):
+        disc._audit_source_only_imports(
+            root=root, top_level="mypkg", preloaded=preloaded)
+
+
+def test_the_message_does_NOT_advise_packaging_a_test_module(
+    installed_project: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The trap, pinned. The old text led with hatch `only-include`, so the
+    obvious action was to package whatever was named — including a conftest."""
+    root = installed_project
+    preloaded = frozenset(sys.modules)
+    monkeypatch.setitem(
+        sys.modules, "cozy_finish",
+        _fake_module("cozy_finish", str(root / "src" / "cozy_finish.py")))
+
+    with pytest.raises(disc.SourceOnlyModuleError) as err:
+        disc._audit_source_only_imports(
+            root=root, top_level="mypkg", preloaded=preloaded)
+
+    detail = str(err.value)
+    assert "DROP THE IMPORT" in detail, detail
+    # the packaging advice must be CONDITIONAL and must come second
+    assert detail.index("DROP THE IMPORT") < detail.index("only-include"), detail
+    assert "never be packaged" in detail.lower(), detail
+    assert "conftest" in detail.lower(), detail
+
+
+def test_the_scan_needs_no_knowledge_of_the_test_runner() -> None:
+    """Excluding by already-loaded rather than by name is the property that
+    keeps this from rotting: a scan that recognises pytest would have to
+    recognise the next tool too."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.cleandoc(
+        inspect.getsource(disc._audit_source_only_imports)))
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    # The DOCSTRING may name pytest — explaining which caller motivated the
+    # scope fix is exactly what it is for. The CODE may not: a branch on a
+    # runner's name is the rot this avoids.
+    body = fn.body[1:] if ast.get_docstring(fn) else fn.body
+    code = "\n".join(ast.dump(node) for node in body)
+    for tool in ("pytest", "_pytest", "unittest", "nose"):
+        assert tool not in code, f"the scan branches on {tool!r}"
+
+
+def test_the_guard_FIRES_on_the_shape_it_exists_for() -> None:
+    """Severance experiment: the audit must still be reachable and still raise.
+    A scope fix that turned the whole gate off would pass every row above."""
+    assert callable(disc._audit_source_only_imports)
+    params = inspect_signature_params()
+    assert "preloaded" in params, params
+
+
+def inspect_signature_params() -> list:
+    import inspect
+
+    return list(inspect.signature(disc._audit_source_only_imports).parameters)


### PR DESCRIPTION
**Cause C of ie#690.** SDK-owned. The three affected endpoints have nothing wrong with their packaging — do not "fix" them.

## The defect

`_audit_source_only_imports` scanned **all** of `sys.modules` for top-level modules under the project root that the installed wheel does not provide. Run from inside pytest, that set includes the **runner's own** modules.

## RED, on unmodified `c9fb5d4a` — ernie's three, verbatim

```
=== origin/master ===
  audit RAISED on the test runner's own modules:
    conftest (imported from /tmp/projX/conftest.py)
    test_aot_declaration (imported from /tmp/projX/tests/test_aot_declaration.py)
    test_ernie_functions (imported from /tmp/projX/tests/test_ernie_functions.py)

  and the advice it gives:
    Fix: include the module in the built package (e.g. hatch
    [tool.hatch.build.targets.wheel] only-include / py-modules), or drop the import.
```

Every offender is a file pytest injected and **a pod never imports**.

## The scope fix

`discover_functions` snapshots `sys.modules` **before** the walk; the audit considers only what the walk **added** — the set it always claimed to be about ("every top-level module that was imported from under `root`").

I chose this over "exclude modules the test runner injected" deliberately: **excluding by already-loaded requires no knowledge of the test runner.** A scan that has to recognise pytest would have to recognise the next tool too. A test asserts the *code* names no runner — parsed via `ast`, not grepped, because the *docstring* may name pytest (explaining the motivating caller is what a docstring is for, and my first cut of that test failed on my own docstring).

## The message was the worse half

It led with hatch `only-include`, so the obvious action was to **package whatever was named** — including `conftest.py` and the whole test suite. That is strictly worse than the failure it claims to fix, and it would have looked like a successful fix.

Now: leads with **DROP THE IMPORT**, states that a test/conftest/dev script must *never* be packaged to satisfy this gate, and makes the packaging advice conditional on the module genuinely running on the pod. Pinned by a test — including the **ordering** of the two clauses, since advice that appears first is the advice that gets followed.

## The guard is not weakened

wan-2.2 1.6.0's `src/cozy_finish.py` — absent from the wheel, imported **by** the walk — still fails the bake. Trading this false positive for a boot-time `ModuleNotFoundError` on every pod a release staffs would be the worse bargain, so that row is pinned too.

## Still unidentified, and worth finding

What selects those three endpoints out of twenty-eight. The endpoint lane disproved two hypotheses (it is *not* a root `conftest.py` — all 28 have one; it is *not* a missing `tests/__init__.py` — sdxl, krea-2, z-image, flux.1-dev and qwen-image all lack it and pass). My leading hypothesis is that it selects on **which suites invoke discovery at all** while their own modules are loaded, rather than on packaging layout — but I have not verified it, and this fix does not depend on it: it removes the whole class regardless of which callers happen to trip it.

Local: mypy clean (267 files), ruff clean, all 11 fast-gate lints green, changelog gate green, **89 passed across all 9 test files that call `discover_functions`**, plus the guard's own `pgw833` suite.