### PR TITLE
pgw#1215 step 2a: lift the mint's packaging tail into aot_mint.pack_graph_classes

### DIFF
--- a/changelog.d/pgw1215.md
+++ b/changelog.d/pgw1215.md
@@ -26,3 +26,16 @@
   `aot_contract` for "every declared graph class refused", and one name for both would make "this
   subject cannot be built here" and "nothing compiled" indistinguishable at the exit-code boundary
   with no test going red.
+
+- **pgw#1215 step 2a: the mint's packaging tail becomes callable — `aot_mint.pack_graph_classes`.**
+  Phase 3's compile child traces and compiles its own share in ONE address space (that is the whole
+  point: the `torch.export.save`/`load` pair is deleted rather than relocated), so the child ends up
+  holding the `_MintedEntry` rows and has to turn them into artifacts itself. Left inline in
+  `_mint_cell`, the child would have had to re-implement packaging — and two packagers is exactly
+  the divergence per-graph-class identity exists to rule out.
+
+  **A move, not a design.** The 136-line tail is lifted verbatim; a line-by-line diff against
+  `origin/master` shows exactly one changed line (`progress.pool_ledger` becomes the `pool_ledger`
+  parameter). The seam is not invented either: `_export_entry` already RETURNS a `_MintedEntry` and
+  `trace_for_key` already builds them internally, so the two halves have always spoken this type.
+  Ordering, refusals, `timings` keys and the phase event are unchanged.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2615,6 +2615,62 @@ def _mint_cell(
     timings["entry_workers"] = float(width.workers)
 
     # ── PACK PER ENTRY (pgw#1176) ──────────────────────────────────────────
+    # Lifted to `pack_graph_classes` (pgw#1215) so the compile child can pack
+    # its own share. Ordering, refusals and timings keys are unchanged.
+    return pack_graph_classes(
+        minted,
+        spec=spec,
+        work=work,
+        out_dir=out_dir,
+        class_aliases=class_aliases,
+        timings=timings,
+        t_mint=t_mint,
+        inductor_configs=inductor_configs,
+        width=width,
+        pool_ledger=progress.pool_ledger,
+        execution_lane_verdict=execution_lane_verdict,
+        progress=progress,
+    )
+
+
+
+def pack_graph_classes(
+    minted: Sequence["_MintedEntry"],
+    *,
+    spec: ExportSpec,
+    work: Path,
+    out_dir: Path,
+    class_aliases: Mapping[str, Sequence[Any]],
+    timings: Dict[str, Any],
+    t_mint: float,
+    inductor_configs: Optional[Mapping[str, Any]] = None,
+    width: Optional[aot_compile_pool.PoolWidth] = None,
+    pool_ledger: Optional[Mapping[str, Any]] = None,
+    execution_lane_verdict: Optional[kernel_path.Verdict] = None,
+    progress: Optional["MintProgress"] = None,
+) -> MintResult:
+    """Pack every compiled graph class into its own artifact — the mint's tail.
+
+    Lifted out of :func:`_mint_cell` UNCHANGED (pgw#1215, th#1834 Phase 3 step
+    2a). It moves because the process-layer rewrite has to call it from the
+    COMPILE CHILD: once a child traces and compiles its own share in one
+    address space it holds the ``_MintedEntry`` rows and must turn them into
+    artifacts itself. Left inline, the child would have to re-implement
+    packaging — and two packagers is exactly the divergence per-graph-class
+    identity exists to rule out.
+
+    It takes ``_MintedEntry`` rows because that is already what
+    :func:`_export_entry` returns and what :func:`trace_for_key` builds
+    internally. The seam is not invented here; the two halves have always
+    spoken this type, which is why the extraction is a move and not a design.
+
+    Byte-identical to the inline version: same order, same refusals, the same
+    ``timings`` keys written at the same points, the same phase event.
+    ``progress`` is optional only so a caller with no beat can pack; every
+    other argument is required because the artifact's identity depends on it.
+    """
+    progress = MintProgress() if progress is None else progress
+    # ── PACK PER ENTRY (pgw#1176) ──────────────────────────────────────────
     #
     # One artifact per graph class, not one per cell. The multi-entry
     # `model.pt2` is DELETED: it made identity, adoption, durability,
@@ -2687,7 +2743,7 @@ def _mint_cell(
     timings["declare_s"] = round(time.monotonic() - t0, 2)
     timings["total_s"] = round(time.monotonic() - t_mint, 2)
     phase_table = _mint_phase_table(
-        minted, timings, inductor_configs, width, progress.pool_ledger)
+        minted, timings, inductor_configs, width, pool_ledger)
     _emit_phase_event(spec, phase_table)
 
     t0 = time.monotonic()
@@ -2750,7 +2806,6 @@ def _mint_cell(
     )
     return MintResult(
         entries=tuple(packed), manifest=manifest, timings=timings)
-
 
 
 def _drive_pool(


### PR DESCRIPTION
**th#1834 Phase 3, step 2a of 4.** A pure move. No behaviour change.

## Why

Phase 3's compile child traces and compiles its own share in **one address space** — that is the whole point of the keystone, since it deletes the `torch.export.save`/`load` pair rather than relocating it (pgw#1216: `child_program_load_s` median **36.04 s**, ~22 min of a 36-class sdxl mint).

That means the child ends up holding the `_MintedEntry` rows and has to turn them into artifacts itself. Left inline in `_mint_cell`, the child would have to **re-implement packaging** — and two packagers is exactly the divergence per-graph-class identity exists to rule out.

So the tail moves out first, alone, ahead of the risky part. Same shape as step 1 (`fc6b025a`): with the seam in place, the keystone is a rewiring instead of an untangle.

## It is a move, not a design

- The 136-line tail is lifted **verbatim**. A line-by-line diff of the extracted body against `origin/master` shows **exactly one changed line**: `progress.pool_ledger` becomes the `pool_ledger` parameter.
- **The seam is not invented either.** `_export_entry` already *returns* a `_MintedEntry`, and `trace_for_key` already builds them internally before projecting them down to `TracedClass`. The two halves have always spoken this type — which is why this is an extraction and not a refactor.
- Ordering, refusals, `timings` keys and the phase event are unchanged.

## Evidence

- `mypy src/gen_worker tests tests_v2` → `Success: no issues found in 771 source files`
- `ruff check src/gen_worker` → clean
- 9 structural fences pass
- **153 passed** across the mint/packaging surface (`aot_mint_pgw723`, `aot_multigraph_pgw758`, `entry_blast_radius_pgw1208`, `overlap_export_compile_pgw1052`, `compile_attribution_pgw830`, `fold_per_entry_pgw1189`, `aot_compile_pool_pgw809`, `precision_stamp_pgw1076`, `artifact_identity_pgw903`) — re-run after rebase
- `git diff --diff-filter=D --name-only origin/master HEAD` → empty

### Could-have-gone-red: the extracted function is the LIVE path

Disabling pgw#1208's fail-closed **inside `pack_graph_classes`** turns `test_every_class_skipped_still_REFUSES` **red**. That is the proof that matters for an extraction — it shows the new function is actually on the path, not dead code beside a surviving copy. Reverted.

### ⚠️ Two coverage gaps found while red-proofing (pre-existing, NOT introduced here, NOT fixed here)

Both were probed and neither fired, so I am reporting them rather than claiming coverage this PR does not have:

1. **The per-class alias block is untested.** Replacing `merged = class_aliases.get(row.name)` with `merged = ()` — which drops pgw#917's `"aliases"` from every packed envelope — leaves the whole suite green.
2. **The manifest digest is untested.** Hard-coding `manifest = "RED-PROOF"` also leaves it green. Defensible, since the manifest is explicitly *"telemetry, never identity"* — but worth knowing it is unpinned.

Neither belongs in a pure-move PR. Flagged for the owning issues.

## Sequencing

Step 1 merged `fc6b025a`. **This is 2a — lands on local evidence, as approved, because it is a refactor.** 2b (the child rewiring, which deletes `save`/`load` and must update `aot_compile_spans.PARTITIONS` in the same commit) does **not** land until the micro-pod leg is green. Then step 4, the executor supervisor.
