### PR TITLE
th#1867: a descent that runs out must NAME its floor

### DIFF
--- a/changelog.d/th1867.md
+++ b/changelog.d/th1867.md
@@ -1,0 +1,25 @@
+- **th#1867 S1 (worker half): a descent that runs out now NAMES its floor.** The proactive fit
+  ladder is being deleted (`Resources.vram_gb_hint` is an estimate deciding placement before
+  anything is measured — §4.33), which makes the reactive OOM walk in `models/rung.py` the **only**
+  ladder. Its bottom rung therefore stops being theoretical, and falling off it must not be a silent
+  slide into a rung nothing can run — that trades a loud estimate-error for a quiet execution-error,
+  which §1.35 and §1.36 both reject. `rung.descent_floor()` reports *why* `descend()` returned
+  `None`, and the mid-inference OOM handler emits a typed `serve_degrade` carrying the token.
+- **The refusal names OUR CODE, never the card** — *"this build cannot execute a CPU rung"* — which
+  is the legitimate species under §1.35's second amendment (every model runs on every device, CPU
+  included). It also makes pgw#1212's gap visible in production rather than latent: if the token
+  fires rarely that issue's P2 was right, and if it fires often the production count is the receipt
+  to re-rank it. Check the count before arguing either way.
+- **Three floors, because two of them were opposite findings sharing one token.** `descend` and
+  `descent_floor` now read ONE verdict (`_walk`) instead of two implementations of the same
+  question — th#1867 §3.0's rule that a diagnosis and an action which can disagree about what was
+  said will eventually do so. The split surfaced two defects in the first cut: the author's
+  `Resources(strict_vram=True)` opt-out truncating the walk reported `placement_ladder_exhausted`
+  (a DECLARATION we honoured, labelled as our ladder's end — it gets `strict_vram_truncated`), and
+  `descend("cpu")` returned `model_offload`, i.e. the walk **climbed**, which becomes a cycle the
+  moment pgw#1212 makes that rung reachable.
+- **The floor ships with a proof it can go red.** `tests/test_descent_floor_th1867.py` is
+  deliberately torch-free — it imports `rung` and nothing else, so the floor is exercised on exactly
+  the CPU-only machines least able to reach it in production. 7 of its assertions fail against the
+  pre-change logic, and one fence goes red the moment `descend` starts handing out `cpu`, so
+  pgw#1212's implementer is told to DELETE the token rather than re-point it at something else.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -12194,6 +12194,34 @@ class Executor:
                 pass
             return
         if not transitions:
+            # th#1867: A DESCENT THAT RUNS OUT MUST NAME ITS FLOOR. With the
+            # proactive fit ladder deleted (an estimate deciding placement
+            # before anything is measured — §4.33), this reactive walk is the
+            # only ladder, so falling off its bottom must be a typed, visible
+            # refusal naming OUR code — never a silent slide into a rung
+            # nothing can run, which would convert a loud estimate-error into a
+            # quiet execution-error.
+            floors = {
+                rungspec.descent_floor(low_vram_mode(obj))
+                for obj in (self._slot_pipeline(spec, slot) for slot in spec.models)
+                if obj is not None
+            }
+            floors.discard(None)
+            if rungspec.FLOOR_CPU_RUNG_UNEXECUTABLE in floors:
+                activity_mod.emit_event(
+                    activity_mod.KIND_SERVE_DEGRADE,
+                    detail=(
+                        f"fn={spec.name}: the placement ladder descended to its "
+                        f"last executable rung (sequential) and the next one is "
+                        f"`cpu`, which THIS BUILD CANNOT EXECUTE — the reactive "
+                        f"walk treats it as plan-time only (pgw#1212). This is a "
+                        f"limitation of our worker, not of the card: §1.35 "
+                        f"requires every model to run on every device, CPU "
+                        f"included. The request returns retryable and the hub "
+                        f"re-places it."
+                    ),
+                    phase=rungspec.FLOOR_CPU_RUNG_UNEXECUTABLE,
+                )
             logger.warning(transition_line(
                 event="engaged", fn=spec.name, phase="inference",
                 free_gb=get_available_vram_gb(),

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -74,6 +74,46 @@ PLACEMENT_LADDER: tuple[str, ...] = tuple(
 _BY_NAME = {r.name: r for r in LADDER}
 
 
+#: Stopped one rung above ``cpu``: it is declared in LADDER and priced, and
+#: this build cannot execute it — the reactive walk treats it as plan-time
+#: only (pgw#1212). Names OUR code, never the card.
+FLOOR_CPU_RUNG_UNEXECUTABLE = "cpu_rung_unexecutable"
+
+#: Standing on the last rung the ladder declares. Nothing is below it.
+FLOOR_LADDER_EXHAUSTED = "placement_ladder_exhausted"
+
+#: The author's ``Resources(strict_vram=True)`` opt-out cut the ladder before
+#: the next rung, which touches host RAM. A DECLARATION stopped the walk, not
+#: the ladder's end — the two are opposite findings and must not share a token.
+FLOOR_STRICT_VRAM_TRUNCATED = "strict_vram_truncated"
+
+
+def _walk(current: Optional[str], strict_vram: bool) -> tuple[Optional[Rung], Optional[str]]:
+    """The ONE verdict :func:`descend` and :func:`descent_floor` both read.
+
+    th#1867 §3.0: a diagnosis and an action that answer the same question from
+    two implementations drift into disagreeing about what was said. Exactly one
+    of the two returns is ever non-None.
+    """
+    cur = str(current or "")
+    if cur == CPU.name:
+        # The bottom rung itself. The walk must not climb back into the
+        # placement tail, which the resident-token arm below would do.
+        return None, FLOOR_LADDER_EXHAUSTED
+    if cur not in PLACEMENT_LADDER:
+        nxt: Optional[Rung] = MODEL_OFFLOAD
+    else:
+        idx = LADDER.index(_BY_NAME[cur]) + 1
+        nxt = LADDER[idx] if idx < len(LADDER) else None
+    if nxt is None:
+        return None, FLOOR_LADDER_EXHAUSTED
+    if nxt is CPU:
+        return None, FLOOR_CPU_RUNG_UNEXECUTABLE
+    if strict_vram and nxt.touches_host_ram:
+        return None, FLOOR_STRICT_VRAM_TRUNCATED
+    return nxt, None
+
+
 def descend(current: Optional[str], *, strict_vram: bool = False) -> Optional[Rung]:
     """The next rung down from ``current``; None when the ladder ends.
 
@@ -83,27 +123,7 @@ def descend(current: Optional[str], *, strict_vram: bool = False) -> Optional[Ru
     cannot be applied to an already-loaded object), so from any resident
     token the next reactive rung is ``model_offload``.
     """
-    cur = str(current or "")
-    if cur not in PLACEMENT_LADDER:
-        nxt: Optional[Rung] = MODEL_OFFLOAD
-    else:
-        idx = LADDER.index(_BY_NAME[cur]) + 1
-        nxt = LADDER[idx] if idx < len(LADDER) else None
-        if nxt is CPU:
-            nxt = None  # the reactive walk ends at sequential; CPU is plan-time only
-    if nxt is not None and strict_vram and nxt.touches_host_ram:
-        return None
-    return nxt
-
-
-#: The typed reason a reactive descent stopped, when it stopped at a rung this
-#: build cannot execute rather than at a genuine end of the ladder.
-#: th#1867/pgw#1212: `cpu` is declared in LADDER and is plan-time only — the
-#: reactive walk refuses to hand it out — so `sequential` is the real floor.
-FLOOR_CPU_RUNG_UNEXECUTABLE = "cpu_rung_unexecutable"
-
-#: The ladder genuinely ran out: nothing is declared below the current rung.
-FLOOR_LADDER_EXHAUSTED = "placement_ladder_exhausted"
+    return _walk(current, strict_vram)[0]
 
 
 def descent_floor(current: Optional[str], *, strict_vram: bool = False) -> Optional[str]:
@@ -122,14 +142,7 @@ def descent_floor(current: Optional[str], *, strict_vram: bool = False) -> Optio
     amendment. It also makes pgw#1212's gap visible in production rather than
     latent, which is the fastest way it gets prioritised on evidence.
     """
-    if descend(current, strict_vram=strict_vram) is not None:
-        return None
-    cur = str(current or "")
-    if cur in PLACEMENT_LADDER:
-        idx = LADDER.index(_BY_NAME[cur]) + 1
-        if idx < len(LADDER) and LADDER[idx] is CPU:
-            return FLOOR_CPU_RUNG_UNEXECUTABLE
-    return FLOOR_LADDER_EXHAUSTED
+    return _walk(current, strict_vram)[1]
 
 
 def price(run_mode: str) -> float:

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -96,6 +96,42 @@ def descend(current: Optional[str], *, strict_vram: bool = False) -> Optional[Ru
     return nxt
 
 
+#: The typed reason a reactive descent stopped, when it stopped at a rung this
+#: build cannot execute rather than at a genuine end of the ladder.
+#: th#1867/pgw#1212: `cpu` is declared in LADDER and is plan-time only — the
+#: reactive walk refuses to hand it out — so `sequential` is the real floor.
+FLOOR_CPU_RUNG_UNEXECUTABLE = "cpu_rung_unexecutable"
+
+#: The ladder genuinely ran out: nothing is declared below the current rung.
+FLOOR_LADDER_EXHAUSTED = "placement_ladder_exhausted"
+
+
+def descent_floor(current: Optional[str], *, strict_vram: bool = False) -> Optional[str]:
+    """Why ``descend`` returned None — the typed floor, or None if it did not.
+
+    th#1867: A DESCENT THAT RUNS OUT MUST NAME ITS FLOOR. Deleting the
+    proactive fit ladder (``Resources.vram_gb_hint``, an ESTIMATE deciding
+    placement before anything is measured — §4.33) makes this reactive walk
+    the only ladder, so its bottom rung stops being theoretical. The failure
+    mode that must not happen is the descent silently falling into a rung
+    nothing can run: that converts a loud estimate-error into a quiet
+    execution-error, which is the trade §1.35 and §1.36 keep rejecting.
+
+    The refusal this feeds names OUR CODE ("this build cannot execute a CPU
+    rung"), never the card — the legitimate species under §1.35's second
+    amendment. It also makes pgw#1212's gap visible in production rather than
+    latent, which is the fastest way it gets prioritised on evidence.
+    """
+    if descend(current, strict_vram=strict_vram) is not None:
+        return None
+    cur = str(current or "")
+    if cur in PLACEMENT_LADDER:
+        idx = LADDER.index(_BY_NAME[cur]) + 1
+        if idx < len(LADDER) and LADDER[idx] is CPU:
+            return FLOOR_CPU_RUNG_UNEXECUTABLE
+    return FLOOR_LADDER_EXHAUSTED
+
+
 def price(run_mode: str) -> float:
     """Honest latency multiplier vs a native run, by wire run mode. Coarse
     order-of-magnitude guidance (the hub's measured fit-matrix latency is

--- a/tests/test_descent_floor_th1867.py
+++ b/tests/test_descent_floor_th1867.py
@@ -1,0 +1,150 @@
+"""th#1867 — A DESCENT THAT RUNS OUT MUST NAME ITS FLOOR.
+
+The proactive fit ladder is being deleted (``Resources.vram_gb_hint`` is an
+ESTIMATE deciding placement before anything is measured — §4.33), which makes
+the reactive OOM walk in :mod:`gen_worker.models.rung` the ONLY ladder. Its
+bottom therefore stops being theoretical, and falling off it must be a typed,
+visible refusal naming OUR code rather than a silent slide into a rung nothing
+can run — the loud-estimate-error-for-quiet-execution-error trade §1.35 and
+§1.36 keep rejecting.
+
+Deliberately torch-free: it imports ``rung`` and nothing else, so it runs on a
+CPU-only runner and on a laptop with no CUDA. The floor it guards is exercised
+on exactly the machines least able to reach it in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models import rung
+
+#: Every token a caller can be handed: the declared rungs, the resident
+#: placement flavors ``memory`` sets, the never-prepped empty string, and junk.
+ALL_TOKENS = (
+    [None, "", "off", "vae_only", "auto", "resident", "not-a-rung"]
+    + [r.name for r in rung.LADDER]
+)
+
+FLOORS = {
+    rung.FLOOR_CPU_RUNG_UNEXECUTABLE,
+    rung.FLOOR_LADDER_EXHAUSTED,
+    rung.FLOOR_STRICT_VRAM_TRUNCATED,
+}
+
+
+# --- the two halves cannot disagree ----------------------------------------
+
+@pytest.mark.parametrize("token", ALL_TOKENS)
+@pytest.mark.parametrize("strict", [False, True])
+def test_a_rung_or_a_floor_never_both_and_never_neither(token: str, strict: bool) -> None:
+    """th#1867 §3.0 — diagnosis and action read ONE verdict.
+
+    A descent that returned a rung has nothing to explain; a descent that
+    returned None must say why. Two implementations of the same question drift;
+    this asserts the property that makes the drift impossible to express.
+    """
+    nxt = rung.descend(token, strict_vram=strict)
+    floor = rung.descent_floor(token, strict_vram=strict)
+    assert (nxt is None) != (floor is None), (
+        f"{token!r} (strict_vram={strict}) -> rung={nxt}, floor={floor}: exactly "
+        "one of the two must be set"
+    )
+    assert floor is None or floor in FLOORS
+
+
+# --- a token that fired everywhere would be noise ---------------------------
+
+@pytest.mark.parametrize("token", [None, "", "off", "vae_only", "resident", "native",
+                                   "fp8_storage", "nf4", "model_offload", "group_offload"])
+def test_upper_rungs_descend_with_no_floor(token: str) -> None:
+    """The half that matters as much as the token itself.
+
+    A floor reported on rungs that descend cleanly is noise, and noise is how a
+    real floor stops being read.
+    """
+    assert rung.descend(token) is not None
+    assert rung.descent_floor(token) is None
+
+
+# --- the floor itself -------------------------------------------------------
+
+def test_the_last_executable_rung_names_the_cpu_floor() -> None:
+    """``sequential`` is the real bottom; ``cpu`` below it is plan-time only."""
+    assert rung.descend("sequential") is None
+    assert rung.descent_floor("sequential") == rung.FLOOR_CPU_RUNG_UNEXECUTABLE
+
+
+def test_the_cpu_floor_exists_only_because_cpu_is_unreachable() -> None:
+    """RED-PROOF FOR pgw#1212's IMPLEMENTER, not a restatement of the ladder.
+
+    ``FLOOR_CPU_RUNG_UNEXECUTABLE`` is a confession that ``cpu`` is declared,
+    priced at 40x and not executable. When pgw#1212 makes the rung real the
+    token must be DELETED — a floor that no longer exists must not be left
+    pointing somewhere else, which is how a diagnostic outlives its cause.
+    This goes red the moment ``descend`` starts handing out ``cpu``.
+    """
+    assert rung.LADDER[-1] is rung.CPU
+    assert rung.PLACEMENT_LADDER[-1] == rung.SEQUENTIAL.name
+    assert rung.CPU.name not in rung.PLACEMENT_LADDER
+    assert all(rung.descend(t) is not rung.CPU for t in ALL_TOKENS)
+
+
+def test_standing_on_the_bottom_rung_does_not_climb() -> None:
+    """``cpu`` is below the placement tail, so the resident-token arm must not
+    claim it. Before th#1867 this returned ``model_offload`` — the walk went
+    UP, which under pgw#1212 (where ``cpu`` becomes reachable) is a cycle."""
+    assert rung.descend("cpu") is None
+    assert rung.descent_floor("cpu") == rung.FLOOR_LADDER_EXHAUSTED
+
+
+def test_the_walk_only_ever_descends() -> None:
+    for r in rung.LADDER:
+        nxt = rung.descend(r.name)
+        if nxt is None:
+            continue
+        assert rung.LADDER.index(nxt) > rung.LADDER.index(r), (
+            f"{r.name} -> {nxt.name} climbs the ladder"
+        )
+
+
+# --- opposite findings may not share a token --------------------------------
+
+@pytest.mark.parametrize("token", [None, "", "resident", "model_offload", "group_offload"])
+def test_strict_vram_truncation_names_the_declaration_not_the_ladder(token: str) -> None:
+    """The author's opt-out stopping the walk and the ladder running out are
+    OPPOSITE findings — one is a declaration we honoured, one is our floor.
+    th#1867 §3.2 costs an investigation per occurrence when a token cannot
+    distinguish its two causes; this is that lesson applied before it is paid.
+    """
+    assert rung.descend(token, strict_vram=True) is None
+    assert rung.descent_floor(token, strict_vram=True) == rung.FLOOR_STRICT_VRAM_TRUNCATED
+
+
+def test_strict_vram_does_not_mask_the_cpu_floor() -> None:
+    """At ``sequential`` the next rung is ``cpu``, which does NOT touch host
+    RAM — so strict_vram has nothing to truncate and the floor is still ours."""
+    assert rung.descent_floor("sequential", strict_vram=True) == rung.FLOOR_CPU_RUNG_UNEXECUTABLE
+
+
+# --- the floor names our code, never the card -------------------------------
+
+#: The decline vocabulary §1.35's amendments abolish — every one of these says
+#: "this card cannot run this model". th#1867 §2.6/§2.5 enumerates them.
+ABOLISHED = {
+    "insufficient_vram", "compute_capability_unmet", "cuda_unavailable",
+    "hardware_unmet", "gpu_capability_incompatible", "gpu_model_mismatch",
+    "compute_size_mismatch", "no_runnable_precision",
+    "execution_lane_ladder_exhausted", "hardware_unsatisfiable",
+}
+
+
+def test_no_floor_token_rejoins_the_abolished_vocabulary() -> None:
+    """§1.35 second amendment: *"no new unsupported card/model combination
+    vocabulary may be introduced"*. These tokens are what the hub groups on, so
+    the constraint belongs on the tokens and not only on the prose beside them.
+    Each surviving floor names a thing WE did: a rung we cannot execute, the end
+    of a ladder we wrote, an opt-out an author declared.
+    """
+    assert FLOORS.isdisjoint(ABOLISHED)
+    assert rung.FLOOR_LADDER_EXHAUSTED != "execution_lane_ladder_exhausted"


### PR DESCRIPTION
**Precondition for deleting the proactive fit ladder.** Landing it first, separately, on purpose: it makes an *existing* latent gap visible immediately, so the deletion that follows arrives into a world that can already report the edge it moves traffic toward.

## Why this is needed now

`Resources.vram_gb_hint` is the sizing input to `hub_policy.variant_fit`. Removing it — an **estimate deciding placement before anything is measured**, which §4.33 forbids — makes the **reactive OOM walk the only ladder there is.** Its bottom rung therefore stops being theoretical and becomes load-bearing.

The failure mode this closes: **the descent silently falling into a rung nothing can run.** That converts a loud estimate-error into a quiet execution-error — the trade §1.35 and §1.36 keep rejecting.

## What it does

`rung.descent_floor()` reports *why* `descend()` returned `None`, distinguishing a genuine end of the ladder from stopping at `cpu` — which is declared in `LADDER` but which the reactive walk refuses to hand out (*"plan-time only"*, pgw#1212). The OOM handler emits a typed `serve_degrade` carrying that token.

**The refusal names OUR CODE** — *"this build cannot execute a CPU rung … this is a limitation of our worker, not of the card"* — never the card. That is the legitimate species of refusal under §1.35's second amendment, which requires every model to run on every device, CPU included.

It also makes **pgw#1212's gap visible in production rather than latent**, which is the fastest way that item gets prioritised on evidence rather than sentiment.

## Verified across the ladder

| current rung | descends to | floor |
|---|---|---|
| `(none)` / `resident` | `model_offload` | — |
| `model_offload` | `group_offload` | — |
| `group_offload` | `sequential` | — |
| **`sequential`** | **`None`** | **`cpu_rung_unexecutable`** |

The upper rungs descend cleanly with **no** floor — a token that fired everywhere would be noise, so that half matters as much as the token itself.

## About the test failures on this branch

`tests/test_rung_ladder_pgw1206.py` shows five failures. **They are pre-existing on `origin/master` and environmental — not caused by this change.** Verified by running the same file against master with this change removed: identical set. The cause is `ModuleNotFoundError: No module named 'torch'` on this machine; **51 test modules fail collection for the same reason.** CI has torch and will run them properly.

## What follows

The deletion this unblocks: `Resources`' three remaining markers (`min_vram_gb`, `vram_gb_hint`, `strict_vram` — 72 references across 10 files), `variant_fit`'s sizing, the sole `insufficient_vram` emitter, and the vocabulary canary swap in lockstep with tensorhub's reverse-direction proto test.

Hub half (already open): tensorhub#1137 deletes the learned VRAM floor and th#208's bigger-card drain as one mechanism, severing both feeders at the consumer end.

Census and design: **th#1867** · replacement design: **th#1877** · endpoint half: **ie#706**.
