### PR TITLE
th#1887: the behaviour-gate scanner can see the shape three gates were hiding in

### DIFF
--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -130,10 +130,10 @@ src/gen_worker/convert/ingest.py::COZY_CLONE_DOWNLOAD_ATTEMPTS STANDALONE COZY_C
 src/gen_worker/models/download.py::COZY_CIVITAI_DOWNLOAD_ATTEMPTS STANDALONE COZY_CIVITAI_DOWNLOAD_ATTEMPTS, provider retry count.
 src/gen_worker/net.py::$name STANDALONE COZY_HTTP_*_TIMEOUT_S. Documented as "read from env on every call (test-tunable)" - i.e. env used as a TEST SEAM, which is what loader `init_kwargs` exists for. Worth fixing; it is the last piece of prose from the old 5-file exception list that is still true.
 src/gen_worker/local_cell_store.py::GEN_WORKER_LOCAL_CELLS_DIR STANDALONE GEN_WORKER_LOCAL_CELLS_DIR, the local cell store's ROOT (pgw#1096 moved the accessor here from local_cells): a path relocation like TENSORHUB_CACHE_DIR, never a behavior knob, and a cross-repo contract with cozy-local's paths.go.
-src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODER STANDALONE GEN_WORKER_VIDEO_ENCODER. pgw#929 rules this MEASURED-then-requested (th#1458-1460 store the evidence, pgw#891 carries the exact requested implementation). Env until then.
+src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODER VIOLATION GEN_WORKER_VIDEO_ENCODER. th#1887: NOT standalone — video_encode.py is a serving hot path, not a CLI, and this read forks the encoder choice. Now also registered in BEHAVIOUR_GATES; deletion target pending a release-declaration check.
 src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODE_CONCURRENCY STANDALONE GEN_WORKER_VIDEO_ENCODE_CONCURRENCY, encode fan-out.
