### PR TITLE
pgw#1192: the sweep enumerates TYPES, and the cross-repo check follows package re-exports — nine live consumers were baselined as dead

### DIFF
--- a/changelog.d/pgw1192.md
+++ b/changelog.d/pgw1192.md
@@ -1,0 +1,12 @@
+- **pgw#1192: the surface sweep enumerates TYPES, and the cross-repo check follows package
+  re-exports.** Two blind spots, both found by checking rather than reasoning. `collect_definitions`
+  recursed into every `ClassDef` and never emitted one, so a public class nobody constructs was
+  invisible to the fence — a dead type survived a whole deletion pass on a sibling lane and only the
+  compiler caught it. And the cross-repo pattern required the DEFINING module path while
+  `training-endpoints` writes `from gen_worker.convert import Dataset` against a class defined in
+  `gen_worker.convert.dataset`, so **every symbol reached through a package re-export read as
+  unreached — nine live consumers were sitting in the baseline marked dead**
+  (`resolve_calibration_action`, `Dataset`, `write_jsonl_shard`, `publish_flavors`, `Source`,
+  `build_svdq_flavor_tree`, `fetch_svdq_checkpoint`, `streaming_fp8_snapshot`,
+  `verify_w8a8_snapshot`). The re-export pattern now over-matches on purpose: over-matching says
+  *do not delete*.

--- a/scripts/author_surface_allowlist.txt
+++ b/scripts/author_surface_allowlist.txt
@@ -60,3 +60,21 @@ request_context._PublisherMixin.checkpoint_dir	training-endpoints/image_lora_fin
 runtime_config.read_snapshot	inference-endpoints/minimax-h3/tests/test_attn_config_ie678.py:7	TEST
 testing.fake_context	inference-endpoints/qwen3.6-27b-mtp-gguf/tests/test_completion.py:90	TEST
 
+
+# pgw#1192 — found only after two widenings of the check, and both are the
+# lesson. (1) TYPES: the sweep enumerated functions only, so
+# `convert.dataset.Dataset` and `convert.source.Source` were invisible to it
+# entirely. (2) RE-EXPORTS: the cross-repo pattern required the DEFINING module
+# path, and training-endpoints writes `from gen_worker.convert import Dataset`
+# against a class defined in `gen_worker.convert.dataset` — so every symbol
+# reached through a package re-export read as unreached. Nine consumers were
+# sitting in the baseline as "dead" because of it.
+convert.calibration.resolve_calibration_action	training-endpoints/conversion/src/conversion/quant/modelopt.py:39	PROD
+convert.dataset.Dataset	training-endpoints/conversion/src/conversion/quant/modelopt.py:39	PROD
+convert.dataset.write_jsonl_shard	training-endpoints/conversion/src/conversion/prompt_corpus.py:32	PROD
+convert.publish.publish_flavors	training-endpoints/conversion/src/conversion/_common.py:9	PROD
+convert.source.Source	training-endpoints/conversion/src/conversion/_common.py:9	PROD
+convert.svdq.build_svdq_flavor_tree	training-endpoints/conversion/src/conversion/quant/svdq.py:36	PROD
+convert.svdq.fetch_svdq_checkpoint	training-endpoints/conversion/src/conversion/quant/svdq.py:36	PROD
+convert.writer.streaming_fp8_snapshot	training-endpoints/tests/test_fuse_lora.py:317	TEST
+convert.writer.verify_w8a8_snapshot	training-endpoints/conversion/src/conversion/quant/modelopt.py:872	PROD

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -198,6 +198,10 @@ class Definition:
     alias_of: Tuple[str, ...]     # private globals a one-line accessor returns
     alias_calls: Tuple[str, ...]  # everything a one-line accessor delegates to
     doc: str = ""
+    #: "callable" or "type". A symbol sweep that enumerates only functions
+    #: misses a dead TYPE entirely — one survived a whole deletion pass on a
+    #: sibling lane and only the compiler caught it (pgw#1189).
+    kind: str = "callable"
 
     @property
     def target(self) -> str:
