### PR TITLE
pgw#1198 (P0): virtuality is a question about STORAGE, never about TYPE — the wan-2.2 structure_not_honored root cause

### DIFF
--- a/changelog.d/pgw1198.md
+++ b/changelog.d/pgw1198.md
@@ -1,0 +1,28 @@
+- **pgw#1198: virtuality is a question about STORAGE, never about TYPE — a `setup()`-time quantizer
+  made a weight-free structure read as a whole checkpoint.** Every virtuality test in the tree asked
+  `isinstance(t, FakeTensor)`. torchao's `quantize_`, which `wan-2.2` and `minimax-h3` both run
+  inside their own `setup()`, replaces each in-scope `nn.Linear.weight` with a `Float8Tensor` — a
+  traceable wrapper subclass whose inner `qdata`/`scale` are the original FAKE tensors and whose
+  OUTER dtype stays bf16. Not a `FakeTensor`, reports `cuda:0`, prices `numel * element_size` at the
+  high-precision dtype. On pod `729431an6ugbvq` (H100-80, 0.113.0) that made `assert_weight_free`
+  refuse `WanPipeline` for holding **56_203_673_600 bytes of REAL parameters** — the entire model —
+  in a process that held none of it, so no boot key could be derived and the pod served eager for
+  life. `is_virtual` now unwraps a wrapper subclass through torch's own `__tensor_flatten__`
+  contract and answers about what it is MADE OF; `device_mismatches` and `_sum_tensor_bytes` route
+  through it. **The fence is not weakened**: every inner tensor must be virtual, so a subclass over
+  real data — or over a mix — is still a breach, and a META tensor is still reported.
+- **The fake↔real swap preserves the QUANTIZATION.** `materialize_random` (pgw#984's warm proof) and
+  `virtualize` rebuilt a quantized parameter as a plain tensor of its outer dtype, which traces bf16
+  Linears for a pod that serves fp8 — a cell for a graph the pod never executes, the defect
+  `_refuse_artifact_lanes` exists to prevent, arriving by the other door — and cost twice the bytes
+  doing it. Both now rebuild the subclass over inner tensors of the right kind.
+- **pgw#1199 (partial): the mint MEASURES the warm proof before it spends it.** `materialize_random`
+  allocates real values for every virtual parameter — one full checkpoint at compute dtype, in the
+  child, concurrently with the parent's resident copy. On that pod it needed 56.2 GB of a card whose
+  serving parent held 63.68 GiB of 79.18, and the child died on `CUDA out of memory. Tried to
+  allocate 50.00 MiB` recorded under `phase=load`, because the `warmup_forward` frame is emitted
+  only after the allocation RETURNS. `mint_child` now compares the exact byte count it is about to
+  allocate (the same walk, not an estimate — no constant, no margin) against
+  `torch.cuda.mem_get_info()` and refuses typed with both numbers. **§4.33's "a mint costs ~8 GiB"
+  is an sdxl-sized measurement**; the in-child does-it-run proof is weight-scale by construction and
+  belongs on the resident parent (§4.33 steps 4-5). That move is pgw#1199 and is not in this change.

--- a/src/gen_worker/meta_instantiation.py
+++ b/src/gen_worker/meta_instantiation.py
@@ -111,11 +111,27 @@ class Census:
         return not self.events
 
 
-def is_virtual(tensor: Any) -> bool:
+def is_virtual(tensor: Any, _depth: int = 0) -> bool:
     """Whether this tensor allocated nothing.
 
     Meta tensors by device; fake tensors by TYPE, because a fake tensor
     deliberately reports a real device while backing it with no storage.
+
+    AND WRAPPER SUBCLASSES BY THEIR CONTENTS (pgw#1198), which is the whole
+    reason this is a function and not an ``isinstance``. A quantizer run inside
+    ``setup()`` — torchao's ``quantize_``, which ``wan-2.2`` and ``minimax-h3``
+    both call on their denoisers — replaces a parameter with a traceable
+    wrapper subclass (``Float8Tensor``) whose inner ``qdata``/``scale`` are the
+    original FAKE tensors and whose OUTER dtype stays bf16. That object is not
+    a ``FakeTensor``, reports ``cuda:0``, and answers ``numel * element_size``
+    at the high-precision dtype — so a type-only test read a structure holding
+    nothing as the entire bf16 checkpoint: 56_203_673_600 bytes across
+    ``WanPipeline``'s two experts, which is exactly the whole model, for
+    storage that did not exist. Measured on pod ``729431an6ugbvq``.
+
+    Every inner tensor must be virtual, never any: a subclass over real data,
+    or over a mix (fake ``qdata``, real ``scale``), is REAL here. Widening the
+    answer is the fence getting more accurate, not weaker.
     """
     fake_cls: Optional[type] = None
     try:
@@ -126,10 +142,44 @@ def is_virtual(tensor: Any) -> bool:
         fake_cls = None
     if fake_cls is not None and isinstance(tensor, fake_cls):
         return True
+    inner = _wrapped_tensors(tensor) if _depth < _WRAPPER_DEPTH else ()
+    if inner:
+        return all(is_virtual(held, _depth + 1) for held in inner)
     device = getattr(tensor, "device", None)
     if device is None:
         return True
     return str(getattr(device, "type", device)) in VIRTUAL_DEVICES
+
+
+#: How far :func:`is_virtual` unwraps nested wrapper subclasses. A subclass
+#: over a subclass is real (torchao stacks them), a cycle is not; a bound that
+#: cannot be reached by real code costs nothing and makes the walk total.
+_WRAPPER_DEPTH = 4
+
+
+def _wrapped_tensors(tensor: Any) -> Tuple[Any, ...]:
+    """The tensors a traceable wrapper subclass is made OF, if it is one.
+
+    ``__tensor_flatten__`` is torch's own contract for exactly this question —
+    the one ``torch.compile`` and ``torch.export`` use to see inside a subclass
+    — so this asks the object rather than knowing a vocabulary of quantizer
+    types. An empty result means "not a wrapper subclass", and the caller falls
+    back to the device test.
+    """
+    try:
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+        if not is_traceable_wrapper_subclass(tensor):
+            return ()
+        names, _ctx = tensor.__tensor_flatten__()
+    except Exception:  # noqa: BLE001 — an unwalkable object is not a subclass
+        return ()
+    held = tuple(
+        value for value in (getattr(tensor, str(name), None) for name in names)
+        if value is not None)
+    # A subclass that flattens to nothing tells us nothing, so it must not
+    # answer `all([]) is True` and pass as virtual.
+    return held
 
 
 def _endpoint_site(skip: int = 0) -> str:

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -929,6 +929,9 @@ def mint(request: MintRequest) -> MintReport:
     device_label = _device_label(request)
     if virtual_modules:
         _reset_peak()
+        _assert_proof_affordable(
+            [module for _name, module in virtual_modules],
+            device=device_label, request=request)
         randomized = sum(
             structure_only.materialize_random(module, device=device_label)
             for _name, module in virtual_modules)
@@ -992,6 +995,57 @@ def mint(request: MintRequest) -> MintReport:
         request, pipe, cfg, target, started=started,
         sha256_file=sha256_file, execution_lane_verdict=verdict, spec=aot_spec,
         footprint=footprint)
