### PR TITLE
pgw#1171 (th#1828): the adopt LOAD travels, so a cold pod can refuse what it cannot survive

### DIFF
--- a/changelog.d/pgw1171.md
+++ b/changelog.d/pgw1171.md
@@ -1,0 +1,8 @@
+- The adopt LOAD cost travels with the cell, so a pod that has never seen it can refuse an adopt it
+  cannot survive. pgw#1169's gate reads a process-local bank and a fresh pod's bank is empty, so on
+  the first wave it had only its unmeasured floor — which omits the loaded-runner term, the term
+  that actually exhausts the card (th#1825). The arm seam banks `load` apart from `load+verify`,
+  publish-intent carries it, tensorhub stores it on `cell_store` and returns it at
+  `/v1/worker/cells/resolve` (th#1828), and a cold pod seeds its budget from that answer before it
+  downloads or arms. A hub that reports nothing seeds nothing: absent is NO EVIDENCE and adopts
+  exactly as it does today.

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -72,7 +72,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from . import (
     activity, aot_identity, artifact_meta, boot_key, cell_resolve,
-    local_cell_store,
+    local_cell_store, mint_budget,
 )
 from .mint_process import CompileCellSpec, MintSlot
 
@@ -524,6 +524,16 @@ def attempt(
             detail=f"the hub holds no entitled cell for {key}",
             derived_key=key, derive_ms=derived.wall_ms,
             family=family, function=fn))
+
+    # pgw#1171/th#1828: LEARN WHAT IT COSTS BEFORE PAYING FOR IT. The hub
+    # carries the load the minting pod measured, so this pod — which has never
+    # seen this cell and whose own banks are empty — can refuse an adopt it
+    # cannot survive instead of SIGSEGVing on it (pgw#1169). Seeded here, ahead
+    # of the download AND the arm, because those are the two things it gates.
+    # A hub that reports nothing seeds nothing: absent is no evidence.
+    mint_budget.note_fleet_adopt_load(
+        family, str(getattr(cell, "lane", "") or ""),
+        int(getattr(cell, "adopt_load_bytes", 0) or 0))
 
     try:
         artifact = cell_resolve.materialize(

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -532,7 +532,7 @@ def attempt(
     # of the download AND the arm, because those are the two things it gates.
     # A hub that reports nothing seeds nothing: absent is no evidence.
     mint_budget.note_fleet_adopt_load(
-        family, str(getattr(cell, "lane", "") or ""),
+        str(getattr(cell, "cell_key", "") or key),
         int(getattr(cell, "adopt_load_bytes", 0) or 0))
 
     try:

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -152,6 +152,12 @@ class ResolvedCell:
     lane: str
     receipt: str
     transport: Transport
+    #: th#1828: the DEVICE cost of loading this cell, measured by the pod that
+    #: minted it (pgw#1168's `load` term — entry runners only, never the §4.32
+    #: verify, which only a minting pod pays). 0 = the hub reported none, which
+    #: is NO EVIDENCE: every cell published before th#1828 is in that case and
+    #: must adopt exactly as it does today.
+    adopt_load_bytes: int = 0
 
     def expected_identity(self) -> aot_identity.ExpectedIdentity:
         """The admission expectation this answer states.
@@ -211,6 +217,8 @@ def _cell_from(body: Mapping[str, Any]) -> ResolvedCell:
         lane=str(body.get("lane") or ""),
         receipt=str(body.get("receipt") or ""),
         transport=_transport_from(body),
+        # Absent stays absent: the hub OMITS this when it holds no measurement.
+        adopt_load_bytes=max(0, int(body.get("adopt_load_bytes") or 0)),
     )
 
 

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -688,7 +688,7 @@ class CellPublisher:
     # -- publish ------------------------------------------------------------
 
     def publish(self, family: str, artifact: Path, meta: dict,
-                mint_duration_ms: int = 0) -> str:
+                mint_duration_ms: int = 0, adopt_load_bytes: int = 0) -> str:
         """Publish one self-minted cell. Returns the checkpoint id.
 
         Steps: attested intent (worker JWT; hub corroborates the axes and
@@ -744,6 +744,12 @@ class CellPublisher:
                 # we ask to publish — so the cost commits in the same INSERT
                 # as the row it describes.
                 "mint_duration_ms": max(0, int(mint_duration_ms or 0)),
+                # th#1828: what loading this cell cost THIS pod's device.
+                # Carried so a pod that has never seen it can refuse an adopt
+                # it cannot survive (pgw#1169) instead of taking the SIGSEGV
+                # that would repeat on every pod of the release. 0 = we never
+                # measured, and the hub renders that as absent, not as zero.
+                "adopt_load_bytes": max(0, int(adopt_load_bytes or 0)),
             },
             timeout=_INTENT_TIMEOUT_S,
         )
@@ -1018,7 +1024,13 @@ def _publish_async(
         t0 = time.monotonic()
         try:
             checkpoint_id = publisher.publish(
-                family, artifact, meta, mint_duration_ms)
+                family, artifact, meta, mint_duration_ms,
+                # pgw#1171/th#1828: what THIS pod measured loading this cell
+                # (pgw#1168's `load` term, banked at the arm seam). The adopt
+                # runs before the publish, so by now the number exists; 0 means
+                # it was never measured and the hub stores no evidence.
+                adopt_load_bytes=mint_budget.adopt_load(
+                    family, str(meta.get("weight_lane") or "")))
         except CellPublishRefused as exc:
             logger.warning("fleet-cells: publish refused (hub decision): %s", exc)
             # pgw#1096/§4.28: the hub has just ASSERTED this hardware's trust

--- a/src/gen_worker/mint_budget.py
+++ b/src/gen_worker/mint_budget.py
@@ -84,6 +84,18 @@ _ENTRY_DEVICE_PEAKS: Dict[Tuple[str, str], int] = {}
 #: the only one of the four that has destroyed a paid mint (th#1825).
 _ADOPT_PEAKS: Dict[Tuple[str, str], int] = {}
 
+#: pgw#1168's LOAD term alone, measured locally: what loading this cell's entry
+#: runners cost, WITHOUT the §4.32 verify. Banked apart from `_ADOPT_PEAKS`
+#: (which is load+verify) because only this half is true for an ADOPTER, and it
+#: is this half that pgw#1171 publishes to the fleet.
+_ADOPT_LOAD: Dict[Tuple[str, str], int] = {}
+
+#: pgw#1171: the load the FLEET measured — carried on the hub's resolve answer
+#: from the pod that actually paid it (th#1828). Kept apart from the local banks
+#: so `MintBudget.measured` can say WHOSE measurement it is, and so a fleet
+#: figure can never be mistaken for something this process observed.
+_FLEET_ADOPT_LOAD: Dict[Tuple[str, str], int] = {}
+
 #: pgw#1169: (family, weight lane) this process has already refused to adopt.
 #: The refusal is STICKY — see :func:`note_adopt_declined`.
 _ADOPT_DECLINED: "set[Tuple[str, str]]" = set()
@@ -279,6 +291,50 @@ def child_peak(family: str, weight_lane: str) -> int:
     return _CHILD_PEAKS.get((str(family or ""), str(weight_lane or "")), 0)
 
 
+def record_adopt_load(family: str, weight_lane: str, load_bytes: int) -> None:
+    """Bank the LOAD half of an adopt this process measured (pgw#1171).
+
+    Monotone, like every other bank here. Separate from
+    :func:`record_adopt_peak` because that one is load+verify — true for the
+    MINTING pod and nobody else — while this is what an ADOPTER pays, and
+    therefore the only half worth telling the fleet about.
+    """
+    if load_bytes <= 0:
+        return
+    key = (str(family or ""), str(weight_lane or ""))
+    _ADOPT_LOAD[key] = max(_ADOPT_LOAD.get(key, 0), int(load_bytes))
+
+
+def adopt_load(family: str, weight_lane: str) -> int:
+    """The locally measured load, or 0. This is what the publish carries."""
+    return _ADOPT_LOAD.get((str(family or ""), str(weight_lane or "")), 0)
+
+
+def note_fleet_adopt_load(family: str, weight_lane: str, load_bytes: int) -> None:
+    """Learn what the FLEET measured this cell's load to be (pgw#1171/th#1828).
+
+    THE POINT: a fresh pod's own banks are empty, so before this the gate had
+    only its unmeasured floor — which omits the loaded-runner term, i.e. the
+    term that actually exhausts the card. One pod paying th#1825's SIGSEGV
+    taught nobody. The hub carries the measurement on its resolve answer now,
+    so a pod that has never seen a cell can still refuse an adopt it cannot
+    survive.
+
+    ``load_bytes <= 0`` is NO EVIDENCE and is ignored outright — every cell
+    published before th#1828 reports nothing, and those must adopt exactly as
+    they do today. Absent is never a pass and never a refusal.
+    """
+    if load_bytes <= 0:
+        return
+    key = (str(family or ""), str(weight_lane or ""))
+    _FLEET_ADOPT_LOAD[key] = max(_FLEET_ADOPT_LOAD.get(key, 0), int(load_bytes))
+
+
+def fleet_adopt_load(family: str, weight_lane: str) -> int:
+    """The fleet-measured load for this (family, lane), or 0 = no evidence."""
+    return _FLEET_ADOPT_LOAD.get((str(family or ""), str(weight_lane or "")), 0)
+
+
 def note_adopt_declined(family: str, weight_lane: str) -> None:
     """Make an adopt refusal STICKY for this process (pgw#1169, §4.31).
 
@@ -368,8 +424,15 @@ def adopt_headroom(
     read = _read_device(device)
     if read is None:
         return _UNPROBEABLE
+    # Strongest evidence wins, and `max` is what makes that safe: the local
+    # bank is load+verify and the fleet figure is load alone, so where both
+    # exist the local one is the larger and the conservative one. pgw#1171: a
+    # FLEET figure is real evidence about this cell — it was measured by a pod
+    # that actually loaded it — and it is the only evidence a FRESH pod has.
     banked = adopt_peak(family, weight_lane)
-    need = banked if banked > 0 else 2 * read.activation
+    fleet = fleet_adopt_load(family, weight_lane)
+    evidence = max(banked, fleet)
+    need = evidence if evidence > 0 else 2 * read.activation
     # pgw#1169: a refusal already taken stands. Re-asking would re-run a load
     # that this process has already decided it cannot survive, and a transient
     # dip in someone else's residency is not evidence that it can.
@@ -377,7 +440,7 @@ def adopt_headroom(
     return MintBudget(
         fits=fits,
         probed=True,
-        measured=banked > 0,
+        measured=evidence > 0,
         free_bytes=read.free_bytes,
         need_bytes=need,
         resident_bytes=read.allocated,
@@ -637,6 +700,7 @@ __all__ = [
     "MintBudget",
     "adopt_declined",
     "adopt_headroom",
+    "adopt_load",
     "adopt_peak",
     "adopt_watermark",
     "child_peak",
@@ -646,7 +710,10 @@ __all__ = [
     "entry_device_peak",
     "entry_peak_rss",
     "probe",
+    "fleet_adopt_load",
     "note_adopt_declined",
+    "note_fleet_adopt_load",
+    "record_adopt_load",
     "record_adopt_peak",
     "record_child_peak",
     "record_entry_device_peak",

--- a/src/gen_worker/mint_budget.py
+++ b/src/gen_worker/mint_budget.py
@@ -94,7 +94,17 @@ _ADOPT_LOAD: Dict[Tuple[str, str], int] = {}
 #: from the pod that actually paid it (th#1828). Kept apart from the local banks
 #: so `MintBudget.measured` can say WHOSE measurement it is, and so a fleet
 #: figure can never be mistaken for something this process observed.
-_FLEET_ADOPT_LOAD: Dict[Tuple[str, str], int] = {}
+#:
+#: KEYED BY `cell_key`, not by (family, lane), and §4.33 is why. A ck1 key names
+#: graph-set x sm x toolchain x env_seal, so a figure under it can only ever
+#: describe the exact artifact it was measured on: a code change re-keys, a new
+#: cell gets a fresh measurement, and a stale number CANNOT outlive the code
+#: that produced it. Keyed by (family, lane) it would be an old measurement
+#: acting as a floor a newer one is not allowed to correct — precisely what
+#: §4.33 forbids, and exactly how the ~32 GiB this ruling retracts would have
+#: gated pods running the fix for it. It also matches the hub's own column,
+#: which is per cell (th#1828).
+_FLEET_ADOPT_LOAD: Dict[str, int] = {}
 
 #: pgw#1169: (family, weight lane) this process has already refused to adopt.
 #: The refusal is STICKY — see :func:`note_adopt_declined`.
@@ -310,7 +320,7 @@ def adopt_load(family: str, weight_lane: str) -> int:
     return _ADOPT_LOAD.get((str(family or ""), str(weight_lane or "")), 0)
 
 
-def note_fleet_adopt_load(family: str, weight_lane: str, load_bytes: int) -> None:
+def note_fleet_adopt_load(cell_key: str, load_bytes: int) -> None:
     """Learn what the FLEET measured this cell's load to be (pgw#1171/th#1828).
 
     THE POINT: a fresh pod's own banks are empty, so before this the gate had
@@ -324,15 +334,15 @@ def note_fleet_adopt_load(family: str, weight_lane: str, load_bytes: int) -> Non
     published before th#1828 reports nothing, and those must adopt exactly as
     they do today. Absent is never a pass and never a refusal.
     """
-    if load_bytes <= 0:
+    key = str(cell_key or "").strip()
+    if load_bytes <= 0 or not key:
         return
-    key = (str(family or ""), str(weight_lane or ""))
     _FLEET_ADOPT_LOAD[key] = max(_FLEET_ADOPT_LOAD.get(key, 0), int(load_bytes))
 
 
-def fleet_adopt_load(family: str, weight_lane: str) -> int:
-    """The fleet-measured load for this (family, lane), or 0 = no evidence."""
-    return _FLEET_ADOPT_LOAD.get((str(family or ""), str(weight_lane or "")), 0)
+def fleet_adopt_load(cell_key: str) -> int:
+    """The fleet-measured load for THIS cell, or 0 = no evidence."""
+    return _FLEET_ADOPT_LOAD.get(str(cell_key or "").strip(), 0)
 
 
 def note_adopt_declined(family: str, weight_lane: str) -> None:
@@ -388,6 +398,7 @@ def adopt_peak(family: str, weight_lane: str) -> int:
 
 def adopt_headroom(
     family: str = "", weight_lane: str = "", device: Optional[int] = None,
+    cell_key: str = "",
 ) -> MintBudget:
     """Can the ADOPT-ARM run here without taking the card down? (pgw#1164)
 
@@ -430,7 +441,7 @@ def adopt_headroom(
     # FLEET figure is real evidence about this cell — it was measured by a pod
     # that actually loaded it — and it is the only evidence a FRESH pod has.
     banked = adopt_peak(family, weight_lane)
-    fleet = fleet_adopt_load(family, weight_lane)
+    fleet = fleet_adopt_load(cell_key)
     evidence = max(banked, fleet)
     need = evidence if evidence > 0 else 2 * read.activation
     # pgw#1169: a refusal already taken stands. Re-asking would re-run a load

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -474,6 +474,9 @@ def arm_aot(
         lane = str((meta or {}).get("weight_lane") or "")
         entries = len((meta or {}).get("entries") or {})
         mint_budget.record_adopt_peak(family, lane, total)
+        # pgw#1171: the LOAD half alone, which is what an ADOPTER pays and
+        # therefore the only half worth telling the fleet about (th#1828).
+        mint_budget.record_adopt_load(family, lane, int(_load_bytes))
         gib = 1 << 30
         activity_mod.emit_event(
             "cell_adopt_budget",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -515,7 +515,10 @@ def arm_aot(
         (meta or {}).get("family") or getattr(cfg, "family", "") or "")
     _budget_lane = str((meta or {}).get("weight_lane") or "")
     _adopt_budget = mint_budget.adopt_headroom(
-        _budget_family, _budget_lane, _budget_device)
+        _budget_family, _budget_lane, _budget_device,
+        # pgw#1171/§4.33: the fleet's figure is looked up by the CELL, so a
+        # measurement can only ever gate the exact artifact it was taken on.
+        cell_key=str((meta or {}).get("cell_key") or ""))
     if not _adopt_budget.fits:
         # STICKY (§4.31): the answer cannot have improved, and re-running a
         # load that killed the last attempt is the behaviour this exists to

--- a/tests/test_adopt_load_fleet_pgw1171.py
+++ b/tests/test_adopt_load_fleet_pgw1171.py
@@ -1,0 +1,208 @@
+"""pgw#1171 / th#1828 — the adopt LOAD travels, so a pod that has never seen a
+cell can still refuse an adopt it cannot survive.
+
+pgw#1169 gates the adopt, but on a PROCESS-LOCAL bank — and a fresh pod's bank
+is empty. So on the first wave the gate had only its unmeasured floor, which
+omits the loaded-runner term: the term that actually exhausts the card
+(th#1825, 1.9 MB free of 47.7 GB, SIGSEGV, $0.81). An AOTI load that exhausts
+the card takes the process rather than raising, so nothing downstream catches
+it and ONE bad cell takes every serving pod on the release.
+
+The loop this closes, end to end:
+
+    arm seam measures `load`  ->  banked locally (pgw#1168/#1171)
+      ->  publish-intent carries it  ->  hub stores it on cell_store (th#1828)
+      ->  resolve answers with it    ->  a COLD pod seeds its budget
+      ->  pgw#1169's gate refuses BEFORE the load
+
+PRODUCER AND CONSUMER ARE PROVEN IN ONE FILE deliberately: a producer with no
+consumer is this program's most common defect, and pgw#1168 existed precisely
+because an emitter had been wired on one of two paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import cell_resolve, mint_budget
+
+_GIB = 1 << 30
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    for d in (mint_budget._ADOPT_PEAKS, mint_budget._ADOPT_LOAD,
+              mint_budget._FLEET_ADOPT_LOAD):
+        d.clear()
+    mint_budget._ADOPT_DECLINED.clear()
+    yield
+    for d in (mint_budget._ADOPT_PEAKS, mint_budget._ADOPT_LOAD,
+              mint_budget._FLEET_ADOPT_LOAD):
+        d.clear()
+    mint_budget._ADOPT_DECLINED.clear()
+
+
+def _device(free_gib: float, allocated_gib: float = 32.0, peak_gib: float = 36.0):
+    allocated = int(allocated_gib * _GIB)
+    peak = int(peak_gib * _GIB)
+    measured = max(0, peak - allocated)
+    return mint_budget._DeviceRead(
+        free_bytes=int(free_gib * _GIB),
+        allocated=allocated,
+        cache_slack=0,
+        measured_activation=measured,
+        activation=max(
+            measured,
+            int(allocated * mint_budget._UNMEASURED_ACTIVATION_FRACTION)),
+    )
+
+
+# --------------------------------------------------------------------------
+# The WIRE: what the hub says becomes what the worker knows.
+# --------------------------------------------------------------------------
+
+
+def _body(**extra: Any) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "found": True, "family": "sdxl", "cell_key": "ck1-x",
+        "cell_ref": "root/family-sdxl#ck1-x", "checkpoint_id": "sha256:cc",
+        "content_digest": "sha256:dd", "artifact_path": "cell.tar.gz",
+        "size_bytes": 4096, "publisher_org": "org", "publisher_tier": "platform",
+        "graph_contract": "gc", "toolchain_digest": "tc", "env_seal_digest": "es",
+        "identity_axes": {"lane": "w8a8"}, "sm": "sm_86", "sku": "a40",
+        "lane": "w8a8", "receipt": "jws",
+        "transport": {"snapshot_digest": "sha256:cc", "files": []},
+    }
+    body.update(extra)
+    return body
+
+
+def test_the_resolve_answer_carries_the_load() -> None:
+    cell = cell_resolve._cell_from(_body(adopt_load_bytes=21 * _GIB))
+    assert cell.adopt_load_bytes == 21 * _GIB
+
+
+def test_an_answer_WITHOUT_the_field_is_no_evidence() -> None:
+    """Every cell published before th#1828 is in this case, and the hub OMITS
+    the key rather than sending 0. It must read as no evidence, not as a
+    measurement of zero."""
+    cell = cell_resolve._cell_from(_body())
+    assert cell.adopt_load_bytes == 0
+
+
+# --------------------------------------------------------------------------
+# The CONSUMER: a fleet measurement gates a pod that measured nothing itself.
+# --------------------------------------------------------------------------
+
+
+def test_a_FLEET_measurement_gates_a_pod_with_an_EMPTY_bank(monkeypatch) -> None:
+    """THE LOAD-BEARING ROW — the whole reason th#1828 exists. Nothing local
+    has ever been measured here; without the fleet figure the budget would fall
+    back to its floor and admit an adopt that kills the process."""
+    # 18 GiB free: the unmeasured floor (2 x 8 GiB activation = 16 GiB) ADMITS,
+    # so the ONLY thing that can refuse below is the fleet figure.
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
+    assert mint_budget.adopt_headroom("sdxl", "w8a8").fits, (
+        "precondition: with no evidence at all this card is admitted")
+
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 21 * _GIB)
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+
+    assert not verdict.fits, (
+        "a fleet-measured 21 GiB load against 18 GiB free must REFUSE — this "
+        "is exactly the th#1825 shape, on a pod that has never seen the cell")
+    assert verdict.measured, "a fleet figure is a measurement, and must say so"
+    assert verdict.need_bytes == 21 * _GIB
+
+
+def test_no_fleet_evidence_leaves_TODAY_S_behaviour_untouched(monkeypatch) -> None:
+    """THE DEGRADATION FENCE. Absent is not a pass and not a refusal — it is
+    the unmeasured floor, exactly as before th#1828."""
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 0)  # the hub said nothing
+
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+
+    assert verdict.fits and not verdict.measured
+    assert verdict.need_bytes == 2 * verdict.activation_bytes
+
+
+def test_a_ZERO_report_records_NOTHING(monkeypatch) -> None:
+    """The guard is at the door, not only downstream. A 0 must not create an
+    entry at all — a stored 0 is a measurement nobody took, and the next reader
+    of this map (there will be one) must not find one."""
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 0)
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", -5)
+    assert ("sdxl", "w8a8") not in mint_budget._FLEET_ADOPT_LOAD, (
+        "a zero/negative report was BANKED — absent must stay absent in the "
+        "store, not merely be filtered by whoever happens to read it next")
+
+
+def test_the_floor_is_what_NO_evidence_falls_back_to(monkeypatch) -> None:
+    """THE DEGRADATION PATH ITSELF. With nothing banked and nothing from the
+    fleet, `need` must be the unmeasured floor — not 0, which would admit
+    everything, and not a refusal."""
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    assert verdict.need_bytes == 2 * verdict.activation_bytes > 0
+    assert verdict.fits and not verdict.measured
+
+
+def test_a_fleet_figure_never_LOWERS_a_local_measurement(monkeypatch) -> None:
+    """THE OVER-TRUST FENCE. The local bank is load+verify and the fleet figure
+    is load alone, so where both exist the local one is larger and must win —
+    a remote number must never talk this pod into an adopt its own hardware
+    already proved it cannot do."""
+    monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(40.0))
+    mint_budget.record_adopt_peak("sdxl", "w8a8", 45 * _GIB)
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 10 * _GIB)
+
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+
+    assert verdict.need_bytes == 45 * _GIB
+    assert not verdict.fits
+
+
+def test_the_fleet_bank_is_monotone_and_scoped() -> None:
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 21 * _GIB)
+    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 3 * _GIB)
+    assert mint_budget.fleet_adopt_load("sdxl", "w8a8") == 21 * _GIB
+    assert mint_budget.fleet_adopt_load("sdxl", "") == 0
+    assert mint_budget.fleet_adopt_load("micro-diffusion", "w8a8") == 0
+
+
+# --------------------------------------------------------------------------
+# The PRODUCER: what the pod measured is what the publish sends.
+# --------------------------------------------------------------------------
+
+
+def test_the_publish_sends_the_locally_measured_LOAD(monkeypatch) -> None:
+    """Producer and consumer in one change: the arm seam banks `load`, and the
+    publish carries THAT — never the load+verify total, which only a minting
+    pod pays and would over-state what an adopter needs."""
+    from gen_worker import fleet_cells
+
+    mint_budget.record_adopt_load("sdxl", "w8a8", 17 * _GIB)
+    mint_budget.record_adopt_peak("sdxl", "w8a8", 23 * _GIB)  # load+verify
+    sent: List[Tuple[Any, ...]] = []
+
+    class _Pub:
+        def publish(self, family, artifact, meta, mint_duration_ms=0,
+                    adopt_load_bytes=0):
+            sent.append((family, adopt_load_bytes))
+            return "ckpt"
+
+    monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
+                        lambda *a, **k: None)
+    import pathlib
+    art = pathlib.Path("/nonexistent/cell.tar.gz")
+    t = fleet_cells._publish_async(
+        _Pub(), "sdxl", art, {"weight_lane": "w8a8"}, cell_key_digest="ck1-x")
+    t.join(timeout=10)
+
+    assert sent == [("sdxl", 17 * _GIB)], (
+        f"the publish must carry the LOAD term (17 GiB), not the load+verify "
+        f"total (23 GiB) and not 0; got {sent!r}")

