### PR TITLE
pgw#1202: the two harness doubles that could not fail are checked

### DIFF
--- a/changelog.d/pgw1202.md
+++ b/changelog.d/pgw1202.md
@@ -1,0 +1,21 @@
+- Typing: the two HARNESS doubles that were **wholly unchecked** are checked.
+  `tests.harness.cell_hub` and `tests.harness.adopt_rig` sat in the
+  `ignore_errors` burn-down, so nothing in them could fail — a bogus attribute
+  plus a `reveal_type` injected into `cell_hub.py` still produced `Success: no
+  issues found`. `cell_hub.py` additionally carried 30
+  `# type: ignore[attr-defined]` comments that suppressed nothing (the module
+  exemption already did, and `warn_unused_ignores` is off for tests), so they
+  read as diligence while being decoration. Ratchet 314 → 312.
+- `cell_hub`'s state is a declared `CellHubServer(ThreadingHTTPServer)` instead
+  of seven attributes bolted onto a stock server after construction. A typo in
+  any of the handler's thirty reads used to be an `AttributeError` raised inside
+  a request thread — the double failing in a way that looks like the system
+  under test failing. Now `srv.objcts` is `error: "CellHubServer" has no
+  attribute "objcts"; maybe "objects"?`. `record_checkpoint` moves onto the
+  server beside the state it mutates, and the duplicate `slock(srv)` spelling of
+  `with srv.lock` dies.
+- `adopt_rig` patched two module objects twice: `executor.activity_mod` IS
+  `gen_worker.activity` and `executor.provision` IS `gen_worker.models.provision`
+  (verified `is`-identical — the executor resolves both attributes at call
+  time), so each pair was one patch written twice, reaching through an implicit
+  re-export to do it. One patch each now.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,8 +383,6 @@ module = [
   "tests.convert.test_publish_status_mapping_pgw1002",
   "tests.convert.test_publish_survival_pgw1003",
   "tests.convert.test_publish_v2_pgw781",
-  "tests.harness.adopt_rig",
-  "tests.harness.cell_hub",
   "tests.harness.deferred_endpoints",
   "tests.harness.hardware_report_hub",
   "tests.harness.modular_endpoint",

--- a/scripts/lint_mypy_ratchet.py
+++ b/scripts/lint_mypy_ratchet.py
@@ -62,7 +62,12 @@ HIGH_WATER: Dict[str, Tuple[int, int]] = {
     "implicit_reexport": (16, 34),
     # pgw#1202 PR 2: test modules still dirty at the relaxed test posture.
     # 170 of 486 were already clean and are checked from that commit on.
-    "ignore_errors": (314, 2016),
+    # 314 -> 312: PR 8 took the two HARNESS doubles — `tests.harness.cell_hub`
+    # and `tests.harness.adopt_rig`. These are the modules the "Protocols for
+    # test doubles" item exists for, and they were wholly unchecked: a bogus
+    # attribute plus a `reveal_type` injected into cell_hub.py still produced
+    # `Success: no issues found`.
+    "ignore_errors": (312, 2016),
 }
 
 #: WILDCARD patterns are structural policy, not debt, so they are not counted

--- a/tests/harness/adopt_rig.py
+++ b/tests/harness/adopt_rig.py
@@ -114,7 +114,7 @@ class Out(msgspec.Struct):
 CELL = msgspec.structs.replace(declaration(), text_len=0)
 
 
-class AdoptedPipeline(ProbePipeline):
+class AdoptedPipeline(ProbePipeline):  # type: ignore[misc]  # pgw#1219: harness.* is Any
     """A WORKER-LOADED slot class — the annotation shape that routes the arm
     order into ``_enable_compiled``. ``from_pretrained`` is what the executor
     tests for; the load itself is the named seam (``provision.load_slot``)."""
@@ -374,8 +374,9 @@ class AdoptRig:
             except Exception:
                 return None
 
+        # ONE patch: `executor.activity_mod` IS this module object, and the
+        # executor resolves the attribute at call time.
         self.monkeypatch.setattr(activity, "emit_event", _spy)
-        self.monkeypatch.setattr(ex_mod.activity_mod, "emit_event", _spy)
 
     def _forget_keys(self) -> None:
         """``_KNOWN_AOT_KEYS`` is PROCESS-global, so a sibling test file that
@@ -412,8 +413,8 @@ class AdoptRig:
             RIG["pipe"] = pipe
             return provision.SlotLoad(obj=pipe, is_pipeline=True, ran="bf16")
 
+        # ONE patch, same reason as `emit_event` above.
         mp.setattr(provision, "load_slot", _load_slot)
-        mp.setattr(ex_mod.provision, "load_slot", _load_slot)
 
         # OBSERVE, never construct: what cfg object did production actually
         # hand the arm? pgw#1150's third variant is a fixture passing a TYPE no
@@ -518,7 +519,7 @@ class AdoptRig:
         eff = ex._dispatched_spec(
             spec,
             {"pipeline": dispatch_mod.SlotOrder(ref=MODEL_REF, components=())})
-        snaps = {normalize_model_ref(MODEL_REF): pb.Snapshot(
+        snaps: Dict[str, pb.Snapshot] = {normalize_model_ref(MODEL_REF): pb.Snapshot(
             digest="d1" * 16,
             files=[pb.SnapshotFile(
                 path="model.safetensors", size_bytes=5, blake3="cd" * 32,

--- a/tests/harness/cell_hub.py
+++ b/tests/harness/cell_hub.py
@@ -33,10 +33,87 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 
+class CellHubServer(http.server.ThreadingHTTPServer):
+    """The hub's state, DECLARED — and the reason this module is checkable.
+
+    Every field below used to be assigned onto a stock ``ThreadingHTTPServer``
+    after construction, which no checker can see. The handler's thirty reads
+    were each ``# type: ignore[attr-defined]`` and the module carried
+    ``ignore_errors`` on top, so a typo in any of them was an AttributeError
+    raised inside a request thread — the double failing in a way that looks
+    like the system under test failing.
+    """
+
+    def __init__(self, handler: type[http.server.BaseHTTPRequestHandler]) -> None:
+        super().__init__(("127.0.0.1", 0), handler)
+        self.lock = threading.Lock()
+        self.objects: Dict[str, bytes] = {}
+        #: publish_id -> (declared digest->size, the publish plan body)
+        self.sessions: Dict[str, Tuple[Dict[str, int], Dict[str, Any]]] = {}
+        self.calls: List[Tuple[str, Any]] = []
+        self.intents: List[Dict[str, Any]] = []
+        self.completes: List[Dict[str, Any]] = []
+        self.checkpoints: List[Dict[str, Any]] = []
+        self._seq = 0
+
+    @property
+    def base(self) -> str:
+        host, port = self.server_address[:2]
+        # `server_address` is a union over address families; only the AF_INET
+        # arm is reachable here, but bytes is spellable so it is decoded rather
+        # than interpolated as `b'127.0.0.1'`.
+        return f"http://{host.decode() if isinstance(host, bytes) else host}:{port}"
+
+    def record_checkpoint(self, repo: str, plan: Dict[str, Any]) -> str:
+        """Turn a completed publish into a listable checkpoint.
+
+        This is the join the discover side reads, and it is the ONE place the
+        double has to model hub bookkeeping: the manifest a ``resolve`` returns
+        has to describe the very objects the publish landed, or an adopting
+        worker downloads bytes that hash to nothing.
+        """
+        files = []
+        for f in plan.get("files") or []:
+            digest = str(f.get("digest") or "")
+            chunks = f.get("chunks") or []
+            entry: Dict[str, Any] = {
+                "path": str(f.get("path") or ""),
+                "size_bytes": int(f.get("size_bytes") or 0),
+                "sha256": digest.split(":", 1)[-1] if digest else "",
+                "digest": digest,
+            }
+            if chunks:
+                entry["chunks"] = [
+                    {"sha256": c["digest"], "len": int(c["len"]),
+                     "url": f"{self.base}/cas/{c['digest']}"}
+                    for c in chunks
+                ]
+                entry["chunk_size_bytes"] = int(chunks[0]["len"])
+            else:
+                entry["url"] = f"{self.base}/cas/{digest.split(':', 1)[-1]}"
+            files.append(entry)
+        self._seq += 1
+        checkpoint_id = "sha256:" + hashlib.sha256(
+            f"{repo}/{plan.get('flavor')}/{self._seq}".encode()).hexdigest()
+        row = {
+            "repo": repo,
+            "checkpoint_id": checkpoint_id,
+            "updated_at": f"2026-08-06T00:00:{self._seq:02d}Z",
+            "metadata": dict(plan.get("metadata") or {}),
+            "files": files,
+        }
+        with self.lock:
+            self.checkpoints.append(row)
+        return checkpoint_id
+
+
 class _Handler(http.server.BaseHTTPRequestHandler):
     """tensorhub's v2 publish contract + the checkpoint/resolve read surface."""
 
     protocol_version = "HTTP/1.1"
+    #: Narrowed from `BaseServer`: this handler is only ever mounted on the
+    #: server above, and every route below reads that server's state.
+    server: CellHubServer
 
     def log_message(self, *_a: Any) -> None:
         pass
@@ -79,8 +156,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         if hashlib.sha256(body).hexdigest() != digest:
             self._json(400, {"error": {"code": "digest_mismatch"}})
             return
-        with srv.lock:  # type: ignore[attr-defined]
-            srv.objects["sha256:" + digest] = body  # type: ignore[attr-defined]
+        with srv.lock:
+            srv.objects["sha256:" + digest] = body
         self.send_response(200)
         self.send_header("Content-Length", "0")
         self.end_headers()
@@ -91,13 +168,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         srv = self.server
         parsed = urllib.parse.urlparse(self.path)
         path, query = parsed.path, urllib.parse.parse_qs(parsed.query)
-        with srv.lock:  # type: ignore[attr-defined]
-            srv.calls.append((path, dict(query)))  # type: ignore[attr-defined]
+        with srv.lock:
+            srv.calls.append((path, dict(query)))
 
         if path.startswith("/cas/"):
             digest = "sha256:" + path.rsplit("/", 1)[-1]
-            with srv.lock:  # type: ignore[attr-defined]
-                blob = srv.objects.get(digest)  # type: ignore[attr-defined]
+            with srv.lock:
+                blob = srv.objects.get(digest)
             if blob is None:
                 self._json(404, {"error": {"code": "not_found"}})
                 return
@@ -107,9 +184,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         # catalog read surface: GET /api/v1/repos/<repo>/checkpoints
         if path.endswith("/checkpoints"):
             repo = path.split("/api/v1/repos/", 1)[-1].rsplit("/checkpoints", 1)[0]
-            with srv.lock:  # type: ignore[attr-defined]
+            with srv.lock:
                 items = [
-                    dict(row) for row in srv.checkpoints  # type: ignore[attr-defined]
+                    dict(row) for row in srv.checkpoints
                     if row["repo"] == repo
                 ]
             self._json(200, {"items": [
@@ -123,9 +200,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         if path.endswith("/resolve"):
             repo = path.split("/api/v1/repos/", 1)[-1].rsplit("/resolve", 1)[0]
             want = (query.get("digest") or [""])[0]
-            with srv.lock:  # type: ignore[attr-defined]
+            with srv.lock:
                 row = next(
-                    (r for r in srv.checkpoints  # type: ignore[attr-defined]
+                    (r for r in srv.checkpoints
                      if r["repo"] == repo and r["checkpoint_id"] == want), None)
             if row is None:
                 self._json(404, {"error": {"code": "not_found"}})
@@ -141,20 +218,20 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         srv = self.server
         path = urllib.parse.urlparse(self.path).path
         body = self._body()
-        with srv.lock:  # type: ignore[attr-defined]
-            srv.calls.append((path, body))  # type: ignore[attr-defined]
+        with srv.lock:
+            srv.calls.append((path, body))
 
         if path.endswith("/v1/worker/cells/publish-intent"):
             family = str(body.get("family") or "")
-            with srv.lock:  # type: ignore[attr-defined]
-                srv.intents.append(dict(body))  # type: ignore[attr-defined]
+            with srv.lock:
+                srv.intents.append(dict(body))
             self._json(200, {"capability_token": "local-rig-cap",
                              "repo": f"root/family-{family}"})
             return
 
         if path.endswith("/v1/worker/cells/publish-complete"):
-            with slock(srv):
-                srv.completes.append(dict(body))  # type: ignore[attr-defined]
+            with srv.lock:
+                srv.completes.append(dict(body))
             self._json(200, {"recorded": True})
             return
 
@@ -167,14 +244,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 if not f.get("chunks"):
                     declared[f["digest"]] = int(f["size_bytes"])
             need, have = [], []
-            with slock(srv):
+            with srv.lock:
                 for digest, size in declared.items():
-                    if digest in srv.objects:  # type: ignore[attr-defined]
+                    if digest in srv.objects:
                         have.append(digest)
                     else:
                         need.append(self._grant(srv, digest, size))
                 pid = str(uuid.uuid4())
-                srv.sessions[pid] = (declared, dict(body))  # type: ignore[attr-defined]
+                srv.sessions[pid] = (declared, dict(body))
             self._json(201, {"publish_id": pid, "have": have, "need": need,
                              "distinct_objects": len(declared),
                              "resident_objects": len(have)})
@@ -182,11 +259,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
 
         if path.endswith("/grants"):
             pid = path.split("/publishes/")[1].split("/")[0]
-            with slock(srv):
-                declared = (srv.sessions.get(pid) or ({}, {}))[0]  # type: ignore[attr-defined]
+            with srv.lock:
+                declared = (srv.sessions.get(pid) or ({}, {}))[0]
                 need = [
                     self._grant(srv, d, s) for d, s in declared.items()
-                    if d not in srv.objects  # type: ignore[attr-defined]
+                    if d not in srv.objects
                 ]
             self._json(200, {"need": need, "have": []})
             return
@@ -194,31 +271,27 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         if path.endswith("/complete"):
             pid = path.split("/publishes/")[1].split("/")[0]
             repo = path.split("/api/v1/repos/", 1)[-1].split("/publishes/")[0]
-            with slock(srv):
-                declared, plan = srv.sessions.get(pid) or ({}, {})  # type: ignore[attr-defined]
+            with srv.lock:
+                declared, plan = srv.sessions.get(pid) or ({}, {})
                 missing = [d for d in declared
-                           if d not in srv.objects]  # type: ignore[attr-defined]
+                           if d not in srv.objects]
             if missing:
                 self._json(409, {"status": {
                     "stage": "repudiated", "terminal": True,
                     "failure": {"code": "objects_missing", "retryable": False,
                                 "message": f"{len(missing)} object(s) never landed"}}})
                 return
-            checkpoint_id = srv.record_checkpoint(repo, plan)  # type: ignore[attr-defined]
+            checkpoint_id = srv.record_checkpoint(repo, plan)
             self._json(200, {"checkpoint": {"checkpoint_id": checkpoint_id}})
             return
 
         self._json(404, {"error": {"code": "not_found"}})
 
     @staticmethod
-    def _grant(srv: Any, digest: str, size: int) -> dict:
+    def _grant(srv: CellHubServer, digest: str, size: int) -> dict:
         return {"digest": digest, "size_bytes": size,
                 "put_url": f"{srv.base}/cas/{digest.split(':', 1)[1]}",
                 "headers": {"x-amz-checksum-sha256": digest}}
-
-
-def slock(srv: Any) -> Any:
-    return srv.lock
 
 
 class LocalCellHub:
@@ -226,91 +299,37 @@ class LocalCellHub:
     the rig's fetch/publish legs take as their ``base_url``."""
 
     def __init__(self) -> None:
-        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        self.httpd.lock = threading.Lock()  # type: ignore[attr-defined]
-        self.httpd.objects = {}  # type: ignore[attr-defined]
-        self.httpd.sessions = {}  # type: ignore[attr-defined]
-        self.httpd.calls = []  # type: ignore[attr-defined]
-        self.httpd.intents = []  # type: ignore[attr-defined]
-        self.httpd.completes = []  # type: ignore[attr-defined]
-        self.httpd.checkpoints = []  # type: ignore[attr-defined]
-        self.httpd.base = self.base  # type: ignore[attr-defined]
-        self.httpd.record_checkpoint = self._record_checkpoint  # type: ignore[attr-defined]
-        self._seq = 0
+        self.httpd = CellHubServer(_Handler)
         threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
 
     # -- state a test reads --------------------------------------------------
 
     @property
     def base(self) -> str:
-        host, port = self.httpd.server_address[:2]
-        return f"http://{host}:{port}"
+        return self.httpd.base
 
     @property
     def intents(self) -> List[dict]:
-        return list(self.httpd.intents)  # type: ignore[attr-defined]
+        return list(self.httpd.intents)
 
     @property
     def completes(self) -> List[dict]:
-        return list(self.httpd.completes)  # type: ignore[attr-defined]
+        return list(self.httpd.completes)
 
     @property
     def checkpoints(self) -> List[dict]:
-        return list(self.httpd.checkpoints)  # type: ignore[attr-defined]
+        return list(self.httpd.checkpoints)
 
     @property
     def calls(self) -> List[Tuple[str, Any]]:
-        return list(self.httpd.calls)  # type: ignore[attr-defined]
+        return list(self.httpd.calls)
 
     def routes(self) -> List[str]:
         return [p for p, _ in self.calls]
 
-    # -- the publish -> discover join ---------------------------------------
-
-    def _record_checkpoint(self, repo: str, plan: dict) -> str:
-        """Turn a completed publish into a listable checkpoint.
-
-        This is the join the discover side reads, and it is the ONE place the
-        double has to model hub bookkeeping: the manifest a ``resolve`` returns
-        has to describe the very objects the publish landed, or an adopting
-        worker downloads bytes that hash to nothing.
-        """
-        files = []
-        for f in plan.get("files") or []:
-            digest = str(f.get("digest") or "")
-            chunks = f.get("chunks") or []
-            entry: Dict[str, Any] = {
-                "path": str(f.get("path") or ""),
-                "size_bytes": int(f.get("size_bytes") or 0),
-                "sha256": digest.split(":", 1)[-1] if digest else "",
-                "digest": digest,
-            }
-            if chunks:
-                entry["chunks"] = [
-                    {"sha256": c["digest"], "len": int(c["len"]),
-                     "url": f"{self.base}/cas/{c['digest']}"}
-                    for c in chunks
-                ]
-                entry["chunk_size_bytes"] = int(chunks[0]["len"])
-            else:
-                entry["url"] = f"{self.base}/cas/{digest.split(':', 1)[-1]}"
-            files.append(entry)
-        self._seq += 1
-        checkpoint_id = "sha256:" + hashlib.sha256(
-            f"{repo}/{plan.get('flavor')}/{self._seq}".encode()).hexdigest()
-        row = {
-            "repo": repo,
-            "checkpoint_id": checkpoint_id,
-            "updated_at": f"2026-08-06T00:00:{self._seq:02d}Z",
-            "metadata": dict(plan.get("metadata") or {}),
-            "files": files,
-        }
-        with self.httpd.lock:  # type: ignore[attr-defined]
-            self.httpd.checkpoints.append(row)  # type: ignore[attr-defined]
-        return checkpoint_id
 
     def artifact_bytes(self) -> int:
-        return sum(len(v) for v in self.httpd.objects.values())  # type: ignore[attr-defined]
+        return sum(len(v) for v in self.httpd.objects.values())
 
     def close(self) -> None:
         self.httpd.shutdown()


### PR DESCRIPTION
`tests.harness.cell_hub` and `tests.harness.adopt_rig` sat in the `ignore_errors` burn-down, so **nothing in them could go red**. Proved on the CI command at `73f826e1`: a bogus attribute plus a `reveal_type` injected into `cell_hub.py` still produced `Success: no issues found in 756 source files`. These are precisely the modules the "Protocols for test doubles" item exists for.

`cell_hub.py` also carried **30 `# type: ignore[attr-defined]` comments that suppressed nothing** — the module exemption already did, and `warn_unused_ignores` is off for `tests.*`, so nothing could report them as decoration. All 30 deleted.

## What the double now declares

`CellHubServer(ThreadingHTTPServer)` owns the hub's state as typed fields instead of seven attributes bolted onto a stock server after construction. A typo in any of the handler's thirty reads used to be an `AttributeError` raised inside a request thread — the double failing in a way that reads as the system under test failing.

## Red-proof — one variable, same tree

With `srv.objects` misspelled `srv.objcts`:

| exemption | result |
|---|---|
| RESTORED | `Success: no issues found in 757 source files` |
| REMOVED | `error: "CellHubServer" has no attribute "objcts"; maybe "objects"?` |

That gap is the whole change.

## Also

`adopt_rig` patched two module objects **twice** — `executor.activity_mod` **is** `gen_worker.activity` and `executor.provision` **is** `gen_worker.models.provision` (verified `is`-identical). One patch each now.

## One error scoped, not hidden

`AdoptedPipeline` subclasses a `ProbePipeline` that resolves to `Any`, because **`harness.*` does not resolve for mypy at all — 172 imports across 91 test files**. Filed as pgw#1219; it is the real blocker for writing Protocols here, since a Protocol in `tests/harness/` would be imported as `Any` by every consumer. Carries a one-line `# type: ignore[misc]` naming the issue instead of the whole-module exemption it used to sit under.

Ratchet 314 → 312. **No `executor.py` changes.**

## Verification
- mypy `Success: no issues found in 757 source files`; ratchet, changelog, ruff green
- `cell_hub` has **no test of its own** (only `scripts/micro_mint_rig.py` uses it), so the restructure was smoke-tested through a real publish → CAS → complete → discover round trip including the digest-mismatch refusal
- `pytest` over the five `adopt_rig` consumers → **52 passed**