### PR TITLE
pgw#1205: bank what a compile costs a card — per graph class, with provenance

### DIFF
--- a/changelog.d/pgw1205.md
+++ b/changelog.d/pgw1205.md
@@ -1,0 +1,38 @@
+- **pgw#1205: what a compile costs a card is BANKED now — per graph class, with the conditions it
+  was measured under.** §4.33 deleted a prediction layer and left one sentence standing: *an
+  estimate may never act as a floor a measurement is not allowed to correct.* pgw#1199 then deleted
+  the last thing that made a mint weight-scale, so the honest requirement is activation scale — and
+  nobody was keeping that number. The instrumentation already existed
+  (`aot_compile_child._peak_device`, marked *"telemetry only"*); what died with `mint_budget.py` was
+  the BANKING and the PROVENANCE.
+- **Two sinks, one measurement, each answering only the question it can.** The machine banks the row
+  (`mint_workers.record_entry_device_peak`) for *"what did this cost HERE"*; the identical rows ride
+  `aot_mint_phases` to the hub for the fleet view. **The artifact schema is untouched**, so there is
+  no adoption risk. The two cannot disagree because they are not two measurements — the parent banks
+  the rows out of the same phase table it forwards.
+- **Why not the cell manifest, which was the alternative.** A manifest is written when a cell SEALS,
+  and **the mint that most needs measuring is the one that OOMed and sealed nothing** — a bank whose
+  writer dies exactly when the interesting data exists is not a bank. The consumer is local too: K
+  is decided in the mint child, on this card, so a fleet table reachable only through a hub is the
+  wrong shape to read it from, and cozy-local has no hub at all.
+- **Written on EVERY outcome, from BOTH sources** — the report when the child reached a terminus
+  under its own power, the phase snapshot when it was killed. pgw#848's rule for the host half,
+  which bites harder here: the attempt that ran out of device memory is the one whose reading the
+  next attempt most needs.
+- **The row carries every axis that makes the number mean anything**: graph class, card SKU **and**
+  `sm` (a cell minted at the wrong arch is unadoptable, so a reading must not be shared across
+  arches), the toolchain digest — the SAME one the cell key's toolchain axis uses, so a banked row
+  and the cell it measured agree on what "this toolchain" is — the gen-worker version, the weight
+  lane, and **the PHASE**, because an export high-water and an entry-compile high-water are
+  different questions about the same card and maxing them together describes neither.
+  `peak_child_device_bytes` survives unchanged beside it: that is one number for a whole cell (18
+  classes on sdxl), which is why it could never answer the question anyone asks of it.
+- **Both readings, kept apart.** `allocated` is what the compile needed; `reserved` is what the
+  caching allocator HELD and therefore what a concurrent sibling could not have. The gap between
+  them is fragmentation, and a single number hides it. Monotone at the write and maxed per field, so
+  a lucky run cannot talk a reading down. An unmeasured row reads `None`, never `0` — "never
+  measured here" and "measured at zero" are different facts.
+- **It MEASURES; it does not SIZE, and a test enforces that.** `entry_workers` is still f(cores,
+  measured child RSS) and no width, placement or admission decision reads a banked row — a fence
+  test fails if any module outside `mint_workers` calls the reader, because a banked number is
+  exactly the shape that invites `mint_budget` back and §4.33 deleted it on measured evidence.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -1104,6 +1104,14 @@ class EntryCompilePool:
         #: child really costs a card is exactly the question P0-E/P0-F ask; it
         #: is not, and was never, a licence to divide free VRAM by it.
         self.peak_device_bytes = 0
+        #: pgw#1205: the same reading, kept PER ENTRY instead of collapsed.
+        #: `peak_device_bytes` above answers "how big was the biggest compile"
+        #: — one number for a whole cell, which is the wrong granularity for
+        #: the only question anyone asks of it ("what does THIS graph class
+        #: cost a card"). Both survive: the max is what the existing phase-table
+        #: field publishes, and these rows are what gets banked with their
+        #: provenance. entry name -> (allocated, reserved).
+        self.entry_device_peaks: Dict[str, Tuple[int, int]] = {}
         self.peak_concurrency = 0
         # pgw#848: the kernel's OOM-kill counter as it stood before this pool
         # ran. A DELTA over the pool's own wall is evidence; the absolute
