### PR TITLE
ci: fence the Hub-worker launch boundary (pgw#1239)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,6 +320,14 @@ jobs:
       - name: pgw#1237 gate - worker value corpus matches its digest
         run: uv run python scripts/check_worker_value_contracts_digest.py
 
+      # GATING (th#1914 / pgw#1239): public carrier for the launch ABI names
+      # the private Hub supplies and this worker consumes. PGW pins layer 1;
+      # Tensorhub performs the meaningful peer comparison after PGW lands.
+      # Running that peer script here without an explicit candidate would be
+      # a local self-comparison, so this required job stays offline.
+      - name: pgw#1239 gate - Hub-worker boundary corpus matches its digest
+        run: uv run python scripts/check_hub_worker_boundary_contracts_digest.py
+
       # GATING (th#1897/pgw#1213): the shared grammar corpora are pinned to the
       # digest BOTH repos commit, so a one-sided hand-edit of
       # compiled_graph_key_vectors.json or ref_grammar_vectors.json is red

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -119,6 +119,15 @@ tasks:
     cmds:
       - uv run python scripts/check_worker_value_contracts_digest.py
 
+  hub-worker-boundary-check:
+    desc: |
+      pgw#1239 / th#1914 — pin the public Hub-to-worker launch ABI carrier.
+      Tensorhub performs the meaningful private-Hub -> public-PGW comparison,
+      so the coupled-cut direction is PGW LANDS FIRST.
+    cmds:
+      - uv run python scripts/check_hub_worker_boundary_contracts_digest.py
+      - scripts/hub-worker-boundary-drift.sh
+
   cozy-runtime-env-check:
     desc: |
       pgw#1237 / cl#56 — pin the public Cozy runtime-env carrier locally.

--- a/changelog.d/pgw1239.md
+++ b/changelog.d/pgw1239.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Pin the Hub-to-worker launch ABI in a public, source-bound contract corpus so
+  Tensorhub can fail closed when launch environment names, endpoint-owned
+  secret names, forbidden C2PA key material, topology delivery, managed fill,
+  or build-input classification drift between repositories.

--- a/scripts/check_hub_worker_boundary_contracts_digest.py
+++ b/scripts/check_hub_worker_boundary_contracts_digest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail if the public Hub-worker boundary corpus misses its pinned digest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = ROOT / "tests" / "testdata" / "hub_worker_boundary_contracts.json"
+DEFAULT_DIGEST = ROOT / "tests" / "testdata" / "HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST"
+
+
+def recorded_digest(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            value = line.split()[0]
+            if len(value) == 64 and all(c in "0123456789abcdef" for c in value):
+                return value
+            return ""
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--digest", type=Path, default=DEFAULT_DIGEST)
+    args = parser.parse_args()
+
+    for path in (args.corpus, args.digest):
+        if not path.is_file():
+            print(f"hub-worker-boundary-digest: missing {path}")
+            return 2
+
+    actual = hashlib.sha256(args.corpus.read_bytes()).hexdigest()
+    recorded = recorded_digest(args.digest)
+    if actual == recorded:
+        print(f"hub-worker-boundary-digest: corpus matches {actual}")
+        return 0
+
+    print(
+        "hub-worker-boundary-digest: FAIL — the public Hub-worker boundary "
+        "corpus changed without its digest\n"
+        f"  recorded: {recorded or '<missing>'}\n"
+        f"  actual:   {actual}\n\n"
+        "Land python-gen-worker first, then copy corpus and digest verbatim "
+        "to tensorhub."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hub-worker-boundary-drift.sh
+++ b/scripts/hub-worker-boundary-drift.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# th#1914 / pgw#1239 — Hub launch names and their worker meanings must remain
+# byte-identical between public python-gen-worker and every private consumer.
+# This script is committed VERBATIM in all participating repositories.
+#
+# Layer 1 in each repo pins its local corpus. Layer 2 runs from each private
+# consumer and compares to public python-gen-worker. Running this in PGW
+# without an explicit peer directory is local-only by design; a public repo
+# cannot fetch its private consumers and must never call a self-comparison
+# peer proof.
+#
+# Direction: PGW LANDS FIRST.
+#
+#   HUB_WORKER_BOUNDARY_PEER_REF=<ref>  PGW ref to fetch (default: master)
+#   HUB_WORKER_BOUNDARY_PEER_DIR=<dir>  local PGW tests/testdata directory
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pgw_rel="tests/testdata"
+hub_rel="internal/wirecontract/testdata"
+trainer_rel="image_lora_finetuner/tests/testdata"
+corpus="hub_worker_boundary_contracts.json"
+digest="HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST"
+
+if [ -f "$here/$pgw_rel/$corpus" ]; then
+  local_dir="$here/$pgw_rel"
+  side="pgw"
+elif [ -f "$here/$hub_rel/$corpus" ]; then
+  local_dir="$here/$hub_rel"
+  side="hub"
+elif [ -f "$here/$trainer_rel/$corpus" ]; then
+  local_dir="$here/$trainer_rel"
+  side="trainer"
+else
+  echo "hub-worker-boundary-drift: no $corpus under $here" >&2
+  exit 2
+fi
+
+for name in "$corpus" "$digest"; do
+  if [ ! -f "$local_dir/$name" ]; then
+    echo "hub-worker-boundary-drift: missing $local_dir/$name" >&2
+    exit 2
+  fi
+done
+
+recorded="$(grep -Eo '^[0-9a-f]{64}' "$local_dir/$digest" | head -1 || true)"
+actual="$(sha256sum "$local_dir/$corpus" | cut -d' ' -f1)"
+if [ -z "$recorded" ]; then
+  echo "hub-worker-boundary-drift: $local_dir/$digest contains no sha256" >&2
+  exit 2
+fi
+if [ "$recorded" != "$actual" ]; then
+  echo "hub-worker-boundary-drift: FAIL — local corpus changed without its digest" >&2
+  echo "  recorded: $recorded" >&2
+  echo "  actual:   $actual" >&2
+  exit 1
+fi
+echo "hub-worker-boundary-drift: local corpus matches $actual"
+
+peer_dir="${HUB_WORKER_BOUNDARY_PEER_DIR:-}"
+if [ "$side" = "pgw" ] && [ -z "$peer_dir" ]; then
+  echo "hub-worker-boundary-drift: PGW layer 1 complete; no self-comparison"
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+peer_ref="${HUB_WORKER_BOUNDARY_PEER_REF:-master}"
+for name in "$corpus" "$digest"; do
+  if [ -n "$peer_dir" ]; then
+    if [ ! -f "$peer_dir/$name" ]; then
+      echo "hub-worker-boundary-drift: FAIL — $peer_dir/$name does not exist" >&2
+      exit 1
+    fi
+    cp "$peer_dir/$name" "$work/$name"
+  else
+    url="https://raw.githubusercontent.com/cozy-creator/python-gen-worker/${peer_ref}/${pgw_rel}/${name}"
+    if ! curl -sSfL --retry 3 --max-time 30 -o "$work/$name" "$url"; then
+      echo "hub-worker-boundary-drift: FAIL — could not fetch $url" >&2
+      exit 1
+    fi
+  fi
+done
+
+peer_recorded="$(grep -Eo '^[0-9a-f]{64}' "$work/$digest" | head -1 || true)"
+peer_actual="$(sha256sum "$work/$corpus" | cut -d' ' -f1)"
+if [ -z "$peer_recorded" ] || [ "$peer_recorded" != "$peer_actual" ]; then
+  echo "hub-worker-boundary-drift: FAIL — PGW peer corpus does not match its digest" >&2
+  echo "  recorded: ${peer_recorded:-<missing>}" >&2
+  echo "  actual:   $peer_actual" >&2
+  exit 1
+fi
+
+status=0
+for name in "$corpus" "$digest"; do
+  if ! cmp -s "$local_dir/$name" "$work/$name"; then
+    echo "hub-worker-boundary-drift: FAIL — $name differs from python-gen-worker@${peer_ref}" >&2
+    diff -u "$local_dir/$name" "$work/$name" | head -40 >&2 || true
+    status=1
+  fi
+done
+if [ "$status" -ne 0 ]; then
+  echo "hub-worker-boundary-drift: land PGW first, then copy corpus, digest and script verbatim to private consumers" >&2
+  exit 1
+fi
+
+echo "hub-worker-boundary-drift: corpus and digest agree with public python-gen-worker@${peer_ref}"

--- a/tests/test_hub_worker_boundary_contracts_pgw1239.py
+++ b/tests/test_hub_worker_boundary_contracts_pgw1239.py
@@ -1,0 +1,406 @@
+"""Bind the public Hub-worker boundary corpus to python-gen-worker sources."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+_ROOT = Path(__file__).parents[1]
+_DEFAULT_CORPUS = Path(__file__).parent / "testdata" / "hub_worker_boundary_contracts.json"
+_DEFAULT_DIGEST = Path(__file__).parent / "testdata" / "HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST"
+_CORPUS = Path(os.environ.get("HUB_WORKER_BOUNDARY_CONTRACT_FILE", _DEFAULT_CORPUS))
+
+_SOURCE_PATHS = {
+    "loader": _ROOT / "src" / "gen_worker" / "config" / "loader.py",
+    "settings": _ROOT / "src" / "gen_worker" / "config" / "settings.py",
+    "c2pa": _ROOT / "src" / "gen_worker" / "content_credentials.py",
+    "topology": _ROOT / "src" / "gen_worker" / "topology.py",
+    "procsplit": _ROOT / "src" / "gen_worker" / "procsplit" / "__init__.py",
+    "discovery": _ROOT / "src" / "gen_worker" / "discovery" / "discover.py",
+    "compile_cache": _ROOT / "src" / "gen_worker" / "compile_cache.py",
+    "model_store": _ROOT / "src" / "gen_worker" / "models" / "store.py",
+    "provision": _ROOT / "src" / "gen_worker" / "models" / "provision.py",
+}
+_SOURCE_ENV = {name: f"HUB_WORKER_BOUNDARY_{name.upper()}_SOURCE" for name in _SOURCE_PATHS}
+
+
+def _document() -> dict[str, Any]:
+    document = json.loads(_CORPUS.read_text(encoding="utf-8"))
+    assert document["schema"] == "hub-worker-boundary-contracts-v1"
+    return document
+
+
+def _sources() -> dict[str, str]:
+    return {
+        name: Path(os.environ.get(_SOURCE_ENV[name], path)).read_text(encoding="utf-8")
+        for name, path in _SOURCE_PATHS.items()
+    }
+
+
+def _assignment(tree: ast.Module, name: str) -> ast.expr:
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            return node.value
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+        ):
+            return node.value
+    raise AssertionError(f"source assignment {name} is missing")
+
+
+def _literal_assignment(tree: ast.Module, name: str) -> Any:
+    return ast.literal_eval(_assignment(tree, name))
+
+
+def _strings_in_assignment(tree: ast.Module, name: str) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(_assignment(tree, name))
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+def _settings_fields(tree: ast.Module) -> set[str]:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Settings":
+            return {
+                item.target.id
+                for item in node.body
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
+            }
+    raise AssertionError("Settings class is missing")
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"source function {name} is missing")
+
+
+def _method(tree: ast.Module, class_name: str, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == name:
+                    return item
+    raise AssertionError(f"source method {class_name}.{name} is missing")
+
+
+def _prints_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Name)
+        and item.func.id == "print"
+        and any(isinstance(arg, ast.Name) and arg.id == name for arg in item.args)
+        for item in ast.walk(node)
+    )
+
+
+def _calls_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(item, ast.Call) and isinstance(item.func, ast.Name) and item.func.id == name
+        for item in ast.walk(node)
+    )
+
+
+def _raw_environ_gets(tree: ast.AST) -> set[str]:
+    values: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "get"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "environ"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "os"
+        ):
+            continue
+        key = node.args[0]
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            values.add(key.value)
+    return values
+
+
+def _attribute_names(tree: ast.AST) -> set[str]:
+    return {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+
+
+def _assert_contracts(document: dict[str, Any], sources: dict[str, str]) -> None:
+    contracts = document["contracts"]
+    trees = {name: ast.parse(source) for name, source in sources.items()}
+
+    loader_map = _literal_assignment(trees["loader"], "_ENV_TO_FIELD")
+    settings_fields = _settings_fields(trees["settings"])
+
+    active = {row["env"]: row["field"] for row in contracts["active_launch_settings"]}
+    assert len(active) == 6, "active_launch_settings must contain exactly six rows"
+    for env_name, field_name in active.items():
+        assert loader_map.get(env_name) == field_name, env_name
+        assert field_name in settings_fields, field_name
+    assert "WORKER_IMAGE_DIGEST" in _raw_environ_gets(trees["compile_cache"]), (
+        "compile_cache must consume the raw WORKER_IMAGE_DIGEST launch value"
+    )
+
+    external_secret_fields = {
+        "CIVITAI_API_KEY": "civitai_api_key",
+        "HF_TOKEN": "hf_token",
+    }
+    external_secret_names = contracts["external_secret_env_names"]
+    assert external_secret_names == sorted(external_secret_names)
+    assert external_secret_names == sorted(external_secret_fields)
+    provision_fields = _attribute_names(trees["provision"])
+    for env_name, field_name in external_secret_fields.items():
+        assert loader_map.get(env_name) == field_name, env_name
+        assert field_name in settings_fields, field_name
+        assert field_name in provision_fields, (
+            f"models.provision no longer consumes Settings.{field_name}"
+        )
+
+    c2pa = contracts["c2pa"]
+    supplied = {row["env"]: row["field"] for row in c2pa["supplied"]}
+    assert len(supplied) == 3, "C2PA supplied must contain exactly three rows"
+    for env_name, field_name in supplied.items():
+        assert loader_map.get(env_name) == field_name, env_name
+        assert field_name in settings_fields, field_name
+
+    forbidden = set(c2pa["forbidden"])
+    loader_forbidden = set(_literal_assignment(trees["loader"], "REFUSED_KEY_MATERIAL"))
+    runtime_forbidden = set(_literal_assignment(trees["c2pa"], "_REFUSED_KEY_ENVS"))
+    assert forbidden == loader_forbidden, "loader C2PA forbidden set drifted"
+    assert forbidden == runtime_forbidden, "runtime C2PA forbidden set drifted"
+    assert not {name.lower().removeprefix("gen_worker_") for name in forbidden} & settings_fields, (
+        "forbidden C2PA key material became a Settings field"
+    )
+
+    fill = contracts["managed_fill_source"]
+    assert loader_map.get(fill["env"]) == fill["field"]
+    assert fill["field"] in settings_fields
+    store_init = _method(trees["model_store"], "ModelStore", "__init__")
+    assert _calls_name(store_init, "tensorhub_fill_source_dir"), (
+        "ModelStore no longer resolves the managed fill source"
+    )
+    assert fill["env"] in _raw_environ_gets(store_init), (
+        "ModelStore no longer names the managed fill env in its boot diagnosis"
+    )
+
+    topology_env = contracts["execution_topology"]["env"]
+    assert _literal_assignment(trees["topology"], "ENV_VAR") == topology_env
+    assert _literal_assignment(trees["procsplit"], "ENV_TOPOLOGY") == topology_env
+    assert topology_env in _strings_in_assignment(trees["loader"], "_OWNED_NON_SETTINGS")
+
+    marker = contracts["build_input_failure"]["marker"]
+    assert _literal_assignment(trees["discovery"], "BUILD_INPUT_FAILURE_MARKER") == marker
+    assert _prints_name(
+        _function(trees["discovery"], "_fail_build_input"),
+        "BUILD_INPUT_FAILURE_MARKER",
+    ), "discovery no longer emits its build-input failure marker"
+
+
+def test_hub_worker_boundary_contracts_match_pgw1239() -> None:
+    _assert_contracts(_document(), _sources())
+
+
+def test_hub_worker_boundary_digest_matches_pgw1239() -> None:
+    active = [
+        line.strip().split()[0]
+        for line in _DEFAULT_DIGEST.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(active) == 1
+    assert active[0] == hashlib.sha256(_DEFAULT_CORPUS.read_bytes()).hexdigest()
+
+
+def test_drift_script_carries_every_private_consumer_path_pgw1239() -> None:
+    script = (_ROOT / "scripts" / "hub-worker-boundary-drift.sh").read_text(encoding="utf-8")
+    assert 'hub_rel="internal/wirecontract/testdata"' in script
+    assert 'trainer_rel="image_lora_finetuner/tests/testdata"' in script
+    assert 'if [ "$side" = "pgw" ] && [ -z "$peer_dir" ]; then' in script
+
+
+def _run_contract_test(
+    *, corpus: Path | None = None, source_override: tuple[str, Path] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    if corpus is not None:
+        env["HUB_WORKER_BOUNDARY_CONTRACT_FILE"] = os.fspath(corpus)
+    if source_override is not None:
+        name, path = source_override
+        env[_SOURCE_ENV[name]] = os.fspath(path)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            os.fspath(Path(__file__)),
+            "-k",
+            "test_hub_worker_boundary_contracts_match_pgw1239",
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "contract_class",
+    [
+        "active_launch_settings",
+        "external_secret_env_names",
+        "c2pa",
+        "managed_fill_source",
+        "execution_topology",
+        "build_input_failure",
+    ],
+)
+def test_each_contract_class_has_semantic_red_pgw1239(tmp_path: Path, contract_class: str) -> None:
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    contracts = document["contracts"]
+    if contract_class == "active_launch_settings":
+        contracts[contract_class][0]["field"] = "broken_active_launch_field"
+    elif contract_class == "external_secret_env_names":
+        contracts[contract_class][0] = "BROKEN_EXTERNAL_SECRET_ENV"
+    elif contract_class == "c2pa":
+        contracts[contract_class]["supplied"][0]["field"] = "broken_c2pa_field"
+    elif contract_class == "managed_fill_source":
+        contracts[contract_class]["field"] = "broken_fill_field"
+    elif contract_class == "execution_topology":
+        contracts[contract_class]["env"] = "BROKEN_EXECUTION_TOPOLOGY"
+    else:
+        contracts[contract_class]["marker"] = "BROKEN_BUILD_INPUT_FAILURE"
+
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    corpus.write_text(json.dumps(document), encoding="utf-8")
+    got = _run_contract_test(corpus=corpus)
+    assert got.returncode == 1, got.stdout + got.stderr
+
+
+@pytest.mark.parametrize(
+    ("source_name", "old", "new"),
+    [
+        ("loader", '"WORKER_ID": "worker_id"', '"WORKER_ID": "broken_worker_id"'),
+        ("settings", "worker_id: str =", "broken_worker_id: str ="),
+        ("loader", '"HF_TOKEN": "hf_token"', '"HF_TOKEN": "broken_hf_token"'),
+        (
+            "provision",
+            "current_or(_STANDALONE).civitai_api_key",
+            "current_or(_STANDALONE).hf_home",
+        ),
+        (
+            "loader",
+            '"GEN_WORKER_C2PA_KEY_PEM": (',
+            '"GEN_WORKER_C2PA_KEY_PEM_BROKEN": (',
+        ),
+        (
+            "c2pa",
+            '"GEN_WORKER_C2PA_KEY_PEM",',
+            '"GEN_WORKER_C2PA_KEY_PEM_BROKEN",',
+        ),
+        (
+            "model_store",
+            "fill_source_dir or tensorhub_fill_source_dir()",
+            "fill_source_dir or tensorhub_cas_dir()",
+        ),
+        (
+            "topology",
+            'ENV_VAR = "WORKER_EXECUTION_TOPOLOGY"',
+            'ENV_VAR = "BROKEN_EXECUTION_TOPOLOGY"',
+        ),
+        (
+            "procsplit",
+            'ENV_TOPOLOGY = "WORKER_EXECUTION_TOPOLOGY"',
+            'ENV_TOPOLOGY = "BROKEN_EXECUTION_TOPOLOGY"',
+        ),
+        (
+            "loader",
+            '    "WORKER_EXECUTION_TOPOLOGY",',
+            '    "BROKEN_EXECUTION_TOPOLOGY",',
+        ),
+        (
+            "discovery",
+            'BUILD_INPUT_FAILURE_MARKER = "TENSORHUB_BUILD_INPUT_FAILURE:discovery"',
+            'BUILD_INPUT_FAILURE_MARKER = "BROKEN_BUILD_INPUT_FAILURE"',
+        ),
+        (
+            "compile_cache",
+            'os.environ.get("WORKER_IMAGE_DIGEST", "")',
+            'os.environ.get("BROKEN_WORKER_IMAGE_DIGEST", "")',
+        ),
+    ],
+)
+def test_each_source_binding_has_red_pgw1239(
+    tmp_path: Path, source_name: str, old: str, new: str
+) -> None:
+    source = _SOURCE_PATHS[source_name].read_text(encoding="utf-8")
+    assert source.count(old) == 1, (source_name, old, source.count(old))
+    candidate = tmp_path / f"{source_name}.py"
+    candidate.write_text(source.replace(old, new, 1), encoding="utf-8")
+    got = _run_contract_test(source_override=(source_name, candidate))
+    assert got.returncode == 1, got.stdout + got.stderr
+
+
+def test_digest_gate_can_go_red_pgw1239(tmp_path: Path) -> None:
+    corpus = tmp_path / _DEFAULT_CORPUS.name
+    digest = tmp_path / _DEFAULT_DIGEST.name
+    corpus.write_bytes(_DEFAULT_CORPUS.read_bytes() + b"\n")
+    digest.write_bytes(_DEFAULT_DIGEST.read_bytes())
+    got = subprocess.run(
+        [
+            sys.executable,
+            os.fspath(_ROOT / "scripts" / "check_hub_worker_boundary_contracts_digest.py"),
+            "--corpus",
+            os.fspath(corpus),
+            "--digest",
+            os.fspath(digest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "changed without its digest" in got.stdout
+
+
+def test_redigested_peer_mutation_reaches_byte_comparison_pgw1239(
+    tmp_path: Path,
+) -> None:
+    peer = tmp_path / "peer"
+    peer.mkdir()
+    document = json.loads(_DEFAULT_CORPUS.read_text(encoding="utf-8"))
+    document["contracts"]["active_launch_settings"][0]["field"] = "peer_mutation"
+    peer_corpus = peer / _DEFAULT_CORPUS.name
+    peer_corpus.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    peer_digest = hashlib.sha256(peer_corpus.read_bytes()).hexdigest()
+    (peer / _DEFAULT_DIGEST.name).write_text(
+        f"{peer_digest}  {_DEFAULT_CORPUS.name}\n", encoding="utf-8"
+    )
+
+    got = subprocess.run(
+        [os.fspath(_ROOT / "scripts" / "hub-worker-boundary-drift.sh")],
+        env={**os.environ, "HUB_WORKER_BOUNDARY_PEER_DIR": os.fspath(peer)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert got.returncode == 1
+    assert "differs from python-gen-worker" in got.stderr
+    assert "peer corpus does not match its digest" not in got.stderr

--- a/tests/testdata/HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST
+++ b/tests/testdata/HUB_WORKER_BOUNDARY_CONTRACTS_DIGEST
@@ -1,0 +1,1 @@
+7e17101546fe43ee98117083e3b420ed5ec5647fd95ca0969ac564245c892834  hub_worker_boundary_contracts.json

--- a/tests/testdata/hub_worker_boundary_contracts.json
+++ b/tests/testdata/hub_worker_boundary_contracts.json
@@ -1,0 +1,65 @@
+{
+  "schema": "hub-worker-boundary-contracts-v1",
+  "contracts": {
+    "active_launch_settings": [
+      {
+        "env": "ORCHESTRATOR_PUBLIC_ADDR",
+        "field": "orchestrator_public_addr"
+      },
+      {
+        "env": "TENSORHUB_PUBLIC_URL",
+        "field": "tensorhub_public_url"
+      },
+      {
+        "env": "WORKER_JWT",
+        "field": "bootstrap_worker_jwt"
+      },
+      {
+        "env": "WORKER_ID",
+        "field": "worker_id"
+      },
+      {
+        "env": "WORKER_CONFIG_GENERATION",
+        "field": "boot_config_generation"
+      },
+      {
+        "env": "WORKER_IMAGE_DIGEST",
+        "field": "worker_image_digest"
+      }
+    ],
+    "external_secret_env_names": [
+      "CIVITAI_API_KEY",
+      "HF_TOKEN"
+    ],
+    "c2pa": {
+      "supplied": [
+        {
+          "env": "GEN_WORKER_C2PA_CERT_PEM",
+          "field": "c2pa_cert_pem"
+        },
+        {
+          "env": "GEN_WORKER_C2PA_ALG",
+          "field": "c2pa_alg"
+        },
+        {
+          "env": "GEN_WORKER_C2PA_TA_URL",
+          "field": "c2pa_ta_url"
+        }
+      ],
+      "forbidden": [
+        "GEN_WORKER_C2PA_KEY_PATH",
+        "GEN_WORKER_C2PA_KEY_PEM"
+      ]
+    },
+    "managed_fill_source": {
+      "env": "TENSORHUB_FILL_SOURCE_DIR",
+      "field": "tensorhub_fill_source_dir"
+    },
+    "execution_topology": {
+      "env": "WORKER_EXECUTION_TOPOLOGY"
+    },
+    "build_input_failure": {
+      "marker": "TENSORHUB_BUILD_INPUT_FAILURE:discovery"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- publish a source-bound `hub-worker-boundary-contracts-v1` carrier for Hub launch env names and worker meanings
- pin the corpus offline in the existing required `fast gates` job and bind live Python sources in the existing required test suite
- prove semantic, stale-digest, source-drift, and independently re-digested peer-copy red paths without adding a CI job or carrying secret values

PGW lands first. Tensorhub will vendor these exact bytes and perform the meaningful private-Hub to public-PGW peer comparison. Running the peer script here without an explicit candidate is intentionally local-only, never a self-comparison claim.

## Local evidence at `4d5c9550`

- `python -m pytest -q tests/test_hub_worker_boundary_contracts_pgw1239.py` — 22 passed
- digest checker and local drift layer — passed (`7e171015...`)
- six independently mutated semantic contract classes — each exited 1
- raw image-digest source mutation — exited 1
- stale digest candidate — exited 1
- independently re-digested peer mutation — reached byte comparison and exited 1
- ruff, actionlint, bash syntax, py_compile, and `git diff --check` — passed

No product behavior, values, secrets, dependency, workflow-job, or runner-cycle changes.