--- a/tests/test_adopt_load_fleet_pgw1171.py
+++ b/tests/test_adopt_load_fleet_pgw1171.py
@@ -104,11 +104,11 @@ def test_a_FLEET_measurement_gates_a_pod_with_an_EMPTY_bank(monkeypatch) -> None
     # 18 GiB free: the unmeasured floor (2 x 8 GiB activation = 16 GiB) ADMITS,
     # so the ONLY thing that can refuse below is the fleet figure.
     monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
-    assert mint_budget.adopt_headroom("sdxl", "w8a8").fits, (
+    assert mint_budget.adopt_headroom("sdxl", "w8a8", cell_key="ck1-x").fits, (
         "precondition: with no evidence at all this card is admitted")
 
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 21 * _GIB)
-    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    mint_budget.note_fleet_adopt_load("ck1-x", 21 * _GIB)
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8", cell_key="ck1-x")
 
     assert not verdict.fits, (
         "a fleet-measured 21 GiB load against 18 GiB free must REFUSE — this "
@@ -121,9 +121,9 @@ def test_no_fleet_evidence_leaves_TODAY_S_behaviour_untouched(monkeypatch) -> No
     """THE DEGRADATION FENCE. Absent is not a pass and not a refusal — it is
     the unmeasured floor, exactly as before th#1828."""
     monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 0)  # the hub said nothing
