### PR TITLE
pgw#1215 (th#1834 Phase 3): the mint's shared substrate leaves the modules that are about to die

### DIFF
--- a/changelog.d/pgw1215.md
+++ b/changelog.d/pgw1215.md
@@ -1,0 +1,28 @@
+- **pgw#1215 (th#1834 Phase 3): the mint's shared substrate leaves the modules that are about to
+  die.** Phase 3 replaces the out-of-process mint driver with a serving parent that supervises
+  compile children directly, one graph class each — at which point `mint_child`, `mint_process` and
+  `mint_delegate` fall out. Measured first: **they are ~20 % substrate, not driver.** `mint_process`
+  is also the tree's home for the parent↔child *vocabulary* and `mint_child` for the child-side
+  *preflight*, and five modules that SURVIVE the rewrite already import both — `executor`,
+  `boot_key`, `boot_adopt`, `measure_child`, `local_serve` — plus `boot_trace_child` and both
+  operator rigs.
+
+  So the substrate moves out first, on its own, with no behaviour change: `child_contract.py`
+  (`MintSlot`, `CompileSpec`, `slot_subjects`, `MintFrame`, `frame_line`) and `child_preflight.py`
+  (`PreflightRefused`, `select_specs`, `bind_slots`, `assert_slots_resolvable`,
+  `pick_compile_target`). With it gone the driver's removal is a **cut**; with it still inside, that
+  removal would have been an untangle — a deletion obliged to preserve two thirds of what it deletes,
+  which is how a rewrite acquires a compatibility shim nobody asked for.
+
+  **A defect fixed on the way out.** `boot_trace_child` and `measure_child` reached into `mint_child`
+  for the same five preflight symbols through **function-local imports at three call sites**, because
+  importing `mint_child` at module scope drags the whole compile brain in behind it — the shape §1.17
+  forbids, and unfixable while the checks lived beside the driver. They are ordinary top-of-file
+  imports now, and the module that owns the mint has stopped being a library for children that do not
+  mint.
+
+  **Renames** (no aliases, pre-launch): `CompileCellSpec` → `CompileSpec` and `MintChildRefused` →
+  `PreflightRefused`. The refusal is deliberately NOT called `MintRefused` — that name is live in
+  `aot_contract` for "every declared graph class refused", and one name for both would make "this
+  subject cannot be built here" and "nothing compiled" indistinguishable at the exit-code boundary
+  with no test going red.

--- a/scripts/boot_key_rig.py
+++ b/scripts/boot_key_rig.py
@@ -73,7 +73,7 @@ def _vehicle(name: str) -> Any:
 
 def _slots(veh: Any, tree: Path) -> Dict[str, Any]:
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import MintSlot
+    from gen_worker.child_contract import MintSlot
 
     return {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path=veh.ref_path, tag="prod"),
@@ -92,10 +92,10 @@ def _declared_hint(family: str) -> int:
 
 
 def _spec(veh: Any) -> Any:
-    from gen_worker.mint_process import CompileCellSpec
+    from gen_worker.child_contract import CompileSpec
 
     cfg = veh.compile_cell()
