### PR TITLE
th#1937 (th#1932 item 7): file_layout gets ONE vocabulary — `multi-file` | `single-file`, no aliases

### DIFF
--- a/changelog.d/th1937.md
+++ b/changelog.d/th1937.md
@@ -1,0 +1,13 @@
+- `file_layout` has ONE vocabulary, ruled at th#1937 (folding th#1932 inventory item 7):
+  **`multi-file` | `single-file`**, plus the empty string for libraries whose loader does not
+  branch on the axis. Four spellings of one field were live across two repositories and none
+  was ever read back — this repo emitted `singlefile`/`diffusers` from `convert/source.py`'s
+  `FileLayout` Literal and `single-file` from `convert/convert.py`'s gguf branch, drifting
+  against its own Literal, while tensorhub stored whatever arrived and re-inferred its own
+  value for the layout gate. Survivable for a display string and fatal for a selector: under
+  the th#1934 redesign the derived contract IS the selector, and a spec asking for
+  `single-file` against a checkpoint stamped `singlefile` resolves to nothing, at deploy, with
+  no bug anywhere to find. `gen_worker/convert/file_layout.py` is now the one home for the
+  tokens; every emission, the internal Literal and the publish boundary use it. **No aliases**:
+  tensorhub refuses a dead spelling at DECLARE with `file_layout_unknown_token`, and
+  `validate_file_layout` refuses it here first, naming what to write instead.

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Mapping, Optional, Sequence
 
 from gen_worker.api.errors import ValidationError