@@ -278,6 +282,13 @@ def collect_definitions(paths: List[Path]) -> List[Definition]:
         def visit(node: ast.AST, prefix: str, is_method: bool) -> None:
             for child in ast.iter_child_nodes(node):
                 if isinstance(child, ast.ClassDef):
+                    if not child.name.startswith("_"):
+                        out.append(Definition(
+                            module=mod, qual=f"{prefix}{child.name}",
+                            name=child.name, path=path, line=child.lineno,
+                            is_method=False, decorators=_decorators(child),
+                            params=(), kwonly=(), alias_of=(), alias_calls=(),
+                            doc=ast.get_docstring(child) or "", kind="type"))
                     visit(child, f"{prefix}{child.name}.", True)
                 elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     if child.name.startswith("_"):
@@ -539,6 +550,15 @@ def exempt(d: Definition, published: Set[str], reach: Reach) -> Optional[str]:
 
 
 def reached(d: Definition, reach: Reach) -> bool:
+    if d.kind == "type":
+        # A type is reached by CONSTRUCTION, by annotation, by subclassing, by
+        # isinstance, by `except`, or by a bare name after an import — all of
+        # which land as a Name or an Attribute. Deliberately permissive: this
+        # half under-reports rather than crying wolf, exactly like the method
+        # half above.
+        return (d.target in reach.qualified
+                or d.name in reach.attrs
+                or any(d.name in names for names in reach.local.values()))
     if d.is_method:
         # A receiver's type is not knowable from the AST: fall back to the
         # attribute name. Conservative — under-reports, never cries wolf.
@@ -656,8 +676,13 @@ def cross_repo_report(findings: List["Finding"], with_branches: bool) -> int:
         parts = target.split(".")
         leaf, mod = parts[-1], ".".join(parts[1:-1])
         modtail = mod.split(".")[-1] if mod else ""
