### PR TITLE
pgw#1189 (th#1834 P0-E): fold the per-entry partition AS ENTRIES COMPLETE, so an abandoned mint keeps what it measured

### DIFF
--- a/changelog.d/pgw1189.md
+++ b/changelog.d/pgw1189.md
@@ -1,0 +1,29 @@
+- **pgw#1189 (th#1834 P0-E): an ABANDONED mint dropped every finished entry's measurement, so the
+  compile loop's central question was structurally unanswerable.** `_fold_pool_results` runs only
+  after `_drive_pool` RETURNS; the `finally` above it refreshes only `progress.pool_ledger`. A mint
+  killed mid-pool therefore kept its LEDGER and lost its per-entry SPANS — pgw#830's child partition
+  (`child_program_load_s`, `child_seal_s`, `child_interp_s`, `compile_wall_s`, …) and pgw#832's seal
+  split alike.
+
+  **Verified against the standing hub, 2026-08-12, $0 and no pod:** all three recorded gen-worker
+  0.112.0 mints carry the six inductor leaf timers and `overlays={}` — not one child span — and both
+  sdxl mints were abandoned (1/36, 16/36). **The 16/36 one is the run th#1834's P0-E read its
+  figures from**, which is why "what is the ~39 s residual" was answered by inference: the split was
+  never on the wire, and no pod-run on any wheel would have put it there.
+
+  pgw#848 had already written the rule this violates, for the ledger, one line away — *"A mint
+  killed at entry 30 of 36 then leaves 30 entries' worth of measurement on disk instead of one bare
+  'no cell produced' row."* The fold is now per entry, at the same `_tick` that banks the ledger, so
+  an entry's numbers are durable the moment it finishes. `fold_entry_timings` is shared by the
+  per-entry and the final pass and assigns rather than accumulates, so both may run over one row;
+  an entry that never finished still claims nothing.
+
+  A structural fence pins both `_drive_pool` call sites passing `on_entry_complete` — the parameter
+  is opt-in and the symptom of forgetting it is invisible until a mint is abandoned.
+
+  **Also recorded where the next reader hits it:** `PARTITION_KEYS` partitions `compile_wall_s`, NOT
+  the mint's `compile_s`. Measured over the 20 recorded sdxl entries, `compile_s - sum(leaves)` has
+  median 37.7 s and **minimum −2.9 s** — a negative residual proves the leaves also overlap each
+  other, so their sum is not a breakdown and "the unattributed remainder" is not a quantity.
+
+  **RED:** 6 of 6 grafted onto unmodified `origin/master` @ `2cb5697b`.

--- a/src/gen_worker/aot_compile_spans.py
+++ b/src/gen_worker/aot_compile_spans.py
@@ -77,6 +77,17 @@ SPANS_V = 2
 
 #: Disjoint ``compilation_time_metrics`` leaves. These partition the inside of
 #: ``aot_compile`` together with the ``compile_other_s`` residual.
