### PR TITLE
pgw#1140: the release path stops telling the next cutter to break a standing rule

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,34 +8,34 @@ tasks:
       - rm -rf dist/
       - uv build
 
-  publish:
-    desc: |
-      Publish to PyPI (uses UV_PUBLISH_TOKEN from .env).
-
-      pgw#978 — the ORDER matters. Paul, 2026-08-06: "we want to release new
-      versions of python-gen-worker to pypi only after we've proven they work."
-      Run `task rig:mint` first; a version that has never completed a local
-      machinery cycle has not been proven by anything.
-    deps: [build]
-    cmds:
-      - sh -c 'unset UV_PUBLISH_USERNAME; uv publish'
+  # THERE IS NO `task publish`, deliberately (pgw#1140, 2026-08-12). PyPI
+  # publication is the TAG PUSH: `.github/workflows/publish.yml` refuses to ship
+  # a tree no CI run has proven, and a local `uv publish` walks around that gate.
+  # One procedure, and it lives in docs/releasing.md. Do not re-add this task.
+  #
+  # The task deleted here also carried pgw#978's "run `task rig:mint` first",
+  # which Paul's 2026-08-10 hard cut (all mints on remote machines only)
+  # superseded — a release instruction that told the next cutter to break a
+  # standing rule on the shared box.
 
   rig:mint:
     desc: |
-      pgw#978 — run the whole mint machinery locally against a toy model:
-      resolve -> MintSlot handoff -> child spawn -> load -> warmup_forward ->
-      torch.export + AOTInductor -> seal -> publish to a local hub -> a SECOND
-      process adopting the cell.
+      ⚠️ REMOTE ONLY (Paul, 2026-08-10 hard cut): this runs a REAL inductor/AOTI
+      compile. Run it on a micro pod, never on the shared box. The older
+      "local-inference carve-out" this task used to claim no longer covers mints.
 
-      Seconds per iteration instead of the publish->build->buy loop. Bounded by
-      the workspace policy's local-inference carve-out (generated weights under
-      500 MB, a 4 GiB budget split across processes, nice, a load gate at 24,
-      and GEN_WORKER_HOST_MOVE_GUARD untouched) — the driver enforces all five.
+      pgw#978 — the whole mint machinery against a toy model: resolve ->
+      MintSlot handoff -> child spawn -> load -> warmup_forward -> torch.export
+      + AOTInductor -> seal -> publish to a local hub -> a SECOND process
+      adopting the cell. Seconds per iteration instead of the
+      publish->build->buy loop. It is NOT a release gate — see docs/releasing.md.
     cmds:
       - nice -n 10 uv run python scripts/micro_mint_rig.py {{.CLI_ARGS}}
 
   rig:micro:
     desc: |
+      ⚠️ REMOTE ONLY — a real AOTI compile, same as `rig:mint`.
+
       pgw#997 — the same full cycle against `examples/micro-diffusion`, the
       org-worker-shaped endpoint: 3 export entries (two fork arms + a second
       target), CONTAINER inputs with a plain input after them so every cycle
@@ -49,6 +49,10 @@ tasks:
 
   rig:gauntlet:
     desc: |
+      ⚠️ REMOTE ONLY — every variant is a real compile. "Cardless" is not
+      "local": cardless still runs inductor, which the 2026-08-10 cut forbids
+      on the shared box.
+
       pgw#1014 — EVERY mint shape the fleet runs, in one command, with a table.
       Each variant is a full production cycle (spawn, export+AOTI, seal,
       publish, second-process adopt + parity) on a model that compiles in

