### PR TITLE
pgw#1217: normalize a client-supplied ref where it ENTERS, so one model is one residency identity

### DIFF
--- a/changelog.d/pgw1217.md
+++ b/changelog.d/pgw1217.md
@@ -1,0 +1,23 @@
+- **Fixed: a client-supplied ref is a residency key, and it was not normalized
+  where it enters.** `payload.source` / `text_encoder` / `candidate` and every
+  `lora overlay.ref` arrive as free-form strings from the job payload. The
+  executor took them verbatim and used each for two things that both require
+  normal form: the `snapshots` lookup (that map is keyed by normalized refs —
+  it is built from `wire_ref`/`binding_wire_refs`) and the residency key passed
+  to `store.ensure_local`. A non-normal spelling of the same model therefore
+  MISSED its snapshot and minted a **second residency identity** for the same
+  weights — a redundant multi-GB download, a second disk-GC entry, and two
+  cache identities where the hub believes there is one. That is the th#736
+  mechanic `api.binding.rebind_pick`'s own docstring warns about. `acme/repo:prod`
+  is the cheapest witness: `prod` is the grammar default, so it is elided and
+  both spellings are one model by definition.
+- Both inlets now call `normalize_model_ref` at the boundary, and a ref the
+  grammar cannot parse is a named `ValidationError` naming its field rather
+  than a bogus residency key nothing can resolve. gw#491 had already fixed this
+  invariant one level down — for the DIGEST spelling, three lines from the
+  adapter site ("one adapter must never mint two cache identities"); it left
+  the REF spelling open, and this closes it.
+- Found by reading during the pgw#1202 typing work, then found AGAIN
+  independently by the type checker: annotating `ModelStore`'s ref surface as
+  `WireRef` makes exactly these two call sites a compile error without being
+  aimed at them. Those two errors disappearing is this fix's acceptance test.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -94,6 +94,7 @@ from .input_assets import (
 from .lifecycle_intents import IntentRegistry
 from .models import disk_gc
 from .models import provision
