### PR TITLE
pgw#1206 C2: the record queries leave the job engine, and a third VRAM probe dies

### DIFF
--- a/changelog.d/pgw1206.md
+++ b/changelog.d/pgw1206.md
@@ -1,12 +1,11 @@
-- **BREAKING (pgw#1206 C1) — `ModelStore` leaves `executor.py`.**
-  `gen_worker.executor.ModelStore` → `gen_worker.models.store.ModelStore`. Phase
-  C splits the executor by LIFETIME, and the store is the longest-lived thing a
-  worker owns — a pod's store outlives every job on it — so it goes first;
-  `executor.py` keeps the job engine and drops from 12,873 to 11,062 lines. A
-  verbatim move: no method body changed. The only content deltas are three
-  `set` → `Set[str]` annotations that strict mypy requires of a new module, and
-  `_sanitize` becoming `gen_worker.redact.sanitize` because the store may not
-  import the executor. Tests and harnesses that patched `executor.ensure_local`,
-  `executor.verify_files`, `executor._snapshot_to_resolved` or
-  `executor._PROGRESS_EVENT_MIN_INTERVAL_S` must patch `gen_worker.models.store`
-  instead — the spy belongs at the DEFINING module (pgw#1210).
+- **pgw#1206 C2: the record queries leave the job engine, and a third copy of
+  the VRAM probe dies.** `Executor._record_refs` / `_records_holding` /
+  `_record_in_use` become free functions in `gen_worker.models.records`, taking
+  exactly what they read (records, jobs, residency) instead of a back-reference.
+  `Executor._vram_allocated` is **deleted outright**: it duplicated
+  `gen_worker.models.memory.cuda_allocated_bytes`, which is the canonical export
+  and already the probe `cli/serve.py` uses; its five call sites now use it too.
+  `shutdown_instances` and `_vacate_record` deliberately stay on the executor —
+  both call `abandon_background_mint`, which is inside th#1834's frozen
+  Phase-3 region, and dragging a frozen method across a module seam is what the
+  fence forbids.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -96,6 +96,7 @@ from .models import provision
 from .models import residency as residency_mod
 from .models.memory import (
     aflush_memory,
+    cuda_allocated_bytes,
     estimate_cuda_resident_gb,
     estimate_pipeline_size_gb,
     flush_memory,
@@ -106,6 +107,7 @@ from .models.memory import (
 )
 from .models import rung as rungspec
 from .models.rung import touches_host_ram, transition_line
+from .models.records import record_in_use, record_refs, records_holding
 from .models.envelope import ArtifactEnvelopeExceeded
 from .models.errors import MissingSnapshotError, UrlExpiredError
 from .models.execution_lanes import ExecutionLaneUnavailableError
@@ -2100,7 +2102,7 @@ class Executor:
             if not rec.ready or not rec.stale:
                 return
             async with self._load_lock:
-                if self._record_in_use(rec):
+                if record_in_use(rec, records=self._classes.values(), jobs=self.jobs.values(), residency=self.store.residency):
                     return
                 await self._vacate_record(rec)
         self._on_state_change()
@@ -5315,7 +5317,7 @@ class Executor:
             setup = getattr(instance, "setup", None)
             inj = _InjectionResult(kwargs={}, loaded={})
 
-            vram_before = self._vram_allocated()
+            vram_before = cuda_allocated_bytes()
             if spec.runtime:
                 rec.server = await self._boot_engine_server(spec, paths)
             if callable(setup):
@@ -6148,7 +6150,7 @@ class Executor:
             self._assert_mint_termini(
                 spec,
                 [p for p in mint_obligations if id(p) not in owned_by_driver])
-            vram_delta = max(0, self._vram_allocated() - vram_before)
+            vram_delta = max(0, cuda_allocated_bytes() - vram_before)
             if rec.server is not None:
                 # Engine subprocess VRAM is invisible to torch's allocator;
                 # book the measured per-PID footprint so the LRU ledger is
@@ -6759,17 +6761,17 @@ class Executor:
             # ref that appeared in the snapshot of LRU candidates.
             if res.tier(ref) is not residency_mod.Tier.RAM:
                 continue
-            owners = self._records_holding(ref)
+            owners = records_holding(self._classes.values(), ref)
             if len(owners) > 1:
                 # A ref shared by several endpoint instances is not an
                 # ownership key. Their unique refs drive record teardown.
                 continue
             rec = owners[0] if owners else None
             if rec is not None:
-                if self._record_in_use(rec, reclaim_ref=ref):
+                if record_in_use(rec, records=self._classes.values(), jobs=self.jobs.values(), residency=self.store.residency, reclaim_ref=ref):
                     continue
                 owned = [
-                    held for held in self._record_refs(rec)
+                    held for held in record_refs(rec)
                     if res.tier(held) in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
                 ]
                 released = await self._vacate_record(rec)
@@ -6915,13 +6917,13 @@ class Executor:
         # Movable demotions weren't enough: tear down idle records holding
         # non-movable LRU victims (tenant-loaded refs).
         for ref in res.lru_vram_victims():
-            owners = self._records_holding(ref)
+            owners = records_holding(self._classes.values(), ref)
             if len(owners) != 1:
                 # Shared refs cannot identify which instance owns the
                 # residency object; wait for a unique record-owned victim.
                 continue
             rec = owners[0]
-            if self._record_in_use(rec, reclaim_ref=ref):
+            if record_in_use(rec, records=self._classes.values(), jobs=self.jobs.values(), residency=self.store.residency, reclaim_ref=ref):
                 continue
             await self._vacate_record(rec)
             if await asyncio.to_thread(make_room):
@@ -7233,7 +7235,7 @@ class Executor:
                         if excl_bytes > 0:
                             await _to_thread_complete(functools.partial(
                                 res.make_room, excl_bytes, for_refs=(ref,)))
-                    before = self._vram_allocated()
+                    before = cuda_allocated_bytes()
                     try:
                         sl = await _to_thread_complete(
                             provision.load_slot, ann, path, binding=binding,
@@ -7422,7 +7424,7 @@ class Executor:
                                 result.pending_self_mints[id(pipe)] = pipe_mint
                             elif armed and selection is not None:
                                 result.active_compile_artifacts[id(pipe)] = selection
-                    delta = max(0, self._vram_allocated() - before)
+                    delta = max(0, cuda_allocated_bytes() - before)
                     if slot_share:
                         execution_lane_obj, execution_lane_bytes = self._register_execution_lane(
                             slot,
@@ -8428,14 +8430,6 @@ class Executor:
             publisher=self._cell_publisher(),
         )
 
-    @staticmethod
-    def _vram_allocated() -> int:
-        if torch is not None and torch.cuda.is_available():
-            try:
-                return int(torch.cuda.memory_allocated())
-            except Exception:
-                return 0
-        return 0
 
     def declares_compile(self) -> bool:
         """Whether ANY discovered spec declares a compile family.
@@ -8569,48 +8563,8 @@ class Executor:
             await self._send(pb.WorkerMessage(model_event=event))
         inj.adoptions.clear()
 
-    def _record_refs(self, rec: _ClassRecord) -> List[str]:
-        """The wire refs a record's instance holds: the load-time booking
-        keys when stamped (gw#494), else the current binding derivation
-        (records that never completed a setup)."""
-        if rec.held_refs:
-            return list(rec.held_refs)
-        return [wire_ref(b) for s in rec.specs for b in s.models.values()]
 
-    def _records_holding(self, ref: str) -> List[_ClassRecord]:
-        return [
-            rec for rec in self._classes.values()
-            if rec.ready and ref in self._record_refs(rec)
-        ]
 
-    def _record_in_use(
-        self, rec: _ClassRecord, *, reclaim_ref: Optional[str] = None,
-    ) -> bool:
-        """Whether teardown would disturb live work.
-
-        ``reclaim_ref`` narrows a pressure-driven teardown to the candidate
-        that selected this record. A different held ref can be pinned by an
-        incoming job before its own setup (the common SDXL VAE); that does not
-        make this record's idle checkpoint active. ``_vacate_record`` leaves
-        such a pinned ref resident because ``release_to_disk`` refuses it.
-        Full-record invalidation omits the argument and remains conservative.
-
-        A job on a rebound spec no longer references the record's held refs;
-        membership of the job's spec in this record is the honest instance-use
-        signal (gw#494).
-        """
-        for job in self.jobs.values():
-            if job.finished or job.superseded or job.spec is None:
-                continue
-            if job.spec in rec.specs:
-                return True
-        refs = [reclaim_ref] if reclaim_ref is not None else self._record_refs(rec)
-        for ref in refs:
-            owners = self._records_holding(ref)
-            if (len(owners) == 1 and owners[0] is rec
-                    and self.store.residency.in_use(ref)):
-                return True
-        return False
 
     async def _vacate_record(self, rec: _ClassRecord) -> List[str]:
         """Tear an instance down and return refs whose owner was released."""
@@ -8618,7 +8572,7 @@ class Executor:
         # stop the driver before any module teardown races a warm forward.
         await self.abandon_background_mint(
             rec, reason="instance vacate", code="vacate")
-        held_refs = self._record_refs(rec)
+        held_refs = record_refs(rec)
         held_objects = rec.held_objects
         released_refs: List[str] = []
         old_obj: Any = None
@@ -8660,7 +8614,7 @@ class Executor:
         for ref in held_refs:
             tier_before = self.store.residency.tier(ref)
             old_obj = held_objects.get(ref)
-            owners = self._records_holding(ref)
+            owners = records_holding(self._classes.values(), ref)
             if owners:
                 # Residency keeps one representative object per wire ref. If
                 # it points at the departing record, transfer it to a survivor
@@ -9823,7 +9777,7 @@ class Executor:
                         # peak - baseline is this request's transient
                         # (activation) footprint, as opposed to the resident
                         # weights already allocated when it took the GPU.
-                        alloc_at_start = self._vram_allocated()
+                        alloc_at_start = cuda_allocated_bytes()
                 # Last execution fence: no adapter mutation or tenant handler
                 # has run yet. The repeated check catches a replacement between
                 # scheduler assignment/intake and this GPU turn.

--- a/src/gen_worker/models/records.py
+++ b/src/gen_worker/models/records.py
@@ -1,0 +1,95 @@
+"""Which instance record holds which ref, and whether tearing it down would
+disturb live work.
+
+pgw#1206 C2. These three are pure QUERIES over the executor's record book:
+they read records, jobs and residency and mutate nothing. Lifting them out as
+free functions is what lets the residency-reconcile lifetime be reasoned about
+without the 11,000-line job engine around it.
+
+They stay free functions taking exactly what they read — the executor passes
+`self._classes.values()` and `self.jobs.values()` — rather than becoming a
+class with a back-reference. A back-reference would re-import the whole
+executor and put us back where we started.
+
+Their two MUTATING callers (`Executor.shutdown_instances` and
+`Executor._vacate_record`) deliberately stay on the executor: both call
+`abandon_background_mint`, which is inside th#1834's frozen Phase-3 region, and
+dragging a frozen method across a module seam is exactly what the fence forbids.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional, Protocol, TypeVar
+
+from ..api.binding import wire_ref
+
+
+class _Record(Protocol):
+    """The record fields these queries read. Structural on purpose: the record
+    type lives in `executor.py` and importing it here would be the cycle."""
+
+    ready: bool
+    held_refs: List[str]
+    specs: Any
+
+
+class _Job(Protocol):
+    finished: bool
+    superseded: bool
+    spec: Any
+
+
+#: Generic so the executor's concrete record type survives the seam — a
+#: Protocol-typed return would erase it at every call site.
+R = TypeVar("R", bound=_Record)
+
+
+def record_refs(rec: _Record) -> List[str]:
+    """The wire refs a record's instance holds: the load-time booking keys when
+    stamped (gw#494), else the current binding derivation (records that never
+    completed a setup)."""
+    if rec.held_refs:
+        return list(rec.held_refs)
+    return [wire_ref(b) for s in rec.specs for b in s.models.values()]
+
+
+def records_holding(records: Iterable[R], ref: str) -> List[R]:
+    return [rec for rec in records if rec.ready and ref in record_refs(rec)]
+
+
+def record_in_use(
+    rec: _Record,
+    *,
+    records: Iterable[_Record],
+    jobs: Iterable[_Job],
+    residency: Any,
+    reclaim_ref: Optional[str] = None,
+) -> bool:
+    """Whether teardown would disturb live work.
+
+    ``reclaim_ref`` narrows a pressure-driven teardown to the candidate that
+    selected this record. A different held ref can be pinned by an incoming job
+    before its own setup (the common SDXL VAE); that does not make this
+    record's idle checkpoint active. ``_vacate_record`` leaves such a pinned ref
+    resident because ``release_to_disk`` refuses it. Full-record invalidation
+    omits the argument and remains conservative.
+
+    A job on a rebound spec no longer references the record's held refs;
+    membership of the job's spec in this record is the honest instance-use
+    signal (gw#494).
+    """
+    for job in jobs:
+        if job.finished or job.superseded or job.spec is None:
+            continue
+        if job.spec in rec.specs:
+            return True
+    records = list(records)
+    refs = [reclaim_ref] if reclaim_ref is not None else record_refs(rec)
+    for ref in refs:
+        owners = records_holding(records, ref)
+        if len(owners) == 1 and owners[0] is rec and residency.in_use(ref):
+            return True
+    return False
+
+
+__all__ = ["record_in_use", "record_refs", "records_holding"]


### PR DESCRIPTION
th#1834 released **six** methods from its Phase-3 fence. This PR takes four of them and states plainly why the other two stay.

## DELETED — `Executor._vram_allocated`

A **third copy** of `models.memory.cuda_allocated_bytes`: same `is_available()` guard, same `torch.cuda.memory_allocated()` call, same zero-on-absence. That one is the canonical `__all__` export and is already the probe `cli/serve.py` uses for the identical load-delta measurement. **The supersessor exists and is cut over — so this is a deletion, not a move.** Five call sites repointed.

This is the peer's supersession rule applied as intended: *verify X exists and is cut over, not merely designed.*

## MOVED — the record query trio → `gen_worker/models/records.py`

`_record_refs` / `_records_holding` / `_record_in_use` are **pure queries**: they read records, jobs and residency and mutate nothing. That is exactly what makes them liftable without dragging the job engine along.

They take **what they read** — `self._classes.values()`, `self.jobs.values()`, `self.store.residency` — rather than a back-reference to the executor. A back-reference would re-import the whole executor and put us straight back where we started. They are **generic over the record type** so the concrete `_ClassRecord` survives the seam instead of being erased to a `Protocol` (mypy caught that erasure at four call sites; fixed with a bound `TypeVar` rather than a cast).

## STAYED, deliberately — `shutdown_instances` and `_vacate_record`

Both open with `await self.abandon_background_mint(...)`, which is **inside th#1834's frozen 17-method region**. They are *callers* of the frozen surface, not members of it — which is why they were correctly released to C — but **moving them would drag a frozen method across a module seam, which is precisely what the fence exists to prevent.** They now call the extracted queries and are otherwise untouched.

If th#1834 would rather these move too, that is one follow-up commit once their rewrite settles `abandon_background_mint`'s home. It should not happen while the method is frozen.

## Fence

None of the frozen 17 is touched. `_background_mint_run` / `_delegated_mint_run` / `_advertise_minted_cells` remain contiguous in the residual file, as that lane asked. The `_InjectionResult` seam is untouched by this PR — `_report_adoptions` is frozen and still reads `inj.adoptions` exactly as before.

## Verification

- strict mypy clean — **762 files**
- ruff clean
- all **13** fast-gate lint scripts green
- **102** residency/record tests green
- **The alias sweep that CI taught C1 was run BEFORE opening this**, not after: resolving every module alias bound to `gen_worker.executor` plus direct symbol imports and dotted references across `tests/`, `tests_v2/` **and** `src/` — **zero** references remain to any of the four removed methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)