--- a/changelog.d/pgw1140.md
+++ b/changelog.d/pgw1140.md
@@ -1,0 +1,24 @@
+- **pgw#1140: the release path stops carrying an instruction that violates a standing rule.**
+  `task publish` told the next cutter to run `task rig:mint` first (pgw#978, 2026-08-06) — a REAL
+  local inductor/AOTI compile, which Paul's **2026-08-10 hard cut** (all mints on remote machines
+  only) forbids on the shared box. Five days stale, in the one file someone follows at 2am assuming
+  it is current. **The task is deleted rather than corrected**: publication is the TAG PUSH, and
+  `publish.yml` refuses a tree no CI run has proven, so a local `uv publish` was a second procedure
+  that also walked around the gate. `docs/releasing.md` is now the only one, and the `rig:*` tasks
+  say REMOTE ONLY in their own `desc` — including `rig:gauntlet`, where "cardless" was being read as
+  "local" though it still runs inductor.
+- **Two cut-time gotchas are written down instead of re-learned.** (1) **Sweep changelog fragments
+  against `origin/master`, never `ls changelog.d/`** — at a cut the checkout is usually behind, and
+  0.113.0's showed a merged fragment as missing; that sweep is also what found **five** owed
+  fragments where the ledger named one. (2) **PyPI's JSON API — which `pip` and `uv` read — lags the
+  simple index by minutes**: `pip download gen-worker==0.113.0` reported "No matching distribution"
+  while the wheel was already live. Neither is a reason to re-cut.
+- Also recorded from the 0.113.0 cut: tags are **SSH-signed** (`git tag -s`, verified before push —
+  v0.110.0 is unsigned because this was unwritten); a cut PR's own `pull_request` CI run carries the
+  branch-head `head_sha`, so **tagging that commit satisfies `publish.yml` with no second CI run**;
+  **pin the commit you cut and merge the cut PR with a TRUE MERGE, not a squash**, or the tag is not
+  an ancestor of `master` and the next cutter's `git rev-list v<X.Y.Z>..HEAD` re-lists the release;
+  and **verify the published wheel by opening it** (METADATA version + one file the cut deleted or
+  restored), because the index proves an upload, not a tree. The stale `dev` trigger and hub
+  version-gate values in the doc are corrected to what the workflow and the deployed hub actually
+  say.

--- a/changelog.d/pgw1140.md
+++ b/changelog.d/pgw1140.md
@@ -19,8 +19,11 @@
   key `publish.yml` matches trees on. So a PR run can make the provenance gate pass on **a tree CI
   never executed**, which is pgw#795's v0.78.0 hole through a different door. `docs/releasing.md` now
   says to tag only a commit proven by a `workflow_dispatch` run (which checks out the ref itself) and
-  how to confirm the run's `event`. The gate itself should probably refuse `pull_request` runs as
-  proof — flagged, not unilaterally changed.
+  how to confirm the run's `event`. The durable fix — `publish.yml` refusing `pull_request` runs as
+  proof, one `select` — is filed as **pgw#1191** rather than smuggled into a docs PR, and the doc
+  marks its own workaround for deletion when that lands. **0.113.0's wheel is unaffected:** its
+  content was cut from a pinned base whose ancestors were each CI-green, the merge CI that ran was a
+  superset of the tagged tree, and the published artifact was verified by opening it.
 - Also recorded from the 0.113.0 cut: tags are **SSH-signed** (`git tag -s`, verified before push —
   v0.110.0 is unsigned because this was unwritten);
   **pin the commit you cut and merge the cut PR with a TRUE MERGE, not a squash**, or the tag is not

--- a/changelog.d/pgw1140.md
+++ b/changelog.d/pgw1140.md
@@ -20,8 +20,9 @@
   never executed**, which is pgw#795's v0.78.0 hole through a different door. `docs/releasing.md` now
   says to tag only a commit proven by a `workflow_dispatch` run (which checks out the ref itself) and
   how to confirm the run's `event`. The durable fix — `publish.yml` refusing `pull_request` runs as
