### PR TITLE
pgw#1245 (th#1934 Stage 0): the declared decode-set — derived at image build, complete, and refusing by name

### DIFF
--- a/changelog.d/pgw1245.md
+++ b/changelog.d/pgw1245.md
@@ -13,14 +13,24 @@
   the running code is not the code the hub selected against.
 - **pgw#1245: a declaration names its DIMENSIONS, not just a handle.**
   `@implements_contract` now requires `decodes=DecodeDimensions(...)`: the
-  element encodings, scale granularities, file topologies, key topologies and
-  structural bakes the decoder reads. A handle alone could not express that
-  `cozy.svdq-nvfp4-lr8@1` differs from `nunchaku.v1@1` exactly by consuming a
-  quantized low-rank branch, or that the optional `input_scale` leaf is
-  decoded rather than ignored. `sp_sharded`, `modulation_baked` and
-  `modulation_table` are registered and declared by NOTHING, deliberately: a
-  variant carrying them finds no decoder and is refused, which is the correct
-  answer until one branches on it.
+  element encodings, scale granularities, key topologies and structural bakes
+  the decoder reads, every axis explicit so a declaration cannot be written by
+  omission. A handle alone could not express that `cozy.fp8-rowwise@1`'s
+  optional `input_scale` leaf is decoded rather than ignored. An EMPTY axis is
+  a statement — "this decoder does not constrain it" — which is the honest
+  answer for the svdq decoders, whose quant handle already fixes their keys.
+
+  Vocabulary is th#1937's ruling, adopted verbatim with no aliases:
+  `diffusers.split-qkv@1`, `native.fused-qkv@1`, `transformers.split-qkv@1`
+  (the provisional `contract.native` was DECLINED — the quant dimension
+  already carries that fact by handle), and the ruled tensor-set names
+  `adaln_projections` / `low_rank_branch`. `native.fused-qkv@1` is registered
+  and declared by NOTHING, deliberately: a minimax-native tree finds no
+  decoder here and is refused by name. `file_layout` is deliberately NOT
+  transcribed into this module — it is ruled `multi-file`/`single-file` with a
+  single pgw home in `convert/file_layout.py`, and a second copy here would be
+  the drift this programme exists to delete; `pre_sharded`/`shard_axis` stay
+  publish-side because no decoder in this image branches on them.
 - **pgw#1245: the decode-set carries a KEY-TOPOLOGY axis, because file
   topology and quant contract cannot see the difference that broke H3.**
   DiffSynth's `MiniMaxH3DiT` ingests the minimax-NATIVE key set (535 keys,

--- a/changelog.d/pgw1245.md
+++ b/changelog.d/pgw1245.md
@@ -1,0 +1,43 @@
+- **pgw#1245 (th#1934 Stage 0): the DECLARED DECODE-SET is a first-class
+  artifact of the built image.** `gen_worker.discovery.decode_set` derives, at
+  image build, which registered tensor-layout contracts this image's decoders
+  actually implement — `cozy.fp8-rowwise@1`, `hf.fp8-blockwise@1`,
+  `nunchaku.v1@1`, `cozy.svdq-nvfp4-lr8@1`, `plain.bf16@1` — and stamps them
+  into `endpoint.lock` as `[decode_set]` with a sha256 digest over the whole
+  derivation. It is th#1938's third intersection: selection is (endpoint's
+  contract patterns) ∩ (worker's decode-set) ∩ (card executability), and no
+  config may select bytes the code cannot read. The `[execution_lanes]` block
+  is now a second RENDER of the same census rather than a second walk that
+  could disagree with it. The boot refuses, typed, if the set this process
+  derives is not the one the lock was stamped with — a stale lock layer means
+  the running code is not the code the hub selected against.
+- **pgw#1245: a declaration names its DIMENSIONS, not just a handle.**
+  `@implements_contract` now requires `decodes=DecodeDimensions(...)`: the
+  element encodings, scale granularities, file topologies, key topologies and
+  structural bakes the decoder reads. A handle alone could not express that
+  `cozy.svdq-nvfp4-lr8@1` differs from `nunchaku.v1@1` exactly by consuming a
+  quantized low-rank branch, or that the optional `input_scale` leaf is
+  decoded rather than ignored. `sp_sharded`, `modulation_baked` and
+  `modulation_table` are registered and declared by NOTHING, deliberately: a
+  variant carrying them finds no decoder and is refused, which is the correct
+  answer until one branches on it.
+- **pgw#1245: the decode-set carries a KEY-TOPOLOGY axis, because file
+  topology and quant contract cannot see the difference that broke H3.**
+  DiffSynth's `MiniMaxH3DiT` ingests the minimax-NATIVE key set (535 keys,
+  fused `blocks.N.attn.qkv_proj`); every minimax-h3 artifact we hold is the
+  DIFFUSERS repackaging (638 keys, split `to_q/to_k/to_v`) — one key in
+  common, both `plain.bf16@1`, both multi-file safetensors trees. It surfaced
+  as `Cannot detect the model type` from an md5-over-key:shape lookup, after a
+  71 GB fetch onto a rented 4×H100. `models/key_topology.py` classifies a
+  snapshot from safetensors HEADERS ONLY, and the load dispatch refuses a
+  topology no decoder ingests with `decode_set_key_topology_unsupported`,
+  naming what was observed and what is accepted. An unrecognized key set is
+  UNKNOWN and refuses nothing.
+- **pgw#1245: the load path refuses bytes the image cannot decode, by name.**
+  `decode_set_contract_undeclared` names the contract asked for, everything
+  declared, and the NEAREST declared contract — ranked by format token, so
+  `bfl.nvfp4-preswizzled@1` points at `cozy.svdq-nvfp4-lr8@1` and not at an
+  fp8 handle a string-similarity match would prefer. Decode paths no
+  registered contract covers (`w4a4`'s flat nvfp4, the GGUF pipeline) are now
+  RECORDED in the derived set with their reason instead of living in a source
+  comment no refusal can read.

--- a/changelog.d/pgw1245.md
+++ b/changelog.d/pgw1245.md
@@ -31,8 +31,22 @@
   71 GB fetch onto a rented 4×H100. `models/key_topology.py` classifies a
   snapshot from safetensors HEADERS ONLY, and the load dispatch refuses a
   topology no decoder ingests with `decode_set_key_topology_unsupported`,
-  naming what was observed and what is accepted. An unrecognized key set is
-  UNKNOWN and refuses nothing.
+  naming what was observed and what is accepted.
+
+  **What happens to a key set nothing recognizes, stated so it cannot be
+  misread — for the DENOISER it REFUSES:**
+  `decode_set_key_topology_unclassified`, naming the artifact, the keys seen
+  and the registered topologies. That is publish's posture (th#1937 refuses an
+  underivable topology rather than guessing a nearest match) held at the place
+  it costs the most, since the model class is chosen from the architecture.
+  For every OTHER component — vae, text encoder, scheduler — the axis is NOT
+  EVALUATED, because no architecture-specific model class is selected from
+  those trees: that is the UNDECLARED rung of the tri-state, not a fail-open,
+  and refusing there would refuse the whole fleet to catch nothing.
+- **pgw#1245: decode-set drift has its own typed refusal.**
+  `DecodeSetDriftError` / `decode_set_drift` names the contracts that appeared
+  or vanished between the lock and the running code, instead of borrowing the
+  contract refusal with a placeholder handle.
 - **pgw#1245: the load path refuses bytes the image cannot decode, by name.**
   `decode_set_contract_undeclared` names the contract asked for, everything
   declared, and the NEAREST declared contract — ranked by format token, so

--- a/changelog.d/pgw1245.md
+++ b/changelog.d/pgw1245.md
@@ -44,15 +44,24 @@
   naming what was observed and what is accepted.
 
   **What happens to a key set nothing recognizes, stated so it cannot be
