### PR TITLE
pgw#1169: the adopt headroom gate reaches every arm route — degrade instead of crash-loop

### DIFF
--- a/changelog.d/pgw1169.md
+++ b/changelog.d/pgw1169.md
@@ -1,0 +1,9 @@
+- The adopt headroom gate reaches **every** arm route, not just the self-mint one. pgw#1164 gated
+  `adopt_delegated_mint`; a **boot adopt** that could not fit the cell had no way to decline and
+  simply ran the load and died — and because an AOTI load that exhausts the card SIGSEGVs rather
+  than raising, nothing downstream could catch it, so one bad cell would take every serving pod on
+  the release. The gate now runs in `provision.arm_aot` (the seam that owns the load), refuses
+  typed as `insufficient_adopt_vram`, emits `cell_adopt_declined`, and is **sticky** per §4.31 so a
+  pod never re-runs a load it has already decided it cannot survive. `mint_budget.adopt_headroom`
+  remains the one authority — the self-mint call site keeps its own earlier call to the same
+  function, so the two cannot drift.

--- a/src/gen_worker/mint_budget.py
+++ b/src/gen_worker/mint_budget.py
@@ -84,6 +84,10 @@ _ENTRY_DEVICE_PEAKS: Dict[Tuple[str, str], int] = {}
 #: the only one of the four that has destroyed a paid mint (th#1825).
 _ADOPT_PEAKS: Dict[Tuple[str, str], int] = {}
 
+#: pgw#1169: (family, weight lane) this process has already refused to adopt.
+#: The refusal is STICKY — see :func:`note_adopt_declined`.
+_ADOPT_DECLINED: "set[Tuple[str, str]]" = set()
+
 
 def _gib(value: int) -> str:
     return f"{value / _GIB:.2f}GiB"
@@ -275,6 +279,30 @@ def child_peak(family: str, weight_lane: str) -> int:
     return _CHILD_PEAKS.get((str(family or ""), str(weight_lane or "")), 0)
 
 
