### PR TITLE
pgw#1247: one refusal, one spelling — the cell-resolve verdicts speak `compiled_graph_resolve_*`

### DIFF
--- a/changelog.d/pgw1247.md
+++ b/changelog.d/pgw1247.md
@@ -1,0 +1,6 @@
+- The cell-resolve refusal vocabulary speaks `compiled_graph_resolve_*`. Seven tokens
+  are renamed off the dead `cell_` prefix: the two the worker raises pre-flight
+  (`too_many_keys`, `duplicate_key`) and the five local verdicts it reaches on a
+  malformed batch (`short_answer`, `answer_out_of_order`, `batch_signature`,
+  `shared_receipt`, `unknown_status`). The hub already spelled its own two in the new
+  vocabulary, so one refusal no longer has two spellings across the two repos.

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -133,16 +133,16 @@ REFUSAL_CODES = (
     "cell_resolve_incomplete",
     "cell_resolve_transport_unavailable",
     "cell_resolve_client_supplied_field",
-    "cell_resolve_too_many_keys",
-    "cell_resolve_duplicate_key",
+    "compiled_graph_resolve_too_many_keys",
+    "compiled_graph_resolve_duplicate_key",
     # Answered, but not to the question that was asked. Local verdicts, and
     # they are refusals rather than misses for the usual reason: a pod that
     # read a mangled batch as misses would pay for a full cold mint per key.
-    "cell_resolve_short_answer",
-    "cell_resolve_answer_out_of_order",
-    "cell_resolve_batch_signature",
-    "cell_resolve_shared_receipt",
-    "cell_resolve_unknown_status",
+    "compiled_graph_resolve_short_answer",
+    "compiled_graph_resolve_answer_out_of_order",
+    "compiled_graph_resolve_batch_signature",
+    "compiled_graph_resolve_shared_receipt",
+    "compiled_graph_resolve_unknown_status",
 )
 
 #: Every field an accepted answer must NAME, and why. An answer omitting one
