### PR TITLE
pgw#1224 (th#1834 Phase 2): the batch compiled-graph wire — keys[] in, one signed answer per key out; entries[] in, one token each out

### DIFF
--- a/changelog.d/pgw1224.md
+++ b/changelog.d/pgw1224.md
@@ -1,0 +1,27 @@
+- **BREAKING (pgw#1224, th#1834 Phase 2) — the worker speaks the BATCH cell wire.**
+  `POST /v1/worker/cells/resolve` now carries `{family, keys[<=256]}` and
+  `POST /v1/worker/cells/publish-intent` carries `{family, axes, entries[<=256]}`.
+  The single-key `{family, cell_key}` and single-entry bodies are **gone** — no
+  alias, no dual-accept, no negotiation. `cell_resolve.resolve()` is replaced by
+  `cell_resolve.resolve_batch()`, which returns one `ResolveAnswer` per requested
+  key in request order; `CellPublisher.publish_intent()` returns one `PublishGrant`
+  per entry, each carrying its own capability token.
+
+  This wheel requires a hub carrying tensorhub th#1842 (#1118 + #1121). The two
+  halves are one fleet: an older hub refuses these bodies and a newer hub refuses
+  the old ones.
+
+  Why: under the per-entry atom (pgw#1176) a boot derives one key per graph class —
+  18-36 for sdxl, 198 for minimax-h3 — so a per-key wire billed a boot that many
+  round trips for one answer set, and one sdxl mint issued 36 publish-intents each
+  carrying full axis attestation. A boot now resolves its whole manifest in ONE
+  call and `aot_mint.publish` pays ONE attested intent per mint.
+
+  Four properties the client enforces, because each is a way a batch could lie and
+  none is checked downstream: **arity** (a short answer is indistinguishable from a
+  batch of misses, and a pod answers a miss by paying for a cold mint), **order**
+  (position AND the echoed key), **per-answer signing** (each hit carries its own
+  receipt; a batch-level signature field is refused, and two answers sharing one
+  receipt is the same fault wearing a different hat), and **a per-key fault does not
+  sink the batch** — `ambiguous`/`incomplete`/`transport_unavailable` are per-answer
+  statuses now, carrying the same typed codes they had as whole-request refusals.

--- a/scripts/credential_identity_allowlist.txt
+++ b/scripts/credential_identity_allowlist.txt
@@ -72,4 +72,4 @@ src/gen_worker/lifecycle.py::Lifecycle.__init__::bootstrap_worker_jwt  RELAYED  
 # DIAGNOSTIC — a log/annotation that degrades to silence in the child, never a
 # decision.
 # ---------------------------------------------------------------------------
-src/gen_worker/fleet_cells.py::CellPublisher.publish::worker_jwt  DIAGNOSTIC  th#1423 401 blame ("N s past its own exp"); silent under the split, where the parent presented the token
+src/gen_worker/fleet_cells.py::CellPublisher.publish_intent::worker_jwt  DIAGNOSTIC  th#1423 401 blame ("N s past its own exp"); silent under the split, where the parent presented the token

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -215,7 +215,7 @@ def verify_declared_identity(
             # An expectation that names no value cannot be verified, and an
             # unverifiable expectation must not read as a pass. BOTH sources
             # refuse an artifact missing any of these at the point they read
-            # it — `plan._artifact` and `cell_resolve.resolve` — so reaching
+            # it — `plan._artifact` and `cell_resolve.resolve_batch` — so reaching
             # this branch means a caller built an ExpectedIdentity by hand.
             return f"{axis}: the spec named no expected value"
         if want != got:

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -4628,29 +4628,6 @@ class _CallableTarget:
 # ---------------------------------------------------------------------------
 
 
-def publish_entry(
-    row: MintedArtifact, publisher: Any, mint_duration_ms: int = 0,
-) -> str:
-    """Publish ONE minted entry through a ``fleet_cells.CellPublisher``.
-
-    Receipts are the HUB's business: it adds them at publish-finalize (#709),
-    so the producer's whole obligation is a keyed ``metadata.json`` inside the
-    tar — which :func:`mint` has already stamped and proven. Refuses before the
-    wire when the artifact carries no key, since an unaddressable entry would
-    be stored under a flavor nothing can request.
-
-    pgw#1176: publish is PER ENTRY, and a failure is per entry. Nothing waits
-    for a set; nothing is rolled back because a sibling failed.
-    """
-    if not row.key:
-        raise MintRefused("cannot publish an artifact with no cell_key")
-    family = str(row.metadata.get("family") or "")
-    if not family:
-        raise MintRefused("cannot publish an artifact with no family")
-    return str(publisher.publish(
-        family, row.artifact, dict(row.metadata), int(mint_duration_ms)))
-
-
 def publish(result: MintResult, publisher: Any) -> Dict[str, str]:
     """Publish every compiled graph a mint produced. ``{key -> checkpoint}``.
 
@@ -4661,11 +4638,20 @@ def publish(result: MintResult, publisher: Any) -> Dict[str, str]:
     stay per entry because the grants are — a token for entry 5 cannot publish
     entry 6's bytes.
 
-    Failures are NOT swallowed and not collected: the first refusal raises, so
-    a caller that wants best-effort per-entry publishing drives
-    :func:`publish_entry` itself and decides what a partial set means. What
-    changed under pgw#1176 is that a partial set is now a coherent outcome
-    rather than a broken cell.
+    Failures are NOT swallowed and not collected: the first refusal raises. A
+    caller that wants best-effort per-entry publishing drives the two halves
+    itself — one ``publish_intent`` for the batch, then ``publish_granted`` per
+    entry — and decides what a partial set means. (``publish_entry`` used to be
+    that seam and is DELETED with the per-entry intent it wrapped: under the
+    batch wire it would have issued one attested intent per artifact, which is
+    the cost this change exists to remove.) What changed under pgw#1176 is that
+    a partial set is now a coherent outcome rather than a broken cell.
+
+    Receipts are the HUB's business: it adds them at publish-finalize (#709),
+    so the producer's whole obligation is a keyed ``metadata.json`` inside the
+    tar — which :func:`mint` has already stamped and proven. An artifact with
+    no key is refused before the wire, since an unaddressable entry would be
+    stored under a flavor nothing can request.
     """
     from . import fleet_cells
 
@@ -4923,7 +4909,6 @@ __all__ = [
     "MINT_COMPILE_THREADS",
     "MintResult",
     "MintedArtifact",
-    "publish_entry",
     "autotune_posture",
     "bench_step",
     "cell_identity",

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -4652,7 +4652,14 @@ def publish_entry(
 
 
 def publish(result: MintResult, publisher: Any) -> Dict[str, str]:
-    """Publish every entry a mint produced. ``{entry key -> checkpoint}``.
+    """Publish every compiled graph a mint produced. ``{key -> checkpoint}``.
+
+    ONE attested intent for the whole mint (pgw#1224 / th#1842 PR #1121), then
+    one transfer per entry under that entry's OWN token. This is the caller the
+    batch wire exists for: it holds every artifact of a mint at once, so a
+    36-class sdxl mint pays one axis attestation instead of 36. The transfers
+    stay per entry because the grants are — a token for entry 5 cannot publish
+    entry 6's bytes.
 
     Failures are NOT swallowed and not collected: the first refusal raises, so
     a caller that wants best-effort per-entry publishing drives
@@ -4660,14 +4667,46 @@ def publish(result: MintResult, publisher: Any) -> Dict[str, str]:
     changed under pgw#1176 is that a partial set is now a coherent outcome
     rather than a broken cell.
     """
+    from . import fleet_cells
+
+    rows = list(result.entries)
+    if not rows:
+        return {}
     # th#1355: the mint pod already measured this (timings["total_s"]), so the
     # cell's own cell_store row records what it cost to build instead of the
     # cost living only in an activity event that carries no cell key.
     mint_duration_ms = max(0, int(round(
         float(result.timings.get("total_s") or 0.0) * 1000)))
+    family = ""
+    entries = []
+    sku = gen_worker = ""
+    for row in rows:
+        if not row.key:
+            raise MintRefused("cannot publish an artifact with no cell_key")
+        row_family = str(row.metadata.get("family") or "")
+        if not row_family:
+            raise MintRefused("cannot publish an artifact with no family")
+        if family and row_family != family:
+            # The family is the batch's namespace and the hub attests it once.
+            # A mint spanning two would have to be two intents, and silently
+            # publishing the second under the first's declaration is how a row
+            # lands in a namespace nobody asked for.
+            raise MintRefused(
+                f"this mint's entries name two families ({family!r} and "
+                f"{row_family!r}); one intent declares one family")
+        family = row_family
+        entry, row_sku, row_gen_worker = fleet_cells.intent_entry(
+            family, dict(row.metadata), mint_duration_ms)
+        sku = sku or row_sku
+        gen_worker = gen_worker or row_gen_worker
+        entries.append(entry)
+    batch = publisher.publish_intent(
+        family, entries, sku=sku, gen_worker=gen_worker)
     return {
-        row.key: publish_entry(row, publisher, mint_duration_ms)
-        for row in result.entries
+        row.key: str(publisher.publish_granted(
+            family, row.artifact, dict(row.metadata),
+            batch.grant_for(row.key), repo=batch.repo))
+        for row in rows
     }
 
 

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -3,14 +3,17 @@
 ONE function, and it is the whole of §4.27's first three steps for a serving
 pod:
 
-1. **Derive** the ``ck1`` key from code alone — ``boot_key.derive``, process-
-   parallel structure-only traces, no weight resident anywhere.
+1. **Derive** the ``cg-key-v1`` key SET from code alone — ``boot_key.derive``,
+   process-parallel structure-only traces, no weight resident anywhere. One key
+   per graph class (pgw#1176), not one per pod.
 2. **Ask THIS MACHINE first** (pgw#1127 S2, §4.28) — ``local_cell_store.
    lookup(key)``. The derived key is the local store's own address, so an
    offline machine holding the exact cell it needs answers here and no hub is
    asked at all. ONE key, TWO lookup routes, the same CAS.
-3. **Ask the hub** by that key — ``cell_resolve.resolve``, ONE artifact or a
-   MISS, never a listing.
+3. **Ask the hub** for everything the machine did not hold, in ONE call —
+   ``cell_resolve.resolve_batch`` (pgw#1224), which answers each requested key
+   with one independently signed answer, in request order. Exact keys in, rows
+   for exactly those keys out: never a listing.
 4. **Materialize** a hit through the EXISTING delivery path and hand the
    caller an admission expectation, so the arm runs the gates the Plan path
    runs and not one gate fewer.
@@ -26,7 +29,7 @@ That is false on exactly the machines §4.28 is about. It survives in the
 honest form — :data:`GATE_REASONS`' ``no_cell_source``, which refuses only when
 BOTH answerers are absent (no hub AND an empty local store).
 
-A MISS returns ``None`` and that is a complete answer: the pod serves eager,
+A MISS is a complete answer, not an absence: the pod serves eager,
 mints in the background (§4.28: trusted hardware publishes, untrusted keeps it
 local) and the request path waits for none of it (pgw#1091).
 
@@ -68,7 +71,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from . import (
     activity, aot_identity, artifact_meta, boot_key, cell_resolve,
@@ -159,7 +162,7 @@ DERIVE_REASONS: Tuple[str, ...] = (
 #: The hub's own typed refusal codes ride through verbatim, which is the point
 #: of them being typed.
 ASK_REASONS: Tuple[str, ...] = (
-    "invalid_request", "cell_resolve_key_mismatch", "resolve_unreachable",
+    "invalid_request", "resolve_unreachable",
     "miss", "materialize_failed", "witness_unreadable",
     "graph_witness_mismatch", "hit",
     # pgw#1122 — the LAST terminus, and the one the journey previously ran off
@@ -489,92 +492,116 @@ def attempt(
     # and a "the boot adopted" boolean over 36 classes is exactly the claim
     # that could lie.
     #
-    # PHASE 2 slots the batch resolve in HERE: the loop below issues one
-    # `cell_resolve.resolve` per key, which is correct and is what the hub
-    # answers today; when the hub grows `POST /v1/worker/cells/resolve`
-    # {family, keys[]} -> one signed answer per key, this becomes one call and
-    # the per-key bodies consume its answers unchanged.
+    # pgw#1224 lands PHASE 2's batch wire HERE: this machine is asked per key
+    # (a local stat, no wire) and the hub is asked ONCE for everything the
+    # machine did not already hold. A 36-class sdxl boot went from 36 resolve
+    # round trips to one; minimax-h3 from 198 to one.
     keys = derived.keys
     if not keys:
         return (report(BootAdoptOutcome(
             reason="derive_failed",
             detail="the declaration traced to no graph class at all",
             derive_ms=derived.wall_ms, family=family, function=fn)),)
-    return tuple(
-        _attempt_key(
-            key, derived, family=family, fn=fn, cache_dir=cache_dir,
-            base_url=base_url, bearer=bearer, hub_absent=hub_absent)
-        for key in keys)
+    logger.info(
+        "boot-adopt: %s asking for %d key(s) (manifest %s, %d class(es), "
+        "K=%d, memo=%s, derived in %d ms)",
+        family, len(keys), derived.manifest, derived.traced, derived.workers,
+        derived.memo, derived.wall_ms)
+
+    # ── §4.28 / pgw#1127: THIS MACHINE, before the wire ────────────────────
+    # The derived key is the local store's own address. A machine that minted
+    # this graph on an earlier boot answers here and the hub is never asked for
+    # it — which is what "never requested" means and what makes an offline box
+    # arm exactly as well as an online one. Costs one stat per key on the fleet
+    # path, where the store is always empty.
+    settled: Dict[str, BootAdoptOutcome] = {}
+    ask: List[str] = []
+    for key in keys:
+        local = _local_answer(key, derived, family=family, fn=fn)
+        if local is not None:
+            settled[key] = local
+        elif hub_absent:
+            # Derived, asked this machine, and there is nobody else. A
+            # DIFFERENT fact from `no_cell_source` (which never derived) and
+            # from `miss` (which asked a hub): this one says the key exists and
+            # nothing here holds it.
+            settled[key] = report(BootAdoptOutcome(
+                reason="local_miss_no_hub", detail=hub_absent,
+                derived_key=key, derive_ms=derived.wall_ms,
+                family=family, function=fn))
+        else:
+            ask.append(key)
+
+    answers: Dict[str, cell_resolve.ResolveAnswer] = {}
+    refused: Tuple[str, str] = ("", "")
+    if ask:
+        try:
+            for answer in cell_resolve.resolve_batch(
+                    family, ask, base_url=base_url, bearer=bearer):
+                answers[answer.compiled_graph_key] = answer
+        except cell_resolve.CellResolveRefused as exc:
+            # A WHOLE-BATCH refusal is a fact about the caller or the request,
+            # so it is true of every key in the batch and each one reports it
+            # under the hub's own code. A typed refusal is NOT a miss — reading
+            # it as one sends the pod to a full cold mint per key believing the
+            # hub holds nothing, which is false and expensive. It still
+            # degrades to the old boot; it is the SENTENCE that differs, and
+            # that sentence is what gets the hub fixed.
+            refused = (exc.code or "resolve_unreachable", exc.detail)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("boot-adopt: resolve call failed", exc_info=True)
+            refused = ("resolve_unreachable", f"{type(exc).__name__}: {exc}")
+
+    out: List[BootAdoptOutcome] = []
+    for key in keys:
+        done = settled.get(key)
+        if done is not None:
+            out.append(done)
+            continue
+        if refused[0]:
+            out.append(report(BootAdoptOutcome(
+                reason=refused[0], detail=refused[1], derived_key=key,
+                derive_ms=derived.wall_ms, family=family, function=fn)))
+            continue
+        out.append(_adopt_answer(
+            answers[key], derived, family=family, fn=fn, cache_dir=cache_dir))
+    return tuple(out)
 
 
-def _attempt_key(
-    key: str,
+def _adopt_answer(
+    answer: cell_resolve.ResolveAnswer,
     derived: "boot_key.DerivedKey",
     *,
     family: str,
     fn: str,
     cache_dir: Optional[Path],
-    base_url: str,
-    bearer: str,
-    hub_absent: str,
 ) -> BootAdoptOutcome:
-    """Ask this machine, then the hub, for ONE derived entry key.
+    """Turn ONE of the batch's answers into this graph class's outcome.
 
-    A miss, a refusal or a witness mismatch here costs THIS graph class. Its
-    siblings are resolved by their own keys and are not affected — which is
-    what makes a partial hit useful instead of a total miss.
+    A miss, a per-answer hub fault, or a witness mismatch here costs THIS graph
+    class. Its siblings were answered by their own keys in the same batch and
+    are not affected — which is what makes a partial hit useful instead of a
+    total miss, and it is the property the per-answer signing buys: nothing
+    about this answer's trust depends on the collection it arrived in.
     """
-    logger.info(
-        "boot-adopt: %s asking for %s (manifest %s, %d class(es), K=%d, "
-        "memo=%s, derived in %d ms)",
-        family, key, derived.manifest, derived.traced, derived.workers,
-        derived.memo, derived.wall_ms)
-
-    # ── §4.28 / pgw#1127: THIS MACHINE, before the wire ────────────────────
-    # The derived key is the local store's own address. A machine that minted
-    # this cell on an earlier boot answers here, and the hub is not asked at
-    # all — which is what "never requested" means and what makes an offline
-    # box arm exactly as well as an online one. Costs one stat on the fleet
-    # path, where the store is always empty.
-    local = _local_answer(key, derived, family=family, fn=fn)
-    if local is not None:
-        return local
-    if hub_absent:
-        # Derived, asked this machine, and there is nobody else. A DIFFERENT
-        # fact from `no_cell_source` (which never derived) and from `miss`
-        # (which asked a hub): this one says the key exists and nothing here
-        # holds it.
+    key = answer.compiled_graph_key
+    if answer.refusal_code:
+        # ambiguous / incomplete / transport_unavailable — a HUB-SIDE fault
+        # about this one key, carrying the code it carried when the same fault
+        # refused a whole request. Not a miss, and the pod must not mint over
+        # it.
         return report(BootAdoptOutcome(
-            reason="local_miss_no_hub", detail=hub_absent,
+            reason=answer.refusal_code, detail=answer.detail,
             derived_key=key, derive_ms=derived.wall_ms,
             family=family, function=fn))
-
-    try:
-        cell = cell_resolve.resolve(
-            family, key, base_url=base_url, bearer=bearer)
-    except cell_resolve.CellResolveRefused as exc:
-        # A typed refusal is NOT a miss — treating it as one sends the pod to
-        # a full cold mint believing the hub holds nothing, which is false and
-        # expensive. It still degrades to the old boot; it is the SENTENCE
-        # that differs, and that sentence is what gets the hub fixed.
-        return report(BootAdoptOutcome(
-            reason=exc.code or "resolve_unreachable", detail=exc.detail,
-            derived_key=key, derive_ms=derived.wall_ms,
-            family=family, function=fn))
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("boot-adopt: resolve call failed", exc_info=True)
-        return report(BootAdoptOutcome(
-            reason="resolve_unreachable", detail=f"{type(exc).__name__}: {exc}",
-            derived_key=key, derive_ms=derived.wall_ms,
-            family=family, function=fn))
-
+    cell = answer.cell
     if cell is None:
         # A pod that DERIVED a key and was told MISS is a different fact from a
         # pod that never derived one — `derived_key` is what tells them apart,
         # and it is on the event.
         return report(BootAdoptOutcome(
             reason="miss",
-            detail=f"the hub holds no entitled cell for {key}",
+            detail=f"the hub holds no entitled compiled graph for {key}",
             derived_key=key, derive_ms=derived.wall_ms,
             family=family, function=fn))
 

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -180,6 +180,13 @@ _DIGEST_HEX = 56
 _REQUIRED = ("graph", "sm", "toolchain")
 _OPTIONAL: tuple = ()
 
+#: The same three, public, because the PUBLISH WIRE has to name them: every
+#: batched entry restates all three (pgw#1224 / th#1842 PR #1121), so the
+#: enumeration the wire enforces and the enumeration the key is built from must
+#: be ONE list. Two copies of an axis set is how a wire starts accepting a row
+#: that cannot restate its own key.
+KEY_AXES: Tuple[str, ...] = _REQUIRED
+
 #: The `kind` METADATA value of an exported .pt2 entry — the only publishable
 #: kind since pgw#1010, and since pgw#1059 a compat-gate fact rather than a
 #: key axis (`aot_serve.verify_declared` refuses on it by name).
@@ -571,6 +578,7 @@ def manifest_digest(class_hashes: Iterable[str]) -> str:
 
 
 __all__ = [
+    "KEY_AXES",
     "KEY_SCHEME",
     "EXPORTED_KIND",
     "EXPORT_ENVELOPE_KEY",

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -345,9 +345,11 @@ def _require_batch(family: str, keys: Sequence[str]) -> Tuple[str, Tuple[str, ..
         if not cell_key.is_key(key):
             raise CellResolveRefused(
                 "invalid_request",
-                f"keys[{i}] is {key!r}, which is not a compiled-graph key; the "
-                f"resolve route addresses compiled graphs by "
-                f"{cell_key.KEY_SCHEME}-<hex digest> and by nothing else")
+                f"keys[{i}] is {key!r}, which is not a compiled-graph key; "
+                f"the resolve route addresses compiled graphs by "
+                f"<scheme>-<lowercase hex digest> and by nothing else. The "
+                f"grammar rules on SHAPE, never scheme (th#1183): a newer "
+                f"fleet's key is addressable here and is ruled on by its axes")
         if key in seen:
             # Answers are POSITIONAL. The hub refuses a repeat for that reason
             # and so does this: collapsing it would shift every later answer

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -34,12 +34,50 @@ axes plus ``materialize_named_artifact``'s two arguments.
 
 A MISS is one shape
 -------------------
-``200 {"found": false}``, byte-identical whether the key is absent, scoped out
-or quarantined. That indistinguishability is the point: a distinguishable
-refusal is an existence oracle across tenants. Refusals (409/400/503) are TYPED
-and are NOT misses — a pod that read ``cell_resolve_incomplete`` as "no cell"
-would go pay for a full cold mint believing the hub holds nothing, which is
-false and expensive.
+``{"status": "miss", "found": false}``, byte-identical whether the key is
+absent, scoped out or quarantined. That indistinguishability is the point: a
+distinguishable refusal is an existence oracle across tenants. Refusals are
+TYPED and are NOT misses — a pod that read ``incomplete`` as "no cell" would go
+pay for a full cold mint believing the hub holds nothing, which is false and
+expensive.
+
+pgw#1224 — THE BATCH WIRE (th#1834 Phase 2, hub half th#1842 PR #1118)
+----------------------------------------------------------------------
+The request is ``{family, keys[<=256]}`` and the answer is one entry per key,
+**in request order, each independently signed**. The single-key
+``{family, cell_key}`` shape is GONE — hard cut, no alias, no dual-accept, no
+negotiation: a client that could speak both would make the hub's own hard cut
+unprovable, and there is no released consumer to protect.
+
+Why batch at all: under the per-entry atom (pgw#1176) a boot derives ONE KEY
+PER GRAPH CLASS — 18-36 for sdxl, 198 for minimax-h3 — so a per-key wire makes
+a boot pay that many round trips for one answer set. The entitlement inputs
+(the caller's endpoint, its viewer org) are properties of the CALLER, so the
+hub resolves them once per batch instead of once per key.
+
+Four properties this client ENFORCES, because each is a way the answer could
+lie and none of them is checked anywhere downstream:
+
+1. **ARITY.** ``len(answers) == len(keys)``, always. A short answer is
+   indistinguishable from a batch of misses, and a pod answers a miss by paying
+   for a full cold mint — so a dropped answer is not a smaller reply, it is a
+   wrong one that costs money.
+2. **ORDER.** ``answers[i]`` answers ``keys[i]``. The hub echoes each key, so
+   the position AND the echo are checked; either alone would admit a batch
+   whose answers were transposed by a middlebox that preserved the other.
+3. **PER-ANSWER SIGNATURE, never per-batch.** Every hit carries ITS OWN receipt
+   — the hub's signature over THAT compiled graph, minted at publish. There is
+   deliberately no signature over the batch, so a batch-level signature field
+   is REFUSED rather than ignored: it would make the COLLECTION the unit of
+   trust, which is the exact mistake th#1834 is undoing one layer down. Two
+   answers sharing one receipt is the same fault wearing a different hat.
+4. **A PER-KEY FAULT DOES NOT SINK THE BATCH.** Ambiguity, incompleteness and
+   transport-unavailability were whole-request refusals; they are per-answer
+   STATUSES now, carrying the SAME typed codes they had as refusals so the
+   caller's vocabulary is unchanged. One duplicated row costs one graph class,
+   not a boot's whole adoption. The refusals that stay whole-batch are the ones
+   that are properties of the CALLER — answering those per key would report a
+   hub fault as 256 misses.
 """
 
 from __future__ import annotations
@@ -47,7 +85,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from . import aot_identity, boot_phases, cell_key
 from .procsplit import broker
@@ -62,12 +100,49 @@ RESOLVE_PATH = "/v1/worker/cells/resolve"
 #: is a boot that never serves.
 RESOLVE_TIMEOUT_S = 30.0
 
-#: The hub's typed refusal codes. NOT misses — see the module docstring.
+#: The hub's bound on one batch (``maxCellResolveKeys``). Mirrored rather than
+#: discovered: over it the hub answers a NAMED 400 for the WHOLE batch, so a
+#: caller that split late would lose every key's answer to learn the number.
+MAX_RESOLVE_KEYS = 256
+
+#: One key's outcome. ``hit`` and ``miss`` are answers; the other three are
+#: HUB-SIDE faults the pod must read and must NOT self-mint over.
+STATUS_HIT = "hit"
+STATUS_MISS = "miss"
+STATUS_AMBIGUOUS = "ambiguous"
+STATUS_INCOMPLETE = "incomplete"
+STATUS_TRANSPORT_UNAVAILABLE = "transport_unavailable"
+
+#: A per-answer status -> the typed code the caller already speaks. These three
+#: were WHOLE-REQUEST refusals before the batch wire; the fault is the same
+#: fact, so it keeps the same name and only its blast radius shrank. Mapping
+#: rather than renaming is what keeps ``boot_adopt.ASK_REASONS`` and every
+#: dashboard grouping on those codes working across the cut.
+_STATUS_REFUSAL_CODE = {
+    STATUS_AMBIGUOUS: "cell_resolve_ambiguous",
+    STATUS_INCOMPLETE: "cell_resolve_incomplete",
+    STATUS_TRANSPORT_UNAVAILABLE: "cell_resolve_transport_unavailable",
+}
+
+#: The hub's typed refusal codes. NOT misses — see the module docstring. The
+#: first three are per-ANSWER now (see :data:`_STATUS_REFUSAL_CODE`); the rest
+#: refuse the whole batch, because each is a property of the CALLER or of the
+#: REQUEST rather than of one key.
 REFUSAL_CODES = (
     "cell_resolve_ambiguous",
     "cell_resolve_incomplete",
     "cell_resolve_transport_unavailable",
     "cell_resolve_client_supplied_field",
+    "cell_resolve_too_many_keys",
+    "cell_resolve_duplicate_key",
+    # Answered, but not to the question that was asked. Local verdicts, and
+    # they are refusals rather than misses for the usual reason: a pod that
+    # read a mangled batch as misses would pay for a full cold mint per key.
+    "cell_resolve_short_answer",
+    "cell_resolve_answer_out_of_order",
+    "cell_resolve_batch_signature",
+    "cell_resolve_shared_receipt",
+    "cell_resolve_unknown_status",
 )
 
 #: Every field an accepted answer must NAME, and why. An answer omitting one
@@ -85,6 +160,13 @@ _REQUIRED: Tuple[Tuple[str, str], ...] = (
                       "rule, and 'unknown publisher' is not a tier"),
     ("cell_ref", "the address the bytes are fetched from"),
     ("content_digest", "what the fetched bytes are verified against"),
+    # pgw#1224: the per-ANSWER signature. Under the batch wire this is the only
+    # thing that makes an answer stand on its own — there is no signature over
+    # the batch, deliberately — so an unsigned hit is refused HERE rather than
+    # discovered by `receipts.verify` after the bytes have been paid for.
+    ("receipt", "the hub's signature over THIS compiled graph, which is what "
+                "lets one answer of a batch be trusted, cached or replayed "
+                "without trusting the collection it arrived in"),
 )
 
 
@@ -163,6 +245,36 @@ class ResolvedCell:
         return aot_identity.ExpectedIdentity.named_by(self, self.graph_contract)
 
 
+@dataclass(frozen=True)
+class ResolveAnswer:
+    """ONE key's answer out of a batch — the unit the caller acts on.
+
+    It is a distinct type from :class:`ResolvedCell` because a batch answers
+    every key, and three of the five outcomes name no artifact at all. Folding
+    them into ``Optional[ResolvedCell]`` is exactly the collapse this wire
+    exists to prevent: ``None`` would make "the hub holds nothing" and "the hub
+    holds something it could not deliver" the same observation, and the pod
+    answers the first by minting and must not answer the second that way.
+    """
+
+    compiled_graph_key: str
+    status: str
+    #: The artifact, on ``hit`` and only on ``hit``.
+    cell: Optional[ResolvedCell] = None
+    #: The typed code for a per-answer HUB FAULT — the same string the fault
+    #: carried when it was a whole-request refusal. Empty on hit and on miss.
+    refusal_code: str = ""
+    detail: str = ""
+
+    @property
+    def hit(self) -> bool:
+        return self.cell is not None
+
+    @property
+    def miss(self) -> bool:
+        return self.status == STATUS_MISS
+
+
 def _transport_from(body: Mapping[str, Any]) -> Transport:
     raw = body.get("transport") or {}
     files: List[TransportFile] = []
@@ -213,41 +325,137 @@ def _cell_from(body: Mapping[str, Any]) -> ResolvedCell:
     )
 
 
-def resolve(
-    family: str,
-    derived_key: str,
-    *,
-    base_url: str = "",
-    bearer: str = "",
-) -> Optional[ResolvedCell]:
-    """Ask the hub for the cell named by ``derived_key``. ``None`` is a MISS.
+def _require_batch(family: str, keys: Sequence[str]) -> Tuple[str, Tuple[str, ...]]:
+    """The request the hub would accept, or a typed refusal before the wire.
 
-    Raises :class:`CellResolveRefused` on a typed refusal — which is NOT a
-    miss and must not be treated as one by the caller. The body carries
-    ``family`` and ``cell_key`` and NOTHING else: every entitlement input is
-    resolved from the live session hub-side, and a body naming one is a named
-    400 (``cell_resolve_client_supplied_field``). Sending an extra field would
-    not merely be ignored — it would refuse the whole boot.
+    Every rule here is one the hub enforces as a NAMED 400 over the WHOLE
+    batch, so failing locally costs one boot's round trip instead of every
+    key's answer — and it names the caller's bug rather than reporting the
+    hub's verdict on it.
     """
-    key = str(derived_key or "").strip()
-    if not cell_key.is_key(key):
-        raise CellResolveRefused(
-            "invalid_request",
-            f"{key!r} is not a cell key; the resolve route addresses cells by "
-            f"ck<scheme>-<56 hex> and by nothing else")
     fam = str(family or "").strip()
     if not fam:
         raise CellResolveRefused(
-            "invalid_request", "resolve requires the cell's family namespace")
+            "invalid_request", "resolve requires the compiled graph's family "
+                               "namespace")
+    asked: List[str] = []
+    seen: Set[str] = set()
+    for i, raw in enumerate(keys):
+        key = str(raw or "").strip()
+        if not cell_key.is_key(key):
+            raise CellResolveRefused(
+                "invalid_request",
+                f"keys[{i}] is {key!r}, which is not a compiled-graph key; the "
+                f"resolve route addresses compiled graphs by "
+                f"{cell_key.KEY_SCHEME}-<hex digest> and by nothing else")
+        if key in seen:
+            # Answers are POSITIONAL. The hub refuses a repeat for that reason
+            # and so does this: collapsing it would shift every later answer
+            # against its request, and answering it twice is work nobody asked
+            # for.
+            raise CellResolveRefused(
+                "cell_resolve_duplicate_key",
+                f"keys[{i}] repeats {key}; answers come back in REQUEST ORDER "
+                f"and a collapsed duplicate would shift every later answer "
+                f"against its request")
+        seen.add(key)
+        asked.append(key)
+    if not asked:
+        raise CellResolveRefused(
+            "invalid_request", "resolve requires a non-empty key set")
+    if len(asked) > MAX_RESOLVE_KEYS:
+        raise CellResolveRefused(
+            "cell_resolve_too_many_keys",
+            f"this batch names {len(asked)} keys and the bound is "
+            f"{MAX_RESOLVE_KEYS}; split it rather than receiving a short "
+            f"answer that reads as misses")
+    return fam, tuple(asked)
+
+
+def _answer_from(
+    raw: Mapping[str, Any], key: str, family: str,
+) -> ResolveAnswer:
+    """One wire answer -> one :class:`ResolveAnswer`. The key is the ASKED one.
+
+    ``status`` is read strictly: an unrecognised status is a refusal, never a
+    miss. A client that defaulted unknown to miss would silently self-mint over
+    every future hub-side fault the day the hub learns to name one.
+    """
+    status = str(raw.get("status") or "").strip()
+    if status == STATUS_MISS:
+        return ResolveAnswer(compiled_graph_key=key, status=STATUS_MISS)
+    if status in _STATUS_REFUSAL_CODE:
+        return ResolveAnswer(
+            compiled_graph_key=key, status=status,
+            refusal_code=_STATUS_REFUSAL_CODE[status],
+            detail=str(raw.get("detail") or ""))
+    if status != STATUS_HIT or not bool(raw.get("found")):
+        raise CellResolveRefused(
+            "cell_resolve_unknown_status",
+            f"the answer for {key} carries status {status!r} "
+            f"(found={raw.get('found')!r}), which this worker cannot act on; "
+            f"reading it as a miss would send this pod to a full cold mint "
+            f"over a fact it did not understand")
+    cell = _cell_from(raw)
+    missing = [(f, why) for f, why in _REQUIRED if not getattr(cell, f)]
+    if missing:
+        # PER ANSWER, not per batch. Refused HERE rather than at the identity
+        # gate, which runs after `materialize` has already paid for the whole
+        # artifact — and refused for THIS key only, so its 35 siblings still
+        # arm. The hub reaches the same verdict from the same evidence and
+        # calls it the same thing.
+        return ResolveAnswer(
+            compiled_graph_key=key, status=STATUS_INCOMPLETE,
+            refusal_code="cell_resolve_incomplete",
+            detail="the answer names no " + "; no ".join(
+                f"{f} ({why})" for f, why in missing))
+    logger.info(
+        "cell-resolve: HIT %s -> %s (%s tier, %d bytes)",
+        key, cell.cell_ref, cell.publisher_tier, cell.size_bytes)
+    return ResolveAnswer(
+        compiled_graph_key=key, status=STATUS_HIT, cell=cell,
+        detail=f"family={family} tier={cell.publisher_tier} "
+               f"checkpoint={cell.checkpoint_id}")
+
+
+#: Top-level names that would make the COLLECTION the unit of trust. The hub
+#: sends none of them, deliberately (#1118: "there is no signature over the
+#: batch"), so seeing one means either a hub that grew a batch signature
+#: without this client agreeing to it, or something in between that minted one.
+#: Both are refused rather than ignored — an ignored signature field is one a
+#: later reader assumes was checked.
+_BATCH_SIGNATURE_FIELDS = ("signature", "receipt", "jws", "answers_signature")
+
+
+def resolve_batch(
+    family: str,
+    keys: Sequence[str],
+    *,
+    base_url: str = "",
+    bearer: str = "",
+) -> Tuple[ResolveAnswer, ...]:
+    """Ask the hub for a whole KEY SET at once. One answer per key, in order.
+
+    ``POST {family, keys[<=256]}`` -> one answer per requested key. The
+    returned tuple is positionally aligned with ``keys`` and is always the same
+    length; a caller may zip them without checking, because this function has
+    already refused every batch where that would not hold.
+
+    Raises :class:`CellResolveRefused` for a WHOLE-BATCH fault — a malformed
+    request, a caller-scoped hub failure, or an answer set that does not
+    answer the question asked. A PER-KEY fault is not a raise: it is an answer
+    with a ``refusal_code``, so one bad row costs one graph class.
+    """
+    fam, asked = _require_batch(family, keys)
 
     with boot_phases.span(
         boot_phases.PHASE_CELL_HUB_RTT, function="cells.resolve",
-        artifact_key=key, ref=fam,
+        artifact_key=asked[0], ref=fam,
     ) if boot_phases.in_boot() else _null() as span:
         resp = broker.request(
             "POST", RESOLVE_PATH,
             base_url=base_url, bearer=bearer,
-            json={"family": fam, "cell_key": key},
+            json={"family": fam, "keys": list(asked)},
             timeout=RESOLVE_TIMEOUT_S,
         )
         try:
@@ -262,38 +470,76 @@ def resolve(
             raise CellResolveRefused(
                 code or f"http_{resp.status_code}", detail,
                 status=resp.status_code)
-        if not bool((body or {}).get("found")):
-            if span is not None:
-                span.classify("miss", f"key={key}")
-            logger.info("cell-resolve: MISS for %s (family=%s)", key, fam)
-            return None
-        cell = _cell_from(body)
+        answers = _answers_of(body, asked)
+        hits = sum(1 for a in answers if a.hit)
         if span is not None:
             span.classify(
-                "hit",
-                f"key={key} tier={cell.publisher_tier} "
-                f"checkpoint={cell.checkpoint_id}")
-    if cell.cell_key != key:
-        # The hub answered a DIFFERENT key than the one asked for. Never a
-        # miss and never adoptable: the admission gate would refuse it anyway,
-        # but refusing here names the seam that lied rather than the artifact
-        # that arrived.
+                "hit" if hits else "miss",
+                f"keys={len(asked)} hits={hits} family={fam}")
+    return answers
+
+
+def _answers_of(
+    body: Any, asked: Tuple[str, ...],
+) -> Tuple[ResolveAnswer, ...]:
+    """Decode the answer list, enforcing arity, order and per-answer signing."""
+    raw = (body or {}) if isinstance(body, Mapping) else {}
+    for field in _BATCH_SIGNATURE_FIELDS:
+        if raw.get(field):
+            raise CellResolveRefused(
+                "cell_resolve_batch_signature",
+                f"the batch carries a top-level {field!r}; every answer is "
+                f"signed on its own and there is deliberately no signature "
+                f"over the collection, so a batch-level one would make the "
+                f"COLLECTION the unit of trust")
+    rows = raw.get("answers")
+    if not isinstance(rows, list):
         raise CellResolveRefused(
-            "cell_resolve_key_mismatch",
-            f"asked for {key}, the hub answered {cell.cell_key!r}")
-    missing = [(f, why) for f, why in _REQUIRED if not getattr(cell, f)]
-    if missing:
-        # Refused HERE rather than at the identity gate, which runs after
-        # `materialize` has already paid for the whole cell. The Plan route
-        # cannot reach that gate incomplete; this one could.
+            "cell_resolve_short_answer",
+            f"asked {len(asked)} keys and the reply names no answers[] at all")
+    if len(rows) != len(asked):
+        # An omission is indistinguishable from a truncation, and the pod
+        # answers a missing answer by paying for a full cold mint. So a short
+        # batch is not a smaller reply — it is a wrong one.
         raise CellResolveRefused(
-            "cell_resolve_incomplete",
-            "the answer names no " + "; no ".join(
-                f"{f} ({why})" for f, why in missing))
-    logger.info(
-        "cell-resolve: HIT %s -> %s (%s tier, %d bytes)",
-        key, cell.cell_ref, cell.publisher_tier, cell.size_bytes)
-    return cell
+            "cell_resolve_short_answer",
+            f"asked {len(asked)} keys, got {len(rows)} answers; answers are "
+            f"positional and a batch that does not answer every key is "
+            f"indistinguishable from one truncated in transit")
+    out: List[ResolveAnswer] = []
+    receipts: Dict[str, str] = {}
+    for i, key in enumerate(asked):
+        row = rows[i]
+        if not isinstance(row, Mapping):
+            raise CellResolveRefused(
+                "cell_resolve_short_answer",
+                f"answers[{i}] is {type(row).__name__}, not an answer")
+        echoed = str(row.get("cell_key") or "").strip()
+        if echoed != key:
+            # POSITION and ECHO both, because either alone admits a batch
+            # transposed by something that preserved the other.
+            raise CellResolveRefused(
+                "cell_resolve_answer_out_of_order",
+                f"answers[{i}] answers {echoed!r} and keys[{i}] asked {key}; "
+                f"answers are consumed positionally, so a transposed batch "
+                f"would arm every class with a sibling's kernels")
+        answer = _answer_from(row, key, str(raw.get("family") or ""))
+        if answer.cell is not None:
+            seen_for = receipts.get(answer.cell.receipt)
+            if seen_for is not None:
+                # One receipt covering two answers is a batch-level signature
+                # wearing a per-answer field name: the receipt is the hub's
+                # signature over ONE compiled graph, so two keys sharing one
+                # means at least one answer is being vouched for by the other's
+                # proof.
+                raise CellResolveRefused(
+                    "cell_resolve_shared_receipt",
+                    f"{key} and {seen_for} were answered with the SAME "
+                    f"receipt; a receipt signs one compiled graph, and reusing "
+                    f"it makes the collection the unit of trust")
+            receipts[answer.cell.receipt] = key
+        out.append(answer)
+    return tuple(out)
 
 
 def materialize(
@@ -332,6 +578,13 @@ __all__ = [
     "Transport",
     "TransportChunk",
     "TransportFile",
+    "MAX_RESOLVE_KEYS",
+    "ResolveAnswer",
+    "STATUS_AMBIGUOUS",
+    "STATUS_HIT",
+    "STATUS_INCOMPLETE",
+    "STATUS_MISS",
+    "STATUS_TRANSPORT_UNAVAILABLE",
     "materialize",
-    "resolve",
+    "resolve_batch",
 ]

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -609,6 +609,84 @@ def control_plane_metadata(meta: Mapping[str, Any]) -> Dict[str, Any]:
     return kept
 
 
+#: The hub's bound on one intent batch (``maxCellPublishEntries``). Over it the
+#: hub refuses the WHOLE batch by name, so splitting late would cost every
+#: entry's grant to learn the number.
+MAX_PUBLISH_ENTRIES = 256
+
+#: Per-entry outcome vocabulary (th#1842 PR #1121). Everything that is a
+#: property of the POD — the three attested axes, the trust tier, the pod
+#: record, the quota — stays a WHOLE-BATCH refusal, because a forged axis
+#: indicts the pod and every entry from it is suspect. Only a fact about ONE
+#: key is answered per entry.
+PUBLISH_STATUS_GRANTED = "granted"
+PUBLISH_STATUS_CONDEMNED = "condemned"
+
+
+@dataclass(frozen=True)
+class PublishEntry:
+    """One compiled graph asking to be published.
+
+    ``identity_axes`` restates ALL THREE key axes (``graph``, ``sm``,
+    ``toolchain``) even though the last two are constant within any real batch.
+    Hoisting them would be the obvious compression and it is the wrong one: the
+    constancy would become a convention the wire DEPENDS on rather than one it
+    enforces, and a row whose identity is only verifiable inside its collection
+    is not an identity. The hub refuses an entry that cannot restate its own
+    key, so this is a wire requirement, not a style.
+    """
+
+    compiled_graph_key: str
+    identity_axes: Mapping[str, str]
+    mint_duration_ms: int = 0
+
+    def wire(self) -> Dict[str, Any]:
+        return {
+            "cell_key": self.compiled_graph_key,
+            "identity_axes": {str(k): str(v)
+                              for k, v in dict(self.identity_axes).items()},
+            "mint_duration_ms": max(0, int(self.mint_duration_ms or 0)),
+        }
+
+
+@dataclass(frozen=True)
+class PublishGrant:
+    """ONE entry's answer — and, when granted, ITS OWN capability token.
+
+    One token per entry is the same argument as batch resolve's per-answer
+    receipt: a single token covering the batch would make the COLLECTION the
+    unit of trust. Each claim names its own key, so a grant can be used,
+    cached, retried or revoked per artifact, and a token for entry 5 cannot
+    publish entry 6's bytes.
+    """
+
+    compiled_graph_key: str
+    status: str
+    capability_token: str = ""
+    expires_at_unix: int = 0
+    detail: str = ""
+
+    @property
+    def granted(self) -> bool:
+        return self.status == PUBLISH_STATUS_GRANTED
+
+
+@dataclass(frozen=True)
+class PublishIntentBatch:
+    """The whole answer: the batch-level repo plus one grant per entry."""
+
+    repo: str
+    family: str
+    grants: Tuple[PublishGrant, ...]
+
+    def grant_for(self, compiled_graph_key: str) -> PublishGrant:
+        for g in self.grants:
+            if g.compiled_graph_key == compiled_graph_key:
+                return g
+        raise CellPublishRefused(
+            f"the intent batch names no answer for {compiled_graph_key}")
+
+
 class CellPublisher:
     """The fleet publish sink: intent -> commit flow -> complete.
 
@@ -706,71 +784,178 @@ class CellPublisher:
 
     # -- publish ------------------------------------------------------------
 
-    def publish(self, family: str, artifact: Path, meta: dict,
-                mint_duration_ms: int = 0) -> str:
-        """Publish one self-minted cell. Returns the checkpoint id.
+    def publish_intent(
+        self, family: str, entries: Sequence[PublishEntry], *, sku: str,
+        gen_worker: str,
+    ) -> PublishIntentBatch:
+        """Ask the hub to admit a WHOLE MINT'S entries, one token each.
 
-        Steps: attested intent (worker JWT; hub corroborates the axes and
-        mints a key-pinned capability token) -> the CHUNKED SHA-256 publish
-        (declare -> {have, need} -> PUT -> complete; mode=replace, no tags —
-        the hub refuses any tag bind under the claim anyway) ->
-        publish-complete bookkeeping. Raises on any failure; the caller
-        treats every raise as non-fatal to serving.
+        ``POST {family, axes, entries[<=256]}`` -> one answer per entry, IN
+        REQUEST ORDER, each ``granted`` answer carrying its own capability
+        token (th#1842 PR #1121). The single-entry body is GONE — hard cut, no
+        alias — so a 36-class sdxl mint pays ONE attested round trip instead of
+        36, each of which carried the full axis attestation.
+
+        ``axes`` is batch-level because all three of its members are properties
+        of the POD: ``gen_worker`` from this session, ``sku`` from the pod's
+        provisioning record, ``image_digest`` from the release. They cannot
+        differ between entries of one mint, and accepting them per entry would
+        invite a body claiming two SKUs for one pod and make the hub choose.
+
+        Raises :class:`CellPublishRefused` / :class:`HubPublishError` for a
+        WHOLE-BATCH refusal. A per-entry refusal is not a raise: it is a grant
+        with ``status="condemned"``, so one quarantined key does not throw away
+        35 siblings whose bytes have not moved.
         """
-
-        # pgw#712 (kept under the exact-identity ruling as
-        # defense-in-depth): a cell whose metadata carries a foreign
-        # adoption provenance must never republish under this worker's
-        # key. Nothing in-tree stamps the mark anymore (equivalence
-        # adoption was deleted with exact identity); a marked cell can only be a
-        # foreign/hand-copied artifact — refuse it.
-        mark = meta.get(ADOPTION_MARK)
-        if mark:
+        asked = tuple(entries)
+        if not family.strip():
+            raise CellPublishRefused("publish-intent requires a family")
+        if not asked:
             raise CellPublishRefused(
-                f"cell carries adoption provenance {mark!r}; republishing "
-                "it is fenced (pgw#712)")
-        key = str(meta.get("cell_key") or "").strip()
-        if not key:
-            key = _recomputed_key(meta).digest
-        axes = {
-            "sku": str(meta.get("sku") or ""),
-            "image_digest": self.image_digest,
-            "gen_worker": str(meta.get("gen_worker") or ""),
-        }
+                "publish-intent requires a non-empty entries[]")
+        if len(asked) > MAX_PUBLISH_ENTRIES:
+            raise CellPublishRefused(
+                f"this batch names {len(asked)} entries and the bound is "
+                f"{MAX_PUBLISH_ENTRIES}; split it rather than receiving a "
+                f"short answer that reads as entries nobody asked to publish")
+        seen: Dict[str, int] = {}
+        for i, entry in enumerate(asked):
+            key = entry.compiled_graph_key
+            if not cell_key.is_key(key):
+                raise CellPublishRefused(
+                    f"entries[{i}].cell_key is {key!r}, which is not a "
+                    f"compiled-graph key")
+            if key in seen:
+                # Answers are positional; a collapsed duplicate would shift
+                # every later answer against its entry.
+                raise CellPublishRefused(
+                    f"entries[{i}] repeats entries[{seen[key]}]'s key {key}")
+            seen[key] = i
+            for axis in cell_key.KEY_AXES:
+                if not str(entry.identity_axes.get(axis) or "").strip():
+                    raise CellPublishRefused(
+                        f"entries[{i}].identity_axes states no {axis!r}; an "
+                        f"entry that cannot restate all of (graph, sm, "
+                        f"toolchain) cannot restate its own key, and a row "
+                        f"whose identity is only verifiable inside its batch "
+                        f"is not an identity")
         # th#1423: a mint outliving its credential is only visible AFTER the
         # compile, in a 401 nothing could group. The credential states its own
         # `exp`, so the lapse is a MEASURED fact at the one moment it decides
         # the outcome — on the wire before the intent, not inferred later.
         lapse = _credential_lapse_s(self.worker_jwt(), now=time.time())
         if lapse:
-            _publish_leg(family, key, "credential_expired",
-                         {"past_exp_s": int(lapse)})
-        intent = self._post(
+            _publish_leg(family, asked[0].compiled_graph_key,
+                         "credential_expired", {"past_exp_s": int(lapse)})
+        body = self._post(
             "/v1/worker/cells/publish-intent",
             {
-                "family": family, "cell_key": key, "axes": axes,
-                # th#1355: the identity the hub could not otherwise learn.
-                # `axes` above are the three the hub ATTESTS against its own
-                # records; `identity_axes` are the ck axes that HASH INTO
-                # `cell_key`. Before this, they reached the hub only on the
-                # DEMAND side and were deleted the moment the demand was
-                # satisfied — so a minted cell's row could not say which lane
-                # or which card it was for. Diagnostic by contract: the hub
-                # cannot recompute the digest and must never select on them.
-                "identity_axes": _identity_axes(family, meta),
-                # The compile wall for THIS cell. Sent at INTENT, not
-                # complete, because the mint is already finished by the time
-                # we ask to publish — so the cost commits in the same INSERT
-                # as the row it describes.
-                "mint_duration_ms": max(0, int(mint_duration_ms or 0)),
+                "family": family,
+                # The three HUB-ATTESTED axes (pgw#709), checked against the
+                # hub's own records before any token is minted.
+                "axes": {
+                    "sku": str(sku or ""),
+                    "image_digest": self.image_digest,
+                    "gen_worker": str(gen_worker or ""),
+                },
+                "entries": [e.wire() for e in asked],
             },
             timeout=_INTENT_TIMEOUT_S,
         )
-        token = str(intent.get("capability_token") or "").strip()
-        repo = str(intent.get("repo") or "").strip()
-        if not token or not repo:
-            raise RuntimeError("publish-intent response missing token/repo")
+        repo = str(body.get("repo") or "").strip()
+        if not repo:
+            raise RuntimeError("publish-intent response missing repo")
+        rows = body.get("answers")
+        if not isinstance(rows, list) or len(rows) != len(asked):
+            # A short batch is not a smaller reply. An omitted answer reads as
+            # an entry nobody asked to publish, and the bytes it was minted
+            # from are already paid for.
+            raise RuntimeError(
+                f"publish-intent asked {len(asked)} entries and was answered "
+                f"{len(rows) if isinstance(rows, list) else 'no answers[]'}; "
+                f"answers are positional and every entry must get one")
+        grants: List[PublishGrant] = []
+        tokens: Dict[str, str] = {}
+        for i, entry in enumerate(asked):
+            row = rows[i]
+            if not isinstance(row, dict):
+                raise RuntimeError(f"publish-intent answers[{i}] is not an answer")
+            echoed = str(row.get("cell_key") or "").strip()
+            if echoed != entry.compiled_graph_key:
+                raise RuntimeError(
+                    f"publish-intent answers[{i}] answers {echoed!r} and "
+                    f"entries[{i}] asked {entry.compiled_graph_key}; answers "
+                    f"are consumed positionally, so a transposed batch would "
+                    f"upload every artifact under a sibling's grant")
+            status = str(row.get("status") or "").strip()
+            if status == PUBLISH_STATUS_CONDEMNED:
+                grants.append(PublishGrant(
+                    compiled_graph_key=echoed, status=PUBLISH_STATUS_CONDEMNED,
+                    detail=str(row.get("detail") or "")))
+                continue
+            token = str(row.get("capability_token") or "").strip()
+            if status != PUBLISH_STATUS_GRANTED or not token:
+                raise RuntimeError(
+                    f"publish-intent answers[{i}] carries status {status!r} "
+                    f"with{'out' if not token else ''} a token; this worker "
+                    f"cannot act on it")
+            if token in tokens:
+                # ONE TOKEN EACH. A token shared between two entries is a
+                # batch-level grant wearing a per-entry field name — and a
+                # grant for entry 5 must not be able to publish entry 6's
+                # bytes.
+                raise RuntimeError(
+                    f"publish-intent granted {echoed} and {tokens[token]} the "
+                    f"SAME capability token; each entry's grant is signed on "
+                    f"its own and must name only its own key")
+            tokens[token] = echoed
+            grants.append(PublishGrant(
+                compiled_graph_key=echoed, status=PUBLISH_STATUS_GRANTED,
+                capability_token=token,
+                expires_at_unix=int(row.get("expires_at_unix") or 0)))
+        return PublishIntentBatch(
+            repo=repo, family=family, grants=tuple(grants))
 
+    def publish(self, family: str, artifact: Path, meta: dict,
+                mint_duration_ms: int = 0) -> str:
+        """Publish ONE self-minted compiled graph. Returns the checkpoint id.
+
+        Steps: attested intent (worker JWT; hub corroborates the axes and mints
+        a key-pinned capability token) -> the CHUNKED SHA-256 publish (declare
+        -> {have, need} -> PUT -> complete; mode=replace, no tags — the hub
+        refuses any tag bind under the claim anyway) -> publish-complete
+        bookkeeping. Raises on any failure; the caller treats every raise as
+        non-fatal to serving.
+
+        A one-entry batch, and that is the honest shape for it: the live
+        publish paths are independent background transfers, one per key
+        (``_publish_async``), so their intents cannot be joined without joining
+        the threads. :meth:`publish_intent` is where a caller holding a whole
+        mint at once — :func:`aot_mint.publish` — asks for every token in one
+        round trip.
+        """
+        entry, sku, gen_worker = intent_entry(family, meta, mint_duration_ms)
+        batch = self.publish_intent(
+            family, [entry], sku=sku, gen_worker=gen_worker)
+        return self.publish_granted(
+            family, artifact, meta, batch.grants[0], repo=batch.repo)
+
+    def publish_granted(
+        self, family: str, artifact: Path, meta: dict, grant: PublishGrant, *,
+        repo: str,
+    ) -> str:
+        """Ship ONE entry's bytes under ITS OWN grant. Returns the checkpoint id.
+
+        Split from :meth:`publish_intent` because the grant is per entry and
+        the transfer is per entry: a caller holding a whole mint's grants
+        uploads them one at a time, each under the token that names only its
+        own key, and one failure costs one artifact.
+        """
+        key = grant.compiled_graph_key
+        if not grant.granted:
+            raise CellPublishRefused(
+                grant.detail or f"the hub refused to admit {key}",
+                code="cell_publish_key_condemned")
         try:
             from .hubio.client import CommitFile, HubClient
 
@@ -788,7 +973,8 @@ class CellPublisher:
             # do not hash to the key; and resume needs no client state — a
             # re-plan comes back with the landed objects already resident, so
             # a pod that dies mid-upload costs only the in-flight chunks.
-            client = HubClient(base_url=self.base_url, token=token)
+            client = HubClient(base_url=self.base_url,
+                               token=grant.capability_token)
             result = client.publish_v2(
                 destination_repo=repo,
                 files=[CommitFile(path=artifact.name, local_path=artifact)],
@@ -833,6 +1019,41 @@ class CellPublisher:
             family, key, checkpoint_id, artifact.stat().st_size / 1e6,
             result.uploaded, result.deduped)
         return checkpoint_id
+
+
+def intent_entry(
+    family: str, meta: dict, mint_duration_ms: int = 0,
+) -> Tuple[PublishEntry, str, str]:
+    """One artifact's metadata -> its entry plus the two pod axes it declares.
+
+    The pod axes come back separately because they are BATCH-level on the wire:
+    ``sku`` and ``gen_worker`` describe the pod, so a caller batching a whole
+    mint reads them once and the hub attests them once.
+    """
+    # pgw#712 (kept under the exact-identity ruling as defense-in-depth): a
+    # cell whose metadata carries a foreign adoption provenance must never
+    # republish under this worker's key. Nothing in-tree stamps the mark
+    # anymore (equivalence adoption was deleted with exact identity); a marked
+    # cell can only be a foreign/hand-copied artifact — refuse it. It sits HERE
+    # because this is what every publisher runs BEFORE the intent: the fence
+    # has to refuse before a byte moves and before the hub is even asked.
+    mark = meta.get(ADOPTION_MARK)
+    if mark:
+        raise CellPublishRefused(
+            f"cell carries adoption provenance {mark!r}; republishing "
+            "it is fenced (pgw#712)")
+    key = str(meta.get("cell_key") or "").strip()
+    if not key:
+        key = _recomputed_key(meta).digest
+    return (
+        PublishEntry(
+            compiled_graph_key=key,
+            identity_axes=_identity_axes(family, meta),
+            mint_duration_ms=max(0, int(mint_duration_ms or 0)),
+        ),
+        str(meta.get("sku") or ""),
+        str(meta.get("gen_worker") or ""),
+    )
 
 
 def _publish_leg(family: str, key: str, stage: str, facts: Dict[str, Any]) -> None:

--- a/src/gen_worker/procsplit/actions.py
+++ b/src/gen_worker/procsplit/actions.py
@@ -134,26 +134,33 @@ ACTIONS: Dict[str, HubAction] = {
         # model since pgw#783). `identity_axes`/`mint_duration_ms` (th#1355)
         # were exactly that gap; `status`/`detail`/`axes` were names on
         # `publish-complete` that no caller and no hub route ever had.
+        # pgw#1224 (th#1842 PR #1121): the intent is a BATCH. `entries[]`
+        # carries the per-artifact facts — `cell_key`, `identity_axes` (all
+        # three key axes restated, never hoisted), `mint_duration_ms` — and
+        # `axes` stays batch-level because all three of ITS members are
+        # properties of the POD, not of a compiled graph. The old top-level
+        # `cell_key`/`identity_axes`/`mint_duration_ms` are GONE: a table that
+        # still admitted them would let a client speak the dead shape past the
+        # one gate that can refuse it.
         _a(
             "cells.publish_intent",
             "POST",
             r"^/v1/worker/cells/publish-intent$",
-            body=("family", "cell_key", "axes", "identity_axes",
-                  "mint_duration_ms"),
+            body=("family", "axes", "entries"),
             timeout_s=60.0,
         ),
-        # pgw#1090/th#1750 (§4.29): pull-by-key. The body carries the family
-        # and the derived cell key and NOTHING else — every entitlement input
-        # is resolved hub-side from the live session, and a body naming one is
-        # a named 400 (`cell_resolve_client_supplied_field`), not an ignored
-        # field. So this enumeration is not a convention, it is the request:
-        # an action table that admitted one more key would make the whole
-        # resolve refuse.
+        # pgw#1090/th#1750 (§4.29), batched by pgw#1224 (th#1842 PR #1118):
+        # pull-by-key-SET. The body carries the family and the derived keys and
+        # NOTHING else — every entitlement input is resolved hub-side from the
+        # live session, and a body naming one is a named 400
+        # (`cell_resolve_client_supplied_field`), not an ignored field. So this
+        # enumeration is not a convention, it is the request: an action table
+        # that admitted one more key would make the whole resolve refuse.
         _a(
             "cells.resolve",
             "POST",
             r"^/v1/worker/cells/resolve$",
-            body=("family", "cell_key"),
+            body=("family", "keys"),
             timeout_s=30.0,
         ),
         _a(

--- a/tests/harness/cell_hub.py
+++ b/tests/harness/cell_hub.py
@@ -225,8 +225,24 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             family = str(body.get("family") or "")
             with srv.lock:
                 srv.intents.append(dict(body))
-            self._json(200, {"capability_token": "local-rig-cap",
-                             "repo": f"root/family-{family}"})
+            # pgw#1224/th#1842 PR #1121: one answer per entry, IN REQUEST
+            # ORDER, each carrying ITS OWN token. The double mints distinct
+            # tokens deliberately — a double that handed every entry one token
+            # would make the client's "one token each" check unfalsifiable.
+            entries = body.get("entries") or []
+            self._json(200, {
+                "object": "cell_publish_intent_batch",
+                "repo": f"root/family-{family}",
+                "family": family,
+                "granted": len(entries),
+                "answers": [
+                    {"cell_key": str(e.get("cell_key") or ""),
+                     "status": "granted",
+                     "capability_token": f"local-rig-cap-{i}",
+                     "expires_at_unix": 4102444800}
+                    for i, e in enumerate(entries)
+                ],
+            })
             return
 
         if path.endswith("/v1/worker/cells/publish-complete"):

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -1069,11 +1069,30 @@ def test_key_scheme_is_cg_key_v1_and_the_axes_are_the_three(
 
 
 class _RecordingPublisher:
+    """The batch publisher's surface (pgw#1224): ONE attested intent for the
+    whole mint, then one transfer per entry under that entry's OWN grant."""
+
     def __init__(self) -> None:
         self.calls: list = []
+        self.intents: list = []
 
-    def publish(self, family: str, artifact: Path, meta: dict,
-                mint_duration_ms: int = 0) -> str:
+    def publish_intent(self, family: str, entries: Any, *, sku: str = "",
+                       gen_worker: str = "") -> Any:
+        from gen_worker import fleet_cells as fc
+
+        asked = list(entries)
+        self.intents.append((family, asked, sku, gen_worker))
+        return fc.PublishIntentBatch(
+            repo=f"root/family-{family}", family=family,
+            grants=tuple(
+                fc.PublishGrant(
+                    compiled_graph_key=e.compiled_graph_key,
+                    status=fc.PUBLISH_STATUS_GRANTED,
+                    capability_token=f"cap-{i}")
+                for i, e in enumerate(asked)))
+
+    def publish_granted(self, family: str, artifact: Path, meta: dict,
+                        grant: Any, *, repo: str) -> str:
         self.calls.append((family, artifact, meta))
         return "checkpoint-1"
 
@@ -1096,6 +1115,11 @@ def test_publish_passes_the_keyed_metadata_through(
     family, _artifact, sent = publisher.calls[0]
     assert family == "tiny"
     assert sent["cell_key"] == meta["cell_key"]
+    # pgw#1224: ONE attested intent for the whole mint, and the entry restates
+    # its own key. A per-entry intent loop reds here.
+    assert len(publisher.intents) == 1
+    _fam, asked, _sku, _gw = publisher.intents[0]
+    assert [e.compiled_graph_key for e in asked] == [meta["cell_key"]]
 
 
 def test_publish_refuses_an_unkeyed_artifact(tmp_path: Path) -> None:

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -333,7 +333,7 @@ def test_the_local_store_is_asked_BEFORE_a_perfectly_reachable_hub(
         family="micro-diffusion", arm_token=ARM_A)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
     monkeypatch.setattr(
-        cell_resolve, "resolve",
+        cell_resolve, "resolve_batch",
         lambda *a, **k: pytest.fail("the hub was asked for a resident cell"))
 
     ex = _executor(tmp_path)

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -371,7 +371,11 @@ def _attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **wires: Any) -> A
     if "derive" in wires:
         monkeypatch.setattr(boot_key, "derive", wires["derive"])
     if "resolve" in wires:
-        monkeypatch.setattr(cell_resolve, "resolve", wires["resolve"])
+        # pgw#1224: the wire is a BATCH. The per-key wires below are lifted to
+        # the batch shape here rather than rewritten one by one, so each row
+        # keeps stating the TERMINUS it is about.
+        monkeypatch.setattr(
+            cell_resolve, "resolve_batch", _batched(wires["resolve"]))
     if "materialize" in wires:
         monkeypatch.setattr(cell_resolve, "materialize", wires["materialize"])
     return boot_adopt.attempt(
@@ -379,6 +383,24 @@ def _attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **wires: Any) -> A
         slots={}, declared_hint=3,
         envelope={"shapes": [[64, 64]], "text_lens": [8], "guidance": []},
         work_root=tmp_path)[0]
+
+
+def _batched(per_key: Any) -> Any:
+    """A single-key wire -> the batch wire, answer for answer.
+
+    A raise stays a WHOLE-BATCH raise (that is what a caller-scoped refusal is,
+    and every key in the batch reports it); a returned cell/None becomes that
+    key's own answer.
+    """
+    def _call(_family: str, keys: Any, **_kw: Any) -> Any:
+        out = []
+        for key in keys:
+            cell = per_key(_family, key)
+            out.append(cell_resolve.ResolveAnswer(
+                compiled_graph_key=key,
+                status="miss" if cell is None else "hit", cell=cell))
+        return tuple(out)
+    return _call
 
 
 def _refuse_hub(code: str) -> Any:
@@ -477,7 +499,18 @@ class _ResolveHub(BaseHTTPRequestHandler):
         # th#1788: the live hub withholds every self-minted cell from a resolve,
         # so a MISS is what a correct worker gets today. The property under test
         # is that it ASKED.
-        out = json.dumps({"found": False}).encode()
+        # pgw#1224: the real hub answers the BATCH — one answer per requested
+        # key, in request order, and a miss is an ANSWER rather than an
+        # omission. This double answers exactly that, so the end-to-end row
+        # exercises the arity and order checks on a real socket.
+        keys = list(body.get("keys") or [])
+        out = json.dumps({
+            "object": "cell_resolve_batch",
+            "family": body.get("family"),
+            "answers": [{"cell_key": k, "status": "miss", "found": False}
+                        for k in keys],
+            "hits": 0, "misses": len(keys),
+        }).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(out)))
@@ -594,11 +627,15 @@ def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
     out = ex._boot_adopt(spec, slots)[0]
 
     resolves = [c for c in hub.calls if c[0] == cell_resolve.RESOLVE_PATH]
-    assert len(resolves) == 3, (
-        "the worker did not ask the hub by its derived key — this is the pod "
-        f"defect, reproduced off-pod. Hub saw: {hub.calls}")
-    assert resolves[0][1] == {
-        "family": "micro-diffusion", "cell_key": out.derived_key}
+    # pgw#1224: THREE declared classes, ONE round trip. The count was 3 while
+    # the wire was per key; a loop that survived the cut reds here.
+    assert len(resolves) == 1, (
+        "the worker did not ask the hub by its derived key set — this is the "
+        f"pod defect, reproduced off-pod. Hub saw: {hub.calls}")
+    assert resolves[0][1]["family"] == "micro-diffusion"
+    assert len(resolves[0][1]["keys"]) == 3
+    assert out.derived_key in resolves[0][1]["keys"]
+    assert "cell_key" not in resolves[0][1]
     assert out.derived_key.startswith("cg-key-v1-")
     assert out.reason == "miss"
 
@@ -665,7 +702,7 @@ def test_the_same_boot_derives_a_key_with_accelerate_UNIMPORTABLE(
     assert out.reason == "miss", out.detail
     assert out.derived_key.startswith("cg-key-v1-")
     resolves = [c for c in hub.calls if c[0] == cell_resolve.RESOLVE_PATH]
-    assert len(resolves) == 3, (
+    assert len(resolves) == 1 and len(resolves[0][1]["keys"]) == 3, (
         "an image without `accelerate` must still ASK — this is the pgw#1123 "
         f"pod defect, reproduced off-pod. Hub saw: {hub.calls}")
     assert _one(events).phase == "miss"

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -154,8 +154,14 @@ class _Hub(http.server.BaseHTTPRequestHandler):
         body = self._body()
 
         if path.endswith("/v1/worker/cells/publish-intent"):
-            self._json(200, {"capability_token": "cap-token",
-                             "repo": f"root/family-{body.get('family')}"})
+            entries = body.get("entries") or []
+            self._json(200, {
+                "repo": f"root/family-{body.get('family')}",
+                "granted": len(entries),
+                "answers": [
+                    {"cell_key": e.get("cell_key"), "status": "granted",
+                     "capability_token": f"cap-token-{i}"}
+                    for i, e in enumerate(entries)]})
             return
         if path.endswith("/v1/worker/cells/publish-complete"):
             with srv.lock:

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -112,8 +112,19 @@ class _Hub(http.server.BaseHTTPRequestHandler):
             srv.calls.append((path, body))
 
         if path.endswith("/v1/worker/cells/publish-intent"):
-            self._json(200, {"capability_token": "cap-token",
-                             "repo": f"root/family-{body.get('family')}"})
+            # pgw#1224: one answer per entry, in request order, ONE TOKEN EACH.
+            entries = body.get("entries") or []
+            self._json(200, {
+                "object": "cell_publish_intent_batch",
+                "repo": f"root/family-{body.get('family')}",
+                "family": body.get("family"),
+                "granted": len(entries),
+                "answers": [
+                    {"cell_key": e.get("cell_key"), "status": "granted",
+                     "capability_token": f"cap-token-{i}",
+                     "expires_at_unix": 4102444800}
+                    for i, e in enumerate(entries)],
+            })
             return
         if path.endswith("/v1/worker/cells/publish-complete"):
             self._json(200, {"recorded": True})
@@ -331,11 +342,16 @@ def test_publish_takes_the_v2_route_and_never_the_frozen_v1_one(
 def test_intent_carries_the_identity_axes_and_the_mint_cost(hub, artifact):
     _publisher(hub).publish(FAMILY, artifact, dict(META), mint_duration_ms=347_940)
     intent = next(b for p, b in hub.httpd.calls if p.endswith("publish-intent"))
-    assert intent["cell_key"] == CELL_KEY
+    # pgw#1224: the three ATTESTED axes are batch-level (all three are
+    # properties of the POD); the key, the identity axes and the mint cost are
+    # per ENTRY — the last one because under the old whole-cell shape ONE
+    # number covered 36 entries and could not answer which class is expensive.
     assert intent["axes"] == {"sku": "l4", "image_digest": "sha256:" + "1" * 64,
                               "gen_worker": "0.87.0"}
-    assert intent["mint_duration_ms"] == 347_940
-    assert intent["identity_axes"]["lane"] == "w8a8-lora64"
+    (entry,) = intent["entries"]
+    assert entry["cell_key"] == CELL_KEY
+    assert entry["mint_duration_ms"] == 347_940
+    assert entry["identity_axes"]["lane"] == "w8a8-lora64"
 
     complete = next(b for p, b in hub.httpd.calls if p.endswith("publish-complete"))
     assert complete["ok"] is True
@@ -366,7 +382,8 @@ def test_publish_intent_states_the_full_arming_identity(hub, artifact):
     that were not in it."""
     _publisher(hub).publish(FAMILY, artifact, dict(META))
     intent = next(b for p, b in hub.httpd.calls if p.endswith("publish-intent"))
-    axes = intent["identity_axes"]
+    (entry,) = intent["entries"]
+    axes = entry["identity_axes"]
 
     # Derived from the recorded blocks, never from a second stamp.
     assert axes["toolchain"] == cell_key.facts_digest(META["toolchain"])
@@ -379,7 +396,7 @@ def test_publish_intent_states_the_full_arming_identity(hub, artifact):
     # demoted store metadata (family, lane) — pgw#1059: neither is identity.
     ck = {k: v for k, v in axes.items()
           if k in ("graph", "sm", "toolchain")}
-    assert cell_key.from_axes(ck).digest == intent["cell_key"] == CELL_KEY
+    assert cell_key.from_axes(ck).digest == entry["cell_key"] == CELL_KEY
     assert set(axes) == {"graph", "sm", "toolchain",
                          fc.GRAPH_CONTRACT_AXIS, fc.ENV_SEAL_AXIS,
                          "family", "lane"}

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -1,8 +1,16 @@
-"""pgw#1090 (§4.29) — the worker half of ``POST /v1/worker/cells/resolve``.
+"""pgw#1090 (§4.29), batched by pgw#1224 — the worker half of
+``POST /v1/worker/cells/resolve``.
 
-Written against th#1750's ANSWER CONTRACT (hub side merged ``26275ff8``), so a
-hub-side field rename reds here rather than on a pod. Every row is off-wire: the
-broker is stubbed, which is what the ``procsplit`` seam exists to make possible.
+Written against the hub's ANSWER CONTRACT (th#1750 merged ``26275ff8``;
+th#1842 PR #1118 made it a batch), so a hub-side field rename reds here rather
+than on a pod. Every row is off-wire: the broker is stubbed, which is what the
+``procsplit`` seam exists to make possible.
+
+The subject is now ``{family, keys[]}`` -> one answer per key, in request
+order, each independently signed. The single-key wire is GONE; the rows that
+drove it drive one-key BATCHES, and the properties that only a batch can have
+— arity, order, per-answer signing, and a per-key fault not sinking the batch —
+have rows of their own below.
 """
 
 from __future__ import annotations
@@ -18,6 +26,7 @@ from gen_worker.procsplit import actions as actions_mod
 
 KEY = "cg-key-v1-" + "ab" * 28
 OTHER_KEY = "cg-key-v1-" + "cd" * 28
+THIRD_KEY = "cg-key-v1-" + "ef" * 28
 
 
 class _Resp:
@@ -31,6 +40,7 @@ class _Resp:
 
 def _hit_body(**over: Any) -> Dict[str, Any]:
     body = {
+        "status": "hit",
         "found": True,
         "family": "sdxl",
         "cell_key": KEY,
@@ -63,6 +73,28 @@ def _hit_body(**over: Any) -> Dict[str, Any]:
     return body
 
 
+def _batch(*answers: Any, **top: Any) -> Dict[str, Any]:
+    """The hub's envelope. ``answers`` is the contract; the counts are logs."""
+    body: Dict[str, Any] = {
+        "object": "cell_resolve_batch",
+        "family": "sdxl",
+        "answers": list(answers),
+        "hits": sum(1 for a in answers if a.get("status") == "hit"),
+        "misses": sum(1 for a in answers if a.get("status") == "miss"),
+    }
+    body.update(top)
+    return body
+
+
+def _miss(key: str = KEY) -> Dict[str, Any]:
+    return {"cell_key": key, "status": "miss", "found": False}
+
+
+def _one(family: str = "sdxl", key: str = KEY, **kw: Any) -> Any:
+    """One key through the BATCH wire — the shape a single-key caller has."""
+    return cell_resolve.resolve_batch(family, [key], **kw)[0]
+
+
 @pytest.fixture
 def stub(monkeypatch):
     """Capture what the client SENDS and control what it receives."""
@@ -72,7 +104,7 @@ def stub(monkeypatch):
         sent.update({"method": method, "path": path, **kw})
         return sent.pop("_resp", None) or _resp["r"]
 
-    _resp: Dict[str, Any] = {"r": _Resp(200, {"found": False})}
+    _resp: Dict[str, Any] = {"r": _Resp(200, _batch(_miss()))}
     monkeypatch.setattr(cell_resolve.broker, "request", _request)
     return sent, _resp
 
@@ -82,26 +114,39 @@ def stub(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_the_body_carries_family_and_cell_key_and_nothing_else(stub) -> None:
+def test_the_body_carries_family_and_keys_and_nothing_else(stub) -> None:
     """A body naming any entitlement input is a NAMED 400 hub-side
     (``cell_resolve_client_supplied_field``) — refused, never ignored. So a
     client that grew a field would not be tolerated, it would refuse the whole
     boot. Pinned here and in the action table, which are the two places the
-    shape is stated."""
+    shape is stated.
+
+    pgw#1224: the field is ``keys[]`` and the single-key ``cell_key`` is GONE.
+    A hard cut needs both halves to be checkable, and this is the worker half."""
     sent, resp = stub
-    resp["r"] = _Resp(200, {"found": False})
-    cell_resolve.resolve("sdxl", KEY, base_url="https://hub", bearer="t")
+    resp["r"] = _Resp(200, _batch(_miss(), _miss(OTHER_KEY)))
+    cell_resolve.resolve_batch(
+        "sdxl", [KEY, OTHER_KEY], base_url="https://hub", bearer="t")
 
     assert sent["method"] == "POST"
     assert sent["path"] == cell_resolve.RESOLVE_PATH == "/v1/worker/cells/resolve"
-    assert sent["json"] == {"family": "sdxl", "cell_key": KEY}
+    assert sent["json"] == {"family": "sdxl", "keys": [KEY, OTHER_KEY]}
     assert sent["timeout"] == cell_resolve.RESOLVE_TIMEOUT_S
+
+
+def test_the_single_key_wire_is_gone(stub) -> None:
+    """HARD CUT. A client that could still speak ``{family, cell_key}`` would
+    make the hub's own hard cut unprovable — the two halves have to land as one
+    fleet, and a surviving alias is how "both sides landed" becomes false while
+    every test stays green."""
+    assert not hasattr(cell_resolve, "resolve")
+    assert "cell_key" not in actions_mod.ACTIONS["cells.resolve"].body
 
 
 def test_the_action_table_admits_exactly_the_two_fields() -> None:
     action = actions_mod.ACTIONS["cells.resolve"]
     assert action.method == "POST"
-    assert action.body == frozenset({"family", "cell_key"})
+    assert action.body == frozenset({"family", "keys"})
     assert action.path.match("/v1/worker/cells/resolve")
     assert not action.path.match("/v1/worker/cells/resolve/extra")
     assert action.timeout_s > 0        # scripts/lint_http_timeouts.py
@@ -119,60 +164,109 @@ def test_the_resolve_action_is_not_a_publish_action() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_miss_is_none(stub) -> None:
+def test_a_miss_is_an_answer_never_an_omission(stub) -> None:
+    """A miss is a full answer in its own slot. An OMITTED answer would be
+    indistinguishable from a truncated response, and the pod answers a miss by
+    paying for a full cold mint — so a dropped answer is not a smaller reply,
+    it is a wrong one that costs money."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, {"found": False})
-    assert cell_resolve.resolve("sdxl", KEY) is None
+    resp["r"] = _Resp(200, _batch(_miss()))
+    answer = _one()
+    assert answer.cell is None and answer.miss
+    assert answer.compiled_graph_key == KEY
+    assert answer.refusal_code == ""
 
 
 @pytest.mark.parametrize("code,status", [
-    ("cell_resolve_ambiguous", 409),
-    ("cell_resolve_incomplete", 409),
-    ("cell_resolve_transport_unavailable", 503),
     ("cell_resolve_client_supplied_field", 400),
+    ("cell_resolve_too_many_keys", 400),
 ])
-def test_a_typed_refusal_is_never_read_as_a_miss(stub, code, status) -> None:
-    """A pod that read ``cell_resolve_incomplete`` as "no cell" would go pay
-    for a full cold mint believing the hub holds nothing, which is false and
-    expensive. Every one of the hub's four refusal classes raises."""
+def test_a_whole_batch_refusal_still_raises(stub, code, status) -> None:
+    """The refusals that survive as whole-request are the ones that are
+    properties of the CALLER or the REQUEST — they are wrong for every key, and
+    answering them per key would report one hub fault as 256 misses."""
     _sent, resp = stub
     resp["r"] = _Resp(status, {"code": code, "message": "because"})
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
-        cell_resolve.resolve("sdxl", KEY)
+        _one()
     assert err.value.code == code
     assert err.value.status == status
     assert code in cell_resolve.REFUSAL_CODES
 
 
-def test_an_answer_naming_a_different_key_is_refused_not_adopted(stub) -> None:
+@pytest.mark.parametrize("status,code", [
+    ("ambiguous", "cell_resolve_ambiguous"),
+    ("incomplete", "cell_resolve_incomplete"),
+    ("transport_unavailable", "cell_resolve_transport_unavailable"),
+])
+def test_a_per_key_fault_is_an_answer_and_keeps_its_own_token(
+    stub, status, code,
+) -> None:
+    """These three were WHOLE-REQUEST refusals; under the atom one duplicated
+    row would strand an entire boot's adoption — 35 good answers thrown away.
+    They are per-answer STATUSES now, carrying the SAME code so the caller's
+    vocabulary did not move. And none of them is a miss: a pod that read one as
+    "no cell" would go pay for a full cold mint over a row the hub HAS."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body(cell_key=OTHER_KEY))
+    resp["r"] = _Resp(200, _batch(
+        {"cell_key": KEY, "status": status, "found": False,
+         "detail": "because"}))
+    answer = _one()
+    assert answer.cell is None
+    assert not answer.miss
+    assert answer.refusal_code == code
+    assert code in cell_resolve.REFUSAL_CODES
+
+
+def test_an_unknown_status_is_refused_and_never_read_as_a_miss(stub) -> None:
+    """RED (default an unrecognised status to miss): the day the hub learns to
+    name a new fault, every pod silently self-mints over it."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(
+        {"cell_key": KEY, "status": "something_new", "found": False}))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
-        cell_resolve.resolve("sdxl", KEY)
-    assert err.value.code == "cell_resolve_key_mismatch"
+        _one()
+    assert err.value.code == "cell_resolve_unknown_status"
 
 
-#: ``cell_key`` is caught one gate earlier — an empty key is not the key that
-#: was asked for, so the mismatch gate names the seam that lied first.
-_EARLIER_GATE = {"cell_key": "cell_resolve_key_mismatch"}
+def test_an_answer_naming_a_different_key_is_refused_not_adopted(stub) -> None:
+    """Answers are consumed POSITIONALLY, so an answer whose echo does not
+    match its slot is refused rather than adopted: a transposed batch would arm
+    every class with a sibling's kernels."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(_hit_body(cell_key=OTHER_KEY)))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        _one()
+    assert err.value.code == "cell_resolve_answer_out_of_order"
+
+
+#: ``cell_key`` is caught one gate earlier — an empty echo is not the key that
+#: was asked for, so the ORDER gate names the seam that lied first.
+_EARLIER_GATE = {"cell_key": "cell_resolve_answer_out_of_order"}
 
 
 @pytest.mark.parametrize("field", [f for f, _ in cell_resolve._REQUIRED])
 def test_an_incomplete_answer_is_refused_before_the_cell_is_paid_for(
     stub, field,
 ) -> None:
-    """A 200 hit that leaves an admission field unnamed is REFUSED here.
+    """A hit that leaves an admission field unnamed is REFUSED here.
 
     The gate that would otherwise catch it runs after ``materialize`` has
     already downloaded the whole cell, so an unnamed admission field has to
-    refuse HERE or it is paid for first.
+    refuse HERE or it is paid for first. PER ANSWER: it costs this graph class
+    and not its 35 siblings.
     """
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body(**{field: ""}))
-    with pytest.raises(cell_resolve.CellResolveRefused) as err:
-        cell_resolve.resolve("sdxl", KEY)
-    assert err.value.code == _EARLIER_GATE.get(field, "cell_resolve_incomplete")
-    assert field in err.value.detail or field == "cell_key"
+    resp["r"] = _Resp(200, _batch(_hit_body(**{field: ""})))
+    if field == "cell_key":
+        with pytest.raises(cell_resolve.CellResolveRefused) as err:
+            _one()
+        assert err.value.code == _EARLIER_GATE[field]
+        return
+    answer = _one()
+    assert answer.cell is None
+    assert answer.refusal_code == "cell_resolve_incomplete"
+    assert field in answer.detail
 
 
 def test_every_expectation_axis_is_required_of_the_answer() -> None:
@@ -206,14 +300,22 @@ def test_a_non_key_is_refused_before_the_hub_is_dialled(stub) -> None:
     for bad in ("", "sdxl", "arm1-" + "ab" * 32, "ck1-short",
                 "cg-key-v1-" + "0" * 55):
         with pytest.raises(cell_resolve.CellResolveRefused):
-            cell_resolve.resolve("sdxl", bad)
+            _one("sdxl", bad)
+    # ...and ONE bad key refuses the WHOLE batch rather than being answered as
+    # a miss the pod would self-mint over — the hub does the same.
+    with pytest.raises(cell_resolve.CellResolveRefused):
+        cell_resolve.resolve_batch("sdxl", [KEY, "ck1-short"])
     assert not sent  # nothing was sent
 
 
 def test_a_missing_family_is_refused_before_the_hub_is_dialled(stub) -> None:
     sent, _resp = stub
     with pytest.raises(cell_resolve.CellResolveRefused):
-        cell_resolve.resolve("", KEY)
+        _one("", KEY)
+    # ...and so is an empty key set: a batch that asks nothing is a caller bug,
+    # not an answer of no misses.
+    with pytest.raises(cell_resolve.CellResolveRefused):
+        cell_resolve.resolve_batch("sdxl", [])
     assert not sent
 
 
@@ -234,8 +336,8 @@ def test_a_hit_builds_the_expected_identity_the_arm_gate_COMPARES(
     the pinned VALUE below plus the ``named_by`` equality: a new axis copied
     wrong, or silently defaulted, reds here."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body())
-    cell = cell_resolve.resolve("sdxl", KEY)
+    resp["r"] = _Resp(200, _batch(_hit_body()))
+    cell = _one().cell
     assert cell is not None
 
     expected = cell.expected_identity()
@@ -279,8 +381,8 @@ def test_the_receipt_rides_the_answer_and_is_never_re_fetched(stub) -> None:
     just offered. The receipt therefore has to come from the answer — and this
     module must contain no receipt fetch at all."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body())
-    cell = cell_resolve.resolve("sdxl", KEY)
+    resp["r"] = _Resp(200, _batch(_hit_body()))
+    cell = _one().cell
     assert cell is not None and cell.receipt == "eyJ.aGVhZA.c2ln"
 
     import inspect
@@ -295,8 +397,8 @@ def test_the_transport_is_shaped_for_the_existing_delivery_path(stub) -> None:
     transport must present the same attributes or the resolve feeds a parallel
     downloader instead of the one with the digest checks in it."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body())
-    cell = cell_resolve.resolve("sdxl", KEY)
+    resp["r"] = _Resp(200, _batch(_hit_body()))
+    cell = _one().cell
     assert cell is not None
 
     files = list(cell.transport.files)
@@ -316,8 +418,8 @@ def test_a_chunked_transport_carries_the_chunk_attributes(stub) -> None:
         {"sha256": "bb" * 32, "url": "https://cas/1", "len": 2048},
     ]
     body["transport"]["files"][0]["chunk_size_bytes"] = 2048
-    resp["r"] = _Resp(200, body)
-    cell = cell_resolve.resolve("sdxl", KEY)
+    resp["r"] = _Resp(200, _batch(body))
+    cell = _one().cell
     assert cell is not None
     chunks = list(cell.transport.files[0].chunks)
     assert [c.len for c in chunks] == [2048, 2048]
@@ -329,8 +431,8 @@ def test_materialize_delegates_and_adds_nothing(monkeypatch, stub) -> None:
     """Deliberately a two-line function: a second downloader is a second place
     for "verified" to mean something slightly different."""
     _sent, resp = stub
-    resp["r"] = _Resp(200, _hit_body())
-    cell = cell_resolve.resolve("sdxl", KEY)
+    resp["r"] = _Resp(200, _batch(_hit_body()))
+    cell = _one().cell
     assert cell is not None
 
     from gen_worker import aot_delivery
@@ -358,14 +460,14 @@ def test_materialize_delegates_and_adds_nothing(monkeypatch, stub) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _attempt(monkeypatch, tmp_path, *, derive=None, resolve=None,
+def _attempt(monkeypatch, tmp_path, *, derive=None, resolve_batch=None,
              materialize=None) -> Any:
     from gen_worker import boot_adopt, boot_key
 
     if derive is not None:
         monkeypatch.setattr(boot_key, "derive", derive)
-    if resolve is not None:
-        monkeypatch.setattr(cell_resolve, "resolve", resolve)
+    if resolve_batch is not None:
+        monkeypatch.setattr(cell_resolve, "resolve_batch", resolve_batch)
     if materialize is not None:
         monkeypatch.setattr(cell_resolve, "materialize", materialize)
 
@@ -388,6 +490,50 @@ def _attempt(monkeypatch, tmp_path, *, derive=None, resolve=None,
                   "guidance": [7.5]},
         work_root=tmp_path)
     return out
+
+
+def _attempt_all(monkeypatch, tmp_path, *, derive=None, resolve_batch=None,
+                 materialize=None) -> Any:
+    """Every outcome, for the declarations that trace to more than one class."""
+    from gen_worker import boot_adopt, boot_key
+
+    if derive is not None:
+        monkeypatch.setattr(boot_key, "derive", derive)
+    if resolve_batch is not None:
+        monkeypatch.setattr(cell_resolve, "resolve_batch", resolve_batch)
+    if materialize is not None:
+        monkeypatch.setattr(cell_resolve, "materialize", materialize)
+
+    class _Cfg:
+        family = "sdxl"
+        targets = ("unet",)
+        shapes = ((1024, 1024),)
+        text_lens = (77,)
+        guidance_scales = (7.5,)
+        lora_bucket = 0
+
+    return boot_adopt.attempt(
+        function="txt2img", modules=("m",), cfg=_Cfg(), slots={},
+        declared_hint=3,
+        envelope={"shapes": [[1024, 1024]], "text_lens": [77],
+                  "guidance": [7.5]},
+        work_root=tmp_path)
+
+
+def _derived_multi() -> Any:
+    """A declaration that traced THREE graph classes — the shape the batch wire
+    exists for, and the one a single-key loop would bill three round trips."""
+    from gen_worker import boot_key, cell_key as ck
+
+    axes = [{"graph": g, "sm": "sm_89", "toolchain": "t" * 16}
+            for g in ("c0ffee0000000000", "beef000000000000",
+                      "dead000000000000")]
+    return boot_key.DerivedKey(
+        entry_keys={f"e{i}": ck.from_axes(a).digest
+                    for i, a in enumerate(axes)},
+        class_hashes={f"e{i}": a["graph"] for i, a in enumerate(axes)},
+        manifest=ck.manifest_digest([a["graph"] for a in axes]),
+        workers=2, width_reason="test", traced=3, memo="miss", wall_ms=1234)
 
 
 def _derived(digest: str = KEY) -> Any:
@@ -428,7 +574,7 @@ def test_a_hub_refusal_degrades_but_keeps_its_own_token(
 
     out = _attempt(
         monkeypatch, tmp_path,
-        derive=lambda **_kw: _derived(), resolve=_refuse)
+        derive=lambda **_kw: _derived(), resolve_batch=_refuse)
     assert not out.adopted
     assert out.reason == "cell_resolve_ambiguous"
     assert out.derived_key.startswith("cg-key-v1-")
@@ -438,7 +584,10 @@ def test_a_hub_refusal_degrades_but_keeps_its_own_token(
 def test_a_miss_degrades_as_miss_not_as_a_failure(monkeypatch, tmp_path) -> None:
     out = _attempt(
         monkeypatch, tmp_path,
-        derive=lambda **_kw: _derived(), resolve=lambda *_a, **_k: None)
+        derive=lambda **_kw: _derived(),
+        resolve_batch=lambda _f, keys, **_k: tuple(
+            cell_resolve.ResolveAnswer(compiled_graph_key=k, status="miss")
+            for k in keys))
     assert not out.adopted
     assert out.reason == "miss"
     assert out.derived_key.startswith("cg-key-v1-")
@@ -461,7 +610,10 @@ def test_a_failed_materialize_degrades_and_is_never_fatal(
     out = _attempt(
         monkeypatch, tmp_path,
         derive=lambda **_kw: _derived(),
-        resolve=lambda *_a, **_k: _Cell(),
+        resolve_batch=lambda _f, keys, **_k: tuple(
+            cell_resolve.ResolveAnswer(
+                compiled_graph_key=k, status="hit", cell=_Cell())
+            for k in keys),
         materialize=_boom)
     assert not out.adopted
     assert out.reason == "materialize_failed"
@@ -479,3 +631,186 @@ def test_an_unexpected_exception_anywhere_still_degrades(
     assert not out.adopted
     assert out.reason == "derive_failed"
     assert "RuntimeError" in out.detail
+
+
+# ---------------------------------------------------------------------------
+# pgw#1224 — the properties only a BATCH can have. Each row names the red it
+# would go if the client stopped checking it.
+# ---------------------------------------------------------------------------
+
+
+def test_one_answer_per_key_in_request_order(stub) -> None:
+    """The whole contract in one row: N keys in, N answers out, positionally
+    aligned, and the caller may zip them without checking."""
+    keys = [KEY, OTHER_KEY, THIRD_KEY]
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(
+        _hit_body(), _miss(OTHER_KEY),
+        _hit_body(cell_key=THIRD_KEY, receipt="eyJ.dGhpcmQ.c2ln")))
+    answers = cell_resolve.resolve_batch("sdxl", keys)
+    assert [a.compiled_graph_key for a in answers] == keys
+    assert [a.status for a in answers] == ["hit", "miss", "hit"]
+
+
+def test_a_short_answer_is_refused_not_read_as_misses(stub) -> None:
+    """RED (omit misses instead of answering them): ``asked 3 keys, got 1
+    answers``. An omission is indistinguishable from a truncation, and the pod
+    answers each phantom miss by paying for a full cold mint."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(_hit_body()))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY, THIRD_KEY])
+    assert err.value.code == "cell_resolve_short_answer"
+    assert "asked 3 keys, got 1 answers" in err.value.detail
+
+
+def test_a_long_answer_is_refused_too(stub) -> None:
+    """Symmetric, and for the same reason: an answer set that is not the
+    question's shape has not answered the question."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(_hit_body(), _miss(OTHER_KEY)))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY])
+    assert err.value.code == "cell_resolve_short_answer"
+
+
+def test_a_reply_with_no_answers_at_all_is_refused(stub) -> None:
+    _sent, resp = stub
+    resp["r"] = _Resp(200, {"object": "cell_resolve_batch", "family": "sdxl"})
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY])
+    assert err.value.code == "cell_resolve_short_answer"
+
+
+def test_transposed_answers_are_refused(stub) -> None:
+    """RED (trust position without checking the echo, or the echo without the
+    position): a batch whose answers were swapped would arm each graph class
+    with a sibling's kernels, and the key is an ingress identity — only the
+    graph-witness floor would stand in the way, after the bytes were paid for."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(_hit_body(cell_key=OTHER_KEY), _hit_body()))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY])
+    assert err.value.code == "cell_resolve_answer_out_of_order"
+    assert "answers[0]" in err.value.detail
+
+
+def test_a_batch_level_signature_is_refused_never_ignored(stub) -> None:
+    """RED (ignore a top-level signature): an ignored signature field is one a
+    later reader assumes was checked. There is deliberately NO signature over
+    the batch — a batch-level one would make the COLLECTION the unit of trust,
+    the exact mistake th#1834 is undoing one layer down."""
+    _sent, resp = stub
+    for field in ("signature", "receipt", "jws", "answers_signature"):
+        resp["r"] = _Resp(200, _batch(_hit_body(), **{field: "eyJ.x.y"}))
+        with pytest.raises(cell_resolve.CellResolveRefused) as err:
+            cell_resolve.resolve_batch("sdxl", [KEY])
+        assert err.value.code == "cell_resolve_batch_signature"
+        assert field in err.value.detail
+
+
+def test_two_answers_may_not_share_one_receipt(stub) -> None:
+    """EVERY ANSWER IS INDEPENDENTLY SIGNED. One receipt covering two answers
+    is a batch-level signature wearing a per-answer field name: the receipt is
+    the hub's signature over ONE compiled graph, so a shared one means at least
+    one answer is vouched for by the other's proof.
+
+    RED (verify signatures per BATCH rather than per answer): both answers are
+    adopted, and the second arms bytes nothing signed for it."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(
+        _hit_body(), _hit_body(cell_key=OTHER_KEY)))
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY])
+    assert err.value.code == "cell_resolve_shared_receipt"
+
+
+def test_distinctly_signed_answers_are_both_adopted(stub) -> None:
+    """The other side of the row above, so the guard cannot pass by refusing
+    everything: two answers, two receipts, both hits."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(
+        _hit_body(), _hit_body(cell_key=OTHER_KEY, receipt="eyJ.b3RoZXI.c2ln")))
+    answers = cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY])
+    assert [a.status for a in answers] == ["hit", "hit"]
+    assert answers[0].cell is not None and answers[1].cell is not None
+    assert answers[0].cell.receipt != answers[1].cell.receipt
+
+
+def test_an_unsigned_hit_is_refused_before_the_bytes_are_paid_for(stub) -> None:
+    """A hit with no receipt states an admission expectation nothing can check,
+    and the gate that would catch it runs after the whole artifact is
+    downloaded."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(_hit_body(receipt="")))
+    answer = _one()
+    assert answer.cell is None
+    assert answer.refusal_code == "cell_resolve_incomplete"
+    assert "receipt" in answer.detail
+
+
+def test_one_bad_answer_does_not_sink_its_siblings(stub) -> None:
+    """THE point of per-answer statuses. Under the atom a boot resolves one key
+    per graph class, so a whole-request 409 on one duplicated row would throw
+    away 35 good answers and re-mint them."""
+    _sent, resp = stub
+    resp["r"] = _Resp(200, _batch(
+        _hit_body(),
+        {"cell_key": OTHER_KEY, "status": "ambiguous", "found": False,
+         "detail": "two rows"},
+        _hit_body(cell_key=THIRD_KEY, receipt="eyJ.dGhpcmQ.c2ln")))
+    answers = cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY, THIRD_KEY])
+    assert [a.status for a in answers] == ["hit", "ambiguous", "hit"]
+    assert sum(1 for a in answers if a.hit) == 2
+    assert answers[1].refusal_code == "cell_resolve_ambiguous"
+
+
+def test_a_duplicate_key_is_refused_before_the_hub_is_dialled(stub) -> None:
+    """Answers are positional; a collapsed duplicate would shift every later
+    answer against its request. The hub refuses it by name and so does this,
+    one round trip earlier."""
+    sent, _resp = stub
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY, KEY])
+    assert err.value.code == "cell_resolve_duplicate_key"
+    assert not sent
+
+
+def test_over_the_bound_is_refused_before_the_hub_is_dialled(stub) -> None:
+    """The bound and the explicit miss are ONE design: over it the hub refuses
+    the WHOLE batch by name, so splitting late would cost every key's answer to
+    learn the number."""
+    sent, _resp = stub
+    too_many = ["cg-key-v1-" + f"{i:056x}"
+                for i in range(cell_resolve.MAX_RESOLVE_KEYS + 1)]
+    with pytest.raises(cell_resolve.CellResolveRefused) as err:
+        cell_resolve.resolve_batch("sdxl", too_many)
+    assert err.value.code == "cell_resolve_too_many_keys"
+    assert not sent
+    # ...and exactly the bound is fine, so the guard is a bound and not a ban.
+    _resp["r"] = _Resp(200, _batch(*[_miss(k) for k in too_many[:-1]]))
+    assert len(cell_resolve.resolve_batch("sdxl", too_many[:-1])) == \
+        cell_resolve.MAX_RESOLVE_KEYS
+
+
+def test_a_boot_resolves_its_whole_manifest_in_ONE_call(
+    monkeypatch, tmp_path,
+) -> None:
+    """The saving the batch wire exists for, asserted as a COUNT: a 3-class
+    declaration costs one round trip, not three. RED (loop per key): calls == 3.
+    """
+    calls: list = []
+
+    def _batched(family, keys, **_kw):
+        calls.append(tuple(keys))
+        return tuple(
+            cell_resolve.ResolveAnswer(compiled_graph_key=k, status="miss")
+            for k in keys)
+
+    outs = _attempt_all(
+        monkeypatch, tmp_path,
+        derive=lambda **_kw: _derived_multi(), resolve_batch=_batched)
+    assert len(calls) == 1
+    assert len(calls[0]) == 3
+    assert len(outs) == 3
+    assert {o.reason for o in outs} == {"miss"}

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -400,6 +400,24 @@ class _FakeResp:
         return json.loads(self.text)
 
 
+def _granted(body, repo: str) -> dict:
+    """The hub's batch answer: one grant per entry, in request order, each
+    with ITS OWN token (pgw#1224 / th#1842 PR #1121)."""
+    entries = (body or {}).get("entries") or []
+    return {
+        "object": "cell_publish_intent_batch",
+        "repo": repo,
+        "family": str((body or {}).get("family") or ""),
+        "granted": len(entries),
+        "answers": [
+            {"cell_key": str(e.get("cell_key") or ""), "status": "granted",
+             "capability_token": f"cap-token-{i}",
+             "expires_at_unix": 4102444800}
+            for i, e in enumerate(entries)
+        ],
+    }
+
+
 def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     posts: list = []
     # pgw#1046: a real exported-cell envelope — the publish path recomputes the
@@ -410,11 +428,7 @@ def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     def _post(url, headers=None, json=None, timeout=None):
         posts.append((url, json))
         if url.endswith("/publish-intent"):
-            return _FakeResp(200, {
-                "capability_token": "cap-token",
-                "repo": "root/family-fam",
-                "cell_key": key,
-            })
+            return _FakeResp(200, _granted(json, "root/family-fam"))
         return _FakeResp(200, {"recorded": True})
 
     import requests
@@ -469,10 +483,13 @@ def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     # The claimed axes the hub will attest.
     assert intent_body["axes"] == {
         "sku": "b200", "image_digest": "sha256:img", "gen_worker": "0.39.0"}
-    assert intent_body["cell_key"] == key
+    # pgw#1224: the KEY is per ENTRY, the attested axes are per BATCH. A
+    # one-artifact publish is a one-entry batch — the single-entry body is gone.
+    assert [e["cell_key"] for e in intent_body["entries"]] == [key]
+    assert set(intent_body) == {"family", "axes", "entries"}
 
     kind, kw = committed[0]
-    assert kind == "client" and kw["token"] == "cap-token"
+    assert kind == "client" and kw["token"] == "cap-token-0"
     kind, kw = committed[1]
     assert kind == "publish_v2", "the cell publisher ships over chunked sha256"
     assert kw["destination_repo"] == "root/family-fam"
@@ -521,8 +538,7 @@ def test_publisher_reports_commit_failure(monkeypatch, tmp_path):
     def _post(url, headers=None, json=None, timeout=None):
         posts.append((url, json))
         if url.endswith("/publish-intent"):
-            return _FakeResp(200, {
-                "capability_token": "cap", "repo": "root/family-fam"})
+            return _FakeResp(200, _granted(json, "root/family-fam"))
         return _FakeResp(200, {"recorded": True})
 
     import requests

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -305,7 +305,12 @@ def _attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
         publisher_tier = "platform"
 
     monkeypatch.setattr(boot_key, "derive", lambda **_kw: derived)
-    monkeypatch.setattr(cell_resolve, "resolve", lambda *_a, **_k: _Cell())
+    monkeypatch.setattr(
+        cell_resolve, "resolve_batch",
+        lambda _f, keys, **_k: tuple(
+            cell_resolve.ResolveAnswer(
+                compiled_graph_key=k, status="hit", cell=_Cell())
+            for k in keys))
     monkeypatch.setattr(
         cell_resolve, "materialize", lambda *_a, **_k: artifact)
 

--- a/tests/test_micro_mint_rig_pgw978.py
+++ b/tests/test_micro_mint_rig_pgw978.py
@@ -274,8 +274,9 @@ def test_arming_a_probes_publish_is_explicit(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("GEN_WORKER_PROBE_PUBLISH_ARMED", "1")
     action, _q, _b = actions.authorize({
         "method": "POST", "path": "/v1/worker/cells/publish-intent",
-        "json": {"family": "microrig", "cell_key": "ck5-" + "a" * 56,
-                 "axes": {}, "identity_axes": {}, "mint_duration_ms": 1}})
+        "json": {"family": "microrig", "axes": {},
+                 "entries": [{"cell_key": "cg-key-v1-" + "a" * 56,
+                              "identity_axes": {}, "mint_duration_ms": 1}]}})
     assert action.name == "cells.publish_intent"
 
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -230,9 +230,14 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
               timeout: Any = None) -> Any:
         posts.append((url, json))
         if url.endswith("/publish-intent"):
+            # pgw#1224: one answer per entry, one token each.
+            entries = (json or {}).get("entries") or []
             return _FakeResp(200, {
-                "capability_token": "cap", "repo": f"root/family-{FAMILY}",
-                "cell_key": key})
+                "repo": f"root/family-{FAMILY}", "granted": len(entries),
+                "answers": [
+                    {"cell_key": e.get("cell_key"), "status": "granted",
+                     "capability_token": f"cap-{i}"}
+                    for i, e in enumerate(entries)]})
         return _FakeResp(200, {"recorded": True})
 
     import requests

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-249187bab3cb714abfa4fe85fc2976384391c6d34ea77b0e73444866427f02e8
+2a0cdb3a006331458220e864a3ecab8f0016f957925f9d4666277f28b98d87f0

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -19,9 +19,16 @@
     ],
     "cell_resolve_hub_refusal_codes": [
       "cell_resolve_ambiguous",
+      "cell_resolve_answer_out_of_order",
+      "cell_resolve_batch_signature",
       "cell_resolve_client_supplied_field",
+      "cell_resolve_duplicate_key",
       "cell_resolve_incomplete",
-      "cell_resolve_transport_unavailable"
+      "cell_resolve_shared_receipt",
+      "cell_resolve_short_answer",
+      "cell_resolve_too_many_keys",
+      "cell_resolve_transport_unavailable",
+      "cell_resolve_unknown_status"
     ],
     "cell_publish_untrusted_refusal_code": "cell_publish_untrusted_tier",
     "hardware_unsuitable_reason_classes": [


### PR DESCRIPTION
# ⛔ HOLD — DO NOT MERGE, DO NOT ENQUEUE. This is the OPENING MOVE of a flag-day window, not a ready PR.

**Green is not permission here.** `fast gates` and `tests` are green at `fe173533` and that is irrelevant to whether this may land.

**The arithmetic, which is the whole reason:** this client is a HARD CUT, so **every wheel cut from `master` after this merges is batch-only** — its `cell_resolve`/`fleet_cells` can speak nothing but `keys[]`/`entries[]`. The hub's batch surface (th#1842 [#1118](https://github.com/cozy-creator/tensorhub/pull/1118) / [#1121](https://github.com/cozy-creator/tensorhub/pull/1121)) is itself **held**, so the DEPLOYED hub still accepts only the single-key/single-entry shapes. A batch-only wheel against that hub cannot resolve or publish at all.

**Concretely: the 0.114.1 cut (PR #775, in flight, carrying the format-axis fix the campaign needs) MUST NOT contain this change**, or the campaign train's workers break against the deployed hub.

This is this PR's own fleet-inconsistency note biting in the direction it did not spell out. The body below says "an older hub refuses these bodies and a newer hub refuses the old ones" — stated as a constraint on when the HUB half may land. It equally constrains **which WHEEL this client half may ship in**, and that half was missing.

**The window this merges in, in order:**

1. the campaign train completes on **0.114.1** (which must not contain this);
2. **this PR merges** — the opening move, and only here;
3. **0.115.0 is cut** = the first batch wheel;
4. the fleet **re-pins** to 0.115.0;
5. the hub half **#1118/#1121 lands**;
6. the old routes die.

Steps 3–6 are not this lane's to declare. Until step 1 is confirmed complete by the coordinator, this PR stays green and rebased and **nothing else**.

---

pgw#1224 (th#1834 Phase 2): the worker speaks the BATCH cell wire — `keys[]` in, one independently signed answer per key out; `entries[]` in, one token each out.

**HARD CUT, both routes.** `cell_resolve.resolve()` and the single-entry publish-intent body are GONE — no alias, no dual-accept, no negotiation. A client that could still speak the old shapes would make the hub's own hard cut unprovable, and pre-launch there is no consumer to protect.

## THE HUB HALF IS th#1842 #1118 + #1121 — AND THIS PR DISCHARGES ONE CLAUSE OF THEIR HOLD, NOT THE HOLD

This is the half those two HELD PRs are waiting on. th#1842 revised its hold on 2026-08-13 to name exactly this work: *"a pgw wheel exists whose `cell_resolve` / `fleet_cells` actually send `keys[]` / `entries[]` — needs its own pgw issue; it is **not** 0.114.0."*

**The fleet is consistent only after BOTH sides land.** An older hub refuses these bodies and a newer hub refuses the old ones, so this PR merging is a PRECONDITION for the hub half and nothing more.

**Do not read this merge as a green light for [#1118](https://github.com/cozy-creator/tensorhub/pull/1118) / [#1121](https://github.com/cozy-creator/tensorhub/pull/1121).** Their hold is a THREE-clause window and this discharges exactly one of it:

1. ✅ **a pgw wheel exists whose `cell_resolve` / `fleet_cells` actually send `keys[]` / `entries[]`** — this PR, and it is the clause th#1842 wrote as *"needs its own pgw issue; it is **not** 0.114.0"*;
2. ⏳ **the campaign is not mid-train on an older wheel.** This is a hard cut with no dual-accept, so a hub that only accepts the batch shapes refuses every worker still running 0.113.0/0.114.0. Landing the hub half against a live campaign breaks it — that clause is about the FLEET's state, and merging this changes nothing about it;
3. ⏳ **th#1897's `IsCellKey` → `IsCompiledGraphKey` rename rebased into both branches**, without which they do not compile against tensorhub master.

Clause 2 is satisfied by a wheel cut and a fleet roll, neither of which is this lane's to declare. **Whoever lands the hub half owns clauses 2 and 3 and must check them at that moment rather than inheriting this line.**

## WHY BATCH

Under the per-entry atom (pgw#1176) a boot derives ONE KEY PER GRAPH CLASS — 18-36 for sdxl, 198 for minimax-h3 — so a per-key wire billed a boot that many round trips for one answer set, and one sdxl mint issued 36 publish-intents each carrying full axis attestation. The entitlement inputs (the release's endpoint, the viewer org) are properties of the CALLER, so the hub resolves them once per batch instead of once per key.

The three sites that stated the gap on 0.114.0: `cell_resolve.py:250` posted `{family, cell_key}`; `fleet_cells.py:733` posted one entry; and `boot_adopt.py:493` said it in terms — *"when the hub grows POST /v1/worker/cells/resolve {family, keys[]} … this becomes one call"*.

## RESOLVE

`resolve_batch(family, keys) -> tuple[ResolveAnswer, ...]`, positionally aligned with the request and always the same length. **Four properties the client ENFORCES**, because each is a way the answer could lie and none is checked anywhere downstream:

1. **ARITY.** A short answer is indistinguishable from a truncated one, and the pod answers a missing answer by paying for a full cold mint — so a dropped answer is not a smaller reply, it is a wrong one that costs money.
2. **ORDER.** Position AND the echoed key, because either alone admits a batch transposed by something that preserved the other. The key is an ingress identity, so a transposed batch would arm each class with a sibling's kernels and only the graph-witness floor would stand in the way — after the bytes were paid for.
3. **PER-ANSWER SIGNATURE, never per-batch.** Every hit carries its own receipt, and `receipt` joins `_REQUIRED` so an unsigned hit is refused before the bytes are paid for. A top-level batch signature field is **refused rather than ignored** — an ignored signature is one a later reader assumes was checked — and two answers sharing one receipt is the same fault wearing a different hat: a receipt signs ONE compiled graph.
4. **A PER-KEY FAULT DOES NOT SINK THE BATCH.** `ambiguous`, `incomplete` and `transport_unavailable` were whole-request refusals; under the atom one duplicated row would strand a whole boot's adoption — 35 good answers thrown away. They are per-answer STATUSES now and carry **the same typed codes**, so `boot_adopt.ASK_REASONS` and every grouping on those codes survive the cut. An UNKNOWN status is refused, never defaulted to miss: the day the hub learns to name a new fault, a defaulting client self-mints over it.

The whole-batch refusals that remain are the ones that are properties of the CALLER or the REQUEST — answering those per key would report one hub fault as 256 misses.

## PUBLISH

`publish_intent(family, entries, sku=, gen_worker=)` posts `{family, axes, entries[]}` and returns one `PublishGrant` per entry, **each with its own token** — a single token covering the batch would make the COLLECTION the unit of trust, and a token for entry 5 must not publish entry 6's bytes. The client refuses a shared token for the same reason it refuses a shared receipt.

`publish_granted` ships one entry's bytes under its own grant. `publish()` is a one-entry batch, which is the honest shape for it: the live publish paths are independent background transfers, one per key (`_publish_async`), so their intents cannot be joined without joining the threads. **`aot_mint.publish` is the real N-entry caller** and now pays ONE attested intent for a whole mint.

Every entry restates **all three** key axes (`graph`, `sm`, `toolchain`), per Paul's 2026-08-12 correction: `sm` and `toolchain` are constant in FACT within a mint, and hoisting them would make that constancy a convention the wire depends on rather than one it enforces — a row verifiable only inside its collection is not an identity. `cell_key.KEY_AXES` is now public so the key and the wire read ONE list.

**One behavioural fix found while building:** the pgw#712 adoption-mark fence moved to `intent_entry`, which is what every publisher runs before the intent — the fence has to refuse before a byte moves and before the hub is asked at all. It briefly sat after the intent during this rewrite and `test_marked_cell_never_republishes` caught it.

## SEAM

The `procsplit` action table moved with the wire: `cells.resolve` admits `{family, keys}`, `cells.publish_intent` admits `{family, axes, entries}`. An unlisted key is an `ActionRefused`, so a client speaking the dead shape refuses at the one gate that can see it.

## TESTS

`test_cell_resolve_pgw1090` is **re-based, not replaced** — every row keeps its subject and drives a one-key BATCH — plus 14 new rows for the properties only a batch can have, each naming the RED it would go:

* omitted misses → `asked 3 keys, got 1 answers`
* transposed answers → `cell_resolve_answer_out_of_order`
* a batch-level signature field (all four spellings) → `cell_resolve_batch_signature`
* two answers, one receipt → `cell_resolve_shared_receipt`, with the distinctly-signed twin beside it so the guard cannot pass by refusing everything
* an unrecognised status → `cell_resolve_unknown_status`, never a miss
* a duplicate key and an over-bound batch, both refused before the hub is dialled

**The end-to-end row on a real HTTP hub now asserts ONE round trip for three declared classes.** It asserted three before, so a surviving per-key loop reds there rather than passing quietly.

Deleted 0 rows, consolidated 0. Vocabulary: everything new is `compiled_graph` / "compiled graph" / `cg-key-v1`, and no key is ever split on `-`.

---

## Rebase log

The merge queue removed this entry twice as master's tip moved under it. That is the queue working, not a defect — it re-runs against the real tip — and both rebases carried a real reconciliation, not just a replay:

1. **over pgw#1213 #767 (fragment-width / th#1897).** Clean apply, but th#1897 made the key grammar deliberately **scheme-agnostic** — it refuses shape, never scheme, so a newer fleet's key stays addressable by an older hub and is ruled on by its axes. `_require_batch`'s refusal still told callers their key had to be `cg-key-v1-<digest>` "and by nothing else", contradicting the grammar it was quoting. Fixed. That was the only place this branch restated a grammar it does not own — `cell_key.is_key` remains the single validator both halves of the wire call, so the client picked up the new grammar and the `MAX_FRAGMENT_LEN` bound by construction rather than by a second copy.
2. **over pgw#1225 #770 + pgw#1202 #760.** One genuine conflict, in `tests/harness/cell_hub.py`: #770 declared the double's server state and removed ~30 `# type: ignore[attr-defined]` reads, and the publish-intent branch I had rewritten was one of them. Resolved by taking **both** — #770's typed reads and this branch's per-entry batch answer. The double still mints a **distinct token per entry** on purpose: one that handed every entry the same token would make the client's "one token each" check unfalsifiable.

Re-verified after each rebase with the commands CI runs: `mypy src/gen_worker tests tests_v2` clean (771 files), all eight `fast gates` guards + `assemble_changelog --check` OK, and 268 passed / 1 skipped across the 15 affected files — including #767's own new `test_key_grammar_vectors_th1897` and #770's `cell_hub` consumers.


---

## 🛠 REBASED A THIRD TIME, 2026-08-13 (flag-day prep lane) — and the rebase found a red this PR was hiding

Rebased onto pgw `master` `0c126df0`, pushed at `ba108468`. **Still DRAFT. Still the flag-day opener.**

**The "GREEN at `fe173533`" line in the hold block was true and is now stale.** It was green against
the master it branched from. **pgw#1237 landed after it** (`b6bd53c5`, PR #782) with the
worker-value contract fence, which binds `cell_resolve.REFUSAL_CODES` byte-for-byte to
`tests/testdata/worker_value_contracts.json`. This branch adds **seven** codes to that tuple, so on
the rebased tree `tests/test_worker_value_contracts_pgw1237.py` was **12 failed / 7 passed**. Fixed
here: the corpus declares all eleven codes and the pinned digest moves with it
(`249187ba…` → `2a0cdb3a…`). 19 passed after.

That file is the **public carrier tensorhub vendors** (`docs/parity-contract-registry.md`: *"PGW
LANDS FIRST"*), so this is not a local fixup — **the hub half (th#1842 #1118/#1121) cannot pass its
own `gates` until these bytes are on pgw `master`.** The window already put step 2 before step 5;
this makes it mechanical instead of a matter of care.

**Note for whoever executes step 2: a DRAFT PR's required checks report SKIPPED, not green.**
`ci.yml`'s job `if:` admits `merge_group`, `workflow_dispatch`, or a non-draft `pull_request` — and
GitHub scores a skipped required check as satisfied. CI for this rebase was obtained by
`gh workflow run ci.yml --ref 1224-batch-wire` (run `31765774546`). **Un-draft first and let a real
`pull_request` cycle go green before enqueueing.**

Local on the rebased tree: `mypy` strict clean (777 files), all 18 fast-gate lints, `ruff`,
`assemble_changelog --check`, and the ten touched-file test modules at **189 passed / 1 skipped**.
The 0.114.2 cut consumed `changelog.d/` underneath this branch without conflict — a cut DELETES
fragments while this branch ADDS one, so pgw#1226's conflict shape did not bite here.

The full 0.115.0 cut checklist and the step-4 fleet re-pin worklist are in the tracker under pgw#1224.