### PR TITLE
ci: carry shared runtime and worker-wire values (pgw#1237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,13 @@ jobs:
       - name: pgw#1237 gate - Cozy runtime env corpus matches its digest
         run: uv run python scripts/check_cozy_runtime_env_digest.py
 
+      # GATING (th#1914 / pgw#1237): public carrier for the exact worker
+      # values and bounded relations Tensorhub consumes. PGW pins layer 1;
+      # private Tensorhub performs the meaningful peer comparison after PGW
+      # lands. Running that peer script here would compare PGW to itself.
+      - name: pgw#1237 gate - worker value corpus matches its digest
+        run: uv run python scripts/check_worker_value_contracts_digest.py
+
       # GATING (th#1897/pgw#1213): the shared grammar corpora are pinned to the
       # digest BOTH repos commit, so a one-sided hand-edit of
       # compiled_graph_key_vectors.json or ref_grammar_vectors.json is red

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,12 @@ jobs:
       - name: pgw#740 guard - registry contract
         run: uv run python scripts/check_registry_contract.py
 
+      # GATING (th#1914 / pgw#1237 / cl#56): this public corpus is the
+      # authority both sides bind to real path behavior. PGW pins it offline;
+      # cozy-local performs the meaningful peer comparison after PGW lands.
+      - name: pgw#1237 gate - Cozy runtime env corpus matches its digest
+        run: uv run python scripts/check_cozy_runtime_env_digest.py
+
       # GATING (th#1897/pgw#1213): the shared grammar corpora are pinned to the
       # digest BOTH repos commit, so a one-sided hand-edit of
       # compiled_graph_key_vectors.json or ref_grammar_vectors.json is red

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,6 +111,14 @@ tasks:
     cmds:
       - scripts/vendor-proto.sh {{.CLI_ARGS}}
 
+  worker-value-contract-check:
+    desc: |
+      pgw#1237 — pin the public worker-value carrier locally. Tensorhub vendors
+      the corpus and runs the meaningful Hub -> public-PGW byte comparison, so
+      the coupled-cut direction is PGW LANDS FIRST.
+    cmds:
+      - uv run python scripts/check_worker_value_contracts_digest.py
+
   proto-check:
     desc: |
       pgw#944 — fail if the VENDORED contract was hand-edited: the local
@@ -190,6 +198,7 @@ tasks:
       - cmd: uv run python scripts/lint_layout_declarations.py
       - cmd: uv run python scripts/lint_cell_key_layout_fence.py
       - cmd: uv run python scripts/check_registry_contract.py
+      - cmd: uv run python scripts/check_worker_value_contracts_digest.py
       - cmd: uv run python scripts/lint_credential_identity.py
       - cmd: uv run python scripts/lint_arm_state_feeders.py
       - cmd: uv run python scripts/lint_ambient_census.py

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,6 +119,14 @@ tasks:
     cmds:
       - uv run python scripts/check_worker_value_contracts_digest.py
 
+  cozy-runtime-env-check:
+    desc: |
+      pgw#1237 / cl#56 — pin the public Cozy runtime-env carrier locally.
+      cozy-local runs the meaningful private-consumer -> public-PGW byte
+      comparison, so the coupled-cut direction is PGW LANDS FIRST.
+    cmds:
+      - uv run python scripts/check_cozy_runtime_env_digest.py
+
   proto-check:
     desc: |
       pgw#944 — fail if the VENDORED contract was hand-edited: the local
@@ -198,6 +206,7 @@ tasks:
       - cmd: uv run python scripts/lint_layout_declarations.py
       - cmd: uv run python scripts/lint_cell_key_layout_fence.py
       - cmd: uv run python scripts/check_registry_contract.py
+      - cmd: uv run python scripts/check_cozy_runtime_env_digest.py
       - cmd: uv run python scripts/check_worker_value_contracts_digest.py
       - cmd: uv run python scripts/lint_credential_identity.py
       - cmd: uv run python scripts/lint_arm_state_feeders.py

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -1,7 +1,8 @@
-- **pgw#1237: Cozy runtime paths are one pinned contract.** The worker now
-  binds the three shared runtime environment names and their path semantics to a
-  public corpus that cozy-local can fence byte-for-byte.
+- **pgw#1237: Cozy runtime inputs are one pinned contract.** The worker now
+  binds the five shared runtime environment names, path semantics and optional
+  secret classification to a public corpus that cozy-local fences byte-for-byte.
 - **pgw#1237: worker values have a public carrier.** Activity decisions,
   cell-resolve and trust refusals, compile-cache ranks, execution lanes, layout
-  identity, fabric admission and the pickle ban are pinned as exact values or
-  explicitly bounded relations for Tensorhub's peer fence.
+  identity, fabric admission, the pickle ban and all seven typed callout
+  refusals are pinned as exact values or explicitly bounded relations for
+  Tensorhub's peer fence.

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -7,7 +7,8 @@
   refusals are pinned as exact values or explicitly bounded relations for
   Tensorhub's peer fence. The carrier also binds the byte-compatible compile
   cache flavor label, model-source and serving vocabularies, request fallback
-  and eager-posture reasons, boot phases/outcomes/sources, and the intentionally
+  and eager-posture reasons, hardware-unsuitable reason classes, the LoRA
+  weight bound, boot phases/outcomes/sources, and the intentionally
   one-way `FnDegraded.ran` relation: the worker's current producer set is a
   subset of the hub's accepted set because the hub retains the retired
   `emergency_quant` value for compatibility. Unknown future boot phases remain

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -1,5 +1,5 @@
 - **pgw#1237: Cozy runtime paths are one pinned contract.** The worker now
-  binds the two shared runtime environment names and their path semantics to a
+  binds the three shared runtime environment names and their path semantics to a
   public corpus that cozy-local can fence byte-for-byte.
 - **pgw#1237: worker values have a public carrier.** Activity decisions,
   cell-resolve and trust refusals, compile-cache ranks, execution lanes, layout

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -1,0 +1,3 @@
+- **pgw#1237: Cozy runtime paths are one pinned contract.** The worker now
+  binds the two shared runtime environment names and their path semantics to a
+  public corpus that cozy-local can fence byte-for-byte.

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -5,4 +5,11 @@
   cell-resolve and trust refusals, compile-cache ranks, execution lanes, layout
   identity, fabric admission, the pickle ban and all seven typed callout
   refusals are pinned as exact values or explicitly bounded relations for
-  Tensorhub's peer fence.
+  Tensorhub's peer fence. The carrier also binds the byte-compatible compile
+  cache flavor label, model-source and serving vocabularies, request fallback
+  and eager-posture reasons, boot phases/outcomes/sources, and the intentionally
+  one-way `FnDegraded.ran` relation: the worker's current producer set is a
+  subset of the hub's accepted set because the hub retains the retired
+  `emergency_quant` value for compatibility. Unknown future boot phases remain
+  storable by Tensorhub; the fenced set is what this worker currently produces
+  and the hub currently interprets.

--- a/changelog.d/pgw1237.md
+++ b/changelog.d/pgw1237.md
@@ -1,3 +1,7 @@
 - **pgw#1237: Cozy runtime paths are one pinned contract.** The worker now
   binds the two shared runtime environment names and their path semantics to a
   public corpus that cozy-local can fence byte-for-byte.
+- **pgw#1237: worker values have a public carrier.** Activity decisions,
+  cell-resolve and trust refusals, compile-cache ranks, execution lanes, layout
+  identity, fabric admission and the pickle ban are pinned as exact values or
+  explicitly bounded relations for Tensorhub's peer fence.

--- a/scripts/check_cozy_runtime_env_digest.py
+++ b/scripts/check_cozy_runtime_env_digest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail if the local Cozy runtime-env corpus misses its pinned digest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = ROOT / "tests" / "testdata" / "cozy_runtime_env_vectors.json"
+DEFAULT_DIGEST = ROOT / "tests" / "testdata" / "COZY_RUNTIME_ENV_DIGEST"
+
+
+def recorded_digest(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            value = line.split()[0]
+            if len(value) == 64 and all(c in "0123456789abcdef" for c in value):
+                return value
+            return ""
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--digest", type=Path, default=DEFAULT_DIGEST)
+    args = parser.parse_args()
+
+    for path in (args.corpus, args.digest):
+        if not path.is_file():
+            print(f"cozy-runtime-env-digest: missing {path}")
+            return 2
+
+    actual = hashlib.sha256(args.corpus.read_bytes()).hexdigest()
+    recorded = recorded_digest(args.digest)
+    if actual == recorded:
+        print(f"cozy-runtime-env-digest: corpus matches {actual}")
+        return 0
+
+    print(
+        "cozy-runtime-env-digest: FAIL — the shared runtime-env corpus changed "
+        "without its digest\n"
+        f"  recorded: {recorded or '<missing>'}\n"
+        f"  actual:   {actual}\n\n"
+        "Land python-gen-worker first, then copy corpus and digest verbatim "
+        "to cozy-local."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_worker_value_contracts_digest.py
+++ b/scripts/check_worker_value_contracts_digest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail if the local worker-value carrier misses its pinned digest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = ROOT / "tests" / "testdata" / "worker_value_contracts.json"
+DEFAULT_DIGEST = ROOT / "tests" / "testdata" / "WORKER_VALUE_CONTRACTS_DIGEST"
+
+
+def recorded_digest(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            value = line.split()[0]
+            if len(value) == 64 and all(c in "0123456789abcdef" for c in value):
+                return value
+            return ""
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--digest", type=Path, default=DEFAULT_DIGEST)
+    args = parser.parse_args()
+
+    for path in (args.corpus, args.digest):
+        if not path.is_file():
+            print(f"worker-value-contracts-digest: missing {path}")
+            return 2
+
+    actual = hashlib.sha256(args.corpus.read_bytes()).hexdigest()
+    recorded = recorded_digest(args.digest)
+    if actual == recorded:
+        print(f"worker-value-contracts-digest: corpus matches {actual}")
+        return 0
+
+    print(
+        "worker-value-contracts-digest: FAIL — the public worker-value corpus "
+        "changed without its digest\n"
+        f"  recorded: {recorded or '<missing>'}\n"
+        f"  actual:   {actual}\n\n"
+        "Land python-gen-worker first, then copy corpus and digest verbatim "
+        "to tensorhub."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cozy-runtime-env-drift.sh
+++ b/scripts/cozy-runtime-env-drift.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# th#1914 / pgw#1237 / cl#56 — the Cozy runner and worker must agree on the
-# exact environment names and the path semantics behind them. This script is
-# committed VERBATIM in python-gen-worker and cozy-local.
+# th#1914 / pgw#1237 / cl#56 — the Cozy runner, hub, and worker must agree on
+# exact environment names and the path semantics behind them. Committed
+# VERBATIM to all three repos.
 #
-# Layer 1 in each repo pins its local corpus. Layer 2 runs from cozy-local and
-# compares to public python-gen-worker. Running this in PGW without an explicit
-# peer directory is local-only by design; a public repo cannot fetch its
-# private consumer and must never call a self-comparison peer proof.
-#
-# Direction: PGW LANDS FIRST.
+# Layer 1 in each repo pins its local corpus. Layer 2 runs from private
+# consumers and compares to public python-gen-worker. Running this in PGW
+# without an explicit peer directory is local-only by design; a public repo
+# cannot fetch its private consumers and must never call a self-comparison a
+# peer proof. Direction: PGW LANDS FIRST.
 #
 #   COZY_RUNTIME_ENV_PEER_REF=<branch>  PGW ref to fetch (default: master)
 #   COZY_RUNTIME_ENV_PEER_DIR=<dir>     local PGW tests/testdata directory
@@ -17,6 +16,7 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 pgw_rel="tests/testdata"
 cozy_rel="internal/cli/testdata"
+hub_rel="internal/orchestrator/localcells/testdata"
 corpus="cozy_runtime_env_vectors.json"
 digest="COZY_RUNTIME_ENV_DIGEST"
 
@@ -26,8 +26,11 @@ if [ -f "$here/$pgw_rel/$corpus" ]; then
 elif [ -f "$here/$cozy_rel/$corpus" ]; then
   local_dir="$here/$cozy_rel"
   side="cozy"
+elif [ -f "$here/$hub_rel/$corpus" ]; then
+  local_dir="$here/$hub_rel"
+  side="hub"
 else
-  echo "cozy-runtime-env-drift: no $corpus under $here" >&2
+  echo "cozy-runtime-env-drift: no $corpus under $here ($pgw_rel, $cozy_rel, or $hub_rel)" >&2
   exit 2
 fi
 
@@ -86,7 +89,7 @@ for name in "$corpus" "$digest"; do
   fi
 done
 if [ "$status" -ne 0 ]; then
-  echo "cozy-runtime-env-drift: land PGW first, then copy corpus and digest verbatim to cozy-local" >&2
+  echo "cozy-runtime-env-drift: land PGW first, then copy corpus and digest verbatim to private consumers" >&2
   exit 1
 fi
 

--- a/scripts/cozy-runtime-env-drift.sh
+++ b/scripts/cozy-runtime-env-drift.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# th#1914 / pgw#1237 / cl#56 — the Cozy runner and worker must agree on the
+# exact environment names and the path semantics behind them. This script is
+# committed VERBATIM in python-gen-worker and cozy-local.
+#
+# Layer 1 in each repo pins its local corpus. Layer 2 runs from cozy-local and
+# compares to public python-gen-worker. Running this in PGW without an explicit
+# peer directory is local-only by design; a public repo cannot fetch its
+# private consumer and must never call a self-comparison peer proof.
+#
+# Direction: PGW LANDS FIRST.
+#
+#   COZY_RUNTIME_ENV_PEER_REF=<branch>  PGW ref to fetch (default: master)
+#   COZY_RUNTIME_ENV_PEER_DIR=<dir>     local PGW tests/testdata directory
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pgw_rel="tests/testdata"
+cozy_rel="internal/cli/testdata"
+corpus="cozy_runtime_env_vectors.json"
+digest="COZY_RUNTIME_ENV_DIGEST"
+
+if [ -f "$here/$pgw_rel/$corpus" ]; then
+  local_dir="$here/$pgw_rel"
+  side="pgw"
+elif [ -f "$here/$cozy_rel/$corpus" ]; then
+  local_dir="$here/$cozy_rel"
+  side="cozy"
+else
+  echo "cozy-runtime-env-drift: no $corpus under $here" >&2
+  exit 2
+fi
+
+for name in "$corpus" "$digest"; do
+  if [ ! -f "$local_dir/$name" ]; then
+    echo "cozy-runtime-env-drift: missing $local_dir/$name" >&2
+    exit 2
+  fi
+done
+
+recorded="$(grep -Eo '^[0-9a-f]{64}' "$local_dir/$digest" | head -1 || true)"
+actual="$(sha256sum "$local_dir/$corpus" | cut -d' ' -f1)"
+if [ -z "$recorded" ]; then
+  echo "cozy-runtime-env-drift: $local_dir/$digest contains no sha256" >&2
+  exit 2
+fi
+if [ "$recorded" != "$actual" ]; then
+  echo "cozy-runtime-env-drift: FAIL — local corpus changed without its digest" >&2
+  echo "  recorded: $recorded" >&2
+  echo "  actual:   $actual" >&2
+  exit 1
+fi
+echo "cozy-runtime-env-drift: local corpus matches $actual"
+
+peer_dir="${COZY_RUNTIME_ENV_PEER_DIR:-}"
+if [ "$side" = "pgw" ] && [ -z "$peer_dir" ]; then
+  echo "cozy-runtime-env-drift: PGW layer 1 complete; no self-comparison"
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+peer_ref="${COZY_RUNTIME_ENV_PEER_REF:-master}"
+for name in "$corpus" "$digest"; do
+  if [ -n "$peer_dir" ]; then
+    if [ ! -f "$peer_dir/$name" ]; then
+      echo "cozy-runtime-env-drift: FAIL — $peer_dir/$name does not exist" >&2
+      exit 1
+    fi
+    cp "$peer_dir/$name" "$work/$name"
+  else
+    url="https://raw.githubusercontent.com/cozy-creator/python-gen-worker/${peer_ref}/${pgw_rel}/${name}"
+    if ! curl -sSfL --retry 3 --max-time 30 -o "$work/$name" "$url"; then
+      echo "cozy-runtime-env-drift: FAIL — could not fetch $url" >&2
+      exit 1
+    fi
+  fi
+done
+
+status=0
+for name in "$corpus" "$digest"; do
+  if ! cmp -s "$local_dir/$name" "$work/$name"; then
+    echo "cozy-runtime-env-drift: FAIL — $name differs from python-gen-worker@${peer_ref}" >&2
+    diff -u "$local_dir/$name" "$work/$name" | head -40 >&2 || true
+    status=1
+  fi
+done
+if [ "$status" -ne 0 ]; then
+  echo "cozy-runtime-env-drift: land PGW first, then copy corpus and digest verbatim to cozy-local" >&2
+  exit 1
+fi
+
+echo "cozy-runtime-env-drift: corpus and digest agree with python-gen-worker@${peer_ref}"

--- a/scripts/worker-value-contract-drift.sh
+++ b/scripts/worker-value-contract-drift.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# th#1914 / pgw#1237 — exact worker values and bounded value relations must
+# remain byte-identical between python-gen-worker and tensorhub. This script is
+# committed VERBATIM in both repositories.
+#
+# Layer 1 in each repo pins its local corpus. Layer 2 runs from tensorhub and
+# compares to public python-gen-worker. Running this in PGW without an explicit
+# peer directory is local-only by design; a public repo cannot fetch its
+# private consumer and must never call a self-comparison peer proof.
+#
+# Direction: PGW LANDS FIRST.
+#
+#   WORKER_VALUE_CONTRACT_PEER_REF=<ref>  PGW ref to fetch (default: master)
+#   WORKER_VALUE_CONTRACT_PEER_DIR=<dir>  local PGW tests/testdata directory
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pgw_rel="tests/testdata"
+hub_rel="internal/wirecontract/testdata"
+corpus="worker_value_contracts.json"
+digest="WORKER_VALUE_CONTRACTS_DIGEST"
+
+if [ -f "$here/$pgw_rel/$corpus" ]; then
+  local_dir="$here/$pgw_rel"
+  side="pgw"
+elif [ -f "$here/$hub_rel/$corpus" ]; then
+  local_dir="$here/$hub_rel"
+  side="hub"
+else
+  echo "worker-value-contract-drift: no $corpus under $here" >&2
+  exit 2
+fi
+
+for name in "$corpus" "$digest"; do
+  if [ ! -f "$local_dir/$name" ]; then
+    echo "worker-value-contract-drift: missing $local_dir/$name" >&2
+    exit 2
+  fi
+done
+
+recorded="$(grep -Eo '^[0-9a-f]{64}' "$local_dir/$digest" | head -1 || true)"
+actual="$(sha256sum "$local_dir/$corpus" | cut -d' ' -f1)"
+if [ -z "$recorded" ]; then
+  echo "worker-value-contract-drift: $local_dir/$digest contains no sha256" >&2
+  exit 2
+fi
+if [ "$recorded" != "$actual" ]; then
+  echo "worker-value-contract-drift: FAIL — local corpus changed without its digest" >&2
+  echo "  recorded: $recorded" >&2
+  echo "  actual:   $actual" >&2
+  exit 1
+fi
+echo "worker-value-contract-drift: local corpus matches $actual"
+
+peer_dir="${WORKER_VALUE_CONTRACT_PEER_DIR:-}"
+if [ "$side" = "pgw" ] && [ -z "$peer_dir" ]; then
+  echo "worker-value-contract-drift: PGW layer 1 complete; no self-comparison"
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+peer_ref="${WORKER_VALUE_CONTRACT_PEER_REF:-master}"
+for name in "$corpus" "$digest"; do
+  if [ -n "$peer_dir" ]; then
+    if [ ! -f "$peer_dir/$name" ]; then
+      echo "worker-value-contract-drift: FAIL — $peer_dir/$name does not exist" >&2
+      exit 1
+    fi
+    cp "$peer_dir/$name" "$work/$name"
+  else
+    url="https://raw.githubusercontent.com/cozy-creator/python-gen-worker/${peer_ref}/${pgw_rel}/${name}"
+    if ! curl -sSfL --retry 3 --max-time 30 -o "$work/$name" "$url"; then
+      echo "worker-value-contract-drift: FAIL — could not fetch $url" >&2
+      exit 1
+    fi
+  fi
+done
+
+peer_recorded="$(grep -Eo '^[0-9a-f]{64}' "$work/$digest" | head -1 || true)"
+peer_actual="$(sha256sum "$work/$corpus" | cut -d' ' -f1)"
+if [ -z "$peer_recorded" ] || [ "$peer_recorded" != "$peer_actual" ]; then
+  echo "worker-value-contract-drift: FAIL — PGW peer corpus does not match its digest" >&2
+  echo "  recorded: ${peer_recorded:-<missing>}" >&2
+  echo "  actual:   $peer_actual" >&2
+  exit 1
+fi
+
+status=0
+for name in "$corpus" "$digest"; do
+  if ! cmp -s "$local_dir/$name" "$work/$name"; then
+    echo "worker-value-contract-drift: FAIL — $name differs from python-gen-worker@${peer_ref}" >&2
+    diff -u "$local_dir/$name" "$work/$name" | head -40 >&2 || true
+    status=1
+  fi
+done
+if [ "$status" -ne 0 ]; then
+  echo "worker-value-contract-drift: land PGW first, then copy corpus and digest verbatim to tensorhub" >&2
+  exit 1
+fi
+
+echo "worker-value-contract-drift: corpus and digest agree with python-gen-worker@${peer_ref}"

--- a/tests/test_cozy_runtime_env_contract_pgw1237.py
+++ b/tests/test_cozy_runtime_env_contract_pgw1237.py
@@ -9,7 +9,10 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from gen_worker import config
+from gen_worker import local_cell_store
 from gen_worker.cli.local_context import _save_local_bytes
 from gen_worker.models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
 
@@ -31,9 +34,11 @@ def _variables() -> dict[str, dict[str, str]]:
     return {row["role"]: row for row in rows}
 
 
-def test_runtime_env_semantics_match_pgw1237(monkeypatch, tmp_path: Path) -> None:
+def test_runtime_env_semantics_match_pgw1237(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     rows = _variables()
-    assert set(rows) == {"cache_root", "asset_ref_root"}
+    assert set(rows) == {"cache_root", "asset_ref_root", "compiled_graph_root"}
 
     cache = rows["cache_root"]
     cache_root = tmp_path / "cache-root"
@@ -46,12 +51,24 @@ def test_runtime_env_semantics_match_pgw1237(monkeypatch, tmp_path: Path) -> Non
         config.reset_for_test()
 
     output = rows["asset_ref_root"]
+    assert output["name"] == "GEN_WORKER_LOCAL_OUTPUT_DIR"
     output_root = tmp_path / "output-root"
     monkeypatch.setenv(output["name"], os.fspath(output_root))
     asset = _save_local_bytes(output["sample_asset_ref"], b"pgw#1237")
     expected = output_root / output["sample_asset_ref"]
+    assert asset.local_path is not None
     assert Path(asset.local_path) == expected
     assert expected.read_bytes() == b"pgw#1237"
+
+    compiled = rows["compiled_graph_root"]
+    assert compiled["name"] == local_cell_store.ENV_STORE_DIR
+    compiled_root = tmp_path / "compiled-graph-root"
+    monkeypatch.setenv(compiled["name"], os.fspath(compiled_root))
+    assert local_cell_store.store_root() == compiled_root
+    assert local_cell_store.cells_root() == (
+        compiled_root / compiled["consumer_relative_path"]
+    )
+    assert compiled["consumer_relative_path"] == local_cell_store.CELLS_DIRNAME
 
 
 def test_runtime_env_corpus_digest_matches_pgw1237() -> None:
@@ -85,9 +102,24 @@ def test_runtime_env_digest_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
     assert "changed without its digest" in got.stdout
 
 
-def test_runtime_env_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("role", "field", "mutation"),
+    [
+        ("cache_root", "consumer_relative_path", "not-cas"),
+        ("asset_ref_root", "name", "GEN_WORKER_LOCAL_OUTPUT_DIR_BROKEN"),
+        (
+            "compiled_graph_root",
+            "name",
+            "GEN_WORKER_LOCAL_CELLS_DIR_BROKEN",
+        ),
+    ],
+)
+def test_runtime_env_semantic_fence_can_go_red_pgw1237(
+    tmp_path: Path, role: str, field: str, mutation: str
+) -> None:
     document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
-    document["variables"][0]["consumer_relative_path"] = "not-cas"
+    row = next(row for row in document["variables"] if row["role"] == role)
+    row[field] = mutation
     corpus = tmp_path / "cozy_runtime_env_vectors.json"
     corpus.write_text(json.dumps(document), encoding="utf-8")
 
@@ -107,7 +139,7 @@ def test_runtime_env_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
         text=True,
     )
     assert got.returncode == 1
-    assert "not-cas" in got.stdout
+    assert mutation in got.stdout
 
 
 def test_runtime_env_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
@@ -116,6 +148,8 @@ def test_runtime_env_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
     for source in (_DEFAULT_CORPUS, _DEFAULT_DIGEST):
         (peer / source.name).write_bytes(source.read_bytes())
     (peer / _DEFAULT_CORPUS.name).write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+    peer_digest = hashlib.sha256((peer / _DEFAULT_CORPUS.name).read_bytes()).hexdigest()
+    (peer / _DEFAULT_DIGEST.name).write_text(peer_digest + "\n", encoding="utf-8")
 
     got = subprocess.run(
         ["bash", os.fspath(Path(__file__).parents[1] / "scripts" / "cozy-runtime-env-drift.sh")],

--- a/tests/test_cozy_runtime_env_contract_pgw1237.py
+++ b/tests/test_cozy_runtime_env_contract_pgw1237.py
@@ -26,7 +26,7 @@ def _document() -> dict[str, Any]:
     return json.loads(_CORPUS.read_text(encoding="utf-8"))
 
 
-def _variables() -> dict[str, dict[str, str]]:
+def _variables() -> dict[str, dict[str, Any]]:
     document = _document()
     assert document["schema"] == "cozy-runtime-env-v1"
     rows = document["variables"]
@@ -38,7 +38,13 @@ def test_runtime_env_semantics_match_pgw1237(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     rows = _variables()
-    assert set(rows) == {"cache_root", "asset_ref_root", "compiled_graph_root"}
+    assert set(rows) == {
+        "cache_root",
+        "asset_ref_root",
+        "compiled_graph_root",
+        "hub_url",
+        "bearer_token",
+    }
 
     cache = rows["cache_root"]
     cache_root = tmp_path / "cache-root"
@@ -69,6 +75,32 @@ def test_runtime_env_semantics_match_pgw1237(
         compiled_root / compiled["consumer_relative_path"]
     )
     assert compiled["consumer_relative_path"] == local_cell_store.CELLS_DIRNAME
+
+    hub_url = rows["hub_url"]
+    assert hub_url == {
+        "name": "TENSORHUB_URL",
+        "role": "hub_url",
+        "config_field": "tensorhub_url",
+    }
+    monkeypatch.setenv(hub_url["name"], "https://hub.invalid")
+    settings = config.reload_for_test()
+    try:
+        assert getattr(settings, hub_url["config_field"]) == "https://hub.invalid"
+    finally:
+        config.reset_for_test()
+
+    bearer = rows["bearer_token"]
+    assert bearer["name"] == "TENSORHUB_TOKEN"
+    assert bearer["config_field"] == "tensorhub_token"
+    assert bearer["optional"] is True
+    assert bearer["secret"] is True
+    assert "value" not in bearer and "sample" not in bearer
+    monkeypatch.setenv(bearer["name"], "redacted-test-sentinel")
+    settings = config.reload_for_test()
+    try:
+        assert getattr(settings, bearer["config_field"]) == "redacted-test-sentinel"
+    finally:
+        config.reset_for_test()
 
 
 def test_runtime_env_corpus_digest_matches_pgw1237() -> None:
@@ -112,6 +144,8 @@ def test_runtime_env_digest_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
             "name",
             "GEN_WORKER_LOCAL_CELLS_DIR_BROKEN",
         ),
+        ("hub_url", "name", "TENSORHUB_URL_BROKEN"),
+        ("bearer_token", "name", "TENSORHUB_TOKEN_BROKEN"),
     ],
 )
 def test_runtime_env_semantic_fence_can_go_red_pgw1237(

--- a/tests/test_cozy_runtime_env_contract_pgw1237.py
+++ b/tests/test_cozy_runtime_env_contract_pgw1237.py
@@ -1,0 +1,128 @@
+"""Bind the shared Cozy runtime-env corpus to the worker's real seams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from gen_worker import config
+from gen_worker.cli.local_context import _save_local_bytes
+from gen_worker.models.cache_paths import tensorhub_cache_dir, tensorhub_cas_dir
+
+
+_DEFAULT_CORPUS = Path(__file__).parent / "testdata" / "cozy_runtime_env_vectors.json"
+_DEFAULT_DIGEST = Path(__file__).parent / "testdata" / "COZY_RUNTIME_ENV_DIGEST"
+_CORPUS = Path(os.environ.get("COZY_RUNTIME_ENV_CORPUS", _DEFAULT_CORPUS))
+
+
+def _document() -> dict[str, Any]:
+    return json.loads(_CORPUS.read_text(encoding="utf-8"))
+
+
+def _variables() -> dict[str, dict[str, str]]:
+    document = _document()
+    assert document["schema"] == "cozy-runtime-env-v1"
+    rows = document["variables"]
+    assert isinstance(rows, list)
+    return {row["role"]: row for row in rows}
+
+
+def test_runtime_env_semantics_match_pgw1237(monkeypatch, tmp_path: Path) -> None:
+    rows = _variables()
+    assert set(rows) == {"cache_root", "asset_ref_root"}
+
+    cache = rows["cache_root"]
+    cache_root = tmp_path / "cache-root"
+    monkeypatch.setenv(cache["name"], os.fspath(cache_root))
+    config.reload_for_test()
+    try:
+        assert tensorhub_cache_dir() == cache_root
+        assert tensorhub_cas_dir() == cache_root / cache["consumer_relative_path"]
+    finally:
+        config.reset_for_test()
+
+    output = rows["asset_ref_root"]
+    output_root = tmp_path / "output-root"
+    monkeypatch.setenv(output["name"], os.fspath(output_root))
+    asset = _save_local_bytes(output["sample_asset_ref"], b"pgw#1237")
+    expected = output_root / output["sample_asset_ref"]
+    assert Path(asset.local_path) == expected
+    assert expected.read_bytes() == b"pgw#1237"
+
+
+def test_runtime_env_corpus_digest_matches_pgw1237() -> None:
+    active = [
+        line.strip().split()[0]
+        for line in _DEFAULT_DIGEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(active) == 1
+    assert active[0] == hashlib.sha256(_DEFAULT_CORPUS.read_bytes()).hexdigest()
+
+
+def test_runtime_env_digest_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
+    corpus = tmp_path / "cozy_runtime_env_vectors.json"
+    digest = tmp_path / "COZY_RUNTIME_ENV_DIGEST"
+    corpus.write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+    digest.write_bytes(_DEFAULT_DIGEST.read_bytes())
+    got = subprocess.run(
+        [
+            os.fspath(Path(__file__).parents[1] / "scripts" / "check_cozy_runtime_env_digest.py"),
+            "--corpus",
+            os.fspath(corpus),
+            "--digest",
+            os.fspath(digest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "changed without its digest" in got.stdout
+
+
+def test_runtime_env_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    document["variables"][0]["consumer_relative_path"] = "not-cas"
+    corpus = tmp_path / "cozy_runtime_env_vectors.json"
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_runtime_env_semantics_match_pgw1237",
+        ],
+        env={**os.environ, "COZY_RUNTIME_ENV_CORPUS": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "not-cas" in got.stdout
+
+
+def test_runtime_env_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
+    peer = tmp_path / "peer"
+    peer.mkdir()
+    for source in (_DEFAULT_CORPUS, _DEFAULT_DIGEST):
+        (peer / source.name).write_bytes(source.read_bytes())
+    (peer / _DEFAULT_CORPUS.name).write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+
+    got = subprocess.run(
+        ["bash", os.fspath(Path(__file__).parents[1] / "scripts" / "cozy-runtime-env-drift.sh")],
+        env={"PATH": "/usr/bin:/bin", "COZY_RUNTIME_ENV_PEER_DIR": os.fspath(peer)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "cozy_runtime_env_vectors.json differs" in got.stderr

--- a/tests/test_ref_grammar_conformance_th1276.py
+++ b/tests/test_ref_grammar_conformance_th1276.py
@@ -12,8 +12,12 @@ tag that must be written explicitly and round-trips stamped.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -25,6 +29,7 @@ from gen_worker.models.refs import (
 )
 
 VECTORS_PATH = Path(__file__).parent / "testdata" / "ref_grammar_vectors.json"
+REF_DIGEST_PATH = Path(__file__).parent / "testdata" / "REF_GRAMMAR_DIGEST"
 _DOC = json.loads(VECTORS_PATH.read_text())
 _VECTORS = _DOC["vectors"]
 
@@ -34,6 +39,55 @@ _ERR = [v for v in _VECTORS if v.get("error")]
 
 def _id(v: dict) -> str:
     return v["ref"] or "<empty>"
+
+
+def _contract_paths() -> tuple[Path, Path]:
+    return (
+        Path(os.environ.get("REF_GRAMMAR_VECTOR_FILE", VECTORS_PATH)),
+        Path(os.environ.get("REF_GRAMMAR_DIGEST_FILE", REF_DIGEST_PATH)),
+    )
+
+
+def _recorded_digest(path: Path) -> str:
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            return line.split()[0]
+    return ""
+
+
+def test_ref_grammar_corpus_digest_th1914() -> None:
+    corpus, digest_file = _contract_paths()
+    actual = hashlib.sha256(corpus.read_bytes()).hexdigest()
+    recorded = _recorded_digest(digest_file)
+    assert recorded == actual, (
+        "ref_grammar_vectors.json changed without its independent digest: "
+        f"recorded={recorded!r}, actual={actual}"
+    )
+
+
+def test_ref_grammar_digest_gate_can_go_red_th1914(tmp_path: Path) -> None:
+    candidate = tmp_path / "ref_grammar_vectors.json"
+    candidate.write_bytes(VECTORS_PATH.read_bytes() + b"\n")
+    env = os.environ.copy()
+    env["REF_GRAMMAR_VECTOR_FILE"] = str(candidate)
+    env["REF_GRAMMAR_DIGEST_FILE"] = str(REF_DIGEST_PATH)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            f"{Path(__file__).resolve()}::test_ref_grammar_corpus_digest_th1914",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0, proc.stdout + proc.stderr
+    assert "changed without its independent digest" in proc.stdout + proc.stderr
 
 
 @pytest.mark.parametrize("vec", _OK, ids=[_id(v) for v in _OK])

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -179,12 +179,39 @@ def test_worker_value_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     assert "compilecache_rank_buckets" in got.stdout
 
 
+def test_worker_value_relation_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    document["relations"]["sku_slug"]["cases"][0]["result"] = "not-rtx-4090"
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_bounded_worker_relations_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "not-rtx-4090" in got.stdout
+
+
 def test_worker_value_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
     peer = tmp_path / "peer"
     peer.mkdir()
     for source in (_DEFAULT_CORPUS, _DEFAULT_DIGEST):
         (peer / source.name).write_bytes(source.read_bytes())
     (peer / _DEFAULT_CORPUS.name).write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+    peer_digest = hashlib.sha256((peer / _DEFAULT_CORPUS.name).read_bytes()).hexdigest()
+    (peer / _DEFAULT_DIGEST.name).write_text(peer_digest + "\n", encoding="utf-8")
 
     got = subprocess.run(
         ["bash", os.fspath(_ROOT / "scripts" / "worker-value-contract-drift.sh")],
@@ -197,4 +224,4 @@ def test_worker_value_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
         text=True,
     )
     assert got.returncode == 1
-    assert "peer corpus does not match its digest" in got.stderr
+    assert "worker_value_contracts.json differs from python-gen-worker" in got.stderr

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -1,0 +1,200 @@
+"""Bind the public worker-value corpus to python-gen-worker's live values."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker import activity, cell_resolve, compile_cache, host_canary
+from gen_worker.convert.layout_converters import derived_artifact_identity
+from gen_worker.local_cell_store import UNTRUSTED_REFUSAL_CODE
+from gen_worker.models import execution_lanes
+from gen_worker.models.cozy_snapshot import PICKLE_WEIGHT_EXTENSIONS
+from gen_worker.models.tensor_layout_contract import (
+    LayoutDeclarationError,
+    LayoutId,
+    parse_layout_id,
+)
+from gen_worker.models.w8a8_lora import RANK_BUCKETS
+
+
+_ROOT = Path(__file__).parents[1]
+_DEFAULT_CORPUS = Path(__file__).parent / "testdata" / "worker_value_contracts.json"
+_DEFAULT_DIGEST = Path(__file__).parent / "testdata" / "WORKER_VALUE_CONTRACTS_DIGEST"
+_CORPUS = Path(os.environ.get("WORKER_VALUE_CONTRACT_FILE", _DEFAULT_CORPUS))
+
+
+def _document() -> dict[str, Any]:
+    document = json.loads(_CORPUS.read_text(encoding="utf-8"))
+    assert document["schema"] == "worker-value-contracts-v1"
+    return document
+
+
+def _lane_rows() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for body in execution_lanes.known_execution_lane_bodies():
+        supported: list[str] = []
+        family = ""
+        for mode in (execution_lanes.EXEC_COMPILED, execution_lanes.EXEC_EAGER):
+            try:
+                lane = execution_lanes.parse_execution_lane(f"{body}+{mode}")
+            except ValueError:
+                continue
+            if execution_lanes.valid_execution_lane(lane):
+                supported.append(mode)
+                family = execution_lanes.family_of(lane)
+        rows.append({"body": body, "family": family, "execution": supported})
+    return rows
+
+
+def test_exact_worker_values_match_pgw1237() -> None:
+    exact = _document()["exact"]
+
+    assert exact["activity_decision_kinds"] == [
+        activity.KIND_SELF_MINT_COMPILE,
+        activity.KIND_WARMUP,
+        activity.KIND_AOT_MINT,
+    ]
+    assert exact["activity_duration_rollups"] == [
+        {"kind": activity.KIND_AOT_MINT, "phase": activity.PHASE_MINTED},
+        {"kind": activity.KIND_JIT_COMPILE, "phase": activity.PHASE_MINTED},
+    ]
+    assert set(exact["cell_resolve_hub_refusal_codes"]) == set(
+        cell_resolve.REFUSAL_CODES
+    )
+    assert exact["cell_publish_untrusted_refusal_code"] == UNTRUSTED_REFUSAL_CODE
+    assert exact["compilecache_rank_buckets"] == list(RANK_BUCKETS)
+    assert exact["execution_lane_bodies"] == _lane_rows()
+    assert exact["pickle_weight_extensions"] == list(PICKLE_WEIGHT_EXTENSIONS)
+
+
+def test_bounded_worker_relations_match_pgw1237() -> None:
+    relations = _document()["relations"]
+
+    assert relations["sku_slug"]["domain"] == "ASCII GPU identity strings"
+    for case in relations["sku_slug"]["cases"]:
+        assert compile_cache.sku_slug(case["input"]) == case["result"]
+
+    assert relations["system_repo"]["domain"] == "non-empty family names"
+    for case in relations["system_repo"]["cases"]:
+        assert compile_cache.system_repo(case["family"]) == case["result"]
+
+    rank_buckets = {0, *RANK_BUCKETS}
+    lane_relation = relations["execution_lane_with_bucket"]
+    for case in lane_relation["cases"]:
+        assert case["bucket"] in rank_buckets
+        assert compile_cache.execution_lane_label(
+            case["base"], case["bucket"]
+        ) == case["result"]
+
+    layout_relation = relations["layout_id"]
+    for case in layout_relation["cases"]:
+        got = parse_layout_id(case["input"], where="pgw#1237 corpus")
+        assert got.topology == case["topology"]
+        assert got.quant == case["quant"]
+        assert got.render() == case["render"]
+    for value in layout_relation["refusals"]:
+        with pytest.raises(LayoutDeclarationError):
+            parse_layout_id(value, where="pgw#1237 corpus")
+
+    for case in relations["derived_artifact_identity"]["cases"]:
+        target = LayoutId(**case["target"])
+        assert derived_artifact_identity(
+            case["source_digest"], case["chain_digests"], target
+        ) == case["result"]
+
+    fabric = relations["sp_fabric"]
+    assert fabric["domain"] == "canonical worker-emitted interconnect spellings"
+    assert host_canary.SP_MIN_PEER_GBPS == fabric["min_peer_gbps"]
+    for case in fabric["cases"]:
+        assert host_canary.sp_admits(
+            case["interconnect"], case["peer_gbps"]
+        ) is case["admits"]
+        assert host_canary.is_fabric_wedge(
+            case["peer_access"], case["peer_gbps"]
+        ) is case["wedge"]
+
+
+def test_worker_value_corpus_digest_matches_pgw1237() -> None:
+    active = [
+        line.strip().split()[0]
+        for line in _DEFAULT_DIGEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(active) == 1
+    assert active[0] == hashlib.sha256(_DEFAULT_CORPUS.read_bytes()).hexdigest()
+
+
+def test_worker_value_digest_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    digest = tmp_path / _DEFAULT_DIGEST.name
+    corpus.write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+    digest.write_bytes(_DEFAULT_DIGEST.read_bytes())
+    got = subprocess.run(
+        [
+            sys.executable,
+            os.fspath(_ROOT / "scripts" / "check_worker_value_contracts_digest.py"),
+            "--corpus",
+            os.fspath(corpus),
+            "--digest",
+            os.fspath(digest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "changed without its digest" in got.stdout
+
+
+def test_worker_value_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    document["exact"]["compilecache_rank_buckets"][0] = 17
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_exact_worker_values_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "compilecache_rank_buckets" in got.stdout
+
+
+def test_worker_value_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:
+    peer = tmp_path / "peer"
+    peer.mkdir()
+    for source in (_DEFAULT_CORPUS, _DEFAULT_DIGEST):
+        (peer / source.name).write_bytes(source.read_bytes())
+    (peer / _DEFAULT_CORPUS.name).write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+
+    got = subprocess.run(
+        ["bash", os.fspath(_ROOT / "scripts" / "worker-value-contract-drift.sh")],
+        env={
+            "PATH": "/usr/bin:/bin",
+            "WORKER_VALUE_CONTRACT_PEER_DIR": os.fspath(peer),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "peer corpus does not match its digest" in got.stderr

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -8,14 +8,23 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 
-from gen_worker import activity, callout, cell_resolve, compile_cache, host_canary
+from gen_worker import (
+    activity,
+    boot_phases,
+    callout,
+    cell_resolve,
+    compile_cache,
+    host_canary,
+    serving_mode,
+)
+from gen_worker.api.binding import ModelSource
 from gen_worker.convert.layout_converters import derived_artifact_identity
 from gen_worker.local_cell_store import UNTRUSTED_REFUSAL_CODE
-from gen_worker.models import execution_lanes
+from gen_worker.models import execution_lanes, rung
 from gen_worker.models.cozy_snapshot import PICKLE_WEIGHT_EXTENSIONS
 from gen_worker.models.tensor_layout_contract import (
     LayoutDeclarationError,
@@ -54,6 +63,24 @@ def _lane_rows() -> list[dict[str, Any]]:
     return rows
 
 
+def _pgw_fn_degraded_ran_values() -> set[str]:
+    """Values this worker can currently put in a degraded report's `ran`.
+
+    A non-native ladder plan emits its coarse run mode. A failed native
+    storage cast emits the actual bf16/fp8 storage family instead. `native`
+    itself is not a degradation and therefore is not a producer value.
+    """
+    non_native = {
+        item.run_mode
+        for item in rung.LADDER
+        if item.run_mode != rung.RUN_NATIVE
+    }
+    return non_native | {
+        execution_lanes.WEIGHTS_BF16,
+        execution_lanes.WEIGHTS_FP8,
+    }
+
+
 def test_exact_worker_values_match_pgw1237() -> None:
     exact = _document()["exact"]
 
@@ -77,6 +104,39 @@ def test_exact_worker_values_match_pgw1237() -> None:
     }
     assert "child_calls_not_declared" in callout_codes
     assert set(callout_codes).isdisjoint(callout._NOT_DECLARED_CODES)  # noqa: SLF001
+    assert exact["model_ref_sources"] == list(get_args(ModelSource))
+    assert exact["serving_modes"] == [
+        serving_mode.MODE_EAGER,
+        serving_mode.MODE_JIT_CELL,
+        serving_mode.MODE_AOT_CELL,
+    ]
+    assert set(exact["per_request_fallback_reasons"]) == (
+        serving_mode._PER_REQUEST_FALLBACKS  # noqa: SLF001
+    )
+    assert exact["eager_posture_reasons"] == [
+        serving_mode.POSTURE_ARM_PENDING,
+        serving_mode.POSTURE_MINT_IN_PROGRESS,
+        serving_mode.POSTURE_NO_COMPILE_DECLARED,
+        serving_mode.POSTURE_UNCOMPILED,
+        serving_mode.POSTURE_GRAPH_BREAK,
+        serving_mode.POSTURE_DECLARED_RANGE_EXCEEDED,
+        serving_mode.POSTURE_OPERATOR_EAGER_ONLY,
+    ]
+    assert exact["boot_phase_producer_values"] == sorted(boot_phases.PHASES)
+    assert exact["boot_outcomes"] == [
+        boot_phases.OUTCOME_OK,
+        boot_phases.OUTCOME_REFUSED,
+        boot_phases.OUTCOME_FAILED,
+        boot_phases.OUTCOME_SKIPPED,
+    ]
+    assert exact["boot_sources"] == [
+        boot_phases.SOURCE_CAS,
+        boot_phases.SOURCE_VOLUME,
+        boot_phases.SOURCE_R2,
+        boot_phases.SOURCE_HF_CACHE,
+        boot_phases.SOURCE_INFLIGHT_SHARE,
+        boot_phases.SOURCE_LOCAL,
+    ]
     assert exact["compilecache_rank_buckets"] == list(RANK_BUCKETS)
     assert exact["execution_lane_bodies"] == _lane_rows()
     assert exact["pickle_weight_extensions"] == list(PICKLE_WEIGHT_EXTENSIONS)
@@ -84,6 +144,27 @@ def test_exact_worker_values_match_pgw1237() -> None:
 
 def test_bounded_worker_relations_match_pgw1237() -> None:
     relations = _document()["relations"]
+
+    flavor_relation = relations["compilecache_flavor_label"]
+    assert flavor_relation["domain"] == (
+        "canonical sku slug, Python torch release, and worker execution-lane alias"
+    )
+    for case in flavor_relation["cases"]:
+        assert compile_cache.flavor_label(
+            case["sku"], case["torch_version"], case["weight_lane"]
+        ) == case["result"]
+
+    degraded = relations["fn_degraded_ran"]
+    assert degraded["relation"] == (
+        "pgw_producer_values are a subset of tensorhub_accepted_values"
+    )
+    producer_values = set(degraded["pgw_producer_values"])
+    accepted_values = set(degraded["tensorhub_accepted_values"])
+    assert producer_values == _pgw_fn_degraded_ran_values()
+    assert producer_values < accepted_values
+    assert set(degraded["hub_only_legacy_values"]) == {
+        "emergency_quant"
+    } == accepted_values - producer_values
 
     assert relations["sku_slug"]["domain"] == "ASCII GPU identity strings"
     for case in relations["sku_slug"]["cases"]:
@@ -186,6 +267,43 @@ def test_worker_value_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     assert "compilecache_rank_buckets" in got.stdout
 
 
+@pytest.mark.parametrize("section", [
+    "model_ref_sources",
+    "serving_modes",
+    "per_request_fallback_reasons",
+    "eager_posture_reasons",
+    "boot_phase_producer_values",
+    "boot_outcomes",
+    "boot_sources",
+])
+def test_each_added_exact_section_can_go_red_pgw1237(
+    tmp_path: Path, section: str,
+) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    mutant = f"broken-{section}"
+    document["exact"][section][0] = mutant
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_exact_worker_values_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert mutant in got.stdout
+
+
 def test_worker_value_relation_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
     document["relations"]["sku_slug"]["cases"][0]["result"] = "not-rtx-4090"
@@ -209,6 +327,62 @@ def test_worker_value_relation_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     )
     assert got.returncode == 1
     assert "not-rtx-4090" in got.stdout
+
+
+def test_worker_value_flavor_relation_can_go_red_pgw1237(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    mutant = "inductor-broken-flavor"
+    document["relations"]["compilecache_flavor_label"]["cases"][0][
+        "result"
+    ] = mutant
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_bounded_worker_relations_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert mutant in got.stdout
+
+
+def test_worker_value_fn_degraded_relation_can_go_red_pgw1237(
+    tmp_path: Path,
+) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    mutant = "broken-degraded-mode"
+    document["relations"]["fn_degraded_ran"]["pgw_producer_values"][0] = mutant
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_bounded_worker_relations_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert mutant in got.stdout
 
 
 def test_worker_value_callout_fence_can_go_red_pgw1237(tmp_path: Path) -> None:

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -18,8 +18,10 @@ from gen_worker import (
     callout,
     cell_resolve,
     compile_cache,
+    cuda_probe,
     host_canary,
     serving_mode,
+    worker_fatal,
 )
 from gen_worker.api.binding import ModelSource
 from gen_worker.convert.layout_converters import derived_artifact_identity
@@ -32,6 +34,7 @@ from gen_worker.models.tensor_layout_contract import (
     parse_layout_id,
 )
 from gen_worker.models.w8a8_lora import RANK_BUCKETS
+from gen_worker.utils.lora import LORA_WEIGHT_BOUND
 
 
 _ROOT = Path(__file__).parents[1]
@@ -97,6 +100,27 @@ def test_exact_worker_values_match_pgw1237() -> None:
         cell_resolve.REFUSAL_CODES
     )
     assert exact["cell_publish_untrusted_refusal_code"] == UNTRUSTED_REFUSAL_CODE
+    assert exact["hardware_unsuitable_reason_classes"] == [
+        "torch_unavailable",
+        "cuda_unavailable",
+        "driver_too_old",
+        "cuda_error",
+        "unknown",
+        worker_fatal.REASON_CLASS,
+    ]
+    assert {
+        cuda_probe.classify_probe_failure(reason)
+        for reason in (
+            "torch unavailable: import failed",
+            "torch.cuda.is_available() is False",
+            "CUDA initialization: driver too old (found version 12080)",
+            "CUDA-capable device is busy",
+            "",
+        )
+    } == set(exact["hardware_unsuitable_reason_classes"]) - {
+        worker_fatal.REASON_CLASS
+    }
+    assert exact["lora_weight_bound"] == LORA_WEIGHT_BOUND
     callout_codes = exact["callout_hub_refusal_codes"]
     assert len(callout_codes) == 7
     assert set(callout_codes) == set(callout._REFUSAL_CODES) | {  # noqa: SLF001
@@ -275,13 +299,18 @@ def test_worker_value_semantic_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     "boot_phase_producer_values",
     "boot_outcomes",
     "boot_sources",
+    "hardware_unsuitable_reason_classes",
+    "lora_weight_bound",
 ])
 def test_each_added_exact_section_can_go_red_pgw1237(
     tmp_path: Path, section: str,
 ) -> None:
     document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
     mutant = f"broken-{section}"
-    document["exact"][section][0] = mutant
+    if isinstance(document["exact"][section], list):
+        document["exact"][section][0] = mutant
+    else:
+        document["exact"][section] = 99.0
     corpus = tmp_path / _DEFAULT_CORPUS.name
     corpus.write_text(json.dumps(document), encoding="utf-8")
 
@@ -301,7 +330,7 @@ def test_each_added_exact_section_can_go_red_pgw1237(
         text=True,
     )
     assert got.returncode == 1
-    assert mutant in got.stdout
+    assert mutant in got.stdout or section in got.stdout
 
 
 def test_worker_value_relation_fence_can_go_red_pgw1237(tmp_path: Path) -> None:

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from gen_worker import activity, cell_resolve, compile_cache, host_canary
+from gen_worker import activity, callout, cell_resolve, compile_cache, host_canary
 from gen_worker.convert.layout_converters import derived_artifact_identity
 from gen_worker.local_cell_store import UNTRUSTED_REFUSAL_CODE
 from gen_worker.models import execution_lanes
@@ -70,6 +70,13 @@ def test_exact_worker_values_match_pgw1237() -> None:
         cell_resolve.REFUSAL_CODES
     )
     assert exact["cell_publish_untrusted_refusal_code"] == UNTRUSTED_REFUSAL_CODE
+    callout_codes = exact["callout_hub_refusal_codes"]
+    assert len(callout_codes) == 7
+    assert set(callout_codes) == set(callout._REFUSAL_CODES) | {  # noqa: SLF001
+        "child_calls_not_declared"
+    }
+    assert "child_calls_not_declared" in callout_codes
+    assert set(callout_codes).isdisjoint(callout._NOT_DECLARED_CODES)  # noqa: SLF001
     assert exact["compilecache_rank_buckets"] == list(RANK_BUCKETS)
     assert exact["execution_lane_bodies"] == _lane_rows()
     assert exact["pickle_weight_extensions"] == list(PICKLE_WEIGHT_EXTENSIONS)
@@ -202,6 +209,31 @@ def test_worker_value_relation_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
     )
     assert got.returncode == 1
     assert "not-rtx-4090" in got.stdout
+
+
+def test_worker_value_callout_fence_can_go_red_pgw1237(tmp_path: Path) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    document["exact"]["callout_hub_refusal_codes"][0] = "call_depth_broken"
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+
+    got = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_exact_worker_values_match_pgw1237",
+        ],
+        env={**os.environ, "WORKER_VALUE_CONTRACT_FILE": os.fspath(corpus)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "call_depth_broken" in got.stdout
 
 
 def test_worker_value_peer_gate_can_go_red_pgw1237(tmp_path: Path) -> None:

--- a/tests/testdata/COZY_RUNTIME_ENV_DIGEST
+++ b/tests/testdata/COZY_RUNTIME_ENV_DIGEST
@@ -1,0 +1,4 @@
+# sha256 of cozy_runtime_env_vectors.json — the shared cozy-local/worker
+# runtime path contract (th#1914 / pgw#1237 / cl#56).
+# PGW lands first; cozy-local vendors both files verbatim.
+fe82d8857ba7aa6472a45fe856e31eaab29bafd8181aa4e57811c64622e74bdf

--- a/tests/testdata/COZY_RUNTIME_ENV_DIGEST
+++ b/tests/testdata/COZY_RUNTIME_ENV_DIGEST
@@ -1,4 +1,4 @@
 # sha256 of cozy_runtime_env_vectors.json — the shared cozy-local/worker
 # runtime path contract (th#1914 / pgw#1237 / cl#56).
 # PGW lands first; cozy-local vendors both files verbatim.
-f35662e035328b21773e70ea93a5fc237a7410665630713a1b59abddc3d5c149
+90ab5b929248df26dc257463d98f8e4cc622b0698ba0d36c5bd606d734b0b283

--- a/tests/testdata/COZY_RUNTIME_ENV_DIGEST
+++ b/tests/testdata/COZY_RUNTIME_ENV_DIGEST
@@ -1,4 +1,4 @@
 # sha256 of cozy_runtime_env_vectors.json — the shared cozy-local/worker
 # runtime path contract (th#1914 / pgw#1237 / cl#56).
 # PGW lands first; cozy-local vendors both files verbatim.
-fe82d8857ba7aa6472a45fe856e31eaab29bafd8181aa4e57811c64622e74bdf
+f35662e035328b21773e70ea93a5fc237a7410665630713a1b59abddc3d5c149

--- a/tests/testdata/COZY_RUNTIME_ENV_DIGEST
+++ b/tests/testdata/COZY_RUNTIME_ENV_DIGEST
@@ -1,4 +1,4 @@
 # sha256 of cozy_runtime_env_vectors.json — the shared cozy-local/worker
 # runtime path contract (th#1914 / pgw#1237 / cl#56).
-# PGW lands first; cozy-local vendors both files verbatim.
+# PGW lands first; private consumers vendor both files verbatim.
 90ab5b929248df26dc257463d98f8e4cc622b0698ba0d36c5bd606d734b0b283

--- a/tests/testdata/REF_GRAMMAR_DIGEST
+++ b/tests/testdata/REF_GRAMMAR_DIGEST
@@ -1,0 +1,3 @@
+# sha256 of ref_grammar_vectors.json. Independent from KEY_GRAMMAR_DIGEST,
+# which pins only compiled_graph_key_vectors.json.
+3a3be7f94f38dac2c7e38f7527984f6f3e4da701810b99797565dbc05fb9f97b

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-0cde4d53ae2b4105b9dbebb9c443b2a8fde2ddf540e5a4010cb4c6cdde507a4d
+48b2de64ed8687d8b173495016887673d3976d0989a68a67d60c0ff67f0f01f7

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,0 +1,3 @@
+# SHA-256 of worker_value_contracts.json.
+# PGW is the public-corpus vendor; peer repositories pin this byte identity.
+0cde4d53ae2b4105b9dbebb9c443b2a8fde2ddf540e5a4010cb4c6cdde507a4d

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-2369ddb0943156d07241e0fa359070fb79dda5f3de54c4dbc33782a9c935fad5
+249187bab3cb714abfa4fe85fc2976384391c6d34ea77b0e73444866427f02e8

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-48b2de64ed8687d8b173495016887673d3976d0989a68a67d60c0ff67f0f01f7
+2369ddb0943156d07241e0fa359070fb79dda5f3de54c4dbc33782a9c935fad5

--- a/tests/testdata/cozy_runtime_env_vectors.json
+++ b/tests/testdata/cozy_runtime_env_vectors.json
@@ -1,0 +1,15 @@
+{
+  "schema": "cozy-runtime-env-v1",
+  "variables": [
+    {
+      "name": "TENSORHUB_CACHE_DIR",
+      "role": "cache_root",
+      "consumer_relative_path": "cas"
+    },
+    {
+      "name": "GEN_WORKER_LOCAL_OUTPUT_DIR",
+      "role": "asset_ref_root",
+      "sample_asset_ref": "outputs/request-1/result.bin"
+    }
+  ]
+}

--- a/tests/testdata/cozy_runtime_env_vectors.json
+++ b/tests/testdata/cozy_runtime_env_vectors.json
@@ -10,6 +10,11 @@
       "name": "GEN_WORKER_LOCAL_OUTPUT_DIR",
       "role": "asset_ref_root",
       "sample_asset_ref": "outputs/request-1/result.bin"
+    },
+    {
+      "name": "GEN_WORKER_LOCAL_CELLS_DIR",
+      "role": "compiled_graph_root",
+      "consumer_relative_path": "aot-cells"
     }
   ]
 }

--- a/tests/testdata/cozy_runtime_env_vectors.json
+++ b/tests/testdata/cozy_runtime_env_vectors.json
@@ -15,6 +15,18 @@
       "name": "GEN_WORKER_LOCAL_CELLS_DIR",
       "role": "compiled_graph_root",
       "consumer_relative_path": "aot-cells"
+    },
+    {
+      "name": "TENSORHUB_URL",
+      "role": "hub_url",
+      "config_field": "tensorhub_url"
+    },
+    {
+      "name": "TENSORHUB_TOKEN",
+      "role": "bearer_token",
+      "config_field": "tensorhub_token",
+      "optional": true,
+      "secret": true
     }
   ]
 }

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -24,6 +24,15 @@
       "cell_resolve_transport_unavailable"
     ],
     "cell_publish_untrusted_refusal_code": "cell_publish_untrusted_tier",
