### PR TITLE
th#1931 consume tensor-aligned HashRepo manifests

### DIFF
--- a/changelog.d/th1931.md
+++ b/changelog.d/th1931.md
@@ -1,0 +1,5 @@
+- **th#1931: workers consume HashRepo's tensor-aligned object layout.**
+  Repository snapshots and compiled-graph delivery now trust each manifest's
+  ordered digest and length pairs instead of reconstructing fixed 64 MiB
+  boundaries. Publishing uses HashRepo 0.3's automatic safetensors-aware writer
+  and bounded fixed-offset fallback for other files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "psutil>=7.0.0",
     "pyyaml>=6.0.0",
     "blake3>=1.0.0",
-    "hashrepo>=0.1.1,<0.2",
+    "hashrepo>=0.3,<0.4",
     "huggingface-hub>=0.26.0",
     # gen_worker.convert (GGUF quantization tooling; small, pure-python)
     "gguf>=0.10.0",

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hashrepo import (
-    CHUNK_SIZE,
     CASRef,
     Chunk,
     DigestMismatch,
@@ -134,11 +133,6 @@ def _materialize_named_artifact(
             f"{what}: transport for {cell_ref!r} declares no size_bytes")
 
     try:
-        if remote_chunks and int(entry.chunk_size_bytes or CHUNK_SIZE) != CHUNK_SIZE:
-            raise ValueError(
-                f"chunk size {entry.chunk_size_bytes} does not match "
-                f"HashRepo v1 ({CHUNK_SIZE})"
-            )
         chunks = tuple(
             Chunk(CASRef.parse(f"sha256:{chunk.sha256}"), int(chunk.len))
             for chunk in remote_chunks

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -195,7 +195,6 @@ class TransportFile:
     digest: str
     url: str
     chunks: Tuple[Any, ...] = ()
-    chunk_size_bytes: int = 0
 
 
 @dataclass(frozen=True)
@@ -293,7 +292,6 @@ def _transport_from(body: Mapping[str, Any]) -> Transport:
             digest=str(row.get("digest") or ""),
             url=str(row.get("url") or ""),
             chunks=chunks,
-            chunk_size_bytes=int(row.get("chunk_size_bytes") or 0),
         ))
     return Transport(
         snapshot_digest=str(raw.get("snapshot_digest") or ""),

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -461,10 +461,10 @@ class HubClient:
         A claimed digest stops being assertable, which kills the
         inherit/overwrite class structurally rather than by guard.
 
-        Files > 64 MiB become an ordered list of enforced chunks, so a retry
-        costs one chunk instead of a 2 GB shard and progress is monotone across
-        retries — a lemon host is bounded by the unit of work rather than by a
-        new watchdog.
+        Files may become an ordered list of enforced chunks at any size. Each
+        manifest length is authoritative, so a retry costs one bounded object
+        and progress is monotone across retries — a lemon host is bounded by
+        the unit of work rather than by a new watchdog.
 
         THERE IS NO PROTOCOL AUTO-SELECT AND NO ENV KNOB. The caller names the
         protocol, so flipping a producer class to sha256 is a code change and a
@@ -514,7 +514,7 @@ class HubClient:
         manifest_ref = manifest.digest()
 
         def _tensorhub_file(entry: Any) -> dict[str, object]:
-            """Adapt HashRepo v1 to Tensorhub's fixed-sha256 request shape."""
+            """Adapt HashRepo v1 to Tensorhub's ordered-sha256 request shape."""
             raw = cast(dict[str, object], entry.to_dict())
             chunks = raw.get("chunks")
             if isinstance(chunks, list):

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Sequence
 
 from hashrepo import (
-    CHUNK_SIZE,
     CASRef,
     Chunk,
     DigestMismatch,
@@ -110,11 +109,6 @@ def _manifest_entry(file: WorkerResolvedRepoFile) -> FileEntry:
         Chunk(CASRef.parse(f"sha256:{chunk.sha256}"), int(chunk.length))
         for chunk in file.chunks
     )
-    if chunks and int(file.chunk_size_bytes or CHUNK_SIZE) != CHUNK_SIZE:
-        raise ValueError(
-            f"resolved model file {file.path}: chunk size {file.chunk_size_bytes} "
-            f"does not match HashRepo v1 ({CHUNK_SIZE})"
-        )
     return FileEntry(
         _norm_rel_path(file.path),
         int(file.size_bytes),
@@ -149,7 +143,9 @@ def _validate_resolved(ref: TensorhubRef, resolved: WorkerResolvedRepo) -> Worke
                 url=str(file.url or "").strip() or None,
                 digest=str(entry.digest),
                 chunks=tuple(file.chunks),
-                chunk_size_bytes=CHUNK_SIZE if entry.chunks else 0,
+                # The ordered chunk lengths are authoritative. Preserve this
+                # transport ceiling as metadata; never infer a layout from it.
+                chunk_size_bytes=int(file.chunk_size_bytes or 0),
             )
         )
 

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -143,9 +143,6 @@ def _validate_resolved(ref: TensorhubRef, resolved: WorkerResolvedRepo) -> Worke
                 url=str(file.url or "").strip() or None,
                 digest=str(entry.digest),
                 chunks=tuple(file.chunks),