-  misread — for the DENOISER it REFUSES:**
-  `decode_set_key_topology_unclassified`, naming the artifact, the keys seen
-  and the registered topologies. That is publish's posture (th#1937 refuses an
-  underivable topology rather than guessing a nearest match) held at the place
-  it costs the most, since the model class is chosen from the architecture.
-  For every OTHER component — vae, text encoder, scheduler — the axis is NOT
-  EVALUATED, because no architecture-specific model class is selected from
-  those trees: that is the UNDECLARED rung of the tri-state, not a fail-open,
-  and refusing there would refuse the whole fleet to catch nothing.
+  misread — a DENOISER carrying ATTENTION substructure spelled in no
+  recognized way REFUSES:** `decode_set_key_topology_unclassified`, naming the
+  artifact, the keys seen and the registered topologies. That is publish's
+  posture (th#1937 refuses an underivable topology rather than guessing a
+  nearest match) held at the place it costs the most, since the model class is
+  chosen from the architecture, and it catches a FOURTH attention spelling —
+  the H3 class of failure — that no rule here has seen.
+
+  The axis is NOT EVALUATED in two cases, both scoped from evidence rather
+  than from optimism: a non-denoiser component (vae, text encoder, scheduler),
+  because no architecture-specific model class is selected from those trees;
+  and a tree carrying no attention substructure at all, because this axis
+  discriminates attention-projection conventions and a tree without one has no
+  convention to get wrong. Those are the UNDECLARED rung of the tri-state, not
+  a fail-open. The second scoping has a concrete counter-example behind it: CI
+  produced one immediately — the corrupt-load quarantine fixture is a
+  root-layout snapshot holding a single tensor named `w`, which the first cut
+  of the rule refused.
 - **pgw#1245: decode-set drift has its own typed refusal.**
   `DecodeSetDriftError` / `decode_set_drift` names the contracts that appeared
   or vanished between the lock and the running code, instead of borrowing the

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -44,7 +44,12 @@ about the WEIGHTS, not about the compiled program:
   (th#1580 / th#1721; was called "the artifact contract".) **th#1803 makes this
   a core platform feature:** code is quant-generic over a declared layout, and
   the platform answers compatibility ahead of time — at rebind and at request
-  time — never by loading and running on a rented pod.
+  time — never by loading and running on a rented pod. **pgw#1245** makes the
+  image's side of that answer a derived artifact: `[decode_set]` in
+  `endpoint.lock` (`gen_worker.discovery.decode_set`) enumerates every contract
+  the image's decoders implement, with the dimensions each reads — elements,
+  scales, shards, KEY TOPOLOGIES and structural bakes — plus a digest the boot
+  checks against what it would derive. It is th#1938's third intersection.
 - **The tensor-binding contract** — the artifact's LINKING rule for tensors:
   bound by name at load (DYNAMIC — an opaque slot the compiler must never
   value-specialize, which is what makes a cell checkpoint-agnostic) versus a

--- a/src/gen_worker/discovery/decode_set.py
+++ b/src/gen_worker/discovery/decode_set.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, Optional
 
 import msgspec
 
+from gen_worker.models.key_topology import SnapshotKeys
 from gen_worker.models.tensor_layout_contract import (
     ContractDecoder,
     DecodeDimensions,
@@ -50,6 +51,8 @@ DEFAULT_DECODER_PACKAGES: tuple[str, ...] = ("gen_worker.models",)
 #: hub cannot drift into two names for one refusal.
 REFUSAL_CONTRACT_UNDECLARED = "decode_set_contract_undeclared"
 REFUSAL_KEY_TOPOLOGY_UNSUPPORTED = "decode_set_key_topology_unsupported"
+REFUSAL_KEY_TOPOLOGY_UNCLASSIFIED = "decode_set_key_topology_unclassified"
+REFUSAL_DECODE_SET_DRIFT = "decode_set_drift"
 
 
 class ExcludedDecoderModule(msgspec.Struct, frozen=True, kw_only=True):
@@ -299,26 +302,68 @@ def runtime_decode_set() -> DecodeSet:
     return _RUNTIME_SET
 
 
+class DecodeSetDriftError(Exception):
+    """The set this process derives is not the one stamped at image build.
+
+    Fails the boot closed. The hub selected variants against the LOCK's set,
+    so a process that would derive a different one accepts work it may not be
+    able to decode — a stale `endpoint.lock` layer, or a decoder whose
+    dependency is present at build and absent in the shipped image.
+    """
+
+    code = REFUSAL_DECODE_SET_DRIFT
+
+    def __init__(
+        self, *, stamped: str, live: str,
+        gained: tuple[str, ...] = (), lost: tuple[str, ...] = (),
+        excluded: tuple[ExcludedDecoderModule, ...] = (),
+    ) -> None:
+        self.stamped, self.live = stamped, live
+        self.gained, self.lost, self.excluded = gained, lost, excluded
+        detail = []
+        if lost:
+            detail.append(
+                f"the lock claims {', '.join(lost)} and this process derives "
+                "no decoder for them")
+        if gained:
+            detail.append(
+                f"this process decodes {', '.join(gained)} and the lock does "
+                "not declare them")
+        if not detail:
+            detail.append(
+                "the contract SET agrees, so a dimension, a decoder name or "
+                "an excluded module differs")
+        if excluded:
+            detail.append(
+                "excluded modules here: " + "; ".join(
+                    f"{m.module} ({m.reason})" for m in excluded))
+        super().__init__(
+            f"decode-set drift: endpoint.lock stamped {stamped[:16]}…, this "
+            f"process derives {live[:16]}… — " + ". ".join(detail) +
+            ". Rebuild the image so the lock and the code are one artifact."
+        )
+
+
 def assert_matches_baked(baked: Dict[str, Any], ds: Optional[DecodeSet] = None) -> None:
     """Refuse when the process's decode-set is not the image's baked one.
 
     A block with no digest is an OLDER image and is not evidence of anything;
-    a digest that disagrees is a real divergence — the code that runs is not
-    the code the hub was told about — and it fails closed.
+    a digest that disagrees is a real divergence and fails closed, naming the
+    contracts that appeared or vanished so the remedy is readable.
     """
     stamped = str((baked or {}).get("digest") or "")
     if not stamped:
         return
-    live = (ds or runtime_decode_set()).digest
-    if stamped != live:
-        raise ContractNotDecodableError(
-            "<image>",
-            declared=(ds or runtime_decode_set()).contracts(),
-            where=(
-                f"decode-set drift: endpoint.lock stamped {stamped[:16]}…, "
-                f"this process derives {live[:16]}…"
-            ),
-        )
+    live = ds or runtime_decode_set()
+    if stamped == live.digest:
+        return
+    was = {str(c.get("contract") or "") for c in (baked.get("contracts") or [])}
+    now = set(live.contracts())
+    raise DecodeSetDriftError(
+        stamped=stamped, live=live.digest,
+        gained=tuple(sorted(now - was)), lost=tuple(sorted(was - now)),
+        excluded=live.excluded_modules,
+    )
 
 
 class KeyTopologyUnsupportedError(Exception):
@@ -357,6 +402,45 @@ class KeyTopologyUnsupportedError(Exception):
         )
 
 
+class KeyTopologyUnclassifiedError(Exception):
+    """A DENOISER tree whose key convention matches no registered topology.
+
+    Fails closed, deliberately. The publish side refuses an underivable
+    topology rather than guessing a nearest match (th#1937), and the load side
+    holds the same line where it costs the most: the model class is selected
+    by the architecture the keys describe, so a convention nothing registers is
+    exactly the state that produced `Cannot detect the model type` after a
+    71 GB fetch.
+
+    Scoped to the denoiser ON PURPOSE. A VAE, text encoder, scheduler or
+    tokenizer is not addressed by an architecture-specific model class, so the
+    axis does not apply to them and "unclassified" there is a fact rather than
+    a hedge — refusing it would refuse the entire fleet to catch nothing.
+    """
+
+    code = REFUSAL_KEY_TOPOLOGY_UNCLASSIFIED
+
+    def __init__(
+        self, contract: str, *, sample: tuple[str, ...],
+        registered: tuple[str, ...], where: str = "",
+    ) -> None:
+        self.contract = contract
+        self.sample = sample
+        self.registered = registered
+        self.where = where
+        subject = f" at {where}" if where else ""
+        super().__init__(
+            f"the denoiser tree{subject} is in a tensor-KEY convention no "
+            f"registered topology matches (registered: "
+            f"{', '.join(registered)}). Keys seen: {', '.join(sample)}. The "
+            f"contract {contract} says what the bytes ARE; this says nothing "
+            f"here knows how they are ADDRESSED, and a model class chosen "
+            f"hopefully fails at load with an unrelated message. Register the "
+            f"topology and declare a decoder for it, or bind a tree in a "
+            f"known one."
+        )
+
+
 def accepted_key_topologies(contract: str, ds: DecodeSet) -> tuple[str, ...]:
     """Every key convention this image's decoders of ``contract`` ingest."""
     out: list[str] = []
@@ -374,15 +458,25 @@ def require_decodable(
     *,
     decode_set: Optional[DecodeSet] = None,
     where: str = "",
-    key_topology: str = "",
+    keys: Optional["SnapshotKeys"] = None,
 ) -> None:
-    """Refuse, typed, unless ``contract`` is in the image's decode-set — and,
-    when the artifact's key convention has been IDENTIFIED, unless a decoder
-    of that contract ingests it.
+    """Refuse, typed, unless this image can decode the artifact. Three checks,
+    three codes, all answered from headers before any tensor is read:
 
-    ``key_topology=""`` means UNKNOWN and refuses nothing: a classifier that
-    refused what it could not name would be an upper bound, and the fleet is
-    full of legal trees it has never seen.
+    1. ``contract`` is in the image's decode-set, else
+       ``decode_set_contract_undeclared``;
+    2. the artifact's key convention was CLASSIFIED — a DENOISER tree matching
+       no registered topology is ``decode_set_key_topology_unclassified``,
+       never a hopeful pass;
+    3. a decoder of ``contract`` ingests that convention, else
+       ``decode_set_key_topology_unsupported``.
+
+    **What "unknown" does, stated so it cannot be misread:** for the DENOISER
+    it REFUSES (check 2). For every other component — vae, text encoder,
+    scheduler — the key-topology axis does not apply and is not evaluated,
+    which is the tri-state's UNDECLARED rung, not a fail-open: a refusal there
+    would refuse the whole fleet to catch nothing, since no
+    architecture-specific model class is chosen from those trees.
     """
     ds = decode_set if decode_set is not None else runtime_decode_set()
     declared = ds.contracts()
@@ -394,9 +488,19 @@ def require_decodable(
             unregistered=ds.unregistered,
             where=where,
         )
-    if not key_topology:
+    if keys is None:
+        return
+    if keys.unclassified_denoiser:
+        from gen_worker.models.tensor_layout_contract import (
+            KNOWN_KEY_TOPOLOGIES,
+        )
+
+        raise KeyTopologyUnclassifiedError(
+            contract, sample=keys.sample, registered=KNOWN_KEY_TOPOLOGIES,
+            where=where)
+    if not keys.topology:
         return
     accepted = accepted_key_topologies(contract, ds)
-    if key_topology not in accepted:
+    if keys.topology not in accepted:
         raise KeyTopologyUnsupportedError(
-            contract, observed=key_topology, accepted=accepted, where=where)
+            contract, observed=keys.topology, accepted=accepted, where=where)

--- a/src/gen_worker/discovery/decode_set.py
+++ b/src/gen_worker/discovery/decode_set.py
@@ -187,7 +187,6 @@ def manifest_block(ds: DecodeSet) -> Dict[str, Any]:
                 "composes_lora": e.composes_lora,
                 "elements": list(e.decodes.elements),
                 "scales": list(e.decodes.scales),
-                "shards": list(e.decodes.shards),
                 "key_topologies": list(e.decodes.key_topologies),
                 "bakes": list(e.decodes.bakes),
             }
@@ -490,6 +489,14 @@ def require_decodable(
         )
     if keys is None:
         return
+    accepted = accepted_key_topologies(contract, ds)
+    if not accepted:
+        # This contract's decoders do not CONSTRAIN the key axis — the quant
+        # handle already fixes the keys (th#1937 declined a synonym token for
+        # exactly that reason). An unconstrained axis is not evaluated, which
+        # is the tri-state's UNDECLARED rung and not a fail-open: the handle
+        # check above already refused anything this image cannot decode.
+        return
     if keys.unclassified_denoiser:
         from gen_worker.models.tensor_layout_contract import (
             KNOWN_KEY_TOPOLOGIES,
@@ -500,7 +507,6 @@ def require_decodable(
             where=where)
     if not keys.topology:
         return
-    accepted = accepted_key_topologies(contract, ds)
     if keys.topology not in accepted:
         raise KeyTopologyUnsupportedError(
             contract, observed=keys.topology, accepted=accepted, where=where)

--- a/src/gen_worker/discovery/decode_set.py
+++ b/src/gen_worker/discovery/decode_set.py
@@ -1,0 +1,402 @@
+"""The DECLARED DECODE-SET — what contracts this image's code can decode,
+derived at IMAGE BUILD from the decoders that survived the import.
+
+th#1938's `resolve()` intersects three things: the endpoint's contract
+patterns, the worker's decode-set, and card executability. This module is the
+second one's ground truth. It exists because different quant recipes are not
+one "quantized" concept — `cozy.fp8-rowwise@1`, `hf.fp8-blockwise@1`,
+`cozy.svdq-nvfp4-lr8@1` and `nunchaku.v1@1` are four byte formats needing four
+decode paths, and no config may select bytes the code cannot read.
+
+Three properties, each of them a thing that could otherwise be faked:
+
+1. **Derived, never written.** The census imports every decoder module and
+   harvests the `@implements_contract` markers that survived. A module that
+   raises contributes no declaration and one excluded-with-reason record.
+2. **A property of the BUILT IMAGE.** `python -m gen_worker.discovery` runs in
+   the image build and stamps the block into `endpoint.lock`; the digest
+   below is what makes "the set the hub read" and "the set this process would
+   derive" comparable rather than merely plausible.
+3. **Complete.** A declaration carries the contract's DIMENSIONS the decoder
+   reads (`DecodeDimensions`), not just its handle, and decode paths whose
+   bytes no registered contract covers are recorded as such instead of living
+   in a source comment nothing can read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import pkgutil
+from typing import Any, Dict, Optional
+
+import msgspec
+
+from gen_worker.models.tensor_layout_contract import (
+    ContractDecoder,
+    DecodeDimensions,
+    UnregisteredDecodePath,
+    contract_decoders_of,
+    unregistered_decode_path_of,
+)
+
+# Names the MECHANISM, so an image that predates it emits no block at all and
+# is UNPROVEN to a reader — distinct from one that derived an empty set.
+DERIVATION = "gen_worker.discovery.decode_set@1"
+
+DEFAULT_DECODER_PACKAGES: tuple[str, ...] = ("gen_worker.models",)
+
+#: The typed refusal wire codes. One spelling each, here, so the worker and the
+#: hub cannot drift into two names for one refusal.
+REFUSAL_CONTRACT_UNDECLARED = "decode_set_contract_undeclared"
+REFUSAL_KEY_TOPOLOGY_UNSUPPORTED = "decode_set_key_topology_unsupported"
+
+
+class ExcludedDecoderModule(msgspec.Struct, frozen=True, kw_only=True):
+    module: str
+    reason: str
+
+
+class DecodeEntry(msgspec.Struct, frozen=True, kw_only=True):
+    """One (contract, decoder) the image ships, with what it decodes."""
+
+    contract: str
+    decoder: str
+    serves: tuple[str, ...]
+    composes_lora: bool
+    decodes: DecodeDimensions
+
+
+class DecodeSet(msgspec.Struct, frozen=True, kw_only=True):
+    derivation: str
+    entries: tuple[DecodeEntry, ...]
+    unregistered: tuple[UnregisteredDecodePath, ...]
+    excluded_modules: tuple[ExcludedDecoderModule, ...]
+    digest: str = ""
+
+    def contracts(self) -> tuple[str, ...]:
+        seen: list[str] = []
+        for entry in self.entries:
+            if entry.contract not in seen:
+                seen.append(entry.contract)
+        return tuple(seen)
+
+
+def _harvest(
+    module: object,
+    declared: dict[tuple[str, str], ContractDecoder],
+    unregistered: dict[str, UnregisteredDecodePath],
+) -> None:
+    for attr in sorted(dir(module)):
+        obj = getattr(module, attr, None)
+        for dec in contract_decoders_of(obj):
+            declared[(dec.contract, dec.decoder)] = dec
+        for path in unregistered_decode_path_of(obj):
+            unregistered[path.decoder] = path
+
+
+def _census(
+    packages: tuple[str, ...],
+) -> tuple[
+    tuple[ContractDecoder, ...],
+    tuple[UnregisteredDecodePath, ...],
+    tuple[ExcludedDecoderModule, ...],
+]:
+    """Import every decoder module and harvest the markers that survived.
+
+    Import is the whole test: a module that raises contributes NO declaration
+    and one excluded-with-reason record. There is no third state where a
+    decoder is claimed but absent.
+    """
+    declared: dict[tuple[str, str], ContractDecoder] = {}
+    unregistered: dict[str, UnregisteredDecodePath] = {}
+    excluded: list[ExcludedDecoderModule] = []
+
+    for package in packages:
+        try:
+            pkg = importlib.import_module(package)
+        except Exception as exc:
+            excluded.append(ExcludedDecoderModule(
+                module=package, reason=f"{type(exc).__name__}: {exc}"))
+            continue
+        _harvest(pkg, declared, unregistered)
+        paths = getattr(pkg, "__path__", None)
+        if not paths:
+            continue
+        for info in sorted(pkgutil.iter_modules(paths), key=lambda m: m.name):
+            name = f"{package}.{info.name}"
+            try:
+                _harvest(importlib.import_module(name), declared, unregistered)
+            except Exception as exc:
+                excluded.append(ExcludedDecoderModule(
+                    module=name, reason=f"{type(exc).__name__}: {exc}"))
+    return (
+        tuple(declared[k] for k in sorted(declared)),
+        tuple(unregistered[k] for k in sorted(unregistered)),
+        tuple(excluded),
+    )
+
+
+def _digest(ds: DecodeSet) -> str:
+    """sha256 over the canonical encoding of everything but the digest.
+
+    Sorted throughout, so two builds of one image agree byte-for-byte and a
+    changed declaration moves the digest. This is what makes "derived at image
+    build" checkable rather than asserted.
+    """
+    payload = msgspec.json.encode(msgspec.structs.replace(ds, digest=""))
+    return hashlib.sha256(payload).hexdigest()
+
+
+def derive_decode_set(
+    packages: tuple[str, ...] = DEFAULT_DECODER_PACKAGES,
+) -> DecodeSet:
+    """The contracts this image's decoders implement, with their dimensions."""
+    declared, unregistered, excluded = _census(packages)
+    ds = DecodeSet(
+        derivation=DERIVATION,
+        entries=tuple(
+            DecodeEntry(
+                contract=d.contract,
+                decoder=d.decoder,
+                serves=tuple(sorted(d.serves)),
+                composes_lora=d.composes_lora,
+                decodes=d.decodes,
+            )
+            for d in declared
+        ),
+        unregistered=unregistered,
+        excluded_modules=excluded,
+    )
+    return msgspec.structs.replace(ds, digest=_digest(ds))
+
+
+def manifest_block(ds: DecodeSet) -> Dict[str, Any]:
+    """The ``[decode_set]`` block as it lands in endpoint.lock."""
+    return {
+        "derivation": ds.derivation,
+        "digest": ds.digest,
+        "contracts": [
+            {
+                "contract": e.contract,
+                "decoder": e.decoder,
+                "serves": list(e.serves),
+                "composes_lora": e.composes_lora,
+                "elements": list(e.decodes.elements),
+                "scales": list(e.decodes.scales),
+                "shards": list(e.decodes.shards),
+                "key_topologies": list(e.decodes.key_topologies),
+                "bakes": list(e.decodes.bakes),
+            }
+            for e in ds.entries
+        ],
+        "unregistered": [
+            {"decoder": u.decoder, "reason": u.reason} for u in ds.unregistered
+        ],
+        "excluded_modules": [
+            {"module": m.module, "reason": m.reason} for m in ds.excluded_modules
+        ],
+    }
+
+
+# ── The refusal ──────────────────────────────────────────────────────────────
+
+
+def _parts(handle: str) -> tuple[str, str, frozenset[str]]:
+    namespace, _, rest = handle.partition(".")
+    name, _, _major = rest.partition("@")
+    return namespace, name, frozenset(t for t in name.replace(".", "-").split("-") if t)
+
+
+def nearest_declared(contract: str, ds: DecodeSet) -> str:
+    """The declared contract closest to ``contract``, or ``""``.
+
+    Nearest is a REMEDY, not a substitution: it is what the refusal names so a
+    reader can tell "you pinned the wrong major" from "nothing in this image
+    is remotely this format". Ranked by same NAME (a major difference), then
+    shared FORMAT TOKENS, then same namespace — the namespace is the PRODUCER
+    and ranks last on purpose: `cozy.fp8-rowwise@1` is nearer to
+    `hf.fp8-blockwise@1` than to `cozy.svdq-nvfp4-lr8@1`, and whole-string
+    similarity gets both of those backwards. Ties break on the handle so two
+    builds answer alike.
+    """
+    from difflib import SequenceMatcher
+
+    want_ns, want_name, want_tokens = _parts(contract)
+    best, best_score = "", -1.0
+    for candidate in sorted(ds.contracts()):
+        ns, name, tokens = _parts(candidate)
+        union = want_tokens | tokens
+        score = 0.5 * SequenceMatcher(None, contract, candidate).ratio()
+        score += 2.0 * len(want_tokens & tokens) / len(union) if union else 0.0
+        if name == want_name:
+            score += 4.0
+        if ns == want_ns:
+            score += 0.5
+        if score > best_score:
+            best, best_score = candidate, score
+    return best
+
+
+class ContractNotDecodableError(Exception):
+    """A bound variant's contract is outside this image's decode-set.
+
+    Typed and named on both halves — the contract asked for and the nearest
+    one declared — because the remedy is on one side or the other and the
+    operator cannot tell which from "load failed".
+    """
+
+    code = REFUSAL_CONTRACT_UNDECLARED
+
+    def __init__(
+        self,
+        contract: str,
+        *,
+        declared: tuple[str, ...],
+        nearest: str = "",
+        unregistered: tuple[UnregisteredDecodePath, ...] = (),
+        where: str = "",
+    ) -> None:
+        self.contract = contract
+        self.declared = declared
+        self.nearest = nearest
+        self.unregistered = unregistered
+        self.where = where
+        subject = f" for {where}" if where else ""
+        remedy = (
+            f"nearest declared contract is {nearest!r}"
+            if nearest else
+            "this image declares NO contract at all — its decoder modules "
+            "failed to import, or it ships none"
+        )
+        note = ""
+        if unregistered:
+            note = (
+                "; this image also carries decode paths no registered contract "
+                "covers (" + ", ".join(u.decoder for u in unregistered) + ")"
+            )
+        super().__init__(
+            f"contract {contract!r}{subject} is not in this image's declared "
+            f"decode-set (declared: {', '.join(declared) or 'none'}); "
+            f"{remedy}. Bind a variant in a declared contract, or ship an "
+            f"image whose decoder declares this one{note}."
+        )
+
+
+_RUNTIME_SET: Optional[DecodeSet] = None
+
+
+def runtime_decode_set() -> DecodeSet:
+    """This process's decode-set, derived once.
+
+    The image's build-time block in endpoint.lock is the artifact the HUB
+    reads; this is the same derivation run against the same code, and
+    :func:`assert_matches_baked` is what proves they are the same answer.
+    """
+    global _RUNTIME_SET
+    if _RUNTIME_SET is None:
+        _RUNTIME_SET = derive_decode_set()
+    return _RUNTIME_SET
+
+
+def assert_matches_baked(baked: Dict[str, Any], ds: Optional[DecodeSet] = None) -> None:
+    """Refuse when the process's decode-set is not the image's baked one.
+
+    A block with no digest is an OLDER image and is not evidence of anything;
+    a digest that disagrees is a real divergence — the code that runs is not
+    the code the hub was told about — and it fails closed.
+    """
+    stamped = str((baked or {}).get("digest") or "")
+    if not stamped:
+        return
+    live = (ds or runtime_decode_set()).digest
+    if stamped != live:
+        raise ContractNotDecodableError(
+            "<image>",
+            declared=(ds or runtime_decode_set()).contracts(),
+            where=(
+                f"decode-set drift: endpoint.lock stamped {stamped[:16]}…, "
+                f"this process derives {live[:16]}…"
+            ),
+        )
+
+
+class KeyTopologyUnsupportedError(Exception):
+    """The artifact's tensor-KEY convention is one no decoder here ingests.
+
+    Distinct from :class:`ContractNotDecodableError` because everything about
+    the bytes is right — right contract, right element, right scales — and the
+    model class still cannot read them: the keys are addressed differently.
+    Measured cost of not having this: `Cannot detect the model type` from an
+    md5-over-key:shape lookup, after a 71 GB fetch onto a rented 4xH100.
+    """
+
+    code = REFUSAL_KEY_TOPOLOGY_UNSUPPORTED
+
+    def __init__(
+        self,
+        contract: str,
+        *,
+        observed: str,
+        accepted: tuple[str, ...],
+        where: str = "",
+    ) -> None:
+        self.contract = contract
+        self.observed = observed
+        self.accepted = accepted
+        self.where = where
+        subject = f" at {where}" if where else ""
+        super().__init__(
+            f"the artifact{subject} is written in key topology {observed!r}, "
+            f"which this image's {contract} decoder does not ingest (it "
+            f"accepts: {', '.join(accepted) or 'none'}). The bytes are the "
+            f"right format and the KEYS are addressed differently, so no "
+            f"quantization or dtype change fixes it — bind the variant in an "
+            f"accepted topology, or ship an image whose model class ingests "
+            f"this one."
+        )
+
+
+def accepted_key_topologies(contract: str, ds: DecodeSet) -> tuple[str, ...]:
+    """Every key convention this image's decoders of ``contract`` ingest."""
+    out: list[str] = []
+    for entry in ds.entries:
+        if entry.contract != contract:
+            continue
+        for token in entry.decodes.key_topologies:
+            if token not in out:
+                out.append(token)
+    return tuple(sorted(out))
+
+
+def require_decodable(
+    contract: str,
+    *,
+    decode_set: Optional[DecodeSet] = None,
+    where: str = "",
+    key_topology: str = "",
+) -> None:
+    """Refuse, typed, unless ``contract`` is in the image's decode-set — and,
+    when the artifact's key convention has been IDENTIFIED, unless a decoder
+    of that contract ingests it.
+
+    ``key_topology=""`` means UNKNOWN and refuses nothing: a classifier that
+    refused what it could not name would be an upper bound, and the fleet is
+    full of legal trees it has never seen.
+    """
+    ds = decode_set if decode_set is not None else runtime_decode_set()
+    declared = ds.contracts()
+    if contract not in declared:
+        raise ContractNotDecodableError(
+            contract,
+            declared=tuple(sorted(declared)),
+            nearest=nearest_declared(contract, ds),
+            unregistered=ds.unregistered,
+            where=where,
+        )
+    if not key_topology:
+        return
+    accepted = accepted_key_topologies(contract, ds)
+    if key_topology not in accepted:
+        raise KeyTopologyUnsupportedError(
+            contract, observed=key_topology, accepted=accepted, where=where)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -31,6 +31,10 @@ from gen_worker.api.types import (
     Tensors,
     VideoAsset,
 )
+from gen_worker.discovery.decode_set import derive_decode_set
+from gen_worker.discovery.decode_set import (
+    manifest_block as decode_set_manifest_block,
+)
 from gen_worker.discovery.execution_lanes import (
     DerivedExecutionLanes,
     derive_execution_lanes,
@@ -945,7 +949,11 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     # same heavy-dep stubbing the endpoint walk used, so a torch-less manifest
     # build derives the same set an in-image build does.
     with stub_missing_heavy_deps(cfg.discovery_heavy_deps) as stubbed:
-        derived = derive_execution_lanes()
+        # ONE import walk: the decode-set is what the image can READ
+        # (th#1938's third intersection) and the lane block is what it can
+        # RUN. Two renders of one census, never two censuses.
+        decode_set = derive_decode_set()
+        derived = derive_execution_lanes(decode_set=decode_set)
         # The AOT lane's STATIC preconditions, decided in the image that will
         # run them. `validate_endpoint_lock` turns a refusal into a build error,
         # so an endpoint that declares an export it cannot compile never reaches
@@ -977,6 +985,7 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     manifest: Dict[str, Any] = {
         "functions": functions,
         "execution_lanes": manifest_block(derived),
+        "decode_set": decode_set_manifest_block(decode_set),
     }
     if preconditions:
         manifest["aot_preconditions"] = [

--- a/src/gen_worker/discovery/execution_lanes.py
+++ b/src/gen_worker/discovery/execution_lanes.py
@@ -1,32 +1,33 @@
-"""The endpoint-side execution-lane declaration, DERIVED at image build from
-the decoders actually present in the image.
+"""The endpoint-side execution-lane declaration: the image's DECODE-SET
+(``discovery.decode_set``) crossed with the runtime's execution options.
 
-Three steps, none of them a list anybody maintains:
+Two steps, neither of them a list anybody maintains:
 
-1. import every module of the decoder packages and collect the
-   ``@implements_contract`` markers that survived the import;
+1. take the derived decode-set — the ``@implements_contract`` markers that
+   survived the import walk, with the dimensions each decoder reads;
 2. cross each declared lane BODY with the execution options the runtime table
    says that body supports (``models.execution_lanes``) — the platform owns
-   eager/compiled, so a decoder never declares it;
-3. subtract nothing. Exclusions are derived per FUNCTION from declared traits
-   (A4 corollary: no exclusion marker in v1).
+   eager/compiled, so a decoder never declares it.
 
-A module that fails to import is EXCLUDED WITH ITS REASON, never silently
-dropped: an image whose svdq decoder cannot import must not claim the svdq
-lane, and it must be able to say why it does not.
+Subtract nothing. Exclusions are derived per FUNCTION from declared traits
+(A4 corollary: no exclusion marker in v1).
+
+ONE census feeds both blocks: what bytes the image can READ is the decode-set
+(th#1938's third intersection) and what lanes it can RUN is this one. Two
+facts, two renders, one import walk — never two censuses that can disagree.
 """
 
 from __future__ import annotations
 
-import importlib
-import pkgutil
 from typing import Any, Dict
 
 import msgspec
 
-from gen_worker.models.tensor_layout_contract import (
-    ContractDecoder,
-    contract_decoders_of,
+from gen_worker.discovery.decode_set import (
+    DEFAULT_DECODER_PACKAGES,
+    DecodeSet,
+    ExcludedDecoderModule,
+    derive_decode_set,
 )
 from gen_worker.models.execution_lanes import (
     execution_lane_body_id,
@@ -39,12 +40,17 @@ from gen_worker.models.execution_lanes import (
 # UNPROVEN hub-side — distinct from an image that derived an empty set.
 DERIVATION = "gen_worker.discovery.execution_lanes@1"
 
-DEFAULT_DECODER_PACKAGES: tuple[str, ...] = ("gen_worker.models",)
-
-
-class ExcludedDecoderModule(msgspec.Struct, frozen=True, kw_only=True):
-    module: str
-    reason: str
+__all__ = [
+    "DERIVATION",
+    "DEFAULT_DECODER_PACKAGES",
+    "DerivedContract",
+    "DerivedExecutionLanes",
+    "ExcludedDecoderModule",
+    "FunctionExclusion",
+    "derive_execution_lanes",
+    "execution_lanes_for_function",
+    "manifest_block",
+]
 
 
 class DerivedContract(msgspec.Struct, frozen=True, kw_only=True):
@@ -59,6 +65,7 @@ class DerivedExecutionLanes(msgspec.Struct, frozen=True, kw_only=True):
     execution_lanes: tuple[str, ...]
     contracts: tuple[DerivedContract, ...]
     excluded_modules: tuple[ExcludedDecoderModule, ...]
+    decode_set: DecodeSet
 
 
 class FunctionExclusion(msgspec.Struct, frozen=True, kw_only=True):
@@ -81,73 +88,33 @@ def _lanes_for_body(body: str) -> tuple[str, ...]:
     return tuple(out)
 
 
-def _collect(
-    packages: tuple[str, ...],
-) -> tuple[tuple[ContractDecoder, ...], tuple[ExcludedDecoderModule, ...]]:
-    """Import every decoder module and harvest the markers that survived.
-
-    Import is the whole test: a module that raises contributes NO declaration
-    and one excluded-with-reason record. There is no third state where a
-    decoder is claimed but absent.
-    """
-    declared: dict[tuple[str, str], ContractDecoder] = {}
-    excluded: list[ExcludedDecoderModule] = []
-
-    def harvest(module: object) -> None:
-        for attr in sorted(dir(module)):
-            for dec in contract_decoders_of(getattr(module, attr, None)):
-                declared[(dec.contract, dec.decoder)] = dec
-
-    for package in packages:
-        try:
-            pkg = importlib.import_module(package)
-        except Exception as exc:
-            excluded.append(
-                ExcludedDecoderModule(
-                    module=package, reason=f"{type(exc).__name__}: {exc}"
-                )
-            )
-            continue
-        harvest(pkg)
-        paths = getattr(pkg, "__path__", None)
-        if not paths:
-            continue
-        for info in sorted(pkgutil.iter_modules(paths), key=lambda m: m.name):
-            name = f"{package}.{info.name}"
-            try:
-                harvest(importlib.import_module(name))
-            except Exception as exc:
-                excluded.append(
-                    ExcludedDecoderModule(
-                        module=name, reason=f"{type(exc).__name__}: {exc}"
-                    )
-                )
-    return tuple(declared[k] for k in sorted(declared)), tuple(excluded)
-
-
-def _derived_contract(dec: ContractDecoder) -> DerivedContract:
+def _derived_contract(entry: Any) -> DerivedContract:
     rank = _rank()
     lanes: list[str] = []
-    for body in dec.serves:
+    for body in entry.serves:
         for lane in _lanes_for_body(body):
             if lane not in lanes:
                 lanes.append(lane)
     lanes.sort(key=lambda lane: rank[lane])
     return DerivedContract(
-        contract=dec.contract,
-        decoder=dec.decoder,
+        contract=entry.contract,
+        decoder=entry.decoder,
         execution_lanes=tuple(lanes),
-        composes_lora=dec.composes_lora,
+        composes_lora=entry.composes_lora,
     )
 
 
 def derive_execution_lanes(
     packages: tuple[str, ...] = DEFAULT_DECODER_PACKAGES,
+    decode_set: DecodeSet | None = None,
 ) -> DerivedExecutionLanes:
-    """Enumerate the contracts this image's decoders implement, crossed with
-    the runtime's execution options."""
-    declared, excluded = _collect(packages)
-    contracts = tuple(_derived_contract(dec) for dec in declared)
+    """Cross the image's decode-set with the runtime's execution options.
+
+    ``decode_set`` lets a caller that already derived one (the manifest build)
+    pass it in rather than paying a second import walk for the same answer.
+    """
+    ds = decode_set if decode_set is not None else derive_decode_set(packages)
+    contracts = tuple(_derived_contract(entry) for entry in ds.entries)
     rank = _rank()
     union: list[str] = []
     for contract in contracts:
@@ -159,7 +126,8 @@ def derive_execution_lanes(
         derivation=DERIVATION,
         execution_lanes=tuple(union),
         contracts=contracts,
-        excluded_modules=excluded,
+        excluded_modules=ds.excluded_modules,
+        decode_set=ds,
     )
 
 

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -410,6 +410,19 @@ def _run_main() -> int:
     manifest = load_manifest(manifest_path)
     user_modules: List[str] = []
     if manifest:
+        # The decode-set the hub was told about is the one stamped in this
+        # lock at IMAGE BUILD. If this process would derive a different one,
+        # the code that runs is not the code the hub selected against, and
+        # every downstream answer is about the wrong image (pgw#1245).
+        try:
+            from .discovery.decode_set import assert_matches_baked
+
+            assert_matches_baked(manifest.get("decode_set") or {})
+        except Exception as e:
+            _log_worker_fatal("decode_set_drift", e, exit_code=1,
+                              settings=settings)
+            logger.error(str(e))
+            return 1
         user_modules = get_modules_from_manifest(manifest)
         _log_startup_phase(
             "manifest_loaded",

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -50,10 +50,8 @@ from .tensor_layout_contract import (
     CONTRACT_HF_FP8_BLOCKWISE,
     ELEMENT_BF16,
     ELEMENT_FP8_E4M3,
-    KEYS_TRANSFORMERS_NATIVE,
+    KEYS_TRANSFORMERS_SPLIT_QKV,
     SCALE_BLOCK_128X128,
-    SHARD_COMPONENT_DIR,
-    SHARD_INDEX_SHARDED,
     DecodeDimensions,
     implements_contract,
 )
@@ -325,9 +323,9 @@ def _hf_model_class(path: Path, cls: Any) -> Any:
         # grid and refuses anything else, so declaring rowwise here would be
         # the exact conflation `cozy.fp8-rowwise@1` exists to prevent.
         scales=(SCALE_BLOCK_128X128,),
-        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED),
         # transformers' own loader, so transformers' own key convention.
-        key_topologies=(KEYS_TRANSFORMERS_NATIVE,),
+        key_topologies=(KEYS_TRANSFORMERS_SPLIT_QKV,),
+        bakes=(),
     ),
     why="th#1803: transformers' FineGrainedFP8 reads this layout natively — "
         "resident fp8 weights with a 128x128 block scale grid, dynamic "

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -48,9 +48,9 @@ import msgspec
 from .safetensors_header import header_len_ok
 from .tensor_layout_contract import (
     CONTRACT_HF_FP8_BLOCKWISE,
-    KEYS_TRANSFORMERS_NATIVE,
     ELEMENT_BF16,
     ELEMENT_FP8_E4M3,
+    KEYS_TRANSFORMERS_NATIVE,
     SCALE_BLOCK_128X128,
     SHARD_COMPONENT_DIR,
     SHARD_INDEX_SHARDED,

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -46,7 +46,17 @@ from typing import Any, Dict, Optional, Tuple
 import msgspec
 
 from .safetensors_header import header_len_ok
-from .tensor_layout_contract import CONTRACT_HF_FP8_BLOCKWISE, implements_contract
+from .tensor_layout_contract import (
+    CONTRACT_HF_FP8_BLOCKWISE,
+    KEYS_TRANSFORMERS_NATIVE,
+    ELEMENT_BF16,
+    ELEMENT_FP8_E4M3,
+    SCALE_BLOCK_128X128,
+    SHARD_COMPONENT_DIR,
+    SHARD_INDEX_SHARDED,
+    DecodeDimensions,
+    implements_contract,
+)
 
 # The registry's declared reference dequant for this contract. Named here so
 # the SDK's transform and tensorhub's descriptor point at ONE spec rather than
@@ -309,6 +319,16 @@ def _hf_model_class(path: Path, cls: Any) -> Any:
     contract=CONTRACT_HF_FP8_BLOCKWISE,
     serves=("fp8-w8a8-dynamic", "fp8-w8a16"),
     composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=(ELEMENT_FP8_E4M3, ELEMENT_BF16),
+        # 128x128 block scales ONLY. `inspect_hf_fp8_blockwise` verifies the
+        # grid and refuses anything else, so declaring rowwise here would be
+        # the exact conflation `cozy.fp8-rowwise@1` exists to prevent.
+        scales=(SCALE_BLOCK_128X128,),
+        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED),
+        # transformers' own loader, so transformers' own key convention.
+        key_topologies=(KEYS_TRANSFORMERS_NATIVE,),
+    ),
     why="th#1803: transformers' FineGrainedFP8 reads this layout natively — "
         "resident fp8 weights with a 128x128 block scale grid, dynamic "
         "per-token activation scales through the triton/DeepGEMM blockwise "
@@ -340,6 +360,9 @@ def load_hf_fp8_blockwise(
     import torch
     from transformers import FineGrainedFP8Config
 
+    from ..discovery.decode_set import require_decodable
+
+    require_decodable(CONTRACT_HF_FP8_BLOCKWISE, where=str(root))
     verified = tree or inspect_hf_fp8_blockwise(root, component=component)
     path = verified.path
     compute = dtype or torch.bfloat16

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -37,7 +37,7 @@ from .safetensors_header import header_len_ok
 from .tensor_layout_contract import (
     KEYS_DIFFUSERS_SPLIT_QKV,
     KEYS_NATIVE_FUSED_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
+    KEYS_TRANSFORMERS_SPLIT_QKV,
 )
 
 # Ordered: the first rule that matches wins. FUSED is checked first because a
@@ -47,8 +47,11 @@ from .tensor_layout_contract import (
 _RULES: tuple[tuple[str, "re.Pattern[str]"], ...] = (
     (KEYS_NATIVE_FUSED_QKV, re.compile(r"\.(qkv_proj|to_qkv|qkv)\.")),
     (KEYS_DIFFUSERS_SPLIT_QKV, re.compile(r"\.(to_q|to_k|to_v)\.")),
-    (KEYS_TRANSFORMERS_NATIVE,
-     re.compile(r"\.(q_proj|k_proj|v_proj|query|key|value)\.")),
+    # th#1937's ruled keying for `transformers.split-qkv@1`:
+    # `*layers.N.self_attn.q_proj` OR `*layers.N.attention.self.query`, so
+    # encoder-style text encoders answer alongside decoder-style ones.
+    (KEYS_TRANSFORMERS_SPLIT_QKV,
+     re.compile(r"layers?\.\d+\.(self_attn\.q_proj|attention\.self\.query)\.")),
 )
 
 #: Header bytes are bounded by `header_len_ok`; this caps how many FILES we

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -67,19 +67,41 @@ _MAX_FILES = 64
 #: enough that the message stays readable.
 _SAMPLE = 6
 
+# Whether the tree has ATTENTION substructure at all. This axis discriminates
+# attention-projection conventions, so a tree with no attention in it is not
+# something the axis can be about — the same reason a vae is out of scope, but
+# derived from the BYTES instead of from the component name.
+#
+# It is what keeps the unclassified REFUSAL precise. Without it, every tree
+# whose keys the three rules do not match refuses, and CI produced the
+# counter-example immediately: the corrupt-load quarantine fixture
+# (`test_p2_residency_reconcile.py`) is a root-layout snapshot holding one
+# tensor named `w`, which is a legal thing to hand a loader and carries no
+# convention to get wrong. With it, a FOURTH attention spelling — the H3 class
+# of failure, one no rule here has seen — still refuses, which is the case the
+# refusal exists for.
+_ATTENTION_SHAPED = re.compile(r"(^|\.)(attn|attention|self_attn)[\._]")
+
 
 class SnapshotKeys(msgspec.Struct, frozen=True, kw_only=True):
     """What the header scan found, and where it looked."""
 
-    topology: str          # a registered token, or "" for unclassified
-    denoiser: bool         # the scanned tree is in the DENOISER position
-    saw_tensors: bool      # any safetensors header was actually read
+    topology: str            # a registered token, or "" for unclassified
+    denoiser: bool           # the scanned tree is in the DENOISER position
+    saw_tensors: bool        # any safetensors header was actually read
+    attention_shaped: bool = False   # the keys carry attention substructure
     sample: tuple[str, ...] = ()
 
     @property
     def unclassified_denoiser(self) -> bool:
-        """The one combination that must fail closed."""
-        return self.denoiser and self.saw_tensors and not self.topology
+        """The one combination that must fail closed: a DENOISER carrying
+        attention substructure spelled in no way this image recognizes."""
+        return (
+            self.denoiser
+            and self.saw_tensors
+            and self.attention_shaped
+            and not self.topology
+        )
 
 
 def tensor_keys(files: Iterable[Path]) -> tuple[str, ...]:
@@ -113,7 +135,12 @@ def identify_keys(keys: Iterable[str]) -> str:
     return ""
 
 
-def _scan(directory: Path) -> tuple[str, tuple[str, ...]]:
+def attention_shaped(keys: Iterable[str]) -> bool:
+    """Whether a tensor-name set carries attention substructure at all."""
+    return any(_ATTENTION_SHAPED.search(name) for name in keys)
+
+
+def _scan(directory: Path) -> tuple[str, bool, tuple[str, ...]]:
     """Classify a directory's shards, stopping at the first file that answers.
 
     Early exit matters on the fail-closed path: reading every shard of a
@@ -123,15 +150,15 @@ def _scan(directory: Path) -> tuple[str, tuple[str, ...]]:
     """
     files = sorted(p for p in directory.glob("*.safetensors") if p.is_file())
     if not files:
-        return "", ()
+        return "", False, ()
     seen: list[str] = []
     for path in files[:_MAX_FILES]:
         keys = tensor_keys([path])
         seen.extend(keys)
         topology = identify_keys(keys)
         if topology:
-            return topology, tuple(sorted(seen)[:_SAMPLE])
-    return "", tuple(sorted(seen)[:_SAMPLE])
+            return topology, True, tuple(sorted(seen)[:_SAMPLE])
+    return "", attention_shaped(seen), tuple(sorted(seen)[:_SAMPLE])
 
 
 def classify_snapshot(root: Path, component: str = "") -> SnapshotKeys:
@@ -151,28 +178,31 @@ def classify_snapshot(root: Path, component: str = "") -> SnapshotKeys:
         keys = tensor_keys([base])
         return SnapshotKeys(topology=identify_keys(keys), denoiser=True,
                             saw_tensors=bool(keys),
+                            attention_shaped=attention_shaped(keys),
                             sample=tuple(sorted(keys)[:_SAMPLE]))
     if not base.is_dir():
         return SnapshotKeys(topology="", denoiser=False, saw_tensors=False)
 
     if component:
-        topology, sample = _scan(base / component)
+        topology, attention, sample = _scan(base / component)
         return SnapshotKeys(
             topology=topology, denoiser=component in denoisers,
-            saw_tensors=bool(sample), sample=sample)
+            saw_tensors=bool(sample), attention_shaped=attention,
+            sample=sample)
 
     for name in denoiser_components():
         directory = base / name
         if not directory.is_dir():
             continue
-        topology, sample = _scan(directory)
+        topology, attention, sample = _scan(directory)
         if sample:
             return SnapshotKeys(topology=topology, denoiser=True,
-                                saw_tensors=True, sample=sample)
-    topology, sample = _scan(base)
+                                saw_tensors=True, attention_shaped=attention,
+                                sample=sample)
+    topology, attention, sample = _scan(base)
     # A root-layout tree IS the denoiser; a pipeline root that merely happens
     # to hold loose tensors beside a `model_index.json` is not.
     return SnapshotKeys(
         topology=topology,
         denoiser=bool(sample) and not (base / "model_index.json").exists(),
-        saw_tensors=bool(sample), sample=sample)
+        saw_tensors=bool(sample), attention_shaped=attention, sample=sample)

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -7,13 +7,20 @@ from an md5-over-key:shape lookup five libraries down.
 
 Classification is by the keys that DIFFER, not by counting: the minimax-h3
 diffusers repackaging and the minimax-native tree share exactly one key out of
-638/535, and the attention projection is where they part — fused
-`blocks.N.attn.qkv_proj` versus split `transformer_blocks.N.attn.to_q`.
+638/535, and the ATTENTION PROJECTIONS are where they part — fused
+`…attn.qkv_proj` versus split `…attn.to_q` / `to_k` / `to_v`. That
+discriminator is used directly rather than through a block-prefix pattern,
+because the block prefix varies across families (`transformer_blocks`,
+`single_transformer_blocks`, `blocks`, `down_blocks.N.attentions.N.…`) and the
+projection split does not.
 
-An unrecognized key set returns ``""``: UNKNOWN, which refuses nothing. A
-classifier that refused what it could not name would be an upper bound
-wearing a lower bound's clothes, and the fleet is full of legal trees this
-one has never seen.
+**Unclassified is not silently OK.** The caller is told three things — the
+token, whether the tree is in the DENOISER position, and whether any tensors
+were read — and it fails closed on the one combination that is dangerous: a
+denoiser whose key convention matches nothing registered. The axis does not
+apply to a VAE, a text encoder or a scheduler, and reporting "unknown" for
+those is a fact, not a hedge; `gen_worker.discovery.decode_set` is where that
+distinction becomes a refusal or a pass.
 """
 
 from __future__ import annotations
@@ -24,6 +31,8 @@ import struct
 from pathlib import Path
 from typing import Iterable
 
+import msgspec
+
 from .safetensors_header import header_len_ok
 from .tensor_layout_contract import (
     KEYS_DIFFUSERS_SPLIT_QKV,
@@ -31,21 +40,38 @@ from .tensor_layout_contract import (
     KEYS_TRANSFORMERS_NATIVE,
 )
 
-# Ordered: the first rule whose pattern appears wins, and the two denoiser
-# conventions are checked before the generic transformers one because a
-# transformers-style prefix can appear inside either.
+# Ordered: the first rule that matches wins. FUSED is checked first because a
+# tree carrying fused projections is the one no diffusers class can ingest, and
+# a tree carrying both spellings is a repackaging in progress, not a diffusers
+# tree.
 _RULES: tuple[tuple[str, "re.Pattern[str]"], ...] = (
-    (KEYS_NATIVE_FUSED_QKV,
-     re.compile(r"(^|\.)blocks\.\d+\..*\.(qkv_proj|qkv)\.")),
-    (KEYS_DIFFUSERS_SPLIT_QKV,
-     re.compile(r"(^|\.)transformer_blocks\.\d+\..*\.to_q\.")),
+    (KEYS_NATIVE_FUSED_QKV, re.compile(r"\.(qkv_proj|to_qkv|qkv)\.")),
+    (KEYS_DIFFUSERS_SPLIT_QKV, re.compile(r"\.(to_q|to_k|to_v)\.")),
     (KEYS_TRANSFORMERS_NATIVE,
-     re.compile(r"(^|\.)(model\.layers|encoder\.layer|encoder\.block)\.\d+\.")),
+     re.compile(r"\.(q_proj|k_proj|v_proj|query|key|value)\.")),
 )
 
 #: Header bytes are bounded by `header_len_ok`; this caps how many FILES we
 #: open, because a sharded tree's shards share one convention.
 _MAX_FILES = 8
+
+#: How many keys a refusal quotes. Enough to recognize the convention, few
+#: enough that the message stays readable.
+_SAMPLE = 6
+
+
+class SnapshotKeys(msgspec.Struct, frozen=True, kw_only=True):
+    """What the header scan found, and where it looked."""
+
+    topology: str          # a registered token, or "" for unclassified
+    denoiser: bool         # the scanned tree is in the DENOISER position
+    saw_tensors: bool      # any safetensors header was actually read
+    sample: tuple[str, ...] = ()
+
+    @property
+    def unclassified_denoiser(self) -> bool:
+        """The one combination that must fail closed."""
+        return self.denoiser and self.saw_tensors and not self.topology
 
 
 def tensor_keys(files: Iterable[Path]) -> tuple[str, ...]:
@@ -79,29 +105,53 @@ def identify_keys(keys: Iterable[str]) -> str:
     return ""
 
 
-def identify_snapshot_keys(root: Path, component: str = "") -> str:
-    """The key convention of a snapshot's denoiser tree, or ``""``.
+def _scan(directory: Path) -> tuple[str, tuple[str, ...]]:
+    files = sorted(p for p in directory.glob("*.safetensors") if p.is_file())
+    if not files:
+        return "", ()
+    keys = tensor_keys(files)
+    return identify_keys(keys), tuple(sorted(keys)[:_SAMPLE])
 
-    ``component`` names the subdirectory to read; empty scans the root's own
-    safetensors (single-file and root-layout trees).
+
+def classify_snapshot(root: Path, component: str = "") -> SnapshotKeys:
+    """Classify a snapshot's tree, reporting whether it is the DENOISER.
+
+    ``component`` names the subdirectory to read; empty scans the denoiser
+    component dirs and then the root. A ROOT-layout tree — one with no
+    ``model_index.json`` — is itself the denoiser (the singlefile and
+    sharded-transformers artifacts the quantized loaders detect), which is why
+    the position is derived here rather than guessed by the caller.
     """
     from ..component_vocab import denoiser_components
 
     base = Path(root)
+    denoisers = set(denoiser_components())
     if base.is_file():
-        return identify_keys(tensor_keys([base]))
+        keys = tensor_keys([base])
+        return SnapshotKeys(topology=identify_keys(keys), denoiser=True,
+                            saw_tensors=bool(keys),
+                            sample=tuple(sorted(keys)[:_SAMPLE]))
     if not base.is_dir():
-        return ""
-    candidates = [base / component] if component else [
-        base / name for name in denoiser_components()
-    ] + [base]
-    for directory in candidates:
+        return SnapshotKeys(topology="", denoiser=False, saw_tensors=False)
+
+    if component:
+        topology, sample = _scan(base / component)
+        return SnapshotKeys(
+            topology=topology, denoiser=component in denoisers,
+            saw_tensors=bool(sample), sample=sample)
+
+    for name in denoiser_components():
+        directory = base / name
         if not directory.is_dir():
             continue
-        files = sorted(p for p in directory.glob("*.safetensors") if p.is_file())
-        if not files:
-            continue
-        found = identify_keys(tensor_keys(files))
-        if found:
-            return found
-    return ""
+        topology, sample = _scan(directory)
+        if sample:
+            return SnapshotKeys(topology=topology, denoiser=True,
+                                saw_tensors=True, sample=sample)
+    topology, sample = _scan(base)
+    # A root-layout tree IS the denoiser; a pipeline root that merely happens
+    # to hold loose tensors beside a `model_index.json` is not.
+    return SnapshotKeys(
+        topology=topology,
+        denoiser=bool(sample) and not (base / "model_index.json").exists(),
+        saw_tensors=bool(sample), sample=sample)

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -52,8 +52,13 @@ _RULES: tuple[tuple[str, "re.Pattern[str]"], ...] = (
 )
 
 #: Header bytes are bounded by `header_len_ok`; this caps how many FILES we
-#: open, because a sharded tree's shards share one convention.
-_MAX_FILES = 8
+#: open. It is high, and the scan stops at the first file that classifies,
+#: because the cap now sits on a FAIL-CLOSED path: a 30-shard denoiser whose
+#: leading shards hold only embeddings would otherwise read as unclassified
+#: and refuse. Attention projections appear early in practice, so the walk
+#: costs one or two headers on every real tree and the cap only bounds the
+#: pathological one.
+_MAX_FILES = 64
 
 #: How many keys a refusal quotes. Enough to recognize the convention, few
 #: enough that the message stays readable.
@@ -106,11 +111,24 @@ def identify_keys(keys: Iterable[str]) -> str:
 
 
 def _scan(directory: Path) -> tuple[str, tuple[str, ...]]:
+    """Classify a directory's shards, stopping at the first file that answers.
+
+    Early exit matters on the fail-closed path: reading every shard of a
+    30-way tree to reach the same answer the first one gave is wasted IO, and
+    reading only the first few and giving up would REFUSE a tree whose leading
+    shards happen to hold embeddings.
+    """
     files = sorted(p for p in directory.glob("*.safetensors") if p.is_file())
     if not files:
         return "", ()
-    keys = tensor_keys(files)
-    return identify_keys(keys), tuple(sorted(keys)[:_SAMPLE])
+    seen: list[str] = []
+    for path in files[:_MAX_FILES]:
+        keys = tensor_keys([path])
+        seen.extend(keys)
+        topology = identify_keys(keys)
+        if topology:
+            return topology, tuple(sorted(seen)[:_SAMPLE])
+    return "", tuple(sorted(seen)[:_SAMPLE])
 
 
 def classify_snapshot(root: Path, component: str = "") -> SnapshotKeys:

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -1,0 +1,107 @@
+"""Which tensor-KEY convention an artifact on disk is written in.
+
+Header reads only — no tensor data, no torch, no model construction. That is
+the whole point: the answer must be available BEFORE a 71 GB fetch turns into
+a rented pod that discovers the mismatch as `Cannot detect the model type`
+from an md5-over-key:shape lookup five libraries down.
+
+Classification is by the keys that DIFFER, not by counting: the minimax-h3
+diffusers repackaging and the minimax-native tree share exactly one key out of
+638/535, and the attention projection is where they part — fused
+`blocks.N.attn.qkv_proj` versus split `transformer_blocks.N.attn.to_q`.
+
+An unrecognized key set returns ``""``: UNKNOWN, which refuses nothing. A
+classifier that refused what it could not name would be an upper bound
+wearing a lower bound's clothes, and the fleet is full of legal trees this
+one has never seen.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import struct
+from pathlib import Path
+from typing import Iterable
+
+from .safetensors_header import header_len_ok
+from .tensor_layout_contract import (
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_NATIVE_FUSED_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
+)
+
+# Ordered: the first rule whose pattern appears wins, and the two denoiser
+# conventions are checked before the generic transformers one because a
+# transformers-style prefix can appear inside either.
+_RULES: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    (KEYS_NATIVE_FUSED_QKV,
+     re.compile(r"(^|\.)blocks\.\d+\..*\.(qkv_proj|qkv)\.")),
+    (KEYS_DIFFUSERS_SPLIT_QKV,
+     re.compile(r"(^|\.)transformer_blocks\.\d+\..*\.to_q\.")),
+    (KEYS_TRANSFORMERS_NATIVE,
+     re.compile(r"(^|\.)(model\.layers|encoder\.layer|encoder\.block)\.\d+\.")),
+)
+
+#: Header bytes are bounded by `header_len_ok`; this caps how many FILES we
+#: open, because a sharded tree's shards share one convention.
+_MAX_FILES = 8
+
+
+def tensor_keys(files: Iterable[Path]) -> tuple[str, ...]:
+    """Every tensor name in the given safetensors files' headers."""
+    keys: list[str] = []
+    for count, path in enumerate(files):
+        if count >= _MAX_FILES:
+            break
+        try:
+            with open(path, "rb") as handle:
+                raw = handle.read(8)
+                if len(raw) < 8:
+                    continue
+                (length,) = struct.unpack("<Q", raw)
+                if not header_len_ok(length):
+                    continue
+                header = json.loads(handle.read(length))
+        except (OSError, ValueError, struct.error):
+            continue
+        if isinstance(header, dict):
+            keys.extend(k for k in header if k != "__metadata__")
+    return tuple(keys)
+
+
+def identify_keys(keys: Iterable[str]) -> str:
+    """The key convention a tensor-name set is written in, or ``""``."""
+    names = list(keys)
+    for token, pattern in _RULES:
+        if any(pattern.search(name) for name in names):
+            return token
+    return ""
+
+
+def identify_snapshot_keys(root: Path, component: str = "") -> str:
+    """The key convention of a snapshot's denoiser tree, or ``""``.
+
+    ``component`` names the subdirectory to read; empty scans the root's own
+    safetensors (single-file and root-layout trees).
+    """
+    from ..component_vocab import denoiser_components
+
+    base = Path(root)
+    if base.is_file():
+        return identify_keys(tensor_keys([base]))
+    if not base.is_dir():
+        return ""
+    candidates = [base / component] if component else [
+        base / name for name in denoiser_components()
+    ] + [base]
+    for directory in candidates:
+        if not directory.is_dir():
+            continue
+        files = sorted(p for p in directory.glob("*.safetensors") if p.is_file())
+        if not files:
+            continue
+        found = identify_keys(tensor_keys(files))
+        if found:
+            return found
+    return ""

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -29,13 +29,13 @@ from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
-    KEYS_DIFFUSERS_SPLIT_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
     CONTRACT_NUNCHAKU_V1,
     CONTRACT_PLAIN_BF16,
     ELEMENT_BF16,
     ELEMENT_FP16,
     ELEMENT_FP32,
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
     SCALE_NONE,
     SHARD_COMPONENT_DIR,
     SHARD_INDEX_SHARDED,

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -27,7 +27,23 @@ import struct
 
 from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
-from .tensor_layout_contract import CONTRACT_PLAIN_BF16, implements_contract
+from .tensor_layout_contract import (
+    CONTRACT_COZY_FP8_ROWWISE,
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
+    CONTRACT_NUNCHAKU_V1,
+    CONTRACT_PLAIN_BF16,
+    ELEMENT_BF16,
+    ELEMENT_FP16,
+    ELEMENT_FP32,
+    SCALE_NONE,
+    SHARD_COMPONENT_DIR,
+    SHARD_INDEX_SHARDED,
+    SHARD_SINGLE_FILE,
+    DecodeDimensions,
+    implements_contract,
+    unregistered_decode_path,
+)
 from .fp8_storage import restructure_fp8_storage
 from .rung import touches_host_ram
 from .memory import (
@@ -612,6 +628,37 @@ def block_offload_active(obj: Any) -> bool:
     )
 
 
+def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
+    """Refuse, typed, before handing bytes to a decoder this IMAGE does not
+    declare (pgw#1245).
+
+    Two questions, both answered from HEADERS, both before any tensor is read:
+    is this contract in the image's decode-set, and is the artifact's tensor-KEY
+    convention one a decoder of that contract ingests. The second is not the
+    first: `plain.bf16@1` minimax-native weights (fused `blocks.N.attn.qkv_proj`)
+    and `plain.bf16@1` diffusers weights (split `to_q/to_k/to_v`) are the same
+    contract, the same file topology and one key in common, and the diffusers
+    class cannot read the native tree at all.
+
+    The declared decode-set is th#1938's third intersection and the hub answers
+    it ahead of time — but the worker is where the bytes actually arrive, so it
+    is where an image that lost a decoder, or was offered the other
+    repackaging, must say so by name instead of dying five libraries away as
+    `Cannot detect the model type`.
+
+    Imported lazily: `discovery` walks `models` to derive the set, and a
+    module-level import here would make that walk import its own caller.
+    """
+    from ..discovery.decode_set import require_decodable as _require
+    from .key_topology import identify_snapshot_keys
+
+    _require(
+        contract,
+        where=str(path),
+        key_topology=identify_snapshot_keys(Path(path), component),
+    )
+
+
 def detect_gguf_snapshot(path: Path) -> Optional[tuple[Path, str]]:
     """Return the GGUF denoiser and qtype in a composed diffusers snapshot."""
     p = Path(path)
@@ -634,6 +681,13 @@ def detect_gguf_snapshot(path: Path) -> Optional[tuple[Path, str]]:
     return (ggufs[0], qtype) if qtype else None
 
 
+@unregistered_decode_path(
+    reason="gguf.native@1 is a TOPOLOGY contract; no QUANT contract names the "
+           "k-quant block encodings this reads, and diffusers' "
+           "GGUFQuantizationConfig decodes them inside its own loader. So the "
+           "bytes are decodable here and unnameable in the decode-set until "
+           "the platform registers a descriptor for them.",
+)
 def load_gguf_pipeline(
     cls: Any,
     path: Path,
@@ -1389,6 +1443,8 @@ def contract_loaded_component(
 
     w8a8_art = detect_w8a8_artifact(weights)
     if w8a8_art is not None and _covers(w8a8_art.component):
+        require_decodable(
+            CONTRACT_COZY_FP8_ROWWISE, weights, component=w8a8_art.component)
         return load_w8a8_denoiser(
             weights, w8a8_art, compute_dtype=compute_dtype, cls=cls)
     w4a4_art = detect_w4a4_artifact(weights)
@@ -2322,6 +2378,19 @@ def _load_modular_pipeline(
     contract=CONTRACT_PLAIN_BF16,
     serves=("bf16-w16a16", "fp8-w8a16"),
     composes_lora=True,
+    decodes=DecodeDimensions(
+        elements=(ELEMENT_BF16, ELEMENT_FP16, ELEMENT_FP32),
+        # `none` is the DECLARATION, not an omission: dense weights carry no
+        # scale tensors, and a tree that does carry them belongs to a
+        # quantized contract whose own decoder reads them.
+        scales=(SCALE_NONE,),
+        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED, SHARD_SINGLE_FILE),
+        # `from_pretrained` addresses tensors by the class's own parameter
+        # names. `native.fused-qkv` is registered and DECLARED BY NOTHING
+        # here: a minimax-native tree offered to this loader is refused by
+        # name rather than dying as an md5 miss inside a detection helper.
+        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_NATIVE),
+    ),
     why="the dense-weights path: plain bf16 bytes are read as stored "
         "(bf16-w16a16), and `storage_dtype=fp8` restructures the SAME bytes "
         "into fp8 storage with per-layer upcast (fp8-w8a16). Both are "
@@ -2386,6 +2455,7 @@ def load_from_pretrained(
 
     svdq_art = detect_svdq_artifact(Path(path))
     if svdq_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        require_decodable(CONTRACT_NUNCHAKU_V1, path)
         if components:
             logger.warning("preloaded components ignored on the svdq lane")
         return load_svdq_pipeline(cls, Path(path), svdq_art)
@@ -2396,6 +2466,7 @@ def load_from_pretrained(
 
     w8a8_art = detect_w8a8_artifact(Path(path))
     if w8a8_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        require_decodable(CONTRACT_COZY_FP8_ROWWISE, path)
         compute = None
         if dtype:
             try:
@@ -2457,6 +2528,10 @@ def load_from_pretrained(
         except Exception:
             pass
         return pipe
+    # The generic arm IS the plain.bf16@1 decoder. An image whose decoder
+    # modules failed to import declares nothing, and "nothing" must refuse by
+    # name here rather than produce a pipeline nobody declared.
+    require_decodable(CONTRACT_PLAIN_BF16, path)
     kwargs: Dict[str, Any] = {}
     if components:
         kwargs.update(components)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -35,11 +35,8 @@ from .tensor_layout_contract import (
     ELEMENT_FP16,
     ELEMENT_FP32,
     KEYS_DIFFUSERS_SPLIT_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
+    KEYS_TRANSFORMERS_SPLIT_QKV,
     SCALE_NONE,
-    SHARD_COMPONENT_DIR,
-    SHARD_INDEX_SHARDED,
-    SHARD_SINGLE_FILE,
     DecodeDimensions,
     implements_contract,
     unregistered_decode_path,
@@ -2386,12 +2383,12 @@ def _load_modular_pipeline(
         # scale tensors, and a tree that does carry them belongs to a
         # quantized contract whose own decoder reads them.
         scales=(SCALE_NONE,),
-        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED, SHARD_SINGLE_FILE),
         # `from_pretrained` addresses tensors by the class's own parameter
-        # names. `native.fused-qkv` is registered and DECLARED BY NOTHING
+        # names. `native.fused-qkv@1` is registered and DECLARED BY NOTHING
         # here: a minimax-native tree offered to this loader is refused by
         # name rather than dying as an md5 miss inside a detection helper.
-        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_NATIVE),
+        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_SPLIT_QKV),
+        bakes=(),
     ),
     why="the dense-weights path: plain bf16 bytes are read as stored "
         "(bf16-w16a16), and `storage_dtype=fp8` restructures the SAME bytes "

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -638,7 +638,9 @@ def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
     first: `plain.bf16@1` minimax-native weights (fused `blocks.N.attn.qkv_proj`)
     and `plain.bf16@1` diffusers weights (split `to_q/to_k/to_v`) are the same
     contract, the same file topology and one key in common, and the diffusers
-    class cannot read the native tree at all.
+    class cannot read the native tree at all. A DENOISER whose convention
+    matches nothing registered refuses too — unknown is never a hopeful pass
+    where a model class is chosen from the architecture.
 
     The declared decode-set is th#1938's third intersection and the hub answers
     it ahead of time — but the worker is where the bytes actually arrive, so it
@@ -650,12 +652,12 @@ def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
     module-level import here would make that walk import its own caller.
     """
     from ..discovery.decode_set import require_decodable as _require
-    from .key_topology import identify_snapshot_keys
+    from .key_topology import classify_snapshot
 
     _require(
         contract,
         where=str(path),
-        key_topology=identify_snapshot_keys(Path(path), component),
+        keys=classify_snapshot(Path(path), component),
     )
 
 

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -63,8 +63,20 @@ from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
 from .tensor_layout_contract import (
+    BAKE_LOWRANK_BRANCH,
+    BAKE_QUANTIZED_LOWRANK,
     CONTRACT_COZY_SVDQ_NVFP4_LR8,
     CONTRACT_NUNCHAKU_V1,
+    ELEMENT_BF16,
+    ELEMENT_FP8_E4M3,
+    ELEMENT_INT4,
+    ELEMENT_NVFP4,
+    KEYS_CONTRACT_NATIVE,
+    SCALE_GROUP_16,
+    SCALE_PER_CHANNEL_OUT,
+    SCALE_PER_TENSOR,
+    SHARD_SINGLE_FILE,
+    DecodeDimensions,
     implements_contract,
 )
 from .nvfp4_quant import BLOCK, pack_e2m1, to_blocked_scales
@@ -485,6 +497,18 @@ def _decode_quantized_lowrank(
     contract=CONTRACT_NUNCHAKU_V1,
     serves=("svdq-fp4-w4a4",),
     composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=(ELEMENT_NVFP4, ELEMENT_INT4, ELEMENT_BF16),
+        # `wscales` are group-of-16; the second level is per-channel
+        # (`wcscales`) or per-tensor (`wtscale`) and the decoder branches on
+        # which is present, so both are decoded shapes of ONE handle.
+        scales=(SCALE_GROUP_16, SCALE_PER_CHANNEL_OUT, SCALE_PER_TENSOR),
+        shards=(SHARD_SINGLE_FILE,),
+        # The descriptor fixes the keys: there is one nunchaku single-file
+        # convention and no repackaging of it in circulation.
+        key_topologies=(KEYS_CONTRACT_NATIVE,),
+        bakes=(BAKE_LOWRANK_BRANCH,),
+    ),
     why="pgw#685: this is THE decoder of the nunchaku v1 single-file layout. "
         "The decoded SvdqLinear has no additive adapter branch (w8a8_lora is "
         "branch-capable on w8a8 / fp8-storage / plain bf16 only).",
@@ -493,6 +517,16 @@ def _decode_quantized_lowrank(
     contract=CONTRACT_COZY_SVDQ_NVFP4_LR8,
     serves=("svdq-fp4-w4a4",),
     composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=(ELEMENT_NVFP4, ELEMENT_INT4, ELEMENT_FP8_E4M3, ELEMENT_BF16),
+        scales=(SCALE_GROUP_16, SCALE_PER_CHANNEL_OUT, SCALE_PER_TENSOR),
+        shards=(SHARD_SINGLE_FILE,),
+        key_topologies=(KEYS_CONTRACT_NATIVE,),
+        # The bake that IS the difference from nunchaku.v1@1: the low-rank
+        # branch stored quantized (`lowrank_quant`), which this decoder
+        # branches on and which the flat declaration could not express.
+        bakes=(BAKE_LOWRANK_BRANCH, BAKE_QUANTIZED_LOWRANK),
+    ),
     why="te#148's quantized low-rank branch is a distinct MAJOR and this "
         "decoder branches on it (`lowrank_quant`), which is what makes the "
         "claim true rather than inherited from nunchaku.v1@1.",

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -63,19 +63,16 @@ from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
 from .tensor_layout_contract import (
-    BAKE_LOWRANK_BRANCH,
-    BAKE_QUANTIZED_LOWRANK,
+    BAKE_LOW_RANK_BRANCH,
     CONTRACT_COZY_SVDQ_NVFP4_LR8,
     CONTRACT_NUNCHAKU_V1,
     ELEMENT_BF16,
     ELEMENT_FP8_E4M3,
     ELEMENT_INT4,
     ELEMENT_NVFP4,
-    KEYS_CONTRACT_NATIVE,
     SCALE_GROUP_16,
     SCALE_PER_CHANNEL_OUT,
     SCALE_PER_TENSOR,
-    SHARD_SINGLE_FILE,
     DecodeDimensions,
     implements_contract,
 )
@@ -503,11 +500,11 @@ def _decode_quantized_lowrank(
         # (`wcscales`) or per-tensor (`wtscale`) and the decoder branches on
         # which is present, so both are decoded shapes of ONE handle.
         scales=(SCALE_GROUP_16, SCALE_PER_CHANNEL_OUT, SCALE_PER_TENSOR),
-        shards=(SHARD_SINGLE_FILE,),
-        # The descriptor fixes the keys: there is one nunchaku single-file
-        # convention and no repackaging of it in circulation.
-        key_topologies=(KEYS_CONTRACT_NATIVE,),
-        bakes=(BAKE_LOWRANK_BRANCH,),
+        # UNCONSTRAINED, and that is a statement: the nunchaku descriptor
+        # fixes the keys, so the fact lives on the HANDLE and a synonym for it
+        # here would be a second home (th#1937 declined `contract.native`).
+        key_topologies=(),
+        bakes=(BAKE_LOW_RANK_BRANCH,),
     ),
     why="pgw#685: this is THE decoder of the nunchaku v1 single-file layout. "
         "The decoded SvdqLinear has no additive adapter branch (w8a8_lora is "
@@ -520,12 +517,11 @@ def _decode_quantized_lowrank(
     decodes=DecodeDimensions(
         elements=(ELEMENT_NVFP4, ELEMENT_INT4, ELEMENT_FP8_E4M3, ELEMENT_BF16),
         scales=(SCALE_GROUP_16, SCALE_PER_CHANNEL_OUT, SCALE_PER_TENSOR),
-        shards=(SHARD_SINGLE_FILE,),
-        key_topologies=(KEYS_CONTRACT_NATIVE,),
-        # The bake that IS the difference from nunchaku.v1@1: the low-rank
-        # branch stored quantized (`lowrank_quant`), which this decoder
-        # branches on and which the flat declaration could not express.
-        bakes=(BAKE_LOWRANK_BRANCH, BAKE_QUANTIZED_LOWRANK),
+        key_topologies=(),
+        # The QUANTIZED low-rank branch is what separates this handle from
+        # nunchaku.v1@1, and the handle is where that fact lives — the ruled
+        # tensor-set registry names the SET, not the scheme it is stored in.
+        bakes=(BAKE_LOW_RANK_BRANCH,),
     ),
     why="te#148's quantized low-rank branch is a distinct MAJOR and this "
         "decoder branches on it (`lowrank_quant`), which is what makes the "

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -55,17 +55,188 @@ KNOWN_CONTRACTS: tuple[str, ...] = (
 
 _HANDLE_RE = re.compile(r"^([a-z0-9]+)\.([a-z0-9][a-z0-9._-]*)@([1-9][0-9]*)$")
 
+# ── The DECODE DIMENSIONS (pgw#1245; th#1937 ratifies the vocabulary) ────────
+#
+# A handle names a byte FORMAT. It does not say which of that format's legal
+# shapes a given decoder reads, and the shapes are exactly where decoders
+# branch: `cozy.fp8-rowwise@1` is one handle whether or not the tree carries
+# the optional `input_scale` leaf, and a decoder that ignores it serves
+# different bytes than one that consumes it. So a declaration carries four
+# axes, and th#1938's `resolve()` intersects a variant's derived contract
+# against them rather than against the handle alone.
+#
+# Registered tokens only, on every axis. An unregistered token fails the
+# BUILD for the same reason an unregistered handle does: a decoder that can
+# mint its own vocabulary is back to being a trusted string.
+
+# Element encoding of the quantized weights the decoder reads.
+ELEMENT_BF16 = "bf16"
+ELEMENT_FP16 = "fp16"
+ELEMENT_FP32 = "fp32"
+ELEMENT_FP8_E4M3 = "fp8_e4m3"
+ELEMENT_NVFP4 = "nvfp4"
+ELEMENT_INT4 = "int4"
+KNOWN_ELEMENTS: tuple[str, ...] = (
+    ELEMENT_BF16, ELEMENT_FP16, ELEMENT_FP32,
+    ELEMENT_FP8_E4M3, ELEMENT_NVFP4, ELEMENT_INT4,
+)
+
+# Scale granularity. `none` is EXPLICIT: a dense decoder states that it reads
+# no scale tensors, which is a fact, where an empty axis would be a silence.
+SCALE_NONE = "none"
+SCALE_PER_TENSOR = "per_tensor"
+SCALE_PER_CHANNEL_OUT = "per_channel_out"
+SCALE_STATIC_ACTIVATION = "static_activation"
+SCALE_BLOCK_128X128 = "block_128x128"
+SCALE_GROUP_16 = "group_16"
+KNOWN_SCALES: tuple[str, ...] = (
+    SCALE_NONE, SCALE_PER_TENSOR, SCALE_PER_CHANNEL_OUT,
+    SCALE_STATIC_ACTIVATION, SCALE_BLOCK_128X128, SCALE_GROUP_16,
+)
+
+# File topology the decoder can consume — the sharding half of th#1937's
+# completeness list. `sp_sharded` (pre-sharded sequence-parallel, the H3
+# int64/SP program) is registered and DECLARED BY NOTHING: a variant that is
+# pre-sharded therefore finds no decoder and is refused, which is the correct
+# answer until a decoder branches on it.
+SHARD_SINGLE_FILE = "single_file"
+SHARD_COMPONENT_DIR = "component_dir"
+SHARD_INDEX_SHARDED = "index_sharded"
+SHARD_SP_SHARDED = "sp_sharded"
+KNOWN_SHARDS: tuple[str, ...] = (
+    SHARD_SINGLE_FILE, SHARD_COMPONENT_DIR,
+    SHARD_INDEX_SHARDED, SHARD_SP_SHARDED,
+)
+
+# Structural bakes the decoder CONSUMES — tensor-set membership facts, not
+# element facts. The two modulation tokens are registered and declared by
+# nothing for the same reason `sp_sharded` is: te#195's two artifacts differ
+# exactly there and are byte-detectable, and no decoder in this image branches
+# on the difference today, so a modulation-baked variant must be REFUSED
+# rather than handed to a loader that would read it as a table.
+BAKE_LOWRANK_BRANCH = "lowrank_branch"
+BAKE_QUANTIZED_LOWRANK = "quantized_lowrank"
+BAKE_MODULATION_TABLE = "modulation_table"
+BAKE_MODULATION_BAKED = "modulation_baked"
+KNOWN_BAKES: tuple[str, ...] = (
+    BAKE_LOWRANK_BRANCH, BAKE_QUANTIZED_LOWRANK,
+    BAKE_MODULATION_TABLE, BAKE_MODULATION_BAKED,
+)
+
+# KEY TOPOLOGY — which tensor-KEY convention the decoder's model class can
+# ingest. Provisional here; th#1937 owns the single published vocabulary.
+#
+# This axis exists because of a measured failure (2026-08-14): DiffSynth's
+# MiniMaxH3DiT accepts the MINIMAX-NATIVE key set (535 keys, fused
+# `blocks.N.attn.qkv_proj`) and every minimax-h3 artifact we hold is the
+# DIFFUSERS repackaging (638 keys, split `transformer_blocks.N.attn.to_q/
+# to_k/to_v`) — ONE key in common. It surfaced as `Cannot detect the model
+# type` from an md5-over-key:shape lookup deep inside a detection helper,
+# after a 71 GB fetch onto a rented 4xH100.
+#
+# **File topology cannot see it**: both are multi-file safetensors trees, so
+# `diffusers.multifile@1` classifies them identically. Nor can the quant
+# contract: both would be `plain.bf16@1`. The key convention is a third fact
+# and it needs its own axis or the decode-set is a lie that dies at load.
+#: `transformer_blocks.N.attn.to_q|to_k|to_v` — the diffusers repackaging.
+KEYS_DIFFUSERS_SPLIT_QKV = "diffusers.split-qkv"
+#: `blocks.N.attn.qkv_proj` — the upstream/native fused set.
+KEYS_NATIVE_FUSED_QKV = "native.fused-qkv"
+#: HF transformers module keys (`model.layers.N.…`, `encoder.layer.N.…`).
+KEYS_TRANSFORMERS_NATIVE = "transformers.native"
+#: The contract's OWN convention: a single-file artifact whose descriptor
+#: fixes the keys, with no alternative repackaging in circulation.
+KEYS_CONTRACT_NATIVE = "contract.native"
+KNOWN_KEY_TOPOLOGIES: tuple[str, ...] = (
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_NATIVE_FUSED_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
+    KEYS_CONTRACT_NATIVE,
+)
+
+DECODE_AXES: tuple[str, ...] = (
+    "elements", "scales", "shards", "bakes", "key_topologies",
+)
+
+
+class DecodeDimensions(msgspec.Struct, frozen=True, kw_only=True):
+    """What one decoder reads WITHIN a contract handle.
+
+    `elements`, `scales`, `shards` and `key_topologies` are non-empty: a
+    decoder that states nothing on them has not declared anything. `bakes` may
+    be empty — "this decoder consumes no structural bake fact" is itself a
+    complete answer, and it is the answer that makes a baked variant refuse.
+    """
+
+    elements: tuple[str, ...]
+    scales: tuple[str, ...]
+    shards: tuple[str, ...]
+    key_topologies: tuple[str, ...]
+    bakes: tuple[str, ...] = ()
+
+
+def _axis(values: object, *, known: tuple[str, ...], axis: str,
+          where: str, allow_empty: bool = False) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(
+            values, (tuple, list)):
+        raise ValueError(
+            f"{where}: decodes.{axis} must be a tuple of tokens, got "
+            f"{type(values).__name__}")
+    out: list[str] = []
+    for item in values:
+        if not isinstance(item, str) or item.strip() not in known:
+            raise ValueError(
+                f"{where}: decodes.{axis} token {item!r} is not registered; "
+                f"valid: {', '.join(known)}")
+        token = item.strip()
+        if token in out:
+            raise ValueError(
+                f"{where}: decodes.{axis} repeats {token!r}; a set states "
+                "each member once")
+        out.append(token)
+    if not out and not allow_empty:
+        raise ValueError(
+            f"{where}: decodes.{axis} is empty. A decoder that states nothing "
+            f"on {axis} has declared nothing — the handle alone is what this "
+            "mechanism replaces.")
+    # Canonical order: the declaration is a SET, and two authors writing the
+    # same set in different orders must produce the same derived bytes or the
+    # image's decode-set digest is not deterministic.
+    return tuple(sorted(out))
+
+
+def _validate_dimensions(dims: object, *, where: str) -> DecodeDimensions:
+    if not isinstance(dims, DecodeDimensions):
+        raise ValueError(
+            f"{where}: decodes= must be a DecodeDimensions, got "
+            f"{type(dims).__name__}")
+    return DecodeDimensions(
+        elements=_axis(dims.elements, known=KNOWN_ELEMENTS,
+                       axis="elements", where=where),
+        scales=_axis(dims.scales, known=KNOWN_SCALES,
+                     axis="scales", where=where),
+        shards=_axis(dims.shards, known=KNOWN_SHARDS,
+                     axis="shards", where=where),
+        key_topologies=_axis(dims.key_topologies,
+                             known=KNOWN_KEY_TOPOLOGIES,
+                             axis="key_topologies", where=where),
+        bakes=_axis(dims.bakes, known=KNOWN_BAKES, axis="bakes",
+                    where=where, allow_empty=True),
+    )
+
 
 class ContractDecoder(msgspec.Struct, frozen=True, kw_only=True):
-    """One decoder's declaration: the contract it decodes, and the lane BODIES
-    the decoded units execute as. The execution axis (eager/compiled) is NOT
-    declared here — the platform owns it, and the derivation crosses these
-    bodies with the lane table's own execution support."""
+    """One decoder's declaration: the contract it decodes, WHICH SHAPES of it
+    it decodes, and the lane BODIES the decoded units execute as. The
+    execution axis (eager/compiled) is NOT declared here — the platform owns
+    it, and the derivation crosses these bodies with the lane table's own
+    execution support."""
 
     contract: str
     decoder: str  # "module:qualname" — the function carrying the marker
     serves: tuple[str, ...]  # lane body tokens, e.g. "svdq-fp4-w4a4"
     composes_lora: bool
+    decodes: DecodeDimensions
     why: str = ""
 
 
@@ -111,20 +282,27 @@ def implements_contract(
     contract: str,
     serves: Iterable[str],
     composes_lora: bool,
+    decodes: DecodeDimensions,
     why: str = "",
 ) -> Callable[[F], F]:
     """Mark a decode entrypoint as implementing ``contract``.
+
+    ``decodes`` is REQUIRED and has no default: a declaration that names a
+    handle and stops is the incomplete declaration pgw#1245 exists to remove,
+    and a default would let one be written by omission.
 
     Stackable: one function may implement several contracts (``decode_linear``
     implements both the nunchaku layout and the quantized-branch major).
     """
 
     def deco(fn: F) -> F:
+        where = f"{fn.__module__}:{fn.__qualname__}"
         dec = ContractDecoder(
             contract=contract,
-            decoder=f"{fn.__module__}:{fn.__qualname__}",
+            decoder=where,
             serves=tuple(serves),
             composes_lora=bool(composes_lora),
+            decodes=_validate_dimensions(decodes, where=where),
             why=why,
         )
         _validate(dec)
@@ -146,6 +324,47 @@ def contract_decoders_of(obj: Any) -> tuple[ContractDecoder, ...]:
     if not isinstance(marked, tuple):
         return ()
     return tuple(d for d in marked if isinstance(d, ContractDecoder))
+
+
+class UnregisteredDecodePath(msgspec.Struct, frozen=True, kw_only=True):
+    """A decoder that reads real bytes NO registered contract covers.
+
+    It satisfies no gate and is never intersected with anything — a decode-set
+    entry needs a handle, and a handle needs a hub-side descriptor (A2). It is
+    recorded because the alternative is a source comment, which no refusal can
+    read: when `resolve()` refuses a variant these bytes belong to, the answer
+    "this image decodes them but the platform has no contract for them" is the
+    remedy, and it is a different remedy from "ship a different image".
+    """
+
+    decoder: str
+    reason: str
+
+
+MARKER_UNREGISTERED = "__cozy_unregistered_decode_path__"
+
+
+def unregistered_decode_path(*, reason: str) -> Callable[[F], F]:
+    """Mark a decode entrypoint whose bytes no registered contract names."""
+
+    def deco(fn: F) -> F:
+        if not reason.strip():
+            raise ValueError(
+                f"{fn.__module__}:{fn.__qualname__}: an unregistered decode "
+                "path without a reason is an untraceable gap")
+        setattr(fn, MARKER_UNREGISTERED, UnregisteredDecodePath(
+            decoder=f"{fn.__module__}:{fn.__qualname__}",
+            reason=reason.strip(),
+        ))
+        return fn
+
+    return deco
+
+
+def unregistered_decode_path_of(obj: Any) -> tuple[UnregisteredDecodePath, ...]:
+    """The unregistered-path record carried by one object, or ``()``."""
+    marked = getattr(obj, MARKER_UNREGISTERED, None)
+    return (marked,) if isinstance(marked, UnregisteredDecodePath) else ()
 
 
 # ── §1.33: the DEMAND side of the same vocabulary ─────────────────────────────

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -94,40 +94,39 @@ KNOWN_SCALES: tuple[str, ...] = (
     SCALE_STATIC_ACTIVATION, SCALE_BLOCK_128X128, SCALE_GROUP_16,
 )
 
-# File topology the decoder can consume — the sharding half of th#1937's
-# completeness list. `sp_sharded` (pre-sharded sequence-parallel, the H3
-# int64/SP program) is registered and DECLARED BY NOTHING: a variant that is
-# pre-sharded therefore finds no decoder and is refused, which is the correct
-# answer until a decoder branches on it.
-SHARD_SINGLE_FILE = "single_file"
-SHARD_COMPONENT_DIR = "component_dir"
-SHARD_INDEX_SHARDED = "index_sharded"
-SHARD_SP_SHARDED = "sp_sharded"
-KNOWN_SHARDS: tuple[str, ...] = (
-    SHARD_SINGLE_FILE, SHARD_COMPONENT_DIR,
-    SHARD_INDEX_SHARDED, SHARD_SP_SHARDED,
-)
+# NO file-layout axis here, deliberately. `file_layout` is RULED
+# (`multi-file` | `single-file`, th#1937) and its pgw home is the
+# `1937-file-layout-vocabulary` lane's `gen_worker/convert/file_layout.py`.
+# Transcribing those tokens here would be the second vocabulary this whole
+# programme exists to delete; the decode-set constrains the axis in a
+# follow-up that IMPORTS that module, once it is on master.
+#
+# `pre_sharded` / `shard_axis` are likewise publish-side dimensions. No decoder
+# in this image branches on an SP-sharded tree and none can detect one, so the
+# decode-set states nothing about them rather than carrying a claim no code
+# backs: a pre-sharded variant must be refused by th#1938 against th#1937's
+# derived `pre_sharded`, not by a declaration here.
 
 # Structural bakes the decoder CONSUMES — tensor-set membership facts, not
-# element facts. The two modulation tokens are registered and declared by
-# nothing for the same reason `sp_sharded` is: te#195's two artifacts differ
-# exactly there and are byte-detectable, and no decoder in this image branches
-# on the difference today, so a modulation-baked variant must be REFUSED
-# rather than handed to a loader that would read it as a table.
-BAKE_LOWRANK_BRANCH = "lowrank_branch"
-BAKE_QUANTIZED_LOWRANK = "quantized_lowrank"
-BAKE_MODULATION_TABLE = "modulation_table"
-BAKE_MODULATION_BAKED = "modulation_baked"
+# element facts. RULED tensor-set names (th#1937): a bake token is a registered
+# tensor set, so this axis and the publish side name one thing once.
+#
+# `modulation_table` / `modulation_baked` are deliberately ABSENT: th#1937
+# keeps that rule UNREGISTERED until te#195's file format exists, because
+# "inventing a pattern that matches nothing is the failure mode, not the fix".
+BAKE_ADALN_PROJECTIONS = "adaln_projections"
+BAKE_LOW_RANK_BRANCH = "low_rank_branch"
 KNOWN_BAKES: tuple[str, ...] = (
-    BAKE_LOWRANK_BRANCH, BAKE_QUANTIZED_LOWRANK,
-    BAKE_MODULATION_TABLE, BAKE_MODULATION_BAKED,
+    BAKE_ADALN_PROJECTIONS,
+    BAKE_LOW_RANK_BRANCH,
 )
 
 # KEY TOPOLOGY — which tensor-KEY convention the decoder's model class can
-# ingest. Provisional here; th#1937 owns the single published vocabulary.
+# ingest. **RULED VOCABULARY (th#1937 lane, 2026-08-14): these exact strings,
+# no aliases.**
 #
-# This axis exists because of a measured failure (2026-08-14): DiffSynth's
-# MiniMaxH3DiT accepts the MINIMAX-NATIVE key set (535 keys, fused
+# This axis exists because of a measured failure (te#185 second stop):
+# DiffSynth's MiniMaxH3DiT accepts the MINIMAX-NATIVE key set (535 keys, fused
 # `blocks.N.attn.qkv_proj`) and every minimax-h3 artifact we hold is the
 # DIFFUSERS repackaging (638 keys, split `transformer_blocks.N.attn.to_q/
 # to_k/to_v`) — ONE key in common. It surfaced as `Cannot detect the model
@@ -135,44 +134,50 @@ KNOWN_BAKES: tuple[str, ...] = (
 # after a 71 GB fetch onto a rented 4xH100.
 #
 # **File topology cannot see it**: both are multi-file safetensors trees, so
-# `diffusers.multifile@1` classifies them identically. Nor can the quant
-# contract: both would be `plain.bf16@1`. The key convention is a third fact
-# and it needs its own axis or the decode-set is a lie that dies at load.
-#: `transformer_blocks.N.attn.to_q|to_k|to_v` — the diffusers repackaging.
-KEYS_DIFFUSERS_SPLIT_QKV = "diffusers.split-qkv"
-#: `blocks.N.attn.qkv_proj` — the upstream/native fused set.
-KEYS_NATIVE_FUSED_QKV = "native.fused-qkv"
-#: HF transformers module keys (`model.layers.N.…`, `encoder.layer.N.…`).
-KEYS_TRANSFORMERS_NATIVE = "transformers.native"
-#: The contract's OWN convention: a single-file artifact whose descriptor
-#: fixes the keys, with no alternative repackaging in circulation.
-KEYS_CONTRACT_NATIVE = "contract.native"
+# `file_layout` classifies them identically. Nor can the quant contract: both
+# would be `plain.bf16@1`. The key convention is a third fact and it needs its
+# own axis or the decode-set is a lie that dies at load.
+#: `…attn.to_q|to_k|to_v` — the diffusers repackaging.
+KEYS_DIFFUSERS_SPLIT_QKV = "diffusers.split-qkv@1"
+#: `…attn.qkv_proj|to_qkv` — the upstream/native fused set.
+KEYS_NATIVE_FUSED_QKV = "native.fused-qkv@1"
+#: `*layers.N.self_attn.q_proj` / `*layers.N.attention.self.query`. RENAMED
+#: from the provisional `transformers.native` by th#1937: the FILE-topology
+#: registry already spends `transformers.native@1` on a different axis, and
+#: one string meaning two things on two dimensions is the confusion this ends.
+KEYS_TRANSFORMERS_SPLIT_QKV = "transformers.split-qkv@1"
 KNOWN_KEY_TOPOLOGIES: tuple[str, ...] = (
     KEYS_DIFFUSERS_SPLIT_QKV,
     KEYS_NATIVE_FUSED_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
-    KEYS_CONTRACT_NATIVE,
+    KEYS_TRANSFORMERS_SPLIT_QKV,
 )
+# The provisional `contract.native` is DECLINED (th#1937): "the descriptor
+# fixes the keys, no repackaging exists" is a fact about the QUANT CONTRACT,
+# and the `quant` dimension already carries it BY HANDLE. A decoder whose
+# handle fixes its keys declares `key_topologies=()` — an axis it does not
+# constrain, rather than a synonym for its own handle.
 
 DECODE_AXES: tuple[str, ...] = (
-    "elements", "scales", "shards", "bakes", "key_topologies",
+    "elements", "scales", "key_topologies", "bakes",
 )
 
 
 class DecodeDimensions(msgspec.Struct, frozen=True, kw_only=True):
     """What one decoder reads WITHIN a contract handle.
 
-    `elements`, `scales`, `shards` and `key_topologies` are non-empty: a
-    decoder that states nothing on them has not declared anything. `bakes` may
-    be empty — "this decoder consumes no structural bake fact" is itself a
-    complete answer, and it is the answer that makes a baked variant refuse.
+    Every axis is REQUIRED — there is no default, so a declaration cannot be
+    written by omission. `elements` and `scales` must be non-empty: a decoder
+    that states nothing there has declared nothing. `key_topologies` and
+    `bakes` MAY be empty, and empty is a statement rather than a silence —
+    "this decoder does not constrain the axis" (the tri-state's UNDECLARED
+    rung), which is the honest answer for a decoder whose quant handle already
+    fixes its keys, and the answer that makes a baked variant refuse.
     """
 
     elements: tuple[str, ...]
     scales: tuple[str, ...]
-    shards: tuple[str, ...]
     key_topologies: tuple[str, ...]
-    bakes: tuple[str, ...] = ()
+    bakes: tuple[str, ...]
 
 
 def _axis(values: object, *, known: tuple[str, ...], axis: str,
@@ -215,11 +220,10 @@ def _validate_dimensions(dims: object, *, where: str) -> DecodeDimensions:
                        axis="elements", where=where),
         scales=_axis(dims.scales, known=KNOWN_SCALES,
                      axis="scales", where=where),
-        shards=_axis(dims.shards, known=KNOWN_SHARDS,
-                     axis="shards", where=where),
         key_topologies=_axis(dims.key_topologies,
                              known=KNOWN_KEY_TOPOLOGIES,
-                             axis="key_topologies", where=where),
+                             axis="key_topologies", where=where,
+                             allow_empty=True),
         bakes=_axis(dims.bakes, known=KNOWN_BAKES, axis="bakes",
                     where=where, allow_empty=True),
     )

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
+from .tensor_layout_contract import unregistered_decode_path
 from typing import Any, Dict, List, Optional
 import shutil
 
@@ -492,11 +493,17 @@ def _dequant_into(sd: Dict[str, Any], name: str, compute: Any) -> None:
         sd.pop(f"{name}{suffix}", None)
 
 
-# NO `@implements_contract` HERE, deliberately: this flat nvfp4 layout has no
-# registry entry yet, and it is NOT `bfl.nvfp4-preswizzled@1` — that one is
-# HIGH-nibble with pre-swizzled scales, and conflating them measures LPIPS 1.11.
-# Registering ours needs a real artifact to read; none has ever passed the
-# publish gate, so this decoder contributes no execution lane.
+# NO `@implements_contract` HERE, deliberately — the marker below records WHY
+# in the derived decode-set rather than only in this comment, so a refusal can
+# name it (pgw#1245).
+@unregistered_decode_path(
+    reason="the flat nvfp4 layout this reads has no registry entry, and it is "
+           "NOT bfl.nvfp4-preswizzled@1 — that one is HIGH-nibble with "
+           "pre-swizzled scales, and conflating them measures LPIPS 1.11. "
+           "Registering ours needs a real artifact to read; none has ever "
+           "passed the publish gate, so this decoder contributes no contract "
+           "and no execution lane.",
+)
 def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
                        compute_dtype: Any = None, mode: str = "",
                        cls: Any = None) -> Any:

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -41,10 +41,10 @@ from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
-    KEYS_DIFFUSERS_SPLIT_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
     ELEMENT_BF16,
     ELEMENT_FP8_E4M3,
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
     SCALE_PER_CHANNEL_OUT,
     SCALE_STATIC_ACTIVATION,
     SHARD_COMPONENT_DIR,

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -44,12 +44,9 @@ from .tensor_layout_contract import (
     ELEMENT_BF16,
     ELEMENT_FP8_E4M3,
     KEYS_DIFFUSERS_SPLIT_QKV,
-    KEYS_TRANSFORMERS_NATIVE,
+    KEYS_TRANSFORMERS_SPLIT_QKV,
     SCALE_PER_CHANNEL_OUT,
     SCALE_STATIC_ACTIVATION,
-    SHARD_COMPONENT_DIR,
-    SHARD_INDEX_SHARDED,
-    SHARD_SINGLE_FILE,
     DecodeDimensions,
     implements_contract,
 )
@@ -604,11 +601,11 @@ def _denoiser_class(root: Path, component: str) -> Any:
         # `Fp8ScaledLinear` registers the buffer and the GEMM reads it
         # (:489, :517), so a statically-calibrated tree is in the set.
         scales=(SCALE_PER_CHANNEL_OUT, SCALE_STATIC_ACTIVATION),
-        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED, SHARD_SINGLE_FILE),
         # It rebuilds the tree's own class from its config and assigns by
         # NAME, so the key convention it can ingest is whichever one that
         # class declares — the diffusers repackaging or a transformers tree.