-    return CompileCellSpec(
+    return CompileSpec(
         shapes=tuple(tuple(int(v) for v in row) for row in (cfg.shapes or ())),
         targets=tuple(str(t) for t in (cfg.targets or ())),
         family=str(cfg.family or ""),
@@ -150,7 +150,7 @@ def real_weight_class_hashes(veh: Any, tree: Path) -> Dict[str, str]:
     """
     from gen_worker import aot_mint, boot_key, fleet_cells
     from gen_worker.cli.run import run_setup
-    from gen_worker.mint_child import pick_compile_target
+    from gen_worker.child_preflight import pick_compile_target
     from gen_worker.registry import collect_endpoints
 
     cfg = veh.compile_cell()

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -256,7 +256,7 @@ def _mint_slot(tree: Path, ref_path: str) -> Any:
     exercise.
     """
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import MintSlot
+    from gen_worker.child_contract import MintSlot
 
     return MintSlot(
         ref=ModelRef(source="tensorhub", path=ref_path, tag="prod"),

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -74,7 +74,7 @@ from . import (
     activity, aot_identity, artifact_meta, boot_key, cell_resolve,
     local_cell_store,
 )
-from .mint_process import CompileCellSpec, MintSlot
+from .child_contract import CompileSpec, MintSlot
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +436,7 @@ def attempt(
     """
     family = str(getattr(cfg, "family", "") or "")
     fn = str(function)
-    spec = CompileCellSpec(
+    spec = CompileSpec(
         shapes=tuple(
             tuple(int(v) for v in row)
             for row in (getattr(cfg, "shapes", ()) or ())),

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -99,7 +99,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 import msgspec
 
 from . import aot_serve, boot_phases, cell_key, compile_cache as cc, env_seal
-from .mint_process import CompileCellSpec, MintSlot, slot_subjects
+from .child_contract import CompileSpec, MintSlot, slot_subjects
 from .postmortem import cpu_quota_cores, effective_cpu_count
 
 logger = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ class TraceJob(msgspec.Struct, frozen=True, kw_only=True):
     function: str
     modules: Tuple[str, ...]
     family: str
-    cfg: CompileCellSpec
+    cfg: CompileSpec
     slots: Dict[str, MintSlot] = {}
     #: This child's share of the declaration's row order, ``rows[i::K]``.
     #: Sharded by INDEX and not by name because the adapter fork is decided by
@@ -365,7 +365,7 @@ MEMO_FILENAME = "boot-key-graphs.json"
 
 
 def closure_digest(
-    family: str, cfg: CompileCellSpec, *, function: str = "",
+    family: str, cfg: CompileSpec, *, function: str = "",
     slots: Optional[Mapping[str, MintSlot]] = None,
 ) -> str:
     """The memo's key: what a per-class graph hash is a pure function OF.
@@ -390,7 +390,7 @@ def closure_digest(
     Deliberately NOT included: sm, toolchain, env seal. They are key AXES and
     they re-derive every boot in milliseconds; folding them in here would make
     the memo miss on facts whose whole point is that they are cheap to restate.
-    Nor the slots' local PATHS — see ``mint_process.slot_subjects``: where the
+    Nor the slots' local PATHS — see ``child_contract.slot_subjects``: where the
     bytes landed on this disk is not what was traced.
     """
     facts = {
@@ -888,7 +888,7 @@ def derive(
     function: str,
     modules: Sequence[str],
     family: str,
-    cfg: CompileCellSpec,
+    cfg: CompileSpec,
     slots: Mapping[str, MintSlot],
     declared_hint: int,
     envelope: Mapping[str, Any],

--- a/src/gen_worker/boot_trace_child.py
+++ b/src/gen_worker/boot_trace_child.py
@@ -64,6 +64,13 @@ from typing import Any, Dict, List
 
 import msgspec
 
+from .child_preflight import (
+    PreflightRefused,
+    assert_slots_resolvable,
+    bind_slots,
+    pick_compile_target,
+    select_specs,
+)
 from .boot_key import (
     CODE_DIGEST, EXIT_BAD_JOB, EXIT_OK, EXIT_REFUSED, TraceJob, TraceReport,
 )
@@ -151,10 +158,6 @@ def run(job: TraceJob) -> int:
     from . import aot_mint, fleet_cells
     from .cli.run import run_setup
     from .registry import collect_endpoints
-    from .mint_child import (
-        MintChildRefused, assert_slots_resolvable, bind_slots,
-        pick_compile_target, select_specs,
-    )
     from .models import structure_only
 
     t_setup = time.monotonic()
@@ -165,7 +168,7 @@ def run(job: TraceJob) -> int:
         assert_slots_resolvable(
             siblings, job.slots,
             what=f"boot key derivation for {job.function!r}")
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         return _fail(report_path, "slots_unresolvable", str(exc))
 
     cfg = job.cfg
@@ -193,7 +196,7 @@ def run(job: TraceJob) -> int:
 
     try:
         _slot, pipeline = pick_compile_target(loaded, cfg)
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         return _fail(report_path, "no_compile_target", str(exc))
 
     resident = off_host_tensors(pipeline)

--- a/src/gen_worker/child_contract.py
+++ b/src/gen_worker/child_contract.py
@@ -1,0 +1,161 @@
+"""The vocabulary a serving parent and any trace/compile child share.
+
+pgw#1215 (th#1834 Phase 3). These types lived in ``mint_process``, whose OTHER
+half is the out-of-process mint DRIVER — and that driver is being replaced by a
+serving parent that supervises compile children directly, one graph class each.
+The vocabulary is not:
+five modules that survive the rewrite already import it (``executor``,
+``boot_key``, ``boot_adopt``, ``measure_child``, ``local_serve``), plus both
+operator rigs.
+
+So it moves out FIRST, on its own, while nothing else changes. That ordering is
+the point: with the substrate gone the driver's removal is a CUT, and with it
+still inside it would be an untangle — a deletion that has to preserve two
+thirds of what it deletes is how a rewrite acquires a compatibility shim nobody
+asked for.
+
+What belongs here is anything a parent must SAY to a child about the work:
+which checkpoints (``MintSlot``), what the declaration asked for
+(``CompileSpec``), what identity those resolve to (``slot_subjects``), and
+how the child reports back while it runs (``MintFrame``). What does not belong
+here is any statement about the child's PROCESS — spawn, supervision, exit
+codes and reports stay with the driver that owns them.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping, Optional, Tuple
+
+import msgspec
+
+from . import cell_key
+from .api.binding import ModelRef, binding_wire_refs, wire_ref
+
+#: Every child progress frame is one stdout line with this prefix. Anything
+#: else the child (or a library it imports) prints is diagnostic tail, never
+#: parsed — a mint must not be steerable by a stray print.
+FRAME_PREFIX = "MINT_FRAME "
+
+
+class CompileSpec(msgspec.Struct, frozen=True, kw_only=True):
+    """The declared compile contract, flattened — exactly the facts the CHILD
+    reads.
+
+    The PARENT sends this rather than letting the child re-derive it from the
+    decorator, because the class-scoped ``guidance_scales``/``text_lens``
+    unions live on the spec and not on the decl: a child rebuilding from
+    ``@endpoint`` alone would export a different declaration than the parent
+    asked for. It is NOT a key-derivation wire — since pgw#758/#1010 the child
+    computes no key at all; the parent stamps it from the returned envelope.
+
+    pgw#1034 therefore dropped ``regional``/``text_len``/``dynamic``: they
+    crossed the wire and no child consumer read them
+    (``fleet_cells.aot_export_spec`` and ``compile_cache.resolve_targets`` read
+    family/targets/shapes/text_lens/guidance/bucket, and nothing else does).
+    Any field added back must name the child code that reads it.
+    """
+
+    shapes: Tuple[Tuple[int, ...], ...] = ()
+    targets: Tuple[str, ...] = ()
+    family: str = ""
+    lora_bucket: int = 0
+    guidance_scales: Tuple[float, ...] = ()
+    text_lens: Tuple[int, ...] = ()
+
+
+class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
+    """One setup slot, as the parent resolved it. Present and complete, or absent.
+
+    pgw#974. This used to be THREE parallel slot-keyed dicts on
+    ``MintRequest`` — ``snapshots`` (bytes), ``slot_bindings`` (identity,
+    pgw#969) and ``component_paths`` (composition, pgw#816) — written by three
+    separate statements, each independently allowed to be empty. Two of the
+    three combinations that describes are incoherent, and one of them cost two
+    L40S pods: ``{"pipeline": "/tmp/x"}`` with no binding decoded, type-checked
+    and looked complete, and the child died 0.0 s into ``warmup_forward`` at
+    ``ctx.slots["pipeline"]``. ``ref`` and ``path`` therefore carry no
+    defaults: a slot with bytes and no identity cannot be constructed and
+    cannot be decoded.
+
+    A slot the parent did not resolve is ABSENT from the map — never a present
+    one with a hole in it. ``child_preflight.assert_slots_resolvable`` still
+    refuses one that the endpoint declares and does not mark optional.
+
+    * ``ref`` — WHICH checkpoint. ``ctx.slots`` is built from bindings, and a
+      child re-runs discovery, so a hub-catalog slot (``Slot(selected_by=...)``
+      with no ``default_checkpoint=``, which is sdxl's shape) rediscovers
+      nothing at all. A slot WITH a code default is the quieter half of the
+      same defect: the child resolves the DECLARED checkpoint while the parent
+      serves the hub's pick, and traces graphs for a model this pod never runs.
+    * ``path`` — WHERE its bytes already are, materialized by the parent, so
+      the child never touches the network: a mint is compute, and a mint
+      process that could download is one that can stall on a lemon host.
+    * ``component_paths`` — pgw#617 per-component overrides, comp -> that
+      component's own local tree. Empty for most slots and part of the
+      composition when not: th#1330 B2 EXCLUDES an overridden component's
+      files from the base fetch, so ``path`` alone then names a narrowed tree
+      (``<digest>__x<fp>``) that no loader can open.
+    """
+
+    ref: ModelRef
+    path: str
+    component_paths: Dict[str, str] = {}
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError(
+                f"a resolved slot must name the tree its bytes are in; got an "
+                f"empty path for {wire_ref(self.ref)!r}")
+
+
+def slot_subjects(
+    slots: Mapping[str, MintSlot],
+    digests: Optional[Mapping[str, str]] = None,
+) -> Tuple[cell_key.SlotSubject, ...]:
+    """The resolved SUBJECT of one arm or one boot trace (pgw#1113).
+
+    THE single derivation, so the arm token, the local-store memo and the
+    boot-key memo cannot disagree about which checkpoint a pipeline is bound
+    to. ``path`` is deliberately excluded — where the bytes were materialized
+    is a location on this machine, never an identity — and so is
+    ``component_paths``, whose identity half is already in the ref's
+    ``component_overrides`` (``binding_wire_refs``).
+    """
+    have = dict(digests or {})
+    return tuple(
+        cell_key.SlotSubject(
+            slot=str(name),
+            refs=tuple(binding_wire_refs(slot.ref)),
+            snapshot_digest=str(have.get(str(name), "") or ""),
+        )
+        for name, slot in sorted(slots.items())
+    )
+
+
+class MintFrame(msgspec.Struct, frozen=True, kw_only=True):
+    """One progress frame. Reporting only — never a liveness claim."""
+
+    phase: str = ""
+    step: int = 0
+    total: int = 0
+    note: str = ""
+
+
+def frame_line(
+    phase: str = "", step: int = 0, total: int = 0, note: str = "",
+) -> str:
+    """One wire line for a progress frame — the child's half of the protocol,
+    kept here so both sides share one encoder."""
+    body = msgspec.json.encode(
+        MintFrame(phase=phase, step=step, total=total, note=note[:400]))
+    return FRAME_PREFIX + body.decode() + "\n"
+
+
+__all__ = [
+    "FRAME_PREFIX",
+    "CompileSpec",
+    "MintFrame",
+    "MintSlot",
+    "frame_line",
+    "slot_subjects",
+]

--- a/src/gen_worker/child_preflight.py
+++ b/src/gen_worker/child_preflight.py
@@ -1,0 +1,190 @@
+"""Can THIS process build the subject the parent named? Asked before any load.
+
+pgw#1215 (th#1834 Phase 3). Every one of these checks lived in ``mint_child``,
+and two other children — ``boot_trace_child`` and ``measure_child`` — already
+reached into it for the same five symbols. They did so through a FUNCTION-LOCAL
+import, at three call sites, for one reason: ``mint_child`` pulls the whole mint
+in behind it, so importing it at module scope costs a child that only wants to
+check its slots the entire compile brain.
+
+That is the shape §1.17 forbids (imports belong at the top of the file), and it
+was not fixable while the checks lived beside the driver. Here they have no
+heavy dependency at all, so the three runtime imports become ordinary top-of-
+file ones and the module that owns the mint stops being a library for children
+that do not mint.
+
+The refusals are DETERMINISTIC by construction — the endpoint's declaration,
+the parent's bindings and the materialized trees are fixed for the life of one
+request — which is why they are a distinct type from anything the compile can
+raise: a caller may re-run a resource shortfall and must never re-run one of
+these.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+from .child_contract import MintSlot
+
+
+class PreflightRefused(RuntimeError):
+    """A named, deterministic reason this process cannot build the subject.
+
+    Never retried by the caller: re-running a named refusal buys a second
+    billed compile for the same sentence.
+
+    ``mint_phases`` carries a refusing mint's PARTIAL phase table when it got
+    far enough to have one (pgw#825) — the entries it exported and compiled
+    before refusing are real minutes and must reach the hub.
+
+    ⚠️ Deliberately NOT named ``MintRefused``: that name is live in
+    ``aot_contract`` for "every declared graph class refused", and one name for
+    both would make "this subject cannot be built here" and "nothing compiled"
+    indistinguishable at the exit-code boundary, with no test going red
+    (th#1834's census names this exact trap).
+    """
+
+    def __init__(
+        self, *args: Any, mint_phases: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(*args)
+        self.mint_phases: Dict[str, Any] = dict(mint_phases or {})
+
+
+def select_specs(
+    specs: Sequence[Any], function: str,
+) -> Tuple[Any, List[Any]]:
+    """The requested function's spec plus every sibling sharing its instance.
+
+    Siblings matter: the warm plan is CLASS-scoped (pgw#654 — one compiled
+    graph per graph class, so turbo and base seed the same capture). Minting
+    from one function's view is how a sibling lane ends up with no compiled
+    graph at all and every adopting boot fails its per-object proof (gw#612).
+    """
+    chosen = next((s for s in specs if s.name == function), None)
+    if chosen is None:
+        raise PreflightRefused(
+            f"function {function!r} is not in this image "
+            f"(have: {sorted(s.name for s in specs)})")
+    if chosen.cls is None:
+        raise PreflightRefused(
+            f"function {function!r} is function-shaped — it has no instance "
+            "to compile")
+    siblings = [
+        s for s in specs
+        if s.cls is chosen.cls and s.instance_key == chosen.instance_key
+    ]
+    if chosen not in siblings:
+        siblings.append(chosen)
+    return chosen, siblings
+
+
+def bind_slots(specs: Sequence[Any], resolved: Mapping[str, MintSlot]) -> None:
+    """Install the PARENT's resolved slot bindings onto rediscovered specs.
+
+    The child re-runs discovery in a fresh interpreter, so ``spec.models``
+    comes back holding only what ``@endpoint`` declared. For a hub-catalog
+    slot — ``Slot(cls, selected_by="model")`` with no ``default_checkpoint=``,
+    which is sdxl's shape and every multi-checkpoint family's — the decorator
+    declares no ref at all, and the resolution chain then has nothing to
+    resolve: ``ctx.slots["pipeline"]`` raises before a graph is traced.
+
+    Applied to the WHOLE sibling set, never one spec: ``instance_key`` is a
+    live property over ``spec.models``, so binding the chosen function alone
+    would move its key out from under its siblings and silently narrow the
+    class-scoped warm plan (pgw#654) to one lane.
+    """
+    for spec in specs:
+        for slot, res in resolved.items():
+            if slot in spec.slots or slot in spec.models:
+                spec.models[slot] = res.ref
+
+
+def assert_slots_resolvable(
+    specs: Sequence[Any],
+    slots: Mapping[str, MintSlot],
+    *,
+    what: str = "",
+) -> None:
+    """pgw#969: refuse a request whose slots cannot resolve — before the load.
+
+    ``slots`` + ``what`` rather than the whole request (pgw#1089): the
+    boot-trace child resolves the same slots for the same reason and must get
+    the same refusal, and a second copy of this check would be a second answer
+    to "can this process trace the checkpoint the parent serves".
+
+    Two distinct failures, both named rather than deferred to a handler's
+    first dereference nine seconds later:
+
+    * the parent sent no binding for a declared, non-optional slot (the wire
+      gap this issue exists for), and
+    * a slot the parent DID bind still fails the resolution chain here, which
+      is real divergence between the two processes and never a normal path.
+
+    An OPTIONAL slot the parent did not bind is deliberately silent: the
+    parent's own warm context resolves it exactly this way (the deploy chose
+    not to serve that lane), and refusing here would refuse a mint the parent
+    can serve.
+    """
+    from . import warmup as warmup_mod
+
+    bound = set(slots)
+    problems: List[str] = []
+    for spec in specs:
+        missing = sorted(
+            name for name, slot in spec.slots.items()
+            if name not in bound
+            and name not in spec.models
+            and not getattr(slot, "optional", False)
+        )
+        for name in missing:
+            problems.append(
+                f"slot {name!r} of {spec.name!r}: the parent sent no resolved "
+                f"binding for it and the endpoint declares no "
+                f"default_checkpoint, so this child has no checkpoint to "
+                f"trace (MintRequest.slots carries "
+                f"{sorted(bound) or '(nothing)'})")
+        errors = warmup_mod.resolved_slots_kwargs(spec, None)["slot_errors"]
+        for name, why in sorted(errors.items()):
+            resolved = slots.get(name)
+            if resolved is not None:
+                problems.append(
+                    f"slot {name!r} of {spec.name!r}: the parent's binding "
+                    f"{resolved.ref.path!r} "
+                    f"crossed but does not resolve in this process — {why}")
+    if not problems:
+        return
+    raise PreflightRefused(
+        f"{what or 'slot resolution'}: cannot build the warmup request — "
+        + "; ".join(problems)
+        + ". A mint cannot trace a graph for a pipeline it was never told "
+          "to load.")
+
+
+def pick_compile_target(loaded: Dict[str, Any], cfg: Any) -> Tuple[str, Any]:
+    """The loaded slot that actually carries the declared compile target(s).
+
+    Public since pgw#1089: the boot-trace child must pick the SAME slot the
+    mint picks, and two pickers would be two compile targets.
+    """
+    from . import compile_cache as cc
+
+    for slot, obj in loaded.items():
+        try:
+            if cc.has_compile_target(obj, cfg):
+                return slot, obj
+        except Exception:
+            continue
+    raise PreflightRefused(
+        f"no compile target resolved on any loaded slot "
+        f"({sorted(loaded) or '(none)'}) for family {cfg.family!r} "
+        f"targets={list(cfg.targets)}")
+
+
+__all__ = [
+    "PreflightRefused",
+    "assert_slots_resolvable",
+    "bind_slots",
+    "pick_compile_target",
+    "select_specs",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -58,7 +58,7 @@ from .api.binding import (
 )
 from .hubio.client import HubPublishError
 from . import cell_key
-from .mint_process import MintSlot, slot_subjects
+from .child_contract import MintSlot, slot_subjects
 from .api.errors import (
     ArtifactTransferError,
     CanceledError,
@@ -2958,7 +2958,7 @@ class _BackgroundMint:
     # rediscover for itself — the endpoint module(s) to walk (the child re-runs
     # discovery in a fresh interpreter) and the parent's own RESOLUTION of each
     # setup slot: identity, already-materialized local tree, and pgw#617
-    # composition, in ONE value per slot (pgw#974, `mint_process.MintSlot`).
+    # composition, in ONE value per slot (pgw#974, `child_contract.MintSlot`).
     # The paths matter because a mint is compute, and a mint process that could
     # download is one that can stall on a lemon host (pgw#786); the refs matter
     # because `ctx.slots` is built from bindings and the child rediscovers none

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -293,7 +293,7 @@ def arm_identity(
     # is the canonical form the cozy-local store verdict and the JIT semantic
     # tag already read), so the obligation and the contract cannot disagree
     # about what was declared. ``targets`` keeps DECLARATION ORDER: the child
-    # picks its compile target first-match (``mint_child.pick_compile_target``),
+    # picks its compile target first-match (``child_preflight.pick_compile_target``),
     # so the order is meaning, not presentation.
     declared = cc.declared_compile_facts(
         cfg, lora_bucket_override=int(lora_bucket or 0))

--- a/src/gen_worker/local_serve.py
+++ b/src/gen_worker/local_serve.py
@@ -49,7 +49,7 @@ from . import aot_compile_pool
 from . import compile_cache as cc
 from . import compile_posture, fleet_cells, handler_proof
 from . import local_cell_store, mint_delegate
-from .mint_process import MintFrame, MintSlot
+from .child_contract import MintFrame, MintSlot
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class LocalMintContext:
     The same three facts the executor hands ``mint_delegate.MintTask``: WHICH
     routable function, WHICH modules to rediscover it in, and the parent's own
     resolution of every setup slot (identity + bytes + pgw#617 composition, as
-    one value — see ``mint_process.MintSlot``). A context with no function or
+    one value — see ``child_contract.MintSlot``). A context with no function or
     no modules cannot be minted from and is declared ``incomplete``: the child
     re-runs discovery, so a module list it cannot import is a silent
     "compiles nothing, forever".
@@ -404,7 +404,7 @@ def slot_map(
 
     A slot the local run did not resolve is ABSENT, never a present entry with
     a hole in it — ``MintSlot`` refuses to be constructed without both halves,
-    and ``mint_child.assert_slots_resolvable`` refuses a declared,
+    and ``child_preflight.assert_slots_resolvable`` refuses a declared,
     non-optional slot that never arrived.
     """
     out: Dict[str, MintSlot] = {}

--- a/src/gen_worker/measure_child.py
+++ b/src/gen_worker/measure_child.py
@@ -120,7 +120,14 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 import msgspec
 
 from . import activity
-from .mint_process import CompileCellSpec, MintSlot
+from .child_contract import CompileSpec, MintSlot
+from .child_preflight import (
+    PreflightRefused,
+    assert_slots_resolvable,
+    bind_slots,
+    pick_compile_target,
+    select_specs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +191,7 @@ class MeasureJob(msgspec.Struct, frozen=True, kw_only=True):
 
     function: str
     modules: Tuple[str, ...]
-    cfg: CompileCellSpec
+    cfg: CompileSpec
     family: str = ""
     slots: Dict[str, MintSlot] = {}
     device: int = -1
@@ -213,7 +220,7 @@ class MeasureDocument(msgspec.Struct, frozen=True, kw_only=True):
     # The runtime envelope's input half.
     function: str = ""
     modules: Tuple[str, ...] = ()
-    cfg: Optional[CompileCellSpec] = None
+    cfg: Optional[CompileSpec] = None
     slots: Dict[str, MintSlot] = {}
     device: int = -1
     execution_lane: str = ""
@@ -375,10 +382,10 @@ def _discard(files: Sequence[str]) -> int:
 # ---------------------------------------------------------------------------
 
 
-def load_document(raw: bytes) -> Tuple[MeasureDocument, CompileCellSpec]:
+def load_document(raw: bytes) -> Tuple[MeasureDocument, CompileSpec]:
     """Decode one request file into ``(document, flattened compile spec)``.
 
-    The committed payload IS a ``CompileCellSpec`` at top level, so the same
+    The committed payload IS a ``CompileSpec`` at top level, so the same
     bytes are read twice against two structs rather than sniffed for a
     discriminator: msgspec drops what each struct does not declare, and a
     document that carries neither half decodes to two empty structs and is
@@ -389,7 +396,7 @@ def load_document(raw: bytes) -> Tuple[MeasureDocument, CompileCellSpec]:
     """
     return (
         msgspec.json.decode(raw, type=MeasureDocument),
-        msgspec.json.decode(raw, type=CompileCellSpec),
+        msgspec.json.decode(raw, type=CompileSpec),
     )
 
 
@@ -509,7 +516,7 @@ def _function_for_family(specs: Sequence[Any], family: str) -> str:
 
 
 def resolve_job(
-    doc: MeasureDocument, flat: CompileCellSpec, *,
+    doc: MeasureDocument, flat: CompileSpec, *,
     function: str = "", slot_flags: Sequence[str] = (),
 ) -> MeasureJob:
     """Build the job the run needs from whichever document arrived.
@@ -519,7 +526,6 @@ def resolve_job(
     omits all live on the declaration, and reading them from anywhere else
     would be a second declaration.
     """
-    from .mint_child import MintChildRefused, select_specs
     from .registry import collect_endpoints
 
     modules = tuple(str(m) for m in doc.modules if str(m).strip())
@@ -567,7 +573,7 @@ def resolve_job(
         specs, family)
     try:
         chosen, _siblings = select_specs(specs, name)
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         raise MeasureRefused("function_underivable", str(exc)) from exc
 
     if not cfg.targets:
@@ -634,10 +640,6 @@ def run(
     """Measure this job's declared class set. Never raises, never publishes."""
     from . import aot_declaration, aot_mint, compile_cache as cc, fleet_cells
     from .cli.run import run_setup
-    from .mint_child import (
-        MintChildRefused, assert_slots_resolvable, bind_slots,
-        pick_compile_target, select_specs,
-    )
     from .models import structure_only
     from .registry import collect_endpoints
 
@@ -657,7 +659,7 @@ def run(
                  f"aot/*.mint.json names ONE checkpoint (`source_ref`), so "
                  f"every other slot the endpoint's setup() requires is named "
                  f"with `--slot NAME=/path/to/tree`")
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         return _fail(report_path, "slots_unresolvable", str(exc),
                      partial=partial)
 
@@ -702,7 +704,7 @@ def run(
 
     try:
         _slot, pipeline = pick_compile_target(loaded, cfg)
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         return _fail(report_path, "no_compile_target", str(exc),
                      partial=partial)
 

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -67,6 +67,14 @@ from . import compile_posture, handler_proof, warm_spans
 from .api.errors import ValidationError
 from .api.export_contract import (
     blocker_refusal, export_declaration, open_blockers)
+from .child_contract import MintSlot, frame_line
+from .child_preflight import (
+    PreflightRefused,
+    assert_slots_resolvable,
+    bind_slots,
+    pick_compile_target,
+    select_specs,
+)
 from .mint_process import (
     EXIT_BAD_REQUEST,
     EXIT_MINTED,
@@ -74,8 +82,6 @@ from .mint_process import (
     EXIT_RESOURCE,
     MintReport,
     MintRequest,
-    MintSlot,
-    frame_line,
 )
 
 logger = logging.getLogger(__name__)
@@ -84,24 +90,6 @@ logger = logging.getLogger(__name__)
 #: also run produced a cell with no consumer, and it is deleted rather than
 #: kept behind a request field nobody may set.
 RECIPE_AOT = "aot"
-
-
-class MintChildRefused(RuntimeError):
-    """A named, deterministic reason this mint cannot happen here.
-
-    Never retried by the parent: re-running a named refusal buys a second
-    billed compile for the same sentence.
-
-    ``mint_phases`` carries the refusing mint's PARTIAL phase table when it
-    got far enough to have one (pgw#825) — the entries it exported and
-    compiled before refusing are real minutes and must reach the hub.
-    """
-
-    def __init__(
-        self, *args: Any, mint_phases: Optional[Mapping[str, Any]] = None,
-    ) -> None:
-        super().__init__(*args)
-        self.mint_phases: Dict[str, Any] = dict(mint_phases or {})
 
 
 def _assert_family_mintable(family: str) -> None:
@@ -119,17 +107,17 @@ def _assert_family_mintable(family: str) -> None:
     try:
         decl = export_declaration(family)
     except Exception as exc:  # noqa: BLE001 — a refusing declaration is a refusal
-        raise MintChildRefused(
+        raise PreflightRefused(
             f"family {family!r}'s export declaration refuses to build "
             f"({type(exc).__name__}): {exc}") from exc
     if decl is None:
         return
     blocked = open_blockers(decl)
     if blocked:
-        raise MintChildRefused(blocker_refusal(family, blocked))
+        raise PreflightRefused(blocker_refusal(family, blocked))
 
 
-def _declaration_refusal(exc: ValidationError) -> MintChildRefused:
+def _declaration_refusal(exc: ValidationError) -> PreflightRefused:
     """pgw#1075: a declared value this SDK's own vocabulary rejects is a
     REFUSAL, not a crash — and the author's fix is already in the message.
 
@@ -153,7 +141,7 @@ def _declaration_refusal(exc: ValidationError) -> MintChildRefused:
     to a custom op with no fake kernel (pgw#1062) — the message is the
     authoring contract, so it is carried whole and never summarised.
     """
-    return MintChildRefused(
+    return PreflightRefused(
         f"declaration refused: {type(exc).__name__}: {exc}",
         mint_phases=getattr(exc, "mint_phases", None))
 
@@ -207,34 +195,6 @@ def _write_report(path: Path, report: MintReport) -> None:
     os.replace(tmp, path)
 
 
-def select_specs(
-    specs: Sequence[Any], function: str,
-) -> Tuple[Any, List[Any]]:
-    """The requested function's spec plus every sibling sharing its instance.
-
-    Siblings matter: the warm plan is CLASS-scoped (pgw#654 — one cell per
-    class, so turbo and base seed the same capture). Minting from one
-    function's view is how a sibling lane ends up absent from the cell and
-    every adopting boot fails its per-object proof (gw#612).
-    """
-    chosen = next((s for s in specs if s.name == function), None)
-    if chosen is None:
-        raise MintChildRefused(
-            f"function {function!r} is not in this image "
-            f"(have: {sorted(s.name for s in specs)})")
-    if chosen.cls is None:
-        raise MintChildRefused(
-            f"function {function!r} is function-shaped — it has no instance "
-            "to compile")
-    siblings = [
-        s for s in specs
-        if s.cls is chosen.cls and s.instance_key == chosen.instance_key
-    ]
-    if chosen not in siblings:
-        siblings.append(chosen)
-    return chosen, siblings
-
-
 def mint_identity(request: MintRequest) -> str:
     """One sentence naming WHICH mint a message belongs to (pgw#969).
 
@@ -248,88 +208,6 @@ def mint_identity(request: MintRequest) -> str:
         f"mint family={request.family!r} arm_key={request.arm_token!r} "
         f"lane={request.execution_lane or '(unset)'!r} "
         f"fn={request.function!r}")
-
-
-def bind_slots(specs: Sequence[Any], resolved: Mapping[str, MintSlot]) -> None:
-    """Install the PARENT's resolved slot bindings onto rediscovered specs.
-
-    The child re-runs discovery in a fresh interpreter, so ``spec.models``
-    comes back holding only what ``@endpoint`` declared. For a hub-catalog
-    slot — ``Slot(cls, selected_by="model")`` with no ``default_checkpoint=``,
-    which is sdxl's shape and every multi-checkpoint family's — the decorator
-    declares no ref at all, and the resolution chain then has nothing to
-    resolve: ``ctx.slots["pipeline"]`` raises before a graph is traced.
-
-    Applied to the WHOLE sibling set, never one spec: ``instance_key`` is a
-    live property over ``spec.models``, so binding the chosen function alone
-    would move its key out from under its siblings and silently narrow the
-    class-scoped warm plan (pgw#654) to one lane.
-    """
-    for spec in specs:
-        for slot, res in resolved.items():
-            if slot in spec.slots or slot in spec.models:
-                spec.models[slot] = res.ref
-
-
-def assert_slots_resolvable(
-    specs: Sequence[Any],
-    slots: Mapping[str, MintSlot],
-    *,
-    what: str = "",
-) -> None:
-    """pgw#969: refuse a request whose slots cannot resolve — before the load.
-
-    ``slots`` + ``what`` rather than the whole ``MintRequest`` (pgw#1089): the
-    boot-trace child resolves the same slots for the same reason and must get
-    the same refusal, and a second copy of this check would be a second answer
-    to "can this process trace the checkpoint the parent serves".
-
-    Two distinct failures, both named rather than deferred to a handler's
-    first dereference nine seconds later:
-
-    * the parent sent no binding for a declared, non-optional slot (the wire
-      gap this issue exists for), and
-    * a slot the parent DID bind still fails the resolution chain here, which
-      is real divergence between the two processes and never a normal path.
-
-    An OPTIONAL slot the parent did not bind is deliberately silent: the
-    parent's own warm context resolves it exactly this way (the deploy chose
-    not to serve that lane), and refusing here would refuse a mint the parent
-    can serve.
-    """
-    from . import warmup as warmup_mod
-
-    bound = set(slots)
-    problems: List[str] = []
-    for spec in specs:
-        missing = sorted(
-            name for name, slot in spec.slots.items()
-            if name not in bound
-            and name not in spec.models
-            and not getattr(slot, "optional", False)
-        )
-        for name in missing:
-            problems.append(
-                f"slot {name!r} of {spec.name!r}: the parent sent no resolved "
-                f"binding for it and the endpoint declares no "
-                f"default_checkpoint, so this child has no checkpoint to "
-                f"trace (MintRequest.slots carries "
-                f"{sorted(bound) or '(nothing)'})")
-        errors = warmup_mod.resolved_slots_kwargs(spec, None)["slot_errors"]
-        for name, why in sorted(errors.items()):
-            resolved = slots.get(name)
-            if resolved is not None:
-                problems.append(
-                    f"slot {name!r} of {spec.name!r}: the parent's binding "
-                    f"{resolved.ref.path!r} "
-                    f"crossed but does not resolve in this process — {why}")
-    if not problems:
-        return
-    raise MintChildRefused(
-        f"{what or 'slot resolution'}: cannot build the warmup request — "
-        + "; ".join(problems)
-        + ". A mint cannot trace a graph for a pipeline it was never told "
-          "to load.")
 
 
 def assert_composable(resolved: Mapping[str, MintSlot]) -> None:
@@ -355,32 +233,12 @@ def assert_composable(resolved: Mapping[str, MintSlot]) -> None:
     )
     if not bad:
         return
-    raise MintChildRefused(
+    raise PreflightRefused(
         f"slot(s) {bad} were materialized as override-narrowed trees "
         f"(the overridden component's files were excluded from the fetch) "
         f"but this request carries no component override for them, so the "
         f"composition cannot be rebuilt: "
         + "; ".join(f"{slot}={resolved[slot].path}" for slot in bad))
-
-
-def pick_compile_target(loaded: Dict[str, Any], cfg: Any) -> Tuple[str, Any]:
-    """The loaded slot that actually carries the declared compile target(s).
-
-    Public since pgw#1089: the boot-trace child must pick the SAME slot this
-    child picks, and two pickers would be two compile targets.
-    """
-    from . import compile_cache as cc
-
-    for slot, obj in loaded.items():
-        try:
-            if cc.has_compile_target(obj, cfg):
-                return slot, obj
-        except Exception:
-            continue
-    raise MintChildRefused(
-        f"no compile target resolved on any loaded slot "
-        f"({sorted(loaded) or '(none)'}) for family {cfg.family!r} "
-        f"targets={list(cfg.targets)}")
 
 
 def _drive_warm_plan(
@@ -423,7 +281,7 @@ def _drive_warm_plan(
         except BaseException as exc:
             if _is_resource_error(exc) or not isinstance(exc, Exception):
                 raise
-            raise MintChildRefused(
+            raise PreflightRefused(
                 f"{mint_identity(request)}: the endpoint's own warm plan does "
                 f"not run — warm job {job.spec.name!r} raised "
                 f"{type(exc).__name__}: {exc}. A cell must not seal for a "
@@ -637,7 +495,7 @@ def _mint_aot(
         # that exposes no logs (pgw#760). pgw#825: the seconds it spent before
         # refusing ride WITH the sentence — a refusal after four paid compiles
         # and a refusal in the first second are not the same event.
-        raise MintChildRefused(
+        raise PreflightRefused(
             f"aot mint refused: {exc}",
             mint_phases=getattr(exc, "mint_phases", None)) from exc
 
@@ -697,7 +555,7 @@ def _mint_aot(
 
 
 def mint(request: MintRequest) -> MintReport:
-    """Build the cell. Raises ``MintChildRefused`` for a named refusal."""
+    """Build the cell. Raises ``PreflightRefused`` for a named refusal."""
     # The two views ``cli.run.run_setup`` takes, both DERIVED from the one
     # resolution (pgw#974) rather than carried beside it.
     paths = {slot: res.path for slot, res in request.slots.items()}
@@ -723,14 +581,14 @@ def mint(request: MintRequest) -> MintReport:
     env_seal.establish()
 
     if not cc.toolchain_present():
-        raise MintChildRefused(
+        raise PreflightRefused(
             "no C toolchain (cc/gcc/clang) — inductor cannot link a kernel")
     if not cc.cxx_toolchain_present():
         # pgw#823: AOTInductor's stricter requirement, asserted BEFORE the
         # weights are read. The guard above passes on a C compiler; AOTI needs
         # a C++ one, and without this the miss surfaces 336 s later as an
         # InductorError from inside the linker.
-        raise MintChildRefused(
+        raise PreflightRefused(
             "no C++ compiler (g++/clang++) — AOTInductor links a shared "
             "object and cannot build one")
 
@@ -824,7 +682,7 @@ def mint(request: MintRequest) -> MintReport:
             # (ie#638). This is buildable-but-not-honored, NOT a stranded
             # family, so it FAILS CLOSED with the authoring cause named rather
             # than degrading to a real-weight export the meta gate never sees.
-            raise MintChildRefused(
+            raise PreflightRefused(
                 f"structure-only was requested for {mint_identity(request)} "
                 f"and the target built weight-free, but the composed pipeline "
                 f"did not carry it: {exc}") from exc
@@ -972,7 +830,7 @@ def assert_traceable_as_loaded(pipeline: Any, request: MintRequest) -> None:
     reason = traceability.untraceable_reason(pipeline)
     if not reason:
         return
-    raise MintChildRefused(
+    raise PreflightRefused(
         f"mint_pipeline_not_traceable: {mint_identity(request)} loaded real "
         f"weights and the placement ladder installed offload hooks — {reason}. "
         f"`torch.export` refuses a `torch.compiler.disable`d function rather "
@@ -1009,7 +867,7 @@ def assert_handler_proven(request: MintRequest) -> None:
     """
     if str(getattr(request, "handler_proof", "") or "").strip():
         return
-    raise MintChildRefused(
+    raise PreflightRefused(
         f"{mint_identity(request)}: this is a WEIGHT-FREE mint and the parent "
         f"sent no handler proof. pgw#984 requires the endpoint's own handler "
         f"to have run before a cell seals, and since pgw#1199 that proof "
@@ -1178,7 +1036,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             # this process — spec build, composition check, branch arm, export
             # declaration — can raise it and they all mean the same thing.
             raise _declaration_refusal(exc) from exc
-    except MintChildRefused as exc:
+    except PreflightRefused as exc:
         # th#1322: a refused mint's phase table is where it spent the time
         # BEFORE refusing — the most useful half of a failed mint. The OPEN
         # phase is read first on purpose: `_close_phases` closes it, and
@@ -1217,7 +1075,4 @@ if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
 
 
-__all__ = ["MintChildRefused", "assert_composable", "assert_slots_resolvable",
-           "pick_compile_target",
-           "bind_slots", "frame", "main",
-           "mint_identity", "mint", "select_specs"]
+__all__ = ["assert_composable", "frame", "main", "mint_identity", "mint"]

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -42,6 +42,8 @@ from . import boot_phases
 from . import compile_posture
 from . import mint_workers
 from . import mint_process
+from .child_contract import (
+    CompileSpec, MintFrame, MintSlot)
 from . import progress as progress_mod
 from .mint_process import MintOutcome, MintRequest
 
@@ -84,8 +86,8 @@ class MintTask:
     # pgw#974: the parent's resolution of each setup slot — identity, bytes and
     # pgw#617 composition in ONE value, resolved together in
     # `_setup_locked_inner` and carried together from here to the child. See
-    # `mint_process.MintSlot`.
-    slots: Dict[str, mint_process.MintSlot] = field(default_factory=dict)
+    # `child_contract.MintSlot`.
+    slots: Dict[str, MintSlot] = field(default_factory=dict)
     weight_lane: str = ""
     execution_lane: str = ""
     configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
@@ -131,7 +133,7 @@ FAILED = "failed"
 ABANDONED = mint_process.ABANDONED
 
 
-def cfg_spec(cfg: Any) -> mint_process.CompileCellSpec:
+def cfg_spec(cfg: Any) -> CompileSpec:
     """Flatten the parent's ``CompileCell`` for the wire.
 
     The parent states the contract because the class-scoped guidance/text-len
@@ -140,7 +142,7 @@ def cfg_spec(cfg: Any) -> mint_process.CompileCellSpec:
     parent asked for. It carries what the child READS and nothing else
     (pgw#1034) — the child computes no key, so this is not a key-parity wire.
     """
-    return mint_process.CompileCellSpec(
+    return CompileSpec(
         shapes=tuple(tuple(int(v) for v in row) for row in (cfg.shapes or ())),
         targets=tuple(str(t) for t in (cfg.targets or ())),
         family=str(getattr(cfg, "family", "") or ""),
@@ -262,7 +264,7 @@ def _bank_device_peaks(phases: Any, *, weight_lane: str) -> int:
 
 
 def _on_frame(act: Any, watch: Optional[Watcher] = None) -> Any:
-    def _apply(frame: mint_process.MintFrame) -> None:
+    def _apply(frame: MintFrame) -> None:
         # No new protocol: the child's phase lands on the SAME
         # self_mint_compile activity the hub already reads, and ships on the
         # ordinary 10s beat — which now actually fires, because nothing on
@@ -343,7 +345,7 @@ def _on_evidence(act: Any) -> Any:
 #: fleet passes nothing and behaves exactly as before; ``local_serve`` passes a
 #: terminal renderer, because a 20-minute compile a user cannot see is a
 #: support ticket regardless of how correct it is.
-Watcher = Callable[[mint_process.MintFrame], None]
+Watcher = Callable[[MintFrame], None]
 
 
 async def build_cell(

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -70,8 +70,9 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
-from . import cell_key, compile_posture
-from .api.binding import ModelRef, binding_wire_refs, wire_ref
+from . import compile_posture
+from .child_contract import (
+    FRAME_PREFIX, CompileSpec, MintFrame, MintSlot)
 from .compile_posture import CompilePosture
 from .stall import SilenceWindow
 
@@ -79,11 +80,6 @@ logger = logging.getLogger(__name__)
 
 #: The child entry point. Kept as a module so the boundary is argv+files.
 MINT_CHILD_MODULE = "gen_worker.mint_child"
-
-#: Every child progress frame is one stdout line with this prefix. Anything
-#: else the child (or a library it imports) prints is diagnostic tail, never
-#: parsed — a mint must not be steerable by a stray print.
-FRAME_PREFIX = "MINT_FRAME "
 
 REQUEST_NAME = "request.json"
 REPORT_NAME = "report.json"
@@ -141,101 +137,6 @@ _REAP_GRACE_S = 15.0
 MAX_ATTEMPTS = 2
 
 
-class CompileCellSpec(msgspec.Struct, frozen=True, kw_only=True):
-    """The declared compile contract, flattened — exactly the facts the CHILD
-    reads.
-
-    The PARENT sends this rather than letting the child re-derive it from the
-    decorator, because the class-scoped ``guidance_scales``/``text_lens``
-    unions live on the spec and not on the decl: a child rebuilding from
-    ``@endpoint`` alone would export a different declaration than the parent
-    asked for. It is NOT a key-derivation wire — since pgw#758/#1010 the child
-    computes no key at all; the parent stamps it from the returned envelope.
-
-    pgw#1034 therefore dropped ``regional``/``text_len``/``dynamic``: they
-    crossed the wire and no child consumer read them
-    (``fleet_cells.aot_export_spec`` and ``compile_cache.resolve_targets`` read
-    family/targets/shapes/text_lens/guidance/bucket, and nothing else does).
-    Any field added back must name the child code that reads it.
-    """
-
-    shapes: Tuple[Tuple[int, ...], ...] = ()
-    targets: Tuple[str, ...] = ()
-    family: str = ""
-    lora_bucket: int = 0
-    guidance_scales: Tuple[float, ...] = ()
-    text_lens: Tuple[int, ...] = ()
-
-
-class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
-    """One setup slot, as the parent resolved it. Present and complete, or absent.
-
-    pgw#974. This used to be THREE parallel slot-keyed dicts on
-    ``MintRequest`` — ``snapshots`` (bytes), ``slot_bindings`` (identity,
-    pgw#969) and ``component_paths`` (composition, pgw#816) — written by three
-    separate statements, each independently allowed to be empty. Two of the
-    three combinations that describes are incoherent, and one of them cost two
-    L40S pods: ``{"pipeline": "/tmp/x"}`` with no binding decoded, type-checked
-    and looked complete, and the child died 0.0 s into ``warmup_forward`` at
-    ``ctx.slots["pipeline"]``. ``ref`` and ``path`` therefore carry no
-    defaults: a slot with bytes and no identity cannot be constructed and
-    cannot be decoded.
-
-    A slot the parent did not resolve is ABSENT from the map — never a present
-    entry with a hole in it. ``mint_child.assert_slots_resolvable`` still
-    refuses one that the endpoint declares and does not mark optional.
-
-    * ``ref`` — WHICH checkpoint. ``ctx.slots`` is built from bindings, and a
-      child re-runs discovery, so a hub-catalog slot (``Slot(selected_by=...)``
-      with no ``default_checkpoint=``, which is sdxl's shape) rediscovers
-      nothing at all. A slot WITH a code default is the quieter half of the
-      same defect: the child resolves the DECLARED checkpoint while the parent
-      serves the hub's pick, and traces graphs for a model this pod never runs.
-    * ``path`` — WHERE its bytes already are, materialized by the parent, so
-      the child never touches the network: a mint is compute, and a mint
-      process that could download is one that can stall on a lemon host.
-    * ``component_paths`` — pgw#617 per-component overrides, comp -> that
-      component's own local tree. Empty for most slots and part of the
-      composition when not: th#1330 B2 EXCLUDES an overridden component's
-      files from the base fetch, so ``path`` alone then names a narrowed tree
-      (``<digest>__x<fp>``) that no loader can open.
-    """
-
-    ref: ModelRef
-    path: str
-    component_paths: Dict[str, str] = {}
-
-    def __post_init__(self) -> None:
-        if not self.path:
-            raise ValueError(
-                f"a resolved slot must name the tree its bytes are in; got an "
-                f"empty path for {wire_ref(self.ref)!r}")
-
-
-def slot_subjects(
-    slots: Mapping[str, MintSlot],
-    digests: Optional[Mapping[str, str]] = None,
-) -> Tuple[cell_key.SlotSubject, ...]:
-    """The resolved SUBJECT of one arm or one boot trace (pgw#1113).
-
-    THE single derivation, so the arm token, the local-store memo and the
-    boot-key memo cannot disagree about which checkpoint a pipeline is bound
-    to. ``path`` is deliberately excluded — where the bytes were materialized
-    is a location on this machine, never an identity — and so is
-    ``component_paths``, whose identity half is already in the ref's
-    ``component_overrides`` (``binding_wire_refs``).
-    """
-    have = dict(digests or {})
-    return tuple(
-        cell_key.SlotSubject(
-            slot=str(name),
-            refs=tuple(binding_wire_refs(slot.ref)),
-            snapshot_digest=str(have.get(str(name), "") or ""),
-        )
-        for name, slot in sorted(slots.items())
-    )
-
-
 class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     """Everything the child needs, and nothing live."""
 
@@ -253,7 +154,7 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     #: never wrote a byte into, so that signal read 0 for every real mint.
     work_root: str
     report: str          # typed terminal report the child writes
-    cfg: CompileCellSpec
+    cfg: CompileSpec
     #: The parent's resolution, whole — slot -> identity + bytes + composition.
     #: See ``MintSlot``: the three views this replaced could disagree.
     slots: Dict[str, MintSlot] = {}
@@ -302,15 +203,6 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     #: measuring. The string is PROVENANCE, not a boolean, so the child's
     #: report says which proof stood behind the cell it sealed.
     handler_proof: str = ""
-
-
-class MintFrame(msgspec.Struct, frozen=True, kw_only=True):
-    """One progress frame. Reporting only — never a liveness claim."""
-
-    phase: str = ""
-    step: int = 0
-    total: int = 0
-    note: str = ""
 
 
 class MintReport(msgspec.Struct, frozen=True, kw_only=True):
@@ -462,16 +354,6 @@ class MintOutcome:
         if self.detail:
             parts.append(f"detail={self.detail[:400]!r}")
         return " ".join(parts)
-
-
-def frame_line(
-    phase: str = "", step: int = 0, total: int = 0, note: str = "",
-) -> str:
-    """One wire line for a progress frame — the child's half of the protocol,
-    kept here so both sides share one encoder."""
-    body = msgspec.json.encode(
-        MintFrame(phase=phase, step=step, total=total, note=note[:400]))
-    return FRAME_PREFIX + body.decode() + "\n"
 
 
 def _decode_report(path: Path) -> Optional[MintReport]:
@@ -860,17 +742,14 @@ async def run_mint(
 __all__ = [
     "ABANDONED",
     "CRASHED",
-    "CompileCellSpec",
     "EXIT_BAD_REQUEST",
     "EXIT_MINTED",
     "EXIT_REFUSED",
     "EXIT_RESOURCE",
-    "FRAME_PREFIX",
     "MAX_ATTEMPTS",
     "PHASES_SNAPSHOT_NAME",
     "MINTED",
     "MINT_CHILD_MODULE",
-    "MintFrame",
     "MintOutcome",
     "MintReport",
     "MintRequest",
@@ -879,7 +758,6 @@ __all__ = [
     "REQUEST_NAME",
     "RESOURCE",
     "child_argv",
-    "frame_line",
     "child_env",
     "run_mint",
     "write_request",

--- a/tests/harness/mint_child_stub.py
+++ b/tests/harness/mint_child_stub.py
@@ -30,7 +30,8 @@ from pathlib import Path
 
 import msgspec
 
-from gen_worker.mint_process import MintReport, MintRequest, frame_line  # type: ignore
+from gen_worker.child_contract import frame_line  # type: ignore
+from gen_worker.mint_process import MintReport, MintRequest  # type: ignore
 
 
 def _seconds() -> float:

--- a/tests/harness/mint_endpoints_pgw784.py
+++ b/tests/harness/mint_endpoints_pgw784.py
@@ -22,6 +22,7 @@ from typing import Any, List
 
 import msgspec
 
+from gen_worker import child_contract
 from gen_worker import RequestContext, endpoint
 from gen_worker import mint_process as mp
 
@@ -59,7 +60,7 @@ def _request(workdir: Path) -> mp.MintRequest:
         target=str(workdir / "cell.tar.gz"),
         work_root=str(workdir / "capture"),
         report=str(workdir / mp.REPORT_NAME),
-        cfg=mp.CompileCellSpec(family="pgw784"),
+        cfg=child_contract.CompileSpec(family="pgw784"),
     )
 
 

--- a/tests/test_abandoned_mint_telemetry_pgw848.py
+++ b/tests/test_abandoned_mint_telemetry_pgw848.py
@@ -32,6 +32,7 @@ from typing import Any, Dict
 
 import pytest
 
+from gen_worker import child_contract
 from gen_worker import aot_compile_pool as pool
 from gen_worker import aot_mint, mint_delegate, mint_process
 from gen_worker.cell_adopt import AdoptOutcome
@@ -106,7 +107,7 @@ def test_an_abandoned_outcome_emits_the_rows_it_measured(
         function="f", modules=(), family="sdxl", arm_token="k",
         target=str(tmp_path / "cell.tar.gz"), work_root=str(tmp_path),
         report=str(tmp_path / "report.json"),
-        cfg=mint_process.CompileCellSpec(),
+        cfg=child_contract.CompileSpec(),
         phases_snapshot=str(snapshot))
     recovered = mint_process._read_phase_snapshot(request.phases_snapshot)
     assert recovered, "the parent could not read what the child wrote"

--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -37,6 +37,7 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from gen_worker import child_preflight
 from gen_worker import aot_mint, fleet_cells, mint_delegate
 from gen_worker.api.decorators import Compile, Dim, GraphClass, Input
 from gen_worker.api.export_contract import (
@@ -518,7 +519,7 @@ def test_a_named_export_refusal_is_a_refusal_not_a_crash(
         arm_token="k", target=str(tmp_path / "cell.tar.gz"),
         work_root=str(tmp_path), report=str(tmp_path / "r.json"),
         cfg=cfg_spec(_Cfg()))
-    with pytest.raises(mint_child.MintChildRefused, match="lane held on dynamo"):
+    with pytest.raises(child_preflight.PreflightRefused, match="lane held on dynamo"):
         mint_child._mint_aot(
             request, _Pipe(), _Cfg(), tmp_path / "cell.tar.gz",
             started=0.0, sha256_file=lambda p: "x")

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -564,7 +564,7 @@ def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
     and the decision is READABLE afterwards, which is the half that was missing.
     """
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import MintSlot
+    from gen_worker.child_contract import MintSlot
     from gen_worker.procsplit import broker
     from gen_worker.registry import collect_endpoints
 
@@ -626,7 +626,7 @@ def test_the_same_boot_derives_a_key_with_accelerate_UNIMPORTABLE(
     from ``_boot_adopt`` down to the child's structure build is the real one.
     """
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import MintSlot
+    from gen_worker.child_contract import MintSlot
     from gen_worker.procsplit import broker
     from gen_worker.registry import collect_endpoints
 

--- a/tests/test_boot_key_pgw1089.py
+++ b/tests/test_boot_key_pgw1089.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 import pytest
 
 from gen_worker import aot_mint, aot_serve, boot_key, cell_key
-from gen_worker.mint_process import CompileCellSpec
+from gen_worker.child_contract import CompileSpec
 
 
 # ---------------------------------------------------------------------------
@@ -328,12 +328,12 @@ def test_the_closure_digest_moves_on_code_and_on_declaration(
     in milliseconds, and folding them in here would make the memo miss on
     facts whose whole point is that they are cheap to restate.
     """
-    cfg = CompileCellSpec(
+    cfg = CompileSpec(
         family="tiny", targets=("unet",), shapes=((1024, 1024),),
         text_lens=(77,), guidance_scales=(7.5,))
     base = boot_key.closure_digest("tiny", cfg)
 
-    wider = CompileCellSpec(
+    wider = CompileSpec(
         family="tiny", targets=("unet",),
         shapes=((1024, 1024), (768, 768)),
         text_lens=(77,), guidance_scales=(7.5,))
@@ -350,7 +350,7 @@ def test_the_closure_digest_ignores_the_re_derived_axes(axis: str) -> None:
     """Stated as a property of the recorded facts rather than by monkeypatching
     a probe: the digest's inputs are enumerated in one dict, and neither the
     sm nor the toolchain is among them."""
-    cfg = CompileCellSpec(family="tiny", targets=("unet",))
+    cfg = CompileSpec(family="tiny", targets=("unet",))
     # The digest is over a literal fact block; assert the axis names appear
     # nowhere in the source of that block.
     import inspect
@@ -478,7 +478,7 @@ def test_a_child_that_produced_no_hashes_refuses_the_whole_derivation(
     with pytest.raises(boot_key.BootKeyUnavailable) as err:
         boot_key.derive(
             function="fn", modules=("m",), family="tiny",
-            cfg=CompileCellSpec(family="tiny", targets=("unet",)),
+            cfg=CompileSpec(family="tiny", targets=("unet",)),
             slots={}, declared_hint=2, envelope=_ENVELOPE,
             work_root=tmp_path)
     assert err.value.reason == "structure_unsupported"
@@ -489,7 +489,7 @@ def test_a_declaration_with_no_classes_refuses(tmp_path: Path) -> None:
     with pytest.raises(boot_key.BootKeyUnavailable) as err:
         boot_key.derive(
             function="fn", modules=("m",), family="tiny",
-            cfg=CompileCellSpec(family="tiny"), slots={}, declared_hint=0,
+            cfg=CompileSpec(family="tiny"), slots={}, declared_hint=0,
             envelope=_ENVELOPE, work_root=tmp_path)
     assert err.value.reason == "no_classes"
 
@@ -507,7 +507,7 @@ def test_a_child_running_drifted_source_refuses_rather_than_being_believed(
     with pytest.raises(boot_key.BootKeyUnavailable) as err:
         boot_key.derive(
             function="fn", modules=("m",), family="tiny",
-            cfg=CompileCellSpec(family="tiny", targets=("unet",)),
+            cfg=CompileSpec(family="tiny", targets=("unet",)),
             slots={}, declared_hint=1, envelope=_ENVELOPE,
             work_root=tmp_path)
     assert err.value.reason == "code_drift"
@@ -527,7 +527,7 @@ def test_a_derivation_that_returns_an_incomplete_class_set_refuses(
     with pytest.raises(boot_key.BootKeyUnavailable) as err:
         boot_key.derive(
             function="fn", modules=("m",), family="tiny",
-            cfg=CompileCellSpec(family="tiny", targets=("unet",)),
+            cfg=CompileSpec(family="tiny", targets=("unet",)),
             slots={}, declared_hint=2, envelope=_ENVELOPE,
             work_root=tmp_path)
     assert err.value.reason == "class_set_gap"
@@ -556,7 +556,7 @@ def test_children_that_enumerated_different_class_sets_refuse(
     with pytest.raises(boot_key.BootKeyUnavailable) as err:
         boot_key.derive(
             function="fn", modules=("m",), family="tiny",
-            cfg=CompileCellSpec(family="tiny", targets=("unet",)),
+            cfg=CompileSpec(family="tiny", targets=("unet",)),
             slots={}, declared_hint=2, envelope=_ENVELOPE,
             work_root=tmp_path)
     assert err.value.reason == "class_set_disagreement"
@@ -587,7 +587,7 @@ def test_derive_end_to_end_with_stubbed_children_memoizes_and_hits(
     monkeypatch.setattr(boot_key, "_run_children", _children)
     kwargs: Dict[str, Any] = dict(
         function="fn", modules=("m",), family="tiny",
-        cfg=CompileCellSpec(family="tiny", targets=("unet",)),
+        cfg=CompileSpec(family="tiny", targets=("unet",)),
         slots={}, declared_hint=2, envelope=_ENVELOPE,
         work_root=tmp_path, memo_dir=tmp_path)
 

--- a/tests/test_compile_politeness_pgw1137.py
+++ b/tests/test_compile_politeness_pgw1137.py
@@ -48,10 +48,11 @@ import msgspec
 import pytest
 
 from gen_worker import (
-    aot_compile_pool, compile_posture, local_serve, mint_child, mint_delegate,
-    mint_process)
+    aot_compile_pool, compile_posture, local_serve, mint_child, mint_delegate)
 from gen_worker.compile_posture import FLEET, USER_MACHINE, CompilePosture
-from gen_worker.mint_process import MintFrame, MintRequest, MintSlot
+from gen_worker.child_contract import (
+    CompileSpec, MintFrame, MintSlot)
+from gen_worker.mint_process import MintRequest
 
 SRC = Path(aot_compile_pool.__file__).parent
 
@@ -236,7 +237,7 @@ def test_a_fleet_mint_declares_nothing_and_gets_the_fleet_posture() -> None:
     assert MintRequest(
         function="f", modules=(), family="x", arm_token="", target="",
         work_root="", report="",
-        cfg=mint_process.CompileCellSpec()).posture == FLEET
+        cfg=CompileSpec()).posture == FLEET
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +331,7 @@ def _drive_child_posture(
     request = MintRequest(
         function="generate", modules=("m",), family="micro-diffusion",
         arm_token="arm2-x", target="/tmp/c.tar.gz", work_root="/tmp",
-        report="/tmp/r.json", cfg=mint_process.CompileCellSpec(),
+        report="/tmp/r.json", cfg=CompileSpec(),
         posture=posture)
     mint_child._install_posture(request)
     return nice, armed
@@ -377,7 +378,7 @@ def test_a_kernel_that_refuses_the_nice_leaves_a_RUDE_mint_not_a_DEAD_one(
     request = MintRequest(
         function="generate", modules=("m",), family="f", arm_token="",
         target="", work_root="", report="",
-        cfg=mint_process.CompileCellSpec(), posture=USER_MACHINE)
+        cfg=CompileSpec(), posture=USER_MACHINE)
     mint_child._install_posture(request)   # must not raise
     assert compile_posture.current() == USER_MACHINE
 

--- a/tests/test_cxx_toolchain_pgw823.py
+++ b/tests/test_cxx_toolchain_pgw823.py
@@ -27,6 +27,7 @@ import types
 
 import pytest
 
+from gen_worker import child_preflight
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells
 
@@ -162,7 +163,7 @@ def test_the_child_refuses_the_AOT_recipe_before_reading_weights(
         target="/tmp/x", work_root="/tmp/y", device=0,
         modules=[], function="generate", cfg=None, configs={}, execution_lane="",
         report="/tmp/r", arm_token="")
-    with pytest.raises(mint_child.MintChildRefused, match="no C\\+\\+ compiler"):
+    with pytest.raises(child_preflight.PreflightRefused, match="no C\\+\\+ compiler"):
         mint_child.mint(req)
 
 

--- a/tests/test_declaration_refusal_pgw1075.py
+++ b/tests/test_declaration_refusal_pgw1075.py
@@ -46,6 +46,8 @@ from typing import Dict, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import mint_child, mint_delegate
 from gen_worker import mint_process as mp
 from gen_worker.api.binding import ModelRef
@@ -91,7 +93,7 @@ def _request(checkpoint: Path, workdir: Path, *, bucket: int) -> mp.MintRequest:
     task = mint_delegate.MintTask(
         pending=pending, pipe=None, function=FUNCTION,
         modules=(ENDPOINT_MODULE,),
-        slots={"pipeline": mp.MintSlot(
+        slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
                          tag="prod"),
             path=str(checkpoint))},
@@ -221,7 +223,7 @@ def test_the_refusal_type_is_the_sdks_own_bad_input_type() -> None:
 
     refusal = mint_child._declaration_refusal(
         ValidationError("invalid lora rank bucket 8 (valid: (16, 32, 64, 128))"))
-    assert isinstance(refusal, mint_child.MintChildRefused), (
+    assert isinstance(refusal, child_preflight.PreflightRefused), (
         "it must land on the type the child already exits EXIT_REFUSED for — "
         "one refusal path, not two")
     assert "invalid lora rank bucket 8" in str(refusal)

--- a/tests/test_declared_blockers_pgw1115.py
+++ b/tests/test_declared_blockers_pgw1115.py
@@ -40,6 +40,8 @@ from typing import Any, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import Compile, MintBlocker, fleet_cells
 from gen_worker import mint_child, mint_delegate
 from gen_worker import mint_process as mp
@@ -369,7 +371,7 @@ def _blocked_request(tmp_path: Path) -> mp.MintRequest:
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function="blocked-echo",
         modules=(HARNESS_MODULE,),
-        slots={"pipeline": mp.MintSlot(
+        slots={"pipeline": child_contract.MintSlot(
             ref=blocked.DECLARED_PIPELINE, path=str(tree))},
         execution_lane="w8a8", device=-1)
     request = mint_delegate.build_request(
@@ -421,7 +423,7 @@ def test_the_mint_child_mints_a_family_whose_blockers_are_all_resolved(
         mint_child._assert_family_mintable(FAMILY)  # no raise
 
         register_export_declaration(blocked.BLOCKED_COMPILE, replace=True)
-        with pytest.raises(mint_child.MintChildRefused) as exc:
+        with pytest.raises(child_preflight.PreflightRefused) as exc:
             mint_child._assert_family_mintable(FAMILY)
         assert all(i in str(exc.value) for i in blocked.OPEN_IDS)
     finally:

--- a/tests/test_entry_blast_radius_pgw1208.py
+++ b/tests/test_entry_blast_radius_pgw1208.py
@@ -54,6 +54,8 @@ import torch.nn as nn  # noqa: E402
 
 from torch._dynamo.exc import Unsupported  # noqa: E402
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import aot_mint, aot_serve, compile_cache  # noqa: E402
 from gen_worker.api.decorators import Compile  # noqa: E402
 from gen_worker.api.export_contract import (  # noqa: E402
@@ -367,10 +369,10 @@ def _drive_to_load(
         target=str(tmp_path / "cell.tar.gz"),
         work_root=str(tmp_path / "capture"),
         report=str(tmp_path / mp.REPORT_NAME),
-        cfg=mp.CompileCellSpec(family="sdxl", shapes=((1024, 1024),),
+        cfg=child_contract.CompileSpec(family="sdxl", shapes=((1024, 1024),),
                                targets=("unet",)),
         handler_proof="test: the parent proved it",
-        slots={"pipeline": mp.MintSlot(
+        slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/composed",
                          tag="prod"),
             path=str(tree))},
@@ -488,13 +490,13 @@ def test_the_mint_refuses_ONCE_before_export_naming_the_construct() -> None:
     request = mp.MintRequest(
         function="f", modules=(), family="sdxl", arm_token="a",
         target="t", work_root="w", report="r",
-        cfg=mp.CompileCellSpec(family="sdxl", targets=("unet",)))
+        cfg=child_contract.CompileSpec(family="sdxl", targets=("unet",)))
 
     # A traceable pipeline passes silently.
     mint_child.assert_traceable_as_loaded(
         types.SimpleNamespace(unet=TinyUNet()), request)
 
-    with pytest.raises(mint_child.MintChildRefused) as caught:
+    with pytest.raises(child_preflight.PreflightRefused) as caught:
         mint_child.assert_traceable_as_loaded(_offloaded(), request)
 
     said = str(caught.value)

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -82,7 +82,7 @@ def _trace(
 
     from gen_worker import aot_mint, fleet_cells
     from gen_worker.cli.run import run_setup
-    from gen_worker.mint_child import pick_compile_target
+    from gen_worker.child_preflight import pick_compile_target
     from gen_worker.registry import collect_endpoints
 
     veh = rig_vehicles.vehicle(vehicle_name)

--- a/tests/test_handler_proof_pgw1199.py
+++ b/tests/test_handler_proof_pgw1199.py
@@ -35,6 +35,8 @@ from typing import Any, Dict, List
 
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import handler_proof
 from gen_worker import mint_delegate, mint_process
 
@@ -131,7 +133,7 @@ def test_the_request_field_defaults_to_unproven() -> None:
     request = mint_process.MintRequest(
         function="generate", modules=(), family="f", arm_token="a",
         target="t", work_root="w", report="r",
-        cfg=mint_process.CompileCellSpec())
+        cfg=child_contract.CompileSpec())
     assert request.handler_proof == ""
 
 
@@ -144,7 +146,7 @@ def _request(**kw: Any) -> mint_process.MintRequest:
     base: Dict[str, Any] = dict(
         function="generate", modules=("m",), family="micro-diffusion",
         arm_token="arm1-x", target="t", work_root="w", report="r",
-        cfg=mint_process.CompileCellSpec(targets=("transformer",)))
+        cfg=child_contract.CompileSpec(targets=("transformer",)))
     base.update(kw)
     return mint_process.MintRequest(**base)
 
@@ -158,7 +160,7 @@ def test_the_child_refuses_a_weight_free_mint_with_no_proof() -> None:
     """
     from gen_worker import mint_child
 
-    with pytest.raises(mint_child.MintChildRefused) as caught:
+    with pytest.raises(child_preflight.PreflightRefused) as caught:
         mint_child.assert_handler_proven(_request())
 
     said = str(caught.value)
@@ -178,7 +180,7 @@ def test_whitespace_is_not_a_proof() -> None:
     a forward, and must be refused exactly as one that set nothing."""
     from gen_worker import mint_child
 
-    with pytest.raises(mint_child.MintChildRefused):
+    with pytest.raises(child_preflight.PreflightRefused):
         mint_child.assert_handler_proven(_request(handler_proof="   "))
 
 

--- a/tests/test_identity_soundness_pgw1113.py
+++ b/tests/test_identity_soundness_pgw1113.py
@@ -28,9 +28,8 @@ from typing import Any, Dict, Mapping
 import pytest
 
 from gen_worker import boot_key, cell_key, fleet_cells, local_cell_store
-from gen_worker import mint_process as mp
 from gen_worker.api.binding import Hub
-from gen_worker.mint_process import CompileCellSpec
+from gen_worker.child_contract import CompileSpec, MintSlot
 
 # --------------------------------------------------------------------------
 # fixtures — two checkpoints of one family, and one declaration over them
@@ -228,14 +227,14 @@ def test_a_subject_difference_is_not_a_handback_divergence() -> None:
 # --------------------------------------------------------------------------
 
 
-def _spec() -> CompileCellSpec:
-    return CompileCellSpec(
+def _spec() -> CompileSpec:
+    return CompileSpec(
         family="qwen-image", targets=("transformer",),
         shapes=((1024, 1024),), text_lens=(77,), guidance_scales=(4.0,))
 
 
-def _slots(ref: Any, path: str = "/cas/a") -> Dict[str, mp.MintSlot]:
-    return {"pipeline": mp.MintSlot(ref=ref, path=path)}
+def _slots(ref: Any, path: str = "/cas/a") -> Dict[str, MintSlot]:
+    return {"pipeline": MintSlot(ref=ref, path=path)}
 
 
 def test_a_rebinding_forces_a_memo_MISS() -> None:

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -38,7 +38,7 @@ import pytest
 from gen_worker import fleet_cells, local_cell_store, local_serve, mint_delegate
 from gen_worker.cell_adopt import AdoptOutcome
 from gen_worker.cli import run as cli_run
-from gen_worker.mint_process import MintSlot
+from gen_worker.child_contract import MintSlot
 
 KEY_A = "ek1-" + "a" * 56
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56

--- a/tests/test_measure_document_pgw1153.py
+++ b/tests/test_measure_document_pgw1153.py
@@ -45,7 +45,8 @@ import msgspec
 import pytest
 
 from gen_worker import measure_child
-from gen_worker.mint_process import CompileCellSpec, MintRequest
+from gen_worker.child_contract import CompileSpec
+from gen_worker.mint_process import MintRequest
 
 REPO = Path(__file__).resolve().parent.parent
 MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
@@ -155,7 +156,7 @@ def test_a_runtime_mint_request_still_decodes_through_the_same_door(
 ) -> None:
     """The OTHER real artifact — a mint work root's ``request.json`` — has to
     keep working, and through the SAME decoder. Two decoders is the defect."""
-    cfg = CompileCellSpec(family=FAMILY, targets=("transformer",))
+    cfg = CompileSpec(family=FAMILY, targets=("transformer",))
     request = MintRequest(
         function="generate-w8a8", modules=("micro_diffusion.main_w8a8",),
         family=FAMILY, arm_token="arm1-deadbeef",

--- a/tests/test_measure_only_pgw1134.py
+++ b/tests/test_measure_only_pgw1134.py
@@ -50,9 +50,11 @@ from typing import Any, Dict, Iterator, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
 from gen_worker import activity, aot_mint, boot_trace_child, boot_key
 from gen_worker import measure_child, mint_child
-from gen_worker.mint_process import CompileCellSpec, MintRequest, MintSlot
+from gen_worker.child_contract import CompileSpec, MintSlot
+from gen_worker.mint_process import MintRequest
 
 REPO = Path(__file__).resolve().parent.parent
 MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
@@ -127,13 +129,13 @@ def blocked_declaration(micro_src: None) -> Iterator[None]:
         ec.register_export_declaration(decl.DECLARATION, replace=True)
 
 
-def _cfg() -> CompileCellSpec:
+def _cfg() -> CompileSpec:
     from gen_worker.registry import collect_endpoints
 
     specs = collect_endpoints(["harness.rig_runtime", "micro_diffusion.main_w8a8"])
     spec = next(s for s in specs if s.name == "generate-w8a8")
     cell = spec.compile_cell()
-    return CompileCellSpec(
+    return CompileSpec(
         shapes=tuple(tuple(int(v) for v in row) for row in (cell.shapes or ())),
         targets=tuple(str(t) for t in (cell.targets or ())),
         family=str(cell.family or ""),
@@ -204,7 +206,7 @@ def test_both_front_doors_are_shut_and_the_measure_child_runs_anyway(
     family because its tree is a quantized artifact. Door 3 — the measure
     child runs, on real weights, and says so.
     """
-    with pytest.raises(mint_child.MintChildRefused) as refusal:
+    with pytest.raises(child_preflight.PreflightRefused) as refusal:
         mint_child._assert_family_mintable(FAMILY)
     assert BLOCKER_ID in str(refusal.value)
 
@@ -258,7 +260,7 @@ def test_the_mint_gate_is_UNTOUCHED_by_a_measurement(
     measure_child.run(
         _measure_job(w8a8_tree), tmp_path / "m.json", compile_entries=False)
 
-    with pytest.raises(mint_child.MintChildRefused) as refusal:
+    with pytest.raises(child_preflight.PreflightRefused) as refusal:
         mint_child._assert_family_mintable(FAMILY)
     assert BLOCKER_ID in str(refusal.value)
 
@@ -322,7 +324,7 @@ def test_a_full_mint_request_decodes_with_its_destinations_dropped(
 ) -> None:
     """The fence, exercised rather than asserted: a REAL MintRequest, encoded
     and decoded as the operator's file, arrives carrying no destination."""
-    cfg = CompileCellSpec(family=FAMILY, targets=("transformer",))
+    cfg = CompileSpec(family=FAMILY, targets=("transformer",))
     request = MintRequest(
         function="generate-w8a8", modules=("micro_diffusion.main_w8a8",), family=FAMILY,
         arm_token="arm1-deadbeef", target=str(tmp_path / "cell.tar.gz"),

--- a/tests/test_micro_mint_rig_pgw978.py
+++ b/tests/test_micro_mint_rig_pgw978.py
@@ -145,7 +145,7 @@ def test_a_slot_with_bytes_and_no_identity_cannot_reach_the_child() -> None:
     this row is what proves the rig did not route around the guard by
     hand-rolling a dict.
     """
-    from gen_worker.mint_process import MintSlot
+    from gen_worker.child_contract import MintSlot
 
     with pytest.raises(TypeError):
         MintSlot(path="/tmp/x")  # type: ignore[call-arg]  # no ref

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -41,6 +41,8 @@ from typing import Any, Dict, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import fleet_cells, mint_child, mint_delegate
 from gen_worker import mint_process as mp
 from gen_worker.api.binding import ModelRef, wire_ref
@@ -247,7 +249,7 @@ def test_the_parent_hands_its_resolved_overrides_across_the_wire(
                         dynamic=(), lora_bucket=0, guidance_scales=(),
                         text_lens=()), target=tmp_path / "cell.tar.gz",
         mint_root=tmp_path, recipe="aot")
-    resolved = mp.MintSlot(
+    resolved = child_contract.MintSlot(
         ref=ModelRef(source="tensorhub", path="harness/composed", tag="prod"),
         path="/cas/snapshots/sha256:cafe__xdeadbeef",
         component_paths={"vae": "/cas/snapshots/sha256:beef"})
@@ -291,8 +293,8 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
     and a stack trace: the refusal names the SLOT and the reason, before a
     single weight is read."""
     base, _vae = trees
-    with pytest.raises(mint_child.MintChildRefused) as exc:
-        mint_child.assert_composable({"pipeline": mp.MintSlot(
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        mint_child.assert_composable({"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/composed",
                          tag="prod"),
             path=str(base))})
@@ -308,14 +310,14 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
         target=str(tmp_path / "cell.tar.gz"),
         work_root=str(tmp_path / "capture"),
         report=str(tmp_path / mp.REPORT_NAME),
-        cfg=mp.CompileCellSpec(family="sdxl", shapes=((1024, 1024),),
+        cfg=child_contract.CompileSpec(family="sdxl", shapes=((1024, 1024),),
                                targets=("unet",)),
-        slots={"pipeline": mp.MintSlot(
+        slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/composed",
                          tag="prod"),
             path=str(base))},
     )
-    with pytest.raises(mint_child.MintChildRefused):
+    with pytest.raises(child_preflight.PreflightRefused):
         mint_child.mint(request)
     assert not (tmp_path / "capture").exists(), (
         "the refusal must precede every side effect")
@@ -326,8 +328,8 @@ def test_a_complete_tree_never_demands_overrides(tmp_path: Path) -> None:
     a bare-digest (complete) tree is loadable alone and must stay that way."""
     ref = ModelRef(source="tensorhub", path="harness/composed", tag="prod")
 
-    def _one(key: str, **comps: str) -> Dict[str, mp.MintSlot]:
-        return {"pipeline": mp.MintSlot(
+    def _one(key: str, **comps: str) -> Dict[str, child_contract.MintSlot]:
+        return {"pipeline": child_contract.MintSlot(
             ref=ref, path=f"/cas/{key}", component_paths=dict(comps))}
 
     complete = snapshot_dir_key("sha256:cafe")
@@ -337,7 +339,7 @@ def test_a_complete_tree_never_demands_overrides(tmp_path: Path) -> None:
     mint_child.assert_composable(_one(complete))
     # A component-SCOPED subset is what the caller asked to fetch; loadable.
     mint_child.assert_composable(_one(subset))
-    with pytest.raises(mint_child.MintChildRefused):
+    with pytest.raises(child_preflight.PreflightRefused):
         mint_child.assert_composable(_one(narrowed))
     # With the override in hand, the same tree is composable.
     mint_child.assert_composable(_one(narrowed, vae="/cas/x"))

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -52,6 +52,8 @@ from typing import Any, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import handler_proof
 from gen_worker import mint_child, mint_delegate, registry, warmup
 from gen_worker import mint_process as mp
@@ -148,7 +150,7 @@ def _request(
         spec=SimpleNamespace(name=function), instance=object(), snapshots=None,
         pendings={}, pipes={},
         modules=(CATALOG_MODULE,),
-        slots=({"pipeline": mp.MintSlot(ref=binding, path=str(tree))}
+        slots=({"pipeline": child_contract.MintSlot(ref=binding, path=str(tree))}
                if binding is not None else {}),
     )
     task = mint_delegate.MintTask(
@@ -165,13 +167,13 @@ def _child_specs(request: mp.MintRequest) -> Tuple[Any, List[Any]]:
     rediscover, select the class-scoped sibling set, install the parent's
     bindings, and refuse if they cannot resolve."""
     specs = registry.collect_endpoints(list(request.modules))
-    chosen, siblings = mint_child.select_specs(specs, request.function)
-    mint_child.bind_slots(siblings, request.slots)
+    chosen, siblings = child_preflight.select_specs(specs, request.function)
+    child_preflight.bind_slots(siblings, request.slots)
     # pgw#1089 took the whole request out of this signature: the boot-trace
     # child resolves the same slots for the same reason and must get the same
     # refusal, and a second copy of the check would be a second answer to "can
     # this process trace the checkpoint the parent serves".
-    mint_child.assert_slots_resolvable(
+    child_preflight.assert_slots_resolvable(
         siblings, request.slots, what=mint_child.mint_identity(request))
     return chosen, siblings
 
@@ -299,7 +301,7 @@ def test_an_unbound_required_slot_refuses_by_name_before_the_load(
     """
     tree, _binding = served
     request = _request(tree, None, tmp_path)
-    with pytest.raises(mint_child.MintChildRefused) as exc:
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
         _child_specs(request)
     text = str(exc.value)
     for fact in ("pgw969", "ck1-catalog", "w8a8-lora64", "catalog-generate",
@@ -354,10 +356,10 @@ def test_a_bound_slot_that_still_fails_names_the_divergence(
         tmp_path, ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
         tmp_path)
     request = msgspec.structs.replace(
-        request, slots={"nonexistent-slot": mp.MintSlot(
+        request, slots={"nonexistent-slot": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
             path=str(tmp_path))})
-    with pytest.raises(mint_child.MintChildRefused) as exc:
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
         _child_specs(request)
     assert "sent no resolved binding" in str(exc.value)
     assert "nonexistent-slot" in str(exc.value), (
@@ -382,10 +384,10 @@ def test_a_code_default_never_stands_in_for_the_parents_pick(
     declared = wire_ref(toy.JUGGLE_DECLARED)
     picked = ModelRef(source="tensorhub", path="harness/juggle-pick", tag="prod")
     specs = registry.collect_endpoints(["harness.toy_endpoints"])
-    chosen, siblings = mint_child.select_specs(specs, "juggle-echo")
+    chosen, siblings = child_preflight.select_specs(specs, "juggle-echo")
     assert wire_ref(chosen.models["pipeline"]) == declared
 
-    mint_child.bind_slots(siblings, {"pipeline": mp.MintSlot(
+    child_preflight.bind_slots(siblings, {"pipeline": child_contract.MintSlot(
         ref=picked, path=str(tmp_path))})
     with __import__("tempfile").TemporaryDirectory() as tmp:
         ctx = warmup.warm_context(
@@ -433,13 +435,13 @@ def test_a_slot_with_bytes_and_no_identity_cannot_be_constructed() -> None:
     with two defaults. ``ref`` and ``path`` now have none.
     """
     with pytest.raises(TypeError):
-        mp.MintSlot(path="/cas/snapshots/sha256:cafe")   # type: ignore[call-arg]
+        child_contract.MintSlot(path="/cas/snapshots/sha256:cafe")   # type: ignore[call-arg]
     with pytest.raises(TypeError):
-        mp.MintSlot(ref=ModelRef(                        # type: ignore[call-arg]
+        child_contract.MintSlot(ref=ModelRef(                        # type: ignore[call-arg]
             source="tensorhub", path="harness/pick", tag="prod"))
     # ...and the degenerate spelling of the same lie.
     with pytest.raises(ValueError):
-        mp.MintSlot(
+        child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
             path="")
 
@@ -468,5 +470,5 @@ def test_the_pods_wire_no_longer_decodes(
     doc["slots"] = {}
     empty = msgspec.json.decode(msgspec.json.encode(doc), type=mp.MintRequest)
     assert empty.slots == {}
-    with pytest.raises(mint_child.MintChildRefused):
+    with pytest.raises(child_preflight.PreflightRefused):
         _child_specs(empty)

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List
 import pytest
 import torch
 
+from gen_worker import child_contract
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells, mint_delegate, mint_workers
 from gen_worker import mint_process as mp
@@ -167,7 +168,7 @@ def test_the_request_carries_the_execution_lane_and_the_effective_config(
         target=tmp_path / "cell.tar.gz", mint_root=tmp_path)
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function="gen",
-        modules=("app",), slots={"pipeline": mp.MintSlot(
+        modules=("app",), slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/sdxl",
                          tag="prod"), path="/cas/sdxl")},
         execution_lane="fp8-w8a16", configs={"gen": {"steps": 28}}, device=3)

--- a/tests/test_mint_memory_fit_pgw848.py
+++ b/tests/test_mint_memory_fit_pgw848.py
@@ -48,6 +48,7 @@ from typing import Any, Dict
 
 import pytest
 
+from gen_worker import child_contract
 from gen_worker import aot_compile_pool as pool
 from gen_worker import mint_workers
 
@@ -249,7 +250,7 @@ def test_the_pools_own_measurement_reaches_the_bank_over_the_real_relay(
     ever read the field. This drives the REAL ``build_cell`` bookkeeping
     against a real ``MintOutcome`` and asserts the ask lands in the bank.
     """
-    from gen_worker import mint_delegate, mint_process
+    from gen_worker import mint_process
     from gen_worker import aot_mint
 
     fam, execution_lane = "pgw848-relay", "w8a8-lora64"
@@ -279,7 +280,7 @@ def test_the_pools_own_measurement_reaches_the_bank_over_the_real_relay(
     request = mint_process.MintRequest(
         function="f", modules=(), family=fam, arm_token="k", target="t",
         work_root="c", report="r",
-        cfg=mint_delegate.mint_process.CompileCellSpec(),
+        cfg=child_contract.CompileSpec(),
         entry_peak_rss_bytes=banked)
     assert request.entry_peak_rss_bytes == 6 * _GIB, (
         "a banked measurement that cannot cross the process boundary is a "

--- a/tests/test_mint_preconditions_pgw996.py
+++ b/tests/test_mint_preconditions_pgw996.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 
+from gen_worker import child_preflight
 from gen_worker import aot_preconditions as pre
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells
@@ -409,7 +410,7 @@ def test_the_CHILD_still_refuses_a_toolchainless_AOT_mint(
         target="/tmp/x", capture="/tmp/y", device=0,
         modules=[], function="generate", cfg=None, configs={},
         execution_lane="", report="/tmp/r", arm_token="")
-    with pytest.raises(mint_child.MintChildRefused, match="no C\\+\\+ compiler"):
+    with pytest.raises(child_preflight.PreflightRefused, match="no C\\+\\+ compiler"):
         mint_child.mint(req)
 
 

--- a/tests/test_mint_process_pgw784.py
+++ b/tests/test_mint_process_pgw784.py
@@ -33,6 +33,7 @@ import msgspec
 import pytest
 import torch
 
+from gen_worker import child_contract
 from gen_worker import mint_process as mp
 
 GIB = 1 << 30
@@ -48,7 +49,7 @@ def _request(tmp_path: Path, **over: Any) -> mp.MintRequest:
         target=str(tmp_path / "cell.tar.gz"),
         work_root=str(tmp_path / "capture"),
         report=str(tmp_path / mp.REPORT_NAME),
-        cfg=mp.CompileCellSpec(family="sdxl", shapes=((1024, 1024),),
+        cfg=child_contract.CompileSpec(family="sdxl", shapes=((1024, 1024),),
                                targets=("unet",)),
     )
     fields.update(over)
@@ -112,7 +113,7 @@ def test_child_env_pins_the_card_and_declares_itself(tmp_path: Path) -> None:
 def test_a_stray_print_is_not_a_frame(tmp_path: Path) -> None:
     """Frames are prefixed. Endpoint code, torch and pip all print; none of
     them may steer a mint."""
-    assert mp.frame_line(phase="load").startswith(mp.FRAME_PREFIX)
+    assert child_contract.frame_line(phase="load").startswith(child_contract.FRAME_PREFIX)
     frames: list = []
     out = asyncio.run(_run(tmp_path, "minted", frames=frames))
     assert out.minted

--- a/tests/test_mint_recipe_parity_pgw984_pgw985.py
+++ b/tests/test_mint_recipe_parity_pgw984_pgw985.py
@@ -31,7 +31,7 @@ and each is a class:
 2. A bare ``RuntimeError`` exits 1, which classifies ``CRASHED`` — the
    retryable class. On a pod that is a second billed mint for a condition the
    first attempt had already settled. The AOT recipe types the identical
-   condition ``MintChildRefused`` -> ``EXIT_REFUSED`` -> terminal.
+   condition ``PreflightRefused`` -> ``EXIT_REFUSED`` -> terminal.
 
 pgw#1010 deleted the dynamo recipe's ARTIFACT (it had no consumer), so the
 child now mints one kind. Both findings survive intact and are asserted where
@@ -54,6 +54,8 @@ from typing import Any, Dict, List, Tuple
 import msgspec
 import pytest
 
+from gen_worker import child_preflight
+from gen_worker import child_contract
 from gen_worker import compile_cache as cc
 from gen_worker import mint_child, mint_delegate
 from gen_worker import mint_process as mp
@@ -189,7 +191,7 @@ def _request(
     task = mint_delegate.MintTask(
         pending=pending, pipe=None, function=FUNCTION,
         modules=(ENDPOINT_MODULE,),
-        slots={"pipeline": mp.MintSlot(
+        slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
                          tag="prod"),
             path=str(checkpoint))},
@@ -336,7 +338,7 @@ def test_an_aot_mint_cannot_seal_for_a_handler_that_cannot_run(
 
     monkeypatch.setattr(ep.MicroRigEndpoint, "rig_generate", _broken)
 
-    with pytest.raises(mint_child.MintChildRefused) as exc:
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
         mint_child.mint(_request(checkpoint, tmp_path / "w"))
 
     text = str(exc.value)

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -33,6 +33,7 @@ from typing import Any, List
 
 import pytest
 
+from gen_worker import child_contract
 import gen_worker.executor as executor_mod
 from gen_worker import fleet_cells, mint_delegate, mint_workers
 from gen_worker.api.binding import ModelRef
@@ -55,10 +56,10 @@ STUB_MODULE = "harness.mint_child_stub"
 SDXL_REF = ModelRef(source="tensorhub", path="harness/sdxl", tag="prod")
 
 
-def _slot(path: str) -> mp.MintSlot:
+def _slot(path: str) -> child_contract.MintSlot:
     """One resolved slot. ``ref`` has no default (pgw#974), so a test cannot
     describe bytes without saying whose they are either."""
-    return mp.MintSlot(ref=SDXL_REF, path=path)
+    return child_contract.MintSlot(ref=SDXL_REF, path=path)
 
 
 class _Pipe:

--- a/tests/test_structure_only_pgw1080.py
+++ b/tests/test_structure_only_pgw1080.py
@@ -231,7 +231,7 @@ def test_the_real_load_seam_raises_NOT_HONORED_on_a_swallowed_injection(
     pipeline drops the injection and carries a real module — so
     ``_load_injected_model`` raises ``StructureNotHonored`` (NOT the buildable
     strand). The mint child's three-line handler turns exactly this type into a
-    ``MintChildRefused`` so the real-weight export never starts; conflating it
+    ``PreflightRefused`` so the real-weight export never starts; conflating it
     with the strand is what let z-image OOM ~40 GiB as `retryable` (ie#638)."""
     from gen_worker.cli import run as run_mod
     from gen_worker.models import provision

--- a/tests/test_trace_child_placement_pgw1124.py
+++ b/tests/test_trace_child_placement_pgw1124.py
@@ -212,13 +212,13 @@ def micro_declaration(micro_tree: Path) -> None:
 
 def _job(micro_tree: Path, report: Path) -> Any:
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import CompileCellSpec, MintSlot
+    from gen_worker.child_contract import CompileSpec, MintSlot
     from gen_worker.registry import collect_endpoints
 
     specs = collect_endpoints(["harness.rig_runtime", "micro_diffusion.main"])
     spec = next(s for s in specs if s.name == "generate")
     cell = spec.compile_cell()
-    cfg = CompileCellSpec(
+    cfg = CompileSpec(
         shapes=tuple(
             tuple(int(v) for v in row) for row in (cell.shapes or ())),
         targets=tuple(str(t) for t in (cell.targets or ())),

--- a/tests/test_weight_free_premise_pgw1173.py
+++ b/tests/test_weight_free_premise_pgw1173.py
@@ -378,13 +378,13 @@ def micro_declaration(micro_tree: Path) -> None:
 
 def _job(micro_tree: Path, report: Path, *, extra_targets: tuple = ()) -> Any:
     from gen_worker.api.binding import ModelRef
-    from gen_worker.mint_process import CompileCellSpec, MintSlot
+    from gen_worker.child_contract import CompileSpec, MintSlot
     from gen_worker.registry import collect_endpoints
 
     specs = collect_endpoints(["harness.rig_runtime", "micro_diffusion.main"])
     spec = next(s for s in specs if s.name == "generate")
     cell = spec.compile_cell()
-    cfg = CompileCellSpec(
+    cfg = CompileSpec(
         shapes=tuple(
             tuple(int(v) for v in row) for row in (cell.shapes or ())),
         targets=tuple(str(t) for t in (cell.targets or ())) + extra_targets,


### PR DESCRIPTION
**th#1834 Phase 3, step 1 of 4.** No behaviour change. Pure move + two renames.

## Why this lands first, alone

Phase 3 replaces the out-of-process mint driver with a serving parent that supervises compile children directly, one graph class each — at which point `mint_child`, `mint_process` and `mint_delegate` fall out.

Measured before touching anything, at `73f826e1` by AST span: **the trio is ~20 % substrate, not driver.** `mint_process` is also the tree's home for the parent↔child *vocabulary*; `mint_child` is also the home for the child-side *preflight*. Five modules that **survive** the rewrite already import both — `executor`, `boot_key`, `boot_adopt`, `measure_child`, `local_serve` — plus `boot_trace_child` and both operator rigs (`scripts/micro_mint_rig.py`, `scripts/boot_key_rig.py`).

With the substrate out, the driver's removal is a **cut**. With it still inside, that removal is an untangle — a deletion obliged to preserve two thirds of what it deletes, which is how a rewrite acquires a compatibility shim nobody asked for.

| new module | holds |
|---|---|
| `child_contract.py` | `MintSlot`, `CompileSpec`, `slot_subjects`, `MintFrame`, `frame_line`, `FRAME_PREFIX` |
| `child_preflight.py` | `PreflightRefused`, `select_specs`, `bind_slots`, `assert_slots_resolvable`, `pick_compile_target` |

## A defect fixed on the way out

`boot_trace_child` and `measure_child` reached into `mint_child` for the same five preflight symbols through **function-local imports at three call sites** — because importing `mint_child` at module scope drags the whole compile brain in behind it. That is the shape §1.17 forbids, and it was not fixable while the checks lived beside the driver. They are ordinary top-of-file imports now.

## Renames (no aliases — pre-launch)

- `CompileCellSpec` → `CompileSpec`. Both `cell` and `entry` are dead vocabulary under Paul's compiled-graph ruling.
- `MintChildRefused` → `PreflightRefused`. Deliberately **not** `MintRefused`: that name is live in `aot_contract` for *"every declared graph class refused"*, and one name for both would make *"this subject cannot be built here"* and *"nothing compiled"* indistinguishable at the exit-code boundary — **with no test going red**.

## Evidence

- `mypy src/gen_worker tests tests_v2` → `Success: no issues found in 759 source files`
- `ruff check src/gen_worker` → clean
- 9 structural fences pass (`lint_unreached_surface`, `lint_config_reads`, `lint_settings_writers`, `lint_fence_symbols`, `lint_mypy_ratchet`, `lint_arm_state_feeders`, `lint_cell_key_layout_fence`, `lint_http_timeouts`, `lint_layout_declarations`)
- **440 passed, 1 skipped** across every touched test file
- `git diff --diff-filter=D --name-only origin/master HEAD` → empty

### Could-have-gone-red, demonstrated rather than asserted

A pure move's green proves nothing until it is shown capable of failing. Two deliberate breaks, both reverted:

1. `child_contract.slot_subjects` — dropped the ref derivation (`refs=()`), a *silent-wrong*, not an import error → `test_identity_soundness_pgw1113` **2 failed**.
2. `child_preflight.assert_slots_resolvable` — made the pgw#969 refusal stop refusing → `test_mint_child_slot_bindings_pgw969` **4 failed**.

### ⚠️ `fast gates` green does NOT cover the test modules this PR touches

`pyproject.toml` carries **434 module-exemptions**, and most of the touched test modules are on that `ignore_errors` list. Measured here: `tests/test_compile_politeness_pgw1137.py` had an **unbound `child_contract` name on three lines**, and `mypy` on that file reported `Success` — the tests caught it, mypy structurally could not. An AST unbound-name check over the whole tree is now clean, but the general point stands for any lane sweeping test imports: **run the tests; mypy is exempted where you are working.**

## Sequencing

Step 1 of 4. Next: (2) micro-pod leg proving one compiled graph from a trace-and-compile child adopts on the resident parent (approved); (3) the child keystone; (4) the executor-side supervisor — the last step, and the one pgw#1206 Phase C was wrongly fenced on (see th#1834's 📨 block: **C is unblocked now**).