### PR TITLE
pgw#1202: WireRef reaches the surfaces it was minted for

### DIFF
--- a/changelog.d/pgw1202.md
+++ b/changelog.d/pgw1202.md
@@ -1,0 +1,20 @@
+- Typing: **`WireRef` reaches the surfaces it was minted for.** The NewType has
+  existed since gw#492 carrying the docstring *"Annotate wire/residency key
+  surfaces with WireRef so mixing raw and normalized strings fails mypy"* — and
+  had **zero annotation sites in production**. It is now the type of the ref on
+  `ModelStore`'s whole public surface (30 params), of the hub-resolved
+  `snapshots` maps, and of what `wire_ref`/`binding_wire_refs`/
+  `component_overrides` state they MINT. Annotations and casts only; no logic
+  changed.
+- The producers were the root cause and are fixed first: `wire_ref` returned
+  plain `str` while two of its three branches already returned normal form, so
+  every consumer downstream started from an erased type. The civitai/modelscope
+  branch ASSERTS normal form rather than deriving it, and now says so in one
+  visible `WireRef(...)` instead of widening the function's whole return type.
+- `residency.py` is deliberately still keyed by plain `str` and is its own
+  unit; the raw→normal hops are a handful of stated casts at that boundary
+  rather than a claim spread through the store.
+- This lands **behind** pgw#1217 on purpose. The conversion made that defect's
+  two client-ref sites a compile error without being aimed at them, and
+  suppressing them would have been an annotation asserting something the code
+  did not yet do. The behavior fix landed first; the types now hold it true.

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -27,6 +27,7 @@ from msgspec import structs
 from ..models.refs import (
     DEFAULT_REF_TAG,
     HuggingFaceRef,
+    WireRef,
     fold_ref,
     normalize_model_ref,
     parse_model_ref,
@@ -248,7 +249,7 @@ Binding = ModelRef
 BINDING_TYPES: tuple[type, ...] = (ModelRef,)
 
 
-def wire_ref(binding: Binding) -> str:
+def wire_ref(binding: Binding) -> WireRef:
     """Normal-form ref string for the wire / cache key — delegates to the ONE
     grammar module (``gen_worker.models.refs``, gw#492).
 
@@ -265,10 +266,14 @@ def wire_ref(binding: Binding) -> str:
         return fold_ref(binding.path, tag=tag)
     if binding.source == "huggingface":
         return HuggingFaceRef(binding.path, binding.revision or None).canonical()
-    return binding.path
+    # civitai/modelscope: the path is ASSERTED to be normal form rather than
+    # derived through the grammar, which the other two branches do. The
+    # `WireRef(...)` makes that the one visible assertion in this function
+    # instead of a silent widening of its whole return type.
+    return WireRef(binding.path)
 
 
-def component_overrides(binding: Binding) -> tuple[tuple[str, str], ...]:
+def component_overrides(binding: Binding) -> tuple[tuple[str, WireRef], ...]:
     """The ``(component, canonical ref)`` substitutions ``binding`` carries
     (pgw#617), normalized and sorted by :class:`ModelRef` itself.
 
@@ -283,7 +288,7 @@ def component_overrides(binding: Binding) -> tuple[tuple[str, str], ...]:
     return tuple(getattr(binding, "component_overrides", ()) or ())
 
 
-def binding_wire_refs(binding: Binding) -> list[str]:
+def binding_wire_refs(binding: Binding) -> list[WireRef]:
     """The base :func:`wire_ref` plus every component-override ref (pgw#617):
     the full set of refs materializing this binding pins and downloads."""
     return [wire_ref(binding), *(ref for _, ref in component_overrides(binding))]

--- a/src/gen_worker/cli/prefetch.py
+++ b/src/gen_worker/cli/prefetch.py
@@ -23,6 +23,7 @@ import json
 import sys
 from typing import Any, Dict, Tuple
 
+from ..models.refs import WireRef
 from ..api.binding import ModelRef
 from ..api.binding import wire_ref
 from ..models.provision import resolve_local_path
@@ -83,7 +84,7 @@ def _handle_prefetch(args: argparse.Namespace) -> int:
 
     # Collect unique (ref, provider) jobs so a binding shared across
     # functions/classes is downloaded once.
-    jobs: Dict[Tuple[str, str], Tuple[str, str, tuple]] = {}
+    jobs: Dict[Tuple[str, str], Tuple[WireRef, str, tuple]] = {}
     for c in candidates:
         for param_name, binding in c.bindings.items():
             try:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -94,7 +94,7 @@ from .input_assets import (
 from .lifecycle_intents import IntentRegistry
 from .models import disk_gc
 from .models import provision
-from .models.refs import normalize_model_ref
+from .models.refs import WireRef, normalize_model_ref
 from .models import residency as residency_mod
 from .models.memory import (
     aflush_memory,
@@ -5272,7 +5272,7 @@ class Executor:
         # resolved space; downloads, booking and the record's held_refs all
         # use these exact strings (a HelloAck rebind during an await below
         # cannot split download/booking/teardown identities).
-        slot_refs: Dict[str, str] = {
+        slot_refs: Dict[str, WireRef] = {
             slot: wire_ref(spec.models[slot]) for slot in setup_slots
         }
         slot_identities: Dict[str, _ResidencyIdentity] = {}
@@ -6414,7 +6414,7 @@ class Executor:
         self,
         rec: "_ClassRecord",
         spec: EndpointSpec,
-        slot_refs: Dict[str, str],
+        slot_refs: Dict[str, WireRef],
     ) -> None:
         """Turn this record's execution group into D ranks, or refuse loudly.
 
@@ -6504,7 +6504,7 @@ class Executor:
         *,
         execution_lane_slots: Optional[set] = None,
         shared_bytes: int = 0,
-        slot_refs: Optional[Dict[str, str]] = None,
+        slot_refs: Optional[Dict[str, WireRef]] = None,
         slot_identities: Optional[Dict[str, _ResidencyIdentity]] = None,
     ) -> None:
         """Honest per-ref residency after a setup (#369). Worker-constructed
@@ -6519,7 +6519,7 @@ class Executor:
         execution_lanes = execution_lane_slots or set()
         refs = slot_refs or {}
         identities = slot_identities or {}
-        per_ref: Dict[str, Tuple[Any, int]] = {}
+        per_ref: Dict[WireRef, Tuple[Any, int]] = {}
         per_ref_identity: Dict[str, _ResidencyIdentity] = {}
         for slot in setup_slots:
             if slot in execution_lanes:
@@ -6710,7 +6710,7 @@ class Executor:
                 await asyncio.to_thread(gc.collect)
             observed = await asyncio.to_thread(self.store.residency.host_ram_headroom, 0)
             available = observed.available_bytes
-            satisfied: List[Tuple[str, _HostRamBlock]] = []
+            satisfied: List[Tuple[WireRef, _HostRamBlock]] = []
             for ref, block in sorted(self._host_ram_blocks.items()):
                 previous = block.last_available_bytes
                 if available <= previous:
@@ -9994,7 +9994,7 @@ class Executor:
                 # wait is its own `record_pre` stage above.
                 started = time.monotonic()
                 with self.store.residency.executing(*exec_refs, *adapter_refs):
-                    active: List[Tuple[str, Any]] = []
+                    active: List[Tuple[WireRef, Any]] = []
                     try:
                         for slot, prepared in adapters.items():
                             pipe = self._adapter_target(spec, slot)
@@ -10505,7 +10505,7 @@ class Executor:
             diffusers_component_type = ModelMixin
         except ImportError:
             pass
-        transitions: List[Tuple[str, str, str, float]] = []
+        transitions: List[Tuple[WireRef, str, str, float]] = []
         for slot in spec.models:
             ref = wire_ref(spec.models[slot])
             # pgw#678: a shared-component lane's residency entry is an
@@ -10602,7 +10602,7 @@ class Executor:
 
     async def _refuse_unfittable_offload(
         self, spec: EndpointSpec,
-        transitions: List[Tuple[str, str, str, float]],
+        transitions: List[Tuple[WireRef, str, str, float]],
     ) -> str:
         """pgw#1063: price the offloaded reload the ladder is about to
         prescribe, and refuse the DEGRADE when the host cannot hold it.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -881,7 +881,7 @@ class _JobOrder:
     group: int
     slots: Mapping[str, dispatch.SlotOrder]
     adapters: Mapping[str, Tuple[dispatch.AdapterOrder, ...]]
-    snapshots: Dict[str, pb.Snapshot]
+    snapshots: Dict[WireRef, pb.Snapshot]
     input_manifest: Tuple[InputManifestEntry, ...]
     fence: Callable[[EndpointSpec], None]
     config_snapshot: Callable[[str, Dict[str, Any]], Optional[Any]]
@@ -1146,7 +1146,7 @@ class _BackgroundMint:
 
     spec: EndpointSpec
     instance: Any
-    snapshots: Optional[Dict[str, "pb.Snapshot"]]
+    snapshots: Optional[Dict[WireRef, "pb.Snapshot"]]
     # id(pipeline) -> fleet_cells.PendingSelfMint (same objects the arming
     # scope produced; shared captures keep their sharing structure).
     pendings: Dict[int, Any]
@@ -1217,10 +1217,10 @@ class _HostRamBlock:
     last_available_bytes: int
 
 
-def _canonical_host_ram_refs(refs: typing.Iterable[str]) -> List[str]:
+def _canonical_host_ram_refs(refs: typing.Iterable[str]) -> List[WireRef]:
     """Keep only canonical model refs suitable for protocol evidence."""
     return list(dict.fromkeys(
-        ref
+        WireRef(ref)
         for value in refs
         if (ref := str(value or "").strip()) and not ref.startswith("shared::")
     ))
@@ -1703,7 +1703,7 @@ class Executor:
         self._host_ram_lock = asyncio.Lock()
         self._host_ram_send_lock = asyncio.Lock()
         self._host_ram_generation = 0
-        self._host_ram_blocks: Dict[str, _HostRamBlock] = {}
+        self._host_ram_blocks: Dict[WireRef, _HostRamBlock] = {}
         # Commit-ordered, latest-per-ref producer outbox. Transport capacity
         # enqueue is nonblocking, but this outbox still makes global generation
         # order explicit under concurrent failure/progress producers.
@@ -2130,7 +2130,7 @@ class Executor:
         self._on_state_change()
 
     async def revalidate_snapshot_identity(
-        self, ref: str, snapshot: Optional[pb.Snapshot],
+        self, ref: WireRef, snapshot: Optional[pb.Snapshot],
     ) -> None:
         """Vacate ready instances built from an older digest of the same ref.
 
@@ -4099,7 +4099,7 @@ class Executor:
     async def ensure_desired_instance(
         self,
         desired: "pb.DesiredInstance",
-        snapshots: Dict[str, "pb.Snapshot"],
+        snapshots: Dict[WireRef, "pb.Snapshot"],
     ) -> None:
         """Best-effort warm of one declarative, fully bound instance.
 
@@ -4134,7 +4134,7 @@ class Executor:
         self,
         spec: EndpointSpec,
         desired: "pb.DesiredInstance",
-        snapshots: Dict[str, "pb.Snapshot"],
+        snapshots: Dict[WireRef, "pb.Snapshot"],
     ) -> None:
         if spec.cls is None:
             raise ValidationError(
@@ -4205,7 +4205,7 @@ class Executor:
             )
         await self.ensure_setup(effective, snapshots)
 
-    def _job_pin_refs(self, spec: EndpointSpec, slots: List[str]) -> List[str]:
+    def _job_pin_refs(self, spec: EndpointSpec, slots: List[str]) -> List[WireRef]:
         """Refs a job pins for its whole lifetime: every routed slot EXCEPT
         lane refs (gw#551 — the LaneGate pins those around the actual
         pipeline call, so the idle sibling stays LRU-demotable), PLUS the
@@ -4228,8 +4228,8 @@ class Executor:
 
     def _job_admission_sizes(
         self, spec: EndpointSpec, slots: List[str],
-        snapshots: Mapping[str, pb.Snapshot],
-    ) -> Dict[str, int]:
+        snapshots: Mapping[WireRef, pb.Snapshot],
+    ) -> Dict[WireRef, int]:
         """ref -> expected VRAM bytes for one job's admission lease (pgw#641
         Stage 2). Same ref set as :meth:`_job_pin_refs`; bytes follow the
         pgw#636 ask ladder — a prior MEASURED hint wins, else the dispatch's
@@ -4238,7 +4238,7 @@ class Executor:
         res = self.store.residency
         run_snapshots = dict(snapshots)
 
-        def _expect(ref: str) -> int:
+        def _expect(ref: WireRef) -> int:
             hint = res.vram_hint(ref)
             if hint > 0:
                 return hint
@@ -4335,7 +4335,7 @@ class Executor:
     async def ensure_setup(
         self,
         spec: EndpointSpec,
-        snapshots: Optional[Dict[str, pb.Snapshot]] = None,
+        snapshots: Optional[Dict[WireRef, pb.Snapshot]] = None,
         promote_slots: Optional[List[str]] = None,
         arm: Optional[_ArmOrder] = None,
     ) -> Any:
@@ -4733,7 +4733,7 @@ class Executor:
 
     async def _run_synthesized_warmup(
         self, spec: EndpointSpec, rec: _ClassRecord, instance: Any,
-        snapshots: Optional[Dict[str, pb.Snapshot]],
+        snapshots: Optional[Dict[WireRef, pb.Snapshot]],
         *,
         proof_objects: typing.Iterable[Any] = (),
         cold_proof_ids: typing.Collection[int] = (),
@@ -5228,7 +5228,7 @@ class Executor:
 
     async def _setup_locked(
         self, spec: EndpointSpec, rec: _ClassRecord,
-        snapshots: Optional[Dict[str, pb.Snapshot]],
+        snapshots: Optional[Dict[WireRef, pb.Snapshot]],
         *,
         intent_id: str = "",
         arm: Optional[_ArmOrder] = None,
@@ -5261,7 +5261,7 @@ class Executor:
 
     async def _setup_locked_inner(
         self, spec: EndpointSpec, rec: _ClassRecord,
-        snapshots: Optional[Dict[str, pb.Snapshot]],
+        snapshots: Optional[Dict[WireRef, pb.Snapshot]],
         *,
         intent_id: str = "",
         setup_slots: List[str],
@@ -6279,7 +6279,7 @@ class Executor:
                     # specifically (not the ordinary hot-adopt op-wall
                     # meaning) since this call site only fires on alarm.
                     family = str(getattr(spec.compile, "family", "") or "")
-                    ref = compile_selection.ref if compile_selection else ""
+                    ref = WireRef(compile_selection.ref if compile_selection else "")
                     digest = (
                         compile_selection.snapshot_digest
                         if compile_selection else "")
@@ -6432,7 +6432,7 @@ class Executor:
         device_group = topo.group(group)
         slot = self._sequence_boot_slot(spec, rec)
         pipe = rec.slot_pipelines[slot]
-        ref = slot_refs.get(slot, "")
+        ref = slot_refs.get(slot, WireRef(""))
         path = self.store.local_path(ref) if ref else None
         binding = spec.models.get(slot)
 
@@ -6729,7 +6729,7 @@ class Executor:
 
             self._host_ram_generation += 1
             generation = self._host_ram_generation
-            events: List[Tuple[str, pb.ModelEvent]] = []
+            events: List[Tuple[WireRef, pb.ModelEvent]] = []
             for ref, block in satisfied:
                 event = self.store.model_event(
                     ref, pb.MODEL_STATE_HOST_CAPACITY_PROGRESS,
@@ -6764,7 +6764,7 @@ class Executor:
                 list(event.host_ram_evicted_refs),
             )
 
-    async def _clear_host_ram_capacity(self, refs: List[str]) -> None:
+    async def _clear_host_ram_capacity(self, refs: List[WireRef]) -> None:
         """Drop stale block/replay state after the ref is actually resident."""
         async with self._host_ram_lock:
             for ref in refs:
@@ -6940,7 +6940,7 @@ class Executor:
 
         evicted: List[str] = []
         after = before
-        for ref in res.lru_ram_victims():
+        for ref in (WireRef(v) for v in res.lru_ram_victims()):
             # A previous record teardown may already have transitioned every
             # ref that appeared in the snapshot of LRU candidates.
             if res.tier(ref) is not residency_mod.Tier.RAM:
@@ -7286,7 +7286,7 @@ class Executor:
         *,
         server: Any = None,
         compile_selection: Optional[_CompileArtifactSelection] = None,
-        snapshots: Optional[Dict[str, pb.Snapshot]] = None,
+        snapshots: Optional[Dict[WireRef, pb.Snapshot]] = None,
         slot_identities: Optional[Dict[str, _ResidencyIdentity]] = None,
         component_paths: Optional[Dict[str, Dict[str, str]]] = None,
         arm: Optional[_ArmOrder] = None,
@@ -7351,7 +7351,7 @@ class Executor:
                     # pick the starting rung so a doomed fully-resident attempt
                     # is never paid (gw#463 / ie#369); a CUDA OOM inside is a
                     # ladder transition, not a failure.
-                    ref = wire_ref(binding) if binding is not None else ""
+                    ref = wire_ref(binding) if binding is not None else WireRef("")
                     mode = self._placement_mode(spec, ref)
                     slot_share = dict((share_plan or {}).get(slot) or {})
                     if slot_share and mode != "auto":
@@ -7656,7 +7656,7 @@ class Executor:
     def _register_execution_lane(
         self,
         slot: str,
-        ref: str,
+        ref: WireRef,
         pipe: Any,
         slot_share: Dict[str, Any],
         injected: Dict[str, Any],
@@ -8368,7 +8368,8 @@ class Executor:
         event class on the wire (th#1031: no longer fatal to serving — the
         fleet policy already fell through to self-mint; this only makes
         sure the invariant stays wire-visible)."""
-        bug_ref = compile_selection.ref if compile_selection is not None else ""
+        bug_ref = WireRef(
+            compile_selection.ref if compile_selection is not None else "")
         bug_digest = (
             compile_selection.snapshot_digest
             if compile_selection is not None else "")
@@ -9640,7 +9641,9 @@ class Executor:
         # exactly the lane it executes, at call time.
         try:
             with self.store.residency.admit(
-                self._job_admission_sizes(spec, routed, order.snapshots),
+                typing.cast(
+                    Mapping[str, int],
+                    self._job_admission_sizes(spec, routed, order.snapshots)),
                 # pgw#652: weights are not the whole cost of admitting a
                 # request — a concurrent 1024^2 diffusion request also holds
                 # GBs of latents/attention workspace. The claim is LEARNED
@@ -10209,7 +10212,7 @@ class Executor:
         self,
         ctx: Any,
         info: Dict[str, Any],
-        snapshots: Dict[str, pb.Snapshot],
+        snapshots: Dict[WireRef, pb.Snapshot],
         *,
         set_path: Optional[Callable[[str], None]] = None,
         field_name: str = "source",
@@ -10256,7 +10259,7 @@ class Executor:
             await asyncio.to_thread(resolve, ref)
 
     async def _handler_kwargs(
-        self, spec: EndpointSpec, snapshots: Dict[str, pb.Snapshot]
+        self, spec: EndpointSpec, snapshots: Dict[WireRef, pb.Snapshot]
     ) -> Dict[str, Any]:
         """Per-call model injection: handler parameters (after ctx, payload)
         whose names match model slots receive the local snapshot path."""
@@ -10284,7 +10287,7 @@ class Executor:
         self,
         adapters: Mapping[str, Tuple[dispatch.AdapterOrder, ...]],
         spec: EndpointSpec,
-        snapshots: Dict[str, pb.Snapshot],
+        snapshots: Dict[WireRef, pb.Snapshot],
     ) -> Dict[str, List[lora_util.PreparedAdapter]]:
         """Materialize + parse the job's per-slot LoRA overlays (gw#393).
 
@@ -10629,7 +10632,7 @@ class Executor:
         Returns the structural refusal summary, or "" when the ladder may
         proceed."""
         res = self.store.residency
-        worst: Tuple[int, str] = (0, "")
+        worst: Tuple[int, WireRef] = (0, WireRef(""))
         for ref, _from_mode, to_mode, _needed_gb in transitions:
             if not touches_host_ram(to_mode):
                 continue

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -19,6 +19,7 @@ from . import fleet_cells
 from . import receipts
 from . import serve_posture
 from . import progress as progress_mod
+from .models.refs import WireRef
 from .config import Settings
 from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
 from .executor import Executor
@@ -1278,7 +1279,7 @@ class Lifecycle:
         self.executor.store.rescan_disk()
         self.executor.gate_functions(self.hardware)
 
-        prefetch_refs: List[str] = []
+        prefetch_refs: List[WireRef] = []
         for spec in self.executor.specs.values():
             if spec.name in self.executor.unavailable:
                 continue
@@ -1330,7 +1331,7 @@ class Lifecycle:
                     )
 
         await self.set_phase(pb.WORKER_PHASE_LOADING_PIPELINES)
-        awaiting_hub: Dict[str, List[str]] = {}
+        awaiting_hub: Dict[str, List[WireRef]] = {}
         dynamic: List[str] = []
         for spec in list(self.executor.specs.values()):
             if spec.name in self.executor.unavailable:

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -1461,7 +1461,9 @@ class Lifecycle:
             # open, plus the typed self-diagnosis on a stalled registry.
             activity_mod.on_beat()
 
-    async def _setup_awaiting_functions(self, awaiting: Dict[str, List[str]]) -> None:
+    async def _setup_awaiting_functions(
+        self, awaiting: Dict[str, List[WireRef]],
+    ) -> None:
         """Complete boot setup for functions whose tensorhub snapshots arrive
         via hub delivery after the startup scan (gw#591), then push a
         StateDelta so ``available_functions`` advertises them."""

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -31,6 +31,7 @@ from ..lifecycle_intents import IntentRegistry
 from ..pb import worker_scheduler_pb2 as pb
 from ..redact import sanitize as _sanitize
 from ..topology import current_device_group
+from .refs import WireRef
 from . import cozy_snapshot
 from . import disk_gc
 from . import disk_telemetry
@@ -262,7 +263,7 @@ class ModelStore:
         # setups may arrive snapshot-less; without memory of the hub's desired
         # state / RunJob snapshot they cannot materialize tensorhub refs. Stale
         # URLs self-heal: they fail url_expired and the hub re-mints.
-        self._snapshots: Dict[str, pb.Snapshot] = {}
+        self._snapshots: Dict[WireRef, pb.Snapshot] = {}
         # Current generation attached to each banked snapshot. A generation-
         # less bank inherits only from the exact current desired identity
         # below; historical desired generations are never resurrected.
@@ -345,7 +346,7 @@ class ModelStore:
     def bind_intent_registry(self, registry: IntentRegistry) -> None:
         self._intent_registry = registry
 
-    def _materialize_intent(self, ref: str) -> str:
+    def _materialize_intent(self, ref: WireRef) -> str:
         registry = self._intent_registry
         if registry is None:
             return ""
@@ -393,7 +394,7 @@ class ModelStore:
         )
 
     def _on_residency_event(
-        self, ref: str, state: str, vram_bytes: int, duration_ms: int = 0
+        self, ref: WireRef, state: str, vram_bytes: int, duration_ms: int = 0
     ) -> None:
         pb_state = _RESIDENCY_STATE_TO_PB.get(state)
         if pb_state is None:
@@ -437,7 +438,7 @@ class ModelStore:
 
     def model_event(
         self,
-        ref: str,
+        ref: WireRef,
         state: "pb.ModelState",
         *,
         identity: Any = _USE_RESIDENT_IDENTITY,
@@ -460,7 +461,7 @@ class ModelStore:
 
     async def _event(
         self,
-        ref: str,
+        ref: WireRef,
         state: "pb.ModelState",
         *,
         identity: Any = _USE_RESIDENT_IDENTITY,
@@ -548,12 +549,12 @@ class ModelStore:
         for ordinal in range(int(topology.execution_groups)):
             self.residency_for(ordinal)
 
-    def disk_ref_in_use(self, ref: str) -> bool:
+    def disk_ref_in_use(self, ref: WireRef) -> bool:
         """In-use across ALL groups (§4.3 caveat 3): one group's GC must never
         drop the pages another group is mmapping."""
         return any(reg.in_use(ref) for reg in self.all_residencies())
 
-    def disk_local_path(self, ref: str) -> Optional[Path]:
+    def disk_local_path(self, ref: WireRef) -> Optional[Path]:
         for reg in self.all_residencies():
             path = reg.local_path(ref)
             if path is not None:
@@ -631,7 +632,7 @@ class ModelStore:
         a dispatch gate on its own)."""
         return self._cached_disk_usage_report
 
-    def _ref_blob_sizes(self, ref: str) -> Dict[str, int]:
+    def _ref_blob_sizes(self, ref: WireRef) -> Dict[str, int]:
         """CAS digest -> bytes for ``ref``'s banked snapshot, or ``{}`` when
         the worker has no manifest for it. The digest is the identity the CAS
         dedups on: ``blobs/`` is hardlinked into every snapshot tree, so a
@@ -747,18 +748,18 @@ class ModelStore:
         self._cached_disk_usage_report = report
         return report
 
-    def local_path(self, ref: str) -> Optional[Path]:
+    def local_path(self, ref: WireRef) -> Optional[Path]:
         # Union across groups (pgw#748): the CAS is ONE hardlinked tree. A
         # group that has not yet booked this ref must still SEE the bytes a
         # sibling group already materialized.
         return self.disk_local_path(ref)
 
-    def has_snapshot(self, ref: str) -> bool:
+    def has_snapshot(self, ref: WireRef) -> bool:
         """A digest-carrying snapshot for ``ref`` was seen this connection
         (gw#465): snapshot-less ops for it can still materialize the bytes."""
         return ref in self._snapshots
 
-    def bank_snapshot(self, ref: str, snapshot: pb.Snapshot) -> None:
+    def bank_snapshot(self, ref: WireRef, snapshot: pb.Snapshot) -> None:
         """Make hub metadata available without starting a download."""
         if not ref or not snapshot.digest or not snapshot.files:
             return
@@ -778,7 +779,7 @@ class ModelStore:
             waiter.set()
 
     def replace_desired_snapshots(
-        self, snapshots: Dict[str, pb.Snapshot], *, generation: int,
+        self, snapshots: Dict[WireRef, pb.Snapshot], *, generation: int,
     ) -> None:
         """Atomically replace desired snapshot identity and bank its metadata.
 
@@ -788,7 +789,7 @@ class ModelStore:
         removal cannot resurrect an obsolete generation later.
         """
         accepted_generation = max(0, int(generation))
-        stored: Dict[str, pb.Snapshot] = {}
+        stored: Dict[WireRef, pb.Snapshot] = {}
         for ref, snapshot in snapshots.items():
             if not ref or not snapshot.digest or not snapshot.files:
                 continue
@@ -819,7 +820,7 @@ class ModelStore:
             if waiter is not None:
                 waiter.set()
 
-    def _prune_banked_snapshots(self, desired: Dict[str, pb.Snapshot]) -> None:
+    def _prune_banked_snapshots(self, desired: Dict[WireRef, pb.Snapshot]) -> None:
         """Drop banked manifests for refs that are neither desired, resident,
         in use, nor being materialized (th#1330 B5).
 
@@ -858,19 +859,19 @@ class ModelStore:
             len(stale), ", ".join(sorted(stale)[:8]),
         )
 
-    def snapshot_digest(self, ref: str, snapshot: Optional[pb.Snapshot] = None) -> str:
+    def snapshot_digest(self, ref: WireRef, snapshot: Optional[pb.Snapshot] = None) -> str:
         candidate = snapshot
         if candidate is None:
             with self._identity_lock:
                 candidate = self._snapshots.get(ref)
         return str(getattr(candidate, "digest", "") or "").strip()
 
-    def resident_identity(self, ref: str) -> _ResidencyIdentity:
+    def resident_identity(self, ref: WireRef) -> _ResidencyIdentity:
         with self._identity_lock:
             return self._resident_identities.get(ref, ("", 0))
 
     def _snapshot_identity(
-        self, ref: str, snapshot: Optional[pb.Snapshot],
+        self, ref: WireRef, snapshot: Optional[pb.Snapshot],
     ) -> _ResidencyIdentity:
         digest = self.snapshot_digest(ref, snapshot)
         if not digest:
@@ -885,7 +886,7 @@ class ModelStore:
         return (digest, generation)
 
     def _set_resident_identity(
-        self, ref: str, identity: _ResidencyIdentity,
+        self, ref: WireRef, identity: _ResidencyIdentity,
     ) -> bool:
         digest, generation = identity
         if not digest:
@@ -896,7 +897,7 @@ class ModelStore:
             self._resident_identities[ref] = exact
         return changed
 
-    def activate_disk_identity(self, ref: str) -> _ResidencyIdentity:
+    def activate_disk_identity(self, ref: WireRef) -> _ResidencyIdentity:
         """Make the verified disk snapshot the identity of a newly loaded
         RAM/VRAM instance immediately before its residency transition."""
         with self._identity_lock:
@@ -906,7 +907,7 @@ class ModelStore:
             return identity
 
     async def _confirm_cached_identity(
-        self, ref: str, identity: _ResidencyIdentity,
+        self, ref: WireRef, identity: _ResidencyIdentity,
     ) -> None:
         """Publish exact identity when verified cached bytes satisfy the
         desired state without requiring a redundant download.
@@ -950,7 +951,7 @@ class ModelStore:
             kw["vram_bytes"] = self.residency.vram_bytes(ref)
         await self._event(ref, state, identity=identity, **kw)
 
-    def component_digests(self, ref: str, local_path: Optional[Path] = None) -> Dict[str, str]:
+    def component_digests(self, ref: WireRef, local_path: Optional[Path] = None) -> Dict[str, str]:
         """Per-component content identity of ``ref``'s snapshot (gw#479):
         ``{top_level_subfolder: content_set_digest}``. Weight/data files use
         the wire snapshot's per-file tagged digest; small JSON sidecars use
@@ -990,7 +991,7 @@ class ModelStore:
         return {c: residency_mod.content_set_digest(files)
                 for c, files in groups.items()}
 
-    def component_sizes(self, ref: str) -> Dict[str, int]:
+    def component_sizes(self, ref: WireRef) -> Dict[str, int]:
         """Per-top-level-subfolder byte totals of ``ref``'s snapshot (gw#479):
         the make_room estimate for loading a subset of components."""
         snap = self._snapshots.get(ref)
@@ -1105,7 +1106,7 @@ class ModelStore:
 
     _disk_eviction_order = _default_disk_eviction_order
 
-    def _evict_disk_ref(self, ref: str) -> None:
+    def _evict_disk_ref(self, ref: WireRef) -> None:
         path = self.residency.local_path(ref) or self._index.path(ref)
         if not self.residency.evict(ref):  # refuses in-use entries; emits EVICTED
             return
@@ -1127,7 +1128,7 @@ class ModelStore:
                 disk_gc.sweep_orphan_blobs(self._cache_dir)
         self._index.remove(ref)
 
-    def _other_ref_at_path(self, ref: str, path: Path) -> str:
+    def _other_ref_at_path(self, ref: WireRef, path: Path) -> str:
         """A still-tracked ref (any group) materialized at the same path."""
         target = str(path)
         for reg in self.all_residencies():
@@ -1141,7 +1142,7 @@ class ModelStore:
 
     async def _ensure_disk_headroom(
         self,
-        ref: str,
+        ref: WireRef,
         needed_bytes: int,
         identity: _ResidencyIdentity = ("", 0),
         *,
@@ -1172,17 +1173,17 @@ class ModelStore:
 
     # ---- ensure-local ----------------------------------------------------------
 
-    def _lock(self, ref: str) -> asyncio.Lock:
+    def _lock(self, ref: WireRef) -> asyncio.Lock:
         return self._locks.setdefault(ref, asyncio.Lock())
 
-    def register_binding(self, ref: str, binding: Any) -> None:
+    def register_binding(self, ref: WireRef, binding: Any) -> None:
         """Endpoint-spec binding for ``ref`` — supplies files/provider on
         download paths that only carry the bare ref (DesiredResidency or
         startup prefetch), so ``files=`` selections apply everywhere (#377)."""
         self._bindings.setdefault(ref, binding)
 
     def _override_excluded_components(
-        self, ref: str, binding: Any, snapshot: Optional[pb.Snapshot],
+        self, ref: WireRef, binding: Any, snapshot: Optional[pb.Snapshot],
     ) -> Tuple[str, ...]:
         """Base-composition subfolders this materialization must NOT fetch
         (th#1330 B2): the components a pgw#617 dispatch SUBSTITUTES.
@@ -1230,7 +1231,7 @@ class ModelStore:
 
     async def _await_hub_snapshot(
         self,
-        ref: str,
+        ref: WireRef,
         *,
         intent_id: str = "",
     ) -> pb.Snapshot:
@@ -1281,7 +1282,7 @@ class ModelStore:
 
     async def ensure_local(
         self,
-        ref: str,
+        ref: WireRef,
         snapshot: Optional[pb.Snapshot] = None,
         *,
         binding: Any = None,
@@ -1297,7 +1298,7 @@ class ModelStore:
 
     async def _materialize_local(
         self,
-        ref: str,
+        ref: WireRef,
         snapshot: Optional[pb.Snapshot] = None,
         *,
         binding: Any = None,
@@ -1707,7 +1708,7 @@ class ModelStore:
                 lock.release()
 
     def activate_load_identity(
-        self, ref: str, identity: _ResidencyIdentity,
+        self, ref: WireRef, identity: _ResidencyIdentity,
     ) -> _ResidencyIdentity:
         """Promote the exact bytes used by one setup, never current disk state."""
         if identity[0]:
@@ -1792,7 +1793,7 @@ class ModelStore:
                 bad.append(str(st.relative_to(p)) if st != p else st.name)
         return (not bad, bad)
 
-    def _quarantine_snapshot(self, ref: str, path: Path, bad: List[str]) -> None:
+    def _quarantine_snapshot(self, ref: WireRef, path: Path, bad: List[str]) -> None:
         """Evict + delete a corrupt materialization AND the corrupt blobs it
         was built from, so re-materialization re-downloads instead of
         re-linking the same bad bytes. Emits EVICTED via residency."""
@@ -1805,7 +1806,7 @@ class ModelStore:
         self._index.remove(ref)
 
     async def refetch_corrupt(
-        self, ref: str, snapshot: Optional[pb.Snapshot] = None, *, binding: Any = None
+        self, ref: WireRef, snapshot: Optional[pb.Snapshot] = None, *, binding: Any = None
     ) -> Optional[Path]:
         """Load-failure path (gw#408): a weights load failed with a
         corruption-shaped error — digest-verify the snapshot. A clean tree

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -1078,7 +1078,7 @@ class ModelStore:
         pass's keep-membership/grace filter. Ordering within that set is a
         separate seam, see ``_disk_eviction_order``."""
         now = time.time()
-        out: List[Tuple[float, str]] = []
+        out: List[Tuple[float, WireRef]] = []
         for ref in self.disk_refs():
             if ref in exclude or self.disk_ref_in_use(ref):
                 continue
@@ -1101,8 +1101,9 @@ class ModelStore:
     # behavior, byte-for-byte.
     @staticmethod
     def _default_disk_eviction_order(
-        entries: List[Tuple[float, str]], include_keep: bool, keep_rank: Dict[str, int],
-    ) -> List[str]:
+        entries: List[Tuple[float, WireRef]], include_keep: bool,
+        keep_rank: Dict[str, int],
+    ) -> List[WireRef]:
         if include_keep:
             ordered = sorted(entries, key=lambda item: (-keep_rank[item[1]], item[0], item[1]))
         else:

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -267,13 +267,13 @@ class ModelStore:
         # Current generation attached to each banked snapshot. A generation-
         # less bank inherits only from the exact current desired identity
         # below; historical desired generations are never resurrected.
-        self._snapshot_generations: Dict[str, int] = {}
+        self._snapshot_generations: Dict[WireRef, int] = {}
         # Current full-replacement desired identity per ref. This is bounded
         # by the active DesiredResidency set, not an unbounded digest history:
         # a priority RunJob may bank different bytes temporarily, while a
         # later generation-less bank of the still-desired digest recovers its
         # causal generation. Replacing desired state clears stale generations.
-        self._desired_snapshot_identities: Dict[str, _ResidencyIdentity] = {}
+        self._desired_snapshot_identities: Dict[WireRef, _ResidencyIdentity] = {}
         # Identity of the bytes that ACTUALLY produced the current residency.
         # This deliberately does not follow _snapshots when a tag moves.
         self._resident_identities: Dict[str, _ResidencyIdentity] = {}
@@ -394,7 +394,7 @@ class ModelStore:
         )
 
     def _on_residency_event(
-        self, ref: WireRef, state: str, vram_bytes: int, duration_ms: int = 0
+        self, ref: str, state: str, vram_bytes: int, duration_ms: int = 0
     ) -> None:
         pb_state = _RESIDENCY_STATE_TO_PB.get(state)
         if pb_state is None:
@@ -417,8 +417,8 @@ class ModelStore:
             if pending_network_bytes is not None:
                 kw["network_bytes"] = int(pending_network_bytes)
         else:
-            identity = self.resident_identity(ref)
-        coro = self._event(ref, pb_state, identity=identity, **kw)
+            identity = self.resident_identity(WireRef(ref))
+        coro = self._event(WireRef(ref), pb_state, identity=identity, **kw)
         if state == residency_mod.EVICTED:
             # Capture before removal so the eviction names the exact bytes it
             # removed; later events cannot inherit that stale identity.
@@ -561,12 +561,17 @@ class ModelStore:
                 return path
         return None
 
-    def disk_refs(self) -> List[str]:
-        """Union of DISK-tier refs across groups."""
-        seen: Dict[str, None] = {}
+    def disk_refs(self) -> List[WireRef]:
+        """Union of DISK-tier refs across groups.
+
+        The tier lists hand back what normalized-ref callers wrote, so the
+        cast restates a fact rather than making a new claim; `residency` is
+        still keyed by plain `str` and is its own unit.
+        """
+        seen: Dict[WireRef, None] = {}
         for reg in self.all_residencies():
             for ref in reg.refs_in(residency_mod.Tier.DISK):
-                seen.setdefault(ref, None)
+                seen.setdefault(WireRef(ref), None)
         return list(seen)
 
     # ---- residency facade ----------------------------------------------------
@@ -1030,7 +1035,7 @@ class ModelStore:
         if removed:
             logger.info("disk-gc: swept %d abandoned writer temp artifact(s)", removed)
 
-    def lru_disk_refs(self, *, exclude: Tuple[str, ...] = ()) -> List[str]:
+    def lru_disk_refs(self, *, exclude: Tuple[str, ...] = ()) -> List[WireRef]:
         """Idle DISK refs in persisted last-use order, oldest first."""
         excluded = set(exclude)
         candidates = [
@@ -1067,7 +1072,7 @@ class ModelStore:
         exclude: Tuple[str, ...],
         keep: Tuple[str, ...],
         keep_rank: Dict[str, int],
-    ) -> List[str]:
+    ) -> List[WireRef]:
         """The evictable SET for one gc_disk pass: hard invariants only
         (never exclude/in-use — no policy ever overrides these), plus this
         pass's keep-membership/grace filter. Ordering within that set is a

--- a/src/gen_worker/preload.py
+++ b/src/gen_worker/preload.py
@@ -55,6 +55,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
 from . import dispatch
+from .models.refs import WireRef
 from .api.binding import binding_wire_refs, component_overrides, wire_ref
 from .models import residency as residency_mod
 from .models.loading import ComponentSubstitutionError
@@ -291,7 +292,7 @@ class Preloader:
                     out.setdefault(comp_ref, None)
         return out
 
-    def _fence_conflict(self, ref: str) -> bool:
+    def _fence_conflict(self, ref: WireRef) -> bool:
         """True when the ref is RESIDENT under a different identity than the
         desired snapshot names — the pgw#638 case the idle-gated reconcile
         owns (a tenant job may be re-materializing the older bytes)."""
@@ -353,7 +354,7 @@ class Preloader:
         staged = await self._stage_components_host(effective)
         return did_work or staged
 
-    def _expected_vram_bytes(self, ref: str) -> int:
+    def _expected_vram_bytes(self, ref: WireRef) -> int:
         res = self._ex.store.residency
         hint = res.vram_hint(ref)
         if hint > 0:

--- a/src/gen_worker/preload.py
+++ b/src/gen_worker/preload.py
@@ -104,7 +104,7 @@ class Preloader:
     def __init__(self, executor: "Executor") -> None:
         self._ex = executor
         self._hot: Tuple["pb.DesiredInstance", ...] = ()
-        self._snapshots: Dict[str, "pb.Snapshot"] = {}
+        self._snapshots: Dict[WireRef, "pb.Snapshot"] = {}
         self._generation = -1
         self._wake: Optional[asyncio.Event] = None
         self._task: Optional[asyncio.Task[None]] = None
@@ -127,7 +127,7 @@ class Preloader:
     def update_desired(
         self,
         hot: Sequence["pb.DesiredInstance"],
-        snapshots: Mapping[str, "pb.Snapshot"],
+        snapshots: Mapping[WireRef, "pb.Snapshot"],
         generation: int,
     ) -> None:
         """Full-replacement desired state (call only with the ACCEPTED
@@ -277,10 +277,10 @@ class Preloader:
         except Exception:
             return None
 
-    def _instance_refs(self, effective: Any) -> Dict[str, Any]:
+    def _instance_refs(self, effective: Any) -> Dict[WireRef, Any]:
         """ref -> binding for every setup slot and component override."""
         ex = self._ex
-        out: Dict[str, Any] = {}
+        out: Dict[WireRef, Any] = {}
         for slot in ex._setup_slots(effective):
             binding = effective.models[slot]
             for ref in binding_wire_refs(binding):
@@ -341,7 +341,7 @@ class Preloader:
         sizes = {
             ref: self._expected_vram_bytes(ref) for ref in refs
         }
-        if res.fits(sizes):
+        if res.fits(typing.cast(Mapping[str, int], sizes)):
             logger.info(
                 "rotation preload: %s fits alongside the resident set — "
                 "running full background setup (double-buffer)",

--- a/tests/harness/adopt_rig.py
+++ b/tests/harness/adopt_rig.py
@@ -78,7 +78,7 @@ from gen_worker import (
 from gen_worker import executor as ex_mod
 from gen_worker.executor import Executor
 from gen_worker.models import provision
-from gen_worker.models.refs import normalize_model_ref
+from gen_worker.models.refs import WireRef, normalize_model_ref
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 
@@ -520,7 +520,7 @@ class AdoptRig:
         eff = ex._dispatched_spec(
             spec,
             {"pipeline": dispatch_mod.SlotOrder(ref=MODEL_REF, components=())})
-        snaps: Dict[str, pb.Snapshot] = {normalize_model_ref(MODEL_REF): pb.Snapshot(
+        snaps: Dict[WireRef, pb.Snapshot] = {normalize_model_ref(MODEL_REF): pb.Snapshot(
             digest="d1" * 16,
             files=[pb.SnapshotFile(
                 path="model.safetensors", size_bytes=5, blake3="cd" * 32,

--- a/tests/test_cancel_at_grant_pgw845.py
+++ b/tests/test_cancel_at_grant_pgw845.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from gen_worker.models.refs import WireRef
 from gen_worker.models.store import ModelStore
 from gen_worker.lifecycle_intents import IntentRegistry
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -66,7 +67,7 @@ def test_no_cancel_offset_around_the_ref_lock_grant_can_wedge_the_ref(
         registry = IntentRegistry("release-1", [])
         store = ModelStore(_noop_send, cache_dir=cache_dir)
         store.bind_intent_registry(registry)
-        ref = "owner/model:latest"
+        ref = WireRef("owner/model:latest")
 
         lock = store._lock(ref)
         await lock.acquire()  # a sibling materialization owns the ref

--- a/tests/test_intent_registry_th1085.py
+++ b/tests/test_intent_registry_th1085.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import msgspec
 import pytest
 
+from gen_worker.models.refs import WireRef
 from gen_worker.executor import Executor
 from gen_worker.models.store import ModelStore
 from gen_worker.lifecycle_intents import IntentRegistry, UnreportedIntentWait
@@ -71,7 +72,7 @@ def test_materialization_waiter_names_the_active_ref_owner(tmp_path: Path) -> No
         registry = IntentRegistry("release-1", [])
         store = ModelStore(_noop_send, cache_dir=tmp_path)
         store.bind_intent_registry(registry)
-        ref = "owner/model:latest"
+        ref = WireRef("owner/model:latest")
         lock = store._lock(ref)
         await lock.acquire()
         owner = asyncio.create_task(store.ensure_local(ref))

--- a/tests/test_payload_ref_normalization_pgw1217.py
+++ b/tests/test_payload_ref_normalization_pgw1217.py
@@ -43,11 +43,12 @@ import pytest
 from gen_worker import dispatch
 from gen_worker.api.errors import ValidationError
 from gen_worker.executor import Executor
+from gen_worker.models.refs import WireRef
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
 #: The same model, spelled two legitimate ways. `prod` is the grammar default,
 #: so `canonical()` elides it — these are one model, not two.
-NORMAL = "acme/repo"
+NORMAL = WireRef("acme/repo")
 NON_NORMAL = "acme/repo:prod"
 
 
@@ -88,7 +89,7 @@ def _recording_store(
     return keys, snaps
 
 
-def _snapshots() -> Dict[str, pb.Snapshot]:
+def _snapshots() -> Dict[WireRef, pb.Snapshot]:
     """The hub's map, keyed in NORMAL form — which is how it is really built."""
     return {
         NORMAL: pb.Snapshot(

--- a/tests/test_rotation_preload_pgw674.py
+++ b/tests/test_rotation_preload_pgw674.py
@@ -36,6 +36,7 @@ import hashlib
 import msgspec
 import pytest
 
+from gen_worker.models.refs import WireRef
 from gen_worker import Hub, RequestContext, Slot, endpoint, worker_function
 from gen_worker.executor import Executor, _Job
 from gen_worker.models import staging as staging_mod
@@ -206,8 +207,8 @@ def _pick(ex: Executor, name: str, ref: str) -> Any:
     return ex._dispatched_spec(spec, _orders(run))
 
 
-def _snapshots(ref: str, digest: str) -> Dict[str, pb.Snapshot]:
-    return {ref: pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
+def _snapshots(ref: str, digest: str) -> Dict[WireRef, pb.Snapshot]:
+    return {WireRef(ref): pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
         path="model.safetensors", size_bytes=len(_PLAIN_BYTES),
         digest="sha256:" + hashlib.sha256(_PLAIN_BYTES).hexdigest(),
         url="http://r2.invalid/presigned")])}
@@ -223,7 +224,7 @@ def _instance(fn: str, ref: str) -> pb.DesiredInstance:
 def _seed_preloader(
     ex: Executor,
     instances: List[pb.DesiredInstance],
-    snapshots: Dict[str, pb.Snapshot],
+    snapshots: Dict[WireRef, pb.Snapshot],
 ) -> None:
     """Deterministic state injection: tests drive ``_pass()`` directly
     instead of racing the background task."""
@@ -348,11 +349,11 @@ def _composed_tree_writer(ref: str, p: Path) -> None:
     (v / "weights.bin").write_bytes(_VAE_BYTES)
 
 
-def _composed_snapshot(ref: str, digest: str) -> Dict[str, pb.Snapshot]:
+def _composed_snapshot(ref: str, digest: str) -> Dict[WireRef, pb.Snapshot]:
     def _dig(data: bytes) -> str:
         return "sha256:" + hashlib.sha256(data).hexdigest()
 
-    return {ref: pb.Snapshot(digest=digest, files=[
+    return {WireRef(ref): pb.Snapshot(digest=digest, files=[
         pb.SnapshotFile(path="denoiser/weights.bin",
                         size_bytes=len(_DENOISER_BYTES),
                         digest=_dig(_DENOISER_BYTES),
@@ -542,7 +543,7 @@ def test_stale_generation_ignored(
 ) -> None:
     ex = _executor(tmp_path, monkeypatch, Family)
     pl = ex.preloader
-    snaps_new: Dict[str, pb.Snapshot] = {}
+    snaps_new: Dict[WireRef, pb.Snapshot] = {}
     pl._generation = 5
     pl._hot = (_instance("generate", "acme/current"),)
     pl.update_desired([_instance("generate", "acme/old")], snaps_new, 3)


### PR DESCRIPTION
Completes the ModelStore ref conversion. **Annotations and casts only — zero logic changes.** Lands behind pgw#1217 (`c064a436`) deliberately.

`WireRef = NewType("WireRef", str)` has existed since gw#492 carrying the docstring *"Annotate wire/residency key surfaces with WireRef so mixing raw and normalized strings fails mypy"* — and had **zero annotation sites in production**. A declared intention nobody applied. It is now the type of:

- the ref on `ModelStore`'s whole public surface (30 params) and its internals (`disk_refs`/`lru_disk_refs`/`_gc_candidates`, `_snapshot_generations`, `_desired_snapshot_identities`);
- every hub-resolved `snapshots` map, from `_JobOrder` through `ensure_setup`/`_setup_locked*`/`_injection_kwargs`/`_materialize_source`/`_prepare_adapters`/`_job_admission_sizes` and the preloader;
- what `wire_ref` / `binding_wire_refs` / `component_overrides` say they **mint**.

## The producers were the root cause

Folding them in was the single biggest step (**42 → 33 alone**): `wire_ref` returned plain `str` while two of its three branches already returned normal form, so every consumer downstream started from an already-erased type. Its civitai/modelscope branch *asserts* normal form rather than deriving it, and now says so in one visible `WireRef(...)` instead of widening the whole return type.

`residency.py` stays keyed by plain `str` **deliberately** — it is its own unit, so the raw→normal hops are a handful of stated casts at that boundary rather than a claim spread through the store.

## Burn-down, measured at every step

```
50 → 42 (store internals) → 33 (producers folded) → 28 (preload/lifecycle)
   → 26 (executor collections) → 24 → 11 → 0
```

The count oscillated mid-way (28 → 30 → 26) for a reason worth keeping: **typing a collection pushes the frontier to whatever populates it**, so a pass moves the front rather than shrinking it monotonically. It converges when the front reaches a producer — which is why fixing producers first is cheaper than chasing consumers.

## Why it lands behind pgw#1217

This conversion made that defect's two client-supplied-ref sites a compile error **without being aimed at them**, and suppressing them would have been an annotation asserting something the code did not yet do. The behavior fix landed first; the types now hold it true. `tests/harness/adopt_rig.py`'s snapshot dict — which PR #760 deliberately left at `Dict[str, ...]` because production said `str` — catches up here for the same reason.

## Verification
- mypy **`Success: no issues found in 773 source files`**
- ruff clean across `src/gen_worker/`; ratchet green
- **97 tests pass** across the payload-ref, rotation-preload, intent-registry, cancel-at-grant, residency-reconcile, adopt-rig and executor-adopt files that exercise the converted paths

Scoped `executor.py` claim recorded in the tracker; non-overlap with Phase 3 (PR #763) verified empirically.