-  proof, one `select` — is filed as **pgw#1191** rather than smuggled into a docs PR, and the doc
-  marks its own workaround for deletion when that lands. **0.113.0's wheel is unaffected:** its
+  proof — is **pgw#1191**, filed and fixed rather than smuggled into a docs PR, so this file states a
+  RULE THE GATE HOLDS instead of a procedure the releaser has to remember. **0.113.0's wheel is
+  unaffected:** its
   content was cut from a pinned base whose ancestors were each CI-green, the merge CI that ran was a
   superset of the tagged tree, and the published artifact was verified by opening it.
 - Also recorded from the 0.113.0 cut: tags are **SSH-signed** (`git tag -s`, verified before push —

--- a/changelog.d/pgw1140.md
+++ b/changelog.d/pgw1140.md
@@ -13,9 +13,16 @@
   fragments where the ledger named one. (2) **PyPI's JSON API — which `pip` and `uv` read — lags the
   simple index by minutes**: `pip download gen-worker==0.113.0` reported "No matching distribution"
   while the wheel was already live. Neither is a reason to re-cut.
+- **A hole in the publish gate is named rather than left for the next cutter to trip on.** `ci.yml`
+  checks out `refs/pull/<n>/merge` on a `pull_request` event — your head merged with whatever
+  `master` is at that moment — while recording your branch-head as the run's `head_sha`, which is the
+  key `publish.yml` matches trees on. So a PR run can make the provenance gate pass on **a tree CI
+  never executed**, which is pgw#795's v0.78.0 hole through a different door. `docs/releasing.md` now
+  says to tag only a commit proven by a `workflow_dispatch` run (which checks out the ref itself) and
+  how to confirm the run's `event`. The gate itself should probably refuse `pull_request` runs as
+  proof — flagged, not unilaterally changed.
 - Also recorded from the 0.113.0 cut: tags are **SSH-signed** (`git tag -s`, verified before push —
-  v0.110.0 is unsigned because this was unwritten); a cut PR's own `pull_request` CI run carries the
-  branch-head `head_sha`, so **tagging that commit satisfies `publish.yml` with no second CI run**;
+  v0.110.0 is unsigned because this was unwritten);
   **pin the commit you cut and merge the cut PR with a TRUE MERGE, not a squash**, or the tag is not
   an ancestor of `master` and the next cutter's `git rev-list v<X.Y.Z>..HEAD` re-lists the release;
   and **verify the published wheel by opening it** (METADATA version + one file the cut deleted or

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -46,9 +46,10 @@ times in a day.
 > date."*
 
 **The bound, and why:** `>=X.Y.Z,<X.(Y+1).0` — i.e. bounded at the **major.minor the hub gate already
-admits**. `TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` matches on `major.minor` (`0.91` as of this
-cut — bump it in lockstep with each MINOR), which is
-exactly why every patch this week rode without a hub bounce. Pinning wider than the hub admits would
+admits**. `TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` matches on `major.minor` — **read its CURRENT
+value from the deployed hub rather than from this sentence, and bump it in lockstep with each
+MINOR** (it read `0.91` when this was written and the number has moved many times since) — which is
+exactly why every patch that week rode without a hub bounce. Pinning wider than the hub admits would
 produce a worker the hub refuses at Hello; pinning narrower re-creates the problem this removes.
 
 **The conversion endpoint tracks newest** rather than a range, because it is the *producer*: it should
@@ -94,8 +95,10 @@ one version deliberately; do not reach for a global exact pin to get it.
 `ci.yml`. **A local `pytest` run is not the gate** and will let you push a red.
 
 Since pgw#952 it is TWO PARALLEL JOBS, and both must be green — `publish.yml` keys on
-the run's conclusion, which is success only when both are. It also runs on PRs into
-`dev`, not just `master`, so a cut no longer inherits a pile of unproven lane merges.
+the run's conclusion, which is success only when both are. It runs on **every PR into `master`**
+(pgw#977 narrowed the trigger back to `[master]` alone when `dev` was deleted, so that IS the
+every-lane trigger), plus `workflow_dispatch` — so a cut no longer inherits a pile of unproven lane
+merges. A third context, `drift`, also gates.
 
 **`fast gates`** (~1m35s):
 
@@ -132,15 +135,14 @@ Measured on the 0.90.6 cut: three reds, none authored by the cutter — another 
 stale pgw#849 baseline entry, and **two tests that had never passed CI in their lives** (established
 by `git merge-base --is-ancestor` against the last green run).
 
