### PR TITLE
pgw#1208 (P0): the mint child never places, and one unexportable class no longer costs the cell

### DIFF
--- a/changelog.d/pgw1208.md
+++ b/changelog.d/pgw1208.md
@@ -10,12 +10,16 @@
   exported in **91.07 s** on an A4500 and was `Unsupported` on an A4000. Six adapter-bearing entries
   exported clean there, so **the LoRA/adapter axis is exonerated** — rows are ordered adapter-bearing
   first (`_rows_source`), so the adapter entry was simply the first one tried.
-- **The arithmetic behind the card discriminator**, from `memory.select_auto_mode`: requirement
-  ≈ 6.31 GiB, `_DEFAULT_SAFETY_MARGIN_GB` = 2.0. A4000 (16 GB) with a resident serving parent leaves
-  ~8 GB free → usable ~6 GB < 6.31 → descend to `group_offload`. A4500 (20 GB) leaves ~12 GB →
-  usable ~10 GB > 6.31 → resident, no hooks, export works. **And the requirement was wrong anyway:**
-  `estimate_pipeline_size_gb` counts a VIRTUAL parameter's declared bytes, so the ladder sized a
-  structure-only pipeline that allocates nothing as if it would hold the whole checkpoint.
+- **CORRECTION, and it matters: this is NOT a card-size story.** My first reading was "the card was
+  too small, so the ladder engaged offload" — **falsified** by the z-image leg, which refused
+  identically on a **48 GiB A40 holding a 19 GiB model** (`CpuOffload.pre_forward`, accelerate's
+  model/sequential offload). Offload here is a pipeline CONFIGURATION, not a response to memory
+  pressure, and the mechanism is family-independent — only the hook class differs. **The
+  A4000/A4500 difference is real and remains UNEXPLAINED**; `place=False` makes it moot rather than
+  answering it, and an unexplained discriminator that stops mattering is still unexplained.
+  (§1.35 has since ruled the card-filter concept out of existence outright: every model runs on
+  every GPU, feasibility is never asked — so a refusal phrased as a capacity verdict would now
+  contradict canon.)
 - **The fix is the pgw#1124 seam, one door over: `place=False` on the weight-free load.** That child
   exports and never runs a forward, so it has no business on the serving ladder — the identical
   argument pgw#1124 made for the boot-trace child. The hooks are **never installed** rather than

