### PR TITLE
pgw#1206 D: no rung quantizes at runtime — the bnb-nf4 emergency rung and the inline bnb converter die

### DIFF
--- a/changelog.d/pgw1206.md
+++ b/changelog.d/pgw1206.md
@@ -69,3 +69,28 @@
   fatal and named, never silently dropped. The expectation an arm gate compares
   against is built by the ONE surviving map (`ExpectedIdentity.named_by`) from
   the hub's `cell_resolve` answer.
+- **BREAKING (D) — the bnb-nf4 emergency rung is DELETED; nothing quantizes at
+  runtime.** Paul, 2026-08-13: *"We shouldn't be doing runtime quants; if we're
+  really memory-constrained then we should be fetching the quant we need, which
+  is hopefully available (we just need to produce it ahead of time)."* Gone:
+  `models/rung.NF4` (one line out of A2's single ordered ladder — the
+  consolidation paying off), `RUN_EMERGENCY`/`emergency_quant` as an emitted
+  run mode, `hub_policy.FIT_EMERGENCY`, and loading's
+  `emergency_quant_enabled` / `bitsandbytes_available` /
+  `emergency_quantization_config` / `_bnb_quantized_components` /
+  `EMERGENCY_FIT_FACTOR` / `RUNG_NF4_UNLANDED`. **The ladder is now quant rungs
+  (AOT artifacts the ladder SELECTS) → runtime fp8-E4M3 storage → CPU-offload →
+  never OOM**; degrade-don't-OOM is unchanged and pinned by the one ruling test.
+  A snapshot that fits none of them serves at stored precision through the
+  offload ladder instead of being 4-bit quantized at an ungated quality.
+  Reading a quant off disk is untouched (`synthesize_quantization_config`) —
+  fetching a produced artifact is exactly the sanctioned path. tensorhub still
+  accepts `emergency_quant` on the wire; no worker sends it.
+- **BREAKING (D) — `gen_worker.convert`'s inline bitsandbytes lane is DELETED**
+  (`nf4`/`fp4`/`int4`/`int4:nf4`/`int4:fp4` target dtypes,
+  `run_inline_conversion`'s bnb arm, `_run_bnb_inline` and
+  `_run_bnb_diffusers_inline`). It was a SECOND producer of the same artifact:
+  the priced `bitsandbytes-quantization` conversion function builds its own
+  `BitsAndBytesConfig` over `Source.iter_hf_components` and never called it,
+  and the only cross-repo caller of `run_inline_conversion` is `convert_gguf`.
+  One conversion surface, one producer.

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -12,11 +12,10 @@ Three buckets:
    files. No conversion needed.
 
 2. **Inline-supported** — weight-only schemes that don't need calibration,
-   streaming per-tensor (peak anon RAM ≈ largest single tensor) except bnb:
+   streaming per-tensor (peak anon RAM ≈ largest single tensor):
    - ``bf16`` / ``fp16`` / ``fp32`` (streaming dtype cast)
    - ``fp8`` / ``fp8:e4m3`` (streaming fp8-E4M3 storage cast — the ``#fp8``
      flavor; scale-free, consumed via diffusers layerwise casting)
-   - ``nf4`` / ``fp4`` / ``int4`` (bitsandbytes; full component load)
    - GGUF quants (``q4_k_m``, ``q8_0``, …) via convert_hf_to_gguf + llama-quantize
 
 3. **Calibration-required** — raise ``InlineConversionNotPossible`` with a
@@ -34,13 +33,8 @@ import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from .writer import NEVER_SHARD_MAX_SIZE
-from .writer import assert_one_file_per_component
 from .writer import streaming_dtype_cast
 from .writer import streaming_fp8_storage_cast