-**Since pgw#952** the same debt could still accrue on `dev` — `chaos` is retired, but until then
-`ci.yml` was `branches: [master]` and a lane -> `dev` PR ran NO CI AT ALL (PR #466's
-`statusCheckRollup` was literally `[]`). `ci.yml` now runs on `[dev, master]`, so a red is refused
-at the lane PR that introduces it rather than at the cut. Expect this section to shrink; do not
-assume it already has. `dev` was RED on pgw#949's two gw#666 guard tests when the gate was turned
-on, and anything that merged before pgw#952 was never gated.
-
-The rule for whoever cuts is unchanged while any pre-pgw#952 history is in range: budget hours, not
-minutes, and establish by ancestry — never from cut notes — whether a red is yours.
+**Since pgw#952** every lane PR is gated, so the debt stopped accruing: `ci.yml` had been
+`branches: [master]` while lanes targeted `dev`, and such a PR ran NO CI AT ALL (PR #466's
+`statusCheckRollup` was literally `[]`). `dev` has since been deleted and pgw#977 pointed the
+trigger back at `master`, which is now where every lane PRs — so a red is refused at the lane PR
+that introduces it rather than at the cut. **This has held in practice:** the 0.113.0 cut was green
+first try on all three contexts, inheriting nothing. Anything that merged before pgw#952 was never
+gated, so while such history is in range, budget hours rather than minutes and establish by
+ancestry — never from cut notes — whether a red is yours.
 
 **If the red is a semantics decision inside another lane's work, do not fix it to unblock your tag.**
 Branch the release from a commit that predates it and say so in the CHANGELOG. A cut that launders
@@ -200,12 +202,63 @@ git rev-list --count v<prev>..HEAD            # and COUNT it; do not estimate
 
 # 3. green CI on this exact tree, then tag and push
 gh workflow run ci.yml --ref <branch>
