### PR TITLE
pgw#1170: the author-CI parity rows were red where they ran, and the one that passed was vacuous

### DIFF
--- a/changelog.d/pgw1170.md
+++ b/changelog.d/pgw1170.md
@@ -1,0 +1,26 @@
+- **pgw#1170: the author-CI parity rows were red where they ran, and the one that passed was
+  passing vacuously.** `test_author_ci_harness_pgw1150`'s `_lint()` imports
+  `inference-endpoints/scripts/lint_author_ci.py` for real and skips when the sibling is not
+  checked out — which CI never has, so **these rows have never run in CI**. On a dev box they run,
+  and two failed.
+
+  The cause was in this repo's own fixture. `_through_the_lint` handed the gate our harness's
+  record (which declares `min_speedup = 1.10`) while leaving the synthetic DECORATOR at the
+  sibling helper's default of `1.2`, so the gate refused **every** record for a reason unrelated
+  to the record: *"the two speed-bar surfaces disagree"*. The decorator is now mirrored FROM the
+  emitted record rather than re-typed, because a literal would be a second copy of the bar and
+  drift the moment either side moved.
+
+  **The third row was worse than the two red ones.**
+  `test_a_failed_record_is_REFUSED_by_the_real_lint` asserts the gate returns 1 — and the broken
+  fixture made it return 1 for everything, so it passed while proving nothing. A new row pins the
+  DISCRIMINATION (proven → 0, failed → 1) so a regression cannot hide behind an assertion that
+  only ever checks the failing direction. It fails on master for the right reason (`assert 1 == 0`
+  on the proven side).
+
+  **Still honest about the gap:** these rows remain invisible to CI, because verifying "the
+  harness emits a record the sibling's gate accepts" needs both halves and only
+  inference-endpoints has them. Vendoring the gate here would be a drifting copy of another repo's
+  lint — the duplicate-map defect these suites exist to prevent — so the durable home for the
+  parity claim is inference-endpoints' own CI, where the gen-worker wheel is installed and the
+  gate is native. Recorded rather than papered over.

--- a/tests/test_author_ci_harness_pgw1150.py
+++ b/tests/test_author_ci_harness_pgw1150.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -445,9 +446,26 @@ def _lint() -> Any:
 
 
 def _through_the_lint(lint: Any, tmp_path: Path, record: Path) -> int:
-    """The emitted record, in the tree shape the real gate reads."""
-    root = lint._tree(tmp_path / "lint", record=record.read_text("utf-8"),
-                      extra=", numerics_floor=0.995")
+    """The emitted record, in the tree shape the real gate reads.
+
+    pgw#1170: the synthetic DECORATOR must carry the same bar as the record
+    this repo's harness emits. `_tree`'s default is the sibling's own fixture
+    value (`min_speedup=1.2`) while our record template declares `1.10`, and
+    leaving them to disagree made the gate refuse EVERY record for a reason
+    that had nothing to do with the record — which is why two of these rows
+    were red and a third was passing vacuously (it asserts a refusal, and the
+    mismatch refused everything).
+    """
+    text = record.read_text("utf-8")
+    # Mirrored FROM the emitted record, never re-typed here: a literal would be
+    # a second copy of the bar and would drift the moment either side moved,
+    # which is the duplicate-map defect these suites exist to prevent. When the
+    # record declares no bar the sibling's own default stands.
+    found = re.search(r"^min_speedup\s*=\s*([0-9.]+)\s*$", text, re.M)
+    bar = (f', speed_metric="stage_ms.denoise", min_speedup={found.group(1)}'
+           if found else lint._tree.__defaults__[0])
+    root = lint._tree(tmp_path / "lint", record=text,
+                      extra=", numerics_floor=0.995", bar=bar)
     return int(lint.check(root, quiet=True))
 
 