+
+
+def _assert_proof_affordable(
+    modules: List[Any], *, device: str, request: MintRequest,
+) -> None:
+    """Refuse the pgw#984 warm proof when the card cannot hold its values.
+
+    **This is a MEASUREMENT, not a budget** (§4.33's standing rule). The left
+    side is the exact byte count :func:`structure_only.materialize_random` is
+    about to allocate — the same walk over the same tensors — and the right
+    side is ``torch.cuda.mem_get_info()`` read now. No constant, no margin, no
+    learned floor: it can only refuse a case that was going to fail anyway,
+    and it stays silent on every case that fits.
+
+    What it buys is the sentence. On pod ``729431an6ugbvq`` (H100-80, wan-2.2)
+    the proof needed 56.2 GB of a card whose serving parent already held 63.68
+    GiB; the child died on ``CUDA out of memory. Tried to allocate 50.00 MiB``
+    recorded under ``phase=load``, because the ``warmup_forward`` frame is
+    emitted only after ``materialize_random`` RETURNS. Two paid attempts said
+    "resource" and named neither the quantity nor the phase.
+
+    The refusal is the finding, not a workaround for it: an in-child
+    does-it-run proof is weight-scale by construction and §4.33 steps 4-5 put
+    verification on the resident parent instead. See pgw#1199.
+    """
+    from .models import structure_only
+
+    try:
+        import torch
+
+        if not str(device).startswith("cuda") or not torch.cuda.is_available():
+            return
+        free, total = torch.cuda.mem_get_info()
+    except Exception:  # noqa: BLE001 — unmeasured is NO EVIDENCE, never a veto
+        return
+    need = structure_only.proof_cost_bytes(modules)
+    if need <= int(free):
+        return
+    gib = float(2 ** 30)
+    raise MintChildRefused(
+        f"the pgw#984 warm proof cannot run for {mint_identity(request)}: it "
+        f"materialises REAL random values for every virtual parameter, which "
+        f"is {need / gib:.2f} GiB here, and this card has {int(free) / gib:.2f} "
+        f"GiB free of {int(total) / gib:.2f} GiB — the serving parent holds "
+        f"the rest, resident and eager. Measured before allocating rather "
+        f"than met as a CUDA OOM. This is pgw#1199: a mint's cost is one FULL "
+        f"checkpoint at compute dtype in the CHILD, concurrently with the "
+        f"parent's copy, so §4.33's ~8 GiB holds for sdxl-sized families and "
+        f"not for this one. The proof belongs on the resident parent "
+        f"(§4.33 steps 4-5), which already holds these weights and pays for "
+        f"them once")
 
 
 def _device_label(request: MintRequest) -> str:

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -637,12 +637,16 @@ def device_mismatches(obj: Any, device: str) -> List[tuple[str, str, str]]:
     on every boot-trace child of two live families. Such a component is
     skipped whole: its fake parameters allocate nothing and its real buffers
     are part of the graph being traced, so MOVING them would be the defect.
