### PR TITLE
pgw#1228: three tests stop measuring the box

### DIFF
--- a/changelog.d/pgw1228.md
+++ b/changelog.d/pgw1228.md
@@ -1,0 +1,20 @@
+- Testing: `test_armed_target_install_pgw1093`'s three tests no longer change
+  verdict with the box. They failed on any host exporting
+  `GEN_WORKER_FORBID_CPU_OFFLOAD` and passed everywhere else — measured A/B on
+  a dev box: **3 failed exported, 3 passed unset**. The chain was environmental
+  end to end: an unreadable free-VRAM probe makes `place_pipeline` select
+  `group_offload` (pgw#940 — an unmeasured card does not license residency),
+  `group_offload` is unavailable so it falls back to `sequential`, and the real
+  applier then raises `CpuOffloadForbidden`. None of that is what these tests
+  assert, which is compile-target installation and eager posture.
+- The fix is the seam `test_rung_ladder_pgw1206` already uses for this exact
+  guard (the th#1043 pattern): the `boot` fixture stubs
+  `apply_low_vram_config`, so the diffusers placement hooks — not the code
+  under test — never run. Pinning free VRAM high instead does NOT work: it
+  selects the resident rung and routes into `pipeline.to("cuda")`, which a
+  cardless box cannot satisfy.
+- The guard itself is deliberately unchanged. It is a ratified weights-locality
+  tripwire (pgw#929), not configuration, and deleting it to quiet three tests
+  would be fixing the wrong end. A test whose verdict depends on a box-wide env
+  is measuring the box, not the code — the discipline pgw#1049 imposed for
+  `PYTHONHASHSEED`, applied here.

--- a/tests/test_armed_target_install_pgw1093.py
+++ b/tests/test_armed_target_install_pgw1093.py
@@ -155,14 +155,33 @@ class H3:
 def boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """One real `ensure_setup()` on the real arm path.
 
-    The ONLY environment fake is `torch.cuda.is_available` — `arming_block`
-    refuses a cardless process, and the defect is not about cards. `apply`,
-    `arm_jit_intake`, `ArmingScope`, the warm plan and the target install are
-    all the production code.
+    TWO environment fakes, both about the CARD and neither about the defect:
+    `torch.cuda.is_available` (`arming_block` refuses a cardless process), and
+    the `apply_low_vram_config` seam. `arm_jit_intake`, `ArmingScope`, the warm
+    plan and the target install are all the production code.
+
+    The applier is stubbed for the reason `test_rung_ladder_pgw1206` stubs it
+    (the established th#1043 seam): the diffusers placement hooks are not the
+    code under test, and a box that exports `GEN_WORKER_FORBID_CPU_OFFLOAD`
+    makes the real applier RAISE. That export is a ratified weights-locality
+    tripwire (pgw#929) and this dev box sets it, so without this seam these
+    three tests fail here and pass in CI — measuring the box rather than the
+    boot. Stubbing at `place_pipeline`'s applier call is the only seam that
+    works: pinning free VRAM high instead would select the resident rung and
+    route into `pipeline.to("cuda")`, which a cardless box cannot satisfy.
     """
     import torch
 
+    from gen_worker.models import memory
+
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def _fake_apply(
+        pipeline: Any, *, mode: str = "auto", logger: Any = None, **_kw: Any,
+    ) -> dict:
+        return {"mode": mode}
+
+    monkeypatch.setattr(memory, "apply_low_vram_config", _fake_apply)
 
     events: List[Any] = []
     real_emit = activity.emit_event


### PR DESCRIPTION
`test_armed_target_install_pgw1093`'s three tests changed verdict with a box-wide export. Measured A/B at `82cbf651`:

| | result |
|---|---|
| `GEN_WORKER_FORBID_CPU_OFFLOAD=1` | **3 failed** |
| variable unset | **3 passed** |

The chain was environmental end to end, and none of it is what these tests assert (compile-target installation and eager posture): the free-VRAM probe fails on a box whose driver torch cannot use → `place_pipeline` selects `group_offload` rather than the resident rung (pgw#940, *an unmeasured card does not license full residency*) → `group_offload` is unavailable so it falls back to `sequential` → the real applier raises `CpuOffloadForbidden`.

## The seam is the one already in the tree

`test_rung_ladder_pgw1206.py:97-100` solved this for the same guard and says so in a comment — the th#1043 pattern: *the ladder WALK is the code under test, the diffusers hooks are not.* The `boot` fixture now stubs `apply_low_vram_config` the same way.

**Pinning free VRAM high instead does NOT work**, and the failure is instructive: a high reading selects the resident rung, which routes into `pipeline.to("cuda")` *before* the applier is reached — unsatisfiable on a cardless box. The applier call is the only seam that holds both ways.

## The guard is deliberately unchanged

It is a ratified weights-locality tripwire (pgw#929) protecting the hard rule that multi-GB weights never transit a dev box on a residential uplink. It carries no behaviour of its own and is recorded as a tripwire in `scripts/config_reads_allowlist.txt`. Deleting a guard on a hard rule to quiet three tests is fixing the wrong end.

## Red-proof, both directions

- post-fix **exported → 3 passed**; post-fix **unset → 3 passed**
- **vacuity probe** — because a stub that hides a guard can also hide the code under test: with `_install_compile_targets` short-circuited in production, the stub in place *and* the variable exported, **2 of 3 go red**. The tests still measure the install.

Also de-noises every lane's local full-suite run on this box permanently — these three were the standing phantom reds.

mypy `Success: no issues found in 763 source files`; ruff and ratchet green. **No production changes.**