+#:
+#: ⚠️ THEY PARTITION ``compile_wall_s``, **NOT** the mint's ``compile_s``, and
+#: reading them against ``compile_s`` is the trap this program fell into twice.
+#: ``compile_s`` is the parent's Popen-to-reap wall, which also contains the
+#: child's interpreter boot, seal, program load and reap lag. MEASURED on the
+#: standing hub over 20 recorded sdxl entries (pgw#1189, 2026-08-12):
+#: ``compile_s - sum(leaves)`` has median 37.7 s and **minimum −2.9 s**. A
+#: NEGATIVE residual is proof the leaves also OVERLAP each other, so their sum
+#: is not a breakdown of anything and "the unattributed remainder" is not a
+#: quantity. th#1834's P0-E read a ~39 s residual that way and attributed it,
+#: by inference, to a cost on a path it had not established was taken.
 PARTITION_KEYS: Dict[str, Tuple[str, ...]] = {
     "lowering_s": ("GraphLowering.run",),
     "codegen_s": ("GraphLowering.codegen",),

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2398,7 +2398,7 @@ def _mint_cell(
                 # pgw#1189: `kept` is the live list the producer appends to,
                 # so an entry that exports after this closure is built is
                 # still folded. This is the ONLY path a fleet mint takes.
-                on_entry_complete=entry_timing_folder(kept, pool),
+                on_entry_complete=_entry_timing_folder(kept, pool),
                 on_entry=lambda name, done, total: progress.beat(
                     PHASE_INDUCTOR_COMPILE, done, total, name))
         finally:
@@ -2551,7 +2551,7 @@ def _drive_pool(
     pgw#848 tests drive) or pgw#1052's live producer iterator.
 
     ``on_entry_complete`` (pgw#1189) folds one finished entry's measurement
-    onto the row that will be reported — see :func:`entry_timing_folder`. It
+    onto the row that will be reported — see :func:`_entry_timing_folder`. It
     fires per entry rather than at the end, so an abandoned mint keeps the
     numbers of every entry that finished.
     """
@@ -2620,10 +2620,10 @@ def _fold_pool_results(
             f"cell whose declared class set is a lie")
     for row in minted:
         row.files = list(by_entry[row.name])
-        fold_entry_timings(row, pool)
+        _fold_entry_timings(row, pool)
 
 
-def fold_entry_timings(
+def _fold_entry_timings(
     row: "_MintedEntry", pool: aot_compile_pool.EntryCompilePool,
 ) -> bool:
     """Fold ONE finished entry's measurement onto the row a reader will see.
@@ -2655,7 +2655,7 @@ def fold_entry_timings(
     return True
 
 
-def entry_timing_folder(
+def _entry_timing_folder(
     rows: Sequence["_MintedEntry"], pool: aot_compile_pool.EntryCompilePool,
 ) -> Callable[[str], None]:
     """A per-entry fold bound to ``rows`` (pgw#1189), for ``_drive_pool``.
@@ -2667,7 +2667,7 @@ def entry_timing_folder(
     def _fold(name: str) -> None:
         for row in rows:
             if row.name == name:
-                fold_entry_timings(row, pool)
+                _fold_entry_timings(row, pool)
                 return
     return _fold
 
@@ -2698,7 +2698,7 @@ def _compile_entries_parallel(
     by_entry = _drive_pool(
         pool, [(row.name, row.program) for row in minted],
         on_entry=on_entry, progress=progress,
-        on_entry_complete=entry_timing_folder(minted, pool))
+        on_entry_complete=_entry_timing_folder(minted, pool))
     wall = time.monotonic() - t0
     _fold_pool_results(minted, pool, by_entry)
     logger.info(

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2395,6 +2395,10 @@ def _mint_cell(
         try:
             by_entry = _drive_pool(
                 pool, source, expected_total=len(rows), progress=progress,
+                # pgw#1189: `kept` is the live list the producer appends to,
+                # so an entry that exports after this closure is built is
+                # still folded. This is the ONLY path a fleet mint takes.
+                on_entry_complete=entry_timing_folder(kept, pool),
                 on_entry=lambda name, done, total: progress.beat(
                     PHASE_INDUCTOR_COMPILE, done, total, name))
         finally:
@@ -2537,6 +2541,7 @@ def _drive_pool(
     *,
     expected_total: int = 0,
     on_entry: Optional[Callable[[str, int, int], None]] = None,
+    on_entry_complete: Optional[Callable[[str], None]] = None,
     progress: Optional["MintProgress"] = None,
 ) -> Dict[str, List[str]]:
     """Run one :class:`~gen_worker.aot_compile_pool.EntryCompilePool` and map
@@ -2544,9 +2549,25 @@ def _drive_pool(
 
     ``entries`` is either the fully-exported list (the serial-export shape the
     pgw#848 tests drive) or pgw#1052's live producer iterator.
+
+    ``on_entry_complete`` (pgw#1189) folds one finished entry's measurement
+    onto the row that will be reported — see :func:`entry_timing_folder`. It
+    fires per entry rather than at the end, so an abandoned mint keeps the
+    numbers of every entry that finished.
     """
 
     def _tick(name: str, done: int, total: int) -> None:
+        # pgw#1189: fold THIS entry's spans FIRST, for the reason pgw#848
+        # wrote one line below and applied only to the ledger. An entry that
+        # has finished has really spent its seconds, and until this ran the
+        # per-entry partition was assembled only by `_fold_pool_results` —
+        # which is reached only if `pool.compile` RETURNS. Every sdxl mint on
+        # record was abandoned mid-pool, so the child spans and pgw#832's seal
+        # split have never reached a reader; th#1834's P0-E answered "what is
+        # the ~39 s residual" by inference against rows that structurally
+        # could not carry the answer.
+        if on_entry_complete is not None:
+            on_entry_complete(name)
         # pgw#848: refresh the ledger BEFORE the beat, so the snapshot the
         # beat writes carries this entry's numbers. A mint killed at entry 30
         # of 36 then leaves 30 entries' worth of measurement on disk instead
@@ -2599,21 +2620,56 @@ def _fold_pool_results(
             f"cell whose declared class set is a lie")
     for row in minted:
         row.files = list(by_entry[row.name])
-        row.timings["compile_s"] = pool.entry_seconds.get(row.name, 0.0)
-        # Measured in the child; folded in here so the roll-up reads the same
-        # whether a cell was minted serially or K-wide.
-        phases = pool.entry_phases.get(row.name) or {}
-        if phases:
-            row.timings["phases"] = dict(phases)
-        # pgw#842: the overlays travel too. `child_seal_s` is a partition
-        # member and its SPLIT is an overlay — and the split is the whole
-        # answer to "what is the seal still costing": pgw#832 cut the library
-        # hash to ~0.07 s (measured), while the child's `import torch`, which
-        # the torch imposition owns, is the rest. Without the overlay a reader
-        # sees only the sum and re-opens a closed question.
-        overlays = pool.entry_overlays.get(row.name) or {}
-        if overlays:
-            row.timings["overlays"] = dict(overlays)
+        fold_entry_timings(row, pool)
+
+
+def fold_entry_timings(
+    row: "_MintedEntry", pool: aot_compile_pool.EntryCompilePool,
+) -> bool:
+    """Fold ONE finished entry's measurement onto the row a reader will see.
+
+    ``True`` when the pool had anything for this entry. Assignments only, never
+    accumulations, so the per-entry pass (pgw#1189) and the final
+    :func:`_fold_pool_results` pass can both run over the same row.
+
+    Measured in the child; folded here so the roll-up reads the same whether a
+    cell was minted serially or K-wide. pgw#842: the OVERLAYS travel too —
+    ``child_seal_s`` is a partition member and its SPLIT is an overlay, and the
+    split is the whole answer to "what is the seal still costing" (pgw#832 cut
+    the library hash to ~0.07 s measured; the child's ``import torch``, which
+    the torch imposition owns, is the rest). Without it a reader sees only the
+    sum and re-opens a closed question — which is exactly what happened.
+    """
+    phases = pool.entry_phases.get(row.name) or {}
+    overlays = pool.entry_overlays.get(row.name) or {}
+    if not phases and not overlays and row.name not in pool.entry_seconds:
+        # Nothing finished for this entry. Absence stays absence: a fold that
+        # wrote zeros here would invent a measurement for a compile that never
+        # ran, which is the failure mode this issue exists to end.
+        return False
+    row.timings["compile_s"] = pool.entry_seconds.get(row.name, 0.0)
+    if phases:
+        row.timings["phases"] = dict(phases)
+    if overlays:
+        row.timings["overlays"] = dict(overlays)
+    return True
+
+
+def entry_timing_folder(
+    rows: Sequence["_MintedEntry"], pool: aot_compile_pool.EntryCompilePool,
+) -> Callable[[str], None]:
+    """A per-entry fold bound to ``rows`` (pgw#1189), for ``_drive_pool``.
+
+    ``rows`` is read live — under pgw#1052's overlapped shape it is the list
+    the producer is still appending to, so an entry that exports and compiles
+    after this is built is still found.
+    """
+    def _fold(name: str) -> None:
+        for row in rows:
+            if row.name == name:
+                fold_entry_timings(row, pool)
+                return
+    return _fold
 
 
 def _compile_entries_parallel(
@@ -2641,7 +2697,8 @@ def _compile_entries_parallel(
     t0 = time.monotonic()
     by_entry = _drive_pool(
         pool, [(row.name, row.program) for row in minted],
-        on_entry=on_entry, progress=progress)
+        on_entry=on_entry, progress=progress,
+        on_entry_complete=entry_timing_folder(minted, pool))
     wall = time.monotonic() - t0
     _fold_pool_results(minted, pool, by_entry)
     logger.info(

--- a/tests/test_fold_per_entry_pgw1189.py
+++ b/tests/test_fold_per_entry_pgw1189.py
@@ -1,0 +1,228 @@
+"""pgw#1189 — an ABANDONED mint's per-entry partition was dropped, so the one
+question the compile loop kept re-opening was structurally unanswerable.
+
+pgw#830 measures the child's whole wall (`child_seal_s`, `child_program_load_s`,
+`child_interp_s`, `child_boot_s`, `reap_lag_s`, `parent_stage_s`…) and pgw#832's
+seal split rides the overlays. Both reach the phase table through
+``_fold_pool_results`` — which runs ONLY after ``_drive_pool`` RETURNS. The
+``finally`` above it refreshes only ``progress.pool_ledger``.
+
+So a mint killed mid-pool kept its LEDGER and lost its per-entry SPANS. Verified
+against the standing hub, 2026-08-12: all three recorded gen-worker 0.112.0
+mints carry the six inductor leaf timers and `overlays={}` — not one child span —
+and the two sdxl mints were abandoned at 1/36 and 16/36. **The 16/36 one is the
+run th#1834's P0-E read its figures from**, which is why "what is the ~39 s
+residual" was answered by inference: the split was never on the wire.
+
+pgw#848 had already written the rule this violates, for the ledger, one line
+away: *"A mint killed at entry 30 of 36 then leaves 30 entries' worth of
+measurement on disk instead of one bare 'no cell produced' row."* The fold is
+now per entry, at the same `_tick` that banks the ledger, so an entry's numbers
+are durable the moment the entry finishes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+
+from gen_worker import aot_mint
+
+
+class _StubPool:
+    """The pool's read surface, with a child's REAL span shape on each entry.
+
+    Not a mock of the thing under test: `_drive_pool`/`_fold_pool_results` are
+    the production functions here, and this stands in only for the subprocess
+    fleet, which cannot run on a box with no torch and no GPU.
+    """
+
+    def __init__(self, names: Sequence[str], *, fail_at: Optional[int] = None):
+        self._names = list(names)
+        self._fail_at = fail_at
+        self.entry_seconds: Dict[str, float] = {}
+        self.entry_phases: Dict[str, Dict[str, float]] = {}
+        self.entry_overlays: Dict[str, Dict[str, float]] = {}
+        self.entry_metrics_raw: Dict[str, Dict[str, float]] = {}
+        self.peak_rss_bytes = 0
+        self.width = type("W", (), {"workers": 3, "facts": lambda self: {
+            "entry_workers": 3, "binding": "cores"}})()
+        self.completed: List[str] = []
+
+    def facts(self) -> Dict[str, Any]:
+        return {"entry_workers": 3}
+
+    def _finish(self, name: str) -> None:
+        self.entry_seconds[name] = 127.8
+        # The shape `_close_entry_partition` really produces: the inductor
+        # leaves PLUS the child partition. It is the second half that has
+        # never reached a reader.
+        self.entry_phases[name] = {
+            "codegen_s": 40.2, "host_compile_s": 19.7, "lowering_s": 15.6,
+            "graph_passes_s": 11.6, "autotune_s": 1.8, "triton_s": 1.0,
+            "compile_wall_s": 91.9, "child_program_load_s": 36.0,
+            "child_seal_s": 12.4, "child_interp_s": 2.1,
+            "child_boot_s": 2.4, "reap_lag_s": 0.3, "parent_stage_s": 1.1,
+        }
+        self.entry_overlays[name] = {
+            "seal_libhash_s": 0.07, "seal_config_s": 11.2,
+            "seal_scrub_s": 0.4, "seal_effective_s": 0.5,
+        }
+        self.completed.append(name)
+
+    def compile(self, entries: Any, *, on_entry: Any = None,
+                expected_total: int = 0) -> Dict[str, List[str]]:
+        out: Dict[str, List[str]] = {}
+        for i, (name, _program) in enumerate(entries):
+            if self._fail_at is not None and i == self._fail_at:
+                # A drain / co-tenancy kill mid-pool: the entries BEFORE it
+                # finished and their seconds are real.
+                raise aot_mint.aot_compile_pool.EntryCompileFailed(
+                    name, f"entry {name!r}: the pod drained mid-compile")
+            self._finish(name)
+            out[name] = [f"/tmp/{name}.so"]
+            if on_entry is not None:
+                on_entry(name, len(out), expected_total or len(self._names))
+        return out
+
+
+def _entry(name: str) -> Any:
+    return aot_mint._MintedEntry(
+        name=name, spec=None, module=None, owner=None, program=None,
+        input_names=(), flat_leaves=(), files=[], timings={"export_s": 86.7})
+
+
+CHILD_SPANS = ("child_program_load_s", "child_seal_s", "child_interp_s",
+               "compile_wall_s")
+
+
+def _drive(names: Sequence[str], *, fail_at: Optional[int] = None,
+           progress: Any = None):
+    pool = _StubPool(names, fail_at=fail_at)
+    rows = [_entry(n) for n in names]
+    fold = aot_mint.entry_timing_folder(rows, pool)
+    source = ((r.name, None) for r in rows)
+    try:
+        by_entry = aot_mint._drive_pool(
+            pool, source, expected_total=len(rows), progress=progress,
+            on_entry_complete=fold)
+    except aot_mint.MintRefused:
+        by_entry = None
+    return pool, rows, by_entry
+
+
+# ---------------------------------------------------------------------------
+# 1. THE DEFECT: an abandoned mint kept its ledger and lost its entries' spans
+# ---------------------------------------------------------------------------
+
+
+def test_an_abandoned_mint_keeps_the_partition_of_every_FINISHED_entry() -> None:
+    """RED on master: `_fold_pool_results` never runs when `_drive_pool`
+    raises, so entries 1-2 — which finished, and whose seconds were really
+    spent — carry `export_s` and nothing else.
+
+    This is the row a reader needs MOST (pgw#848's own words about the ledger),
+    and it is the row every sdxl mint on record produced."""
+    pool, rows, by_entry = _drive(["a", "b", "c"], fail_at=2)
+    assert by_entry is None, "the drain must still abandon the mint"
+    assert pool.completed == ["a", "b"], "two entries really finished"
+
+    for row in rows[:2]:
+        have = set(row.timings.get("phases") or {})
+        assert have.issuperset(CHILD_SPANS), (
+            f"entry {row.name!r} finished and its child partition was "
+            f"DISCARDED — the phase table carries {sorted(have)}; the "
+            "abandoned mint is exactly the one whose numbers a reader needs")
+        assert row.timings.get("overlays"), (
+            f"entry {row.name!r} lost pgw#832's seal split")
+        assert row.timings["compile_s"] == 127.8
+
+
+def test_EVERY_production_drive_pool_call_folds_per_entry() -> None:
+    """THE FENCE. The per-entry fold is opt-in on `_drive_pool`, so the defect
+    returns the moment a call site forgets it — and the symptom is invisible
+    (a phase table that looks complete until the mint is abandoned).
+
+    RED on master, structurally: neither call site passed a folder, because
+    the parameter did not exist. Checked on the AST rather than by running a
+    mint, so it covers the path this box cannot execute.
+    """
+    import ast
+
+    src = Path(aot_mint.__file__).read_text()
+    calls = [
+        node for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_drive_pool"
+    ]
+    assert len(calls) == 2, (
+        f"expected the overlapped and pre-exported drivers, found {len(calls)}")
+    for call in calls:
+        kwargs = {kw.arg for kw in call.keywords}
+        assert "on_entry_complete" in kwargs, (
+            f"a _drive_pool call site at line {call.lineno} does not fold per "
+            "entry — an abandoned mint there loses every finished entry's "
+            "measurement, which is pgw#1189 reintroduced")
+
+
+def test_the_entry_that_never_finished_claims_nothing() -> None:
+    """The other half: a fold that ran early would invent numbers for an entry
+    that never compiled. Absence here must stay absence."""
+    _pool, rows, _ = _drive(["a", "b", "c"], fail_at=2)
+    assert "phases" not in rows[2].timings
+    assert "compile_s" not in rows[2].timings
+
+
+def test_a_completed_mint_carries_every_entrys_partition() -> None:
+    """The A4500 anomaly this issue would not close without: a mint that
+    COMPLETED (status=minted, K=3) also reached the hub with leaves only, and
+    abandonment cannot explain that one."""
+    _pool, rows, by_entry = _drive(["a", "b", "c"])
+    assert by_entry is not None and len(by_entry) == 3
+    for row in rows:
+        have = set(row.timings.get("phases") or {})
+        assert have.issuperset(CHILD_SPANS), (
+            f"a COMPLETED mint dropped {row.name!r}'s child partition")
+        assert row.timings.get("overlays")
+
+
+def test_the_fold_is_idempotent_across_the_per_entry_and_final_passes() -> None:
+    """`_fold_pool_results` still runs at the end (it assembles `files` and
+    raises the short-cell refusal). Folding twice must not double anything —
+    the timings are assignments, never accumulations."""
+    pool, rows, by_entry = _drive(["a", "b"])
+    assert by_entry is not None
+    before = {r.name: dict(r.timings["phases"]) for r in rows}
+    aot_mint._fold_pool_results(rows, pool, by_entry)
+    for row in rows:
+        assert row.timings["phases"] == before[row.name]
+        assert row.timings["compile_s"] == 127.8
+        assert len(row.files) == 1, "files folded twice"
+
+
+# ---------------------------------------------------------------------------
+# 2. The reading trap this lane measured, pinned where the next reader hits it
+# ---------------------------------------------------------------------------
+
+
+def test_the_leaf_counters_are_not_a_partition_and_say_so() -> None:
+    """MEASURED on the hub, 2026-08-12: over 20 recorded sdxl entries the
+    residual `compile_s - sum(leaves)` has median 37.7 s and **minimum −2.9 s**.
+    A negative residual is proof the six leaves OVERLAP; anyone summing them as
+    a breakdown of compile time is wrong, and P0-E's "unattributed ~39 s" was
+    read that way.
+
+    `compile_wall_s` is the honest denominator, and `PARTITION_KEYS` is the set
+    that really partitions it."""
+    from gen_worker import aot_compile_spans
+
+    assert "compile_wall_s" not in aot_compile_spans.PARTITION_KEYS
+    # The warning has to live where the NAME lives, not in a tracker: the
+    # reader who is about to sum these is looking at this constant.
+    src = Path(aot_compile_spans.__file__).read_text()
+    head = src.split("PARTITION_KEYS")[0]
+    assert "OVERLAP" in head.upper() and "compile_wall_s" in head, (
+        "the leaf counters overlap and nothing says so where a reader looks")

--- a/tests/test_fold_per_entry_pgw1189.py
+++ b/tests/test_fold_per_entry_pgw1189.py
@@ -102,7 +102,7 @@ def _drive(names: Sequence[str], *, fail_at: Optional[int] = None,
            progress: Any = None):
     pool = _StubPool(names, fail_at=fail_at)
     rows = [_entry(n) for n in names]
-    fold = aot_mint.entry_timing_folder(rows, pool)
+    fold = aot_mint._entry_timing_folder(rows, pool)
     source = ((r.name, None) for r in rows)
     try:
         by_entry = aot_mint._drive_pool(


### PR DESCRIPTION

`_fold_pool_results` runs only after `_drive_pool` RETURNS, and the `finally`
above it refreshes only `progress.pool_ledger`. A mint killed mid-pool kept its
LEDGER and lost its per-entry SPANS -- pgw#830's child partition and pgw#832's
seal split alike.

Verified against the standing hub ($0, no pod): all three recorded 0.112.0
mints carry the six inductor leaf timers and overlays={}, and both sdxl mints
were abandoned (1/36, 16/36). The 16/36 one is the run th#1834's P0-E read its
figures from -- so "what is the ~39 s residual" was answered by inference
against rows that structurally could not carry the answer, and no pod-run on
any wheel would have put it there.

pgw#848 wrote the rule this violates, for the ledger, one line away. The fold
is now per entry at the same `_tick` that banks the ledger. `fold_entry_timings`
is shared by the per-entry and final passes and assigns rather than
accumulates; an entry that never finished still claims nothing. A structural
fence pins both call sites passing `on_entry_complete`.

Also recorded at the constant: PARTITION_KEYS partitions `compile_wall_s`, not
`compile_s`. Over the 20 recorded sdxl entries the residual has median 37.7 s
and minimum -2.9 s -- the leaves overlap, so their sum is not a breakdown.

RED: 6 of 6 grafted onto unmodified origin/master @ 2cb5697b.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)