@@ -1571,10 +1579,18 @@ class EntryCompilePool:
         have — and K is a question about siblings. A child too old to report
         reserved still contributes its allocated figure rather than nothing.
         """
-        peak = int(report.peak_device_reserved_bytes or 0) \
-            or int(report.peak_device_bytes or 0)
+        allocated = max(0, int(report.peak_device_bytes or 0))
+        reserved = max(0, int(report.peak_device_reserved_bytes or 0))
+        peak = reserved or allocated
         if peak > 0:
             self.peak_device_bytes = max(self.peak_device_bytes, peak)
+        # pgw#1205: and the per-class row, both readings kept apart. Maxed per
+        # field so a retry of the same entry widens rather than replaces.
+        entry = str(report.entry or "").strip()
+        if entry and (allocated > 0 or reserved > 0):
+            held_a, held_r = self.entry_device_peaks.get(entry, (0, 0))
+            self.entry_device_peaks[entry] = (
+                max(held_a, allocated), max(held_r, reserved))
 
     def _collect(self, row: _Running) -> List[str]:
         elapsed = time.monotonic() - row.started

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2709,6 +2709,56 @@ def _compile_entries_parallel(
     return _pool_facts(pool)
 
 
+#: The mint window `entry_device_peaks` measures. Named on the row rather than
+#: implied, because an EXPORT high-water and an entry COMPILE high-water are
+#: different questions about the same card and maxing them together would
+#: produce a number describing neither (`_ExportFootprint`'s own docstring is
+#: the worked example of that mistake).
+DEVICE_PEAK_PHASE = "entry_compile"
+
+
+def _device_peak_provenance() -> Dict[str, str]:
+    """The conditions every row in this pool's device census was taken under.
+
+    Stated ONCE beside the rows rather than repeated on each: they come from
+    one child, on one card, under one toolchain, so per-row copies could only
+    ever disagree with each other. Read in the CHILD deliberately — it is the
+    process that ran on the card, and on a multi-GPU box the parent's probe can
+    name a different device.
+
+    ``weight_lane`` is NOT here: the parent owns it (it is what it already keys
+    the RSS bank by) and adds it when banking. A fact belongs to whoever knows
+    it first-hand.
+    """
+    from . import cell_key
+    from . import compile_cache as cc
+
+    try:
+        runtime = cc.runtime_key()
+    except Exception:  # noqa: BLE001 — telemetry never fails a mint
+        runtime = {}
+    try:
+        toolchain = cell_key.toolchain_axis_digest(dict(cc.toolchain_digest()))
+    except Exception:  # noqa: BLE001
+        toolchain = ""
+    try:
+        version = cc.gen_worker_version()
+    except Exception:  # noqa: BLE001
+        version = ""
+    return {
+        # Both namings of the card: the SKU a human reads and the arch the
+        # kernels were built for. A cell minted at the wrong arch is
+        # unadoptable, so a reading must never be shared across arches.
+        "card": str(runtime.get("sku") or ""),
+        "sm": str(runtime.get("sm") or ""),
+        # The SAME digest the cell key's toolchain axis uses, so a banked row
+        # and the cell it was measured for agree on what this toolchain is.
+        "toolchain": str(toolchain),
+        "gen_worker": str(version),
+        "phase": DEVICE_PEAK_PHASE,
+    }
+
+
 def _pool_facts(pool: aot_compile_pool.EntryCompilePool) -> Dict[str, Any]:
     """The pool block of the phase table, on BOTH termini (pgw#848).
 
@@ -2727,6 +2777,18 @@ def _pool_facts(pool: aot_compile_pool.EntryCompilePool) -> Dict[str, Any]:
         # the phase table is what survives the mint child, and the mint child
         # is the process that dies.
         "peak_child_device_bytes": int(pool.peak_device_bytes),
+        # pgw#1205: the same reading, PER GRAPH CLASS, with the conditions it
+        # was taken under stated once beside it. `peak_child_device_bytes`
+        # above is the max across a whole cell — one number for 18 classes,
+        # which cannot answer the only question anyone asks of it. These rows
+        # can, and they ride the SAME phase table, so the row the hub receives
+        # and the row this machine banks are the same bytes rather than two
+        # measurements that have to be reconciled.
+        "entry_device_peaks": {
+            name: {"allocated_bytes": int(a), "reserved_bytes": int(r)}
+            for name, (a, r) in sorted(pool.entry_device_peaks.items())
+        },
+        "device_peak_provenance": _device_peak_provenance(),
     }
     if pool.oom_entry:
         facts["oom_entry"] = pool.oom_entry

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -212,6 +212,55 @@ def _pool_stat(phases: Any, key: str) -> int:
         return 0
 
 
+def _bank_device_peaks(phases: Any, *, weight_lane: str) -> int:
+    """Bank every per-graph-class device reading in one phase table.
+
+    Returns how many rows were banked, so a caller can tell "no rows" from
+    "banked nothing" — an absent measurement is NO EVIDENCE, not a zero
+    (§4.33), and the two must not look alike here either.
+
+    Called on EVERY outcome, from the report AND from the snapshot, for the
+    reason pgw#848 gives about the host half and which is sharper here: the
+    attempt that ran out of device memory is the one whose reading the next
+    attempt most needs, and it is exactly the attempt that seals no cell and
+    writes no manifest. A bank whose writer only runs on success is not a bank.
+
+    ``weight_lane`` is the parent's own fact — the same axis it keys the RSS
+    bank by — and it is the one axis the child does not state, because the
+    parent is what knows it first-hand.
+    """
+    try:
+        block = (phases or {}).get("pool") or {}
+        rows = block.get("entry_device_peaks") or {}
+        prov = block.get("device_peak_provenance") or {}
+        if not isinstance(rows, dict) or not isinstance(prov, dict):
+            return 0
+    except (TypeError, AttributeError):
+        return 0
+    banked = 0
+    for graph_class, reading in rows.items():
+        if not isinstance(reading, dict):
+            continue
+        try:
+            key = mint_workers.DevicePeakKey(
+                graph_class=str(graph_class),
+                card=str(prov.get("card") or ""),
+                sm=str(prov.get("sm") or ""),
+                toolchain=str(prov.get("toolchain") or ""),
+                gen_worker=str(prov.get("gen_worker") or ""),
+                weight_lane=str(weight_lane or ""),
+                phase=str(prov.get("phase") or ""),
+            )
+            mint_workers.record_entry_device_peak(
+                key,
+                int(reading.get("allocated_bytes") or 0),
+                int(reading.get("reserved_bytes") or 0))
+        except (TypeError, ValueError):
+            continue
+        banked += 1
+    return banked
+
+
 def _on_frame(act: Any, watch: Optional[Watcher] = None) -> Any:
     def _apply(frame: mint_process.MintFrame) -> None:
         # No new protocol: the child's phase lands on the SAME