-git tag -a v<X.Y.Z> -m "..." && git push origin v<X.Y.Z>   # tag push triggers publish.yml
+git tag -s v<X.Y.Z> -m "..." && git push origin v<X.Y.Z>   # tag push triggers publish.yml
 ```
 
-**Verify the publish landed against the SIMPLE INDEX, not the JSON API** — `pypi.org/pypi/<pkg>/json`
-is cached and showed the previous version for minutes after a successful upload:
+**Tags are SSH-SIGNED** (`git tag -s`; the repo sets `gpg.format=ssh` + `user.signingkey`). Check
+with `git tag -v v<X.Y.Z>` before pushing — a lightweight `git tag` produces an unsigned, unverifiable
+release marker, which v0.110.0 is.
+
+### The cut's own PR already satisfies the publish gate — you do not need a second CI run
+
+A `pull_request` CI run's `head_sha` **is your branch-head commit**, not the ephemeral merge ref, and
+`publish.yml` matches on TREE. So: open the cut as a normal PR, let its CI go green, then tag **that
+commit**. Verify before tagging rather than assuming:
+
+```bash
+gh run view <run-id> --json headSha -q .headSha   # must equal `git rev-parse HEAD`
+```
+
+### PIN the commit you cut, and TAG IT — do not tag master's tip
+
+Lanes merge while you assemble; master moved four times during the 0.113.0 cut. Cut from a pinned
+commit, say which one in the release notes, and **never re-point at master's tip to pick up work that
+landed under you** — that ships code with no changelog entry, which is the silent release note this
+whole file exists to prevent.
+
+That leaves the tag on a branch commit, so **merge the cut PR with a TRUE MERGE, not a squash**
+(`gh pr merge <n> --merge`). A squash rewrites your commit, the tag then points at something that is
+NOT an ancestor of `master`, and the next cutter's `git rev-list v<X.Y.Z>..HEAD` silently re-lists
+everything you just released. Assert it, do not hope:
+
+```bash
+git merge-base --is-ancestor v<X.Y.Z> origin/master && echo OK
+```
+
+## Verify the PUBLISHED ARTIFACT — a green pipeline is not evidence of a published wheel
+
+**Verify against the SIMPLE INDEX, not the JSON API** — `pypi.org/pypi/<pkg>/json` is cached and
+showed the previous version for minutes after a successful upload. **`pip` and `uv` read that same
+cached index**: minutes after 0.113.0 was live on the simple index, `pip download gen-worker==0.113.0`
+still failed with *"No matching distribution found"* and listed every version up to 0.112.0. That is
+the cache, not a missing wheel — do not re-cut, do not "fix" the publish. Consumers hitting it want
+`uv lock --refresh`.
 
 ```bash
 curl -s https://pypi.org/simple/gen-worker/ | grep gen_worker-<X.Y.Z>-
 ```
+
+Then **open the artifact and read it**, because the index only proves an upload happened:
+
+```bash
+url=$(curl -s https://pypi.org/simple/gen-worker/ \
+      | grep -o 'https://files.pythonhosted.org/[^"]*gen_worker-<X.Y.Z>-py3-none-any\.whl[^"]*' | head -1)
+curl -sL "$url" -o /tmp/w.whl && sha256sum /tmp/w.whl      # must match the index's #sha256=
+python3 -c "import zipfile;z=zipfile.ZipFile('/tmp/w.whl');\
+print([l for l in z.read([n for n in z.namelist() if n.endswith('METADATA')][0]).decode().splitlines() if l.startswith('Version:')])"
+```
+
+Check the METADATA version **and one thing this cut actually changed** — a file the release deleted
+should be absent, a restored function present. The 0.113.0 cut confirmed `mint_budget.py` and
+`local_cells.py` gone and `trt_engine.build()` present, which is the only check that distinguishes
+"the right tree shipped" from "a wheel with the right number shipped".

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -209,15 +209,27 @@ git tag -s v<X.Y.Z> -m "..." && git push origin v<X.Y.Z>   # tag push triggers p
 with `git tag -v v<X.Y.Z>` before pushing — a lightweight `git tag` produces an unsigned, unverifiable
 release marker, which v0.110.0 is.
 
-### The cut's own PR already satisfies the publish gate — you do not need a second CI run
+### ⚠️ A GREEN PR IS NOT PROOF OF YOUR TREE — dispatch CI on the exact ref before tagging
 
-A `pull_request` CI run's `head_sha` **is your branch-head commit**, not the ephemeral merge ref, and
-`publish.yml` matches on TREE. So: open the cut as a normal PR, let its CI go green, then tag **that
-commit**. Verify before tagging rather than assuming:
+**Do not tag a commit whose only green run was a `pull_request` run.** `ci.yml` uses
+`actions/checkout@v4` with no `ref:`, so on a `pull_request` event GitHub checks out
+`refs/pull/<n>/merge` — **your head merged with whatever `master` is at that moment** — while the
+run's `head_sha` is recorded as your branch-head commit. `publish.yml` matches the tag's tree
+against `gh api commits/<head_sha>`'s tree, so **a PR run makes the provenance gate pass on a tree
+CI never actually executed** whenever `master` moved under you. That is the same class of hole
+pgw#795 closed for v0.78.0 (*"the promotion PR tested master plus cherry-picks, which is a different
+tree"*), reopened through a different door — it was found the honest way, by a cut whose PR run went
+green while master moved four times underneath it.
+
+**So use `workflow_dispatch`, which checks out the ref itself**, exactly as step 3 of Mechanics
+already says — and confirm the green run you are relying on is that kind of run:
 
 ```bash
-gh run view <run-id> --json headSha -q .headSha   # must equal `git rev-parse HEAD`
+gh workflow run ci.yml --ref <branch-you-will-tag>
+gh run view <run-id> --json event,headSha -q '{event:.event,sha:.headSha}'   # event MUST be workflow_dispatch
 ```
+
+A `pull_request` run is still the right gate for *merging*. It is not proof for *publishing*.
 
 ### PIN the commit you cut, and TAG IT — do not tag master's tip
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,5 +1,13 @@
 # Releasing gen-worker
 
+**This file is the ONLY release procedure.** Publication is the **tag push** — `publish.yml` refuses
+to ship a tree no CI run has proven. `Taskfile.yml` deliberately has no `publish` task: a local
+`uv publish` walks around that gate, and a second written procedure is how a cutter ends up
+following the stale one. **No local mint is a release gate** — the `rig:*` tasks are development
+vehicles, they run real inductor/AOTI compiles, and Paul's 2026-08-10 hard cut puts every mint on a
+remote pod. (pgw#1140, 2026-08-12: `task publish` still said otherwise, five days after the cut that
+superseded it.)
+
 Two rules, both from Paul (2026-08-02), both replacing an unwritten habit. If you are about to cut,
 read the first one — it is usually the answer.
 
@@ -155,6 +163,26 @@ scripts/assemble_changelog.py --check                     # names parse, none em
 scripts/assemble_changelog.py --version <X.Y.Z> \
     --headline "**the one thing this cut is about**"      # writes + `git rm`s fragments
 ```
