### PR TITLE
pgw#1199 (P0, §4.33 correction): the does-it-run proof runs where the weights already are

### DIFF
--- a/changelog.d/pgw1199.md
+++ b/changelog.d/pgw1199.md
@@ -1,0 +1,40 @@
+- **pgw#1199 (§4.33 CORRECTION, measured on hardware): a mint no longer costs a full checkpoint —
+  the does-it-run proof runs on the RESIDENT parent.** §4.33 says a mint costs ~8 GiB because the
+  model *"is fully resident and serving eager"* and the compile is *"weight-free … VRAM cost is
+  negligible"*. The compile is. The MINT was not: `mint_child` discharged pgw#984's does-it-run
+  proof by calling `materialize_random` — REAL random values for every virtual parameter, one full
+  checkpoint at compute dtype, in a child process holding none, **concurrently with the parent's
+  resident copy**. On pod `729431an6ugbvq` (H100-80, wan-2.2) that is 56.2 GB against 15.5 GiB
+  free: `CUDA out of memory` twice, recorded under `phase=load` because the `warmup_forward` frame
+  is only emitted after the allocation returns, then `delegated_no_cell`, then
+  `boot_ended_uncompiled`. **The "~8 GiB" that anchored this subsystem was measuring that walk for
+  an sdxl-sized family** (~5 GB), and nothing said so.
+- **The proof was in the wrong process, and §4.33 steps 4-5 already said where it goes** — *"load
+  the cell into the LIVE pipeline, already running eager, and verify it works"*, against weights
+  that are resident and paid for once. New `gen_worker.handler_proof`: one warm forward through the
+  endpoint's OWN handler, on the resident pipeline, with REAL checkpoint values — strictly stronger
+  than a random-value re-run. On the fleet path it costs **nothing**: the executor's boot warm plan
+  already runs every declared handler, and setup completes before `bg.task` is ever created, so the
+  record is simply taken where the forward already happens. The request carries PROVENANCE (not a
+  boolean), so the child's report says which proof stood behind the cell it sealed.
+- **pgw#984 is not weakened — it is addressed to the process that can afford it.** A weight-free
+  mint with no proof REFUSES (`mint_child.assert_handler_proven`), naming what the caller must set.
+  It never degrades to "mint anyway", and the child never proves it itself, because proving it
+  there IS the allocation. The real-weight fallback (a quantized artifact lane, a class with no
+  config surface) keeps its in-child proof: the checkpoint is already resident in that process, so
+  it costs nothing extra.
+- **cozy-local mints in the fleet's order now.** `enable_compiled` is reached from inside the SLOT
+  LOAD, before `setup()` has bound the pipeline to the endpoint instance — so no handler exists to
+  run yet. Arming from the local store stays in the load; the MINT is deferred (`DeferredMint`) and
+  runs after `setup()` and `warmup()` return, when one real forward can prove the handler. Same
+  shape as pgw#671's eager-first boot. **This is what makes a 6-8 GiB card viable**: a mint that
+  needed a whole extra checkpoint resident could never run there; one that needs activation-scale
+  is routine.
+- **Deleted, not deprecated:** `structure_only.materialize_random`, `restore_virtual`,
+  `stray_real_tensors` and pgw#1198's `proof_cost_bytes` / affordability guard — the guard measured
+  an allocation that no longer happens. `stray_real_tensors` hunted a REAL tensor cached on a plain
+  attribute by a lazily-built device-pinned table (ie#628's call-time class); that residue existed
+  *because* a real forward had just run in that process. With no real values there the same lazy
+  build fires inside the export's fake mode and yields a FAKE constant, which `aot_package` cannot
+  pack — still loud, at pack time instead of at a stray walk. `test_structure_only_pgw1080` asserts
+  the absence, so nobody reintroduces a route to real values.

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -668,12 +668,20 @@ def run_setup(
     mint = _local_mint_context(
         instance, resolved_models, wanted,
         component_paths=component_paths, selected=selected)
+    # pgw#1199: a mint this load OWES is collected, not run. Arming from the
+    # local store still happens inside the load (the endpoint's `setup()` must
+    # receive an armed pipeline), but the MINT waits until `setup()` and
+    # `warmup()` have returned — because the mint child no longer proves the
+    # endpoint's handler itself, and proving it needs an instance whose
+    # pipeline is bound. Same order the fleet boots in (pgw#671).
+    deferred: List[Any] = []
     loaded = {
         k: _load_injected_model(
             hints.get(k), v, decl=decl, slot=k, device=device,
             arm_compile=arm_compile, place=place,
             overrides=dict((component_paths or {}).get(k) or {}),
-            structure_only=tuple(structure_only), mint=mint)
+            structure_only=tuple(structure_only), mint=mint,
+            defer=deferred)
         for k, v in resolved_models.items()
         if k in wanted
     }
@@ -682,6 +690,11 @@ def run_setup(
     warmup_fn = getattr(instance, "warmup", None)
     if callable(warmup_fn):
         warmup_fn()
+    if deferred and selected is not None:
+        from .. import local_serve
+
+        local_serve.run_deferred(
+            deferred, instance=instance, specs=[selected.spec])
     return loaded if return_loaded else None
 
 
@@ -818,6 +831,7 @@ def _load_injected_model(
     overrides: Optional[Dict[str, str]] = None,
     structure_only: Sequence[str] = (),
     mint: Optional["local_serve.LocalMintContext"] = None,
+    defer: Optional[List[Any]] = None,
 ) -> Any:
     """Load one setup slot via the shared core, with a per-process warm cache
     (so ``serve`` and repeated local dispatches never reload weights).
@@ -909,7 +923,8 @@ def _load_injected_model(
         # pgw#1086 wave 1's deletion of that module would have taken compiled
         # serving off cozy-local outright.
         local_serve.enable_compiled(
-            sl.obj, compile_cfg, Path(tensorhub_cas_dir()), mint=mint)
+            sl.obj, compile_cfg, Path(tensorhub_cas_dir()), mint=mint,
+            defer=defer)
     _INJECTED_CACHE[key] = sl.obj
     return sl.obj
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -38,6 +38,7 @@ from . import boot_adopt
 from . import boot_phases as boot_mod
 from . import cell_adopt
 from . import dispatch
+from . import handler_proof
 from .procsplit import broker as procsplit_broker
 from .plan import (
     InputAssetRef,
@@ -6739,6 +6740,14 @@ class Executor:
                             pass
 
                 await _to_thread_complete(_consume)
+            # pgw#1199: THE proof, recorded where it already happens. This call
+            # is the endpoint's own handler, running on the RESIDENT pipeline
+            # with real checkpoint values, and every warm path in this process
+            # goes through it. A delegated mint reads the record instead of
+            # materialising a second copy of the weights in its child to
+            # re-prove the same sentence with random values (§4.33 steps 4-5).
+            handler_proof.record(
+                spec.name, f"boot warm forward {spec.name!r} (real weights)")
         finally:
             postmortem.clear_inflight(inflight_token)
 
@@ -9880,6 +9889,15 @@ class Executor:
                     execution_lane=self._served_execution_lane(spec),
                     configs={spec.name: self._effective_config(spec)},
                     device=mint_workers.device_of(pipe),
+                    # pgw#1199: this boot ran the endpoint's own handler on the
+                    # resident pipeline before any mint was delegated (setup
+                    # completes, THEN `bg.task` is created), so the child gets
+                    # pgw#984's guarantee for free and allocates nothing for
+                    # it. Empty when a custom `warmup()` stood in for the
+                    # synthesized plan and no handler actually ran — the child
+                    # refuses on that, honestly, rather than proving it at the
+                    # cost of a checkpoint.
+                    handler_proof=handler_proof.provenance(spec.name),
                 ),
                 act=act, abandon=bg.abandon)
             if result.status == mint_delegate.ABANDONED:

--- a/src/gen_worker/handler_proof.py
+++ b/src/gen_worker/handler_proof.py
@@ -1,0 +1,218 @@
+"""pgw#1199: the does-it-run proof belongs to the process that HOLDS the weights.
+
+WHAT THIS REPLACES, AND WHY IT IS A CORRECTION AND NOT A CLEANUP
+----------------------------------------------------------------
+pgw#984 proves the endpoint's own handler RUNS before a cell seals, because
+``torch.export`` traces the declared graph classes off the modules directly and
+never enters the handler — so a mint's phase table could read green for an
+endpoint whose handler could not run at all (pgw#969: ``ctx.slots["pipeline"]``,
+0.0 s into ``warmup_forward``).
+
+It ran in the MINT CHILD, which on a weight-free mint holds no weights — so the
+child first materialised REAL random values for every virtual parameter. That is
+one full checkpoint at compute dtype, in the child, **concurrently with the
+parent's resident copy**. Measured on pod ``729431an6ugbvq`` (H100-80, wan-2.2):
+56.2 GB wanted, 15.5 GiB free, `CUDA out of memory` twice, no cell, eager for
+life. §4.33's *"compile weight-free … VRAM cost is negligible"* was true of the
+compile and false of the mint, and the ~8 GiB figure that anchored the subsystem
+was measuring exactly this allocation for an sdxl-sized family.
+
+§4.33 steps 4-5 already say where verification goes: *"load the cell into the
+LIVE pipeline — already running eager — and verify it works"*, against weights
+that are resident and are not paid for twice. The proof was in the wrong
+process. This module is that correction, and the SDK had already made the same
+call once: ``mint_child.execution_lane_verdict_for`` skips the kernel-lane A/B
+on a meta mint because *"running it would put weight-scale values back in the
+one process this slice exists to keep empty"*.
+
+WHAT A PROOF IS
+---------------
+One warm forward through the endpoint's OWN handler, on the RESIDENT pipeline,
+with REAL checkpoint values — strictly stronger than the child's random-value
+re-run, and free on the fleet path, where the executor's boot warm plan already
+runs every declared handler before a mint is ever delegated.
+
+The record is a per-PROCESS ledger keyed by function name, because that is the
+scope of the claim: *this* process ran *that* handler against the weights it is
+about to mint for. It never crosses a process boundary as a ledger — the mint
+request carries the PROVENANCE string, so the child's report says which proof
+stood behind the cell it sealed rather than asserting one it cannot see.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+import threading
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: function name -> how it was proven (the provenance that rides the request).
+_PROVEN: Dict[str, str] = {}
+_LOCK = threading.Lock()
+
+
+class HandlerProofFailed(Exception):
+    """The endpoint's own handler does not run on the resident pipeline.
+
+    A cell must not seal for a handler that cannot serve — pgw#984's sentence,
+    unchanged. What moved is only WHERE the sentence is spoken: here, in the
+    process that holds the weights, instead of in a child that had to allocate
+    a second copy of them to say it.
+    """
+
+
+def record(function: str, how: str) -> None:
+    """Note that ``function``'s handler ran to completion in THIS process."""
+    name = str(function or "").strip()
+    if not name:
+        return
+    with _LOCK:
+        _PROVEN.setdefault(name, str(how or "handler ran"))
+
+
+def provenance(function: str) -> str:
+    """How ``function`` was proven here, or "" if it never was."""
+    with _LOCK:
+        return _PROVEN.get(str(function or "").strip(), "")
+
+
+def proven(function: str) -> bool:
+    return bool(provenance(function))
+
+
+def _forget(function: str = "") -> None:
+    """Drop the ledger (a whole process's, or one function's).
+
+    Private, and it is meant to stay that way: production never un-proves a
+    handler that ran, so a public name here would be public surface with no
+    production caller. Tests reach it deliberately.
+    """
+    with _LOCK:
+        if function:
+            _PROVEN.pop(str(function), None)
+        else:
+            _PROVEN.clear()
+
+
+# ---------------------------------------------------------------------------
+# Running one, for the callers that do not get it for free
+# ---------------------------------------------------------------------------
+
+
+def warm_jobs(specs: Sequence[Any]) -> List[Any]:
+    """The endpoint's own declared warm plan.
+
+    Moved here from ``mint_child`` unchanged: the plan a proof runs and the
+    plan the executor warms on must be the SAME derivation, or the two
+    processes prove different graphs.
+    """
+    from . import warmup as warmup_mod
+    from .api.decorators import ATTR as DECL_ATTR
+
+    if not specs:
+        raise HandlerProofFailed("no endpoint spec to derive a warm plan from")
+    decl = getattr(specs[0].cls, DECL_ATTR, None)
+    if decl is None:
+        raise HandlerProofFailed(
+            "the endpoint class carries no @endpoint declaration, so no warm "
+            "plan can be derived")
+    jobs, _skips = warmup_mod.plan(
+        specs, decl_warmup=decl.warmup, has_warmup_method=False)
+    jobs, _mode = warmup_mod.select_runs(jobs, tracing=True)
+    if not jobs:
+        raise HandlerProofFailed(
+            "the derived warm plan is empty — there is nothing to prove")
+    return jobs
+
+
+def run_warm_job(
+    instance: Any, job: Any, config: Dict[str, Any], execution_lane: str,
+    origin: str = "",
+) -> None:
+    """One warm forward through the endpoint's OWN handler.
+
+    Mirrors the executor's ``_invoke_warmup`` (bound handler, ctx+payload
+    kwargs, stream consumed) — deliberately the same call shape, because the
+    graphs this exercises are the graphs the pod will later have to hit.
+    """
+    import asyncio
+
+    from . import warmup
+
+    spec = job.spec
+    with tempfile.TemporaryDirectory(prefix="gw-proof-") as tmp:
+        payload = job.build(tmp)
+        if payload is None:
+            return
+        # pgw#828: the SAME construction the executor's warm path uses. This
+        # was three hand-rolled contexts, and one of them had no slots at all —
+        # `ctx.slots["pipeline"]` raised `KeyError: 'pipeline'` on a real L4
+        # after a 16.45 s load.
+        ctx = warmup.warm_context(
+            spec, request_id=f"handler-proof-{spec.name}",
+            local_output_dir=tmp, execution_lane=execution_lane, config=config,
+            origin=origin)
+        bound = getattr(instance, spec.attr_name)
+        kwargs = {spec.ctx_param: ctx, spec.payload_param: payload}
+        if spec.is_async_gen:
+            async def _drain() -> None:
+                async for _ in bound(**kwargs):
+                    pass
+
+            asyncio.run(_drain())
+        elif spec.is_async:
+            asyncio.run(bound(**kwargs))
+        else:
+            out = bound(**kwargs)
+            if spec.output_mode == "stream":
+                for _ in out:
+                    pass
+
+
+def prove(
+    instance: Any, specs: Sequence[Any], function: str, *,
+    execution_lane: str = "", config: Optional[Dict[str, Any]] = None,
+    origin: str = "",
+) -> str:
+    """Run ONE warm forward on the resident pipeline and record the proof.
+
+    Returns the provenance string. Idempotent: a function already proven in
+    this process costs nothing, which is what makes the fleet path free — the
+    executor's boot warm plan has already run every declared handler by the
+    time a mint is delegated.
+
+    Raises :class:`HandlerProofFailed` when the handler does not run. That is
+    fatal to the MINT and to nothing else: the caller keeps serving eager, and
+    a pod whose handler cannot run was never going to serve a request either.
+    """
+    name = str(function or "").strip()
+    already = provenance(name)
+    if already:
+        return already
+    jobs = warm_jobs(specs)
+    job = jobs[0]
+    try:
+        run_warm_job(
+            instance, job, dict(config or {}), execution_lane, origin=origin)
+    except Exception as exc:
+        raise HandlerProofFailed(
+            f"the endpoint's own warm plan does not run on the resident "
+            f"pipeline — warm job {job.spec.name!r} raised "
+            f"{type(exc).__name__}: {exc}. A cell must not seal for a handler "
+            f"that cannot serve.") from exc
+    how = f"resident warm forward {job.spec.name!r} (real weights)"
+    record(name, how)
+    return how
+
+
+__all__ = [
+    "HandlerProofFailed",
+    "prove",
+    "provenance",
+    "proven",
+    "record",
+    "run_warm_job",
+    "warm_jobs",
+]

--- a/src/gen_worker/local_serve.py
+++ b/src/gen_worker/local_serve.py
@@ -42,12 +42,13 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from . import activity as activity_mod
 from . import aot_compile_pool
 from . import compile_cache as cc
-from . import compile_posture, fleet_cells, local_cell_store, mint_delegate
+from . import compile_posture, fleet_cells, handler_proof
+from . import local_cell_store, mint_delegate
 from .mint_process import MintFrame, MintSlot
 
 logger = logging.getLogger(__name__)
@@ -85,12 +86,36 @@ class LocalMintContext:
         return ""
 
 
+@dataclass
+class DeferredMint:
+    """A mint this machine owes, held until the endpoint's handler has RUN.
+
+    pgw#1199: the mint child no longer proves the handler itself, because on a
+    weight-free mint proving it meant materialising a whole checkpoint in a
+    process that holds none. The proof belongs to the resident parent — but on
+    cozy-local the parent reaches ``enable_compiled`` from inside the SLOT
+    LOAD, before ``setup()`` has bound the pipeline to the endpoint instance,
+    so there is no handler to run yet. So the mint waits: arm from the local
+    store now (that must stay in the load, or the endpoint's ``setup()`` sees
+    an unarmed pipeline), and mint after ``setup()`` and ``warmup()`` have
+    returned, when one real forward can be run on the resident weights.
+
+    This is the same ORDER the fleet already boots in — eager-first, setup
+    complete, handler warmed, then the background mint (pgw#671).
+    """
+
+    pipe: Any
+    pending: Any
+    mint: "LocalMintContext"
+
+
 def enable_compiled(
     pipe: Any,
     cfg: Any,
     cache_dir: Optional[Path] = None,
     *,
     mint: Optional[LocalMintContext] = None,
+    defer: Optional[List["DeferredMint"]] = None,
 ) -> bool:
     """Arm ``pipe`` from this machine's own cells, minting one if it has none.
 
@@ -128,7 +153,44 @@ def enable_compiled(
             "serving eager", pending.family,
             mint.incomplete if mint is not None else "no mint context")
         return False
+    if defer is not None:
+        # pgw#1199: the handler cannot run yet — see `DeferredMint`.
+        defer.append(DeferredMint(pipe=pipe, pending=pending, mint=mint))
+        return False
     return _mint_here(pipe, pending, mint)
+
+
+def run_deferred(
+    deferred: List[DeferredMint], *, instance: Any, specs: Any,
+    execution_lane: str = "", config: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Prove the handler on the resident pipeline, then mint what is owed.
+
+    pgw#1199's cozy-local half. ``setup()`` and ``warmup()`` have returned, so
+    the endpoint instance is bound to the pipeline this machine will serve
+    from, and ONE warm forward through its own handler discharges pgw#984 —
+    on real checkpoint values, in the process that already holds them, for the
+    price of one forward instead of a second copy of the model.
+
+    A handler that does not run mints NOTHING and says so. That is the same
+    disposition the child had (`a cell must not seal for a handler that cannot
+    serve`), reached before a compile is paid for rather than after.
+    """
+    if not deferred:
+        return
+    for owed in deferred:
+        try:
+            handler_proof.prove(
+                instance, specs, owed.mint.function,
+                execution_lane=execution_lane, config=config,
+                origin=f"cozy-local:{owed.pending.family}")
+        except handler_proof.HandlerProofFailed as exc:
+            _say(
+                f"{owed.pending.family} is not compiled on this machine: the "
+                f"endpoint's own handler does not run ({exc}). Serving eager.")
+            fleet_cells.abandon_self_mint(owed.pending)
+            continue
+        _mint_here(owed.pipe, owed.pending, owed.mint)
 
 
 def _say(line: str) -> None:
@@ -236,6 +298,7 @@ def _mint_here(
     """
     result: Optional[mint_delegate.DelegatedResult] = None
     family = str(pending.family)
+    proof = handler_proof.provenance(mint.function)
     # §4.30 / pgw#1137: the ONE site in the tree that declares a user-machine
     # posture. It is stated here, not derived from `publisher is None` or from
     # `local_cell_store.trust_class()` — both are facts about the SINK, and a
@@ -258,6 +321,7 @@ def _mint_here(
                     weight_lane=cc.cell_base_execution_lane(pipe),
                     device=mint.device,
                     posture=posture,
+                    handler_proof=proof,
                 ),
                 act=act, watch=watch))
         except Exception as exc:  # noqa: BLE001 — a mint must never kill a serve

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -57,14 +57,13 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
-from . import compile_posture, warm_spans
+from . import compile_posture, handler_proof, warm_spans
 from .api.errors import ValidationError
 from .api.export_contract import (
     blocker_refusal, export_declaration, open_blockers)
@@ -384,69 +383,6 @@ def pick_compile_target(loaded: Dict[str, Any], cfg: Any) -> Tuple[str, Any]:
         f"targets={list(cfg.targets)}")
 
 
-def _warm_jobs(specs: Sequence[Any]) -> List[Any]:
-    from . import warmup as warmup_mod
-    from .api.decorators import ATTR as DECL_ATTR
-
-    decl = getattr(specs[0].cls, DECL_ATTR, None)
-    if decl is None:
-        raise MintChildRefused(
-            "the endpoint class carries no @endpoint declaration, so no warm "
-            "plan can be derived")
-    jobs, _skips = warmup_mod.plan(
-        specs, decl_warmup=decl.warmup, has_warmup_method=False)
-    jobs, _mode = warmup_mod.select_runs(jobs, tracing=True)
-    if not jobs:
-        raise MintChildRefused(
-            "the derived warm plan is empty — there is nothing to compile")
-    return jobs
-
-
-def _run_warm_job(
-    instance: Any, job: Any, config: Dict[str, Any], execution_lane: str,
-    origin: str = "",
-) -> None:
-    """One warm forward through the endpoint's OWN handler.
-
-    Mirrors the executor's ``_invoke_warmup`` (bound handler, ctx+payload
-    kwargs, stream consumed) — deliberately the same call shape, because the
-    graphs this traces are the graphs the parent will later have to hit.
-    """
-    import asyncio
-
-    from . import warmup
-
-    spec = job.spec
-    with tempfile.TemporaryDirectory(prefix="gw-mintchild-") as tmp:
-        payload = job.build(tmp)
-        if payload is None:
-            return
-        # pgw#828: the SAME construction the executor's warm path uses. This
-        # was three hand-rolled contexts, and the child's had no slots at
-        # all — `ctx.slots["pipeline"]` raised `KeyError: 'pipeline'` on a
-        # real L4 after a 16.45 s load, so the dynamo mint route published
-        # nothing.
-        ctx = warmup.warm_context(
-            spec, request_id=f"mint-child-{spec.name}",
-            local_output_dir=tmp, execution_lane=execution_lane, config=config,
-            origin=origin)
-        bound = getattr(instance, spec.attr_name)
-        kwargs = {spec.ctx_param: ctx, spec.payload_param: payload}
-        if spec.is_async_gen:
-            async def _drain() -> None:
-                async for _ in bound(**kwargs):
-                    pass
-
-            asyncio.run(_drain())
-        elif spec.is_async:
-            asyncio.run(bound(**kwargs))
-        else:
-            out = bound(**kwargs)
-            if spec.output_mode == "stream":
-                for _ in out:
-                    pass
-
-
 def _drive_warm_plan(
     instance: Any, jobs: Sequence[Any], request: MintRequest, *,
     proof_only: bool = False,
@@ -480,7 +416,7 @@ def _drive_warm_plan(
               note=job.spec.name)
         try:
             with ledger.job(job.spec.name):
-                _run_warm_job(
+                handler_proof.run_warm_job(
                     instance, job,
                     dict(request.configs.get(job.spec.name) or {}),
                     request.execution_lane, origin=mint_identity(request))
@@ -903,88 +839,43 @@ def mint(request: MintRequest) -> MintReport:
                 f"{f.virtual_param_bytes / 2 ** 20:.1f} MiB virtual, "
                 f"{f.real_buffer_bytes / 2 ** 20:.1f} MiB real buffers"
                 for f in facts)))
-    # pgw#984: PROVE the endpoint's own forward runs, before a byte is
-    # exported. `torch.export` traces the declared graph classes off the
-    # modules directly and never enters the handler, so an AOT mint's
-    # phase table read `load / trace_graph / seal_publish / finalize` —
-    # green, with no `warmup_forward` row, for an endpoint whose handler
-    # could not run at all. That is precisely pgw#969's crash class
-    # (`ctx.slots["pipeline"]`, 0.0 s into `warmup_forward`), and it was
-    # unreachable on this recipe.
+    # pgw#984's guarantee, discharged where it costs nothing (pgw#1199).
     #
-    # ONE forward, not the whole plan: the export derives its own class set, so
-    # a full eager pass would buy minutes and prove nothing more than the first
-    # job does. Eager — nothing is armed here — so it specializes no graph the
-    # export then has to trace around.
+    # The endpoint's own handler must be PROVEN to run before a cell seals:
+    # `torch.export` traces the declared graph classes off the modules directly
+    # and never enters the handler, so a mint's phase table could read
+    # `load / trace_graph / seal_publish / finalize` — green — for an endpoint
+    # whose handler could not run at all (pgw#969: `ctx.slots["pipeline"]`,
+    # 0.0 s into `warmup_forward`).
     #
-    # pgw#1080 (coordinator ruling 2026-08-10): on a structure-only mint the
-    # proof runs on RANDOM values. It is a does-it-run proof, not a numerics
-    # one, and the ratified variability rule already forbids value-dependent
-    # program structure — so a handler whose control flow breaks under random
-    # weights is violating that rule and surfacing it here is the point.
-    # Random values are NOT checkpoint values, but they ARE weight-scale for
-    # the length of the proof, so the window is measured and reported
-    # separately from the export's, which is the number the pgw#992 census
-    # must size the next export child against.
-    device_label = _device_label(request)
+    # It used to be proven HERE, which on a weight-free mint meant materialising
+    # REAL random values for every virtual parameter first — one full checkpoint
+    # at compute dtype, in a process holding none, concurrently with the
+    # parent's resident copy. That is 56.2 GB on wan-2.2 against 15.5 GiB free,
+    # and it is what §4.33's "~8 GiB" was actually measuring (`materialize_random`
+    # for an sdxl-sized family). §4.33 steps 4-5 put verification on the LIVE
+    # pipeline that already holds these weights, so the proof travels as the
+    # parent's PROVENANCE and this process allocates nothing for it. The SDK had
+    # already made the same call for the kernel-lane A/B — see
+    # `execution_lane_verdict_for`'s `meta_mint` branch.
+    #
+    # REFUSED, never re-proven here: a child that proved it itself would
+    # reintroduce the allocation, and a caller that cannot prove its handler
+    # runs has no business publishing a cell for it.
     if virtual_modules:
-        _reset_peak()
-        _assert_proof_affordable(
-            [module for _name, module in virtual_modules],
-            device=device_label, request=request)
-        randomized = sum(
-            structure_only.materialize_random(module, device=device_label)
-            for _name, module in virtual_modules)
+        assert_handler_proven(request)
+        footprint["handler_proof"] = str(request.handler_proof)
         frame(phase="warmup_forward", note=(
-            f"values=random ({randomized / 2 ** 20:.1f} MiB) on "
-            f"{[name for name, _m in virtual_modules]}"))
-        # The BASELINE for the call-time check below. The lane installs real
-        # tensors of its own before any forward runs — LoRA branch containers
-        # are the standing example, and they are legitimate (a lifted adapter
-        # is a graph INPUT, not a baked constant). What the check is looking
-        # for is a tensor that APPEARS during the proof, so it compares
-        # against what was already there instead of hardcoding a vocabulary.
-        strays_before = {
-            f"{name}.{path}"
-            for name, module in virtual_modules
-            for path, _tensor in structure_only.stray_real_tensors(module)
-        }
-    _drive_warm_plan(instance, _warm_jobs(siblings), request, proof_only=True)
-    if virtual_modules:
-        footprint["warm_proof_peak_bytes"] = _peak_vram()
-        footprint["warm_proof_values"] = "random"
-        for _name, module in virtual_modules:
-            structure_only.restore_virtual(module, device=device_label)
-        # ie#628's call-time class, caught where it CAN be caught on a
-        # weightless mint. Inside a fake-mode export every allocation is fake,
-        # so the mode-based gate cannot see a lazily-built pinned table — but
-        # the warm proof just ran the handler for real, so if one was built it
-        # is now cached on a plain attribute, still real, about to be traced.
-        strays = [
-            (f"{name}.{path}", tensor)
-            for name, module in virtual_modules
-            for path, tensor in structure_only.stray_real_tensors(module)
-            if f"{name}.{path}" not in strays_before
-        ]
-        if strays:
-            raise MintChildRefused(
-                "meta-instantiation gate (ie#628, call-time): after the warm "
-                "proof released its random values, "
-                + ", ".join(
-                    f"{path} still holds a REAL {tuple(t.shape)} "
-                    f"{t.dtype} tensor on {t.device}" for path, t in strays[:4])
-                + ". A weightless mint traces what the module holds, so this "
-                "tensor would be exported as an anonymous graph literal and "
-                "the cell would carry values no adopter can rebind. It is "
-                "built at CALL time instead of at __init__: register derived "
-                "tables with `register_buffer` and NO device pin (ie#630's "
-                "`rope_buffers` is the worked example); an explicit "
-                "`with torch.device(...)` inside model code is itself the "
-                "violation to remove.")
-        _release()
-        frame(phase="warmup_forward", note=(
-            f"random values released; warm-proof device peak "
-            f"{footprint['warm_proof_peak_bytes'] / 2 ** 20:.1f} MiB"))
+            f"handler proven by the parent, on resident weights: "
+            f"{request.handler_proof} — this child allocates nothing for it"))
+    else:
+        # The real-weight fallback: structure-only was refused for this family
+        # (a quantized artifact lane, a class with no config surface), so the
+        # checkpoint is already resident IN THIS PROCESS and the proof costs
+        # what it has always cost — nothing extra.
+        _drive_warm_plan(
+            instance, handler_proof.warm_jobs(siblings), request,
+            proof_only=True)
     _reset_peak()
     # Deliberately NOT `aot_mint.compose_for_mint` (which builds a pipeline
     # from a model ref for an operator's mint pod): the graphs this cell must
@@ -997,55 +888,38 @@ def mint(request: MintRequest) -> MintReport:
         footprint=footprint)
 
 
-def _assert_proof_affordable(
-    modules: List[Any], *, device: str, request: MintRequest,
-) -> None:
-    """Refuse the pgw#984 warm proof when the card cannot hold its values.
+def assert_handler_proven(request: MintRequest) -> None:
+    """A weight-free mint REFUSES unless the parent proved the handler runs.
 
-    **This is a MEASUREMENT, not a budget** (§4.33's standing rule). The left
-    side is the exact byte count :func:`structure_only.materialize_random` is
-    about to allocate — the same walk over the same tensors — and the right
-    side is ``torch.cuda.mem_get_info()`` read now. No constant, no margin, no
-    learned floor: it can only refuse a case that was going to fail anyway,
-    and it stays silent on every case that fits.
+    pgw#984's guarantee, and the one thing pgw#1199 had to be careful not to
+    drop while moving where it is discharged. The child cannot prove it itself
+    on this path: it holds no weights, so proving it means materialising one
+    full checkpoint at compute dtype beside the parent's resident copy — 56.2
+    GB on wan-2.2 against 15.5 GiB free, which is the mint that died on pod
+    `729431an6ugbvq`, and which is what §4.33's "~8 GiB" was measuring for an
+    sdxl-sized family.
 
-    What it buys is the sentence. On pod ``729431an6ugbvq`` (H100-80, wan-2.2)
-    the proof needed 56.2 GB of a card whose serving parent already held 63.68
-    GiB; the child died on ``CUDA out of memory. Tried to allocate 50.00 MiB``
-    recorded under ``phase=load``, because the ``warmup_forward`` frame is
-    emitted only after ``materialize_random`` RETURNS. Two paid attempts said
-    "resource" and named neither the quantity nor the phase.
+    So the obligation moves to the caller, whole: run ONE warm forward on the
+    resident pipeline and say so. It is free on the fleet path (the executor's
+    boot warm plan has already run every declared handler before a mint is
+    delegated) and one forward on cozy-local. Refusing here is not a fence
+    weakened to make a case pass — it is the same sentence, addressed to the
+    process that can afford to say it.
 
-    The refusal is the finding, not a workaround for it: an in-child
-    does-it-run proof is weight-scale by construction and §4.33 steps 4-5 put
-    verification on the resident parent instead. See pgw#1199.
+    Public because it IS the contract between the two processes, and a caller
+    that wants to know whether its request will be accepted should be able to
+    ask the same question the child asks.
     """
-    from .models import structure_only
-
-    try:
-        import torch
-
-        if not str(device).startswith("cuda") or not torch.cuda.is_available():
-            return
-        free, total = torch.cuda.mem_get_info()
-    except Exception:  # noqa: BLE001 — unmeasured is NO EVIDENCE, never a veto
+    if str(getattr(request, "handler_proof", "") or "").strip():
         return
-    need = structure_only.proof_cost_bytes(modules)
-    if need <= int(free):
-        return
-    gib = float(2 ** 30)
     raise MintChildRefused(
-        f"the pgw#984 warm proof cannot run for {mint_identity(request)}: it "
-        f"materialises REAL random values for every virtual parameter, which "
-        f"is {need / gib:.2f} GiB here, and this card has {int(free) / gib:.2f} "
-        f"GiB free of {int(total) / gib:.2f} GiB — the serving parent holds "
-        f"the rest, resident and eager. Measured before allocating rather "
-        f"than met as a CUDA OOM. This is pgw#1199: a mint's cost is one FULL "
-        f"checkpoint at compute dtype in the CHILD, concurrently with the "
-        f"parent's copy, so §4.33's ~8 GiB holds for sdxl-sized families and "
-        f"not for this one. The proof belongs on the resident parent "
-        f"(§4.33 steps 4-5), which already holds these weights and pays for "
-        f"them once")
+        f"{mint_identity(request)}: this is a WEIGHT-FREE mint and the parent "
+        f"sent no handler proof. pgw#984 requires the endpoint's own handler "
+        f"to have run before a cell seals, and since pgw#1199 that proof "
+        f"belongs to the process that HOLDS the weights — proving it here "
+        f"would mean materialising one full checkpoint at compute dtype in a "
+        f"process that holds none. Run one warm forward on the resident "
+        f"pipeline and declare it (`MintRequest.handler_proof`).")
 
 
 def _device_label(request: MintRequest) -> str:

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -95,6 +95,12 @@ class MintTask:
     #: knows (``local_serve``) states it and every other caller gets ``FLEET``
     #: by construction — there is no ambient value to forget to set.
     posture: compile_posture.CompilePosture = compile_posture.FLEET
+    #: pgw#1199: how this process proved the endpoint's handler RUNS, on the
+    #: resident pipeline, before delegating. Declared by the caller because
+    #: only the caller knows — the executor gets it for free from the boot warm
+    #: plan it has already run; `local_serve` runs one forward for it after
+    #: setup. An empty string is honest and the child refuses on it.
+    handler_proof: str = ""
 
 
 @dataclass(frozen=True)
@@ -181,6 +187,7 @@ def build_request(
         execution_lane=task.execution_lane,
         configs={k: dict(v) for k, v in task.configs.items()},
         posture=task.posture,
+        handler_proof=str(task.handler_proof or ""),
     )
 
 

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -293,6 +293,15 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     #: a VALUE and may not carry a DECISION. Politeness is a decision: it
     #: changes the nice level of every process in the mint tree and halves K.
     posture: CompilePosture = compile_posture.FLEET
+    #: pgw#1199: HOW the parent proved this endpoint's handler runs, on the
+    #: RESIDENT pipeline with real checkpoint values, before this mint was
+    #: delegated. Empty = unproven, and the child refuses rather than proving
+    #: it itself: proving it there means materialising one full checkpoint at
+    #: compute dtype in a process that holds none (56.2 GB on wan-2.2, against
+    #: 15.5 GiB free), which is the allocation §4.33's "~8 GiB" was actually
+    #: measuring. The string is PROVENANCE, not a boolean, so the child's
+    #: report says which proof stood behind the cell it sealed.
+    handler_proof: str = ""
 
 
 class MintFrame(msgspec.Struct, frozen=True, kw_only=True):

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -724,9 +724,12 @@ def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
       so every rung read "off").
 
     It still COUNTS toward the requirement (``cuda_only=False``): the shape and
