### PR TITLE
pgw#1184 (th#1834 Phase 4): the exported lane boots on the EAGER warm plan — 18 full generates per handler where 2 would do

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2776,12 +2776,6 @@ class _WarmupEvidence:
 
     count: int = 0
     functions_by_object: Dict[int, set[str]] = dc_field(default_factory=dict)
-    #: pgw#844: per object, the aliases that proved SOME but not all of their
-    #: declared graph classes on the EXPORTED lane -> the classes that stayed
-    #: eager. Non-empty means "compiled for these shapes, eager for those",
-    #: which is a serving posture, not a boot failure.
-    partial_by_object: Dict[int, Dict[str, Tuple[str, ...]]] = dc_field(
-        default_factory=dict)
     #: pgw#677 reopen: non-empty when the warm plan was CUT SHORT (OOM
     #: backoff) — names the truncation. A truncated plan must never publish
     #: its partial capture as the family cell.
@@ -6439,23 +6433,26 @@ class Executor:
         memory = self._warm_contract_runs.setdefault(
             self._warm_contract_key(spec), set())
         armed_refs = tuple(armed_cell_refs)
-        # Tracing == some artifact is armed or minting on this setup; only
-        # then does the full class x bucket cross-product buy anything (each
-        # graph must trace into the capture / prove against the cell).
+        # Tracing == some object under proof still needs the full class x
+        # bucket cross-product, because its graphs must trace INTO something:
+        # a dynamo/TRT lane whose per-class FX cache-hit ledger is its only
+        # detector of a silent recompile, or a fresh self-mint capture every
+        # declared graph must land in.
         #
