### PR TITLE
pgw#1226: a cut MARKS changelog fragments consumed, and the TAGS date them

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -23,6 +23,29 @@ heading — no `##` heading of your own, no version, no date:
 - **pgw#968: lanes no longer serialise on one mutable CHANGELOG.** ...
 ```
 
-At a cut, `scripts/assemble_changelog.py --version X.Y.Z` concatenates every
-fragment into a new section (ordered by issue number, so the result does not
-depend on filesystem order) and deletes them. See `docs/releasing.md`.
+At a cut, `scripts/assemble_changelog.py --version X.Y.Z` concatenates the
+unconsumed fragments into a section (ordered by issue number, so the result does
+not depend on filesystem order). See `docs/releasing.md`.
+
+## The cut half (pgw#1226) — a fragment is dated by the TAGS, not by the cutter
+
+The paragraphs above document only the lane-vs-lane half, and used to read as if
+that were the whole problem. It is not: a fragment also races the CUT.
+
+**A cut does not delete fragments.** It records what it consumed in
+`consumed.tsv` — `<version>\t<fragment>`, written only by the assembler — and
+which version a fragment belongs to is **derived, not chosen**: the earliest
+`vX.Y.Z` tag whose tree contains the fragment, or the version being cut if no tag
+does. Two things follow, and they are the reason this exists:
+
+- your fragment merging while a cut is mid-queue is **fine**. It is in no tag, so
+  the next cut takes it, and it cannot be deleted out from under your branch.
+- a fragment that WAS in a tagged tree and never got assembled is written into
+  **that** version's section, under a one-line "attributed after the cut" note —
+  not silently re-dated onto the next wheel. `changelog.d/pgw1244.md` is the case
+  that forced this: 0.114.3 shipped pgw#1244's code and left its fragment behind.
+
+Consumed fragments stay on disk for one further release and are then pruned; the
+`consumed.tsv` row outlives the file, so a re-added fragment is never re-consumed.
+**Nothing here is a lane's job.** Do not edit `consumed.tsv`, and do not delete a
+fragment because you see it in `CHANGELOG.md`.

--- a/changelog.d/pgw1226.md
+++ b/changelog.d/pgw1226.md
@@ -1,0 +1,20 @@
+- **pgw#1226: a release cut MARKS changelog fragments consumed instead of deleting
+  them, and the TAGS decide which version owns one.** `scripts/assemble_changelog.py`
+  no longer `unlink()`s what it assembles — it appends `<version>\t<fragment>` rows to
+  `changelog.d/consumed.tsv` — and it no longer dates a fragment to whatever version
+  the cutter happens to be cutting. Attribution is derived: a fragment belongs to the
+  **earliest `vX.Y.Z` tag whose tree contains it**, and to the version being cut only
+  if no tag contains it. So a lane fragment that merges while a cut sits mid-queue is
+  simply the next cut's, and — the failure this replaces — a fragment that WAS in a
+  tagged tree and never got assembled is written into **that** version's section under
+  an *attributed after the cut* note instead of being silently re-dated onto the next
+  wheel. That is not hypothetical: 0.114.3 was tagged with pgw#1244's code in the tree
+  and `changelog.d/pgw1244.md` unconsumed, and the old tooling would have printed its
+  bullet under 0.115.0, pointing readers at a wheel that did not contain the change.
+  Consumed fragments are pruned one release later, ledger row outliving the file, so a
+  re-added fragment can never be re-consumed. The assembler refuses on a shallow
+  repository (a graft makes `tag --contains` answer about history the checkout does not
+  have) and refuses when no release tag exists at all, rather than guessing; `--check`
+  reads no git and stays the cheap `fast gates` guard. **The half of the cutter's sweep
+  that no tool can see — a merge that wrote no fragment at all — is unchanged and still
+  the cutter's.** Hardcut: the deletion behaviour is gone, with no flag and no dual mode.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -163,10 +163,54 @@ filesystem order:
 ```bash
 scripts/assemble_changelog.py --check                     # names parse, none empty
 scripts/assemble_changelog.py --version <X.Y.Z> \