+    mint_budget.note_fleet_adopt_load("ck1-x", 0)  # the hub said nothing
 
-    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8", cell_key="ck1-x")
 
     assert verdict.fits and not verdict.measured
     assert verdict.need_bytes == 2 * verdict.activation_bytes
@@ -133,9 +133,9 @@ def test_a_ZERO_report_records_NOTHING(monkeypatch) -> None:
     """The guard is at the door, not only downstream. A 0 must not create an
     entry at all — a stored 0 is a measurement nobody took, and the next reader
     of this map (there will be one) must not find one."""
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 0)
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", -5)
-    assert ("sdxl", "w8a8") not in mint_budget._FLEET_ADOPT_LOAD, (
+    mint_budget.note_fleet_adopt_load("ck1-x", 0)
+    mint_budget.note_fleet_adopt_load("ck1-x", -5)
+    assert "ck1-x" not in mint_budget._FLEET_ADOPT_LOAD, (
         "a zero/negative report was BANKED — absent must stay absent in the "
         "store, not merely be filtered by whoever happens to read it next")
 
@@ -145,7 +145,7 @@ def test_the_floor_is_what_NO_evidence_falls_back_to(monkeypatch) -> None:
     fleet, `need` must be the unmeasured floor — not 0, which would admit
     everything, and not a refusal."""
     monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(18.0))
-    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8", cell_key="ck1-x")
     assert verdict.need_bytes == 2 * verdict.activation_bytes > 0
     assert verdict.fits and not verdict.measured
 
@@ -157,20 +157,23 @@ def test_a_fleet_figure_never_LOWERS_a_local_measurement(monkeypatch) -> None:
     already proved it cannot do."""
     monkeypatch.setattr(mint_budget, "_read_device", lambda _d: _device(40.0))
     mint_budget.record_adopt_peak("sdxl", "w8a8", 45 * _GIB)
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 10 * _GIB)
+    mint_budget.note_fleet_adopt_load("ck1-x", 10 * _GIB)
 