@@ -358,6 +407,18 @@ async def build_cell(
         mint_workers.record_entry_peak_rss(
             family, task.weight_lane,
             _pool_stat(outcome.partial_phases, "peak_child_rss_bytes"))
+        # pgw#1205: the DEVICE reading, per graph class, from both sources for
+        # the same reason — the report when the child reached a terminus, the
+        # snapshot when it was killed. The rows are banked HERE, on this
+        # machine, because the consumer is local (K is decided in the mint
+        # child) and because a cell manifest cannot carry them: a mint that
+        # OOMs seals no cell. The identical rows ride `aot_mint_phases` to the
+        # hub below, so the two sinks cannot disagree — they are the same bytes.
+        if outcome.report is not None:
+            _bank_device_peaks(
+                outcome.report.mint_phases, weight_lane=task.weight_lane)
+        _bank_device_peaks(
+            outcome.partial_phases, weight_lane=task.weight_lane)
         # pgw#1010: every delegated mint is an AOT mint, so there is one
         # phase emitter. The JIT twin measured a child recipe that no longer
         # exists.

--- a/src/gen_worker/mint_workers.py
+++ b/src/gen_worker/mint_workers.py
@@ -28,7 +28,7 @@ ever grows a term it did not measure, it belongs in the deleted module.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 
 #: One entry child's measured HOST high-water, keyed by (family, weight lane).
@@ -54,6 +54,136 @@ def record_entry_peak_rss(family: str, weight_lane: str, peak_bytes: int) -> Non
 def entry_peak_rss(family: str, weight_lane: str) -> int:
     """0 = never measured on this pod; ``entry_workers`` says so in its basis."""
     return _ENTRY_RSS_PEAKS.get((str(family or ""), str(weight_lane or "")), 0)
+
+
+# ---------------------------------------------------------------------------
+# pgw#1205: the DEVICE reading, banked per GRAPH CLASS with its provenance
+# ---------------------------------------------------------------------------
+#
+# §4.33 deleted a prediction layer and left one sentence standing: *"an estimate
+# may never act as a floor a measurement is not allowed to correct, and an
+# absent measurement means NO EVIDENCE."* pgw#1199 then deleted the last thing
+# that made a mint weight-scale, so the honest requirement is what a compile
+# actually costs a card — activation scale — and that is a MEASUREMENT nobody
+# was keeping.
+#
+# WHY THE MACHINE, AND NOT THE CELL MANIFEST. The manifest is written when a
+# cell SEALS, and the mint that most needs measuring is the one that OOMed and
+# sealed nothing — a bank whose writer dies exactly when the interesting data
+# exists is not a bank. And the consumer is local: K is decided in the mint
+# child, on this card, so a fleet table reachable only through a hub is the
+# wrong shape to read it from and cozy-local has no hub at all. So the reading
+# goes to two sinks that answer different questions: HERE for "what did this
+# cost on THIS machine", and onto `aot_mint_phases` for the fleet view. One
+# measurement, taken once, in the child that ran it.
+#
+# WHAT THIS IS NOT. It sizes nothing. `entry_workers` is still f(cores,
+# measured child RSS) and no width, placement or admission decision reads a row
+# below. Wiring one in would re-create precisely what §4.33 deleted, and this
+# module's own header says where such a term belongs: the deleted module.
+
+
+class DevicePeak(NamedTuple):
+    """One compile's device high-water, both readings.
+
+    Both, deliberately: ``allocated`` is what the compile needed and
+    ``reserved`` is what the caching allocator HELD and therefore what a
+    concurrent sibling could not have. The GAP between them is allocator
+    fragmentation, which is itself worth seeing and which a single number
+    hides.
+    """
+
+    allocated_bytes: int
+    reserved_bytes: int
+
+
+class DevicePeakKey(NamedTuple):
+    """WHAT was measured, and under WHICH conditions.
+
+    Every axis is here because the number is meaningless without it: the same
+    graph class costs a different amount on a different card, under a different
+    toolchain, at a different weight lane, and in a different PHASE of the mint.
+    A row that cannot say all five is not a measurement, it is a number.
+    """
+
+    graph_class: str
+    #: The card, both ways it can be named: a human-legible SKU slug
+    #: (``h100-80gb-hbm3``) and the arch the kernels were built for
+    #: (``sm_90``). A cell minted at the wrong arch is unadoptable, so the
+    #: reading must not be shared across arches.
+    card: str
+    sm: str
+    #: The SAME digest the cell key's toolchain axis uses
+    #: (``cell_key.toolchain_axis_digest``), so a banked row and the cell it
+    #: was measured for agree about what "this toolchain" means.
+    toolchain: str
+    gen_worker: str
+    weight_lane: str
+    #: WHICH window this high-water covers — an export peak and an entry
+    #: compile peak are different questions and must never be maxed together.
+    phase: str
+
+
+#: The bank. Monotone at the WRITE, exactly as the RSS bank is: a compile that
+#: peaked high once can peak that high again, and a lucky run must not talk the
+#: reading down.
+_DEVICE_PEAKS: Dict[DevicePeakKey, DevicePeak] = {}
+
+
+def record_entry_device_peak(
+    key: DevicePeakKey, allocated_bytes: int, reserved_bytes: int,
+) -> None:
+    """Bank one compile's measured device high-water.
+
+    Written on EVERY outcome including failures — pgw#848's rule for the host
+    half, which applies here with more force: the attempt that ran out of
+    device memory is the one whose reading the next attempt most needs, and it
+    is exactly the attempt that seals no cell.
+
+    Each reading is maxed INDEPENDENTLY. They come from one child and normally
+    move together, but taking ``max`` per field can only ever widen a reading,
+    and a bank that under-reports is the failure mode that matters.
+    """
+    allocated, reserved = max(0, int(allocated_bytes)), max(0, int(reserved_bytes))
+    if allocated <= 0 and reserved <= 0:
+        return
+    if not str(key.graph_class or "").strip():
+        # A row with no subject cannot be looked up and would silently
+        # accumulate every class into one entry.
+        return
+    held = _DEVICE_PEAKS.get(key)
+    if held is None:
+        _DEVICE_PEAKS[key] = DevicePeak(allocated, reserved)
+        return
+    _DEVICE_PEAKS[key] = DevicePeak(
+        max(held.allocated_bytes, allocated),
+        max(held.reserved_bytes, reserved))
+
+
+def entry_device_peak(key: DevicePeakKey) -> Optional[DevicePeak]:
+    """The banked reading, or ``None`` — which means NO EVIDENCE.
+
+    ``None`` rather than a zero-valued row on purpose (§4.33): "never measured
+    here" and "measured at zero" are different facts, and a caller that cannot
+    tell them apart will read the first as the second.
+    """
+    return _DEVICE_PEAKS.get(key)
+
+
+def device_peak_rows() -> Dict[DevicePeakKey, DevicePeak]:
+    """Every row this machine has banked. A copy — the bank is append-and-widen
+    only, and a caller must not be able to lower a reading by holding it."""
+    return dict(_DEVICE_PEAKS)
+
+
+def _forget_device_peaks() -> None:
+    """Drop the bank.
+
+    Private, and meant to stay so: production never un-measures a card, so a
+    public name here would be public surface with no production caller. Tests
+    reach it deliberately.
+    """
+    _DEVICE_PEAKS.clear()
 
 
 def device_of(pipeline: Any) -> Optional[int]:

--- a/tests/test_cell_key_pgw1059.py
+++ b/tests/test_cell_key_pgw1059.py
@@ -133,6 +133,24 @@ _DERIVATION_ALLOWLIST = {
         "cell_key.py",     # def (+ toolchain_facts)
         "fleet_cells.py",  # arm_identity + arm_axis_divergence
         "aot_identity.py",  # artifact_identity (the wire fact)
+        # pgw#1205: the device-peak census's provenance. Added CONSCIOUSLY,
+        # which is what this fence's own message offers as the alternative to
+        # reading a stamped value — and here there is no stamped value to
+        # read: the census is taken in the MINT CHILD, which holds an
+        # `arm_token` (a hash of the facts) and never the facts themselves.
+        #
+        # It is the right call rather than merely the available one. A banked
+        # reading says "this graph class cost this much under THIS toolchain",
+        # and the only useful meaning of "this toolchain" is the one the CELL
+        # uses — same membership, same digest. A second notion computed
+        # locally would drift from the cell's exactly where it matters (the
+        # header above: "the two ends can disagree about membership"), and the
+        # bank would then be keyed on a toolchain nothing else recognises.
+        #
+        # It derives NO KEY: nothing compares this value against a cell key,
+        # an arm key or a boot key. It is a bank axis, and the bank sizes
+        # nothing (`test_device_peak_bank_pgw1205` fences that structurally).
+        "aot_mint.py",
     },
 }
 

