### PR TITLE
pgw#1164 (th#1825): the adopt-arm gets its own headroom budget

### DIFF
--- a/changelog.d/pgw1164.md
+++ b/changelog.d/pgw1164.md
@@ -1,0 +1,8 @@
+- The **adopt-arm** has its own VRAM headroom budget (`mint_budget.adopt_headroom`), checked in
+  `fleet_cells.adopt_delegated_mint` **before** the arm and refused typed as
+  `insufficient_adopt_vram`. Until now `probe`/`co_residency` budgeted the COMPILE and nothing
+  budgeted the step after it — so a pod could pass its pre-mint gate, compile 36/36 sdxl entries
+  over 1 h 37 m, and then SIGSEGV loading what it had just built (th#1825, 1.9 MB free of 47.7 GB,
+  $0.81). The adopt's measured device high-water is now banked per (family, weight lane) and
+  emitted as a `cell_adopt_budget` row, so one adopt teaches the next pod and th#1820's placement
+  floor gets the number it has never had.

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -69,6 +69,7 @@ from . import activity as activity_mod
 from . import aot_identity, aot_serve, artifact_meta, cell_key, env_seal
 from . import boot_phases as boot_mod
 from . import local_cell_store
+from . import mint_budget
 from . import serve_posture
 from . import compile_cache as cc
 from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