-    A fake tensor is exempt wherever it is found, for the same reason. A META
-    tensor is exempt only inside a structure-only component — elsewhere it is
-    an unmaterialized load, which :func:`meta_tensors` exists to report."""
+    A fake tensor is exempt wherever it is found, for the same reason — and so
+    is a wrapper SUBCLASS over fake data (pgw#1198), which is what a
+    ``setup()``-time quantizer leaves behind and which an ``isinstance``
+    against ``FakeTensor`` cannot see. A META tensor is exempt only inside a
+    structure-only component — elsewhere it is an unmaterialized load, which
+    :func:`meta_tensors` exists to report."""
     try:
         import torch
-        from torch._subclasses.fake_tensor import FakeTensor
+
+        from ..meta_instantiation import is_virtual
 
         target = torch.device(device).type
     except Exception:
@@ -660,7 +664,14 @@ def device_mismatches(obj: Any, device: str) -> List[tuple[str, str, str]]:
         except Exception:
             continue
         for tname, t in named:
-            if not isinstance(t, torch.Tensor) or isinstance(t, FakeTensor):
+            if not isinstance(t, torch.Tensor):
+                continue
+            # Allocates nothing => not misplaced. Asked of the STORAGE, so a
+            # wrapper subclass over fake data answers like the fake it wraps
+            # (pgw#1198). A META tensor is the one virtual thing this walk must
+            # still report: outside a structure-only component it is an
+            # unmaterialized load, which `meta_tensors` reads out of here.
+            if t.device.type != "meta" and is_virtual(t):
                 continue
             if t.device.type != target:
                 out.append((cname, tname, str(t.device)))
@@ -718,7 +729,8 @@ def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
     two questions, and virtuality answers them differently.
     """
     import torch
-    from torch._subclasses.fake_tensor import FakeTensor
+
+    from ..meta_instantiation import is_virtual
 
     total = 0
     #: ``("ptr", data_ptr)`` for a tensor with storage — shared storages are
@@ -735,7 +747,10 @@ def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
             for t in tensors:
                 if not isinstance(t, torch.Tensor):
                     continue
-                virtual = isinstance(t, FakeTensor)
+                # pgw#1198: asked of the STORAGE. A `setup()`-time quantizer
+                # leaves a wrapper subclass over fake data, which is a
+                # FakeTensor to nobody and occupies the card to nothing.
+                virtual = t.device.type != "meta" and is_virtual(t)
                 if cuda_only and (virtual or t.device.type != "cuda"):
                     continue
                 key: tuple[str, int]

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -400,6 +400,56 @@ def _torch_dtype(root: Path, component: str, dtype: str) -> Any:
     return None
 
 
+def _wrapper_parts(tensor: Any) -> Optional[Tuple[List[str], Any]]:
+    """``(inner attribute names, context)`` when ``tensor`` is a traceable
+    wrapper subclass — torch's own contract for seeing inside one.
+
+    A ``setup()``-time quantizer leaves these behind on a virtual structure
+    (torchao's ``Float8Tensor``: fake ``qdata`` + fake ``scale``, outer dtype
+    bf16), and both directions of the mint's fake↔real swap have to rebuild
+    the SUBCLASS rather than a plain tensor of the outer dtype. Flattening one
+    to bf16 traces bf16 Linears for a pod that serves fp8 — a cell for a graph
+    the pod never executes, which is the defect ``_refuse_artifact_lanes``
+    exists to prevent, arriving by the other door (pgw#1198).
+    """
+    try:
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+        if not is_traceable_wrapper_subclass(tensor):
+            return None
+        names, ctx = tensor.__tensor_flatten__()
+    except Exception:  # noqa: BLE001 — an unwalkable object is not a subclass
+        return None
+    return ([str(n) for n in names], ctx) if names else None
+
+
+def _rebuild_wrapper(tensor: Any, inner: Dict[str, Any]) -> Any:
+    parts = _wrapper_parts(tensor)
+    ctx = parts[1] if parts is not None else None
+    return type(tensor).__tensor_unflatten__(
+        inner, ctx, tuple(tensor.shape), tuple(tensor.stride()))
+
+
+def _fake_like(tensor: Any, *, dtype: Any = None) -> Any:
+    """A zero-storage twin of ``tensor``. Call inside the fake mode + device.
+
+    ``dtype`` casts a plain floating-point tensor to the composition's compute
+    precision; a wrapper subclass is rebuilt from fake inner tensors and is
+    NEVER cast — its outer dtype already IS the compute precision and its
+    payload's dtype is the quantization.
+    """
+    import torch
+
+    parts = _wrapper_parts(tensor)
+    if parts is not None:
+        names, _ctx = parts
+        return _rebuild_wrapper(tensor, {
+            name: _fake_like(getattr(tensor, name)) for name in names})
+    want = dtype if (dtype is not None
+                     and tensor.is_floating_point()) else tensor.dtype
+    return torch.empty(tuple(tensor.shape), dtype=want)
+
+
 def virtualize(module: Any, *, device: str = "", dtype: Any = None) -> Any:
     """Parameters → fake tensors on ``device``; buffers → real, on ``device``.
 
@@ -418,11 +468,8 @@ def virtualize(module: Any, *, device: str = "", dtype: Any = None) -> Any:
             for name, param in list(sub._parameters.items()):
                 if param is None:
                     continue
-                want = dtype if (dtype is not None
-                                 and param.is_floating_point()) else param.dtype
                 sub._parameters[name] = nn.Parameter(
-                    torch.empty(tuple(param.shape), dtype=want),
-                    requires_grad=False)
+                    _fake_like(param, dtype=dtype), requires_grad=False)
     for sub in module.modules():
         for name, buf in list(sub._buffers.items()):
             if buf is None:
