### PR TITLE
th#1867 S1: derive the upper-rung list, so a deleted rung cannot pass silently

### DIFF
--- a/changelog.d/th1867.md
+++ b/changelog.d/th1867.md
@@ -1,0 +1,8 @@
+- **th#1867 S1 follow-up, caught by the merge queue itself: a green assertion about a deleted rung.**
+  pgw#1206 D removed the bnb-nf4 rung while PR #757 sat in the queue. The queue re-ran against
+  master's real tip and stayed green — but one parametrized case in
+  `tests/test_descent_floor_th1867.py` still named `"nf4"` and **passed for a different reason than
+  it was written for**: an unknown token also descends to `model_offload`. The upper-rung list is
+  now DERIVED from `rung.LADDER`, so a rung added or deleted is covered automatically. A green
+  assertion about a symbol that no longer exists is exactly the class this file was written to
+  guard, and it took one merge to produce one.

--- a/tests/test_descent_floor_th1867.py
+++ b/tests/test_descent_floor_th1867.py
@@ -55,8 +55,18 @@ def test_a_rung_or_a_floor_never_both_and_never_neither(token: str, strict: bool
 
 # --- a token that fired everywhere would be noise ---------------------------
 
-@pytest.mark.parametrize("token", [None, "", "off", "vae_only", "resident", "native",
-                                   "fp8_storage", "nf4", "model_offload", "group_offload"])
+#: Every rung above the floor, DERIVED so a rung added or deleted is covered
+#: automatically. Hardcoding this list is how it came to name `nf4` — a rung
+#: pgw#1206 D deleted while this file sat on the merge queue, after which the
+#: case still passed, for a different reason (an unknown token also descends to
+#: `model_offload`). A green assertion about a symbol that no longer exists is
+#: the defect class this file was written to guard.
+UPPER_RUNGS = [None, "", "off", "vae_only", "resident"] + [
+    r.name for r in rung.LADDER if rung.descend(r.name) is not None
+]
+
+
+@pytest.mark.parametrize("token", UPPER_RUNGS)
 def test_upper_rungs_descend_with_no_floor(token: str) -> None:
     """The half that matters as much as the token itself.
 


### PR DESCRIPTION
**Follow-up to #757, and the merge queue is what caught it.**

pgw#1206 D (#755) deleted the bnb-nf4 rung while #757 sat in the queue. The queue did exactly its job — it re-ran both gates against master's real tip *with* `nf4` gone, and `tests/test_descent_floor_th1867.py` stayed green.

But green was partly luck. One parametrized case still named `"nf4"`, and it **passed for a different reason than it was written for**: `nf4` is no longer a rung, so it falls through as an unknown token, and unknown tokens also descend to `model_offload`. The assertion stopped testing what it was written to test and said nothing about the change.

That is precisely the defect class this file exists to guard — `test_the_cpu_floor_exists_only_because_cpu_is_unreachable` is there so a diagnostic cannot outlive its cause, and th#1867's own S1 hub half was reddened by `tree-fences` naming a test that no longer existed. **It should not be this file carrying the same bug**, and it took one merge to produce one.

## The fix

`UPPER_RUNGS` is now derived from `LADDER` via `descend` rather than hardcoded, so a rung added or deleted is covered automatically and the list cannot name a rung that is gone.

## The count moves 47 → 46, and the drop is accounted for

Derived: `[native, fp8_storage, model_offload, group_offload]` + 5 resident tokens (`None`, `""`, `off`, `vae_only`, `resident`) = **9**. The hardcoded list had **10**, including the deleted `nf4`. No assertion was lost — one stale one was.

Verified locally at `9d5a432c`: `ruff check` and `mypy` clean on the file, 46 pass, still torch-free (imports `rung` and nothing else).