### PR TITLE
pgw#1202: the slot types propagate D instead of erasing it

### DIFF
--- a/changelog.d/pgw1202.md
+++ b/changelog.d/pgw1202.md
@@ -46,3 +46,13 @@
   `tests/test_device_peak_bank_pgw1205.py`. They reached `master` because CI
   runs only on `pull_request`: pgw#1205 and pgw#1202 PR 3 were each green
   against a base that lacked the other, and nothing re-checked the merge.
+- Typing: `Slot[Any]`/`RequestContext[Any]` audited one signature at a time
+  against a single rule — **a type variable that appears exactly once in a
+  signature is identical to `Any`**, so it is worth writing only where `D`
+  binds two or more positions. 11 sites converted, 14 kept with a stated
+  reason. The one that matters: `resolve_slot` took `Slot[D]` *and*
+  `Type[D]` and returned `ResolvedSlot[Any]`, throwing the type away at the
+  point it was known; it now returns `ResolvedSlot[D]`, so an endpoint author
+  reading `ctx.slots[...].defaults` gets their own defaults class instead of
+  `Any`. Verified by A/B: with the TypeVar a wrong annotation is an error;
+  with `Any` the same code reports `Success`.

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -49,13 +49,13 @@ from .export_contract import (
     validate_contract, validate_speed_bar,
 )
 from .formula import RuntimeFormula
-from .slot import OBJECTIVES, TASKS, Slot
+from .slot import OBJECTIVES, TASKS, D, Slot
 from ..models import execution_lanes as lanespec
 from ..runtimes.server import ServerHandle
 from .tree import is_introspectable
 
 T = TypeVar("T")
-SlotLike = Union[Binding, "Slot[Any]"]
+SlotLike = Union[Binding, "Slot[D]"]
 
 KINDS = ("inference", "training", "dataset", "conversion", "eval")
 
@@ -1350,7 +1350,9 @@ def _reject_producer_generator(owner: str, fn: Callable[..., Any], kind: str) ->
         )
 
 
