### PR TITLE
pgw#1206 C3 (th#1834's ruled seam): the residency teardown leaves executor.py — abandonment is a SUPERVISION verb, and residency calls it

### DIFF
--- a/changelog.d/pgw1206.md
+++ b/changelog.d/pgw1206.md
@@ -1,0 +1,10 @@
+- **pgw#1206 C3: the residency teardown leaves `executor.py`.** `shutdown_instances`
+  and `_vacate_record` — the two mutators over the instance record book, parked in
+  the executor since C2 because both open with `await self.abandon_background_mint(...)`
+  — move to `gen_worker.models.records` as `shutdown_instances` / `vacate_record`,
+  against th#1834's ruled seam: `abandon_background_mint(rec, *, reason,
+  code="unspecified", free_targets=False)` stays with the mint supervisor and is
+  injected into the record book as a typed callable, so residency CALLS supervision
+  instead of owning it. A pure move — no behaviour change, no shim, every caller
+  (`lifecycle`'s drain, five executor sites, three test modules) repointed at the
+  defining module. `executor.py` 11,248 → 11,143.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -110,7 +110,13 @@ from .models.memory import (
 )
 from .models import rung as rungspec
 from .models.rung import touches_host_ram, transition_line
-from .models.records import record_in_use, record_refs, records_holding
+from .models.records import (
+    RecordTeardown,
+    record_in_use,
+    record_refs,
+    records_holding,
+    vacate_record,
+)
 from .models.envelope import ArtifactEnvelopeExceeded
 from .models.errors import MissingSnapshotError, UrlExpiredError
 from .models.execution_lanes import ExecutionLaneUnavailableError
@@ -2133,7 +2139,7 @@ class Executor:
             async with self._load_lock:
                 if record_in_use(rec, records=self._classes.values(), jobs=self.jobs.values(), residency=self.store.residency):
                     return
-                await self._vacate_record(rec)
+                await vacate_record(rec, self.teardown_seam)
         self._on_state_change()
 
     async def revalidate_snapshot_identity(
@@ -4386,7 +4392,7 @@ class Executor:
                     reason=pb.LIFECYCLE_WAIT_REASON_LOAD_LOCK,
                     resume_stage=pb.LIFECYCLE_INTENT_STAGE_LOADING_HOST,
                 ):
-                    await self._vacate_record(rec)
+                    await vacate_record(rec, self.teardown_seam)
             if rec.ready:
                 await self._promote_setup_refs(spec, promote_slots, rec=rec)
                 self._intent_transition(
@@ -5208,7 +5214,7 @@ class Executor:
         if not self._record_has_setup_ownership(rec):
             return
         async with self._load_lock:
-            released = await self._vacate_record(rec)
+            released = await vacate_record(rec, self.teardown_seam)
         await aflush_memory()
         released_pinned = await asyncio.to_thread(
             release_unused_pinned_host_cache)
@@ -6877,7 +6883,7 @@ class Executor:
         A warm pipeline is owned by both Residency and its endpoint
         ``_ClassRecord``. Clearing only the Residency reference reports
         ON_DISK while ``record.instance`` still owns every tensor. Evict
-        record-owned victims through ``_vacate_record``; only ownerless
+        record-owned victims through ``records.vacate_record``; only ownerless
         entries may use ``release_to_disk`` directly. Re-probe observed RAM
         after every teardown and fail RETRYABLE if the real headroom still
         cannot cover the incoming bytes plus the derived floor.
@@ -6969,7 +6975,7 @@ class Executor:
                     held for held in record_refs(rec)
                     if res.tier(held) in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
                 ]
-                released = await self._vacate_record(rec)
+                released = await vacate_record(rec, self.teardown_seam)
                 evicted.extend(released)
                 logger.info(
                     "host-RAM admission vacated warm record refs=%s for %s",
@@ -7120,7 +7126,7 @@ class Executor:
             rec = owners[0]
             if record_in_use(rec, records=self._classes.values(), jobs=self.jobs.values(), residency=self.store.residency, reclaim_ref=ref):
                 continue
-            await self._vacate_record(rec)
+            await vacate_record(rec, self.teardown_seam)
             if await asyncio.to_thread(make_room):
                 self._on_state_change()
                 return
@@ -8634,27 +8640,22 @@ class Executor:
             publisher=self._cell_publisher(),
         )
 
-    async def shutdown_instances(self) -> None:
-        for rec in self._classes.values():
-            await self.abandon_background_mint(
-                rec, reason="worker shutdown", code="shutdown")
-            inst, rec.instance, rec.ready = rec.instance, None, False
-            rec.compile_targets.clear()
-            rec.applied_lanes.clear()
-            rec.posture.clear()
-            shutdown = getattr(inst, "shutdown", None)
-            if inst is not None and callable(shutdown):
-                try:
-                    if asyncio.iscoroutinefunction(shutdown):
-                        await shutdown()
-                    else:
-                        await asyncio.to_thread(shutdown)
-                except Exception:
-                    logger.exception("shutdown() failed for %s", rec.cls.__name__)
-            server, rec.server = rec.server, None
-            if server is not None:
-                await asyncio.to_thread(server.stop)
-        self._on_state_change()
+    @property
+    def teardown_seam(self) -> RecordTeardown:
+        """What `models.records`' two mutators need from here.
+
+        Built per call, never cached: `_on_state_change` is reassigned after
+        `__init__` (worker.py wires it once Lifecycle exists).
+        `abandon_background_mint` is th#1834's ruled seam — abandonment stays
+        with the mint supervisor and residency calls it through this."""
+        return RecordTeardown(
+            records=self._classes.values(),
+            residency=self.store.residency,
+            abandon_background_mint=self.abandon_background_mint,
+            on_state_change=self._on_state_change,
+            close_sequence_group=self._close_sequence_group,
+            observe_host_ram_progress=self._observe_host_ram_progress,
+        )
 
     # ---- Compile-cache adoption -------------------------------------------
 
@@ -8755,112 +8756,6 @@ class Executor:
                 "" if adoption.armed else f" reason={adoption.reason}")
             await self._send(pb.WorkerMessage(model_event=event))
         inj.adoptions.clear()
-
-
-
-
-    async def _vacate_record(self, rec: _ClassRecord) -> List[str]:
-        """Tear an instance down and return refs whose owner was released."""
-        # pgw#671: a departing instance takes its background mint with it —
-        # stop the driver before any module teardown races a warm forward.
-        await self.abandon_background_mint(
-            rec, reason="instance vacate", code="vacate")
-        held_refs = record_refs(rec)
-        held_objects = rec.held_objects
-        released_refs: List[str] = []
-        old_obj: Any = None
-        inst, rec.instance, rec.ready = rec.instance, None, False
-        rec.compile_targets.clear()
-        # pgw#1104: the applied lane belonged to THESE weights; the next setup
-        # re-reports it or the lane honestly reverts to the binding's.
-        rec.applied_lanes.clear()
-        # th#1871 P1: and so does the posture. A lever applied to weights that
-        # no longer exist would qualify the NEXT instance's measurements with
-        # the last one's degradation.
-        rec.posture.clear()
-        # The next full StateDelta must remove the old address before any
-        # replacement can become READY. Do this synchronously before teardown
-        # awaits; adoption's second validation then rejects the stale ID.
-        self._on_state_change()
-        shutdown = getattr(inst, "shutdown", None)
-        if inst is not None and callable(shutdown):
-            try:
-                if asyncio.iscoroutinefunction(shutdown):
-                    await shutdown()
-                else:
-                    await asyncio.to_thread(shutdown)
-            except Exception:
-                logger.exception("shutdown() during vacate failed")
-        # A bound method owns its instance. Drop it before measuring cgroup
-        # headroom, otherwise this teardown frame itself can retain the whole
-        # departing pipeline and suppress a genuine capacity transition.
-        shutdown = None
-        del inst
-        server, rec.server = rec.server, None
-        if server is not None:
-            await asyncio.to_thread(server.stop)
-        server = None
-        # No gc pass here: the caller holds the load lock and the departing
-        # objects' owners were just dropped above, so only the allocator cache
-        # needs returning (pgw#657 fold).
-        await aflush_memory(collect=False)
-        # gw#494: inspect exactly what the instance BOOKED (held_refs) —
-        # re-deriving from spec.models would inspect the wrong keys after a
-        # resolution rebind. A multiply-held ref stays resident until its last
-        # ready record owner leaves.
-        for ref in held_refs:
-            tier_before = self.store.residency.tier(ref)
-            old_obj = held_objects.get(ref)
-            owners = records_holding(self._classes.values(), ref)
-            if owners:
-                # Residency keeps one representative object per wire ref. If
-                # it points at the departing record, transfer it to a survivor
-                # so the old pipeline can actually be collected. This is an
-                # ownership handoff, not an ON_DISK transition.
-                if old_obj is not None and self.store.residency.obj(ref) is old_obj:
-                    replacement = next(
-                        (owner.held_objects.get(ref) for owner in reversed(owners)
-                         if owner.held_objects.get(ref) is not None),
-                        None,
-                    )
-                    self.store.residency.replace_object(ref, replacement)
-                if old_obj is not None:
-                    released_refs.append(ref)
-                continue
-            if (
-                tier_before in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
-                and self.store.residency.release_to_disk(ref)
-            ):
-                released_refs.append(ref)
-        rec.held_refs = []
-        rec.held_snapshot_digests = {}
-        rec.held_bindings = []
-        rec.execution_lane_refs = set()
-        rec.held_objects = {}
-        rec.slot_pipelines = {}  # pgw#678: pipelines die with the instance
-        # pgw#748: the rank siblings are an implementation detail of THIS
-        # instance's pipeline; they must not outlive it holding D cards.
-        self._close_sequence_group(rec)
-        # Do not let this teardown frame itself retain a departing pipeline
-        # while the cgroup probe decides whether capacity really progressed.
-        old_obj = None
-        replacement = None
-        owners = []
-        held_objects.clear()
-        rec.stale = False
-        if rec.shared_keys:
-            # Drop this record's holds on content-keyed shared components
-            # (gw#479). pgw#636: entries no other record references are NOT
-            # drained eagerly — a hot GPU keeps them resident as ordinary LRU
-            # candidates so the next pick that matches their bytes aliases
-            # them for free; real pressure reclaims them through make_room.
-            for key in rec.shared_keys:
-                self.store.residency.release_shared(key)
-            rec.shared_keys.clear()
-        self._on_state_change()
-        released_refs = list(dict.fromkeys(released_refs))
-        await self._observe_host_ram_progress(released_refs, collect_host=True)
-        return released_refs
 
     # ---- job intake --------------------------------------------------------
 

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -19,6 +19,7 @@ from . import fleet_cells
 from . import receipts
 from . import serve_posture
 from . import progress as progress_mod
+from .models.records import shutdown_instances
 from .models.refs import WireRef
 from .config import Settings
 from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
@@ -1531,7 +1532,7 @@ class Lifecycle:
             await self.maybe_send_state_delta()
             await self.intent_registry.guard_await(
                 drain_intent,
-                self.executor.shutdown_instances(),
+                shutdown_instances(self.executor.teardown_seam),
                 operation="drain instance shutdown",
             )
             if self.transport is not None:

--- a/src/gen_worker/models/records.py
+++ b/src/gen_worker/models/records.py
@@ -1,27 +1,47 @@
-"""Which instance record holds which ref, and whether tearing it down would
-disturb live work.
+"""The instance record book: which record holds which ref, whether tearing it
+down would disturb live work, and the teardown itself.
 
-These three are pure QUERIES over the executor's record book:
-they read records, jobs and residency and mutate nothing. Lifting them out as
-free functions is what lets the residency-reconcile lifetime be reasoned about
-without the 11,000-line job engine around it.
+`record_refs` / `records_holding` / `record_in_use` are pure QUERIES: they read
+records, jobs and residency and mutate nothing. `vacate_record` and
+`shutdown_instances` are the two MUTATORS over the same book — the residency
+side of an instance's death.
 
-They stay free functions taking exactly what they read — the executor passes
-`self._classes.values()` and `self.jobs.values()` — rather than becoming a
-class with a back-reference. A back-reference would re-import the whole
-executor and put us back where we started.
+Everything here is a free function taking exactly what it reads — the executor
+passes `self._classes.values()`, `self.jobs.values()` and a `RecordTeardown`
+seam — rather than a class with a back-reference. A back-reference would
+re-import the whole executor and put us back where we started.
 
-Their two MUTATING callers (`Executor.shutdown_instances` and
-`Executor._vacate_record`) deliberately stay on the executor: both call
-`abandon_background_mint`, which is inside a frozen region, and dragging a
-frozen method across a module seam is what that fence forbids.
+`abandon_background_mint` is NOT ours (th#1834's ruling, 2026-08-13): under
+per-graph-class accretion there is no project called "the mint" to abandon, so
+what survives is *"stop supervising further compiles for this record, and give
+the card back"* — a supervision verb with a residency side effect. It stays
+with the mint supervisor and arrives here as an injected callable on
+`RecordTeardown`. Residency CALLS supervision; the direction is the ruling.
 """
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional, Protocol, TypeVar
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Set,
+    TypeVar,
+)
 
 from ..api.binding import wire_ref
+from .memory import aflush_memory
+from . import residency as residency_mod
+
+logger = logging.getLogger(__name__)
 
 
 class _Record(Protocol):
@@ -92,4 +112,186 @@ def record_in_use(
     return False
 
 
-__all__ = ["record_in_use", "record_refs", "records_holding"]
+class _TeardownRecord(_Record, Protocol):
+    """The record fields teardown MUTATES, on top of what the queries read."""
+
+    cls: type
+    instance: Any
+    server: Any
+    posture: Any
+    stale: bool
+    compile_targets: Dict[str, Any]
+    applied_lanes: List[Any]
+    shared_keys: List[Any]
+    held_objects: Dict[str, Any]
+    held_snapshot_digests: Dict[str, str]
+    held_bindings: List[Any]
+    execution_lane_refs: Set[Any]
+    slot_pipelines: Dict[str, Any]
+
+
+class AbandonBackgroundMint(Protocol):
+    """th#1834's ruled seam, typed here so the contract is checked and not
+    merely described. The body behind it — one background-mint task today, a
+    per-graph-class supervisor after the reroute — is the supervisor's to
+    change without touching this module."""
+
+    def __call__(
+        self, rec: Any, *, reason: str, code: str = ...,
+        free_targets: bool = ...,
+    ) -> Awaitable[None]: ...
+
+
+@dataclass(frozen=True)
+class RecordTeardown:
+    """What tearing an instance record down needs from outside the record book.
+
+    Built per call by the executor, never cached: `on_state_change` is
+    reassigned after construction (worker.py wires it once Lifecycle exists),
+    so a seam that captured it at `__init__` would call the placeholder.
+    """
+
+    records: Iterable[Any]
+    residency: Any
+    abandon_background_mint: AbandonBackgroundMint
+    on_state_change: Callable[[], None]
+    close_sequence_group: Callable[[Any], None]
+    observe_host_ram_progress: Callable[..., Awaitable[None]]
+
+
+async def shutdown_instances(seam: RecordTeardown) -> None:
+    for rec in seam.records:
+        await seam.abandon_background_mint(
+            rec, reason="worker shutdown", code="shutdown")
+        inst, rec.instance, rec.ready = rec.instance, None, False
+        rec.compile_targets.clear()
+        rec.applied_lanes.clear()
+        rec.posture.clear()
+        shutdown = getattr(inst, "shutdown", None)
+        if inst is not None and callable(shutdown):
+            try:
+                if asyncio.iscoroutinefunction(shutdown):
+                    await shutdown()
+                else:
+                    await asyncio.to_thread(shutdown)
+            except Exception:
+                logger.exception("shutdown() failed for %s", rec.cls.__name__)
+        server, rec.server = rec.server, None
+        if server is not None:
+            await asyncio.to_thread(server.stop)
+    seam.on_state_change()
+
+
+async def vacate_record(rec: _TeardownRecord, seam: RecordTeardown) -> List[str]:
+    """Tear an instance down and return refs whose owner was released."""
+    # pgw#671: a departing instance takes its background mint with it —
+    # stop the driver before any module teardown races a warm forward.
+    await seam.abandon_background_mint(
+        rec, reason="instance vacate", code="vacate")
+    held_refs = record_refs(rec)
+    held_objects = rec.held_objects
+    released_refs: List[str] = []
+    old_obj: Any = None
+    inst, rec.instance, rec.ready = rec.instance, None, False
+    rec.compile_targets.clear()
+    # pgw#1104: the applied lane belonged to THESE weights; the next setup
+    # re-reports it or the lane honestly reverts to the binding's.
+    rec.applied_lanes.clear()
+    # th#1871 P1: and so does the posture. A lever applied to weights that
+    # no longer exist would qualify the NEXT instance's measurements with
+    # the last one's degradation.
+    rec.posture.clear()
+    # The next full StateDelta must remove the old address before any
+    # replacement can become READY. Do this synchronously before teardown
+    # awaits; adoption's second validation then rejects the stale ID.
+    seam.on_state_change()
+    shutdown = getattr(inst, "shutdown", None)
+    if inst is not None and callable(shutdown):
+        try:
+            if asyncio.iscoroutinefunction(shutdown):
+                await shutdown()
+            else:
+                await asyncio.to_thread(shutdown)
+        except Exception:
+            logger.exception("shutdown() during vacate failed")
+    # A bound method owns its instance. Drop it before measuring cgroup
+    # headroom, otherwise this teardown frame itself can retain the whole
+    # departing pipeline and suppress a genuine capacity transition.
+    shutdown = None
+    del inst
+    server, rec.server = rec.server, None
+    if server is not None:
+        await asyncio.to_thread(server.stop)
+    server = None
+    # No gc pass here: the caller holds the load lock and the departing
+    # objects' owners were just dropped above, so only the allocator cache
+    # needs returning (pgw#657 fold).
+    await aflush_memory(collect=False)
+    # gw#494: inspect exactly what the instance BOOKED (held_refs) —
+    # re-deriving from spec.models would inspect the wrong keys after a
+    # resolution rebind. A multiply-held ref stays resident until its last
+    # ready record owner leaves.
+    for ref in held_refs:
+        tier_before = seam.residency.tier(ref)
+        old_obj = held_objects.get(ref)
+        owners = records_holding(seam.records, ref)
+        if owners:
+            # Residency keeps one representative object per wire ref. If
+            # it points at the departing record, transfer it to a survivor
+            # so the old pipeline can actually be collected. This is an
+            # ownership handoff, not an ON_DISK transition.
+            if old_obj is not None and seam.residency.obj(ref) is old_obj:
+                replacement = next(
+                    (owner.held_objects.get(ref) for owner in reversed(owners)
+                     if owner.held_objects.get(ref) is not None),
+                    None,
+                )
+                seam.residency.replace_object(ref, replacement)
+            if old_obj is not None:
+                released_refs.append(ref)
+            continue
+        if (
+            tier_before in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+            and seam.residency.release_to_disk(ref)
+        ):
+            released_refs.append(ref)
+    rec.held_refs = []
+    rec.held_snapshot_digests = {}
+    rec.held_bindings = []
+    rec.execution_lane_refs = set()
+    rec.held_objects = {}
+    rec.slot_pipelines = {}  # pgw#678: pipelines die with the instance
+    # pgw#748: the rank siblings are an implementation detail of THIS
+    # instance's pipeline; they must not outlive it holding D cards.
+    seam.close_sequence_group(rec)
+    # Do not let this teardown frame itself retain a departing pipeline
+    # while the cgroup probe decides whether capacity really progressed.
+    old_obj = None
+    replacement = None
+    owners = []
+    held_objects.clear()
+    rec.stale = False
+    if rec.shared_keys:
+        # Drop this record's holds on content-keyed shared components
+        # (gw#479). pgw#636: entries no other record references are NOT
+        # drained eagerly — a hot GPU keeps them resident as ordinary LRU
+        # candidates so the next pick that matches their bytes aliases
+        # them for free; real pressure reclaims them through make_room.
+        for key in rec.shared_keys:
+            seam.residency.release_shared(key)
+        rec.shared_keys.clear()
+    seam.on_state_change()
+    released_refs = list(dict.fromkeys(released_refs))
+    await seam.observe_host_ram_progress(released_refs, collect_host=True)
+    return released_refs
+
+
+__all__ = [
+    "AbandonBackgroundMint",
+    "RecordTeardown",
+    "record_in_use",
+    "record_refs",
+    "records_holding",
+    "shutdown_instances",
+    "vacate_record",
+]

--- a/tests/test_applied_lane_pgw1104.py
+++ b/tests/test_applied_lane_pgw1104.py
@@ -36,6 +36,7 @@ from gen_worker import (
 from gen_worker.executor import Executor
 from gen_worker.models import execution_lanes as lanespec
 from gen_worker.models import provision
+from gen_worker.models.records import vacate_record
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 from gen_worker.models import store as store_mod
@@ -207,7 +208,7 @@ def test_the_lane_dies_with_the_instance(boot) -> None:
         await ex.ensure_setup(eff, snaps)
         rec = ex._classes[eff.instance_key]
         assert rec.applied_lanes
-        await ex._vacate_record(rec)
+        await vacate_record(rec, ex.teardown_seam)
         assert rec.applied_lanes == []
         assert ex._served_execution_lane(eff).startswith("bf16-w16a16+")
 

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -26,6 +26,7 @@ from gen_worker import (
 )
 from gen_worker import compile_cache as cc
 from gen_worker.models import provision
+from gen_worker.models.records import vacate_record
 from gen_worker.api.binding import Hub
 from gen_worker.api.binding import wire_ref
 from gen_worker.api.errors import RetryableError
@@ -364,7 +365,7 @@ def test_target_vacate_removes_address_before_replacement(tmp_path):
     ex._on_state_change = lambda: state_snapshots.append(
         [t.incarnation_id for t in ex.compile_targets()])
 
-    asyncio.run(ex._vacate_record(rec))
+    asyncio.run(vacate_record(rec, ex.teardown_seam))
     assert ex.compile_targets() == []
     assert state_snapshots and state_snapshots[0] == []
 

--- a/tests/test_residency_teardown_seam_pgw1206.py
+++ b/tests/test_residency_teardown_seam_pgw1206.py
@@ -1,0 +1,156 @@
+"""pgw#1206 C3: residency's two mutators live in `models.records` and reach
+the mint supervisor ONLY through th#1834's injected seam.
+
+The ruling (th#1834, 2026-08-13): `abandon_background_mint` stays with the
+mint supervisor and is exposed to residency as an injected callable
+`(rec, *, reason, code="unspecified", free_targets=False)`. `vacate_record`
+and `shutdown_instances` are residency operations that must first tell the
+supervisor to stop — residency CALLS supervision.
+
+These rows exercise the seam through the REAL supervisor body (a real
+`_BackgroundMint` on a real `Executor`), so they go red if the call is
+dropped, if the direction is inverted, or if the ruled reason/code stop being
+what a stopped mint reports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Tuple
+
+import msgspec
+
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor, _BackgroundMint
+from gen_worker.models.records import (
+    RecordTeardown,
+    shutdown_instances,
+    vacate_record,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Fake:
+    def setup(self, pipeline: Any) -> None:  # pragma: no cover - never run here
+        self.pipeline = pipeline
+
+    def generate(self, ctx: Any, payload: _In) -> Dict[str, Any]:  # pragma: no cover
+        return {}
+
+
+def _executor() -> Executor:
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    spec = EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": Hub("acme/z-image")},
+        resources=Resources(gpu=True),
+    )
+    return Executor([spec], _send)
+
+
+def _ready_record_with_mint(ex: Executor) -> Tuple[Any, Any]:
+    spec = ex.specs["generate"]
+    rec = ex._classes[spec.instance_key]
+    rec.instance = _Fake()
+    rec.ready = True
+    bg = _BackgroundMint(
+        spec=spec, instance=rec.instance, snapshots=None, pendings={}, pipes={})
+    rec.background_mint = bg
+    return rec, bg
+
+
+def test_vacate_record_stops_the_mint_through_the_seam() -> None:
+    """pgw#671 through th#1834's seam: a departing instance takes its
+    background mint with it, and the supervisor is told WHY."""
+
+    async def _run() -> None:
+        ex = _executor()
+        rec, bg = _ready_record_with_mint(ex)
+
+        released = await vacate_record(rec, ex.teardown_seam)
+
+        assert released == []
+        assert bg.abandon.is_set(), "the supervisor was never signalled"
+        assert (bg.abandon_reason, bg.abandon_code) == ("instance vacate", "vacate")
+        assert rec.background_mint is None
+        assert rec.instance is None and rec.ready is False
+
+    asyncio.run(_run())
+
+
+def test_shutdown_instances_stops_every_mint_through_the_seam() -> None:
+    async def _run() -> None:
+        ex = _executor()
+        rec, bg = _ready_record_with_mint(ex)
+
+        await shutdown_instances(ex.teardown_seam)
+
+        assert bg.abandon.is_set()
+        assert (bg.abandon_reason, bg.abandon_code) == ("worker shutdown", "shutdown")
+        assert rec.background_mint is None
+        assert rec.instance is None and rec.ready is False
+
+    asyncio.run(_run())
+
+
+def test_the_seam_is_the_supervisor_and_nothing_else() -> None:
+    """The record book owns no abandonment of its own: what it calls IS the
+    executor's supervisor method, injected, with the ruled keyword contract."""
+
+    ex = _executor()
+    seam = ex.teardown_seam
+
+    assert isinstance(seam, RecordTeardown)
+    assert seam.abandon_background_mint == ex.abandon_background_mint
+
+    import inspect
+
+    sig = inspect.signature(ex.abandon_background_mint)
+    assert list(sig.parameters) == ["rec", "reason", "code", "free_targets"]
+    assert sig.parameters["code"].default == "unspecified"
+    assert sig.parameters["free_targets"].default is False
+    for kw in ("reason", "code", "free_targets"):
+        assert sig.parameters[kw].kind is inspect.Parameter.KEYWORD_ONLY
+
+    # Residency calls supervision, never the reverse: the record book must not
+    # import the executor, at module scope or inside a function.
+    import ast
+
+    import gen_worker.models.records as records_mod
+
+    tree = ast.parse(inspect.getsource(records_mod))
+    imported: List[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(f"{'.' * node.level}{node.module or ''}")
+    assert not [m for m in imported if "executor" in m], imported
+
+
+def test_state_change_is_read_at_call_time_not_construction() -> None:
+    """worker.py assigns `_on_state_change` after `Executor.__init__`, so a
+    seam that captured it at construction would call the placeholder."""
+
+    async def _run() -> None:
+        ex = _executor()
+        rec, _bg = _ready_record_with_mint(ex)
+        ticks: List[int] = []
+        ex._on_state_change = lambda: ticks.append(1)
+
+        await vacate_record(rec, ex.teardown_seam)
+
+        assert ticks, "the vacate never reported a state change"
+
+    asyncio.run(_run())

--- a/tests/test_resolution_rekey_gw494.py
+++ b/tests/test_resolution_rekey_gw494.py
@@ -19,6 +19,7 @@ import msgspec
 import pytest
 
 from gen_worker.api.binding import Hub, rebind_pick, wire_ref
+from gen_worker.models.records import vacate_record
 from gen_worker.models.refs import FlavorSelectorRemoved
 from gen_worker.api.decorators import Resources
 from gen_worker.executor import Executor
@@ -123,14 +124,14 @@ def test_repick_rekeys_residency_zero_orphans() -> None:
         assert mid_key not in ex._classes
         assert _vram_refs(ex) == {"acme/z-image"}
 
-        await ex._vacate_record(ex._classes[spec.instance_key])
+        await vacate_record(ex._classes[spec.instance_key], ex.teardown_seam)
         assert _vram_refs(ex) == set()
 
     asyncio.run(_run())
 
 
 def test_vacate_releases_booked_keys_not_rebound_ones() -> None:
-    """_vacate_record must release the LOAD-TIME keys even after the spec
+    """vacate_record must release the LOAD-TIME keys even after the spec
     was rebound (the exact orphan mechanic)."""
 
     async def _run() -> None:
@@ -143,7 +144,7 @@ def test_vacate_releases_booked_keys_not_rebound_ones() -> None:
         ex.apply_model_resolutions({"acme/z-image": ("", "fp8", "")})
         # The rehome carried the live record to the new key; vacate it.
         rec = next(r for r in ex._classes.values() if r is rec)
-        await ex._vacate_record(rec)
+        await vacate_record(rec, ex.teardown_seam)
         assert _vram_refs(ex) == set(), f"orphan under {old_ref!r}"
         await asyncio.sleep(0.05)  # settle the scheduled revalidate task
 


### PR DESCRIPTION
**The parked follow-up, executed.** pgw#1206 C2 took four of the six methods th#1834
released and deliberately left `shutdown_instances` and `_vacate_record` in
`executor.py`: both open with `await self.abandon_background_mint(...)`, which was
inside the frozen 17-name fence, and moving them would have dragged a frozen symbol
across a module seam. th#1834's Phase 3 step-4 lane ruled the home on 2026-08-13 and
the ruling is a **shape, not a body**, so it did not have to wait for the supervisor's
rewrite:

```python
abandon_background_mint(rec, *, reason: str, code: str = "unspecified",
                        free_targets: bool = False) -> Awaitable[None]