@@ -2110,10 +2111,56 @@ def adopt_delegated_mint(
     # identical or refuse, no gray band — because an adopter runs no gate that
     # could re-check what ships. A refusal below unwraps, serves eager, emits
     # `self_mint_abort` to the hub and publishes nothing.
+    #
+    # pgw#1164 THE ADOPT'S OWN HEADROOM GATE, and it runs BEFORE the arm
+    # because the arm is the step that cannot survive being wrong. th#1825:
+    # an A40 passed its pre-mint budget, compiled 36/36 entries over 1 h 37 m
+    # and then SIGSEGV'd here with 1.9 MB free of 47.7 GB — the budget it
+    # passed described the compile, and nothing described this. The refusal is
+    # named and typed the way `insufficient_vram` is, so a family that cannot
+    # adopt on this card says so instead of dying at finalize.
+    lane = str(cc.cell_base_execution_lane(pipe) or "")
+    device = mint_budget.device_of(pipe)
+    budget = mint_budget.adopt_headroom(pending.family, lane, device)
+    if not budget.fits:
+        state["adopt_refusal"] = (
+            "insufficient_adopt_vram", budget.line("adopt_declined", "insufficient_adopt_vram"))
+        activity_mod.emit_event(
+            "self_mint_abort",
+            f"family={pending.family} arm_key={pending.arm_token}: "
+            f"{budget.line('adopt_declined', 'insufficient_adopt_vram')} — the "
+            f"cell is BUILT and this card cannot load it beside the residents "
+            f"it is serving; nothing is armed and nothing is published",
+            phase="insufficient_adopt_vram",
+        )
+        return None
+    resident_before, _peak_before = mint_budget.adopt_watermark(device)
+
     armed, meta, refusal = _arm_exported_cell(
         pipe, pending.cfg, pending.cache_dir,
         int(getattr(pending.cfg, "lora_bucket", 0) or 0),
         pending.target, pending.arm_key, verify_numerics=True)
+    # pgw#1164: bank what it actually cost, pass or fail — a refused arm still
+    # paid the device high-water, and that number is the one thing this program
+    # has never had. `max_memory_allocated` is process-monotone and never reset
+    # here, so this is the water mark ABOVE the resident set the adopt started
+    # from. Emitted as well as banked: the bank dies with the pod, the row does
+    # not, and th#1820's placement floor needs the row.
+    _, peak_after = mint_budget.adopt_watermark(device)
+    adopt_cost = max(0, peak_after - resident_before)
+    if adopt_cost > 0:
+        mint_budget.record_adopt_peak(pending.family, lane, adopt_cost)
+        activity_mod.emit_event(
+            "cell_adopt_budget",
+            f"family={pending.family} lane={lane or '(plain)'} "
+            f"adopt_device_peak={adopt_cost / (1 << 30):.2f}GiB "
+            f"resident_before={resident_before / (1 << 30):.2f}GiB "
+            f"armed={bool(armed)} basis=measured — the device cost of loading "
+            f"this cell beside the live residents and proving it against "
+            f"eager. th#1820's mint placement is sized on the COMPILE; this is "
+            f"the number the adopt needs.",
+            phase="measured",
+        )
     if not armed:
         reason, detail = refusal
         # pgw#999: `phase` is the countable column, so it carries the CLASS —

--- a/src/gen_worker/mint_budget.py
+++ b/src/gen_worker/mint_budget.py
@@ -78,6 +78,12 @@ _ENTRY_RSS_PEAKS: Dict[Tuple[str, str], int] = {}
 #: run it 37-127 wide.
 _ENTRY_DEVICE_PEAKS: Dict[Tuple[str, str], int] = {}
 
+#: pgw#1164: and the ADOPT's, which is a different process AND a different
+#: step from all three above. Those measure a compile; this measures loading
+#: the finished cell onto the serving card and proving it against eager. It is
+#: the only one of the four that has destroyed a paid mint (th#1825).
+_ADOPT_PEAKS: Dict[Tuple[str, str], int] = {}
+
 
 def _gib(value: int) -> str:
     return f"{value / _GIB:.2f}GiB"
@@ -267,6 +273,106 @@ def record_child_peak(family: str, weight_lane: str, peak_bytes: int) -> None:
 
 def child_peak(family: str, weight_lane: str) -> int:
     return _CHILD_PEAKS.get((str(family or ""), str(weight_lane or "")), 0)
+
+
+def record_adopt_peak(family: str, weight_lane: str, peak_bytes: int) -> None:
+    """Bank the ADOPT-ARM's measured device high-water for the next ask.
+
+    pgw#1164. Every other bank in this module measures a COMPILE; this one
+    measures the step after it, which is the one that has actually killed a
+    mint. ``adopt_delegated_mint`` loads the packed cell onto the serving card
+    and runs ``gate_cell_numerics``, whose probe holds, simultaneously: the
+    retained eager callable, EVERY loaded AOTI entry runner, and two forwards'
+    activation working set per axis (``numerics_probe.probe_cell`` iterates
+    ``axes_from_meta`` and reads ``state["original"]`` and ``state["runner"]``
+    for each). sdxl declares 36 entries. Nothing measured that.
+
+    Monotone for the same reason the others are: an adopt that peaked higher
+    once can peak that high again, and the ask must not drift down on a lucky
+    run.
+    """
+    if peak_bytes <= 0:
+        return
+    key = (str(family or ""), str(weight_lane or ""))
+    _ADOPT_PEAKS[key] = max(_ADOPT_PEAKS.get(key, 0), int(peak_bytes))
+
+
+def adopt_peak(family: str, weight_lane: str) -> int:
+    """0 = this pod has never completed an adopt for this (family, lane)."""
+    return _ADOPT_PEAKS.get((str(family or ""), str(weight_lane or "")), 0)
+
+
+def adopt_headroom(
+    family: str = "", weight_lane: str = "", device: Optional[int] = None,
+) -> MintBudget:
+    """Can the ADOPT-ARM run here without taking the card down? (pgw#1164)
+
+    The gap this closes, stated exactly: :func:`probe` and :func:`co_residency`
+    budget the COMPILE. Nothing budgeted the adopt, so a pod could pass its
+    pre-mint gate, compile 36/36 entries over 1 h 37 m, and then die loading
+    what it had just built — which is th#1825, \\$0.81, one step from durable.
+    The budget it passed never described the step that killed it.
+
+    TWO BASES, and the difference is stated rather than blended:
+
+    * **measured** — this pod has completed an adopt for this (family, lane),
+      so :func:`adopt_peak` holds a real high-water and ``need`` IS that fact.
+      This is the ask that can refuse.
+    * **unmeasured** — no adopt has ever completed here. ``need`` is then a
+      FLOOR built only of measured terms: ``2 * activation``, the verify's own
+      two-forward working set, on the same construction :func:`probe` already
+      uses and for the same reason (the probe runs eager AND compiled on one
+      feed, so both allocate).
+
+    **The unmeasured floor is deliberately INCOMPLETE and must not be read as
+    a prediction.** It omits the loaded entry runners' own device footprint —
+    the term nobody has ever measured, and the term this function exists to
+    start banking. So an unmeasured verdict can refuse a card that cannot even
+    hold the verify, and it CANNOT refuse a card that merely cannot hold 36
+    runners. That is an honest under-refusal, not a guess dressed as a bound:
+    inventing a per-entry constant here is exactly the magic number this
+    codebase forbids, and the real figure arrives the moment one adopt
+    completes anywhere on this family.
+
+    ``probed=False`` (no CUDA) fits by construction, like every other budget
+    here — an unprobeable device never blocks a mint.
+    """
+    read = _read_device(device)
+    if read is None:
+        return _UNPROBEABLE
+    banked = adopt_peak(family, weight_lane)
+    need = banked if banked > 0 else 2 * read.activation
+    return MintBudget(
+        fits=read.free_bytes >= need,
+        probed=True,
+        measured=banked > 0,
+        free_bytes=read.free_bytes,
+        need_bytes=need,
+        resident_bytes=read.allocated,
+        activation_bytes=read.activation,
+        cache_slack_bytes=read.cache_slack,
+        cap_bytes=need,
+    )
+
+
+def adopt_watermark(device: Optional[int] = None) -> Tuple[int, int]:
+    """``(allocated_now, peak_so_far)`` on this device, or ``(0, 0)``.
+
+    The pair an adopt brackets itself with. ``max_memory_allocated`` is
+    process-monotone, so the caller takes ``peak_after - allocated_before`` —
+    the high-water the adopt added ABOVE the resident set it started from —
+    and never resets the counter, which other readers on this process share.
+    """
+    read = _read_device(device)
+    if read is None:
+        return 0, 0
+    try:
+        import torch
+
+        dev = torch.cuda.current_device() if device is None else int(device)
+        return read.allocated, int(torch.cuda.max_memory_allocated(dev))
+    except Exception:
+        return read.allocated, 0
 
 
 def record_entry_peak_rss(family: str, weight_lane: str, peak_bytes: int) -> None:
@@ -497,6 +603,9 @@ def co_residency(
 
 __all__ = [
     "MintBudget",
+    "adopt_headroom",
+    "adopt_peak",
+    "adopt_watermark",
     "child_peak",
     "co_residency",
     "device_of",
@@ -504,6 +613,7 @@ __all__ = [
     "entry_device_peak",
     "entry_peak_rss",
     "probe",
+    "record_adopt_peak",
     "record_child_peak",
     "record_entry_device_peak",
     "record_entry_peak_rss",

--- a/tests/test_adopt_headroom_pgw1164.py
+++ b/tests/test_adopt_headroom_pgw1164.py
@@ -1,0 +1,231 @@
+"""pgw#1164 / th#1825 — the ADOPT-ARM gets its own headroom budget.
+
+th#1825, measured: an A40 passed its pre-mint budget, compiled 36/36 sdxl
+entries over 1 h 37 m, and then SIGSEGV'd in `finalize` with 1.9 MB free of
+47.7 GB. `publish_self_mint` refuses unless `_state["minted"]` is set and the
+only writer of that key is `adopt_delegated_mint`, so the ONLY path from
+"packed on disk" to "durable" ran through a GPU load that nothing budgeted.
+
+These rows drive the REAL `mint_budget.adopt_headroom`, the REAL
+`fleet_cells.adopt_delegated_mint` and the REAL banking registry. The only
+double is the CUDA reading itself (`_read_device`), which is the one thing a
+box with no usable GPU cannot supply — every decision under test is the
+production one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import fleet_cells, mint_budget
+
+_GIB = 1 << 30
+
+
+@pytest.fixture(autouse=True)
+def _clean_bank():
+    mint_budget._ADOPT_PEAKS.clear()
+    yield
+    mint_budget._ADOPT_PEAKS.clear()
+
+
+def _device(free_gib: float, allocated_gib: float, peak_gib: float):
+    """One fake CUDA reading, in the shape `_read_device` returns."""
+    allocated = int(allocated_gib * _GIB)
+    peak = int(peak_gib * _GIB)
+    measured_activation = max(0, peak - allocated)
+    return mint_budget._DeviceRead(
+        free_bytes=int(free_gib * _GIB),
+        allocated=allocated,
+        cache_slack=0,
+        measured_activation=measured_activation,
+        activation=max(
+            measured_activation,
+            int(allocated * mint_budget._UNMEASURED_ACTIVATION_FRACTION),
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# The budget itself.
+# --------------------------------------------------------------------------
+
+
+def test_unprobeable_device_never_blocks_an_adopt(monkeypatch) -> None:
+    """Every budget in this module fits by construction with no CUDA to read.
+    A CPU rig must keep today's behaviour exactly."""
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: None)
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    assert verdict.fits and not verdict.probed
+
+
+def test_an_unmeasured_adopt_states_its_basis_and_does_not_invent_a_number(
+    monkeypatch,
+) -> None:
+    """THE HONESTY ROW. With no banked peak the need is `2 * activation` — the
+    verify's own two-forward working set, every term measured — and `measured`
+    is False so no reader can mistake the floor for a prediction."""
+    monkeypatch.setattr(
+        mint_budget, "_read_device",
+        lambda _d: _device(free_gib=15.0, allocated_gib=32.0, peak_gib=36.0))
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    assert verdict.probed and not verdict.measured
+    assert verdict.need_bytes == 2 * verdict.activation_bytes, (
+        "the unmeasured floor must be exactly two activation working sets — "
+        "any other figure means a constant was smuggled in")
+    assert verdict.activation_bytes == int(8.0 * _GIB), (
+        "activation is `_read_device`'s own figure (max of the measured "
+        "high-water and the pre-forward fraction), not a new one")
+    assert not verdict.fits  # 15 GiB free against a 16 GiB floor
+
+
+def test_a_BANKED_peak_becomes_the_ask_and_can_refuse(monkeypatch) -> None:
+    """THE ROW THAT SAVES THE SECOND POD. Once one adopt has completed
+    anywhere on this (family, lane), the ask is that FACT, and a card that
+    cannot meet it refuses before the arm."""
+    monkeypatch.setattr(
+        mint_budget, "_read_device",
+        lambda _d: _device(free_gib=15.0, allocated_gib=32.0, peak_gib=36.0))
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    assert verdict.measured, "a banked peak must report basis=measured"
+    assert verdict.need_bytes == int(21.0 * _GIB)
+    assert not verdict.fits, (
+        "21 GiB of measured adopt cost against 15 GiB free must NOT fit — "
+        "this is exactly the th#1825 shape and it has to refuse")
+
+
+def test_the_bank_is_monotone(monkeypatch) -> None:
+    """An adopt that peaked higher once can peak that high again; a lucky run
+    must never lower the ask."""
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(20.0 * _GIB))
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(3.0 * _GIB))
+    assert mint_budget.adopt_peak("sdxl", "w8a8") == int(20.0 * _GIB)
+
+
+def test_the_bank_is_keyed_per_family_and_lane() -> None:
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(20.0 * _GIB))
+    assert mint_budget.adopt_peak("sdxl", "") == 0
+    assert mint_budget.adopt_peak("wan-2.2", "w8a8") == 0
+
+
+# --------------------------------------------------------------------------
+# The CALL SITE. These are the rows that go red if the gate is disconnected.
+# --------------------------------------------------------------------------
+
+
+class _Pending:
+    def __init__(self, target: Path) -> None:
+        self.family = "sdxl"
+        self.target = target
+        self.cache_dir = target.parent
+        self.arm_token = "arm2-deadbeef"
+        self.arm_key = None
+        self.cfg = type("Cfg", (), {"lora_bucket": 0})()
+        self.armed_at = 0.0
+        self.mint_root = target.parent
+        self.publisher = None
+        self._state: Dict[str, Any] = {}
+
+
+@pytest.fixture()
+def _pending(tmp_path: Path) -> "_Pending":
+    art = tmp_path / "cell.tar.gz"
+    art.write_bytes(b"not a real cell - the arm must never be reached")
+    return _Pending(art)
+
+
+def _install(monkeypatch, free_gib: float, events: List[Tuple[str, str, str]],
+             arm_calls: List[int]) -> None:
+    monkeypatch.setattr(
+        mint_budget, "_read_device",
+        lambda _d: _device(free_gib=free_gib, allocated_gib=32.0, peak_gib=36.0))
+    monkeypatch.setattr(mint_budget, "device_of", lambda _p: 0)
+    monkeypatch.setattr(mint_budget, "adopt_watermark", lambda _d: (0, 0))
+    monkeypatch.setattr(
+        fleet_cells.cc, "cell_base_execution_lane",
+        lambda _p: "w8a8")
+
+    def _arm(*_a: Any, **_k: Any):
+        arm_calls.append(1)
+        return True, {"cell_key": "ck1-x"}, ("", "")
+
+    monkeypatch.setattr(fleet_cells, "_arm_exported_cell", _arm)
+    monkeypatch.setattr(
+        fleet_cells.activity_mod, "emit_event",
+        lambda kind, detail, phase="", **_k: events.append((kind, phase, detail)))
+
+
+def test_a_measured_shortfall_REFUSES_BEFORE_THE_ARM(monkeypatch, _pending) -> None:
+    """THE LOAD-BEARING ROW. The whole point of th#1825 is that the arm is the
+    step that cannot survive being wrong, so the refusal must land with
+    `_arm_exported_cell` NEVER ENTERED."""
+    events: List[Tuple[str, str, str]] = []
+    arm_calls: List[int] = []
+    _install(monkeypatch, free_gib=15.0, events=events, arm_calls=arm_calls)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    out = fleet_cells.adopt_delegated_mint(
+        object(), _pending, _pending.target)
+
+    assert out is None, "a declined adopt must produce no SelfMint"
+    assert arm_calls == [], (
+        "THE ARM RAN ANYWAY — the gate is downstream of the thing it protects")
+    assert _pending._state["adopt_refusal"][0] == "insufficient_adopt_vram"
+    phases = [p for _k, p, _d in events]
+    assert "insufficient_adopt_vram" in phases, (
+        f"the refusal must be typed and countable; got phases {phases!r}")
+
+
+def test_the_refusal_publishes_NOTHING(monkeypatch, _pending) -> None:
+    """A declined adopt must leave `minted` unset, because that is the key
+    `publish_self_mint` refuses on — an unverified cell must never ship."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, free_gib=15.0, events=events, arm_calls=[])
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    fleet_cells.adopt_delegated_mint(object(), _pending, _pending.target)
+
+    assert "minted" not in _pending._state
+
+
+def test_an_UNMEASURED_first_adopt_is_NOT_refused(monkeypatch, _pending) -> None:
+    """THE NEGATIVE THAT KEEPS THIS HONEST. With nothing banked the budget has
+    no fact about the loaded ENTRY RUNNERS, so on a card that clears the
+    measured floor it must let the first adopt through and MEASURE it.
+    Refusing here would mean refusing on an invented per-entry constant, which
+    is the magic number this codebase forbids — 64 GiB free clears the 16 GiB
+    floor, and nothing else is known."""
+    events: List[Tuple[str, str, str]] = []
+    arm_calls: List[int] = []
+    _install(monkeypatch, free_gib=64.0, events=events, arm_calls=arm_calls)
+
+    fleet_cells.adopt_delegated_mint(object(), _pending, _pending.target)
+
+    assert arm_calls == [1], (
+        "the first adopt on a family was refused on a number nobody has "
+        "measured — that is a guess, not a budget")
+
+
+def test_the_adopt_cost_is_BANKED_AND_EMITTED(monkeypatch, _pending) -> None:
+    """One adopt teaches the next, and teaches th#1820's placement floor: the
+    bank dies with the pod, so the row has to carry the number too."""
+    events: List[Tuple[str, str, str]] = []
+    arm_calls: List[int] = []
+    _install(monkeypatch, free_gib=64.0, events=events, arm_calls=arm_calls)
+    # A real watermark pair this time: 17 GiB of high-water above resident.
+    monkeypatch.setattr(
+        mint_budget, "adopt_watermark",
+        lambda _d: (0, int(17.0 * _GIB)) if arm_calls else (0, 0))
+
+    fleet_cells.adopt_delegated_mint(object(), _pending, _pending.target)
+
+    assert mint_budget.adopt_peak("sdxl", "w8a8") == int(17.0 * _GIB), (
+        "the adopt's measured device cost was not banked, so the next adopt "
+        "on this pod is as blind as this one was")
+    kinds = [k for k, _p, _d in events]
+    assert "cell_adopt_budget" in kinds, (
+        f"the number never reached the wire; got {kinds!r}")


### PR DESCRIPTION
**th#1825**: an A40 passed its pre-mint budget, compiled 36/36 sdxl entries over 1 h 37 m, and then SIGSEGV'd in `finalize` with **1.9 MB free of 47.7 GB**. $0.81, one step from durable.

## The gap, from source

`publish_self_mint` refuses unless `pending._state["minted"]` is set; the only writer is `adopt_delegated_mint` → `_arm_exported_cell(..., verify_numerics=True)`. **The only path from "packed on disk" to "durable" runs through a GPU load on the serving card**, and `mint_budget.probe`/`co_residency` budget the *compile*. Nothing budgeted this.

What the adopt holds — not a second copy of the weights (`aot_serve.enable`: "constants bound from resident weights") but `numerics_probe.probe_cell` iterating every axis and reading both `state["original"]` (retained eager callable) and `state["runner"]` (loaded AOTI entry), plus two forwards' activations. **sdxl declares 36 entries.**

## The budget — no new constant, no env knob

- **measured** — a banked adopt peak for this (family, lane) *is* the ask, and it can refuse.
- **unmeasured** — a floor of `2 * activation`, the verify's own two-forward working set, on the identical construction `probe()` already uses. **Deliberately incomplete**: it omits the loaded runners' footprint — the term nobody has measured and the term this change starts banking. An honest under-refusal beats a per-entry constant invented to look like a bound.

It also **measures itself**: the arm is bracketed with `adopt_watermark`, the high-water above the pre-arm resident set is banked monotonically, and emitted as `cell_adopt_budget` — the bank dies with the pod, the row does not, and th#1820's placement floor learns from compile declines only today.

## RED before GREEN

Three delete-the-call-site experiments, each red alone: disconnect the gate's call site (2 rows red); leave the gate but never refuse (2 rows red); drop the banking (1 row red). 9 new rows green; 82 green across the adjacent adopt/budget/publish suites.

Scope: this does **not** make the artifact durable earlier — that is pgw#1162, filed as a specified design and deliberately not built.