### PR TITLE
pgw#1167: the declared latent divisor is RECONCILED against the pipeline, before the export is paid for

### DIFF
--- a/changelog.d/pgw1167.md
+++ b/changelog.d/pgw1167.md
@@ -1,0 +1,37 @@
+- **pgw#1167: the declared latent divisor is RECONCILED against the pipeline, before the export is
+  paid for.** Graph class rows are derived by dividing declared PIXEL shapes by a divisor the
+  author passes to `derive.cfg_image_classes(latent_scale=…)`, and nothing checked it against the
+  checkpoint. A wrong one minted a whole cell of correctly-shaped, permanently unusable artifacts
+  — silent, at full mint price, and the only entry on the accepted-but-wrong census that costs a
+  FULL MINT.
+
+  **Why `mint()` and nowhere earlier.** Not declaration time: `Compile` is built at import, no
+  pipeline exists, and the divisor is a claim about the CHECKPOINT. Not a derivation:
+  §4.27/pgw#1089 requires `ck1` to derive from CODE ALONE before any weight is resident, and the
+  class rows feed the key — reading it off a loaded pipeline would break boot-time adopt. Not
+  `aot_export_spec`: `_load_spec` builds an `ExportSpec` from the operator's mint-request JSON with
+  NO pipeline, so that seam would have exempted the operator route entirely — a false pass BY
+  OMISSION. `mint()` is reached by both routes and is still before the first export.
+
+  **The carrier.** The divisor is passed ONCE, to the deriver. `DerivedClasses` is a tuple subclass
+  that carries it out with the rows it produced; `Compile.__post_init__` transfers it to the
+  cell-level `Compile.latent_basis` BEFORE the row coercion rebuilds `classes` as a plain tuple.
+  Transport, then a home — never a second declaration by the author, and never a cell-wide scalar
+  stamped on every row and read back off `rows[0]`.
+
+  **Fenced against a fleet-wide re-key.** `latent_basis` is PROVENANCE, not a shape-contract axis
+  (the extents it produced are already digested via `classes`), so it is absent from
+  `contract_axes()` and three tests hold it there: the carrier is absent from the digest, the same
+  rows digest identically with and without it, and a DIFFERENT divisor still changes the digest
+  through the rows. One line adding it to `contract_axes()` would silently re-key every cell.
+
+  **UNRECONCILED is a state, not a pass.** diffusers computes `vae_scale_factor` as
+  `2 ** (len(vae.config.block_out_channels) - 1) if vae else 8`, so a pipeline with no vae reports
+  **8** — a default nobody chose, indistinguishable from a real observation of 8. Believing it
+  would reproduce pgw#1058's silent dtype default one field over. Unobservable and undeclared are
+  named apart from reconciled and both are reported. The gate also never KILLS a mint it cannot
+  read (caught by pgw#848's telemetry rows, which hand `mint()` placeholder arguments).
+
+  The refusal blames the COMPOSITION, never the checkpoint: a `component_overrides` vae swap
+  genuinely makes the declared extents wrong for that composition, and a refusal that misattributes
+  sends the next reader to the wrong repo.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1692,6 +1692,91 @@ class MintProgress:
             logger.debug("aot-mint progress callback failed", exc_info=True)
 
 
+#: pgw#1167 verdicts. UNRECONCILED is a FIRST-CLASS state, not a silent pass:
+#: the whole point is that a gate which cannot fire is indistinguishable from
+#: one that passed, so the two are named apart and both are reported.
+LATENT_RECONCILED = "latent_basis_reconciled"
+LATENT_UNRECONCILED_UNDECLARED = "latent_basis_unreconciled_no_declared_basis"
+LATENT_UNRECONCILED_NO_VAE = "latent_basis_unreconciled_no_vae"
+
+
+def observed_latent_basis(pipeline: Any) -> Optional[int]:
+    """The pipeline's REAL latent divisor, or ``None`` when unobservable.
+
+    diffusers computes it as ``2 ** (len(vae.config.block_out_channels) - 1)
+    if vae else 8`` — so a pipeline with NO vae reports **8**, a default nobody
+    chose and indistinguishable from a real observation of 8. Believing the
+    attribute alone would reproduce pgw#1058's silent-dtype-default defect one
+    field over, so the vae is required before the number is believed.
+    """
+    if getattr(pipeline, "vae", None) is None:
+        return None
+    value = getattr(pipeline, "vae_scale_factor", None)
+    try:
+        basis = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return basis if basis > 0 else None
+
+
+def reconcile_latent_basis(pipeline: Any, spec: ExportSpec) -> str:
+    """Refuse a mint whose declared latent divisor is not the pipeline's.
+
+    pgw#1167. The class rows are derived by dividing declared PIXEL shapes by a
+    latent divisor the author passes to ``derive.cfg_image_classes``. Nothing
+    checked that divisor against the checkpoint, so a wrong one produced a
+    whole cell of correctly-shaped, permanently unusable artifacts — silent,
+    and paid for at full mint price.
+
+    It is checked HERE because here is the first place both facts exist and the
+    last place before the export is paid for: ``mint()`` is reached by the
+    production child (``mint_child``) AND the operator CLI, whereas
+    ``aot_export_spec`` is on the pod route only and would have exempted the
+    operator entirely.
+
+    The divisor cannot be VALIDATED at declaration time (no pipeline) nor
+    DERIVED from one (§4.27/pgw#1089 requires ``ck1`` to derive from code alone,
+    before any weight is resident, and the class rows feed the key). So it is
+    declared once, carried, and reconciled — and when either side is missing
+    the verdict is UNRECONCILED, never a pass.
+    """
+    # This gate must never be the thing that kills a mint. Its only two
+    # outcomes are a NAMED refusal for a proven mismatch and an explicit
+    # UNRECONCILED; anything it cannot read is the latter, so a caller with no
+    # spec (the telemetry paths hand `mint` placeholder arguments) degrades
+    # instead of raising an AttributeError from inside a correctness check.
+    family = str(getattr(spec, "family", "") or "")
+    declaration = export_declaration(family) if family else None
+    declared = getattr(declaration, "latent_basis", None) if declaration else None
+    if declared is None:
+        logger.info(
+            "aot-mint: %s — the class rows carry no derived latent basis, so "
+            "the pipeline's divisor is not reconciled against anything",
+            LATENT_UNRECONCILED_UNDECLARED)
+        return LATENT_UNRECONCILED_UNDECLARED
+
+    observed = observed_latent_basis(pipeline)
+    if observed is None:
+        logger.info(
+            "aot-mint: %s — this pipeline exposes no vae, and diffusers' "
+            "`else 8` fallback is a default nobody chose; declared basis %d is "
+            "left unreconciled rather than compared against it",
+            LATENT_UNRECONCILED_NO_VAE, declared)
+        return LATENT_UNRECONCILED_NO_VAE
+
+    if declared != observed:
+        raise MintRefused(
+            f"latent_basis_mismatch: the declaration derived its graph classes "
+            f"at a latent divisor of {declared}, and the composed pipeline's "
+            f"vae divides by {observed}. Every declared latent extent is "
+            f"therefore wrong for THIS composition, and the cell would mint "
+            f"correctly-shaped artifacts that serve nothing. This declaration "
+            f"does not match this composition — check the `latent_scale=` "
+            f"passed to the class deriver, and any component override that "
+            f"swaps the vae for one of a different architecture")
+    return LATENT_RECONCILED
+
+
 def mint(
     pipeline: Any,
     spec: ExportSpec,
@@ -1740,6 +1825,9 @@ def mint(
     # refuse by name here; they can no longer move the (declaration-derived)
     # seal, so this is the only place ambient mutation can surface.
     env_seal.assert_seal_unchanged("aot_mint")
+    # pgw#1167: before ANY export, while a wrong latent divisor still costs
+    # seconds instead of a whole cell of unusable artifacts.
+    reconcile_latent_basis(pipeline, spec)
     progress = MintProgress(
         inductor_configs=inductor_configs, on_progress=on_progress)
     if phase_snapshot is not None:

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -1053,9 +1053,33 @@ class Compile(msgspec.Struct, frozen=True):
     # Deliberately NOT a contract axis (`contract_axes()`): resolving a blocker
     # must not re-key a cell.
     blockers: tuple[MintBlocker, ...] = ()
+    #: pgw#1167: the latent divisor the CLASS ROWS were derived at, carried so
+    #: the mint can reconcile it against the pipeline's real `vae_scale_factor`
+    #: before it spends an export. CELL-LEVEL because that is what it is — one
+    #: divisor per declaration, not a fact about any single row.
+    #:
+    #: NEVER AUTHORED. It is transferred off `derive.cfg_image_classes`'s
+    #: return value in `__post_init__`; an author who writes it by hand is
+    #: declaring the same number twice, which is the duplicate-map defect
+    #: (pgw#1150/#1152) in the surface pgw#1158 fenced. `None` means the class
+    #: rows did not come from a deriver that knows the divisor, and the mint
+    #: reports UNRECONCILED — never a pass.
+    #:
+    #: DELIBERATELY ABSENT FROM :meth:`contract_axes`, and fenced by
+    #: `test_latent_basis_pgw1167`: it is a provenance fact about how the rows
+    #: were COMPUTED, not a shape-contract axis (the latent extents it produced
+    #: are already digested, via `classes`). Adding it there would re-key every
+    #: cell in the fleet.
+    latent_basis: Optional[int] = None
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
+        # BEFORE the row coercion below, which rebuilds `classes` as a PLAIN
+        # tuple and drops any subclass attribute with it. The deriver's return
+        # value is the transport; this field is the home.
+        carried = getattr(self.classes, "latent_basis", None)
+        if carried is not None and self.latent_basis is None:
+            force(self, "latent_basis", int(carried))
         shapes = tuple(tuple(int(v) for v in s) for s in self.shapes)
         if (
             (not shapes and not self.classes)

--- a/src/gen_worker/api/derive.py
+++ b/src/gen_worker/api/derive.py
@@ -64,6 +64,31 @@ __all__ = [
 CFG_BATCH_REGIMES: Tuple[Tuple[bool, int], ...] = ((True, 2), (False, 1))
 
 
+class DerivedClasses(tuple):
+    """The deriver's class rows, carrying the divisor they were derived AT.
+
+    A tuple subclass so every existing call site is unaffected — it IS the
+    tuple they already got, and `Compile(classes=…)` still receives a sequence
+    of :class:`GraphClass`. The extra attribute exists only to survive the trip
+    from the deriver to `Compile.__post_init__`, which transfers it to
+    `Compile.latent_basis` and then rebuilds `classes` as a plain tuple.
+
+    So this is TRANSPORT, not storage: nothing downstream reads it, and it
+    deliberately does not persist on the declaration. The alternative — a
+    cell-wide scalar stamped onto every row and read back off `rows[0]` — is
+    the shape that produced a P0 filed on a false premise, because a label
+    written beside a thing cannot be told from a label describing it, and it
+    silently answers a question nothing asks (what if two rows disagree?).
+    """
+
+    latent_basis: int
+
+    def __new__(cls, rows: Sequence[GraphClass], *, latent_basis: int) -> "DerivedClasses":
+        self = super().__new__(cls, tuple(rows))
+        self.latent_basis = int(latent_basis)
+        return self
+
+
 def cfg_image_classes(
     *,
     shapes: Sequence[Sequence[int]],
@@ -108,7 +133,11 @@ def cfg_image_classes(
                 },
                 fork={cfg_fork: cfg},
             ))
-    return tuple(dict.fromkeys(out))
+    # pgw#1167: the divisor rides out with the rows it produced, so the mint
+    # can reconcile it against the pipeline instead of the author declaring it
+    # a second time.
+    return DerivedClasses(
+        tuple(dict.fromkeys(out)), latent_basis=int(latent_scale))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flavor_deletion_pgw1148.py
+++ b/tests/test_flavor_deletion_pgw1148.py
@@ -160,33 +160,24 @@ def test_the_trt_cell_predicate_still_reads_its_fragment() -> None:
     assert not trt_engine.is_engine_ref("owner/repo")
 
 
-def test_the_compile_cache_modules_are_byte_untouched_by_this_deletion() -> None:
-    """The GPU/compile-cell homonym is NOT this ruling's subject. Asserted as
-    a fact about the diff, not a promise in a comment: every module that owns
-    a cell KEY path must be identical to `origin/master`."""
-    import subprocess
-    from pathlib import Path
-
-    root = Path(__file__).resolve().parents[1]
-    fenced = [
-        "src/gen_worker/compile_cache.py",
-        "src/gen_worker/cell_key.py",
-        "src/gen_worker/aot_mint.py",
-        "src/gen_worker/aot_serve.py",
-        "src/gen_worker/trt_engine.py",
-        "src/gen_worker/fleet_cells.py",
-        "src/gen_worker/local_cells.py",
-        "src/gen_worker/mint_budget.py",
-    ]
-    base = subprocess.run(
-        ["git", "merge-base", "HEAD", "origin/master"],
-        cwd=root, capture_output=True, text=True)
-    if base.returncode != 0:
-        pytest.skip("no origin/master to diff against")
-    changed = subprocess.run(
-        ["git", "diff", "--name-only", base.stdout.strip(), "--", *fenced],
-        cwd=root, capture_output=True, text=True)
-    assert changed.returncode == 0
-    assert changed.stdout.strip() == "", (
-        "pgw#1148 must not touch a compile-cell module; changed: "
-        + changed.stdout)
+# pgw#1167 REMOVED `test_the_compile_cache_modules_are_byte_untouched_by_this_deletion`.
+#
+# It asserted that eight cell-KEY modules (`compile_cache`, `cell_key`,
+# `aot_mint`, `aot_serve`, `trt_engine`, `fleet_cells`, `local_cells`,
+# `mint_budget`) were byte-identical to `origin/master` — by diffing the
+# WORKING TREE against the merge-base. On pgw#1148's own branch that proved
+# something real: THIS deletion did not touch a compile-cell module.
+#
+# Merged, it stops meaning that and becomes a permanent FREEZE: every future
+# branch that edits any of those eight files fails it, for no reason connected
+# to flavors. It is unfalsifiable by the change it was written about (pgw#1148
+# is merged and cannot touch anything again) and false for everyone else — it
+# went red on the very next lane to edit `aot_mint.py`, which was this one.
+#
+# The concern it encoded — "the GPU/compile-cell homonym is NOT this ruling's
+# subject" — is already covered DURABLY and by CONTENT immediately above:
+# `test_the_cell_fragment_still_parses`, `test_parse_cell_ref_is_unchanged`,
+# `test_a_cell_ref_round_trips_through_the_normal_form` and
+# `test_the_trt_cell_predicate_still_reads_its_fragment` all keep working no
+# matter who edits those modules, which is what a fence should do. A diff
+# against master is a fact about a branch, not an invariant of the codebase.

--- a/tests/test_latent_basis_pgw1167.py
+++ b/tests/test_latent_basis_pgw1167.py
@@ -1,0 +1,258 @@
+"""pgw#1167 — the declared latent divisor is reconciled against the pipeline.
+
+The class rows are derived by dividing declared PIXEL shapes by a latent
+divisor the author passes to `derive.cfg_image_classes(latent_scale=…)`.
+Nothing checked that divisor against the checkpoint, so a wrong one produced a
+whole cell of correctly-shaped, permanently unusable artifacts — silent, and
+paid for at full mint price. On the census of accepted-but-wrong declarations
+it was the only entry that costs a FULL MINT.
+
+WHY IT IS CHECKED AT `mint()` AND NOWHERE EARLIER
+
+* Not at declaration time: `Compile` is built at endpoint import, no pipeline
+  exists, and a latent divisor is a claim about the CHECKPOINT.
+* Not as a derivation: §4.27/pgw#1089 requires `ck1` to derive from CODE ALONE,
+  on fake/meta tensors, before any weight is resident, and the class rows feed
+  the key. Reading the divisor off a loaded pipeline would make the key depend
+  on runtime state and break boot-time adopt.
+* Not at `aot_export_spec`: `_load_spec` builds an `ExportSpec` from the
+  operator's mint-request JSON with NO pipeline, so that seam is on the pod
+  route only and would have exempted the operator entirely — a false pass BY
+  OMISSION. `mint()` is reached by both (`mint_child.py:745`,
+  `aot_mint.py` CLI) and is still before the export is paid for.
+
+THE CARRIER
+
+The divisor is passed ONCE, to the deriver. `DerivedClasses` is a tuple
+subclass that carries it out with the rows it produced, and
+`Compile.__post_init__` transfers it to `Compile.latent_basis` BEFORE the row
+coercion rebuilds `classes` as a plain tuple. Transport, then a cell-level
+home — never a second declaration by the author, and never a cell-wide scalar
+stamped on every row and read back off `rows[0]` (the shape that produced a P0
+filed on a false premise, because a label written beside a thing cannot be
+told from one describing it).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gen_worker import aot_mint
+from gen_worker.api import derive
+from gen_worker.api.decorators import Compile
+from gen_worker.api.export_contract import (
+    Dim, Fork, register_export_declaration, reset_export_declarations)
+
+_SHAPES = ((1024, 1024), (1152, 896))
+
+
+def _decl(latent_scale: int = 8, *, derived: bool = True) -> Compile:
+    rows = derive.cfg_image_classes(
+        shapes=_SHAPES, latent_scale=latent_scale, text_len=77)
+    return Compile(
+        family="pgw1167-fam", targets=("transformer",), text_len=77,
+        dims=(Dim("B", carried_by=(("x", 0),)),
+              Dim("H_lat", carried_by=(("x", 2),)),
+              Dim("W_lat", carried_by=(("x", 3),)),
+              Dim("T_txt", carried_by=(("y", 1),))),
+        forks=(Fork("cfg", served=(True, False)),),
+        classes=rows if derived else tuple(rows),
+        shape_strategy="static-rows", warm_changes_key=False)
+
+
+class _Vae:
+    def __init__(self, blocks: int) -> None:
+        self.config = type("Cfg", (), {"block_out_channels": [0] * blocks})()
+
+
+class _Pipe:
+    """A pipeline whose divisor is real, or absent entirely."""
+
+    def __init__(self, basis: int | None) -> None:
+        if basis is None:
+            self.vae = None
+            # diffusers still exposes the attribute, defaulted — the trap.
+            self.vae_scale_factor = 8
+        else:
+            self.vae = _Vae(1)
+            self.vae_scale_factor = basis
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+def _spec() -> Any:
+    return aot_mint.ExportSpec(family="pgw1167-fam", target="")
+
+
+# ---------------------------------------------------------------------------
+# The carrier: declared once, transferred, digest-neutral
+# ---------------------------------------------------------------------------
+
+
+def test_the_divisor_rides_the_rows_and_lands_on_the_DECLARATION() -> None:
+    """The author writes the number once, to the deriver."""
+    rows = derive.cfg_image_classes(shapes=_SHAPES, latent_scale=8, text_len=77)
+    assert rows.latent_basis == 8
+    assert _decl(8).latent_basis == 8
+
+
+def test_the_transport_is_a_drop_in_tuple() -> None:
+    """Every existing call site keeps working — it IS the tuple they got."""
+    rows = derive.cfg_image_classes(shapes=_SHAPES, latent_scale=8, text_len=77)
+    assert isinstance(rows, tuple)
+    assert tuple(rows) == tuple(iter(rows)) and len(rows) == 4
+
+
+def test_classes_are_still_coerced_to_a_PLAIN_tuple() -> None:
+    """The carrier is transport, not storage: nothing downstream reads it off
+    `classes`, and the declaration keeps the exact type it always had."""
+    assert type(_decl(8).classes) is tuple
+
+
+def test_rows_from_a_NON_deriver_leave_the_basis_UNDECLARED() -> None:
+    """`None` is the honest answer for rows nobody derived — it must not
+    default to a number, which is the whole defect one level up."""
+    assert _decl(8, derived=False).latent_basis is None
+
+
+# ---------------------------------------------------------------------------
+# THE FENCE: the carrier must never reach the contract digest
+# ---------------------------------------------------------------------------
+
+
+def test_the_carrier_is_ABSENT_from_the_contract_digest() -> None:
+    """Mechanically fenced, because the failure mode is a fleet-wide re-key
+    nobody notices until every pod re-mints.
+
+    `latent_basis` is PROVENANCE — how the rows were computed — not a
+    shape-contract axis; the latent extents it produced are already digested
+    via `classes`. One line adding it to `contract_axes()` would silently
+    re-key every cell in the fleet.
+    """
+    assert "latent_basis" not in _decl(8).contract_axes()
+
+
+def test_declaring_the_basis_changes_NO_existing_digest() -> None:
+    """The same rows, with and without the carrier, digest identically — so
+    every declaration that adopts the deriver keeps its cells."""
+    assert _decl(8).contract_axes() == _decl(8, derived=False).contract_axes()
+
+
+def test_a_DIFFERENT_basis_still_changes_the_digest_through_the_ROWS() -> None:
+    """The fence must not be read as "the divisor does not matter": a
+    different divisor produces different latent extents, and THOSE are
+    digested. Only the provenance scalar is excluded."""
+    assert _decl(8).contract_axes() != _decl(16).contract_axes()
+
+
+# ---------------------------------------------------------------------------
+# The reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_a_WRONG_divisor_refuses_before_the_export_is_paid_for() -> None:
+    """RED on master: accepted, and the mint proceeded to build a whole cell
+    of correctly-shaped, unusable artifacts."""
+    register_export_declaration(_decl(8))
+    with pytest.raises(aot_mint.MintRefused, match="latent_basis_mismatch"):
+        aot_mint.reconcile_latent_basis(_Pipe(16), _spec())
+
+
+def test_the_refusal_blames_the_COMPOSITION_not_the_checkpoint() -> None:
+    """A `component_overrides` vae swap genuinely makes the declared latent
+    extents wrong for that composition, so refusing is right — but the text
+    must not send the next reader to the checkpoint's repo."""
+    register_export_declaration(_decl(8))
+    with pytest.raises(aot_mint.MintRefused) as err:
+        aot_mint.reconcile_latent_basis(_Pipe(16), _spec())
+    detail = str(err.value)
+    assert "does not match this composition" in detail, detail
+    assert "8" in detail and "16" in detail, detail
+    assert "latent_scale=" in detail, detail
+
+
+def test_a_MATCHING_divisor_reconciles() -> None:
+    register_export_declaration(_decl(8))
+    assert aot_mint.reconcile_latent_basis(_Pipe(8), _spec()) == \
+        aot_mint.LATENT_RECONCILED
+
+
+# ---------------------------------------------------------------------------
+# UNOBSERVABLE is a state, not a pass — the `else 8` trap
+# ---------------------------------------------------------------------------
+
+
+def test_a_pipeline_with_NO_vae_is_UNRECONCILED_not_reconciled() -> None:
+    """diffusers reports `vae_scale_factor == 8` when there is no vae — a
+    default nobody chose, indistinguishable from a real observation of 8.
+    Believing it would reproduce pgw#1058's silent dtype default one field
+    over, so the verdict is named apart from a pass."""
+    register_export_declaration(_decl(8))
+    verdict = aot_mint.reconcile_latent_basis(_Pipe(None), _spec())
+    assert verdict == aot_mint.LATENT_UNRECONCILED_NO_VAE
+    assert verdict != aot_mint.LATENT_RECONCILED
+
+
+def test_the_no_vae_case_does_not_accidentally_MATCH_a_declared_8() -> None:
+    """The sharpest form of the trap: declared 8 against a defaulted 8 would
+    look like a successful reconciliation while proving nothing."""
+    register_export_declaration(_decl(8))
+    assert _Pipe(None).vae_scale_factor == 8      # the default is really there
+    assert aot_mint.observed_latent_basis(_Pipe(None)) is None
+
+
+def test_an_UNDECLARED_basis_is_UNRECONCILED_not_reconciled() -> None:
+    register_export_declaration(_decl(8, derived=False))
+    assert aot_mint.reconcile_latent_basis(_Pipe(8), _spec()) == \
+        aot_mint.LATENT_UNRECONCILED_UNDECLARED
+
+
+# ---------------------------------------------------------------------------
+# Delete-the-call-site: the reconciler must be WIRED, not merely present
+# ---------------------------------------------------------------------------
+
+
+def test_mint_actually_CALLS_the_reconciler() -> None:
+    """A reconciliation that never fires is precisely the defect class this
+    issue removes, so the wiring is asserted rather than assumed: delete the
+    call from `mint()` and this row goes red.
+    """
+    import inspect
+
+    source = inspect.getsource(aot_mint.mint)
+    assert "reconcile_latent_basis(pipeline, spec)" in source, (
+        "mint() no longer calls the reconciler — the gate cannot fire")
+
+
+def test_the_call_precedes_the_first_export() -> None:
+    """Refusing after the export is paid for would keep the correctness and
+    throw away the entire prize, which is that a wrong divisor costs seconds."""
+    import inspect
+
+    source = inspect.getsource(aot_mint.mint)
+    call = source.index("reconcile_latent_basis(pipeline, spec)")
+    progress = source.index("MintProgress(")
+    assert call < progress, "the reconciliation must run before the mint starts"
+
+
+def test_the_gate_never_KILLS_a_mint_it_cannot_read() -> None:
+    """It has exactly two outcomes: a NAMED refusal for a proven mismatch, and
+    an explicit UNRECONCILED. Anything it cannot read is the latter.
+
+    Caught by `test_abandoned_mint_telemetry_pgw848`, which hands `mint()`
+    placeholder arguments because pipeline and spec are irrelevant to the
+    telemetry it measures — the first cut raised `AttributeError` from inside a
+    correctness check and took an unrelated path down with it. A gate that can
+    crash a mint is worse than the silence it replaced.
+    """
+    assert aot_mint.reconcile_latent_basis(None, None) == \
+        aot_mint.LATENT_UNRECONCILED_UNDECLARED
+    assert aot_mint.reconcile_latent_basis(_Pipe(8), None) == \
+        aot_mint.LATENT_UNRECONCILED_UNDECLARED


### PR DESCRIPTION
The only entry on the accepted-but-wrong census that costs a **full mint**: class rows are derived by dividing declared PIXEL shapes by a divisor the author passes to `derive.cfg_image_classes(latent_scale=…)`, and nothing checked it against the checkpoint. A wrong one mints a whole cell of correctly-shaped, permanently unusable artifacts — silently.

> ## ⚠️ Contains an urgent unblock for every lane — please read
>
> This PR removes `test_the_compile_cache_modules_are_byte_untouched_by_this_deletion` (pgw#1148, merged ~an hour ago). **It blocks every branch that edits any of eight cell-key modules** — `compile_cache`, `cell_key`, `aot_mint`, `aot_serve`, `trt_engine`, `fleet_cells`, `local_cells`, `mint_budget`.
>
> It diffs the **working tree** against merge-base. On pgw#1148's own branch that proved something real: *this deletion touched no compile-cell module.* Merged, it stops meaning that and becomes a permanent **freeze** — unfalsifiable by the change it was written about (pgw#1148 can never touch anything again) and false for everyone else. It went red on the very next lane to edit `aot_mint.py`, which was this one.
>
> Its concern is already covered **durably and by content** immediately above it — `test_the_cell_fragment_still_parses`, `test_parse_cell_ref_is_unchanged`, `test_a_cell_ref_round_trips_through_the_normal_form`, `test_the_trt_cell_predicate_still_reads_its_fragment` — all of which keep working no matter who edits those modules. **A diff against master is a fact about a branch, not an invariant of the codebase.**

## Why `mint()` and nowhere earlier

- **Not declaration time** — `Compile` is built at import, no pipeline exists, and the divisor is a claim about the *checkpoint*.
- **Not a derivation** — §4.27/pgw#1089 requires `ck1` to derive from **code alone** before any weight is resident, and the class rows feed the key. Reading it off a loaded pipeline would break boot-time adopt.
- **Not `aot_export_spec`** — `_load_spec` builds an `ExportSpec` from the operator's mint-request JSON with **no pipeline**, so that seam is pod-route-only and would have exempted the operator entirely: a false pass *by omission*. `mint()` is reached by both (`mint_child.py:745` and the CLI) and is still before the first export.

## The carrier

The divisor is passed **once**, to the deriver. `DerivedClasses` is a tuple subclass that carries it out with the rows it produced; `Compile.__post_init__` transfers it to the cell-level `Compile.latent_basis` **before** the row coercion rebuilds `classes` as a plain tuple. Transport, then a home — never a second declaration by the author, and never a cell-wide scalar stamped on every row and read back off `rows[0]`.

## Fenced against a fleet-wide re-key

`latent_basis` is **provenance**, not a shape-contract axis (the extents it produced are already digested via `classes`), so it is absent from `contract_axes()` and three tests hold it there — including one proving a *different* divisor still changes the digest through the rows, so the fence can't be read as "the divisor doesn't matter".

## UNRECONCILED is a state, not a pass

```python
vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1) if vae else 8
```

A pipeline with no vae reports **8** — a default nobody chose, indistinguishable from a real observation of 8. Believing it would reproduce pgw#1058's silent-dtype-default one field over. Unobservable and undeclared are named apart from reconciled, and both are reported.

The gate also **never kills a mint it cannot read** — caught by pgw#848's telemetry rows, which hand `mint()` placeholder arguments; the first cut raised `AttributeError` from inside a correctness check.

The refusal blames the **composition**, never the checkpoint.

## RED / severance

On unmodified master: deriver returns a plain `tuple` carrying nothing, `Compile.latent_basis` does not exist, the reconciler does not exist, `mint()` does not call it.

Severance on the reconciler itself — cutting `reconcile_latent_basis(pipeline, spec)` out of `mint()` turns 2 rows red (it is wired, and wired *before* the export); restoring greens them.

Local: mypy clean (267 files), ruff clean, all 11 fast-gate lints + registry-contract + changelog gates green, **1464 passed** across all 104 affected test files. The 5 remaining failures (`pgw1093` ×3, `pgw1150` ×2) fail identically on unmodified `origin/master` in isolation while master's CI is green — order-dependent, pre-existing, untouched by this change.