-        pats = [rf"from gen_worker\.{re.escape(mod)} import [^\n]*\b{re.escape(leaf)}\b",
-                rf"from gen_worker import [^\n]*\b{re.escape(leaf)}\b",
+        # ANY gen_worker module, not just the defining one: packages re-export,
+        # and training-endpoints imports `from gen_worker.convert import
+        # Dataset` while the class is defined in `gen_worker.convert.dataset`.
+        # Requiring the defining path made this check blind to every re-export
+        # — which is the same shape of miss that severed a priced consumer, so
+        # it over-matches on purpose. Over-matching says "do not delete".
+        pats = [rf"from gen_worker[.\w]* import [^\n]*\b{re.escape(leaf)}\b",
                 rf"\bctx\.{re.escape(leaf)}\s*\("]
         if modtail:
             pats.append(rf"\b{re.escape(modtail)}\.{re.escape(leaf)}\s*\(")
@@ -708,10 +733,10 @@ def run(scope_all: bool, want_params: bool, explain: bool) -> List[Finding]:
         if not reached(d, reach):
             note = ("reached only by an operator script — not the pod's "
                     "production path") if reached(d, tools) else ""
-            findings.append(
-                Finding("callable", f"{d.target}()", d.path, d.line, note))
+            label = d.target if d.kind == "type" else f"{d.target}()"
+            findings.append(Finding(d.kind, label, d.path, d.line, note))
             continue
-        if not want_params:
+        if not want_params or d.kind == "type":
             continue
         # Parameters of a callable that IS reached.
         keys = [d.target, d.name] if not d.is_method else [d.name]

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -230,7 +230,7 @@ gen_worker.guard_closure.manifest_digest()
 # anything absent was cleared.
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
-# pgw#1189 — TYPES are enumerated now, and the cross-repo check follows package
+# pgw#1192 — TYPES are enumerated now, and the cross-repo check follows package
 # RE-EXPORTS. Both were blind spots and both were found the same way: by
 # checking, not by reasoning. A symbol sweep over functions alone let a dead
 # type survive a whole deletion pass on a sibling lane (only the compiler caught
@@ -242,8 +242,20 @@ gen_worker.guard_closure.manifest_digest()
 # Entries are `module.Symbol` for a type and `module.symbol()` for a callable.
 # ---------------------------------------------------------------------------
 
+gen_worker.aot_compile_spans.dark_fraction()
+gen_worker.aot_inputs.inputs_for()
+gen_worker.aot_inputs.latent_dims()
+gen_worker.aot_package.package_entry_names()
+gen_worker.aot_serve.EntryDispatch.refusal_counts()
+gen_worker.aot_serve.realigned_inputs()
+gen_worker.aot_serve.served_entry_calls()
 gen_worker.boot_key.assert_memo_honest()
 gen_worker.boot_key.prop_economy()
+gen_worker.boot_phases.BootSpan.skipped()
+gen_worker.boot_phases.servable_ms()
+gen_worker.compile_cache.artifact_metadata()
+gen_worker.compile_cache.pack()
+gen_worker.compile_cache.seed_artifact()
 gen_worker.component_vocab.ComponentVocabulary.role_of()
 gen_worker.component_vocab.declare_components()
 gen_worker.component_vocab.reset_component_vocabulary()
@@ -278,6 +290,8 @@ gen_worker.convert.writer.streaming_w8a8_snapshot()
 gen_worker.discovery.validation.validate_endpoint()
 gen_worker.families.base.family_registry()
 gen_worker.geometry.FamilyGeometry.assert_declared()
+gen_worker.guard_closure.closure_manifest()
+gen_worker.guard_closure.manifest_digest()
 gen_worker.input_assets.inputs_dir_for_request()
 gen_worker.io.exists()
 gen_worker.io.read_audio()

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -208,7 +208,7 @@ gen_worker.guard_closure.manifest_digest()
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 # pgw#1182 — THE SCOPE IS NOW THE WHOLE PACKAGE, and this list grew from 14 to
-# 113 because of it. Nothing below was newly written; it was always there and the
+# 107 because of it. Nothing below was newly written; it was always there and the
 # fence was pointed at one seventh of the tree.
 #
 # Read the count as the SIZE OF THE QUESTION, not a backlog of confirmed dead
@@ -229,6 +229,18 @@ gen_worker.guard_closure.manifest_digest()
 # A line leaves this file only one of those three ways. `--explain` shows why
 # anything absent was cleared.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# pgw#1189 — TYPES are enumerated now, and the cross-repo check follows package
+# RE-EXPORTS. Both were blind spots and both were found the same way: by
+# checking, not by reasoning. A symbol sweep over functions alone let a dead
+# type survive a whole deletion pass on a sibling lane (only the compiler caught
+# it), and requiring the DEFINING module path let nine live consumers sit in
+# this file marked dead — `training-endpoints` imports
+# `from gen_worker.convert import Dataset` against a class defined in
+# `gen_worker.convert.dataset`.
+#
+# Entries are `module.Symbol` for a type and `module.symbol()` for a callable.
+# ---------------------------------------------------------------------------
 
 gen_worker.boot_key.assert_memo_honest()
 gen_worker.boot_key.prop_economy()
@@ -239,11 +251,9 @@ gen_worker.config.loader.unrecognised_owned_env()
 gen_worker.config.process.current()
 gen_worker.convert.base_model_families.declare_foreign_family_map()
 gen_worker.convert.base_model_families.reset_foreign_family_maps()
-gen_worker.convert.calibration.resolve_calibration_action()
 gen_worker.convert.dataset.Dataset.as_dataloader()
 gen_worker.convert.dataset.Dataset.is_prompt_corpus()
 gen_worker.convert.dataset.Dataset.iter_rows()
-gen_worker.convert.dataset.write_jsonl_shard()
 gen_worker.convert.layout_converters.ConversionIO.set_metadata()
 gen_worker.convert.layout_converters.classify_layout()
 gen_worker.convert.layout_converters.conversion_provenance()
@@ -254,7 +264,6 @@ gen_worker.convert.layout_converters.registered_layout_productions()
 gen_worker.convert.layout_converters.reset_layout_conversions()
 gen_worker.convert.layout_converters.run_layout_conversion()
 gen_worker.convert.loaded_component.LoadedComponent.save_to()
-gen_worker.convert.publish.publish_flavors()
 gen_worker.convert.registry.load_declaration_module()
 gen_worker.convert.registry.register_layout()
 gen_worker.convert.registry.register_repackage_family()
@@ -263,13 +272,9 @@ gen_worker.convert.source.Source.as_hf_model()
 gen_worker.convert.source.Source.iter_hf_components()
 gen_worker.convert.source.Source.tokenizer()
 gen_worker.convert.source.Source.weights_size_bytes()
-gen_worker.convert.svdq.build_svdq_flavor_tree()
-gen_worker.convert.svdq.fetch_svdq_checkpoint()
 gen_worker.convert.writer.fp8_te_components()
 gen_worker.convert.writer.streaming_cast_snapshot()
-gen_worker.convert.writer.streaming_fp8_snapshot()
 gen_worker.convert.writer.streaming_w8a8_snapshot()
-gen_worker.convert.writer.verify_w8a8_snapshot()
 gen_worker.discovery.validation.validate_endpoint()
 gen_worker.families.base.family_registry()
 gen_worker.geometry.FamilyGeometry.assert_declared()
@@ -311,8 +316,10 @@ gen_worker.plan.Plan.snapshot_digests()
 gen_worker.plan.PlanLedger.forget()
 gen_worker.procsplit.group.GroupPlan.child()
 gen_worker.progress.reset()
+gen_worker.progress.tracking
 gen_worker.runtimes.llama.chat_deltas()
 gen_worker.runtimes.llama.completion_deltas()
+gen_worker.shape_growth.Debounce
 gen_worker.shape_growth.GrowthLedger.counts()
 gen_worker.shape_growth.GrowthLedger.seen()
 gen_worker.shape_growth.register_backend()


### PR DESCRIPTION
pgw#1192: the sweep enumerates TYPES, and the cross-repo check follows package RE-EXPORTS — nine live consumers were sitting in the baseline marked dead

Two blind spots in the fence, both found by checking rather than reasoning, and
both of the same family: **a sweep sees only what it enumerates.**

**1. TYPES.** `collect_definitions` recursed into every `ClassDef` and never
emitted one, so the whole guard was a function sweep wearing a symbol sweep's
name. A public class nobody constructs was invisible to it — which is how a dead
type survived a whole deletion pass on a sibling lane and only the compiler
caught it. Types are collected now, reported as `[type] module.Symbol`, with a
deliberately permissive reached-test (construction, annotation, subclassing,
`isinstance`, `except`, a bare name after an import) so this half under-reports
rather than crying wolf, exactly like the existing method half.

Four fall out on this tree, and **two of them were live cross-repo surface**,
which is the second point.

**2. RE-EXPORTS, and this is the one that mattered.** The cross-repo pattern
required the DEFINING module path. `training-endpoints` writes

    from gen_worker.convert import Dataset

against a class defined in `gen_worker.convert.dataset`. So every symbol reached
through a package re-export read as unreached, and **nine live consumers were
sitting in the baseline marked dead**:

    convert.calibration.resolve_calibration_action   convert.source.Source
    convert.dataset.Dataset                          convert.svdq.build_svdq_flavor_tree
    convert.dataset.write_jsonl_shard                convert.svdq.fetch_svdq_checkpoint
    convert.publish.publish_flavors                  convert.writer.streaming_fp8_snapshot
                                                     convert.writer.verify_w8a8_snapshot

Each is now an allowlist row with its call site. The pattern matches any
`gen_worker` module path now — it **over-matches on purpose**, because
over-matching says *do not delete*, and this is the same shape of miss that
severed a priced consumer.

Baseline regenerated at 107 (105 callables + 2 types: `progress.tracking`,
`shape_growth.Debounce`). `--siblings` clean. `trt_engine.build`'s row is gone
with TensorRT itself (pgw#1187).

Deleted: 0 production lines. Consolidated: 0.