+from .file_layout import MULTI_FILE, SINGLE_FILE
 
 _PICKLE_EXTS = {".bin", ".pt", ".pth", ".ckpt", ".pickle", ".pkl"}
 _JUNK_EXTS = {
@@ -418,7 +419,7 @@ def classify_repo(
         dtypes = sorted(set(resolved.values()))
         return _finish("diffusers", "diffusers", d_weights, d_indexes,
                        {"dtype": dtypes[0] if len(dtypes) == 1 else "",
-                        "file_layout": "diffusers"},
+                        "file_layout": MULTI_FILE},
                        "model_index.json at root")
 
     # 3.5 standalone diffusers component. Diffusers ModelMixin repos use a
@@ -432,7 +433,7 @@ def classify_repo(
     )
     if diffusers_class and component_weights:
         component_attrs = {
-            "file_layout": "singlefile",
+            "file_layout": SINGLE_FILE,
             "architecture": diffusers_class,
         }
         if component_dtype:
@@ -463,7 +464,7 @@ def classify_repo(
             # A component directory tree, not a root single file: the layout
             # label matches what detect_huggingface_source_layout reads off
             # the same tree, so passthrough and cast publishes agree.
-            sub_attrs = {"file_layout": "diffusers", "architecture": sub_class}
+            sub_attrs = {"file_layout": MULTI_FILE, "architecture": sub_class}
             if sub_dtype:
                 sub_attrs["dtype"] = sub_dtype
             return _finish(
@@ -483,14 +484,14 @@ def classify_repo(
     if "pipeline.json" in root_set and has_st:
         pt_weights = sorted(p for p in paths if p.lower().endswith(".safetensors"))
         return _finish("pipeline_tree", "trellis2", pt_weights, [],
-                       {"file_layout": "singlefile"}, "pipeline.json at root")
+                       {"file_layout": SINGLE_FILE}, "pipeline.json at root")
 
     # 5. transformers
     if config_json is not None and "config.json" in root_set and (has_st or has_st_index):
         t_indexes = [p for p in root if _is_safetensors_index(p)]
         t_weights, t_dtype = _pick_weight_set(
             [p for p in root if p.lower().endswith(".safetensors")], dtype_pref)
-        attrs: dict[str, str] = {"file_layout": "singlefile"}
+        attrs: dict[str, str] = {"file_layout": SINGLE_FILE}
         if t_dtype:
             attrs["dtype"] = t_dtype
         arch = config_json.get("architectures")
@@ -525,7 +526,7 @@ def classify_repo(
             gguf_pick = gguf_pick or sorted(gguf_files)[0]
         return _finish("gguf", "llama-cpp", [gguf_pick], [],
                        {"dtype": f"gguf:{_quant_of(gguf_pick) or 'unknown'}",
-                        "file_type": "gguf", "file_layout": "singlefile"},
+                        "file_type": "gguf", "file_layout": SINGLE_FILE},
                        f"{len(gguf_files)} *.gguf at root")
 
     # 7/8. root safetensors: native LoRA vs AIO singlefile
@@ -541,7 +542,7 @@ def classify_repo(
             is_lora = all(int(sizes.get(p, 0)) < gb for p in st_root) and bool(
                 all(sizes.get(p) is not None for p in st_root))
         if is_lora:
-            attrs = {"file_layout": "singlefile"}
+            attrs = {"file_layout": SINGLE_FILE}
             for k in ("ss_base_model_version", "ss_sd_model_name", "ss_network_module"):
                 if md.get(k):
                     attrs[f"kohya_{k}"] = str(md[k])
@@ -549,12 +550,12 @@ def classify_repo(
                            "root safetensors + LoRA signature")
         if len(st_root) == 1:
             return _finish("aio_singlefile", "diffusers-single-file", st_root, [],
-                           {"file_layout": "singlefile"},
+                           {"file_layout": SINGLE_FILE},
                            "single safetensors at root, no structured signals")
         # Multiple untyped root safetensors: pick by dtype preference.
         weights, dtype = _pick_weight_set(st_root, dtype_pref)
         return _finish("aio_singlefile", "diffusers-single-file", weights, [],
-                       {"file_layout": "singlefile", "dtype": dtype},
+                       {"file_layout": SINGLE_FILE, "dtype": dtype},
                        "root safetensors, dtype-variant pick")
 
     # Refusals — say what IS there.

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -76,7 +76,9 @@ _KNOWN_DTYPES = {
     "q4_0", "q4_1", "q3_k_m", "q3_k_s", "q2_k",
 }
 from ..component_vocab import quant_candidate_components
-_KNOWN_FILE_LAYOUTS = {"diffusers", "singlefile"}
+from .file_layout import KNOWN_FILE_LAYOUTS, MULTI_FILE, SINGLE_FILE
+
+_KNOWN_FILE_LAYOUTS = set(KNOWN_FILE_LAYOUTS)
 _KNOWN_FILE_TYPES = {"safetensors", "gguf"}
 
 _default_quant_components = quant_candidate_components
@@ -158,7 +160,7 @@ def normalize_tags(values: Iterable[str] | None) -> list[str]:
     return sorted(out)
 
 
-def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffusers") -> list[OutputSpec]:
+def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = MULTI_FILE) -> list[OutputSpec]:
     out: list[OutputSpec] = []
     seen: set[tuple[str, str, str]] = set()
     for item in values or []:
@@ -183,7 +185,7 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
             seen.add(key)
             out.append(OutputSpec(dtype=dtype, file_layout=layout, file_type=ftype))
     if not out:
-        layout = layout_hint if layout_hint in _KNOWN_FILE_LAYOUTS else "diffusers"
+        layout = layout_hint if layout_hint in _KNOWN_FILE_LAYOUTS else MULTI_FILE
         out.append(OutputSpec(dtype="bf16", file_layout=layout, file_type="safetensors"))
     return out
 
@@ -222,7 +224,7 @@ def build_flavor_tree(
                              "file_type": spec.file_type}
 
     source_dir = Path(source.dir)
-    source_layout = source.layout if source.layout in _KNOWN_FILE_LAYOUTS else "singlefile"
+    source_layout = source.layout if source.layout in _KNOWN_FILE_LAYOUTS else SINGLE_FILE
     source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
 
     # dtype="source": pure mirror — publish the source weights untouched and
@@ -271,7 +273,7 @@ def build_flavor_tree(
         # of failing deep inside the converter.
         declared = repackage_family(family)
         if declared is None or not (
-            declared.supports_singlefile_to_diffusers if source_layout == "singlefile"
+            declared.supports_singlefile_to_diffusers if source_layout == SINGLE_FILE
             else declared.supports_diffusers_to_singlefile
         ):
             raise ValueError(
@@ -280,8 +282,8 @@ def build_flavor_tree(
 
         repack_dir = out_dir.parent / f"{out_dir.name}.__repack__"
         repack_dir.mkdir(parents=True, exist_ok=True)
-        if source_layout == "singlefile":
-            groups = snapshot_weight_groups(source_dir, "singlefile")
+        if source_layout == SINGLE_FILE:
+            groups = snapshot_weight_groups(source_dir, SINGLE_FILE)
             if not groups:
                 raise ValueError("no safetensors entry for repackage")
             singlefile_to_diffusers(
@@ -307,7 +309,7 @@ def build_flavor_tree(
     groups = snapshot_weight_groups(work_root, work_layout)
     is_fp8 = spec.dtype == "fp8"
     fp8_block_scope = False
-    if is_fp8 and work_layout != "diffusers":
+    if is_fp8 and work_layout != MULTI_FILE:
         # One root weight set = a transformers backbone (the whole checkpoint
         # IS the denoiser, e.g. HiDream-O1's UiT): block-scoped fp8 cast.
         # Multi-set singlefile bundles still refuse — component identity is
@@ -487,7 +489,7 @@ def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
                                         for path, _ in files)
                 else "safetensors"
             )
-            attrs = {"file_layout": "singlefile", "file_type": source_type}
+            attrs = {"file_layout": SINGLE_FILE, "file_type": source_type}
             if source_type == "gguf":
                 strategy = "gguf"
         # run_clone routes a strategy="aio_singlefile" source whose family
@@ -723,7 +725,7 @@ def run_clone(
     provider = str(provider or "").strip().lower()
     destination = normalize_destination_ref(destination_repo)
     tags = normalize_tags(destination_repo_tags)
-    layout_hint = str(target_layout or "diffusers").strip().lower() or "diffusers"
+    layout_hint = str(target_layout or MULTI_FILE).strip().lower() or MULTI_FILE
     specs = normalize_outputs(outputs, layout_hint=layout_hint)
     include = normalize_source_include(source_include)
     objective_fact = str(objective or "").strip().lower()
@@ -892,7 +894,7 @@ def run_clone(
                         # changes.
                         effective_layout = (
                             source.layout if source.layout in _KNOWN_FILE_LAYOUTS
-                            else "singlefile"
+                            else SINGLE_FILE
                         )
                         cast_spec = OutputSpec(
                             dtype=spec.dtype, file_layout=effective_layout,

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -37,6 +37,7 @@ from .writer import streaming_dtype_cast
 from .writer import streaming_fp8_storage_cast
 from ..subproc import ProcessStalledError, run_process
 from .gguf_tools import (GGUF_TOOLCHAIN_STALL_WINDOW_S, prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
+from .file_layout import SINGLE_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -421,7 +422,7 @@ def _run_gguf_inline(
     attrs = {
         "dtype": f"gguf:{dtype}",
         "file_type": "gguf",
-        "file_layout": "single-file",
+        "file_layout": SINGLE_FILE,
         "conversion_strategy": "inline_gguf",
         "quant_library": "gguf",
         "quant_recipe": f"gguf:{dtype}",

--- a/src/gen_worker/convert/file_layout.py
+++ b/src/gen_worker/convert/file_layout.py
@@ -31,20 +31,20 @@ speaking the language the hub accepts.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Final, Literal
 
 #: A component-directory tree, read through a multi-component loader entry
 #: point (``DiffusionPipeline.from_pretrained``).
-MULTI_FILE = "multi-file"
+MULTI_FILE: Final[Literal["multi-file"]] = "multi-file"
 
 #: One flat key namespace, read through a single-file entry point
 #: (``from_single_file``).
-SINGLE_FILE = "single-file"
+SINGLE_FILE: Final[Literal["single-file"]] = "single-file"
 
 #: The absent value: the declaring library's loader does not branch on this
 #: axis.  Distinct from "unknown" only in that nothing may state it in a
 #: contract-spec — an absent dimension already matches everything.
-NOT_APPLICABLE = ""
+NOT_APPLICABLE: Final[Literal[""]] = ""
 
 FileLayout = Literal["multi-file", "single-file"]
 

--- a/src/gen_worker/convert/file_layout.py
+++ b/src/gen_worker/convert/file_layout.py
@@ -1,0 +1,89 @@
+"""The ``file_layout`` vocabulary — ONE set of tokens, ruled at th#1937.
+
+th#1932 inventory item 7 measured four live spellings of one axis across two
+repositories, none of which was ever read back::
+
+    tensorhub   "multi-file" / "single-file"   the coarse-tier map's keys, and
+                                               the only place the value has
+                                               ever MEANT anything
+    tensorhub   "transformers"                 emitted by its metadata
+                                               inferrer — a LIBRARY name spent
+                                               as a layout value
+    this repo   "singlefile" / "diffusers"     the ``FileLayout`` Literal, and
+                                               what the classifier publishes
+    this repo   "single-file"                  ``convert.py``'s gguf branch,
+                                               drifting against its own Literal
+
+Publish stored whatever a producer sent while the hub's layout gate re-inferred
+its own value, so nothing ever disagreed out loud.  That is survivable for a
+display string and fatal for a selector: under the th#1934 redesign the derived
+contract IS the selector, and a spec asking for ``single-file`` against a
+checkpoint stamped ``singlefile`` resolves to nothing, at deploy, with no bug
+anywhere to find.
+
+RULED: ``multi-file`` | ``single-file``.  They win because they are the only
+spelling that ever carried meaning, and because ``diffusers`` spends a LIBRARY
+name on a layout value — a second collision on top of the first.  There are no
+aliases: tensorhub refuses a dead spelling at DECLARE with
+``file_layout_unknown_token``, so this module is what keeps this repo's publishes
+speaking the language the hub accepts.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+#: A component-directory tree, read through a multi-component loader entry
+#: point (``DiffusionPipeline.from_pretrained``).
+MULTI_FILE = "multi-file"
+
+#: One flat key namespace, read through a single-file entry point
+#: (``from_single_file``).
+SINGLE_FILE = "single-file"
+
+#: The absent value: the declaring library's loader does not branch on this
+#: axis.  Distinct from "unknown" only in that nothing may state it in a
+#: contract-spec — an absent dimension already matches everything.
+NOT_APPLICABLE = ""
+
+FileLayout = Literal["multi-file", "single-file"]
+
+KNOWN_FILE_LAYOUTS: frozenset[str] = frozenset({MULTI_FILE, SINGLE_FILE})
+
+#: Named in a refusal so a caller still sending one learns what happened.  They
+#: are NOT accepted: naming a dead spelling in an error message is help;
+#: accepting it is a compatibility shim, and this repo is pre-launch.
+_DEAD_SPELLINGS = {
+    "singlefile": f"this repo's pre-th#1937 Literal; write {SINGLE_FILE!r}",
+    "diffusers": f"a LIBRARY name — it belongs in library_name, and this axis wants {MULTI_FILE!r}",
+    "multifile": f"write {MULTI_FILE!r}",
+    "transformers": "a LIBRARY name — a transformers tree declares no file_layout at all",
+    "single_file": f"write {SINGLE_FILE!r}",
+    "multi_file": f"write {MULTI_FILE!r}",
+}
+
+
+def validate_file_layout(token: str) -> str:
+    """Return the token, or raise ``ValueError`` naming the vocabulary.
+
+    The empty string is admitted: the axis does not apply to every library.
+    """
+    token = (token or "").strip()
+    if token == NOT_APPLICABLE or token in KNOWN_FILE_LAYOUTS:
+        return token
+    why = _DEAD_SPELLINGS.get(token.lower())
+    detail = f" ({why})" if why else ""
+    raise ValueError(
+        f"file_layout_unknown_token: {token!r} is not a file_layout token{detail}. "
+        f"The vocabulary is {SINGLE_FILE} | {MULTI_FILE}, ruled at th#1937 with no aliases"
+    )
+
+
+__all__ = [
+    "FileLayout",
+    "KNOWN_FILE_LAYOUTS",
+    "MULTI_FILE",
+    "NOT_APPLICABLE",
+    "SINGLE_FILE",
+    "validate_file_layout",
+]

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -33,6 +33,7 @@ from ..net import hf, install_hf_http_timeouts
 from ..models.safetensors_header import header_len_ok
 from .classifier import RepoClassification, apply_source_include, classify_repo
 from .layout import detect_huggingface_source_layout
+from .file_layout import SINGLE_FILE
 from huggingface_hub.errors import EntryNotFoundError, GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError
 
 
@@ -179,7 +180,7 @@ class IngestedSource:
     source_ref: str               # canonical repo id / civitai version id
     source_revision: str          # resolved commit sha / manifest hash
     dir: Path                     # local snapshot root
-    layout: str                   # diffusers | singlefile | unknown
+    layout: str                   # multi-file | single-file | unknown
     model_family: str
     model_family_variant: str
     classification: Optional[RepoClassification] = None
@@ -744,7 +745,7 @@ def ingest_civitai(
         "base_model_family": base_family,
         "base_model_civitai_baseModel": base_model_raw,
         "lineage_source": "civitai_baseModel" if base_model_raw else "unknown",
-        "file_layout": layout_info.source_layout if layout_info.source_layout != "unknown" else "singlefile",
+        "file_layout": layout_info.source_layout if layout_info.source_layout != "unknown" else SINGLE_FILE,
     }
     on_disk_dtype = detect_snapshot_dtype(dest_dir)
     if on_disk_dtype:
@@ -765,7 +766,7 @@ def ingest_civitai(
         quant = _local_gguf_quant(dest_dir / gguf_names[0])
         attrs["dtype"] = f"gguf:{quant}" if quant else "gguf"
         attrs["file_type"] = "gguf"
-        attrs["file_layout"] = "singlefile"
+        attrs["file_layout"] = SINGLE_FILE
         classification = RepoClassification(
             strategy="gguf",
             runtime_library="diffusers-single-file",

--- a/src/gen_worker/convert/layout.py
+++ b/src/gen_worker/convert/layout.py
@@ -165,6 +165,9 @@ def detect_huggingface_source_layout(*, repo_dir: Path, files: list[str]) -> Sou
     """
     signals = _DEFAULT_SIGNALS
     normalized = _normalize_paths(files)
+    # Annotated `str`, not inferred: the ruled tokens are `Final[Literal[...]]`
+    # so an inferred type here would narrow to the first branch's literal.
+    source_layout: str
     if _has_diffusers_layout_signals(normalized, signals):
         source_layout = MULTI_FILE
         reason = "diffusers_layout_signals_present"

--- a/src/gen_worker/convert/layout.py
+++ b/src/gen_worker/convert/layout.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from .layout_spec import LayoutSignals, normalize_letters_digits
 from .registry import registered_layouts
+from .file_layout import MULTI_FILE, SINGLE_FILE
 
 _DEFAULT_SIGNALS = LayoutSignals()
 
@@ -165,10 +166,10 @@ def detect_huggingface_source_layout(*, repo_dir: Path, files: list[str]) -> Sou
     signals = _DEFAULT_SIGNALS
     normalized = _normalize_paths(files)
     if _has_diffusers_layout_signals(normalized, signals):
-        source_layout = "diffusers"
+        source_layout = MULTI_FILE
         reason = "diffusers_layout_signals_present"
     elif any(p.lower().endswith(signals.weight_suffixes) for p in normalized):
-        source_layout = "singlefile"
+        source_layout = SINGLE_FILE
         reason = "single_file_weight_signals_present"
     else:
         source_layout = "unknown"
@@ -177,7 +178,7 @@ def detect_huggingface_source_layout(*, repo_dir: Path, files: list[str]) -> Sou
     variant = _detect_variant_from_model_index(repo_dir)
     if variant == "unknown":
         variant = _detect_variant_from_components(normalized)
-    if variant == "unknown" and source_layout == "singlefile":
+    if variant == "unknown" and source_layout == SINGLE_FILE:
         variant = _detect_variant_from_paths(normalized)
     if variant == "unknown":
         variant = _detect_variant_from_sentinels(normalized)

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -28,6 +28,7 @@ from ..hubio.client import CommitFile, CommitResult, HubClient, files_from_tree
 from ..hubio.journal import JOURNAL_NAME
 from .produced import ProducedFlavor
 from .writer import assert_one_file_per_component
+from .file_layout import validate_file_layout
 
 _PLACEMENT_ATTR_KEYS = ("placement_sm_allowed", "placement_sm_min", "placement_engines")
 
@@ -246,7 +247,7 @@ def publish_flavors(
             # header before recording it.
             artifact_contract=attrs.get("artifact_contract", ""),
             dtype=attrs.get("dtype", ""),
-            file_layout=attrs.get("file_layout", ""),
+            file_layout=validate_file_layout(attrs.get("file_layout", "")),
             file_type=attrs.get("file_type", ""),
             objective=str(objective or ""),
             distilled=distilled,

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -24,7 +24,7 @@ from .writer import iter_source_tensors
 if TYPE_CHECKING:
     import torch
 
-FileLayout = Literal["singlefile", "diffusers"]
+from .file_layout import MULTI_FILE, SINGLE_FILE, FileLayout  # noqa: F401  (re-exported)
 
 
 # Default set of component subdirs that the iter_hf_components passthrough
@@ -71,10 +71,10 @@ def _weight_component_dirs() -> frozenset[str]:
 
 
 def _detect_file_layout(path: Path) -> FileLayout:
-    """Return 'diffusers' if the snapshot has a model_index.json, else 'singlefile'."""
+    """MULTI_FILE when the snapshot has a model_index.json, else SINGLE_FILE."""
     if (path / "model_index.json").exists():
-        return "diffusers"
-    return "singlefile"
+        return MULTI_FILE
+    return SINGLE_FILE
 
 
 def _enumerate_components(path: Path) -> dict[str, Component]:
@@ -98,7 +98,7 @@ class Source:
 
     Public surface:
       path              -- root of materialized snapshot (filesystem escape hatch)
-      file_layout       -- "singlefile" | "diffusers"
+      file_layout       -- "single-file" | "multi-file" (th#1937 vocabulary)
       attributes        -- full resolved variant attribute map (provenance)
       ref               -- the wire ref string (e.g. "owner/repo") for logging
       components        -- dict[str, Component] for diffusers; {} for singlefile
@@ -147,7 +147,7 @@ class Source:
     def components(self) -> dict[str, Component]:
         """Diffusers component map. Empty for singlefile sources."""
         if self._components is None:
-            if self._file_layout == "diffusers":
+            if self._file_layout == MULTI_FILE:
                 self._components = _enumerate_components(self._path)
             else:
                 self._components = {}
@@ -162,7 +162,7 @@ class Source:
         always have one but we don't want to crash the tenant on odd sources).
         """
         if self._config is None:
-            if self._file_layout == "diffusers":
+            if self._file_layout == MULTI_FILE:
                 candidate = self._path / "model_index.json"
             else:
                 candidate = self._path / "config.json"
@@ -189,7 +189,7 @@ class Source:
         (e.g. ``unet/diffusion_pytorch_model.fp16.safetensors`` → ``"fp16"``).
         Mirrors gen_worker.models.loading.detect_diffusers_variant — repo-cas
         mirrors cloned with a dtype preference keep HF's variant suffix."""
-        if self._file_layout != "diffusers":
+        if self._file_layout != MULTI_FILE:
             return None
         candidates = ("bf16", "fp8", "fp16", "int8", "int4")
         try:
@@ -210,12 +210,12 @@ class Source:
         Override by passing an explicit ``model_cls=SomeClass`` kwarg.
         """
         model_cls = kwargs.pop("model_cls", None)
-        if self._file_layout == "diffusers" and "variant" not in kwargs:
+        if self._file_layout == MULTI_FILE and "variant" not in kwargs:
             if v := self.diffusers_variant():
                 kwargs["variant"] = v
         if model_cls is not None:
             return model_cls.from_pretrained(str(self._path), **kwargs)
-        if self._file_layout == "diffusers":
+        if self._file_layout == MULTI_FILE:
             from diffusers import DiffusionPipeline
             return DiffusionPipeline.from_pretrained(str(self._path), **kwargs)
         from transformers import AutoModelForCausalLM
@@ -287,7 +287,7 @@ class Source:
         """
         weight_exts = (".safetensors", ".bin", ".pt", ".pth", ".ckpt")
         total = 0
-        if self._file_layout == "diffusers":
+        if self._file_layout == MULTI_FILE:
             for comp_name in _weight_component_dirs():
                 comp_path = self._path / comp_name
                 if not comp_path.is_dir():
@@ -391,7 +391,7 @@ class Source:
         if offload_path is not None:
             offload_path.mkdir(parents=True, exist_ok=True)
 
-        if self._file_layout == "diffusers":
+        if self._file_layout == MULTI_FILE:
             yield from _iter_diffusers_components(
                 self._path,
                 quant_set=quant_set,

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -217,6 +217,7 @@ def _tensor_to_bytes(t: "torch.Tensor") -> Any:
 
 
 # ---------------------------------------------------------------------------
+from .file_layout import MULTI_FILE, SINGLE_FILE
 from ..component_vocab import (
     denoiser_components,
     text_encoder_components,
@@ -276,7 +277,7 @@ def iter_source_tensors(
     components_filter: list[str] | None = None,
 ) -> Iterator[tuple[str, str, "torch.Tensor"]]:
     """Yield (component, name, tensor) across a whole source snapshot."""
-    if file_layout == "singlefile":
+    if file_layout == SINGLE_FILE:
         for name, tensor in iter_component_tensors(root):
             yield "", name, tensor
         return
@@ -702,7 +703,7 @@ def snapshot_weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Pat
                  if p.is_file() and p.name not in sharded_members]
         return idx + loose
 
-    if layout == "diffusers":
+    if layout == MULTI_FILE:
         for entry in sorted(source_dir.iterdir()):
             if entry.is_dir():
                 found = _entries_for(entry)
@@ -1011,7 +1012,7 @@ def streaming_fp8_snapshot(
     if components is None:
         components = fp8_default_components()
     source_dir, out_dir = Path(source_dir), Path(out_dir)
-    if file_layout != "diffusers":
+    if file_layout != MULTI_FILE:
         root_groups = snapshot_weight_groups(source_dir, file_layout)
         if len(root_groups) != 1 or root_groups[0][0] != "":
             raise ConversionImplementationError(
@@ -1034,7 +1035,7 @@ def streaming_fp8_snapshot(
                 "converted_count": int(result["converted_count"]),
                 "components": [""], "output_dir": out_dir}
     denoiser_set, te_set = set(components), set(te_components)
-    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
+    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, MULTI_FILE)
               if c in denoiser_set | te_set]
     if not groups:
         raise ConversionImplementationError(
@@ -1134,7 +1135,7 @@ def streaming_w8a8_snapshot(
         components = fp8_default_components()
 
     source_dir, out_dir = Path(source_dir), Path(out_dir)
-    if file_layout != "diffusers":
+    if file_layout != MULTI_FILE:
         if te_components:
             raise ConversionImplementationError(
                 "te_components need a diffusers layout (no component "
@@ -1194,7 +1195,7 @@ def streaming_w8a8_snapshot(
             "weight_set_patterns applies to non-diffusers layouts only "
             "(diffusers selection is by component name)")
     denoiser_set, te_set = set(components), set(te_components)
-    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
+    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, MULTI_FILE)
               if c in denoiser_set | te_set]
     if not any(c in denoiser_set for c, _ in groups):
         raise ConversionImplementationError(

--- a/tests/convert/test_clone_classification_pgw1009.py
+++ b/tests/convert/test_clone_classification_pgw1009.py
@@ -47,10 +47,10 @@ def _source(dest_dir: Path) -> IngestedSource:
     (dest_dir / "model.safetensors").write_bytes(b"\x00" * 64)
     return IngestedSource(
         provider="huggingface", source_ref="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-        source_revision="5be7df96", dir=dest_dir, layout="singlefile",
+        source_revision="5be7df96", dir=dest_dir, layout="single-file",
         model_family="wan", model_family_variant="wan22",
         classification=SimpleNamespace(strategy="transformers"),
-        attrs={"dtype": "fp32", "file_layout": "singlefile"},
+        attrs={"dtype": "fp32", "file_layout": "single-file"},
         metadata={"source_provider": "huggingface"},
         repo_spec={"kind": "model", "library_name": "transformers"},
     )
@@ -68,7 +68,7 @@ def _run(fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
         source_ref="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
         destination_repo="tensorhub/wan22-t2v-a14b",
         destination_repo_tags=["prod"],
-        outputs=[{"dtype": "fp32", "file_layout": "diffusers",
+        outputs=[{"dtype": "fp32", "file_layout": "multi-file",
                   "file_type": "safetensors"}],
         **kw,
     )

--- a/tests/convert/test_clone_preflight_dtype_pgw1121.py
+++ b/tests/convert/test_clone_preflight_dtype_pgw1121.py
@@ -158,7 +158,7 @@ def _with_free(monkeypatch: pytest.MonkeyPatch, free: int) -> None:
             total=free * 2, used=free, free=free))
 
 
-BF16 = OutputSpec(dtype="bf16", file_layout="diffusers", file_type="safetensors")
+BF16 = OutputSpec(dtype="bf16", file_layout="multi-file", file_type="safetensors")
 
 
 def test_untagged_fp32_source_resolves_its_dtype_at_plan_time(

--- a/tests/convert/test_component_subfolder_pgw761.py
+++ b/tests/convert/test_component_subfolder_pgw761.py
@@ -106,7 +106,7 @@ def test_ingest_leaves_a_root_component_repo_alone(
     assert source.classification.component_subfolder == ""
     assert source.repo_spec["library_name"] == "diffusers"
     assert source.repo_spec["class_name"] == "AutoencoderKL"
-    assert source.attrs["file_layout"] == "singlefile"
+    assert source.attrs["file_layout"] == "single-file"
     assert "component_subfolder" not in source.metadata
     assert sorted(p.name for p in source.dir.rglob("*") if p.is_file()) == [
         "config.json", "diffusion_pytorch_model.safetensors"]

--- a/tests/convert/test_convert_producer_contract.py
+++ b/tests/convert/test_convert_producer_contract.py
@@ -43,7 +43,7 @@ def test_concurrent_same_source_clones_serialize(fake_hub, tmp_path: Path, monke
     def _fake_source(dest_dir: Path) -> IngestedSource:
         return IngestedSource(
             provider="huggingface", source_ref="org/tiny", source_revision="sha-1",
-            dir=dest_dir, layout="diffusers", model_family="", model_family_variant="",
+            dir=dest_dir, layout="multi-file", model_family="", model_family_variant="",
             classification=None, attrs={"dtype": "bf16"},
             metadata={"source_provider": "huggingface"},
             repo_spec={"kind": "model", "library_name": "diffusers"},

--- a/tests/convert/test_file_layout_vocabulary_th1937.py
+++ b/tests/convert/test_file_layout_vocabulary_th1937.py
@@ -1,0 +1,62 @@
+"""th#1937 / th#1932 item 7 — ONE ``file_layout`` vocabulary, enforced here too.
+
+Four spellings of one axis were live across two repositories and none was read
+back.  tensorhub now refuses a dead spelling at DECLARE with
+``file_layout_unknown_token``; these pin that this repo cannot emit one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.convert.clone import OutputSpec, normalize_outputs
+from gen_worker.convert.file_layout import (
+    KNOWN_FILE_LAYOUTS,
+    MULTI_FILE,
+    NOT_APPLICABLE,
+    SINGLE_FILE,
+    validate_file_layout,
+)
+
+
+@pytest.mark.parametrize(
+    "dead", ["singlefile", "diffusers", "multifile", "transformers", "single_file", "multi_file"]
+)
+def test_dead_spellings_are_refused_and_named(dead: str) -> None:
+    """RED-VERIFIED: every pre-ruling spelling raises, and the message says what
+    to write instead.  A validator that accepted everything would pass a test
+    that only asserted the good tokens."""
+    with pytest.raises(ValueError) as excinfo:
+        validate_file_layout(dead)
+    message = str(excinfo.value)
+    assert "file_layout_unknown_token" in message
+    assert SINGLE_FILE in message or MULTI_FILE in message
+
+
+@pytest.mark.parametrize("live", [SINGLE_FILE, MULTI_FILE, NOT_APPLICABLE, "  "])
+def test_ruled_tokens_and_the_absent_value_pass(live: str) -> None:
+    assert validate_file_layout(live) in KNOWN_FILE_LAYOUTS | {NOT_APPLICABLE}
+
+
+def test_normalize_outputs_speaks_only_the_ruled_vocabulary() -> None:
+    specs = normalize_outputs(
+        [{"dtype": "bf16", "file_layout": MULTI_FILE, "file_type": "safetensors"}]
+    )
+    assert specs == [OutputSpec(dtype="bf16", file_layout=MULTI_FILE, file_type="safetensors")]
+
+    # The default when the caller states no layout is still the ruled token.
+    assert normalize_outputs(None)[0].file_layout in KNOWN_FILE_LAYOUTS
+
+    with pytest.raises(ValueError, match="unsupported output.file_layout"):
+        normalize_outputs([{"dtype": "bf16", "file_layout": "diffusers"}])
+
+
+def test_source_detection_returns_ruled_tokens(tmp_path) -> None:
+    from gen_worker.convert.source import _detect_file_layout
+
+    (tmp_path / "model_index.json").write_text("{}", encoding="utf-8")
+    assert _detect_file_layout(tmp_path) == MULTI_FILE
+
+    flat = tmp_path / "flat"
+    flat.mkdir()
+    assert _detect_file_layout(flat) == SINGLE_FILE

--- a/tests/convert/test_file_layout_vocabulary_th1937.py
+++ b/tests/convert/test_file_layout_vocabulary_th1937.py
@@ -7,6 +7,8 @@ back.  tensorhub now refuses a dead spelling at DECLARE with
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from gen_worker.convert.clone import OutputSpec, normalize_outputs
@@ -51,7 +53,7 @@ def test_normalize_outputs_speaks_only_the_ruled_vocabulary() -> None:
         normalize_outputs([{"dtype": "bf16", "file_layout": "diffusers"}])
 
 
-def test_source_detection_returns_ruled_tokens(tmp_path) -> None:
+def test_source_detection_returns_ruled_tokens(tmp_path: Path) -> None:
     from gen_worker.convert.source import _detect_file_layout
 
     (tmp_path / "model_index.json").write_text("{}", encoding="utf-8")

--- a/tests/convert/test_p8_convert_publish_contract.py
+++ b/tests/convert/test_p8_convert_publish_contract.py
@@ -49,9 +49,9 @@ def _transformers_source(dest_dir: Path, *, dtype: str = "fp32") -> IngestedSour
     (dest_dir / "model.safetensors").write_bytes(b"\x00" * 64)
     return IngestedSource(
         provider="huggingface", source_ref="org/hidream-like", source_revision="sha-1",
-        dir=dest_dir, layout="singlefile", model_family="hidream", model_family_variant="",
+        dir=dest_dir, layout="single-file", model_family="hidream", model_family_variant="",
         classification=SimpleNamespace(strategy="transformers"),
-        attrs={"dtype": dtype, "file_layout": "singlefile"},
+        attrs={"dtype": dtype, "file_layout": "single-file"},
         metadata={"source_provider": "huggingface"},
         repo_spec={"kind": "model", "library_name": "transformers"},
     )
@@ -94,7 +94,7 @@ def test_explicit_dtype_mismatch_casts_not_silent_passthrough(
     result = run_clone(
         _Ctx(fake_hub), provider="huggingface", source_ref="org/hidream-like",
         destination_repo="acme/dest",
-        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+        outputs=[{"dtype": "bf16", "file_layout": "multi-file", "file_type": "safetensors"}],
     )
 
     assert not result.failed_flavors, result.failed_flavors
@@ -115,7 +115,7 @@ def test_matching_dtype_is_genuinely_zero_work(
     result = run_clone(
         _Ctx(fake_hub), provider="huggingface", source_ref="org/hidream-like",
         destination_repo="acme/dest",
-        outputs=[{"dtype": "fp32", "file_layout": "diffusers", "file_type": "safetensors"}],
+        outputs=[{"dtype": "fp32", "file_layout": "multi-file", "file_type": "safetensors"}],
     )
     assert not result.failed_flavors
     assert result.published[0]["dtype"] == "fp32"
@@ -135,9 +135,9 @@ def test_non_cast_eligible_strategy_refuses_mismatch_loudly(
     (dest / "model.q4_k_m.gguf").write_bytes(b"\x00" * 32)
     source = IngestedSource(
         provider="huggingface", source_ref="org/gguf-src", source_revision="sha-1",
-        dir=dest, layout="singlefile", model_family="", model_family_variant="",
+        dir=dest, layout="single-file", model_family="", model_family_variant="",
         classification=SimpleNamespace(strategy="gguf"),
-        attrs={"dtype": "q4_k_m", "file_layout": "singlefile"}, metadata={}, repo_spec={},
+        attrs={"dtype": "q4_k_m", "file_layout": "single-file"}, metadata={}, repo_spec={},
     )
     _install_fake_ingest(monkeypatch, source)
     calls: list = []
@@ -147,7 +147,7 @@ def test_non_cast_eligible_strategy_refuses_mismatch_loudly(
         run_clone(
             _Ctx(fake_hub), provider="huggingface", source_ref="org/gguf-src",
             destination_repo="acme/dest",
-            outputs=[{"dtype": "bf16", "file_layout": "singlefile", "file_type": "gguf"}],
+            outputs=[{"dtype": "bf16", "file_layout": "single-file", "file_type": "gguf"}],
         )
     assert calls == [], "a refused dtype mismatch must never reach the cast path"
 

--- a/tests/convert/test_publish_survival_pgw1003.py
+++ b/tests/convert/test_publish_survival_pgw1003.py
@@ -337,12 +337,12 @@ def test_a_retained_cast_output_is_republished_instead_of_rebuilt(
             destination_repo="acme/model", files=files,
             journal_path=workdir / JOURNAL_NAME,
             journal_state={"spec_label": "fp8", "tree": str(flavor_dir),
-                           "attrs": {"dtype": "fp8", "file_layout": "diffusers"}},
+                           "attrs": {"dtype": "fp8", "file_layout": "multi-file"}},
         )
 
     # The successor recognises its predecessor's finished output.
     attrs = clone._reusable_flavor_tree(workdir, "fp8", flavor_dir)
-    assert attrs == {"dtype": "fp8", "file_layout": "diffusers"}
+    assert attrs == {"dtype": "fp8", "file_layout": "multi-file"}
 
     # A tree that no longer matches the declaration is rebuilt, not published.
     (flavor_dir / "stray.json").write_bytes(b"{}")

--- a/tests/test_component_dtype_pins_pgw1133.py
+++ b/tests/test_component_dtype_pins_pgw1133.py
@@ -87,8 +87,8 @@ def _source(root: Path) -> IngestedSource:
         source_ref="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
         source_revision="5be7df9619b54f4e2667b2755bc6a756675b5cd7",
         dir=str(root),
-        layout="diffusers",
-        attrs={"dtype": "fp32", "file_layout": "diffusers", "file_type": "safetensors"},
+        layout="multi-file",
+        attrs={"dtype": "fp32", "file_layout": "multi-file", "file_type": "safetensors"},
         metadata={},
         model_family="wan",
         model_family_variant="wan22",
@@ -120,7 +120,7 @@ def test_bf16_cast_keeps_the_pinned_vae_byte_identical_and_casts_the_experts(tmp
 
     out, attrs = build_flavor_tree(
         _source(src),
-        OutputSpec(dtype="bf16", file_layout="diffusers", file_type="safetensors"),
+        OutputSpec(dtype="bf16", file_layout="multi-file", file_type="safetensors"),
         tmp_path / "out",
     )
 
@@ -147,7 +147,7 @@ def test_an_explicit_request_to_quantize_the_pinned_component_is_refused_by_name
     with pytest.raises(ComponentDtypePinError) as excinfo:
         build_flavor_tree(
             _source(src),
-            OutputSpec(dtype="fp8", file_layout="diffusers", file_type="safetensors"),
+            OutputSpec(dtype="fp8", file_layout="multi-file", file_type="safetensors"),
             tmp_path / "out",
             quantize_components=["transformer", "vae"],
         )
@@ -162,7 +162,7 @@ def test_an_fp32_cast_of_a_pinned_component_is_not_refused(tmp_path):
     src = _wan_tree(tmp_path / "src")
     out, _ = build_flavor_tree(
         _source(src),
-        OutputSpec(dtype="fp32", file_layout="diffusers", file_type="safetensors"),
+        OutputSpec(dtype="fp32", file_layout="multi-file", file_type="safetensors"),
         tmp_path / "out",
     )
     assert component_dtypes_on_disk(out)["vae"] == "fp32"

--- a/tests/test_deshard_mirror_th1362.py
+++ b/tests/test_deshard_mirror_th1362.py
@@ -192,7 +192,7 @@ def test_sharded_reads_still_work_after_the_ruling(tmp_path):
 # The real mirror path
 # --------------------------------------------------------------------------
 
-def _source(tmp_path: Path, layout: str = "diffusers") -> IngestedSource:
+def _source(tmp_path: Path, layout: str = "multi-file") -> IngestedSource:
     return IngestedSource(
         provider="huggingface", source_ref="acme/thing", source_revision="deadbeef",
         dir=tmp_path, layout=layout, model_family="sdxl", model_family_variant="sdxl",
@@ -211,7 +211,7 @@ def test_pure_passthrough_mirror_is_desharded(tmp_path):
 
     out = tmp_path / "out"
     tree, attrs = build_flavor_tree(
-        _source(src), OutputSpec(dtype="source", file_layout="diffusers",
+        _source(src), OutputSpec(dtype="source", file_layout="multi-file",
                                  file_type="safetensors"), out)
 
     assert attrs["dtype"] == "bf16"
@@ -236,7 +236,7 @@ def test_dtype_matching_mirror_is_desharded(tmp_path):
 
     out = tmp_path / "out"
     tree, _ = build_flavor_tree(
-        _source(src), OutputSpec(dtype="bf16", file_layout="diffusers",
+        _source(src), OutputSpec(dtype="bf16", file_layout="multi-file",
                                  file_type="safetensors"), out)
     weights = sorted(p.name for p in (tree / "transformer").glob("*.safetensors"))
     assert weights == ["diffusion_pytorch_model.safetensors"]

--- a/tests/test_fail_loud_pgw657.py
+++ b/tests/test_fail_loud_pgw657.py
@@ -140,7 +140,7 @@ def test_diffusers_singlefile_is_a_typed_refusal(tmp_path) -> None:
 
     (tmp_path / "model.safetensors").write_bytes(b"\x00")
     src = Source(tmp_path)
-    assert src.file_layout == "singlefile"
+    assert src.file_layout == "single-file"
     with pytest.raises(ValidationError) as exc:
         list(src.iter_hf_components())
     assert "as_hf_model" in str(exc.value)

--- a/tests/test_objectives_pgw654.py
+++ b/tests/test_objectives_pgw654.py
@@ -581,7 +581,7 @@ def _diffusers_source(tmp_path: Path) -> "object":
     (src / "model_index.json").write_text(json.dumps({"_class_name": "StableDiffusionXLPipeline"}))
     return IngestedSource(
         provider="huggingface", source_ref="acme/gonzalomo-xl", source_revision="sha1",
-        dir=src, layout="diffusers", model_family="sdxl", model_family_variant="",
+        dir=src, layout="multi-file", model_family="sdxl", model_family_variant="",
         attrs={"dtype": "fp16"},
     )
 
@@ -590,7 +590,7 @@ def test_distilled_fact_writes_trailing_timestep_spacing(tmp_path: Path) -> None
     from gen_worker.convert.clone import OutputSpec, build_flavor_tree
 
     source = _diffusers_source(tmp_path)
-    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    spec = OutputSpec(dtype="fp16", file_layout="multi-file", file_type="safetensors")
     tree, _attrs = build_flavor_tree(
         source, spec, tmp_path / "flavor-distilled", distilled=True)
 
@@ -603,7 +603,7 @@ def test_v_prediction_objective_writes_zero_snr_v_pred(tmp_path: Path) -> None:
     from gen_worker.convert.clone import OutputSpec, build_flavor_tree
 
     source = _diffusers_source(tmp_path)
-    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    spec = OutputSpec(dtype="fp16", file_layout="multi-file", file_type="safetensors")
     tree, _attrs = build_flavor_tree(
         source, spec, tmp_path / "flavor-vpred", objective="v_prediction")
 
@@ -616,7 +616,7 @@ def test_epsilon_unstamped_leaves_scheduler_config_untouched(tmp_path: Path) -> 
     from gen_worker.convert.clone import OutputSpec, build_flavor_tree
 
     source = _diffusers_source(tmp_path)
-    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    spec = OutputSpec(dtype="fp16", file_layout="multi-file", file_type="safetensors")
     tree, _attrs = build_flavor_tree(source, spec, tmp_path / "flavor-plain")
 
     cfg = json.loads((tree / "scheduler" / "config.json").read_text())

--- a/tests/test_producer_no_shards_th1362.py
+++ b/tests/test_producer_no_shards_th1362.py
@@ -72,7 +72,7 @@ def test_a_real_cast_of_a_sharded_source_emits_one_file_per_component(tmp_path):
 
     out = tmp_path / "out"
     streaming_cast_snapshot(src, out, target_dtype=torch.bfloat16,
-                            file_layout="diffusers")
+                            file_layout="multi-file")
 
     assert find_producer_shards(out) == []
     for comp, prefix in (("unet", "diffusion_pytorch_model"), ("text_encoder", "model")):
@@ -100,7 +100,7 @@ def test_a_cast_of_an_unsharded_source_stays_one_file(tmp_path):
 
     out = tmp_path / "out"
     streaming_cast_snapshot(src, out, target_dtype=torch.float16,
-                            file_layout="diffusers")
+                            file_layout="multi-file")
     assert find_producer_shards(out) == []
     assert sorted(p.name for p in (out / "transformer").glob("*.safetensors")) \
         == ["diffusion_pytorch_model.safetensors"]

--- a/tests/test_repack_engine_pgw740.py
+++ b/tests/test_repack_engine_pgw740.py
@@ -418,7 +418,7 @@ def test_root_sentinels_detect_a_layout_with_no_family_token(tmp_path: Path) -> 
         ],
     )
     assert (info.model_family_variant, info.model_family) == ("beta2", "beta")
-    assert info.source_layout == "singlefile"
+    assert info.source_layout == "single-file"
 
 
 def test_component_dirs_detect_the_variant(tmp_path: Path) -> None:
@@ -429,7 +429,7 @@ def test_component_dirs_detect_the_variant(tmp_path: Path) -> None:
         files=["model_index.json", "unet/config.json", "text_encoder/config.json"],
     )
     assert info.model_family_variant == "alpha1"
-    assert info.source_layout == "diffusers"
+    assert info.source_layout == "multi-file"
 
     dual = layout.detect_huggingface_source_layout(
         repo_dir=tmp_path,
@@ -460,7 +460,7 @@ def test_nothing_is_detected_when_nothing_is_declared(tmp_path: Path) -> None:
     info = layout.detect_huggingface_source_layout(
         repo_dir=tmp_path, files=["unet/config.json", "model_index.json"])
     assert (info.model_family, info.model_family_variant) == ("unknown", "unknown")
-    assert info.source_layout == "diffusers"  # layout shape is family-free
+    assert info.source_layout == "multi-file"  # layout shape is family-free
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_w8a8_snapshot_skip_patterns_ie681.py
+++ b/tests/test_w8a8_snapshot_skip_patterns_ie681.py
@@ -65,7 +65,7 @@ def _produce(tmp_path: Path, name: str, **kw) -> dict:
     out = tmp_path / name
     streaming_w8a8_snapshot(
         _h3_shaped_denoiser(tmp_path / name / "in"), out,
-        file_layout="diffusers", components=("transformer",), **kw)
+        file_layout="multi-file", components=("transformer",), **kw)
     return _header(out / "transformer" / "diffusion_pytorch_model.safetensors")
 
 


### PR DESCRIPTION
The pgw half of th#1937's `file_layout` cut. Hub half: tensorhub [#1198](https://github.com/cozy-creator/tensorhub/pull/1198), which **refuses** a dead spelling at DECLARE with `file_layout_unknown_token` — so this must land for this repo's publishes to keep working.

## The drift, measured

Four spellings of one field were live across two repositories and **none was ever read back** — publish stored whatever a producer sent while tensorhub's layout gate re-inferred its own value:

| spelling | where |
|---|---|
| `multi-file` / `single-file` | tensorhub's coarse-tier map — the only place the value has ever *meant* anything |
| `transformers` | tensorhub's own metadata inferrer — a LIBRARY name spent as a layout value |
| `singlefile` / `diffusers` | this repo, `convert/source.py`'s `FileLayout` Literal, and what the classifier publishes |
| `single-file` | this repo, `convert/convert.py:424`'s gguf branch — **drifting against its own Literal** |

Survivable for a display string, fatal for a selector. Under the th#1934 redesign the publish-derived contract **is** the selector, so a checkpoint stamped `singlefile` is one a `single-file` spec silently never matches — at deploy, with no bug anywhere to find.

## The ruling

**`multi-file` | `single-file`**, plus the empty string for libraries whose loader does not branch on the axis. They win because they are the only spelling that ever carried meaning, and because `diffusers` spends a LIBRARY name on a layout value — a second collision on top of the first.

`gen_worker/convert/file_layout.py` is the one home. The internal Literal, the classifier's attrs, the ingest fallbacks, the clone output specs, the writer's layout branches and the gguf branch all read it. `publish.py` validates at the boundary, so a bad token is refused here with a named message rather than as a hub 400.

**No aliases, no normalization pass.** Pre-launch: a dead spelling is a typed `file_layout_unknown_token` that says what to write instead.

## Tests

`tests/convert/test_file_layout_vocabulary_th1937.py` red-verifies every dead spelling (`singlefile`, `diffusers`, `multifile`, `transformers`, `single_file`, `multi_file`) against a control that the ruled tokens and the absent value pass — a validator that accepted everything would sail through a good-tokens-only test. Existing tests are cut over to the ruled tokens (values only; no `singlefile_to_diffusers` *function* was renamed — those name a conversion direction, not a token).

Targeted runs, green: `tests/convert/` publish+clone+classification set (53 passed) and the touched `tests/*.py` set (102 passed).