### PR TITLE
pgw#1190: master's fast gates is red — turn the ratchet, and stop the guard telling readers to hunt a caller that does not exist

### DIFF
--- a/changelog.d/pgw1190.md
+++ b/changelog.d/pgw1190.md
@@ -8,5 +8,8 @@
   `--siblings`, and states the §4.34 rule where the reader meets it. It also names **collateral
   invalidation** — this gate reads the MERGED tree, so somebody else's PR can strand a callable and
   redden yours while theirs was green — and prints the `git log -S` that finds the change
-  responsible. That failure mode blocked four lanes once already. Also dedupes 14 baseline rows a
-  regeneration had duplicated.
+  responsible. That failure mode blocked four lanes once already. It also recognises the commonest red of all — **BEHIND MASTER**: if the stale row is already gone
+  from the baseline on `origin/master`, somebody turned that ratchet upstream and the branch simply
+  predates it, so the message says *rebase, this is not a finding* instead of sending a third lane
+  to investigate a deletion that has already happened. Also dedupes 14 baseline rows a regeneration
+  had duplicated.

--- a/changelog.d/pgw1190.md
+++ b/changelog.d/pgw1190.md
@@ -1,9 +1,12 @@
-- **pgw#1190: master's `fast gates` was red, and the guard's own message was sending readers to look
-  for something that does not exist.** pgw#1184 correctly deleted `shape_growth.coverage_line` under
-  §4.34 and left its baseline row behind, so `lint_unreached_surface` failed on a clean checkout —
-  and told every reader *"it now has a production caller"*, which is false in the deletion case and
-  is a search with no ending. A stale row has two causes needing opposite fixes, and the guard can
-  tell them apart, so it does: **WIRED UP** (still defined, now called — good news, turn the
-  ratchet) versus **DELETED** (gone from the tree; do not go looking for its caller). The NEW-finding
-  message now names all three dispositions and points at `--siblings`, because "no call site in this
-  repo" is not "no consumer".
+- **pgw#1190: the unreached-surface gate's MESSAGES, after the fourth time this session a gate's text
+  was the difference between a minute and a stall.** A stale baseline row has two causes needing
+  opposite fixes and the guard conflated them, telling master's readers that a symbol pgw#1184 had
+  *deleted* "now has a production caller" — a search with no ending. It now says **WIRED UP** (still
+  defined, now called: good news, turn the ratchet) or **DELETED** (gone; do not go looking for its
+  caller), and it echoes the row's own **OWNER/EXPIRY** note, which the file already wrote as prose
+  above each block and nothing ever read. A NEW finding now names all three dispositions, points at
+  `--siblings`, and states the §4.34 rule where the reader meets it. It also names **collateral
+  invalidation** — this gate reads the MERGED tree, so somebody else's PR can strand a callable and
+  redden yours while theirs was green — and prints the `git log -S` that finds the change
+  responsible. That failure mode blocked four lanes once already. Also dedupes 14 baseline rows a
+  regeneration had duplicated.

--- a/changelog.d/pgw1190.md
+++ b/changelog.d/pgw1190.md
@@ -1,0 +1,9 @@
+- **pgw#1190: master's `fast gates` was red, and the guard's own message was sending readers to look
+  for something that does not exist.** pgw#1184 correctly deleted `shape_growth.coverage_line` under
+  §4.34 and left its baseline row behind, so `lint_unreached_surface` failed on a clean checkout —
+  and told every reader *"it now has a production caller"*, which is false in the deletion case and
+  is a search with no ending. A stale row has two causes needing opposite fixes, and the guard can
+  tell them apart, so it does: **WIRED UP** (still defined, now called — good news, turn the
+  ratchet) versus **DELETED** (gone from the tree; do not go looking for its caller). The NEW-finding
+  message now names all three dispositions and points at `--siblings`, because "no call site in this
+  repo" is not "no consumer".

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -149,6 +149,11 @@ AUTHOR_SURFACE: Dict[str, str] = author_surface()
 #: every module was collected; in guarded scope most targets are simply absent.
 SCOPE_ALL = False
 
+#: Every label this tree currently DEFINES, set by `run`. A baseline row can go
+#: stale two ways that need opposite fixes, and telling a reader the wrong one
+#: sends them hunting for a caller that does not exist.
+DEFINED_LABELS: Set[str] = set()
+
 # target -> why it is unreached AND who deletes it. Each row is a DELETION
 # THAT IS OWED, never a permanent pardon: the only legitimate reason to be in
 # here is that something outside this lane's scope owns the removal, so every
@@ -678,7 +683,7 @@ def cross_repo_report(findings: List["Finding"], with_branches: bool) -> int:
 
 
 def run(scope_all: bool, want_params: bool, explain: bool) -> List[Finding]:
