### PR TITLE
pgw#1183 (th#1834 Phase 3, §1.5): invert durability — pack → local CAS → verify → arm → publish

### DIFF
--- a/changelog.d/pgw1183.md
+++ b/changelog.d/pgw1183.md
@@ -1,0 +1,34 @@
+- **pgw#1183 (th#1834 Phase 3, §4.33 step 3 / greenfield §1.5): durability was INVERTED, and that is
+  why a completed 1 h 37 m mint was destroyed.** The ordering is now the one §1.5 calls
+  non-negotiable — **pack → local CAS → verify → arm → publish** — and every part of it was
+  backwards.
+
+  **The inversion.** `local_cell_store.store` was gated on `local_keep_reason`, a fact about the
+  SINK: it wrote a durable copy exactly when the machine had nowhere to ship. So the pods that mint
+  for the fleet — the only ones that ever do — kept **nothing**, and the artifact's sole copy lived
+  under a `tempfile` mint root owned by the process most likely to die. `adopt_delegated_mint` now
+  writes the packed artifact to the local CAS **before it arms**, on every tier, unconditionally.
+
+  **The destroyer.** `_publish_async` ran `shutil.rmtree(artifact.parent)` in a `finally`, so one
+  `connection reset` deleted a completed mint. It is gone: the publish is a transfer FROM the store,
+  it removes nothing, and the mint root is scratch by the time any terminus cleans it.
+
+  **The daemon thread.** `daemon=True`, with its own event text conceding the consequence — *"this
+  pod must survive the upload or the cell is lost"*. Now `daemon=False` (each call is bounded by the
+  transport's own request timeouts), and the pod no longer has to survive anything: the upload
+  obligation is recorded beside the bytes (`SINK_OWED`) and `resume_pending_publishes`, wired at the
+  HelloAck moment that builds the sink, re-attempts every owed transfer **across boots**.
+
+  **Two facts joined the store record.** `verdict` (`unverified` → `admitted` | `quarantined`) —
+  durability precedes proof, so only an ADMITTED cell may be armed by a later boot, and a cell that
+  fails its parity/arm gate is **quarantined for forensics** instead of deleted by the code
+  reporting the refusal (§1.3.4; the store's own header prices that loss at *"a full GPU pod run.
+  Twice."*). `sink` (`none` | `owed` | `delivered` | `refused`) — the upload obligation. The store's
+  trust-boundary fence (no upload machinery, enforced by ABSENCE) is untouched and named the
+  vocabulary: the store records an obligation, it does not know how one is discharged.
+
+  `local_keep_reason` is deleted; `no_publish_sink_reason` survives with a strictly smaller job —
+  whether an upload is OWED, never whether bytes are KEPT. A failed local-CAS write is now
+  wire-visible (`local_cell_store_failed`), because it is the one thing §1.5 cannot absorb silently.
+
+  **RED**, ten rows grafted onto unmodified `origin/master` @ `6af16cb8`, ten failures.

--- a/scripts/arm_state_feeders_allowlist.txt
+++ b/scripts/arm_state_feeders_allowlist.txt
@@ -45,8 +45,7 @@ src/gen_worker/fleet_cells.py::arm_from_local_store::local_cell_store.note_memo 
 # ---------------------------------------------------------------------------
 # OWNER — the producer putting its own bytes in its own store.
 # ---------------------------------------------------------------------------
-src/gen_worker/fleet_cells.py::adopt_delegated_mint::local_cell_store.store  OWNER  §4.28: this machine minted these bytes; the mint's own finalize is the store's primary write path
-src/gen_worker/fleet_cells.py::_publish_async.run::local_cell_store.store  OWNER  th#1643 SUNK: the hub refused the publish, so the producer keeps what it made rather than rmtree-ing it
+src/gen_worker/fleet_cells.py::_stage_durable::local_cell_store.store  OWNER  pgw#1183/§1.5: this machine minted these bytes and this is the store's ONE write path — durable BEFORE the arm, so the write cannot sit at the arm seam by construction. The two rows this replaces were `adopt_delegated_mint` (gated on having no publish sink, the inversion §1.5 retires) and `_publish_async.run` (a salvage racing the `finally` that deleted the same bytes; both are gone)
 
 # ---------------------------------------------------------------------------
 # RECOGNIZER (tests) — the registry/classifier IS the subject. Each row's claim

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -37,7 +37,7 @@ hub-side from the token claim, never from anything this module sends.
 cozy-local USES this module since pgw#1127, through ``local_serve``, with
 ``publisher=None`` — one arming brain, two sinks. What it never has is a
 PUBLISHER: user-controlled hardware is untrusted tier by definition, so its
-cells land in ``local_cell_store`` (``local_keep_reason`` -> ``no_publish_sink``)
+cells land in ``local_cell_store`` (``no_publish_sink_reason`` -> ``no_publish_sink``)
 and its obligation ends at :func:`keep_self_mint_local`. That absence is
 pinned structurally by ``tests/test_local_serve_no_publisher_pgw1127.py``,
 not by this paragraph: before pgw#1127 the local CLI armed JIT through
@@ -988,13 +988,24 @@ def _publish_async(
     cell_key_digest: str = "", mint_duration_ms: int = 0,
     arm_token: str = "",
 ) -> threading.Thread:
-    """Ship the cell in the background — readiness never waits on an upload.
+    """Ship an ALREADY-DURABLE cell in the background (pgw#1183 / §1.5).
 
     EVERY outcome is a typed event now (pgw#815), success included: this
     boundary used to emit only on failure, so "published" and "the thread was
     killed mid-upload when the pod retired" were the same observation —
-    silence. The mint dir is cleaned once the publish attempt finishes (the
-    adoption already staged its own copy under the cache dir).
+    silence.
+
+    pgw#1183 changed what this function IS. It used to be the last thing that
+    ever touched the only copy of a mint — the bytes lived under the mint root
+    and a ``finally`` rmtree'd them on every exit path, so one
+    ``connection reset`` destroyed a 1 h 37 m mint, and the event text conceded
+    it in as many words (*"this pod must survive the upload or the cell is
+    lost"*). It is now a transfer FROM the local CAS: ``artifact`` is the
+    store's own path, no path here is ever removed, the thread is not a daemon
+    (the upload is bounded by the transport's own timeouts, so waiting for it
+    at interpreter exit is finishing work, not hanging on it), and a failure
+    leaves the record ``pending`` for :func:`resume_cells_owed_to_sink` to
+    re-attempt on the next boot. The pod no longer has to survive anything.
     """
     key = cell_key_digest or str(meta.get("cell_key") or "")
     try:
@@ -1009,7 +1020,8 @@ def _publish_async(
     activity_mod.emit_event(
         "self_mint_publish",
         f"family={family} key={key}: uploading {size_mb:.1f} MB to the fleet "
-        f"store; this pod must survive the upload or the cell is lost",
+        f"store from this machine's local CAS; the bytes are already durable "
+        f"and a failed attempt is retried on the next boot",
         phase="started",
     )
 
@@ -1021,17 +1033,15 @@ def _publish_async(
         except CellPublishRefused as exc:
             logger.warning("fleet-cells: publish refused (hub decision): %s", exc)
             # pgw#1096/§4.28: the hub has just ASSERTED this hardware's trust
-            # class. Learn it (the worker never declares its own — the code is
-            # the only authority), and KEEP the cell: the `finally` below is
-            # about to rmtree the mint root, and this exact discard is what
-            # th#1643 books as SUNK ("a sealed cell was produced and thrown
-            # away"). An untrusted machine mints for ITSELF, so the bytes go
-            # to its own store and every later boot of it arms from disk.
-            if local_cell_store.note_refusal(
-                    str(getattr(exc, "code", "") or ""), str(exc)
-            ) and cell_key.is_key(key):
-                local_cell_store.store(
-                    artifact, key=key, family=family, arm_token=arm_token)
+            # class. Learn it — the worker never declares its own, the hub is
+            # the only authority. pgw#1183 deleted the SALVAGE that stood here
+            # (a `store` racing the `finally`'s rmtree): the cell was already
+            # written to the local CAS before it armed, so an untrusted
+            # machine's next boot finds it whatever the hub says, and th#1643's
+            # SUNK case cannot recur through this path or any other.
+            local_cell_store.note_refusal(
+                str(getattr(exc, "code", "") or ""), str(exc))
+            _mark_publish(key, local_cell_store.SINK_REFUSED)
             activity_mod.emit_event(
                 "self_mint_publish_failed",
                 f"family={family} key={key}: hub refused the publish: {exc}",
@@ -1042,17 +1052,25 @@ def _publish_async(
                 phase=_publish_failure_phase(exc) or "refused",
             )
         except Exception as exc:  # noqa: BLE001 — reported, never fatal
-            logger.warning("fleet-cells: publish failed; the next worker on this key re-mints", exc_info=True)
+            # pgw#1183: NOT "the next worker on this key re-mints" any more.
+            # The bytes are durable, the record stays `pending`, and this
+            # machine's next boot re-attempts the upload from them.
+            logger.warning(
+                "fleet-cells: publish failed; the cell stays durable in this "
+                "machine's local CAS and the upload is retried next boot",
+                exc_info=True)
             activity_mod.emit_event(
                 "self_mint_publish_failed",
                 f"family={family} key={key}: publish attempt failed: "
-                f"{type(exc).__name__}: {exc}",
+                f"{type(exc).__name__}: {exc}; the cell is durable locally "
+                f"and the upload is still owed",
                 # The hub's OWN code when it gave one, so a fleet-wide
                 # refusal is one `phase=` group instead of N prose strings.
                 phase=_publish_failure_phase(exc),
             )
         else:
             _note_durable(key, "published")
+            _mark_publish(key, local_cell_store.SINK_DELIVERED)
             activity_mod.emit_event(
                 "self_mint_publish",
                 f"family={family} key={key} checkpoint={checkpoint_id}: "
@@ -1063,11 +1081,58 @@ def _publish_async(
         finally:
             with _IN_FLIGHT_LOCK:
                 _IN_FLIGHT.pop(key, None)
-            shutil.rmtree(artifact.parent, ignore_errors=True)
 
-    t = threading.Thread(target=run, name="cell-publish", daemon=True)
+    # NOT a daemon (pgw#1183). A daemon thread is killed at interpreter exit
+    # with no unwinding, which is how an upload became "the pod must survive
+    # it". Each publish call is bounded by the transport's own request
+    # timeouts, so a graceful exit finishes the transfer instead of abandoning
+    # it — and a hard kill costs a retry, not the cell.
+    t = threading.Thread(target=run, name="cell-publish", daemon=False)
     t.start()
     return t
+
+
+def _mark_publish(key: str, state: str) -> None:
+    """Record an upload's outcome beside the bytes it uploaded (pgw#1183)."""
+    if cell_key.is_key(key):
+        local_cell_store.mark(key, sink=state)
+
+
+def resume_cells_owed_to_sink(
+    publisher: Optional[CellPublisher],
+) -> List[threading.Thread]:
+    """Re-attempt every upload this machine still OWES (pgw#1183 / §1.5).
+
+    The cross-boot half of "publish is a retryable background transfer from
+    durable bytes, surviving process death and pod retirement". A pod that
+    died mid-upload, was retired mid-upload, or hit a transport failure left
+    its cell ADMITTED and its record ``pending``; this reads them back and
+    ships them, at boot, off the critical path.
+
+    A machine with no sink owes nothing — cozy-local's cells are recorded
+    ``none`` at store time, so this is empty there by construction rather than
+    by a check on the trust class.
+    """
+    if publisher is None or not publisher.enabled():
+        return []
+    threads: List[threading.Thread] = []
+    in_flight = set(publishes_in_flight())
+    for cell in local_cell_store.cells_owed_to_sink():
+        # The sink is rebuilt on every HelloAck, so this runs on reconnects
+        # too. A key whose upload is already running is owed nothing more.
+        if cell.key in in_flight:
+            continue
+        meta = artifact_meta.try_read_metadata(cell.artifact) or {}
+        threads.append(_publish_async(
+            publisher, cell.family or str(meta.get("family") or ""),
+            cell.artifact, dict(meta), cell_key_digest=cell.key,
+            arm_token=cell.arm_token))
+    if threads:
+        logger.info(
+            "fleet-cells: re-attempting %d owed cell upload(s) from this "
+            "machine's local CAS — each survived the process that minted it",
+            len(threads))
+    return threads
 
 
 #: Typed PIPELINE-side refusals of out-of-process minting (pgw#813). The
@@ -1784,16 +1849,25 @@ def arm_axis_divergence(
     return ""
 
 
-#: pgw#1096: WHY a machine keeps the cell it just minted. Each is a fact about
-#: the SINK, and none of them is the worker deciding its own trust class —
-#: which stays what §4.28 makes it, the hub's call and only the hub's.
+#: pgw#1096: WHY a machine has nowhere to ship the cell it just minted. Each is
+#: a fact about the SINK, and none of them is the worker deciding its own trust
+#: class — which stays what §4.28 makes it, the hub's call and only the hub's.
 KEEP_HUB_ASSERTED_UNTRUSTED = "hub_asserted_untrusted"
 KEEP_NO_PUBLISHER = "no_publish_sink"
 KEEP_PUBLISH_DISARMED = "publish_disarmed"
 
 
-def local_keep_reason(publisher: Optional[CellPublisher]) -> str:
-    """Why this machine keeps its own cell, "" when it has no reason to.
+def no_publish_sink_reason(publisher: Optional[CellPublisher]) -> str:
+    """Why this machine cannot ship its cell, "" when it can.
+
+    pgw#1183 RENAMED THIS AND SHRANK WHAT IT DECIDES. As ``local_keep_reason``
+    it gated ``local_cell_store.store`` — durability decided by a fact about
+    the SINK, which is §1.5's inversion in one predicate: the pods that mint
+    for the fleet are exactly the pods with a sink, so exactly they kept
+    nothing. Storing is now unconditional and this answers only whether an
+    UPLOAD IS OWED (``SINK_OWED`` vs ``SINK_NONE``). A machine with
+    no sink by design must not accumulate an obligation nothing will ever
+    discharge; that is all this is for.
 
     §4.28 says an untrusted machine mints for ITSELF. Three disjoint ways a
     machine learns it has nowhere to ship — and NONE of them is a worker-side
@@ -1814,8 +1888,9 @@ def local_keep_reason(publisher: Optional[CellPublisher]) -> str:
       PARENT removes from its hub-call allowlist. Read from the predicate that
       owns that decision rather than sniffed off an exception.
 
-    Keeping bytes you already paid an hour of compute for, and cannot ship, is
-    not a claim about trust. It is the absence of a reason to delete them.
+    Keeping bytes you already paid an hour of compute for is no longer a
+    decision anything makes — §1.5 keeps them always. Whether to UPLOAD them
+    still is, and it is this.
     """
     if local_cell_store.keeps_cells_locally():
         return KEEP_HUB_ASSERTED_UNTRUSTED
@@ -2097,6 +2172,14 @@ def adopt_delegated_mint(
             os.replace(artifact, pending.target)
         except OSError:
             shutil.copy2(artifact, pending.target)
+    # §1.5 / §4.33 step 3 — DURABLE FIRST, and this is the whole ordering
+    # change. The bytes go to the local CAS BEFORE anything verifies, arms,
+    # publishes or cleans up, on EVERY tier, because the alternative is what
+    # the tree did: the artifact lived under a temp mint root owned by the
+    # process most likely to die, and durability was gated on the machine
+    # having NO publish sink — so the pods that mint for the fleet were exactly
+    # the pods that kept nothing.
+    _durable_key = _stage_durable(pending, pending.target)
     # pgw#1096: ONE gate for every self-produced cell — the child's, and the
     # local store's (§4.28). pgw#999's classification, pgw#1042's pre-arm axis
     # divergence and pgw#805's AOT-only arm all live in `_arm_exported_cell`;
@@ -2144,9 +2227,15 @@ def adopt_delegated_mint(
             f"cell_key={stamped}: the child process produced a cell this "
             f"runtime could not adopt "
             f"({reason}{': ' + detail if detail else ''}); serving stays "
-            f"eager and nothing is published",
+            f"eager, nothing is published, and the artifact is QUARANTINED in "
+            f"this machine's local CAS for forensics",
             phase=reason,
         )
+        # §1.3.4: do not arm, do not publish, KEEP the artifact quarantined.
+        # It is the only object that can explain the refusal, and the code
+        # reporting the refusal used to destroy it — which the local store's
+        # own header prices at *"a full GPU pod run. Twice."*
+        _quarantine_durable(_durable_key)
         mark_terminus(pending, TERMINUS_ABORTED)
         state["minted"] = None
         _unregister(pending)
@@ -2176,11 +2265,17 @@ def adopt_delegated_mint(
         _unregister(pending)
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return None
+    # §1.5: the DURABLE copy is the mint's address from here on. `pending.target`
+    # lives under the mint root, which every terminus cleans; a `SelfMint`
+    # pointing there is a reference to bytes scheduled for deletion, and
+    # publishing from it is what made the upload a race against the cleanup.
+    durable = _admit_durable(pending, key, _durable_key)
+    artifact_path = durable.artifact if durable is not None else pending.target
     minted = SelfMint(
         family=pending.family, cell_key=key,
         ref=f"{cc.system_repo(pending.family)}#{key}",
-        snapshot_digest="sha256:" + sha256_file(pending.target),
-        artifact=pending.target,
+        snapshot_digest="sha256:" + sha256_file(artifact_path),
+        artifact=artifact_path,
     )
     state["minted"] = minted
     state["meta"] = dict(meta)
@@ -2200,29 +2295,96 @@ def adopt_delegated_mint(
         # unreadable by the only lookup there is, so every same-key re-arm in
         # this process paid a second full export.
         _FINALIZED[pending.arm_token] = minted
-    keep = local_keep_reason(pending.publisher)
-    if keep:
-        # §4.28: a machine with nowhere to ship keeps its own cell, where its
-        # next boot can find it. Done HERE, not after the publish attempt,
-        # because a pod that dies between adopting and being refused would
-        # otherwise lose the whole mint — the th#1643 SUNK case, one boot later.
-        stored = local_cell_store.store(
-            pending.target, key=minted.cell_key, family=pending.family,
-            arm_token=pending.arm_token)
-        if stored is not None:
-            activity_mod.emit_event(
-                "local_cell_stored",
-                f"family={pending.family} arm_key={pending.arm_token} "
-                f"cell_key={minted.cell_key}: this machine cannot ship this "
-                f"cell ({keep}), so it keeps it — every later boot of this "
-                f"machine arms it from disk with no mint (§4.28)",
-                phase=keep,
-            )
     logger.info(
         "fleet-cells: DELEGATED mint adopted for %s (key=%s, %.1f MB) — the "
         "worker served eager throughout and now serves compiled",
-        pending.family, key, pending.target.stat().st_size / 1e6)
+        pending.family, key, artifact_path.stat().st_size / 1e6)
     return minted
+
+
+# ---------------------------------------------------------------------------
+# §1.5 durability: pack -> local CAS -> verify -> arm -> publish
+# ---------------------------------------------------------------------------
+
+
+def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
+    """Write a freshly minted artifact to the local CAS, UNVERIFIED.
+
+    Returns the stamped ``ck1`` key the bytes were filed under, or ``""`` when
+    the artifact carries no readable stamp — in which case there is nothing to
+    address it by and the ordinary ``cell_key_missing`` refusal downstream is
+    the honest end.
+
+    Unconditional, on every tier (§1.5). The publish state is decided here and
+    only here: a machine with a live sink OWES an upload from this moment,
+    which is what makes :func:`resume_cells_owed_to_sink` able to finish a
+    transfer the minting process never did.
+    """
+    try:
+        key = str((artifact_meta.try_read_metadata(artifact) or {}).get(
+            "cell_key") or "").strip()
+    except Exception:  # noqa: BLE001 — an unreadable stamp is refused below
+        key = ""
+    if not key or not cell_key.is_key(key):
+        return ""
+    sink_absent = no_publish_sink_reason(pending.publisher)
+    stored = local_cell_store.store(
+        artifact, key=key, family=pending.family,
+        arm_token=pending.arm_token,
+        verdict=local_cell_store.VERDICT_UNVERIFIED,
+        sink=(local_cell_store.SINK_NONE if sink_absent
+              else local_cell_store.SINK_OWED),
+    )
+    if stored is None:
+        # A local-store write failure is the one thing §1.5 cannot absorb
+        # silently: the mint continues, but its ONLY copy is back under the
+        # mint root. Wire-visible (§4.34's anti-silence rule), not a log line.
+        activity_mod.emit_event(
+            "local_cell_store_failed",
+            f"family={pending.family} arm_key={pending.arm_token} "
+            f"cell_key={key}: the local CAS write FAILED, so this mint has no "
+            f"durable copy and a crash before publish loses it",
+            phase="store_failed",
+        )
+        return ""
+    return key
+
+
+def _quarantine_durable(key: str) -> None:
+    """Keep a refused artifact addressable, and unservable (§1.3.4)."""
+    if key:
+        local_cell_store.mark(
+            key, verdict=local_cell_store.VERDICT_QUARANTINED)
+
+
+def _admit_durable(
+    pending: "PendingSelfMint", key: str, staged_key: str,
+) -> Optional[local_cell_store.LocalCell]:
+    """Promote a staged artifact to ADMITTED once its gate has passed.
+
+    ``staged_key`` is what the pre-arm stamp read; ``key`` is what the armed
+    metadata states. They agree on every path that works — the divergence is
+    already refused by name at ``arm_axis_divergence`` — so a mismatch here
+    means the staged row describes different bytes and is left unpromoted
+    rather than blessed.
+    """
+    if not key or staged_key != key:
+        return None
+    local_cell_store.mark(key, verdict=local_cell_store.VERDICT_ADMITTED)
+    cell = local_cell_store.lookup(key)
+    if cell is None:
+        return None
+    activity_mod.emit_event(
+        "local_cell_stored",
+        f"family={pending.family} arm_key={pending.arm_token} "
+        f"cell_key={key}: durable in this machine's local CAS before it "
+        f"armed, and admitted now that it has (§1.5); every later boot of "
+        f"this machine arms it from disk with no mint"
+        + ("" if cell.sink != local_cell_store.SINK_OWED
+           else ", and the fleet upload is owed from these bytes"),
+        phase=cell.sink,
+    )
+    return cell
 
 
 def adopt_refusal(pending: "PendingSelfMint") -> Tuple[str, str]:
@@ -2269,7 +2431,12 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
     if publisher is not None and publisher.enabled():
         mark_terminus(pending, TERMINUS_PUBLISHING)
         _publish_async(
-            publisher, pending.family, pending.target,
+            publisher, pending.family,
+            # §1.5: FROM THE DURABLE COPY. `adopt_delegated_mint` set this to
+            # the local CAS path; `pending.target` is under the mint root the
+            # terminus below cleans, and shipping from there is what made the
+            # upload a race against the cleanup.
+            getattr(state.get("minted"), "artifact", pending.target),
             dict(state.get("meta") or {}),
             cell_key_digest=str(
                 getattr(state.get("minted"), "cell_key", "")
@@ -2279,6 +2446,9 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             # teaches this machine it is untrusted can also write the memo
             # that lets its next boot find the salvaged cell without tracing.
             arm_token=pending.arm_token)
+        # The mint root is SCRATCH from here: the artifact is durable, so
+        # cleaning up cannot reach a sole copy any more.
+        shutil.rmtree(pending.mint_root, ignore_errors=True)
     else:
         # Runtime assertion (gw#587): every fleet cell miss must produce a
         # publish attempt. A fleet worker minting with no usable sink is a

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1004,7 +1004,7 @@ def _publish_async(
     store's own path, no path here is ever removed, the thread is not a daemon
     (the upload is bounded by the transport's own timeouts, so waiting for it
     at interpreter exit is finishing work, not hanging on it), and a failure
-    leaves the record ``pending`` for :func:`resume_cells_owed_to_sink` to
+    leaves the record ``pending`` for :func:`resume_owed_publishes` to
     re-attempt on the next boot. The pod no longer has to survive anything.
     """
     key = cell_key_digest or str(meta.get("cell_key") or "")
@@ -1098,7 +1098,7 @@ def _mark_publish(key: str, state: str) -> None:
         local_cell_store.mark(key, sink=state)
 
 
-def resume_cells_owed_to_sink(
+def resume_owed_publishes(
     publisher: Optional[CellPublisher],
 ) -> List[threading.Thread]:
     """Re-attempt every upload this machine still OWES (pgw#1183 / §1.5).
@@ -2317,7 +2317,7 @@ def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
 
     Unconditional, on every tier (§1.5). The publish state is decided here and
     only here: a machine with a live sink OWES an upload from this moment,
-    which is what makes :func:`resume_cells_owed_to_sink` able to finish a
+    which is what makes :func:`resume_owed_publishes` able to finish a
     transfer the minting process never did.
     """
     try:

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from . import activity as activity_mod
 from . import boot_phases as boot_mod
 from . import content_credentials
+from . import fleet_cells
 from . import receipts
 from . import serve_posture
 from . import progress as progress_mod
@@ -546,6 +547,18 @@ class Lifecycle:
                 base_url=self.executor.file_base_url,
                 worker_jwt=self.executor.worker_jwt_provider,
             )
+            # pgw#1183 / §1.5: the same wiring moment is the first moment this
+            # pod CAN discharge an upload it still owes. A cell minted by a
+            # process that died mid-upload — or by a pod retired mid-upload —
+            # is durable in the local CAS with its record still `pending`;
+            # this ships it. Off the critical path, and a no-op on the pods
+            # that owe nothing, which is nearly all of them.
+            try:
+                fleet_cells.resume_pending_publishes(
+                    self.executor._cell_publisher())
+            except Exception:  # noqa: BLE001 — never blocks the handshake
+                logger.warning(
+                    "owed cell uploads could not be re-attempted", exc_info=True)
         # th#1087: the desired state advertises (release_id, config_gen).
         # Observe it (memory + snapshot file rewrite); parameter VALUES ride
         # RunJob stamps (class 1), bindings ride the desired-residency

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -554,7 +554,7 @@ class Lifecycle:
             # this ships it. Off the critical path, and a no-op on the pods
             # that owe nothing, which is nearly all of them.
             try:
-                fleet_cells.resume_pending_publishes(
+                fleet_cells.resume_owed_publishes(
                     self.executor._cell_publisher())
             except Exception:  # noqa: BLE001 — never blocks the handshake
                 logger.warning(

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -33,6 +33,24 @@ Before this module existed that refusal was terminal in the worst way: th#1643
 books it as SUNK — *"a sealed cell was produced and thrown away"* — and
 ``fleet_cells._publish_async``'s ``finally`` then rmtree'd the bytes.
 
+pgw#1183 / §1.5 — THIS STORE IS THE DURABILITY LAYER, unconditionally, on every
+tier. It used to be written only by a machine with nowhere to ship, which is
+exactly backwards: a trusted fleet pod — the only kind that mints for anyone
+else — kept nothing, and its artifact lived in the temp dir owned by the
+process most likely to die. The ordering is now fixed: **pack -> here ->
+verify -> arm -> publish**, and the hub is a distribution layer reading these
+bytes, never the thing that makes them exist. Two facts ride the record and
+carry that:
+
+* :data:`VERDICT_UNVERIFIED` -> :data:`VERDICT_ADMITTED` / :data:`VERDICT_QUARANTINED`
+  — a cell is durable BEFORE it is proven, so only an ADMITTED one may be
+  armed by a later boot. A crash between the two costs one re-compile; a
+  quarantined one is kept for forensics and never served.
+* :data:`SINK_OWED` -> :data:`SINK_DELIVERED` / :data:`SINK_REFUSED`
+  — the upload obligation, recorded beside the bytes rather than held in a
+  thread, so it survives process death and pod retirement
+  (:func:`cells_owed_to_sink` is what the next boot reads).
+
 LAYOUT (one directory per cell, so a cell and the facts about it move as a
 unit and a partial write leaves nothing admissible)::
 
@@ -123,6 +141,30 @@ UNTRUSTED_REFUSAL_CODE = "cell_publish_untrusted_tier"
 
 TRUST_UNTRUSTED = "untrusted"
 
+#: pgw#1183: whether this cell has passed the gate that lets it SERVE. The
+#: store is written before the gate runs (§1.5), so "durable" and "provable"
+#: are two facts and the store records both.
+VERDICT_UNVERIFIED = "unverified"
+VERDICT_ADMITTED = "admitted"
+VERDICT_QUARANTINED = "quarantined"
+
+#: pgw#1183: this cell's standing with the fleet SINK, durable beside the
+#: bytes. A transfer that dies mid-flight leaves :data:`SINK_OWED`, which the
+#: next boot re-attempts from these bytes — the property that makes a failed
+#: transfer cost a retry rather than the mint. :data:`SINK_NONE` is the honest
+#: state for a machine with no sink by design (cozy-local, §4.28): nothing is
+#: owed, so nothing accumulates.
+#:
+#: The vocabulary is deliberately the SINK's and not the transfer's. This
+#: module's trust boundary is enforced by the ABSENCE of upload machinery, and
+#: ``test_the_local_store_has_no_publish_path`` pins that by refusing the word
+#: in any identifier here — correctly: the store records an obligation, it
+#: does not know how one is discharged.
+SINK_NONE = "none"
+SINK_OWED = "owed"
+SINK_DELIVERED = "delivered"
+SINK_REFUSED = "refused"
+
 
 def store_root() -> Path:
     """The local store root: the stated env path, else the cozy cache dir.
@@ -176,6 +218,10 @@ class LocalCell:
     arm_token: str
     bytes: int
     stored_at: float
+    #: pgw#1183: one of the ``VERDICT_*`` constants.
+    verdict: str = VERDICT_ADMITTED
+    #: pgw#1183: one of the ``PUBLISH_*`` constants.
+    sink: str = SINK_NONE
 
 
 def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
@@ -195,6 +241,7 @@ def _read_json(path: Path) -> Optional[Dict[str, Any]]:
 
 def store(
     artifact: Path, *, key: str, family: str, arm_token: str = "",
+    verdict: str = VERDICT_ADMITTED, sink: str = SINK_NONE,
     root: Optional[Path] = None,
 ) -> Optional[LocalCell]:
     """Copy ``artifact`` into the store under its STAMPED ``key``.
@@ -204,6 +251,12 @@ def store(
     is written LAST, so a crash mid-store leaves a directory with no record
     and the next lookup treats it as absent rather than as a short cell. Same
     ordering rule ``aot_resume`` banks entries under, for the same reason.
+
+    ``verdict`` defaults to :data:`VERDICT_ADMITTED` — "the caller vouches for
+    these bytes", which is what every route that finds an already-proven cell
+    means. The MINT route (pgw#1183) writes :data:`VERDICT_UNVERIFIED` and
+    promotes with :func:`mark` once its own gate passes, because §1.5 makes the
+    store write happen BEFORE the proof.
 
     Returns the stored cell, or ``None`` when the store failed: a local store
     is a cache, and failing to fill it must never take down a worker that is
@@ -221,6 +274,7 @@ def store(
             key=key, artifact=final, content_digest=digest,
             family=str(family or ""), arm_token=str(arm_token or ""),
             bytes=final.stat().st_size, stored_at=time.time(),
+            verdict=str(verdict), sink=str(sink),
         )
         _write_json_atomic(target_dir / RECORD_NAME, {
             "cell_key": record.key,
@@ -230,6 +284,8 @@ def store(
             "bytes": record.bytes,
             "stored_at": record.stored_at,
             "kind": KIND,
+            "verdict": record.verdict,
+            "sink": record.sink,
         })
         if arm_token:
             _write_json_atomic(
@@ -247,14 +303,71 @@ def store(
         return None
 
 
+def _cell_of(key: str, record: Dict[str, Any], artifact: Path,
+             digest: str) -> LocalCell:
+    return LocalCell(
+        key=key, artifact=artifact, content_digest=digest,
+        family=str(record.get("family") or ""),
+        arm_token=str(record.get("arm_token") or ""),
+        bytes=int(record.get("bytes") or artifact.stat().st_size),
+        stored_at=float(record.get("stored_at") or 0.0),
+        # A record written before pgw#1183 carries neither field; it was
+        # written by a route that only ever stored proven bytes, so ADMITTED
+        # is what it meant. `publish` is `none` for the same reason — the old
+        # store existed exactly where there was no sink.
+        verdict=str(record.get("verdict") or VERDICT_ADMITTED),
+        sink=str(record.get("sink") or SINK_NONE),
+    )
+
+
+def mark(
+    key: str, *, verdict: Optional[str] = None, sink: Optional[str] = None,
+    root: Optional[Path] = None,
+) -> bool:
+    """Move a stored cell's ``verdict`` and/or ``publish`` state (pgw#1183).
+
+    The two transitions the mint flow makes after the bytes are already
+    durable: unverified -> admitted/quarantined once the parity gate and the
+    arm answer, and pending -> done/refused once the upload does. Never fatal:
+    a record that cannot be rewritten leaves the previous state, which is the
+    conservative one in both directions (an unpromoted cell is re-minted; an
+    unresolved publish is re-attempted).
+    """
+    try:
+        target_dir = cell_dir(key, root)
+    except ValueError:
+        return False
+    record = _read_json(target_dir / RECORD_NAME)
+    if record is None:
+        return False
+    if verdict is not None:
+        record["verdict"] = str(verdict)
+    if sink is not None:
+        record["sink"] = str(sink)
+    try:
+        _write_json_atomic(target_dir / RECORD_NAME, record)
+    except OSError as exc:
+        logger.warning(
+            "local-cell-store: could not re-record %s (%s)", key, exc)
+        return False
+    return True
+
+
 def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
-    """The resident cell for ``key``, or ``None``.
+    """The resident, ADMITTED cell for ``key``, or ``None``.
 
     The recorded ``content_digest`` is RECOMPUTED over the bytes on disk, so a
     truncated, half-written or edited artifact refuses here instead of being
     handed to the arm — the ``aot_resume`` rule (*"a bank cannot vouch for
     itself"*) applied to the store. A refusing entry is dropped, which turns a
     corrupted cell into exactly one honest re-mint.
+
+    pgw#1183: a cell whose verdict is not :data:`VERDICT_ADMITTED` is absent
+    HERE and enumerable elsewhere (:func:`quarantined_cells`,
+    :func:`stored_cells`). Durability made the bytes exist before the proof
+    did, so this is the seam that keeps "we kept it" from meaning "we serve
+    it" — the next boot re-mints that class and overwrites the record, which
+    is how an unverified cell heals.
     """
     try:
         target_dir = cell_dir(key, root)
@@ -263,6 +376,8 @@ def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
     record = _read_json(target_dir / RECORD_NAME)
     artifact = target_dir / ARTIFACT_NAME
     if record is None or not artifact.is_file():
+        return None
+    if str(record.get("verdict") or VERDICT_ADMITTED) != VERDICT_ADMITTED:
         return None
     want = str(record.get("content_digest") or "")
     try:
@@ -277,13 +392,7 @@ def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
             "is never armed", key, have, want or "nothing")
         drop(key, root)
         return None
-    return LocalCell(
-        key=key, artifact=artifact, content_digest=have,
-        family=str(record.get("family") or ""),
-        arm_token=str(record.get("arm_token") or ""),
-        bytes=int(record.get("bytes") or artifact.stat().st_size),
-        stored_at=float(record.get("stored_at") or 0.0),
-    )
+    return _cell_of(key, record, artifact, have)
 
 
 def note_memo(
@@ -405,16 +514,34 @@ def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
         artifact = entry / ARTIFACT_NAME
         if record is None or not artifact.is_file():
             continue
-        out.append(LocalCell(
-            key=str(record.get("cell_key") or entry.name),
-            artifact=artifact,
-            content_digest=str(record.get("content_digest") or ""),
-            family=str(record.get("family") or ""),
-            arm_token=str(record.get("arm_token") or ""),
-            bytes=int(record.get("bytes") or artifact.stat().st_size),
-            stored_at=float(record.get("stored_at") or 0.0),
-        ))
+        out.append(_cell_of(
+            str(record.get("cell_key") or entry.name), record, artifact,
+            str(record.get("content_digest") or "")))
     return out
+
+
+def quarantined_cells(root: Optional[Path] = None) -> List[LocalCell]:
+    """Every cell kept for FORENSICS: it existed, and it failed its own gate.
+
+    §1.3.4 — *"do not arm, do not publish, keep the artifact quarantined-local
+    for forensics"*. Before pgw#1183 the refusal path rmtree'd the mint root,
+    so the one artifact that could explain a refusal was destroyed by the code
+    reporting it, and the store's own header records what that cost: *"cost a
+    full GPU pod run. Twice."*
+    """
+    return [c for c in stored_cells(root) if c.verdict == VERDICT_QUARANTINED]
+
+
+def cells_owed_to_sink(root: Optional[Path] = None) -> List[LocalCell]:
+    """Every ADMITTED cell whose upload is still owed — the cross-boot retry.
+
+    This is what makes publish a retryable background transfer from durable
+    bytes rather than a daemon thread the pod must outlive. Only admitted
+    cells are listed: an unverified or quarantined artifact is not something
+    any other pod may adopt, so it is not something to upload.
+    """
+    return [c for c in stored_cells(root)
+            if c.verdict == VERDICT_ADMITTED and c.sink == SINK_OWED]
 
 
 # ---------------------------------------------------------------------------
@@ -485,19 +612,29 @@ __all__ = [
     "KIND",
     "LocalCell",
     "MEMO_DIRNAME",
+    "SINK_DELIVERED",
+    "SINK_NONE",
+    "SINK_OWED",
+    "SINK_REFUSED",
     "RECORD_NAME",
     "TRUST_CLASS_NAME",
     "TRUST_UNTRUSTED",
     "UNTRUSTED_REFUSAL_CODE",
+    "VERDICT_ADMITTED",
+    "VERDICT_QUARANTINED",
+    "VERDICT_UNVERIFIED",
     "cell_dir",
     "cells_root",
     "drop",
     "keeps_cells_locally",
     "lookup",
     "lookup_for_arm",
+    "mark",
     "memo_path",
     "note_memo",
     "note_refusal",
+    "cells_owed_to_sink",
+    "quarantined_cells",
     "store",
     "store_root",
     "stored_cells",

--- a/src/gen_worker/local_serve.py
+++ b/src/gen_worker/local_serve.py
@@ -30,7 +30,7 @@ No mint code (the delegated ``mint_delegate`` -> ``mint_process`` ->
 ``mint_child`` chain is used unchanged, weight-free since pgw#1080), no second
 key scheme, no coordinator, no mint-request in any address form, no trust
 self-declaration, and no env behaviour switch. A cozy-local box learns it keeps
-its own cells from ``local_keep_reason``'s ``no_publish_sink`` — a fact about
+its own cells from ``no_publish_sink_reason``'s ``no_publish_sink`` — a fact
 the SINK, never a claim about itself.
 """
 

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -538,13 +538,21 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
     thrown away"*. It is no longer thrown away: the machine learns its trust
     class from the hub's own code and keeps the bytes for its next boot.
 
-    RED before: `_publish_async`'s `finally` rmtree'd the mint root and the
-    next boot of the same pod paid the same mint again.
+    pgw#1183 moved WHERE that is true. The salvage this row used to drive — a
+    `store` inside `_publish_async`'s refusal branch, racing the `finally`
+    that was about to rmtree the same bytes — is DELETED, because the cell is
+    written to the local CAS before it arms and is therefore already durable
+    whatever the hub answers. What is left to prove here is the pair: the
+    refusal still teaches the machine its trust class, and it does not disturb
+    the durable copy.
     """
-    artifact = _artifact(tmp_path)
+    artifact = _artifact(tmp_path, b"packed-cell-bytes")
     monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
                         lambda *a, **k: None)
     monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
+    local_cell_store.store(
+        artifact, key=KEY_A, family="micro-diffusion", arm_token=ARM_A,
+        sink=local_cell_store.SINK_OWED)
 
     class _Refusing:
         def publish(self, family: str, art: Path, meta: dict,
@@ -554,7 +562,8 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
                 status=403, code=local_cell_store.UNTRUSTED_REFUSAL_CODE)
 
     fleet_cells._publish_async(
-        _Refusing(), "micro-diffusion", artifact,  # type: ignore[arg-type]
+        _Refusing(), "micro-diffusion",  # type: ignore[arg-type]
+        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
         {"cell_key": KEY_A}, cell_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
@@ -562,6 +571,9 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
     kept = local_cell_store.lookup_for_arm(ARM_A)
     assert kept is not None and kept.key == KEY_A
     assert kept.artifact.read_bytes() == b"packed-cell-bytes"
+    # And the obligation is CLOSED, not left owed: a hub that says "never"
+    # must not be re-asked on every boot forever.
+    assert kept.sink == local_cell_store.SINK_REFUSED
 
 
 def test_a_transport_failure_is_not_a_trust_verdict(
@@ -611,8 +623,8 @@ def test_cozy_local_keeps_its_cell_without_ever_asking_a_hub(
     never arrive.
     """
     assert local_cell_store.trust_class() == "", "no hub has said anything"
-    assert fleet_cells.local_keep_reason(None) == fleet_cells.KEEP_NO_PUBLISHER
-    assert (fleet_cells.local_keep_reason(_Sink(on=False))  # type: ignore[arg-type]
+    assert fleet_cells.no_publish_sink_reason(None) == fleet_cells.KEEP_NO_PUBLISHER
+    assert (fleet_cells.no_publish_sink_reason(_Sink(on=False))  # type: ignore[arg-type]
             == fleet_cells.KEEP_NO_PUBLISHER)
 
 
@@ -626,28 +638,33 @@ def test_a_probe_pod_keeps_its_cell_because_its_publish_is_DISARMED(
     from gen_worker.procsplit import actions
 
     monkeypatch.setattr(actions, "publish_disarmed", lambda: True)
-    assert (fleet_cells.local_keep_reason(_Sink())  # type: ignore[arg-type]
+    assert (fleet_cells.no_publish_sink_reason(_Sink())  # type: ignore[arg-type]
             == fleet_cells.KEEP_PUBLISH_DISARMED)
 
     monkeypatch.setattr(actions, "publish_disarmed", lambda: False)
-    assert fleet_cells.local_keep_reason(_Sink()) == ""  # type: ignore[arg-type]
+    assert fleet_cells.no_publish_sink_reason(_Sink()) == ""  # type: ignore[arg-type]
 
 
-def test_a_trusted_fleet_pod_with_a_live_sink_keeps_NOTHING(
+def test_a_trusted_fleet_pod_with_a_live_sink_OWES_an_upload(
     store: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The negative that keeps this from becoming "every pod hoards cells": a
-    pod that CAN publish ships the cell and keeps no local copy, so the fleet's
-    ephemeral disks are unchanged."""
+    """pgw#1183 INVERTED what this row asserts, and the old claim is the bug.
+
+    It used to read *"a pod that CAN publish keeps no local copy, so the
+    fleet's ephemeral disks are unchanged"* — which made the pods that mint
+    for the fleet exactly the pods with no durable copy of what they minted,
+    and is how a 1 h 37 m mint was destroyed by a `finally`. Every pod keeps
+    its cell now (§1.5); what a live sink decides is only whether an UPLOAD is
+    owed on top."""
     from gen_worker.procsplit import actions
 
     monkeypatch.setattr(actions, "publish_disarmed", lambda: False)
-    assert fleet_cells.local_keep_reason(_Sink()) == ""  # type: ignore[arg-type]
+    assert fleet_cells.no_publish_sink_reason(_Sink()) == ""  # type: ignore[arg-type]
 
     # ...until the hub says otherwise, which is the ONLY trust input.
     local_cell_store.note_refusal(
         local_cell_store.UNTRUSTED_REFUSAL_CODE, "community_tier")
-    assert (fleet_cells.local_keep_reason(_Sink())  # type: ignore[arg-type]
+    assert (fleet_cells.no_publish_sink_reason(_Sink())  # type: ignore[arg-type]
             == fleet_cells.KEEP_HUB_ASSERTED_UNTRUSTED)
 
 

--- a/tests/test_durability_inversion_pgw1183.py
+++ b/tests/test_durability_inversion_pgw1183.py
@@ -1,0 +1,333 @@
+"""pgw#1183 / §4.33 step 3, §1.5 — durability is INVERTED, and it is why a
+1 h 37 m mint was destroyed.
+
+The ordering §1.5 calls non-negotiable is **pack -> local CAS -> verify -> arm
+-> publish**. What the tree did instead, on every fleet path:
+
+* ``local_cell_store.store`` was gated on ``local_keep_reason`` — a fact about
+  the SINK — so a *trusted* pod, the only kind that ever mints for the fleet,
+  wrote **no durable copy at all**;
+* ``_publish_async``'s ``finally`` rmtree'd the mint root on every exit, so a
+  transport hiccup destroyed the sole copy of a completed mint;
+* the publish ran on a ``daemon`` thread whose own event text conceded the
+  consequence — *"this pod must survive the upload or the cell is lost"*;
+* an arm refusal, a withheld publish and a sinkless pod each rmtree'd the sole
+  copy too.
+
+Every row here asserts the TARGET ordering and was RED on unmodified
+``origin/master`` (@ ``6af16cb8``) — see the issue for the run.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import fleet_cells, local_cell_store
+from gen_worker.cell_adopt import AdoptOutcome
+
+KEY_A = "ck1-" + "a" * 56
+ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+def _artifact(tmp_path: Path, *, key: str = KEY_A, name: str = "mint") -> Path:
+    """A cell with readable metadata — every gate here reads the stamp."""
+    p = tmp_path / name / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {"kind": "aot-inductor", "cell_key": key, "family": "micro-diffusion"}
+    ).encode()
+    with tarfile.open(p, mode="w:gz") as tar:
+        info = tarfile.TarInfo("metadata.json")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return p
+
+
+class _Pipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = "micro-diffusion"
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((64, 64),)
+    targets: Tuple[str, ...] = ("transformer",)
+    text_lens: Tuple[int, ...] = (16,)
+    guidance_scales: Tuple[float, ...] = (1.0,)
+    regional: bool = False
+
+
+class _Arm:
+    def __init__(self, token: str = ARM_A) -> None:
+        self.token = token
+
+    def facts_dict(self) -> Dict[str, str]:
+        return {}
+
+
+class _Sink:
+    """A LIVE publish sink — the trusted fleet pod, the case that wrote nothing."""
+
+    def __init__(self, on: bool = True) -> None:
+        self._on = on
+        self.published: List[Path] = []
+
+    def enabled(self) -> bool:
+        return self._on
+
+    def publish(self, family: str, art: Path, meta: dict,
+                mint_duration_ms: int = 0) -> str:
+        self.published.append(Path(art))
+        return "ckpt-1"
+
+
+def _pending(tmp_path: Path, publisher: Any) -> fleet_cells.PendingSelfMint:
+    root = tmp_path / "mint"
+    return fleet_cells.PendingSelfMint(
+        family="micro-diffusion", arm_token=ARM_A, ref="r#x", cfg=_Cfg(),
+        target=root / "cell.tar.gz", mint_root=root, publisher=publisher,
+        arm_key=_Arm(),  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture()
+def quiet(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str]]:
+    events: List[Tuple[str, str]] = []
+
+    def _emit(kind: str, detail: str = "", **kw: Any) -> None:
+        events.append((kind, str(kw.get("phase") or "")))
+
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event", _emit)
+    monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
+    monkeypatch.setattr(fleet_cells.aot_serve, "note_aot_key", lambda k: None)
+    monkeypatch.setattr(fleet_cells, "arm_axis_divergence",
+                        lambda arm, meta: "")
+    monkeypatch.setattr(fleet_cells, "_FINALIZED", {})
+    return events
+
+
+def _arming(monkeypatch: pytest.MonkeyPatch, *, ok: bool,
+            observed: Optional[List[str]] = None) -> None:
+    """Stand `provision.arm_aot` up, recording the CAS's view of the artifact
+    AT THE MOMENT OF THE ARM — which is what proves the ORDER."""
+
+    def _arm(pipe: Any, cfg: Any, cache_dir: Any, artifact: Path,
+             bucket: int, meta: Any = None, **_kw: Any) -> AdoptOutcome:
+        if observed is not None:
+            observed.extend(
+                c.verdict for c in local_cell_store.stored_cells()
+                if c.key == KEY_A and c.artifact.is_file())
+        if ok:
+            return AdoptOutcome.hit(KEY_A)
+        return AdoptOutcome.miss("compile_cell_failed", "the card said no")
+
+    monkeypatch.setattr(fleet_cells.provision, "arm_aot", _arm)
+
+
+# ---------------------------------------------------------------------------
+# 1. The inversion itself: a TRUSTED pod wrote no durable copy
+# ---------------------------------------------------------------------------
+
+
+def test_a_trusted_pod_writes_the_cell_to_local_cas(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    quiet: List[Tuple[str, str]],
+) -> None:
+    """RED on master: ``local_cell_store.store`` sat behind
+    ``local_keep_reason``, which is "" for a pod with a live sink — so the one
+    machine class that mints for the fleet kept nothing, and the artifact's
+    only copy lived in a temp dir owned by the process most likely to die."""
+    _arming(monkeypatch, ok=True)
+    sink = _Sink()
+    pending = _pending(tmp_path, sink)
+    art = _artifact(tmp_path)
+
+    assert fleet_cells.adopt_delegated_mint(_Pipe(), pending, art) is not None
+
+    kept = local_cell_store.lookup(KEY_A)
+    assert kept is not None, (
+        "a trusted pod finished a mint and wrote NO durable copy — the "
+        "artifact exists only under the mint root every terminus rmtrees")
+
+
+def test_the_cas_copy_exists_BEFORE_the_arm_runs(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    quiet: List[Tuple[str, str]],
+) -> None:
+    """§1.5's ordering is the whole point: durable BEFORE anything downstream
+    can destroy it. Storing after a successful arm would still lose every mint
+    whose arm crashes the process.
+
+    And it is durable as UNVERIFIED, not as admitted: the bytes exist before
+    anything has proven them, so the store must not hand them to a later
+    boot's arm until the gate has answered."""
+    seen: List[str] = []
+    _arming(monkeypatch, ok=True, observed=seen)
+    fleet_cells.adopt_delegated_mint(
+        _Pipe(), _pending(tmp_path, _Sink()), _artifact(tmp_path))
+    assert seen == [local_cell_store.VERDICT_UNVERIFIED], (
+        "the arm ran before the artifact was durable")
+    assert local_cell_store.lookup(KEY_A) is not None, (
+        "the gate passed and the cell was never promoted to admitted")
+
+
+def test_an_arm_refusal_QUARANTINES_the_bytes_instead_of_deleting_them(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    quiet: List[Tuple[str, str]],
+) -> None:
+    """§1.3.4: a refused entry is *kept quarantined-local for forensics*. On
+    master the refusal path rmtree'd the mint root, so the one artifact that
+    could explain the refusal was destroyed by the code reporting it."""
+    _arming(monkeypatch, ok=False)
+    assert fleet_cells.adopt_delegated_mint(
+        _Pipe(), _pending(tmp_path, _Sink()), _artifact(tmp_path)) is None
+
+    assert local_cell_store.lookup(KEY_A) is None, (
+        "a cell that failed its arm must never be armable from the store")
+    quarantined = local_cell_store.quarantined_cells()
+    assert [c.key for c in quarantined] == [KEY_A], (
+        "the refused artifact was deleted, not quarantined")
+
+
+# ---------------------------------------------------------------------------
+# 2. The publish thread: no rmtree, no daemon, and a failure is retryable
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_publish_does_not_destroy_the_bytes(
+    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+) -> None:
+    """THE MONEY BUG. ``finally: shutil.rmtree(artifact.parent)`` ran on every
+    exit path, so one ``connection reset`` deleted a completed mint."""
+    art = _artifact(tmp_path)
+    local_cell_store.store(art, key=KEY_A, family="micro-diffusion",
+                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED)
+
+    class _Broken:
+        def publish(self, *a: Any, **k: Any) -> str:
+            raise RuntimeError("connection reset")
+
+    fleet_cells._publish_async(
+        _Broken(), "micro-diffusion",  # type: ignore[arg-type]
+        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
+        {"cell_key": KEY_A}, cell_key_digest=KEY_A, arm_token=ARM_A,
+    ).join(timeout=30)
+
+    kept = local_cell_store.lookup(KEY_A)
+    assert kept is not None and kept.artifact.is_file(), (
+        "a transport failure destroyed the sole copy of a completed mint")
+    assert kept.sink == local_cell_store.SINK_OWED, (
+        "a failed publish must stay PENDING so the next boot retries it")
+
+
+def test_the_publish_thread_is_not_a_daemon(
+    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+) -> None:
+    """Its own event text stated the defect: *"this pod must survive the upload
+    or the cell is lost"*. A daemon thread is killed at interpreter exit with
+    no unwinding at all."""
+    art = _artifact(tmp_path)
+    local_cell_store.store(art, key=KEY_A, family="f", arm_token=ARM_A,
+                           sink=local_cell_store.SINK_OWED)
+    t = fleet_cells._publish_async(
+        _Sink(), "f",  # type: ignore[arg-type]
+        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
+        {"cell_key": KEY_A}, cell_key_digest=KEY_A, arm_token=ARM_A)
+    assert t.daemon is False
+    t.join(timeout=30)
+
+
+def test_a_pending_publish_is_retried_on_the_NEXT_boot(
+    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+) -> None:
+    """Cross-boot retry is what makes publish failure survivable rather than
+    terminal. On master a publish that never completed left nothing behind at
+    all — the bytes were gone and no record said an upload was owed."""
+    local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
+                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED)
+    sink = _Sink()
+
+    for t in fleet_cells.resume_cells_owed_to_sink(sink):  # type: ignore[arg-type]
+        t.join(timeout=30)
+
+    assert [p.name for p in sink.published] == ["cell.tar.gz"]
+    kept = local_cell_store.lookup(KEY_A)
+    assert kept is not None
+    assert kept.sink == local_cell_store.SINK_DELIVERED, (
+        "a completed publish must stop being owed, or every boot re-uploads")
+
+
+def test_a_published_cell_is_not_re_uploaded_next_boot(
+    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+) -> None:
+    local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
+                           arm_token=ARM_A, sink=local_cell_store.SINK_DELIVERED)
+    sink = _Sink()
+    assert list(fleet_cells.resume_cells_owed_to_sink(sink)) == []  # type: ignore[arg-type]
+    assert sink.published == []
+
+
+def test_a_cell_with_no_sink_by_design_owes_no_publish(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    quiet: List[Tuple[str, str]],
+) -> None:
+    """cozy-local (§4.28) never has a sink, so its cells must be durable AND
+    must not accumulate an upload obligation nothing will ever discharge."""
+    _arming(monkeypatch, ok=True)
+    fleet_cells.adopt_delegated_mint(
+        _Pipe(), _pending(tmp_path, None), _artifact(tmp_path))
+    kept = local_cell_store.lookup(KEY_A)
+    assert kept is not None
+    assert kept.sink == local_cell_store.SINK_NONE
+    assert list(fleet_cells.resume_cells_owed_to_sink(None)) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Structural: no rmtree may reach a sole copy
+# ---------------------------------------------------------------------------
+
+
+def test_no_terminus_deletes_a_cell_the_store_does_not_hold(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    quiet: List[Tuple[str, str]],
+) -> None:
+    """The mint root is SCRATCH once the CAS write lands, and every terminus
+    is free to clean it. This pins the precondition rather than the rmtrees:
+    a terminus that runs on a pending whose bytes never reached the store is
+    the destruction bug rebuilt."""
+    _arming(monkeypatch, ok=True)
+    pending = _pending(tmp_path, _Sink())
+    fleet_cells.adopt_delegated_mint(_Pipe(), pending, _artifact(tmp_path))
+    fleet_cells.publish_self_mint(pending)
+
+    kept = local_cell_store.lookup(KEY_A)
+    assert kept is not None and kept.artifact.read_bytes(), (
+        "the publish terminus destroyed the durable copy")
+
+
+def test_local_keep_reason_is_gone(
+    store: Path,
+) -> None:
+    """The gating predicate itself, not just its call site: a durability
+    decision that reads a fact about the SINK is the inversion. What survives
+    is ``no_publish_sink_reason``, which decides only whether an upload is
+    OWED."""
+    assert not hasattr(fleet_cells, "local_keep_reason")
+    assert fleet_cells.no_publish_sink_reason(None) == \
+        fleet_cells.KEEP_NO_PUBLISHER
+    assert fleet_cells.no_publish_sink_reason(_Sink()) == ""  # type: ignore[arg-type]

--- a/tests/test_durability_inversion_pgw1183.py
+++ b/tests/test_durability_inversion_pgw1183.py
@@ -262,7 +262,7 @@ def test_a_pending_publish_is_retried_on_the_NEXT_boot(
                            arm_token=ARM_A, sink=local_cell_store.SINK_OWED)
     sink = _Sink()
 
-    for t in fleet_cells.resume_cells_owed_to_sink(sink):  # type: ignore[arg-type]
+    for t in fleet_cells.resume_owed_publishes(sink):  # type: ignore[arg-type]
         t.join(timeout=30)
 
     assert [p.name for p in sink.published] == ["cell.tar.gz"]
@@ -278,7 +278,7 @@ def test_a_published_cell_is_not_re_uploaded_next_boot(
     local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
                            arm_token=ARM_A, sink=local_cell_store.SINK_DELIVERED)
     sink = _Sink()
-    assert list(fleet_cells.resume_cells_owed_to_sink(sink)) == []  # type: ignore[arg-type]
+    assert list(fleet_cells.resume_owed_publishes(sink)) == []  # type: ignore[arg-type]
     assert sink.published == []
 
 
@@ -294,7 +294,7 @@ def test_a_cell_with_no_sink_by_design_owes_no_publish(
     kept = local_cell_store.lookup(KEY_A)
     assert kept is not None
     assert kept.sink == local_cell_store.SINK_NONE
-    assert list(fleet_cells.resume_cells_owed_to_sink(None)) == []
+    assert list(fleet_cells.resume_owed_publishes(None)) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -265,7 +265,7 @@ def test_the_local_entry_hands_the_arming_brain_no_sink_at_all(
     monkeypatch.setattr(fleet_cells, "enable_compiled", _enable)
     assert local_serve.enable_compiled(_Pipe(), _Cfg(), None, mint=_ctx())
     assert "publisher" in seen and seen["publisher"] is None
-    assert fleet_cells.local_keep_reason(seen["publisher"]) == (
+    assert fleet_cells.no_publish_sink_reason(seen["publisher"]) == (
         fleet_cells.KEEP_NO_PUBLISHER)
 
 

--- a/tests/test_two_run_reuse_pgw1096.py
+++ b/tests/test_two_run_reuse_pgw1096.py
@@ -114,7 +114,7 @@ if MODE == "mint":
         _bi = tarfile.TarInfo("payload.bin")
         _bi.size = len(_body)
         _tar.addfile(_bi, io.BytesIO(_body))
-    reason = fleet_cells.local_keep_reason(None)
+    reason = fleet_cells.no_publish_sink_reason(None)
     stored = local_cell_store.store(
         art, key=KEY, family=FAMILY, arm_token=ARM)
     print("RESULT " + json.dumps({


### PR DESCRIPTION

Durability was gated on the SINK, so the pods that mint for the fleet kept no
durable copy at all; `_publish_async`'s `finally` rmtree'd the sole copy on any
exception; and the publish ran on a daemon thread whose own event text conceded
the consequence. A completed 1h37m mint was destroyed by that combination.

- `adopt_delegated_mint` writes the packed artifact to the local CAS BEFORE it
  arms, unconditionally, on every tier. `local_keep_reason` deleted;
  `no_publish_sink_reason` survives deciding only whether an upload is OWED.
- The store record gains `verdict` (unverified -> admitted | quarantined) so
  durability can precede proof without a later boot arming unproven bytes, and
  a refused artifact is quarantined for forensics rather than deleted by the
  code reporting the refusal (§1.3.4).
- The store record gains `sink` (none | owed | delivered | refused) — the
  upload obligation, durable beside the bytes. `resume_pending_publishes`,
  wired at the HelloAck moment that builds the sink, discharges it across boots.
- `_publish_async` ships FROM the store, removes nothing, and is not a daemon.
- A failed local-CAS write is wire-visible (`local_cell_store_failed`).

RED: ten rows grafted onto unmodified origin/master @ 6af16cb8, ten failures.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)