### PR TITLE
pgw#1159: the publish body stops sending the three flavor fields the hub reads none of

### DIFF
--- a/changelog.d/pgw1159.md
+++ b/changelog.d/pgw1159.md
@@ -1,0 +1,31 @@
+- **pgw#1159 (P1 SILENT DROP): the publish body stops sending three fields the
+  hub has read since NEVER.** th#1803 deleted the flavor as an address, but
+  `HubClient.publish_v2` kept minting `flavor`, `flavors`, `default_flavor` and
+  `tags[].default_flavor`. tensorhub decoded all four and read none of them, so
+  a producer that published a flavored variant believed it had named a catalog
+  row that was never written — a 200 that quietly discards data. **Deleted, not
+  aliased**: `publish_v2(flavor=…)` / `(flavors=…)` / `(default_flavor=…)` is a
+  `TypeError` now, not a body key thrown away downstream.
+- **What carries the semantics instead.** `tags[].head` (th#1803) replaces
+  `default_flavor`'s one real job — "this publish owns the bare row" — so
+  `clone.py`'s primary output states `head=True` rather than inferring headship
+  from a flavor token. `artifact_contract` (`ns.name@N`, th#1580/§1.33) is now
+  reachable from `publish_v2` and from `publish_flavors` via the
+  `artifact_contract` attribute: what the bytes ARE, PROVEN hub-side against the
+  safetensors header, where the flavor token was only ever asserted. It rides
+  the typed field alone and is not copied into `metadata`.
+- **`ProducedFlavor.flavors` is deleted; `ProducedFlavor.flavor` narrows to a
+  PRODUCER-LOCAL label.** A multi-artifact job is N publishes joining one tag
+  group, which is what `publish_flavors` already does — a label SET on a single
+  publish named nothing. The remaining `flavor` label classifies the th#697
+  placement stamp and names the publish's activity legs; it does not reach the
+  hub. No producer in `training-endpoints` passed `flavors=`, so its 26
+  `ProducedFlavor` sites are source-compatible with this wheel.
+- **`convert.hub._token` becomes `_dtype_token`** — narrowed to the one field it
+  normalizes that the hub still reads (`gguf:q4_k_m` → `gguf-q4_k_m`).
+  `clone.py`'s `flavor_label` is `dtype_label`, and its per-publish report row
+  states `dtype` + `head` instead of `flavor`.
+- **The hub half is SEQUENCED, not simultaneous** (th#1837): every fleet worker
+  on a wheel predating this one still sends the dead fields, so tensorhub LOGS
+  and ECHOES them (`removed_fields` on the declare response) today and only 400s
+  after the fleet repins onto the wheel carrying this change.

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -54,7 +54,7 @@ from .dtype_pins import (
 from .layout import canonical_model_family_from_variant, infer_model_family_variant_from_hint
 from .registry import repackage_family
 from ..api.slot import OBJECTIVES
-from .hub import _token as flavor_token
+from .hub import _dtype_token
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class OutputSpec:
     @property
     def label(self) -> str:
 
-        return flavor_token(f"{self.dtype}-{self.file_layout}-{self.file_type}")
+        return _dtype_token(f"{self.dtype}-{self.file_layout}-{self.file_type}")
 
 
 @dataclass
@@ -885,7 +885,7 @@ def run_clone(
         publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES or no_repackager
 
         for i, spec in enumerate(specs):
-            flavor_label = spec.dtype
+            dtype_label = spec.dtype
             try:
                 if publish_as_is:
                     source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
@@ -898,7 +898,7 @@ def run_clone(
                         # requested.
                         tree = source.dir
                         attrs = dict(source.attrs)
-                        flavor_label = source_dtype or spec.dtype
+                        dtype_label = source_dtype or spec.dtype
                         # th#1362: this passthrough bypasses build_flavor_tree
                         # entirely (every one of ITS branches de-shards), so
                         # de-shard it here too — the ruling is EXPLICIT that
@@ -955,7 +955,7 @@ def run_clone(
                             objective=objective_fact,
                             distilled=distilled_fact,
                         )
-                        flavor_label = str(attrs.get("dtype") or spec.dtype)
+                        dtype_label = str(attrs.get("dtype") or spec.dtype)
                     else:
                         # Only the source's own flavor is published for
                         # classes this worker cannot cast in-line (quant/gguf
@@ -988,13 +988,10 @@ def run_clone(
                             distilled=distilled_fact,
                         )
                     # dtype="source" resolves to the detected on-disk dtype.
-                    flavor_label = str(attrs.get("dtype") or spec.dtype)
-                # Hub flavor tokens are [a-z0-9][a-z0-9._-]{0,63}: the gguf
-                # dtype-axis label ("gguf:q4_k_m") publishes as "gguf-q4_k_m"
-                # (the th#611 flavor convention).
-                from .hub import _token as flavor_token
-
-                flavor_label = flavor_token(flavor_label)
+                    dtype_label = str(attrs.get("dtype") or spec.dtype)
+                # The gguf dtype-axis label ("gguf:q4_k_m") publishes as
+                # "gguf-q4_k_m"; the hub's dtype column takes the dash form.
+                dtype_label = _dtype_token(dtype_label)
             except InlineConversionNotPossible as exc:
                 entry: dict[str, Any] = {
                     "spec_label": spec.label, "dtype": spec.dtype,
@@ -1018,7 +1015,7 @@ def run_clone(
             # gw#522: EVERY publish path emits canonical filenames — this
             # seam also covers the publish-as-is lane build_flavor_tree
             # never touches. Idempotent on already-normalized trees.
-            if spec.file_type != "gguf" and flavor_label in _CAST_NORMALIZE_DTYPES:
+            if spec.file_type != "gguf" and dtype_label in _CAST_NORMALIZE_DTYPES:
                 _normalize_variant_filenames(Path(tree))
 
             files = files_from_tree(tree)
@@ -1088,12 +1085,11 @@ def run_clone(
                 files=files,
                 tags=tags,
                 mode=mode if i == 0 else "merge",
-                flavor=flavor_label,
-                # gw#419: the PRIMARY output also owns the bare selector row —
-                # tensorhub (th#597 C1) never moves flavor='' for an
-                # explicit-flavor publish unless default_flavor names it, and
-                # every serve/convert flow references mirrors bare (repo:tag).
-                default_flavor=flavor_label if i == 0 else "",
+                # gw#419, re-keyed by pgw#1159: the PRIMARY output owns the
+                # bare row. th#1803 replaced `default_flavor` with `head` —
+                # a variant publish joins the tag group, and the head is
+                # stated, not inferred from a flavor token.
+                head=(i == 0),
                 dtype=str(attrs.get("dtype") or spec.dtype),
                 file_layout=str(attrs.get("file_layout") or spec.file_layout),
                 file_type=str(attrs.get("file_type") or spec.file_type),
@@ -1124,7 +1120,10 @@ def run_clone(
                 },
             )
             result.published.append({
-                "flavor": flavor_label,
+                # pgw#1159: the report states the DTYPE it published, not a
+                # flavor token — the token names nothing catalog-side.
+                "dtype": dtype_label,
+                "head": i == 0,
                 "spec_label": spec.label,
                 "revision_id": commit.revision_id,
                 "checkpoint_id": commit.checkpoint_id,

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -2,13 +2,15 @@
 
   POST /api/v1/repos/{org}/{name}/publishes
       {files: [{path, size_bytes, digest:"sha256:<hex>", chunks?}], mode,
-       tags, flavor/dtype/file_layout/file_type, metadata, provenance, ...}
+       tags: [{tag, head?}], dtype/file_layout/file_type, artifact_contract,
+       metadata, provenance, ...}
   → {publish_id, have: [...], need: [{digest, put_url, headers, ...}]}
 
 Then PUT every `need` grant VERBATIM (the sha256 is signed into the presigned
 URL, so the store itself refuses bytes that do not hash to the key), re-plan
-`.../grants` to resume, and POST `.../complete`. One publish == one checkpoint
-== one flavor.
+`.../grants` to resume, and POST `.../complete`. One publish == one
+checkpoint; N artifacts are N publishes joining one tag group, and exactly
+one of them is `head=True`.
 
 THE v1 (blake3) `/commits` PROTOCOL IS GONE FROM THIS CLIENT (pgw#807). It was
 frozen hub-side (th#1303 phase 3.5 — every new v1 commit answers 410
@@ -87,16 +89,14 @@ _COMPLETE_TIMEOUT_S = 600.0
 # way twice. Waiting stays observable: the loop beats liveness every pass.
 _COMPLETE_SILENCE_WINDOW_S = 6.0 * _COMPLETE_TIMEOUT_S
 
-def _token(v: str) -> str:
-    """Publish-body token hygiene (gw#488): the internal dtype-axis colon
+def _dtype_token(v: str) -> str:
+    """Publish-body dtype hygiene (gw#488): the internal dtype-axis colon
     forms (``gguf:q4_k_m``, ``int8:awq``) publish as ``-`` forms.
 
-    Moved here from ``models.refs`` by pgw#1148: the ref grammar no longer
-    has a flavor axis, so this is publish-body hygiene and nothing else. The
-    ``flavor``/``flavors``/``default_flavor`` publish fields it normalizes
-    are themselves DEAD hub-side (th#1803 decodes them and reads none) —
-    re-keying this surface onto ``tags[].head`` + ``artifact_contract`` is
-    the conversion-surface residual filed on pgw#1148.
+    pgw#1159 narrowed this to `dtype`, the one field it normalizes that the
+    hub still reads. `flavor`/`flavors`/`default_flavor` are GONE from the
+    publish body — th#1803 deleted the flavor as an address, and this surface
+    kept sending fields the hub decoded and never read.
     """
     return str(v or "").replace(":", "-")
 
@@ -440,9 +440,15 @@ class HubClient:
         # what it is for: assembling ONE checkpoint across several commits
         # (clone.py's chunked full-clone, _stream.py's streamed output).
         mode: str = "replace",
-        flavor: str = "",
-        flavors: list[str] | None = None,
-        default_flavor: str = "",
+        # th#1803/pgw#1159: HEAD, not `default_flavor`. A variant publish
+        # (one carrying quant provenance) JOINS the tag group without moving
+        # the tag; `head=True` says this publish owns the bare row.
+        head: bool = False,
+        # th#1580: `ns.name@N` — what the bytes ARE. PROVEN at tier 1 against
+        # the safetensors header, so an unprovable claim refuses the publish
+        # instead of being stored as a maybe. This replaces the `flavor`
+        # token, which stated the same thing and was never read.
+        artifact_contract: str = "",
         dtype: str = "",
         file_layout: str = "",
         file_type: str = "",
@@ -548,20 +554,16 @@ class HubClient:
         # the wire (the classification gate refuses an OMITTED tags field on
         # repos that carry tag rows); only None omits the field.
         if tags is not None:
-            df = _token(default_flavor)
             body["tags"] = [
-                {"tag": t, **({"default_flavor": df} if df else {})} for t in tags
+                {"tag": t, **({"head": True} if head else {})} for t in tags
             ]
         for key, val in (
-            ("flavor", _token(flavor)), ("default_flavor", _token(default_flavor)),
-            ("dtype", _token(dtype)), ("file_layout", file_layout),
+            ("dtype", _dtype_token(dtype)), ("file_layout", file_layout),
             ("file_type", file_type), ("display_label", display_label),
-            ("objective", objective),
+            ("objective", objective), ("artifact_contract", artifact_contract),
         ):
             if val:
                 body[key] = val
-        if flavors:
-            body["flavors"] = [_token(f) for f in flavors]
         if distilled is not None:
             body["distilled"] = bool(distilled)
         if required_paths:

--- a/src/gen_worker/convert/produced.py
+++ b/src/gen_worker/convert/produced.py
@@ -48,19 +48,24 @@ class ProducedFlavor(msgspec.Struct):
         what belongs here vs what belongs in the orchestrator job record.
       - extra_files: rare escape hatch — sibling artifacts attached to the
         same flavor (e.g. a tokenizer.json next to a non-tree output).
-      - flavor: optional owner-facing row label such as ``bf16``, ``fp8``,
-        or ``int4``. When empty, the library falls back to attributes such
-        as ``flavor``.
-      - flavors: optional full flavor-label set such as
-        ``["fp8", "aio"]``. ``flavor`` is kept as the primary
-        compatibility label and is included automatically when present.
+      - flavor: optional PRODUCER-LOCAL label such as ``bf16``, ``fp8`` or
+        ``int4``. pgw#1159: it is NOT published and it names no catalog row —
+        th#1803 deleted the flavor as an address. It classifies the placement
+        stamp (th#697) and names the publish's activity legs; when empty the
+        ``dtype`` attribute is used. What the bytes ARE is stated by the
+        ``dtype`` attribute and, when the producer knows it, an
+        ``artifact_contract`` attribute (``ns.name@N``, PROVEN hub-side
+        against the safetensors header — th#1580/§1.33).
+
+    A job that emits several artifacts hands over several ``ProducedFlavor``
+    entries: N publishes joining ONE tag group. There is no flavor-label set
+    on a single publish (``flavors`` was deleted with the wire field).
     """
 
     path: _PathField
     attributes: dict = msgspec.field(default_factory=dict)
     extra_files: list[_PathField] = msgspec.field(default_factory=list)
     flavor: str = ""
-    flavors: list[str] = msgspec.field(default_factory=list)
 
 
 __all__ = ["ProducedFlavor"]

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -203,7 +203,11 @@ def publish_flavors(
         # per-component precision is published either way.
         produced_dtypes = verify_produced_tree(Path(flavor.path))
         attrs = {str(k): str(v) for k, v in (flavor.attributes or {}).items()}
-        label = str(flavor.flavor or attrs.get("flavor") or attrs.get("dtype") or "").strip()
+        # pgw#1159: a PRODUCER-LOCAL label. It classifies the placement stamp
+        # and names the activity leg; it is NOT sent to the hub and does not
+        # name a catalog row — `dtype` + `artifact_contract` state what the
+        # bytes are (th#1803 §1.32(d)).
+        label = str(flavor.flavor or attrs.get("dtype") or "").strip()
         # th#606: worker-addable provenance stamp fields. Producers declare
         # quant identity in the flavor attribute bag; it rides the commit's
         # `provenance` object onto the checkpoint's node stamp (parents /
@@ -217,6 +221,9 @@ def publish_flavors(
         meta = {**(dict(metadata) if metadata else {}), **attrs}
         for k in _PLACEMENT_ATTR_KEYS:
             meta.pop(k, None)
+        # It rides its own typed field (and is PROVEN there); a metadata copy
+        # would be an unproven second statement of the same thing.
+        meta.pop("artifact_contract", None)
         if placement:
             meta["placement"] = placement
         if produced_dtypes:
@@ -249,8 +256,9 @@ def publish_flavors(
             # lost here.)
             on_stage=functools.partial(_publish_leg, dest, label),
             journal_path=journal_path or _journal_beside(flavor),
-            flavor=label,
-            flavors=list(flavor.flavors or []),
+            # th#1580: when the producer declares one, the hub PROVES it
+            # against the header before recording it.
+            artifact_contract=attrs.get("artifact_contract", ""),
             dtype=attrs.get("dtype", ""),
             file_layout=attrs.get("file_layout", ""),
             file_type=attrs.get("file_type", ""),

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -774,7 +774,10 @@ class CellPublisher:
                 destination_repo=repo,
                 files=[CommitFile(path=artifact.name, local_path=artifact)],
                 mode="replace",
-                flavor=key,
+                # pgw#1159: the cell key is NOT a publish-body field. It is
+                # the capability token's cell claim (th#1340) — the hub
+                # derives the cell identity there and refuses a body that
+                # states one.
                 # th#1645: CONTROL only. The bulk envelope is in the artifact.
                 metadata=control_plane_metadata(meta),
                 on_stage=lambda stage, facts: _publish_leg(

--- a/tests/convert/test_p8_convert_publish_contract.py
+++ b/tests/convert/test_p8_convert_publish_contract.py
@@ -100,7 +100,7 @@ def test_explicit_dtype_mismatch_casts_not_silent_passthrough(
     )
 
     assert not result.failed_flavors, result.failed_flavors
-    assert result.published[0]["flavor"] == "bf16"
+    assert result.published[0]["dtype"] == "bf16"
     assert len(calls) == 1 and calls[0]["dtype"] == "bf16"  # a real cast ran
 
 
@@ -120,7 +120,7 @@ def test_matching_dtype_is_genuinely_zero_work(
         outputs=[{"dtype": "fp32", "file_layout": "diffusers", "file_type": "safetensors"}],
     )
     assert not result.failed_flavors
-    assert result.published[0]["flavor"] == "fp32"
+    assert result.published[0]["dtype"] == "fp32"
     assert calls == []
 
 

--- a/tests/convert/test_producer_flip_th1303.py
+++ b/tests/convert/test_producer_flip_th1303.py
@@ -124,7 +124,9 @@ def test_flavor_identity_and_provenance_survive_the_flip(
     _publish(ctx, _tree(tmp_path))
 
     req = _FakeHub.state["publish_request"]
-    assert req["flavor"] == "fp8-w8a8"
+    # pgw#1159: `flavor` is GONE from the body; `dtype` is the axis the hub
+    # actually records.
+    assert "flavor" not in req
     assert req["dtype"] == "fp8"
     assert req["mode"] == "replace"          # th#597 C2 default, unchanged
     assert req["tags"] == [{"tag": "prod"}]

--- a/tests/convert/test_publish_flavor_fields_pgw1159.py
+++ b/tests/convert/test_publish_flavor_fields_pgw1159.py
@@ -1,0 +1,145 @@
+"""pgw#1159: the publish body stops carrying fields th#1803 deleted.
+
+`flavor` / `flavors` / `default_flavor` were decoded hub-side and read by
+NOTHING after th#1803 (§1.32(d) deleted the flavor as an address). A producer
+that sent them believed it had named a catalog row it had not — a silent drop.
+
+What replaces them: `tags[].head` (this publish owns the bare row) and
+`artifact_contract` (what the bytes ARE, PROVEN against the header).
+
+Revert-turns-red: put `flavor=`/`default_flavor=` back into
+`HubClient.publish_v2`'s body and every assertion here fails on the field it
+names.
+
+    pytest tests/convert/test_publish_flavor_fields_pgw1159.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import msgspec
+import pytest
+
+from gen_worker.convert.produced import ProducedFlavor
+from gen_worker.convert.publish import publish_flavors
+
+from fake_hub import _FakeHub
+
+_DEAD_FIELDS = ("flavor", "flavors", "default_flavor")
+
+
+class _Ctx:
+    def __init__(self, base_url: str) -> None:
+        self._file_api_base_url = base_url
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+
+    def log(self, message: str, **fields: Any) -> None:
+        pass
+
+
+def _tree(tmp_path: Path) -> Path:
+    out = tmp_path / "w8a8"
+    out.mkdir()
+    (out / "diffusion.safetensors").write_bytes(b"\x11" * 4096)
+    (out / "config.json").write_text('{"architectures": ["Fake"]}')
+    return out
+
+
+def _publish(ctx: _Ctx, tree: Path, **attrs: str) -> Any:
+    return publish_flavors(
+        ctx,
+        [ProducedFlavor(
+            path=str(tree), flavor="fp8-w8a8",
+            attributes={"dtype": "fp8", "quantization_method": "w8a8", **attrs},
+        )],
+        destination_repo="acme/quant",
+        tags=["prod"],
+    )
+
+
+def test_no_dead_flavor_field_reaches_the_publish_body(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """The whole point: not one of the three names is on the wire, at the top
+    level OR inside a tag binding."""
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    _publish(ctx, _tree(tmp_path))
+
+    req = _FakeHub.state["publish_request"]
+    for field in _DEAD_FIELDS:
+        assert field not in req, f"{field} is dead hub-side (th#1803)"
+    for binding in req["tags"]:
+        assert "default_flavor" not in binding
+    # Not smuggled through the metadata bag either — the producer's local
+    # label is not a catalog statement under any key.
+    assert "flavor" not in (req.get("metadata") or {})
+
+
+def test_the_producer_label_still_classifies_placement(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """`ProducedFlavor.flavor` survives as a PRODUCER-LOCAL label: it stamps
+    placement (th#697). Deleting it silently would drop the stamp."""
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    _publish(ctx, _tree(tmp_path))
+
+    meta = _FakeHub.state["publish_request"]["metadata"]
+    assert meta["placement"]["precision_class"] == "fp8"
+
+
+def test_artifact_contract_rides_its_own_proven_field(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """th#1580/§1.33: the statement of what the bytes ARE. It goes to the
+    typed field the hub PROVES, and is not duplicated into metadata."""
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    _publish(ctx, _tree(tmp_path), artifact_contract="cozy.w8a8@2")
+
+    req = _FakeHub.state["publish_request"]
+    assert req["artifact_contract"] == "cozy.w8a8@2"
+    assert "artifact_contract" not in req["metadata"]
+
+
+def test_head_replaces_default_flavor_on_the_tag_binding(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """`default_flavor`'s only real job was "this publish owns the bare row".
+    That is `tags[].head` now — stated, not inferred from a token."""
+    from gen_worker.convert.hub import CommitFile, HubClient
+
+    tree = _tree(tmp_path)
+    client = HubClient(
+        base_url=f"http://127.0.0.1:{fake_hub.server_port}", token="cap-token")
+    files = [CommitFile(path="config.json", local_path=tree / "config.json")]
+
+    client.publish_v2(destination_repo="acme/quant", files=files,
+                      tags=["latest"], head=True)
+    assert _FakeHub.state["publish_request"]["tags"] == [
+        {"tag": "latest", "head": True}]
+
+    client.publish_v2(destination_repo="acme/quant", files=files,
+                      tags=["latest"])
+    assert _FakeHub.state["publish_request"]["tags"] == [{"tag": "latest"}]
+
+
+def test_publish_v2_refuses_the_deleted_keyword_arguments() -> None:
+    """A caller still writing `flavor=`/`default_flavor=` gets a TypeError,
+    not a body field the hub throws away."""
+    from gen_worker.convert.hub import HubClient
+
+    client = HubClient(base_url="http://127.0.0.1:1", token="t")
+    for kw in _DEAD_FIELDS:
+        with pytest.raises(TypeError):
+            client.publish_v2(destination_repo="a/b", files=[], **{kw: "fp8"})
+
+
+def test_produced_flavor_has_no_flavor_label_set() -> None:
+    """N artifacts are N publishes joining one tag group; a single publish
+    never carried a label SET the hub could record."""
+    with pytest.raises(TypeError):
+        ProducedFlavor(path="/tmp/x", flavors=["fp8", "aio"])  # type: ignore[call-arg]
+    names = {f.name for f in msgspec.structs.fields(ProducedFlavor)}
+    assert "flavors" not in names and "flavor" in names

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -302,7 +302,9 @@ def test_publish_takes_the_v2_route_and_never_the_frozen_v1_one(
     # Genuinely chunked, and the chunk digests are what was PUT.
     assert len(f["chunks"]) > 1
     assert sorted(hub.httpd.puts) == sorted(c["digest"] for c in f["chunks"])
-    assert decl["mode"] == "replace" and decl["flavor"] == CELL_KEY
+    assert decl["mode"] == "replace"
+    # pgw#1159: the cell key is the token's claim, never a body field.
+    assert "flavor" not in decl
     assert "tags" not in decl and "default_flavor" not in decl
     # th#1340: the cell identity is hub-derived and rides the token.
     for forbidden in ("cell_publish", "cell_key", "family",

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -478,7 +478,7 @@ def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     assert kind == "publish_v2", "the cell publisher ships over chunked sha256"
     assert kw["destination_repo"] == "root/family-fam"
     assert kw["mode"] == "replace"
-    assert kw["flavor"] == key
+    assert "flavor" not in kw  # pgw#1159: dead hub-side, so it is not sent
     assert "tags" not in kw  # a cell publish never binds tags
     # th#1340 refuses a body that names the cell identity: it is hub-derived
     # and rides the capability token.


### PR DESCRIPTION
**P1 SILENT DROP** (the th#1812 defect class: a 200 that quietly discards data).

th#1803 deleted the flavor as an ADDRESS. `HubClient.publish_v2` kept minting `flavor`, `flavors`, `default_flavor` and `tags[].default_flavor` anyway — tensorhub decodes all four and reads **none** of them. A producer that published a flavored variant believed it had named a catalog row the catalog never wrote.

**Deleted, not aliased.** Those keyword arguments are a `TypeError` now, not a body key thrown away two hops downstream.

### What carries the semantics instead
- `tags[].head` (th#1803) replaces `default_flavor`'s one real job — *"this publish owns the bare row"*. `clone.py`'s primary output now STATES `head=True` rather than inferring headship from a token; the hub already reads `binding.Head || !variantOnly`.
- `artifact_contract` (`ns.name@N`, th#1580/§1.33) is now reachable from `publish_v2`, and from `publish_flavors` via an `artifact_contract` attribute — what the bytes ARE, **PROVEN** hub-side against the safetensors header where the flavor token was only asserted. It rides the typed field alone (popped from `metadata`, so there is no unproven second statement).

### Surface changes
- `ProducedFlavor.flavors` deleted — a label SET on ONE publish named nothing; N artifacts are N publishes joining one tag group, which `publish_flavors` already does.
- `ProducedFlavor.flavor` narrows to a PRODUCER-LOCAL label: it classifies the th#697 placement stamp and names the publish's activity legs, and is not sent.
- `convert.hub._token` → `_dtype_token`, scoped to the one field it normalizes that the hub still reads (`gguf:q4_k_m` → `gguf-q4_k_m`). `clone.py`'s `flavor_label` → `dtype_label`; its report row states `dtype` + `head`.

### RED evidence
`tests/convert/test_publish_flavor_fields_pgw1159.py` on `origin/master` (detached worktree, same venv): **5 failed, 1 passed** — the body carried `flavor`/`default_flavor`, `head` never reached a tag binding, `artifact_contract` was unsendable, and both deleted names were accepted. On this branch: 6 passed. `tests/convert` 107 passed / 2 skipped; fleet-cell + pgw#1148 suites 47 passed; mypy + ruff clean.

### Sequencing — deployment order hazard, handled
Every fleet worker on `0.112.0` still SENDS these fields, so a hub 400 today breaks live publishes. tensorhub's half (**th#1837**) LOGS and ECHOES them (`removed_fields` on the declare response) now, and flips to a typed 400 only after the fleet repins onto the wheel carrying this commit. Two-step recorded on pgw#1159 and th#1837 with the trigger named.

### Wheel
No solo cut — ledger entry added to pgw#1140 (breaking SDK-API change; rides the next batched number). `training-endpoints` needs **no** PR: nothing there passes `flavors=`, and its 26 `ProducedFlavor` sites stay source-compatible.

Closes pgw#1159.