@@ -961,20 +1008,69 @@ def materialize_random(module: Any, *, device: str = "") -> int:
         for name, param in list(sub._parameters.items()):
             if param is None:
                 continue
-            real = torch.empty(tuple(param.shape), dtype=param.dtype,
-                               device=dev)
-            if param.is_floating_point() and real.dtype in (
-                    torch.float16, torch.bfloat16, torch.float32,
-                    torch.float64):
-                real.normal_(0.0, RANDOM_STD, generator=generator)
-            else:
-                # fp8 and integer parameters have no `normal_`; a defined
-                # value beats an undefined one, and NaN/overflow would make
-                # every downstream cosine undefined (pgw#1056's guard).
-                real.zero_()
+            real, bytes_ = _real_like(param, device=dev, generator=generator)
             sub._parameters[name] = nn.Parameter(real, requires_grad=False)
-            total += int(real.numel()) * int(real.element_size())
+            total += bytes_
     return total
+
+
+def _real_like(tensor: Any, *, device: str, generator: Any) -> Tuple[Any, int]:
+    """``(a REAL twin of ``tensor``, the bytes it allocated)``.
+
+    A wrapper subclass is rebuilt AS a subclass over real inner tensors
+    (pgw#1198): flattening one to its outer dtype would both cost twice the
+    bytes (bf16 where the payload is fp8) and hand the export a graph the pod
+    does not serve.
+    """
+    import torch
+
+    parts = _wrapper_parts(tensor)
+    if parts is not None:
+        names, _ctx = parts
+        inner: Dict[str, Any] = {}
+        bytes_ = 0
+        for name in names:
+            held, held_bytes = _real_like(
+                getattr(tensor, name), device=device, generator=generator)
+            inner[name] = held
+            bytes_ += held_bytes
+        return _rebuild_wrapper(tensor, inner), bytes_
+    real = torch.empty(tuple(tensor.shape), dtype=tensor.dtype, device=device)
+    if real.dtype in (torch.float16, torch.bfloat16, torch.float32,
+                      torch.float64):
+        real.normal_(0.0, RANDOM_STD, generator=generator)
+    else:
+        # fp8 and integer parameters have no `normal_`; a defined value beats
+        # an undefined one, and NaN/overflow would make every downstream
+        # cosine undefined (pgw#1056's guard).
+        real.zero_()
+    return real, int(real.numel()) * int(real.element_size())
+
+
+def proof_cost_bytes(modules: Any) -> int:
+    """Exactly what :func:`materialize_random` will allocate on the device.
+
+    Not an estimate — the same walk, summing the same tensors, so the mint can
+    compare it against MEASURED free VRAM before it allocates instead of
+    meeting the answer as an anonymous CUDA OOM (pgw#1199). A wrapper subclass
+    counts its PAYLOAD, which is the thing that gets allocated, not its
+    high-precision outer view.
+    """
+    total = 0
+    for module in modules:
+        for sub in module.modules():
+            for param in sub._parameters.values():
+                if param is not None:
+                    total += _payload_bytes(param)
+    return total
+
+
+def _payload_bytes(tensor: Any) -> int:
+    parts = _wrapper_parts(tensor)
+    if parts is None:
+        return int(tensor.numel()) * int(tensor.element_size())
+    names, _ctx = parts
+    return sum(_payload_bytes(getattr(tensor, name)) for name in names)
 
 
 def stray_real_tensors(module: Any) -> Tuple[Tuple[str, Any], ...]:
@@ -1049,6 +1145,7 @@ __all__ = [
     "materialize_random",
     "modules_of",
     "program_shape_env",
+    "proof_cost_bytes",
     "refusal_token",
     "restore_virtual",
     "revirtualize_from_meta",

--- a/tests/test_wrapper_subclass_virtuality_pgw1198.py
+++ b/tests/test_wrapper_subclass_virtuality_pgw1198.py
@@ -1,0 +1,350 @@
+"""pgw#1198: virtuality is a question about STORAGE, never about TYPE.
+
+THE BOUNDARY THIS FILE FIXES IN PLACE
+-------------------------------------
+§4.33 rests on "the compile is weight-free", and pod ``729431an6ugbvq``
+(H100-80, wan-2.2, 0.113.0) refused it:
+
+    structure-only build of component 'transformer,transformer_2' (WanPipeline)
+    is not possible: 2 of 2 declared compile target(s) hold REAL parameters
+    totalling 56_203_673_600 bytes
+
+The forge had NOT failed. Both experts were built from code + config, stamped,
+injected through ``components=`` and carried by the pipeline. What ran next was
+the ENDPOINT's own ``setup()`` — which ``run_setup`` calls after composition —
+and ``wan_2_2.main._quantize_fp8`` swapped every in-scope ``nn.Linear.weight``
+for a torchao ``Float8Tensor``: a traceable wrapper subclass whose inner
+``qdata``/``scale`` are the original FAKE tensors and whose OUTER dtype stays
+bf16. Every virtuality test in the tree asked ``isinstance(t, FakeTensor)``,
+which that object is not, and then priced ``numel * element_size`` at the outer
+dtype — the ENTIRE bf16 checkpoint, for storage that did not exist.
+
+So the boundary of the structure-only forge is NOT a list of pipeline classes,
+and a survey of families would have gone stale the day one of them added a
+quantizer. It is two properties, and this file tests the second one because the
+first was already fenced:
+
+1. the declared compile target must be buildable from code + config
+   (``load_config`` + ``from_config``, named in ``model_index.json``) — refused
+   by name in ``StructureOnlyUnsupported``, covered by
+   ``test_structure_only_pgw1080``;
+2. **whatever the endpoint's own ``setup()``/``warmup()`` then does to that
+   module must remain visible AS virtual.** A quantizer that re-wraps a fake
+   parameter in a tensor subclass is the shape the fleet actually ships
+   (``wan-2.2``, ``minimax-h3``), and nothing fenced it.
+
+Torchao is not in this image, so the subclass here is written to torch's own
+wrapper-subclass contract — ``__tensor_flatten__`` / ``__tensor_unflatten__``,
+outer dtype bf16 over an fp8 payload and an fp32 scale — which is precisely the
+contract ``Float8Tensor`` implements and precisely what the fix consults. The
+test drives the REAL seams: ``structure_only.build_component`` on the micro
+family's real tree, then the real fences.
+
+NOTHING HERE WEAKENS A FENCE
+----------------------------
+``StructureNotHonored`` behaved exactly as designed on that pod — it refused
+rather than mint garbage. The rows below pin both directions: a subclass over
+FAKE data is weight-free, and a subclass over REAL data (or over a MIX) is a
+breach, still, by the same walk.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("accelerate")
+
+import torch.nn as nn  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+from gen_worker import meta_instantiation as mi  # noqa: E402
+from gen_worker.models import structure_only as so  # noqa: E402
+from gen_worker.models.memory import device_mismatches  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# The shape the fleet actually produces: a quantizer's wrapper subclass
+# ---------------------------------------------------------------------------
+
+
+class Quantized(torch.Tensor):
+    """torchao ``Float8Tensor``'s contract, minus torchao.
+
+    Outer dtype is the HIGH-PRECISION one (that is what makes the outer
+    ``numel * element_size`` overstate by 2x on an fp8 payload); the storage
+    lives in the inner tensors, which are whatever the weight was made of.
+    """
+
+    @staticmethod
+    def __new__(cls, qdata: Any, scale: Any, dtype: Any) -> "Quantized":
+        return torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+            cls, qdata.shape, dtype=dtype, device=qdata.device,
+            requires_grad=False)
+
+    def __init__(self, qdata: Any, scale: Any, dtype: Any) -> None:
+        self.qdata = qdata
+        self.scale = scale
+
+    def __tensor_flatten__(self) -> Tuple[list, Dict[str, Any]]:
+        return ["qdata", "scale"], {"dtype": self.dtype}
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, inner: Dict[str, Any], meta: Dict[str, Any],
+        outer_size: Any, outer_stride: Any,
+    ) -> "Quantized":
+        return cls(inner["qdata"], inner["scale"], meta["dtype"])
+
+    @classmethod
+    def __torch_dispatch__(cls, func: Any, types: Any, args: Any = (),
+                           kwargs: Any = None) -> Any:
+        # `nn.Parameter(...)` detaches its data, so the subclass has to survive
+        # that much — the same op torchao's own table implements first. Nothing
+        # else is claimed: an op this test never exercises must say so rather
+        # than silently produce a plain tensor.
+        if func in (torch.ops.aten.detach.default, torch.ops.aten.alias.default):
+            held = args[0]
+            return cls(func(held.qdata), func(held.scale), held.dtype)
+        raise NotImplementedError(func)  # pragma: no cover
+
+
+def quantize_like_setup(module: Any) -> int:
+    """What ``wan-2.2``'s ``setup()`` does to the module the forge just built.
+
+    Runs inside the module's OWN fake mode, exactly as torchao's ``quantize_``
+    does when it is handed a structure-only expert: the inner tensors it
+    derives from a fake weight are fake, and it hands back a subclass.
+    """
+    mode = so.fake_mode_of(module)
+    swapped = 0
+    for sub in module.modules():
+        if not isinstance(sub, nn.Linear):
+            continue
+        weight = sub.weight
+        with mode, torch.device(str(weight.device)):
+            qdata = torch.empty(tuple(weight.shape),
+                                dtype=torch.float8_e4m3fn)
+            scale = torch.empty((weight.shape[0], 1), dtype=torch.float32)
+        sub._parameters["weight"] = nn.Parameter(
+            Quantized(qdata, scale, weight.dtype), requires_grad=False)
+        swapped += 1
+    return swapped
+
+
+def real_quantized(shape: Tuple[int, ...], *, scale_real: bool = True,
+                   qdata_real: bool = True) -> Any:
+    """The same subclass over REAL storage — the case that must still breach.
+
+    ``scale_real=False`` / ``qdata_real=False`` build the MIXED tensor: part
+    fake, part real. Every inner tensor has to be virtual for the whole to be,
+    so a mix is real.
+    """
+    def _make(size: Tuple[int, ...], dtype: Any, real: bool) -> Any:
+        if real:
+            return torch.empty(size, dtype=dtype)
+        with torch._subclasses.fake_tensor.FakeTensorMode() as mode:
+            return torch.empty(size, dtype=dtype)
+
+    qdata = _make(shape, torch.float8_e4m3fn, qdata_real)
+    scale = _make((shape[0], 1), torch.float32, scale_real)
+    return Quantized(qdata, scale, torch.bfloat16)
+
+
+class _Composed:
+    """A diffusers-shaped composition: ``.components`` plus plain attributes,
+    the same fixture shape ``test_weight_free_premise_pgw1173`` uses."""
+
+    def __init__(self, **parts: Any) -> None:
+        self._parts = dict(parts)
+        for name, part in parts.items():
+            setattr(self, name, part)
+
+    @property
+    def components(self) -> Dict[str, Any]:
+        return dict(self._parts)
+
+
+@pytest.fixture(scope="module")
+def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from micro_diffusion.weights import SEED, materialize
+
+    root = tmp_path_factory.mktemp("micro-tree")
+    return materialize(root, seed=SEED)
+
+
+@pytest.fixture()
+def quantized_target(tree: Path) -> Any:
+    module, _facts = so.build_component(tree, "transformer", device="cpu")
+    assert quantize_like_setup(module) > 0, (
+        "the micro denoiser must carry Linears for this to test anything")
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. The primitive: virtuality answers about STORAGE
+# ---------------------------------------------------------------------------
+
+
+def test_a_subclass_over_fake_data_is_VIRTUAL() -> None:
+    from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+    with FakeTensorMode():
+        qdata = torch.empty((64, 32), dtype=torch.float8_e4m3fn)
+        scale = torch.empty((64, 1), dtype=torch.float32)
+    wrapped = Quantized(qdata, scale, torch.bfloat16)
+
+    assert not isinstance(wrapped, FakeTensor), (
+        "the premise of this whole issue: the object is NOT a FakeTensor")
+    assert wrapped.dtype is torch.bfloat16, "the outer view is high precision"
+    assert mi.is_virtual(wrapped), "it allocated nothing and must say so"
+
+
+def test_a_subclass_over_REAL_data_is_NOT_virtual() -> None:
+    assert not mi.is_virtual(real_quantized((64, 32)))
+
+
+@pytest.mark.parametrize("qdata_real,scale_real", [(True, False), (False, True)])
+def test_a_MIXED_subclass_is_NOT_virtual(qdata_real: bool,
+                                         scale_real: bool) -> None:
+    """All-of, not any-of. A quantizer that leaves a real scale beside a fake
+    payload has allocated, and the fence must charge for it."""
+    assert not mi.is_virtual(
+        real_quantized((64, 32), qdata_real=qdata_real, scale_real=scale_real))
+
+
+def test_a_plain_real_tensor_is_still_NOT_virtual() -> None:
+    assert not mi.is_virtual(torch.empty((8, 8), dtype=torch.bfloat16))
+
+
+# ---------------------------------------------------------------------------
+# 2. The fence pod 729431an6ugbvq tripped
+# ---------------------------------------------------------------------------
+
+
+def test_the_weight_free_fence_passes_a_setup_QUANTIZED_structure(
+    quantized_target: Any,
+) -> None:
+    """RED before pgw#1198: this is the wan-2.2 refusal, reproduced.
+
+    Without the fix every quantized Linear is priced at its OUTER bf16 dtype,
+    so the breach total is the whole checkpoint of a module holding nothing.
+    """
+    pipe = _Composed(transformer=quantized_target)
+
+    assert so.weight_free_breaches(pipe, ("transformer",)) == ()
+    so.assert_weight_free(pipe, ("transformer",), what="the pgw#1198 boundary")
+
+
+def test_the_fence_still_FIRES_when_the_quantizer_left_real_weights(
+    quantized_target: Any,
+) -> None:
+    """The other direction, in the same walk. A fence that cannot fire is
+    worse than no fence, and widening what counts as virtual must not have
+    bought that."""
+    quantized_target.proj_out.weight = nn.Parameter(
+        real_quantized(tuple(quantized_target.proj_out.weight.shape)),
+        requires_grad=False)
+    pipe = _Composed(transformer=quantized_target)
+
+    breaches = so.weight_free_breaches(pipe, ("transformer",))
+    assert len(breaches) == 1
+    assert breaches[0].reason == "real_parameters"
+    assert breaches[0].real_param_bytes > 0
+    with pytest.raises(so.StructureNotHonored):
+        so.assert_weight_free(pipe, ("transformer",))
+
+
+def test_the_placement_walk_does_not_read_a_quantized_structure_as_misplaced() -> None:
+    """``device_mismatches`` had the same ``isinstance`` and the same blindness
+    (pgw#1124 defect 2, arriving by the other door): a structure that allocates
+    nothing cannot be moved, and counting it makes a CPU rollback unsatisfiable.
+
+    The parameter must CLAIM THE CARD for this to test anything — that is the
+    whole shape on the pod, and a fake tensor can claim one on a cardless box.
+    """
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode(), torch.device("cuda"):
+        qdata = torch.empty((32, 16), dtype=torch.float8_e4m3fn)
+        scale = torch.empty((32, 1), dtype=torch.float32)
+    module = nn.Module()
+    module._parameters["weight"] = nn.Parameter(  # type: ignore[assignment]
+        Quantized(qdata, scale, torch.bfloat16), requires_grad=False)
+
+    assert str(module.weight.device).startswith("cuda")
+    assert device_mismatches(_Composed(transformer=module), "cpu") == []
+
+
+def test_a_META_tensor_is_still_reported_by_the_placement_walk() -> None:
+    """The one virtual thing that walk must keep reporting: outside a
+    structure-only component a meta tensor is an unmaterialized load, and
+    ``meta_tensors`` reads it out of here."""
+    module = nn.Linear(4, 4, device="meta")
+    found = device_mismatches(_Composed(transformer=module), "cpu")
+    assert [name for _c, name, _d in found] == ["weight", "bias"]
+
+
+# ---------------------------------------------------------------------------
+# 3. The fake <-> real swap must preserve the graph, and price the payload
+# ---------------------------------------------------------------------------
+
+
+def test_the_warm_proof_keeps_the_QUANTIZED_topology(
+    quantized_target: Any,
+) -> None:
+    """pgw#984's proof gives every virtual parameter real values. Rebuilding a
+    quantized weight as a plain tensor of its outer dtype would trace bf16
+    Linears for a pod that serves fp8 — a cell for a graph the pod never
+    executes, which is exactly what ``_refuse_artifact_lanes`` exists to
+    prevent — and would cost twice the bytes doing it."""
+    quantized = {name for name, p in quantized_target.named_parameters()
+                 if isinstance(p.data, Quantized) or isinstance(p, Quantized)}
+    assert quantized, "the fixture must have swapped something"
+
+    so.materialize_random(quantized_target, device="cpu")
+
+    after = dict(quantized_target.named_parameters())
+    for name in quantized:
+        held = after[name]
+        inner = held.data if not isinstance(held, Quantized) else held
+        assert isinstance(inner, Quantized), (
+            f"{name} lost its quantization to the warm proof")
+        assert inner.qdata.dtype is torch.float8_e4m3fn
+        assert not mi.is_virtual(inner), "the proof runs on REAL values"
+
+
+def test_restoring_returns_the_quantized_parameters_to_virtual(
+    quantized_target: Any,
+) -> None:
+    so.materialize_random(quantized_target, device="cpu")
+    so.restore_virtual(quantized_target, device="cpu")
+
+    for name, param in quantized_target.named_parameters():
+        assert mi.is_virtual(param), f"{name} survived the restore as real"
+
+
+def test_the_proof_cost_is_the_PAYLOAD_and_is_measured_before_it_is_spent(
+    quantized_target: Any,
+) -> None:
+    """pgw#1199's left-hand side. It must be the same walk over the same
+    tensors that ``materialize_random`` performs — an estimate here would be
+    the disease §4.33 names — and it must price the fp8 payload rather than
+    the bf16 outer view."""
+    predicted = so.proof_cost_bytes([quantized_target])
+    spent = so.materialize_random(quantized_target, device="cpu")
+
+    assert predicted == spent, "the forecast IS the walk, not a model of it"
+
+    outer = sum(int(p.numel()) * int(p.element_size())
+                for p in quantized_target.parameters())
+    assert predicted < outer, (
+        "an fp8 payload under a bf16 outer view must not be priced at bf16")


### PR DESCRIPTION
## What pod `729431an6ugbvq` actually hit

The wan-2.2 AOT mint probe (H100-80, 0.113.0) cleared the placement gate for the first time and then refused:

```
structure-only build of component 'transformer,transformer_2' (WanPipeline) is not possible:
2 of 2 declared compile target(s) hold REAL parameters totalling 56_203_673_600 bytes —
transformer (WanTransformer3DModel) is stamped structure-only and still holds
28_101_836_800 byte(s) of REAL parameters on cuda:0; transformer_2 likewise.
```

**The forge did not fail.** Both experts were built from code + config, stamped, injected through `components=`, and carried by the pipeline — `_assert_structure_honored` passed and `off_host_tensors` passed. What ran next is the ENDPOINT's own `setup()`, which `run_setup` calls after composition: `wan_2_2.main._quantize_fp8` → torchao `quantize_`, which replaces every in-scope `nn.Linear.weight` with a **`Float8Tensor` — a traceable wrapper tensor subclass** whose inner `qdata`/`scale` are the original FakeTensors and whose OUTER dtype stays bf16.

`meta_instantiation.is_virtual` answered `isinstance(t, FakeTensor)`. That object is not one, reports `cuda:0`, and prices `numel * element_size` at the outer dtype — so a module holding nothing was charged the whole bf16 checkpoint: `28_101_836_800 = 14_050_918_400 params × 2 B`, exactly.

Corroboration from the recorded evidence, not a rerun:

* the pod emitted `applied_lane … fp8-w8a8-dynamic modules=400 kept_bf16=6`, twice — the quantizer ran;
* the boot-trace child **refused cleanly in 13 s**. Had 52.3 GiB genuinely materialised it would have OOMed — only 15.5 GiB were free.

Measured locally on the pinned torch 2.13.0 (CPU, no GPU): a `_make_wrapper_subclass` over two FakeTensors is not a `FakeTensor`, `is_virtual` says `False`, and `is_traceable_wrapper_subclass` + `__tensor_flatten__` see straight through it.

## The fix

* `is_virtual` unwraps a traceable wrapper subclass through torch's own `__tensor_flatten__` contract and answers about what the tensor is **made of**. `device_mismatches` and `_sum_tensor_bytes` route through it — same blindness, same door.
* **Not weakened**: every inner tensor must be virtual, so a subclass over real data — or over a MIX (fake payload, real scale) — still breaches, and a META tensor is still reported by the placement walk. Rows pin both directions.
* `materialize_random` / `virtualize` rebuilt a quantized parameter as a plain tensor of its **outer** dtype — which traces bf16 Linears for a pod that serves fp8 (a cell for a graph the pod never executes, the defect `_refuse_artifact_lanes` exists to prevent) at twice the bytes. Both now rebuild the subclass.
* `mint_child` measures the pgw#984 warm proof before spending it — see below.

## The §4.33 falsification (pgw#1199), partially handled here

`materialize_random` gives every virtual parameter REAL values. Its own docstring says *"they ARE weight-scale for the length of the proof"*, so a mint's cost is **one full checkpoint at compute dtype, in the child, concurrently with the parent's resident copy** — ~5 GB for sdxl (which is where "8 GiB" came from) and **56.2 GB for wan-2.2's two experts**. That is what killed the mint: `CUDA out of memory. Tried to allocate 50.00 MiB … this process has 15.44 GiB memory in use`, recorded under `phase=load` because the `warmup_forward` frame is emitted only *after* `materialize_random` returns.

This PR makes that a **measurement, not a crash**: the exact byte count about to be allocated (the same walk, no constant, no margin, so it can only refuse a case that was going to fail) against `torch.cuda.mem_get_info()`, refused typed with both numbers. **Moving the proof onto the resident parent (§4.33 steps 4-5) is pgw#1199 and is not in this change.**

## The boundary, as a test rather than a survey

The forge's limit is not a list of pipeline classes — such a list goes stale the day a family adds a quantizer. It is two properties:

1. the declared compile target must be buildable from code + config (`load_config`/`from_config`, named in `model_index.json`) — already fenced, `test_structure_only_pgw1080`;
2. **whatever the endpoint's own `setup()`/`warmup()` then does to that module must remain visible AS virtual** — unfenced until now. Affected today: `wan-2.2` (both experts) and `minimax-h3` (`serve_recipe.quantize_dit`/`quantize_conditioner`).

`tests/test_wrapper_subclass_virtuality_pgw1198.py`, 12 rows, driven through the real seams on the micro family's real tree. **5 are RED on `origin/master`**, including the wan-2.2 refusal reproduced verbatim.

## Verification

`mypy src/gen_worker` clean (265 files); all 13 fast-gate lint scripts OK; `tests/test_wrapper_subclass_virtuality_pgw1198.py` 12 passed; the neighbouring structure-only/mint suites (`pgw1080`, `pgw1173`, `pgw1124`, `pgw1128`, `pgw1123`, `pgw1111`) 65 passed and the mint/memory suites 50 passed. No pod was bought.

Tracker: pgw#1198, pgw#1199.