### PR TITLE
pgw#1213 follow-up: the key scheme the 0.114.0 wheel ships is cg-key-v1

### DIFF
--- a/changelog.d/pgw1213.md
+++ b/changelog.d/pgw1213.md
@@ -1,0 +1,12 @@
+- **pgw#1213: the key scheme is `cg-key-v1`.** The per-entry key scheme minted by
+  `cell_key` is renamed `ek1` -> `cg-key-v1`, landed before the `v0.114.0` tag
+  existed and before anything published, so no artifact was ever addressed by
+  `ek1` — the 0.114.0 wheel ships `cg-key-v1`. `is_key` generalizes with it: the
+  scheme token now contains hyphens, so the grammar is `<scheme>-<56 lowercase
+  hex>` matched from the RIGHT (the fixed-width digest is anchored to the end and
+  everything before it is the scheme) and no reader may split a key on `-` or
+  slice a fixed prefix width off one. The grammar is also scheme-PINNED, replacing
+  the scheme-agnostic reading of th#1183: with no older corpus to admit, a token
+  of an unknown scheme names a digest over axes this runtime cannot restate.
+  tensorhub's `compilecache.IsCellKey` carries the byte-identical Go half plus a
+  cross-repo vector fence (th#1897).

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -869,7 +869,7 @@ def _entry_dir_name(entry: str) -> str:
     Entry names carry ``/``, ``=`` and ``,`` (``denoiser/h=16,w=16``), so they
     are not path components. The digest keeps two entries apart without
     inventing a second naming scheme anyone has to keep in sync — nothing
-    reads this name back; the ARTIFACT is addressed by its ``ek1`` key.
+    reads this name back; the ARTIFACT is addressed by its ``cg-key-v1`` key.
     """
     return hashlib.sha256(str(entry).encode("utf-8")).hexdigest()[:16]
 
@@ -4163,7 +4163,7 @@ def _treespec_text(spec: Any) -> str:
 
 
 def cell_identity(meta: Mapping[str, Any]) -> cell_key.CellKey:
-    """The ``ek1`` key ONE entry artifact's OWN recorded facts describe.
+    """The ``cg-key-v1`` key ONE entry artifact's OWN recorded facts describe.
 
     The computation is :func:`cell_key.from_entry_metadata` — ONE
     implementation, so the key the mint stamps and the axes the publish path

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -1,8 +1,8 @@
-"""pgw#1089 (DESIGN-RULINGS §4.27 step 1): derive this worker's ``ek1`` entry
+"""pgw#1089 (DESIGN-RULINGS §4.27 step 1): derive this worker's ``cg-key-v1`` entry
 key SET AT BOOT, from CODE ALONE, before a single weight byte is resident.
 
 pgw#1176: §4.27 said "THE cell key" (singular). It is a KEY SET plus a derived
-contract manifest now — one ``ek1`` per declared graph class. Every property
+contract manifest now — one ``cg-key-v1`` per declared graph class. Every property
 the ruling wanted survives STRENGTHENED, because a partial resolve now helps:
 a pod that resolves 30 of 36 keys arms 30 classes and compiles 6, where the
 cell key made that same outcome a total miss and a full re-mint.
@@ -243,7 +243,7 @@ class DerivedKey:
     PARTIAL resolve now helps instead of falling back to a full re-mint.
     """
 
-    #: entry name -> that class's ``ek1`` key. THE thing resolve asks for.
+    #: entry name -> that class's ``cg-key-v1`` key. THE thing resolve asks for.
     entry_keys: Mapping[str, str]
     #: entry name -> that class's 16-hex ``class_hash``. THE memoizable half.
     class_hashes: Mapping[str, str]

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -237,7 +237,7 @@ class CellAdoption:
     #: adoption to that object's own warmup proof (its cache hit/miss deltas)
     #: instead of attributing another slot's evidence to it.
     pipeline_id: int = 0
-    #: pgw#1176: WHICH graph class this attempt was about, and the ``ek1`` key
+    #: pgw#1176: WHICH graph class this attempt was about, and the ``cg-key-v1`` key
     #: it was about. A boot resolves a KEY SET, so an attempt that MISSED has
     #: no artifact ``ref`` BY CONSTRUCTION — and a miss is the most common
     #: per-entry outcome there is. These two carry the identity a ref-less

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -132,11 +132,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
-# pgw#1176: ``ck1`` (the 36-entry CELL key) is REPLACED by ``ek1`` (one graph
-# class). This is a §1.34 third-category change — a name persisted as an
+# pgw#1176: ``ck1`` (the 36-entry CELL key) is REPLACED by the per-entry key
+# below (one graph class). This is a §1.34 third-category change — a name persisted as an
 # ADDRESS — so it is a COORDINATED FLEET RE-KEY, never a quiet rename: every
 # stored cell is orphaned by it, and the cut carries scheme + per-entry store
 # schema + resolve/publish wire + pack format + the
@@ -144,13 +145,21 @@ from typing import Any, Dict, Iterable, Mapping, Tuple
 # Priced today: the adoptable corpus is ONE toy family, so the re-key costs
 # one re-mint of a 3-class toy — effectively free, and never this cheap
 # again. The scheme-prefix machinery STAYS: post-launch, the identical change
-# would be ek2 with strand-by-name. New identity FACTS ride the content
-# digests (toolchain entries), never new axes and never a new scheme number.
-KEY_SCHEME = "ek1"
+# would be a new scheme token with strand-by-name. New identity FACTS ride the
+# content digests (toolchain entries), never new axes and never a new scheme.
+#
+# pgw#1213: the scheme token is ``cg-key-v1`` (Paul, final). It landed before
+# the ``v0.114.0`` tag existed and before anything published, so no artifact
+# was ever addressed by ``ek1`` — the 0.114.0 wheel ships ``cg-key-v1``. The
+# token CONTAINS hyphens, so no reader may split a key on ``-``: the grammar
+# is scheme + ``-`` + the fixed-width hex digest, matched from the RIGHT
+# (``is_key``).
+KEY_SCHEME = "cg-key-v1"
 _PREFIX = KEY_SCHEME + "-"
-# The key digest doubles as the store flavor token, whose shared grammar
-# (th#597 C5: [a-z0-9][a-z0-9._-]{0,63}, Go+Py identical) caps tokens at 64
-# chars: 56 hex chars of SHA-256 (224 bits) keeps the whole key at 60.
+# The key doubles as the store flavor token, whose shared grammar (th#597 C5:
+# [a-z0-9][a-z0-9._-]{0,63}, Go+Py identical) caps tokens at 64 chars. 56 hex
+# chars of SHA-256 (224 bits) + the 10-char ``cg-key-v1-`` prefix is 66, so
+# th#1897 carries the matching cap widening on both halves of that grammar.
 _DIGEST_HEX = 56
 
 # THE three axes, all required — see THE MEMBERSHIP AXIOM in the module
@@ -218,44 +227,46 @@ class CellKey:
         return _PREFIX + h[:_DIGEST_HEX]
 
 
+#: pgw#1213: the digest is FIXED-WIDTH and terminal, so it is matched from the
+#: RIGHT and everything before it is the scheme. The scheme token contains
+#: hyphens (``cg-key-v1``), which is exactly why no reader may split a key on
+#: ``-`` or slice a fixed number of leading characters off one.
+_DIGEST_RE = re.compile(r"-(?P<digest>[0-9a-f]{%d})$" % _DIGEST_HEX)
+
+
 def is_key(value: str) -> bool:
-    """True when ``value`` has entry-key SHAPE: ``ek`` + 1-2 scheme digits +
-    ``-`` + 56 lowercase hex.
+    """True when ``value`` is a key of THIS scheme: ``cg-key-v1`` + ``-`` +
+    56 lowercase hex.
 
-    Scheme-AGNOSTIC, byte-for-byte the grammar tensorhub's
-    ``compilecache.IsCellKey`` must enforce after the pgw#1176 cut, and for
-    the same reason it gives (th#1183): pinning the current scheme here turns
-    every other-scheme entry into ``unreadable_cell_key``, which is both a
-    lie and a filter no axis justifies. An entry of an older scheme is
-    admitted to the candidate list and then ruled on by the axes that
-    actually decide whether this runtime can execute it — the identity axes
-    and the ingress contract — not by the label on it.
+    This grammar must remain byte-for-byte what tensorhub's hub-side
+    validator (``compilecache.IsCellKey``) enforces — th#1897 lands the Go
+    half together with a cross-repo vector fence, so the two halves are
+    compared against one shared vector file rather than by inspection. A
+    divergence here is a divergence in what the fleet considers addressable.
 
-    NOTE the ``ck`` prefix is NOT accepted. A ck1 key names a 36-entry
-    all-or-nothing cell, which is not a thing this runtime can arm at all; a
-    grammar that admitted both would let a cell ref reach a per-entry code
-    path and fail late instead of at the comparison.
+    Scheme-PINNED (pgw#1213, superseding the scheme-agnostic reading of
+    th#1183): `cg-key-v1` is the first scheme any published artifact was ever
+    addressed by, so there is no older corpus for agnosticism to admit, and a
+    grammar that accepts unknown schemes accepts tokens whose digest was
+    computed over axes this runtime cannot restate.
+
+    NOTE ``ck1``/``ek1`` are NOT accepted. A ck1 key names a 36-entry
+    all-or-nothing cell, which is not a thing this runtime can arm at all; an
+    ek1 key never addressed anything. A grammar that admitted either would
+    let such a ref reach a per-entry code path and fail late instead of at
+    the comparison.
     """
     v = str(value or "")
-    rest = v[2:] if v.startswith("ek") else ""
-    if not rest:
+    m = _DIGEST_RE.search(v)
+    if m is None:
         return False
-    digits = 0
-    while digits < len(rest) and rest[digits].isdigit():
-        digits += 1
-    if not 1 <= digits <= 2 or digits >= len(rest) or rest[digits] != "-":
-        return False
-    hexpart = rest[digits + 1:]
-    return (
-        len(hexpart) == _DIGEST_HEX
-        and all(c in "0123456789abcdef" for c in hexpart)
-    )
+    return v[:m.start()] == KEY_SCHEME
 
 
 def _refuse_key_shaped(where: str, name: str, value: str) -> None:
     """A KEY where a DIGEST belongs is a category error, not a bad value.
 
-    pgw#1176: `ck1-`/`ek1-` and the 16-hex fact digests are all `str`, so
+    pgw#1176: `cg-key-v1-` keys and the 16-hex fact digests are all `str`, so
     nothing in the type system distinguishes them — that is the honest reason
     a whole class of confusion type-checks cleanly. An opaque `NewType` cannot
     close it either at the places that matter: `is_key` is a BOUNDARY

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -903,7 +903,7 @@ def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
     So this FAILS CLOSED (pgw#1046): a mint that cannot name an axis raises
     :class:`CellPublishRefused` here, before a byte moves.
 
-    Contents (pgw#1176): the three ek1 key axes (``graph``, ``sm``,
+    Contents (pgw#1176): the three cg-key-v1 key axes (``graph``, ``sm``,
     ``toolchain``) verbatim, plus the wire facts the hub requires by name
     (``graph_contract`` — the DECLARATION-wide manifest digest, which is what
     the hub folds compile-health coverage under; ``env_seal``) and the demoted

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -646,7 +646,7 @@ def _mint_aot(
     # pgw#1176: the child moves EVERY entry it packed into the parent's
     # directory, one file per graph class, and reports the set. `target` names
     # the directory the parent watches; the per-entry file names are the
-    # entries' own `ek1` keys, so the parent addresses each by identity rather
+    # entries' own `cg-key-v1` keys, so the parent addresses each by identity rather
     # than by position.
     target.parent.mkdir(parents=True, exist_ok=True)
     moved: List[Tuple[str, str, str]] = []

--- a/src/gen_worker/models/refs.py
+++ b/src/gen_worker/models/refs.py
@@ -37,10 +37,23 @@ import re
 from dataclasses import dataclass
 from typing import NewType, Optional
 
-# th#597 C5: `#` fragment charset [a-z0-9][a-z0-9._-]{0,63} (matches
+# th#597 C5: `#` fragment charset [a-z0-9][a-z0-9._-]{0,126} (matches
 # tensorhub's validation.IsValidFlavorToken). Cell fragments only — see the
 # module docstring.
-_TENSORHUB_FRAGMENT_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
+#
+# pgw#1213 widened the cap from 64 to 127. The fragment IS where an entry key
+# travels (`aot_serve.parse_cell_ref` -> `cell_key.is_key`), and the
+# `cg-key-v1` scheme makes a key 66 chars — under the old cap the very
+# identity this grammar exists to carry did not parse, which surfaced as
+# `is_aot_ref` returning False for a cell the process had just armed. The cap
+# is shared with tensorhub's Go half and th#1897 carries the identical
+# widening there; the conformance vectors in
+# tests/testdata/ref_grammar_vectors.json pin no length case, so both parsers
+# stay green on every vector while that lands.
+MAX_FRAGMENT_LEN = 127
+_TENSORHUB_FRAGMENT_RE = re.compile(
+    r"[a-z0-9][a-z0-9._-]{0,%d}" % (MAX_FRAGMENT_LEN - 1)
+)
 
 
 class FlavorSelectorRemoved(ValueError):

--- a/tests/harness/adopt_rig.py
+++ b/tests/harness/adopt_rig.py
@@ -233,7 +233,7 @@ def _derived(digest: str) -> boot_key.DerivedKey:
     return boot_key.DerivedKey(
         # pgw#1176: the rig's derived manifest — one entry key per declared
         # class. `digest` stands in for the traced graph, as it always did.
-        entry_keys={"rig": "ek1-" + (digest * 56)[:56]},
+        entry_keys={"rig": "cg-key-v1-" + (digest * 56)[:56]},
         class_hashes={}, manifest="", workers=1, width_reason="rig",
         traced=len(ROWS), memo="miss", wall_ms=10_291,
     )

--- a/tests/test_adopt_seam_budget_pgw1168.py
+++ b/tests/test_adopt_seam_budget_pgw1168.py
@@ -36,7 +36,7 @@ _GIB = 1 << 30
 _META: Dict[str, Any] = {
     "family": "sdxl",
     "weight_lane": "w8a8",
-    "cell_key": "ek1-" + "0" * 56,
+    "cell_key": "cg-key-v1-" + "0" * 56,
     "entry": {"name": "unet/e0", "target": "unet"},
 }
 

--- a/tests/test_adopted_cell_warm_proof_pgw1141.py
+++ b/tests/test_adopted_cell_warm_proof_pgw1141.py
@@ -411,7 +411,7 @@ def _rig(monkeypatch: pytest.MonkeyPatch, *, seed: str,
          revoke: bool = False, dispatch: bool = False) -> Tuple[str, str]:
     RIG.clear()
     RIG["dispatch"] = dispatch
-    key = "ek1-" + (seed * 56)[:56]
+    key = "cg-key-v1-" + (seed * 56)[:56]
     ref = f"root/family-{FAMILY}#{key}"
     monkeypatch.setattr(
         fleet_cells, "enable_compiled",

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -38,7 +38,7 @@ from gen_worker import activity, aot_serve
 FAMILY = "sdxl"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
            "cuda": "13.0"}
-KEY = "ek1-" + "a" * 56
+KEY = "cg-key-v1-" + "a" * 56
 
 INPUTS = [
     {"name": "sample", "position": 0, "dtype": "bfloat16",

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -210,7 +210,7 @@ def _rig(monkeypatch: pytest.MonkeyPatch, *, seed: str, exercise: bool,
     RIG["exercise"] = exercise
     if weight_lane:
         RIG["weight_lane"] = weight_lane
-    key = "ek1-" + (seed * 56)[:56]
+    key = "cg-key-v1-" + (seed * 56)[:56]
     ref = f"root/family-{FAMILY}#{key}"
     monkeypatch.setattr(fleet_cells, "enable_compiled", _fake_arm(key, ref))
     return key, ref

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -33,8 +33,8 @@ import pytest
 from gen_worker import aot_resume, cell_key, fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
-KEY_A = "ek1-" + "a" * 56
-KEY_B = "ek1-" + "b" * 56
+KEY_A = "cg-key-v1-" + "a" * 56
+KEY_B = "cg-key-v1-" + "b" * 56
 # pgw#1113: spelled in the CURRENT token scheme — a predecessor-scheme memo
 # is swept by `fleet_cells._sweep_superseded_memos_once`, which is the point.
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -1044,11 +1044,11 @@ def test_cell_identity_refuses_an_artifact_with_no_sm(
         aot_mint.cell_identity(meta)
 
 
-def test_key_scheme_is_ek1_and_the_axes_are_the_three(
+def test_key_scheme_is_cg_key_v1_and_the_axes_are_the_three(
     _gpu_runtime: None, packages: Dict[str, Path],
 ) -> None:
     """pgw#1176: the exported ENTRY keys on exactly graph x sm x toolchain
-    under the ek1 scheme — `kind` is a metadata fact the compat gates read,
+    under the cg-key-v1 scheme — `kind` is a metadata fact the compat gates read,
     never an axis, and `envelope` is a manifest fact for the same reason."""
     spec = _spec()
     meta = _meta_for(_export_lifted(), packages["code_only"], spec)
@@ -1058,7 +1058,7 @@ def test_key_scheme_is_ek1_and_the_axes_are_the_three(
     assert (key.axes_dict()["graph"]
             == meta[cell_key.ENTRY_BLOCK_KEY]["class_hash"])
     assert key.digest.startswith(cell_key.KEY_SCHEME + "-")
-    assert cell_key.KEY_SCHEME == "ek1"
+    assert cell_key.KEY_SCHEME == "cg-key-v1"
     assert cell_key.is_key(key.digest)
 
 

--- a/tests/test_aot_mint_unblock_pgw813_pgw815.py
+++ b/tests/test_aot_mint_unblock_pgw813_pgw815.py
@@ -365,7 +365,7 @@ def test_eager_first_admits_a_DELEGATED_pending_with_no_router(
         "name": "generate",
     })()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-" + "a" * 56, ref="r", cfg=cfg,
+        family=FAMILY, arm_token="cg-key-v1-" + "a" * 56, ref="r", cfg=cfg,
         target=tmp_path / "c.tar.gz", mint_root=tmp_path, publisher=None, delegated=True,)
     inj = _Inj(compile_objects=[_Candidate(pipe)],
                pending_self_mints={id(pipe): pending})
@@ -390,7 +390,7 @@ def test_eager_first_still_requires_a_router_for_an_IN_PROCESS_capture(
         "name": "generate",
     })()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-" + "b" * 56, ref="r", cfg=cfg,
+        family=FAMILY, arm_token="cg-key-v1-" + "b" * 56, ref="r", cfg=cfg,
         target=tmp_path / "c.tar.gz", mint_root=tmp_path, publisher=None, delegated=False)
     inj = _Inj(compile_objects=[_Candidate(pipe)],
                pending_self_mints={id(pipe): pending})
@@ -405,7 +405,7 @@ def test_eager_first_still_requires_a_router_for_an_IN_PROCESS_capture(
 
 def _finalized_pending(tmp_path: Path, publisher: Any) -> Any:
     """A pending that has been packed — a real file, a real key, real bytes."""
-    key = "ek1-" + "c" * 56
+    key = "cg-key-v1-" + "c" * 56
     target = tmp_path / "cell.tar.gz"
     target.write_bytes(b"x" * 4096)
     pending = fleet_cells.PendingSelfMint(
@@ -464,7 +464,7 @@ def test_a_publish_gate_with_nothing_packed_is_NAMED(
     pendings it believes it packed, so reaching it with nothing packed is a
     real defect and must not be a no-op."""
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-" + "d" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, arm_token="cg-key-v1-" + "d" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", mint_root=tmp_path / "root2", publisher=_Publisher())
 
     fleet_cells.publish_self_mint(pending)
@@ -477,7 +477,7 @@ def test_a_withhold_with_nothing_packed_is_NAMED(
     tmp_path: Path, _events: List[Tuple[str, str, str]],
 ) -> None:
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-" + "e" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, arm_token="cg-key-v1-" + "e" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", mint_root=tmp_path / "root3", publisher=_Publisher())
 
     fleet_cells.withhold_self_mint_publish(pending, "sibling never exercised")
@@ -524,7 +524,7 @@ def test_a_boot_that_resolves_NOTHING_confesses(
     ex = _executor(tmp_path)
     spec = type("_S", (), {"name": "generate"})()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-" + "f" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, arm_token="cg-key-v1-" + "f" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", mint_root=tmp_path / "root4", publisher=_Publisher())
     pending.mint_root.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -444,7 +444,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
     # pgw#1176: a `ck1` key names a 36-entry all-or-nothing cell, which this
     # runtime cannot arm at all — `cell_key.is_key` refuses the prefix
     # deliberately, so a fixture keyed that way tests a shape nothing produces.
-    key = "ek1-" + "a" * 56
+    key = "cg-key-v1-" + "a" * 56
     packed = tmp_path / "aot" / f"{key}.tar.gz"
     seen: Dict[str, Any] = {}
 
@@ -482,7 +482,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
 
     assert report.status == "minted"
     # pgw#1176: the child moves EVERY entry it packed into the parent's
-    # directory, one file per graph class NAMED BY ITS OWN `ek1` key — so the
+    # directory, one file per graph class NAMED BY ITS OWN `cg-key-v1` key — so the
     # parent addresses each by identity rather than by position, and `target`
     # names the directory rather than the single file it used to be. The
     # one-element unpack asserts this declaration's arity.
@@ -569,7 +569,7 @@ def test_a_self_minted_aot_cell_arms_through_the_aot_gates(
         _info.size = len(_payload)
         _tar.addfile(_info, _io.BytesIO(_payload))
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ck1-handle", ref="root/family-sdxl#ek1-handle",
+        family=FAMILY, arm_token="ck1-handle", ref="root/family-sdxl#cg-key-v1-handle",
         cfg=_Cfg(), target=artifact,
         mint_root=tmp_path, publisher=None)
 

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -562,9 +562,9 @@ def test_an_aot_ref_is_recognized_only_by_a_REGISTERED_stamped_key():
     """
     # File-unique, and UNREGISTERED afterwards. `_KNOWN_AOT_KEYS` is
     # process-global, so a key left registered is a claim every later test in
-    # this worker inherits — `"ek1-" + "b" * 56` is a shared literal in four
+    # this worker inherits — `"cg-key-v1-" + "b" * 56` is a shared literal in four
     # other files and would have been exactly that landmine.
-    key = "ek1-" + "d721" + "f" * 52
+    key = "cg-key-v1-" + "d721" + "f" * 52
     try:
         assert aot.is_aot_ref(f"root/family-{FAMILY}#{key}") is False
         aot.note_aot_key(key)
@@ -576,7 +576,7 @@ def test_an_aot_ref_is_recognized_only_by_a_REGISTERED_stamped_key():
         # A dynamo cache ref must not be mistaken for an exported cell (pgw#735:
         # it would then be scored by FX hits).
         assert aot.is_aot_ref(
-            f"root/family-{FAMILY}#ek1-0123456789abcdef") is False
+            f"root/family-{FAMILY}#cg-key-v1-0123456789abcdef") is False
     finally:
         with aot._KNOWN_AOT_KEYS_LOCK:
             aot._KNOWN_AOT_KEYS.discard(key)

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -50,13 +50,13 @@ from gen_worker import (
 from gen_worker import executor as executor_mod
 from gen_worker.cell_adopt import AdoptOutcome
 
-# pgw#1176: `ek1`, because `local_cell_store.store` refuses anything that is
+# pgw#1176: `cg-key-v1`, because `local_cell_store.store` refuses anything that is
 # not an entry key and a `ck1`-keyed cell is orphaned by the re-key. These
 # fixtures stored under `ck1-` and the store silently declined them, so
 # `no_cell_source` short-circuited a machine that WAS holding cells — the §1.34
 # orphaning the re-key predicts, surfacing exactly where it should.
-KEY_A = "ek1-" + "a" * 56
-KEY_B = "ek1-" + "b" * 56
+KEY_A = "cg-key-v1-" + "a" * 56
+KEY_B = "cg-key-v1-" + "b" * 56
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
 
 

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -55,7 +55,7 @@ def _raise(exc: BaseException) -> Any:
 REPO = Path(__file__).resolve().parent.parent
 MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
 
-KEY = "ek1-" + "3f" * 28
+KEY = "cg-key-v1-" + "3f" * 28
 
 
 # ---------------------------------------------------------------------------
@@ -452,7 +452,7 @@ def test_a_pod_that_derived_and_missed_is_not_a_pod_that_never_derived(
     never = _one(events)
 
     assert missed.phase == "miss" and never.phase == "no_export_declaration"
-    assert "key=ek1-" in missed.detail, (
+    assert "key=cg-key-v1-" in missed.detail, (
         "a MISS must carry the key that missed — it is the whole difference "
         "between 'the hub holds nothing for me' and 'I never asked'")
     assert "key=-" in never.detail
@@ -598,7 +598,7 @@ def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
         f"defect, reproduced off-pod. Hub saw: {hub.calls}")
     assert resolves[0][1] == {
         "family": "micro-diffusion", "cell_key": out.derived_key}
-    assert out.derived_key.startswith("ek1-")
+    assert out.derived_key.startswith("cg-key-v1-")
     assert out.reason == "miss"
 
     row = _one(events)
@@ -662,7 +662,7 @@ def test_the_same_boot_derives_a_key_with_accelerate_UNIMPORTABLE(
         "the trace children still cannot build a structure without "
         f"`accelerate`: {out.detail}")
     assert out.reason == "miss", out.detail
-    assert out.derived_key.startswith("ek1-")
+    assert out.derived_key.startswith("cg-key-v1-")
     resolves = [c for c in hub.calls if c[0] == cell_resolve.RESOLVE_PATH]
     assert len(resolves) == 3, (
         "an image without `accelerate` must still ASK — this is the pgw#1123 "

--- a/tests/test_boot_key_pgw1089.py
+++ b/tests/test_boot_key_pgw1089.py
@@ -132,10 +132,10 @@ def test_the_fold_is_the_mints_own_stamp_not_a_second_arithmetic() -> None:
     assert all(len(h) == 16 for h in class_hashes.values())
 
 
-def test_every_key_is_an_ek1_key_over_exactly_three_axes() -> None:
+def test_every_key_is_a_cg_key_v1_key_over_exactly_three_axes() -> None:
     entry_keys, _hashes, _manifest = _fold({"a": _block()})
     (key,) = entry_keys.values()
-    assert key.startswith("ek1-")
+    assert key.startswith("cg-key-v1-")
     assert cell_key.is_key(key)
     # The axes are the key's, and `from_axes` is the only way to build one —
     # so the axis set is asserted where it is DEFINED rather than restated.
@@ -264,7 +264,7 @@ def test_the_memo_never_holds_the_folded_key(tmp_path: Path) -> None:
     blob = json.dumps(doc)
     for key in entry_keys.values():
         assert key not in blob
-    assert "ek1-" not in blob
+    assert "cg-key-v1-" not in blob
     assert set(doc["closures"][digest]["blocks"]) == {"a", "b"}
     # And not the axes that must re-derive every boot, either.
     for axis in ("envelope", "toolchain", "sm_89"):
@@ -596,7 +596,7 @@ def test_derive_end_to_end_with_stubbed_children_memoizes_and_hits(
     assert first.traced == 2
     assert first.nodes == {"a": 41, "b": 41}
     assert len(first.keys) == 2
-    assert all(k.startswith("ek1-") for k in first.keys)
+    assert all(k.startswith("cg-key-v1-") for k in first.keys)
 
     # A HIT MUST NOT TRACE. Any child spawn now is a hard failure.
     def _never(jobs, python=""):

--- a/tests/test_cell_adoption_measurement_pgw923.py
+++ b/tests/test_cell_adoption_measurement_pgw923.py
@@ -31,7 +31,7 @@ from gen_worker.cell_adopt import AdoptOutcome, CellAdoption
 from gen_worker.executor import Executor, _InjectionResult
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
-REF = "root/family-sdxl#ek1-" + "b" * 56
+REF = "root/family-sdxl#cg-key-v1-" + "b" * 56
 DIGEST = "blake3:" + "c" * 64
 
 #: The arm is INDUCED to take this long, and the floor asserted against it is a

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -78,25 +78,36 @@ def test_unknown_and_missing_axes_refuse():
         ck.from_axes({k: v for k, v in _AXES.items() if k != "toolchain"})
 
 
-def test_key_scheme_ek1_foreign_keys_are_key_shaped_but_distinct():
-    """pgw#958 (§1.27(g)) + pgw#1059 amendment 1: ck1 is the only scheme
-    this runtime mints — the redefinition kept the number (Paul: "stick
-    with version-1 for now since we're still pre-launch") and PURGES the
-    pre-redefinition corpus instead of minting ck2.
+def test_the_deriver_and_the_validator_agree_on_cg_key_v1():
+    """pgw#1213: `is_key` admits exactly what `from_axes(...).digest` mints.
 
-    Shape stays scheme-AGNOSTIC, byte-identical to tensorhub's
-    `compilecache.IsCellKey` (th#1183): a foreign-scheme token IS
-    key-shaped; it simply names no artifact this runtime computes.
+    THE row that can go red on a scheme change: the deriver writes the
+    scheme through `_PREFIX` and the validator reads it through the
+    right-anchored digest match, so a change to one that is not made in the
+    other fails here rather than at a resolve nobody watches. The grammar is
+    also what tensorhub's `compilecache.IsCellKey` must enforce byte-for-byte
+    (th#1897 lands the Go half + the cross-repo vector fence).
     """
     key = ck.from_axes(_AXES).digest
-    assert key.startswith("ek1-")
-    for dead in ("ek2-", "ek3-", "ek4-", "ek5-", "ek6-"):
-        token = dead + "a" * 56
-        assert ck.is_key(token), "a foreign-scheme token is still key-SHAPED"
-        assert token != key
-    assert not ck.is_key("ck-" + "a" * 56)      # no scheme digits
-    assert not ck.is_key("ek1-" + "a" * 55)     # wrong digest width
-    assert not ck.is_key("ek1-" + "A" * 56)     # uppercase hex
+    assert key.startswith("cg-key-v1-")
+    assert ck.is_key(key) is True
+
+
+def test_only_cg_key_v1_is_a_key():
+    """Scheme-PINNED (pgw#1213, superseding th#1183's agnostic reading):
+    `cg-key-v1` is the first scheme any artifact was addressed by, so there
+    is no older corpus for agnosticism to admit. The scheme token contains
+    hyphens, so the grammar is matched from the RIGHT — never split on `-`.
+    """
+    assert not ck.is_key("ek1-" + "a" * 56)           # the pre-cut spelling
+    assert not ck.is_key("ck1-" + "a" * 56)           # the 36-entry cell key
+    assert not ck.is_key("cg-key-v2-" + "a" * 56)     # foreign scheme
+    assert not ck.is_key("key-v1-" + "a" * 56)        # a SUFFIX of the scheme
+    assert not ck.is_key("cg-key-v1-" + "a" * 55)     # digest too short
+    assert not ck.is_key("cg-key-v1-" + "a" * 57)     # digest too long
+    assert not ck.is_key("cg-key-v1-" + "A" * 56)     # uppercase hex
+    assert not ck.is_key("cg-key-v1" + "a" * 56)      # no separator
+    assert not ck.is_key("")
 
 
 def test_execution_lane_canonicalization():
@@ -127,9 +138,9 @@ def test_execution_lane_canonicalization():
 #
 # Every property they fenced survives on the exported lane BY CONSTRUCTION
 # rather than by comparison, which is the point of a content-addressed key:
-# sm, the declared contract, the env seal and the lane are all axes of `ek1`
+# sm, the declared contract, the env seal and the lane are all axes of `cg-key-v1`
 # or fold into one (pgw#1176),
 # so an entry that disagrees on any of them has a different key and never
 # resolves. `tests/test_cell_key_pgw1059.py` is where that is stated, with the
 # staleness matrix naming each axis. What is left here is the key itself —
-# determinism, axis sensitivity, the ek1 scheme, and lane canonicalization.
+# determinism, axis sensitivity, the cg-key-v1 scheme, and lane canonicalization.

--- a/tests/test_cell_key_pgw1059.py
+++ b/tests/test_cell_key_pgw1059.py
@@ -42,7 +42,7 @@ SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
 
 
 def test_membership_axiom_the_key_is_exactly_three_axes():
-    """The ek1 key contains exactly {graph, sm, toolchain}.
+    """The cg-key-v1 key contains exactly {graph, sm, toolchain}.
 
     If this test is failing because you added an axis: STOP. The membership
     axiom (pgw#1059 amendment 6, Paul 2026-08-09) admits an axis only when
@@ -270,7 +270,7 @@ def _old_schema_digest(meta: dict) -> str:
     canonical = json.dumps(
         axes, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     # STAYS "ck1-": this helper deliberately reconstructs the OLD scheme, and
-    # a blanket ck1->ek1 rename would have made it reconstruct the new one and
+    # a blanket ck1->cg-key-v1 rename would have made it reconstruct the new one and
     # assert nothing.
     return "ck1-" + hashlib.sha256(canonical.encode()).hexdigest()[:56]
 
@@ -339,14 +339,14 @@ def test_pre_redefinition_artifact_is_structurally_refused():
     # its (old-formula) stamp is present but unrestatable => admission refuses.
     # An ek-shaped stamp, because a ck1 stamp is not an identity CLAIM to this
     # runtime at all — `is_key` refuses it, so it never reaches the restate.
-    old["cell_key"] = "ek1-" + "5" * 56
+    old["cell_key"] = "cg-key-v1-" + "5" * 56
     reason = aot_serve.verify_contract(old)
     assert "malformed declared contract" in reason or "not restatable" in reason
 
 
 def test_forged_stamp_is_refused_at_admission():
     meta = _admissible_meta()
-    meta["cell_key"] = "ek1-" + "0" * 56
+    meta["cell_key"] = "cg-key-v1-" + "0" * 56
     reason = aot_serve.verify_contract(meta)
     assert "recorded facts describe" in reason
 

--- a/tests/test_cell_key_space_pgw1033.py
+++ b/tests/test_cell_key_space_pgw1033.py
@@ -54,7 +54,7 @@ FAMILY = "sdxl"
 ARM_KEY = "arm1-" + "a" * 56
 #: What the child's envelope is STAMPED with — the cell identity, unknowable
 #: until the export finishes. A different digest, always.
-STAMPED_KEY = "ek1-" + "b" * 56
+STAMPED_KEY = "cg-key-v1-" + "b" * 56
 
 
 class _Pipe:
@@ -348,7 +348,7 @@ def test_an_owed_mint_advertises_no_artifact_identity(
         "pgw#1010 deleted the recipe axis; a guard that reads one is dead")
 
     delivered = executor._CompileArtifactSelection(
-        path=Path("/dev/null"), ref=f"root/family-{FAMILY}#ek1-" + "c" * 56,
+        path=Path("/dev/null"), ref=f"root/family-{FAMILY}#cg-key-v1-" + "c" * 56,
         snapshot_digest="sha256:c", self_mint=False)
 
     assert executor._selection_for(None, pending) is None

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -263,7 +263,7 @@ META["cell_key"] = CELL_KEY
 #: as a fixture so the refusal below is pinned against the real historical row,
 #: not against an invented one.
 TODAYS_FALLBACK_META = {
-    "cell_key": "ek1-" + "b" * 56, "family": FAMILY, "sku": "l4", "sm": "89",
+    "cell_key": "cg-key-v1-" + "b" * 56, "family": FAMILY, "sku": "l4", "sm": "89",
     "gen_worker": "0.87.0", "kind": "aot-inductor", "format": "pt2",
     "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
 }
@@ -417,7 +417,7 @@ def test_a_stamp_that_disagrees_with_the_recorded_axes_is_refused(hub, artifact)
     """A cell whose `cell_key` does not describe its own blocks is a cell the
     hub would index under one identity and the worker would fence on another."""
     forged = dict(META)
-    forged["cell_key"] = "ek1-" + "9" * 56
+    forged["cell_key"] = "cg-key-v1-" + "9" * 56
     with pytest.raises(fc.CellPublishRefused, match="disagrees"):
         _publisher(hub).publish(FAMILY, artifact, forged)
     assert not hub.httpd.calls

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -16,8 +16,8 @@ from gen_worker import aot_identity, cell_key as ck, cell_resolve, env_seal
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.procsplit import actions as actions_mod
 
-KEY = "ek1-" + "ab" * 28
-OTHER_KEY = "ek1-" + "cd" * 28
+KEY = "cg-key-v1-" + "ab" * 28
+OTHER_KEY = "cg-key-v1-" + "cd" * 28
 
 
 class _Resp:
@@ -429,7 +429,7 @@ def test_a_hub_refusal_degrades_but_keeps_its_own_token(
         derive=lambda **_kw: _derived(), resolve=_refuse)
     assert not out.adopted
     assert out.reason == "cell_resolve_ambiguous"
-    assert out.derived_key.startswith("ek1-")
+    assert out.derived_key.startswith("cg-key-v1-")
     assert out.derive_ms == 1234
 
 
@@ -439,7 +439,7 @@ def test_a_miss_degrades_as_miss_not_as_a_failure(monkeypatch, tmp_path) -> None
         derive=lambda **_kw: _derived(), resolve=lambda *_a, **_k: None)
     assert not out.adopted
     assert out.reason == "miss"
-    assert out.derived_key.startswith("ek1-")
+    assert out.derived_key.startswith("cg-key-v1-")
 
 
 def test_a_failed_materialize_degrades_and_is_never_fatal(

--- a/tests/test_computed_key_demand_retired_pgw1032.py
+++ b/tests/test_computed_key_demand_retired_pgw1032.py
@@ -57,7 +57,7 @@ def test_a_non_exported_kind_has_no_key_identity() -> None:
     a torch-inductor-cache artifact is refused by name."""
     with pytest.raises(cell_key.CellKeyError, match="no entry-key identity"):
         cell_key.from_entry_metadata(
-            {"kind": "torch-inductor-cache", "cell_key": "ek1-" + "b" * 56})
+            {"kind": "torch-inductor-cache", "cell_key": "cg-key-v1-" + "b" * 56})
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ def test_serving_tier_and_serving_mode_answer_DIFFERENT_questions(
     assert cc.is_compile_armed(pipe) is True
     # A cell ref IS what makes the tier compiled — nothing else.
     assert serving_mode.classify_mode(
-        f"root/family-{FAMILY}#ek1-" + "b" * 56, None) == serving_mode.MODE_JIT_CELL
+        f"root/family-{FAMILY}#cg-key-v1-" + "b" * 56, None) == serving_mode.MODE_JIT_CELL
 
 
 def test_an_armed_target_still_advertises_the_identity_it_serves() -> None:
@@ -213,7 +213,7 @@ def test_an_armed_target_still_advertises_the_identity_it_serves() -> None:
     store before W8A8 dispatch rides it — the load-bearing fence."""
     from gen_worker import executor as executor_mod
 
-    ref = f"root/family-{FAMILY}#ek1-" + "b" * 56
+    ref = f"root/family-{FAMILY}#cg-key-v1-" + "b" * 56
     target = executor_mod._CompileTargetRecord(
         incarnation_id="inc-1", spec=None, pipeline=object(),  # type: ignore[arg-type]
         pipeline_weight_lane="w8a8", lora_bucket=0, contract_digest="d",

--- a/tests/test_delegated_adopt_reason_pgw999.py
+++ b/tests/test_delegated_adopt_reason_pgw999.py
@@ -78,7 +78,7 @@ def _sealed_cell(path: Path, **over: Any) -> Path:
     import tarfile as _tarfile
 
     meta = {"format": 2, "kind": "aot-inductor", "family": FAMILY,
-            "cell_key": "ek1-" + "e" * 56, "entries": {}, **over}
+            "cell_key": "cg-key-v1-" + "e" * 56, "entries": {}, **over}
     payload = _json.dumps(meta).encode()
     with _tarfile.open(path, mode="w:gz") as tar:
         info = _tarfile.TarInfo("metadata.json")
@@ -99,7 +99,7 @@ def pending(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(fleet_cells, "mark_terminus", lambda p, t, **_kw: None)
     artifact = _sealed_cell(tmp_path / "cell.tar.gz")
     return fleet_cells.PendingSelfMint(
-        family=FAMILY, arm_token="ek1-sealed", ref=f"root/family-{FAMILY}#ek1-sealed",
+        family=FAMILY, arm_token="cg-key-v1-sealed", ref=f"root/family-{FAMILY}#cg-key-v1-sealed",
         cfg=_Cfg(), target=artifact, mint_root=tmp_path / "root", publisher=None, delegated=True,)
 
 
@@ -166,7 +166,7 @@ def test_every_classified_reason_survives_verbatim(
         _arm_returns(monkeypatch, AdoptOutcome.miss(reason, f"detail for {reason}"))
         artifact = _sealed_cell(tmp_path / f"cell-{i}.tar.gz")
         p = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token=f"ek1-{i}", ref=f"root/family-{FAMILY}#ek1-{i}",
+            family=FAMILY, arm_token=f"cg-key-v1-{i}", ref=f"root/family-{FAMILY}#cg-key-v1-{i}",
             cfg=_Cfg(), target=artifact, mint_root=tmp_path / f"root{i}", publisher=None, delegated=True,)
         assert fleet_cells.adopt_delegated_mint(_Pipe(), p, [artifact]) is None
         phase, _detail = _abort(seen)
@@ -267,7 +267,7 @@ def test_a_pending_that_never_refused_reports_no_reason(
     an always-non-empty reason is as useless as an always-empty one."""
     _arm_returns(monkeypatch, AdoptOutcome.hit("family=x key=y"))
     monkeypatch.setattr(
-        fleet_cells, "_packed_metadata", lambda a: {"cell_key": "ek1-sealed"})
+        fleet_cells, "_packed_metadata", lambda a: {"cell_key": "cg-key-v1-sealed"})
     monkeypatch.setattr(fleet_cells, "sha256_file", lambda p: "beef")
 
     assert fleet_cells.adopt_delegated_mint(_Pipe(), pending, [pending.target]) is not None

--- a/tests/test_durability_inversion_pgw1183.py
+++ b/tests/test_durability_inversion_pgw1183.py
@@ -32,7 +32,7 @@ import pytest
 from gen_worker import fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
-KEY_A = "ek1-" + "a" * 56
+KEY_A = "cg-key-v1-" + "a" * 56
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
 
 

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -222,8 +222,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token="ek1-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ek1-{'a' * 56}",
+            family=FAMILY, arm_token="cg-key-v1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#cg-key-v1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz", mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
         )

--- a/tests/test_eager_only_command_pgw1142.py
+++ b/tests/test_eager_only_command_pgw1142.py
@@ -124,7 +124,7 @@ META: Dict[str, Any] = {
     "torch": "2.13.0+cu130", "cuda": "13.0",
     # pgw#1176: this is now an ENTRY key and rides the marker's `entries` row,
     # so it is spelled in the grammar `cell_key.is_key` actually admits.
-    "cell_key": "ek1-" + "d" * 56,
+    "cell_key": "cg-key-v1-" + "d" * 56,
     "lora_bucket": 0,
 }
 
@@ -290,7 +290,7 @@ def test_an_ordered_aot_arm_is_obeyed_as_eager_not_refused() -> None:
     outcome = fleet_cells.arm_ordered(
         FakePipeline(FakeModule()), Cfg(), None,
         backend="aot_cell", artifact=Path("/nonexistent/cell.pt2"),
-        delivered_ref="root/family-sdxl-base#ek1-abc",
+        delivered_ref="root/family-sdxl-base#cg-key-v1-abc",
         delivered_digest="sha256:abc", expected=None, publisher_org="root")
     assert outcome.armed is False
     assert outcome.eager_reason == EagerPhase.OPERATOR_EAGER_ONLY
@@ -372,12 +372,12 @@ def test_the_two_triggers_report_different_reasons() -> None:
 
 
 def test_a_suppressed_request_is_not_reported_as_compiled() -> None:
-    ref = "root/family-sdxl-base#ek1-abc"
+    ref = "root/family-sdxl-base#cg-key-v1-abc"
     # The noted key must be the key the ref NAMES — `is_aot_ref` recognises an
-    # AOT cell by exactly that match, so a `ck1`-stamped note against an `ek1`
+    # AOT cell by exactly that match, so a `ck1`-stamped note against an `cg-key-v1`
     # ref resolves `jit_cell` and this row would assert the suppression
     # vocabulary on the wrong serving mode.
-    aot_serve.note_aot_key("ek1-abc")
+    aot_serve.note_aot_key("cg-key-v1-abc")
     armed = serving_mode.resolve(active_compile_ref=ref, sm="89")
     assert armed.serving_mode == serving_mode.MODE_AOT_CELL
 
@@ -396,7 +396,7 @@ def test_a_suppressed_request_is_not_reported_as_compiled() -> None:
 def test_a_real_guard_miss_still_reports_itself() -> None:
     """The order must not swallow the per-request fallback vocabulary."""
     missed = serving_mode.resolve(
-        active_compile_ref="root/family-sdxl-base#ek1-abc", guard_missed=True)
+        active_compile_ref="root/family-sdxl-base#cg-key-v1-abc", guard_missed=True)
     assert missed.fallback_reason == serving_mode.FALLBACK_GUARD_MISS
     assert missed.served_eager_fallback is True
 

--- a/tests/test_envelope_unreadable_pgw1098.py
+++ b/tests/test_envelope_unreadable_pgw1098.py
@@ -60,7 +60,7 @@ def _cell(path: Path, meta: Dict[str, Any], *, pad_to: int = 0) -> Path:
 #: DELIBERATELY PRE-pgw#1176, and left that way: `format: 2`, an `entries` MAP
 #: and a `ck1` key. This fixture's job is to reproduce a REAL artifact from the
 #: row 7 incident so the metadata SIZE bound is measured against bytes that
-#: actually existed. Migrating it to a one-entry `ek1` envelope would shrink
+#: actually existed. Migrating it to a one-entry `cg-key-v1` envelope would shrink
 #: the very thing under test — a 36-entry cell is what made the envelope
 #: exceed 16 MiB — and would assert the bound against a shape that never
 #: overflowed it.

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -729,7 +729,7 @@ def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ek1-" + "d" * 56
+    mint_key = "cg-key-v1-" + "d" * 56
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
@@ -818,7 +818,7 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
         compile=Compile(shapes=((768, 768),), family=FAMILY, text_len=0),
     )
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ek1-" + "f" * 56
+    mint_key = "cg-key-v1-" + "f" * 56
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
     mint_artifact.parent.mkdir()
     mint_artifact.write_bytes(b"cell-bytes")

--- a/tests/test_exported_proof_pgw735.py
+++ b/tests/test_exported_proof_pgw735.py
@@ -59,7 +59,7 @@ def _arm(pipe, *, calls: int, failed: bool = False) -> None:
                 "runner": _dispatch(calls, failed),
             },
         }},
-        "entries": {"unet/main": {"key": "ek1-" + "0" * 56}},
+        "entries": {"unet/main": {"key": "cg-key-v1-" + "0" * 56}},
     })
 
 

--- a/tests/test_flavor_deletion_pgw1148.py
+++ b/tests/test_flavor_deletion_pgw1148.py
@@ -24,7 +24,7 @@ from gen_worker.models.refs import (
     refuse_flavor_selector,
 )
 
-CELL_REF = "root/family-sdxl:cells#ek1-4f2a9b"
+CELL_REF = "root/family-sdxl:cells#cg-key-v1-4f2a9b"
 
 
 # --------------------------------------------------------------------------
@@ -141,11 +141,11 @@ def test_the_cell_fragment_still_parses() -> None:
     th = parse_model_ref(CELL_REF).tensorhub
     assert th is not None
     assert (th.owner, th.repo, th.tag, th.flavor) == (
-        "root", "family-sdxl", "cells", "ek1-4f2a9b")
+        "root", "family-sdxl", "cells", "cg-key-v1-4f2a9b")
 
 
 def test_parse_cell_ref_is_unchanged() -> None:
-    assert cc.parse_cell_ref(CELL_REF) == ("sdxl", "ek1-4f2a9b")
+    assert cc.parse_cell_ref(CELL_REF) == ("sdxl", "cg-key-v1-4f2a9b")
     assert cc.family_from_ref(CELL_REF) == "sdxl"
 
 

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -62,7 +62,7 @@ class _Pipe:
         self.transformer = _Denoiser()
 
 
-FAKE_KEY = "ek1-" + "a" * 56
+FAKE_KEY = "cg-key-v1-" + "a" * 56
 
 
 @pytest.fixture(autouse=True)
@@ -120,7 +120,7 @@ def _publisher(calls):
 # ---------------------------------------------------------------------------
 
 
-_ADOPT_META = {"cell_key": "ek1-" + "d" * 56, "family": "fam",
+_ADOPT_META = {"cell_key": "cg-key-v1-" + "d" * 56, "family": "fam",
                "kind": "aot-inductor"}
 
 

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -76,7 +76,7 @@ def _gpu_runtime() -> Any:
 def _trace(
     vehicle_name: str, tree: Path,
 ) -> Tuple[Dict[str, Any], Any, Dict[str, Any]]:
-    """``({entry: keying block}, {entry: ek1 key}, declared envelope)`` — trace
+    """``({entry: keying block}, {entry: cg-key-v1 key}, declared envelope)`` — trace
     only. pgw#1176: a declaration folds to a KEY SET, not one key."""
     from harness import rig_vehicles
 

--- a/tests/test_handback_key_axes_pgw1042.py
+++ b/tests/test_handback_key_axes_pgw1042.py
@@ -62,7 +62,7 @@ def _arm_key(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> fleet_cells.Arm
 
 def _envelope(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> Dict[str, Any]:
     return {
-        "cell_key": "ek1-" + "e" * 56,
+        "cell_key": "cg-key-v1-" + "e" * 56,
         "kind": "aot-inductor",
         "format": "2",
         "family": "micro-diffusion",

--- a/tests/test_identity_soundness_pgw1113.py
+++ b/tests/test_identity_soundness_pgw1113.py
@@ -320,7 +320,7 @@ def test_the_arm_token_scheme_is_its_fact_set(tmp_path: Path) -> None:
     stale = memo_dir / ("arm1-" + "a" * 56 + ".json")
     current = memo_dir / (fleet_cells.ARM_SCHEME + "-" + "b" * 56 + ".json")
     for entry in (stale, current):
-        entry.write_text(json.dumps({"cell_key": "ek1-" + "c" * 56}))
+        entry.write_text(json.dumps({"cell_key": "cg-key-v1-" + "c" * 56}))
 
     dropped = local_cell_store.sweep_superseded_memos(
         fleet_cells.ARM_SCHEME, tmp_path)

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -40,7 +40,7 @@ from gen_worker.cell_adopt import AdoptOutcome
 from gen_worker.cli import run as cli_run
 from gen_worker.mint_process import MintSlot
 
-KEY_A = "ek1-" + "a" * 56
+KEY_A = "cg-key-v1-" + "a" * 56
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * 56
 
 SRC = Path(fleet_cells.__file__).parent

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -421,7 +421,7 @@ def _fake_card(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _task(tmp_path: Path) -> mint_delegate.MintTask:
     pending = fleet_cells.PendingSelfMint(
-        family="sdxl", arm_token="ck1-abc", ref="root/family-sdxl#ek1-abc",
+        family="sdxl", arm_token="ck1-abc", ref="root/family-sdxl#cg-key-v1-abc",
         cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
                         family="sdxl", regional=False, text_len=77,
                         dynamic=(), lora_bucket=0, guidance_scales=(),

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -187,7 +187,7 @@ def test_the_request_carries_the_execution_lane_and_the_effective_config(
 def _task(tmp_path: Path, **over: Any) -> mint_delegate.MintTask:
     pending = fleet_cells.PendingSelfMint(
         family="sdxl", arm_token="ck1-abc",
-        ref="root/family-sdxl#ek1-abc", cfg=_cfg(),
+        ref="root/family-sdxl#cg-key-v1-abc", cfg=_cfg(),
         target=tmp_path / "cell.tar.gz",
         mint_root=tmp_path / "root", publisher=None, cache_dir=tmp_path)
     fields: Dict[str, Any] = dict(
@@ -236,7 +236,7 @@ def test_a_minted_child_is_adopted_through_the_delivered_cell_path(
         rows = [Path(a) for a in artifacts]
         adopted.extend(rows)
         return fleet_cells.SelfMint(
-            family="sdxl", cell_key="ek1-abc", ref="r#k",
+            family="sdxl", cell_key="cg-key-v1-abc", ref="r#k",
             snapshot_digest="blake3:x", artifact=rows[0])
 
     monkeypatch.setattr(fleet_cells, "adopt_delegated_mint", _adopt)

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -208,8 +208,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token="ek1-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ek1-{'a' * 56}",
+            family=FAMILY, arm_token="cg-key-v1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#cg-key-v1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz", mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
         )

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -235,8 +235,8 @@ class _Harness:
         capture = self.tmp_path / f"capture-{id(pipe)}"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token="ek1-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ek1-{'a' * 56}",
+            family=FAMILY, arm_token="cg-key-v1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#cg-key-v1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz", mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
         )
@@ -514,8 +514,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root = tmp_path / "m"
         (mint_root / "capture").mkdir(parents=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token="ek1-" + "b" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ek1-{'b' * 56}",
+            family=FAMILY, arm_token="cg-key-v1-" + "b" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#cg-key-v1-{'b' * 56}",
             cfg=None, target=mint_root / "cell.tar.gz", mint_root=mint_root,
             publisher=None, cache_dir=None,
         )
@@ -534,8 +534,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root2 = tmp_path / "m2"
         (mint_root2 / "capture").mkdir(parents=True)
         pending2 = fleet_cells.PendingSelfMint(
-            family=FAMILY, arm_token="ek1-" + "c" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ek1-{'c' * 56}",
+            family=FAMILY, arm_token="cg-key-v1-" + "c" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#cg-key-v1-{'c' * 56}",
             cfg=None, target=mint_root2 / "cell.tar.gz", mint_root=mint_root2,
             publisher=None, cache_dir=None,
         )

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -83,7 +83,7 @@ def _stub_child(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _pending(tmp_path: Path) -> Any:
     return fleet_cells.PendingSelfMint(
-        family="sdxl", arm_token="ck1-abc", ref="root/family-sdxl#ek1-abc",
+        family="sdxl", arm_token="ck1-abc", ref="root/family-sdxl#cg-key-v1-abc",
         cfg=_cfg(), target=tmp_path / "cell.tar.gz",
         mint_root=tmp_path / "root", publisher=None, cache_dir=tmp_path)
 
@@ -243,8 +243,8 @@ def test_the_delegated_route_mints_in_a_child_adopts_and_advertises(
         rows = [Path(a) for a in artifacts]
         adopted.extend(rows)
         return fleet_cells.SelfMint(
-            family="sdxl", cell_key="ek1-abc",
-            ref="root/family-sdxl#ek1-abc", snapshot_digest="blake3:aa",
+            family="sdxl", cell_key="cg-key-v1-abc",
+            ref="root/family-sdxl#cg-key-v1-abc", snapshot_digest="blake3:aa",
             artifact=rows[0])
 
     monkeypatch.setattr(fleet_cells, "adopt_delegated_mint", _adopt)
@@ -265,7 +265,7 @@ def test_the_delegated_route_mints_in_a_child_adopts_and_advertises(
     # Phase 4, shared with the in-process route: the target now advertises the
     # worker's OWN key (th#910's self-attested fence).
     target = rec.compile_targets["t0"]
-    assert target.active_compile_ref == "root/family-sdxl#ek1-abc"
+    assert target.active_compile_ref == "root/family-sdxl#cg-key-v1-abc"
     assert target.active_compile_snapshot_digest == "blake3:aa"
     assert target.active_self_mint is True
     assert "finalize" in act.phases

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -141,7 +141,7 @@ def test_a_faithful_cell_arms_AND_THE_PASS_IS_ANNOUNCED(
     # each naming its own class and carrying its own key.
     for (detail, _phase), (h, w) in zip(rows, ROWS):
         assert "axes=1/1" in detail
-        assert f"family={FAMILY}" in detail and "key=ek1-" in detail
+        assert f"family={FAMILY}" in detail and "key=cg-key-v1-" in detail
         assert entry_name(h, w) in detail
         assert "cos=1.00000" in detail
 

--- a/tests/test_per_entry_atom_pgw1176.py
+++ b/tests/test_per_entry_atom_pgw1176.py
@@ -100,9 +100,9 @@ def test_a_ck1_key_is_not_an_entry_key() -> None:
     would let a cell ref reach a per-entry path and fail late.
 
     THE FIFTH SWEEP ERROR, and it landed in the atom's own proof: a blanket
-    ``ck1-`` -> ``ek1-`` fixture sweep rewrote the REFUSAL line here, leaving
+    ``ck1-`` -> ``cg-key-v1-`` fixture sweep rewrote the REFUSAL line here, leaving
     a contradictory pair one character apart —
-    ``assert not is_key("ek1-…")`` beside ``assert is_key("ek1-…")``. The row
+    ``assert not is_key("cg-key-v1-…")`` beside ``assert is_key("cg-key-v1-…")``. The row
     went red, which is the only reason it surfaced, and while it was red the
     ck1-refusal invariant had NO passing guard in this file at all.
 
@@ -111,15 +111,18 @@ def test_a_ck1_key_is_not_an_entry_key() -> None:
     and the exception here is the one line that must keep naming the OLD
     scheme. Fixed, and annotated so the next sweep leaves it alone.
     """
-    assert cell_key.KEY_SCHEME == "ek1"
+    assert cell_key.KEY_SCHEME == "cg-key-v1"
     # fence-symbol-exempt: `ck1` is the SUPERSEDED scheme and naming it is the
     # whole assertion — a sweep that renames this line deletes the invariant.
     assert not cell_key.is_key("ck1-" + "0" * 56)
-    assert cell_key.is_key("ek1-" + "0" * 56)
-    # The refusal is about the PREFIX, not the length: a well-formed ck1 key
-    # of exactly the right shape is still refused, which is what makes an
-    # orphaned ref fail at the comparison rather than late.
-    assert len("ck1-" + "0" * 56) == len("ek1-" + "0" * 56)
+    assert cell_key.is_key("cg-key-v1-" + "0" * 56)
+    # The refusal is about the SCHEME, not the digest: the ck1 token above
+    # carries a digest of exactly the admitted width and is still refused,
+    # which is what makes an orphaned ref fail at the comparison rather than
+    # late. pgw#1213 made the two spellings different LENGTHS (`cg-key-v1` is
+    # longer than `ck1`), so length can no longer stand in for that claim —
+    # state it on the digest, which is the part the grammar actually fixes.
+    assert len("ck1-" + "0" * 56) - len("ck1-") == 56
 
 
 # --- 2. ARTIFACT -----------------------------------------------------------
@@ -144,7 +147,7 @@ def test_one_artifact_carries_exactly_one_graph(tmp_path: Path) -> None:
 
 def test_a_forged_key_stamp_is_refused_on_the_staged_bytes() -> None:
     meta = entry_meta(*rig.ROWS[0])
-    meta["cell_key"] = "ek1-" + "0" * 56
+    meta["cell_key"] = "cg-key-v1-" + "0" * 56
     reason = aot.verify_contract(meta)
     assert "!=" in reason and "recorded facts describe" in reason
 
@@ -155,7 +158,7 @@ def test_a_format_2_cell_cannot_restate_a_per_entry_identity() -> None:
     recomputation raises rather than matching."""
     legacy = {
         "format": 2, "kind": aot.ARTIFACT_KIND, **rig.RUNTIME,
-        "family": rig.FAMILY, "cell_key": "ek1-" + "0" * 56,
+        "family": rig.FAMILY, "cell_key": "cg-key-v1-" + "0" * 56,
         "entries": {rig.entry_name(h, w): rig._entry(h, w)
                     for h, w in rig.ROWS},
         "combined_graph_hash": "0" * 16,

--- a/tests/test_receipt_identity_seam_pgw1122.py
+++ b/tests/test_receipt_identity_seam_pgw1122.py
@@ -426,7 +426,7 @@ def _hit(family: str = FAMILY, function: str = "generate") -> Any:
     executor now carries onto the arm order."""
     return boot_adopt.BootAdoptOutcome(
         adoption=None, reason=boot_adopt.HIT,
-        derived_key="ek1-" + "f0" * 28, derive_ms=10_895,
+        derived_key="cg-key-v1-" + "f0" * 28, derive_ms=10_895,
         family=family, function=function)
 
 
@@ -487,7 +487,7 @@ def test_an_adopted_cell_that_will_not_arm_does_not_kill_the_function(
     detail = events.detail(activity_mod.KIND_BOOT_ADOPT, "arm_refused")
     assert "cause=artifact_receipt_refused" in detail
     assert "publisher_untrusted" in detail
-    assert f"family={FAMILY}" in detail and "key=ek1-" in detail
+    assert f"family={FAMILY}" in detail and "key=cg-key-v1-" in detail
 
 
 def test_a_HUB_ordered_arm_stays_terminal(

--- a/tests/test_receipts_pgw709.py
+++ b/tests/test_receipts_pgw709.py
@@ -57,7 +57,7 @@ class TestVerifyReceiptJWS:
         # poisoning move receipts exist to prevent.
         jws = sign_receipt(rsa_key, make_claims("sha256:" + SHA_HEX, 4096))
         head, _, sig = jws.split(".")
-        forged_claims = make_claims("sha256:" + SHA_HEX, 4096, cell_key="ek1-" + "f" * 56)
+        forged_claims = make_claims("sha256:" + SHA_HEX, 4096, cell_key="cg-key-v1-" + "f" * 56)
         forged = head + "." + _b64url(json.dumps(forged_claims).encode()) + "." + sig
         with pytest.raises(receipts.ReceiptError) as exc:
             receipts.verify_receipt_jws(forged, pub_map)
@@ -139,7 +139,7 @@ class TestGateDeliveredArtifact:
         # Nix Deriver lesson — key binding must be inside the signature.
         artifact = make_artifact(tmp_path)
         ref = receipts.artifact_digest(artifact)
-        claims = make_claims(ref, artifact.stat().st_size, cell_key="ek1-" + "e" * 56)
+        claims = make_claims(ref, artifact.stat().st_size, cell_key="cg-key-v1-" + "e" * 56)
         hub.receipts[(ref, CELL_KEY)] = sign_receipt(hub.key, claims)
         _configure(hub)
         assert receipts.gate_delivered_artifact(artifact, FAMILY) is False
@@ -161,7 +161,7 @@ class TestGateDeliveredArtifact:
     def test_other_revocation_does_not_block(self, tmp_path: Path, hub: HubStub) -> None:
         artifact = make_artifact(tmp_path)
         hub.serve_receipt_for(artifact)
-        hub.revoked.append({"cell_key": "ek1-" + "d" * 56, "snapshot_digest": "other", "reason": "x"})
+        hub.revoked.append({"cell_key": "cg-key-v1-" + "d" * 56, "snapshot_digest": "other", "reason": "x"})
         _configure(hub)
         assert receipts.gate_delivered_artifact(artifact, FAMILY) is True
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -89,11 +89,11 @@ def test_static_closure_reaches_the_composition_code() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ek1_axes_are_the_recipe(pinned_runtime: None,
+def test_cg_key_v1_axes_are_the_recipe(pinned_runtime: None,
                                  monkeypatch: pytest.MonkeyPatch) -> None:
     meta = exported_cell_meta()
     key = ck.from_entry_metadata(meta)
-    assert key.digest.startswith("ek1-")
+    assert key.digest.startswith("cg-key-v1-")
     axes = key.axes_dict()
     assert set(axes) == {"graph", "sm", "toolchain"}
     # Version strings and image identity are GONE from the key: a
@@ -198,7 +198,7 @@ def test_marked_cell_never_republishes(monkeypatch: pytest.MonkeyPatch,
     artifact.write_bytes(b"bytes")
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "jwt", image_digest="")
-    meta = {"cell_key": "ek1-" + "a" * 56, fc.ADOPTION_MARK: ["foreign"]}
+    meta = {"cell_key": "cg-key-v1-" + "a" * 56, fc.ADOPTION_MARK: ["foreign"]}
     with pytest.raises(fc.CellPublishRefused, match="pgw#712"):
         pub.publish(FAMILY, artifact, meta)
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -102,11 +102,14 @@ def test_cg_key_v1_axes_are_the_recipe(pinned_runtime: None,
     bumped = dict(meta, gen_worker="99.0.0", torch="9.9.9",
                   image_digest="sha256:other")
     assert ck.from_entry_metadata(bumped).digest == key.digest
-    # Foreign schemes can never collide with a current key; they stay
-    # key-SHAPED (pgw#990 — is_key mirrors tensorhub's scheme-agnostic
-    # IsCellKey) and are ruled on by axes, not by their label.
-    for dead in ("ek2-", "ek3-", "ek4-", "ek5-", "ek6-"):
-        assert ck.is_key(dead + "a" * 56)
+    # pgw#1213: the grammar is scheme-PINNED, superseding pgw#990's
+    # scheme-agnostic reading. Agnosticism existed so an entry of an OLDER
+    # scheme would be ruled on by its axes rather than its label; `cg-key-v1`
+    # is the first scheme any published artifact is addressed by, so there is
+    # no such corpus, and a foreign scheme now names a digest over axes this
+    # runtime cannot restate.
+    for dead in ("ek1-", "ek2-", "cg-key-v2-"):
+        assert not ck.is_key(dead + "a" * 56)
         assert key.digest != dead + "a" * 56
     # pgw#1176: a ``ck`` key is NOT merely a foreign scheme — it names a
     # 36-entry all-or-nothing cell this runtime cannot arm at all, so it does

--- a/tests/test_ref_and_manifest_fuzz_pgw867.py
+++ b/tests/test_ref_and_manifest_fuzz_pgw867.py
@@ -36,6 +36,7 @@ from gen_worker.models.chunk_cas import parse_cas_ref
 from gen_worker.models.hub_client import HubResolveError, parse_chunk_list, resolved_entry_digest
 from gen_worker.models.refs import (
     DEFAULT_REF_TAG,
+    MAX_FRAGMENT_LEN,
     format_model_ref,
     normalize_model_ref,
     parse_model_ref,
@@ -53,7 +54,11 @@ def _ref_seeds() -> list[str]:
     seeds = [
         "", " ", "/", "//", "a/", "/b", "owner/repo", "owner/repo:", "owner/repo:prod",
         "owner/repo:latest", "owner/repo#fp8", "owner/repo#FP8", "owner/repo#",
-        "owner/repo#a#b", "owner/repo#fp8?attr=1", "owner/repo#" + "a" * 65,
+        "owner/repo#a#b", "owner/repo#fp8?attr=1",
+        # An over-long fragment. pgw#1213 widened the cap to MAX_FRAGMENT_LEN
+        # so a `cg-key-v1` key (66 chars) fits, so the seed tracks the cap
+        # rather than the old literal 64 — its job is to be one too long.
+        "owner/repo#" + "a" * (MAX_FRAGMENT_LEN + 1),
         f"owner/repo@sha256:{HEX64}", f"owner/repo@blake3:{'b' * 64}",
         f"owner/repo@SHA256:{HEX64.upper()}", "owner/repo@sha256:", "owner/repo@deadbeef",
         "owner/repo@v1", f"owner/repo:tag@sha256:{HEX64}#fp8",
@@ -127,7 +132,7 @@ def test_ref_acceptance_implies_well_formed_components(raw: str) -> None:
     assert th.tag, f"{raw!r} accepted with an empty tag; the default is {DEFAULT_REF_TAG!r}"
     if th.flavor is not None:
         assert th.flavor == th.flavor.lower()
-        assert 1 <= len(th.flavor) <= 64
+        assert 1 <= len(th.flavor) <= MAX_FRAGMENT_LEN
     if th.digest is not None:
         # A digest that reached a parsed ref is used to ADDRESS CAS objects, so
         # "present" is not enough — it must name its algorithm. An inferred

--- a/tests/test_two_run_reuse_pgw1096.py
+++ b/tests/test_two_run_reuse_pgw1096.py
@@ -49,7 +49,7 @@ from gen_worker import fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
 MODE = sys.argv[1]
-KEY = "ek1-" + "c" * 56
+KEY = "cg-key-v1-" + "c" * 56
 ARM = fleet_cells.ARM_SCHEME + "-" + "9" * 56
 FAMILY = "micro-diffusion"
 
@@ -180,10 +180,10 @@ def test_run_one_mints_and_keeps_run_two_reuses_with_no_mint(
     assert two["mints_opened"] == 0, (
         "the second run opened a mint — compile-once-run-forever is the whole "
         "product promise and this is what breaking it looks like")
-    assert two["cell_key"] == "ek1-" + "c" * 56
+    assert two["cell_key"] == "cg-key-v1-" + "c" * 56
     assert two["artifact"].startswith(str(store)), (
         "run 2 must serve the STORE's bytes, not a leftover from the mint")
-    assert two["resident"] == ["ek1-" + "c" * 56]
+    assert two["resident"] == ["cg-key-v1-" + "c" * 56]
 
 
 def test_a_cold_run_with_an_EMPTY_store_mints_rather_than_inventing_a_hit(


### PR DESCRIPTION
0.114.0 merged to `master` carrying `KEY_SCHEME = "ek1"`, but **no `v0.114.0` tag exists and nothing has published** — `publish.yml` fires on tag push. Landing the rename before the tag makes it one commit; landing it after burns a version number on a scheme name nothing wanted.

## The grammar, not just the token

`KEY_SCHEME = "cg-key-v1"` (Paul, final). The interesting half is `is_key`, which assumed a `<letters><digits>` token and read the scheme by slicing `[2:]`:

```python
rest = v[2:] if v.startswith("ek") else ""   # then count 1-2 digits, then "-"
```

`cg-key-v1` breaks that twice: it is not letters-then-digits, and it **contains hyphens**, so splitting a key on `-` is wrong too. The digest is fixed-width and terminal, so the grammar is matched from the RIGHT:

```python
_DIGEST_RE = re.compile(r"-(?P<digest>[0-9a-f]{56})$")
m = _DIGEST_RE.search(v)
return m is not None and v[:m.start()] == KEY_SCHEME
```

Scheme is whatever precedes the anchored digest, and it must equal `KEY_SCHEME` exactly.

**Scheme-PINNED**, superseding th#1183's scheme-agnostic reading. That reading existed so an entry of an *older* scheme would be ruled on by its axes rather than by its label. There is no older corpus — `cg-key-v1` is the first scheme any published artifact is addressed by — so all agnosticism can admit now is a token whose digest was computed over axes this runtime cannot restate.

## The row that can go red

`test_the_deriver_and_the_validator_agree_on_cg_key_v1` asserts `is_key(from_axes(...).digest) is True` — the deriver writes the scheme through `_PREFIX`, the validator reads it through the right-anchored match, and moving one without the other fails here instead of at a resolve nobody watches. Verified red-capable by flipping `KEY_SCHEME` back to `ek1` locally: **2 failed, 3 passed**.

`test_only_cg_key_v1_is_a_key` carries the negatives: `ek1-<56hex>`, `ck1-<56hex>`, `cg-key-v2-<56hex>`, `key-v1-<56hex>` (a *suffix* of the scheme), 55- and 57-wide digests, uppercase hex, missing separator.

## Cross-repo

The grammar must remain byte-for-byte what tensorhub's `compilecache.IsCellKey` enforces — **th#1897** lands the Go half plus the cross-repo vector fence, which is what actually holds the two halves together.

## ⚠️ Companion item for th#1897 — NOT fixed here

`cg-key-v1-` is 10 chars, so a key is **66 chars**. The th#597 C5 ref-fragment token grammar (`[a-z0-9][a-z0-9._-]{0,63}`, Go+Py byte-identical, `models/refs.py:_TENSORHUB_FRAGMENT_RE`) caps a fragment at **64**, and keys travel as ref fragments (`compile_cache.py:153` reads `flavor` through `is_key`). Verified on this branch:

```
FAILED len=66: ValueError tensorhub ref fragment 'cg-key-v1-aaaa…' is not a valid token
PARSED ok len=60   (the old ek1- spelling)
```

Deliberately **not** widened here: that grammar is shared with tensorhub and pinned by `tests/testdata/ref_grammar_vectors.json` (byte-identical copy in tensorhub), so widening it unilaterally in Python would create exactly the Go/Py divergence the fence exists to catch. It belongs to th#1897 with the rest of the cross-repo half. No test on this branch exercises a key-bearing ref through `parse_model_ref`, so it is latent rather than red.

## Scope

`cell_key.py` (scheme + grammar + docstrings), the literal-scheme docstrings in `aot_mint` / `boot_key` / `cell_adopt` / `fleet_cells` / `mint_child`, the `ek1-` fixtures across 44 test files, and `changelog.d/pgw1213.md`. One length-equality assertion in `test_per_entry_atom_pgw1176.py` was restated on the digest — it used `len(ck1 key) == len(entry key)` to claim "the refusal is about the scheme, not the length", which stops being a true sentence once the two schemes are different lengths.