-src/gen_worker/models/native_kernels.py::GEN_WORKER_NATIVE_KERNELS STANDALONE GEN_WORKER_NATIVE_KERNELS, same measured-then-requested ruling as the video encoder.
-src/gen_worker/models/svdq.py::GEN_WORKER_SVDQ_ENGINE STANDALONE GEN_WORKER_SVDQ_ENGINE, same measured-then-requested ruling.
+src/gen_worker/models/native_kernels.py::GEN_WORKER_NATIVE_KERNELS VIOLATION GEN_WORKER_NATIVE_KERNELS. th#1887: NOT standalone — a serving-path rollout gate, not a CLI. Now also registered in BEHAVIOUR_GATES; deletion target pending a release-declaration check.
+src/gen_worker/models/svdq.py::GEN_WORKER_SVDQ_ENGINE VIOLATION GEN_WORKER_SVDQ_ENGINE. th#1887: NOT standalone — an in-code 'operational kill-switch' on the serving path. Now also registered in BEHAVIOUR_GATES; deletion target pending a release-declaration check.
 src/gen_worker/aot_resume.py::GEN_WORKER_MINT_RESUME_MAX_BYTES STANDALONE GEN_WORKER_MINT_RESUME_MAX_BYTES, resume-area capacity bound.
 src/gen_worker/aot_resume.py::GEN_WORKER_MINT_RESUME_DIR STANDALONE GEN_WORKER_MINT_RESUME_DIR. Operator override for the resume root; production wiring is `aot_resume.set_root` (pgw#1030 deleted the zero-caller `resume_enabled()` wrapper — `open_bank` states the decision).
 

--- a/scripts/lint_config_reads.py
+++ b/scripts/lint_config_reads.py
@@ -296,6 +296,40 @@ BEHAVIOUR_GATES: Dict[Tuple[str, str], str] = {
         "reaching a pod. Carries no behaviour of its own — its only outcome is "
         "a loud refusal.",
 
+    # ---------------------------------------------------------------------
+    # th#1887: found by the discriminated-locals pass, which is new. All four
+    # were INVISIBLE to the syntactic pass and sat misfiled as STANDALONE ("a
+    # CLI that loads no app config") in the allowlist, while living in serving
+    # hot-path modules. They are registered here rather than deleted because
+    # deletion needs one fact this box cannot produce: whether any published
+    # release DECLARES the variable in `endpoint_env_entries`. That is not
+    # hypothetical — GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF above is declared by
+    # five live SDXL releases, so "nothing sets it" is a hub query, not an
+    # assumption. Deleting a declared switch is exactly the
+    # GEN_WORKER_PREFER_AOT failure this whole gate exists to prevent.
+    # ---------------------------------------------------------------------
+    ("src/gen_worker/models/native_kernels.py", "GEN_WORKER_NATIVE_KERNELS"):
+        "th#1887 DELETION TARGET, pending a declaration check. Tri-state "
+        "rollout gate (unset/on/off) for the native-kernel path; unset means "
+        "the automatic choice, so deletion should be a no-op for every pod "
+        "that does not declare it. Threat while it lives: a dormant rollout "
+        "switch nobody re-tests, dark exactly like PREFER_AOT was.",
+    ("src/gen_worker/models/svdq.py", "GEN_WORKER_SVDQ_ENGINE"):
+        "th#1887 DELETION TARGET, pending a declaration check. Self-described "
+        "in-code as an 'operational kill-switch' that PINS the svdq engine for "
+        "the process; empty (the default) means choose per artifact and host. "
+        "Threat while it lives: a pinned engine outliving the incident it was "
+        "pinned for, silently serving a stale path on every later boot.",
+    ("src/gen_worker/video_encode.py", "GEN_WORKER_VIDEO_ENCODER"):
+        "th#1887 DELETION TARGET, pending a declaration check. Selects the "
+        "video encoder: 'auto' probes NVENC, 'x264' skips the probe entirely. "
+        "Threat while it lives: a pod pinned to x264 keeps encoding on CPU "
+        "after its GPU encoder starts working, and nothing reports the gap.",
+    ("src/gen_worker/parallel/group.py", "NCCL_NVLS_ENABLE"):
+        "READ-ONLY WARNING PREDICATE, same class as lifecycle.py above. Reads "
+        "the pre-imposition value only to decide whether to warn that the "
+        "settings authority overrode an ambient NCCL setting. Selects a log "
+        "line, never a code path — NOT a deletion target.",
 }
 
 #: Predicate-shaped function names: a `return <env read>` inside one of these is
@@ -303,24 +337,169 @@ BEHAVIOUR_GATES: Dict[Tuple[str, str], str] = {
 _PREDICATE_SUFFIXES = ("enabled", "disabled", "_on", "_off", "armed", "forced")
 
 
+#: Calls that only NORMALIZE a scalar without changing where it came from.
+#: Peeling these is what lets the taint pass see `str(os.environ.get(X) or
+#: "auto").strip().lower()` as a read, while refusing to peel `Path(...)`,
+#: `json.loads(...)` or a dict literal — which is the entire reason the pass
+#: does not drown in value config.
+_SCALAR_CASTS = ("str", "int", "float", "bool")
+_SCALAR_METHODS = ("strip", "lower", "upper", "lstrip", "rstrip", "casefold")
+
+#: Comparison operators that DISCRIMINATE a value against known alternatives.
+#: Truthiness (`if raw:`) is deliberately excluded: that is the dominant shape
+#: of genuine value config (`if not cache_dir: cache_dir = default`).
+_DISCRIMINATORS = (ast.Eq, ast.NotEq, ast.In, ast.NotIn)
+
+
+def _peel_scalar(node: ast.AST) -> ast.AST:
+    """Strip scalar-normalizing wrappers until the underlying expression shows.
+
+    Closed set on purpose. Anything not listed — `Path(...)`, `json.loads`,
+    arithmetic, a dict/list literal — is NOT peeled, so a read wrapped in it is
+    not treated as a gate. That single restriction is what keeps
+    TORCHINDUCTOR_CACHE_DIR and PYTHONHASHSEED out of the results.
+    """
+    while True:
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if (isinstance(fn, ast.Name) and fn.id in _SCALAR_CASTS
+                    and len(node.args) == 1):
+                node = node.args[0]
+                continue
+            if (isinstance(fn, ast.Attribute) and fn.attr in _SCALAR_METHODS):
+                node = fn.value
+                continue
+        # `os.environ.get(X) or "auto"` — the default-value idiom.
+        if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or) and node.values:
+            node = node.values[0]
+            continue
+        return node
+
+
+def _env_read_name(node: ast.AST, consts: Dict[str, str]) -> str | None:
+    """The env var name iff `node` ITSELF is an env read — never a nested one.
+
+    Root-only on purpose. Probing a whole subtree instead would treat
+    `Path(os.environ.get(X) or "")` and `{"seed": os.environ.get(X)}` as reads
+    bound to a local, which is how a directory path and a hash seed end up
+    accused of being behaviour gates. The read must survive peeling as the
+    WHOLE right-hand side.
+    """
+    probe = EnvVisitor()
+    probe.consts = dict(consts)
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            base = func.value
+            if ((isinstance(base, ast.Attribute) and base.attr == "environ")
+                    or (isinstance(base, ast.Name) and base.id == "environ")
+                    or (isinstance(base, ast.Name) and base.id == "os"
+                        and func.attr == "getenv")):
+                return probe._name(node.args[0] if node.args else None)
+        return None
+    if isinstance(node, ast.Subscript):
+        value = node.value
+        if ((isinstance(value, ast.Attribute) and value.attr == "environ")
+                or (isinstance(value, ast.Name) and value.id == "environ")):
+            return probe._name(node.slice)
+    return None
+
+
+def _literal_collections(tree: ast.AST) -> Set[str]:
+    """Module-level names bound to a collection of literals (svdq's SVDQ_ENGINES)."""
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target, value = node.targets[0], node.value
+        if (isinstance(target, ast.Name)
+                and isinstance(value, (ast.Tuple, ast.List, ast.Set))
+                and value.elts
+                and all(isinstance(e, ast.Constant) for e in value.elts)):
+            found.add(target.id)
+    return found
+
+
+def _is_literal_alternatives(node: ast.AST, collections: Set[str]) -> bool:
+    """True when `node` is a set of known alternatives to discriminate against."""
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (str, int, bool)) or node.value is None
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return bool(node.elts) and all(isinstance(e, ast.Constant) for e in node.elts)
+    # A module-level collection of literals, e.g. svdq.py's SVDQ_ENGINES.
+    return isinstance(node, ast.Name) and node.id in collections
+
+
 class BehaviourVisitor(ast.NodeVisitor):
     """Env reads whose value reaches a CONDITIONAL rather than a value slot.
 
-    Deliberately syntactic and conservative. It cannot follow a read through a
-    variable into an `if` three functions away, and it does not try — a gate
-    that pretends to completeness it does not have is worse than one whose
-    reach is stated. What it DOES catch is every shape the four switches
-    deleted by pgw#995 were written in, which is the shape this defect keeps
-    being written in.
+    Deliberately syntactic and conservative. What it catches is stated, and so
+    is what it does not — a gate that pretends to completeness it does not have
+    is worse than one whose reach is stated.
+
+    TWO passes, because one was not enough:
+
+    1. `_scan_conditions` — the read sits syntactically inside an `if`/`while`/
+       ternary/`assert` test, a comprehension guard, or the `return` of a
+       predicate-shaped function. Every switch deleted by pgw#995 was this
+       shape.
+
+    2. `_scan_discriminated_locals` (th#1887) — the read is assigned to a local
+       and that local is then discriminated against known alternatives
+       (`==`/`!=`/`in`/`not in`, or a `match` subject). This shape was
+       STRUCTURALLY INVISIBLE to pass 1, and three real gates were hiding in
+       it: GEN_WORKER_NATIVE_KERNELS, GEN_WORKER_SVDQ_ENGINE and
+       GEN_WORKER_VIDEO_ENCODER, all misfiled as STANDALONE. A registry that
+       cannot see a whole gate SHAPE is a guard that cannot fire, which is
+       worse than the three gates it missed.
+
+    Still out of reach, stated honestly: a read stored in a module-level
+    constant and branched on elsewhere; a read passed as a call argument to a
+    callee that branches; `BoolOp` short-circuit used as control flow; a read
+    hidden in a collection and reached by lookup.
     """
 
     def __init__(self) -> None:
         self.hits: List[Tuple[int, str]] = []
 