-    global SCOPE_ALL
+    global SCOPE_ALL, DEFINED_LABELS
     SCOPE_ALL = scope_all
     src_files = py_files([PKG])
     defs = [d for d in collect_definitions(src_files)
@@ -686,6 +691,7 @@ def run(scope_all: bool, want_params: bool, explain: bool) -> List[Finding]:
     reach = collect_reach(py_files(POD_ROOTS))
     tools = collect_reach(py_files(TOOL_ROOTS))
     published = published_names()
+    DEFINED_LABELS = {f"{d.target}()" for d in defs}
 
     findings: List[Finding] = []
     for target in stale_exemptions(defs):
@@ -917,15 +923,36 @@ def main() -> int:
     stale = sorted(known - current)
     for label in new:
         print(f"NEW unreached public surface: {label}\n"
-              f"  Nothing on the pod's production path calls this. This is the "
-              f"program's dominant defect class (pgw#849) — wire it, delete it, "
-              f"or, if its caller is genuinely outside this tree, add an "
-              f"exemption WITH A REASON in {SELF.name}.", file=sys.stderr)
+              f"  Nothing in src/ reaches this. That is the program's dominant "
+              f"defect class (pgw#849) and one of three things:\n"
+              f"    WIRE IT    the caller is missing and should exist;\n"
+              f"    DELETE IT  with its tests, never porting them (§4.34);\n"
+              f"    PROVE IT   the caller is in an ENDPOINT REPO — run\n"
+              f"               `python {SELF.name} --siblings` and, if it "
+              f"passes, add the row WITH its call site to\n"
+              f"               scripts/author_surface_allowlist.txt.\n"
+              f"  'No call site in this repo' is NOT 'no consumer' (§4.34, "
+              f"eb245671): a symbol behind a priced hub function has a consumer "
+              f"even when no code imports it.", file=sys.stderr)
+    # A row goes stale two ways and they need opposite readings. Saying the
+    # wrong one is not a cosmetic problem: `shape_growth.coverage_line()` was
+    # DELETED by pgw#1184 and this guard told master's readers it "now has a
+    # production caller", which is a search for something that does not exist.
+    # A gate's message is part of the gate.
     for label in stale:
-        print(f"STALE baseline entry: {label}\n"
-              f"  It now has a production caller. Remove the line from "
-              f"{BASELINE.name} in the same commit — the ratchet only turns "
-              f"one way if somebody turns it.", file=sys.stderr)
+        if label in DEFINED_LABELS:
+            print(f"WIRED UP — turn the ratchet: {label}\n"
+                  f"  This is GOOD news, not a regression: the symbol still "
+                  f"exists and now HAS a production caller. That is the "
+                  f"outcome this guard exists to produce. Delete its line from "
+                  f"{BASELINE.name} in the same commit as the wiring.",
+                  file=sys.stderr)
+        else:
+            print(f"DELETED — turn the ratchet: {label}\n"
+                  f"  The symbol is GONE from the tree, so nothing calls it and "
+                  f"nothing can. Delete its line from {BASELINE.name} in the "
+                  f"same commit as the deletion. (Do not go looking for its new "
+                  f"caller — there isn't one.)", file=sys.stderr)
     return 1 if (new or stale) else 0
 
 

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -863,6 +863,29 @@ def inert_declarations() -> List[Tuple[str, Dict[str, List[str]]]]:
 
 
 