-def _split_slot_like(key: str, v: "SlotLike") -> Tuple[Optional[Binding], Optional[Slot[Any]]]:
+def _split_slot_like(
+    key: str, v: "SlotLike[D]",
+) -> Tuple[Optional[Binding], Optional[Slot[D]]]:
     """One ``models={}``/``model=`` value -> ``(binding_or_None, slot_or_None)``.
 
     A ``Slot`` contributes its ``default_checkpoint`` (if any) to the plain
@@ -1369,8 +1371,8 @@ def _split_slot_like(key: str, v: "SlotLike") -> Tuple[Optional[Binding], Option
 
 
 def _normalize_models(
-    model: Optional["SlotLike"], models: Optional[Mapping[str, "SlotLike"]]
-) -> Tuple[Dict[str, Binding], Dict[str, Slot[Any]]]:
+    model: Optional["SlotLike[D]"], models: Optional[Mapping[str, "SlotLike[D]"]]
+) -> Tuple[Dict[str, Binding], Dict[str, Slot[D]]]:
     if model is not None and models is not None:
         raise ValueError("@endpoint: pass model= OR models=, not both")
     if model is not None:
@@ -1378,7 +1380,7 @@ def _normalize_models(
         # setup()/handler parameter name at class validation time.
         binding, slot = _split_slot_like("", model)
         out_models: Dict[str, Binding] = {"": binding} if binding is not None else {}
-        out_slots: Dict[str, Slot[Any]] = {"": slot} if slot is not None else {}
+        out_slots: Dict[str, Slot[D]] = {"": slot} if slot is not None else {}
         return out_models, out_slots
     out_models = {}
     out_slots = {}
@@ -1436,9 +1438,9 @@ def _is_server_handle_param(p: inspect.Parameter) -> bool:
 def _resolve_single_slot(
     cls: type,
     models: Dict[str, Binding],
-    slots: Dict[str, Slot[Any]],
+    slots: Dict[str, Slot[D]],
     handlers: list[tuple[str, Callable[..., Any]]],
-) -> Tuple[Dict[str, Binding], Dict[str, Slot[Any]]]:
+) -> Tuple[Dict[str, Binding], Dict[str, Slot[D]]]:
     """Resolve the ``model=`` shorthand's slot name from setup()/handler
     params. Exactly one of ``models``/``slots`` holds the ``""`` key (a bare
     binding or a Slot, never both — ``_normalize_models`` is the only
@@ -1789,8 +1791,8 @@ def endpoint(target: T) -> T: ...  # bare @endpoint on a class/function
 def endpoint(
     *,
     kind: str = ...,
-    model: Optional[SlotLike] = ...,
-    models: Optional[Mapping[str, SlotLike]] = ...,
+    model: Optional["SlotLike[Any]"] = ...,
+    models: Optional[Mapping[str, "SlotLike[Any]"]] = ...,
     resources: Optional[Resources] = ...,
     runtime: Union[str, RuntimeFormula, Mapping[str, RuntimeFormula], None] = ...,
     name: Optional[str] = ...,
@@ -1809,8 +1811,8 @@ def endpoint(
     target: Optional[T] = None,
     *,
     kind: str = "inference",
-    model: Optional[SlotLike] = None,
-    models: Optional[Mapping[str, SlotLike]] = None,
+    model: Optional["SlotLike[Any]"] = None,
+    models: Optional[Mapping[str, "SlotLike[Any]"]] = None,
     resources: Optional[Resources] = None,
     runtime: Union[str, RuntimeFormula, Mapping[str, RuntimeFormula], None] = None,
     name: Optional[str] = None,

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -307,6 +307,14 @@ def _apply_lora_overrides(
 def _finish_resolved(
     name: str,
     ref: ModelRef,
+    # pgw#1202: NOT `D`, and not `Optional[D]` either. `ResolvedSlot.__init__`
+    # declares `defaults: D` (bound to GenerationDefaults) but `resolve_slot`
+    # passes None on the no-schema path below, and nothing in the tree guards
+    # `.defaults is None`. So the declared type already disagrees with runtime;
+    # this helper cannot honestly promise `ResolvedSlot[D]` until that is
+    # settled, and settling it is an API decision about what an endpoint author
+    # is handed, not a typing sweep. The PUBLIC `resolve_slot` below is still
+    # `-> ResolvedSlot[D]`, which is where the propagation is worth having.
     defaults: Any,
     *,
     objective: str,
@@ -375,7 +383,7 @@ def resolve_slot(
     distilled_status: str = "",
     allowed_objectives: Optional[Sequence[str]] = None,
     allowed_distilled: Optional[bool] = None,
-) -> "ResolvedSlot[Any]":
+) -> "ResolvedSlot[D]":
     """SDK v2 resolution chain: decode the catalog-resolved recipe
     (``raw_metadata_json``) against the handler's DERIVED config schema
     (``defaults_cls``, from ``ctx: RequestContext[D]``), then apply per-lora

--- a/src/gen_worker/testing/__init__.py
+++ b/src/gen_worker/testing/__init__.py
@@ -78,7 +78,7 @@ C = TypeVar("C", bound="RequestContext[Any]")
 
 def stub_slots(
     slots: Mapping[str, Tuple[ModelRef, GenerationDefaults]],
-) -> Dict[str, "ResolvedSlot[Any]"]:
+) -> Dict[str, "ResolvedSlot[GenerationDefaults]"]:
     """``{slot_name: (ref, defaults)}`` -> ``{slot_name: ResolvedSlot}`` —
     the same shape ``ctx.slots`` hands a handler in production, built
     directly instead of via the repo-metadata resolution chain."""


### PR DESCRIPTION
**Defect class this makes impossible:** an endpoint author's own defaults class being silently widened to `Any` as it passes through the SDK. `resolve_slot` took `Slot[D]` **and** `Type[D]` and returned `ResolvedSlot[Any]` — the type was known at the door and thrown away on the way out, so `ctx.slots[...].defaults` came back untyped and every downstream mistake on it was unreportable.

## The rule the audit ran on

**A type variable that appears exactly once in a signature is identical to `Any`.** It binds nothing, constrains nothing, and only reads as rigour. So a TypeVar is worth writing exactly where `D` binds two or more positions. That rule is what makes each remaining `Any` a decision rather than a shrug.

## Two-number report: converted 11 / kept-with-reason 14

**Converted (11):** `resolve_slot` → `ResolvedSlot[D]`; `SlotLike` became a generic alias; `_split_slot_like`, `_normalize_models` and `_resolve_single_slot` carry `D` from parameter to return; `stub_slots` returns `ResolvedSlot[GenerationDefaults]` — concrete rather than a TypeVar, because its input defaults type is concrete.

**Kept, each with a stated reason (14):**
- `endpoint()` overload + implementation take `SlotLike[Any]`: **D never reaches their return** — they return the decorated object, so a TypeVar there would appear once and *be* `Any`.
- Same for the four `-> None` validators, the two builders returning `type` / `Callable`, and `diffusers_step_callback`.
- `Compile.slots` stays `Mapping[str, Slot[Any]]`: **`D` is phantom on `Slot`** — it appears in the class header and in no attribute — so making the Struct generic would propagate nothing.
- `C = TypeVar("C", bound=RequestContext[Any])` is the ordinary spelling of "any `RequestContext`"; the bound is where the constraint lives.

## One site isolated — a finding, not a judgement call

`_finish_resolved` **cannot honestly promise** `ResolvedSlot[D]`: `ResolvedSlot.__init__` declares `defaults: D` (bound to `GenerationDefaults`) while `resolve_slot` passes `None` on the no-schema path — and **nothing in the tree guards `.defaults is None`**. The declared type already disagrees with runtime, which is exactly the defect class this mandate exists to remove, but settling it is an API decision about what an author is handed, not a typing sweep. Recorded in a comment at the site and in the tracker.

## Red-proof by A/B, varying exactly one line

A handler that assigns `got.defaults` to an `int`:

| annotation | mypy |
|---|---|
| `-> ResolvedSlot[D]` (this PR) | `Incompatible types in assignment (expression has type "MyDefaults", variable has type "int")` |
| `-> ResolvedSlot[Any]` (restored, nothing else changed) | **`Success: no issues found`** |

The `Any` swallowed it in silence. That pair is the whole argument for preferring a TypeVar to erasure.

`# type: ignore` removed 0 / suppressed-with-reason 0.
