### PR TITLE
pgw#1209: the two merge-queue gotchas measured live — and the queue's landing proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,25 @@ name: CI
 #
 # The trigger is deliberately bare (no `branches:`/`paths:` filter). A filter
 # that excludes a merge group is indistinguishable from case 1.
+#
+# TWO THINGS MEASURED WHILE TURNING THIS ON, both of which cost a live queue
+# stall and neither of which is in the obvious write-ups:
+#
+#   * **GitHub reads workflows from the MERGE-GROUP ref, not from `master`.**
+#     Verified: with the queue switched on before this trigger had landed, four
+#     entries were queued and exactly ONE run existed — the group for the entry
+#     that carried this file's own edit. The three ahead of it showed
+#     `statusCheckRollup: none` and would have sat until the 60-minute timeout
+#     evicted them. So **enable the queue only AFTER the `merge_group:` trigger
+#     is already on `master`**, or the first entries queued cannot pass.
+#     (Corollary, and the reason the ordering is easy to get wrong: a PR that
+#     ADDS the trigger can validate itself in the queue, because its own group
+#     contains its own edit. That works and still leaves everyone else stuck.)
+#   * **The repo setting "Allow auto-merge" must be ON.** `gh pr merge <n>`
+#     routes a queue merge through `enablePullRequestAutoMerge`, so with it off
+#     the enqueue fails outright with
+#     `Auto merge is not allowed for this repository`. It is a repository
+#     setting, not part of the ruleset, so enabling the queue does not turn it on.
 on:
   workflow_dispatch: {}
   merge_group:


### PR DESCRIPTION
Follow-up to #746. Two operational findings from turning the queue on, both of which cost a live queue stall, and neither of which appears in the obvious write-ups. They go in `ci.yml`'s header next to the trigger they explain.

**1. GitHub resolves workflows for a `merge_group` event from the MERGE-GROUP REF, not from `master`.**
Measured directly: the queue was switched on before the `merge_group:` trigger had landed. Four entries queued, and exactly **one** run existed — the group belonging to the entry that carried the trigger's own edit. The three ahead of it reported `statusCheckRollup: none` and would have been evicted at the 60-minute `check_response_timeout_minutes`.

The rule that follows is **land the trigger first, then enable the queue.** The trap is that this is not self-correcting: the PR *adding* the trigger validates itself perfectly well, because its own merge group contains its own edit — so the enabling lane watches a green merge_group run while every other lane is silently stuck. (The three PRs involved were released unharmed by removing the rule; all four went straight back to `MERGEABLE`/`CLEAN`, none were dequeued, closed or rebased individually.)

**2. "Allow auto-merge" is a REPOSITORY setting, not a ruleset rule, and enabling a merge queue does not turn it on.**
`gh pr merge <n>` routes a queue merge through `enablePullRequestAutoMerge`, so with it off every enqueue fails outright with `Auto merge is not allowed for this repository`. Set via `gh api --method PATCH repos/cozy-creator/python-gen-worker -f allow_auto_merge=true`.

### This PR is the queue's landing proof

`master` now carries the trigger, so this PR is **enqueued rather than merged** and its merge_group run both executes and lands. A merge queue that has never merged anything is a dark feature.

Comment-only — no source, workflow-logic or packaging change.

Tracker: pgw#1209.