-                # The ordered chunk lengths are authoritative. Preserve this
-                # transport ceiling as metadata; never infer a layout from it.
-                chunk_size_bytes=int(file.chunk_size_bytes or 0),
             )
         )
 

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -40,7 +40,8 @@ class WorkerResolvedRepoFile:
     #: Algorithm-tagged whole-file digest ("sha256:<hex>"). Every resolved
     #: entry carries one; an entry that does not is refused, not skipped.
     digest: str = ""
-    #: Present only when the file is stored as chunks (size > chunk_size).
+    #: Present whenever the manifest stores an ordered object list; file size
+    #: does not determine whether tensor-aligned chunks exist.
     chunks: tuple["WorkerResolvedChunk", ...] = ()
     chunk_size_bytes: int = 0
 

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -43,7 +43,6 @@ class WorkerResolvedRepoFile:
     #: Present whenever the manifest stores an ordered object list; file size
     #: does not determine whether tensor-aligned chunks exist.
     chunks: tuple["WorkerResolvedChunk", ...] = ()
-    chunk_size_bytes: int = 0
 
     def cas_ref(self) -> str:
         """The algorithm-tagged digest of this entry.
@@ -271,7 +270,6 @@ def resolve_repo(
         files.append(WorkerResolvedRepoFile(
             path=path, size_bytes=int(ent.get("size_bytes") or 0), url=u,
             digest=tagged, chunks=chunks,
-            chunk_size_bytes=int(ent.get("chunk_size_bytes") or 0),
         ))
     if not digest or not files:
         raise HubResolveError(

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -134,7 +134,6 @@ def _snapshot_to_resolved(snap: pb.Snapshot) -> "WorkerResolvedRepo":
                     )
                     for c in f.chunks
                 ),
-                chunk_size_bytes=int(f.chunk_size_bytes or 0),
             )
             for f in snap.files
         ],

--- a/tests/convert/test_publish_v2_pgw781.py
+++ b/tests/convert/test_publish_v2_pgw781.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 
 import pytest
 from fake_hub import _client, _FakeHub
-from hashrepo import CHUNK_SIZE
+from hashrepo import MAX_CHUNK_SIZE
 
 from gen_worker.hubio.client import CommitFile, HubPublishError
 
@@ -36,16 +37,44 @@ def test_small_file_publishes_as_one_hashrepo_object(fake_hub, tmp_path: Path) -
     assert result.uploaded == 1
 
 
-def test_large_file_uses_fixed_hashrepo_v1_chunks(fake_hub, tmp_path: Path) -> None:
-    data = b"a" * CHUNK_SIZE + b"tail"
+def test_non_safetensors_file_uses_bounded_hashrepo_chunks(fake_hub, tmp_path: Path) -> None:
+    data = b"a" * MAX_CHUNK_SIZE + b"tail"
     result = _client(fake_hub).publish_v2(
         destination_repo="acme/model",
         files=[_write(tmp_path, "weights.safetensors", data)],
         tags=["prod"],
     )
     declaration = next(iter(_FakeHub.state["publishes"].values()))["files"][0]
-    assert [chunk["len"] for chunk in declaration["chunks"]] == [CHUNK_SIZE, 4]
+    assert [chunk["len"] for chunk in declaration["chunks"]] == [MAX_CHUNK_SIZE, 4]
     assert all("sha256:" not in chunk["digest"] for chunk in declaration["chunks"])
+    assert result.uploaded == 2
+
+
+def test_valid_safetensors_publishes_header_and_tensor_chunks_at_small_size(
+    fake_hub, tmp_path: Path
+) -> None:
+    body = b"tensor-bytes"
+    header = json.dumps(
+        {
+            "weight": {
+                "dtype": "U8",
+                "shape": [len(body)],
+                "data_offsets": [0, len(body)],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    header += b" " * (-len(header) % 8)
+    data = len(header).to_bytes(8, "little") + header + body
+
+    result = _client(fake_hub).publish_v2(
+        destination_repo="acme/model",
+        files=[_write(tmp_path, "weights.safetensors", data)],
+        tags=["prod"],
+    )
+
+    declaration = next(iter(_FakeHub.state["publishes"].values()))["files"][0]
+    assert [chunk["len"] for chunk in declaration["chunks"]] == [8 + len(header), len(body)]
     assert result.uploaded == 2
 
 

--- a/tests/test_aot_variable_chunks_th1931.py
+++ b/tests/test_aot_variable_chunks_th1931.py
@@ -1,0 +1,68 @@
+"""AOT delivery consumes recorded HashRepo object lengths, never a fixed layout."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from hashrepo import LocalCAS, TransferGrant, TransferReport
+
+from gen_worker import aot_delivery
+
+
+def test_aot_delivery_materializes_small_variable_chunks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pieces = (b"header", b"tensor-body")
+    payload = b"".join(pieces)
+    whole = "sha256:" + hashlib.sha256(payload).hexdigest()
+    remotes = tuple(
+        SimpleNamespace(
+            sha256=hashlib.sha256(piece).hexdigest(),
+            len=len(piece),
+            url=f"https://objects.invalid/{index}",
+        )
+        for index, piece in enumerate(pieces)
+    )
+    presigned = SimpleNamespace(
+        files=[
+            SimpleNamespace(
+                path="compiled-graph.tar.gz",
+                size_bytes=len(payload),
+                url="",
+                chunks=remotes,
+                # Deliberately unrelated to either exact object length.
+                chunk_size_bytes=2048,
+            )
+        ]
+    )
+    by_digest = {
+        "sha256:" + hashlib.sha256(piece).hexdigest(): piece for piece in pieces
+    }
+
+    def fake_download(
+        grants: Sequence[TransferGrant], cas: LocalCAS
+    ) -> TransferReport:
+        assert [grant.size_bytes for grant in grants] == [len(piece) for piece in pieces]
+        for grant in grants:
+            cas.put_bytes(by_digest[str(grant.digest)], expected=grant.digest)
+        return TransferReport(
+            examined=len(grants),
+            succeeded=len(grants),
+            bytes_transferred=len(payload),
+        )
+
+    monkeypatch.setattr(aot_delivery, "download", fake_download)
+
+    output = aot_delivery._materialize_named_artifact(
+        "repo/family#compiled-graph",
+        whole,
+        presigned,
+        cache_dir=tmp_path / "cache",
+        what="th#1931 variable-layout proof",
+    )
+
+    assert output.read_bytes() == payload

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -52,7 +52,7 @@ GUARD_MANIFEST_BLOCK = "guard_manifest"
 
 
 from harness.cell_meta import exported_cell_meta