+from .models.refs import normalize_model_ref
 from .models import residency as residency_mod
 from .models.memory import (
     aflush_memory,
@@ -10218,9 +10219,20 @@ class Executor:
         ``payload.source``, also used for ``payload.text_encoder``) locally
         before the handler runs. Same ModelStore path as model bindings —
         identical retry/classification and ModelEvent emission."""
-        ref = str(info.get("ref") or "").strip()
-        if not ref:
+        raw = str(info.get("ref") or "").strip()
+        if not raw:
             raise ValidationError(f"payload.{field_name}.ref must be a non-empty repo ref")
+        # pgw#1217: NORMALIZE WHERE IT ENTERS. This ref is client-supplied and
+        # is then used as both the `snapshots` lookup key (that map is keyed in
+        # normal form) and the residency key. Taken verbatim, a non-normal
+        # spelling misses its snapshot and mints a SECOND residency identity for
+        # one model — the th#736 mechanic `binding.rebind_pick` warns about.
+        try:
+            ref = normalize_model_ref(raw)
+        except ValueError as exc:
+            raise ValidationError(
+                f"payload.{field_name}.ref {raw!r} is not a valid repo ref: {exc}"
+            ) from exc
         path = await self.store.ensure_local(ref, snapshots.get(ref))
         (set_path or ctx._set_source_path)(str(path))
 
@@ -10295,9 +10307,20 @@ class Executor:
                 raise ValidationError(f"lora overlay names unknown model slot {slot!r}")
             prepared: List[lora_util.PreparedAdapter] = []
             for overlay in loras:
-                ref = str(overlay.ref or "").strip()
-                if not ref:
+                raw = str(overlay.ref or "").strip()
+                if not raw:
                     raise ValidationError(f"lora overlay on slot {slot!r} has an empty ref")
+                # pgw#1217, same boundary as `_materialize_source`: gw#491 made
+                # one adapter mint one cache identity for the DIGEST spelling
+                # (see below); this does it for the REF spelling, which it left
+                # open.
+                try:
+                    ref = normalize_model_ref(raw)
+                except ValueError as exc:
+                    raise ValidationError(
+                        f"lora overlay on slot {slot!r} has an invalid ref "
+                        f"{raw!r}: {exc}"
+                    ) from exc
                 weight = lora_util.validate_overlay_weight(overlay.weight, ref=ref)
                 t0 = time.monotonic()
                 path = await self.store.ensure_local(ref, snapshots.get(ref))

--- a/tests/test_payload_ref_normalization_pgw1217.py
+++ b/tests/test_payload_ref_normalization_pgw1217.py
@@ -1,0 +1,251 @@
+"""pgw#1217: a CLIENT-SUPPLIED ref is a residency key, so it must be normalized
+where it enters — or one model mints TWO residency identities.
+
+`payload.source` (and `text_encoder`/`candidate`) and every `lora overlay.ref`
+arrive as free-form strings from the job payload. Before this fix the executor
+took them verbatim and used each for TWO things that both require normal form:
+
+  1. `snapshots.get(ref)` — a lookup into the hub-resolved snapshot map, which
+     is keyed by NORMALIZED refs (it is built from `binding_wire_refs` /
+     `wire_ref`, i.e. `models.refs` normal form); and
+  2. `store.ensure_local(ref, ...)` — the residency key itself.
+
+So a non-normal spelling of the same model MISSED its snapshot and then minted
+a second residency identity for the same weights: a redundant multi-GB
+download, a second disk-GC entry, and two cache identities where the hub
+believes there is one. That is the th#736 mechanic `api.binding.rebind_pick`'s
+own docstring warns about — *"a pick the rebound binding cannot re-mint would
+split the slot into two residency identities"*.
+
+`acme/repo:prod` is the cheapest witness: `prod` is `DEFAULT_REF_TAG`, so the
+grammar ELIDES it and both spellings are the same model by definition
+(`models/refs.py::TensorhubRef.canonical`). Nothing about that is exotic — a
+client that echoes back the tag it was given produces it.
+
+REVERT-TURNS-RED: every test below fails on the parent commit — the recorded
+residency key is `acme/repo:prod`, the snapshot lookup returns None, and the
+two spellings produce two distinct keys.
+
+Sibling context: gw#491 fixed exactly this invariant one level down, for the
+DIGEST spelling, three lines from the adapter site here (*"one adapter must
+never mint two cache identities"*). It left the REF spelling open; this closes
+it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from gen_worker import dispatch
+from gen_worker.api.errors import ValidationError
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+#: The same model, spelled two legitimate ways. `prod` is the grammar default,
+#: so `canonical()` elides it — these are one model, not two.
+NORMAL = "acme/repo"
+NON_NORMAL = "acme/repo:prod"
+
+
+class _Ctx:
+    """Only the surface `_materialize_source` touches."""
+
+    def __init__(self) -> None:
+        self.source_path = ""
+
+    def _set_source_path(self, p: str) -> None:
+        self.source_path = p
+
+
+def _executor(tmp_path: Path) -> Executor:
+    async def _send(_msg: pb.WorkerMessage) -> None:
+        return None
+
+    return Executor([], _send)
+
+
+def _recording_store(
+    ex: Executor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Tuple[List[str], List[Optional[pb.Snapshot]]]:
+    """Record the residency key and the snapshot each call actually resolved."""
+    keys: List[str] = []
+    snaps: List[Optional[pb.Snapshot]] = []
+
+    async def _ensure_local(
+        ref: str, snapshot: Optional[pb.Snapshot] = None, **_kw: Any,
+    ) -> Path:
+        keys.append(ref)
+        snaps.append(snapshot)
+        p = tmp_path / ref.replace("/", "_").replace(":", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(ex.store, "ensure_local", _ensure_local)
+    return keys, snaps
+
+
+def _snapshots() -> Dict[str, pb.Snapshot]:
+    """The hub's map, keyed in NORMAL form — which is how it is really built."""
+    return {
+        NORMAL: pb.Snapshot(
+            digest="blake3:" + "a" * 64,
+            files=[pb.SnapshotFile(
+                path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+                url="http://r2.invalid/p")],
+        )
+    }
+
+
+# --- payload.source ---------------------------------------------------------
+
+
+def test_a_non_normal_source_ref_resolves_to_the_normalized_residency_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE defect. `acme/repo:prod` must reach the store as `acme/repo`."""
+    ex = _executor(tmp_path)
+    keys, _snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    asyncio.run(ex._materialize_source(
+        _Ctx(), {"ref": NON_NORMAL}, _snapshots()))
+
+    assert keys == [NORMAL], (
+        f"the residency key must be normal form; got {keys!r}. A non-normal "
+        f"spelling here mints a SECOND residency identity for one model."
+    )
+
+
+def test_a_non_normal_source_ref_still_finds_its_hub_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consequence that costs money: the hub's snapshot map is keyed in
+    normal form, so an unnormalized lookup MISSES and the worker re-downloads
+    weights it was already handed the manifest for."""
+    ex = _executor(tmp_path)
+    _keys, snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    asyncio.run(ex._materialize_source(
+        _Ctx(), {"ref": NON_NORMAL}, _snapshots()))
+
+    assert snaps and snaps[0] is not None, (
+        "the snapshot lookup missed: the map is keyed in normal form, so an "
+        "unnormalized ref re-downloads weights whose manifest is in hand"
+    )
+    assert snaps[0].digest == "blake3:" + "a" * 64
+
+
+def test_both_spellings_of_one_model_are_ONE_residency_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invariant, stated directly (th#736): one model, one identity."""
+    ex = _executor(tmp_path)
+    keys, _snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    asyncio.run(ex._materialize_source(_Ctx(), {"ref": NORMAL}, _snapshots()))
+    asyncio.run(ex._materialize_source(
+        _Ctx(), {"ref": NON_NORMAL}, _snapshots()))
+
+    assert len(set(keys)) == 1, (
+        f"two spellings of ONE model produced {len(set(keys))} residency "
+        f"identities: {keys!r}"
+    )
+
+
+def test_a_malformed_source_ref_is_a_named_refusal_not_a_bogus_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normalizing at the boundary means the grammar is enforced there. A ref
+    that cannot be parsed must be REFUSED by name — never carried on to become
+    a residency key nothing can resolve."""
+    ex = _executor(tmp_path)
+    keys, _snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        asyncio.run(ex._materialize_source(
+            _Ctx(), {"ref": "no-owner-segment"}, _snapshots()))
+
+    assert "source" in str(exc.value)
+    assert keys == [], "a refused ref must never reach the store"
+
+
+def test_the_refusal_names_the_field_it_came_from(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_materialize_source` serves `source`, `text_encoder` and `candidate`;
+    the refusal has to say which one, or an operator cannot find it."""
+    ex = _executor(tmp_path)
+    _recording_store(ex, tmp_path, monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        asyncio.run(ex._materialize_source(
+            _Ctx(), {"ref": "no-owner-segment"}, _snapshots(),
+            field_name="text_encoder"))
+
+    assert "text_encoder" in str(exc.value)
+
+
+# --- lora overlay.ref -------------------------------------------------------
+
+
+def _spec_with_slot() -> Any:
+    class _Spec:
+        models = {"pipeline": object()}
+    return _Spec()
+
+
+def test_a_non_normal_lora_ref_resolves_to_the_normalized_residency_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second inlet, same defect. gw#491 fixed the DIGEST spelling three
+    lines from here and left the REF spelling open."""
+    ex = _executor(tmp_path)
+    keys, snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    monkeypatch.setattr(
+        "gen_worker.utils.lora.parse_adapter",
+        lambda *_a, **_kw: {}, raising=False)
+
+    async def _go() -> None:
+        await ex._prepare_adapters(
+            {"pipeline": (dispatch.AdapterOrder(ref=NON_NORMAL, weight=1.0),)},
+            _spec_with_slot(),
+            _snapshots(),
+        )
+
+    try:
+        asyncio.run(_go())
+    except Exception:
+        # Parsing a real adapter is not what this asserts; the residency key is
+        # recorded before any parse can fail.
+        pass
+
+    assert keys == [NORMAL], (
+        f"the lora residency key must be normal form; got {keys!r}"
+    )
+    assert snaps and snaps[0] is not None, (
+        "the lora snapshot lookup missed for a non-normal spelling"
+    )
+
+
+def test_a_malformed_lora_ref_is_a_named_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ex = _executor(tmp_path)
+    keys, _snaps = _recording_store(ex, tmp_path, monkeypatch)
+
+    async def _go() -> None:
+        await ex._prepare_adapters(
+            {"pipeline": (dispatch.AdapterOrder(ref="no-owner-segment"),)},
+            _spec_with_slot(),
+            _snapshots(),
+        )
+
+    with pytest.raises(ValidationError) as exc:
+        asyncio.run(_go())
+
+    assert "lora" in str(exc.value).lower()
+    assert keys == [], "a refused lora ref must never reach the store"


### PR DESCRIPTION
`payload.source`/`text_encoder`/`candidate` and every `lora overlay.ref` arrive as free-form strings from the job payload. The executor took them **verbatim** and used each for two things that both require normal form:

1. `snapshots.get(ref)` — the hub-resolved map, which is keyed by **normalized** refs (built from `wire_ref`/`binding_wire_refs`); and
2. `store.ensure_local(ref, ...)` — the residency key itself.

So a non-normal spelling of the same model **missed its snapshot** and then minted a **second residency identity** for the same weights: a redundant multi-GB download, a second disk-GC entry, and two cache identities where the hub believes there is one. That is the th#736 mechanic `api.binding.rebind_pick`'s own docstring warns about — *"a pick the rebound binding cannot re-mint would split the slot into two residency identities"*.

`acme/repo:prod` is the cheapest witness, and nothing about it is exotic: `prod` is `DEFAULT_REF_TAG`, so `TensorhubRef.canonical` **elides** it and both spellings are the same model *by definition*. A client echoing back the tag it was given produces this.

## The change is exactly two boundary normalizations

Both inlets call `normalize_model_ref` on arrival. A ref the grammar cannot parse is now a named `ValidationError` naming its field, instead of being carried on to become a residency key nothing can resolve. **No other logic changed.**

gw#491 already fixed this invariant one level down — for the *digest* spelling, **three lines from the adapter site** (*"one adapter must never mint two cache identities"*). It left the *ref* spelling open. This closes it.

## Red-proof

All **7 tests fail on the parent commit `7aac21c7`** and pass here. They assert the residency key is normal form, that a non-normal spelling still **finds its hub snapshot** (the half that costs the download), that two spellings are **one** identity, and that a malformed ref is refused by name and never reaches the store.

## Acceptance test — and why this PR comes first

Annotating `ModelStore`'s ref surface as `WireRef` (pgw#1202, landing next) makes exactly these two call sites a compile error **without being aimed at them**. Verified by applying that conversion on top of this commit:

| | executor.py errors | the two `ensure_local` sites |
|---|---|---|
| before | 24 | **both error** |
| after this fix | 22 | **gone** |

The defect was found by reading, re-found independently by the checker, and is now closed by code the checker will hold true.

## Verification
- mypy `Success: no issues found in 772 source files`; ruff + ratchet green
- **63 tests green** across the reserved-source, adapter, lora-cell and slot-binding files that exercise these paths

Scoped `executor.py` claim recorded in the tracker; verified non-overlapping with Phase 3 (PR #763), whose entire executor.py delta is two hunks (an import rename at L58, a comment at L2958).