-import json as _json
-import shutil as _shutil
-from ._hf_load import load_component_module
 from ..subproc import ProcessStalledError, run_process
 from .gguf_tools import (GGUF_TOOLCHAIN_STALL_WINDOW_S, prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
 
@@ -110,18 +104,6 @@ class InlineConversionNotPossible(Exception):
 # fp8-E4M3 storage flavor (`#fp8`) — a streaming per-tensor cast with the
 # layerwise-casting skip patterns honored. No model load, no scales.
 _INLINE_FP8_STORAGE_DTYPES: frozenset[str] = frozenset({"fp8", "fp8:e4m3"})
-
-# bitsandbytes 4-bit weight-only: nf4 / fp4. Works on CPU (the quantization
-# pass + save_pretrained run end-to-end without CUDA; LLM.int8() is the only
-# bnb path that genuinely requires CUDA). Loads via transformers'
-# BitsAndBytesConfig integration which is mature and stable.
-_INLINE_BNB_SCHEMES: dict[str, str] = {
-    "nf4":           "nf4",
-    "fp4":           "fp4",
-    "int4":          "nf4",   # plain "int4" → nf4 (bnb's default 4-bit)
-    "int4:nf4":      "nf4",
-    "int4:fp4":      "fp4",
-}
 
 # Pure dtype casts that go through the streaming primitive — no HF model load.
 _INLINE_CAST_DTYPES: frozenset[str] = frozenset({
@@ -205,7 +187,7 @@ def run_inline_conversion(
 
     ``source_repo_dir`` is the parent component directory containing
     ``config.json`` and tokenizer assets — used by the GGUF path and by
-    the bnb path (which loads the component as an HF model). When
+    the calibrated paths (which load the component as an HF model). When
     omitted we fall back to ``source_path.parent``.
 
     Raises ``InlineConversionNotPossible`` for calibrated dtypes; the
@@ -256,17 +238,6 @@ def run_inline_conversion(
             out_dir=out_dir,
             output_stem=output_stem,
             block_scope=fp8_block_scope,
-        )
-
-    # bitsandbytes nf4 / fp4 — runs on CPU for the quant pass; save_pretrained
-    # handles Params4bit transparently (no flatten helper needed). The fast
-    # path for "I want a 4-bit model on a laptop" use case.
-    if dtype in _INLINE_BNB_SCHEMES:
-        return _run_bnb_inline(
-            source_path=source_path,
-            source_repo_dir=source_repo_dir or source_path.parent,
-            out_dir=out_dir,
-            target_dtype=dtype,
         )
 
     # Fallthrough: dtype is not in any known bucket.
@@ -360,286 +331,6 @@ def _run_fp8_storage_inline(
         target_file_type="safetensors",
         attributes=attrs,
         summary=dict(result),
-    )
-
-
-def _run_bnb_inline(
-    *,
-    source_path: Path,
-    source_repo_dir: Path,
-    out_dir: Path,
-    target_dtype: str,
-) -> InlineConversionResult:
-    """bitsandbytes nf4 / fp4 weight-only quantization (CPU-friendly).
-
-    Routes through transformers' ``BitsAndBytesConfig`` integration.
-    bitsandbytes' ``Params4bit`` is a parameter subclass that handles
-    its own save/load via ``save_pretrained`` directly — no flatten helper
-    needed.
-
-    LLM.int8() (8-bit) is the only bnb path that genuinely requires CUDA;
-    nf4/fp4 quantization runs end-to-end on CPU.
-    """
-    import torch
-
-    dtype = _normalize(target_dtype)
-    bnb_quant_type = _INLINE_BNB_SCHEMES.get(dtype)
-    if bnb_quant_type is None:
-        raise InlineConversionNotPossible(
-            reason=f"_run_bnb_inline got unexpected dtype {dtype!r}",
-            target_dtype=dtype,
-        )
-    # Stamp the PRODUCED dtype: an "int4" request routes through bnb nf4, so
-    # the checkpoint must be labeled nf4/fp4 — inference dispatches on it (#358).
-    produced_dtype = bnb_quant_type  # "nf4" | "fp4"
-    if produced_dtype != dtype:
-        logger.warning(
-            "inline bnb: requested dtype %s produces %s; stamping %s",
-            dtype, produced_dtype, produced_dtype,
-        )
-
-    repo_dir = Path(source_repo_dir)
-    if not repo_dir.exists() or not repo_dir.is_dir():
-        repo_dir = Path(source_path).parent
-
-    is_diffusers = (repo_dir / "model_index.json").is_file()
-    is_transformers = (repo_dir / "config.json").is_file() and not is_diffusers
-    if not (is_diffusers or is_transformers):
-        raise InlineConversionNotPossible(
-            reason=(
-                f"source dir at {repo_dir} has neither model_index.json "
-                f"(diffusers) nor config.json (transformers) — can't load "
-                f"as a model for inline {dtype}"
-            ),
-            target_dtype=dtype,
-        )
-
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        from transformers import BitsAndBytesConfig
-        from ._hf_load import load_component_module
-    except ImportError as exc:
-        raise InlineConversionNotPossible(
-            reason=f"transformers/bitsandbytes not installed for {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-
-    # Diffusers-layout fan-out: per-component bnb quantization.
-    if is_diffusers:
-        return _run_bnb_diffusers_inline(
-            repo_dir=repo_dir,
-            out_dir=out_dir,
-            dtype=dtype,
-            bnb_quant_type=bnb_quant_type,
-        )
-
-    # bnb_4bit_compute_dtype=bf16 keeps activations in bf16 during dequant
-    # at inference time. Standard bitsandbytes 4-bit recipe.
-    cfg = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_quant_type=bnb_quant_type,
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
-
-    cfg_path = repo_dir / "config.json"
-    try:
-        cfg_blob = _json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.is_file() else {}
-    except Exception:
-        cfg_blob = {}
-    try:
-        model = load_component_module(
-            repo_dir, cfg_blob, quantization_config=cfg,
-        )
-    except Exception as exc:
-        raise InlineConversionNotPossible(
-            reason=f"bitsandbytes load failed for {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-
-    try:
-        model.save_pretrained(str(out_dir), max_shard_size=NEVER_SHARD_MAX_SIZE)
-    except Exception as exc:
-        raise InlineConversionNotPossible(
-            reason=f"bitsandbytes save_pretrained failed for {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-
-    assert_one_file_per_component(out_dir, producer="bitsandbytes quantize")
-    saved_files: list[Path] = sorted(
-        f for f in out_dir.rglob("*") if f.is_file()
-    )
-    if not saved_files:
-        raise RuntimeError(
-            f"_run_bnb_inline: no files produced for {dtype} from {repo_dir}"
-        )
-
-    try:
-        import bitsandbytes as bnb
-        bnb_version = str(bnb.__version__)
-    except Exception:
-        bnb_version = ""
-
-    attrs = {
-        "dtype": produced_dtype,
-        "file_type": "safetensors",
-        "conversion_strategy": "inline_bitsandbytes",
-        "quant_scheme": f"bitsandbytes:{bnb_quant_type}",
-        "quant_library": "bitsandbytes",
-    }
-    if bnb_version:
-        attrs["quant_library_version"] = bnb_version
-    return InlineConversionResult(
-        output_paths=saved_files,
-        target_dtype=produced_dtype,
-        target_file_type="safetensors",
-        attributes=attrs,
-        summary={
-            "scheme": bnb_quant_type,
-            "file_count": len(saved_files),
-        },
-    )
-
-
-from ..component_vocab import quant_candidate_components
-# Components that hold quantizable weights (DiT, UNet, text encoders, etc.).
-# Everything not in this set passes through unchanged.
-def _diffusers_quant_components() -> frozenset[str]:
-    return frozenset(quant_candidate_components())
-
-# Top-level files copied verbatim into the destination snapshot.
-_DIFFUSERS_ROOT_FILES: tuple[str, ...] = (
-    "model_index.json", "README.md", "LICENSE", "LICENSE.md", "USAGE_POLICY.md",
-)
-
-
-def _run_bnb_diffusers_inline(
-    *,
-    repo_dir: Path,
-    out_dir: Path,
-    dtype: str,
-    bnb_quant_type: str,
-) -> InlineConversionResult:
-    """Per-component bitsandbytes nf4/fp4 for a diffusers-layout source.
-
-    Walk components, quantize
-    weight-bearing ones (transformer / unet / text_encoder*), copy the rest
-    verbatim. bitsandbytes' `Params4bit` is a parameter subclass that
-    handles its own save/load via ``module.save_pretrained`` directly — no
-    flatten helper needed.
-    """
-    import torch
-    from transformers import BitsAndBytesConfig
-
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    cfg = BitsAndBytesConfig(
-        load_in_4bit=True,
-        bnb_4bit_quant_type=bnb_quant_type,
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
-
-    quantized_components: list[str] = []
-    passthrough_components: list[str] = []
-
-    for entry in sorted(repo_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        comp_name = entry.name
-        comp_out = out_dir / comp_name
-
-        if comp_name in _diffusers_quant_components():
-            cfg_path = entry / "config.json"
-            if not cfg_path.is_file():
-                _shutil.copytree(entry, comp_out, dirs_exist_ok=True)
-                passthrough_components.append(comp_name)
-                continue
-            try:
-                cfg_data = _json.loads(cfg_path.read_text(encoding="utf-8"))
-            except Exception:
-                cfg_data = {}
-            try:
-                module = load_component_module(
-                    entry, cfg_data, quantization_config=cfg,
-                )
-            except Exception as exc:
-                raise InlineConversionNotPossible(
-                    reason=(
-                        f"failed to load diffusers component {comp_name!r} for "
-                        f"inline {dtype}: {exc}"
-                    ),
-                    target_dtype=dtype,
-                ) from exc
-
-            comp_out.mkdir(parents=True, exist_ok=True)
-            try:
-                module.save_pretrained(
-                    str(comp_out), max_shard_size=NEVER_SHARD_MAX_SIZE)
-            except Exception as exc:
-                raise InlineConversionNotPossible(
-                    reason=(
-                        f"bitsandbytes save_pretrained failed for component "
-                        f"{comp_name!r} ({dtype}): {exc}"
-                    ),
-                    target_dtype=dtype,
-                ) from exc
-            assert_one_file_per_component(
-                comp_out, producer=f"bitsandbytes quantize [{comp_name}]")
-            quantized_components.append(comp_name)
-            del module
-        else:
-            _shutil.copytree(entry, comp_out, dirs_exist_ok=True)
-            passthrough_components.append(comp_name)
-
-    for fname in _DIFFUSERS_ROOT_FILES:
-        src = repo_dir / fname
-        if src.is_file():
-            _shutil.copy2(src, out_dir / fname)
-
-    if not quantized_components:
-        raise InlineConversionNotPossible(
-            reason=(
-                f"diffusers source at {repo_dir} has no quantizable "
-                f"components for {dtype} (looked for: "
-                f"{sorted(_diffusers_quant_components())})"
-            ),
-            target_dtype=dtype,
-        )
-
-    saved_files: list[Path] = sorted(
-        f for f in out_dir.rglob("*") if f.is_file()
-    )
-
-    try:
-        import bitsandbytes as bnb
-        bnb_version = str(bnb.__version__)
-    except Exception:
-        bnb_version = ""
-
-    attrs = {
-        "dtype": dtype,
-        "file_type": "safetensors",
-        "conversion_strategy": "inline_bitsandbytes_diffusers",
-        "quant_scheme": f"bitsandbytes:{bnb_quant_type}",
-        "quant_library": "bitsandbytes",
-        "quant_components": ",".join(sorted(quantized_components)),
-        "passthrough_components": ",".join(sorted(passthrough_components)),
-    }
-    if bnb_version:
-        attrs["quant_library_version"] = bnb_version
-    return InlineConversionResult(
-        output_paths=saved_files,
-        target_dtype=dtype,
-        target_file_type="safetensors",
-        attributes=attrs,
-        summary={
-            "scheme": bnb_quant_type,
-            "quantized_components": quantized_components,
-            "passthrough_components": passthrough_components,
-            "file_count": len(saved_files),
-        },
     )
 
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -168,7 +168,7 @@ from .compile_cache import CompiledExecutionLaneUnavailableError
 from .preload import Preloader
 from .api.binding import rebind_pick
 from .models.hub_policy import FIT_INCOMPATIBLE, TensorhubWorkerCapabilities
-from .models.serve_fit import (RUN_CPU, RUN_EMERGENCY, RUN_FP8_STORAGE,
+from .models.serve_fit import (RUN_CPU, RUN_FP8_STORAGE,
                                    RUN_OFFLOAD, plan_serve)
 from . import postmortem
 from .models.serve_fit import replan
@@ -9073,8 +9073,7 @@ class Executor:
                     if sl.rung_detail:
                         self._record_rung_transition(
                             spec, ref=ref, phase="load",
-                            run_mode=(RUN_FP8_STORAGE if sl.rung == "fp8"
-                                      else RUN_EMERGENCY),
+                            run_mode=RUN_FP8_STORAGE,
                             detail=sl.rung_detail)
                     elif sl.cast_fail_detail:
                         self._record_rung_transition(

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -4,7 +4,7 @@ import importlib.util
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from .memory import effective_vram_requirement_gb
-from .loading import EMERGENCY_FIT_FACTOR, FP8_STORAGE_FIT_FACTOR
+from .loading import FP8_STORAGE_FIT_FACTOR
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,6 @@ FIT_NVFP4 = "nvfp4"
 FIT_SVDQ_FP4 = "svdq_fp4"
 FIT_SVDQ_INT4 = "svdq_int4"
 FIT_EMERGENCY_FP8 = "emergency_fp8"
-FIT_EMERGENCY = "emergency_quant"
 FIT_GGUF = "gguf_quant"
 FIT_OFFLOAD = "offload"
 FIT_INCOMPATIBLE = "incompatible"
@@ -122,10 +121,6 @@ def variant_fit(
     - ``emergency_fp8``: does not fit as stored, but runtime fp8-E4M3 weight
       storage (loading.apply_fp8_storage: fp8 bytes resident, bf16 compute,
       no fp8 silicon required) would fit — quality ~= a stored #fp8 flavor.
-    - ``emergency_quant``: even the fp8 estimate does not fit, but the
-      emergency nf4 rung (th#546 emergency lane; loading layer, automatic on
-      CUDA hosts) applies and the 4-bit estimate fits — runs at
-      below-platform quality, loudly.
     - ``offload``: runnable, but the recommended card size (vram_gb minus the
       fixed GPU reserve) exceeds free VRAM — the models/memory.py offload
       ladder carries it (slower).
@@ -157,11 +152,6 @@ def variant_fit(
             return FIT_EMERGENCY_FP8, (
                 f"runs (fp8 storage): {float(vram):g} GB VRAM via runtime "
                 f"fp8-E4M3 weight storage, {float(free_vram_gb):.1f} GB free"
-            )
-        if float(vram) * EMERGENCY_FIT_FACTOR <= float(free_vram_gb):
-            return FIT_EMERGENCY, (
-                f"runs (emergency quality): {float(vram):g} GB VRAM via 4-bit "
-                f"emergency quantization, {float(free_vram_gb):.1f} GB free"
             )
     return FIT_OFFLOAD, (
         f"declares {float(vram):g} GB VRAM, {float(free_vram_gb):.1f} GB free"

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -14,7 +14,7 @@ internal/orchestrator/precision resolver) and delivers picks via HelloAck;
 this module is the classification + placement half, plus the family lane
 policy (th#964). The former local walk (``resolve``/``resolve_local_bindings``)
 was deleted with pgw#515 — locally, fit is the loading layer's job (runtime
-fp8/nf4 rungs + the offload ladder). pgw#1148 deleted the local AUTO fp8
+fp8 rung + the offload ladder). pgw#1148 deleted the local AUTO fp8
 FOLD on top of it: it selected among sibling FLAVOR rows, and th#1803 deleted
 those rows (`repo_tags` is re-keyed to (repo, tag, checkpoint), the flavor
 column is gone, and selection within a tag group is §1.33 contract
@@ -150,14 +150,6 @@ CONV_UNET_W8A8_EXCLUDED_ROOTS = frozenset({"sd1", "sd2", "sdxl"})
 
 
 
-EMERGENCY_NF4_VRAM_FACTOR = 0.45  # nf4 denoiser, encoders/VAE at compute dtype
-
-# Per-component resident-bytes factor for a bnb-nf4 quantized module vs its
-# bf16/fp16 stored bytes (4-bit packed + double-quant + quant-state overhead).
-# Used by the load-time fit ladder's per-component estimate (gw#521); the
-# whole-model EMERGENCY_NF4_VRAM_FACTOR above stays the hub-side coarse spec.
-NF4_WEIGHT_BYTES_FACTOR = 0.30
-
 
 # th#1361/pgw#1065: the flavor-token parses (classify_flavor_token,
 # placement_for_flavor) are package-internal choke points, not public API —
@@ -175,8 +167,6 @@ __all__ = [
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
     "CONV_UNET_W8A8_EXCLUDED_ROOTS",
-    "EMERGENCY_NF4_VRAM_FACTOR",
-    "NF4_WEIGHT_BYTES_FACTOR",
     "Placement",
     "default_placement",
     "placement_to_metadata",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -19,13 +19,11 @@ from ..component_vocab import (
     weight_components,
 )
 from ..families.facts import component_dtype_for_class
-from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
 import importlib
 import importlib.util
 import inspect
 import os
 import struct
-import sys
 
 from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
@@ -233,14 +231,6 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
 _fp8_storage_components = denoiser_components
 # The "+te" rung (component fit-ladder rung 2): the pipeline's text encoders.
 _fp8_text_encoder_components = text_encoder_components
-
-#: pgw#824: the emergency nf4 rung was engaged and landed on ZERO modules. A
-#: rung OUTCOME, not the absence of one — the pipeline serves full precision on
-#: a host whose free VRAM was already below the stored-precision footprint,
-#: which is the worst outcome the ladder can produce. Distinct from "nf4" (it
-#: landed) and from "" (no rung was needed), because placement must be able to
-#: tell those three apart. Consumed by ``models.provision``.
-RUNG_NF4_UNLANDED = "nf4-unlanded"
 
 class _Fp8WeightWindow:
     """Weight-only fp8 storage for one transformer block: the block's
@@ -818,7 +808,7 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
 # dodged is +1.9% for the structural storage lane (pgw#727 re-measure; the
 # +44-73% figure that justified it measured the retired HOOK form), so it
 # traded ~2x weight VRAM for ~1.9% latency AND identity determinism.
-# Involuntary transitions stay: the fit-ladder rungs below (can't-fit fp8/nf4)
+# Involuntary transitions stay: the fit-ladder rung below (can't-fit fp8)
 # and the w8a8/w4a4 dequant-on-unsupported-host lanes are declared rungs, not
 # probe outcomes.
 
@@ -871,35 +861,22 @@ def pipeline_weight_lane(pipeline: Any) -> str:
     return ""
 
 
-# --- Runtime fit rungs (th#546 emergency lane + th#683 fp8 storage) --------
+# --- The runtime fit rung (th#683 fp8 storage) -----------------------------
 # Fit ladder: bf16 -> #fp8 flavor -> #nvfp4 (Blackwell) -> runtime fp8-E4M3
-# storage -> EMERGENCY nf4 -> CPU offload. When even the downloaded flavor
-# cannot fit free VRAM, the load path first tries fp8-E4M3 weight storage
-# (apply_fp8_storage: fp8 bytes resident, bf16 compute — quality ~= a stored
-# #fp8 flavor), then runtime-quantizes the denoiser to bnb nf4. Always armed
-# on CUDA hosts (gw#420: fitting is the runtime's job, not a flag); the
-# platform never reaches it because its scheduler places by declared
-# Resources.
-# Coarse whole-model resident factor after nf4-quantizing the denoiser
-# (denoiser ~4x smaller; encoders/VAE stay at compute dtype). Single-sourced
-# from the shared ladder spec (ladder.EMERGENCY_NF4_VRAM_FACTOR) so the
-# runtime rung and the Go/Py ladder never drift.
-EMERGENCY_FIT_FACTOR = EMERGENCY_NF4_VRAM_FACTOR
+# storage -> CPU offload. When even the downloaded flavor cannot fit free
+# VRAM, the load path tries fp8-E4M3 weight storage (apply_fp8_storage: fp8
+# bytes resident, bf16 compute — quality ~= a stored #fp8 flavor) and then
+# hands the slot to the offload ladder. Nothing QUANTIZES here: the bnb-nf4
+# emergency rung was deleted in pgw#1206 D (Paul: "We shouldn't be doing
+# runtime quants; if we're really memory-constrained then we should be
+# fetching the quant we need"). Armed on CUDA hosts (gw#420: fitting is the
+# runtime's job, not a flag).
 # Resident factor after fp8-E4M3 storage of the denoiser, expressed against
 # the declared CARD SIZE (resources.vram_gb — includes activation/framework
 # headroom over raw weights). The ONE fp8 fit factor (pgw#515 deleted the
 # duplicate ladder walk and its weight-bytes-based 0.75 estimate).
 FP8_STORAGE_FIT_FACTOR = 0.55
 _EMERGENCY_MARGIN_GB = 2.0
-
-
-def emergency_quant_enabled() -> bool:
-    try:
-        import torch
-
-        return bool(torch.cuda.is_available())
-    except ImportError:
-        return False
 
 
 def runtime_fp8_storage_supported() -> bool:
@@ -2216,117 +2193,22 @@ def specialized_weight_layout(model_path: str | Path) -> str:
     return ""
 
 
-def bitsandbytes_available() -> bool:
-    """Importability gate for the bnb-nf4 rung (gw#469): the quant config
-    constructs fine without bitsandbytes and the load then dies deep in
-    ``validate_environment`` (PackageNotFoundError -> setup_failed). An
-    unavailable rung must be SKIPPED, never attempted."""
-
-    if "bitsandbytes" in sys.modules:
-        return True
-    try:
-        return importlib.util.find_spec("bitsandbytes") is not None
-    except (ImportError, ValueError):
-        return False
-
-
-def emergency_quantization_config(
-    cls: Any,
-    *,
-    components: Optional[List[str]] = None,
-    compute_dtype: Any = None,
-) -> Optional[Any]:
-    """bnb-nf4 config for the emergency rung, scoped to ``components`` (the
-    snapshot's REAL denoiser/text-encoder names — gw#521: a config naming
-    absent components is silently ignored by diffusers, so the caller derives
-    the list from the tree and this function refuses an empty one). None
-    (with a warning) when the stack can't do it — the offload ladder then
-    carries it."""
-    if not bitsandbytes_available():
-        logger.warning(
-            "emergency nf4 unavailable (bitsandbytes not installed in this "
-            "image); skipping the quantized rung — the offload ladder carries it"
-        )
-        return None
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return None
-        import diffusers
-        from diffusers.quantizers import PipelineQuantizationConfig
-    except ImportError as exc:
-        logger.warning("emergency nf4 unavailable (%s); falling to offload", exc)
-        return None
-    kwargs: Dict[str, Any] = {
-        "load_in_4bit": True,
-        "bnb_4bit_quant_type": "nf4",
-        "bnb_4bit_compute_dtype": compute_dtype or torch.bfloat16,
-        "bnb_4bit_use_double_quant": True,
-    }
-    if isinstance(cls, type) and issubclass(cls, diffusers.DiffusionPipeline):
-        targets = list(_fp8_storage_components()) if components is None else list(components)
-        if not targets:
-            logger.warning(
-                "emergency nf4 skipped: no quantizable component in the "
-                "snapshot (denoiser-less tree); the offload ladder carries it"
-            )
-            return None
-        try:
-            return PipelineQuantizationConfig(
-                quant_backend="bitsandbytes_4bit",
-                quant_kwargs=kwargs,
-                components_to_quantize=targets,
-            )
-        except ValueError as exc:
-            # diffusers validates the bnb config signature against BOTH
-            # libraries; a diffusers/transformers skew raises here — skip the
-            # rung instead of killing the load.
-            logger.warning("emergency nf4 unavailable (%s); falling to offload", exc)
-            return None
-    from diffusers.quantizers.quantization_config import BitsAndBytesConfig
-
-    return BitsAndBytesConfig(**kwargs)
-
-
-def _bnb_quantized_components(pipe: Any, targets: List[str]) -> List[str]:
-    """The subset of ``targets`` whose modules actually hold bnb 4-bit layers
-    after the load — the gw#521 no-op detector (diffusers silently ignores
-    config components absent from the pipeline)."""
-    landed: List[str] = []
-    for name in targets:
-        mod = getattr(pipe, name, None)
-        if mod is None or not hasattr(mod, "modules"):
-            continue
-        try:
-            for m in mod.modules():
-                if type(m).__name__ in ("Linear4bit", "LinearNF4", "LinearFP4"):
-                    landed.append(name)
-                    break
-        except Exception:  # noqa: BLE001
-            continue
-    return landed
-
-
 def _adaptive_fit_rung(
     cls: Any, path: Path, *, fp8_planned: bool, compute_dtype: Any = None
 ) -> tuple[str, Optional[Any]]:
-    """Serve-time fit ladder at load (th#683 P3): when the snapshot's
-    estimated resident bytes (after any planned fp8 storage) exceed free
-    VRAM, engage the cheapest-quality-loss runtime lever that FITS:
-    fp8-E4M3 storage first (denoiser weights ~halve, quality ~= a stored
-    #fp8 flavor), then the nf4 emergency rung — denoiser first, text
-    encoders joining only when the denoiser alone isn't enough. Targets are
-    the snapshot's REAL component names (gw#521: a config naming absent
-    components is silently ignored by diffusers — the rung must never be a
-    hard-coded archetype guess). When even nf4 cannot fit, the rung is
-    SKIPPED (full-precision weights preserved; the offload ladder carries
-    it) instead of paying the quality cost for nothing.
+    """Serve-time fit rung at load (th#683 P3): when the snapshot's estimated
+    resident bytes exceed free VRAM, engage runtime fp8-E4M3 weight storage
+    if it makes the difference (denoiser weights ~halve, quality ~= a stored
+    #fp8 flavor). Otherwise the rung is SKIPPED and the OFFLOAD ladder carries
+    the slot — a lower-precision serve is never manufactured here (pgw#1206 D).
 
-    Returns ``(mode, config)``: ``("", None)`` fits as planned (or no rung
-    helps); ``("fp8", None)`` engage fp8 storage; ``("nf4", qc)``
-    emergency-quantize."""
-    if not emergency_quant_enabled():
+    Returns ``(mode, config)``: ``("", None)`` fits as planned, or no rung
+    helps and offload takes it; ``("fp8", None)`` engage fp8 storage. The
+    config slot stays in the signature because the caller's contract is
+    "a rung may hand me a quantization_config" — an AOT artifact read off disk
+    still does, through ``synthesize_quantization_config``.
+    """
+    if not runtime_fp8_storage_supported():
         return "", None
 
     free_gb = get_available_vram_gb()
@@ -2341,8 +2223,6 @@ def _adaptive_fit_rung(
     named = model_index_components(path) or set(comp_bytes)
     denoisers = [c for c in _fp8_storage_components()
                  if c in named and comp_bytes.get(c, 0) > 0]
-    encoders = [c for c in _fp8_text_encoder_components()
-                if c in named and comp_bytes.get(c, 0) > 0]
     denoiser_bytes = sum(comp_bytes[c] for c in denoisers)
 
     on_disk = detect_on_disk_dtype(path)
@@ -2355,7 +2235,6 @@ def _adaptive_fit_rung(
     # fp8-storage rung: only for un-quantized bf16/fp16 snapshots (an already
     # quantized flavor can't be halved again) when the halved estimate fits.
     if not fp8_planned and on_disk in ("bf16", "fp16") and denoisers \
-            and runtime_fp8_storage_supported() \
             and total - 0.5 * denoiser_bytes <= budget:
         logger.warning(
             "fp8-E4M3 emergency weight storage engaged for %s (%.1f GB "
@@ -2364,38 +2243,14 @@ def _adaptive_fit_rung(
             path, total_gb, free_gb,
         )
         return "fp8", None
-    if not denoisers:
-        logger.warning(
-            "emergency nf4 skipped for %s: no denoiser component in the "
-            "snapshot (components: %s); the offload ladder carries it",
-            path, sorted(named),
-        )
-        return "", None
-    # nf4 rung: denoiser first; text encoders join only when needed.
-    targets = list(denoisers)
-    est = total - denoiser_bytes * (1.0 - NF4_WEIGHT_BYTES_FACTOR)
-    if est > budget and encoders:
-        targets += encoders
-        est -= sum(comp_bytes[c] for c in encoders) * (1.0 - NF4_WEIGHT_BYTES_FACTOR)
-    if est > budget:
-        logger.warning(
-            "emergency nf4 skipped for %s: even 4-bit weights (~%.1f GB) "
-            "exceed the %.1f GB budget; keeping full precision — the "
-            "offload ladder carries it",
-            path, est / float(1 << 30), budget / float(1 << 30),
-        )
-        return "", None
-    qc = emergency_quantization_config(
-        cls, components=targets, compute_dtype=compute_dtype)
-    if qc is not None:
-        logger.warning(
-            "EMERGENCY 4-bit quantization engaged for %s (components %s; "
-            "%.1f GB weights, %.1f GB free) — quality below platform "
-            "standards; a larger card or Blackwell SKU would serve stored "
-            "flavors instead.",
-            path, targets, total_gb, free_gb,
-        )
-    return "nf4", qc
+    logger.warning(
+        "no runtime fit rung applies to %s (%.1f GB weights, %.1f GB free): "
+        "serving at stored precision and letting the OFFLOAD ladder carry it "
+        "— a smaller-precision serve is an AOT artifact to fetch, never one "
+        "to manufacture here",
+        path, total_gb, free_gb,
+    )
+    return "", None
 
 
 def _load_modular_pipeline(
@@ -2500,8 +2355,8 @@ def load_from_pretrained(
     snapshot) keeps denoiser weights in fp8 storage with per-layer upcast to
     the compute dtype; ``"fp8+te"`` extends that to the pipeline's text
     encoders (transformers-aware, gw#460). When the snapshot cannot fit free
-    VRAM as stored, the adaptive fit ladder engages runtime fp8-E4M3 storage
-    first, then the emergency nf4 rung (automatic on CUDA hosts).
+    VRAM as stored, the adaptive fit rung engages runtime fp8-E4M3 storage
+    (automatic on CUDA hosts); below that, the offload ladder carries it.
     ``components`` are PRELOADED module objects (content-keyed shared
     components, gw#479) forwarded to ``from_pretrained`` — diffusers skips
     loading those from disk and wires the given objects in. Used by the
@@ -2653,13 +2508,10 @@ def load_from_pretrained(
                 cls, Path(path), fp8_planned=fp8_storage,
                 compute_dtype=kwargs.get("torch_dtype"),
             )
+            assert eqc is None  # the fp8 rung carries no quantization_config
             if mode == "fp8":
                 fp8_storage = True  # runtime fp8-E4M3 storage rung (th#683)
                 adaptive_rung = "fp8"
-            elif eqc is not None:
-                qc = eqc
-                fp8_storage = False  # nf4 supersedes the fp8 rung
-                adaptive_rung = "nf4"
         if qc is not None:
             kwargs["quantization_config"] = qc
     # The composition's ONE compute dtype, captured before pgw#667's
@@ -2727,43 +2579,6 @@ def load_from_pretrained(
                 setattr(pipe, _WEIGHT_LANE_ATTR, "fp8-hooks")
         except Exception:
             pass
-    if adaptive_rung == "nf4":
-        # gw#521: verify the quant actually LANDED — a config whose component
-        # names miss the pipeline is silently ignored by diffusers, and a
-        # full-precision pipeline stamped "nf4" lies to placement and billing.
-        targets = list(getattr(
-            kwargs.get("quantization_config"), "components_to_quantize", None) or [])
-        if targets and not _bnb_quantized_components(pipe, targets):
-            logger.error(
-                "EMERGENCY nf4 did NOT land on %s (targets %s, pipeline %s) — "
-                "serving full precision; the offload ladder carries it",
-                path, targets, type(pipe).__name__,
-            )
-            # pgw#824: this was `adaptive_rung = ""`, which made the failure
-            # SELF-SUPPRESSING — the `if adaptive_rung:` stamp below is the
-            # very mechanism that reports rung outcomes to placement, and
-            # clearing the variable is exactly what switches it off. So the
-            # worst rung outcome on the ladder (serving FULL PRECISION over
-            # the budgeted VRAM, on a host that was already too tight for
-            # stored precision) was the only one that reported nothing at all,
-            # while every sibling rung reported itself.
-            #
-            # A distinct token instead: `provision` routes it to
-            # SlotLoad.rung/rung_detail, so it reaches placement through the
-            # SAME ServePlan/FnDegraded path as every other rung
-            # (`_record_adaptive_rung`) rather than through a log line no
-            # hub-spawned pod can expose.
-            adaptive_rung = RUNG_NF4_UNLANDED
-            activity_mod.emit_event(
-                activity_mod.KIND_SERVE_DEGRADE,
-                f"model={path} pipeline={type(pipe).__name__} "
-                f"targets={targets}: the emergency nf4 rung was engaged "
-                f"because free VRAM was below the stored-precision footprint, "
-                f"and it landed on ZERO modules (the config's component names "
-                f"miss this pipeline). Serving FULL PRECISION over the "
-                f"budgeted VRAM; only the offload ladder carries it now",
-                phase="nf4_rung_did_not_land",
-            )
     if adaptive_rung:
         # gw#491: a silently-engaged emergency rung is the th#736 bug class —
         # the executor reconciles this stamp into ServePlan.ran / FnDegraded.
@@ -2790,10 +2605,7 @@ __all__ = [
     "apply_block_window_offload",
     "block_offload_active",
     "pipeline_weight_lane",
-    "emergency_quant_enabled",
-    "bitsandbytes_available",
     "runtime_fp8_storage_supported",
-    "emergency_quantization_config",
     "component_load_dtypes",
     "model_index_components",
     "model_index_component_classes",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -38,7 +38,6 @@ from .cache_paths import tensorhub_cas_dir
 from .errors import UrlExpiredError
 from .envelope import envelope_refusal
 from .loading import (
-    RUNG_NF4_UNLANDED,
     assert_uniform_compute_dtype,
     composition_compute_dtype,
     detect_diffusers_variant,
@@ -88,7 +87,7 @@ class SlotLoad:
     # dropped before the load.
     pre_drop_wanted: str = ""
     pre_drop_detail: str = ""
-    # gw#491: the loader engaged an emergency fit rung ("fp8" / "nf4").
+    # gw#491: the loader engaged the fp8-storage fit rung.
     rung: str = ""
     rung_detail: str = ""
     # th#737 backstop: the resolved cast was attempted at load and failed on
@@ -230,21 +229,9 @@ def load_slot(
         cast_failed = getattr(
             pipe, "_cozy_fp8_storage_requested", False
         ) and not getattr(pipe, "_cozy_fp8_storage_ok", True)
-        if rung == RUNG_NF4_UNLANDED:
-            # pgw#824: the emergency rung ENGAGED and landed on nothing. Routed
-            # through the same SlotLoad.rung path as every sibling rung, so it
-            # reaches ServePlan/FnDegraded via `_record_adaptive_rung` instead of
-            # dying in a log line. It used to clear the stamp, which suppressed the
-            # only report the ladder had — the worst outcome was the silent one.
-            out.rung = rung
-            out.rung_detail = (
-                f"adaptive fit rung 'nf4' engaged at load for slot {slot!r} "
-                f"({type(pipe).__name__}) and landed on ZERO modules; this slot "
-                f"serves FULL PRECISION over the VRAM it was budgeted, and only "
-                f"the offload ladder carries it")
-        elif rung == "nf4" or (rung == "fp8" and not cast_failed):
-            # gw#491: the loader engaged an emergency rung because free VRAM at
-            # load was tighter than planning assumed.
+        if rung == "fp8" and not cast_failed:
+            # gw#491: the loader engaged the fp8-storage fit rung because free
+            # VRAM at load was tighter than planning assumed.
             out.rung = rung
             out.rung_detail = (
                 f"adaptive fit rung {rung!r} engaged at load for slot {slot!r} "

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -3,15 +3,23 @@
 Degrade-don't-OOM (Paul, 2026-07-10) used to span three vocabularies in five
 files, joined by f-strings: plan-time ``serve_fit.RUN_*`` (hub wire), placement
 modes in ``memory`` (``model_offload``/``group_offload``/``sequential``), and
-bare ``"fp8"``/``"nf4"`` load-rung strings through the executor's bookkeepers.
-This module is the single ordered ladder they all project from.
+bare ``"fp8"`` load-rung strings through the executor's bookkeepers. This
+module is the single ordered ladder they all project from.
+
+**No rung quantizes at runtime** (Paul, 2026-08-13, pgw#1206 D: *"We shouldn't
+be doing runtime quants; if we're really memory-constrained then we should be
+fetching the quant we need"*). The bnb-nf4 emergency rung sat between
+``FP8_STORAGE`` and ``MODEL_OFFLOAD`` and is deleted: a quant rung is an AOT
+artifact the ladder SELECTS, never one the loader manufactures. Deleting a
+rung is one line here because A2 made this the only ordering.
 
 ``off``/``vae_only``/``auto`` are NOT rungs — they are resident-placement
 flavors ``memory.select_auto_mode`` picks *inside* the native rung.
 
 The wire contract: ``ServePlan.ran``/``run_mode`` carry ONLY the
 ``RUN_MODES`` vocabulary. tensorhub matches ``FnDegraded.ran`` EXACTLY
-(``degradation_reschedule.go``: ``case "offload","cpu","emergency_quant"``),
+(``degradation_reschedule.go``: ``case "offload","cpu","emergency_quant"`` —
+we no longer produce the third, and the hub keeps accepting it),
 so a decorated value like ``offload:model_offload`` silently misses the
 VRAM-driven-drain arm — placement detail travels in ``reason``, never in
 ``ran``.
@@ -29,7 +37,7 @@ class Rung:
 
     ``placement`` is the ``memory`` placement mode this rung implies ("" for
     rungs that keep full residency); ``storage`` the runtime weight-storage
-    transform ("", "fp8", "nf4"); ``run_mode`` the hub-wire projection
+    transform ("" or "fp8"); ``run_mode`` the hub-wire projection
     (``serve_fit.RUN_*``); ``latency`` the honest price vs a native run;
     ``touches_host_ram`` whether weights become host-resident (the
     ``strict_vram`` opt-out boundary, and the pgw#1063 host-RAM pricing
@@ -47,13 +55,11 @@ class Rung:
 # contract; tensorhub matches them EXACTLY.
 RUN_NATIVE = "native"
 RUN_FP8_STORAGE = "fp8_storage"
-RUN_EMERGENCY = "emergency_quant"
 RUN_OFFLOAD = "offload"
 RUN_CPU = "cpu"
 
 NATIVE = Rung("native", "", "", RUN_NATIVE, 1.0, False)
 FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
-NF4 = Rung("nf4", "", "nf4", RUN_EMERGENCY, 1.1, False)
 MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
 GROUP_OFFLOAD = Rung("group_offload", "group_offload", "", RUN_OFFLOAD, 3.0, True)
 SEQUENTIAL = Rung("sequential", "sequential", "", RUN_OFFLOAD, 4.0, True)
@@ -61,7 +67,7 @@ CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, False)
 
 #: The ONE ordering, best first. ``descend`` walks it; nothing else may.
 LADDER: tuple[Rung, ...] = (
-    NATIVE, FP8_STORAGE, NF4, MODEL_OFFLOAD, GROUP_OFFLOAD, SEQUENTIAL, CPU,
+    NATIVE, FP8_STORAGE, MODEL_OFFLOAD, GROUP_OFFLOAD, SEQUENTIAL, CPU,
 )
 
 #: The reactive placement tail, shallowest first (gw#463): a load-time CUDA

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -11,7 +11,6 @@ means and is HONEST about the trade. The full ladder, best-first:
   fp8 storage   -> runtime fp8-E4M3 weight storage + bf16 compute
                   (loading.apply_fp8_storage; no fp8 silicon required):
                   near-native quality, weights ~halve
-  emergency nf4 -> runtime 4-bit, below-platform quality, still on-GPU
   offload       -> weights spill to CPU/disk, slower but valid (the PRIMARY
                   lever at the low end where weights exceed VRAM even quantized)
   cpu           -> no GPU at all: very slow, offered behind a loud warning
@@ -32,7 +31,7 @@ Selection ACROSS stored flavors stays upstream: this planner marks each
 function serveable/unserveable + how-it-runs, and the hub's routing (th#597
 ranking) picks the highest-quality fitting flavor. bf16 -> fp8 -> nvfp4 ->
 int4 falls out of that ranking over the serveable set; this planner adds the
-RUNTIME rungs (fp8 storage / nf4 / offload / cpu) for the one function it
+RUNTIME rungs (fp8 storage / offload / cpu) for the one function it
 was given, plus an honest hint when a stored flavor would have served
 natively.
 
@@ -47,7 +46,6 @@ from dataclasses import dataclass, replace
 from typing import Any, Optional
 
 from .hub_policy import (
-    FIT_EMERGENCY,
     FIT_EMERGENCY_FP8,
     FIT_FITS,
     FIT_FP8,
@@ -63,7 +61,6 @@ from .hub_policy import (
 # here because this module is the hub-vocabulary projection.
 from .rung import (
     RUN_CPU as RUN_CPU,
-    RUN_EMERGENCY as RUN_EMERGENCY,
     RUN_FP8_STORAGE as RUN_FP8_STORAGE,
     RUN_NATIVE as RUN_NATIVE,
     RUN_OFFLOAD as RUN_OFFLOAD,
@@ -184,15 +181,10 @@ def plan_serve(
             ran=wanted,
         )
 
-    # Runs, but degraded: runtime fp8 storage, emergency 4-bit, or the offload
-    # ladder. At the low end offload is the PRIMARY lever (weights exceed VRAM
-    # even quantized) — fit over speed. Only offload is CPU-touching.
-    if verdict == FIT_EMERGENCY_FP8:
-        run_mode = RUN_FP8_STORAGE
-    elif verdict == FIT_EMERGENCY:
-        run_mode = RUN_EMERGENCY
-    else:
-        run_mode = RUN_OFFLOAD
+    # Runs, but degraded: runtime fp8 storage or the offload ladder. Offload
+    # is the PRIMARY lever whenever the weights exceed VRAM — fit over speed.
+    # Only offload is CPU-touching. Nothing quantizes at runtime (pgw#1206 D).
+    run_mode = RUN_FP8_STORAGE if verdict == FIT_EMERGENCY_FP8 else RUN_OFFLOAD
     if run_mode == RUN_OFFLOAD and strict_vram:
         return ServePlan(
             serveable=False,
@@ -273,11 +265,5 @@ def _honest_warning(run_mode: str, recommended_vram_gb: Optional[float], detail:
             "does not fit at full precision; running fp8-E4M3 weight storage: "
             "near-native quality. A stored #fp8 flavor of this model would "
             "serve natively here." + ideal
-        )
-    if run_mode == RUN_EMERGENCY:
-        return (
-            "does not fit at full precision; running 4-bit emergency "
-            "quantization: below-platform quality. A stored 4-bit flavor "
-            "(#nvfp4 / #svdq-int4) would serve natively here." + ideal
         )
     return detail

--- a/tests/test_lane_determinism_pgw772.py
+++ b/tests/test_lane_determinism_pgw772.py
@@ -140,7 +140,6 @@ def test_involuntary_cant_fit_rung_still_engages(
         # but DOES fit with the fp8-storage rung's halved denoiser:
         # budget = total - 0.25 * denoiser.
         free_gb = 2.0 + (total - 0.25 * denoiser) / float(_GiB)
-        monkeypatch.setattr(loading, "emergency_quant_enabled", lambda: True)
         monkeypatch.setattr(
             loading, "runtime_fp8_storage_supported", lambda: True)
         _pin_free_vram(monkeypatch, free_gb)

--- a/tests/test_rung_ladder_pgw1206.py
+++ b/tests/test_rung_ladder_pgw1206.py
@@ -15,6 +15,7 @@ EXACTLY (degradation_reschedule.go: ``case "offload","cpu","emergency_quant"``)
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
 
@@ -22,7 +23,7 @@ from gen_worker.models import rung
 from gen_worker.models.memory import place_pipeline
 from gen_worker.models.serve_fit import (
     RUN_CPU,
-    RUN_EMERGENCY,
+    plan_serve,
     RUN_FP8_STORAGE,
     RUN_NATIVE,
     RUN_OFFLOAD,
@@ -30,8 +31,10 @@ from gen_worker.models.serve_fit import (
 )
 
 #: tensorhub's exact-match FnDegraded.ran vocabulary
-#: (profiling/degradation.go + autoscale/degradation_reschedule.go).
-GO_RAN_VOCABULARY = {RUN_NATIVE, RUN_FP8_STORAGE, RUN_EMERGENCY, RUN_OFFLOAD, RUN_CPU, "bf16", "fp8"}
+#: (profiling/degradation.go + autoscale/degradation_reschedule.go). The hub
+#: still accepts "emergency_quant"; pgw#1206 D deleted the only rung that
+#: produced it, so nothing here may emit it again.
+GO_RAN_VOCABULARY = {RUN_NATIVE, RUN_FP8_STORAGE, RUN_OFFLOAD, RUN_CPU, "bf16", "fp8"}
 
 
 # --- the ladder itself ------------------------------------------------------
@@ -40,9 +43,15 @@ def test_one_ordered_ladder() -> None:
     """One ladder, best-first, price monotonic, projections coherent."""
     names = [r.name for r in rung.LADDER]
     assert names == [
-        "native", "fp8_storage", "nf4",
+        "native", "fp8_storage",
         "model_offload", "group_offload", "sequential", "cpu",
     ]
+    # pgw#1206 D: no rung manufactures a quant at runtime. A quant rung is an
+    # AOT artifact the ladder SELECTS; the only runtime storage transform left
+    # is fp8-E4M3, which is a re-encoding of the same weights, not a quant
+    # recipe with an ungated quality verdict.
+    assert [r.storage for r in rung.LADDER if r.storage] == ["fp8"]
+    assert "emergency_quant" not in {r.run_mode for r in rung.LADDER}
     prices = [r.latency for r in rung.LADDER]
     assert prices == sorted(prices), "price must be monotonic down the ladder"
     # Host-RAM-touching == exactly the placement tail (the strict_vram
@@ -163,10 +172,74 @@ def test_demotion_ran_matches_go_vocabulary_exactly() -> None:
 def test_load_rung_and_cast_drop_share_the_one_replan() -> None:
     """The load-time rungs and the th#737 cast-drop report through the SAME
     projection — no third vocabulary, wanted/ran stay honest."""
-    engaged = replan(None, run_mode=RUN_EMERGENCY, detail="load fit: nf4")
-    assert engaged.run_mode == RUN_EMERGENCY and engaged.ran == RUN_EMERGENCY
+    engaged = replan(None, run_mode=RUN_FP8_STORAGE, detail="load fit: fp8")
+    assert engaged.run_mode == RUN_FP8_STORAGE and engaged.ran == RUN_FP8_STORAGE
     assert engaged.degraded
     dropped = replan(None, wanted="fp8", ran="bf16", detail="no cast surface")
     assert dropped.run_mode == RUN_NATIVE
     assert dropped.wanted == "fp8" and dropped.ran == "bf16"
     assert dropped.degraded  # ran != wanted must surface as FnDegraded
+
+
+# --- pgw#1206 D: no rung manufactures a quant, and the floor still holds -----
+
+
+def _resources(vram_gb: float, *, strict: bool = False) -> Any:
+    from gen_worker.api.decorators import Resources
+
+    return Resources(gpu=True, vram_gb_hint=vram_gb, strict_vram=strict)
+
+
+def _cuda_caps() -> Any:
+    from gen_worker.models.hub_policy import TensorhubWorkerCapabilities
+
+    return TensorhubWorkerCapabilities(
+        cuda_version="13.0", gpu_sm=90, torch_version="2.13.0", installed_libs=[])
+
+
+@pytest.mark.parametrize("free_gb", [
+    40.0,  # THE nf4 window: 0.45*80 <= 40 < 0.55*80 — master answers
+           # `emergency_quant` here and nothing else in the suite covers it
+    8.0,   # far past every resident rung
+])
+def test_a_model_over_VRAM_lands_on_OFFLOAD_and_never_refuses(free_gb: float) -> None:
+    """Degrade-don't-OOM (Paul, 2026-07-10) survives the nf4 deletion.
+
+    At 40 GB free the old ladder had exactly one answer — quantize the
+    denoiser to 4 bits at load, at a quality nobody gated. The rung is gone,
+    so the same input must serve through the OFFLOAD ladder: slower, honest,
+    still a serve. A hard fail here would be the OOM the ruling forbids, and
+    a silent 4-bit serve is what the ruling now forbids instead.
+    """
+    plan = plan_serve(_resources(80.0), _cuda_caps(), free_vram_gb=free_gb)
+
+    assert plan.serveable, plan.reason
+    assert plan.run_mode == RUN_OFFLOAD
+    assert plan.ran in GO_RAN_VOCABULARY
+    assert plan.degraded
+    assert "emergency" not in (plan.warning or "").lower()
+    assert "4-bit" not in (plan.warning or "")
+
+
+def test_the_only_refusal_left_is_the_authors_own_strict_vram_optout() -> None:
+    """The floor is universal; the ONE exception is the author saying weights
+    may not touch host RAM. That is an opt-out, not a hardware verdict."""
+    plan = plan_serve(_resources(80.0, strict=True), _cuda_caps(), free_vram_gb=8.0)
+    assert not plan.serveable
+    assert "strict_vram" in plan.reason
+
+
+def test_no_runtime_quant_rung_exists_to_be_reached() -> None:
+    """The mechanism, not just the decision: the fit verdict vocabulary has no
+    runtime-quant member, so nothing can route to one again by adding a caller.
+    """
+    from gen_worker.models import hub_policy, loading
+
+    assert not hasattr(hub_policy, "FIT_EMERGENCY")
+    assert not hasattr(loading, "emergency_quantization_config")
+    assert not hasattr(loading, "emergency_quant_enabled")
+    assert not hasattr(loading, "bitsandbytes_available")
+    assert not hasattr(loading, "EMERGENCY_FIT_FACTOR")
+    # ...while the AOT path that READS a quant off disk is untouched: a
+    # fetched artifact still loads through its own config.
+    assert hasattr(loading, "synthesize_quantization_config")

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -506,33 +506,34 @@ def test_the_delegated_mint_actually_passes_the_evidence_callback() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_an_unlanded_nf4_rung_is_a_rung_OUTCOME_not_the_absence_of_one() -> None:
-    """RED before pgw#824: the failure did `adaptive_rung = ""`, and the
-    `if adaptive_rung:` stamp below it is the very mechanism that reports rung
-    outcomes to placement — so clearing the variable SELF-SUPPRESSED the
-    report. The worst outcome the ladder can produce (serving full precision
-    over the budgeted VRAM, on a host already too tight for stored precision)
-    was the only one that reported nothing, while every sibling rung reported
-    itself.
+def test_a_rung_OUTCOME_reaches_placement_THROUGH_SlotLoad_not_a_log_line() -> None:
+    """RED before pgw#824: an emergency rung that engaged and landed on nothing
+    did ``adaptive_rung = ""``, and the ``if adaptive_rung:`` stamp below it is
+    the very mechanism that reports rung outcomes to placement — so clearing
+    the variable SELF-SUPPRESSED the report. The worst outcome the ladder could
+    produce was the only one that reported nothing.
+
+    pgw#1206 D deleted the rung that carried this incident (bnb-nf4 —
+    Paul: no runtime quants), and the INVARIANT is what survives it: a rung
+    outcome reaches placement through ``SlotLoad.rung`` ->
+    ``_record_rung_transition``, never through a log line a hub-spawned pod
+    cannot expose. The surviving fp8-storage rung is checked on the same seam.
     """
-    from gen_worker.models import loading, provision
-
-    # Three states placement must be able to tell apart.
-    assert loading.RUNG_NF4_UNLANDED not in ("", "nf4")
-    assert provision.RUNG_NF4_UNLANDED == loading.RUNG_NF4_UNLANDED
-
-
-def test_the_unlanded_rung_reaches_placement_through_SlotLoad() -> None:
-    """An event alone would not be enough: every sibling rung reaches
-    ServePlan/FnDegraded via SlotLoad.rung -> `_record_rung_transition`, and a
-    fix that only logged-but-typed would still leave placement blind."""
     import inspect
 
-    from gen_worker.models import provision
+    from gen_worker.models import loading, provision
 
     src = inspect.getsource(provision)
-    assert "if rung == RUNG_NF4_UNLANDED:" in src
+    assert 'if rung == "fp8" and not cast_failed:' in src
     assert "out.rung = rung" in src
+    assert "out.rung_detail = (" in src
+    # The stamp the seam reads, still written by the loader and still gated on
+    # the rung being non-empty (which is what made the bug possible).
+    loader = inspect.getsource(loading)
+    assert "pipe._cozy_adaptive_rung = adaptive_rung" in loader
+    # ...and the rung that carried the incident cannot come back silently.
+    assert not hasattr(loading, "RUNG_NF4_UNLANDED")
+    assert not hasattr(provision, "RUNG_NF4_UNLANDED")
 
 
 def test_a_failed_eviction_stays_booked_in_vram(


### PR DESCRIPTION
**Paul, 2026-08-13:** *"yeah agreed. Cut it. We shouldn't be doing runtime quants; if we're really memory-constrained then we should be fetching the quant we need, which is hopefully available (we just need to produce it ahead of time)."*

## The ladder change is ONE LINE, and that is the point

`models/rung.py` loses `NF4` from `LADDER`. That is the entire ladder edit. Before A2 this rung lived in three vocabularies across five files joined by f-strings — the One Rung ladder is what makes a rung deletable in one place, so this PR is the consolidation paying off rather than a second cleanup.

The ladder now reads: **quant rungs (AOT artifacts the ladder SELECTS) → runtime fp8-E4M3 storage → CPU-offload → never OOM.**

Deleted with it: `RUN_EMERGENCY` as an emitted run mode, `hub_policy.FIT_EMERGENCY` and its verdict branch, loading's `emergency_quant_enabled` / `bitsandbytes_available` / `emergency_quantization_config` / `_bnb_quantized_components` / `EMERGENCY_FIT_FACTOR` / `RUNG_NF4_UNLANDED` and the post-load landing check, provision's unlanded arm, serve_fit's warning text.

`_adaptive_fit_rung` survives as an fp8-only decision and states the new rule in its own refusal: a snapshot that fits no rung serves at stored precision and the OFFLOAD ladder carries it, *because a smaller-precision serve is an AOT artifact to fetch, never one to manufacture at load*. **Reading a quant off disk is untouched** — `synthesize_quantization_config` still loads a produced bnb artifact, which is the sanctioned path, not the deleted one.

## Degrade-don't-OOM survives as THE test, red-verified

`tests/test_rung_ladder_pgw1206.py` (A2's ruling test, still the only one) gains the floor: an 80 GB model at **40 GB free — THE nf4 window, `0.45*80 <= 40 < 0.55*80`** — and at 8 GB free both land on `RUN_OFFLOAD`, serveable and honest. The sole refusal left is the author's own `strict_vram` opt-out.

**Red-verified at `6a4349d3` in a throwaway master worktree: 3 of 15 cases fail there**, and the load-bearing one is the 40 GB window, where master answers `emergency_quant`. (The far-over-VRAM case passes on both — which is exactly why the window case is in the test.)

`pgw#824`'s incident test is **ported, not deleted**: the rung that carried it is gone, and the invariant that outlives it — a rung outcome reaches placement through `SlotLoad.rung`, never a log line — is asserted on the surviving fp8 rung, plus a guard that the deleted state cannot return.

## The inline converter: a SECOND producer of the same artifact

`gen_worker.convert` loses its bitsandbytes lane (`nf4`/`fp4`/`int4`/`int4:nf4`/`int4:fp4` dtypes, `run_inline_conversion`'s bnb arm, `_run_bnb_inline`, `_run_bnb_diffusers_inline`). Cross-repo evidence: the **priced** `bitsandbytes-quantization` conversion function (training-endpoints `conversion/src/conversion/quant/bnb.py`) builds its own `BitsAndBytesConfig` over `Source.iter_hf_components` and never called ours, and the only cross-repo caller of `run_inline_conversion` is `convert_gguf`. One conversion surface, one producer. **The conversion ENDPOINT's own lane is untouched.**

## Requirement checks

- **Config keys**: there is no key to fail loudly on. The rung read `torch.cuda.is_available()`, never an env var — verified against `config/loader.py` and `scripts/config_reads_allowlist.txt`. Nothing to deprecate.
- **No new fallback wired.** The seam where nf4 fired now returns `("", None)` and the existing offload ladder takes the slot.

## Cross-repo follow-ups (no breakage; recorded so nobody re-derives them)

- **cozy-local** branches on the verdict we no longer emit (`install.go:196`, `doctor.go:149`) and warns *"it will run via the emergency nf4-quantization rung (reduced quality)"* — now unreachable, worth deleting on their side.
- **e2e** `j23_sdxl_cloud_test.go:830`'s known-red `optional` case is annotated *"the ladder reaches the bnb rung (bitsandbytes not in the image -> setup_failed)"*. This cut removes that failure mode; the comment is now stale. Notably the rung's only observed production appearance was a failure.
- **inference-endpoints** `flux.2-klein-4b/9b` carry `bitsandbytes>=0.45`; still legitimate if they load bnb-quantized artifacts (that path survives), otherwise droppable.

## Verification

Strict mypy clean (754 files, fleet venv), all nine gating fast-gate guards green, **ruff delta zero**, 639 adjacent tests green (`rung|ladder|serve_fit|fit|loading|lane|memory|place|provision|convert|quant|degrade|silent_failure`). The one failure in `test_armed_target_install_pgw1093` reproduces identically on master — box-local CUDA-driver artifact, not a regression.

**Measured: 12 files, +188/−629 (net −441); src 8 files +62/−601 (net −539).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)