-        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_NATIVE),
+        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_SPLIT_QKV),
+        bakes=(),
     ),
     why="gw#547: Fp8ScaledLinear reads lora_a/lora_b non-persistent buffers "
         "in its own forward, so the w8a8 lane composes runtime adapters "

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -39,7 +39,20 @@ from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
-from .tensor_layout_contract import CONTRACT_COZY_FP8_ROWWISE, implements_contract
+from .tensor_layout_contract import (
+    CONTRACT_COZY_FP8_ROWWISE,
+    KEYS_DIFFUSERS_SPLIT_QKV,
+    KEYS_TRANSFORMERS_NATIVE,
+    ELEMENT_BF16,
+    ELEMENT_FP8_E4M3,
+    SCALE_PER_CHANNEL_OUT,
+    SCALE_STATIC_ACTIVATION,
+    SHARD_COMPONENT_DIR,
+    SHARD_INDEX_SHARDED,
+    SHARD_SINGLE_FILE,
+    DecodeDimensions,
+    implements_contract,
+)
 from typing import Any, Dict, List, Optional
 import shutil
 
@@ -585,6 +598,18 @@ def _denoiser_class(root: Path, component: str) -> Any:
     contract=CONTRACT_COZY_FP8_ROWWISE,
     serves=("fp8-w8a8-dynamic",),
     composes_lora=True,