--- a/tests/test_device_peak_bank_pgw1205.py
+++ b/tests/test_device_peak_bank_pgw1205.py
@@ -1,0 +1,312 @@
+"""pgw#1205: what a compile costs a card, banked per GRAPH CLASS with provenance.
+
+§4.33 deleted a prediction layer and left one sentence standing — *an estimate
+may never act as a floor a measurement is not allowed to correct, and an absent
+measurement means NO EVIDENCE.* pgw#1199 then deleted the last thing that made a
+mint weight-scale, so the honest requirement is what a compile actually costs a
+card (activation scale), and nobody was keeping that number: the instrumentation
+existed (`aot_compile_child._peak_device`, marked *"telemetry only"*) but the
+BANKING and the PROVENANCE died with `mint_budget.py`.
+
+WHY THE MACHINE AND NOT THE CELL MANIFEST — the argument that decided the shape
+------------------------------------------------------------------------------
+The manifest is written when a cell SEALS. **The mint that most needs measuring
+is the one that OOMed and sealed nothing**, so a manifest-only bank has a writer
+that dies exactly when the interesting data exists. And the consumer is local:
+K is decided in the mint child, on this card, so a fleet table reachable only
+through a hub is the wrong shape to read it from — and cozy-local has no hub.
+
+So: two sinks, one measurement, each answering only the question it can. The
+machine banks the row for "what did this cost HERE"; `aot_mint_phases` carries
+the identical bytes to the hub for the fleet view. The artifact schema is
+untouched, so there is no adoption risk.
+
+WHAT THIS IS NOT
+----------------
+It sizes nothing. `entry_workers` is still f(cores, measured child RSS), and no
+width, placement or admission decision reads a banked row. Wiring one in would
+re-create precisely what §4.33 deleted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import mint_delegate, mint_workers
+
+
+@pytest.fixture(autouse=True)
+def _clean_bank() -> Any:
+    mint_workers._forget_device_peaks()
+    yield
+    mint_workers._forget_device_peaks()
+
+
+PROVENANCE: Dict[str, str] = {
+    "card": "h100-80gb-hbm3",
+    "sm": "sm_90",
+    "toolchain": "e4b2b170438af354",
+    "gen_worker": "0.113.2",
+    "phase": "entry_compile",
+}
+
+
+def _phases(rows: Dict[str, Dict[str, int]], **prov: str) -> Dict[str, Any]:
+    """A mint phase table shaped exactly as `_pool_facts` writes one."""
+    return {"pool": {
+        "peak_child_device_bytes": max(
+            [r.get("reserved_bytes", 0) for r in rows.values()] or [0]),
+        "entry_device_peaks": rows,
+        "device_peak_provenance": {**PROVENANCE, **prov},
+    }}
+
+
+def _key(graph_class: str, **over: str) -> mint_workers.DevicePeakKey:
+    base = dict(
+        graph_class=graph_class, card=PROVENANCE["card"], sm=PROVENANCE["sm"],
+        toolchain=PROVENANCE["toolchain"], gen_worker=PROVENANCE["gen_worker"],
+        weight_lane="w8a8", phase=PROVENANCE["phase"])
+    base.update(over)
+    return mint_workers.DevicePeakKey(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# The bank: a reading, per class, with every axis that makes it meaningful
+# ---------------------------------------------------------------------------
+
+
+def test_an_unmeasured_row_is_NONE_and_not_a_zero() -> None:
+    """§4.33: an absent measurement is NO EVIDENCE. A zero-valued row would be
+    read as "measured at zero", which is a different fact and a dangerous one."""
+    assert mint_workers.entry_device_peak(_key("unet")) is None
+
+
+def test_both_readings_are_kept_because_the_GAP_is_the_information() -> None:
+    """`allocated` is what the compile needed; `reserved` is what the caching
+    allocator HELD and therefore what a concurrent sibling could not have. The
+    gap between them is fragmentation, which one number hides."""
+    mint_workers.record_entry_device_peak(_key("unet"), 2_000_000, 3_500_000)
+
+    peak = mint_workers.entry_device_peak(_key("unet"))
+    assert peak is not None
+    assert peak.allocated_bytes == 2_000_000
+    assert peak.reserved_bytes == 3_500_000
+
+
+def test_the_bank_is_MONOTONE_so_a_lucky_run_cannot_talk_it_down() -> None:
+    mint_workers.record_entry_device_peak(_key("unet"), 9_000_000, 9_500_000)
+    mint_workers.record_entry_device_peak(_key("unet"), 1_000, 2_000)
+
+    peak = mint_workers.entry_device_peak(_key("unet"))
+    assert peak == mint_workers.DevicePeak(9_000_000, 9_500_000)
+
+
+def test_each_reading_widens_INDEPENDENTLY() -> None:
+    """Maxed per field: widening can only ever make a reading more honest, and
+    a bank that under-reports is the failure mode that matters."""
+    mint_workers.record_entry_device_peak(_key("unet"), 9_000_000, 1_000)
+    mint_workers.record_entry_device_peak(_key("unet"), 1_000, 9_500_000)
+
+    assert mint_workers.entry_device_peak(_key("unet")) == \
+        mint_workers.DevicePeak(9_000_000, 9_500_000)
+
+
+@pytest.mark.parametrize(
+    "axis,value",
+    [("card", "a4500"), ("sm", "sm_86"), ("toolchain", "deadbeefdeadbeef"),
+     ("gen_worker", "0.114.0"), ("weight_lane", "bf16"),
+     ("phase", "export")],
+)
+def test_every_provenance_axis_SEPARATES_a_reading(axis: str, value: str) -> None:
+    """The number is meaningless without its conditions. The same graph class
+    costs a different amount on a different card, under a different toolchain,
+    at a different weight lane — and an EXPORT high-water and an entry COMPILE
+    high-water are different questions about the same card, which is why the
+    phase is on the key and not implied."""
+    mint_workers.record_entry_device_peak(_key("unet"), 5_000, 6_000)
+
+    assert mint_workers.entry_device_peak(_key("unet", **{axis: value})) is None
+    assert mint_workers.entry_device_peak(_key("unet")) is not None
+
+
+def test_graph_classes_do_not_share_a_row() -> None:
+    """The whole reason this exists: `peak_child_device_bytes` was ONE number
+    for a whole cell — 18 classes on sdxl — which cannot answer "what does this
+    class cost"."""
+    mint_workers.record_entry_device_peak(_key("unet"), 5_000, 6_000)
+    mint_workers.record_entry_device_peak(_key("vae.decode"), 100, 200)
+
+    assert mint_workers.entry_device_peak(_key("unet")).reserved_bytes == 6_000
+    assert mint_workers.entry_device_peak(_key("vae.decode")).reserved_bytes == 200
+
+
+def test_a_row_with_no_subject_is_refused() -> None:
+    """It could not be looked up, and it would silently accumulate every class
+    into one entry."""
+    mint_workers.record_entry_device_peak(_key(""), 5_000, 6_000)
+    assert mint_workers.device_peak_rows() == {}
+
+
+def test_an_empty_reading_banks_nothing() -> None:
+    mint_workers.record_entry_device_peak(_key("unet"), 0, 0)
+    assert mint_workers.device_peak_rows() == {}
+
+
+def test_the_returned_rows_are_a_COPY() -> None:
+    """The bank is append-and-widen only; a caller must not be able to lower a
+    reading by holding the map."""
+    mint_workers.record_entry_device_peak(_key("unet"), 5_000, 6_000)
+    rows = mint_workers.device_peak_rows()
+    rows.clear()
+    assert mint_workers.entry_device_peak(_key("unet")) is not None
+
+
+# ---------------------------------------------------------------------------
+# THE TWO-SINK PROOF
+# ---------------------------------------------------------------------------
+
+
+class _Outcome:
+    """The shape `build_cell` reads: a report on a terminus, a snapshot always."""
+
+    def __init__(self, report: Any = None, partial: Any = None) -> None:
+        self.report = report
+        self.partial_phases = partial or {}
+
+
+class _Report:
+    def __init__(self, phases: Dict[str, Any]) -> None:
+        self.mint_phases = phases
+
+
+def test_a_FAILED_mint_leaves_a_bank_row() -> None:
+    """The deliverable, and the argument that chose this design over the cell
+    manifest: a mint that OOMs seals no cell and writes no manifest, and it is
+    the attempt whose reading the next attempt most needs.
+
+    The killed child writes no report at all — only the phase SNAPSHOT — so the
+    row has to come off that path or it does not exist.
+    """
+    rows = {"unet": {"allocated_bytes": 7_000_000, "reserved_bytes": 8_100_000}}
+    killed = _Outcome(report=None, partial=_phases(rows))
+    assert killed.report is None, "a killed child writes no report — only a snapshot"
+
+    banked = mint_delegate._bank_device_peaks(
+        killed.partial_phases, weight_lane="w8a8")
+
+    assert banked == 1, "a killed mint's snapshot must still bank"
+    peak = mint_workers.entry_device_peak(_key("unet"))
+    assert peak == mint_workers.DevicePeak(7_000_000, 8_100_000)
+
+
+def test_a_mint_that_REACHED_a_terminus_banks_from_its_report() -> None:
+    """The other source. `build_cell` drains BOTH — the report when the child
+    reached a terminus under its own power, the snapshot always — so neither
+    kind of ending loses its measurement."""
+    rows = {"unet": {"allocated_bytes": 1_500, "reserved_bytes": 2_500}}
+    refused = _Outcome(report=_Report(_phases(rows)), partial={})
+
+    banked = mint_delegate._bank_device_peaks(
+        refused.report.mint_phases, weight_lane="w8a8")
+
+    assert banked == 1
+    assert mint_workers.entry_device_peak(_key("unet")) == \
+        mint_workers.DevicePeak(1_500, 2_500)
+
+
+def test_the_HUB_row_and_the_LOCAL_row_are_the_same_bytes() -> None:
+    """The two sinks cannot disagree, because they are not two measurements.
+
+    `_bank_device_peaks` reads the rows out of the mint phase table, and
+    `_emit_aot_phases` sends that SAME table to the hub. So the proof is
+    identity, not reconciliation: whatever the hub is told, this machine
+    banked, field for field.
+    """
+    rows = {
+        "unet": {"allocated_bytes": 2_000_000, "reserved_bytes": 3_500_000},
+        "vae.decode": {"allocated_bytes": 400, "reserved_bytes": 900},
+    }
+    phases = _phases(rows)
+
+    banked = mint_delegate._bank_device_peaks(phases, weight_lane="w8a8")
+    assert banked == 2
+
+    # What the hub receives, verbatim out of the same table.
+    hub = phases["pool"]["entry_device_peaks"]
+    prov = phases["pool"]["device_peak_provenance"]
+
+    for graph_class, hub_row in hub.items():
+        local = mint_workers.entry_device_peak(
+            mint_workers.DevicePeakKey(
+                graph_class=graph_class, card=prov["card"], sm=prov["sm"],
+                toolchain=prov["toolchain"], gen_worker=prov["gen_worker"],
+                weight_lane="w8a8", phase=prov["phase"]))
+        assert local is not None, f"{graph_class} reached the hub and not the bank"
+        assert local.allocated_bytes == hub_row["allocated_bytes"]
+        assert local.reserved_bytes == hub_row["reserved_bytes"]
+
+
+def test_a_table_with_no_device_rows_banks_nothing_and_says_so() -> None:
+    """"No rows" and "banked nothing" must be distinguishable — the same reason
+    `entry_device_peak` returns None rather than a zero."""
+    assert mint_delegate._bank_device_peaks({}, weight_lane="w8a8") == 0
+    assert mint_delegate._bank_device_peaks(
+        {"pool": {"peak_child_rss_bytes": 5}}, weight_lane="w8a8") == 0
+    assert mint_workers.device_peak_rows() == {}
+
+
+def test_a_malformed_table_never_costs_a_mint() -> None:
+    """This runs on the outcome path of a mint that may already be failing; it
+    must not add a second failure to the one being reported."""
+    for junk in (None, {"pool": None}, {"pool": {"entry_device_peaks": "no"}},
+                 {"pool": {"entry_device_peaks": {"unet": "no"}}}):
+        assert mint_delegate._bank_device_peaks(junk, weight_lane="w") == 0
+
+
+def test_the_parent_supplies_the_LANE_because_the_child_does_not_state_it() -> None:
+    """A fact belongs to whoever knows it first-hand. The child states card,
+    sm, toolchain, version and phase — everything about the process that ran on
+    the card. The lane is the parent's, and it is the axis it already keys the
+    RSS bank by."""
+    rows = {"unet": {"allocated_bytes": 10, "reserved_bytes": 20}}
+    assert "weight_lane" not in _phases(rows)["pool"]["device_peak_provenance"]
+
+    mint_delegate._bank_device_peaks(_phases(rows), weight_lane="bf16")
+
+    assert mint_workers.entry_device_peak(_key("unet", weight_lane="bf16")) \
+        is not None
+    assert mint_workers.entry_device_peak(_key("unet", weight_lane="w8a8")) is None
+
+
+# ---------------------------------------------------------------------------
+# The fence: this measures, it does not size
+# ---------------------------------------------------------------------------
+
+
+def test_no_width_or_placement_decision_reads_the_bank() -> None:
+    """§4.33's whole lesson. `entry_workers` is f(cores, measured child RSS);
+    reintroducing a device divisor is what pgw#1175 deleted, and a banked
+    number is exactly the shape that invites it back.
+
+    Asserted structurally rather than by comment: nothing outside this module
+    and its tests may call the reader.
+    """
+    import pathlib
+    import re
+
+    # The READER only. `record_entry_device_peak` contains the reader's name as
+    # a substring, and the writer is the whole point — a guard that cannot tell
+    # them apart names its own plumbing and then gets deleted for crying wolf.
+    reader = re.compile(r"(?<!record_)entry_device_peak\s*\(")
+    root = pathlib.Path(mint_workers.__file__).resolve().parent
+    callers = [
+        path.name for path in sorted(root.rglob("*.py"))
+        if path.name != "mint_workers.py"
+        and reader.search(path.read_text())
+    ]
+    assert callers == [], (
+        f"{callers} reads the device bank — if a width, placement or admission "
+        f"decision now divides by it, that is mint_budget returning and §4.33 "
+        f"deleted it on measured evidence")

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List
@@ -345,20 +346,71 @@ def test_a_mint_spawns_a_child_with_no_pre_flight_verdict(
         "the DECLINED vocabulary survived its only producer")
 
 