-from hashrepo import CHUNK_SIZE
+from hashrepo import MAX_CHUNK_SIZE
 
 from gen_worker import fleet_cells as fc
 from gen_worker import http_origin
@@ -412,7 +412,7 @@ def test_a_real_200mb_cell_publishes_through_the_real_cap(hub, artifact, monkeyp
     # ...and the DATA still moved, all of it, over presigned PUTs, every
     # object refused unless it hashed to the digest signed into its grant.
     assert hub.httpd.put_bytes == ARTIFACT_BYTES
-    expected_chunks = -(-ARTIFACT_BYTES // CHUNK_SIZE)
+    expected_chunks = -(-ARTIFACT_BYTES // MAX_CHUNK_SIZE)
     assert len(hub.httpd.objects) == expected_chunks
 
     assert hub.httpd.completes[-1]["ok"] is True

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -21,7 +21,6 @@ from typing import Any, Dict
 import pytest
 
 from gen_worker import aot_identity, cell_key as ck, cell_resolve, env_seal
-from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.procsplit import actions as actions_mod
 
 KEY = "cg-key-v1-" + "ab" * 28
@@ -404,9 +403,9 @@ def test_the_transport_is_shaped_for_the_existing_delivery_path(stub) -> None:
     files = list(cell.transport.files)
     assert len(files) == 1
     entry = files[0]
-    for attr in ("path", "size_bytes", "digest", "url", "chunks",
-                 "chunk_size_bytes"):
+    for attr in ("path", "size_bytes", "digest", "url", "chunks"):
         assert hasattr(entry, attr), attr
+    assert not hasattr(entry, "chunk_size_bytes")
     assert str(entry.path).endswith(".tar.gz")
 
 
@@ -424,7 +423,7 @@ def test_a_chunked_transport_carries_the_chunk_attributes(stub) -> None:
     chunks = list(cell.transport.files[0].chunks)
     assert [c.len for c in chunks] == [2048, 2048]
     assert chunks[0].sha256 == "aa" * 32
-    assert cell.transport.files[0].chunk_size_bytes == 2048
+    assert not hasattr(cell.transport.files[0], "chunk_size_bytes")
 
 
 def test_materialize_delegates_and_adds_nothing(monkeypatch, stub) -> None:

--- a/tests/test_snapshot_v2_fill_pgw781.py
+++ b/tests/test_snapshot_v2_fill_pgw781.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hashrepo import CHUNK_SIZE, CASRef, FileEntry, LocalCAS, RepositoryManifest
+from hashrepo import CASRef, FileEntry, LocalCAS, RepositoryManifest
 
 import gen_worker.models.cozy_snapshot as snapshot_mod
 from gen_worker.models.cozy_snapshot import NetworkBytesScope, ensure_snapshot_async
@@ -346,9 +346,9 @@ def test_same_snapshot_key_in_two_scoped_roots_does_not_crosstalk(
     assert (right / "config.json").read_bytes() == body
 
 
-def test_chunked_file_uses_hashrepo_v1_manifest(tmp_path: Path) -> None:
-    first = b"a" * CHUNK_SIZE
-    second = b"tail"
+def test_chunked_file_uses_manifest_recorded_variable_lengths(tmp_path: Path) -> None:
+    first = b"header"
+    second = b"tensor-body"
     chunks = (first, second)
     whole = hashlib.sha256(first + second).hexdigest()
     blobs = {_sha(chunk): chunk for chunk in chunks}
@@ -359,14 +359,16 @@ def test_chunked_file_uses_hashrepo_v1_manifest(tmp_path: Path) -> None:
             files=[
                 WorkerResolvedRepoFile(
                     "weights.safetensors",
-                    CHUNK_SIZE + len(second),
+                    len(first) + len(second),
                     None,
                     digest="sha256:" + whole,
                     chunks=tuple(
                         WorkerResolvedChunk(_sha(chunk), server.url(_sha(chunk)), len(chunk))
                         for chunk in chunks
                     ),
-                    chunk_size_bytes=CHUNK_SIZE,
+                    # This scalar is deliberately unrelated to either chunk;
+                    # consumers must trust the ordered recorded lengths.
+                    chunk_size_bytes=2048,
                 )
             ],
         )
@@ -374,7 +376,7 @@ def test_chunked_file_uses_hashrepo_v1_manifest(tmp_path: Path) -> None:
             ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
         )
         output = path / "weights.safetensors"
-        assert output.stat().st_size == CHUNK_SIZE + len(second)
+        assert output.stat().st_size == len(first) + len(second)
         assert hashlib.sha256(output.read_bytes()).hexdigest() == whole
         assert all(server.hits(digest) == 1 for digest in blobs)
     finally:

--- a/tests/test_snapshot_v2_fill_pgw781.py
+++ b/tests/test_snapshot_v2_fill_pgw781.py
@@ -22,6 +22,8 @@ from gen_worker.models.hub_client import (
     WorkerResolvedRepoFile,
 )
 from gen_worker.models.refs import TensorhubRef
+from gen_worker.models.store import _snapshot_to_resolved
+from gen_worker.pb import worker_scheduler_pb2 as pb
 
 
 def _sha(data: bytes) -> str:
@@ -71,6 +73,30 @@ class BlobServer:
 
 def _ref() -> TensorhubRef:
     return TensorhubRef(owner="acme", repo="model", tag="latest")
+
+
+def test_grpc_adapter_keeps_ordered_lengths_and_drops_fixed_layout_scalar() -> None:
+    snapshot = pb.Snapshot(
+        digest="sha256:" + "ff" * 32,
+        files=[
+            pb.SnapshotFile(
+                path="weights.safetensors",
+                size_bytes=60,
+                digest="sha256:" + "ee" * 32,
+                chunk_size_bytes=64 * 1024 * 1024,
+                chunks=[
+                    pb.ChunkRef(sha256="aa" * 32, url="https://cas/0", len=3),
+                    pb.ChunkRef(sha256="bb" * 32, url="https://cas/1", len=56),
+                    pb.ChunkRef(sha256="cc" * 32, url="https://cas/2", len=1),
+                ],
+            )
+        ],
+    )
+
+    file = _snapshot_to_resolved(snapshot).files[0]
+
+    assert [chunk.length for chunk in file.chunks] == [3, 56, 1]
+    assert not hasattr(file, "chunk_size_bytes")
 
 
 class _BarrierCAS(LocalCAS):
@@ -366,9 +392,6 @@ def test_chunked_file_uses_manifest_recorded_variable_lengths(tmp_path: Path) ->
                         WorkerResolvedChunk(_sha(chunk), server.url(_sha(chunk)), len(chunk))
                         for chunk in chunks
                     ),
-                    # This scalar is deliberately unrelated to either chunk;
-                    # consumers must trust the ordered recorded lengths.
-                    chunk_size_bytes=2048,
                 )
             ],
         )