+def _upstream_baseline() -> Optional[Set[str]]:
+    """The ratchet file as `origin/master` has it, or None if unavailable.
+
+    Why a gate reads git: a STALE row is usually not a finding at all. Master
+    moves, somebody turns the ratchet there, and every branch that predates the
+    turn goes red on a row that is already gone upstream. Two lanes have now
+    spent time treating that as a real defect. The guard can tell — the row is
+    absent from `origin/master` — so it should say REBASE instead of letting a
+    reader investigate a deletion that has already happened.
+    """
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "show", f"origin/master:{BASELINE.relative_to(REPO)}"],
+            cwd=REPO, capture_output=True, text=True, timeout=30)
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return {ln.strip() for ln in out.stdout.splitlines()
+            if ln.strip() and not ln.startswith("#")}
+
+
 def baseline_rows() -> Tuple[Set[str], Dict[str, str]]:
     """The ratchet's labels, and the OWNER/EXPIRY note governing each.
 
@@ -986,7 +1009,15 @@ def main() -> int:
     # DELETED by pgw#1184 and this guard told master's readers it "now has a
     # production caller", which is a search for something that does not exist.
     # A gate's message is part of the gate.
+    upstream = _upstream_baseline() if stale else None
     for label in stale:
+        if upstream is not None and label not in upstream:
+            print(f"BEHIND MASTER — rebase, this is not a finding: {label}\n"
+                  f"  The row is already gone from {BASELINE.name} on "
+                  f"origin/master: somebody turned this ratchet upstream and "
+                  f"your branch predates it. Rebase and the red goes with it. "
+                  f"Nothing here needs investigating.", file=sys.stderr)
+            continue
         note = notes.get(label, "")
         owed = f"\n  THE ROW SAID: {note}" if note else ""
         if label in DEFINED_LABELS:

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -863,6 +863,45 @@ def inert_declarations() -> List[Tuple[str, Dict[str, List[str]]]]:
 
 
 
+def baseline_rows() -> Tuple[Set[str], Dict[str, str]]:
+    """The ratchet's labels, and the OWNER/EXPIRY note governing each.
+
+    The file already writes those notes as prose above the rows they cover
+    (pgw#1178's block is the model). Parsing them costs nothing and turns a
+    note nobody reads into the first line of the failure that needs it: a row
+    with an owner and an expiry is a deletion somebody OWES, and the reader who
+    trips the gate is usually not that somebody.
+    """
+    known: Set[str] = set()
+    notes: Dict[str, str] = {}
+    current = ""
+    buf: List[str] = []
+    for raw in BASELINE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            body = line.lstrip("#").strip()
+            if set(body) == {"-"} or not body:
+                # a separator or a blank comment ends the block's scope
+                if buf:
+                    current = " ".join(buf)
+                    buf = []
+                elif set(body) == {"-"}:
+                    current = ""
+                continue
+            if "OWNER:" in body or "EXPIRY:" in body or buf:
+                buf.append(body)
+            continue
+        if not line:
+            continue
+        if buf:
+            current = " ".join(buf)
+            buf = []
+        known.add(line)
+        if current:
+            notes[line] = current
+    return known, notes
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true",
@@ -917,8 +956,7 @@ def main() -> int:
         print(f"wrote {len(current)} entries to {BASELINE}", file=sys.stderr)
         return 0
 
-    known = {ln.strip() for ln in BASELINE.read_text(encoding="utf-8").splitlines()
-             if ln.strip() and not ln.startswith("#")}
+    known, notes = baseline_rows()
     new = sorted(current - known)
     stale = sorted(known - current)
     for label in new:
@@ -933,22 +971,33 @@ def main() -> int:
               f"               scripts/author_surface_allowlist.txt.\n"
               f"  'No call site in this repo' is NOT 'no consumer' (§4.34, "
               f"eb245671): a symbol behind a priced hub function has a consumer "
-              f"even when no code imports it.", file=sys.stderr)
+              f"even when no code imports it.\n"
+              f"  IT MAY NOT BE YOUR CHANGE. This gate reads the MERGED tree, "
+              f"so a callable whose last caller was removed by somebody else's "
+              f"PR goes red on yours — and on theirs it was green. That is "
+              f"invisible to both authors and it has cost this program four "
+              f"blocked lanes once already. Before you touch anything, find "
+              f"the change that stranded it:\n"
+              f"      git log --oneline -S {label.rstrip('()').rsplit('.', 1)[-1]!r} -- src/\n"
+              f"  If the answer is not your commit, the fix is a baseline row "
+              f"WITH AN OWNER AND AN EXPIRY, not a deletion.", file=sys.stderr)
     # A row goes stale two ways and they need opposite readings. Saying the
     # wrong one is not a cosmetic problem: `shape_growth.coverage_line()` was
     # DELETED by pgw#1184 and this guard told master's readers it "now has a
     # production caller", which is a search for something that does not exist.
     # A gate's message is part of the gate.
     for label in stale:
+        note = notes.get(label, "")
+        owed = f"\n  THE ROW SAID: {note}" if note else ""
         if label in DEFINED_LABELS:
-            print(f"WIRED UP — turn the ratchet: {label}\n"
+            print(f"WIRED UP — turn the ratchet: {label}{owed}\n"
                   f"  This is GOOD news, not a regression: the symbol still "
                   f"exists and now HAS a production caller. That is the "
                   f"outcome this guard exists to produce. Delete its line from "
                   f"{BASELINE.name} in the same commit as the wiring.",
                   file=sys.stderr)
         else:
-            print(f"DELETED — turn the ratchet: {label}\n"
+            print(f"DELETED — turn the ratchet: {label}{owed}\n"
                   f"  The symbol is GONE from the tree, so nothing calls it and "
                   f"nothing can. Delete its line from {BASELINE.name} in the "
                   f"same commit as the deletion. (Do not go looking for its new "

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -173,11 +173,14 @@ gen_worker.boot_phases.servable_ms()
 #       this function as its owner.
 #     * `guard_closure.closure_manifest` is the guard-closure dependency dump
 #       that rode the cell; the guard-miss doctrine it belongs to is KEPT.
-#   OWNER: the per-entry atom (compile-loop greenfield Phase 1), which deletes
-#   the multi-entry tarball, `pack`/`unpack`'s fixed member set and
-#   `combined_graph_hash` as identity in one coherent change. EXPIRY: that
-#   change. If Phase 1 lands and these three are still here, the consumer half
-#   was never re-based and this note was wrong.
+#   OWNER: the per-entry atom (compile-loop greenfield Phase 1, `pgw#1176`),
+#   which deletes the multi-entry tarball, `pack`/`unpack`'s fixed member set
+#   and `combined_graph_hash` as identity in one coherent change.
+#   EXPIRY, restated 2026-08-12 rather than copied: these rows die when
+#   `pgw1176-per-entry-atom` lands. That PR (#718) is OPEN and holding on a
+#   proto-window reply, not on work — so this baseline is short-lived BY
+#   CONSTRUCTION, and if Phase 1 lands with these five still here, the consumer
+#   half was never re-based and this note was wrong.
 #
 gen_worker.compile_cache.seed_artifact()
 gen_worker.compile_cache.artifact_metadata()
@@ -227,20 +230,8 @@ gen_worker.guard_closure.manifest_digest()
 # anything absent was cleared.
 # ---------------------------------------------------------------------------
 
-gen_worker.aot_compile_spans.dark_fraction()
-gen_worker.aot_inputs.inputs_for()
-gen_worker.aot_inputs.latent_dims()
-gen_worker.aot_package.package_entry_names()
-gen_worker.aot_serve.EntryDispatch.refusal_counts()
-gen_worker.aot_serve.realigned_inputs()
-gen_worker.aot_serve.served_entry_calls()
 gen_worker.boot_key.assert_memo_honest()
 gen_worker.boot_key.prop_economy()
-gen_worker.boot_phases.BootSpan.skipped()
-gen_worker.boot_phases.servable_ms()
-gen_worker.compile_cache.artifact_metadata()
-gen_worker.compile_cache.pack()
-gen_worker.compile_cache.seed_artifact()
 gen_worker.component_vocab.ComponentVocabulary.role_of()
 gen_worker.component_vocab.declare_components()
 gen_worker.component_vocab.reset_component_vocabulary()
@@ -282,8 +273,6 @@ gen_worker.convert.writer.verify_w8a8_snapshot()
 gen_worker.discovery.validation.validate_endpoint()
 gen_worker.families.base.family_registry()
 gen_worker.geometry.FamilyGeometry.assert_declared()
-gen_worker.guard_closure.closure_manifest()
-gen_worker.guard_closure.manifest_digest()
 gen_worker.input_assets.inputs_dir_for_request()
 gen_worker.io.exists()
 gen_worker.io.read_audio()


### PR DESCRIPTION
pgw#1190: master's fast gates is red, and the guard's message was sending readers after something that does not exist

**The gate first.** `lint_unreached_surface` fails on a clean `origin/master`
checkout — `exit=1`, `STALE baseline entry: gen_worker.shape_growth.coverage_line()`.
pgw#1184 (`77457aca`) deleted `coverage_line` and its test, correctly and under
§4.34, and left the baseline row behind. Every lane in the rewrite is otherwise
about to burn CI runs on a failure none of them caused. The row is turned.

**Then the message, which was worse than the red.** It said:

    It now has a production caller. Remove the line from
    unreached_surface_baseline.txt in the same commit — the ratchet only turns
    one way if somebody turns it.

`coverage_line` does not exist. There is no new caller, and a competent reader
following that sentence goes looking for one until they give up and read the
guard's source. A baseline row goes stale two ways that need OPPOSITE readings,
and the guard already holds the fact that distinguishes them — what the tree
defines — so it now says which one happened:

    WIRED UP — turn the ratchet: <symbol>
      This is GOOD news, not a regression: the symbol still exists and now HAS
      a production caller. That is the outcome this guard exists to produce.

    DELETED — turn the ratchet: <symbol>
      The symbol is GONE from the tree, so nothing calls it and nothing can.
      (Do not go looking for its new caller — there isn't one.)

Both proved by construction: deleting `coverage_line`'s row back in produces
DELETED; wiring `worker_goals.install()` into `hot_swap` produces WIRED UP.

**And the NEW-finding message**, which had one disposition and needed three. It
now names WIRE IT / DELETE IT / PROVE IT, points at `--siblings`, and states the
§4.34 (`eb245671`) rule in the place a reader actually meets it: *"no call site
in this repo" is NOT "no consumer" — a symbol behind a priced hub function has a
consumer even when no code imports it.* That gap is what severed
`trt_engine.build`; the sentence belongs in the failure text, not only in a
ruling nobody is reading at 2am.

Deleted: 0 production lines. Consolidated: 0.
