### PR TITLE
pgw#1243 (P0 train-blocker): a compile child's terminus is its report, and a wedged share can be seen

### DIFF
--- a/changelog.d/pgw1243.md
+++ b/changelog.d/pgw1243.md
@@ -1,0 +1,27 @@
+- **pgw#1243: a compile child's terminus is its REPORT, not its exit.** Both
+  `aot_compile_pool` (the production path) and `mint_process` (the one-shot
+  rig/operator path) now watch for the child's report beside `proc.poll()` and
+  classify from it when a child reaches its own terminus and then fails to die.
+  Two production mints compiled, sealed and reported an entire cell and then
+  sat in `finalize` for 78.9 and 62 minutes publishing nothing, because the
+  supervisor was waiting on an interpreter teardown that never finished. A
+  healthy child still exits first and is still classified by its exit code.
+- **pgw#1243: the compile pool has a give-up test at all.** Its drain loop
+  polled `proc.poll()` and slept, with nothing else in it — the three-tier
+  stack got a silence window for free from the mint child's own supervisor and
+  pgw#1215 step 4 deleted that tier without moving the watch down. Each share
+  now carries its own progress-staleness window over MEASURED evidence
+  (process-tree CPU plus bytes written, separate high-water marks per
+  pgw#964), and a share that stops advancing fails the build by name — never a
+  duration bound, so a forty-minute `aot_compile` is untouched.
+- **pgw#1243: past a mint child's terminal phase, ambient CPU is not
+  progress.** One of the two wedges burned exactly one core, which re-touched
+  the silence window every single poll; an axis that cannot go silent is not a
+  progress axis. A wedge inside `finalize` is now detected and named with the
+  phase, the missing report and what was measured instead.
+- **pgw#1243: the mint counts against an honest total.** The evidence counter
+  has no total by construction, so a frozen position was indistinguishable from
+  a slow one and the worker reported `self_stalled=FALSE` for an hour. The
+  supervisor's frames already carried a real `step/total`; they now reach a
+  counter, which is the only thing the hub's liveness rule and
+  `progress.self_diagnosis` read.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -76,6 +76,7 @@ from .child_contract import CompileSpec, MintSlot
 from .compile_posture import (
     USER_MACHINE_RSS_RESERVE_BYTES, CompilePosture)
 from .postmortem import cpu_quota_cores
+from .stall import SilenceWindow
 import hashlib
 
 logger = logging.getLogger(__name__)
@@ -215,6 +216,19 @@ DEFAULT_ENTRY_PEAK_RSS_BYTES = 3 * 1024**3
 
 _KILL_GRACE_S = 10.0
 _POLL_S = 0.25
+
+#: pgw#1243: how long ONE compile child's measured evidence — its process
+#: tree's CPU seconds plus the bytes it has written — may fail to advance
+#: before the pool calls it wedged. A SILENCE window, never a compile budget:
+#: an entry that spends forty minutes inside one `aot_compile` advances this
+#: every poll and is never touched. It exists because the drain loop below had
+#: no give-up test of ANY kind — it polled `proc.poll()` forever — and the
+#: three-tier stack's own window (which used to cover this whole tree from the
+#: mint child) went away with the middle tier.
+_ENTRY_SILENCE_WINDOW_S = 300.0
+
+#: Evidence advance (CPU-seconds + MiB written) that counts as progress.
+_ENTRY_EVIDENCE_EPS = 0.05
 
 
 @dataclass(frozen=True)
@@ -830,6 +844,17 @@ class _Running:
     #: Wall clock at the moment ``Popen`` returned — the other end of the
     #: child's boot span, which no monotonic clock can close across processes.
     spawn_epoch: float = 0.0
+    #: pgw#1243: this child's own silence window, and the high-water marks it
+    #: judges. Per ROW, because the pool's question is per row: one share
+    #: finishing tells you nothing about whether a sibling has wedged, and a
+    #: pool-wide signal lets a busy sibling vouch for a dead one.
+    window: Optional[SilenceWindow] = None
+    cpu_s: Optional[float] = None
+    work_mib: Optional[float] = None
+    #: True when the child wrote its report and the PARENT ended it, rather
+    #: than the child exiting under its own power. The exit code is then the
+    #: parent's signal and says nothing about the compile — read the report.
+    reaped_at_terminus: bool = False
 
 
 @dataclass
@@ -1123,6 +1148,57 @@ def _peak_rss_bytes(proc: subprocess.Popen) -> int:
     return sum(_vmhwm_bytes(pid) for pid in _descendants(proc.pid))
 
 
+def _tree_cpu_seconds(pid: int) -> Optional[float]:
+    """CPU seconds burned by a child's whole process tree, reaped members
+    included (pgw#964, ported to the pool by pgw#1243).
+
+    The reaped counters are what make it monotonic: a member's CPU leaves its
+    own ``utime/stime`` and enters its parent's ``cutime/cstime`` the instant
+    the parent waits for it, so a plain live-member sum falls into a hole one
+    finished sub-process deep — and a supervisor comparing against a
+    high-water mark reads that as death. ``None`` (never 0) when the tree
+    cannot be sampled: an absent measurement is no evidence, not a zero.
+    """
+    try:
+        import psutil
+    except Exception:  # pragma: no cover — psutil is a hard dep in practice
+        return None
+    try:
+        proc = psutil.Process(pid)
+        members = [proc] + proc.children(recursive=True)
+    except Exception:
+        return None
+    total = 0.0
+    for member in members:
+        try:
+            times = member.cpu_times()
+        except Exception:
+            continue
+        total += float(times.user) + float(times.system)
+        total += float(getattr(times, "children_user", 0.0) or 0.0)
+        total += float(getattr(times, "children_system", 0.0) or 0.0)
+    return total
+
+
+def _dir_mib(root: Path) -> Optional[float]:
+    """MiB a child has written into its scratch — generated sources, objects,
+    the packed artifact. It grows in BURSTS (sources land, then a single
+    ``cc1plus`` chews for minutes writing nothing), so its growth proves work
+    and its silence proves nothing: an independent positive signal that can
+    never, on its own, vote to condemn."""
+    total = 0
+    try:
+        for path in root.rglob("*"):
+            try:
+                if path.is_file():
+                    total += path.stat().st_size
+            except OSError:
+                continue
+    except OSError:
+        return None
+    return total / (1 << 20)
+
+
 class EntryCompilePool:
     """Trace, compile and pack a family's declared graph classes K-wide, out
     of process.
@@ -1148,8 +1224,13 @@ class EntryCompilePool:
         inductor_configs: Optional[Mapping[str, Any]] = None,
         cache_dir: str = "",
         python: str = "",
+        entry_silence_window_s: float = _ENTRY_SILENCE_WINDOW_S,
     ) -> None:
         self.workdir = Path(workdir)
+        #: pgw#1243: how long ONE share may make no measured progress. A
+        #: parameter so a tape can drive the window rather than wait it out;
+        #: production never passes it.
+        self.entry_silence_window_s = float(entry_silence_window_s)
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.width = width
         #: pgw#842/th#1359: the width facts as last EMITTED, so a re-emit
@@ -1621,7 +1702,71 @@ class EntryCompilePool:
             self.peak_rss_bytes = max(self.peak_rss_bytes, row.peak_rss_bytes)
             if row.proc.poll() is not None:
                 return row
+            # pgw#1243: A CHILD'S TERMINUS IS ITS REPORT, NOT ITS EXIT.
+            # `aot_compile_child.run` writes the report as its last statement
+            # and returns; everything after is interpreter teardown, and a
+            # process that has just traced and AOTI-compiled has plenty that
+            # can hang there — a non-daemon thread, a subproc pool, CUDA. Two
+            # production mints packed and reported an entire cell and then sat
+            # in `finalize` for 78.9 and 62 minutes while the tier above them
+            # waited on an exit that never came. Everything this pool needs is
+            # in the report; the corpse is not part of the contract.
+            if _read_report(Path(row.job.report)) is not None:
+                logger.info(
+                    "aot-pool: %s wrote its report and did not exit — reaping "
+                    "its group; the report is the terminus (pgw#1243)",
+                    row.entry)
+                row.reaped_at_terminus = True
+                _terminate_group(row.proc)
+                return row
+            self._judge_entry_liveness(row)
         return None
+
+    def _judge_entry_liveness(self, row: _Running) -> None:
+        """Condemn a share that has stopped making MEASURED progress.
+
+        pgw#1243. Until this existed the drain loop had no give-up test at
+        all: `proc.poll()` forever, `time.sleep(_POLL_S)` forever. The
+        three-tier stack used to get this for free — the mint child's own
+        supervisor watched this whole process tree — and pgw#1215 step 4
+        deleted that tier without moving the watch down with it.
+
+        Progress is MEASURED (process-tree CPU plus bytes written), never a
+        clock and never a frame the child could print while wedged, and the two
+        signals keep separate high-water marks so a quiet one cannot cancel a
+        moving one (pgw#964). A child inside a forty-minute `aot_compile`
+        advances this every poll and is never touched.
+        """
+        if row.window is None:
+            row.window = SilenceWindow(self.entry_silence_window_s)
+        cpu = _tree_cpu_seconds(row.proc.pid)
+        mib = _dir_mib(Path(row.job.work))
+        advanced = False
+        if cpu is not None and (
+                row.cpu_s is None or cpu - row.cpu_s >= _ENTRY_EVIDENCE_EPS):
+            row.cpu_s, advanced = cpu, True
+        if mib is not None and (
+                row.work_mib is None
+                or mib - row.work_mib >= _ENTRY_EVIDENCE_EPS):
+            row.work_mib, advanced = mib, True
+        if advanced:
+            row.window.touch()
+            return
+        if not row.window.stalled():
+            return
+        raise EntryCompileFailed(
+            row.entry,
+            f"{row.entry} (rows[{row.job.share_index}::"
+            f"{row.job.share_count}]): the compile child made no measured "
+            f"progress for {row.window.silent_for():.0f}s (window "
+            f"{row.window.window_s:.0f}s) and wrote no report — process-tree "
+            f"CPU "
+            f"{'unreadable' if row.cpu_s is None else f'{row.cpu_s:.1f}s'} "
+            f"and its work dir "
+            f"{'unreadable' if row.work_mib is None else f'{row.work_mib:.1f}MiB'} "
+            f"are both flat. It is wedged, not compiling; this build FAILS and "
+            f"this worker keeps serving eager",
+            peak_rss_bytes=row.peak_rss_bytes)
 
     def observe_entry_device(self, report: EntryReport) -> None:
         """Bank one entry child's DEVICE high-water (pgw#877 #2).
@@ -1651,6 +1796,15 @@ class EntryCompilePool:
         self.entry_seconds[row.entry] = round(elapsed, 2)
         code = row.proc.returncode
         report = _read_report(Path(row.job.report))
+        if row.reaped_at_terminus and report is not None:
+            # pgw#1243: this child reached its own terminus and then failed to
+            # die, so the parent ended it — the exit code below is the
+            # PARENT's signal and says nothing about the compile. The report
+            # carries the same classification the exit code does, so read it
+            # there and let the ladder run unchanged. Without this a share
+            # that packed every one of its graph classes would be reported as
+            # a signal death and its artifacts thrown away.
+            code = EXIT_COMPILED if report.status == COMPILED else EXIT_REFUSED
         if report is not None:
             # pgw#877: banked BEFORE any gate can raise, and on the failure
             # path too — pgw#848's rule for the host half applies unchanged

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -120,6 +120,18 @@ _EVIDENCE_WINDOW_S = 300.0
 #: Evidence advance (CPU-seconds + MiB written) that counts as progress.
 _EVIDENCE_EPS = 0.05
 
+#: pgw#1243: the phase after which the child has no WORK left — only a JSON
+#: write and an interpreter teardown. ``mint_child._mint_aot`` emits it once
+#: every entry is packed, moved and hashed and the manifest is named; ``main``
+#: then writes the report and returns. So two things are true past this frame
+#: and neither was expressed anywhere: the child's own TERMINUS is its report,
+#: not its exit; and process-tree CPU is RESIDUE (a leftover pool grandchild, a
+#: non-daemon thread torch never joined, a CUDA teardown that spins) rather than
+#: evidence of work. Both instances of the wedge were exactly this — the child
+#: said ``finalize`` and never spoke again, while its residue burned one core at
+#: 1.00 CPU-s/s, re-touching the silence window every poll for 62 minutes.
+TERMINAL_CHILD_PHASE = "finalize"
+
 #: Bytes of the child's stderr kept for the failure report.
 _STDERR_TAIL_BYTES = 8192
 
@@ -545,6 +557,8 @@ async def _observe(
     window: SilenceWindow,
     on_evidence: Optional[Callable[[float], None]],
     interval_s: float,
+    *,
+    state: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Watch the child's MEASURED progress. Returns the stall reason, or ''
     when cancelled because the child exited.
@@ -557,18 +571,30 @@ async def _observe(
     * a signal that is merely quiet — work-root bytes during a long ``g++`` —
       cannot cancel one that is moving. Only the absence of BOTH advances is
       silence, which is the only thing this window is entitled to judge.
+
+    pgw#1243 — THE TERMINAL PHASE ADMITS NO AMBIENT EVIDENCE. Both signals
+    describe a child that is BUILDING something. Past ``TERMINAL_CHILD_PHASE``
+    the child is not building anything: it has packed, moved and hashed every
+    entry, and the only progress it has left is its report. Crediting tree CPU
+    there does not merely measure the wrong thing — it makes the window
+    UNFIREABLE, because any residue that spins re-touches it every poll. That
+    is precisely how a mint that had finished its work sat in ``finalize`` for
+    62 minutes reporting ``self_stalled=FALSE``: the counter was admitted as a
+    position, and in this phase the position is a lie. An axis that cannot go
+    silent is not a progress axis, so in this phase it is not consulted.
     """
     cpu, mib = _evidence(pid, work_root)
     window.touch()
     while True:
         await asyncio.sleep(interval_s)
         now_cpu, now_mib = _evidence(pid, work_root)
+        terminal = str((state or {}).get("phase") or "") == TERMINAL_CHILD_PHASE
         advanced = False
         if now_cpu is not None and (cpu is None or now_cpu - cpu >= _EVIDENCE_EPS):
             cpu, advanced = now_cpu, True
         if now_mib is not None and (mib is None or now_mib - mib >= _EVIDENCE_EPS):
             mib, advanced = now_mib, True
-        if advanced:
+        if advanced and not terminal:
             window.touch()
             if on_evidence is not None:
                 try:
@@ -576,13 +602,61 @@ async def _observe(
                 except Exception:
                     logger.exception("mint evidence callback failed")
         elif window.stalled():
+            cpu_note = "unreadable" if now_cpu is None else f"{now_cpu:.1f}s"
+            mib_note = "unreadable" if now_mib is None else f"{now_mib:.1f}MiB"
+            if terminal:
+                return (
+                    f"the mint process reached its terminal phase "
+                    f"{TERMINAL_CHILD_PHASE!r} and then stopped: it has not "
+                    f"written its report for {window.silent_for():.0f}s "
+                    f"(window {window.window_s:.0f}s). Past that phase every "
+                    f"entry is already packed and moved, so the report is the "
+                    f"only progress left and process-tree CPU ({cpu_note}) is "
+                    f"residue — a leftover compile worker or an interpreter "
+                    f"teardown that never finished — not work. Observed "
+                    f"work-root {mib_note}")
             return (
                 f"the mint process made no measured progress for "
                 f"{window.silent_for():.0f}s (window {window.window_s:.0f}s): "
-                f"process-tree CPU {'unreadable' if now_cpu is None else f'{now_cpu:.1f}s'} "
+                f"process-tree CPU {cpu_note} "
                 f"and work-root "
-                f"{'unreadable' if now_mib is None else f'{now_mib:.1f}MiB'} "
+                f"{mib_note} "
                 f"both flat")
+
+
+async def _await_terminus(report_path: Path, interval_s: float) -> "MintReport":
+    """Resolve when the child has written its report — its own TERMINUS.
+
+    pgw#1243. ``mint_child.main`` writes the report as its LAST statement on
+    every path (minted, refused, resource, classified failure) and then
+    returns; whatever the process does afterwards is interpreter teardown, and
+    teardown is not work the parent has any reason to wait on. Waiting on the
+    EXIT instead of the report is what turned a completed 45-minute compile
+    into a 62-minute wedge that published nothing: the artifacts were on disk
+    and the report named them, and the parent sat on ``proc.wait()``.
+
+    The write is atomic (``os.replace`` off a ``.part``), so a decodable report
+    is a whole one — there is no torn-read window to poll around.
+    """
+    while True:
+        report = _decode_report(report_path)
+        if report is not None:
+            return report
+        await asyncio.sleep(interval_s)
+
+
+#: The exit code a report's own status stands for, when the child wrote the
+#: report and then failed to exit. Anything unrecognised is the classified
+#: failure code — the child caught something, named it, and wrote it down.
+_REPORT_EXIT_CODES: Dict[str, int] = {
+    "minted": EXIT_MINTED,
+    "refused": EXIT_REFUSED,
+    "resource": EXIT_RESOURCE,
+}
+
+
+def _code_for_report(report: MintReport) -> int:
+    return _REPORT_EXIT_CODES.get(str(report.status), 1)
 
 
 def _terminate_group(pid: int, *, grace_s: float = 10.0) -> None:
@@ -653,21 +727,38 @@ async def run_mint(
     errs = asyncio.ensure_future(_pump_stderr(proc.stderr, state))
     watch = asyncio.ensure_future(_observe(
         proc.pid, work_root,
-        SilenceWindow(evidence_window_s), on_evidence, observe_interval_s))
+        SilenceWindow(evidence_window_s), on_evidence, observe_interval_s,
+        state=state))
     reap = asyncio.ensure_future(proc.wait())
+    # pgw#1243: the child's terminus, watched beside its exit. A healthy child
+    # exits within milliseconds of writing, so `reap` wins this race on every
+    # normal mint and nothing below changes; this only ever fires for a child
+    # that finished its work and then failed to die.
+    terminus = asyncio.ensure_future(
+        _await_terminus(report_path, observe_interval_s))
     stop = (
         asyncio.ensure_future(abandon.wait()) if abandon is not None
         else None)
-    waits = [reap, watch] + ([stop] if stop is not None else [])
+    waits = [reap, watch, terminus] + ([stop] if stop is not None else [])
 
     killed_reason = ""
+    #: True when the child did not exit under its own power and the parent
+    #: reaped its group — so a signal exit code below is the PARENT's, and
+    #: says nothing about how the mint ended (pgw#1243).
+    reaped_by_parent = False
     try:
         await asyncio.wait(waits, return_when=asyncio.FIRST_COMPLETED)
         if not reap.done():
+            reaped_by_parent = True
             if watch.done() and watch.result():
                 killed_reason = watch.result()
             elif stop is not None and stop.done():
                 killed_reason = ABANDONED
+            elif terminus.done():
+                logger.info(
+                    "mint_process: pid=%s wrote its report and did not exit "
+                    "— reaping its group; the report is the terminus "
+                    "(pgw#1243)", proc.pid)
             await asyncio.to_thread(_terminate_group, proc.pid)
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(
@@ -676,11 +767,12 @@ async def run_mint(
         await asyncio.to_thread(_terminate_group, proc.pid)
         raise
     finally:
-        for fut in (frames, errs, watch, reap, stop):
+        for fut in (frames, errs, watch, reap, terminus, stop):
             if fut is not None and not fut.done():
                 fut.cancel()
         with contextlib.suppress(Exception):
-            await asyncio.gather(frames, errs, watch, return_exceptions=True)
+            await asyncio.gather(
+                frames, errs, watch, terminus, return_exceptions=True)
 
     code = reap.result() if reap.done() and not reap.cancelled() else None
     elapsed = time.monotonic() - started
@@ -705,6 +797,21 @@ async def run_mint(
 
     if killed_reason == ABANDONED:
         return _out(ABANDONED, "the parent abandoned this mint")
+    # pgw#1243: a report and a missing exit code are not a contradiction —
+    # they are a child that reached its own terminus and then failed to die.
+    # The report carries the same CLASSIFICATION the exit code does, so read
+    # it off there and let the ladder below run unchanged. This also
+    # reinterprets a stall the parent had to kill: a mint whose report is on
+    # disk produced whatever the report says it produced, and calling that a
+    # crash would throw away a finished cell over a teardown that hung.
+    if reaped_by_parent and report is not None:
+        code = _code_for_report(report)
+        logger.info(
+            "mint_process: classifying pid=%s from its report (status=%r) — "
+            "it reached its terminus and never exited%s",
+            proc.pid, report.status,
+            f" ({killed_reason})" if killed_reason else "")
+        killed_reason = ""
     if killed_reason:
         return _out(CRASHED, killed_reason)
 

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -230,18 +230,51 @@ EVIDENCE_COUNTER = "compile:mint_child_evidence"
 Watcher = Callable[[MintFrame], None]
 
 
+#: pgw#1243: the mint's BOUNDED axis — whatever the current phase is counting,
+#: out of the total it declares (shares landed during `inductor_compile`, and
+#: every other phase that states a total).
+#:
+#: ``EVIDENCE_COUNTER`` counts against no total at all, which is what let the
+#: wedge hide: two mints reported `counter_done=1077.99 counter_total=0
+#: self_stalled=FALSE` for an hour, and with no total there is no fraction, so
+#: a frozen position is indistinguishable from a slow one. The frames have
+#: carried a real `step/total` all along; it just never reached a COUNTER,
+#: which is the only thing the hub's liveness rule and
+#: ``progress.self_diagnosis`` read. An unbounded counter is not progress
+#: evidence; this one is.
+PROGRESS_COUNTER = "compile:mint_progress"
+
+
 def _on_frame(act: Any, watch: Optional[Watcher] = None) -> Any:
     """Land one supervision frame on the activity the hub already reads."""
 
     def _apply(frame: MintFrame) -> None:
         if frame.phase:
             act.phase(frame.phase, frame.step, frame.total)
+            _count_progress(act, frame)
         if frame.note:
             act.note(frame.note[:200])
         if watch is not None:
             watch(frame)
 
     return _apply
+
+
+def _count_progress(act: Any, frame: MintFrame) -> None:
+    """Carry a frame's step/total onto a real counter (best effort).
+
+    The activity's own `step`/`total_steps` already ride the wire, but the
+    hub's liveness rule and ``progress.self_diagnosis`` both read COUNTERS —
+    which is why a mint whose shares had stopped landing still confessed
+    ``self_stalled=FALSE``.
+    """
+    if frame.total <= 0:
+        return
+    make = getattr(act, "counter", None)
+    if not callable(make):
+        return
+    make(PROGRESS_COUNTER, progress_mod.UNIT_STEPS,
+         float(frame.total)).set_done(float(frame.step))
 
 
 def _on_evidence(act: Any) -> Any:
@@ -757,6 +790,7 @@ __all__ = [
     "ABANDONED",
     "ADOPTED",
     "EVIDENCE_COUNTER",
+    "PROGRESS_COUNTER",
     "FAILED",
     "GRAPH_DIRNAME",
     "MAX_ATTEMPTS",

--- a/tests/harness/fake_compile_child.py
+++ b/tests/harness/fake_compile_child.py
@@ -43,6 +43,15 @@ if mode in ("hang", "die-and-hang"):
     # A share that will NOT exit on its own: only a group-wide teardown ends
     # it, which is the property the pool's failure path has to hold.
     time.sleep(600)
+if mode == "wedged-no-report":
+    # pgw#1243: wedged BEFORE writing a report, and SPINNING while it is —
+    # the shape that defeated every evidence window the platform had, because
+    # a burning core is admitted as progress. One core, exactly, which is
+    # what instance A's `@ 1.00/s` counter rate literally was.
+    acc = 0
+    while True:
+        for i in range(200000):
+            acc += i * i
 
 declared = int(os.environ.get("PGW_FAKE_DECLARED", "6"))
 mine = [f"cls/dim={{i}}" for i in range(index, declared, count)]
@@ -96,6 +105,14 @@ report.write_bytes(json.dumps({{
     "report_epoch": now,
     "code_digest": {digest!r}, "code_dir": {code_dir!r},
 }}).encode())
+if mode == "wedged-after-report":
+    # pgw#1243, the observed wedge: every graph class packed, the report
+    # written — and then the interpreter never comes down. Two production
+    # mints did exactly this for 78.9 and 62 minutes.
+    acc = 0
+    while True:
+        for i in range(200000):
+            acc += i * i
 sys.exit(2 if refused else 0)
 '''
 

--- a/tests/harness/mint_child_stub.py
+++ b/tests/harness/mint_child_stub.py
@@ -18,6 +18,13 @@ Behaviour is chosen with ``MINT_STUB_MODE``:
 ``busy``        burn CPU for MINT_STUB_SECONDS, then mint
 ``silent``      sleep for MINT_STUB_SECONDS doing nothing at all
 ``grow``        write work-root bytes slowly (CPU-quiet but progressing)
+
+pgw#1243's three wedge shapes — each walks the real terminal frames
+(``seal_publish`` then ``finalize``) and then never exits:
+
+``wedged_spin``      report written, then one core spins forever
+``wedged_block``     report written, then blocked forever (flat CPU)
+``wedged_no_report`` wedged INSIDE finalize: no report is ever written
 """
 
 from __future__ import annotations
@@ -112,6 +119,30 @@ def main() -> int:
             time.sleep(0.2)
         _mint(request)
         return 0
+    if mode in ("wedged_spin", "wedged_block", "wedged_no_report"):
+        # pgw#1243: the wedge, in its three observable shapes. Each one walks
+        # the real terminal frames (`seal_publish` then `finalize`) and then
+        # never dies — which is what both production instances did.
+        sys.stdout.write(frame_line(
+            phase="seal_publish", note="packed 4 entry artifact(s)"))
+        sys.stdout.flush()
+        sys.stdout.write(frame_line(phase="finalize", note="manifest stub"))
+        sys.stdout.flush()
+        if mode != "wedged_no_report":
+            # The child reached its OWN terminus: entries moved, report
+            # written. Only the interpreter teardown hangs.
+            _mint(request)
+        acc = 0
+        while True:
+            if mode == "wedged_block":
+                # A non-daemon thread `threading._shutdown` will never join:
+                # flat CPU, flat bytes, alive forever.
+                time.sleep(3600)
+            # ...and the shape instance A measured: one core at 1.00 CPU-s/s,
+            # which re-touched the parent's silence window every single poll.
+            for i in range(200000):
+                acc += i * i
+
     if mode == "busy":
         sys.stdout.write(frame_line(phase="inductor_compile", note="burning"))
         sys.stdout.flush()

--- a/tests/test_finalize_wedge_pgw1243.py
+++ b/tests/test_finalize_wedge_pgw1243.py
@@ -1,0 +1,601 @@
+"""pgw#1243: a compile that finished its work and then failed to die.
+
+Two production mints, two families, two wheels, one signature::
+
+    kind=self_mint_compile  phase=finalize  state=running
+    counter=compile:mint_child_evidence  counter_done=1077.99  counter_total=0
+    self_stalled=FALSE   worker HEARTBEAT: 9s old
+
+sdxl compiled 36 graph classes in 45m08s, sealed them, said ``finalize`` — and
+then sat there for 78.9 minutes. z-image did the same for 62 minutes on
+0.114.2 and had to be terminated by a human. Nothing was ever published, and
+the serving path was fine throughout: both pods answered eager requests while
+their mint was dead.
+
+The load-bearing evidence was ``aot_mint_phases`` rows = 0. That table is
+emitted PARENT-side and unconditionally the moment the compile call returns, so
+zero rows means the parent never returned from it — the compiling process said
+its last word and then never terminated.
+
+TWO DEFECTS, and the second is what made the first invisible:
+
+1. **The parent waited on the child's EXIT, not on its TERMINUS.** A compile
+   child writes its report as its last statement and returns; everything after
+   is interpreter teardown, and a process that has just traced and
+   AOTI-compiled has plenty that can hang there — a non-daemon thread, a
+   subprocess pool, CUDA. The whole compile was on disk and the supervisor
+   threw it away waiting for a corpse.
+2. **Ambient CPU was admitted as progress after the work was done, so no
+   silence window could fire.** One production wedge burned *exactly one core*
+   — which is what its ``@ 1.00/s`` counter rate literally is — and that
+   re-touched the window every single poll, forever. An axis that cannot go
+   silent is not a progress axis.
+
+Both live in the SUPERVISION of a compile child, so pgw#1215 step 4 moving the
+supervision down a tier moved the defect with it, and made it worse: the pool's
+drain loop has no give-up test of any kind — ``proc.poll()`` forever,
+``time.sleep`` forever — because the three-tier stack used to get one for free
+from the mint child's own supervisor. Both tiers are fixed here: the pool
+(``aot_compile_pool``, the production path) and the one-shot mint child
+(``mint_process``, the operator/rig path, which is where the literal
+``finalize`` frame still lives).
+
+Paul's ruling on the fix shape (2026-08-14):
+
+    "The worker was fine, but the graph-compilation process failed and just
+    stayed dead. In that case, it should report back to its parent execution
+    group, which reports back to the worker, which reports back to tensorhub
+    that the build failed. Just because the compilation failed doesn't mean
+    the worker should be killed; it can continue to serve eager forever, but
+    we should be aware of, and log, and make aware to operators, when builds
+    fail, precisely why they fail."
+
+Every tape drives the REAL supervisor against REAL child processes that really
+wedge — spinning and blocked, with and without a report. ``timeout=`` values
+are the TAPE's guard so a hang cannot take the suite with it; nothing in
+production keys on a duration, and the detection tapes prove that by driving
+the silence window itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import subprocess
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker import aot_compile_pool as pool
+from gen_worker import child_contract
+from gen_worker import mint_process as mp
+from gen_worker import mint_supervisor
+from gen_worker import progress as progress_mod
+from harness import fake_compile_child
+
+torch = pytest.importorskip("torch")
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+#: The tape's own guard. Generous against the fix (which returns in about one
+#: poll) and tiny against the defect (62 minutes in production), so a RED run
+#: fails fast instead of hanging the suite.
+_TAPE_GUARD_S = 90.0
+
+#: A silence window a tape can actually drive. The detection tapes need it
+#: reachable; the terminus tapes set it far ABOVE their own runtime on purpose,
+#: so a pass there cannot be the window firing.
+_SHORT_WINDOW_S = 3.0
+_UNREACHABLE_WINDOW_S = 600.0
+
+_DECLARED = 6
+
+
+# ======================================================================
+# TIER 1 — the compile pool: the production path since pgw#1215 step 4
+# ======================================================================
+
+def _pool(
+    tmp_path: Path, *, mode: str, window_s: float, workers: int = 1,
+) -> pool.EntryCompilePool:
+    os.environ["PGW_FAKE_CHILD"] = mode
+    os.environ["PGW_FAKE_DECLARED"] = str(_DECLARED)
+    width = pool.entry_workers(
+        _DECLARED, limit=workers, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    assert width.workers == workers
+    return pool.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=fake_compile_child.script(tmp_path),
+        entry_silence_window_s=window_s)
+
+
+def _template(tmp_path: Path) -> pool.EntryJob:
+    return pool.EntryJob(
+        function="generate", modules=("harness.toy_endpoints",),
+        out_dir=str(tmp_path / "artifacts"))
+
+
+@pytest.fixture(autouse=True)
+def _clean_fake_child_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PGW_FAKE_CHILD", raising=False)
+    monkeypatch.delenv("PGW_FAKE_DECLARED", raising=False)
+
+
+def _survivors(script: str) -> List[int]:
+    """Every live process still running THIS tape's child script.
+
+    Matched on the command line, not the parent's process group: the pool
+    spawns with ``start_new_session=True`` so it can kill a child's whole
+    group, which means a leaked child is never in the parent's group and a
+    pgrp sweep can only ever return the empty set.
+    """
+    out = subprocess.run(
+        ["ps", "-eo", "pid=,args="], capture_output=True, text=True).stdout
+    return [
+        int(line.split(None, 1)[0]) for line in out.splitlines()
+        if script in line and " -eo " not in line]
+
+
+def _kill_survivors(script: str) -> None:
+    """End every child of this tape, group first and then the bare pid.
+
+    Both, because a leaked child here is a process at 100% CPU on a shared
+    machine: ``killpg`` is the right instrument, and ``getpgid`` can lose a
+    race with the process it is asking about, so the pid kill is the backstop.
+    """
+    for pid in _survivors(script):
+        with contextlib.suppress(OSError):
+            os.killpg(os.getpgid(pid), 9)
+        with contextlib.suppress(OSError):
+            os.kill(pid, 9)
+
+
+def test_a_share_that_packed_and_reported_and_never_died_still_lands(
+    tmp_path: Path,
+) -> None:
+    """RED before pgw#1243, and this is the production wedge.
+
+    The child packs every graph class in its share, writes its report, and
+    then burns a core forever. The old pool polled ``proc.poll()`` and slept,
+    with nothing else in the loop at all: the compile was complete, on disk and
+    reported, and the pool would have sat on it until the pod was destroyed.
+
+    The window is ten minutes and the tape guard is ninety seconds, so a pass
+    CANNOT be a silence window firing: the only thing that can end this run is
+    the report.
+    """
+    script = fake_compile_child.script(tmp_path)
+    p = _pool(tmp_path, mode="wedged-after-report",
+              window_s=_UNREACHABLE_WINDOW_S)
+    packed = p.compile(_template(tmp_path))
+
+    assert sorted(packed) == sorted(f"cls/dim={i}" for i in range(_DECLARED)), (
+        "a child that packed and REPORTED its whole share produced those "
+        "graph classes; its teardown is not the pool's business")
+    for row in packed.values():
+        assert Path(row.artifact).exists()
+    # ...and the corpse does not outlive the pool. A wedged child the parent
+    # walked away from would keep burning a core on a serving pod.
+    assert _survivors(script) == [], (
+        "the pool reaped the child's GROUP at its terminus; a spinning "
+        "survivor is a pod billing for a compile nobody is waiting for")
+
+
+def test_a_share_that_stops_making_progress_is_detected_and_named(
+    tmp_path: Path,
+) -> None:
+    """RED before pgw#1243 — the drain loop had NO give-up test of any kind.
+
+    ``hang`` writes no report and blocks: flat CPU, flat bytes, alive forever.
+    Before this the pool polled ``proc.poll()`` and slept, so this run never
+    ended and no wire event was ever emitted. The three-tier stack got this
+    watch for free from the mint child's own supervisor; pgw#1215 step 4
+    deleted that tier without moving the watch down with it.
+
+    The window is three seconds against a ninety-second guard, so a pass
+    proves the window FIRED.
+    """
+    script = fake_compile_child.script(tmp_path)
+    p = _pool(tmp_path, mode="hang", window_s=_SHORT_WINDOW_S)
+
+    with pytest.raises(pool.EntryCompileFailed) as caught:
+        p.compile(_template(tmp_path))
+
+    # Paul: "make aware to operators ... precisely why they fail." The reason
+    # must name the share, what is missing, and what was measured instead.
+    detail = str(caught.value)
+    assert "no measured progress" in detail
+    assert "wrote no report" in detail
+    assert "process-tree CPU" in detail
+    assert "keeps serving eager" in detail
+    assert caught.value.entry, "the failure must name WHICH share wedged"
+    assert not caught.value.resource, (
+        "a wedge is not a memory shortfall — mis-classifying it would buy a "
+        "second billed compile at a narrower K for a defect K cannot fix")
+    assert _survivors(script) == [], (
+        "condemning a share must take its whole group with it")
+
+
+def test_a_share_that_is_really_compiling_is_never_condemned(
+    tmp_path: Path,
+) -> None:
+    """The positive control, and it is part of the method.
+
+    A window that cannot tell a wedge from a working compile is useless in the
+    other direction, so prove the identical loop with the identical
+    three-second window passes a real run.
+    """
+    p = _pool(tmp_path, mode="ok", window_s=_SHORT_WINDOW_S)
+    packed = p.compile(_template(tmp_path))
+    assert sorted(packed) == sorted(f"cls/dim={i}" for i in range(_DECLARED))
+
+
+def test_a_burning_share_with_no_report_is_deliberately_NOT_condemned(
+    tmp_path: Path,
+) -> None:
+    """THE HONEST LIMIT, asserted rather than left as a surprise.
+
+    A pool child that burns CPU and has written no report is, on every signal
+    that exists, INDISTINGUISHABLE from a child forty minutes into one
+    ``aot_compile`` — that is the whole reason the shape has no phase frames to
+    key on. So it is not condemned, and that is correct: the doctrine's cost is
+    that a spinning wedge here is only detectable once it stops burning, and
+    the alternative (a duration bound) kills real 45-minute compiles.
+
+    What makes this acceptable is that the OBSERVED wedge is not this shape.
+    Both production instances had already REPORTED — every graph class packed,
+    manifest named — and the terminus rule above ends those in one poll.
+    Recorded so nobody reads the absence as an oversight and nobody "fixes" it
+    with a timeout.
+    """
+    script = fake_compile_child.script(tmp_path)
+    p = _pool(tmp_path, mode="wedged-no-report", window_s=_SHORT_WINDOW_S)
+
+    done: List[Any] = []
+
+    def _drive() -> None:
+        # The pool will never return on its own; when the tape kills its
+        # children below it raises, and that raise is the tape's own doing.
+        with contextlib.suppress(Exception):
+            done.append(p.compile(_template(tmp_path)))
+
+    thread = threading.Thread(target=_drive, daemon=True)
+    thread.start()
+    # Several windows' worth: a burning child is never condemned, however long
+    # it burns.
+    thread.join(timeout=_SHORT_WINDOW_S * 3)
+    assert thread.is_alive() and not done, (
+        "a share burning CPU must NEVER be condemned — that is a live compile "
+        "on every signal that exists, and killing it is the failure mode the "
+        "no-magic-timeouts doctrine exists to prevent")
+    # Tape hygiene: end the children by hand and let the pool unwind.
+    _kill_survivors(script)
+    thread.join(timeout=30.0)
+    assert _survivors(script) == [], "the tape must not leak a spinning child"
+
+
+def test_a_refusal_that_hangs_on_the_way_out_is_still_a_refusal(
+    tmp_path: Path,
+) -> None:
+    """The report carries the CLASSIFICATION, not just the artifacts.
+
+    ``refuse-midway`` writes a ``status=refused`` report naming the classes it
+    did pack. Read off a signal exit instead, the pool would report a share
+    that exited on SIGKILL — losing both the refusal and the artifacts that
+    ARE on disk, which is pgw#1183's whole point.
+    """
+    os.environ["PGW_FAKE_CHILD"] = "refuse-midway"
+    p = _pool(tmp_path, mode="refuse-midway", window_s=_UNREACHABLE_WINDOW_S)
+    with pytest.raises(pool.EntryCompileFailed) as caught:
+        p.compile(_template(tmp_path))
+    assert "ARE packed and on disk" in str(caught.value), (
+        f"the partial pack must survive the refusal: {caught.value}")
+
+
+# ======================================================================
+# TIER 2 — the one-shot mint child: `finalize` still lives here
+# ======================================================================
+
+STUB_MODULE = "harness.mint_child_stub"
+_POLL_S = 0.2
+
+
+@pytest.fixture
+def _stub_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mp, "MINT_CHILD_MODULE", STUB_MODULE)
+
+
+def _request(tmp_path: Path) -> mp.MintRequest:
+    return mp.MintRequest(
+        function="gen", modules=("harness.toy_endpoints",), family="sdxl",
+        arm_token="arm1-deadbeef",
+        target=str(tmp_path / "cell.tar.gz"),
+        work_root=str(tmp_path / "capture"),
+        report=str(tmp_path / mp.REPORT_NAME),
+        cfg=child_contract.CompileSpec(
+            family="sdxl", shapes=((1024, 1024),), targets=("unet",)))
+
+
+def _env(mode: str) -> Dict[str, str]:
+    root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(root / "src"), str(root / "tests"), env.get("PYTHONPATH", "")])
+    env["MINT_STUB_MODE"] = mode
+    return env
+
+
+def _run(
+    tmp_path: Path, mode: str, *, window_s: float,
+    frames: Optional[List[child_contract.MintFrame]] = None,
+) -> mp.MintOutcome:
+    async def _drive() -> mp.MintOutcome:
+        return await asyncio.wait_for(
+            mp.run_mint(
+                _request(tmp_path), workdir=tmp_path / "work", env=_env(mode),
+                on_frame=(frames.append if frames is not None else None),
+                evidence_window_s=window_s, observe_interval_s=_POLL_S),
+            timeout=_TAPE_GUARD_S)
+
+    return asyncio.run(_drive())
+
+
+@pytest.mark.parametrize("mode", ["wedged_spin", "wedged_block"])
+def test_a_mint_child_that_reported_and_never_died_still_mints(
+    tmp_path: Path, mode: str, _stub_child: None,
+) -> None:
+    """RED before pgw#1243, on the tier where ``finalize`` is a real frame.
+
+    ``wedged_spin`` is the production shape: walk ``seal_publish`` ->
+    ``finalize``, write the entries and the report, then burn a core forever.
+    ``wedged_block`` is the flat-CPU teardown, which the old supervisor could
+    only escape by calling a finished mint a CRASH and discarding its cell.
+    """
+    frames: List[child_contract.MintFrame] = []
+    outcome = _run(tmp_path, mode, window_s=_UNREACHABLE_WINDOW_S,
+                   frames=frames)
+
+    assert outcome.status == mp.MINTED, (
+        f"a child that packed, moved and REPORTED its entries produced a "
+        f"mint; its teardown is not the parent's business: {outcome.detail}")
+    assert [p.name for p in outcome.artifacts] == ["cell.tar.gz"]
+    assert outcome.report is not None and outcome.report.status == "minted"
+    assert outcome.last_phase == mp.TERMINAL_CHILD_PHASE
+    assert [f.phase for f in frames][-1] == mp.TERMINAL_CHILD_PHASE
+
+
+def test_a_healthy_mint_child_is_still_classified_by_its_exit_code(
+    tmp_path: Path, _stub_child: None,
+) -> None:
+    """The terminus watcher must not change the ordinary path.
+
+    A child that exits under its own power is reaped before the report poll
+    fires, so every existing classification is untouched. Its own tape because
+    "I fixed the wedge and broke every normal mint" is the failure that
+    matters here.
+    """
+    outcome = _run(tmp_path, "minted", window_s=_UNREACHABLE_WINDOW_S)
+    assert outcome.status == mp.MINTED
+    assert outcome.exit_code == mp.EXIT_MINTED, (
+        "a child that exits normally must still be classified by its exit "
+        f"code, not synthesized from its report: {outcome.exit_code}")
+
+
+def test_a_wedge_inside_finalize_is_detected_and_named(
+    tmp_path: Path, _stub_child: None,
+) -> None:
+    """``wedged_no_report`` declares ``finalize`` and then spins forever
+    without writing a report — stuck INSIDE the terminal phase, where the
+    terminus watcher cannot help. Under the old rule its core was admitted as
+    progress and the window was re-touched every poll."""
+    outcome = _run(tmp_path, "wedged_no_report", window_s=_SHORT_WINDOW_S)
+
+    assert outcome.status == mp.CRASHED, (
+        "a child wedged inside its terminal phase must be DETECTED; it was "
+        f"burning a core, which is not progress there: {outcome.detail}")
+    detail = outcome.detail
+    assert mp.TERMINAL_CHILD_PHASE in detail
+    assert "report" in detail and "residue" in detail
+    assert "process-tree CPU" in detail
+    assert outcome.last_phase == mp.TERMINAL_CHILD_PHASE
+
+
+def test_ambient_cpu_still_proves_progress_before_the_terminal_phase(
+    tmp_path: Path, _stub_child: None,
+) -> None:
+    """The positive control for tier 2: a child burning CPU in
+    ``inductor_compile`` for three windows must never be killed."""
+    env = _env("busy")
+    env["MINT_STUB_SECONDS"] = str(_SHORT_WINDOW_S * 3)
+
+    async def _drive() -> mp.MintOutcome:
+        return await asyncio.wait_for(
+            mp.run_mint(
+                _request(tmp_path), workdir=tmp_path / "work", env=env,
+                evidence_window_s=_SHORT_WINDOW_S, observe_interval_s=_POLL_S),
+            timeout=_TAPE_GUARD_S)
+
+    outcome = asyncio.run(_drive())
+    assert outcome.status == mp.MINTED, (
+        f"that is the whole doctrine: {outcome.detail}")
+
+
+# ======================================================================
+# The counter that let it hide
+# ======================================================================
+
+class _Act:
+    """Just enough Activity to record what the hub would have seen."""
+
+    def __init__(self) -> None:
+        self.phases: List[str] = []
+        self.notes: List[str] = []
+
+    def phase(self, phase: str, step: int = 0, total: int = 0) -> None:
+        self.phases.append(phase)
+
+    def note(self, detail: str) -> None:
+        self.notes.append(detail)
+
+    def heartbeat(self) -> None:
+        pass
+
+    def counter(
+        self, name: str, unit: str, total: float = 0.0,
+    ) -> progress_mod.Counter:
+        return progress_mod.counter(name, unit, total, owner="tape")
+
+
+def test_the_mint_counts_against_an_honest_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``counter_total=0`` is why nothing upstream noticed.
+
+    The evidence counter counts against no total, so no fraction exists and a
+    frozen position is indistinguishable from a slow one — which is exactly
+    what both pods reported for an hour. The frames have carried a real
+    ``step/total`` all along; it just never reached a COUNTER, and a counter is
+    the only thing the hub's liveness rule and ``progress.self_diagnosis``
+    read. Driven on a fake clock: no sleeping, no wall-clock rule.
+    """
+    progress_mod.reset()
+    clock = {"t": 1_000.0}
+    monkeypatch.setattr(progress_mod, "_now", lambda: clock["t"])
+    act = _Act()
+
+    apply = mint_supervisor._on_frame(act)
+    apply(child_contract.MintFrame(
+        phase="inductor_compile", step=1, total=4, note="share-000"))
+
+    snap = progress_mod.freshest("tape")
+    assert snap is not None and snap.name == mint_supervisor.PROGRESS_COUNTER
+    assert snap.total == 4.0 and snap.done == 1.0, (
+        f"an unbounded counter is not progress evidence: {snap}")
+
+    # Nothing lands after that — which is the wedge. Past its own window the
+    # worker CONFESSES instead of reporting `self_stalled=FALSE` for an hour.
+    assert progress_mod.self_diagnosis("tape") is None
+    clock["t"] += progress_mod.window_for(
+        mint_supervisor.PROGRESS_COUNTER) + 1.0
+    stalled = progress_mod.self_diagnosis("tape")
+    assert stalled is not None
+    assert stalled.name == mint_supervisor.PROGRESS_COUNTER
+    progress_mod.reset()
+
+
+# ======================================================================
+# The chain: pool -> execution group -> worker -> hub
+# ======================================================================
+
+def _cfg() -> Any:
+    from gen_worker.api.decorators import DynamicDim
+    from gen_worker.registry import CompileCell
+    return CompileCell(
+        shapes=((1024, 1024),), targets=("unet",), family="sdxl",
+        regional=False, text_len=77,
+        dynamic=(DynamicDim(dim="batch", min=2, max=8),),
+        lora_bucket=64, guidance_scales=(5.0,), text_lens=(77,))
+
+
+def _task(tmp_path: Path) -> Any:
+    from gen_worker import fleet_cells
+    pending = fleet_cells.PendingSelfMint(
+        family="sdxl", arm_token="ck1-abc",
+        ref="root/family-sdxl#cg-key-v1-abc", cfg=_cfg(),
+        target=tmp_path / "cell.tar.gz",
+        mint_root=tmp_path / "root", publisher=None, cache_dir=tmp_path)
+    pending.mint_root.mkdir(parents=True, exist_ok=True)
+    return mint_supervisor.MintTask(
+        pending=pending, pipe=object(), function="gen",
+        modules=("harness.toy_endpoints",), weight_lane="fp8", device=0)
+
+
+def test_a_wedged_compile_fails_the_BUILD_and_never_the_WORKER(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paul's ruling, on the worker seam, with the wedge's own sentence.
+
+    A condemned share leaves the pool as ``EntryCompileFailed``, which
+    ``aot_mint`` turns into ``MintRefused`` (a wedge is deterministic — a
+    retry buys a second billed 45-minute compile for a defect a retry cannot
+    change). This drives the REAL ``supervise`` with that exception and asserts
+    the three properties the ruling asks for past detection:
+
+    2. TYPED PROPAGATION carrying the precise reason, all the way to the hub;
+    3. the worker SERVES EAGER — ``supervise`` returns, never raises;
+    4. the mint honestly ENDS — the obligation is resolved, so every
+       "is this pod minting" predicate reads false afterwards.
+
+    Per Paul's 2026-08-14 amendment this asserts NO occupancy/hold semantics:
+    retiring a minting pod is fine now that graph classes land incrementally,
+    and that debt is th#1930's. What is owed here is the honest terminal state,
+    and nothing more.
+    """
+    from gen_worker import aot_mint, fleet_cells
+    from gen_worker import activity as activity_mod
+
+    monkeypatch.setattr(
+        mint_supervisor, "assert_family_mintable", lambda family: None)
+    monkeypatch.setattr(
+        fleet_cells, "aot_export_spec",
+        lambda pipe, cfg: SimpleNamespace(
+            family="sdxl", strict=True, lora_bucket=0))
+    monkeypatch.setattr(
+        mint_supervisor, "export_declaration", lambda family: object())
+    monkeypatch.setattr(
+        aot_mint, "declared_class_rows", lambda pipe, spec, decl: [object()] * 4)
+
+    seen: List[tuple] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, phase="", **_kw: seen.append((kind, phase, detail)))
+    abandoned: List[Any] = []
+    monkeypatch.setattr(
+        fleet_cells, "abandon_self_mint",
+        lambda pending: abandoned.append(pending))
+
+    wedge = (
+        "share-000 (rows[0::1]): the compile child made no measured progress "
+        "for 312s (window 300s) and wrote no report — process-tree CPU 41.2s "
+        "and its work dir 18.4MiB are both flat. It is wedged, not compiling; "
+        "this build FAILS and this worker keeps serving eager")
+
+    calls: List[int] = []
+
+    def _mint(template: Any, **kw: Any) -> Any:
+        calls.append(1)
+        raise aot_mint.MintRefused(wedge)
+
+    monkeypatch.setattr(aot_mint, "mint_graph_classes", _mint)
+
+    act = _Act()
+    result = asyncio.run(mint_supervisor.supervise(
+        _task(tmp_path), act=act, max_attempts=3))
+
+    # 3. THE WORKER LIVES: a failed build is a returned value, never a raise.
+    assert result.status == mint_supervisor.FAILED and not result.ok
+    # ...and it does not buy a second 45-minute compile for a wedge.
+    assert len(calls) == 1 and result.attempts == 1, (
+        "a wedge is deterministic: re-running it is a second billed compile "
+        "for the same sentence")
+
+    # 2. TYPED PROPAGATION, carrying the precise reason to the hub.
+    aborts = [e for e in seen if e[0] == "self_mint_abort"]
+    assert aborts, "a failed build must be wire-visible, not a pod-log line"
+    _kind, phase, detail = aborts[0]
+    assert phase.startswith("supervised_"), phase
+    assert "no measured progress" in detail and "wrote no report" in detail, (
+        f"the event must carry the operator-actionable observation: {detail}")
+    assert "kept serving eager" in detail, detail
+
+    # 4. THE MINT ENDS. No hold semantics are asserted (Paul, 2026-08-14):
+    #    only that the obligation is resolved, so nothing downstream still
+    #    believes a build is running.
+    assert abandoned, (
+        "a declared build failure must resolve the mint obligation — a build "
+        "that has reported failure is not running")


### PR DESCRIPTION
**P0, holds e2e#1865's 15-family train.** Rebased onto current master (post the 0.114.3 cut, the supervisor #792, and the batch wire #769/#795); rides the **0.115.0** batch cut.

Two production mints compiled, sealed and **reported** an entire cell and then wedged — sdxl for 78.9 min (36 graph classes in 45m08s, killed by `idle_retire`), z-image for 62 min on 0.114.2 (terminated by a human) — publishing nothing, while both pods answered eager requests throughout. Same signature: `phase=finalize state=running counter=compile:mint_child_evidence counter_total=0 self_stalled=FALSE`, a 9s-old heartbeat, `aot_mint_phases` empty.

`aot_mint_phases` = 0 is the load-bearing fact: that table is emitted parent-side and *unconditionally* the moment the compile call returns. Zero rows means **the parent never returned from it** — the compiling process said its last word and then never terminated.

## Root cause — two defects, the second hid the first

**1. The parent waited on the child's EXIT, not on its TERMINUS.** A compile child writes its report as its *last statement* and returns; everything after is interpreter teardown, and a process that has just traced and AOTI-compiled has plenty that can hang there (non-daemon threads, a subprocess pool, CUDA). Both instances had the whole compile on disk — packed, moved, hashed, reported — and the supervisor threw it away waiting for a corpse.

**2. Ambient CPU was admitted as progress after the work was done.** One wedge burned *exactly one core* — which is what its `@ 1.00/s` counter rate literally is — and re-touched the silence window every single poll, forever. An axis that cannot go silent is not a progress axis.

### …and #792 moved the defect down a tier and made it worse

pgw#1215 step 4 deleted the middle mint tier, so the serving parent now supervises compile children directly. **The pool's drain loop has no give-up test of any kind** — `proc.poll()` forever, `time.sleep` forever — because the three-tier stack got a silence window for free from the mint child's own supervisor, and the watch was not moved down with it. So the wedge is now *unbounded and undetectable* on the only compile path there is. Fixed in both tiers.

## The fix

- **`aot_compile_pool` (production):** a decodable report is the share's terminus — reap its group and classify from `EntryReport.status` (so a hung refusal stays deterministic instead of becoming a SIGKILL death that discards the classes pgw#1183 keeps). Plus a per-share progress-staleness window over MEASURED evidence: process-tree CPU (reaped counters included, pgw#964) and bytes written, separate high-water marks so a quiet signal cannot cancel a moving one.
- **`mint_process` (one-shot rig / operator path, where the literal `finalize` frame still lives):** the same terminus rule, plus "past the terminal phase nothing ambient is admitted", so a wedge *inside* `finalize` is detected and named.
- **`mint_supervisor`:** the frames' existing `step/total` now reaches a real counter, so `counter_total` is honest and `progress.self_diagnosis` can confess.

**No duration constants added anywhere.** Detection is liveness + progress-staleness on the existing `SilenceWindow`.

## Paul's four properties

1. **Detected at the parent** — `test_a_share_that_stops_making_progress_is_detected_and_named` (pool) and `test_a_wedge_inside_finalize_is_detected_and_named` (mint child). Both drive the real window.
2. **Typed propagation, precise reason** — `test_a_wedged_compile_fails_the_BUILD_and_never_the_WORKER` drives the real `supervise` and asserts the `self_mint_abort` event carries the wedge's own sentence (`no measured progress`, `wrote no report`) plus `kept serving eager`.
3. **The worker serves eager** — same tape: `supervise` returns `FAILED`, never raises, and does not buy a second billed 45-minute compile for a deterministic wedge.
4. **The mint honestly ENDS** — the obligation is resolved, so every "is this pod minting" predicate reads false afterwards. **Per Paul's 2026-08-14 amendment this asserts NO occupancy/hold semantics** — retiring a minting pod is fine now that graph classes land incrementally, and that debt is th#1930's.

## The honest limit, asserted rather than left as a surprise

`test_a_burning_share_with_no_report_is_deliberately_NOT_condemned`: a pool child burning CPU with no report is, on every signal that exists, indistinguishable from a child deep inside one `aot_compile`. It is deliberately **not** condemned — the alternative is a duration bound that kills real 45-minute compiles. What makes that acceptable is that the observed wedge is not this shape: both instances had already reported, and the terminus rule ends those in one poll. Recorded so nobody reads the absence as an oversight or "fixes" it with a timeout.

## Red proof

```
PYTHONPATH=$PWD/src:$PWD/tests pytest tests/test_finalize_wedge_pgw1243.py -q -p no:randomly
```
- **With the fix: 12 passed in ~32s.**
- **With `src/` reverted to master: 9 failed, 3 passed** (run completed in 282s). The behavioural reds are the mint-child tapes, which fail by *reproducing the hang* against the tape's 90s guard, plus the counter tape. The pool tapes go red at construction on reverted `src` (the window knob does not exist there) — stated plainly rather than overclaimed; their behavioural content was separately confirmed by disabling only the two new rules in place, which hangs the pool exactly as production did.
- Two **positive controls** are part of the method: `a_healthy_mint_child_is_still_classified_by_its_exit_code`, and `a_share_that_is_really_compiling_is_never_condemned` / `ambient_cpu_still_proves_progress_before_the_terminal_phase` — the instrument is shown able to go green as well as red.

Also green: `test_mint_supervisor_pgw1215`, `test_aot_compile_pool_pgw809`, `test_mint_process_pgw784`, `test_mint_liveness_pgw964`, `test_mint_evidence_counter_pgw1157`, `test_abandoned_mint_telemetry_pgw848` (82 passed); `test_magic_timeouts_gw666`, `test_scoped_stall_clocks_pgw894`, `test_progress_keyed_bounds_pgw887_pgw892`, `test_production_entrypoints_pgw849`, `test_silent_failure_audit_pgw824`, `test_pool_sizing_pgw842` (96 passed); `mypy src/gen_worker tests tests_v2` clean over 780 files; ruff clean on `src`; **all 16 fast-gate lints exit 0**.

Refs: pgw#1243, e2e#1865, pgw#1215, th#1874, th#1881, th#1930.
