### PR TITLE
pgw#1230 (P0): the `format` arm axis has ONE derivation — two constants shared one name

### DIFF
--- a/changelog.d/pgw1230.md
+++ b/changelog.d/pgw1230.md
@@ -1,0 +1,15 @@
+- **pgw#1230 (P0): the `format` arm axis had TWO derivations, so every freshly minted
+  cell failed to arm.** Two different facts shared the name `ARTIFACT_FORMAT`:
+  `aot_serve.ARTIFACT_FORMAT` (the AOT cell metadata schema, which the child stamps) and
+  `compile_cache.ARTIFACT_FORMAT` (the torch-inductor-cache producer format from gw#391,
+  an ingredient of the JIT semantic cache tag). `fleet_cells.arm_identity` computed its
+  `format` fact from the second and compared it against the first. Both were 2, so it
+  passed by coincidence until pgw#1176 moved the cell schema to 3 — after which every
+  freshly minted cell was refused at arm with `key_axis_divergence: format: child cell
+  states '3', this runtime computed '2'`, served eager, and published nothing (observed
+  on Cell Zero across all 4 z-image graph classes: compiled, quarantined, zero published).
+  The arm axis now reads the producer's own symbol, and the inductor constant is renamed
+  `compile_cache.SEMANTIC_TAG_FORMAT` — same value, so no cache tag churns — so the two
+  facts can no longer be confused for one. **No key is orphaned:** `format` is an arm
+  fact, never a cell-key axis (the axes are graph x sm x toolchain), so the four stamped
+  `cg-key-v1` keys were always correct and a re-mint reproduces them byte-for-byte.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -98,11 +98,23 @@ from .models import loading as _loading
 
 logger = logging.getLogger(__name__)
 
+# The JIT/torch-inductor-cache PRODUCER format, and NOTHING ELSE — it is an
+# ingredient of the semantic cache tag (`_semantic_cache_tag`) and is not the
+# AOT cell metadata schema, which is `aot_serve.ARTIFACT_FORMAT`.
+#
+# pgw#1230 RENAMED it from `ARTIFACT_FORMAT`. Two different facts shared that
+# name across two modules; `fleet_cells.arm_identity` read THIS one to compute
+# the `format` axis it compares against what the child stamped from
+# `aot_serve`'s. They were both 2, so the comparison passed by coincidence
+# until pgw#1176 moved the cell schema to 3 — after which every freshly minted
+# cell failed to arm with `key_axis_divergence`. The value is unchanged, so no
+# cache tag moves; only the name that made the confusion possible does.
+#
 # 2 (gw#391): key gained the producer gen-worker version. ie#496 extends its
 # metadata with the canonical module graph, shape/target table and weight-lane
 # schema without gratuitously invalidating proven non-W8A8 cells. New W8A8
 # consumers require those fields; checkpoint bytes remain deliberately absent.
-ARTIFACT_FORMAT = 2
+SEMANTIC_TAG_FORMAT = 2
 _MARKER_ATTR = "_cozy_compile"
 _LOCK_TYPE = type(threading.Lock())
 
