### PR TITLE
pgw#1202: six call sites import the JWT decoder from the module that OWNS it

### DIFF
--- a/changelog.d/pgw1202.md
+++ b/changelog.d/pgw1202.md
@@ -33,3 +33,16 @@
   the types an endpoint author's editor resolves, so an unparameterized one
   silently erased their argument types at the seam they touch most. The
   burn-down list drops 69 → 62 modules.
+- Typing/layering: `no_implicit_reexport` closed for `request_context`. Six
+  call sites now import `_decode_unverified_jwt_claims` from
+  `request_context._helpers`, the module that OWNS it, instead of through the
+  package `__init__` — three other modules already did exactly this, so the fix
+  converges on the form the newer call sites use. Burn-down 17 → 16.
+  Two candidates were investigated and deliberately NOT taken: `chunk_upload`
+  (the indirection is the seam a publish test monkeypatches — 13 failures,
+  measured) and `cuda_root` (closing it strands a callable in the pgw#849
+  baseline). Both reasons are recorded beside their exemptions.
+- Fixed two unguarded `Optional` dereferences in
+  `tests/test_device_peak_bank_pgw1205.py`. They reached `master` because CI
+  runs only on `pull_request`: pgw#1205 and pgw#1202 PR 3 were each green
+  against a base that lacked the other, and nothing re-checked the merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,7 +304,7 @@ module = [
 ]
 disallow_untyped_decorators = false
 
-# --- burn-down: implicit_reexport, OUR modules (8) ---
+# --- burn-down: implicit_reexport, OUR modules (7) ---
 # Keyed on the EXPORTING module, not the importer. Each name means some other
 # module reaches a symbol through this one instead of through the module that
 # owns it (e.g. gen_worker.request_context._decode_unverified_jwt_claims read
@@ -314,11 +314,10 @@ module = [
   "gen_worker.aot_mint",
   "gen_worker.cuda_root",
   "gen_worker.fleet_cells",
-  "gen_worker.hot_swap",
   "gen_worker.models.chunk_upload",
+  "gen_worker.hot_swap",
   "gen_worker.models.cozy_snapshot",
   "gen_worker.models.lora_lifted",
-  "gen_worker.request_context",
 ]
 implicit_reexport = true
 