--- a/tests/test_stream_bounds_pgw1013.py
+++ b/tests/test_stream_bounds_pgw1013.py
@@ -515,7 +515,6 @@ def _fetch_cell(rig: _Rig, cache: Path, entry: Dict[str, Any],
         size_bytes=int(entry.get("size_bytes") or 0),
         digest=str(entry.get("digest") or ""),
         url=str(entry.get("url") or ""),
-        chunk_size_bytes=0,
         chunks=(),
     )])
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ requires-dist = [
     { name = "gguf", specifier = ">=0.10.0" },
     { name = "grpcio", specifier = ">=1.82.1" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.82.1" },
-    { name = "hashrepo", specifier = ">=0.1.1,<0.2" },
+    { name = "hashrepo", specifier = ">=0.3,<0.4" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "msgspec", specifier = ">=0.18.6" },
@@ -780,11 +780,11 @@ wheels = [
 
 [[package]]
 name = "hashrepo"
-version = "0.1.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/e1/c268607bd64bee8d7ec19683aececd173ad827776152421e9e8bf989fa8d/hashrepo-0.1.1.tar.gz", hash = "sha256:e3fd83ead91496c738a1aacbf7e60a9583f3948480ee05b5cd95c766540ea71b", size = 19184, upload-time = "2026-08-14T02:13:11.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/b8/131b79595232b7dd66ce9c4a8f0c3a086a1ae7f4188fb3661e00d88db123/hashrepo-0.3.0.tar.gz", hash = "sha256:7dd05166bef0cca0e4fa4ae7ddc5063b887bfb088ac8fa7c89c251faa0b345a8", size = 23269, upload-time = "2026-08-14T07:35:47.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/dc/0efab9caf2701a0b64a204a6a7721d6de8eeda58c1b4ef5dc304f83ec936/hashrepo-0.1.1-py3-none-any.whl", hash = "sha256:2dd065fbc6763f3102b37ed6267038d3058d32a495de09ed45aaff062da4dc49", size = 19545, upload-time = "2026-08-14T02:13:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b2/8d1ed46a761cbff197ca6c0b4f51e3389a488aaba20ed2431a93e8126add/hashrepo-0.3.0-py3-none-any.whl", hash = "sha256:dda546e0c718eb69c2dd3d537578407d9ecf5c7840efe0f33bd7e7e787e2f7b6", size = 23085, upload-time = "2026-08-14T07:35:46.505Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -780,11 +780,11 @@ wheels = [
 
 [[package]]
 name = "hashrepo"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/b8/131b79595232b7dd66ce9c4a8f0c3a086a1ae7f4188fb3661e00d88db123/hashrepo-0.3.0.tar.gz", hash = "sha256:7dd05166bef0cca0e4fa4ae7ddc5063b887bfb088ac8fa7c89c251faa0b345a8", size = 23269, upload-time = "2026-08-14T07:35:47.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/5a/50245200737dea160cf162de44ce3aeaa100084a9dfc429f14befabe72fd/hashrepo-0.3.1.tar.gz", hash = "sha256:b08f5c8c31427d5a0aa981002c50e4d601041e5031c145ffaa22ffe720e5eab4", size = 23520, upload-time = "2026-08-14T09:24:23.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/b2/8d1ed46a761cbff197ca6c0b4f51e3389a488aaba20ed2431a93e8126add/hashrepo-0.3.0-py3-none-any.whl", hash = "sha256:dda546e0c718eb69c2dd3d537578407d9ecf5c7840efe0f33bd7e7e787e2f7b6", size = 23085, upload-time = "2026-08-14T07:35:46.505Z" },
+    { url = "https://files.pythonhosted.org/packages/34/67/61fb63a28e7ea6243d6a3bc4e520850f59afdf794d7c41631f02ba5a503d/hashrepo-0.3.1-py3-none-any.whl", hash = "sha256:c9450e07c96b0a060db5ab420b9202f0e1efabaa1690c66f03f56ff7b7b3847a", size = 23348, upload-time = "2026-08-14T09:24:21.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- lock the worker to released HashRepo 0.3.1 within the package constraint `hashrepo>=0.3,<0.4`; this is the measured single-pass ingest patch
- let HashRepo automatically tensor-align valid safetensors and use bounded fixed-offset fallback for every other file
- delete the worker fixed-64-MiB reader checks: ordered manifest digest/length pairs are the complete layout
- delete the dead internal `chunk_size_bytes` scalar from REST, gRPC, snapshot, and compiled-graph transport models; Tensorhub may still send the pre-launch wire field during the coupled cut, but PGW does not retain or infer from it

This is a deletion in production code: 7 additions / 24 deletions across Python sources (net -17). The base had 7 `CHUNK_SIZE`/fixed-CAS-size references and 10 `chunk_size_bytes` references; this head has zero of either. `open_worker_cas()` remains the sole worker `LocalCAS` constructor.

## Sequencing

Rebased onto exact #788 merge `a6bd910421c3931c7ccf86e092daed2a4a115dad`. The original tensor-layout commit is semantic range-diff equal after the rebase. Current exact signed head is `45f8c60b31fdcb086c61b6f983d23495ba447660`; the PR now targets `master`.

## Boundary

HashRepo owns object layout, hashing, manifests, local CAS, transfer sessions, and transfer recovery. PGW retains only product adapters: Tensorhub HTTP declaration/grants, snapshot and compiled-graph materialization, one cache-root constructor, endpoint fill-source verification, and worker retention/GC policy. No second CAS, chunker, uploader, journal, compatibility facade, or fixed-layout reader is introduced here.

## Red proofs

- Against the pre-cut parent, an AOT manifest with recorded lengths 6 and 11 plus `chunk_size_bytes=2048` failed with `NamedArtifactUnavailable: ... chunk size 2048 does not match HashRepo v1 (67108864)`.
- Against exact prior head `aadb13f28034912194b330ec668be748568186e1`, the hard-cut fence requiring `chunk_size_bytes` to be absent from both worker transport dataclasses failed with `AssertionError`.
- The green gRPC proof sends the obsolete scalar with ordered lengths `[3, 56, 1]`; the lengths survive byte-for-byte and the scalar does not enter the worker model.

## Validation

On exact local head with HashRepo 0.3.1 installed:

- 5 targeted proofs passed: identical-publish reuse, bounded fixed-output fallback, safetensors header/tensor publication, gRPC `[3, 56, 1]`, and variable-length AOT delivery
- 109 broader publish/snapshot/AOT/REST/gRPC/stream/one-CAS/fill-source tests passed
- pinned Ruff passed on every touched Python file
- strict mypy passed on 11 touched source/test files
- `uv lock --check`, `git diff --check`, wheel build, and sdist build passed\n- required hosted CI on exact head `45f8c60b31fdcb086c61b6f983d23495ba447660` passed: fast gates, **4,944 passed / 45 skipped** in v1, **21 passed** in v2, and the skip-census gate
- built wheel metadata carries `Requires-Dist: hashrepo<0.4,>=0.3`; the lock resolves exact 0.3.1 with released wheel hash `c9450e07...3847a` and sdist hash `b08f5c8...eab4`

A full local `task lint` cannot be authoritative because the locked Torch 2.13.0+cu130 artifact currently returns the known upstream hash mismatch; the existing partial environment consequently lacks Torch/Pillow types. Required hosted fast gates and the full v1/v2 suites are green on the exact head. Merge queue is intentionally disabled while #797s failing merge-group candidate is dispositioned; this PR must be rebased if master moves.