-        # pgw#1141 DELIBERATELY LEAVES THIS ALONE, and the omission is the
-        # decision. §4.31 deletes the warm plan as a PREREQUISITE TO ARMING —
-        # which is this issue — and notes that the per-class cost then buys
-        # nothing on an exported adopt. Collapsing it to the eager plan is a
-        # real saving (sdxl: 18 full generates per handler -> 2) but it is not
-        # free: this plan is also what produces pgw#844's BOOT-TIME coverage
-        # census (`compiled_shape_coverage`, which names the declared classes a
-        # cell does not carry before any tenant meets one) and what feeds the
-        # dynamo lane's per-class cache-hit ledger, its only detector of a
-        # silent recompile. Both deserve an answer of their own rather than a
-        # rider on a P0 arm fix, so the collapse is filed as its own change
-        # with its own red tests. Nothing about the ARM depends on it.
-        tracing = bool(objects)
+        # pgw#1184 CUTS THE EXPORTED LANE OUT OF IT (th#1834 Phase 4). An
+        # armed `.pt2` is ahead-of-time machine code for this exact
+        # sm x toolchain: it performs no FX lookup, there is no ledger to
+        # move, and §4.31 already ruled that warmup "never made a cell faster,
+        # it only checked it." The 18 runs sdxl was paying per handler bought
+        # exactly one thing the arm did not already have — a BOOT-TIME census
+        # of which declared classes the dispatcher could route to — and that
+        # census is deleted with them (see `_arm_class_coverage`, and the
+        # commit message for why 16 extra full generates is not what that
+        # question is worth). The per-shape truth still arrives, per request,
+        # typed, at the ingress that already refuses a class BY NAME and
+        # charges the request `fallback_reason=ingress_refused`.
+        tracing = bool(cold_proof_ids) or any(
+            not aot_serve.holds_exported_cell(obj) for obj in objects)
         skip_ok = (
             allow_contract_skip
             and not cold_proof_ids
@@ -6495,7 +6492,16 @@ class Executor:
         # a per-shape posture, not a silent recompile — which is what lets the
         # attribution below be per-class for this lane and stay all-or-nothing
         # for dynamo, where an unproven class means an unannounced recompile.
-        exported_proof_ids: set = set()
+        #
+        # pgw#1184: the exported lane no longer runs the full plan, so this set
+        # is seeded from the LANE rather than discovered by executing 18
+        # generates. An armed exported object is on it from the start; what
+        # `_one` still adds is nothing this lane needs, and what the
+        # attribution below still does with it is attribute every alias
+        # (§4.31: the arm has no warm prerequisite).
+        exported_proof_ids: set = {
+            id(obj) for obj in objects if aot_serve.holds_exported_cell(obj)
+        }
 
         async def _one(wj: Any, build: Any, mode: str, *, variant: bool) -> bool:
             """One warmup forward; False = OOM, stop warming."""
@@ -6677,59 +6683,43 @@ class Executor:
         for wj in jobs:
             for name in (wj.covers or (wj.spec.name,)):
                 keys_by_name.setdefault(name, set()).add(wj.graph_key)
-        for obj_id, proven in proven_keys.items():
-            names = {
-                name for name, keys in keys_by_name.items()
-                if keys and keys <= proven
-            }
-            # pgw#844: …and on the EXPORTED lane an alias that proved SOME of
-            # its graph classes is attributed too, with the rest named.
-            #
-            # The measured shape (attempt twelve, pod o0legpgj5olhic): a
-            # regional sdxl cell armed all 72 entries, dispatched 1024x1024
-            # correctly, and refused the other eight aspect buckets
-            # `entry_ambiguous` because a transformer block sees H_lat*W_lat
-            # and the entries are keyed on H and W separately. Those eight
-            # classes went unproven, the all-or-nothing rule above attributed
-            # NO alias, the target was omitted as `target_applicability_
-            # incomplete`, and the boot ended `boot_ended_uncompiled` — so the
-            # ONE bucket that was armed, correct and unambiguous served eager
-            # too. One undispatchable shape cost the pod every shape.
+        for obj_id in set(proven_keys) | exported_proof_ids:
+            proven = proven_keys.get(obj_id, set())
+            # pgw#844's ORIGINAL FINDING, now answered at the lane instead of
+            # per class (pgw#1184). The measured shape (attempt twelve, pod
+            # o0legpgj5olhic): a regional sdxl cell armed all 72 entries,
+            # dispatched 1024x1024 correctly, and refused the other eight
+            # aspect buckets `entry_ambiguous`. Those eight classes went
+            # unproven, the all-or-nothing rule attributed NO alias, the
+            # target was omitted `target_applicability_incomplete`, and the
+            # boot ended `boot_ended_uncompiled` — so the ONE bucket that was
+            # armed, correct and unambiguous served eager too. One
+            # undispatchable shape cost the pod every shape.
             #
             # `boot_ended_uncompiled` must mean "nothing is dispatchable", not
             # "something wasn't". An exported artifact refuses a shape it
             # cannot serve BY NAME, counts it, emits `aot_ingress_refused`,
             # charges the request `fallback_reason=ingress_refused`, and stays
-            # armed — so the degradation is per shape and fully visible, which
-            # is exactly the fail-soft posture the compiled lane is built on.
-            # Dynamo keeps the strict rule: there an unproven class means an
-            # unannounced recompile at serve time, which is silent.
-            partial: Dict[str, Tuple[str, ...]] = {}
+            # armed — so the degradation is per shape and fully visible.
+            #
+            # pgw#844 bought that with a per-class warm census. §4.31 deleted
+            # the premise underneath it: the arm has NO warm prerequisite, so
+            # an armed exported object is attributed to every alias its plan
+            # covers, and the count of classes it served AT BOOT decides
+            # nothing. That is also what makes the eager plan sound above —
+            # attribution can no longer depend on how many runs happened.
+            #
+            # Dynamo keeps the strict rule verbatim: there an unproven class
+            # means an unannounced recompile at serve time, which is silent.
             if obj_id in exported_proof_ids:
-                for name, keys in keys_by_name.items():
-                    if not keys or name in names or not (keys & proven):
-                        continue
-                    names.add(name)
-                    partial[name] = tuple(sorted(
-                        str(key) for key in (keys - proven)))
+                names = {name for name, keys in keys_by_name.items() if keys}
+            else:
+                names = {
+                    name for name, keys in keys_by_name.items()
+                    if keys and keys <= proven
+                }
             if names:
                 evidence.functions_by_object[obj_id] = names
-            if partial:
-                evidence.partial_by_object[obj_id] = partial
-                for name, missing in sorted(partial.items()):
-                    total = len(keys_by_name[name])
-                    activity_mod.emit_event(
-                        "compiled_shape_coverage",
-                        f"fn={name}: {total - len(missing)}/{total} declared "
-                        f"graph classes served COMPILED at boot; the compiled "
-                        f"lane stays armed and these {len(missing)} class(es) "
-                        f"serve EAGER per request (each one named at ingress, "
-                        f"and every such request reports "
-                        f"fallback_reason="
-                        f"{serving_mode_mod.FALLBACK_INGRESS_REFUSED}): "
-                        f"{list(missing[:8])!r}",
-                        phase="partial_shape_coverage",
-                    )
         return evidence
 
     async def _invoke_warmup(

--- a/src/gen_worker/shape_growth.py
+++ b/src/gen_worker/shape_growth.py
@@ -12,14 +12,20 @@ every AOT (and TRT) arm the executor's three growth call sites are no-ops, the
 and pgw#1010 deleted the republish backend outright (a grown JIT cache is
 this pod's, and its cell had no consumer).
 
-What that costs, measured on the standing stack: one
-``compiled_shape_coverage`` row reporting **2 of 18 declared graph classes
-served compiled at boot**.  Under dynamo each of the other 16 would be routed
-eager once, warmed in one background thread and republished so the fleet never
-pays it again.  Under AOT they stay eager for the life of the pod, every pod,
-forever — and the ratified reuse strategy is *AOT cells only, JIT demotes to
-intake mode*, with pgw#731 deleting the very apparatus the growth system lives
-inside.  "It heals on the JIT path" is therefore not an answer.
+What that costs: a declared class outside the armed cell's envelope stays
+eager for the life of the pod, every pod, forever.  Under dynamo it would be
+routed eager once, warmed in one background thread and republished so the fleet
+never pays it again — but the ratified reuse strategy is *AOT cells only, JIT
+demotes to intake mode*, with pgw#731 deleting the very apparatus the growth
+system lives inside.  "It heals on the JIT path" is therefore not an answer.
+
+pgw#1184 DELETED THE BOOT-TIME CENSUS this paragraph used to quote (a
+``compiled_shape_coverage`` row reading "2 of 18 declared graph classes served
+compiled at boot").  It was an OBSERVATION: it could only name a class a warm
+run happened to dispatch, and on sdxl the warm plan it depended on cost 18 full
+generates per handler where the eager plan needs 2.  :data:`activity.
+KIND_SHAPE_GAP` — reported per request at the ingress that refuses the class BY
+NAME — is the same fact, measured on the traffic that actually asks for it.
 
 What this module owns
 ---------------------
@@ -297,23 +303,6 @@ class Debounce:
                 self._dirty = False
 
 
-def coverage_line(
-    declared: Sequence[str], gaps: Mapping[Tuple[str, str, str], int],
-) -> str:
-    """One human-readable convergence line for ``compiled_shape_coverage``.
-
-    The acceptance asks the coverage event to report CONVERGENCE, not only the
-    initial gap, so the reader needs both numbers in one place.
-    """
-    total = len(declared)
-    open_classes = sorted({key[2] for key in gaps})
-    return (
-        f"{total - len(open_classes)}/{total} declared graph classes are "
-        f"covered by the armed cell; {len(open_classes)} still serve EAGER: "
-        f"{open_classes[:8]!r}"
-    )
-
-
 __all__ = [
     "ARM_AOT",
     "ARM_DYNAMO",
@@ -327,7 +316,6 @@ __all__ = [
     "TurnGateBusy",
     "TurnGateClosed",
     "backend_for",
-    "coverage_line",
     "register_backend",
     "report",
     "report_and_submit",

--- a/tests/test_partial_shape_coverage_pgw844.py
+++ b/tests/test_partial_shape_coverage_pgw844.py
@@ -385,11 +385,6 @@ def test_one_undispatchable_bucket_does_not_cost_the_boot_its_compiled_execution
         "though two sibling buckets are undispatchable")
     assert target.active_compile_snapshot_digest == CELL_DIGEST
     assert list(target.function_names) == ["generate"]
-
-    # One warm unit dispatched; the other two were refused and served eager.
-    assert aot_serve.execution_count(pipe) == 1
-    assert aot_serve.ingress_refusals(pipe) == 2
-    assert pipe.unet.eager_calls == 2
     assert aot_serve.is_armed(pipe)
 
     kinds = [(kind, phase) for kind, phase, _d in events]
@@ -399,16 +394,38 @@ def test_one_undispatchable_bucket_does_not_cost_the_boot_its_compiled_execution
     assert ("serve_eager_posture", "target_applicability_incomplete") \
         not in kinds
 
-    coverage = [d for k, p, d in events
-                if k == "compiled_shape_coverage" and p == "partial_shape_coverage"]
-    assert len(coverage) == 1, events
-    assert "1/3 declared graph classes served COMPILED" in coverage[0]
-    assert "wide" in coverage[0] and "tall" in coverage[0]
-    assert serving_mode.FALLBACK_INGRESS_REFUSED in coverage[0]
-
     # pgw#844 defect 2: the exported lane's OWN revocation signal is what
     # keeps this target advertisable — nothing installed a dynamo marker.
     assert not hasattr(pipe, cc._MARKER_ATTR)
+
+
+def test_the_exported_lane_boots_on_the_eager_warm_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """pgw#1184 — an ARMED `.pt2` costs ONE warm generate, not one per class.
+
+    The fixture's three aspect classes share one eager group (one function,
+    one guidance class, one text pin), so the eager plan is one run and the
+    class x bucket cross-product is three. sdxl's real declaration is 18
+    classes in 2 eager groups: the same ratio, and the 18-where-2-would-do the
+    tree's own comment quoted while leaving it in place.
+
+    Nothing is being traced. A `.pt2` is ahead-of-time machine code that
+    performs no FX lookup, there is no per-class cache-hit ledger to move, and
+    §4.31 deleted the warm plan as a prerequisite to arming — so every run
+    past the first bought nothing but wall clock.
+
+    RED on unmodified master: `the boot ran 3 full warm generates against an
+    ARMED exported cell (1 dispatched, 2 refused at ingress), want 1`.
+    """
+    _ex, _generate, pipe, _events = _boot(tmp_path, monkeypatch)
+
+    dispatched = aot_serve.execution_count(pipe)
+    refused = aot_serve.ingress_refusals(pipe)
+    assert dispatched + refused == 1, (
+        f"the boot ran {dispatched + refused} full warm generates against an "
+        f"ARMED exported cell ({dispatched} dispatched, {refused} refused at "
+        f"ingress), want 1")
 
 
 def test_an_ambiguous_request_is_charged_ingress_refused_not_counted_compiled(
@@ -461,8 +478,12 @@ def test_the_partial_coverage_claim_is_scoped_to_the_exported_execution_lane(
     is an unannounced recompile at serve time, so the same warm plan on the
     dynamo lane must NOT produce a partial-coverage claim.
     """
-    _ex, _generate, pipe, events = _boot(tmp_path, monkeypatch, exported=False)
+    _ex, _generate, pipe, _events = _boot(tmp_path, monkeypatch, exported=False)
 
-    assert not [d for k, _p, d in events if k == "compiled_shape_coverage"]
+    # The FULL plan, all three classes: one served by the compiled callable,
+    # two fell through to eager. On this lane an unproven class is an
+    # unannounced recompile, so the runs are the only detector there is —
+    # which is exactly why pgw#1184 cut the exported lane out of the plan and
+    # left this one alone.
     assert cc.execution_count(pipe) == 1
     assert pipe.unet.eager_calls == 2

--- a/tests/test_shape_growth_pgw916.py
+++ b/tests/test_shape_growth_pgw916.py
@@ -252,10 +252,3 @@ def test_the_dynamo_arm_books_its_permanent_holes_in_the_same_ledger():
     assert "ARM_DYNAMO" in source
 
 
-def test_coverage_reports_convergence_not_only_the_initial_gap():
-    declared = [f"unet/class{i}" for i in range(18)]
-    assert "18/18" in shape_growth.coverage_line(declared, {})
-    gaps: Dict[Tuple[str, str, str], int] = {
-        ("sdxl", "unet", name): 3 for name in declared[2:]}
-    line = shape_growth.coverage_line(declared, gaps)
-    assert "2/18" in line and "16 still serve EAGER" in line


### PR DESCRIPTION
pgw#1184 (th#1834 Phase 4): the exported lane boots on the EAGER warm plan — 18 full generates per handler where 2 would do

RED, grafted onto unmodified `origin/master` (`e65c32dc`) through pgw#844's own
fixture, which drives the real `ensure_setup`, the real derived warm plan and
the real `EntryDispatch`:

    the boot ran 3 full warm generates against an ARMED exported cell
    (1 dispatched, 2 refused at ingress), want 1

Three declared aspect classes in ONE eager group. sdxl's real declaration is 18
classes in 2 eager groups — the same ratio at production scale, and the figure
the tree's own comment quoted while leaving the code in place:

    "Collapsing it to the eager plan is a real saving (sdxl: 18 full generates
     per handler -> 2) but it is not free."

THE CLAIM CHECKS OUT AND SO DOES THE "NOT FREE". The comment named two things
the plan also fed, and they are not the same thing:

* the dynamo lane's per-class FX cache-hit ledger, its only detector of a
  silent recompile — REAL, and untouched. `tracing` now asks whether any object
  under proof is NOT an exported cell (or a fresh self-mint capture is
  pending); a dynamo or TRT object still gets the full cross-product, and the
  scoping test is re-based to assert exactly that.
* pgw#844's boot-time `compiled_shape_coverage` census — DELETED with the runs
  that produced it, and this is the decision worth arguing.

WHY THE CENSUS GOES. It is an OBSERVATION, not a reading: it can only name a
declared class that a warm run happened to dispatch, so it is not a property of
the artifact at all. It also cannot be re-derived from data on this tree —
`verify_graph_witness` refuses any cell whose class set differs from the traced
set, so an armed artifact always carries every declared class, and the case the
census actually reports is dispatch AMBIGUITY (pgw#844's 72-entry regional
sdxl: entries keyed on H and W separately, a transformer block that sees
H_lat*W_lat, eight buckets admitting two entries each). Its price for telling
an operator that a few minutes early is 16 extra full generates per handler on
every boot of every pod.

§4.31 already ruled the identical trade the other way — "warmup never made a
cell faster, it only checked it" — and the per-shape truth still arrives, per
request, typed, at the ingress that refuses the class BY NAME, emits
`aot_ingress_refused`, files a `KIND_SHAPE_GAP`, and charges the request
`fallback_reason=ingress_refused`. That signal is measured on the traffic that
actually asks for the shape. Nothing is left silent.

THE ATTRIBUTION HALF IS LOAD-BEARING AND HAD TO MOVE WITH IT. pgw#844's
relaxation ("an alias that proved SOME of its classes is attributed too") was
what stopped one undispatchable bucket costing the pod every shape. Under the
eager plan an exported object proves ~2 of 18 classes, so a rule that counts
proofs would omit the target and end the boot `boot_ended_uncompiled` — the
exact regression pgw#844 fixed. So attribution on the exported lane now follows
the LANE, not the count: an armed exported object is attributed to every alias
its plan covers, because §4.31 says the arm has no warm prerequisite. Dynamo
keeps the strict all-classes rule verbatim.

Also gone, as residue of the census: `_WarmupEvidence.partial_by_object`
(written, never read) and `shape_growth.coverage_line` (zero production callers
— it rendered `compiled_shape_coverage` and nothing else).

VERIFIED, NOT ASSUMED: `function_proofs` is NOT residue and STAYS. The brief
allowed deleting it "if nothing consumes it"; it is consumed at
`executor.py:4785-4794` to compute `permitted_names` and
`object_proven_by_custom_warmup` — but only on the `not exported_arm` branch.
It is live for the dynamo lane and dead only for the exported one, which is a
distinction the deletion would have flattened.

TESTS: 0 deleted whole, 2 consolidated. `test_partial_shape_coverage_pgw844`
keeps its two real subjects (the target survives an undispatchable bucket; a
refused request is charged `ingress_refused` and never counted compiled), sheds
the census assertions with the census, and gains the RED above as a permanent
row. `test_the_partial_coverage_claim_is_scoped_to_the_exported_execution_lane`
is re-based onto "the dynamo lane still runs the FULL plan". One row deleted
from `test_shape_growth_pgw916` (its subject `coverage_line` is deleted).

Severance experiment: restoring `tracing = bool(objects)` fails
`test_the_exported_lane_boots_on_the_eager_warm_plan` and nothing else.