-    dtype it declares are the bytes a real load — or ``materialize_random`` in
-    the mint child — will go on to allocate. The two estimates below are the
-    two questions, and virtuality answers them differently.
+    dtype it declares are the bytes a real load will go on to allocate. The two
+    estimates below are the two questions, and virtuality answers them
+    differently. (Until pgw#1199 the mint child was a second such allocator —
+    it materialised random values for the pgw#984 proof. It does not any more:
+    the proof runs on the resident parent, so nothing downstream of a
+    structure-only build allocates a checkpoint.)
     """
     import torch
 

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -74,15 +74,6 @@ STAMP = "_cozy_structure_only"
 MODE_STAMP = "_cozy_structure_fake_mode"
 FACTS_STAMP = "_cozy_structure_facts"
 
-#: Standard deviation of the random values the pgw#984 warm proof runs on.
-#: Small enough that a deep stack of matmuls cannot overflow fp16, non-zero so
-#: a degenerate all-zero forward cannot pass a proof a real one would fail.
-RANDOM_STD = 0.02
-#: Fixed, because a proof that behaves differently on two runs of the same cell
-#: is not a proof. Not configurable: the value is not a tuning knob.
-RANDOM_SEED = 1080
-
-
 class StructureOnlyUnsupported(WorkerError):
     """This component cannot be built from code + config alone.
 