@@ -481,6 +499,38 @@ def test_a_failed_record_is_REFUSED_by_the_real_lint(
     _code, report = invoke(record, "Regressed")
     assert report.status == author_ci.STATUS_FAILED
     assert _through_the_lint(lint, tmp_path, record) == 1
+
+
+def test_the_lint_DISCRIMINATES_proven_from_failed(
+        tmp_path, monkeypatch, declared, on_the_line):
+    """pgw#1170: the anti-vacuity row.
+
+    `test_a_failed_record_is_REFUSED_by_the_real_lint` asserts the gate returns
+    1. Before this fix it returned 1 for EVERY record — the synthetic
+    decorator's bar disagreed with the one our own record declares, so the gate
+    refused unconditionally for a reason unrelated to the record. The refusal
+    row therefore passed while proving nothing, and the two acceptance rows
+    were red.
+
+    One record of each status through ONE call each, so a regression that
+    re-breaks the fixture cannot hide behind an assertion that only ever
+    checks the failing direction.
+    """
+    armed_cell(tmp_path, monkeypatch, declared, 1.0, verify_numerics=False)
+    lint = _lint()
+
+    (tmp_path / "ok").mkdir()
+    ok_record = record_file(tmp_path / "ok")
+    _code, report = invoke(ok_record, "Fast")
+    assert report.status == author_ci.STATUS_PROVEN
+
+    (tmp_path / "bad").mkdir()
+    bad_record = record_file(tmp_path / "bad")
+    _code2, report2 = invoke(bad_record, "Regressed")
+    assert report2.status == author_ci.STATUS_FAILED
+
+    assert _through_the_lint(lint, tmp_path / "ok", ok_record) == 0
+    assert _through_the_lint(lint, tmp_path / "bad", bad_record) == 1
 
 
 def test_the_harness_and_the_lint_agree_on_the_status_vocabulary():


### PR DESCRIPTION
`_lint()` imports `inference-endpoints/scripts/lint_author_ci.py` for real and skips when the sibling is not checked out — which CI never has. **These rows have never run in CI.** On a dev box they run, and two failed.

## The cause was our own fixture

`_through_the_lint` handed the gate our harness's record (declaring `min_speedup = 1.10`) while leaving the synthetic **decorator** at the sibling helper's default of `1.2`. So the gate refused *every* record, for a reason with nothing to do with the record:

```
probe: the two speed-bar surfaces disagree — author-ci.toml [speed] says
stage_ms.denoise >= 1.1x, the Compile(...) says stage_ms.denoise >= 1.2x
```

The decorator is now **mirrored from the emitted record** rather than re-typed — a literal here would be a second copy of the bar and would drift the moment either side moved, which is the duplicate-map defect these suites exist to prevent.

## The row that passed was the worst of the three

`test_a_failed_record_is_REFUSED_by_the_real_lint` asserts the gate returns `1`. The broken fixture made it return `1` for **everything**, so it passed while proving nothing — and its presence is what stopped anyone asking why the other two were red.

New row pins the **discrimination** (proven → 0, failed → 1), so a regression cannot hide behind an assertion that only ever checks the failing direction.

## RED, demonstrated rather than asserted

Grafting only the new row onto master's **unfixed** helper:

```
FAILED test_a_proven_record_passes_the_real_lint
FAILED test_a_never_run_record_passes_the_real_lint
FAILED test_the_lint_DISCRIMINATES_proven_from_failed     <- assert 1 == 0, proven side
3 failed, 16 passed
```

`test_a_failed_record_is_REFUSED_by_the_real_lint` passes there — that *is* the vacuity.

(My first RED attempt copied the whole fixed file onto master and showed 19 passing, which proved nothing since the fix lives in that file. Grafting only the new row onto the original helper is the honest form.)

## The CI gap is recorded, not papered over

These rows are still invisible to CI. Verifying "the harness emits a record the sibling's gate accepts" needs **both halves**, and only inference-endpoints has them. Vendoring the gate here would be a drifting copy of another repo's lint — the same defect class. **The durable home for the parity claim is inference-endpoints' own CI**, where the gen-worker wheel is installed and the gate is native.

## Handing over the value question

Not mine to settle, and now separable: `author-ci.toml` at **1.10** vs `Compile(...)` at **1.2** decides which surface is authoritative. Context for whoever takes it — ie#692 mirrored **1.10** from each endpoint's own `author-ci.toml` onto all 16 `Compile` objects, precisely because the hub parses the decorator and none of them declared it. So both surfaces now exist in every family and their agreement is load-bearing. This PR does not touch that; it only stops the *test fixture* from inventing a disagreement.

Local: 19 passed, ruff clean, changelog gate green.