-    --headline "**the one thing this cut is about**"      # writes + `git rm`s fragments
+    --headline "**the one thing this cut is about**"      # writes; deletes nothing
 ```
 
+### A cut MARKS fragments consumed, and the TAGS decide which version owns one (pgw#1226)
+
+**What this replaces:** the cut used to `unlink()` every fragment it assembled, and
+it dated every fragment it found to the version being cut. Both halves were wrong
+in the same direction — they trusted the moment the cutter happened to run the
+script.
+
+- **Nothing is deleted at cut time.** The assembler appends
+  `<version>\t<fragment>` rows to `changelog.d/consumed.tsv` and leaves the files
+  alone. Fragments consumed by a release older than the previous one are pruned on
+  a later cut; the ledger row outlives the file, so a re-added fragment can never
+  be re-consumed.
+- **Attribution is derived from `git tag --contains`,** not from what the cutter
+  swept: a fragment belongs to the **earliest `vX.Y.Z` tag whose tree contains it**,
+  and to the version being cut only if no tag contains it.
+
+**The failure this kills, named:** *a fragment sitting in the tagged tree, absent
+from that version's section, silently re-dated onto the next wheel by the next
+cut.* It is not hypothetical — **0.114.3 was tagged with pgw#1244's code in the
+tree and `changelog.d/pgw1244.md` unconsumed**, and under the old tooling 0.115.0
+would have printed that bullet under `## 0.115.0`, pointing readers at a wheel
+that did not contain the change. The fragment is now written into the existing
+`## 0.114.3` section under a one-line *attributed after the cut* note, by the tool,
+with no cutter decision involved.
+
+The corollary the freeze convention kept failing to buy: **a lane fragment that
+merges while your cut is mid-queue is simply the next cut's.** It is in no tag, so
+it cannot be mis-dated, and the cut never deletes it, so it cannot be lost.
+
+Two refusals rather than a wrong answer: the assembler **refuses on a shallow
+repository** (a graft makes `tag --contains` answer about history the checkout does
+not have — the failure recorded in th#1810) and **refuses if no `vX.Y.Z` tag
+exists at all**. `--check` reads no git and stays the cheap `fast gates` guard; it
+now prints each fragment as `pending` or `consumed -> <version>`.
+
+**`--version` with nothing pending for it is not an error** — it is how a
+mis-attribution is repaired without cutting: the older sections are corrected, no
+new section is written, and the tool says so.
+
 ### SWEEP THE FRAGMENTS AGAINST `origin/master`, NOT YOUR CHECKOUT
+
+**pgw#1226 took one half of this off you and left the other.** A fragment that EXISTS and was
+never assembled is now handled by the tool — it is attributed back to the tag whose tree holds it,
+loudly. What is still yours is the half no tool can see: **a merge that never wrote a fragment at
+all.** That is the sweep below, and it is unchanged.
 
 A merge with no fragment is a **silent release note**, and the sweep for one is the cutter's job —
 lanes forget. Do it by listing the range's commits against the fragments **as they exist on the

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
-"""Collapse changelog.d/ fragments into a CHANGELOG.md section at cut time.
+"""Assemble changelog.d/ fragments into CHANGELOG.md sections at cut time.
 
 Every lane appending to one mutable CHANGELOG.md makes a conflict near-certain
 for any PR that sits through a sibling merge. Lanes write
 changelog.d/<issue>.md -- a path nobody else touches -- and a cut concatenates
 them here.
+
+pgw#1226: a cut MARKS the fragments it consumed in changelog.d/consumed.tsv; it
+no longer deletes them, and it does not decide which version a fragment belongs
+to. That is DERIVED: a fragment is attributed to the earliest release tag whose
+tree contains it, and to the version being cut if no tag contains it. So
+
+  * a fragment that lands after the tag is in no tag, and rides the NEXT cut;
+  * a fragment that was in a TAGGED tree and never got assembled is attributed
+    BACK to that version instead of being silently re-dated to this one.
+
+The second case is the failure this replaces. 0.114.3 shipped pgw#1244's code
+with changelog.d/pgw1244.md still unconsumed, and under the old tooling the next
+cut would have written that bullet under its own version -- a release note
+pointing at the wrong wheel, with nothing in the tree able to notice.
 
     scripts/assemble_changelog.py --check
     scripts/assemble_changelog.py --version 0.92.0 --headline "**what changed**"
@@ -15,22 +29,77 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-FRAGMENTS = ROOT / "changelog.d"
-CHANGELOG = ROOT / "CHANGELOG.md"
 
 # <prefix><number>.md -- prefix names the id space (pgw, th, te, ...).
 NAME = re.compile(r"^(?P<prefix>[a-z]+)(?P<number>\d+)$")
 UNRELEASED = re.compile(r"^## Unreleased\b.*?(?=^## )", re.M | re.S)
+VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+RELEASE_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+
+LEDGER = "consumed.tsv"
+LEDGER_HEADER = (
+    "# pgw#1226: fragments a cut has already assembled, and the version whose TREE\n"
+    "# contains them. Written by scripts/assemble_changelog.py; lanes never edit it.\n"
+    "# <version>\\t<fragment stem>\n"
+)
+LATE_NOTE = (
+    "*Attributed after the cut (pgw#1226): this fragment was in the tagged tree "
+    "and was not assembled into the section at cut time.*"
+)
+# Consumed fragments stay on disk for this many PRIOR releases, so that a
+# fragment a recently-merged branch could still be carrying is never removed
+# underneath it. The cut's own are always kept.
+RETAIN_PRIOR_RELEASES = 1
 
 
-def collect() -> list[tuple[int, str, Path]]:
-    """Fragments ordered by issue NUMBER, never by filesystem order."""
-    out = []
-    for path in FRAGMENTS.glob("*.md"):
+def fragments_dir(root: Path) -> Path:
+    return root / "changelog.d"
+
+
+def ledger_path(root: Path) -> Path:
+    return fragments_dir(root) / LEDGER
+
+
+def read_ledger(root: Path) -> list[tuple[str, str]]:
+    path = ledger_path(root)
+    if not path.exists():
+        return []
+    rows: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        if not line.strip() or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 2:
+            sys.exit(f"{path}:{lineno}: want '<version>\\t<fragment>', got {line!r}")
+        version, stem = parts[0].strip(), parts[1].strip()
+        if not VERSION.match(version):
+            sys.exit(f"{path}:{lineno}: {version!r} is not an X.Y.Z version")
+        if not NAME.match(stem):
+            sys.exit(f"{path}:{lineno}: {stem!r} is not a <prefix><number> fragment")
+        if stem in seen:
+            sys.exit(f"{path}:{lineno}: {stem} is recorded twice")
+        seen.add(stem)
+        rows.append((version, stem))
+    return rows
+
+
+def write_ledger(root: Path, rows: list[tuple[str, str]]) -> None:
+    body = "".join(f"{version}\t{stem}\n" for version, stem in rows)
+    ledger_path(root).write_text(LEDGER_HEADER + body)
+
+
+def collect(root: Path) -> tuple[list[tuple[int, str, Path]], list[tuple[str, Path]]]:
+    """(pending, consumed) fragments -- pending ordered by issue NUMBER."""
+    consumed_at = {stem: version for version, stem in read_ledger(root)}
+    pending: list[tuple[int, str, Path]] = []
+    consumed: list[tuple[str, Path]] = []
+    for path in fragments_dir(root).glob("*.md"):
         if path.name == "README.md":
             continue
         m = NAME.match(path.stem)
@@ -41,12 +110,78 @@ def collect() -> list[tuple[int, str, Path]]:
             )
         if not path.read_text().strip():
             sys.exit(f"{path}: empty fragment")