+    decodes=DecodeDimensions(
+        elements=(ELEMENT_FP8_E4M3, ELEMENT_BF16),
+        # The optional `input_scale` leaf is DECODED, not ignored:
+        # `Fp8ScaledLinear` registers the buffer and the GEMM reads it
+        # (:489, :517), so a statically-calibrated tree is in the set.
+        scales=(SCALE_PER_CHANNEL_OUT, SCALE_STATIC_ACTIVATION),
+        shards=(SHARD_COMPONENT_DIR, SHARD_INDEX_SHARDED, SHARD_SINGLE_FILE),
+        # It rebuilds the tree's own class from its config and assigns by
+        # NAME, so the key convention it can ingest is whichever one that
+        # class declares — the diffusers repackaging or a transformers tree.
+        key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_NATIVE),
+    ),
     why="gw#547: Fp8ScaledLinear reads lora_a/lora_b non-persistent buffers "
         "in its own forward, so the w8a8 lane composes runtime adapters "
         "natively.",

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -585,7 +585,8 @@ def test_unknown_means_REFUSE_for_a_denoiser_and_NOT_APPLICABLE_elsewhere(
         "_class_name": "FakePipeline",
         "transformer": ["diffusers", "FakeTransformer"],
     }))
-    alien = {"stack.0.mixer.in.weight": "BF16", "stack.0.mixer.out.weight": "BF16"}
+    alien = {"blocks.0.attention.wqkv.weight": "BF16",
+             "blocks.0.attention.wo.weight": "BF16"}
     _safetensors(root / "transformer" / "model.safetensors", alien)
     _safetensors(root / "vae" / "model.safetensors", alien)
 
