### PR TITLE
pgw#1209: master goes behind a merge queue, and CI learns to run on the queue ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,26 @@ name: CI
 # REQUIRED contexts (`fast gates`, `tests`) — they gate the merge, and unlike
 # tensorhub this repo keeps its full suite pre-merge because it is public,
 # unmetered, and ~10m rather than ~18m.
+# pgw#1209 (2026-08-13): `master` has a MERGE QUEUE. A queued PR is validated on
+# a `gh-readonly-queue/master/...` ref carrying master's tip plus every entry
+# ahead of it — which is the only place the "two PRs green alone, red together"
+# collision is visible. Two lines below are what make that work, and BOTH are
+# load-bearing:
+#
+#   1. `merge_group:` in the trigger list. Without it no run is created on the
+#      queue ref at all, the required contexts never report, and the queue sits
+#      until `check_response_timeout_minutes` expires and evicts the PR.
+#   2. `github.event_name == 'merge_group'` in each job's `if:`. On a merge_group
+#      event `github.event.pull_request` is NULL, so the draft guard alone
+#      evaluates false and the job SKIPS — and GitHub scores a skipped required
+#      check as satisfied. That failure is worse than the first: the queue merges
+#      having run nothing, and the PR page shows green.
+#
+# The trigger is deliberately bare (no `branches:`/`paths:` filter). A filter
+# that excludes a merge group is indistinguishable from case 1.
 on:
   workflow_dispatch: {}
+  merge_group:
   pull_request:
     branches: [master]
     # `ready_for_review` is NOT a default `pull_request` type, and the jobs below
@@ -163,7 +181,10 @@ jobs:
   # behind an 11-minute pytest run.
   gates:
     name: fast gates
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # `merge_group` is listed FIRST and explicitly: on that event
+    # `github.event.pull_request` is null, so the draft clause alone skips the
+    # job and GitHub scores the skip as a satisfied required check (pgw#1209).
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -326,7 +347,10 @@ jobs:
   # header on why that is worth a dev trigger rather than master-only.
   tests:
     name: tests
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # `merge_group` is listed FIRST and explicitly: on that event
+    # `github.event.pull_request` is null, so the draft clause alone skips the
+    # job and GitHub scores the skip as a satisfied required check (pgw#1209).
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:

--- a/changelog.d/pgw1209.md
+++ b/changelog.d/pgw1209.md
@@ -1,0 +1,10 @@
+- CI: `master` is now behind a **merge queue**. A PR is re-validated on a
+  `gh-readonly-queue/master/...` ref carrying master's tip plus every entry ahead
+  of it, so two PRs that are each green alone but red together are caught before
+  either lands rather than after both do. `ci.yml` gained the `merge_group:`
+  trigger, and both required jobs (`fast gates`, `tests`) gained
+  `github.event_name == 'merge_group'` in their `if:` — without the second, the
+  jobs skip on the queue ref and GitHub scores the skip as a satisfied required
+  check. Queue merge method is a **true merge**, not a squash, so a release cut's
+  tagged branch commit stays an ancestor of `master` (`docs/releasing.md`).
+  No source or packaging change.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -237,10 +237,15 @@ commit, say which one in the release notes, and **never re-point at master's tip
 landed under you** — that ships code with no changelog entry, which is the silent release note this
 whole file exists to prevent.
 
-That leaves the tag on a branch commit, so **merge the cut PR with a TRUE MERGE, not a squash**
-(`gh pr merge <n> --merge`). A squash rewrites your commit, the tag then points at something that is
-NOT an ancestor of `master`, and the next cutter's `git rev-list v<X.Y.Z>..HEAD` silently re-lists
-everything you just released. Assert it, do not hope:
+That leaves the tag on a branch commit, so the cut PR must land as a **TRUE MERGE, not a squash**. A
+squash rewrites your commit, the tag then points at something that is NOT an ancestor of `master`,
+and the next cutter's `git rev-list v<X.Y.Z>..HEAD` silently re-lists everything you just released.
+
+Since pgw#1209 you do not choose this per-PR: `master` is behind a **merge queue**, and the queue's
+merge method is set to a true merge for exactly this reason — one method applies to every entry, and
+a squash queue would break every release cut silently. So `gh pr merge <n>` enqueues, the queue
+re-runs `fast gates` + `tests` against master's tip, and it lands as a merge commit. Assert it, do
+not hope:
 
 ```bash
 git merge-base --is-ancestor v<X.Y.Z> origin/master && echo OK


### PR DESCRIPTION
Three times this week two PRs that were each green alone merged **red together**. CI only ever validated a PR against the master it branched from, and the continuous typing-ratchet PRs landing alongside code PRs make that collision near-certain to recur. A merge queue re-validates each entry against the *actual merge result* — master's tip plus everything ahead of it in the queue — before anything lands.

Paul approved enabling it (2026-08-13). The ruleset half is applied out-of-band on `Master required checks`; this PR is the **tree-side half**, which is the half that is easy to get wrong.

### What changes

- **`merge_group:` joins `ci.yml`'s trigger list**, bare — no `branches:`/`paths:` filter. A workflow without it produces no run *at all* on the `gh-readonly-queue/master/…` ref, the required contexts never report, and the queue evicts the PR when `check_response_timeout_minutes` expires. A filter that excludes a merge group is indistinguishable from omitting the trigger.
- **Both required jobs gain `github.event_name == 'merge_group'` in their `if:`.** This is the sharper edge and the one that does not appear in most write-ups: on a merge_group event `github.event.pull_request` is **null**, so the existing draft guard evaluates false on its own, the job **skips**, and GitHub scores a skipped required check as *satisfied*. The queue would merge having run nothing, and the PR page would read green.
- `docs/releasing.md` records that the queue merges with a **true merge**, not a squash — that file already required one for release-cut PRs so the tagged branch commit stays an ancestor of `master`, and a queue applies one method to every entry, so a squash queue would have broken every future cut silently.

### Deliberately not changed

`native-kernels` and `proto contract` stay on `pull_request` only. Neither is a required context, so neither can hold the queue open; and `native-kernels` is a 45-minute toolchain compile whose verdict is a property of `csrc/` alone rather than of the merge.

### This PR is its own proof

A merge queue that has never merged anything is a dark feature. This PR is enqueued rather than merged directly, so the `merge_group` run visible on it *is* the evidence that the trigger and the `if:` both work — the workflows read from the merge-group ref, which carries this PR's own edits.

Tracker: pgw#1209.