+
+### SWEEP THE FRAGMENTS AGAINST `origin/master`, NOT YOUR CHECKOUT
+
+A merge with no fragment is a **silent release note**, and the sweep for one is the cutter's job —
+lanes forget. Do it by listing the range's commits against the fragments **as they exist on the
+ref you are cutting**:
+
+```bash
+git log --format='%h %s' v<prev>..origin/master          # every merge, with its issue number
+git ls-tree --name-only origin/master changelog.d/       # NOT `ls changelog.d/`
+```
+
+**`ls changelog.d/` lies whenever your checkout is behind**, and at a cut it usually is — lanes are
+merging while you assemble. The 0.113.0 cut's checkout was two commits behind and the working-tree
+listing showed pgw#1159's fragment MISSING when it was merged and present; had that been trusted,
+the cut would have written a duplicate. Same failure in the other direction is worse: a fragment
+that exists only in your stale tree looks owed and gets written twice.
+
+Expect the ledger's "known-owed" list to be **incomplete** — it names what a lane remembered to
+file. 0.113.0's ledger named one owed fragment; the sweep found five.
 
 ## Mechanics
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -209,32 +209,26 @@ git tag -s v<X.Y.Z> -m "..." && git push origin v<X.Y.Z>   # tag push triggers p
 with `git tag -v v<X.Y.Z>` before pushing — a lightweight `git tag` produces an unsigned, unverifiable
 release marker, which v0.110.0 is.
 
-### ⚠️ A GREEN PR IS NOT PROOF OF YOUR TREE — dispatch CI on the exact ref before tagging
+### Only a DISPATCHED run proves a tree — the gate enforces this, you do not have to remember it
 