@@ -603,7 +604,7 @@ def test_unknown_means_REFUSE_for_a_denoiser_and_NOT_APPLICABLE_elsewhere(
                           where=str(root), keys=denoiser)
     err = excinfo.value
     assert err.code == "decode_set_key_topology_unclassified"
-    assert "stack.0.mixer.in.weight" in str(err)
+    assert "blocks.0.attention.wqkv.weight" in str(err)
     assert "native.fused-qkv@1" in str(err)   # what IS registered
     # The same bytes under a non-denoiser component pass, by design.
     require_decodable(CONTRACT_PLAIN_BF16, decode_set=ds, where=str(root),
@@ -635,8 +636,8 @@ def test_an_unclassifiable_denoiser_refuses_through_the_load_dispatch(
         "transformer": ["diffusers", "FakeTransformer"],
     }))
     _safetensors(root / "transformer" / "model.safetensors", {
-        "stack.0.mixer.weight": "F8_E4M3",
-        "stack.0.mixer.weight_scale": "F32",
+        "blocks.0.attention.wqkv.weight": "F8_E4M3",
+        "blocks.0.attention.wqkv.weight_scale": "F32",
     })
 
     with pytest.raises(KeyTopologyUnclassifiedError) as excinfo:
@@ -705,3 +706,51 @@ def test_a_late_shard_still_classifies_the_denoiser(tmp_path: Path) -> None:
     keys = classify_snapshot(root, "transformer")
     assert keys.topology == "diffusers.split-qkv@1"
     assert keys.unclassified_denoiser is False