@@ -980,152 +971,38 @@ def revirtualize_from_meta(program: Any) -> Optional[Any]:
 
 
 # ---------------------------------------------------------------------------
-# The pgw#984 warm proof runs on RANDOM values (coordinator ruling, 2026-08-10)
+# pgw#1199: what USED to live here, and why it does not any more
 # ---------------------------------------------------------------------------
-
-
-def materialize_random(module: Any, *, device: str = "") -> int:
-    """Give every virtual parameter REAL random values; return the bytes.
-
-    The endpoint's own handler is proved to RUN before a byte is exported
-    (pgw#984), and a handler cannot run against zero-storage tensors. The
-    ruling is random values — the proof is structural ("does it run"), and the
-    ratified variability rule already forbids value-dependent program
-    structure, so a handler whose control flow breaks under random weights is
-    violating that rule and surfacing it is the point.
-
-    Random values are NOT checkpoint values: nothing this process holds came
-    from the model's bytes. The cost is reported (``values=random``) rather
-    than hidden, because it IS weight-scale for the length of the proof.
-    """
-    import torch
-    import torch.nn as nn
-
-    dev = device or "cpu"
-    generator = torch.Generator(device=dev).manual_seed(RANDOM_SEED)
-    total = 0
-    for sub in module.modules():
-        for name, param in list(sub._parameters.items()):
-            if param is None:
-                continue
-            real, bytes_ = _real_like(param, device=dev, generator=generator)
-            sub._parameters[name] = nn.Parameter(real, requires_grad=False)
-            total += bytes_
-    return total
-
-
-def _real_like(tensor: Any, *, device: str, generator: Any) -> Tuple[Any, int]:
-    """``(a REAL twin of ``tensor``, the bytes it allocated)``.
-
-    A wrapper subclass is rebuilt AS a subclass over real inner tensors
-    (pgw#1198): flattening one to its outer dtype would both cost twice the
-    bytes (bf16 where the payload is fp8) and hand the export a graph the pod
-    does not serve.
-    """
-    import torch
-
-    parts = _wrapper_parts(tensor)
-    if parts is not None:
-        names, _ctx = parts
-        inner: Dict[str, Any] = {}
-        bytes_ = 0
-        for name in names:
-            held, held_bytes = _real_like(
-                getattr(tensor, name), device=device, generator=generator)
-            inner[name] = held
-            bytes_ += held_bytes
-        return _rebuild_wrapper(tensor, inner), bytes_
-    real = torch.empty(tuple(tensor.shape), dtype=tensor.dtype, device=device)
-    if real.dtype in (torch.float16, torch.bfloat16, torch.float32,
-                      torch.float64):
-        real.normal_(0.0, RANDOM_STD, generator=generator)
-    else:
-        # fp8 and integer parameters have no `normal_`; a defined value beats
-        # an undefined one, and NaN/overflow would make every downstream
-        # cosine undefined (pgw#1056's guard).
-        real.zero_()
-    return real, int(real.numel()) * int(real.element_size())
-
-
-def proof_cost_bytes(modules: Any) -> int:
-    """Exactly what :func:`materialize_random` will allocate on the device.
-
-    Not an estimate — the same walk, summing the same tensors, so the mint can
-    compare it against MEASURED free VRAM before it allocates instead of
-    meeting the answer as an anonymous CUDA OOM (pgw#1199). A wrapper subclass
-    counts its PAYLOAD, which is the thing that gets allocated, not its
-    high-precision outer view.
-    """
-    total = 0
-    for module in modules:
-        for sub in module.modules():
-            for param in sub._parameters.values():
-                if param is not None:
-                    total += _payload_bytes(param)
-    return total
-
-
-def _payload_bytes(tensor: Any) -> int:
-    parts = _wrapper_parts(tensor)
-    if parts is None:
-        return int(tensor.numel()) * int(tensor.element_size())
-    names, _ctx = parts
-    return sum(_payload_bytes(getattr(tensor, name)) for name in names)
-
-
-def stray_real_tensors(module: Any) -> Tuple[Tuple[str, Any], ...]:
-    """Real tensors hanging off the tree that are NEITHER parameter nor buffer.
-
-    This is how the z-image rope class actually shows up on a weightless mint,
-    and it is the one place it CAN be seen. The gate's call-time half
-    (ie#628) watches for a real allocation — but inside a fake-mode export
-    every allocation is fake, so a lazily-built pinned table is invisible
-    there. What it cannot hide is the RESIDUE: the pgw#984 warm proof runs the
-    handler for real, the lazy build fires, and the table is cached on a plain
-    attribute where ``restore_virtual`` (which only re-fakes parameters) does
-    not reach. A real tensor still on the tree when the export begins is
-    exactly the property failing.
-
-    Searched: each module's own ``__dict__``, plus one level into plain
-    objects it holds — the shape upstream uses (``RopeEmbedder`` is not an
-    ``nn.Module``), and deep enough to name the attribute an author edits.
-    """
-    import torch
-
-    out: List[Tuple[str, Any]] = []
-    for prefix, sub in module.named_modules():
-        registered = set(sub._parameters) | set(sub._buffers)
-        for name, value in list(vars(sub).items()):
-            if name.startswith("_") or name in registered:
-                continue
-            path = f"{prefix}.{name}" if prefix else name
-            if isinstance(value, torch.Tensor):
-                if not mi.is_virtual(value):
-                    out.append((path, value))
-                continue
-            if isinstance(value, torch.nn.Module) or not hasattr(
-                    value, "__dict__"):
-                continue
-            for inner, held in list(vars(value).items()):
-                if isinstance(held, torch.Tensor) and not mi.is_virtual(held):
-                    out.append((f"{path}.{inner}", held))
-    return tuple(out)
-
-
-def restore_virtual(module: Any, *, device: str = "") -> Any:
-    """Return every parameter to a fake tensor, freeing the random values.
-
-    A NEW fake mode, deliberately: the values that ran the proof are gone and
-    the export must not carry a mode that ever held them.
-    """
-    return virtualize(module, device=device)
+#
+# `materialize_random` / `restore_virtual` / `stray_real_tensors` gave every
+# virtual parameter REAL random values so the mint child could run the pgw#984
+# does-it-run proof, then took them away again. That is one full checkpoint at
+# compute dtype, allocated in the process this module exists to keep empty,
+# concurrently with the parent's resident copy — 56.2 GB on wan-2.2 against
+# 15.5 GiB free, measured on pod `729431an6ugbvq`. It is also the number
+# §4.33's "a mint costs ~8 GiB" was really measuring: this walk, for an
+# sdxl-sized family.
+#
+# The proof did not need to be here. §4.33 steps 4-5 put verification on the
+# LIVE pipeline that already holds the weights, and `gen_worker.handler_proof`
+# is that: one warm forward through the endpoint's own handler, on the resident
+# pipeline, with REAL checkpoint values — strictly stronger than a random-value
+# re-run, and free on the fleet path where the executor's boot warm plan has
+# already run every declared handler before a mint is delegated.
+#
+# `stray_real_tensors` went with them, and this is the part worth stating
+# plainly rather than quietly: it hunted a REAL tensor cached on a plain
+# attribute by a lazily-built device-pinned table (ie#628's call-time class).
+# That residue existed *because* a real forward had just run here. With no real
+# values in this process the same lazy build fires inside the export's fake
+# mode and produces a FAKE constant, which `aot_package` cannot pack — the
+# failure is still loud, it just arrives at pack time instead of at a stray
+# walk. Nothing silently ships.
 
 
 __all__ = [
     "FACTS_STAMP",
     "MODE_STAMP",
-    "RANDOM_SEED",
-    "RANDOM_STD",
     "STAMP",
     "TOKEN_CAPABILITY_MISSING",
     "TOKEN_UNSUPPORTED",
@@ -1142,14 +1019,10 @@ __all__ = [
     "fake_mode_of_program",
     "has_meta_params",
     "is_structure_only",
-    "materialize_random",
     "modules_of",
     "program_shape_env",
-    "proof_cost_bytes",
     "refusal_token",
-    "restore_virtual",
     "revirtualize_from_meta",
-    "stray_real_tensors",
     "structure_only_components",
     "target_module",
     "to_meta_for_save",

--- a/tests/test_handler_proof_pgw1199.py
+++ b/tests/test_handler_proof_pgw1199.py
@@ -1,0 +1,328 @@
+"""pgw#1199: the does-it-run proof runs where the weights already are.
+
+§4.33 said a mint costs ~8 GiB because *"the model is fully resident and serving
+eager"* and *"compile weight-free … VRAM cost is negligible"*. The compile is.
+The MINT was not: `mint_child` ran pgw#984's does-it-run proof by materialising
+REAL random values for every virtual parameter — one full checkpoint at compute
+dtype, in a child process holding none, concurrently with the parent's resident
+copy. On pod `729431an6ugbvq` (H100-80, wan-2.2) that is 56.2 GB against 15.5
+GiB free: `CUDA out of memory`, twice, then `delegated_no_cell`, then
+`boot_ended_uncompiled`. The ~8 GiB figure was measuring that same walk for an
+sdxl-sized family.
+
+§4.33 steps 4-5 already put verification on the LIVE pipeline — *"already
+running eager"* — against weights that are resident and paid for once. So the
+proof was in the wrong process, and this file fences the correction from both
+ends:
+
+* the CHILD may not prove it (and may not mint without one), because proving it
+  there is the allocation;
+* the PARENT records it from the forward it already runs, and cozy-local — whose
+  mint is opened from inside the slot load, before `setup()` has bound the
+  pipeline — defers the mint until a handler exists to run.
+
+WHAT IS DELIBERATELY NOT WEAKENED
+---------------------------------
+pgw#984's sentence is unchanged: *a cell must not seal for a handler that cannot
+serve*. A missing proof REFUSES the mint. It never degrades to "mint anyway".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker import handler_proof
+from gen_worker import mint_delegate, mint_process
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+
+@pytest.fixture(autouse=True)
+def _clean_ledger() -> Any:
+    handler_proof._forget()
+    yield
+    handler_proof._forget()
+
+
+# ---------------------------------------------------------------------------
+# The ledger — a claim about THIS process and this function
+# ---------------------------------------------------------------------------
+
+
+def test_a_function_is_unproven_until_its_handler_has_run() -> None:
+    assert handler_proof.provenance("generate") == ""
+    assert not handler_proof.proven("generate")
+
+    handler_proof.record("generate", "boot warm forward 'generate' (real weights)")
+
+    assert handler_proof.proven("generate")
+    assert "real weights" in handler_proof.provenance("generate")
+
+
+def test_the_proof_is_PROVENANCE_and_not_a_boolean() -> None:
+    """The child's report has to be able to say WHICH proof stood behind the
+    cell it sealed. A bare True would make "proven" unauditable across the
+    process boundary — the child cannot see the parent's ledger, only what the
+    request carries."""
+    handler_proof.record("generate", "boot warm forward 'generate' (real weights)")
+    assert isinstance(handler_proof.provenance("generate"), str)
+    assert handler_proof.provenance("generate").strip()
+
+
+def test_the_first_proof_wins_and_a_later_one_does_not_overwrite_it() -> None:
+    handler_proof.record("generate", "boot warm forward (real weights)")
+    handler_proof.record("generate", "something later and weaker")
+    assert handler_proof.provenance("generate") == "boot warm forward (real weights)"
+
+
+def test_functions_are_proven_INDIVIDUALLY() -> None:
+    """A pod serves several handlers off one pipeline and mints per function.
+    Proving one must not vouch for another — that is how a broken sibling
+    handler would seal a cell."""
+    handler_proof.record("generate", "boot warm forward (real weights)")
+    assert not handler_proof.proven("generate_turbo")
+
+
+# ---------------------------------------------------------------------------
+# The wire — the parent declares it, the request carries it
+# ---------------------------------------------------------------------------
+
+
+def _task(**kw: Any) -> mint_delegate.MintTask:
+    pending = type("_Pending", (), {
+        "family": "micro-diffusion", "arm_token": "arm1-x",
+        "mint_root": "/tmp", "cfg": type("_Cfg", (), {
+            "shapes": (), "targets": ("transformer",), "family": "micro-diffusion",
+            "lora_bucket": 0, "guidance_scales": (), "text_lens": (),
+        })(),
+    })()
+    base: Dict[str, Any] = dict(
+        pending=pending, pipe=object(), function="generate", modules=("m",))
+    base.update(kw)
+    return mint_delegate.MintTask(**base)
+
+
+def test_the_request_carries_the_parents_proof(tmp_path: Path) -> None:
+    task = _task(handler_proof="boot warm forward 'generate' (real weights)")
+    request = mint_delegate.build_request(task, workdir=tmp_path)
+    assert request.handler_proof == "boot warm forward 'generate' (real weights)"
+
+
+def test_an_unproven_parent_sends_an_EMPTY_proof_rather_than_a_guess(
+    tmp_path: Path,
+) -> None:
+    """An absent measurement is no evidence — never a silent pass. A parent
+    that cannot say its handler ran says nothing, and the child refuses."""
+    request = mint_delegate.build_request(_task(), workdir=tmp_path)
+    assert request.handler_proof == ""
+
+
+def test_the_request_field_defaults_to_unproven() -> None:
+    """A field that defaulted to "proven" would make every caller that forgot
+    to set it silently satisfy pgw#984."""
+    assert mint_process.MintRequest.__struct_defaults__ is not None
+    request = mint_process.MintRequest(
+        function="generate", modules=(), family="f", arm_token="a",
+        target="t", work_root="w", report="r",
+        cfg=mint_process.CompileCellSpec())
+    assert request.handler_proof == ""
+
+
+# ---------------------------------------------------------------------------
+# The child — refuses rather than re-proving, because re-proving IS the cost
+# ---------------------------------------------------------------------------
+
+
+def _request(**kw: Any) -> mint_process.MintRequest:
+    base: Dict[str, Any] = dict(
+        function="generate", modules=("m",), family="micro-diffusion",
+        arm_token="arm1-x", target="t", work_root="w", report="r",
+        cfg=mint_process.CompileCellSpec(targets=("transformer",)))
+    base.update(kw)
+    return mint_process.MintRequest(**base)
+
+
+def test_the_child_refuses_a_weight_free_mint_with_no_proof() -> None:
+    """The whole of pgw#1199 in one row.
+
+    A weight-free mint whose parent sent no proof must REFUSE. The tempting
+    alternative — prove it here — is the 56.2 GB allocation that killed
+    wan-2.2; the other — mint anyway — drops pgw#984.
+    """
+    from gen_worker import mint_child
+
+    with pytest.raises(mint_child.MintChildRefused) as caught:
+        mint_child.assert_handler_proven(_request())
+
+    said = str(caught.value)
+    assert "no handler proof" in said
+    assert "handler_proof" in said, "the message must name what to set"
+
+
+def test_the_child_accepts_a_mint_whose_parent_DID_prove_the_handler() -> None:
+    from gen_worker import mint_child
+
+    mint_child.assert_handler_proven(
+        _request(handler_proof="boot warm forward 'generate' (real weights)"))
+
+
+def test_whitespace_is_not_a_proof() -> None:
+    """A caller that sets the field to something empty-but-truthy has not run
+    a forward, and must be refused exactly as one that set nothing."""
+    from gen_worker import mint_child
+
+    with pytest.raises(mint_child.MintChildRefused):
+        mint_child.assert_handler_proven(_request(handler_proof="   "))
+
+
+def test_the_child_still_proves_on_the_REAL_WEIGHT_fallback() -> None:
+    """Not every family has a structure-only path (a quantized artifact lane,
+    a class with no config surface). Those mints load the checkpoint into the
+    child anyway, so the proof costs nothing extra there and must NOT have been
+    deleted with the weight-free one — otherwise pgw#1199 would have removed a
+    guarantee instead of relocating it."""
+    from gen_worker import mint_child
+
+    source = Path(mint_child.__file__).read_text()
+    assert "_drive_warm_plan(" in source
+    assert "proof_only=True" in source
+
+
+def test_the_structure_only_module_offers_no_route_to_real_values() -> None:
+    from gen_worker.models import structure_only
+
+    for gone in ("materialize_random", "restore_virtual", "stray_real_tensors",
+                 "proof_cost_bytes"):
+        assert not hasattr(structure_only, gone), gone
+
+
+# ---------------------------------------------------------------------------
+# cozy-local — the mint waits for a handler to exist
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_mint_is_DEFERRED_rather_than_run_inside_the_slot_load() -> None:
+    """cozy-local reaches `enable_compiled` from inside the SLOT LOAD, before
+    `setup()` has bound the pipeline to the endpoint instance — so at that
+    moment there is no handler to run, and a mint started there could only ever
+    have proven itself the expensive way.
+
+    Deferring is not a workaround: it is the order the fleet already boots in
+    (pgw#671 eager-first — setup completes, the handler warms, THEN the
+    background mint).
+    """
+    from gen_worker import local_serve
+
+    deferred: List[Any] = []
+    pending = object.__new__(local_serve.fleet_cells.PendingSelfMint)
+    outcome = type("_Outcome", (), {"armed": False, "self_mint": pending})()
+    ctx = local_serve.LocalMintContext(
+        function="generate", modules=("m",), slots={})
+
+    armed = local_serve.enable_compiled.__wrapped__ if hasattr(
+        local_serve.enable_compiled, "__wrapped__") else None
+    assert armed is None  # not decorated; the call below is the real one
+
+    # Drive the branch directly: a pending nobody deferred would be minted
+    # in-line, which is what this must not do.
+    import gen_worker.fleet_cells as fleet_cells
+
+    original = fleet_cells.enable_compiled
+    try:
+        fleet_cells.enable_compiled = lambda *a, **k: outcome  # type: ignore[assignment]
+        result = local_serve.enable_compiled(
+            object(), object(), None, mint=ctx, defer=deferred)
+    finally:
+        fleet_cells.enable_compiled = original  # type: ignore[assignment]
+
+    assert result is False, "a deferred mint has not armed anything yet"
+    assert len(deferred) == 1
+    assert deferred[0].pending is pending
+    assert deferred[0].mint is ctx
+
+
+def test_run_deferred_refuses_the_mint_when_the_handler_does_not_run() -> None:
+    """pgw#984's sentence, spoken on the parent: a handler that cannot serve
+    mints nothing. Reached BEFORE a compile is paid for, which is strictly
+    earlier than the child's version managed."""
+    from gen_worker import local_serve
+
+    abandoned: List[Any] = []
+    minted: List[Any] = []
+    pending = type("_P", (), {"family": "micro-diffusion"})()
+    owed = local_serve.DeferredMint(
+        pipe=object(), pending=pending,
+        mint=local_serve.LocalMintContext(
+            function="generate", modules=("m",), slots={}))
+
+    def _boom(*_a: Any, **_k: Any) -> str:
+        raise handler_proof.HandlerProofFailed("the handler raised TypeError")
+
+    import gen_worker.fleet_cells as fleet_cells
+
+    original_prove = handler_proof.prove
+    original_abandon = fleet_cells.abandon_self_mint
+    original_mint = local_serve._mint_here
+    try:
+        handler_proof.prove = _boom  # type: ignore[assignment]
+        fleet_cells.abandon_self_mint = abandoned.append  # type: ignore[assignment]
+        local_serve._mint_here = (  # type: ignore[assignment]
+            lambda *a, **k: minted.append(a))
+        local_serve.run_deferred([owed], instance=object(), specs=[])
+    finally:
+        handler_proof.prove = original_prove  # type: ignore[assignment]
+        fleet_cells.abandon_self_mint = original_abandon  # type: ignore[assignment]
+        local_serve._mint_here = original_mint  # type: ignore[assignment]
+
+    assert minted == [], "a mint must not start behind a failed proof"
+    assert abandoned == [pending], "and the obligation must end somewhere named"
+
+
+def test_run_deferred_mints_once_the_handler_is_proven() -> None:
+    from gen_worker import local_serve
+
+    minted: List[Any] = []
+    owed = local_serve.DeferredMint(
+        pipe=object(), pending=type("_P", (), {"family": "micro-diffusion"})(),
+        mint=local_serve.LocalMintContext(
+            function="generate", modules=("m",), slots={}))
+
+    original_prove = handler_proof.prove
+    original_mint = local_serve._mint_here
+    try:
+        handler_proof.prove = (  # type: ignore[assignment]
+            lambda *a, **k: "resident warm forward 'generate' (real weights)")
+        local_serve._mint_here = (  # type: ignore[assignment]
+            lambda *a, **k: minted.append(a))
+        local_serve.run_deferred([owed], instance=object(), specs=[])
+    finally:
+        handler_proof.prove = original_prove  # type: ignore[assignment]
+        local_serve._mint_here = original_mint  # type: ignore[assignment]
+
+    assert len(minted) == 1
+
+
+def test_prove_is_idempotent_so_the_fleet_path_pays_nothing() -> None:
+    """The executor's boot warm plan has already run every declared handler by
+    the time a mint is delegated, so `prove` must be a no-op there rather than
+    a second forward."""
+    calls: List[Any] = []
+    handler_proof.record("generate", "boot warm forward (real weights)")
+
+    original = handler_proof.run_warm_job
+    try:
+        handler_proof.run_warm_job = (  # type: ignore[assignment]
+            lambda *a, **k: calls.append(a))
+        how = handler_proof.prove(object(), [], "generate")
+    finally:
+        handler_proof.run_warm_job = original  # type: ignore[assignment]
+
+    assert calls == [], "an already-proven handler must not be re-run"
+    assert how == "boot warm forward (real weights)"

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -52,6 +52,7 @@ from typing import Any, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import handler_proof
 from gen_worker import mint_child, mint_delegate, registry, warmup
 from gen_worker import mint_process as mp
 from gen_worker.api.binding import ModelRef, wire_ref
@@ -196,16 +197,16 @@ def test_a_rediscovered_catalog_slot_carries_no_ref_at_all() -> None:
 
 def test_the_production_traceback_reproduced(tmp_path: Path) -> None:
     """The pod's sentence, byte-for-byte, from an unbound warm context — the
-    exact ``_run_warm_job`` -> handler -> ``ctx.slots`` frame that crashed."""
+    exact ``run_warm_job`` -> handler -> ``ctx.slots`` frame that crashed."""
     spec = next(
         s for s in registry.collect_endpoints([CATALOG_MODULE])
         if s.name == "catalog-generate")
     instance = spec.cls()
     instance.pipeline_path = str(tmp_path)
-    job = next(j for j in mint_child._warm_jobs([spec])
+    job = next(j for j in handler_proof.warm_jobs([spec])
                if j.spec.name == spec.name)
     with pytest.raises(ValueError) as exc:
-        mint_child._run_warm_job(instance, job, {}, "w8a8-lora64")
+        handler_proof.run_warm_job(instance, job, {}, "w8a8-lora64")
     assert "slot 'pipeline': no resolved model ref for this request" in str(exc.value)
 
 
@@ -237,8 +238,8 @@ def test_the_child_warms_the_checkpoint_THE_PARENT_SERVED(
     assert loaded["pipeline"] == str(tree)
 
     catalog.RESOLVED_REFS.clear()
-    for job in mint_child._warm_jobs(siblings):
-        mint_child._run_warm_job(
+    for job in handler_proof.warm_jobs(siblings):
+        handler_proof.run_warm_job(
             instance, job, {}, request.execution_lane,
             origin=mint_child.mint_identity(request))
 

--- a/tests/test_mint_child_warm_context_pgw828.py
+++ b/tests/test_mint_child_warm_context_pgw828.py
@@ -11,7 +11,7 @@ holding on this route too — and then dies in the endpoint's own warm job:
                                 phases={'load': 16.455, 'warmup_forward': 0.0}
     self_mint_abort delegated_crashed (phase=warmup_forward, deterministic)
 
-      File ".../mint_child.py", line 339, in _run_warm_job
+      File ".../handler_proof.py", in run_warm_job
         out = bound(**kwargs)
       File ".../sdxl/main.py", line 326, in generate
         resolved = ctx.slots["pipeline"]
@@ -46,6 +46,7 @@ from typing import Any, List
 
 import pytest
 
+from gen_worker import handler_proof
 from gen_worker import mint_child, registry, warmup
 from gen_worker.request_context import RequestContext
 
@@ -76,12 +77,12 @@ def test_the_childs_warm_job_resolves_the_endpoints_declared_slots(spec) -> None
     """RED at HEAD with the pod's exact sentence, ``KeyError: 'pipeline'``."""
     instance = spec.cls()
     instance.pipeline_path = "/tmp/does-not-matter"
-    jobs = mint_child._warm_jobs([spec])
+    jobs = handler_proof.warm_jobs([spec])
     job = next(j for j in jobs if j.spec.name == spec.name)
 
     # No exception is the assertion: the handler dereferences
     # `ctx.slots["pipeline"]` and returns.
-    mint_child._run_warm_job(instance, job, {}, "w8a8")
+    handler_proof.run_warm_job(instance, job, {}, "w8a8")
 
 
 def test_the_child_and_the_executor_build_the_SAME_context(spec) -> None:

--- a/tests/test_structure_only_pgw1080.py
+++ b/tests/test_structure_only_pgw1080.py
@@ -125,35 +125,35 @@ def test_the_structure_EXPORTS_and_AOT_COMPILES(tree: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# The pgw#984 warm proof runs on RANDOM values, and gives them back
+# The structure NEVER holds values — not even for the pgw#984 proof (pgw#1199)
 # ---------------------------------------------------------------------------
 
 
-def test_random_values_are_defined_and_are_released_again(tree: Path) -> None:
+def test_nothing_in_this_module_can_put_values_back_on_a_structure(
+    tree: Path,
+) -> None:
+    """Two rows used to live here: the pgw#984 warm proof materialised REAL
+    random values for every virtual parameter and then released them again.
+
+    That was one full checkpoint at compute dtype, allocated in the process
+    this slice exists to keep empty — 56.2 GB on wan-2.2 against 15.5 GiB free
+    (pod `729431an6ugbvq`), and the number §4.33's "~8 GiB" was really
+    measuring. pgw#1199 moved the proof onto the RESIDENT parent, which already
+    holds the weights, and deleted the materialiser rather than leaving it
+    where a future caller could reach for it.
+
+    So the property is now absolute and is asserted as such: this module offers
+    no way to give a virtual structure real values.
+    """
     module, facts = so.build_component(tree, "transformer", device="cpu")
-
-    materialized = so.materialize_random(module, device="cpu")
-    assert materialized == facts.virtual_param_bytes
-    values = torch.cat([p.detach().reshape(-1) for p in module.parameters()])
-    assert not mi.is_virtual(next(module.parameters()))
-    assert torch.isfinite(values).all(), (
-        "a NaN/inf init would make every downstream cosine undefined")
-    assert float(values.abs().max()) > 0.0
-
-    so.restore_virtual(module, device="cpu")
+    assert facts.virtual_param_bytes > 0
     assert all(mi.is_virtual(p) for p in module.parameters())
 
-
-def test_the_random_values_are_REPRODUCIBLE(tree: Path) -> None:
-    """A proof that behaves differently on two runs of the same cell is not a
-    proof, so the seed is fixed rather than clock-derived."""
-    first, _ = so.build_component(tree, "decoder", device="cpu")
-    second, _ = so.build_component(tree, "decoder", device="cpu")
-    so.materialize_random(first, device="cpu")
-    so.materialize_random(second, device="cpu")
-    for (name, a), (_n, b) in zip(first.named_parameters(),
-                                  second.named_parameters()):
-        assert torch.equal(a, b), name
+    for gone in ("materialize_random", "restore_virtual", "stray_real_tensors",
+                 "proof_cost_bytes"):
+        assert not hasattr(so, gone), (
+            f"{gone} is back: a weight-free mint must have no route to real "
+            f"values, and every one of these was such a route")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_virtual_bytes_pgw1128.py
+++ b/tests/test_virtual_bytes_pgw1128.py
@@ -73,7 +73,7 @@ def test_a_structure_only_component_is_not_resident_vram() -> None:
 def test_the_requirement_still_counts_what_the_virtual_structure_declares() -> None:
     """The other half, and the reason this is not a blanket "ignore fakes": the
     shape and dtype a fake parameter declares are the bytes a real load — or
-    ``materialize_random`` in the mint child — goes on to allocate."""
+    a real load — goes on to allocate."""
     pipe = _Pipeline(transformer=virtual_component(40.0, device="cuda"))
     assert memory.estimate_pipeline_size_gb(pipe) == pytest.approx(40.0)
 

--- a/tests/test_wrapper_subclass_virtuality_pgw1198.py
+++ b/tests/test_wrapper_subclass_virtuality_pgw1198.py
@@ -294,57 +294,35 @@ def test_a_META_tensor_is_still_reported_by_the_placement_walk() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. The fake <-> real swap must preserve the graph, and price the payload
+# 3. Re-virtualizing must preserve the QUANTIZED topology
 # ---------------------------------------------------------------------------
 
 
-def test_the_warm_proof_keeps_the_QUANTIZED_topology(
+def test_revirtualizing_keeps_the_quantized_topology(
     quantized_target: Any,
 ) -> None:
-    """pgw#984's proof gives every virtual parameter real values. Rebuilding a
-    quantized weight as a plain tensor of its outer dtype would trace bf16
-    Linears for a pod that serves fp8 — a cell for a graph the pod never
-    executes, which is exactly what ``_refuse_artifact_lanes`` exists to
-    prevent — and would cost twice the bytes doing it."""
+    """`virtualize` rebuilt every parameter as a plain tensor of its OUTER
+    dtype, which turns a quantized weight into a bf16 one — so the export would
+    trace bf16 Linears for a pod that serves fp8: a cell for a graph the pod
+    never executes, which is exactly what `_refuse_artifact_lanes` exists to
+    prevent, arriving by the other door.
+
+    (The rows that used to sit here drove `materialize_random` — the pgw#984
+    warm proof's real-value materialisation. pgw#1199 deleted it: the proof
+    runs on the RESIDENT parent now, so nothing in this module can put values
+    on a structure. `test_structure_only_pgw1080` asserts that absence.)
+    """
     quantized = {name for name, p in quantized_target.named_parameters()
                  if isinstance(p.data, Quantized) or isinstance(p, Quantized)}
     assert quantized, "the fixture must have swapped something"
 
-    so.materialize_random(quantized_target, device="cpu")
+    so.virtualize(quantized_target, device="cpu")
 
     after = dict(quantized_target.named_parameters())
     for name in quantized:
         held = after[name]
         inner = held.data if not isinstance(held, Quantized) else held
         assert isinstance(inner, Quantized), (
-            f"{name} lost its quantization to the warm proof")
+            f"{name} lost its quantization to the re-virtualize")
         assert inner.qdata.dtype is torch.float8_e4m3fn
-        assert not mi.is_virtual(inner), "the proof runs on REAL values"
-
-
-def test_restoring_returns_the_quantized_parameters_to_virtual(
-    quantized_target: Any,
-) -> None:
-    so.materialize_random(quantized_target, device="cpu")
-    so.restore_virtual(quantized_target, device="cpu")
-
-    for name, param in quantized_target.named_parameters():
-        assert mi.is_virtual(param), f"{name} survived the restore as real"
-
-
-def test_the_proof_cost_is_the_PAYLOAD_and_is_measured_before_it_is_spent(
-    quantized_target: Any,
-) -> None:
-    """pgw#1199's left-hand side. It must be the same walk over the same
-    tensors that ``materialize_random`` performs — an estimate here would be
-    the disease §4.33 names — and it must price the fp8 payload rather than
-    the bf16 outer view."""
-    predicted = so.proof_cost_bytes([quantized_target])
-    spent = so.materialize_random(quantized_target, device="cpu")
-
-    assert predicted == spent, "the forecast IS the walk, not a model of it"
-
-    outer = sum(int(p.numel()) * int(p.element_size())
-                for p in quantized_target.parameters())
-    assert predicted < outer, (
-        "an fp8 payload under a bf16 outer view must not be priced at bf16")
+        assert mi.is_virtual(inner), "and it must still allocate nothing"


### PR DESCRIPTION
## The finding this discharges

§4.33 says a mint costs ~8 GiB because the model *"is fully resident and serving eager"* and the compile is *"weight-free … VRAM cost is negligible"*. The compile is. **The mint was not.**

`mint_child` discharged pgw#984's does-it-run proof by calling `materialize_random` — REAL random values for every virtual parameter: one full checkpoint at compute dtype, in a child process holding none, **concurrently with the parent's resident copy**. Its own docstring said so (*"they ARE weight-scale for the length of the proof"*) and nothing connected that to the ruling.

On pod `729431an6ugbvq` (H100-80, wan-2.2) that is **56.2 GB against 15.5 GiB free**:

```
CUDA out of memory. Tried to allocate 50.00 MiB … this process has 15.44 GiB memory in use.
```

recorded under `phase=load`, because the `warmup_forward` frame is only emitted *after* `materialize_random` returns. Then `delegated_no_cell`, then `boot_ended_uncompiled`.

| family | what the proof materialised | inside 8 GiB? |
|---|---|---|
| sdxl | ~5 GB (2.6B × bf16) | yes — **this is the measurement "8 GiB" came from** |
| wan-2.2-t2v-a14b | **56.2 GB** (2 × 14.05B × bf16) | no, by 7× |

**The number that has anchored this subsystem was measuring the thing this PR deletes.**

## The correction, and why it is toward the stated design

§4.33 steps 4-5 already put verification on the LIVE pipeline — *"already running eager"* — against weights that are resident and paid for once. The proof was simply in the wrong process.

New `gen_worker.handler_proof`: ONE warm forward through the endpoint's OWN handler, on the resident pipeline, with REAL checkpoint values — strictly stronger than a random-value re-run.

* **Fleet: free.** The executor's boot warm plan already runs every declared handler, and setup completes *before* `bg.task` is created (verified in `_setup_locked_inner` → `_run_synthesized_warmup`, then `rec.ready = True`, then the mint task). The record is taken where the forward already happens — one line in `_invoke_warmup`.
* **The request carries PROVENANCE, not a boolean**, so the child's report says which proof stood behind the cell it sealed. The child cannot see the parent's ledger; it can only see what the request carries.
* **The SDK had already made this exact call once** — `execution_lane_verdict_for`'s `meta_mint` branch skips the kernel-lane A/B because *"running it would put weight-scale values back in the one process this slice exists to keep empty."*

## pgw#984 is not weakened

A weight-free mint with no proof **REFUSES** (`mint_child.assert_handler_proven`), naming what the caller must set. It never degrades to "mint anyway", and the child never proves it itself — proving it there *is* the allocation. The **real-weight fallback keeps its in-child proof**: for a family with no structure-only path (a quantized artifact lane, a class with no config surface) the checkpoint is already resident in that process, so it costs nothing extra.

## cozy-local now mints in the fleet's order

`enable_compiled` is reached from inside the **slot load**, before `setup()` has bound the pipeline to the endpoint instance — so there is no handler to run yet, and a mint started there could only ever have proven itself the expensive way. Arming from the local store stays in the load (the endpoint's `setup()` must receive an armed pipeline); the **mint** is deferred and runs after `setup()` and `warmup()` return. Same shape as pgw#671's eager-first boot.

This is the difference between a 6-8 GiB card being impossible and being routine.

## Deleted, not deprecated

`structure_only.materialize_random`, `restore_virtual`, `stray_real_tensors`, and pgw#1198's `proof_cost_bytes` / affordability guard — the guard measured an allocation that no longer happens.

`stray_real_tensors` deserves the explicit note: it hunted a REAL tensor cached on a plain attribute by a lazily-built device-pinned table (ie#628's call-time class). **That residue existed *because* a real forward had just run in that process.** With no real values there, the same lazy build fires inside the export's fake mode and yields a FAKE constant, which `aot_package` cannot pack — still loud, at pack time rather than at a stray walk. `test_structure_only_pgw1080` now asserts the absence of every route to real values, so nobody reintroduces one.

## Verification

`mypy src/gen_worker` clean (266 files); `ruff` clean on every touched file; all 12 fast-gate lint scripts OK; `assemble_changelog --check` OK. `tests/test_handler_proof_pgw1199.py` 16 passed; the affected neighbours (`pgw1080`, `pgw1173`, `pgw1198`, `pgw1128`, `pgw969`, `pgw828`, `pgw1124`) 78 passed. **No pod was bought.**

Follow-on, already agreed and not in this PR: with the checkpoint-scale allocation gone, the mint's real requirement is **activation-scale**, and that is the number to bank — per graph class, measured, with the card and toolchain observed. The wan-2.2 leg is approved once this lands; a cost comes back before anything is bought.

Tracker: pgw#1199 (and pgw#1198, merged as `702687f6`).