### PR TITLE
pgw#1168: measure the adopt at the one seam every arm route passes, and split load from verify

### DIFF
--- a/changelog.d/pgw1168.md
+++ b/changelog.d/pgw1168.md
@@ -1,0 +1,8 @@
+- The adopt's device cost is measured at **`provision.arm_aot`** — the one seam every arm route
+  passes — instead of at the self-mint call site, and its two terms are reported apart. pgw#1164
+  measured only `adopt_delegated_mint`, so the boot adopt, the local-store adopt and the re-arm ran
+  the identical `aot_serve.enable` -> `load_and_wrap` and reported nothing. `cell_adopt_budget` now
+  carries `load` (what EVERY adopting pod pays, for the life of the arm) apart from `verify` (the
+  §4.32 gate's two forwards, paid only by the minting pod), plus the entry count. A boot-adopt row
+  taken on a 48 GB card is therefore the empirical answer to "does this cell fit its serving fleet"
+  (th#1825), where before there was one blended number from a pod that had just compiled.

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -2134,33 +2134,17 @@ def adopt_delegated_mint(
             phase="insufficient_adopt_vram",
         )
         return None
-    resident_before, _peak_before = mint_budget.adopt_watermark(device)
-
+    # pgw#1168: the MEASUREMENT that stood here has MOVED to
+    # `provision.arm_aot`, the one seam every arm route passes. It measured the
+    # self-mint adopt only, so the boot adopt — the same `load_and_wrap`, on the
+    # card the fleet actually serves on — reported nothing. The gate above stays
+    # here, because this is the call site where a refusal has consequences
+    # (nothing is armed, nothing is published); the ACCOUNTING belongs at the
+    # seam so it cannot be wired on one path again.
     armed, meta, refusal = _arm_exported_cell(
         pipe, pending.cfg, pending.cache_dir,
         int(getattr(pending.cfg, "lora_bucket", 0) or 0),
         pending.target, pending.arm_key, verify_numerics=True)
-    # pgw#1164: bank what it actually cost, pass or fail — a refused arm still
-    # paid the device high-water, and that number is the one thing this program
-    # has never had. `max_memory_allocated` is process-monotone and never reset
-    # here, so this is the water mark ABOVE the resident set the adopt started
-    # from. Emitted as well as banked: the bank dies with the pod, the row does
-    # not, and th#1820's placement floor needs the row.
-    _, peak_after = mint_budget.adopt_watermark(device)
-    adopt_cost = max(0, peak_after - resident_before)
-    if adopt_cost > 0:
-        mint_budget.record_adopt_peak(pending.family, lane, adopt_cost)
-        activity_mod.emit_event(
-            "cell_adopt_budget",
-            f"family={pending.family} lane={lane or '(plain)'} "
-            f"adopt_device_peak={adopt_cost / (1 << 30):.2f}GiB "
-            f"resident_before={resident_before / (1 << 30):.2f}GiB "
-            f"armed={bool(armed)} basis=measured — the device cost of loading "
-            f"this cell beside the live residents and proving it against "
-            f"eager. th#1820's mint placement is sized on the COMPILE; this is "
-            f"the number the adopt needs.",
-            phase="measured",
-        )
     if not armed:
         reason, detail = refusal
         # pgw#999: `phase` is the countable column, so it carries the CLASS —

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -50,6 +50,7 @@ from .loading import (
 from .memory import place_pipeline
 from .refs import DEFAULT_REF_TAG, parse_model_ref
 from .. import activity as activity_mod
+from .. import mint_budget
 
 if TYPE_CHECKING:
     from ..aot_identity import ExpectedIdentity
@@ -431,7 +432,67 @@ def arm_aot(
                     "aot arm: lifted-binding install failed on %r (%s); a "
                     "lifted artifact will refuse at assert_lifted_contract",
                     module_name, exc)
+    # pgw#1168: THE ADOPT'S DEVICE COST, MEASURED AT THE ONE SEAM EVERY ARM
+    # ROUTE PASSES. pgw#1164 measured this in `fleet_cells.adopt_delegated_mint`
+    # — the SELF-MINT adopt only — so the boot adopt, the local-store adopt and
+    # the re-arm ran the identical `aot_serve.enable` -> `load_and_wrap` and
+    # reported nothing. That is this program's most common defect shape (an
+    # emitter wired on one of N paths), and the fix is one emitter here rather
+    # than a second call site there.
+    #
+    # The two terms are measured SEPARATELY because they answer different
+    # questions, and the split is what decides whether the CELL or the GATE is
+    # the problem (th#1825):
+    #   load   — every loaded entry runner, which EVERY serving pod pays for the
+    #            life of the arm. This is the term that decides whether a cell
+    #            fits on the fleet it was built for.
+    #   verify — the §4.32 parity gate's two forwards, paid ONLY on the minting
+    #            pod (`verify_numerics=True`), never by an adopter.
+    # A boot adopt therefore reports `verify=0` by construction, and that row —
+    # taken on the card the fleet actually serves on — is the empirical answer
+    # to "does this cell fit", where before there was only arithmetic.
+    _budget_device = mint_budget.device_of(pipe)
+    _resident_before, _ = mint_budget.adopt_watermark(_budget_device)
+    _load_bytes = 0
+    _emitted = False
+
+    def _emit_adopt_budget(verify_bytes: int, armed: bool) -> None:
+        """One `cell_adopt_budget` row per arm attempt, whatever the outcome.
+
+        Emitted even for a REFUSED arm: the device high-water was paid either
+        way, and a refusal is exactly when the number is most worth having.
+        """
+        nonlocal _emitted
+        if _emitted:
+            return
+        _emitted = True
+        total = int(_load_bytes) + max(0, int(verify_bytes))
+        if total <= 0:
+            return
+        family = str((meta or {}).get("family") or getattr(cfg, "family", "") or "")
+        # The cell's OWN recorded lane, so this key matches the one
+        # `mint_budget`'s other banks use without importing compile_cache here.
+        lane = str((meta or {}).get("weight_lane") or "")
+        entries = len((meta or {}).get("entries") or {})
+        mint_budget.record_adopt_peak(family, lane, total)
+        gib = 1 << 30
+        activity_mod.emit_event(
+            "cell_adopt_budget",
+            f"family={family} lane={lane or '(plain)'} entries={entries} "
+            f"adopt_device_peak={total / gib:.3f}GiB "
+            f"load={_load_bytes / gib:.3f}GiB "
+            f"verify={max(0, int(verify_bytes)) / gib:.3f}GiB "
+            f"resident_before={_resident_before / gib:.3f}GiB "
+            f"verified={bool(verify_numerics)} armed={bool(armed)} "
+            f"basis=measured — `load` is what EVERY adopting pod pays and is "
+            f"the term that decides whether this cell fits its serving fleet; "
+            f"`verify` is the §4.32 gate and is paid only by the minting pod.",
+            phase="measured",
+        )
+
     outcome = aot_serve.enable(pipe, cfg, cache_dir, artifact, expected=expected)
+    _, _peak_after_load = mint_budget.adopt_watermark(_budget_device)
+    _load_bytes = max(0, _peak_after_load - _resident_before)
     if not outcome.armed and lifted_install_error:
         # The refusal is real; its ROOT is one frame up. Both, in the order a
         # reader needs them: what refused, and what made it refuse.
@@ -444,8 +505,12 @@ def arm_aot(
     if outcome.armed:
         # §4.32: quality is proven at MINT and in author CI, never at adoption.
         # An adopting pod materializes, arms and serves.
-        if not verify_numerics or gate_cell_numerics(pipe, cfg, strict=True):
+        gate_ok = not verify_numerics or gate_cell_numerics(pipe, cfg, strict=True)
+        _, _peak_after_verify = mint_budget.adopt_watermark(_budget_device)
+        if gate_ok:
+            _emit_adopt_budget(_peak_after_verify - _peak_after_load, True)
             return outcome
+        _emit_adopt_budget(_peak_after_verify - _peak_after_load, False)
         # A refused cell is UNARMED, not merely reported: the whole point is
         # that it must not serve. Staying eager is the ordinary miss policy
         # every other adopt gate uses, so the tenant keeps being served.
@@ -465,6 +530,10 @@ def arm_aot(
             f"they were traced from — nothing is published and this pod serves "
             f"eager (pgw#868, §4.32)",
             outcome.identity)
+    # An arm that never reached the gate (refused at `enable`) still paid the
+    # load, so it still reports — `_emit_adopt_budget` dedupes, so the armed
+    # paths above have already had their say.
+    _emit_adopt_budget(0, bool(outcome.armed))
     if lifted_installed:
         from . import lora_lifted
 

--- a/tests/test_adopt_headroom_pgw1164.py
+++ b/tests/test_adopt_headroom_pgw1164.py
@@ -210,22 +210,36 @@ def test_an_UNMEASURED_first_adopt_is_NOT_refused(monkeypatch, _pending) -> None
         "measured — that is a guess, not a budget")
 
 
-def test_the_adopt_cost_is_BANKED_AND_EMITTED(monkeypatch, _pending) -> None:
-    """One adopt teaches the next, and teaches th#1820's placement floor: the
-    bank dies with the pod, so the row has to carry the number too."""
+def test_this_call_site_does_NOT_measure__the_SEAM_does(
+    monkeypatch, _pending,
+) -> None:
+    """pgw#1168 MOVED the measurement, and this row is the fence that keeps it
+    moved.
+
+    It used to assert that `adopt_delegated_mint` banked and emitted the
+    adopt's device cost. That was true and it was WIRED ON ONE OF N PATHS: the
+    boot adopt, the local-store adopt and the re-arm run the identical
+    `aot_serve.enable` -> `load_and_wrap` and reported nothing, so the cheap
+    measurement on the card the fleet actually serves on did not exist. The
+    accounting lives in `provision.arm_aot` now — the one seam every arm route
+    passes — and is covered by `test_adopt_seam_budget_pgw1168.py`.
+
+    So what belongs HERE is the negative: a second emitter at this call site
+    would double-count every self-mint adopt and re-open the one-of-N shape.
+    The GATE stays here (see the rows above); only the accounting left.
+    """
     events: List[Tuple[str, str, str]] = []
     arm_calls: List[int] = []
     _install(monkeypatch, free_gib=64.0, events=events, arm_calls=arm_calls)
-    # A real watermark pair this time: 17 GiB of high-water above resident.
     monkeypatch.setattr(
         mint_budget, "adopt_watermark",
         lambda _d: (0, int(17.0 * _GIB)) if arm_calls else (0, 0))
 
     fleet_cells.adopt_delegated_mint(object(), _pending, _pending.target)
 
-    assert mint_budget.adopt_peak("sdxl", "w8a8") == int(17.0 * _GIB), (
-        "the adopt's measured device cost was not banked, so the next adopt "
-        "on this pod is as blind as this one was")
+    assert arm_calls == [1], "the arm must still run; only the accounting moved"
     kinds = [k for k, _p, _d in events]
-    assert "cell_adopt_budget" in kinds, (
-        f"the number never reached the wire; got {kinds!r}")
+    assert "cell_adopt_budget" not in kinds, (
+        f"this call site emitted a budget row again — the seam in "
+        f"provision.arm_aot already does, so this is a double count and the "
+        f"one-of-N wiring shape is back. Got {kinds!r}")

--- a/tests/test_adopt_seam_budget_pgw1168.py
+++ b/tests/test_adopt_seam_budget_pgw1168.py
@@ -1,0 +1,211 @@
+"""pgw#1168 — the adopt's device cost is measured at the ONE seam every arm
+route passes, and its two terms are reported apart.
+
+pgw#1164 put the measurement in `fleet_cells.adopt_delegated_mint`, i.e. on the
+SELF-MINT adopt only. The boot adopt, the local-store adopt and the re-arm run
+the identical `aot_serve.enable` -> `load_and_wrap` and reported nothing — the
+"emitter wired on one of N paths" shape this program keeps producing. It lives
+in `provision.arm_aot` now, which owns both the load and the §4.32 gate.
+
+Why the SPLIT matters (th#1825): `load` is what EVERY adopting pod pays for the
+life of the arm and is the term that decides whether a cell fits the fleet it
+was built for; `verify` is the parity gate's two forwards and is paid only by
+the minting pod. A boot-adopt row on a 48 GB card is therefore the EMPIRICAL
+answer to "does this cell fit", where before there was only arithmetic over a
+single blended number.
+
+These rows drive the REAL `arm_aot` and the REAL banking registry. The doubles
+are the CUDA reading and `aot_serve.enable`/`gate_cell_numerics` — the GPU work
+this box may not do.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import mint_budget
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.models import provision
+
+_GIB = 1 << 30
+
+
+@pytest.fixture(autouse=True)
+def _clean_bank():
+    mint_budget._ADOPT_PEAKS.clear()
+    yield
+    mint_budget._ADOPT_PEAKS.clear()
+
+
+_META: Dict[str, Any] = {
+    "family": "sdxl",
+    "weight_lane": "w8a8",
+    "mode": "",
+    "cell_key": "ck1-testtesttest",
+    "entries": {f"unet/e{i}": {"target": "unet"} for i in range(36)},
+}
+
+
+def _install(
+    monkeypatch,
+    events: List[Tuple[str, str, str]],
+    *,
+    watermarks: List[Tuple[int, int]],
+    armed: bool = True,
+    gate_passes: bool = True,
+):
+    """Real arm_aot; doubled CUDA reading, load and gate."""
+    from gen_worker import aot_serve
+
+    calls = {"n": 0}
+
+    def _watermark(_device: Any = None) -> Tuple[int, int]:
+        i = min(calls["n"], len(watermarks) - 1)
+        calls["n"] += 1
+        return watermarks[i]
+
+    monkeypatch.setattr(mint_budget, "adopt_watermark", _watermark)
+    monkeypatch.setattr(mint_budget, "device_of", lambda _p: 0)
+    monkeypatch.setattr(
+        aot_serve, "enable",
+        lambda *a, **k: (AdoptOutcome.hit("armed") if armed
+                         else AdoptOutcome.miss("load_failed", "no")))
+    monkeypatch.setattr(aot_serve, "armed_metadata", lambda _p: dict(_META))
+    monkeypatch.setattr(aot_serve, "unwrap", lambda _p: None)
+    monkeypatch.setattr(
+        provision, "gate_cell_numerics", lambda *a, **k: gate_passes)
+    monkeypatch.setattr(
+        provision.activity_mod, "emit_event",
+        lambda kind, detail, phase="", **_k: events.append((kind, phase, detail)))
+
+
+def _arm(tmp_path: Path, **kw: Any):
+    return provision.arm_aot(
+        object(), type("Cfg", (), {"family": "sdxl"})(), None,
+        tmp_path / "cell.tar.gz", 0, dict(_META), **kw)
+
+
+def _row(events: List[Tuple[str, str, str]]) -> str:
+    rows = [d for k, _p, d in events if k == "cell_adopt_budget"]
+    assert len(rows) == 1, f"expected exactly ONE budget row, got {len(rows)}"
+    return rows[0]
+
+
+# --------------------------------------------------------------------------
+# GAP 1 — the boot-adopt path reports at all.
+# --------------------------------------------------------------------------
+
+
+def test_the_BOOT_ADOPT_path_emits_a_budget_row(monkeypatch, tmp_path) -> None:
+    """THE LOAD-BEARING ROW. `verify_numerics=False` is the boot adopt, the
+    local-store adopt and the re-arm — every route that is NOT the self-mint.
+    Before pgw#1168 none of them reported, so the cheap measurement on the card
+    the fleet actually serves on did not exist."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events,
+             watermarks=[(10 * _GIB, 10 * _GIB), (0, 27 * _GIB), (0, 27 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=False)
+
+    detail = _row(events)
+    assert "load=17.000GiB" in detail, detail
+    assert "verified=False" in detail
+
+
+def test_a_boot_adopt_reports_verify_ZERO_by_construction(
+    monkeypatch, tmp_path,
+) -> None:
+    """An adopter runs no parity gate (§4.32), so its row must attribute the
+    whole cost to `load`. That is what makes the row comparable to a serving
+    pod's requirement rather than to a minting pod's."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events,
+             watermarks=[(10 * _GIB, 10 * _GIB), (0, 27 * _GIB), (0, 27 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=False)
+
+    assert "verify=0.000GiB" in _row(events)
+
+
+# --------------------------------------------------------------------------
+# GAP 2 — the two terms are reported APART.
+# --------------------------------------------------------------------------
+
+
+def test_load_and_verify_are_reported_SEPARATELY(monkeypatch, tmp_path) -> None:
+    """THE ROW THAT DECIDES WHETHER THE CELL OR THE GATE IS THE PROBLEM.
+    A single blended number cannot answer it; `R + load` is the serving
+    requirement and `verify` is the minting pod's alone."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events,
+             watermarks=[(10 * _GIB, 10 * _GIB), (0, 27 * _GIB), (0, 33 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=True)
+
+    detail = _row(events)
+    assert "load=17.000GiB" in detail, detail
+    assert "verify=6.000GiB" in detail, detail
+    assert "adopt_device_peak=23.000GiB" in detail, detail
+
+
+def test_the_row_names_the_entry_count(monkeypatch, tmp_path) -> None:
+    """36 entries and 3 entries must never be pooled — the whole fit question
+    is about how the cost scales with entry count."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events,
+             watermarks=[(0, 0), (0, 5 * _GIB), (0, 5 * _GIB)])
+    _arm(tmp_path, verify_numerics=False)
+    assert "entries=36" in _row(events)
+
+
+# --------------------------------------------------------------------------
+# Banking, dedup, and the refused arm.
+# --------------------------------------------------------------------------
+
+
+def test_the_seam_feeds_the_BANK_under_the_cell_s_own_lane(
+    monkeypatch, tmp_path,
+) -> None:
+    """The lane key is read from the cell's recorded `weight_lane`, so this
+    bank agrees with `mint_budget`'s other three without importing
+    compile_cache into provision."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events,
+             watermarks=[(0, 0), (0, 21 * _GIB), (0, 21 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=False)
+
+    assert mint_budget.adopt_peak("sdxl", "w8a8") == 21 * _GIB
+
+
+def test_a_REFUSED_arm_still_reports_what_it_paid(monkeypatch, tmp_path) -> None:
+    """A refusal is exactly when the number is most worth having — the device
+    high-water was paid either way, and th#1825 died at a refusal."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events, armed=False,
+             watermarks=[(0, 0), (0, 12 * _GIB), (0, 12 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=False)
+
+    detail = _row(events)
+    assert "armed=False" in detail
+    assert "load=12.000GiB" in detail
+
+
+def test_a_numerics_REFUSAL_reports_ONCE_with_both_terms(
+    monkeypatch, tmp_path,
+) -> None:
+    """The gate-refused path falls through to the tail emit; the dedup must
+    stop it reporting twice."""
+    events: List[Tuple[str, str, str]] = []
+    _install(monkeypatch, events, gate_passes=False,
+             watermarks=[(0, 0), (0, 17 * _GIB), (0, 23 * _GIB)])
+
+    _arm(tmp_path, verify_numerics=True)
+
+    detail = _row(events)  # asserts exactly one
+    assert "armed=False" in detail
+    assert "verify=6.000GiB" in detail


### PR DESCRIPTION
Closes both instrument gaps th#1825's separator experiment needs.

## Gap 1 — the emitter was wired on one of N paths

pgw#1164 measured the adopt in `fleet_cells.adopt_delegated_mint` — the **self-mint** adopt only. The boot adopt, the local-store adopt and the re-arm run the identical `aot_serve.enable` → `load_and_wrap` and reported nothing. That is this program's most common defect shape, so the fix is **one emitter at the seam**, not a second call site.

`provision.arm_aot` owns both halves — `aot_serve.enable` (load) and `gate_cell_numerics` (§4.32 verify) — which is why it is the right seam **and** why gap 2 falls out of it for free.

## Gap 2 — the two terms, apart

- **`load`** — every loaded entry runner. **Every** adopting pod pays this for the life of the arm, so it is the term that decides whether a cell fits the fleet it was built for.
- **`verify`** — the parity gate's two forwards, paid **only** by the minting pod.

A blended number could not answer th#1825's question, because it came from a pod that had just compiled and was not comparable to a serving pod's requirement. **A boot-adopt row reports `verify=0` by construction, so taken on a 48 GB card it is the empirical answer to "does this cell fit" — at the cost of an ordinary boot, replacing arithmetic with a measurement on the card the fleet actually serves on.**

The row also carries the entry count, so a 36-entry sdxl cell is never pooled with micro-diffusion's 3.

The lane key is read from the cell's own recorded `weight_lane` — the same value `cell_base_execution_lane(pipe)` produced at mint — so this bank agrees with `mint_budget`'s other three with no new parameter and no circular import.

## RED before GREEN

Three delete-the-call-site experiments, each red alone:

| experiment | result |
|---|---|
| restore the pgw#1164 world (only `verify_numerics=True` reports) — **gap 1 itself** | 5 rows red |
| blend the two terms into one number | 5 rows red |
| drop the emit dedup so the gate-refused path double-counts | 1 row red |

7 new rows; **95 green** across the adjacent adopt/budget/publish suites.

pgw#1164's `test_the_adopt_cost_is_BANKED_AND_EMITTED` is **replaced, not deleted** — it now fences that call site against a *second* emitter, which would double-count and re-open the one-of-N shape. The headroom **gate** stays there, where a refusal has consequences; only the accounting moved.