@@ -356,7 +356,7 @@ def _require_batch(family: str, keys: Sequence[str]) -> Tuple[str, Tuple[str, ..
             # against its request, and answering it twice is work nobody asked
             # for.
             raise CellResolveRefused(
-                "cell_resolve_duplicate_key",
+                "compiled_graph_resolve_duplicate_key",
                 f"keys[{i}] repeats {key}; answers come back in REQUEST ORDER "
                 f"and a collapsed duplicate would shift every later answer "
                 f"against its request")
@@ -367,7 +367,7 @@ def _require_batch(family: str, keys: Sequence[str]) -> Tuple[str, Tuple[str, ..
             "invalid_request", "resolve requires a non-empty key set")
     if len(asked) > MAX_RESOLVE_KEYS:
         raise CellResolveRefused(
-            "cell_resolve_too_many_keys",
+            "compiled_graph_resolve_too_many_keys",
             f"this batch names {len(asked)} keys and the bound is "
             f"{MAX_RESOLVE_KEYS}; split it rather than receiving a short "
             f"answer that reads as misses")
@@ -393,7 +393,7 @@ def _answer_from(
             detail=str(raw.get("detail") or ""))
     if status != STATUS_HIT or not bool(raw.get("found")):
         raise CellResolveRefused(
-            "cell_resolve_unknown_status",
+            "compiled_graph_resolve_unknown_status",
             f"the answer for {key} carries status {status!r} "
             f"(found={raw.get('found')!r}), which this worker cannot act on; "
             f"reading it as a miss would send this pod to a full cold mint "
@@ -489,7 +489,7 @@ def _answers_of(
     for field in _BATCH_SIGNATURE_FIELDS:
         if raw.get(field):
             raise CellResolveRefused(
-                "cell_resolve_batch_signature",
+                "compiled_graph_resolve_batch_signature",
                 f"the batch carries a top-level {field!r}; every answer is "
                 f"signed on its own and there is deliberately no signature "
                 f"over the collection, so a batch-level one would make the "
@@ -497,14 +497,14 @@ def _answers_of(
     rows = raw.get("answers")
     if not isinstance(rows, list):
         raise CellResolveRefused(
-            "cell_resolve_short_answer",
+            "compiled_graph_resolve_short_answer",
             f"asked {len(asked)} keys and the reply names no answers[] at all")
     if len(rows) != len(asked):
         # An omission is indistinguishable from a truncation, and the pod
         # answers a missing answer by paying for a full cold mint. So a short
         # batch is not a smaller reply — it is a wrong one.
         raise CellResolveRefused(
-            "cell_resolve_short_answer",
+            "compiled_graph_resolve_short_answer",
             f"asked {len(asked)} keys, got {len(rows)} answers; answers are "
             f"positional and a batch that does not answer every key is "
             f"indistinguishable from one truncated in transit")
@@ -514,14 +514,14 @@ def _answers_of(
         row = rows[i]
         if not isinstance(row, Mapping):
             raise CellResolveRefused(
-                "cell_resolve_short_answer",
+                "compiled_graph_resolve_short_answer",
                 f"answers[{i}] is {type(row).__name__}, not an answer")
         echoed = str(row.get("cell_key") or "").strip()
         if echoed != key:
             # POSITION and ECHO both, because either alone admits a batch
             # transposed by something that preserved the other.
             raise CellResolveRefused(
-                "cell_resolve_answer_out_of_order",
+                "compiled_graph_resolve_answer_out_of_order",
                 f"answers[{i}] answers {echoed!r} and keys[{i}] asked {key}; "
                 f"answers are consumed positionally, so a transposed batch "
                 f"would arm every class with a sibling's kernels")
@@ -535,7 +535,7 @@ def _answers_of(
                 # means at least one answer is being vouched for by the other's
                 # proof.
                 raise CellResolveRefused(
-                    "cell_resolve_shared_receipt",
+                    "compiled_graph_resolve_shared_receipt",
                     f"{key} and {seen_for} were answered with the SAME "
                     f"receipt; a receipt signs one compiled graph, and reusing "
                     f"it makes the collection the unit of trust")

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -505,7 +505,7 @@ class _ResolveHub(BaseHTTPRequestHandler):
         # exercises the arity and order checks on a real socket.
         keys = list(body.get("keys") or [])
         out = json.dumps({
-            "object": "cell_resolve_batch",
+            "object": "compiled_graph_resolve_batch",
             "family": body.get("family"),
             "answers": [{"cell_key": k, "status": "miss", "found": False}
                         for k in keys],

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -76,7 +76,7 @@ def _hit_body(**over: Any) -> Dict[str, Any]:
 def _batch(*answers: Any, **top: Any) -> Dict[str, Any]:
     """The hub's envelope. ``answers`` is the contract; the counts are logs."""
     body: Dict[str, Any] = {
-        "object": "cell_resolve_batch",
+        "object": "compiled_graph_resolve_batch",
         "family": "sdxl",
         "answers": list(answers),
         "hits": sum(1 for a in answers if a.get("status") == "hit"),
@@ -179,7 +179,7 @@ def test_a_miss_is_an_answer_never_an_omission(stub) -> None:
 
 @pytest.mark.parametrize("code,status", [
     ("cell_resolve_client_supplied_field", 400),
-    ("cell_resolve_too_many_keys", 400),
+    ("compiled_graph_resolve_too_many_keys", 400),
 ])
 def test_a_whole_batch_refusal_still_raises(stub, code, status) -> None:
     """The refusals that survive as whole-request are the ones that are
@@ -226,7 +226,7 @@ def test_an_unknown_status_is_refused_and_never_read_as_a_miss(stub) -> None:
         {"cell_key": KEY, "status": "something_new", "found": False}))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         _one()
-    assert err.value.code == "cell_resolve_unknown_status"
+    assert err.value.code == "compiled_graph_resolve_unknown_status"
 
 
 def test_an_answer_naming_a_different_key_is_refused_not_adopted(stub) -> None:
@@ -237,12 +237,12 @@ def test_an_answer_naming_a_different_key_is_refused_not_adopted(stub) -> None:
     resp["r"] = _Resp(200, _batch(_hit_body(cell_key=OTHER_KEY)))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         _one()
-    assert err.value.code == "cell_resolve_answer_out_of_order"
+    assert err.value.code == "compiled_graph_resolve_answer_out_of_order"
 
 
 #: ``cell_key`` is caught one gate earlier — an empty echo is not the key that
 #: was asked for, so the ORDER gate names the seam that lied first.
-_EARLIER_GATE = {"cell_key": "cell_resolve_answer_out_of_order"}
+_EARLIER_GATE = {"cell_key": "compiled_graph_resolve_answer_out_of_order"}
 
 
 @pytest.mark.parametrize("field", [f for f, _ in cell_resolve._REQUIRED])
@@ -660,7 +660,7 @@ def test_a_short_answer_is_refused_not_read_as_misses(stub) -> None:
     resp["r"] = _Resp(200, _batch(_hit_body()))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY, THIRD_KEY])
-    assert err.value.code == "cell_resolve_short_answer"
+    assert err.value.code == "compiled_graph_resolve_short_answer"
     assert "asked 3 keys, got 1 answers" in err.value.detail
 
 
@@ -671,15 +671,15 @@ def test_a_long_answer_is_refused_too(stub) -> None:
     resp["r"] = _Resp(200, _batch(_hit_body(), _miss(OTHER_KEY)))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY])
-    assert err.value.code == "cell_resolve_short_answer"
+    assert err.value.code == "compiled_graph_resolve_short_answer"
 
 
 def test_a_reply_with_no_answers_at_all_is_refused(stub) -> None:
     _sent, resp = stub
-    resp["r"] = _Resp(200, {"object": "cell_resolve_batch", "family": "sdxl"})
+    resp["r"] = _Resp(200, {"object": "compiled_graph_resolve_batch", "family": "sdxl"})
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY])
-    assert err.value.code == "cell_resolve_short_answer"
+    assert err.value.code == "compiled_graph_resolve_short_answer"
 
 
 def test_transposed_answers_are_refused(stub) -> None:
@@ -691,7 +691,7 @@ def test_transposed_answers_are_refused(stub) -> None:
     resp["r"] = _Resp(200, _batch(_hit_body(cell_key=OTHER_KEY), _hit_body()))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY])
-    assert err.value.code == "cell_resolve_answer_out_of_order"
+    assert err.value.code == "compiled_graph_resolve_answer_out_of_order"
     assert "answers[0]" in err.value.detail
 
 
@@ -705,7 +705,7 @@ def test_a_batch_level_signature_is_refused_never_ignored(stub) -> None:
         resp["r"] = _Resp(200, _batch(_hit_body(), **{field: "eyJ.x.y"}))
         with pytest.raises(cell_resolve.CellResolveRefused) as err:
             cell_resolve.resolve_batch("sdxl", [KEY])
-        assert err.value.code == "cell_resolve_batch_signature"
+        assert err.value.code == "compiled_graph_resolve_batch_signature"
         assert field in err.value.detail
 
 
@@ -722,7 +722,7 @@ def test_two_answers_may_not_share_one_receipt(stub) -> None:
         _hit_body(), _hit_body(cell_key=OTHER_KEY)))
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY])
-    assert err.value.code == "cell_resolve_shared_receipt"
+    assert err.value.code == "compiled_graph_resolve_shared_receipt"
 
 
 def test_distinctly_signed_answers_are_both_adopted(stub) -> None:
@@ -772,7 +772,7 @@ def test_a_duplicate_key_is_refused_before_the_hub_is_dialled(stub) -> None:
     sent, _resp = stub
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", [KEY, OTHER_KEY, KEY])
-    assert err.value.code == "cell_resolve_duplicate_key"
+    assert err.value.code == "compiled_graph_resolve_duplicate_key"
     assert not sent
 
 
@@ -785,7 +785,7 @@ def test_over_the_bound_is_refused_before_the_hub_is_dialled(stub) -> None:
                 for i in range(cell_resolve.MAX_RESOLVE_KEYS + 1)]
     with pytest.raises(cell_resolve.CellResolveRefused) as err:
         cell_resolve.resolve_batch("sdxl", too_many)
-    assert err.value.code == "cell_resolve_too_many_keys"
+    assert err.value.code == "compiled_graph_resolve_too_many_keys"
     assert not sent
     # ...and exactly the bound is fine, so the guard is a bound and not a ban.
     _resp["r"] = _Resp(200, _batch(*[_miss(k) for k in too_many[:-1]]))

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-2a0cdb3a006331458220e864a3ecab8f0016f957925f9d4666277f28b98d87f0
+6be8adf6e6dd0df931bda27c37c10d105658e5a70cabdc9e7f0704851cd27c1a

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -19,16 +19,16 @@
     ],
     "cell_resolve_hub_refusal_codes": [
       "cell_resolve_ambiguous",
-      "cell_resolve_answer_out_of_order",
-      "cell_resolve_batch_signature",
+      "compiled_graph_resolve_answer_out_of_order",
+      "compiled_graph_resolve_batch_signature",
       "cell_resolve_client_supplied_field",
-      "cell_resolve_duplicate_key",
+      "compiled_graph_resolve_duplicate_key",
       "cell_resolve_incomplete",
-      "cell_resolve_shared_receipt",
-      "cell_resolve_short_answer",
-      "cell_resolve_too_many_keys",
+      "compiled_graph_resolve_shared_receipt",
+      "compiled_graph_resolve_short_answer",
+      "compiled_graph_resolve_too_many_keys",
       "cell_resolve_transport_unavailable",
-      "cell_resolve_unknown_status"
+      "compiled_graph_resolve_unknown_status"
     ],
     "cell_publish_untrusted_refusal_code": "cell_publish_untrusted_tier",
     "hardware_unsuitable_reason_classes": [


### PR DESCRIPTION
**One refusal, one spelling.** th#1842 gave the hub's three born-here wire strings the compiled-graph vocabulary §1.38 requires. That left a split: the worker raised `cell_resolve_too_many_keys` and `cell_resolve_duplicate_key` for the *identical* conditions the hub now reports as `compiled_graph_resolve_*`.

Nothing was broken — the worker refuses locally before posting and reads the hub's returned code generically — but one condition with two names reads as two faults on every dashboard that groups by code, and **the 0.115.0 wheel must not ship speaking both.**

### Seven tokens move

| | |
|---|---|
| the two pre-flight refusals | `too_many_keys`, `duplicate_key` |
| the five verdicts only the CALLER can reach | `short_answer`, `answer_out_of_order`, `batch_signature`, `shared_receipt`, `unknown_status` |

The five are judgements *about a batch the hub sent* — a short, transposed, batch-signed or shared-receipt answer set — so the hub structurally cannot emit them. Renaming them is vocabulary hygiene; renaming the first two is the actual split-fix.

### Four tokens deliberately do NOT move

`cell_resolve_ambiguous`, `_incomplete`, `_transport_unavailable`, `_client_supplied_field`. **The hub emits those spellings itself**, on its HTTP refusal and its activity events, so they have ONE spelling consistently on both sides — no split exists. Renaming them is a coordinated hub change and belongs to the wider `cell` → `compiled_graph` sweep (th#1890 / pgw#1214), not here.

That leaves the corpus section briefly mixed-vocabulary. That is honest: it mirrors the fact that the two halves rename on different schedules.

### The corpus moves with the vocabulary

`2a0cdb3a…` → `6be8adf6…`. tensorhub vendors these bytes and updates its per-axis binder in the paired PR, enqueued the moment this merges. **PGW LANDS FIRST is mechanical here, not a convention** — `scripts/worker-value-contract-drift.sh` fetches `python-gen-worker@master` live inside tensorhub's required `gates`, so the hub half cannot be green until this is on master.

### Why the fence did not catch the split itself

It could not see it. th#1945's binder was **prefix-scoped**, so renaming three strings out of `cell_resolve_` moved them outside its scan. The paired tensorhub PR widens axis 1 to bind by ROLE (the `writeError` call sites) across both prefixes, which is the actual fix — an axis is a role on the wire, not a prefix.

### Verification

mypy strict clean (779 files), ruff clean, six lint scripts including the corpus digest gate, and 83 targeted tests across `test_cell_resolve_pgw1090`, `test_worker_value_contracts_pgw1237` and `test_boot_adopt_observability_pgw1116`.