+
+
+def test_a_tree_with_no_attention_substructure_is_out_of_the_axis(
+    tmp_path: Path,
+) -> None:
+    """CI's counter-example, kept as a test.
+
+    The corrupt-load quarantine fixture (`test_p2_residency_reconcile.py`) is a
+    root-layout snapshot holding ONE tensor named `w`. It is a legal thing to
+    hand a loader and it carries no attention convention to get wrong, so the
+    key-topology axis is not about it. The first cut of the fail-closed rule
+    refused it — the axis is scoped to attention substructure now, derived from
+    the BYTES rather than from the component name."""
+    root = tmp_path / "tiny"
+    root.mkdir()
+    _safetensors(root / "model.safetensors", {"w": "F32"})
+
+    keys = classify_snapshot(root)
+    assert keys.denoiser is True           # root layout IS the denoiser
+    assert keys.saw_tensors is True
+    assert keys.attention_shaped is False
+    assert keys.unclassified_denoiser is False
+    require_decodable(CONTRACT_PLAIN_BF16, decode_set=derive_decode_set(),
+                      where=str(root), keys=keys)   # does not raise
+
+
+def test_a_FOURTH_attention_spelling_still_refuses(tmp_path: Path) -> None:
+    """The case the refusal exists for survives the scoping: a denoiser whose
+    attention is spelled in a way no rule here has seen is the H3 class of
+    failure, and it must not be handed to a model class hopefully."""
+    root = tmp_path / "fourth"
+    (root / "transformer").mkdir(parents=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+    }))
+    _safetensors(root / "transformer" / "model.safetensors", {
+        "blocks.0.attention.wqkv.weight": "BF16",
+        "blocks.0.attention.wo.weight": "BF16",
+    })
+
+    keys = classify_snapshot(root, "transformer")
+    assert keys.topology == ""
+    assert keys.attention_shaped is True
+    assert keys.unclassified_denoiser is True
+    with pytest.raises(KeyTopologyUnclassifiedError):
+        require_decodable(CONTRACT_PLAIN_BF16, decode_set=derive_decode_set(),
+                          where=str(root), keys=keys)

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -34,6 +34,8 @@ from gen_worker.discovery.decode_set import (
     REFUSAL_KEY_TOPOLOGY_UNSUPPORTED,
     ContractNotDecodableError,
     DecodeSet,
+    DecodeSetDriftError,
+    KeyTopologyUnclassifiedError,
     KeyTopologyUnsupportedError,
     accepted_key_topologies,
     assert_matches_baked,
@@ -42,7 +44,7 @@ from gen_worker.discovery.decode_set import (
     nearest_declared,
     require_decodable,
 )
-from gen_worker.models.key_topology import identify_keys, identify_snapshot_keys
+from gen_worker.models.key_topology import classify_snapshot, identify_keys
 from gen_worker.models.tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
     CONTRACT_COZY_SVDQ_NVFP4_LR8,
@@ -153,10 +155,20 @@ def test_drift_between_the_baked_block_and_this_process_fails_closed() -> None:
     live = derive_decode_set()
     assert_matches_baked(manifest_block(live), live)  # agreement is silent
 
-    stale = dict(manifest_block(live), digest="0" * 64)
-    with pytest.raises(ContractNotDecodableError) as excinfo:
+    # A lock claiming a contract this process cannot derive: the shape of a
+    # decoder whose dependency is present at build and absent in the image.
+    stale = manifest_block(live)
+    stale["digest"] = "0" * 64
+    stale["contracts"] = stale["contracts"] + [
+        {"contract": "bfl.nvfp4-preswizzled@1", "decoder": "gone:decode"}]
+    with pytest.raises(DecodeSetDriftError) as excinfo:
         assert_matches_baked(stale, live)
-    assert "decode-set drift" in str(excinfo.value)
+    err = excinfo.value
+    assert err.code == "decode_set_drift"
+    assert err.lost == ("bfl.nvfp4-preswizzled@1",)
+    assert err.gained == ()
+    assert "decode-set drift" in str(err)
+    assert "Rebuild the image" in str(err)
 
     # An image that predates the block is UNPROVEN, not divergent.
     assert_matches_baked({}, live)
@@ -531,8 +543,11 @@ def test_the_two_h3_repackagings_classify_differently() -> None:
     assert identify_keys(_DIFFUSERS_KEYS) == "diffusers.split-qkv"
     assert identify_keys(("model.layers.0.self_attn.q_proj.weight",)) \
         == "transformers.native"
-    # A key set the classifier has never seen is UNKNOWN, never a refusal: a
-    # classifier that refused what it could not name would be an upper bound.
+    # The block prefix varies by family and the projection split does not, so
+    # flux's `single_transformer_blocks` classifies with everything else.
+    assert identify_keys(
+        ("single_transformer_blocks.0.attn.to_q.weight",)) \
+        == "diffusers.split-qkv"
     assert identify_keys(("some.tensor.weight",)) == ""
     assert identify_keys(()) == ""
 
@@ -545,8 +560,53 @@ def test_the_classifier_reads_headers_only(tmp_path: Path) -> None:
     _safetensors(root / "transformer" / "model.safetensors",
                  {k: "BF16" for k in _NATIVE_KEYS})
 
-    assert identify_snapshot_keys(root) == "native.fused-qkv"
-    assert identify_snapshot_keys(root, "transformer") == "native.fused-qkv"
+    whole = classify_snapshot(root)
+    assert whole.topology == "native.fused-qkv"
+    assert whole.denoiser is True
+    assert classify_snapshot(root, "transformer").topology == "native.fused-qkv"
+
+
+def test_unknown_means_REFUSE_for_a_denoiser_and_NOT_APPLICABLE_elsewhere(
+    tmp_path: Path,
+) -> None:
+    """The exact semantics of "unclassified", because the phrase is the one a
+    later reader will get wrong.
+
+    A DENOISER whose keys match nothing registered fails closed — the model
+    class is chosen from the architecture, so a hopeful pass is te#185's
+    second stop. A VAE's keys are not evaluated at all: no
+    architecture-specific class is selected from them, and refusing there
+    would refuse the whole fleet to catch nothing."""
+    root = tmp_path / "snap"
+    (root / "transformer").mkdir(parents=True)
+    (root / "vae").mkdir()
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+    }))
+    alien = {"stack.0.mixer.in.weight": "BF16", "stack.0.mixer.out.weight": "BF16"}
+    _safetensors(root / "transformer" / "model.safetensors", alien)
+    _safetensors(root / "vae" / "model.safetensors", alien)
+
+    denoiser = classify_snapshot(root, "transformer")
+    assert denoiser.topology == ""
+    assert denoiser.unclassified_denoiser is True
+
+    vae = classify_snapshot(root, "vae")
+    assert vae.topology == ""
+    assert vae.unclassified_denoiser is False   # the axis does not apply
+
+    ds = derive_decode_set()
+    with pytest.raises(KeyTopologyUnclassifiedError) as excinfo:
+        require_decodable(CONTRACT_PLAIN_BF16, decode_set=ds,
+                          where=str(root), keys=denoiser)
+    err = excinfo.value
+    assert err.code == "decode_set_key_topology_unclassified"
+    assert "stack.0.mixer.in.weight" in str(err)
+    assert "native.fused-qkv" in str(err)   # what IS registered
+    # The same bytes under a non-denoiser component pass, by design.
+    require_decodable(CONTRACT_PLAIN_BF16, decode_set=ds, where=str(root),
+                      keys=vae)
 
 
 def test_no_decoder_here_ingests_the_native_key_set() -> None:
@@ -558,6 +618,30 @@ def test_no_decoder_here_ingests_the_native_key_set() -> None:
         assert "native.fused-qkv" not in accepted_key_topologies(contract, ds)
     assert accepted_key_topologies(CONTRACT_PLAIN_BF16, ds) == (
         "diffusers.split-qkv", "transformers.native")
+
+
+def test_an_unclassifiable_denoiser_refuses_through_the_load_dispatch(
+    tmp_path: Path,
+) -> None:
+    """The fail-closed half, through the production dispatch rather than
+    through `require_decodable` directly."""
+    from gen_worker.models import loading
+
+    root = tmp_path / "alien"
+    (root / "transformer").mkdir(parents=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+    }))
+    _safetensors(root / "transformer" / "model.safetensors", {
+        "stack.0.mixer.weight": "F8_E4M3",
+        "stack.0.mixer.weight_scale": "F32",
+    })
+
+    with pytest.raises(KeyTopologyUnclassifiedError) as excinfo:
+        loading.contract_loaded_component(root, "transformer", cls=_FakeCls)
+    assert excinfo.value.contract == CONTRACT_COZY_FP8_ROWWISE
+    assert str(root) in str(excinfo.value)
 
 
 def test_a_topology_mismatch_refuses_before_the_load(tmp_path: Path) -> None:
@@ -597,7 +681,7 @@ def test_the_accepted_topology_passes_the_same_gate(
 ) -> None:
     """Positive control: the diffusers repackaging of the same contract gets
     past both halves of the guard."""