@@ -1163,7 +1175,7 @@ def _semantic_cache_tag(pipeline: Any, cfg: Any) -> str:
         pipeline_weight_lane(pipeline),
         int(getattr(cfg, "lora_bucket", 0) or 0))
     payload = "|".join((
-        str(ARTIFACT_FORMAT), "inductor",
+        str(SEMANTIC_TAG_FORMAT), "inductor",
         str(getattr(cfg, "family", "") or ""), execution_lane,
         "regional" if bool(getattr(cfg, "regional", False)) else "whole",
         cell_key.facts_digest(declared_compile_facts(cfg)),
@@ -3030,11 +3042,11 @@ def arm_jit_intake(pipe: Any, cfg: Any) -> None:
 
 
 __all__ = [
-    "ARTIFACT_FORMAT",
     "AdoptError",
     "CellSelectionBugError",
     "CompileArmRefused",
     "CompiledExecutionLaneUnavailableError",
+    "SEMANTIC_TAG_FORMAT",
     "apply",
     "apply_lora_execution_lane",
     "arming_block",

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -308,7 +308,15 @@ def arm_identity(
         cfg, lora_bucket_override=int(lora_bucket or 0))
     facts = {
         "family": str(family or ""),
-        "format": str(cc.ARTIFACT_FORMAT),
+        # THE producer's constant, read from the module that WRITES the value
+        # this is compared against (`aot_serve.entry_metadata` stamps
+        # `meta["format"]` from the same symbol). pgw#1230: this said
+        # `cc.ARTIFACT_FORMAT`, a DIFFERENT fact that merely shared the name —
+        # the torch-inductor-cache producer format (gw#391), which has been 2
+        # since 2026 and has nothing to do with the cell metadata schema. The
+        # two agreed by coincidence until pgw#1176 moved the real one to 3, and
+        # from that commit every freshly minted cell failed to arm.
+        "format": str(aot_serve.ARTIFACT_FORMAT),
         "lane": cc.execution_lane_label(
             str(weight_lane or ""), int(lora_bucket or 0)),
         "sm": sm,

--- a/tests/test_format_one_derivation_pgw1230.py
+++ b/tests/test_format_one_derivation_pgw1230.py
@@ -1,0 +1,189 @@
+"""pgw#1230 — the ``format`` arm axis has ONE derivation.
+
+THE DEFECT, and why nothing caught it. Two different facts shared the name
+``ARTIFACT_FORMAT`` in two modules:
+
+  * ``aot_serve.ARTIFACT_FORMAT``   — the AOT cell metadata schema. The CHILD
+    stamps it into every artifact (``aot_serve.entry_metadata``).
+  * ``compile_cache.ARTIFACT_FORMAT`` — the torch-inductor-cache PRODUCER
+    format (gw#391), an ingredient of the JIT semantic cache tag and nothing
+    to do with cell metadata.
+
+``fleet_cells.arm_identity`` computed its ``format`` fact from the SECOND one
+and compared it against the first. Both were 2, so it passed by coincidence
+for a year. pgw#1176 moved the cell schema to 3 and left the inductor format
+at 2, and from that commit **every freshly minted cell failed to arm** —
+`key_axis_divergence: format: child cell states '3', this runtime computed
+'2'` — compiled fine, quarantined, published nothing. Observed on Cell Zero
+across all 4 z-image graph classes.
+
+Nothing was red, for two separate reasons, and both are the point of this
+file:
+
+  1. Six test files monkeypatch ``arm_axis_divergence`` to return ``""``. The
+     seam that catches this is stubbed out wherever it would have run.
+  2. The one file that DOES call it (``test_handback_key_axes_pgw1042``)
+     hand-wrote ``"format": "2"`` on BOTH sides — it encoded the parent's
+     wrong constant instead of deriving from the producer, so it agreed with
+     the bug and stayed green through the 2->3 bump.
+
+So the rows here are deliberately built from the REAL derivations on both
+sides — ``fleet_cells.arm_identity`` for the parent, ``aot_serve``'s own
+producer for the child — because a double on either side is what hid a P0.
+
+The arm check itself was NOT at fault and is not weakened: it fired, named
+the axis, named both values, and refused loudly. That is why this was
+diagnosable at all.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import aot_serve, cell_key, compile_cache as cc, env_seal
+from gen_worker import fleet_cells
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+RUNTIME_KEY = {"sm": "sm_89", "sku": "l4", "torch": "2.13.0", "cuda": "12.8",
+               "image_digest": ""}
+TOOLCHAIN = (("libtorch.so", "cafe0123cafe0123"),)
+
+
+class _Cfg:
+    family = "micro-diffusion"
+    shapes = ((64, 64),)
+    text_lens = (7,)
+    guidance_scales = (1.0,)
+    lora_bucket = 0
+
+
+@pytest.fixture()
+def one_process_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parent and child in ONE process tree: the same runtime facts feed both
+    derivations, which is the premise the arm comparison is written against.
+
+    Only the DEVICE probe is stubbed — a CPU test box has no sm, and the axis
+    under test is not the device. Every axis this file rules on is computed by
+    production code from these same inputs.
+    """
+    monkeypatch.setattr(cc, "runtime_key", lambda: dict(RUNTIME_KEY))
+    monkeypatch.setattr(cc, "toolchain_digest", lambda: TOOLCHAIN)
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME_KEY))
+
+
+def _child_meta() -> Dict[str, Any]:
+    """What the CHILD stamps, through the producer that owns the envelope."""
+    from tests.harness import exported_cell
+
+    meta = exported_cell.metadata()
+    meta.update(RUNTIME_KEY)
+    meta["family"] = _Cfg.family
+    meta["weight_lane"] = ""
+    meta["lora_bucket"] = 0
+    meta["toolchain"] = dict(TOOLCHAIN)
+    meta[env_seal.SEAL_KEY] = dict(env_seal.effective_seal())
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# 1. THE ROW. stamp == computed, both sides real.
+# ---------------------------------------------------------------------------
+
+
+def test_the_stamp_and_the_computed_format_are_the_same_value(
+    one_process_tree: None,
+) -> None:
+    """The whole P0 in one assertion.
+
+    Goes red on the tree as it stood before this fix: the parent computed
+    ``'2'`` from ``compile_cache`` while the child stamped ``3`` from
+    ``aot_serve``.
+    """
+    parent = fleet_cells.arm_identity(_Cfg.family, "", 0, _Cfg())
+    stamped = aot_serve.entry_metadata(
+        family=_Cfg.family, precision="w8a8", cell_key="", name="x",
+        entry=_child_meta()[cell_key.ENTRY_BLOCK_KEY],
+    )
+    assert parent.facts_dict()["format"] == str(stamped["format"])
+
+
+def test_a_freshly_minted_cell_arms_in_the_tree_that_minted_it(
+    one_process_tree: None,
+) -> None:
+    """The seam, end to end, with NOTHING stubbed on it — the exact call that
+    quarantined Cell Zero's four classes."""
+    parent = fleet_cells.arm_identity(_Cfg.family, "", 0, _Cfg())
+    divergence = fleet_cells.arm_axis_divergence(parent, _child_meta())
+    assert divergence == "", divergence
+
+
+# ---------------------------------------------------------------------------
+# 2. The refusal still fires — the fix must not buy agreement by deleting it
+# ---------------------------------------------------------------------------
+
+
+def test_a_divergent_format_is_still_refused_by_name(
+    one_process_tree: None,
+) -> None:
+    """Credit where due: this check is what made the outage diagnosable. The
+    fix removes the DISAGREEMENT, never the detection — a cell of a foreign
+    schema must still be refused loudly rather than armed hopefully."""
+    parent = fleet_cells.arm_identity(_Cfg.family, "", 0, _Cfg())
+    foreign = dict(_child_meta(), format=aot_serve.ARTIFACT_FORMAT + 1)
+    got = fleet_cells.arm_axis_divergence(parent, foreign)
+    assert got.startswith("format: ")
+    assert str(aot_serve.ARTIFACT_FORMAT + 1) in got
+    assert str(aot_serve.ARTIFACT_FORMAT) in got
+
+
+# ---------------------------------------------------------------------------
+# 3. The twin cannot come back
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_one_module_defines_an_artifact_format(
+    one_process_tree: None,
+) -> None:
+    """A second constant of this name in a second module is the defect itself,
+    not a step towards it — the values agreeing today is precisely how it hid
+    for a year. One definition, or this is red.
+    """
+    definers = sorted(
+        path.name
+        for path in SRC.rglob("*.py")
+        if re.search(r"^ARTIFACT_FORMAT\s*=", path.read_text(), re.M)
+    )
+    assert definers == ["aot_serve.py"], definers
+
+
+def test_the_inductor_cache_format_is_not_called_a_format_of_the_artifact(
+    one_process_tree: None,
+) -> None:
+    """The renamed constant keeps its VALUE — the semantic cache tag is a
+    published-cache identity and must not churn on a rename — while losing the
+    name that let it be read as the cell schema."""
+    assert cc.SEMANTIC_TAG_FORMAT == 2
+    assert not hasattr(cc, "ARTIFACT_FORMAT")
+    assert aot_serve.ARTIFACT_FORMAT == 3
+
+
+def test_no_module_computes_the_format_axis_from_a_second_source(
+    one_process_tree: None,
+) -> None:
+    """The arm axis is built in exactly one place, from the producer's symbol.
+
+    Stated structurally because the failure mode was structural: the parent
+    was not WRONG about the format, it was asking a different module.
+    """
+    text = (SRC / "fleet_cells.py").read_text()
+    assert '"format": str(aot_serve.ARTIFACT_FORMAT)' in text
+    # CODE only — the comment above that line names the old symbol on purpose,
+    # because a reader who does not know what it was cannot see why this one
+    # is spelled the way it is.
+    code = [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
+    assert not [ln for ln in code if "cc.ARTIFACT_FORMAT" in ln]

--- a/tests/test_handback_key_axes_pgw1042.py
+++ b/tests/test_handback_key_axes_pgw1042.py
@@ -51,7 +51,7 @@ _DECLARED_ENVELOPE = {
 def _arm_key(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> fleet_cells.ArmIdentity:
     return fleet_cells.ArmIdentity(facts=tuple(sorted({
         "family": "micro-diffusion",
-        "format": "2",
+        "format": str(aot_serve.ARTIFACT_FORMAT),
         "lane": "w8a8-lora64",
         "sm": "sm_89",
         "envelope": cell_key.envelope_digest(_DECLARED_ENVELOPE),
@@ -64,7 +64,7 @@ def _envelope(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> Dict[str, Any]
     return {
         "cell_key": "cg-key-v1-" + "e" * 56,
         "kind": "aot-inductor",
-        "format": "2",
+        "format": str(aot_serve.ARTIFACT_FORMAT),
         "family": "micro-diffusion",
         "weight_lane": "w8a8",
         "lora_bucket": 64,


### PR DESCRIPTION
Closes the Cell Zero train-blocker. **Root cause found, one-derivation fix, red-proof reproduces the production error byte-for-byte.**

## The cause: two different facts, one name

| symbol | what it actually is | value |
|---|---|---|
| `aot_serve.ARTIFACT_FORMAT` | the **AOT cell metadata schema** — what the CHILD stamps (`entry_metadata`) | **3** |
| `compile_cache.ARTIFACT_FORMAT` | the **torch-inductor-cache producer format** (gw#391) — an ingredient of the JIT semantic cache tag, nothing to do with cell metadata | **2** |

`fleet_cells.arm_identity` computed its `format` fact from the **second** and compared it against the first.

**The parent was never wrong about the format — it was asking a different module.**

### Why it detonated exactly when it did

| commit | what happened |
|---|---|
| `e676e09b` (gw#391) | `compile_cache.ARTIFACT_FORMAT = 2` is born — the inductor producer format |
| `08c283c4` (pgw#1059) | `arm_identity` starts reading **`cc.ARTIFACT_FORMAT`** for the `format` fact. Both constants are 2, so it agrees **by coincidence** |
| `42f6a707` (pgw#1176) | the cell schema moves **2 → 3** (one graph class per artifact). The inductor format stays at 2 |

From `42f6a707` onward **every freshly minted cell failed to arm.** It took a real-family mint to reach the arm seam at all — micro-diffusion's cells predate the bump and adopt from store.

## Why nothing was red — half the defect

1. **Six test files monkeypatch `arm_axis_divergence` to return `""`.** The seam that catches this is stubbed out wherever it would have run.
2. **The one file that does call it hand-wrote `"format": "2"` on both sides** (`test_handback_key_axes_pgw1042._arm_key` / `_envelope`) — it encoded the *parent's wrong constant* instead of deriving from the producer, so it agreed with the bug and sailed through the 2→3 bump. Both sides now derive from `aot_serve`.

This is the pgw#1202 "doubles that could not fail" class, landing on a P0.

## The fix — one derivation, not a bump

- `fleet_cells.arm_identity` reads **`aot_serve.ARTIFACT_FORMAT`** — the same symbol, in the same module, that writes the value it is compared against.
- `compile_cache.ARTIFACT_FORMAT` → **`SEMANTIC_TAG_FORMAT`**, **value unchanged (2)**, so no semantic cache tag churns; only the name that made the confusion possible goes away.

A constant bump would have bought agreement today and reproduced this the next time either moved — which is precisely how it got here.

## Red-proof

`tests/test_format_one_derivation_pgw1230.py` builds **both sides from production code** — the real `fleet_cells.arm_identity` and the real `aot_serve` producer, in one process tree. Reverting the one-line fix:

```
AssertionError: format: child cell states '3', this runtime computed '2'
4 failed, 2 passed
```

Byte-identical to the `worker_activity_events` row. Six rows: stamp == computed; a freshly minted cell arms in the tree that minted it (nothing stubbed on the seam); a genuinely foreign format is **still refused by name**; exactly one module may define an `ARTIFACT_FORMAT`; the renamed constant keeps its value; and the axis is built from one source.

## Answering the issue's open question: **no key is orphaned**

`format` is an **arm fact**, never a cell-key axis — the axes are `graph × sm × toolchain`. Verified:

```
key with format=3  : cg-key-v1-ba5d7c3f43723638ccd4b7950c4368badc8a58b26d2253af2f08f4a7
key with format=999: cg-key-v1-ba5d7c3f43723638ccd4b7950c4368badc8a58b26d2253af2f08f4a7
IDENTICAL -> True
```

So the four stamped `cg-key-v1` keys were **always correct** and a re-mint reproduces them byte-for-byte. Only the arm **token** moves (it hashes the fact set), which invalidates pending obligation memos — exactly what memo invalidation is for. th#1897's hub grammar is not implicated; the hub never refused anything.

## Credit where due

The arm check was not at fault and is not weakened. It fired, named the axis, named both values, and refused loudly instead of arming an artifact whose key does not describe the runtime — a silent adopt would have published a cell that later boots fetch and mis-execute. **The loud refusal is why this was diagnosable at all**, and `test_a_divergent_format_is_still_refused_by_name` keeps it.

Local: **267 passed** across the arm, key, fleet-cells, compile-cache and mint-wiring files; mypy clean over all 275 source files; every `fast gates` lint green.

Rides a **0.114.1** wheel — cut coordination with the campaign lane.