-        out.append((int(m["number"]), m["prefix"], path))
-    return sorted(out)
+        if path.stem in consumed_at:
+            consumed.append((consumed_at[path.stem], path))
+            continue
+        pending.append((int(m["number"]), m["prefix"], path))
+    return sorted(pending), sorted(consumed)
+
+
+def git(root: Path, *args: str) -> str:
+    done = subprocess.run(
+        ("git", *args), cwd=root, capture_output=True, text=True, check=False
+    )
+    if done.returncode != 0:
+        sys.exit(f"git {' '.join(args)}: {done.stderr.strip()}")
+    return done.stdout.strip()
+
+
+def release_versions(root: Path) -> list[str]:
+    """Released versions, oldest first."""
+    tags = git(root, "tag", "--list", "v*", "--sort=v:refname").splitlines()
+    return [m["version"] for t in tags if (m := RELEASE_TAG.match(t.strip()))]
+
+
+def attribution(root: Path, path: Path, cutting: str) -> str:
+    """The earliest released version whose tree holds this fragment, else `cutting`.
+
+    Derived rather than declared: the cutter cannot mis-remember which sweep
+    they ran, and a fragment that shipped inside a tag cannot be re-dated.
+    """
+    rel = path.relative_to(root).as_posix()
+    added = git(root, "log", "--diff-filter=A", "--format=%H", "-1", "--", rel)
+    if not added:
+        return cutting  # not committed yet -- it is this cut's own
+    contains = git(root, "tag", "--contains", added, "--sort=v:refname").splitlines()
+    for tag in contains:
+        if m := RELEASE_TAG.match(tag.strip()):
+            return m["version"]
+    return cutting
+
+
+def render(body: list[Path]) -> str:
+    return "\n\n".join(p.read_text().strip() for p in body)
+
+
+def new_section(version: str, date: str, headline: str, body: list[Path]) -> str:
+    heading = f"## {version} ({date})"
+    if headline:
+        heading += f" — {headline}"
+    return f"{heading}\n\n{render(body)}\n\n"
+
+
+def insert_new_section(text: str, section: str) -> str:
+    m = UNRELEASED.search(text)
+    if not m:
+        sys.exit("CHANGELOG.md: no '## Unreleased' block to insert after")
+    return text[: m.end()] + section + text[m.end() :]
+
+
+def append_to_section(text: str, version: str, body: list[Path]) -> str:
+    m = re.search(rf"^## {re.escape(version)}\b.*?(?=^## |\Z)", text, re.M | re.S)
+    if not m:
+        sys.exit(
+            f"CHANGELOG.md: no '## {version}' section to attribute "
+            f"{', '.join(p.stem for p in body)} to. That version is released and "
+            "its section should exist; do not invent one."
+        )
+    note = "" if LATE_NOTE in m.group(0) else f"{LATE_NOTE}\n\n"
+    return text[: m.end()] + f"{note}{render(body)}\n\n" + text[m.end() :]
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
+    ap.add_argument("--root", type=Path, default=ROOT)
     ap.add_argument("--version")
     ap.add_argument("--date", default=dt.date.today().isoformat())
     ap.add_argument("--headline", default="")