-    assert identify_snapshot_keys(fp8_rowwise_tree) == "diffusers.split-qkv"
+    assert classify_snapshot(fp8_rowwise_tree).topology == "diffusers.split-qkv"
 
     with pytest.raises(Exception) as excinfo:
         loading_module().contract_loaded_component(

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -1,0 +1,605 @@
+"""pgw#1245: the DECLARED DECODE-SET — what this image can decode, derived at
+image build, and the typed refusal when a bound variant is outside it.
+
+The properties proven here are the ones a claim could otherwise fake:
+
+  1. the set is DERIVED and DETERMINISTIC — two derivations of one image agree
+     byte-for-byte, including across processes, and a changed declaration
+     MOVES the digest (the instrument is shown going red);
+  2. it is COMPLETE — every entry carries the dimensions its decoder reads, a
+     declaration cannot be written by omission, and decode paths no registered
+     contract covers are recorded instead of living in a source comment;
+  3. it REFUSES, typed, naming the contract and the nearest declared one —
+     and the refusal is proven by RUNNING the production load dispatch, not by
+     inspecting a registry;
+  4. removing a decoder's declaration removes the contract and turns the same
+     load into that refusal.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from gen_worker.discovery.decode_set import (
+    DERIVATION,
+    REFUSAL_CONTRACT_UNDECLARED,
+    REFUSAL_KEY_TOPOLOGY_UNSUPPORTED,
+    ContractNotDecodableError,
+    DecodeSet,
+    KeyTopologyUnsupportedError,
+    accepted_key_topologies,
+    assert_matches_baked,
+    derive_decode_set,
+    manifest_block,
+    nearest_declared,
+    require_decodable,
+)
+from gen_worker.models.key_topology import identify_keys, identify_snapshot_keys
+from gen_worker.models.tensor_layout_contract import (
+    CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    CONTRACT_HF_FP8_BLOCKWISE,
+    CONTRACT_NUNCHAKU_V1,
+    CONTRACT_PLAIN_BF16,
+    DecodeDimensions,
+    implements_contract,
+)
+
+# The contracts this image's decoders implement. Enumerated, not counted: the
+# point of the mechanism is that `cozy.fp8-rowwise@1` and `hf.fp8-blockwise@1`
+# are two contracts and not one "fp8" concept.
+EXPECTED_CONTRACTS = {
+    CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    CONTRACT_HF_FP8_BLOCKWISE,
+    CONTRACT_NUNCHAKU_V1,
+    CONTRACT_PLAIN_BF16,
+}
+
+_FAKE_DECODER = '''
+from gen_worker.models.tensor_layout_contract import (
+    DecodeDimensions, implements_contract,
+)
+
+@implements_contract(
+    contract="{contract}", serves=("{body}",), composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=("{element}",), scales=("{scale}",), shards=("single_file",),
+        key_topologies=("contract.native",)),
+    why="fake decoder",
+)
+def decode(tensors):
+    return tensors
+'''
+
+
+def _fake_image(root: Path, modules: dict[str, str]) -> str:
+    """A package standing in for one image's decoder set."""
+    pkg = root / "decode_set_fixture"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", "utf-8")
+    for name, body in modules.items():
+        (pkg / f"{name}.py").write_text(textwrap.dedent(body), "utf-8")
+    for name in [n for n in sys.modules if n.startswith("decode_set_fixture")]:
+        del sys.modules[name]
+    return "decode_set_fixture"
+
+
+@pytest.fixture
+def fake_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    yield tmp_path
+    for name in [n for n in sys.modules if n.startswith("decode_set_fixture")]:
+        del sys.modules[name]
+
+
+# ---------------------------------------------------------------------------
+# 1. derived, and deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_two_derivations_of_one_image_are_identical() -> None:
+    first, second = derive_decode_set(), derive_decode_set()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert first.derivation == DERIVATION
+    assert len(first.digest) == 64
+
+
+def test_a_second_process_derives_the_same_digest() -> None:
+    """Built twice = identical. In-process caching cannot prove this; a fresh
+    interpreter with its own import order can."""
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "from gen_worker.discovery.decode_set import derive_decode_set;"
+         "print(derive_decode_set().digest)"],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == derive_decode_set().digest
+
+
+def test_a_changed_declaration_moves_the_digest(fake_image: Path) -> None:
+    """The instrument goes red: a digest that never moves proves nothing."""
+    pkg = _fake_image(fake_image, {"d": _FAKE_DECODER.format(
+        contract=CONTRACT_NUNCHAKU_V1, body="svdq-fp4-w4a4",
+        element="nvfp4", scale="group_16")})
+    before = derive_decode_set(packages=(pkg,))
+
+    # SAME contract, SAME decoder, one dimension changed.
+    (fake_image / "decode_set_fixture" / "d.py").write_text(
+        textwrap.dedent(_FAKE_DECODER.format(
+            contract=CONTRACT_NUNCHAKU_V1, body="svdq-fp4-w4a4",
+            element="int4", scale="group_16")), "utf-8")
+    for name in [n for n in sys.modules if n.startswith("decode_set_fixture")]:
+        del sys.modules[name]
+    after = derive_decode_set(packages=(pkg,))
+
+    assert before.contracts() == after.contracts()  # the handle did NOT move
+    assert before.digest != after.digest            # what it decodes did
+
+
+def test_drift_between_the_baked_block_and_this_process_fails_closed() -> None:
+    live = derive_decode_set()
+    assert_matches_baked(manifest_block(live), live)  # agreement is silent
+
+    stale = dict(manifest_block(live), digest="0" * 64)
+    with pytest.raises(ContractNotDecodableError) as excinfo:
+        assert_matches_baked(stale, live)
+    assert "decode-set drift" in str(excinfo.value)
+
+    # An image that predates the block is UNPROVEN, not divergent.
+    assert_matches_baked({}, live)
+
+
+# ---------------------------------------------------------------------------
+# 2. complete
+# ---------------------------------------------------------------------------
+
+
+def test_the_image_declares_exactly_these_contracts() -> None:
+    ds = derive_decode_set()
+
+    assert set(ds.contracts()) == EXPECTED_CONTRACTS
+    # Registered but decoded by NOTHING here — the set is what ships, not what
+    # the platform knows about (te#151: conflating the two nvfp4 layouts
+    # measures LPIPS 1.11).
+    assert "bfl.nvfp4-preswizzled@1" not in ds.contracts()
+    assert ds.excluded_modules == ()
+
+
+def test_every_entry_carries_the_dimensions_its_decoder_reads() -> None:
+    ds = derive_decode_set()
+
+    for entry in ds.entries:
+        assert entry.decodes.elements, entry.contract
+        assert entry.decodes.scales, entry.contract
+        assert entry.decodes.shards, entry.contract
+        assert entry.decodes.key_topologies, entry.contract
+
+    by_contract = {e.contract: e for e in ds.entries}
+    # The two fp8 contracts differ on the axis that BRANCHES the decoder.
+    rowwise = by_contract[CONTRACT_COZY_FP8_ROWWISE].decodes
+    blockwise = by_contract[CONTRACT_HF_FP8_BLOCKWISE].decodes
+    assert "per_channel_out" in rowwise.scales
+    assert "block_128x128" not in rowwise.scales
+    assert blockwise.scales == ("block_128x128",)
+    # The bake that IS the difference between the two svdq contracts.
+    assert "quantized_lowrank" in by_contract[
+        CONTRACT_COZY_SVDQ_NVFP4_LR8].decodes.bakes
+    assert "quantized_lowrank" not in by_contract[
+        CONTRACT_NUNCHAKU_V1].decodes.bakes
+    # A dense decoder states `none`, which is a fact; silence would not be.
+    assert by_contract[CONTRACT_PLAIN_BF16].decodes.scales == ("none",)
+
+
+def test_a_declaration_cannot_be_written_by_omission() -> None:
+    with pytest.raises(TypeError):
+        @implements_contract(  # type: ignore[call-arg]
+            contract=CONTRACT_PLAIN_BF16, serves=("bf16-w16a16",),
+            composes_lora=False,
+        )
+        def _no_dimensions(x):
+            return x
+
+    with pytest.raises(ValueError, match="decodes.elements is empty"):
+        @implements_contract(
+            contract=CONTRACT_PLAIN_BF16, serves=("bf16-w16a16",),
+            composes_lora=False,
+            decodes=DecodeDimensions(
+                elements=(), scales=("none",), shards=("single_file",),
+                key_topologies=("contract.native",)),
+        )
+        def _empty_axis(x):
+            return x
+
+    with pytest.raises(ValueError, match="is not registered"):
+        @implements_contract(
+            contract=CONTRACT_PLAIN_BF16, serves=("bf16-w16a16",),
+            composes_lora=False,
+            decodes=DecodeDimensions(
+                elements=("fp6_e3m2",), scales=("none",),
+                shards=("single_file",), key_topologies=("contract.native",)),
+        )
+        def _invented_token(x):
+            return x
+
+
+def test_decode_paths_no_contract_covers_are_recorded_not_commented() -> None:
+    ds = derive_decode_set()
+
+    decoders = {u.decoder: u.reason for u in ds.unregistered}
+    assert "gen_worker.models.w4a4:load_w4a4_denoiser" in decoders
+    assert "gen_worker.models.loading:load_gguf_pipeline" in decoders
+    assert "bfl.nvfp4-preswizzled@1" in decoders[
+        "gen_worker.models.w4a4:load_w4a4_denoiser"]
+    # Recorded is not declared: they satisfy no intersection.
+    for decoder in decoders:
+        assert decoder not in ds.contracts()
+
+
+def test_the_manifest_block_carries_the_set_and_its_digest() -> None:
+    ds = derive_decode_set()
+    block = manifest_block(ds)
+
+    assert block["derivation"] == DERIVATION
+    assert block["digest"] == ds.digest
+    assert {c["contract"] for c in block["contracts"]} == EXPECTED_CONTRACTS
+    rowwise = next(c for c in block["contracts"]
+                   if c["contract"] == CONTRACT_COZY_FP8_ROWWISE)
+    assert rowwise["decoder"] == "gen_worker.models.w8a8:load_w8a8_denoiser"
+    assert set(rowwise["elements"]) == {"fp8_e4m3", "bf16"}
+    assert {u["decoder"] for u in block["unregistered"]}
+
+
+def test_the_image_build_stamps_the_block_into_endpoint_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`python -m gen_worker.discovery` is what the Dockerfile runs; this is
+    the same entry point, so the set is a property of the BUILT IMAGE."""
+    from gen_worker.discovery.discover import discover_manifest
+
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent("""
+        [project]
+        name = "ep1245"
+
+        [tool.gen_worker]
+        main = "ep1245.main"
+    """))
+    src = tmp_path / "ep1245"
+    src.mkdir()
+    (src / "__init__.py").write_text("")
+    (src / "main.py").write_text(textwrap.dedent("""
+        import msgspec
+        from gen_worker import RequestContext, Resources, Slot, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str = ""
+
+        class Pipe:
+            pass
+
+        @endpoint(
+            models={"pipeline": Slot(Pipe)},
+            resources=Resources(gpu=True),
+        )
+        class Gen:
+            def setup(self, pipeline: Pipe) -> None: ...
+
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_()
+    """))
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manifest = discover_manifest(tmp_path)
+
+    block = manifest["decode_set"]
+    assert block["derivation"] == DERIVATION
+    assert block["digest"]
+    assert {c["contract"] for c in block["contracts"]} == EXPECTED_CONTRACTS
+    # ONE census feeds both blocks: the lane block's contracts are the decode
+    # set's, never a second walk that could disagree.
+    assert {c["contract"] for c in manifest["execution_lanes"]["contracts"]} \
+        == EXPECTED_CONTRACTS
+
+
+# ---------------------------------------------------------------------------
+# 3. the refusal
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_names_the_contract_and_the_nearest_declared() -> None:
+    ds = derive_decode_set()
+
+    with pytest.raises(ContractNotDecodableError) as excinfo:
+        require_decodable("bfl.nvfp4-preswizzled@1", decode_set=ds,
+                          where="/snapshots/abc")
+    err = excinfo.value
+    assert err.code == REFUSAL_CONTRACT_UNDECLARED
+    assert err.contract == "bfl.nvfp4-preswizzled@1"
+    # Nearest by FORMAT, not by string: both are nvfp4, and an fp8 handle is
+    # a closer string than it is a closer artifact.
+    assert err.nearest == CONTRACT_COZY_SVDQ_NVFP4_LR8
+    assert "bfl.nvfp4-preswizzled@1" in str(err)
+    assert CONTRACT_COZY_SVDQ_NVFP4_LR8 in str(err)
+    # The remedy is on either side, so the refusal says so.
+    assert "ship an image whose decoder declares this one" in str(err)
+
+
+@pytest.mark.parametrize("asked,nearest", [
+    ("cozy.fp8-rowwise@2", CONTRACT_COZY_FP8_ROWWISE),   # wrong major
+    ("hf.fp8-blockwise@2", CONTRACT_HF_FP8_BLOCKWISE),
+    ("bfl.nvfp4-preswizzled@1", CONTRACT_COZY_SVDQ_NVFP4_LR8),
+])
+def test_nearest_declared_answers_by_format(asked: str, nearest: str) -> None:
+    assert nearest_declared(asked, derive_decode_set()) == nearest
+
+
+def test_an_image_that_declares_nothing_says_so() -> None:
+    empty = DecodeSet(derivation=DERIVATION, entries=(), unregistered=(),
+                      excluded_modules=())
+
+    with pytest.raises(ContractNotDecodableError) as excinfo:
+        require_decodable(CONTRACT_PLAIN_BF16, decode_set=empty)
+    assert excinfo.value.nearest == ""
+    assert "declares NO contract at all" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 4. RUNNING the production dispatch — a registered decoder is not a running one
+# ---------------------------------------------------------------------------
+
+
+def _safetensors(path: Path, tensors: dict[str, str]) -> None:
+    """A header-only safetensors file. The w8a8 detector reads headers and
+    nothing else, so this is the real artifact as far as it is concerned."""
+    header: dict[str, object] = {}
+    offset = 0
+    for name, dtype in tensors.items():
+        header[name] = {"dtype": dtype, "shape": [1],
+                        "data_offsets": [offset, offset + 4]}
+        offset += 4
+    blob = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + b"\0" * offset)
+
+
+@pytest.fixture
+def fp8_rowwise_tree(tmp_path: Path) -> Path:
+    """A diffusers tree whose denoiser is `cozy.fp8-rowwise@1` bytes."""
+    root = tmp_path / "snapshot"
+    (root / "transformer").mkdir(parents=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+    }))
+    _safetensors(root / "transformer" / "model.safetensors", {
+        "transformer_blocks.0.attn.to_q.weight": "F8_E4M3",
+        "transformer_blocks.0.attn.to_q.weight_scale": "F32",
+    })
+    return root
+
+
+class _FakeCls:
+    @classmethod
+    def from_pretrained(cls, *a: Any, **k: Any) -> Any:  # pragma: no cover
+        raise AssertionError("the guard should have refused first")
+
+
+def test_the_load_dispatch_refuses_bytes_the_image_cannot_decode(
+    fp8_rowwise_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The execution assertion. A decode-set WITHOUT `cozy.fp8-rowwise@1` and
+    a real call into the production contract dispatch — not a registry read."""
+    from gen_worker.discovery import decode_set as ds_mod
+    from gen_worker.models import loading
+
+    full = derive_decode_set()
+    without = ds_mod.DecodeSet(
+        derivation=full.derivation,
+        entries=tuple(e for e in full.entries
+                      if e.contract != CONTRACT_COZY_FP8_ROWWISE),
+        unregistered=full.unregistered,
+        excluded_modules=full.excluded_modules,
+        digest=full.digest,
+    )
+    monkeypatch.setattr(ds_mod, "runtime_decode_set", lambda: without)
+
+    with pytest.raises(ContractNotDecodableError) as excinfo:
+        loading.contract_loaded_component(
+            fp8_rowwise_tree, "transformer", cls=_FakeCls)
+
+    err = excinfo.value
+    assert err.contract == CONTRACT_COZY_FP8_ROWWISE
+    assert str(fp8_rowwise_tree) in str(err)
+    assert err.nearest == CONTRACT_HF_FP8_BLOCKWISE
+
+
+def test_the_same_load_passes_the_guard_when_the_contract_is_declared(
+    fp8_rowwise_tree: Path,
+) -> None:
+    """The positive control: a guard that refuses everything would pass the
+    test above and be worthless."""
+    with pytest.raises(Exception) as excinfo:
+        loading_module().contract_loaded_component(
+            fp8_rowwise_tree, "transformer", cls=_FakeCls)
+
+    # It got PAST the guard and died further in, on the fake class.
+    assert not isinstance(excinfo.value, ContractNotDecodableError)
+
+
+def loading_module() -> Any:
+    from gen_worker.models import loading
+
+    return loading
+
+
+def test_removing_a_declaration_removes_the_contract_and_refuses(
+    fake_image: Path,
+) -> None:
+    """pgw#1245's acceptance: a decoder that stops declaring stops being in
+    the set, and the same request then refuses, typed."""
+    both = {
+        "svdq": _FAKE_DECODER.format(
+            contract=CONTRACT_NUNCHAKU_V1, body="svdq-fp4-w4a4",
+            element="nvfp4", scale="group_16"),
+        "fp8": _FAKE_DECODER.format(
+            contract=CONTRACT_COZY_FP8_ROWWISE, body="fp8-w8a8-dynamic",
+            element="fp8_e4m3", scale="per_channel_out"),
+    }
+    pkg = _fake_image(fake_image, both)
+    before = derive_decode_set(packages=(pkg,))
+    assert set(before.contracts()) == {
+        CONTRACT_NUNCHAKU_V1, CONTRACT_COZY_FP8_ROWWISE}
+    require_decodable(CONTRACT_NUNCHAKU_V1, decode_set=before)  # decodable
+
+    # The decoder loses its declaration — the ONLY edit.
+    (fake_image / "decode_set_fixture" / "svdq.py").write_text(
+        "def decode(tensors):\n    return tensors\n", "utf-8")
+    for name in [n for n in sys.modules if n.startswith("decode_set_fixture")]:
+        del sys.modules[name]
+    after = derive_decode_set(packages=(pkg,))
+
+    assert set(after.contracts()) == {CONTRACT_COZY_FP8_ROWWISE}
+    with pytest.raises(ContractNotDecodableError) as excinfo:
+        require_decodable(CONTRACT_NUNCHAKU_V1, decode_set=after)
+    assert excinfo.value.code == REFUSAL_CONTRACT_UNDECLARED
+    assert excinfo.value.nearest == CONTRACT_COZY_FP8_ROWWISE
+
+
+def test_a_decoder_that_cannot_import_is_excluded_with_its_reason(
+    fake_image: Path,
+) -> None:
+    """An image whose kernel extension is missing must not CLAIM the lane —
+    and must be able to say why it does not."""
+    pkg = _fake_image(fake_image, {
+        "fp8": _FAKE_DECODER.format(
+            contract=CONTRACT_COZY_FP8_ROWWISE, body="fp8-w8a8-dynamic",
+            element="fp8_e4m3", scale="per_channel_out"),
+        "svdq": "import a_kernel_this_image_lacks  # noqa: F401\n" +
+                _FAKE_DECODER.format(
+                    contract=CONTRACT_NUNCHAKU_V1, body="svdq-fp4-w4a4",
+                    element="nvfp4", scale="group_16"),
+    })
+    ds = derive_decode_set(packages=(pkg,))
+
+    assert set(ds.contracts()) == {CONTRACT_COZY_FP8_ROWWISE}
+    excluded = {m.module: m.reason for m in ds.excluded_modules}
+    assert "decode_set_fixture.svdq" in excluded
+    assert "a_kernel_this_image_lacks" in excluded["decode_set_fixture.svdq"]
+    with pytest.raises(ContractNotDecodableError):
+        require_decodable(CONTRACT_NUNCHAKU_V1, decode_set=ds)
+
+
+# ---------------------------------------------------------------------------
+# 5. KEY TOPOLOGY — the axis file topology and the quant contract cannot see
+# ---------------------------------------------------------------------------
+#
+# Measured 2026-08-14: DiffSynth's MiniMaxH3DiT accepts the minimax-NATIVE key
+# set (535 keys, fused `blocks.N.attn.qkv_proj`); every minimax-h3 artifact we
+# hold is the DIFFUSERS repackaging (638 keys, split `to_q/to_k/to_v`) — ONE
+# key in common. It failed as `Cannot detect the model type` from an
+# md5-over-key:shape lookup, after a 71 GB fetch onto a rented 4xH100, with
+# 126 green tests blind to it because none exercised the load path.
+
+_NATIVE_KEYS = (
+    "blocks.0.attn.qkv_proj.weight",
+    "blocks.0.attn.out_proj.weight",
+    "blocks.0.mlp.fc1.weight",
+)
+_DIFFUSERS_KEYS = (
+    "transformer_blocks.0.attn.to_q.weight",
+    "transformer_blocks.0.attn.to_k.weight",
+    "transformer_blocks.0.attn.to_v.weight",
+)
+
+
+def test_the_two_h3_repackagings_classify_differently() -> None:
+    assert identify_keys(_NATIVE_KEYS) == "native.fused-qkv"
+    assert identify_keys(_DIFFUSERS_KEYS) == "diffusers.split-qkv"
+    assert identify_keys(("model.layers.0.self_attn.q_proj.weight",)) \
+        == "transformers.native"
+    # A key set the classifier has never seen is UNKNOWN, never a refusal: a
+    # classifier that refused what it could not name would be an upper bound.
+    assert identify_keys(("some.tensor.weight",)) == ""
+    assert identify_keys(()) == ""
+
+
+def test_the_classifier_reads_headers_only(tmp_path: Path) -> None:
+    """It must answer BEFORE the fetch is worth anything, so it may not
+    construct a model or read tensor data."""
+    root = tmp_path / "snap"
+    (root / "transformer").mkdir(parents=True)
+    _safetensors(root / "transformer" / "model.safetensors",
+                 {k: "BF16" for k in _NATIVE_KEYS})
+
+    assert identify_snapshot_keys(root) == "native.fused-qkv"
+    assert identify_snapshot_keys(root, "transformer") == "native.fused-qkv"
+
+
+def test_no_decoder_here_ingests_the_native_key_set() -> None:
+    """The honest state of this image, stated rather than assumed: every
+    decoder reads a repackaging, so a native tree has nowhere to land."""
+    ds = derive_decode_set()
+
+    for contract in ds.contracts():
+        assert "native.fused-qkv" not in accepted_key_topologies(contract, ds)
+    assert accepted_key_topologies(CONTRACT_PLAIN_BF16, ds) == (
+        "diffusers.split-qkv", "transformers.native")
+
+
+def test_a_topology_mismatch_refuses_before_the_load(tmp_path: Path) -> None:
+    """The coordinator's acceptance case. Right contract, right file topology,
+    WRONG key convention — and it refuses by name instead of dying as an md5
+    miss inside a detection helper."""
+    from gen_worker.models import loading
+
+    root = tmp_path / "native_snapshot"
+    (root / "transformer").mkdir(parents=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipeline",
+        "transformer": ["diffusers", "FakeTransformer"],
+    }))
+    # `cozy.fp8-rowwise@1` bytes — a DECLARED contract — written in the
+    # minimax-native key convention, which no decoder here ingests.
+    _safetensors(root / "transformer" / "model.safetensors", {
+        "blocks.0.attn.qkv_proj.weight": "F8_E4M3",
+        "blocks.0.attn.qkv_proj.weight_scale": "F32",
+    })
+
+    with pytest.raises(KeyTopologyUnsupportedError) as excinfo:
+        loading.contract_loaded_component(root, "transformer", cls=_FakeCls)
+
+    err = excinfo.value
+    assert err.code == REFUSAL_KEY_TOPOLOGY_UNSUPPORTED
+    assert err.observed == "native.fused-qkv"
+    assert err.accepted == ("diffusers.split-qkv", "transformers.native")
+    assert "native.fused-qkv" in str(err)
+    assert "the KEYS are addressed differently" in str(err)
+    # And the contract check did NOT fire: the format was never the problem.
+    assert not isinstance(err, ContractNotDecodableError)
+
+
+def test_the_accepted_topology_passes_the_same_gate(
+    fp8_rowwise_tree: Path,
+) -> None:
+    """Positive control: the diffusers repackaging of the same contract gets
+    past both halves of the guard."""
+    assert identify_snapshot_keys(fp8_rowwise_tree) == "diffusers.split-qkv"
+
+    with pytest.raises(Exception) as excinfo:
+        loading_module().contract_loaded_component(
+            fp8_rowwise_tree, "transformer", cls=_FakeCls)
+    assert not isinstance(excinfo.value, KeyTopologyUnsupportedError)

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -687,3 +687,20 @@ def test_the_accepted_topology_passes_the_same_gate(
         loading_module().contract_loaded_component(
             fp8_rowwise_tree, "transformer", cls=_FakeCls)
     assert not isinstance(excinfo.value, KeyTopologyUnsupportedError)
+
+
+def test_a_late_shard_still_classifies_the_denoiser(tmp_path: Path) -> None:
+    """The fail-closed path may not be defeated by shard ORDER: a tree whose
+    leading shards hold only embeddings must not read as unclassified."""
+    root = tmp_path / "sharded"
+    denoiser = root / "transformer"
+    denoiser.mkdir(parents=True)
+    for i in range(1, 12):
+        _safetensors(denoiser / f"model-{i:05d}-of-00012.safetensors",
+                     {f"embeddings.{i}.weight": "BF16"})
+    _safetensors(denoiser / "model-00012-of-00012.safetensors",
+                 {"transformer_blocks.0.attn.to_q.weight": "BF16"})
+
+    keys = classify_snapshot(root, "transformer")
+    assert keys.topology == "diffusers.split-qkv"
+    assert keys.unclassified_denoiser is False

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -74,8 +74,7 @@ from gen_worker.models.tensor_layout_contract import (
 @implements_contract(
     contract="{contract}", serves=("{body}",), composes_lora=False,
     decodes=DecodeDimensions(
-        elements=("{element}",), scales=("{scale}",), shards=("single_file",),
-        key_topologies=("contract.native",)),
+        elements=("{element}",), scales=("{scale}",), key_topologies=(), bakes=()),
     why="fake decoder",
 )
 def decode(tensors):
@@ -196,8 +195,6 @@ def test_every_entry_carries_the_dimensions_its_decoder_reads() -> None:
     for entry in ds.entries:
         assert entry.decodes.elements, entry.contract
         assert entry.decodes.scales, entry.contract
-        assert entry.decodes.shards, entry.contract
-        assert entry.decodes.key_topologies, entry.contract
 
     by_contract = {e.contract: e for e in ds.entries}
     # The two fp8 contracts differ on the axis that BRANCHES the decoder.
@@ -206,11 +203,12 @@ def test_every_entry_carries_the_dimensions_its_decoder_reads() -> None:
     assert "per_channel_out" in rowwise.scales
     assert "block_128x128" not in rowwise.scales
     assert blockwise.scales == ("block_128x128",)
-    # The bake that IS the difference between the two svdq contracts.
-    assert "quantized_lowrank" in by_contract[
-        CONTRACT_COZY_SVDQ_NVFP4_LR8].decodes.bakes
-    assert "quantized_lowrank" not in by_contract[
-        CONTRACT_NUNCHAKU_V1].decodes.bakes
+    # The svdq decoders CONSTRAIN no key topology, and that is a statement:
+    # the nunchaku descriptor fixes the keys, so the fact lives on the handle
+    # (th#1937 declined a `contract.native` synonym — one home per value).
+    assert by_contract[CONTRACT_NUNCHAKU_V1].decodes.key_topologies == ()
+    assert by_contract[CONTRACT_COZY_SVDQ_NVFP4_LR8].decodes.bakes == (
+        "low_rank_branch",)
     # A dense decoder states `none`, which is a fact; silence would not be.
     assert by_contract[CONTRACT_PLAIN_BF16].decodes.scales == ("none",)
 
@@ -229,8 +227,8 @@ def test_a_declaration_cannot_be_written_by_omission() -> None:
             contract=CONTRACT_PLAIN_BF16, serves=("bf16-w16a16",),
             composes_lora=False,
             decodes=DecodeDimensions(
-                elements=(), scales=("none",), shards=("single_file",),
-                key_topologies=("contract.native",)),
+                elements=(), scales=("none",), key_topologies=(),
+                bakes=()),
         )
         def _empty_axis(x):
             return x