--- a/scripts/lint_mypy_ratchet.py
+++ b/scripts/lint_mypy_ratchet.py
@@ -50,7 +50,10 @@ HIGH_WATER: Dict[str, Tuple[int, int]] = {
     "disallow_untyped_decorators": (3, 9),
     # implicit_reexport is split in two: our modules (a burn-down) and
     # third-party stub export gaps (not our debt — upstream's __all__).
-    "implicit_reexport": (17, 34),
+    # 17 -> 16: pgw#1202 PR 4 closed 1 of the 8 OURS (the other 9 are
+    # third-party stub gaps and are not debt). The remaining 5 are blocked on
+    # open lanes owning their importers, not on difficulty.
+    "implicit_reexport": (16, 34),
     # pgw#1202 PR 2: test modules still dirty at the relaxed test posture.
     # 170 of 486 were already clean and are checked from that commit on.
     "ignore_errors": (316, 2016),

--- a/src/gen_worker/capability_renewal.py
+++ b/src/gen_worker/capability_renewal.py
@@ -15,7 +15,7 @@ from typing import Callable, Optional, Tuple
 
 from . import activity as activity_mod
 from .procsplit import broker
-from .request_context import _decode_unverified_jwt_claims
+from .request_context._helpers import _decode_unverified_jwt_claims
 
 logger = logging.getLogger(__name__)
 

--- a/src/gen_worker/hardware_report.py
+++ b/src/gen_worker/hardware_report.py
@@ -131,7 +131,7 @@ def _identity_from_settings(settings: Settings) -> Tuple[str, str]:
     token = worker_credential.current()
     if token:
         try:
-            from .request_context import _decode_unverified_jwt_claims
+            from .request_context._helpers import _decode_unverified_jwt_claims
 
             claims = _decode_unverified_jwt_claims(token)
             if not worker_id:

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -281,7 +281,7 @@ class Lifecycle:
         # credential to AUTHENTICATE must use `worker_credential.current()`.
         _boot_jwt = (settings.bootstrap_worker_jwt or "").strip()
         if _boot_jwt:
-            from .request_context import _decode_unverified_jwt_claims
+            from .request_context._helpers import _decode_unverified_jwt_claims
 
             claims = _decode_unverified_jwt_claims(_boot_jwt)
         self.worker_id = (

--- a/src/gen_worker/procsplit/capability.py
+++ b/src/gen_worker/procsplit/capability.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
-from ..request_context import _decode_unverified_jwt_claims
+from ..request_context._helpers import _decode_unverified_jwt_claims
 
 # A per-job grant living longer than this is worth naming. Not a refusal: the
 # minter chooses the TTL (runtimestore.WorkerCapabilityTokenTTL) and only it

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -1530,7 +1530,7 @@ class ParentControl:
         token = (self._settings.bootstrap_worker_jwt or "").strip()
         if token:
             try:
-                from ..request_context import _decode_unverified_jwt_claims
+                from ..request_context._helpers import _decode_unverified_jwt_claims
 
                 claims = _decode_unverified_jwt_claims(token)
                 worker_id = worker_id or str(claims.get("sub") or "").strip()

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -1081,7 +1081,7 @@ class Transport:
     @staticmethod
     def _credential_claims(token: str) -> dict:
         try:
-            from .request_context import _decode_unverified_jwt_claims
+            from .request_context._helpers import _decode_unverified_jwt_claims
 
             return _decode_unverified_jwt_claims(token) or {}
         except Exception:  # noqa: BLE001 — a probe never breaks a connect
@@ -1242,7 +1242,7 @@ class Transport:
         no name.
         """
         try:
-            from .request_context import _decode_unverified_jwt_claims
+            from .request_context._helpers import _decode_unverified_jwt_claims
 
             claims = _decode_unverified_jwt_claims(token) or {}
             exp = float(claims.get("exp") or 0.0)

--- a/tests/test_device_peak_bank_pgw1205.py
+++ b/tests/test_device_peak_bank_pgw1205.py
@@ -138,8 +138,10 @@ def test_graph_classes_do_not_share_a_row() -> None:
     mint_workers.record_entry_device_peak(_key("unet"), 5_000, 6_000)
     mint_workers.record_entry_device_peak(_key("vae.decode"), 100, 200)
 
-    assert mint_workers.entry_device_peak(_key("unet")).reserved_bytes == 6_000
-    assert mint_workers.entry_device_peak(_key("vae.decode")).reserved_bytes == 200
+    unet = mint_workers.entry_device_peak(_key("unet"))
+    vae = mint_workers.entry_device_peak(_key("vae.decode"))
+    assert unet is not None and unet.reserved_bytes == 6_000
+    assert vae is not None and vae.reserved_bytes == 200
 
 
 def test_a_row_with_no_subject_is_refused() -> None:


### PR DESCRIPTION
**Defect class this makes impossible:** reaching a symbol through a module that merely imported it. The importer takes a dependency the exporter never offered, so the exporter cannot reorganize its own imports without breaking callers it does not know it has. `no_implicit_reexport` closed for `request_context`; burn-down **17 → 16**.

## The one that needed no judgement call

`_decode_unverified_jwt_claims` is a **private** JWT-claims decoder owned by `request_context/_helpers.py`, reached through the package `__init__` by six modules. Three others — `executor`, `fleet_cells`, `worker_identity` — **already import it from `_helpers`**. The tree was split on it, so the fix converges on the form the newer call sites already use rather than inventing one.

Deferred imports stay deferred: five sites are function-local **on purpose** (`gen_worker` defers `request_context` so `import gen_worker` and `gen-worker --help` stay cheap — why E402 is off). Only the module *path* changed.

## Two candidates investigated and deliberately NOT taken

This started as a seven-site change. The tree said no twice, and **both refusals are recorded in `pyproject.toml` beside their exemptions** so nobody re-derives them:

- **`models.chunk_upload` is not a leak and should probably never leave the list.** `hubio/client` reads `CAS_CHUNK_SIZE_BYTES` through it rather than from `chunk_cas` *on purpose* — that indirection is the seam `test_cell_publish_v2_pgw807` monkeypatches to shrink the chunk size. Reading from the owning module is **13 test failures, measured in CI, not predicted**. The method's own comment said so and I read past it: *"a call-time read keeps that single source of truth substitutable in tests without exposing a tuning knob on this method."* **An implicit re-export can be load-bearing, and no type checker can see that.**
- **`cuda_root`**: `aot_preconditions` reaches `pathlib.Path` through it — a real leak, one-line fix — but deleting that `cr.Path(...)` call strands `aot_package.constant_names()` in the pgw#849 unreached-surface baseline. Bisected to that single line, one variable at a time, and by no mechanism either guard makes legible (`cuda_root` doesn't reference `aot_package`, and the `cr` binding keeps two other live calls). pgw#849 rightly demands a baseline row carry an owner and an expiry; a trivial leak doesn't justify that debt.

## A finding, not a drive-by: master was mypy-red

Two unguarded `Optional` dereferences in `tests/test_device_peak_bank_pgw1205.py` were **on master**. **CI runs only on `pull_request`** (`ci.yml` `on:` is `workflow_dispatch` + `pull_request`; no push-to-master job). pgw#1205 (#741) and pgw#1202 PR 3 (#742) were each green against a base that lacked the other, both squash-merged without a rebase, and nothing re-checked the result. The strict gate caught it on the next branch containing both — the gate working, a full merge-cycle late. Worth a separate decision: a push-to-master run, or required-branch-up-to-date, closes it.

## Red-proof, varying exactly one thing

Everything else unchanged, a single import path in `capability_renewal.py` reverted to the package-level form → `[attr-defined]`. The guard then failed the build demanding `HIGH_WATER` drop, which is why the number moved in the same diff as the code.

## Two-number report

`# type: ignore` **removed 0 / suppressed-with-reason 0.**