+    "callout_hub_refusal_codes": [
+      "call_depth_exceeded",
+      "call_cycle_detected",
+      "tree_budget_exceeded",
+      "tier_escalation_denied",
+      "parent_not_running",
+      "budget_not_root",
+      "child_calls_not_declared"
+    ],
     "compilecache_rank_buckets": [
       16,
       32,

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -33,6 +33,67 @@
       "budget_not_root",
       "child_calls_not_declared"
     ],
+    "model_ref_sources": [
+      "tensorhub",
+      "huggingface",
+      "civitai",
+      "modelscope"
+    ],
+    "serving_modes": [
+      "eager",
+      "jit_cell",
+      "aot_cell"
+    ],
+    "per_request_fallback_reasons": [
+      "guard_miss",
+      "ingress_refused",
+      "healing",
+      "volatile"
+    ],
+    "eager_posture_reasons": [
+      "arm_pending",
+      "mint_in_progress",
+      "no_compile_declared",
+      "uncompiled",
+      "graph_break",
+      "declared_range_exceeded",
+      "operator_eager_only"
+    ],
+    "boot_phase_producer_values": [
+      "cell_arm",
+      "cell_fetch",
+      "cell_hub_rtt",
+      "cell_verify",
+      "compiled_swap",
+      "component_fetch",
+      "declaration_compose",
+      "eager_ready",
+      "entry_admit",
+      "env_establish",
+      "first_request_servable",
+      "hello",
+      "key_fold",
+      "lib_memo",
+      "pipeline_load",
+      "sdk_ready",
+      "trace_for_key",
+      "warmup",
+      "weights_fetch"
+    ],
+    "boot_outcomes": [
+      "ok",
+      "refused",
+      "failed",
+      "skipped"
+    ],
+    "boot_sources": [
+      "cas",
+      "volume",
+      "r2",
+      "hf_cache",
+      "inflight_share",
+      "local"
+    ],
     "compilecache_rank_buckets": [
       16,
       32,
@@ -95,6 +156,50 @@
     ]
   },
   "relations": {
+    "compilecache_flavor_label": {
+      "domain": "canonical sku slug, Python torch release, and worker execution-lane alias",
+      "cases": [
+        {
+          "sku": "rtx-4090",
+          "torch_version": "2.9.1+cu128",
+          "weight_lane": "",
+          "result": "inductor-rtx-4090-torch2.9"
+        },
+        {
+          "sku": "h100-80gb-hbm3",
+          "torch_version": "2.13.0+cu130",
+          "weight_lane": "w8a8",
+          "result": "inductor-h100-80gb-hbm3-torch2.13-w8a8"
+        },
+        {
+          "sku": "rtx-4090",
+          "torch_version": "2.9.1",
+          "weight_lane": "fp8-hooks",
+          "result": "inductor-rtx-4090-torch2.9-w8a16"
+        }
+      ]
+    },
+    "fn_degraded_ran": {
+      "relation": "pgw_producer_values are a subset of tensorhub_accepted_values",
+      "pgw_producer_values": [
+        "bf16",
+        "cpu",
+        "fp8",
+        "fp8_storage",
+        "offload"
+      ],
+      "tensorhub_accepted_values": [
+        "bf16",
+        "cpu",
+        "emergency_quant",
+        "fp8",
+        "fp8_storage",
+        "offload"
+      ],
+      "hub_only_legacy_values": [
+        "emergency_quant"
+      ]
+    },
     "sku_slug": {
       "domain": "ASCII GPU identity strings",
       "cases": [

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -24,6 +24,15 @@
       "cell_resolve_transport_unavailable"
     ],
     "cell_publish_untrusted_refusal_code": "cell_publish_untrusted_tier",
+    "hardware_unsuitable_reason_classes": [
+      "torch_unavailable",
+      "cuda_unavailable",
+      "driver_too_old",
+      "cuda_error",
+      "unknown",
+      "worker_fatal"
+    ],
+    "lora_weight_bound": 4.0,
     "callout_hub_refusal_codes": [
       "call_depth_exceeded",
       "call_cycle_detected",

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -1,0 +1,271 @@
+{
+  "schema": "worker-value-contracts-v1",
+  "_comment": "th#1914 / pgw#1237: public carrier for exact worker values and deliberately bounded cross-repo relations. Tensorhub vendors this file byte-for-byte and binds its private consumers to the same rows. Rows under relations state their domain explicitly; they are not claims about arbitrary inputs.",
+  "exact": {
+    "activity_decision_kinds": [
+      "self_mint_compile",
+      "warmup",
+      "aot_mint_phases"
+    ],
+    "activity_duration_rollups": [
+      {
+        "kind": "aot_mint_phases",
+        "phase": "minted"
+      },
+      {
+        "kind": "jit_compile",
+        "phase": "minted"
+      }
+    ],
+    "cell_resolve_hub_refusal_codes": [
+      "cell_resolve_ambiguous",
+      "cell_resolve_client_supplied_field",
+      "cell_resolve_incomplete",
+      "cell_resolve_transport_unavailable"
+    ],
+    "cell_publish_untrusted_refusal_code": "cell_publish_untrusted_tier",
+    "compilecache_rank_buckets": [
+      16,
+      32,
+      64,
+      128
+    ],
+    "execution_lane_bodies": [
+      {
+        "body": "fp8-w8a8-dynamic",
+        "family": "fp8",
+        "execution": [
+          "compiled"
+        ]
+      },
+      {
+        "body": "nvfp4-w4a4-static",
+        "family": "4bit",
+        "execution": [
+          "compiled"
+        ]
+      },
+      {
+        "body": "svdq-fp4-w4a4",
+        "family": "4bit",
+        "execution": [
+          "eager"
+        ]
+      },
+      {
+        "body": "svdq-int4-w4a4",
+        "family": "4bit",
+        "execution": [
+          "eager"
+        ]
+      },
+      {
+        "body": "bf16-w16a16",
+        "family": "bf16",
+        "execution": [
+          "compiled",
+          "eager"
+        ]
+      },
+      {
+        "body": "fp8-w8a16",
+        "family": "fp8",
+        "execution": [
+          "compiled",
+          "eager"
+        ]
+      }
+    ],
+    "pickle_weight_extensions": [
+      ".bin",
+      ".ckpt",
+      ".pt",
+      ".pth",
+      ".pkl",
+      ".pickle"
+    ]
+  },
+  "relations": {
+    "sku_slug": {
+      "domain": "ASCII GPU identity strings",
+      "cases": [
+        {
+          "input": "NVIDIA GeForce RTX 4090",
+          "result": "rtx-4090"
+        },
+        {
+          "input": "NVIDIA H100 80GB HBM3",
+          "result": "h100-80gb-hbm3"
+        },
+        {
+          "input": " NVIDIA---RTX 5090 ",
+          "result": "rtx-5090"
+        },
+        {
+          "input": "",
+          "result": ""
+        }
+      ]
+    },
+    "system_repo": {
+      "domain": "non-empty family names",
+      "cases": [
+        {
+          "family": "sdxl",
+          "result": "root/family-sdxl"
+        },
+        {
+          "family": "  wan22  ",
+          "result": "root/family-wan22"
+        }
+      ]
+    },
+    "execution_lane_with_bucket": {
+      "domain": "canonical base lane plus zero or a declared rank bucket",
+      "cases": [
+        {
+          "base": "",
+          "bucket": 0,
+          "result": ""
+        },
+        {
+          "base": "",
+          "bucket": 32,
+          "result": "lora32"
+        },
+        {
+          "base": "w8a16",
+          "bucket": 0,
+          "result": "w8a16"
+        },
+        {
+          "base": "w8a16",
+          "bucket": 16,
+          "result": "w8a16-lora16"
+        },
+        {
+          "base": "w8a8",
+          "bucket": 128,
+          "result": "w8a8-lora128"
+        },
+        {
+          "base": "w4a4",
+          "bucket": 64,
+          "result": "w4a4-lora64"
+        }
+      ]
+    },
+    "layout_id": {
+      "domain": "registered handles shared by both repositories",
+      "cases": [
+        {
+          "input": "plain.bf16@1",
+          "topology": null,
+          "quant": "plain.bf16@1",
+          "render": "+plain.bf16@1"
+        },
+        {
+          "input": "diffusers.multifile@1+plain.bf16@1",
+          "topology": "diffusers.multifile@1",
+          "quant": "plain.bf16@1",
+          "render": "diffusers.multifile@1+plain.bf16@1"
+        },
+        {
+          "input": "any+cozy.fp8-rowwise@1",
+          "topology": "any",
+          "quant": "cozy.fp8-rowwise@1",
+          "render": "any+cozy.fp8-rowwise@1"
+        },
+        {
+          "input": "transformers.native@1+",
+          "topology": "transformers.native@1",
+          "quant": null,
+          "render": "transformers.native@1+"
+        }
+      ],
+      "refusals": [
+        "",
+        "unknown.contract@1",
+        "plain.bf16@1+plain.bf16@1+extra"
+      ]
+    },
+    "derived_artifact_identity": {
+      "domain": "string source digest, ordered string converter digests, LayoutId wire render",
+      "cases": [
+        {
+          "source_digest": "sha256:source-a",
+          "chain_digests": [],
+          "target": {
+            "topology": null,
+            "quant": "plain.bf16@1"
+          },
+          "result": "582c7d9e7bc318ba8e3c57ef31d9741ee52286c1d15af13e8e418cc06d9a195c"
+        },
+        {
+          "source_digest": "sha256:source-b",
+          "chain_digests": [
+            "0123456789abcdef"
+          ],
+          "target": {
+            "topology": "diffusers.multifile@1",
+            "quant": "plain.bf16@1"
+          },
+          "result": "ceb9e6edf36a45e5c53443a784eda3319e55c9b496dc63459e16539caf7f2366"
+        },
+        {
+          "source_digest": "sha256:source-b",
+          "chain_digests": [
+            "aaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbb"
+          ],
+          "target": {
+            "topology": "diffusers.multifile@1",
+            "quant": "cozy.fp8-rowwise@1"
+          },
+          "result": "1341d3b74f287daf879f4928564720e6145edfa667e2375eeeb574334de58cac"
+        }
+      ]
+    },
+    "sp_fabric": {
+      "domain": "canonical worker-emitted interconnect spellings",
+      "min_peer_gbps": 200.0,
+      "cases": [
+        {
+          "interconnect": "nvlink",
+          "peer_gbps": 241.9,
+          "peer_access": true,
+          "admits": true,
+          "wedge": false
+        },
+        {
+          "interconnect": "nvlink",
+          "peer_gbps": 199.9,
+          "peer_access": true,
+          "admits": false,
+          "wedge": false
+        },
+        {
+          "interconnect": "pcie-p2p",
+          "peer_gbps": 500.0,
+          "peer_access": true,
+          "admits": false,
+          "wedge": false
+        },
+        {
+          "interconnect": "host-staged",
+          "peer_gbps": 0.0,
+          "peer_access": true,
+          "admits": false,
+          "wedge": true
+        },
+        {
+          "interconnect": "",
+          "peer_gbps": 0.0,
+          "peer_access": false,
+          "admits": false,
+          "wedge": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes the public-carrier half of th#1914. Adds pinned runtime-env and worker-value corpora, live-source semantic binders, byte/digest drift gates, and deliberately mutated red proofs inside existing required jobs. No product values change and no new job or schedule is added. PGW lands first so Tensorhub/cozy-local can compare the public carrier without a private credential.