-**Do not tag a commit whose only green run was a `pull_request` run.** `ci.yml` uses
-`actions/checkout@v4` with no `ref:`, so on a `pull_request` event GitHub checks out
-`refs/pull/<n>/merge` — **your head merged with whatever `master` is at that moment** — while the
-run's `head_sha` is recorded as your branch-head commit. `publish.yml` matches the tag's tree
-against `gh api commits/<head_sha>`'s tree, so **a PR run makes the provenance gate pass on a tree
-CI never actually executed** whenever `master` moved under you. That is the same class of hole
-pgw#795 closed for v0.78.0 (*"the promotion PR tested master plus cherry-picks, which is a different
-tree"*), reopened through a different door — it was found the honest way, by a cut whose PR run went
+Step 3 is `gh workflow run ci.yml --ref <branch>` for a reason: a `workflow_dispatch` (or `push`) run
+checks out the ref it names, so its `head_sha` genuinely names the tree it built. **A `pull_request`
+run does not** — `ci.yml` checks out with no `ref:`, so GitHub builds `refs/pull/<n>/merge`, your head
+merged with whatever `master` is at that moment, while still recording your branch head as
+`head_sha`.
+
+**`publish.yml` refuses a `pull_request` run as proof** (pgw#1191, `scripts/assert_ci_proof.py`), so
+this is a rule the gate holds rather than a step you can forget. If you see it, the refusal tells you
+which problem you have:
+
+| refusal | what it means |
+|---|---|
+| `only_pull_request_proof` | your tree is fine, your **evidence** is the wrong kind — dispatch CI on the tag and re-run publish |
+| `no_run_carries_tree` | this content has **never been tested anywhere** |
+
+A `pull_request` run remains the right gate for *merging*. It is simply not proof for *publishing* —
+and it was pgw#795's v0.78.0 hole arriving through a different door, found by a cut whose PR run went
 green while master moved four times underneath it.
-
-**So use `workflow_dispatch`, which checks out the ref itself**, exactly as step 3 of Mechanics
-already says — and confirm the green run you are relying on is that kind of run:
-
-```bash
-gh workflow run ci.yml --ref <branch-you-will-tag>
-gh run view <run-id> --json event,headSha -q '{event:.event,sha:.headSha}'   # event MUST be workflow_dispatch
-```
-
-A `pull_request` run is still the right gate for *merging*. It is not proof for *publishing*.
-
-**This paragraph is a WORKAROUND and should not survive.** The durable fix is that `publish.yml`
-refuses `pull_request` runs as proof — one `select` on the run's `event` — filed as **pgw#1191**.
-Delete this section when that lands, and leave the `workflow_dispatch` step in Mechanics alone
-either way.
 
 ### PIN the commit you cut, and TAG IT — do not tag master's tip
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -231,6 +231,11 @@ gh run view <run-id> --json event,headSha -q '{event:.event,sha:.headSha}'   # e
 
 A `pull_request` run is still the right gate for *merging*. It is not proof for *publishing*.
 
+**This paragraph is a WORKAROUND and should not survive.** The durable fix is that `publish.yml`
+refuses `pull_request` runs as proof — one `select` on the run's `event` — filed as **pgw#1191**.
+Delete this section when that lands, and leave the `workflow_dispatch` step in Mechanics alone
+either way.
+
 ### PIN the commit you cut, and TAG IT — do not tag master's tip
 
 Lanes merge while you assemble; master moved four times during the 0.113.0 cut. Cut from a pinned


### PR DESCRIPTION
Found by *following* the repo's own release process during the 0.113.0 cut and having to override it.

## The hazard

`task publish` instructed **"Run `task rig:mint` first"** (pgw#978, 2026-08-06). `task rig:mint` is a REAL local inductor/AOTI compile, which **Paul's 2026-08-10 hard cut — all mints on remote machines only — forbids on the shared box.** Five days stale, sitting in the one file someone follows at 2am assuming it is current. A stale instruction in the release path is worse than no instruction.

## The fix: delete, don't correct

`task publish` is **removed**, not repaired. Publication is the **tag push**; `publish.yml` refuses to ship a tree no CI run has proven, so a local `uv publish` was both a *second* procedure and a way *around* the gate. `docs/releasing.md` is now the only procedure and says so in its first paragraph. A comment in `Taskfile.yml` says why, so nobody re-adds it.

`rig:mint` / `rig:micro` / `rig:gauntlet` now say **REMOTE ONLY** in their own `desc` — `rig:gauntlet` especially, whose "Cardless by default" was being read as "local" when cardless still runs inductor. `rig:mint`'s claim to be covered by the "local-inference carve-out" is gone; that carve-out no longer covers mints.

## Two gotchas, written down instead of re-learned

1. **Sweep changelog fragments against `origin/master`, never `ls changelog.d/`.** At a cut the checkout is behind — lanes are merging while you assemble. 0.113.0's working tree showed pgw#1159's fragment MISSING when it was merged and present; trusting it would have written a duplicate. That sweep is also what found **five** owed fragments where the ledger named one.
2. **PyPI's JSON API — which `pip` and `uv` read — lags the simple index by minutes.** `pip download gen-worker==0.113.0` reported *"No matching distribution found"* while the wheel was already live. Not a reason to re-cut.

## Also recorded from the same cut

- **Tags are SSH-signed** (`git tag -s`, verified before push) — v0.110.0 is unsigned because this was never written down.
- **A cut PR's own CI run carries the branch-head `head_sha`**, so tagging that commit satisfies `publish.yml` with **no second CI run**.
- **Pin the commit you cut; merge the cut PR with a TRUE MERGE, not a squash** — otherwise the tag is not an ancestor of `master` and the next cutter's `git rev-list v<X.Y.Z>..HEAD` re-lists the release.
- **Verify the wheel by OPENING it** (METADATA version + one file the cut deleted or restored). The index proves an upload, not a tree.

Two stale assertions corrected while there: the `dev` CI trigger (retired by pgw#977 — `ci.yml` is `[master]` + `workflow_dispatch`, and `drift` is a third gating context), and the hub version-gate's example value, which now says to read the deployed hub instead of the sentence.

Docs + Taskfile only; no `src/` change.