--- a/changelog.d/pgw1208.md
+++ b/changelog.d/pgw1208.md
@@ -1,0 +1,40 @@
+- **pgw#1208 (P0): the mint child ran the SERVING placement ladder, and the offload hooks it
+  installed made the graph unexportable.** The first sdxl full-circle leg died in `trace_graph`,
+  deterministically: `torch.export(strict=True) failed for UNet2DConditionModel: Unsupported: Skip
+  inlining `torch.compiler.disable()`d function … <function ModuleGroup.onload_>`. That function is
+  **diffusers group offloading**. The child ran the ladder, the ladder engaged group offload (a
+  serving parent was already resident on that card), and the hooks put a `@torch.compiler.disable`d
+  call in the traced path — which `torch.export` refuses, fatally.
+- **The diagnosis is a controlled comparison, not a reading of a stack trace.** The SAME entry
+  (`unet/adapter=true,cfg=true/B=2,H_lat=80,T_txt=77,W_lat=192`) on the SAME wheel (0.113.2)
+  exported in **91.07 s** on an A4500 and was `Unsupported` on an A4000. Six adapter-bearing entries
+  exported clean there, so **the LoRA/adapter axis is exonerated** — rows are ordered adapter-bearing
+  first (`_rows_source`), so the adapter entry was simply the first one tried.
+- **The arithmetic behind the card discriminator**, from `memory.select_auto_mode`: requirement
+  ≈ 6.31 GiB, `_DEFAULT_SAFETY_MARGIN_GB` = 2.0. A4000 (16 GB) with a resident serving parent leaves
+  ~8 GB free → usable ~6 GB < 6.31 → descend to `group_offload`. A4500 (20 GB) leaves ~12 GB →
+  usable ~10 GB > 6.31 → resident, no hooks, export works. **And the requirement was wrong anyway:**
+  `estimate_pipeline_size_gb` counts a VIRTUAL parameter's declared bytes, so the ladder sized a
+  structure-only pipeline that allocates nothing as if it would hold the whole checkpoint.
+- **The fix is the pgw#1124 seam, one door over: `place=False` on the weight-free load.** That child
+  exports and never runs a forward, so it has no business on the serving ladder — the identical
+  argument pgw#1124 made for the boot-trace child. The hooks are **never installed** rather than
+  stripped afterwards, which is what keeps this small instead of clever. The REAL-WEIGHT fallback
+  keeps its placement, deliberately and fenced by a test: a stranded family loads its checkpoint
+  into that process and runs the pgw#984 warm proof, which is a real forward.
+- **A deterministic per-entry export failure no longer kills the mint** — the more important half.
+  The entry is already the unit of identity and of publish (pgw#718); it is now the unit of FAILURE
+  too. A class `torch.export` refuses is skipped, named, and reported (`entry_export_unsupported`,
+  carrying dynamo's own `Explanation:`/`Developer debug context:` lines), and the remaining classes
+  mint and publish. Fail-closed stays fail-closed AT THE ENTRY: a skipped class is never packed and
+  never published, and serving covers it eager exactly as it covers any shape outside a cell's
+  declared envelope (pgw#844). A cell with NO surviving entries still refuses, on the path that
+  already refused (`_pack`: *"cannot package a cell with no entries"*).
+- **What is NOT skippable, because the existing suite caught the first cut being too broad.** Only
+  **torch's own** export refusal (the `torch._dynamo` / `torch._export` / `torch.export` namespace)
+  is a property of the graph class. A CUDA OOM or host shortfall aborts the mint so the parent can
+  retry narrower — skipping there would publish a cell whose missing classes are an artifact of
+  memory pressure. A `MintRefused` from our own gates is a correctness verdict, and a correctness
+  gate that can be skipped is not a gate. A declared WARM that blows up stays pgw#758's named
+  refusal: a cell whose classes were never warm-proven must not publish. `test_aot_multigraph_pgw758`
+  passes unchanged, which is the proof those contracts survived.

--- a/changelog.d/pgw1208.md
+++ b/changelog.d/pgw1208.md
@@ -38,3 +38,19 @@
   gate that can be skipped is not a gate. A declared WARM that blows up stays pgw#758's named
   refusal: a cell whose classes were never warm-proven must not publish. `test_aot_multigraph_pgw758`
   passes unchanged, which is the proof those contracts survived.
+- **(a) `mint_requires_resident_parent`: the pipeline that cannot be traced AS LOADED refuses ONCE,
+  before any export.** The weight-free path never places, so it never acquires these hooks; this is
+  for the REAL-WEIGHT fallback, which does load a checkpoint and does run the ladder. Without it the
+  per-entry skip above would do exactly its job and dutifully skip all 36 classes — thirty-six typed
+  refusals and an hour of wall clock to say once what was knowable before the first export began.
+  The skip is for a class that is individually unexportable; this is the whole PIPELINE being
+  untraceable, which is a different fact and gets its own sentence. Cost was already covered by
+  attempt-is-the-budget (§4.33); what this buys is LEGIBILITY.
+- **The detector asks the object, not the placement logic.** `models/traceability.py` walks the
+  pipeline's modules for hooks carrying `torch.compiler.disable`d work, keyed on torch's own
+  `_torchdynamo_disable` marker rather than on a class name — so it stays true for any future source
+  of such hooks, not just the offload rung that produced the first one. It reads diffusers'
+  `_diffusers_hook` REGISTRY as well as torch's `_forward_pre_hooks`, because group offloading
+  registers there and a walk that only knew torch's dicts would have seen nothing at all on the one
+  case it exists for. Tested against **real `apply_group_offloading`** — no mock — and it names
+  `ModuleGroup.onload_`, the exact function from the pod's error.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1172,6 +1172,101 @@ def _measured_precision(pipeline: Any, rows: Sequence[Tuple[Any, Any]]) -> str:
     return "mixed(" + "+".join(sorted(labels)) + ")"
 
 
+#: pgw#1208: the phase token an unexportable class reports under. One kind, so
+#: the hub can COUNT them per family — a class that cannot be exported is a
+#: standing authoring/toolchain fact, not a transient, and the fleet's answer to
+#: "which classes never compile" should be a query rather than a log hunt.
+KIND_ENTRY_EXPORT_UNSUPPORTED = "entry_export_unsupported"
+
+
+def _export_skippable(exc: BaseException) -> bool:
+    """Whether ONE class's export failure may be skipped, leaving the rest.
+
+    Skippable means DETERMINISTIC, LOCAL, and TORCH'S OWN: this graph class
+    contains a construct `torch.export` refuses, and it will refuse identically
+    on every retry, on every pod, forever. Skipping it costs one class and
+    saves the other thirty-five.
+
+    NOT skippable, and the distinction is the whole safety of this:
+
+    * a RESOURCE shortfall (CUDA OOM, host memory) — it says nothing about the
+      class, it says the pod is out of room, and the mint must abort so the
+      parent can retry narrower. Skipping here would silently publish a partial
+      cell whose missing classes are an artifact of memory pressure and would
+      have exported fine on the retry.
+    * a ``BaseException`` that is not an ``Exception`` (KeyboardInterrupt,
+      SystemExit) — a shutdown is not a property of the graph.
+    * ``MintResourceExhausted`` and anything else carrying the duck-typed
+      ``mint_resource_shortfall`` marker, for the same reason as the first.
+    """
+    from .models.memory import is_cuda_oom
+
+    if not isinstance(exc, Exception):
+        return False
+    if is_cuda_oom(exc):
+        return False
+    if getattr(exc, "mint_resource_shortfall", False) is True:
+        return False
+    # ...and it must be TORCH'S OWN export refusal, not any deterministic
+    # exception that happened to surface during the export step.
+    #
+    # `_export_entry` resolves, feeds, WARMS, exports, GATES and compiles. Only
+    # the export's own "I cannot trace this construct" is a property of the
+    # graph class. The others are not, and skipping them would be the silent
+    # failure this issue exists to remove, wearing a new hat:
+    #
+    #   * a declared WARM that blows up says the class cannot RUN — pgw#758
+    #     made that a named refusal deliberately, and a cell whose classes were
+    #     never warm-proven must not publish;
+    #   * a MintRefused from our own gates (the folding fence, ingress
+    #     admission, identity) is a CORRECTNESS verdict, and a correctness gate
+    #     that can be skipped is not a gate;
+    #   * a plain exception from the module's own forward is a broken forward,
+    #     not an unsupported construct.
+    #
+    # So the test is the exception's ORIGIN: torch's dynamo/export namespace.
+    module = type(exc).__module__ or ""
+    return module.startswith(("torch._dynamo", "torch._export", "torch.export",
+                              "torch.fx.experimental"))
+
+
+def _unsupported_construct(exc: BaseException) -> str:
+    """The CONSTRUCT that refused, named, in one line.
+
+    A skipped class is only actionable if the reason names the thing an author
+    or a toolchain bump has to change. Dynamo says it precisely and then buries
+    it in a page of traceback, so the useful lines are lifted out: its own
+    ``Explanation:`` and ``Developer debug context:`` when present, else the
+    first line of the message. Never the whole traceback — this rides an event.
+    """
+    text = str(exc).strip()
+    picked = [
+        line.strip() for line in text.splitlines()
+        if line.strip().startswith(("Explanation:", "Developer debug context:"))
+    ]
+    head = text.splitlines()[0].strip() if text else type(exc).__name__
+    out = f"{type(exc).__name__}: {head}"
+    if picked:
+        out += " — " + " ".join(picked[:2])
+    return out[:600]
+
+
+def _emit_entry_export_unsupported(
+    entry: str, detail: str, *, family: str = "",
+) -> None:
+    """Tell the hub which class was skipped and why. Never fails a mint."""
+    try:
+        activity_mod.emit_event(
+            KIND_ENTRY_EXPORT_UNSUPPORTED,
+            f"family={family} entry={entry}: torch.export refused this graph "
+            f"class and it is SKIPPED — {detail}. The remaining classes still "
+            f"mint and publish; this class serves eager.",
+            phase=PHASE_TRACE_GRAPH,
+        )
+    except Exception:  # noqa: BLE001 — telemetry never fails a mint
+        logger.debug("aot-mint: entry-skip event dropped", exc_info=True)
+
+
 def _export_entry(
     pipeline: Any,
     spec: ExportSpec,
@@ -2258,6 +2353,11 @@ def _mint_cell(
     progress.width = width
 
     minted = progress.minted
+    #: pgw#1208: classes this mint could not export, each with the construct
+    #: that refused. They are NOT packed and NOT published — they are recorded,
+    #: so a cell that covers 35 of 36 classes says which one it does not and
+    #: why, instead of the whole mint disappearing behind one refusal.
+    skipped: List[Tuple[str, str]] = []
     # pgw#822: the adapter-BEARING classes are exported from the lifted
     # forward. Arming it is this function's job, not the caller's — see
     # `_arm_branches`.
@@ -2313,11 +2413,42 @@ def _mint_cell(
                 progress.beat(
                     PHASE_TRACE_GRAPH, index, len(rows),
                     _decl.plan_entry_name(plan))
-                with export_footprint.row():
-                    entry = _export_entry(
-                        pipeline, spec, plan, decl,
-                        inductor_configs=inductor_configs,
-                        compile_now=not parallel)
+                name = _decl.plan_entry_name(plan)
+                try:
+                    with export_footprint.row():
+                        entry = _export_entry(
+                            pipeline, spec, plan, decl,
+                            inductor_configs=inductor_configs,
+                            compile_now=not parallel)
+                except BaseException as exc:  # noqa: BLE001 — classified below
+                    # pgw#1208: ONE class that cannot export must not cost the
+                    # other 35. Before this, a single deterministic refusal
+                    # anywhere in the row loop aborted the whole mint and threw
+                    # away every class that had already exported clean — the
+                    # per-entry atom's own philosophy (pgw#718: the entry is
+                    # the unit of identity and of publish) applied everywhere
+                    # EXCEPT to the loop that produces the entries.
+                    #
+                    # Fail-closed stays fail-closed AT THE ENTRY: this class
+                    # proved nothing, so it is never packed and never
+                    # published, and serving covers it eager by the same
+                    # mechanism that covers any shape outside a cell's declared
+                    # envelope (pgw#844 — refused BY NAME, served eager, still
+                    # armed). What changes is only the blast radius.
+                    if not _export_skippable(exc):
+                        raise
+                    detail = _unsupported_construct(exc)
+                    skipped.append((name, detail))
+                    logger.warning(
+                        "aot-mint: entry %s cannot be exported and is SKIPPED "
+                        "— %s. The remaining classes still mint; this one "
+                        "serves eager.", name, detail)
+                    _emit_entry_export_unsupported(
+                        name, detail, family=str(spec.family or ""))
+                    progress.beat(
+                        PHASE_TRACE_GRAPH, index, len(rows),
+                        f"{name}: SKIPPED ({detail})")
+                    continue
                 minted.append(entry)
                 yield entry
         finally:
@@ -2435,6 +2566,20 @@ def _mint_cell(
         # correct either way — the parallel path refuses at ARRIVAL
         # (pgw#1052), which is where it matters.
         minted, class_aliases = canonicalize_dispatch_classes(minted)
+    # pgw#1208: what this cell does NOT cover, and why. Recorded on the mint's
+    # own timings so it reaches the phase table (and therefore the hub) beside
+    # the classes that did export — a partial cell must be able to say which
+    # classes are missing, or "35 of 36" is indistinguishable from "36 of 36".
+    #
+    # A cell with NO entries still refuses: `_pack` raises `cannot package a
+    # cell with no entries`, so "every class was skipped" fails closed on the
+    # path it already failed closed on rather than through a second check here.
+    timings["skipped_entries"] = float(len(skipped))
+    if skipped:
+        logger.warning(
+            "aot-mint: %d of %d declared class(es) could not be exported and "
+            "are absent from this cell: %s", len(skipped), len(rows),
+            "; ".join(f"{n} ({d})" for n, d in skipped[:4]))
     timings["canonicalized_entries"] = float(
         sum(len(rows) for rows in class_aliases.values()))
     timings["entry_workers"] = float(width.workers)

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -778,6 +778,29 @@ def mint(request: MintRequest) -> MintReport:
             got = run_setup(
                 obj, dict(paths), arm_compile=False,
                 return_loaded=True, component_paths=overrides,
+                # pgw#1208: NO SERVING PLACEMENT on the weight-free path. The
+                # pgw#1124 seam, and the same argument one door over: the
+                # placement ladder is for a pipeline that will run a forward,
+                # and this one never will — it exports and nothing else. Since
+                # pgw#1199 the child runs no warm proof either, so the last
+                # reason to place it is gone.
+                #
+                # This is not a tuning choice, it is the whole of the sdxl
+                # A4000 failure. The ladder engaged diffusers GROUP OFFLOADING
+                # (the card had a resident serving parent on it), which
+                # installs hooks whose `ModuleGroup.onload_` is decorated
+                # `@torch.compiler.disable` — and `torch.export(strict=True)`
+                # refuses to inline a disabled function, fatally and
+                # deterministically:
+                #
+                #   Unsupported: Skip inlining `torch.compiler.disable()`d
+                #   function <function ModuleGroup.onload_>
+                #
+                # Measured, same wheel (0.113.2), same entry
+                # (`unet/adapter=true,cfg=true/B=2,H_lat=80,T_txt=77,W_lat=192`):
+                # 91.07 s export on an A4500, `Unsupported` on an A4000. The
+                # hooks are not stripped here — they are never installed.
+                place=False,
                 structure_only=structure_targets) or {}
         except StructureNotHonored as exc:
             # pgw#1080 z-image tail: the target WAS built weight-free and the
@@ -806,6 +829,11 @@ def mint(request: MintRequest) -> MintReport:
             frame(phase="load", note=(
                 f"structure-only {structure_only.refusal_token(exc)}: {exc}"))
             obj = spec.cls()
+            # The REAL-WEIGHT fallback keeps its placement, deliberately:
+            # structure-only was refused for this family, so this process
+            # holds the checkpoint AND runs the pgw#984 warm proof — a real
+            # forward, which needs a placed pipeline. Only the path that
+            # exports and never executes may skip the ladder.
             got = run_setup(
                 obj, dict(paths), arm_compile=False,
                 return_loaded=True, component_paths=overrides) or {}

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -839,6 +839,7 @@ def mint(request: MintRequest) -> MintReport:
                 return_loaded=True, component_paths=overrides) or {}
         _slot, loaded_pipe = pick_compile_target(got, cfg)
         frame(phase="load", note=f"compile target on slot {_slot!r}")
+        assert_traceable_as_loaded(loaded_pipe, request)
         if cfg.lora_bucket:
             cc.apply_lora_execution_lane(loaded_pipe, cfg.lora_bucket)
         return obj, loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
@@ -914,6 +915,49 @@ def mint(request: MintRequest) -> MintReport:
         request, pipe, cfg, target, started=started,
         sha256_file=sha256_file, execution_lane_verdict=verdict, spec=aot_spec,
         footprint=footprint)
+
+
+def assert_traceable_as_loaded(pipeline: Any, request: MintRequest) -> None:
+    """Refuse ONCE, before any export, when this pipeline cannot be traced.
+
+    pgw#1208 (a). The weight-free path never places and so never acquires these
+    hooks; this is for the REAL-WEIGHT fallback, which loads a checkpoint into
+    this process and runs the serving placement ladder over it. On a card too
+    small to hold it resident the ladder engages diffusers group offloading,
+    whose `ModuleGroup.onload_` is `@torch.compiler.disable`d — and every one of
+    the family's declared graph classes then refuses `Unsupported: Skip inlining
+    …` for the same reason.
+
+    Without this, pgw#1208's per-entry skip would do exactly what it is supposed
+    to do and dutifully skip all 36: thirty-six typed refusals and an hour of
+    wall clock to say once what was knowable before the first export began. The
+    per-entry skip is for a class that is individually unexportable. This is the
+    whole PIPELINE being untraceable as loaded, which is a different fact and
+    gets its own sentence.
+
+    Cost is already covered by the attempt-is-the-budget rule (§4.33); what this
+    buys is LEGIBILITY — a pod that cannot mint says why, once, in a countable
+    typed refusal, instead of emitting a refusal per class and publishing
+    nothing.
+
+    No placement logic and no card arithmetic: it asks the object in front of it
+    whether it carries disabled work, so it stays true for any future source of
+    such hooks rather than only for the offload rung that produced the first.
+    """
+    from .models import traceability
+
+    reason = traceability.untraceable_reason(pipeline)
+    if not reason:
+        return
+    raise MintChildRefused(
+        f"mint_requires_resident_parent: {mint_identity(request)} loaded real "
+        f"weights and this card could not hold them resident, so the placement "
+        f"ladder installed offload hooks — and {reason}. `torch.export` refuses "
+        f"a `torch.compiler.disable`d function rather than tracing around it, "
+        f"so EVERY declared graph class would refuse identically. Refused once, "
+        f"before the first export, instead of once per class. This pod can "
+        f"serve this family eager; it cannot mint it — mint it where the "
+        f"pipeline fits resident.")
 
 
 def assert_handler_proven(request: MintRequest) -> None:

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -786,20 +786,24 @@ def mint(request: MintRequest) -> MintReport:
                 # reason to place it is gone.
                 #
                 # This is not a tuning choice, it is the whole of the sdxl
-                # A4000 failure. The ladder engaged diffusers GROUP OFFLOADING
-                # (the card had a resident serving parent on it), which
-                # installs hooks whose `ModuleGroup.onload_` is decorated
-                # `@torch.compiler.disable` — and `torch.export(strict=True)`
-                # refuses to inline a disabled function, fatally and
-                # deterministically:
+                # and z-image export failures. The ladder installs OFFLOAD
+                # HOOKS, and an offload hook puts a `@torch.compiler.disable`d
+                # function in the traced path — which `torch.export(strict=True)`
+                # refuses to inline, fatally and deterministically:
                 #
                 #   Unsupported: Skip inlining `torch.compiler.disable()`d
                 #   function <function ModuleGroup.onload_>
                 #
-                # Measured, same wheel (0.113.2), same entry
-                # (`unet/adapter=true,cfg=true/B=2,H_lat=80,T_txt=77,W_lat=192`):
-                # 91.07 s export on an A4500, `Unsupported` on an A4000. The
-                # hooks are not stripped here — they are never installed.
+                # The MECHANISM is family-independent; only the hook class
+                # differs (`ModuleGroup.onload_` for sdxl's group offload,
+                # `CpuOffload.pre_forward` for z-image's). It is NOT a
+                # card-capacity story: z-image refused on a 48 GiB A40 holding
+                # a 19 GiB model, so offload here is a CONFIGURATION and not a
+                # response to memory pressure. `place_pipeline` has exactly one
+                # call site, guarded by `if place and ...`, and no endpoint
+                # installs offload itself — so this line removes every offload
+                # hook for every family. The hooks are not stripped; they are
+                # never installed.
                 place=False,
                 structure_only=structure_targets) or {}
         except StructureNotHonored as exc:
@@ -922,11 +926,20 @@ def assert_traceable_as_loaded(pipeline: Any, request: MintRequest) -> None:
 
     pgw#1208 (a). The weight-free path never places and so never acquires these
     hooks; this is for the REAL-WEIGHT fallback, which loads a checkpoint into
-    this process and runs the serving placement ladder over it. On a card too
-    small to hold it resident the ladder engages diffusers group offloading,
-    whose `ModuleGroup.onload_` is `@torch.compiler.disable`d — and every one of
-    the family's declared graph classes then refuses `Unsupported: Skip inlining
-    …` for the same reason.
+    this process and runs the serving placement ladder over it. An offload hook
+    puts a `@torch.compiler.disable`d function in the traced path — diffusers'
+    `ModuleGroup.onload_` (group offload) or accelerate's
+    `CpuOffload.pre_forward` (model/sequential offload) — and every one of the
+    family's declared graph classes then refuses `Unsupported: Skip …` for the
+    same reason.
+
+    **This is NOT a capacity verdict, and must never be read as one.** z-image
+    refused on a 48 GiB A40 holding a 19 GiB model, so offload is a pipeline
+    CONFIGURATION rather than a response to memory pressure — and §1.35 has
+    since ruled the whole card-filter concept out of existence (every model runs
+    on every GPU, best effort; feasibility is never asked). What this detects is
+    exactly what it says: the pipeline AS LOADED carries hooks that cannot be
+    traced.
 
     Without this, pgw#1208's per-entry skip would do exactly what it is supposed
     to do and dutifully skip all 36: thirty-six typed refusals and an hour of
@@ -950,14 +963,16 @@ def assert_traceable_as_loaded(pipeline: Any, request: MintRequest) -> None:
     if not reason:
         return
     raise MintChildRefused(
-        f"mint_requires_resident_parent: {mint_identity(request)} loaded real "
-        f"weights and this card could not hold them resident, so the placement "
-        f"ladder installed offload hooks — and {reason}. `torch.export` refuses "
-        f"a `torch.compiler.disable`d function rather than tracing around it, "
-        f"so EVERY declared graph class would refuse identically. Refused once, "
-        f"before the first export, instead of once per class. This pod can "
-        f"serve this family eager; it cannot mint it — mint it where the "
-        f"pipeline fits resident.")
+        f"mint_pipeline_not_traceable: {mint_identity(request)} loaded real "
+        f"weights and the placement ladder installed offload hooks — {reason}. "
+        f"`torch.export` refuses a `torch.compiler.disable`d function rather "
+        f"than tracing around it, so EVERY declared graph class would refuse "
+        f"identically. Refused once, before the first export, instead of once "
+        f"per class. NOT a statement about this card (§1.35: every model runs "
+        f"on every GPU, feasibility is never asked) — it is a statement about "
+        f"this PIPELINE AS CONFIGURED. This pod serves the family eager "
+        f"exactly as before; only minting is unavailable while it is loaded "
+        f"this way.")
 
 
 def assert_handler_proven(request: MintRequest) -> None:

--- a/src/gen_worker/models/traceability.py
+++ b/src/gen_worker/models/traceability.py
@@ -5,12 +5,18 @@ cannot be exported. `torch.export(strict=True)` does not degrade around it — i
 refuses, per graph class, with `Unsupported: Skip inlining
 torch.compiler.disable()d function`.
 
-THE CASE THIS EXISTS FOR. diffusers' group offloading installs hooks whose
-`ModuleGroup.onload_` is decorated `@torch.compiler.disable` (verified on
-diffusers 0.39.0: `ModuleGroup.onload_._torchdynamo_disable is True`). A pod
-whose card cannot hold the pipeline resident gets those hooks from the
-placement ladder — and then every one of its 36 declared graph classes refuses,
+THE CASE THIS EXISTS FOR. Offload hooks. diffusers' group offloading marks
+`ModuleGroup.onload_` (verified on diffusers 0.39.0:
+`ModuleGroup.onload_._torchdynamo_disable is True`); accelerate's model/
+sequential offload marks `CpuOffload.pre_forward`. Either puts disabled work in
+a forward path, and then every one of a family's declared graph classes refuses,
 one at a time, for the same reason.
+
+**It is not a card-size story.** sdxl refused on a 16 GiB A4000 and z-image on a
+**48 GiB A40 holding a 19 GiB model** — so offload here is a pipeline
+CONFIGURATION, not a response to memory pressure. This module therefore asks
+about HOOKS and never about capacity, which is also what §1.35 requires: every
+model runs on every GPU, feasibility is never asked.
 
 WHY A PRE-EXPORT CHECK RATHER THAN LETTING THE PER-ENTRY SKIP HANDLE IT.
 pgw#1208's blast-radius fix would dutifully skip all 36 and publish nothing:

--- a/src/gen_worker/models/traceability.py
+++ b/src/gen_worker/models/traceability.py
@@ -1,0 +1,170 @@
+"""pgw#1208: can this pipeline, AS LOADED, be traced at all?
+
+A pipeline that carries `torch.compiler.disable`d work in its forward path
+cannot be exported. `torch.export(strict=True)` does not degrade around it — it
+refuses, per graph class, with `Unsupported: Skip inlining
+torch.compiler.disable()d function`.
+
+THE CASE THIS EXISTS FOR. diffusers' group offloading installs hooks whose
+`ModuleGroup.onload_` is decorated `@torch.compiler.disable` (verified on
+diffusers 0.39.0: `ModuleGroup.onload_._torchdynamo_disable is True`). A pod
+whose card cannot hold the pipeline resident gets those hooks from the
+placement ladder — and then every one of its 36 declared graph classes refuses,
+one at a time, for the same reason.
+
+WHY A PRE-EXPORT CHECK RATHER THAN LETTING THE PER-ENTRY SKIP HANDLE IT.
+pgw#1208's blast-radius fix would dutifully skip all 36 and publish nothing:
+thirty-six typed refusals and an hour of wall clock to say once what is knowable
+before the first export begins. The per-entry skip is for a class that is
+individually unexportable; this is the whole PIPELINE being untraceable as
+loaded, which is a different fact and deserves its own sentence.
+
+It reads no placement logic and does no card arithmetic — it asks the object in
+front of it whether it carries disabled work. That keeps it true for any future
+source of such hooks, not just the offload rung that produced the first one.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, List, Tuple
+
+#: The attribute `torch.compiler.disable` stamps on what it wraps. Read rather
+#: than inferred from a class name: the marker is torch's own contract and
+#: survives diffusers renaming or re-homing its hooks.
+DISABLE_MARKER = "_torchdynamo_disable"
+
+#: How far into a hook's own object graph to look. A registered hook does not
+#: usually CARRY the disabled function — diffusers' `GroupOffloadingHook` holds
+#: a `ModuleGroup` and the marker is on `ModuleGroup.onload_` — so one hop past
+#: the hook is required to see it at all. Two hops is where it stops: deeper is
+#: someone else's object graph, and an unbounded walk over live model state is
+#: how a diagnostic becomes a hang.
+_DEPTH = 2
+
+
+def _is_disabled(obj: Any) -> bool:
+    return bool(getattr(obj, DISABLE_MARKER, False))
+
+
+def _disabled_in(obj: Any, depth: int = _DEPTH) -> str:
+    """The name of a `torch.compiler.disable`d callable reachable from ``obj``.
+
+    Empty string when there is none. Checks the object, its class's methods,
+    and (one hop at a time) the objects it holds — which is what it takes to
+    see `hook.group.onload_` from a registered hook.
+    """
+    if obj is None or depth < 0:
+        return ""
+    if _is_disabled(obj):
+        return getattr(obj, "__qualname__", None) or type(obj).__name__
+    # A bound method's owner, and the class's own methods: the marker lives on
+    # the FUNCTION, so it is reached through the type rather than the instance.
+    for holder in (obj, type(obj)):
+        try:
+            names = list(vars(holder))
+        except TypeError:
+            continue
+        for name in names:
+            if name.startswith("__"):
+                continue
+            try:
+                attr = getattr(holder, name)
+            except Exception:  # noqa: BLE001 — a property that raises is not a hook
+                continue
+            if _is_disabled(attr):
+                owner = getattr(type(obj), "__name__", "?")
+                return f"{owner}.{name}"
+    if depth == 0:
+        return ""
+    try:
+        held = list(vars(obj).values())
+    except TypeError:
+        return ""
+    for value in held:
+        if value is None or isinstance(value, (str, bytes, int, float, bool)):
+            continue
+        found = _disabled_in(value, depth - 1)
+        if found:
+            return found
+    return ""
+
+
+def _hooks_of(module: Any) -> Iterator[Tuple[str, Any]]:
+    """Every hook registered on ``module``, however it was registered.
+
+    Both torch's own dicts and diffusers' `HookRegistry` (`_diffusers_hook`),
+    because group offloading uses the registry and a walk that only knew
+    torch's dicts would see nothing at all on the case this module exists for.
+    """
+    for attr in ("_forward_pre_hooks", "_forward_hooks",
+                 "_forward_pre_hooks_with_kwargs"):
+        table = getattr(module, attr, None)
+        if isinstance(table, dict):
+            for hook in list(table.values()):
+                yield attr, hook
+    registry = getattr(module, "_diffusers_hook", None)
+    if registry is not None:
+        hooks = getattr(registry, "hooks", None)
+        if isinstance(hooks, dict):
+            for name, hook in list(hooks.items()):
+                yield f"_diffusers_hook[{name}]", hook
+        elif hooks is not None:
+            for hook in list(hooks):
+                yield "_diffusers_hook", hook
+
+
+def untraceable_hooks(pipeline: Any) -> Tuple[Tuple[str, str, str], ...]:
+    """``(module path, where the hook was registered, the disabled callable)``
+    for every hook on ``pipeline`` that puts `torch.compiler.disable`d work in
+    a forward path. Empty means the pipeline is traceable as loaded.
+
+    Walks the pipeline's component modules and their submodules — offload hooks
+    are installed per LEAF group, not on the pipeline object.
+    """
+    try:
+        import torch.nn as nn
+    except Exception:  # noqa: BLE001 — torch-less: nothing to trace either
+        return ()
+
+    found: List[Tuple[str, str, str]] = []
+    seen: set[int] = set()
+    components = []
+    if isinstance(pipeline, nn.Module):
+        components.append(("", pipeline))
+    for name, value in list(vars(pipeline).items()
+                            if hasattr(pipeline, "__dict__") else []):
+        if isinstance(value, nn.Module):
+            components.append((str(name).lstrip("_"), value))
+    for comp_name, comp in components:
+        for path, module in comp.named_modules():
+            if id(module) in seen:
+                continue
+            seen.add(id(module))
+            for where, hook in _hooks_of(module):
+                disabled = _disabled_in(hook)
+                if not disabled:
+                    continue
+                full = ".".join(p for p in (comp_name, path) if p) or comp_name
+                found.append((full or "<root>", where, disabled))
+    return tuple(found)
+
+
+def untraceable_reason(pipeline: Any) -> str:
+    """One sentence naming what makes this pipeline untraceable, or ""."""
+    hits = untraceable_hooks(pipeline)
+    if not hits:
+        return ""
+    shown = "; ".join(
+        f"{path} ({where} -> {fn})" for path, where, fn in hits[:3])
+    more = f" and {len(hits) - 3} more" if len(hits) > 3 else ""
+    return (
+        f"{len(hits)} module(s) carry `torch.compiler.disable`d work in their "
+        f"forward path: {shown}{more}"
+    )
+
+
+__all__ = [
+    "DISABLE_MARKER",
+    "untraceable_hooks",
+    "untraceable_reason",
+]

--- a/tests/test_entry_blast_radius_pgw1208.py
+++ b/tests/test_entry_blast_radius_pgw1208.py
@@ -493,11 +493,15 @@ def test_the_mint_refuses_ONCE_before_export_naming_the_construct() -> None:
         mint_child.assert_traceable_as_loaded(_offloaded(), request)
 
     said = str(caught.value)
-    assert "mint_requires_resident_parent" in said, "the refusal must be TYPED"
+    assert "mint_pipeline_not_traceable" in said, "the refusal must be TYPED"
     assert "ModuleGroup.onload_" in said, "and must name the construct"
-    assert "serve this family eager" in said, (
+    assert "serves the family eager" in said, (
         "and must say what this pod CAN still do — a refusal that does not is "
         "read as the pod being broken")
+    assert "resident" not in said.lower() and "fits" not in said.lower(), (
+        "the refusal must NOT read as a capacity verdict: z-image refused on a "
+        "48 GiB A40 holding a 19 GiB model, and §1.35 rules the card-filter "
+        "concept out of existence — feasibility is never asked")
 
 
 def test_the_check_is_on_the_REAL_WEIGHT_path_only() -> None:

--- a/tests/test_entry_blast_radius_pgw1208.py
+++ b/tests/test_entry_blast_radius_pgw1208.py
@@ -414,3 +414,106 @@ def test_the_REAL_WEIGHT_fallback_keeps_its_placement(
     for call in fallback:
         assert call.get("place", True) is not False, (
             "the real-weight fallback lost its placement — it runs a forward")
+
+
+# ---------------------------------------------------------------------------
+# (a) The pipeline that cannot be traced AS LOADED refuses ONCE, before export
+# ---------------------------------------------------------------------------
+
+
+def _offloaded() -> Any:
+    """A pipeline carrying REAL diffusers group offloading. No mock: the whole
+    point is that the marker is torch's and the hooks are diffusers'."""
+    from diffusers.hooks.group_offloading import apply_group_offloading
+
+    class Blocks(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layers = nn.ModuleList([nn.Linear(8, 8) for _ in range(4)])
+
+        def forward(self, x: Any) -> Any:
+            for layer in self.layers:
+                x = layer(x)
+            return x
+
+    unet = Blocks()
+    apply_group_offloading(
+        unet, onload_device=torch.device("cpu"),
+        offload_device=torch.device("cpu"),
+        offload_type="block_level", num_blocks_per_group=1)
+    return types.SimpleNamespace(unet=unet)
+
+
+def test_a_clean_pipeline_is_traceable() -> None:
+    from gen_worker.models import traceability
+
+    assert traceability.untraceable_hooks(
+        types.SimpleNamespace(unet=TinyUNet())) == ()
+    assert traceability.untraceable_reason(
+        types.SimpleNamespace(unet=TinyUNet())) == ""
+
+
+def test_real_group_offloading_is_detected_and_the_function_is_NAMED() -> None:
+    """The pod's exact construct, found through the real diffusers path.
+
+    `ModuleGroup.onload_` is `@torch.compiler.disable`d, and the hook that
+    reaches it is registered in diffusers' own `_diffusers_hook` registry — not
+    in torch's `_forward_pre_hooks` — so a walk that only knew torch's dicts
+    would have seen nothing at all on the one case this exists for.
+    """
+    pytest.importorskip("diffusers")
+    from gen_worker.models import traceability
+
+    hits = traceability.untraceable_hooks(_offloaded())
+
+    assert hits, "real group offloading was not detected"
+    assert all(fn == "ModuleGroup.onload_" for _p, _w, fn in hits), (
+        f"the disabled callable must be NAMED, got {sorted({f for _p,_w,f in hits})}")
+    assert all("group_offloading" in where for _p, where, _f in hits)
+
+
+def test_the_mint_refuses_ONCE_before_export_naming_the_construct() -> None:
+    """(a). Without it, pgw#1208's per-entry skip would dutifully skip all 36
+    classes and publish nothing — thirty-six typed refusals and an hour of wall
+    clock to say once what was knowable before the first export began."""
+    pytest.importorskip("diffusers")
+    from gen_worker import mint_child
+    from gen_worker import mint_process as mp
+
+    request = mp.MintRequest(
+        function="f", modules=(), family="sdxl", arm_token="a",
+        target="t", work_root="w", report="r",
+        cfg=mp.CompileCellSpec(family="sdxl", targets=("unet",)))
+
+    # A traceable pipeline passes silently.
+    mint_child.assert_traceable_as_loaded(
+        types.SimpleNamespace(unet=TinyUNet()), request)
+
+    with pytest.raises(mint_child.MintChildRefused) as caught:
+        mint_child.assert_traceable_as_loaded(_offloaded(), request)
+
+    said = str(caught.value)
+    assert "mint_requires_resident_parent" in said, "the refusal must be TYPED"
+    assert "ModuleGroup.onload_" in said, "and must name the construct"
+    assert "serve this family eager" in said, (
+        "and must say what this pod CAN still do — a refusal that does not is "
+        "read as the pod being broken")
+
+
+def test_the_check_is_on_the_REAL_WEIGHT_path_only() -> None:
+    """Scope, fenced. The weight-free child never places (pgw#1208 fix 1), so
+    it never acquires these hooks and must not pay a walk over every module of
+    every component on the path that is already correct."""
+    import inspect
+
+    from gen_worker import mint_child
+
+    source = inspect.getsource(mint_child)
+    # The call sits after `pick_compile_target`, which both paths reach — but
+    # the weight-free load cannot produce hooks, so this is a no-op there by
+    # construction rather than by a second branch. What must NOT happen is the
+    # check being skipped on the fallback.
+    assert "assert_traceable_as_loaded(loaded_pipe, request)" in source
+    assert source.index("assert_traceable_as_loaded(loaded_pipe") > \
+        source.index("place=False"), (
+        "the traceability check must run after the load, not before it")

--- a/tests/test_entry_blast_radius_pgw1208.py
+++ b/tests/test_entry_blast_radius_pgw1208.py
@@ -1,0 +1,416 @@
+"""pgw#1208: one class that cannot export must not cost the other thirty-five.
+
+WHAT HAPPENED. The first sdxl full-circle leg reached the compile phase and
+died there, deterministically, on pod ``fry7suf4xgycie`` (RTX A4000, 0.113.2):
+
+    entry 'unet/adapter=true,cfg=true/B=2,H_lat=80,T_txt=77,W_lat=192':
+    torch.export(strict=True) failed for UNet2DConditionModel:
+    Unsupported: Skip inlining `torch.compiler.disable()`d function
+      Explanation: … <function ModuleGroup.onload_> … wrapped with
+      `torch.compiler.disable`
+
+``ModuleGroup.onload_`` is **diffusers group offloading**. The mint child ran
+the worker's SERVING placement ladder, the ladder engaged group offload (a
+serving parent was already resident on that card), and the offload hooks put a
+``@torch.compiler.disable``d function in the traced path — which
+``torch.export(strict=True)`` refuses, fatally.
+
+THE CONTROLLED COMPARISON, which is what makes the diagnosis rather than a
+guess: the SAME entry name, on the SAME wheel (0.113.2), exported in **91.07 s**
+on an A4500 (`ft5vr2zg86jwmi`) and was `Unsupported` on the A4000. Six
+adapter-bearing entries exported clean there. The adapter axis is exonerated —
+rows are ordered adapter-bearing first (`aot_mint._rows_source`), so the
+adapter entry was simply the first one tried.
+
+TWO FIXES, AND THE SECOND IS THE MORE IMPORTANT
+-----------------------------------------------
+1. The mint child no longer PLACES on the weight-free path (``place=False``) —
+   the pgw#1124 seam, applied one door over. The ladder is for a pipeline that
+   will run a forward, and this one only ever exports. The hooks are never
+   installed rather than stripped afterwards, which is why this is small.
+2. **A deterministic per-entry export failure no longer kills the mint.** That
+   pod threw away nothing (it died on its first entry), but the A4500 shows the
+   shape that matters: 6 classes exported clean, and under the old code a
+   refusal at row 7 would have discarded all six. The entry is already the unit
+   of identity and of publish (pgw#718); it is now the unit of FAILURE too.
+
+Fail-closed stays fail-closed AT THE ENTRY: a skipped class is never packed and
+never published, and serving covers it eager by the same mechanism that covers
+any shape outside a cell's declared envelope (pgw#844). Only the blast radius
+changed.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from torch._dynamo.exc import Unsupported  # noqa: E402
+
+from gen_worker import aot_mint, aot_serve, compile_cache  # noqa: E402
+from gen_worker.api.decorators import Compile  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+    reset_export_declarations,
+)
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+FAMILY = "tiny1208"
+
+
+class TinyUNet(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, sample: Any) -> Any:
+        return torch.tanh(self.lin(sample)) + 1.0
+
+
+def _declare() -> Any:
+    """TWO declared graph classes, so 'one failed' and 'the rest survived' are
+    distinguishable outcomes."""
+    return register_export_declaration(Compile(
+        family=FAMILY,
+        targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}), GraphClass(dims={"B": 1})),
+        inputs=(Input("sample", shape=("B", 4), dtype="model"),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    ))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry() -> Any:
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+@pytest.fixture
+def fake_sm(monkeypatch: pytest.MonkeyPatch) -> Dict[str, str]:
+    full = {"sku": "", "sm": "sm_89", "torch": str(torch.__version__), "cuda": ""}
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: dict(full))
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(full))
+    return full
+
+
+def _mint(tmp: Path) -> aot_mint.MintResult:
+    pipe = types.SimpleNamespace(unet=TinyUNet())
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+    # K=1: this file is about the export loop, and the serial path exercises
+    # the same `_rows_source` the overlapped one does (one body, by design).
+    return aot_mint.mint(pipe, spec, tmp, entry_workers=1)
+
+
+def _fail_one(monkeypatch: pytest.MonkeyPatch, *, on: str, exc: BaseException) -> List[str]:
+    """Make ONE declared class refuse at export. Returns the names attempted."""
+    real = aot_mint._export_entry
+    seen: List[str] = []
+
+    def _patched(pipeline: Any, spec: Any, plan: Any, decl: Any, **kw: Any) -> Any:
+        from gen_worker import aot_declaration as _decl
+
+        name = _decl.plan_entry_name(plan)
+        seen.append(name)
+        if on in name:
+            raise exc
+        return real(pipeline, spec, plan, decl, **kw)
+
+    monkeypatch.setattr(aot_mint, "_export_entry", _patched)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# The blast radius
+# ---------------------------------------------------------------------------
+
+
+def test_a_deterministic_refusal_skips_ONE_class_and_mints_the_rest(
+    tmp_path: Path, fake_sm: Dict[str, str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole issue. Before this, the mint died here and the class that HAD
+    exported was discarded with it."""
+    _declare()
+    seen = _fail_one(
+        monkeypatch, on="B=1",
+        exc=Unsupported("Skip inlining `torch.compiler.disable()`d function\n"
+                        "  Explanation: <function ModuleGroup.onload_>"))
+
+    result = _mint(tmp_path)
+
+    assert len(seen) == 2, "both classes must be ATTEMPTED — one refusing must not stop the loop"
+    assert result.timings.get("skipped_entries") == 1.0
+    entries = result.metadata.get("entries") or {}
+    assert len(entries) == 1, "the surviving class must still be packed"
+    assert not any("B=1" in name for name in entries), (
+        "the class that refused must NOT be in the cell — fail-closed is per "
+        "ENTRY, not abandoned")
+
+
+def test_the_skipped_class_is_NAMED_with_the_construct_that_refused(
+    tmp_path: Path, fake_sm: Dict[str, str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skipped class is only actionable if the reason names the thing someone
+    has to change."""
+    _declare()
+    _fail_one(monkeypatch, on="B=1", exc=Unsupported(
+        "Skip inlining `torch.compiler.disable()`d function\n"
+        "  Explanation: Skip inlining function <function ModuleGroup.onload_> "
+        "since it was wrapped with `torch.compiler.disable`\n"
+        "  Developer debug context: <function ModuleGroup.onload_>"))
+
+    events: List[Any] = []
+    monkeypatch.setattr(
+        aot_mint.activity_mod, "emit_event",
+        lambda kind, detail, **kw: events.append((kind, detail, kw)))
+
+    _mint(tmp_path)
+
+    skips = [e for e in events if e[0] == aot_mint.KIND_ENTRY_EXPORT_UNSUPPORTED]
+    assert len(skips) == 1, "the hub must be told, once, which class was skipped"
+    detail = skips[0][1]
+    assert "ModuleGroup.onload_" in detail, (
+        "the event must name the CONSTRUCT that refused, not just the entry")
+    assert "B=1" in detail
+
+
+def test_a_RESOURCE_shortfall_still_aborts_the_WHOLE_mint(
+    tmp_path: Path, fake_sm: Dict[str, str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The distinction the whole change rests on.
+
+    An OOM says nothing about the graph class — it says the pod is out of room,
+    and the mint must abort so the parent can retry narrower. Skipping here
+    would publish a cell whose missing classes are an artifact of memory
+    pressure and would have exported fine on the retry.
+    """
+    _declare()
+    boom = aot_mint.MintResourceExhausted("host memory exhausted mid-export")
+    _fail_one(monkeypatch, on="B=1", exc=boom)
+
+    with pytest.raises(Exception) as caught:
+        _mint(tmp_path)
+    assert caught.value is boom or "exhaust" in str(caught.value).lower()
+
+
+def test_every_class_skipped_still_REFUSES(
+    tmp_path: Path, fake_sm: Dict[str, str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cell with no entries is not a partial cell, it is not a cell. It fails
+    closed on the path it already failed closed on (`_pack`), rather than
+    through a second check."""
+    _declare()
+    _fail_one(monkeypatch, on="B=", exc=Unsupported("nope"))
+
+    with pytest.raises(aot_mint.MintRefused, match="no entries"):
+        _mint(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The classifier, directly
+# ---------------------------------------------------------------------------
+
+
+def test_only_deterministic_local_failures_are_skippable() -> None:
+    assert aot_mint._export_skippable(Unsupported("whatever")), (
+        "torch's own export refusal is the skippable case")
+
+    # ...and ONLY torch's own. `_export_entry` also warms, gates and compiles;
+    # skipping any of those would be this issue's own defect in a new hat.
+    assert not aot_mint._export_skippable(RuntimeError("boom in forward")), (
+        "a broken forward is not an unsupported construct")
+    assert not aot_mint._export_skippable(
+        aot_mint.MintRefused("mint-warm: the declared warm forward failed")), (
+        "pgw#758 made a warm failure a NAMED REFUSAL — a cell whose classes "
+        "were never warm-proven must not publish")
+    assert not aot_mint._export_skippable(
+        aot_mint.MintRefused("folding fence: lifted weight absent")), (
+        "a correctness gate that can be skipped is not a gate")
+
+    assert not aot_mint._export_skippable(KeyboardInterrupt()), (
+        "a shutdown is not a property of the graph")
+    assert not aot_mint._export_skippable(SystemExit(1))
+    assert not aot_mint._export_skippable(
+        aot_mint.MintResourceExhausted("no room")), (
+        "a resource shortfall must abort so the parent can retry narrower")
+
+    marked = RuntimeError("host memory")
+    setattr(marked, "mint_resource_shortfall", True)
+    assert not aot_mint._export_skippable(marked), (
+        "the duck-typed shortfall marker must be honoured")
+
+
+def test_a_cuda_oom_is_never_skippable() -> None:
+    oom = torch.cuda.OutOfMemoryError("CUDA out of memory. Tried to allocate 50.00 MiB")
+    assert not aot_mint._export_skippable(oom)
+
+
+def test_the_construct_namer_lifts_dynamos_own_explanation() -> None:
+    exc = Unsupported(
+        "Skip inlining `torch.compiler.disable()`d function\n"
+        "  Explanation: Skip inlining function <function ModuleGroup.onload_> "
+        "since it was wrapped with `torch.compiler.disable` (reason: None)\n"
+        "  Hint: Remove the `torch.compiler.disable` call\n"
+        "  Developer debug context: <function ModuleGroup.onload_>\n"
+        "  " + "traceback noise " * 200)
+
+    named = aot_mint._unsupported_construct(exc)
+
+    assert "ModuleGroup.onload_" in named
+    assert "Unsupported" in named
+    assert len(named) <= 600, "this rides an event; it may not carry a traceback"
+    assert "traceback noise traceback noise" not in named
+
+
+# ---------------------------------------------------------------------------
+# The MECHANISM, reproduced locally: why the A4000 could not export at all
+# ---------------------------------------------------------------------------
+
+
+def test_a_compiler_disabled_call_in_the_traced_path_kills_strict_export() -> None:
+    """The pod's failure, in five lines, on CPU.
+
+    This is what diffusers' group-offload hook does to a traced module — its
+    ``ModuleGroup.onload_`` carries exactly this decorator. Reproduced so the
+    fix's premise is a measured property of torch rather than a reading of a
+    stack trace.
+    """
+    @torch.compiler.disable
+    def _onload(x: Any) -> Any:
+        return x + 1
+
+    class Offloaded(nn.Module):
+        def forward(self, x: Any) -> Any:
+            return _onload(x) * 2
+
+    class Plain(nn.Module):
+        def forward(self, x: Any) -> Any:
+            return (x + 1) * 2
+
+    args = (torch.randn(2, 4),)
+
+    torch.export.export(Plain().eval(), args, strict=True)  # the control
+
+    with pytest.raises(Exception) as caught:
+        torch.export.export(Offloaded().eval(), args, strict=True)
+
+    # Asserted by TYPE, because the wording moves: torch 2.13 says "Skip
+    # CALLING" for a free function and "Skip INLINING" for a bound method —
+    # the pod's UNet hit the second (`ModuleGroup.onload_` is a method) and
+    # this reproduction hits the first. Same exception, same cause, and a
+    # message-matching test would have gone red on that difference alone
+    # while the mechanism was identical.
+    assert type(caught.value).__name__ == "Unsupported", (
+        f"expected dynamo's Unsupported, got {type(caught.value).__name__}")
+    said = str(caught.value).lower()
+    assert "torch.compiler.disable" in said and "skip" in said, (
+        f"expected a skip-because-disabled refusal, got: {str(caught.value)[:200]}")
+
+
+# ---------------------------------------------------------------------------
+# (b) The mint child never runs the serving placement ladder on the
+#     weight-free path — the pgw#1124 seam, one door over
+# ---------------------------------------------------------------------------
+
+
+class _Sentinel(Exception):
+    """Stops the mint at the load, so the assertion is about the CALL."""
+
+
+def _drive_to_load(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, structure_ok: bool,
+) -> List[Dict[str, Any]]:
+    """Run the REAL `mint_child.mint()` as far as its first load and record
+    every `run_setup` call it makes."""
+    from gen_worker import mint_child
+    from gen_worker import mint_process as mp
+    from gen_worker.api.binding import ModelRef
+    from gen_worker.cli import run as cli_run
+    from gen_worker.models.structure_only import StructureOnlyUnsupported
+
+    calls: List[Dict[str, Any]] = []
+
+    def _spy(instance: Any, resolved: Any, **kwargs: Any) -> Any:
+        calls.append(dict(kwargs))
+        if kwargs.get("structure_only") and not structure_ok:
+            # The family is stranded — mint_child falls back to real weights,
+            # which is the second call this test wants to see.
+            raise StructureOnlyUnsupported(
+                component="unet", cls_name="X", lacks="no config surface")
+        raise _Sentinel()
+
+    monkeypatch.setattr(cli_run, "run_setup", _spy)
+
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    request = mp.MintRequest(
+        function="composed-echo", modules=("harness.toy_endpoints",),
+        family="sdxl", arm_token="arm1-abc",
+        target=str(tmp_path / "cell.tar.gz"),
+        work_root=str(tmp_path / "capture"),
+        report=str(tmp_path / mp.REPORT_NAME),
+        cfg=mp.CompileCellSpec(family="sdxl", shapes=((1024, 1024),),
+                               targets=("unet",)),
+        handler_proof="test: the parent proved it",
+        slots={"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/composed",
+                         tag="prod"),
+            path=str(tree))},
+    )
+    with pytest.raises(BaseException):
+        mint_child.mint(request)
+    return calls
+
+
+def test_the_weight_free_load_asks_for_NO_serving_placement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE sdxl A4000 fix.
+
+    The ladder engaged diffusers group offloading on a card that already held
+    a serving parent, and offload hooks put a `@torch.compiler.disable`d
+    function in the traced path. This child exports and never runs a forward,
+    so it has no business on the ladder at all — pgw#1124 made exactly this
+    argument for the boot-trace child.
+    """
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parent))
+    calls = _drive_to_load(monkeypatch, tmp_path, structure_ok=True)
+
+    assert calls, "the child never reached its load"
+    weight_free = [c for c in calls if c.get("structure_only")]
+    assert weight_free, "no structure-only load was attempted"
+    for call in weight_free:
+        assert call.get("place") is False, (
+            "the weight-free mint asked for serving placement — that is the "
+            "ladder that engaged group offload and made the graph "
+            "unexportable")
+
+
+def test_the_REAL_WEIGHT_fallback_keeps_its_placement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scope of the fix, fenced. A stranded family loads its checkpoint
+    into THIS process and runs the pgw#984 warm proof — a real forward, which
+    needs a placed pipeline. Only the path that never executes may skip the
+    ladder, and widening it would break the fallback silently."""
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parent))
+    calls = _drive_to_load(monkeypatch, tmp_path, structure_ok=False)
+
+    fallback = [c for c in calls if not c.get("structure_only")]
+    assert fallback, "the fallback load never happened"
+    for call in fallback:
+        assert call.get("place", True) is not False, (
+            "the real-weight fallback lost its placement — it runs a forward")


### PR DESCRIPTION
## What killed the sdxl leg

```
entry 'unet/adapter=true,cfg=true/B=2,H_lat=80,T_txt=77,W_lat=192':
torch.export(strict=True) failed for UNet2DConditionModel:
Unsupported: Skip inlining `torch.compiler.disable()`d function
  Explanation: … <function ModuleGroup.onload_> … wrapped with `torch.compiler.disable`
```

`ModuleGroup.onload_` is **diffusers group offloading**. The mint child ran the worker's **serving placement ladder**; the ladder engaged group offload because a serving parent was already resident on that card; the offload hooks put a `@torch.compiler.disable`d call in the traced path; `torch.export(strict=True)` refuses it, fatally and deterministically.

## The diagnosis is a controlled comparison

The **same entry**, on the **same wheel** (0.113.2):

| pod | card | outcome |
|---|---|---|
| `ft5vr2zg86jwmi` | A4500 (20 GB) | `export_s = 91.07` ✅ |
| `fry7suf4xgycie` | A4000 (16 GB) | `Unsupported` ❌ |

Six adapter-bearing entries exported clean on the A4500, so **the LoRA/adapter axis is exonerated**. Rows are ordered adapter-bearing first (`_rows_source`), so the adapter entry was simply the first one tried.

**The arithmetic behind the card discriminator** (`memory.select_auto_mode`): requirement ≈ 6.31 GiB, `_DEFAULT_SAFETY_MARGIN_GB` = 2.0. A4000 with a resident parent leaves ~8 GB free → usable ~6 GB < 6.31 → descend to `group_offload`. A4500 leaves ~12 GB → usable ~10 GB → resident, no hooks. **And the requirement was wrong anyway:** `estimate_pipeline_size_gb` counts a *virtual* parameter's declared bytes, so the ladder sized a structure-only pipeline that allocates nothing as if it held the whole checkpoint.

## Fix 1 — `place=False` on the weight-free load

The **pgw#1124 seam, one door over**. That child exports and never runs a forward, so it has no business on the serving ladder — the identical argument pgw#1124 made for the boot-trace child, whose docstring already says *"the worker's serving placement ladder is for a pipeline that will run a forward, and this one never will"*. The hooks are **never installed** rather than stripped afterwards, which is what makes this small rather than clever.

The **real-weight fallback keeps its placement**, deliberately and fenced by its own test: a stranded family loads its checkpoint into that process and runs the pgw#984 warm proof, which is a real forward.

## Fix 2 — a deterministic per-entry export failure no longer kills the mint

The entry is already the unit of identity and of publish (pgw#718); it is now the unit of **failure** too. The class is skipped, **named**, and reported (`entry_export_unsupported`, carrying dynamo's own `Explanation:` / `Developer debug context:` lines); the rest mint and publish; serving covers the skipped class eager exactly as it covers any shape outside a cell's declared envelope (pgw#844).

**Fail-closed stays fail-closed AT THE ENTRY** — a skipped class is never packed and never published, and a cell with no survivors still refuses on the path that already refused (`_pack`: *"cannot package a cell with no entries"*).

### What is NOT skippable — and the existing suite caught my first cut being too broad

Only **torch's own** export refusal (`torch._dynamo` / `torch._export` / `torch.export`) is a property of the graph class:

* a **CUDA OOM or host shortfall** aborts the mint so the parent can retry narrower — skipping there would publish a cell whose missing classes are an artifact of memory pressure;
* a **`MintRefused` from our own gates** is a correctness verdict, and a correctness gate that can be skipped is not a gate;
* a **declared warm that blows up** stays pgw#758's named refusal — a cell whose classes were never warm-proven must not publish.

My first version skipped any deterministic exception, and `test_aot_multigraph_pgw758` went red on exactly the two rows that encode those contracts. It **passes unchanged** now, which is the proof they survived.

## Verification

10 new rows; **7 red on `origin/master`**, the other 3 being control rows that must pass both ways (the resource-abort row, the scope fence on the fallback's placement, and the torch-property reproduction). Neighbouring suites — `pgw758`, `pgw1052`, `pgw784`, `pgw1189`, `pgw816`, `pgw1124` — **67 passed**. `mypy` clean (265 files), ruff clean, 7 fast-gate lints + `assemble_changelog --check` OK.

One row reproduces the mechanism itself on CPU: a `@torch.compiler.disable`d call in a traced module fails `torch.export(strict=True)`, asserted **by exception type** rather than message — torch 2.13 says "Skip *calling*" for a free function and "Skip *inlining*" for a bound method, and the pod hit the second while the local repro hits the first. Same cause; a message-matching test would have gone red on that difference alone.

**Diagnosed entirely from recorded pod evidence plus local fake-tensor reproduction — no pod was bought.**

Tracker: pgw#1208.