+def note_adopt_declined(family: str, weight_lane: str) -> None:
+    """Make an adopt refusal STICKY for this process (pgw#1169, §4.31).
+
+    §4.31's serve-first posture is that a cell-attributable failure de-arms the
+    cell and serves eager IN-REQUEST. An adopt that cannot fit the card is that
+    failure in its worst-behaved form — it takes the process rather than
+    returning an error — so the refusal has to survive the decision that
+    produced it. Without this, a pod re-asks a question whose answer cannot
+    have improved and re-runs a load that killed the last attempt.
+
+    Deliberately NOT in :func:`compile_cache.arming_block`, which documents
+    that every reason it names *"is deterministic for the life of this
+    process: none of them can differ on a retry."* Free VRAM is not: it moves
+    with what is resident. So the STICKINESS lives here, next to the bank whose
+    numbers it is made of, and `arming_block`'s invariant stays true.
+    """
+    _ADOPT_DECLINED.add((str(family or ""), str(weight_lane or "")))
+
+
+def adopt_declined(family: str, weight_lane: str) -> bool:
+    """Whether this process has already refused to adopt this (family, lane)."""
+    return (str(family or ""), str(weight_lane or "")) in _ADOPT_DECLINED
+
+
 def record_adopt_peak(family: str, weight_lane: str, peak_bytes: int) -> None:
     """Bank the ADOPT-ARM's measured device high-water for the next ask.
 
@@ -342,8 +370,12 @@ def adopt_headroom(
         return _UNPROBEABLE
     banked = adopt_peak(family, weight_lane)
     need = banked if banked > 0 else 2 * read.activation
+    # pgw#1169: a refusal already taken stands. Re-asking would re-run a load
+    # that this process has already decided it cannot survive, and a transient
+    # dip in someone else's residency is not evidence that it can.
+    fits = read.free_bytes >= need and not adopt_declined(family, weight_lane)
     return MintBudget(
-        fits=read.free_bytes >= need,
+        fits=fits,
         probed=True,
         measured=banked > 0,
         free_bytes=read.free_bytes,
@@ -603,6 +635,7 @@ def co_residency(
 
 __all__ = [
     "MintBudget",
+    "adopt_declined",
     "adopt_headroom",
     "adopt_peak",
     "adopt_watermark",
@@ -613,6 +646,7 @@ __all__ = [
     "entry_device_peak",
     "entry_peak_rss",
     "probe",
+    "note_adopt_declined",
     "record_adopt_peak",
     "record_child_peak",
     "record_entry_device_peak",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -489,6 +489,49 @@ def arm_aot(
             phase="measured",
         )
 
+    # pgw#1169: THE HEADROOM GATE, AT THE SAME SEAM AND FOR EVERY ARM ROUTE.
+    # pgw#1164 gated the SELF-MINT adopt only, so a BOOT adopt that could not
+    # fit the cell had no way to decline — it simply ran the load and died.
+    # That is the shape that turns one bad cell into a fleet-wide crash loop:
+    # every serving pod on the release attempts the same adopt and takes the
+    # same SIGSEGV, and because the load kills the process rather than raising,
+    # nothing downstream can catch it.
+    #
+    # This is §4.31 applied where it could not previously reach, NOT new
+    # policy: a cell-attributable failure de-arms the cell and serves eager,
+    # and an adopt that cannot fit the card is that failure in its worst-
+    # behaved form. Declining here turns an outage into a logged degradation,
+    # and `cell_adopt_budget` still records what the attempt would have needed.
+    #
+    # ONE AUTHORITY, MANY CALLERS — the `compile_cache.arming_block` pattern.
+    # `mint_budget.adopt_headroom` is the only place that decides; the
+    # self-mint call site keeps its own earlier call to the SAME function so it
+    # can refuse before it even reads the artifact, and the two cannot drift
+    # because there is nothing to drift from.
+    _budget_family = str(
+        (meta or {}).get("family") or getattr(cfg, "family", "") or "")
+    _budget_lane = str((meta or {}).get("weight_lane") or "")
+    _adopt_budget = mint_budget.adopt_headroom(
+        _budget_family, _budget_lane, _budget_device)
+    if not _adopt_budget.fits:
+        # STICKY (§4.31): the answer cannot have improved, and re-running a
+        # load that killed the last attempt is the behaviour this exists to
+        # stop. A later arm of the same (family, lane) refuses without
+        # re-reading the card.
+        mint_budget.note_adopt_declined(_budget_family, _budget_lane)
+        detail = _adopt_budget.line("adopt_declined", "insufficient_adopt_vram")
+        activity_mod.emit_event(
+            "cell_adopt_declined",
+            f"family={_budget_family} lane={_budget_lane or '(plain)'} "
+            f"entries={len((meta or {}).get('entries') or {})}: {detail} — this "
+            f"pod cannot load the cell beside what it is already serving, so "
+            f"it serves EAGER and stays up. Nothing is armed.",
+            phase="insufficient_adopt_vram",
+        )
+        logger.warning(
+            "aot arm: %s — serving eager", detail)
+        return AdoptOutcome.miss("insufficient_adopt_vram", detail)
+
     outcome = aot_serve.enable(pipe, cfg, cache_dir, artifact, expected=expected)
     _, _peak_after_load = mint_budget.adopt_watermark(_budget_device)
     _load_bytes = max(0, _peak_after_load - _resident_before)

--- a/tests/test_adopt_gate_seam_pgw1169.py
+++ b/tests/test_adopt_gate_seam_pgw1169.py
@@ -1,0 +1,234 @@
+"""pgw#1169 — the adopt headroom gate reaches EVERY arm route, and declining
+serves eager instead of taking the process.
+
+pgw#1164 gated the SELF-MINT adopt only. A BOOT adopt that could not fit the
+cell had no way to decline: it ran the load and died. Because an AOTI load that
+exhausts the card SIGSEGVs rather than raising, nothing downstream can catch it
+— so one bad cell becomes a fleet-wide crash loop, every serving pod on the
+release taking the same death.
+
+This is §4.31 applied where it could not previously reach, not new policy: a
+cell-attributable failure de-arms and serves eager, and an adopt that cannot fit
+is that failure in its worst-behaved form.
+
+THE TWO DIRECTIONS BOTH MATTER, and the second one more than usual: an
+over-refusing adopt gate would silently return the whole fleet to eager serving
+and look like nothing at all — the AOT program's failure mode with the best
+manners. So every "refuses" row here is paired with a "still adopts" row.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import mint_budget
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.models import provision
+
+_GIB = 1 << 30
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    mint_budget._ADOPT_PEAKS.clear()
+    mint_budget._ADOPT_DECLINED.clear()
+    yield
+    mint_budget._ADOPT_PEAKS.clear()
+    mint_budget._ADOPT_DECLINED.clear()
+
+
+_META: Dict[str, Any] = {
+    "family": "sdxl",
+    "weight_lane": "w8a8",
+    "mode": "",
+    "cell_key": "ck1-testtesttest",
+    "entries": {f"unet/e{i}": {"target": "unet"} for i in range(36)},
+}
+
+
+def _device(free_gib: float, allocated_gib: float = 32.0, peak_gib: float = 36.0):
+    allocated = int(allocated_gib * _GIB)
+    peak = int(peak_gib * _GIB)
+    measured = max(0, peak - allocated)
+    return mint_budget._DeviceRead(
+        free_bytes=int(free_gib * _GIB),
+        allocated=allocated,
+        cache_slack=0,
+        measured_activation=measured,
+        activation=max(
+            measured,
+            int(allocated * mint_budget._UNMEASURED_ACTIVATION_FRACTION)),
+    )
+
+
+def _install(monkeypatch, events: List[Tuple[str, str, str]],
+             loads: List[int], *, free_gib: float):
+    from gen_worker import aot_serve
+
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(free_gib))
+    monkeypatch.setattr(mint_budget, "device_of", lambda _p: 0)
+    monkeypatch.setattr(mint_budget, "adopt_watermark", lambda _d: (0, 0))
+
+    def _enable(*_a: Any, **_k: Any):
+        loads.append(1)
+        return AdoptOutcome.hit("armed")
+
+    monkeypatch.setattr(aot_serve, "enable", _enable)
+    monkeypatch.setattr(aot_serve, "armed_metadata", lambda _p: dict(_META))
+    monkeypatch.setattr(aot_serve, "unwrap", lambda _p: None)
+    monkeypatch.setattr(provision, "gate_cell_numerics", lambda *a, **k: True)
+    monkeypatch.setattr(
+        provision.activity_mod, "emit_event",
+        lambda kind, detail, phase="", **_k: events.append((kind, phase, detail)))
+
+
+def _arm(tmp_path: Path, **kw: Any):
+    return provision.arm_aot(
+        object(), type("Cfg", (), {"family": "sdxl"})(), None,
+        tmp_path / "cell.tar.gz", 0, dict(_META), **kw)
+
+
+# --------------------------------------------------------------------------
+# Direction 1 — a pod that CANNOT fit serves eager instead of dying.
+# --------------------------------------------------------------------------
+
+
+def test_a_BOOT_ADOPT_that_cannot_fit_DECLINES_instead_of_loading(
+    monkeypatch, tmp_path,
+) -> None:
+    """THE LOAD-BEARING ROW. `verify_numerics=False` is the boot adopt — the
+    route the whole serving fleet takes. The load must NOT be reached."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=15.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert loads == [], (
+        "aot_serve.enable RAN ANYWAY — on a real pod this is the SIGSEGV the "
+        "gate exists to prevent, and it would repeat on every pod in the fleet")
+    assert not outcome.armed
+    assert outcome.reason == "insufficient_adopt_vram", outcome.reason
+
+
+def test_the_refusal_is_TYPED_and_EMITTED(monkeypatch, tmp_path) -> None:
+    """A fleet-wide fact must be visible, not inferred from an absence of
+    adoptions."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=15.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    _arm(tmp_path, verify_numerics=False)
+
+    rows = [(p, d) for k, p, d in events if k == "cell_adopt_declined"]
+    assert len(rows) == 1, f"expected one typed refusal row, got {events!r}"
+    phase, detail = rows[0]
+    assert phase == "insufficient_adopt_vram"
+    assert "entries=36" in detail, detail
+    assert "serves EAGER" in detail
+
+
+def test_the_refusal_is_STICKY_across_later_arms(monkeypatch, tmp_path) -> None:
+    """§4.31: a pod must not re-run a load it has already decided it cannot
+    survive. The second arm refuses even though the card now looks roomy."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=15.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+    _arm(tmp_path, verify_numerics=False)
+    assert mint_budget.adopt_declined("sdxl", "w8a8")
+
+    # The card frees up — a transient dip in someone else's residency is not
+    # evidence that the doomed load has become survivable.
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(400.0))
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert loads == [], "a sticky refusal was retried — that is the crash loop"
+    assert outcome.reason == "insufficient_adopt_vram"
+
+
+def test_stickiness_is_scoped_to_the_family_and_lane(
+    monkeypatch, tmp_path,
+) -> None:
+    """One family's refusal must not mute another's adopt."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=15.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+    _arm(tmp_path, verify_numerics=False)
+
+    assert mint_budget.adopt_declined("sdxl", "w8a8")
+    assert not mint_budget.adopt_declined("micro-diffusion", "plain")
+    assert not mint_budget.adopt_declined("sdxl", "")
+
+
+# --------------------------------------------------------------------------
+# Direction 2 — THE OVER-REFUSAL FENCE. A gate that never adopts looks like
+# nothing at all, and would return the whole fleet to eager serving silently.
+# --------------------------------------------------------------------------
+
+
+def test_a_pod_that_CAN_fit_STILL_ADOPTS(monkeypatch, tmp_path) -> None:
+    """THE FENCE. If this row ever goes green while the others do too by
+    refusing everything, the AOT program has silently ended."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=64.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert loads == [1], "a card with room did not reach the load"
+    assert outcome.armed, "a card with room did not adopt"
+    assert not [k for k, _p, _d in events if k == "cell_adopt_declined"]
+
+
+def test_an_UNMEASURED_family_on_a_roomy_card_still_adopts(
+    monkeypatch, tmp_path,
+) -> None:
+    """No banked figure and room to spare must NOT refuse — the unmeasured
+    floor is `2 * activation`, never a guess about the entry runners."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=64.0)
+
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert loads == [1] and outcome.armed
+
+
+def test_an_UNPROBEABLE_device_never_blocks_an_adopt(
+    monkeypatch, tmp_path,
+) -> None:
+    """A CPU rig keeps today's behaviour exactly — every budget in this module
+    fits by construction with no CUDA to read."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=1.0)
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: None)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(900.0 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert loads == [1] and outcome.armed
+
+
+def test_the_SELF_MINT_route_is_gated_by_the_same_authority(
+    monkeypatch, tmp_path,
+) -> None:
+    """One authority, many callers. The self-mint route reaches the same
+    decision through the same function, so the two cannot drift."""
+    events: List[Tuple[str, str, str]] = []
+    loads: List[int] = []
+    _install(monkeypatch, events, loads, free_gib=15.0)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", int(21.0 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert loads == []
+    assert outcome.reason == "insufficient_adopt_vram"


### PR DESCRIPTION
pgw#1164 gated the **self-mint** adopt only. A **boot adopt** that could not fit the cell had no way to decline: it ran the load and died. An AOTI load that exhausts the card **SIGSEGVs rather than raising**, so nothing downstream can catch it — which is how *one* bad cell becomes a fleet-wide crash loop, every serving pod on the release taking the same death. We are one successful sdxl mint away from that state.

## Not new policy — §4.31 applied where it could not reach

The serve-first posture already says a cell-attributable failure de-arms the cell and serves eager in-request. An adopt that cannot fit the card is that failure in its worst-behaved form. Declining turns an outage into a **logged degradation**, and `cell_adopt_budget` still records what the attempt would have needed.

## One authority, many callers

`mint_budget.adopt_headroom` is the only place that decides — the `compile_cache.arming_block` pattern. The self-mint call site keeps its own earlier call to the *same* function so it can refuse before it even reads the artifact; the two cannot drift because there is nothing to drift from.

**Sticky**, and deliberately *not* in `arming_block`, which documents that every reason it names *"is deterministic for the life of this process: none of them can differ on a retry."* Free VRAM is not — it moves with what is resident. So the stickiness lives in `mint_budget` next to the bank whose numbers it is made of, and `arming_block`'s invariant stays true.

## RED both ways

An over-refusing adopt gate would silently return the entire fleet to eager serving and look like nothing at all — the AOT program's failure mode with the best manners. So every "refuses" row is paired with a "still adopts" row.

| experiment | result |
|---|---|
| gate removed from the seam (the pgw#1164 world) | 4 rows red |
| stickiness removed | 1 row red |
| **the over-refusal — gate refuses everything** | **3 rows red**, incl. the unprobeable-device row pinning CPU-rig behaviour unchanged |

8 new rows; **118 green** across the adjacent adopt/budget/publish suites.

## Known limit, stated rather than implied

On a **fresh** pod the bank is empty, so the gate has only the unmeasured floor and **will not by itself stop the first wave** of a fleet-wide crash loop. What closes that is the measured `load` term travelling from the pod that took it to the pods that have not — the mint measures it *before* it publishes, so it can ride the publish's control-plane metadata and come back at cell resolve. Filed, not smuggled in here.