### PR TITLE
ci: pin the shared formula corpus (pgw#1236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,13 @@ jobs:
       - name: th#1897 gate - the shared grammar corpora match their digest
         run: uv run python scripts/check_grammar_corpus_digest.py
 
+      # GATING (th#1914 / pgw#1236): both languages execute their formula
+      # implementation against a vendored corpus. Pin the PGW copy offline;
+      # Tensorhub performs the one meaningful peer comparison because this
+      # repository is public and Tensorhub is private. No network here.
+      - name: pgw#1236 gate - the shared formula corpus matches its digest
+        run: uv run python scripts/check_formula_corpus_digest.py
+
       # GATING (pgw#1122): the compute child holds no worker credential BY
       # CONSTRUCTION, so a gate that reads one to answer "who am I?" or "is
       # there a hub?" refuses on every real serving pod (pgw#1108, then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,6 +120,14 @@ tasks:
     cmds:
       - PROTO_SKIP_PEER=1 scripts/proto-drift-check.sh
 
+  formula-vector-check:
+    desc: |
+      pgw#1236 / th#1914 — pin this repo's shared formula corpus offline.
+      Tensorhub performs the peer comparison; PGW lands first.
+    cmds:
+      - uv run python scripts/check_formula_corpus_digest.py
+      - scripts/formula-vector-drift.sh
+
   proto:
     desc: Regenerate src/gen_worker/pb/ from proto/ (grpcio-tools codegen)
     cmds:

--- a/changelog.d/pgw1236.md
+++ b/changelog.d/pgw1236.md
@@ -1,0 +1,4 @@
+- **pgw#1236: formula parity is pinned.** CI now pins the shared
+  Tensorhub/python-gen-worker conformance corpus to one digest, so a one-sided
+  ledger edit fails before either language can quietly certify a different
+  contract.

--- a/scripts/check_formula_corpus_digest.py
+++ b/scripts/check_formula_corpus_digest.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Fail if the local shared formula corpus does not match its pinned digest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = ROOT / "tests" / "testdata" / "formula_vectors.json"
+DEFAULT_DIGEST = ROOT / "tests" / "testdata" / "FORMULA_VECTORS_DIGEST"
+
+
+def recorded_digest(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            return line.split()[0]
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--digest", type=Path, default=DEFAULT_DIGEST)
+    args = parser.parse_args()
+
+    for path in (args.corpus, args.digest):
+        if not path.is_file():
+            print(f"formula-corpus-digest: missing {path}")
+            return 2
+
+    actual = hashlib.sha256(args.corpus.read_bytes()).hexdigest()
+    recorded = recorded_digest(args.digest)
+    if actual == recorded:
+        print(f"formula-corpus-digest: formula_vectors.json matches {actual}")
+        return 0
+
+    print(
+        "formula-corpus-digest: FAIL — the shared formula corpus changed "
+        "without its digest\n"
+        f"  recorded: {recorded or '<missing>'}\n"
+        f"  actual:   {actual}\n\n"
+        "Land the python-gen-worker semantic change and corpus first, record "
+        "the new digest in both repos, then copy both files to Tensorhub."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/formula-vector-drift.sh
+++ b/scripts/formula-vector-drift.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# th#1914 / pgw#1236 — formula_vectors.json is a byte-identical contract
+# between Tensorhub's Go formula implementation and python-gen-worker's Python
+# implementation. This script is committed VERBATIM in both repositories.
+#
+# Layer 1 (both repos, offline): the local corpus must match the shared pinned
+# digest beside it. Layer 2 (Tensorhub only): compare the local corpus and
+# digest to public python-gen-worker. Tensorhub is private, so a default run in
+# python-gen-worker deliberately stops after layer 1; it never self-compares
+# and calls that peer parity.
+#
+# Direction: PGW LANDS FIRST. Tensorhub reads PGW's public tree.
+#
+#   FORMULA_VECTOR_PEER_REF=<branch>  PGW ref to fetch (default: master)
+#   FORMULA_VECTOR_PEER_DIR=<dir>     local PGW tests/testdata directory
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hub_rel="internal/formula/testdata"
+pgw_rel="tests/testdata"
+corpus="formula_vectors.json"
+digest="FORMULA_VECTORS_DIGEST"
+
+if [ -f "$here/$hub_rel/$corpus" ]; then
+  local_dir="$here/$hub_rel"
+  side="hub"
+elif [ -f "$here/$pgw_rel/$corpus" ]; then
+  local_dir="$here/$pgw_rel"
+  side="pgw"
+else
+  echo "formula-vector-drift: no $corpus under $here" >&2
+  exit 2
+fi
+
+for name in "$corpus" "$digest"; do
+  if [ ! -f "$local_dir/$name" ]; then
+    echo "formula-vector-drift: missing $local_dir/$name" >&2
+    exit 2
+  fi
+done
+
+recorded="$(grep -Eo '^[0-9a-f]{64}' "$local_dir/$digest" | head -1 || true)"
+actual="$(sha256sum "$local_dir/$corpus" | cut -d' ' -f1)"
+if [ -z "$recorded" ]; then
+  echo "formula-vector-drift: $local_dir/$digest contains no sha256" >&2
+  exit 2
+fi
+if [ "$recorded" != "$actual" ]; then
+  echo "formula-vector-drift: FAIL — local corpus changed without its digest" >&2
+  echo "  recorded: $recorded" >&2
+  echo "  actual:   $actual" >&2
+  exit 1
+fi
+echo "formula-vector-drift: local corpus matches $actual"
+
+peer_dir="${FORMULA_VECTOR_PEER_DIR:-}"
+if [ "$side" = "pgw" ] && [ -z "$peer_dir" ]; then
+  echo "formula-vector-drift: Tensorhub is private — PGW layer 1 complete; no peer comparison"
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+peer_ref="${FORMULA_VECTOR_PEER_REF:-master}"
+for name in "$corpus" "$digest"; do
+  if [ -n "$peer_dir" ]; then
+    if [ ! -f "$peer_dir/$name" ]; then
+      echo "formula-vector-drift: FAIL — $peer_dir/$name does not exist" >&2
+      exit 1
+    fi
+    cp "$peer_dir/$name" "$work/$name"
+  else
+    url="https://raw.githubusercontent.com/cozy-creator/python-gen-worker/${peer_ref}/${pgw_rel}/${name}"
+    if ! curl -sSfL --retry 3 --max-time 30 -o "$work/$name" "$url"; then
+      echo "formula-vector-drift: FAIL — could not fetch $url" >&2
+      exit 1
+    fi
+  fi
+done
+
+status=0
+for name in "$corpus" "$digest"; do
+  if ! cmp -s "$local_dir/$name" "$work/$name"; then
+    echo "formula-vector-drift: FAIL — $name differs from python-gen-worker@${peer_ref}" >&2
+    diff -u "$local_dir/$name" "$work/$name" | head -40 >&2 || true
+    status=1
+  fi
+done
+if [ "$status" -ne 0 ]; then
+  echo "formula-vector-drift: land PGW first, then copy corpus and digest verbatim to Tensorhub" >&2
+  exit 1
+fi
+
+echo "formula-vector-drift: corpus and digest agree with python-gen-worker@${peer_ref}"

--- a/tests/test_formula_conformance_th1534.py
+++ b/tests/test_formula_conformance_th1534.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import math
+import os
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -22,9 +24,9 @@ from gen_worker.api.formula import (
     RuntimeFormula,
 )
 
-_DOCUMENT = json.loads(
-    (Path(__file__).parent / "testdata" / "formula_vectors.json").read_text()
-)
+_DEFAULT_CORPUS = Path(__file__).parent / "testdata" / "formula_vectors.json"
+_CORPUS = Path(os.environ.get("FORMULA_VECTOR_CORPUS", _DEFAULT_CORPUS))
+_DOCUMENT = json.loads(_CORPUS.read_text())
 _BASE_LIMITS = FormulaLimits(**_DOCUMENT["limits"])
 
 
@@ -71,3 +73,73 @@ def test_formula_conformance_vector(vector: dict[str, Any]) -> None:
         assert got is None
     else:
         assert got == vector["term_values"]
+
+
+def test_formula_corpus_digest_gate_can_go_red(tmp_path: Path) -> None:
+    corpus = tmp_path / "formula_vectors.json"
+    digest = tmp_path / "FORMULA_VECTORS_DIGEST"
+    corpus.write_bytes((Path(__file__).parent / "testdata" / "formula_vectors.json").read_bytes())
+    digest.write_bytes((Path(__file__).parent / "testdata" / "FORMULA_VECTORS_DIGEST").read_bytes())
+    corpus.write_bytes(corpus.read_bytes() + b"\n")
+
+    got = subprocess.run(
+        [
+            os.fspath(Path(__file__).parents[1] / "scripts" / "check_formula_corpus_digest.py"),
+            "--corpus",
+            os.fspath(corpus),
+            "--digest",
+            os.fspath(digest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "changed without its digest" in got.stdout
+
+
+def test_formula_semantic_fence_can_go_red(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text())
+    document["vectors"][0]["term_values"]["x"] = 4
+    corpus = tmp_path / "formula_vectors.json"
+    corpus.write_text(json.dumps(document))
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_formula_conformance_vector",
+        ],
+        env={**os.environ, "FORMULA_VECTOR_CORPUS": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "ordinary evaluation" in got.stdout
+    assert "4" in got.stdout
+
+
+def test_formula_peer_drift_gate_can_go_red(tmp_path: Path) -> None:
+    peer = tmp_path / "peer"
+    peer.mkdir()
+    testdata = Path(__file__).parent / "testdata"
+    for name in ("formula_vectors.json", "FORMULA_VECTORS_DIGEST"):
+        (peer / name).write_bytes((testdata / name).read_bytes())
+    (peer / "formula_vectors.json").write_bytes(
+        (peer / "formula_vectors.json").read_bytes() + b"\n"
+    )
+
+    got = subprocess.run(
+        ["bash", os.fspath(Path(__file__).parents[1] / "scripts" / "formula-vector-drift.sh")],
+        env={"PATH": "/usr/bin:/bin", "FORMULA_VECTOR_PEER_DIR": os.fspath(peer)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "formula_vectors.json differs" in got.stderr

--- a/tests/testdata/FORMULA_VECTORS_DIGEST
+++ b/tests/testdata/FORMULA_VECTORS_DIGEST
@@ -1,0 +1,5 @@
+# sha256 of formula_vectors.json — the shared Tensorhub/python-gen-worker
+# formula grammar, limit and canonicalization corpus (th#1914 / pgw#1236).
+# A corpus change is a coupled cross-repo contract change: PGW lands first,
+# then Tensorhub copies the corpus and this digest verbatim.
+3e9d1cbe2b1e319b0ec86994a3e2809d0073bdfcda508fee141423800d862291


### PR DESCRIPTION
Closes pgw#1236. Paired with tensorhub th#1914.

Pins the unchanged cross-language formula corpus to a shared digest, proves the local digest and semantic fences can go red, and adds the verbatim PGW-first drift script. This PR is the public carrier and lands first; Tensorhub then compares its copy to PGW master.

Actions cost: no new workflow or job; one subsecond digest step in existing fast gates and focused tests in the existing test job.