@@ -241,7 +239,7 @@ def test_a_declaration_cannot_be_written_by_omission() -> None:
             composes_lora=False,
             decodes=DecodeDimensions(
                 elements=("fp6_e3m2",), scales=("none",),
-                shards=("single_file",), key_topologies=("contract.native",)),
+                key_topologies=(), bakes=()),
         )
         def _invented_token(x):
             return x
@@ -267,6 +265,7 @@ def test_the_manifest_block_carries_the_set_and_its_digest() -> None:
     assert block["derivation"] == DERIVATION
     assert block["digest"] == ds.digest
     assert {c["contract"] for c in block["contracts"]} == EXPECTED_CONTRACTS
+    assert "shards" not in block["contracts"][0]
     rowwise = next(c for c in block["contracts"]
                    if c["contract"] == CONTRACT_COZY_FP8_ROWWISE)
     assert rowwise["decoder"] == "gen_worker.models.w8a8:load_w8a8_denoiser"
@@ -539,15 +538,17 @@ _DIFFUSERS_KEYS = (
 
 
 def test_the_two_h3_repackagings_classify_differently() -> None:
-    assert identify_keys(_NATIVE_KEYS) == "native.fused-qkv"
-    assert identify_keys(_DIFFUSERS_KEYS) == "diffusers.split-qkv"
+    assert identify_keys(_NATIVE_KEYS) == "native.fused-qkv@1"
+    assert identify_keys(_DIFFUSERS_KEYS) == "diffusers.split-qkv@1"
     assert identify_keys(("model.layers.0.self_attn.q_proj.weight",)) \
-        == "transformers.native"
+        == "transformers.split-qkv@1"
+    assert identify_keys(("encoder.layer.0.attention.self.query.weight",)) \
+        == "transformers.split-qkv@1"
     # The block prefix varies by family and the projection split does not, so
     # flux's `single_transformer_blocks` classifies with everything else.
     assert identify_keys(
         ("single_transformer_blocks.0.attn.to_q.weight",)) \
-        == "diffusers.split-qkv"
+        == "diffusers.split-qkv@1"
     assert identify_keys(("some.tensor.weight",)) == ""
     assert identify_keys(()) == ""
 
@@ -561,9 +562,9 @@ def test_the_classifier_reads_headers_only(tmp_path: Path) -> None:
                  {k: "BF16" for k in _NATIVE_KEYS})
 
     whole = classify_snapshot(root)
-    assert whole.topology == "native.fused-qkv"
+    assert whole.topology == "native.fused-qkv@1"
     assert whole.denoiser is True
-    assert classify_snapshot(root, "transformer").topology == "native.fused-qkv"
+    assert classify_snapshot(root, "transformer").topology == "native.fused-qkv@1"
 
 
 def test_unknown_means_REFUSE_for_a_denoiser_and_NOT_APPLICABLE_elsewhere(
@@ -603,7 +604,7 @@ def test_unknown_means_REFUSE_for_a_denoiser_and_NOT_APPLICABLE_elsewhere(
     err = excinfo.value
     assert err.code == "decode_set_key_topology_unclassified"
     assert "stack.0.mixer.in.weight" in str(err)
-    assert "native.fused-qkv" in str(err)   # what IS registered
+    assert "native.fused-qkv@1" in str(err)   # what IS registered
     # The same bytes under a non-denoiser component pass, by design.
     require_decodable(CONTRACT_PLAIN_BF16, decode_set=ds, where=str(root),
                       keys=vae)
@@ -615,9 +616,9 @@ def test_no_decoder_here_ingests_the_native_key_set() -> None:
     ds = derive_decode_set()
 
     for contract in ds.contracts():
-        assert "native.fused-qkv" not in accepted_key_topologies(contract, ds)
+        assert "native.fused-qkv@1" not in accepted_key_topologies(contract, ds)
     assert accepted_key_topologies(CONTRACT_PLAIN_BF16, ds) == (
-        "diffusers.split-qkv", "transformers.native")
+        "diffusers.split-qkv@1", "transformers.split-qkv@1")
 
 
 def test_an_unclassifiable_denoiser_refuses_through_the_load_dispatch(
@@ -668,9 +669,9 @@ def test_a_topology_mismatch_refuses_before_the_load(tmp_path: Path) -> None:
 
     err = excinfo.value
     assert err.code == REFUSAL_KEY_TOPOLOGY_UNSUPPORTED
-    assert err.observed == "native.fused-qkv"
-    assert err.accepted == ("diffusers.split-qkv", "transformers.native")
-    assert "native.fused-qkv" in str(err)
+    assert err.observed == "native.fused-qkv@1"
+    assert err.accepted == ("diffusers.split-qkv@1", "transformers.split-qkv@1")
+    assert "native.fused-qkv@1" in str(err)
     assert "the KEYS are addressed differently" in str(err)
     # And the contract check did NOT fire: the format was never the problem.
     assert not isinstance(err, ContractNotDecodableError)
@@ -681,7 +682,7 @@ def test_the_accepted_topology_passes_the_same_gate(
 ) -> None:
     """Positive control: the diffusers repackaging of the same contract gets
     past both halves of the guard."""
-    assert classify_snapshot(fp8_rowwise_tree).topology == "diffusers.split-qkv"
+    assert classify_snapshot(fp8_rowwise_tree).topology == "diffusers.split-qkv@1"
 
     with pytest.raises(Exception) as excinfo:
         loading_module().contract_loaded_component(
@@ -702,5 +703,5 @@ def test_a_late_shard_still_classifies_the_denoiser(tmp_path: Path) -> None:
                  {"transformer_blocks.0.attn.to_q.weight": "BF16"})
 
     keys = classify_snapshot(root, "transformer")
-    assert keys.topology == "diffusers.split-qkv"
+    assert keys.topology == "diffusers.split-qkv@1"
     assert keys.unclassified_denoiser is False

--- a/tests/test_derived_execution_lanes_th1580.py
+++ b/tests/test_derived_execution_lanes_th1580.py
@@ -34,8 +34,8 @@ from gen_worker.models.tensor_layout_contract import (
 )
 
 _DIMS = DecodeDimensions(
-    elements=("bf16",), scales=("none",), shards=("component_dir",),
-    key_topologies=("diffusers.split-qkv",))
+    elements=("bf16",), scales=("none",),
+    key_topologies=("diffusers.split-qkv@1",), bakes=())
 
 _GOOD_A = '''
 from gen_worker.models.tensor_layout_contract import (
@@ -45,8 +45,8 @@ from gen_worker.models.tensor_layout_contract import (
 @implements_contract(
     contract="nunchaku.v1@1", serves=("svdq-fp4-w4a4",), composes_lora=False,
     decodes=DecodeDimensions(
-        elements=("nvfp4",), scales=("group_16",), shards=("single_file",),
-        key_topologies=("contract.native",)),
+        elements=("nvfp4",), scales=("group_16",), key_topologies=(),
+        bakes=()),
     why="fake svdq decoder",
 )
 def decode_svdq(tensors):
@@ -63,7 +63,7 @@ from gen_worker.models.tensor_layout_contract import (
     composes_lora=True,
     decodes=DecodeDimensions(
         elements=("fp8_e4m3",), scales=("per_channel_out",),
-        shards=("component_dir",), key_topologies=("diffusers.split-qkv",)),
+        key_topologies=("diffusers.split-qkv@1",), bakes=()),
     why="fake fp8 decoder",
 )
 def decode_fp8(tensors):
@@ -83,8 +83,8 @@ from gen_worker.models.tensor_layout_contract import (
     contract="bfl.nvfp4-preswizzled@1", serves=("nvfp4-w4a4-static",),
     composes_lora=False,
     decodes=DecodeDimensions(
-        elements=("nvfp4",), scales=("per_tensor",), shards=("single_file",),
-        key_topologies=("contract.native",)),
+        elements=("nvfp4",), scales=("per_tensor",), key_topologies=(),
+        bakes=()),
     why="never reached",
 )
 def decode_nvfp4(tensors):

--- a/tests/test_derived_execution_lanes_th1580.py
+++ b/tests/test_derived_execution_lanes_th1580.py
@@ -29,14 +29,24 @@ from gen_worker.discovery.execution_lanes import (
 from gen_worker.models.tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
     CONTRACT_NUNCHAKU_V1,
+    DecodeDimensions,
     implements_contract,
 )
 
+_DIMS = DecodeDimensions(
+    elements=("bf16",), scales=("none",), shards=("component_dir",),
+    key_topologies=("diffusers.split-qkv",))
+
 _GOOD_A = '''
-from gen_worker.models.tensor_layout_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import (
+    DecodeDimensions, implements_contract,
+)
 
 @implements_contract(
     contract="nunchaku.v1@1", serves=("svdq-fp4-w4a4",), composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=("nvfp4",), scales=("group_16",), shards=("single_file",),
+        key_topologies=("contract.native",)),
     why="fake svdq decoder",
 )
 def decode_svdq(tensors):
@@ -44,11 +54,17 @@ def decode_svdq(tensors):
 '''
 
 _GOOD_B = '''
-from gen_worker.models.tensor_layout_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import (
+    DecodeDimensions, implements_contract,
+)
 
 @implements_contract(
     contract="cozy.fp8-rowwise@1", serves=("fp8-w8a8-dynamic",),
-    composes_lora=True, why="fake fp8 decoder",
+    composes_lora=True,
+    decodes=DecodeDimensions(
+        elements=("fp8_e4m3",), scales=("per_channel_out",),
+        shards=("component_dir",), key_topologies=("diffusers.split-qkv",)),
+    why="fake fp8 decoder",
 )
 def decode_fp8(tensors):
     return tensors
@@ -59,11 +75,17 @@ def decode_fp8(tensors):
 _BROKEN = '''
 import a_dependency_this_image_does_not_have  # noqa: F401
 
-from gen_worker.models.tensor_layout_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import (
+    DecodeDimensions, implements_contract,
+)
 
 @implements_contract(
     contract="bfl.nvfp4-preswizzled@1", serves=("nvfp4-w4a4-static",),
-    composes_lora=False, why="never reached",
+    composes_lora=False,
+    decodes=DecodeDimensions(
+        elements=("nvfp4",), scales=("per_tensor",), shards=("single_file",),
+        key_topologies=("contract.native",)),
+    why="never reached",
 )
 def decode_nvfp4(tensors):
     return tensors
@@ -155,13 +177,15 @@ def test_unregistered_contract_fails_the_build():
             contract="acme.secret-format@1",
             serves=("bf16-w16a16",),
             composes_lora=False,
+            decodes=_DIMS,
         )
         def _decode(x):
             return x
 
     with pytest.raises(ValueError, match="not a contract handle"):
         @implements_contract(
-            contract="nvfp4", serves=("bf16-w16a16",), composes_lora=False
+            contract="nvfp4", serves=("bf16-w16a16",), composes_lora=False,
+            decodes=_DIMS,
         )
         def _decode2(x):
             return x
@@ -171,6 +195,7 @@ def test_unregistered_contract_fails_the_build():
             contract=CONTRACT_NUNCHAKU_V1,
             serves=("svdq-fp4-w4a4+eager",),  # execution axis is not a body
             composes_lora=False,
+            decodes=_DIMS,
         )
         def _decode3(x):
             return x

--- a/tests/test_slot_layout_demand_pgw1143.py
+++ b/tests/test_slot_layout_demand_pgw1143.py
@@ -36,6 +36,14 @@ from gen_worker.discovery.execution_lanes import (
     DerivedContract,
     DerivedExecutionLanes,
 )
+from gen_worker.discovery.decode_set import DERIVATION as _DS_DERIVATION
+from gen_worker.discovery.decode_set import DecodeSet
+
+#: The census reads `contracts` only; an empty set states that plainly
+#: rather than letting the field be omitted.
+_EMPTY_DECODE_SET = DecodeSet(
+    derivation=_DS_DERIVATION, entries=(), unregistered=(),
+    excluded_modules=())
 from gen_worker.families.base import GenerationDefaults
 from gen_worker.models.tensor_layout_contract import (
     CONTRACT_HF_FP8_BLOCKWISE,
@@ -284,6 +292,7 @@ def test_a_declared_handle_no_decoder_backs_is_reported_not_refused() -> None:
             composes_lora=True,
         ),),
         excluded_modules=(),
+        decode_set=_EMPTY_DECODE_SET,
     )
     fn = {
         "name": "generate",
@@ -306,6 +315,7 @@ def test_the_census_is_silent_for_an_undeclared_slot() -> None:
     derived = DerivedExecutionLanes(
         derivation="gen_worker.discovery.execution_lanes@1",
         execution_lanes=(), contracts=(), excluded_modules=(),
+        decode_set=_EMPTY_DECODE_SET,
     )
     fn = {
         "name": "generate",


### PR DESCRIPTION
**th#1934 Stage 0, parallel lane.** Selection under the ruled design is
(endpoint's contract patterns) ∩ (worker's DECLARED DECODE-SET) ∩ (card
executability). This is intersection #3's ground truth.

Design of record: `research/checkpoint-selection-redesign.md`. Issue: pgw#1245.
Does NOT touch th#1938's matcher or the narrowing/substitution apparatus
(pgw#1246 ⇄ th#1941).

## What the image now declares, and how it is derived

`gen_worker.discovery.decode_set` imports every decoder module, harvests the
`@implements_contract` markers that survived, and stamps `[decode_set]` into
`endpoint.lock` — the block `python -m gen_worker.discovery` already writes in
the Dockerfile's `RUN`. Five contracts, enumerated because the point is that
they are five and not one "quantized" concept:

| contract | decoder | key topologies |
|---|---|---|
| `cozy.fp8-rowwise@1` | `w8a8:load_w8a8_denoiser` | diffusers.split-qkv, transformers.native |
| `hf.fp8-blockwise@1` | `hf_fp8_blockwise:load_hf_fp8_blockwise` | transformers.native |
| `nunchaku.v1@1` | `svdq_layout:decode_linear` | contract.native |
| `cozy.svdq-nvfp4-lr8@1` | `svdq_layout:decode_linear` | contract.native |
| `plain.bf16@1` | `loading:load_from_pretrained` | diffusers.split-qkv, transformers.native |

A sha256 over the whole derivation rides with it, so "built twice = identical"
is checkable, and the boot refuses typed if this process would derive a
different set than the lock carries (a stale lock layer means the running code
is not the code the hub selected against). `[execution_lanes]` is now a second
RENDER of the same census, not a second import walk that could disagree.

## Completeness

`decodes=DecodeDimensions(...)` is REQUIRED with no default — a declaration
cannot be written by omission. Five axes: elements, scales, shards, key
topologies, structural bakes. A handle alone cannot express that
`cozy.svdq-nvfp4-lr8@1` differs from `nunchaku.v1@1` exactly by consuming a
quantized low-rank branch, or that `cozy.fp8-rowwise@1`'s optional
`input_scale` leaf is decoded rather than ignored.

`sp_sharded`, `modulation_baked` and `modulation_table` are registered and
declared by NOTHING, deliberately: a variant carrying them finds no decoder and
is refused, which is the correct answer until one branches on it. Decode paths
no registered contract covers (w4a4's flat nvfp4, the GGUF pipeline) are
RECORDED with their reason instead of living in source comments no refusal can
read.

## The key-topology axis (coordinator's scope refinement, from tonight's H3 failure)

DiffSynth's `MiniMaxH3DiT` ingests the minimax-NATIVE key set (535 keys, fused
`blocks.N.attn.qkv_proj`); every minimax-h3 artifact we hold is the DIFFUSERS
repackaging (638 keys, split `to_q/to_k/to_v`) — one key in common. Same quant
contract, same file topology; `diffusers.multifile@1` classifies them
identically. It surfaced as `Cannot detect the model type` from an
md5-over-key:shape lookup after a 71 GB fetch onto a rented 4×H100.

`models/key_topology.py` classifies a snapshot from safetensors HEADERS ONLY,
and the load dispatch refuses with `decode_set_key_topology_unsupported`,
naming observed and accepted. An unrecognized key set is UNKNOWN and refuses
nothing. Vocabulary is provisional and coordinated with th#1937 (which owns the
single published vocabulary).

## The refusals

- `decode_set_contract_undeclared` — names the contract, the whole declared
  set, and the NEAREST declared contract, ranked by FORMAT TOKEN so
  `bfl.nvfp4-preswizzled@1` → `cozy.svdq-nvfp4-lr8@1` and not the fp8 handle
  whole-string similarity prefers.
- `decode_set_key_topology_unsupported` — names the observed topology and the
  accepted ones, and says the bytes are right and the keys are addressed
  differently, so no dtype change fixes it.

Both fire from the production contract dispatch, and the tests drive that
dispatch: a decoder being REGISTERED proves nothing about whether it RUNS.

## Red-verified

| proof | how |
|---|---|
| the load-dispatch guard is what refuses | removing the `require_decodable` call reddens `test_the_load_dispatch_refuses_bytes_the_image_cannot_decode` |
| the topology check is what refuses | removing the `key_topology=` argument reddens `test_a_topology_mismatch_refuses_before_the_load` |
| the digest instrument can go red | `test_a_changed_declaration_moves_the_digest` — same handle, same decoder, one dimension changed |
| removing a declaration refuses | `test_removing_a_declaration_removes_the_contract_and_refuses` |
| positive controls | the accepted topology and the declared contract both get PAST the guard and die further in |

Local (`nice -n 19`, ≤2 workers): 24 new tests + 83 across the touched modules
green; `mypy` strict clean over 783 files; every `fast gates` lint script green;
`ruff` clean; `assemble_changelog --check` parses `changelog.d/pgw1245.md`.

## Coordination

Checked before push and before arming `--auto`: **no dated 0.115.0 freeze note
in the coordination section**, and the 0.114.3 condition is discharged —
`v0.114.3` is tagged and published on PyPI.