-    verdict = mint_budget.adopt_headroom("sdxl", "w8a8")
+    verdict = mint_budget.adopt_headroom("sdxl", "w8a8", cell_key="ck1-x")
 
     assert verdict.need_bytes == 45 * _GIB
     assert not verdict.fits
 
 
 def test_the_fleet_bank_is_monotone_and_scoped() -> None:
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 21 * _GIB)
-    mint_budget.note_fleet_adopt_load("sdxl", "w8a8", 3 * _GIB)
-    assert mint_budget.fleet_adopt_load("sdxl", "w8a8") == 21 * _GIB
-    assert mint_budget.fleet_adopt_load("sdxl", "") == 0
-    assert mint_budget.fleet_adopt_load("micro-diffusion", "w8a8") == 0
+    mint_budget.note_fleet_adopt_load("ck1-x", 21 * _GIB)
+    mint_budget.note_fleet_adopt_load("ck1-x", 3 * _GIB)
+    assert mint_budget.fleet_adopt_load("ck1-x") == 21 * _GIB
+    assert mint_budget.fleet_adopt_load("ck1-other") == 0, (
+        "§4.33: a figure keyed per CELL cannot gate a different artifact — "
+        "keyed by (family, lane) it would be an old measurement acting as a "
+        "floor a newer one may not correct")
+    assert mint_budget.fleet_adopt_load("") == 0
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -548,7 +548,8 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
 
     class _Refusing:
         def publish(self, family: str, art: Path, meta: dict,
-                    mint_duration_ms: int = 0) -> str:
+                    mint_duration_ms: int = 0,
+                    adopt_load_bytes: int = 0) -> str:
             raise fleet_cells.CellPublishRefused(
                 "publish-intent refused (403): community_tier",
                 status=403, code=local_cell_store.UNTRUSTED_REFUSAL_CODE)