```

stays with the **mint supervisor** and is exposed to residency as an **injected
callable**. Residency CALLS supervision — that direction is fixed by the greenfield
regardless of what the supervisor's body becomes, which is why this could land today.

## What moved

`shutdown_instances` / `_vacate_record` → `gen_worker.models.records`, beside the three
queries C2 already lifted there, as free functions `shutdown_instances(seam)` /
`vacate_record(rec, seam)`.

* **`RecordTeardown`** is the seam — the record view, residency, the ruled
  `abandon_background_mint`, and the three executor callbacks teardown needs
  (`on_state_change`, `close_sequence_group`, `observe_host_ram_progress`).
* **`AbandonBackgroundMint` is a Protocol**, so the ruled keyword contract is CHECKED by
  mypy instead of described in prose. Whether one `_BackgroundMint` task or a
  per-graph-class supervisor sits behind it stays the supervisor's to change without
  touching this module.
* **`Executor.teardown_seam` builds the seam per call and never caches it.**
  `_on_state_change` is reassigned after `__init__` (worker.py wires it once Lifecycle
  exists), so a seam captured at construction would call the placeholder.

**A MOVE, not a rewrite.** Both bodies are verbatim — including the two near-identical
inline `shutdown()` blocks, which are deliberately NOT folded into one helper because
that would change a log line. **No shim, no alias:** `lifecycle`'s drain, five executor
call sites and three test modules are repointed at the defining module.
`executor.py` 11,248 → 11,143.

## Tests

`tests/test_residency_teardown_seam_pgw1206.py`, four rows — the first two are coverage
the seam never had. Both mutators are driven through the REAL supervisor body (a real
`_BackgroundMint` on a real `Executor`) and assert the mint is stopped with the ruled
reason/code pair; one row pins the injected callable's keyword contract and proves the
record book imports no executor at all (AST over its own source); one pins the
call-time `_on_state_change` read.

**RED-VERIFIED:** severing either `abandon_background_mint` call reds exactly the two
rows that name it (2 failed, 2 passed) — the direction row and the state-change row are
correctly independent of the call.

## Gates (this box, `nice -n 19`)

mypy strict clean, 779 files · ruff clean · all 14 fast-gate lint scripts exit 0
(incl. `lint_fence_symbols`, `lint_mypy_ratchet`) · `assemble_changelog --check` parses ·
hub-worker boundary digest matches · **287 targeted tests green** across the
residency/teardown/mint-abandon set and every test module importing `Lifecycle`.

Rebased onto `aa8faa23` (#786) before pushing; `git diff --diff-filter=D` against
`origin/master` is empty.
