### PR TITLE
pgw#1210 (P1): one contract dispatch, asked by BOTH entry points

### DIFF
--- a/changelog.d/pgw1210.md
+++ b/changelog.d/pgw1210.md
@@ -1,0 +1,32 @@
+- **pgw#1210 (P1, SERVING GAP): a MODULAR pipeline component never routed through the contract
+  loader, and a produced `cozy.fp8-rowwise@1` tree killed the pod at hydration.** minimax-h3 0.4.34,
+  two releases, three pods, one signature: `ModularHydrationError … Failed to create component
+  transformer: modular_pipeline_utils.py load -> modeling_utils.py from_pretrained ->
+  config["quantization_config"] = DiffusersAutoQuantizer.merge_quantization_configs(…)`, then
+  `deterministic_fault_loop` and the pod serves nothing, forever.
+- **This is a DISPATCH UNIFICATION, not new logic — and `load_component`'s own docstring already
+  described the failure**: *"A modelopt-produced tree carries a `quantization_config` block diffusers
+  reconstructs into `NVIDIAModelOptConfig` … so a bare `from_pretrained` on the denoiser dies at
+  config reconstruction on every flavor the fleet actually serves (pgw#689 defect 1)."* The
+  NON-modular path solved this and dispatches to `load_w8a8_denoiser`; the MODULAR path hydrates
+  through `ComponentSpec.load()` → plain `from_pretrained` and never learned. One artifact shape,
+  two entry points, one of them blind.
+- **The dispatch is now a function both callers ask.** `loading.contract_loaded_component` is the
+  only place that decides: a recognised layout returns a module built by its registered loader
+  (`@implements_contract`), an unrecognised one returns `None` and the caller's generic load is
+  correct, and a layout we RECOGNISE but cannot build at component level raises
+  `ComponentExecutionLaneUnsupported` — a typed refusal naming our own code, never a silent
+  fall-through. Two dispatches that agree today are two dispatches that will disagree later, which is
+  exactly what happened here; wan-2.2's fp8 lane (ie#702) consumes the same artifact shape on the
+  non-modular path, so the filing's own requirement was that both entry points end up on one.
+- **The modular side injects through `update_components`** — the same seam a gw#479 preloaded shared
+  module already uses — so the pipeline registers a contract-loaded component exactly as it registers
+  any component it did not load itself. The class comes from `ComponentSpec.type_hint`, because a
+  modular pipeline has no `model_index.json`; that is why the two paths share the DISPATCH rather
+  than the whole of `load_component`.
+- **Two self-inflicted errors the tests caught, both worth naming.** (1) The first guard required
+  `from_pretrained` on the component class — which would have refused exactly the classes this path
+  exists to serve, since contract loaders build through `load_config` + `from_config` precisely to
+  avoid the generic loader. (2) The first assertion checked for `Fp8ScaledLinear` leaves, which
+  depends on `torch._scaled_mm` availability and would have been a CUDA test wearing a routing test's
+  name. The row now asserts **which loader ran**, so it measures the routing it claims to measure.

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1404,42 +1404,80 @@ def load_component(
         except ImportError:
             pass  # torch-less environment: loader fails on its own terms
 
-    def _covers(artifact_component: str) -> bool:
-        """The artifact's weight set IS this component: a diffusers tree
-        names it, a bare override tree (root layout) has nothing else in
-        it."""
-        return artifact_component == component or (
-            not artifact_component and src == root
-        )
-
-    w8a8_art = detect_w8a8_artifact(root)
-    if w8a8_art is not None and _covers(w8a8_art.component):
-        return load_w8a8_denoiser(
-            root, w8a8_art, compute_dtype=torch_dtype, cls=cls)
-    w4a4_art = detect_w4a4_artifact(root)
-    if w4a4_art is not None and _covers(w4a4_art.component):
-        return load_w4a4_denoiser(
-            root, w4a4_art, compute_dtype=torch_dtype, cls=cls)
-    svdq_art = detect_svdq_artifact(root)
-    if svdq_art is not None and _covers(svdq_art.component):
-        raise ComponentExecutionLaneUnsupported(
-            f"component {component!r} of {root} is an svdq-{svdq_art.precision} "
-            f"artifact ({svdq_art.file.name}): its denoiser is built by the "
-            f"svdq engine during the PIPELINE load, so there is no "
-            f"component-level production loader to borrow"
-        )
-    if component in denoiser_components() and detect_gguf_snapshot(root):
-        raise ComponentExecutionLaneUnsupported(
-            f"component {component!r} of {root} is a GGUF denoiser: it is "
-            f"dequantized by the pipeline's own gguf loader, so there is no "
-            f"component-level production loader to borrow"
-        )
+    contracted = contract_loaded_component(
+        root, component, cls=cls, compute_dtype=torch_dtype, src=src)
+    if contracted is not None:
+        return contracted
 
     kwargs: Dict[str, Any] = {}
     if torch_dtype is not None and _accepts_kwarg(
             cls.from_pretrained, "torch_dtype"):
         kwargs["torch_dtype"] = torch_dtype
     return cls.from_pretrained(str(src), **kwargs)
+
+
+def contract_loaded_component(
+    root: Path, component: str, *, cls: Any, compute_dtype: Any = None,
+    src: Optional[Path] = None,
+) -> Optional[Any]:
+    """THE contract dispatch: one component's tree -> its registered loader.
+
+    ``None`` means this tree declares no layout contract and the caller's own
+    generic load is correct. A module means the tree's layout was recognised
+    and the SDK's declaring loader built it. A raise means the layout IS
+    recognised and has no component-level loader — a typed refusal, never a
+    fall-through.
+
+    **Why this is a function and not two copies (pgw#1210).** It was inline in
+    :func:`load_component`, so the NON-modular path routed a produced
+    `cozy.fp8-rowwise@1` tree to :func:`load_w8a8_denoiser` while a diffusers
+    MODULAR pipeline hydrated the same bytes through `ComponentSpec.load()` ->
+    plain `from_pretrained` and died inside `DiffusersAutoQuantizer` on the
+    tree's own `quantization_config` — minimax-h3 0.4.34, two releases, three
+    pods, `deterministic_fault_loop`, serving nothing. The fp8 lane that
+    wan-2.2 (ie#702) binds is the same artifact shape on the other entry
+    point, so the two had to become ONE dispatch rather than two that agree
+    today.
+
+    The silent fall-through is the defect. A contract-bearing tree that is
+    loaded generically does not fail loudly — it produces a module whose
+    numerics cannot serve, or (here) an exception from three libraries away
+    that names none of this.
+    """
+    weights = Path(root)
+    where = Path(src) if src is not None else weights
+
+    def _covers(artifact_component: str) -> bool:
+        """The artifact's weight set IS this component: a diffusers tree
+        names it, a bare override tree (root layout) has nothing else in
+        it."""
+        return artifact_component == component or (
+            not artifact_component and where == weights
+        )
+
+    w8a8_art = detect_w8a8_artifact(weights)
+    if w8a8_art is not None and _covers(w8a8_art.component):
+        return load_w8a8_denoiser(
+            weights, w8a8_art, compute_dtype=compute_dtype, cls=cls)
+    w4a4_art = detect_w4a4_artifact(weights)
+    if w4a4_art is not None and _covers(w4a4_art.component):
+        return load_w4a4_denoiser(
+            weights, w4a4_art, compute_dtype=compute_dtype, cls=cls)
+    svdq_art = detect_svdq_artifact(weights)
+    if svdq_art is not None and _covers(svdq_art.component):
+        raise ComponentExecutionLaneUnsupported(
+            f"component {component!r} of {weights} is an "
+            f"svdq-{svdq_art.precision} artifact ({svdq_art.file.name}): its "
+            f"denoiser is built by the svdq engine during the PIPELINE load, "
+            f"so there is no component-level production loader to borrow"
+        )
+    if component in denoiser_components() and detect_gguf_snapshot(weights):
+        raise ComponentExecutionLaneUnsupported(
+            f"component {component!r} of {weights} is a GGUF denoiser: it is "
+            f"dequantized by the pipeline's own gguf loader, so there is no "
+            f"component-level production loader to borrow"
+        )
+    return None
 
 
 def load_component_override(
@@ -1937,6 +1975,33 @@ def _place_and_release(pipe: Any, name: str, device: str) -> None:
     flush_memory()
 
 
+def _contract_component_for_spec(
+    spec: Any, name: str, src: Path,
+) -> Optional[Any]:
+    """A modular component's contract loader, or ``None`` for a plain tree.
+
+    The class comes from the spec (`ComponentSpec.type_hint`) because a modular
+    pipeline has no `model_index.json` to name it — which is precisely why
+    :func:`load_component` cannot simply be called here and why the DISPATCH,
+    not the whole loader, is what the two paths share.
+
+    A spec with no class at all is left to diffusers rather than guessed at: a
+    contract loader needs a class to build, and inventing one would be a second
+    source of truth for what a component IS.
+
+    The class is NOT required to expose ``from_pretrained``. The contract
+    loaders build through ``load_config`` + ``from_config`` (that is the whole
+    point — they do not go through the generic loader), so demanding the
+    generic entry point here would refuse exactly the classes this path exists
+    to serve. Caught by `test_a_MODULAR_component_routes_through_the_contract_loader`,
+    which went red on a denoiser that has no `from_pretrained` at all.
+    """
+    cls = getattr(spec, "type_hint", None)
+    if cls is None or not isinstance(cls, type):
+        return None
+    return contract_loaded_component(src, name, cls=cls, src=src)
+
+
 def hydrate_modular_pipeline(
     pipe: Any,
     path: str | Path,
@@ -2104,7 +2169,29 @@ def hydrate_modular_pipeline(
                 if dt is not None:
                     kwargs["torch_dtype"] = dt
                     dtypes[n] = str(dt).removeprefix("torch.")
-                pipe.load_components(names=[n], **kwargs)
+                # pgw#1210: THE CONTRACT DISPATCH, on the modular path too.
+                #
+                # `load_components` is diffusers' own hydration and reaches
+                # plain `from_pretrained`, which never consults the SDK's
+                # registered contract loaders. A produced `cozy.fp8-rowwise@1`
+                # tree then dies inside `DiffusersAutoQuantizer` on its own
+                # `quantization_config` — minimax-h3 0.4.34, two releases,
+                # three pods, serving nothing — while the NON-modular path
+                # loaded the identical bytes correctly through
+                # `load_w8a8_denoiser`. One artifact shape, two entry points,
+                # one of them blind; wan-2.2's fp8 lane (ie#702) is the other
+                # consumer of exactly this.
+                #
+                # The contract-loaded module is injected through
+                # `update_components` — the same seam a gw#479 preloaded
+                # shared module already uses, so the pipeline registers it
+                # exactly as it registers any component it did not load
+                # itself.
+                built = _contract_component_for_spec(specs[n], n, comp_src)
+                if built is not None:
+                    pipe.update_components(**{n: built})
+                else:
+                    pipe.load_components(names=[n], **kwargs)
                 # pgw#1026: place it now and drop the host copy, so the next
                 # component's admission above sees the host RAM this one
                 # gave back rather than the tree accumulating behind it.

--- a/tests/test_modular_contract_loader_pgw1210.py
+++ b/tests/test_modular_contract_loader_pgw1210.py
@@ -104,14 +104,21 @@ def test_a_MODULAR_component_routes_through_the_contract_loader(
     from micro_diffusion.model import MicroDenoiser
 
     comp = _w8a8_component(tmp_path)
-    called: list = []
-    real = loading.load_w8a8_denoiser
+    called: list[tuple[str, str]] = []
+    from gen_worker.models.w8a8 import load_w8a8_denoiser as _real_loader
+
+    real = _real_loader
 
     def _spy(root: Any, art: Any, **kw: Any) -> Any:
         called.append((str(root), art.component))
         return real(root, art, **kw)
 
-    monkeypatch.setattr(loading, "load_w8a8_denoiser", _spy)
+    # Patched by dotted PATH, not by attribute: `loading` re-exports
+    # `load_w8a8_denoiser` without listing it in `__all__`, and strict mypy
+    # (correctly) refuses an implicit re-export. Widening the production
+    # surface to suit a test would be the wrong direction.
+    monkeypatch.setattr(
+        "gen_worker.models.loading.load_w8a8_denoiser", _spy)
 
     built = loading._contract_component_for_spec(
         _spec(MicroDenoiser, comp), "transformer", tmp_path)

--- a/tests/test_modular_contract_loader_pgw1210.py
+++ b/tests/test_modular_contract_loader_pgw1210.py
@@ -1,0 +1,178 @@
+"""pgw#1210: a component declaring a layout contract loads through that
+contract's registered loader — on BOTH entry points, or it is a typed refusal.
+
+THE FAULT (filed by the ie#681/ie#699 lane; minimax-h3 0.4.34, two releases,
+three pods, same signature):
+
+    ModularHydrationError: … Failed to create component transformer:
+      modular_pipeline_utils.py load -> modeling_utils.py from_pretrained
+      -> config["quantization_config"] = DiffusersAutoQuantizer.merge_…
+
+The artifact is a PROVEN `cozy.fp8-rowwise@1` tree and the SDK ships the
+declaring loader for exactly that layout (`w8a8.load_w8a8_denoiser`,
+`@implements_contract`). The NON-modular path dispatches to it. A diffusers
+MODULAR pipeline hydrates through `ComponentSpec.load()` -> plain
+`from_pretrained`, which never consults it — so the same bytes that serve fine
+on one path kill the pod on the other, forever (`deterministic_fault_loop`).
+
+THE INVARIANT, and why the fix is a shared dispatch rather than a second copy:
+one artifact shape has two entry points, and two dispatches that agree today
+are two dispatches that will disagree later. `contract_loaded_component` is now
+the only place that decides, and both callers ask it.
+
+wan-2.2's fp8 lane (ie#702) is the sibling consumer — it binds a produced fp8
+tree on the non-modular path — which is why "keep both entry points on one
+dispatch" was the filing's own requirement.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+from gen_worker.models import loading, w8a8  # noqa: E402
+
+
+def _w8a8_component(root: Path, component: str = "transformer") -> Path:
+    """A produced fp8-rowwise component tree: fp8 weights + their scales.
+
+    Written with real safetensors because detection reads real headers — a
+    stub would prove the test's own fiction rather than the contract.
+    """
+    from micro_diffusion.model import MicroConfig, MicroDenoiser
+
+    comp = root / component
+    comp.mkdir(parents=True)
+    denoiser = MicroDenoiser(MicroConfig())
+    tensors = {}
+    for name, param in denoiser.named_parameters():
+        if name.endswith(".weight") and param.ndim == 2:
+            tensors[name] = param.detach().to(torch.float8_e4m3fn)
+            tensors[name[: -len("weight")] + "weight_scale"] = torch.ones(
+                param.shape[0], 1, dtype=torch.float32)
+        else:
+            tensors[name] = param.detach().clone()
+    save_file(tensors, str(comp / "model.safetensors"))
+    (comp / "config.json").write_text(json.dumps(MicroConfig().as_dict()))
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "MicroW8a8Pipeline",
+        component: ["micro_diffusion.model", "MicroDenoiser"],
+    }))
+    return comp
+
+
+def _spec(cls: Any, path: Path) -> Any:
+    return types.SimpleNamespace(
+        type_hint=cls, pretrained_model_name_or_path=str(path),
+        subfolder="", default_creation_method="from_pretrained")
+
+
+def test_the_tree_really_is_a_contract_artifact(tmp_path: Path) -> None:
+    """The fixture must be the thing, or everything below proves nothing."""
+    _w8a8_component(tmp_path)
+    art = w8a8.detect_w8a8_artifact(tmp_path)
+    assert art is not None and art.component == "transformer"
+    assert art.quantized, "no fp8 weight/weight_scale pairs were detected"
+
+
+def test_a_MODULAR_component_routes_through_the_contract_loader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE issue. Before this, modular hydration reached plain
+    `from_pretrained` and died inside `DiffusersAutoQuantizer`.
+
+    Asserted by WHICH LOADER RAN, not by the leaf classes it produced: whether
+    `Fp8ScaledLinear` actually replaces a leaf depends on `torch._scaled_mm`
+    availability on the box, so a leaf-class assertion would be a CUDA test
+    wearing a routing test's name. The property under test is the ROUTING.
+    """
+    from micro_diffusion.model import MicroDenoiser
+
+    comp = _w8a8_component(tmp_path)
+    called: list = []
+    real = loading.load_w8a8_denoiser
+
+    def _spy(root: Any, art: Any, **kw: Any) -> Any:
+        called.append((str(root), art.component))
+        return real(root, art, **kw)
+
+    monkeypatch.setattr(loading, "load_w8a8_denoiser", _spy)
+
+    built = loading._contract_component_for_spec(
+        _spec(MicroDenoiser, comp), "transformer", tmp_path)
+
+    assert built is not None, (
+        "the modular path did not route a `cozy.fp8-rowwise@1` tree through "
+        "its registered loader — this is the h3 fault exactly")
+    assert called, (
+        "a module came back but `load_w8a8_denoiser` never ran — the tree was "
+        "loaded generically, which is the defect wearing a passing assertion")
+    assert called[0][1] == "transformer"
+
+
+def test_a_PLAIN_tree_is_left_to_the_generic_loader(tmp_path: Path) -> None:
+    """`None` means 'no contract here' and the caller's own load is correct —
+    the dispatch must not capture every component it is shown."""
+    from micro_diffusion.model import MicroConfig, MicroDenoiser
+
+    comp = tmp_path / "transformer"
+    comp.mkdir(parents=True)
+    denoiser = MicroDenoiser(MicroConfig())
+    save_file({n: p.detach().clone() for n, p in denoiser.named_parameters()},
+              str(comp / "model.safetensors"))
+    (comp / "config.json").write_text(json.dumps(MicroConfig().as_dict()))
+
+    assert loading._contract_component_for_spec(
+        _spec(MicroDenoiser, comp), "transformer", comp) is None
+
+
+def test_BOTH_entry_points_ask_the_SAME_dispatch(tmp_path: Path) -> None:
+    """One artifact shape, two entry points. Two dispatches that agree today
+    are two dispatches that will disagree later — so there is only one, and
+    this asserts both callers reach it rather than trusting they do."""
+    import inspect
+
+    src = inspect.getsource(loading)
+    # the non-modular path
+    assert "contracted = contract_loaded_component(" in src
+    # the modular path, via the spec-typed shim
+    assert "_contract_component_for_spec(specs[n], n, comp_src)" in src
+    assert "return contract_loaded_component(src, name, cls=cls, src=src)" in src
+
+
+def test_a_recognised_lane_with_NO_component_loader_REFUSES(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of the invariant, and the reason this is a dispatch and
+    not a lookup: a layout we RECOGNISE but cannot build at component level is
+    a typed refusal naming our own code — never a silent fall-through to
+    generic loading, which is what produced numerics that could not serve."""
+    from micro_diffusion.model import MicroDenoiser
+
+    comp = tmp_path / "transformer"
+    comp.mkdir(parents=True)
+    monkeypatch.setattr(
+        loading, "detect_gguf_snapshot", lambda root: {"gguf": True})
+
+    with pytest.raises(loading.ComponentExecutionLaneUnsupported) as caught:
+        loading.contract_loaded_component(
+            tmp_path, "transformer", cls=MicroDenoiser, src=comp)
+
+    said = str(caught.value)
+    assert "transformer" in said and "GGUF" in said
+    assert "no component-level production loader" in said


### PR DESCRIPTION
## The fault

minimax-h3 0.4.34 — two releases, three pods, one signature:

```
ModularHydrationError: … Failed to create component transformer:
  modular_pipeline_utils.py:336 load
  -> modeling_utils.py:1150 from_pretrained
  -> config["quantization_config"] = DiffusersAutoQuantizer.merge_quantization_configs(…)
```

…then `deterministic_fault_loop`, and the pod serves nothing, forever. The artifact is a PROVEN `cozy.fp8-rowwise@1` tree and the SDK ships the declaring loader for exactly that layout.

## This is a dispatch unification, not new logic

**`load_component`'s own docstring already describes this failure:**

> *"A modelopt-produced tree carries a `quantization_config` block diffusers reconstructs into `NVIDIAModelOptConfig`, whose constructor requires a `quant_type` the block does not supply — so a bare `from_pretrained` on the denoiser dies at config reconstruction on every flavor the fleet actually serves (pgw#689 defect 1)."*

The **non-modular** path solved this and dispatches to `load_w8a8_denoiser`. The **modular** path hydrates through `ComponentSpec.load()` → plain `from_pretrained` and never learned. One artifact shape, two entry points, one of them blind.

So the fix adds no new understanding — it makes the two paths ask the same question. `loading.contract_loaded_component` is now the only place that decides:

| tree | outcome |
|---|---|
| recognised layout | the module its registered `@implements_contract` loader builds |
| unrecognised | `None` — the caller's generic load is correct |
| recognised, no component-level loader | `ComponentExecutionLaneUnsupported` — typed, naming our code |

**Two dispatches that agree today are two dispatches that will disagree later**, which is exactly what happened here. wan-2.2's fp8 lane (ie#702) consumes the same artifact shape on the non-modular path, so "keep both entry points on one dispatch" was the filing's own requirement.

The modular side injects through `update_components` — the same seam a gw#479 preloaded shared module already uses — so the pipeline registers a contract-loaded component exactly as it registers any component it did not load itself. The class comes from `ComponentSpec.type_hint`, because a modular pipeline has no `model_index.json`; **that** is why the two paths share the *dispatch* rather than the whole of `load_component`.

## Two errors my own tests caught

Both are worth stating, because in each case a green result would have meant nothing:

1. **The first guard required `from_pretrained` on the component class** — which would have refused exactly the classes this path exists to serve. Contract loaders build through `load_config` + `from_config` *precisely to avoid* the generic loader; demanding the generic entry point would have made the fix a no-op on its own target. Caught by the routing row going red on a denoiser that has no `from_pretrained` at all.
2. **The first assertion checked for `Fp8ScaledLinear` leaves** — which depends on `torch._scaled_mm` availability on the box, i.e. a CUDA test wearing a routing test's name. It now asserts **which loader ran** (spy on `load_w8a8_denoiser`), so it measures the routing it claims to measure and is environment-independent.

## Verification

5 new rows, including one that pins **both** entry points reaching the shared dispatch. Neighbours — `pgw1036` (modular hydration), `pgw617` (component bindings), `pgw1071` (modular dtype), `th1330` (override fetch), `quantization_lanes` — **41 passed**. `mypy` clean (266 files), ruff clean, 5 fast-gate lints + `assemble_changelog --check` OK.

The fixture writes a **real** fp8 safetensors tree (weights + `weight_scale`) because detection reads real headers — a stub would prove the test's own fiction rather than the contract.

Tracker: pgw#1210. Filed by the ie#681/ie#699 lane; this is the hand-off they offered to the 0.114.0 cut chain.