@@ -54,36 +189,76 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true", help="print, do not write")
     args = ap.parse_args()
 
-    fragments = collect()
+    root: Path = args.root.resolve()
+    pending, consumed = collect(root)
+
     if args.check:
-        for _, _, path in fragments:
-            print(path.relative_to(ROOT))
+        for _, _, path in pending:
+            print(f"pending  {path.relative_to(root)}")
+        for version, path in consumed:
+            print(f"consumed {path.relative_to(root)} -> {version}")
         return 0
     if not args.version:
         ap.error("--version is required unless --check")
-    if not fragments:
-        sys.exit("changelog.d/ is empty -- nothing to release")
+    if not VERSION.match(args.version):
+        ap.error(f"--version {args.version!r} is not X.Y.Z")
+    if not pending:
+        sys.exit("no unconsumed fragments in changelog.d/ -- nothing to release")
 
-    heading = f"## {args.version} ({args.date})"
-    if args.headline:
-        heading += f" — {args.headline}"
-    body = "\n\n".join(p.read_text().strip() for _, _, p in fragments)
-    section = f"{heading}\n\n{body}\n\n"
+    # Attribution reads tags, and a graft file makes `tag --contains` answer
+    # about a history the repo does not have. Refuse rather than mis-attribute.
+    if git(root, "rev-parse", "--is-shallow-repository") == "true":
+        sys.exit("refusing: shallow repository -- run `git fetch --unshallow` first")
+    released = release_versions(root)
+    if not released:
+        sys.exit("refusing: no vX.Y.Z tags found -- attribution cannot be derived")
 
-    text = CHANGELOG.read_text()
-    m = UNRELEASED.search(text)
-    if not m:
-        sys.exit("CHANGELOG.md: no '## Unreleased' block to insert after")
-    updated = text[: m.end()] + section + text[m.end() :]
+    by_version: dict[str, list[Path]] = {}
+    for _, _, path in pending:
+        by_version.setdefault(attribution(root, path, args.version), []).append(path)
+
+    changelog = root / "CHANGELOG.md"
+    text = changelog.read_text()
+    # Late attributions first: inserting the new section shifts every offset
+    # below it, and the sections being appended to are all below it.
+    for version in sorted(v for v in by_version if v != args.version):
+        text = append_to_section(text, version, by_version[version])
+        for path in by_version[version]:
+            print(f"{path.name} -> {version} (late; its code shipped in v{version})")
+    section = ""
+    mine = by_version.get(args.version, [])
+    if mine:
+        section = new_section(args.version, args.date, args.headline, mine)
+        text = insert_new_section(text, section)
+        for path in mine:
+            print(f"{path.name} -> {args.version}")
+    else:
+        # Not an error: naming the NEXT version with nothing pending for it is
+        # how a mis-attribution is repaired without cutting anything.
+        print(f"note: nothing pending belongs to {args.version} -- no new section")
+
+    ledger = read_ledger(root) + [
+        (version, path.stem)
+        for version in sorted(by_version)
+        for path in by_version[version]
+    ]
 
     if args.dry_run:
-        print(section)
+        print(section, end="")
         return 0
 
-    CHANGELOG.write_text(updated)
-    for _, _, path in fragments:
-        path.unlink()  # `git add changelog.d` stages the removals
-    print(f"{len(fragments)} fragment(s) -> {heading}")
+    changelog.write_text(text)
+    write_ledger(root, ledger)
+
+    # Consumed fragments are marked, not deleted -- but they do not accumulate
+    # forever either. Prune what an older release already consumed.
+    keep = {args.version, *released[-RETAIN_PRIOR_RELEASES:]}
+    for version, path in consumed:
+        if version not in keep:
+            path.unlink()
+            print(f"pruned {path.name} (consumed by {version})")
+
+    print(f"{len(pending)} fragment(s) assembled; {len(ledger)} in {LEDGER}")
     print("now: git add CHANGELOG.md changelog.d  (with the version bump)")
     return 0
 

--- a/tests/test_changelog_consumption_pgw1226.py
+++ b/tests/test_changelog_consumption_pgw1226.py
@@ -1,0 +1,266 @@
+"""pgw#1226: a cut MARKS fragments consumed; attribution comes from the tags.
+
+Driven against a REAL git repository built in a tmpdir -- real commits, real
+`v*` tags, the real script as a subprocess -- because every claim here is a
+claim about what `git tag --contains` answers. A filesystem mock would assert
+the fixture rather than the mechanism.
+
+The narrative is the one that actually happened. 0.114.3 was tagged with
+pgw#1244's code in the tree and `changelog.d/pgw1244.md` never assembled; under
+the old tooling the next cut swept that fragment into ITS section, so the
+release note pointed at a wheel that did not contain the change. Here the same
+fragment is attributed back to 0.114.3 with no cutter intervention, while a
+fragment that landed after the tag rides the version being cut.
+
+The fixture repo inherits NO git config (`GIT_CONFIG_GLOBAL`/`SYSTEM` are
+/dev/null), so it needs no signing bypass flag and cannot write to the real
+box's configuration.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "assemble_changelog.py"
+LEDGER = "changelog.d/consumed.tsv"
+LATE = "Attributed after the cut (pgw#1226)"
+
+CHANGELOG = """\
+# Changelog
+
+## Unreleased
+
+Unreleased entries live in `changelog.d/`, one file per issue.
+
+## 0.114.3 (2026-08-13) — the resume half
+
+- **pgw#1240: the resume load half.**
+
+## 0.114.2 (2026-08-12) — the format axis
+
+- **pgw#1230: the format axis fix.**
+"""
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_AUTHOR_NAME": "pgw1226 fixture",
+    "GIT_AUTHOR_EMAIL": "pgw1226@fixture.invalid",
+    "GIT_COMMITTER_NAME": "pgw1226 fixture",
+    "GIT_COMMITTER_EMAIL": "pgw1226@fixture.invalid",
+}
+
+
+def git(root: Path, *args: str) -> str:
+    done = subprocess.run(
+        ("git", *args), cwd=root, env=GIT_ENV, capture_output=True, text=True
+    )
+    assert done.returncode == 0, f"git {args}: {done.stderr}"
+    return done.stdout.strip()
+
+
+def fragment(root: Path, stem: str, text: str) -> None:
+    (root / "changelog.d" / f"{stem}.md").write_text(f"- **{stem}: {text}**\n")
+
+
+def assemble(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        (sys.executable, str(SCRIPT), "--root", str(root), *args),
+        capture_output=True,
+        text=True,
+    )
+
+
+def section(text: str, version: str) -> str:
+    m = re.search(rf"^## {re.escape(version)}\b.*?(?=^## |\Z)", text, re.M | re.S)
+    assert m, f"no '## {version}' section in:\n{text}"
+    return m.group(0)
+
+
+@pytest.fixture
+def cut_repo(tmp_path: Path) -> Path:
+    """Two releases tagged; three fragments none of them consumed.
+
+    pgw1200 is in BOTH tags' trees, pgw1244 only in v0.114.3's, and pgw1250 in
+    neither -- one fixture that exercises earliest-tag, single-tag and no-tag
+    attribution in a single run.
+    """
+    root = tmp_path / "pgw"
+    (root / "changelog.d").mkdir(parents=True)
+    (root / "CHANGELOG.md").write_text(CHANGELOG)
+    (root / "changelog.d" / "README.md").write_text("# changelog.d\n")
+    git(root, "init", "-q", "-b", "master")
+
+    fragment(root, "pgw1200", "in both tags")
+    git(root, "add", "CHANGELOG.md", "changelog.d")
+    git(root, "commit", "-q", "-m", "base")
+    git(root, "tag", "v0.114.2")
+
+    fragment(root, "pgw1244", "in the 0.114.3 tree, never assembled")
+    git(root, "add", "changelog.d/pgw1244.md")
+    git(root, "commit", "-q", "-m", "pgw#1244")
+    git(root, "tag", "v0.114.3")
+
+    fragment(root, "pgw1250", "landed after the tag")
+    git(root, "add", "changelog.d/pgw1250.md")
+    git(root, "commit", "-q", "-m", "pgw#1250")
+    return root
+
+
+# --------------------------------------------------------------------------
+# the defect: a fragment that shipped inside a tag, re-dated by the next cut
+# --------------------------------------------------------------------------
+
+
+def test_tagged_fragments_are_attributed_back_and_nothing_is_deleted(
+    cut_repo: Path,
+) -> None:
+    done = assemble(cut_repo, "--version", "0.115.0")
+    assert done.returncode == 0, done.stderr
+
+    text = (cut_repo / "CHANGELOG.md").read_text()
+
+    # each fragment landed under the version whose TREE contains it
+    assert "pgw1200" in section(text, "0.114.2")
+    assert "pgw1244" in section(text, "0.114.3")
+    assert "pgw1250" in section(text, "0.115.0")
+
+    # ... and NOT under the version being cut, which is the whole defect
+    assert "pgw1244" not in section(text, "0.115.0")
+    assert "pgw1200" not in section(text, "0.115.0")
+
+    # a late attribution says so in the section it edits
+    assert LATE in section(text, "0.114.3")
+    assert LATE in section(text, "0.114.2")
+    assert LATE not in section(text, "0.115.0")
+
+    # the cut deleted nothing -- pgw#1226's hardcut
+    for stem in ("pgw1200", "pgw1244", "pgw1250"):
+        assert (cut_repo / "changelog.d" / f"{stem}.md").exists()
+
+    ledger = (cut_repo / LEDGER).read_text()
+    rows = [ln for ln in ledger.splitlines() if not ln.startswith("#")]
+    assert rows == ["0.114.2\tpgw1200", "0.114.3\tpgw1244", "0.115.0\tpgw1250"]
+
+
+def test_a_consumed_fragment_is_never_assembled_twice(cut_repo: Path) -> None:
+    assert assemble(cut_repo, "--version", "0.115.0").returncode == 0
+    before = (cut_repo / "CHANGELOG.md").read_text()
+
+    again = assemble(cut_repo, "--version", "0.116.0")
+    assert again.returncode != 0
+    assert "nothing to release" in again.stdout + again.stderr
+    assert (cut_repo / "CHANGELOG.md").read_text() == before
+
+
+def test_the_ledger_is_what_stops_the_second_write(cut_repo: Path) -> None:
+    """Severance: the tag rule fixes the VERSION, the ledger fixes the COUNT.
+
+    Without the ledger, attribution is still correct -- and pgw#1244's bullet is
+    written into 0.114.3 a second time. Two mechanisms, two jobs; this proves
+    neither is carrying the other's weight.
+    """
+    assert assemble(cut_repo, "--version", "0.115.0").returncode == 0
+    (cut_repo / LEDGER).unlink()
+
+    assert assemble(cut_repo, "--version", "0.116.0").returncode == 0
+    assert section((cut_repo / "CHANGELOG.md").read_text(), "0.114.3").count(
+        "pgw1244"
+    ) == 2
+
+
+def test_consumed_fragments_are_pruned_one_release_later(cut_repo: Path) -> None:
+    assert assemble(cut_repo, "--version", "0.115.0").returncode == 0
+    git(cut_repo, "add", "CHANGELOG.md", "changelog.d")
+    git(cut_repo, "commit", "-q", "-m", "cut 0.115.0")
+    git(cut_repo, "tag", "v0.115.0")
+
+    fragment(cut_repo, "pgw1260", "after the 0.115.0 tag")
+    git(cut_repo, "add", "changelog.d/pgw1260.md")
+    git(cut_repo, "commit", "-q", "-m", "pgw#1260")
+
+    done = assemble(cut_repo, "--version", "0.116.0")
+    assert done.returncode == 0, done.stderr
+
+    frags = cut_repo / "changelog.d"
+    # 0.115.0 is the previous release, so its fragment is still on disk; the
+    # two older ones are not. Nothing an open branch could carry is pending.
+    assert (frags / "pgw1250.md").exists()
+    assert not (frags / "pgw1200.md").exists()
+    assert not (frags / "pgw1244.md").exists()
+
+    # the ledger keeps the rows for the pruned files: the attribution record
+    # outlives the fragment, so a re-added file cannot be re-consumed.
+    rows = [
+        ln for ln in (cut_repo / LEDGER).read_text().splitlines()
+        if not ln.startswith("#")
+    ]
+    assert rows == [
+        "0.114.2\tpgw1200",
+        "0.114.3\tpgw1244",
+        "0.115.0\tpgw1250",
+        "0.116.0\tpgw1260",
+    ]
+    assert "pgw1260" in section((cut_repo / "CHANGELOG.md").read_text(), "0.116.0")
+
+
+# --------------------------------------------------------------------------
+# the refusals
+# --------------------------------------------------------------------------
+
+
+def test_attribution_refuses_without_release_tags(cut_repo: Path) -> None:
+    for tag in ("v0.114.2", "v0.114.3"):
+        git(cut_repo, "tag", "-d", tag)
+    done = assemble(cut_repo, "--version", "0.115.0")
+    assert done.returncode != 0
+    assert "no vX.Y.Z tags" in done.stdout + done.stderr
+
+
+def test_check_needs_no_git_and_reports_both_states(tmp_path: Path) -> None:
+    """`--check` is the fast-gates guard, so it must not depend on a repository."""
+    root = tmp_path / "bare"
+    (root / "changelog.d").mkdir(parents=True)
+    (root / "changelog.d" / "README.md").write_text("# changelog.d\n")
+    fragment(root, "pgw1250", "pending")
+    fragment(root, "pgw1244", "consumed")
+    (root / LEDGER).write_text("0.114.3\tpgw1244\n")
+
+    done = assemble(root, "--check")
+    assert done.returncode == 0, done.stderr
+    assert "pending  changelog.d/pgw1250.md" in done.stdout
+    assert "consumed changelog.d/pgw1244.md -> 0.114.3" in done.stdout
+
+
+@pytest.mark.parametrize(
+    "row, expected",
+    [
+        ("0.114.3 pgw1244\n", "want '<version>"),
+        ("0.114\tpgw1244\n", "is not an X.Y.Z version"),
+        ("0.114.3\tpgw868-a4\n", "is not a <prefix><number>"),
+        ("0.114.3\tpgw1244\n0.115.0\tpgw1244\n", "recorded twice"),
+    ],
+)
+def test_check_refuses_a_malformed_ledger(
+    tmp_path: Path, row: str, expected: str
+) -> None:
+    root = tmp_path / "bad"
+    (root / "changelog.d").mkdir(parents=True)
+    (root / LEDGER).write_text(row)
+    done = assemble(root, "--check")
+    assert done.returncode != 0
+    assert expected in done.stdout + done.stderr
+
+
+def test_the_repos_own_pending_fragments_parse() -> None:
+    """The pgw#968 guard `fast gates` runs, against the real tree."""
+    done = assemble(REPO, "--check")
+    assert done.returncode == 0, done.stderr