@@ -573,7 +574,8 @@ def test_a_transport_failure_is_not_a_trust_verdict(
 
     class _Broken:
         def publish(self, family: str, art: Path, meta: dict,
-                    mint_duration_ms: int = 0) -> str:
+                    mint_duration_ms: int = 0,
+                    adopt_load_bytes: int = 0) -> str:
             raise RuntimeError("connection reset")
 
     fleet_cells._publish_async(

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -111,7 +111,8 @@ def _mintable(monkeypatch, *, key=FAKE_KEY):
 
 def _publisher(calls):
     class _Pub(fc.CellPublisher):
-        def publish(self, family, artifact, meta, mint_duration_ms=0):
+        def publish(self, family, artifact, meta, mint_duration_ms=0,
+                    adopt_load_bytes=0):
             calls.append((family, Path(artifact), dict(meta), int(mint_duration_ms)))
             return "cp-1"
 
@@ -256,7 +257,8 @@ def test_adopt_publishes_exactly_the_bytes_that_armed(monkeypatch, tmp_path):
     published = threading.Event()
 
     class _Pub(fc.CellPublisher):
-        def publish(self, family, artifact, meta, mint_duration_ms=0):
+        def publish(self, family, artifact, meta, mint_duration_ms=0,
+                    adopt_load_bytes=0):
             calls.append((family, artifact.read_bytes(), dict(meta),
                           int(mint_duration_ms)))
             published.set()
@@ -333,7 +335,8 @@ def test_publish_failure_never_affects_serving(monkeypatch, tmp_path):
     refused = threading.Event()
 
     class _Pub(fc.CellPublisher):
-        def publish(self, family, artifact, meta, mint_duration_ms=0):
+        def publish(self, family, artifact, meta, mint_duration_ms=0,
+                    adopt_load_bytes=0):
             refused.set()
             raise fc.CellPublishRefused("cell_publish_untrusted_tier: community_tier")
 


### PR DESCRIPTION
Worker half of the cross-repo propagation. **Hub half: cozy-creator/tensorhub#1101.**

## Why

pgw#1169 gates the adopt — but on a **process-local bank**, and **a fresh pod's bank is empty**. So on the first wave the gate has only its unmeasured floor, which omits the loaded-runner term: the term that actually exhausts the card (th#1825 — 1.9 MB free of 47.7 GB, SIGSEGV, $0.81).

An AOTI load that exhausts the card **takes the process rather than raising**, so nothing downstream can catch it and **one bad cell takes every serving pod on the release**. That is the difference between a fleet that degrades and a fleet that crash-loops, and we are one successful sdxl mint from finding out which.

## The loop, closed end to end

```
arm seam measures `load`  ->  banked locally, APART from load+verify
  ->  publish-intent carries it  ->  hub stores it on cell_store (th#1828)
  ->  resolve answers with it    ->  a COLD pod seeds its budget
  ->  pgw#1169's gate refuses BEFORE the load
```

**Producer and consumer land together**, because a producer with no consumer is this program's most common defect — pgw#1168 existed for exactly that reason.

`load` is banked apart from `load+verify` deliberately: only the load half is true for an **adopter**, so it is the only half worth telling the fleet. The publish carries `adopt_load`, never `adopt_peak`.

## Absent is no evidence, at both ends

The hub **omits** the field when it holds no measurement; a 0/negative report banks **nothing** (not a stored zero); and with no evidence `need` falls back to the unmeasured floor — exactly today's behaviour. Every cell published before th#1828 is in that case.

**Over-trust fence:** evidence is `max(local, fleet)`. The local bank is load+verify and the fleet figure is load alone, so where both exist the local one is larger and wins — a remote number can never talk a pod into an adopt its own hardware has already proved it cannot do.

## RED before GREEN

| experiment | result |
|---|---|
| consumer ignores the fleet figure | 1 red |
| door guard removed, so a 0 is banked | 1 red |
| no-evidence floor collapsed | 2 red |
| publish sends load+verify total instead of load | 1 red |

**Two defects the tests caught in this change's own work:** the `publish` signature edit silently no-op'd (matched a trailing comma that does not exist), and my first "absent" experiment stayed **green** because the guard I removed was redundant with a downstream check — the test now pins the guard at the door *and* the behaviour downstream.

165 green across the adjacent adopt/budget/publish/resolve suites. Three in-tree `publish` doubles updated to mirror the new contract.