-    def _collect(self, node: ast.AST) -> None:
-        sub = EnvVisitor()
-        sub.visit(node)
-        self.hits.extend(sub.hits)
+    def _scan_discriminated_locals(
+        self, tree: ast.AST, consts: Dict[str, str], collections: Set[str]
+    ) -> None:
+        """Pass 2: read -> local -> discriminated against known alternatives."""
+        for scope in ast.walk(tree):
+            if not isinstance(scope, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            # Locals bound to a (scalar-normalized) env read, ROOT-ONLY: the
+            # read must be the whole right-hand side once wrappers are peeled.
+            tainted: Dict[str, Tuple[int, str]] = {}
+            for node in ast.walk(scope):
+                targets: List[ast.expr] = []
+                if isinstance(node, ast.Assign):
+                    targets = node.targets
+                elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                    targets = [node.target]
+                if len(targets) != 1 or not isinstance(targets[0], ast.Name):
+                    continue
+                if node.value is None:
+                    continue
+                peeled = _peel_scalar(node.value)
+                name = _env_read_name(peeled, consts)
+                if name is not None:
+                    tainted[targets[0].id] = (peeled.lineno, name)
+            if not tainted:
+                continue
+            for node in ast.walk(scope):
+                local = ""
+                if isinstance(node, ast.Compare) and isinstance(node.ops[0], _DISCRIMINATORS):
+                    left, right = node.left, node.comparators[0]
+                    if isinstance(left, ast.Name) and _is_literal_alternatives(right, collections):
+                        local = left.id
+                    elif isinstance(right, ast.Name) and _is_literal_alternatives(left, collections):
+                        local = right.id
+                elif isinstance(node, ast.Match) and isinstance(node.subject, ast.Name):
+                    local = node.subject.id
+                if local in tainted:
+                    self.hits.append(tainted.pop(local))
 
     def _scan_conditions(self, tree: ast.AST, consts: Dict[str, str]) -> None:
         for node in ast.walk(tree):
@@ -361,6 +540,8 @@ def scan_behaviour() -> Dict[Tuple[str, str], int]:
         consts.load_consts(tree)
         visitor = BehaviourVisitor()
         visitor._scan_conditions(tree, consts.consts)
+        visitor._scan_discriminated_locals(
+            tree, consts.consts, _literal_collections(tree))
         rel = str(path.relative_to(REPO))
         for lineno, name in visitor.hits:
             sites.setdefault((rel, name or UNRESOLVED), lineno)

--- a/tests/test_behaviour_gate_visitor_th1887.py
+++ b/tests/test_behaviour_gate_visitor_th1887.py
@@ -1,0 +1,124 @@
+"""th#1887: the behaviour-gate scanner must see the discriminated-locals shape.
+
+`scripts/lint_config_reads.py` enforces BEHAVIOUR_GATES bidirectionally, so an
+undeclared gate fails CI. But its scanner was purely syntactic: a read counted
+only if it landed inside an `if` test or a predicate function's `return`. Three
+real gates lived in a shape it could not see at all — read into a local, then
+discriminated against a set of known strings — and sat misfiled as STANDALONE.
+
+A registry that cannot see a whole gate SHAPE is a guard that cannot fire, which
+is worse than the gates it misses: it reports OK. These tests pin the shape, not
+the three instances, so the pass cannot be quietly narrowed back.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "lint_config_reads", REPO / "scripts" / "lint_config_reads.py")
+assert _spec and _spec.loader
+lint = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint)
+
+
+def _scan(source: str) -> set[str]:
+    """Env names the behaviour scanner finds in one module of source."""
+    tree = ast.parse(source)
+    consts = lint.EnvVisitor()
+    consts.load_consts(tree)
+    visitor = lint.BehaviourVisitor()
+    visitor._scan_conditions(tree, consts.consts)
+    visitor._scan_discriminated_locals(
+        tree, consts.consts, lint._literal_collections(tree))
+    return {name for _, name in visitor.hits}
+
+
+def test_read_into_local_then_compared_is_a_gate() -> None:
+    assert "X_MODE" in _scan(
+        'import os\n'
+        'def pick():\n'
+        '    mode = os.environ.get("X_MODE", "auto").strip().lower()\n'
+        '    if mode == "x264":\n'
+        '        return 1\n'
+        '    return 2\n')
+
+
+def test_membership_against_a_module_level_tuple_is_a_gate() -> None:
+    """svdq's shape: `raw not in SVDQ_ENGINES`, the alternatives named elsewhere."""
+    assert "X_ENGINE" in _scan(
+        'import os\n'
+        'ENGINES = ("a", "b")\n'
+        '_ENV = "X_ENGINE"\n'
+        'def override() -> str:\n'
+        '    raw = str(os.environ.get(_ENV, "") or "").strip().lower()\n'
+        '    if raw and raw not in ENGINES:\n'
+        '        raise ValueError(raw)\n'
+        '    return raw\n')
+
+
+def test_match_subject_is_a_gate() -> None:
+    assert "X_KIND" in _scan(
+        'import os\n'
+        'def pick():\n'
+        '    kind = os.environ.get("X_KIND", "")\n'
+        '    match kind:\n'
+        '        case "fast":\n'
+        '            return 1\n'
+        '    return 0\n')
+
+
+def test_a_path_built_from_env_is_not_a_gate() -> None:
+    """The read must be the WHOLE right-hand side once scalar wrappers peel.
+
+    Without the root-only rule this pass accuses TORCHINDUCTOR_CACHE_DIR and
+    PYTHONHASHSEED — a cache directory and a hash seed — of being behaviour
+    switches, which is the false-positive flood that would get it turned off.
+    """
+    # The discriminator is deliberately a BARE NAME against a string constant,
+    # so the ONLY thing that can keep this out of the results is the root-only
+    # peel rule. Written the obvious way (`if str(base) == "/tmp"`) the test
+    # would pass even with that rule deleted — a false-clean.
+    assert "X_DIR" not in _scan(
+        'import os\n'
+        'from pathlib import Path\n'
+        'def where():\n'
+        '    base = Path(os.environ.get("X_DIR", "") or "")\n'
+        '    if base == "/tmp":\n'
+        '        return None\n'
+        '    return base\n')
+
+
+def test_env_inside_a_dict_literal_is_not_a_gate() -> None:
+    assert "X_SEED" not in _scan(
+        'import os\n'
+        'def seal():\n'
+        '    base = {"seed": os.environ.get("X_SEED", "")}\n'
+        '    if base == "sentinel":\n'
+        '        return None\n'
+        '    return base\n')
+
+
+def test_truthiness_alone_is_not_a_gate() -> None:
+    """`if not x: x = default` is the dominant shape of genuine value config."""
+    assert "X_URL" not in _scan(
+        'import os\n'
+        'def url():\n'
+        '    u = os.environ.get("X_URL", "")\n'
+        '    if not u:\n'
+        '        u = "https://default"\n'
+        '    return u\n')
+
+
+def test_the_three_th1887_gates_are_still_seen_in_the_real_tree() -> None:
+    """Instance-level backstop for the shape tests above."""
+    found = set(lint.scan_behaviour())
+    for site in (
+        ("src/gen_worker/video_encode.py", "GEN_WORKER_VIDEO_ENCODER"),
+        ("src/gen_worker/models/svdq.py", "GEN_WORKER_SVDQ_ENGINE"),
+        ("src/gen_worker/models/native_kernels.py", "GEN_WORKER_NATIVE_KERNELS"),
+    ):
+        assert site in found, f"{site} went invisible again"


### PR DESCRIPTION
`BEHAVIOUR_GATES` is enforced bidirectionally, so an undeclared gate fails CI. But the scanner was purely **syntactic**: a read counted only if it landed inside an `if`/`while`/ternary/`assert` test, a comprehension guard, or the `return` of a `-> bool`-annotated or predicate-named function.

Three real gates lived in a shape it could not see **at all** — read into a local, then discriminated against a set of known strings — and all three sat misfiled as `STANDALONE` ("a CLI that loads no app config") while living in serving hot-path modules:

| gate | shape |
|---|---|
| `GEN_WORKER_NATIVE_KERNELS` | `raw = os.environ.get(...).strip().lower()` → `if raw in (...)` |
| `GEN_WORKER_SVDQ_ENGINE` | `raw = str(os.environ.get(...) or "").strip().lower()` → `if raw not in SVDQ_ENGINES` |
| `GEN_WORKER_VIDEO_ENCODER` | `mode = (os.environ.get(...) or "auto").strip().lower()` → `if mode == "x264"` |

**A registry that cannot see a whole gate SHAPE is worse than one that misses three gates: it reports OK.**

## The fix

Adds `_scan_discriminated_locals`. A local bound to a scalar-normalized env read is *tainted*; a taint discriminated by `==`/`!=`/`in`/`not in` against literal alternatives — or used as a `match` subject — is a gate.

**Two restrictions do the real work, and both were measured against the tree rather than guessed:**

- **Root-only** — the read must be the *whole* right-hand side once wrappers peel. Probing the subtree instead accuses `Path(os.environ.get(...))` and `{"seed": os.environ.get(...)}` — a cache directory and a hash seed — of being behaviour switches.
- **Discrimination, not truthiness** — `if not x: x = default` is the dominant shape of genuine value config. Including it flagged **30 sites, 27 of them noise**.

Peeling is a closed set (`str`/`int`/`float`/`bool`, `strip`/`lower`/`upper`/`casefold`, and the `or default` idiom). `Path`, `json.loads`, arithmetic and collection literals are deliberately **not** peeled.

A rejected alternative, for the record: widening the return-annotation rule to `Optional[bool]`/`str` catches **zero** of the three (their `return` values are bare names and constants, never env reads) and adds 4 false positives. Strictly worse.

**Net: 12 detected sites → 16.** The census is unchanged at **73 pairs** — this reclassifies existing reads, it does not find new ones. If that number moves, the census changed, not the gate.

## Why these are registered rather than deleted

Paul's rule says a behaviour gate ends activated-or-deleted, and three of these are genuine deletion targets. **Deletion needs one fact this box cannot produce: whether any published release DECLARES the variable in `endpoint_env_entries`.**

That is not hypothetical — `GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF` is declared by **five live SDXL releases**. So "nothing sets it" is a hub query, not an assumption, and deleting a declared switch is precisely the `GEN_WORKER_PREFER_AOT` failure this gate exists to prevent. They are registered as **`th#1887 DELETION TARGET`** with the threat each poses while it lives, and their allowlist rows corrected `STANDALONE` → `VIOLATION`.

`NCCL_NVLS_ENABLE` (the 4th find) is **not** a deletion target — a read-only warning predicate that selects a log line, same class as the already-registered `lifecycle.py` entry.

## Verification

`uv run python scripts/lint_config_reads.py` → `OK — 73 accepted (file, variable) pair(s), all classified.`

New `tests/test_behaviour_gate_visitor_th1887.py` (7 tests) pins the **shape**, not the three instances, so the pass cannot be quietly narrowed back.

**Red-proofed in three directions:**
1. Drop one registry entry → the undeclared-gate error fires on `video_encode.py:125`.
2. Disable the new pass → all four go stale ("no such conditional env read exists any more").
3. Neuter the root-only rule → the two false-positive tests fail.

**One of those proofs caught a bug in my own tests.** The false-positive tests were initially false-clean: they compared `str(base) == "/tmp"` rather than a bare name, so the discriminator never matched and they passed *even with the root-only rule deleted*. Fixed to discriminate a bare `Name`, so the rule is the only thing holding them — which is the condition under which a green result means something.

Refs: th#1887, §1.18, §4.22, pgw#931, pgw#995.