### PR DESCRIPTION
**Option 3 of pgw#1226, ratified.** The freeze convention has now failed four times — 0.114.0 ejected 4×, 0.114.2 re-pinned twice, and 0.114.3 shipped **with pgw#1244's code in the tree and `changelog.d/pgw1244.md` unconsumed**. Paul's standing doctrine: a recurring process failure gets replaced by mechanism, not re-scheduled around. **Hardcut — the deletion behaviour is gone, no flag, no dual mode.**

## What changes, in one sentence each

`scripts/assemble_changelog.py`:

1. **It no longer deletes what it assembles.** Consumption is recorded as `<version>\t<fragment>` rows in `changelog.d/consumed.tsv`. The cut adds rather than deletes, so a lane fragment merging while the cut sits mid-queue is never removed under its branch.
2. **It no longer dates a fragment to whatever version the cutter happens to be cutting.** Attribution is DERIVED from `git tag --contains`: **the earliest `vX.Y.Z` tag whose tree holds the fragment**, and the version being cut only if no tag does.

## The failure this kills, named

*A fragment sitting in the tagged tree, absent from that version's section, silently re-dated onto the next wheel by the next cut.* Not hypothetical — it is the state `master` is in right now.

**`pgw1244.md` therefore needs no special handling from the 0.115.0 cutter.** Verified on this tree:

```
$ git tag --contains $(git log --diff-filter=A --format=%H -1 -- changelog.d/pgw1244.md)
v0.114.3

$ python3 scripts/assemble_changelog.py --version 0.115.0 --dry-run
pgw1244.md -> 0.114.3 (late; its code shipped in v0.114.3)
```

Its bullet is written into the existing `## 0.114.3` section under a one-line *attributed after the cut* note, by the tool.

## The rest

* Consumed fragments are pruned **one release later**; the ledger row outlives the file, so a re-added fragment can never be re-consumed.
* Two refusals rather than a wrong answer: **shallow repository** (a graft makes `tag --contains` answer about history the checkout does not have — th#1810's failure) and **no `vX.Y.Z` tag at all**.
* `--check` reads no git and stays the cheap `fast gates` guard; it now prints each fragment as `pending` or `consumed -> <version>`, and validates the ledger.
* `--version` with nothing pending for it is **not** an error — it is how a mis-attribution is repaired without cutting.
* Docs: `docs/releasing.md` names the mechanism and the failure it prevents; `changelog.d/README.md` gains the cut-vs-lane half it was missing (pgw#1226's third "done when" box).

## ⚠️ What this does NOT claim

The issue's own mechanism section says *"a commit that deletes N files conflicts with every open branch that adds or touches one of them."* **That is not what git does** — add-vs-delete of *different* paths merges cleanly, and the tracker's own 2026-08-13 note under pgw#1224 records the counter-observation. Only a modify/delete of the *same* fragment conflicts, which is rare.

**So the four 0.114.0 ejections were most likely `uv.lock`/`pyproject.toml`/`CHANGELOG.md`, and this PR must not be quoted as having fixed them.** That half is unowned and wants its own issue. What is provably fixed here is ATTRIBUTION, plus the cut's delete surface is gone.

## Testing

`tests/test_changelog_consumption_pgw1226.py` — 11 tests, driving the **real script as a subprocess against a real git repository** (real commits, real `v*` tags). No filesystem mocks: every claim here is a claim about what `git tag --contains` answers, and a mock would assert the fixture. The fixture repo inherits no git config (`GIT_CONFIG_GLOBAL`/`SYSTEM` → `/dev/null`), so it needs no signing bypass flag and cannot write to the box's configuration.

The fixture holds one fragment in **both** tags' trees, one in **only the newest** tag's, and one in **neither** — earliest-tag, single-tag and no-tag attribution exercised in a single run.

**Both mechanisms red-proven by severance, each reddening a different set** (so neither test is carrying the other's weight):

| severance | reds |
|---|---|
| `attribution()` always returns the cut version | `attributed_back_and_nothing_is_deleted`, `ledger_is_what_stops_the_second_write`, `pruned_one_release_later` |
| the ledger is ignored | `never_assembled_twice`, `pruned_one_release_later`, `check_needs_no_git` |

Local: all **20 fast-gate lint scripts** exit 0, `assemble_changelog.py --check` OK, `mypy` clean on both changed files. `mypy src/gen_worker` and `task lint` cannot run on this box (torch is deliberately absent and `uv sync --extra dev` fails on a `torch==2.13.0+cu130` hash mismatch) — no `src/` file is touched by this PR, and CI covers it.

## For the 0.115.0 cutter

Run `scripts/assemble_changelog.py --version 0.115.0 --headline "..."` exactly as before. Three differences: pgw#1244 lands in the **0.114.3** section by itself; nothing is deleted, so `git add changelog.d` now stages `consumed.tsv` and the fragments stay; and a lane fragment that merges under you is simply the next cut's — no freeze needed for `changelog.d/`. The `uv.lock` freeze reason is untouched by this PR.

Closes the three "done when" boxes except the live proof, which lands when a cut runs with two fragment-carrying PRs open.