### PR TITLE
pgw#1206 A2: the One Rung ladder — three degrade vocabularies become one, and the wire stops lying to the hub

### DIFF
--- a/changelog.d/pgw1206.md
+++ b/changelog.d/pgw1206.md
@@ -22,3 +22,18 @@
   PromptRole` (minimax-h3) → `from gen_worker import PromptRole`;
   `gen_worker.convert.hub` imports in training-endpoints →
   `gen_worker.hubio.client`.
+- **A2 — One Rung ladder.** The degrade-don't-OOM machinery's three
+  vocabularies (plan-time `serve_fit.RUN_*`, placement modes, bare load-rung
+  strings) now project from ONE ordered ladder, `models/rung.py`
+  (`descend()`/`price()`/`floor_of()`/`touches_host_ram()`). serve_fit's three
+  runtime re-constructors (`demoted`/`load_rung_engaged`/`cast_dropped`)
+  collapse into one `replan()`; the executor's three bookkeepers into one
+  `_record_rung_transition()`; `memory.degraded_log_line` moves to
+  `rung.transition_line`. The ruling is now ONE red-verified test
+  (`tests/test_rung_ladder_pgw1206.py`).
+- **Fix (wire): `FnDegraded.ran` stays inside the hub's exact-match RunMode
+  vocabulary.** `demoted()` used to send `ran="offload:<placement>"`, which
+  tensorhub's `degradation_reschedule.go` exact-match switch never recognizes —
+  runtime demotions silently missed the VRAM-driven-drain arm. Placement detail
+  now travels in `reason`; the lifecycle re-emit dedupe keys on (ran, warning)
+  so deeper same-mode demotions still re-report.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -112,18 +112,16 @@ from .models import residency as residency_mod
 from .models import staging as staging_mod
 from .models.memory import (
     aflush_memory,
-    deeper_offload_mode,
-    degraded_log_line,
     estimate_cuda_resident_gb,
     estimate_pipeline_size_gb,
     flush_memory,
     get_available_vram_gb,
     is_cuda_oom,
-    keeps_weights_in_host_ram,
     low_vram_mode,
-    next_offload_rung,
     release_unused_pinned_host_cache,
 )
+from .models import rung as rungspec
+from .models.rung import touches_host_ram, transition_line
 from .models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from .models.download import ensure_local, lookup_provider_for_ref
 from .models.envelope import ArtifactEnvelopeExceeded
@@ -179,11 +177,10 @@ from .compile_cache import CompiledExecutionLaneUnavailableError
 from .preload import Preloader
 from .api.binding import rebind_pick
 from .models.hub_policy import FIT_INCOMPATIBLE, TensorhubWorkerCapabilities
-from .models.serve_fit import RUN_CPU, RUN_OFFLOAD, plan_serve
+from .models.serve_fit import (RUN_CPU, RUN_EMERGENCY, RUN_FP8_STORAGE,
+                                   RUN_OFFLOAD, plan_serve)
 from . import postmortem
-from .models.serve_fit import demoted
-from .models.serve_fit import load_rung_engaged
-from .models.serve_fit import cast_dropped
+from .models.serve_fit import replan
 from .models.loading import pipeline_weight_lane
 from .models import attention_modes as attnspec
 from .models import execution_lanes as lanespec
@@ -4111,71 +4108,48 @@ class Executor:
                 self._gate_owned.add(name)
                 continue
             if plan.degraded:
-                logger.warning(degraded_log_line(
+                logger.warning(transition_line(
                     event="planned", fn=name, phase="gate",
                     from_rung=plan.wanted, to_rung=plan.ran or plan.run_mode,
                     free_gb=free_vram_gb,
                     detail=f"~{plan.est_latency_multiplier:.1f}x latency: {plan.warning}",
                 ))
 
-    def _record_demotion(
+    def _record_rung_transition(
         self,
         spec: EndpointSpec,
         *,
         ref: str,
         phase: str,
-        from_rung: str,
-        to_rung: str,
+        from_rung: str = "",
+        to_rung: str = "",
+        run_mode: str = "",
+        wanted: str = "",
+        ran: str = "",
         needed_gb: float = 0.0,
-        detail: str = "",
+        detail: str,
     ) -> None:
-        """One ladder-demotion bookkeeper (gw#463): learned per-ref floor +
-        updated ServePlan + loud DEGRADED_MODE warning + FnDegraded re-emit
-        via the state-delta path."""
+        """THE ladder-transition bookkeeper (pgw#1206 A2; folds gw#463
+        demotion, gw#491 load-rung engagement and th#737 cast-drop): learned
+        per-ref placement floor + updated ServePlan via serve_fit.replan +
+        loud DEGRADED_MODE line + FnDegraded re-emit via the state-delta
+        path — never a log-line-only fallback."""
 
-        if ref:
-            self.degraded_floor[ref] = deeper_offload_mode(
+        if ref and rungspec.touches_host_ram(to_rung):
+            self.degraded_floor[ref] = rungspec.floor_of(
                 self.degraded_floor.get(ref, ""), to_rung)
-        line = degraded_log_line(
+        line = transition_line(
             event="engaged", fn=spec.name, model=ref, phase=phase,
-            from_rung=from_rung, to_rung=to_rung,
-            needed_gb=needed_gb, free_gb=get_available_vram_gb(),
-            detail=(detail or "CUDA OOM") + " — sticky for this worker until "
-                   "reload; fix capacity/config, do not rely on this mode",
+            from_rung=from_rung, to_rung=to_rung or run_mode,
+            needed_gb=needed_gb,
+            free_gb=get_available_vram_gb() if (from_rung or to_rung) else 0.0,
+            detail=detail,
         )
         logger.warning(line)
-        self.serve_plans[spec.name] = demoted(
-            self.serve_plans.get(spec.name), detail=line, placement_mode=to_rung)
-        self._on_state_change()
-
-    def _record_adaptive_rung(self, spec: EndpointSpec, *, ref: str,
-                              rung: str, detail: str) -> None:
-        """gw#491: the load-time adaptive fit ladder engaged an emergency
-        rung (runtime fp8 storage / nf4). Surface it exactly like the
-        plan-time rungs — updated ServePlan + FnDegraded via the state-delta
-        path — never as a log-line-only fallback."""
-
-        logger.warning(
-            "LOAD_RUNG_ENGAGED fn=%s model=%s rung=%s detail=%s",
-            spec.name, ref, rung, detail)
-        self.serve_plans[spec.name] = load_rung_engaged(
-            self.serve_plans.get(spec.name), rung=rung, detail=detail)
-        self._on_state_change()
-
-    def _record_cast_drop(self, spec: EndpointSpec, *, ref: str,
-                          wanted: str, detail: str, ran: str = "bf16") -> None:
-        """th#737: a resolved cast (storage_dtype) cannot apply — the
-        pipeline has no denoiser/cast surface. Serve at base precision but
-        surface it STRUCTURALLY (FnDegraded wanted=fp8 ran=bf16 via the
-        state-delta path), never as a silent log-line fallback: the recipe
-        budgeted the cast's VRAM headroom."""
-
-        logger.warning(
-            "CAST_DROPPED fn=%s model=%s wanted=%s ran=%s detail=%s",
-            spec.name, ref, wanted or "fp8", ran or "bf16", detail)
-        self.serve_plans[spec.name] = cast_dropped(
-            self.serve_plans.get(spec.name), wanted=wanted, detail=detail,
-            ran=ran)
+        self.serve_plans[spec.name] = replan(
+            self.serve_plans.get(spec.name),
+            run_mode=run_mode, wanted=wanted, ran=ran, detail=line,
+        )
         self._on_state_change()
 
     def available_functions(self) -> List[str]:
@@ -8762,7 +8736,7 @@ class Executor:
         ) else "auto"
         floor = self.degraded_floor.get(ref, "")
         if floor:
-            mode = deeper_offload_mode("" if mode == "auto" else mode, floor)
+            mode = rungspec.floor_of("" if mode == "auto" else mode, floor)
         return mode
 
     @staticmethod
@@ -9106,22 +9080,28 @@ class Executor:
                     # the state-delta path — the shared core decides WHAT
                     # degraded (details non-empty), the executor reports it.
                     if sl.pre_drop_detail:
-                        self._record_cast_drop(
-                            spec, ref=ref, wanted=sl.pre_drop_wanted,
-                            ran=sl.ran, detail=sl.pre_drop_detail)
+                        self._record_rung_transition(
+                            spec, ref=ref, phase="load",
+                            wanted=sl.pre_drop_wanted, ran=sl.ran,
+                            detail=sl.pre_drop_detail)
                     if sl.rung_detail:
-                        self._record_adaptive_rung(
-                            spec, ref=ref, rung=sl.rung, detail=sl.rung_detail)
+                        self._record_rung_transition(
+                            spec, ref=ref, phase="load",
+                            run_mode=(RUN_FP8_STORAGE if sl.rung == "fp8"
+                                      else RUN_EMERGENCY),
+                            detail=sl.rung_detail)
                     elif sl.cast_fail_detail:
-                        self._record_cast_drop(
-                            spec, ref=ref, wanted=sl.cast_fail_wanted,
-                            ran=sl.ran, detail=sl.cast_fail_detail)
+                        self._record_rung_transition(
+                            spec, ref=ref, phase="load",
+                            wanted=sl.cast_fail_wanted, ran=sl.ran,
+                            detail=sl.cast_fail_detail)
                     placed = sl.placed
                     if placed.get("oom_demotions"):
-                        self._record_demotion(
+                        self._record_rung_transition(
                             spec, ref=ref, phase="load",
                             from_rung=str(placed.get("requested_mode") or mode),
                             to_rung=str(placed.get("mode") or ""),
+                            run_mode=RUN_OFFLOAD,
                             needed_gb=estimate_pipeline_size_gb(pipe),
                             detail="CUDA OOM at load; pipeline placed offloaded",
                         )
@@ -9360,9 +9340,9 @@ class Executor:
             return False
         # Offload-hooked objects book the RAM tier (their VRAM is hook-owned).
         self.store.residency.track_vram(ref, pipe)
-        self._record_demotion(
+        self._record_rung_transition(
             spec, ref=ref, phase="serve", from_rung="resident",
-            to_rung="model_offload",
+            to_rung="model_offload", run_mode=RUN_OFFLOAD,
             needed_gb=estimate_pipeline_size_gb(pipe),
             detail="VRAM promote could not fit after LRU demotions; serving "
                    "CPU-offloaded (gw#551)",
@@ -12406,7 +12386,8 @@ class Executor:
             )):
                 continue
             before = low_vram_mode(obj)
-            after = next_offload_rung(before)
+            after_rung = rungspec.descend(before)
+            after = after_rung.name if after_rung is not None else None
             if after is not None:
                 transitions.append(
                     (ref, before, after, estimate_pipeline_size_gb(obj))
@@ -12415,10 +12396,10 @@ class Executor:
         if refused:
             transitions = []
         for ref, from_mode, to_mode, needed_gb in transitions:
-            self._record_demotion(
+            self._record_rung_transition(
                 spec, ref=ref, phase="inference",
                 from_rung=from_mode or "resident", to_rung=to_mode,
-                needed_gb=needed_gb,
+                run_mode=RUN_OFFLOAD, needed_gb=needed_gb,
                 detail=f"CUDA OOM mid-inference ({type(exc).__name__}); "
                        "quarantining this instance for a clean offloaded reload",
             )
@@ -12440,7 +12421,7 @@ class Executor:
                 pass
             return
         if not transitions:
-            logger.warning(degraded_log_line(
+            logger.warning(transition_line(
                 event="engaged", fn=spec.name, phase="inference",
                 free_gb=get_available_vram_gb(),
                 detail="CUDA OOM with no worker-owned pipeline rung; "
@@ -12485,7 +12466,7 @@ class Executor:
         res = self.store.residency
         worst: Tuple[int, str] = (0, "")
         for ref, _from_mode, to_mode, _needed_gb in transitions:
-            if not keeps_weights_in_host_ram(to_mode):
+            if not touches_host_ram(to_mode):
                 continue
             local = res.local_path(ref)
             if local is None:
@@ -12516,7 +12497,7 @@ class Executor:
                 available_after_bytes=headroom.available_bytes,
                 total_bytes=headroom.total_bytes,
             ))
-            logger.warning(degraded_log_line(
+            logger.warning(transition_line(
                 event="engaged", fn=spec.name, model=ref, phase="inference",
                 from_rung="resident", to_rung="model_offload",
                 free_gb=get_available_vram_gb(),
@@ -12543,7 +12524,7 @@ class Executor:
             f"{headroom.required_bytes / float(1 << 30):.1f}GiB against a "
             f"{headroom.total_bytes / float(1 << 30):.1f}GiB host total"
         )
-        logger.error(degraded_log_line(
+        logger.error(transition_line(
             event="refused", fn=spec.name, model=ref, phase="inference",
             from_rung="resident", to_rung="model_offload",
             free_gb=get_available_vram_gb(),

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -1250,9 +1250,14 @@ class Lifecycle:
             if not plan.degraded or name in self.executor.unavailable:
                 continue
             ran = plan.ran or plan.run_mode
-            if self._emitted_degraded.get(name) == ran:
+            # pgw#1206 A2: `ran` now stays inside the hub's exact-match
+            # RunMode vocabulary (the placement sub-rung no longer decorates
+            # it), so a deeper demotion re-reports via the WARNING text —
+            # dedupe on both or an escalation inside one run mode goes silent.
+            emitted_key = f"{ran}\x1f{plan.warning}"
+            if self._emitted_degraded.get(name) == emitted_key:
                 continue
-            self._emitted_degraded[name] = ran
+            self._emitted_degraded[name] = emitted_key
             await self._send_state_message(
                 pb.WorkerMessage(
                     fn_degraded=pb.FnDegraded(

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -31,10 +31,10 @@ from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
 from .tensor_layout_contract import CONTRACT_PLAIN_BF16, implements_contract
 from .fp8_storage import restructure_fp8_storage
+from .rung import touches_host_ram
 from .memory import (
     flush_memory,
     get_available_vram_gb,
-    keeps_weights_in_host_ram,
     meta_tensors,
     probe_host_ram,
 )
@@ -1879,7 +1879,7 @@ def decide_streamed_hydration(
         device_free_bytes=int(device_free_bytes),
         placement_mode=str(placement_mode or ""),
     )
-    if keeps_weights_in_host_ram(placement_mode):
+    if touches_host_ram(placement_mode):
         # pgw#1063: the discount is admissible ONLY because each component
         # leaves the host for the card. An offload rung puts it back — the
         # weights live on the host by definition — so the honest requirement

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -71,49 +71,14 @@ def effective_vram_requirement_gb(recommended_gb: float) -> float:
     """
     return max(0.0, float(recommended_gb) - GPU_VRAM_OVERHEAD_GB)
 
-# Modes that spill model weights to system RAM and run parts of inference on CPU.
-_CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
-
-# The reactive (degraded-mode) half of the fit ladder, shallowest first
-# (gw#463). A load-time CUDA OOM rolls back and retries one rung lower. A
-# mid-inference OOM records the next rung, quarantines the live object, and
-# applies that rung only during a clean reload.
-OFFLOAD_LADDER: tuple[str, ...] = _CPU_OFFLOAD_MODES
-
-
-def keeps_weights_in_host_ram(mode: Optional[str]) -> bool:
-    """True when this placement rung leaves the model's weights RESIDENT IN
-    HOST RAM (pgw#1063).
-
-    Every CPU-offload rung does: that is what offloading IS — the weights
-    live on the host and stream to the card per forward. So an offloaded
-    pipeline's host-RAM requirement is its WHOLE TREE, and any accounting
-    that charges it less (pgw#1026's per-component staging discount, which
-    is admissible only because each component LEAVES the host for the card)
-    is admitting a load the host cannot hold."""
-    return str(mode or "") in _CPU_OFFLOAD_MODES
-
-
-def next_offload_rung(mode: Optional[str]) -> Optional[str]:
-    """The next rung down the offload ladder from ``mode``.
-
-    Resident modes (''/off/vae_only/auto) fall to model_offload; each offload
-    mode falls to the next deeper one; None when already terminal.
-    """
-    cur = str(mode or "")
-    if cur not in OFFLOAD_LADDER:
-        return OFFLOAD_LADDER[0]
-    idx = OFFLOAD_LADDER.index(cur) + 1
-    return OFFLOAD_LADDER[idx] if idx < len(OFFLOAD_LADDER) else None
-
-
-def deeper_offload_mode(a: Optional[str], b: Optional[str]) -> str:
-    """The more-degraded of two placement modes ('' / non-ladder = shallowest)."""
-    def rank(m: Optional[str]) -> int:
-        m = str(m or "")
-        return OFFLOAD_LADDER.index(m) + 1 if m in OFFLOAD_LADDER else 0
-    a_s, b_s = str(a or ""), str(b or "")
-    return a_s if rank(a_s) >= rank(b_s) else b_s
+# The ladder itself lives in rung.py (pgw#1206 A2): one ordered Rung, one
+# walk, one price. This module keeps the probes and the appliers.
+from .rung import (
+    PLACEMENT_LADDER,
+    descend as _descend_rung,
+    touches_host_ram,
+    transition_line,
+)
 
 
 def is_cuda_oom(exc: Optional[BaseException]) -> bool:
@@ -133,37 +98,6 @@ def is_cuda_oom(exc: Optional[BaseException]) -> bool:
             or "cudnn_status_alloc_failed" in text
         )
     return False
-
-
-def degraded_log_line(
-    *,
-    event: str,
-    fn: str = "",
-    model: str = "",
-    phase: str = "",
-    from_rung: str = "",
-    to_rung: str = "",
-    needed_gb: float = 0.0,
-    free_gb: float = 0.0,
-    detail: str = "",
-) -> str:
-    """The ONE degraded-mode log format (gw#463; quality bar: ie#369's ltx
-    DEGRADED_MODE lines). event: planned | engaged | serving."""
-    parts = [f"DEGRADED_MODE={event}"]
-    if fn:
-        parts.append(f"fn={fn}")
-    if model:
-        parts.append(f"model={model}")
-    if phase:
-        parts.append(f"phase={phase}")
-    if from_rung or to_rung:
-        parts.append(f"rung={from_rung or '?'}->{to_rung or '?'}")
-    if needed_gb > 0:
-        parts.append(f"needed_gb={needed_gb:.1f}")
-    if free_gb > 0:
-        parts.append(f"free_gb={free_gb:.1f}")
-    line = " ".join(parts)
-    return f"{line}: {detail}" if detail else line
 
 
 # ---------------------------------------------------------------------------
@@ -986,7 +920,7 @@ def select_auto_mode(
             # cohorts (VRAM-posture-dependent proof_failed roulette). The
             # FIT decisions above/below stay free-VRAM-based (safety); a
             # card that later runs tight degrades reactively down
-            # OFFLOAD_LADDER instead of choosing a nondeterministic mint
+            # PLACEMENT_LADDER instead of choosing a nondeterministic mint
             # posture up front. pgw#1025 does NOT touch this comparison: it
             # is the GROSS requirement against a per-SKU constant, and
             # netting out live residency here would restore exactly the
@@ -1234,7 +1168,7 @@ def _gguf_resident_override(
     pipeline: Any, effective: Mode, log: logging.Logger,
 ) -> Mode:
     """Keep a selected GGUF rung resident when its remaining weights fit."""
-    if effective not in _CPU_OFFLOAD_MODES or not getattr(
+    if not touches_host_ram(effective) or not getattr(
         pipeline, "_cozy_gguf_quant", None
     ):
         return effective
@@ -1302,7 +1236,7 @@ def place_pipeline(
     # author's opt-out with no OOM and no error — the th#1043 shape
     # ("shared-component lanes require resident placement") reached serving as
     # a silent 5-10x tax. Refuse here too, with the same typed message.
-    if strict_vram and effective in _CPU_OFFLOAD_MODES:
+    if strict_vram and touches_host_ram(effective):
         raise RuntimeError(
             f"placement selected {effective!r} for "
             f"{ref or type(pipeline).__name__!r} "
@@ -1325,10 +1259,11 @@ def place_pipeline(
         except BaseException as exc:
             if not is_cuda_oom(exc):
                 raise
-            nxt = next_offload_rung(effective)
+            nxt_rung = _descend_rung(effective)
+            nxt = nxt_rung.name if nxt_rung is not None else None
             if nxt is None:
                 raise
-            if strict_vram and nxt in _CPU_OFFLOAD_MODES:
+            if strict_vram and touches_host_ram(nxt):
                 raise RuntimeError(
                     f"CUDA OOM placing {ref or type(pipeline).__name__!r} at "
                     f"{effective!r} ({estimate_pipeline_size_gb(pipeline):.1f} GB, "
@@ -1349,7 +1284,7 @@ def place_pipeline(
                     f"failed ({missed[:5]!r})"
                 ) from exc
             flush_memory()
-            log.warning(degraded_log_line(
+            log.warning(transition_line(
                 event="engaged", model=ref, phase="load",
                 from_rung=effective, to_rung=nxt,
                 needed_gb=estimate_pipeline_size_gb(pipeline),
@@ -1589,12 +1524,10 @@ __all__ = [
     "low_vram_mode",
     "rearm_offload",
     "place_pipeline",
-    "next_offload_rung",
-    "deeper_offload_mode",
-    "keeps_weights_in_host_ram",
+    "touches_host_ram",
     "is_cuda_oom",
-    "degraded_log_line",
-    "OFFLOAD_LADDER",
+    "transition_line",
+    "PLACEMENT_LADDER",
     "select_auto_mode",
     "device_mismatches",
     "repair_device_placement",

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -1,0 +1,155 @@
+"""THE degrade ladder (pgw#1206 A2) — one ordered ``Rung``, one walk, one price.
+
+Degrade-don't-OOM (Paul, 2026-07-10) used to span three vocabularies in five
+files, joined by f-strings: plan-time ``serve_fit.RUN_*`` (hub wire), placement
+modes in ``memory`` (``model_offload``/``group_offload``/``sequential``), and
+bare ``"fp8"``/``"nf4"`` load-rung strings through the executor's bookkeepers.
+This module is the single ordered ladder they all project from.
+
+``off``/``vae_only``/``auto`` are NOT rungs — they are resident-placement
+flavors ``memory.select_auto_mode`` picks *inside* the native rung.
+
+The wire contract: ``ServePlan.ran``/``run_mode`` carry ONLY the
+``RUN_MODES`` vocabulary. tensorhub matches ``FnDegraded.ran`` EXACTLY
+(``degradation_reschedule.go``: ``case "offload","cpu","emergency_quant"``),
+so a decorated value like ``offload:model_offload`` silently misses the
+VRAM-driven-drain arm — placement detail travels in ``reason``, never in
+``ran``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Rung:
+    """One step of the degrade ladder.
+
+    ``placement`` is the ``memory`` placement mode this rung implies ("" for
+    rungs that keep full residency); ``storage`` the runtime weight-storage
+    transform ("", "fp8", "nf4"); ``run_mode`` the hub-wire projection
+    (``serve_fit.RUN_*``); ``latency`` the honest price vs a native run;
+    ``touches_host_ram`` whether weights become host-resident (the
+    ``strict_vram`` opt-out boundary, and the pgw#1063 host-RAM pricing
+    trigger)."""
+
+    name: str
+    placement: str
+    storage: str
+    run_mode: str
+    latency: float
+    touches_host_ram: bool
+
+
+# Wire run modes (Go-mirrored: tensorhub profiling.RunMode). Values are the
+# contract; tensorhub matches them EXACTLY.
+RUN_NATIVE = "native"
+RUN_FP8_STORAGE = "fp8_storage"
+RUN_EMERGENCY = "emergency_quant"
+RUN_OFFLOAD = "offload"
+RUN_CPU = "cpu"
+
+NATIVE = Rung("native", "", "", RUN_NATIVE, 1.0, False)
+FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
+NF4 = Rung("nf4", "", "nf4", RUN_EMERGENCY, 1.1, False)
+MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
+GROUP_OFFLOAD = Rung("group_offload", "group_offload", "", RUN_OFFLOAD, 3.0, True)
+SEQUENTIAL = Rung("sequential", "sequential", "", RUN_OFFLOAD, 4.0, True)
+CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, False)
+
+#: The ONE ordering, best first. ``descend`` walks it; nothing else may.
+LADDER: tuple[Rung, ...] = (
+    NATIVE, FP8_STORAGE, NF4, MODEL_OFFLOAD, GROUP_OFFLOAD, SEQUENTIAL, CPU,
+)
+
+#: The reactive placement tail, shallowest first (gw#463): a load-time CUDA
+#: OOM rolls back and retries one rung lower; a mid-inference OOM records the
+#: next rung and applies it only during a clean reload.
+PLACEMENT_LADDER: tuple[str, ...] = tuple(
+    r.name for r in LADDER if r.touches_host_ram
+)
+
+_BY_NAME = {r.name: r for r in LADDER}
+
+
+def descend(current: Optional[str], *, strict_vram: bool = False) -> Optional[Rung]:
+    """The next rung down from ``current``; None when the ladder ends.
+
+    ``strict_vram`` truncates the ladder before the first host-RAM-touching
+    rung (the author's ``Resources(strict_vram=True)`` opt-out). The reactive
+    OOM path descends only through the PLACEMENT tail (a storage transform
+    cannot be applied to an already-loaded object), so from any resident
+    token the next reactive rung is ``model_offload``.
+    """
+    cur = str(current or "")
+    if cur not in PLACEMENT_LADDER:
+        nxt: Optional[Rung] = MODEL_OFFLOAD
+    else:
+        idx = LADDER.index(_BY_NAME[cur]) + 1
+        nxt = LADDER[idx] if idx < len(LADDER) else None
+        if nxt is CPU:
+            nxt = None  # the reactive walk ends at sequential; CPU is plan-time only
+    if nxt is not None and strict_vram and nxt.touches_host_ram:
+        return None
+    return nxt
+
+
+def price(run_mode: str) -> float:
+    """Honest latency multiplier vs a native run, by wire run mode. Coarse
+    order-of-magnitude guidance (the hub's measured fit-matrix latency is
+    authoritative when available); monotonic down the ladder."""
+    for r in LADDER:
+        if r.run_mode == run_mode:
+            return r.latency
+    return 1.0
+
+
+def touches_host_ram(mode: Optional[str]) -> bool:
+    """True when this placement token leaves weights RESIDENT IN HOST RAM
+    (pgw#1063): that is what offloading IS — the whole tree lives on the host
+    and streams to the card per forward, so host-RAM accounting must charge
+    the full tree."""
+    return str(mode or "") in PLACEMENT_LADDER
+
+
+def floor_of(a: Optional[str], b: Optional[str]) -> str:
+    """The more-degraded of two placement tokens ('' / non-ladder =
+    shallowest). The learned per-ref floor (gw#463) only ever deepens."""
+    def rank(m: Optional[str]) -> int:
+        token = str(m or "")
+        return PLACEMENT_LADDER.index(token) + 1 if token in PLACEMENT_LADDER else 0
+    a_s, b_s = str(a or ""), str(b or "")
+    return a_s if rank(a_s) >= rank(b_s) else b_s
+
+
+def transition_line(
+    *,
+    event: str,
+    fn: str = "",
+    model: str = "",
+    phase: str = "",
+    from_rung: str = "",
+    to_rung: str = "",
+    needed_gb: float = 0.0,
+    free_gb: float = 0.0,
+    detail: str = "",
+) -> str:
+    """The ONE degraded-mode log format (gw#463; quality bar: ie#369's ltx
+    DEGRADED_MODE lines). event: planned | engaged | serving | refused."""
+    parts = [f"DEGRADED_MODE={event}"]
+    if fn:
+        parts.append(f"fn={fn}")
+    if model:
+        parts.append(f"model={model}")
+    if phase:
+        parts.append(f"phase={phase}")
+    if from_rung or to_rung:
+        parts.append(f"rung={from_rung or '?'}->{to_rung or '?'}")
+    if needed_gb > 0:
+        parts.append(f"needed_gb={needed_gb:.1f}")
+    if free_gb > 0:
+        parts.append(f"free_gb={free_gb:.1f}")
+    line = " ".join(parts)
+    return f"{line}: {detail}" if detail else line

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -59,25 +59,16 @@ from .hub_policy import (
     variant_fit,
 )
 
-# Run modes, cheapest(fastest)-first. Mirrors the profiling.RunMode vocabulary
-# on the hub side so the two speak the same language.
-RUN_NATIVE = "native"
-RUN_FP8_STORAGE = "fp8_storage"
-RUN_EMERGENCY = "emergency_quant"
-RUN_OFFLOAD = "offload"
-RUN_CPU = "cpu"
-
-# Coarse latency multipliers vs a native GPU run, for honest-guidance. These are
-# order-of-magnitude guides (the hub's measured fit-matrix latency is the
-# authoritative source when available); they exist so the worker never stays
-# silent about a slow trade.
-_LATENCY_MULTIPLIER = {
-    RUN_NATIVE: 1.0,
-    RUN_FP8_STORAGE: 1.05,  # per-layer upcast overhead; near-native quality
-    RUN_EMERGENCY: 1.1,     # quality hit, not much slower
-    RUN_OFFLOAD: 2.5,       # weights stream from CPU/disk
-    RUN_CPU: 40.0,          # no GPU: dramatically slower
-}
+# Run modes and prices are the One Rung ladder's (pgw#1206 A2); re-exported
+# here because this module is the hub-vocabulary projection.
+from .rung import (
+    RUN_CPU as RUN_CPU,
+    RUN_EMERGENCY as RUN_EMERGENCY,
+    RUN_FP8_STORAGE as RUN_FP8_STORAGE,
+    RUN_NATIVE as RUN_NATIVE,
+    RUN_OFFLOAD as RUN_OFFLOAD,
+    price as price,
+)
 
 # The FIT verdicts that run natively: full residency at the binding's own
 # stored precision on supported silicon.
@@ -162,7 +153,7 @@ def plan_serve(
             run_mode=RUN_CPU,
             fit=FIT_INCOMPATIBLE,
             warning=_honest_warning(RUN_CPU, recommended),
-            est_latency_multiplier=_LATENCY_MULTIPLIER[RUN_CPU],
+            est_latency_multiplier=price(RUN_CPU),
             recommended_vram_gb=recommended,
             wanted=wanted,
             ran=RUN_CPU,
@@ -220,85 +211,43 @@ def plan_serve(
         run_mode=run_mode,
         fit=verdict,
         warning=_honest_warning(run_mode, recommended, detail),
-        est_latency_multiplier=_LATENCY_MULTIPLIER[run_mode],
+        est_latency_multiplier=price(run_mode),
         recommended_vram_gb=recommended,
         wanted=wanted,
         ran=run_mode,
     )
 
 
-def demoted(
+def replan(
     plan: Optional[ServePlan],
     *,
+    run_mode: str = "",
+    wanted: str = "",
+    ran: str = "",
     detail: str,
-    placement_mode: str = "",
 ) -> ServePlan:
-    """The reactive ladder transition (gw#463): a runtime CUDA OOM demoted this
-    function to the offload rung. Produces the updated ServePlan so plan-time
-    and reactive degradation share one vocabulary, warning, and FnDegraded
-    shape. ``placement_mode`` (model_offload/group_offload/sequential) rides
-    ``ran`` as ``offload:<mode>`` so each deeper sub-rung re-reports."""
+    """The ONE runtime re-projection (pgw#1206 A2; folds gw#463 demotion,
+    gw#491 load-rung engagement and th#737 cast-drop into one seam).
+
+    A runtime ladder transition re-prices the plan at ``run_mode`` and reports
+    it structurally (FnDegraded) with the SAME vocabulary as plan-time.
+    ``ran`` stays inside the hub's exact-match RunMode vocabulary — placement
+    detail travels in ``detail``/``warning``, never decorates the token
+    tensorhub switches on (degradation_reschedule.go). A cast that could not
+    apply passes ``wanted``/``ran`` dtype tokens with no ``run_mode`` change.
+    """
     base = plan if plan is not None else ServePlan(
         serveable=True, run_mode=RUN_NATIVE, fit="", wanted="bf16", ran="bf16",
     )
-    ran = f"{RUN_OFFLOAD}:{placement_mode}" if placement_mode else RUN_OFFLOAD
+    mode = run_mode or base.run_mode
     return replace(
         base,
         serveable=True,
-        run_mode=RUN_OFFLOAD,
+        run_mode=mode,
+        wanted=(wanted or base.wanted),
+        ran=(ran or (mode if run_mode else base.ran)),
         warning=detail,
-        est_latency_multiplier=_LATENCY_MULTIPLIER[RUN_OFFLOAD],
-        ran=ran,
-    )
-
-
-def cast_dropped(
-    plan: Optional[ServePlan],
-    *,
-    wanted: str,
-    detail: str,
-    ran: str = "bf16",
-) -> ServePlan:
-    """th#737: a resolved cast (``storage_dtype``) could not be applied —
-    the pipeline has no denoiser/cast surface (latent upsamplers, VAE-only
-    repos). The function still runs natively at base precision (``ran``,
-    default bf16), but the recipe budgeted the cast's VRAM: report it
-    structurally (FnDegraded wanted=fp8 ran=bf16), never as a silent
-    fallback."""
-    base = plan if plan is not None else ServePlan(
-        serveable=True, run_mode=RUN_NATIVE, fit="", wanted="", ran="",
-    )
-    return replace(
-        base,
-        serveable=True,
-        wanted=(wanted or base.wanted or "fp8"),
-        ran=(ran or "bf16"),
-        warning=detail,
-    )
-
-
-def load_rung_engaged(
-    plan: Optional[ServePlan],
-    *,
-    rung: str,
-    detail: str,
-) -> ServePlan:
-    """gw#491: the load-time adaptive fit ladder engaged an emergency rung
-    (runtime fp8 storage or nf4) because free VRAM at load was tighter than
-    gate-time planning assumed. Same ServePlan/FnDegraded shape as the
-    plan-time emergency rungs — a 4-bit pipeline must never report
-    RUN_NATIVE wanted==ran."""
-    run_mode = RUN_FP8_STORAGE if rung == "fp8" else RUN_EMERGENCY
-    base = plan if plan is not None else ServePlan(
-        serveable=True, run_mode=RUN_NATIVE, fit="", wanted="bf16", ran="bf16",
-    )
-    return replace(
-        base,
-        serveable=True,
-        run_mode=run_mode,
-        warning=detail,
-        est_latency_multiplier=_LATENCY_MULTIPLIER[run_mode],
-        ran=run_mode,
+        est_latency_multiplier=price(mode),
     )
 
 
@@ -308,7 +257,7 @@ def _honest_warning(run_mode: str, recommended_vram_gb: Optional[float], detail:
         if recommended_vram_gb
         else ""
     )
-    mult = _LATENCY_MULTIPLIER.get(run_mode, 1.0)
+    mult = price(run_mode)
     if run_mode == RUN_CPU:
         return (
             "running on CPU (no GPU detected): expect dramatically slower "

--- a/tests/test_degraded_reload_refusal_pgw1063.py
+++ b/tests/test_degraded_reload_refusal_pgw1063.py
@@ -45,9 +45,9 @@ from gen_worker.models.loading import (
     decide_streamed_hydration,
     plan_streamed_hydration,
 )
-from gen_worker.models.memory import (
-    OFFLOAD_LADDER,
-    keeps_weights_in_host_ram,
+from gen_worker.models.rung import (
+    PLACEMENT_LADDER,
+    touches_host_ram,
 )
 from gen_worker.models.residency import HostRamHeadroom
 
@@ -87,7 +87,7 @@ def _h3(**over: Any):
 
 def test_an_offload_rung_never_takes_the_per_component_discount() -> None:
     assert _h3().engaged, "the resident shape must still engage"
-    for rung in OFFLOAD_LADDER:
+    for rung in PLACEMENT_LADDER:
         plan = _h3(placement_mode=rung)
         assert not plan.engaged, rung
         assert "host RAM" in plan.reason and rung in plan.reason
@@ -96,7 +96,7 @@ def test_an_offload_rung_never_takes_the_per_component_discount() -> None:
 def test_the_resident_rungs_are_untouched() -> None:
     for rung in ("", "auto", "off", "vae_only"):
         assert _h3(placement_mode=rung).engaged, rung
-        assert not keeps_weights_in_host_ram(rung)
+        assert not touches_host_ram(rung)
 
 
 def test_the_rung_travels_with_the_plan(tmp_path, monkeypatch) -> None:

--- a/tests/test_device_peak_bank_pgw1205.py
+++ b/tests/test_device_peak_bank_pgw1205.py
@@ -138,8 +138,10 @@ def test_graph_classes_do_not_share_a_row() -> None:
     mint_workers.record_entry_device_peak(_key("unet"), 5_000, 6_000)
     mint_workers.record_entry_device_peak(_key("vae.decode"), 100, 200)
 
-    assert mint_workers.entry_device_peak(_key("unet")).reserved_bytes == 6_000
-    assert mint_workers.entry_device_peak(_key("vae.decode")).reserved_bytes == 200
+    unet = mint_workers.entry_device_peak(_key("unet"))
+    vae = mint_workers.entry_device_peak(_key("vae.decode"))
+    assert unet is not None and unet.reserved_bytes == 6_000
+    assert vae is not None and vae.reserved_bytes == 200
 
 
 def test_a_row_with_no_subject_is_refused() -> None:

--- a/tests/test_rung_ladder_pgw1206.py
+++ b/tests/test_rung_ladder_pgw1206.py
@@ -1,0 +1,172 @@
+"""pgw#1206 A2 — THE degrade-don't-OOM ruling as ONE test on the One Rung ladder.
+
+The ruling (Paul, 2026-07-10): a CUDA OOM is a ladder transition, never a hard
+fail — descend one rung and retry, down to the terminal rung; the only opt-out
+is the author's ``Resources(strict_vram=True)``. The implementation used to
+span three vocabularies in five files; this file is the ruling's single
+red-verified guard on the consolidated ladder.
+
+The wire half was RED against 91df247a: ``serve_fit.demoted`` wrote
+``ran="offload:<placement>"`` while tensorhub matches ``FnDegraded.ran``
+EXACTLY (degradation_reschedule.go: ``case "offload","cpu","emergency_quant"``)
+— so every runtime demotion silently missed the VRAM-driven-drain arm.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gen_worker.models import rung
+from gen_worker.models.memory import place_pipeline
+from gen_worker.models.serve_fit import (
+    RUN_CPU,
+    RUN_EMERGENCY,
+    RUN_FP8_STORAGE,
+    RUN_NATIVE,
+    RUN_OFFLOAD,
+    replan,
+)
+
+#: tensorhub's exact-match FnDegraded.ran vocabulary
+#: (profiling/degradation.go + autoscale/degradation_reschedule.go).
+GO_RAN_VOCABULARY = {RUN_NATIVE, RUN_FP8_STORAGE, RUN_EMERGENCY, RUN_OFFLOAD, RUN_CPU, "bf16", "fp8"}
+
+
+# --- the ladder itself ------------------------------------------------------
+
+def test_one_ordered_ladder() -> None:
+    """One ladder, best-first, price monotonic, projections coherent."""
+    names = [r.name for r in rung.LADDER]
+    assert names == [
+        "native", "fp8_storage", "nf4",
+        "model_offload", "group_offload", "sequential", "cpu",
+    ]
+    prices = [r.latency for r in rung.LADDER]
+    assert prices == sorted(prices), "price must be monotonic down the ladder"
+    # Host-RAM-touching == exactly the placement tail (the strict_vram
+    # boundary and the pgw#1063 whole-tree host-RAM charge).
+    assert rung.PLACEMENT_LADDER == ("model_offload", "group_offload", "sequential")
+    for r in rung.LADDER:
+        assert r.touches_host_ram == (r.name in rung.PLACEMENT_LADDER)
+    # Resident flavors are not rungs: from any of them the reactive walk
+    # starts at the first placement rung.
+    for flavor in ("", "off", "vae_only", "auto"):
+        nxt = rung.descend(flavor)
+        assert nxt is not None and nxt.name == "model_offload"
+
+
+def test_descend_walks_every_rung_and_terminates() -> None:
+    """From any resident token the reactive walk visits each placement rung
+    exactly once and ends — it never wraps, never skips to CPU."""
+    seen = []
+    cur = ""
+    while True:
+        nxt = rung.descend(cur)
+        if nxt is None:
+            break
+        seen.append(nxt.name)
+        cur = nxt.name
+    assert seen == list(rung.PLACEMENT_LADDER)
+
+
+def test_strict_vram_truncates_before_host_ram() -> None:
+    """The author's opt-out: no descent may reach a host-RAM-touching rung."""
+    assert rung.descend("", strict_vram=True) is None
+    assert rung.descend("model_offload", strict_vram=True) is None
+
+
+def test_floor_only_deepens() -> None:
+    """The learned per-ref floor (gw#463) is a max, not a last-write."""
+    assert rung.floor_of("group_offload", "model_offload") == "group_offload"
+    assert rung.floor_of("model_offload", "sequential") == "sequential"
+    assert rung.floor_of("", "model_offload") == "model_offload"
+    assert rung.floor_of("auto", "") == "auto"  # non-ladder tokens rank equal-shallowest
+
+
+# --- OOM at each rung: descend, never die -----------------------------------
+# The seam is apply_low_vram_config (the established th#1043 pattern): the
+# ladder WALK is the code under test; the diffusers hooks are not, and this
+# box exports GEN_WORKER_FORBID_CPU_OFFLOAD, which the real applier honors.
+
+
+def _arm(monkeypatch: pytest.MonkeyPatch, serves_at: str) -> list[str]:
+    import torch
+
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(memory, "_move_pipeline_to_cpu", lambda *_: None)
+    monkeypatch.setattr(memory, "repair_device_placement", lambda *_: [])
+    monkeypatch.setattr(memory, "flush_memory", lambda: None)
+    attempted: list[str] = []
+
+    def fake_apply(pipeline: object, *, mode: str, logger: object = None) -> dict:
+        attempted.append(mode)
+        if mode != serves_at:
+            raise RuntimeError("CUDA error: out of memory")
+        return {"mode": mode}
+
+    monkeypatch.setattr(memory, "apply_low_vram_config", fake_apply)
+    return attempted
+
+
+@pytest.mark.parametrize("serves_at", ["model_offload", "group_offload", "sequential"])
+def test_oom_descends_one_rung_at_a_time_and_serves(
+    serves_at: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CUDA OOM at each rung engages the NEXT rung — one at a time, in order,
+    never a hard fail while a rung remains."""
+    attempted = _arm(monkeypatch, serves_at)
+    applied = place_pipeline(object(), mode="off", logger=logging.getLogger("t"))
+    ladder_prefix = list(rung.PLACEMENT_LADDER[: rung.PLACEMENT_LADDER.index(serves_at) + 1])
+    assert attempted == ["off"] + ladder_prefix
+    assert applied["mode"] == serves_at
+    assert applied.get("oom_demotions") == len(ladder_prefix)
+    assert applied.get("requested_mode") == "off"
+
+
+def test_oom_below_terminal_rung_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When even the terminal rung OOMs the failure surfaces (typed CUDA OOM)
+    — the ladder ends, it does not wrap or invent capacity."""
+    attempted = _arm(monkeypatch, serves_at="never")
+    with pytest.raises(RuntimeError, match="out of memory"):
+        place_pipeline(object(), mode="off", logger=logging.getLogger("t"))
+    assert attempted == ["off"] + list(rung.PLACEMENT_LADDER)
+
+
+def test_strict_vram_refuses_instead_of_descending(monkeypatch: pytest.MonkeyPatch) -> None:
+    """th#1107/th#1043: strict_vram refuses BEFORE any host-RAM rung — on the
+    reactive path too, with a typed message, never a silent slow serve."""
+    attempted = _arm(monkeypatch, serves_at="model_offload")
+    with pytest.raises(RuntimeError, match="strict_vram"):
+        place_pipeline(
+            object(), mode="off", strict_vram=True, logger=logging.getLogger("t"))
+    assert attempted == ["off"]
+
+
+# --- the wire: ran is the Go vocabulary, exactly ----------------------------
+
+def test_demotion_ran_matches_go_vocabulary_exactly() -> None:
+    """RED against 91df247a: a runtime demotion must report ``ran`` from the
+    hub's exact-match vocabulary; placement detail rides the reason, not the
+    token tensorhub switches on."""
+    plan = replan(None, run_mode=RUN_OFFLOAD, detail="CUDA OOM mid-inference; model_offload")
+    assert plan.ran in GO_RAN_VOCABULARY, plan.ran
+    assert plan.ran == RUN_OFFLOAD
+    assert plan.run_mode == RUN_OFFLOAD
+    assert plan.degraded
+    assert plan.est_latency_multiplier == rung.price(RUN_OFFLOAD)
+
+
+def test_load_rung_and_cast_drop_share_the_one_replan() -> None:
+    """The load-time rungs and the th#737 cast-drop report through the SAME
+    projection — no third vocabulary, wanted/ran stay honest."""
+    engaged = replan(None, run_mode=RUN_EMERGENCY, detail="load fit: nf4")
+    assert engaged.run_mode == RUN_EMERGENCY and engaged.ran == RUN_EMERGENCY
+    assert engaged.degraded
+    dropped = replan(None, wanted="fp8", ran="bf16", detail="no cast surface")
+    assert dropped.run_mode == RUN_NATIVE
+    assert dropped.wanted == "fp8" and dropped.ran == "bf16"
+    assert dropped.degraded  # ran != wanted must surface as FnDegraded

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -524,7 +524,7 @@ def test_an_unlanded_nf4_rung_is_a_rung_OUTCOME_not_the_absence_of_one() -> None
 
 def test_the_unlanded_rung_reaches_placement_through_SlotLoad() -> None:
     """An event alone would not be enough: every sibling rung reaches
-    ServePlan/FnDegraded via SlotLoad.rung -> `_record_adaptive_rung`, and a
+    ServePlan/FnDegraded via SlotLoad.rung -> `_record_rung_transition`, and a
     fix that only logged-but-typed would still leave placement blind."""
     import inspect
 


### PR DESCRIPTION
Phase A2 of pgw#1206 (lever 3; design section "pgw#1206 phase A2" in `research/gen-worker-architecture-audit.md`, written before code).

- **One ordered ladder** in `models/rung.py`: `descend()` (strict_vram truncation built in), `price()`, `floor_of()`, `touches_host_ram()`, `transition_line()`. serve_fit keeps the Go-mirrored `RUN_*` wire vocabulary and becomes the projection — `demoted`/`load_rung_engaged`/`cast_dropped` → ONE `replan()`; executor's three bookkeepers → ONE `_record_rung_transition()`; memory's walk functions die into rung.py.
- **Wire fix (red-verified against `91df247a`)**: `demoted()` sent `ran="offload:<placement>"` — tensorhub's `degradation_reschedule.go:106` matches `Ran` EXACTLY against `offload|cpu|emergency_quant`, so every runtime demotion missed the VRAM-driven-drain arm. `ran` now carries only the RunMode vocabulary; placement detail rides `reason`; lifecycle's re-emit dedupe keys on (ran, warning) so deeper same-mode demotions still re-report.
- **The ruling is ONE test**: `tests/test_rung_ladder_pgw1206.py` — OOM at each rung descends exactly one rung, never a hard fail before the ladder ends; strict_vram never reaches a host-RAM rung; floor only deepens; price monotonic; `ran` ∈ Go vocabulary. SP refuses-as-a-group and the pgw#1063 refusal untouched.

Verification: strict mypy clean (266 files); ratchet + surface lints green; ruff delta zero; 300+ targeted tests + tests_v2 pass locally; executor touch-points all outside th#1834's fenced regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)