-def test_the_surviving_bank_is_the_host_rss_one(
+def test_the_only_bank_that_SIZES_anything_is_the_host_rss_one(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """K = f(cores, ONE measured child RSS). That measurement is banked and
-    handed down on the request; nothing else is."""
+    """K = f(cores, ONE measured child RSS), and no device number takes part.
+
+    §4.33 / pgw#1175 deleted five peak banks whose arithmetic declined four
+    families at 49-113 GiB. This fence keeps that deletion — but it now states
+    the PROPERTY rather than a list of forbidden names.
+
+    WHY IT CHANGED (pgw#1205, coordinator ruling 2026-08-13). It used to assert
+    `not hasattr(mint_workers, "record_entry_device_peak")`, and §4.33's own
+    follow-up then asked for exactly that function back: *"Bank, per GRAPH
+    CLASS … Provenance on every row — this is the point … Monotone per (class,
+    card, toolchain, lane), as `record_child_peak` already was."* A banked
+    MEASUREMENT is not the thing §4.33 deleted; a banked measurement that SIZES
+    something is. Naming symbols could not tell those apart, and this session
+    watched the same form fail in both directions — a required gate stayed
+    green while naming a symbol that had been deleted, and then a legitimate
+    reintroduction went red on a name while the protected invariant was
+    stronger than before.
+
+    So: prohibition by STRUCTURE, not by vocabulary.
+
+    * `record_child_peak` and `record_adopt_peak` stay banned BY NAME. They had
+      consumers; their names are load-bearing history and their return would be
+      the arithmetic itself coming back.
+    * The device census that DOES exist may not be read outside its own module
+      — asserted here, and asserted more fully by
+      `test_device_peak_bank_pgw1205.test_no_width_or_placement_decision_reads_the_bank`.
+    * Nothing device-shaped is handed down on the request.
+    """
     mint_workers._ENTRY_RSS_PEAKS.clear()
     assert mint_workers.entry_peak_rss("sdxl", "w8a8") == 0
     mint_workers.record_entry_peak_rss("sdxl", "w8a8", 5 * GIB)
     mint_workers.record_entry_peak_rss("sdxl", "w8a8", 2 * GIB)
     assert mint_workers.entry_peak_rss("sdxl", "w8a8") == 5 * GIB, (
         "the bank is not monotone — a lucky run talked the ask down")
+
+    # The two whose names are history: they had consumers, and a consumer is
+    # what turns a reading into a floor.
     assert not hasattr(mint_workers, "record_child_peak")
-    assert not hasattr(mint_workers, "record_entry_device_peak")
     assert not hasattr(mint_workers, "record_adopt_peak")
+
+    # The invariant itself. A device reading may be BANKED (it is a
+    # measurement) and may not be READ by anything that decides a width, a
+    # placement or an admission.
+    reader = re.compile(r"(?<!record_)entry_device_peak\s*\(")
+    src_root = Path(mint_workers.__file__).resolve().parent
+    consumers = [
+        path.name for path in sorted(src_root.rglob("*.py"))
+        if path.name != "mint_workers.py" and reader.search(path.read_text())
+    ]
+    assert consumers == [], (
+        f"{consumers} reads the device census — that is `mint_budget`'s "
+        f"arithmetic returning, and §4.33 deleted it on measured evidence")
+
+    # ...and nothing device-shaped crosses to the child, which is the other
+    # half of the sentence this fence used to carry. `entry_peak_rss_bytes` is
+    # the one measurement handed down; `vram_cap_bytes` died with pgw#1175.
+    handed_down = set(mp.MintRequest.__struct_fields__)
+    assert "entry_peak_rss_bytes" in handed_down
+    assert not [
+        f for f in handed_down
+        if ("vram" in f or "device" in f) and f.endswith("_bytes")
+    ], "a device budget is being handed down on the request again"
 
 
 def test_delegation_is_unconditional_and_has_no_kill_switch(


### PR DESCRIPTION
## The gap this closes

§4.33 deleted a prediction layer and left one sentence standing: *an estimate may never act as a floor a measurement is not allowed to correct.* pgw#1199 then deleted the last thing that made a mint weight-scale — so the honest requirement is **activation scale**, and nobody was keeping that number.

The instrumentation already existed: `aot_compile_child._peak_device()` returns `peak_device_bytes` and `peak_device_reserved_bytes` and is explicitly marked *"telemetry only"*. What died with `mint_budget.py` was the **banking** and the **provenance**.

## Two sinks, one measurement

* **The machine banks the row** (`mint_workers.record_entry_device_peak`) — "what did this cost HERE".
* **The identical rows ride `aot_mint_phases`** to the hub — the fleet view.

They cannot disagree, because they are not two measurements: the parent banks the rows **out of the same phase table it forwards**. **The artifact schema is untouched**, so there is no adoption risk.

### Why not the cell manifest — the argument that decided it

A manifest is written when a cell **seals**, and **the mint that most needs measuring is the one that OOMed and sealed nothing**. A bank whose writer dies exactly when the interesting data exists is not a bank. The consumer is local too: K is decided in the mint child, on this card, so a fleet table reachable only through a hub is the wrong shape to read it from — and cozy-local has no hub at all.

## What a row carries

`(graph class, card SKU, sm, toolchain digest, gen-worker version, weight lane, phase)` → `(allocated_bytes, reserved_bytes)`.

* **Card twice** — the SKU a human reads and the arch the kernels were built for. A cell minted at the wrong arch is unadoptable, so a reading must never be shared across arches.
* **The toolchain digest is the SAME one the cell key's toolchain axis uses** (`cell_key.toolchain_axis_digest`), so a banked row and the cell it measured agree on what "this toolchain" means.
* **The phase is on the key, not implied** — an export high-water and an entry-compile high-water are different questions about the same card, and maxing them together produces a number describing neither (`_ExportFootprint`'s own docstring is the worked example of that mistake).
* **Both readings, kept apart** — `allocated` is what the compile needed, `reserved` is what the caching allocator HELD and therefore what a concurrent sibling could not have. The gap is fragmentation; one number hides it.
* `peak_child_device_bytes` survives unchanged beside it. That is one number for a whole cell — 18 classes on sdxl — which is exactly why it could never answer the question anyone asks of it.
* Monotone at the write, maxed per field, so a lucky run cannot talk a reading down. An unmeasured row reads `None`, never `0`: "never measured here" and "measured at zero" are different facts (§4.33).

## Written on every outcome

From **both** sources, mirroring the RSS bank: the report when the child reached a terminus under its own power, the phase **snapshot** when it was killed. pgw#848's rule for the host half, which bites harder here — the attempt that ran out of device memory is the one whose reading the next attempt most needs.

## It measures; it does not size — and a test enforces that

`entry_workers` is still f(cores, measured child RSS). No width, placement or admission decision reads a banked row, and `test_no_width_or_placement_decision_reads_the_bank` fails if any module outside `mint_workers` calls the reader. A banked number is exactly the shape that invites `mint_budget` back, and §4.33 deleted it on measured evidence.

## The deliverable proof

* `test_a_FAILED_mint_leaves_a_bank_row` — a killed child writes no report at all, only a snapshot; the row has to come off that path or it does not exist.
* `test_the_HUB_row_and_the_LOCAL_row_are_the_same_bytes` — proof by identity, not reconciliation: whatever the hub is told, this machine banked, field for field.

## Verification

21 rows in the new file; the neighbouring mint/pool suites (`pgw848` ×3, `pgw842`, `pgw1053`) 39 passed; `mypy` clean (264 files); `ruff` clean on every touched file; `lint_unreached_surface` / `lint_config_reads` / `lint_settings_writers` / `lint_ambient_census` / `lint_arm_state_feeders` / `assemble_changelog --check` all OK. No pod was bought.

Tracker: pgw#1205.