### PR TITLE
pgw#1250: a mint leg is create -> invoke -> read -> stop on a private deployment

### DIFF
--- a/scripts/private_deployment_leg.py
+++ b/scripts/private_deployment_leg.py
@@ -1,0 +1,996 @@
+#!/usr/bin/env python3
+"""A mint leg on a tensorhub PRIVATE DEPLOYMENT: create -> invoke -> read -> stop.
+
+    python scripts/private_deployment_leg.py --hub URL --org O --endpoint org/name \\
+        --release <id> --pair a40:bf16-w16a16+compiled --confirm
+    python scripts/private_deployment_leg.py --dry --state merged     # no hub, no money
+
+WHY THIS EXISTS (pgw#1250, for tensorhub th#1929 / epic th#1925)
+
+`scripts/micro_mint_rig.py` proves a mint before a wheel reaches PyPI. Its legs
+2-3 spawn a REAL child interpreter on this box and compile there. Paul's
+2026-08-10 hard cut removed that ground: **all mints and compiles run on remote
+pods only**, with no carve-out. So the rig's producer has to move off the box,
+and the only question was what replaces it.
+
+Before private deployments the answer was ugly, and it is written down in this
+repo's own tracker as a THREE-STEP TEARDOWN PROTOCOL: cancel your own demand by
+request id, then QUERY `tensorhub.endpoint_tags` to find out whether the release
+you just used is tag-routable, and force-terminate the pod ONLY if that query
+comes back empty — because a force-terminate against a tag-routable release can
+take production capacity with it. Plus tagging a release in the first place to
+manufacture the demand that buys the pod, and hoping the platform spend cap did
+not count your rig against production.
+
+**All of that collapses into `stop`.** A private deployment is an owner-paid
+rental of (endpoint, PINNED release, ONE (GPU, lane) pair) that no capacity pass
+can see and no reaper can touch:
+
+  * the release does not need a routing tag, so there is no tag to delete and
+    no demand to cancel — an UNTAGGED release is rentable by design;
+  * the pod is attributable to one deployment id, so the kill set is that id
+    and the `endpoint_tags` gate has nothing left to protect against;
+  * the spend is the owner's, bounded by the rental's own `spend_limit_micros`,
+    and never lands on the platform's concurrent-spend cap.
+
+THE SEAM, AND WHAT IS NOT MERGED YET
+
+The resource surface (tensorhub th#1926) is merged. The INVOKE route
+(`POST /v1/private-deployments/:id/:function`, th#1927's follow-up) and
+per-second settlement (th#1928) are not. Both are modelled here against the
+settled contract, and a leg run against a hub that lacks them reports a typed
+BLOCKED phase naming the issue -- never a skipped assertion and never a green.
+`--dry` runs the whole leg against an in-process model of the contract, with
+`--state resource|fences|merged` selecting which slices have "merged", so the
+report shows exactly what is owed today.
+
+WHAT THIS FILE DOES NOT DO
+
+It does not edit the rig. `scripts/micro_mint_rig.py` is carried by an open PR
+(pgw#1214/#761) and its mint modules are rewritten by th#1834's step 4, so the
+rig's own switch to this driver is a separate, ~10-line change made by whoever
+lands those -- see `REPOINT_NOTE` at the bottom of this file for the exact call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Vocabulary. A copy across a repo boundary of tensorhub's
+# internal/orchestrator/privatedeployment and its schema CHECKs, so the
+# assertions below check the invariants rather than trusting the copy.
+# ---------------------------------------------------------------------------
+
+STATE_ACTIVE = "active"
+STATE_STOPPING = "stopping"
+STATE_STOPPED = "stopped"
+
+STOP_REASON_NONE = ""
+STOP_REASON_OWNER = "owner_stop"
+STOP_REASON_ADMIN = "admin_stop"
+
+ACCESS_OWNER = "owner"
+ACCESS_ORG = "org"
+
+ON_POD_FAILURE_REPLACE = "replace"
+ON_POD_FAILURE_STOP = "stop"
+
+CHOOSER_ORCHESTRATOR = "orchestrator"
+CHOOSER_PRIVATE_DEPLOYMENT = "private_deployment"
+
+HISTORY_SOURCE_CREATE = "create"
+HISTORY_SOURCE_STOP = "stop"
+
+#: worker_pods states that do NOT hold a deployment in `stopping`.
+DEAD_POD_STATES = frozenset({"terminated", "startup_error", "startup_error_claimed"})
+#: worker_pods states that can take a dispatch.
+READY_POD_STATES = frozenset({"ready", "connected", "running", "serving"})
+
+BLOCKER_INVOKE_ROUTE = "th#1927 follow-up (POST /v1/private-deployments/:id/:function)"
+BLOCKER_RECONCILER = "th#1927 (provisioning reconciler)"
+BLOCKER_SETTLEMENT = "th#1928 (per-second settlement)"
+BLOCKER_PUBLISH_READ = "pgw#1250 (a hub read for per-graph publish durability)"
+
+OK = "ok"
+FAILED = "failed"
+BLOCKED = "blocked"
+SKIPPED = "skipped"
+
+_RANK = {OK: 0, SKIPPED: 1, BLOCKED: 2, FAILED: 3}
+
+
+def _worse(a: str, b: str) -> str:
+    return b if _RANK[b] > _RANK[a] else a
+
+
+def parse_pair(raw: str) -> Tuple[str, str]:
+    """Read the wire form "gpu:lane".
+
+    A rental may NOT name a bare lane: "any card" is not a choice a per-second
+    bill can be attributed to, so the lane-only spelling a release ladder
+    accepts is a refusal here.
+    """
+    text = raw.strip().lower()
+    if not text:
+        raise ValueError("empty pair")
+    if ":" not in text:
+        raise ValueError(f"pair {raw!r} names no GPU; a rental pins one card, and {raw!r} is a lane on its own")
+    gpu, lane = (part.strip() for part in text.split(":", 1))
+    if not gpu:
+        raise ValueError(f"pair {raw!r}: the GPU half before ':' is empty")
+    if not lane:
+        raise ValueError(f"pair {raw!r}: names no execution lane")
+    return gpu, lane
+
+
+def coherence_error(state: str, stop_reason: str, stopped_at: Optional[str]) -> Optional[str]:
+    """Mirror the two schema CHECKs, and name the violation when one fails.
+
+        (state = 'active')       = (stop_reason = '' AND stopped_at IS NULL)
+        (stopped_at IS NOT NULL) = (state = 'stopped')
+
+    Checked on every observation rather than assumed: this driver's job is to be
+    the outside witness that a money-bearing row never lies.
+    """
+    quiet = not stop_reason.strip() and stopped_at is None
+    if (state == STATE_ACTIVE) != quiet:
+        return f"coherence: state={state!r} with stop_reason={stop_reason!r} stopped_at={stopped_at!r}"
+    if (stopped_at is not None) != (state == STATE_STOPPED):
+        return f"coherence: stopped_at={stopped_at!r} with state={state!r}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The API seam
+# ---------------------------------------------------------------------------
+
+
+class ApiError(Exception):
+    """A typed hub refusal. `code` is the hub's refusal vocabulary when it named one."""
+
+    def __init__(self, method: str, path: str, status: int, code: str, detail: str) -> None:
+        super().__init__(f"{method} {path}: HTTP {status} {code or 'unnamed'}: {detail}")
+        self.method = method
+        self.path = path
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+    @property
+    def route_missing(self) -> bool:
+        """True when this is "the hub does not serve that route".
+
+        A hub that HAS the route answers a typed code, so "no such route" and
+        "no such rental" stay distinguishable — which is what lets a report say
+        BLOCKED honestly instead of claiming a resource vanished.
+        """
+        return (self.status == 404 and not self.code) or self.status == 405
+
+
+class DeploymentAPI(Protocol):
+    """Everything a leg needs. HttpDeploymentAPI speaks to a real hub; the tests
+    drive an in-memory model of the same contract."""
+
+    def create(self, org: str, body: Mapping[str, Any]) -> Dict[str, Any]: ...
+    def get(self, org: str, deployment_id: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]: ...
+    def stop(self, org: str, deployment_id: str, reason: str) -> Tuple[Dict[str, Any], bool]: ...
+    def usage(self, org: str, deployment_id: str) -> Dict[str, Any]: ...
+    def config_history(self, org: str, deployment_id: str) -> List[Dict[str, Any]]: ...
+    def invoke(self, deployment_id: str, function: str, payload: Mapping[str, Any]) -> str: ...
+    def request(self, request_id: str) -> Dict[str, Any]: ...
+
+
+class HttpDeploymentAPI:
+    """The real surface. Every call carries an explicit timeout — a rig that can
+    hang forever is a rig that leaves a pod running."""
+
+    def __init__(self, base: str, token: str, timeout_s: float = 60.0) -> None:
+        self.base = base.rstrip("/")
+        self.token = token
+        self.timeout_s = timeout_s
+
+    def _call(self, method: str, path: str, body: Optional[Mapping[str, Any]] = None) -> Any:
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(self.base + path, data=data, method=method)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        if self.token:
+            req.add_header("Authorization", "Bearer " + self.token)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            code, detail = "", raw.decode(errors="replace")[:600].strip()
+            try:
+                envelope = json.loads(raw)
+                inner = envelope.get("error", envelope)
+                code = str(inner.get("code", ""))
+                detail = str(inner.get("message", detail))
+            except (ValueError, AttributeError):
+                pass
+            raise ApiError(method, path, exc.code, code, detail) from None
+        except urllib.error.URLError as exc:
+            raise ApiError(method, path, 0, "", f"transport: {exc.reason}") from None
+        return json.loads(raw) if raw else {}
+
+    def _base(self, org: str) -> str:
+        return "/v1/orgs/" + urllib.parse.quote(org, safe="") + "/private-deployments"
+
+    def create(self, org: str, body: Mapping[str, Any]) -> Dict[str, Any]:
+        out = self._call("POST", self._base(org), body)
+        return dict(out.get("deployment", {}))
+
+    def get(self, org: str, deployment_id: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+        out = self._call("GET", f"{self._base(org)}/{urllib.parse.quote(deployment_id)}")
+        return dict(out.get("deployment", {})), list(out.get("pods", []))
+
+    def stop(self, org: str, deployment_id: str, reason: str) -> Tuple[Dict[str, Any], bool]:
+        out = self._call("POST", f"{self._base(org)}/{urllib.parse.quote(deployment_id)}/stop",
+                         {"reason": reason})
+        return dict(out.get("deployment", {})), bool(out.get("already_stopped", False))
+
+    def usage(self, org: str, deployment_id: str) -> Dict[str, Any]:
+        return dict(self._call("GET", f"{self._base(org)}/{urllib.parse.quote(deployment_id)}/usage"))
+
+    def config_history(self, org: str, deployment_id: str) -> List[Dict[str, Any]]:
+        out = self._call("GET", f"{self._base(org)}/{urllib.parse.quote(deployment_id)}/config/history")
+        return list(out.get("history", []))
+
+    def invoke(self, deployment_id: str, function: str, payload: Mapping[str, Any]) -> str:
+        path = ("/v1/private-deployments/" + urllib.parse.quote(deployment_id)
+                + "/" + urllib.parse.quote(function))
+        out = self._call("POST", path, payload)
+        request_id = str(out.get("request_id") or out.get("id") or "")
+        if not request_id:
+            raise ApiError("POST", path, 200, "", "answered no request id")
+        return request_id
+
+    def request(self, request_id: str) -> Dict[str, Any]:
+        return dict(self._call("GET", "/v1/requests/" + urllib.parse.quote(request_id)))
+
+
+# ---------------------------------------------------------------------------
+# The leg
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    ident: str
+    status: str
+    detail: str = ""
+    blocker: str = ""
+
+
+@dataclass
+class Phase:
+    name: str
+    status: str = OK
+    findings: List[Finding] = field(default_factory=list)
+    seconds: float = 0.0
+
+
+@dataclass
+class Leg:
+    """One rental: ONE (GPU, lane), one release, N invokes."""
+
+    org: str
+    endpoint: str
+    release_id: str
+    pair: Tuple[str, str]
+    function: str = "generate"
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    invocations: int = 1
+    pod_count: int = 1
+    access_mode: str = ACCESS_OWNER
+    # A mint leg measures ONE machine: replacing a dead pod mid-leg would
+    # silently change the producer, which is the whole subject of the proof.
+    on_pod_failure: str = ON_POD_FAILURE_STOP
+    spend_limit_usd: float = 1.0
+    reason: str = "pgw#1250 mint leg on a private deployment"
+
+    def validate(self) -> None:
+        if not self.org.strip():
+            raise ValueError("leg: org is required (it is the payer)")
+        if not self.endpoint.strip():
+            raise ValueError("leg: endpoint is required")
+        if not self.release_id.strip():
+            raise ValueError(
+                "leg: release_id is required — a rental pins its release and never follows a tag")
+        if not self.pair[0] or not self.pair[1]:
+            raise ValueError("leg: the pair must name both a GPU and a lane")
+        if self.pod_count < 1:
+            raise ValueError("leg: pod_count must be at least 1")
+        if self.access_mode not in (ACCESS_OWNER, ACCESS_ORG):
+            raise ValueError(f"leg: access_mode {self.access_mode!r} must be owner or org")
+        if self.on_pod_failure not in (ON_POD_FAILURE_REPLACE, ON_POD_FAILURE_STOP):
+            raise ValueError(f"leg: on_pod_failure {self.on_pod_failure!r} must be replace or stop")
+        if self.spend_limit_usd < 0:
+            raise ValueError("leg: spend_limit_usd cannot be negative")
+
+
+@dataclass
+class LegResult:
+    leg: Leg
+    deployment_id: str = ""
+    phases: List[Phase] = field(default_factory=list)
+    deployment: Dict[str, Any] = field(default_factory=dict)
+    pods: List[Dict[str, Any]] = field(default_factory=list)
+    requests: List[Dict[str, Any]] = field(default_factory=list)
+    usage: Dict[str, Any] = field(default_factory=dict)
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        out = OK
+        for phase in self.phases:
+            out = _worse(out, phase.status)
+        return out
+
+    @property
+    def findings(self) -> List[Finding]:
+        return [f for phase in self.phases for f in phase.findings]
+
+    @property
+    def blockers(self) -> List[str]:
+        return sorted({f.blocker for f in self.findings if f.status == BLOCKED and f.blocker})
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "deployment_id": self.deployment_id,
+            "status": self.status,
+            "blockers": self.blockers,
+            "phases": [
+                {"name": p.name, "status": p.status, "seconds": round(p.seconds, 3),
+                 "findings": [vars(f) for f in p.findings]}
+                for p in self.phases
+            ],
+            "deployment": self.deployment,
+            "pods": self.pods,
+            "requests": self.requests,
+            "usage": self.usage,
+        }
+
+
+def _live(pods: Sequence[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
+    return [p for p in pods if str(p.get("state", "")) not in DEAD_POD_STATES]
+
+
+def _ready(pods: Sequence[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
+    return [p for p in pods if str(p.get("state", "")) in READY_POD_STATES]
+
+
+class _Run:
+    """Driver state. Give-up is PROGRESS STALENESS plus the caller's own budget —
+    never a fixed duration standing in for a lifecycle decision (the standing
+    no-magic-timeouts rule). Whatever happens, the rental is stopped."""
+
+    def __init__(self, api: DeploymentAPI, leg: Leg, *, poll_s: float,
+                 stall_budget_s: float, log: Callable[[str], None],
+                 clock: Callable[[], float], sleep: Callable[[float], None]) -> None:
+        self.api = api
+        self.leg = leg
+        self.poll_s = poll_s
+        self.stall_budget_s = stall_budget_s
+        self.log = log
+        self.clock = clock
+        self.sleep = sleep
+        self.result = LegResult(leg=leg)
+        self.phase = Phase(name="init")
+        self.last_progress = clock()
+        self.fingerprint = ""
+
+    # -- phase plumbing ----------------------------------------------------
+    def begin(self, name: str) -> None:
+        self.phase = Phase(name=name)
+        self.phase.seconds = self.clock()
+        self.result.phases.append(self.phase)
+
+    def end(self) -> None:
+        self.phase.seconds = self.clock() - self.phase.seconds
+
+    def find(self, ident: str, status: str, detail: str, blocker: str = "") -> None:
+        self.phase.findings.append(Finding(ident, status, detail, blocker))
+        self.phase.status = _worse(self.phase.status, status)
+        self.log(f"[{self.phase.name}] {status} {ident}: {detail}")
+
+    def check(self, ident: str, ok: bool, detail: str) -> bool:
+        self.find(ident, OK if ok else FAILED, detail)
+        return ok
+
+    def note_progress(self, fingerprint: str) -> None:
+        if fingerprint != self.fingerprint:
+            self.fingerprint = fingerprint
+            self.last_progress = self.clock()
+
+    def stalled(self) -> bool:
+        return (self.clock() - self.last_progress) >= self.stall_budget_s
+
+    # -- legs --------------------------------------------------------------
+    def create(self) -> bool:
+        self.begin("create")
+        body: Dict[str, Any] = {
+            "endpoint": self.leg.endpoint,
+            "release_id": self.leg.release_id,
+            "pair": f"{self.leg.pair[0]}:{self.leg.pair[1]}",
+            "pod_count": self.leg.pod_count,
+            "access_mode": self.leg.access_mode,
+            "on_pod_failure": self.leg.on_pod_failure,
+            "reason": self.leg.reason,
+        }
+        if self.leg.spend_limit_usd > 0:
+            body["spend_limit_usd"] = self.leg.spend_limit_usd
+        try:
+            dep = self.api.create(self.leg.org, body)
+        except ApiError as exc:
+            if exc.route_missing:
+                self.find("create.route", BLOCKED,
+                          f"the hub does not serve the resource surface: {exc}",
+                          "th#1926 (private-deployment resource)")
+            else:
+                self.find("create.accepted", FAILED, f"create refused: {exc}")
+            self.end()
+            return False
+        self.result.deployment_id = str(dep.get("id", ""))
+        self.result.deployment = dep
+        self.check("create.accepted", bool(self.result.deployment_id),
+                   f"deployment {self.result.deployment_id} created")
+        self.check("create.state_active", dep.get("state") == STATE_ACTIVE,
+                   f"state={dep.get('state')!r}")
+        err = coherence_error(str(dep.get("state", "")), str(dep.get("stop_reason", "")),
+                              dep.get("stopped_at"))
+        self.check("create.row_coherent", err is None, err or "state/stop_reason/stopped_at agree")
+        self.check("create.release_pinned", dep.get("release_id") == self.leg.release_id,
+                   f"release_id={dep.get('release_id')!r} (asked {self.leg.release_id!r})")
+        self.check("create.pair_roundtrip",
+                   dep.get("gpu_slug") == self.leg.pair[0] and dep.get("execution_lane") == self.leg.pair[1],
+                   f"pair={dep.get('pair')!r}")
+        self.check("create.generation_genesis", dep.get("config_generation") == 1,
+                   f"config_generation={dep.get('config_generation')}")
+        self.check("create.owner_recorded", bool(str(dep.get("created_by", "")).strip()),
+                   f"created_by={dep.get('created_by')!r}")
+        self.end()
+        return True
+
+    def provision(self) -> None:
+        self.begin("provision")
+        pods = self._wait_pods()
+        self.result.pods = list(pods)
+        live = _live(pods)
+        if not live:
+            self.find("provision.pods", BLOCKED,
+                      "no pod was provisioned for the rental", BLOCKER_RECONCILER)
+            self.end()
+            return
+        self.check("provision.pod_count", len(live) >= self.leg.pod_count,
+                   f"{len(live)} live pod(s) for pod_count={self.leg.pod_count}")
+        for pod in live:
+            pod_id = str(pod.get("pod_id", "?"))
+            self.check(f"provision.chooser[{pod_id}]",
+                       pod.get("placement_chooser") == CHOOSER_PRIVATE_DEPLOYMENT,
+                       f"placement_chooser={pod.get('placement_chooser')!r}")
+            self.check(f"provision.attributed[{pod_id}]",
+                       pod.get("private_deployment_id") == self.result.deployment_id,
+                       f"private_deployment_id={pod.get('private_deployment_id')!r}")
+            # The provider figure is READ, never re-derived: the ledger column
+            # is already the WHOLE-POD rate (compute AND disk), and re-deriving
+            # a disk rate on top of it double-bills the owner.
+            self.check(f"provision.rate_recorded[{pod_id}]",
+                       int(pod.get("cost_micros_per_hour", 0)) > 0,
+                       f"cost_micros_per_hour={pod.get('cost_micros_per_hour')} (whole pod)")
+        self.end()
+
+    def _wait_pods(self) -> List[Dict[str, Any]]:
+        pods: List[Dict[str, Any]] = []
+        while True:
+            try:
+                dep, pods = self.api.get(self.leg.org, self.result.deployment_id)
+            except ApiError as exc:
+                self.log(f"[provision] read failed, retrying: {exc}")
+            else:
+                self.result.deployment = dep
+                self.note_progress(json.dumps(
+                    [dep.get("state"), dep.get("config_generation"),
+                     sorted(f"{p.get('pod_id')}={p.get('state')}" for p in pods)], sort_keys=True))
+                if dep.get("state") != STATE_ACTIVE:
+                    self.find("provision.still_active", FAILED,
+                              f"the rental left active before serving: state={dep.get('state')!r} "
+                              f"stop_reason={dep.get('stop_reason')!r}")
+                    return pods
+                if len(_ready(pods)) >= self.leg.pod_count:
+                    self.find("provision.ready", OK, f"{len(_ready(pods))} pod(s) ready")
+                    return pods
+                if not _live(pods) and self.stalled():
+                    return pods
+            if self.stalled():
+                self.find("provision.ready", FAILED,
+                          f"no observable progress for {self.stall_budget_s:.0f}s; "
+                          f"{len(_live(pods))} live / {len(_ready(pods))} ready")
+                return pods
+            self.sleep(self.poll_s)
+
+    def invoke(self) -> None:
+        self.begin("invoke")
+        if self.leg.invocations <= 0:
+            self.find("invoke.workload", SKIPPED, "leg declares no invocations (lifecycle only)")
+            self.end()
+            return
+        for index in range(self.leg.invocations):
+            started = self.clock()
+            try:
+                request_id = self.api.invoke(self.result.deployment_id, self.leg.function, self.leg.payload)
+            except ApiError as exc:
+                self.result.requests.append({"index": index, "error": str(exc)})
+                if exc.route_missing:
+                    self.find("invoke.route", BLOCKED,
+                              f"the hub does not serve the private invoke route yet: {exc}",
+                              BLOCKER_INVOKE_ROUTE)
+                else:
+                    self.find("invoke.accepted", FAILED, f"invocation {index} refused: {exc}")
+                self.end()
+                return
+            self.note_progress("invoke:" + request_id)
+            record = self._wait_request(request_id)
+            record["index"] = index
+            record["seconds"] = round(self.clock() - started, 3)
+            self.result.requests.append(record)
+            self.check(f"invoke.completed[{index}]", record.get("status") == "completed",
+                       f"request {request_id} status={record.get('status')!r} in {record['seconds']}s")
+        self.end()
+
+    def _wait_request(self, request_id: str) -> Dict[str, Any]:
+        last = ""
+        while True:
+            try:
+                record = self.api.request(request_id)
+            except ApiError as exc:
+                self.log(f"[invoke] request read failed, retrying: {exc}")
+            else:
+                status = str(record.get("status", ""))
+                if status != last:
+                    last = status
+                    self.note_progress(f"request:{request_id}:{status}")
+                if status in ("completed", "failed", "canceled", "cancelled"):
+                    return dict(record)
+            if self.stalled():
+                return {"request_id": request_id, "status": last,
+                        "error": f"no observable progress for {self.stall_budget_s:.0f}s"}
+            self.sleep(self.poll_s)
+
+    def read(self) -> None:
+        self.begin("read")
+        try:
+            usage = self.api.usage(self.leg.org, self.result.deployment_id)
+        except ApiError as exc:
+            self.find("read.usage", FAILED, f"usage read failed: {exc}")
+        else:
+            self.result.usage = usage
+            self.find("read.usage", OK,
+                      f"pod_rows={usage.get('pod_rows')} pod_seconds={usage.get('pod_seconds')}")
+            self._assert_settlement(usage)
+        try:
+            history = self.api.config_history(self.leg.org, self.result.deployment_id)
+        except ApiError as exc:
+            self.find("read.history", FAILED, f"config history read failed: {exc}")
+            self.end()
+            return
+        self.result.history = history
+        genesis = [row for row in history if row.get("config_generation") == 1]
+        if not genesis:
+            self.find("read.history_genesis", FAILED,
+                      f"no generation-1 row among {len(history)} history entries")
+        else:
+            self.check("read.history_genesis", genesis[0].get("source") == HISTORY_SOURCE_CREATE,
+                       f"genesis source={genesis[0].get('source')!r}")
+            self.check("read.history_actor", bool(str(genesis[0].get("actor", "")).strip()),
+                       f"genesis actor={genesis[0].get('actor')!r}")
+        # The mint leg's PRODUCT is published compiled graphs, and the durable
+        # evidence for that is the worker's activity events, not the request
+        # row. There is no verified hub read for it from this side yet, so it is
+        # reported as owed rather than inferred from a completed request.
+        self.find("read.publish_durability", BLOCKED,
+                  "per-graph publish durability is not asserted from here; a completed request is "
+                  "not evidence that a graph was sealed and published",
+                  BLOCKER_PUBLISH_READ)
+        self.end()
+
+    def _assert_settlement(self, usage: Mapping[str, Any]) -> None:
+        settlement = dict(usage.get("settlement", {}))
+        if not settlement.get("available", False):
+            reason = str(settlement.get("reason", "")).strip()
+            if not reason:
+                self.find("settle.honest_absence", FAILED,
+                          "settlement is unavailable and states no reason")
+                return
+            self.find("settle.honest_absence", OK, f"settlement unavailable, stated: {reason}")
+            figures = [settlement.get(key, 0) for key in
+                       ("captured_micros", "settled_micros", "held_micros")]
+            if any(figures):
+                # A zero here reads as "nothing was owed" rather than "nothing
+                # has settled", and a figure is worse.
+                self.find("settle.no_phantom_figures", FAILED,
+                          f"unavailable settlement carries figures: {figures}")
+                return
+            self.find("settle.windows", BLOCKED,
+                      "no settlement window exists for this rental", BLOCKER_SETTLEMENT)
+            return
+        windows = int(settlement.get("windows", 0))
+        if not self.check("settle.windows", windows > 0, f"{windows} settlement window(s)"):
+            return
+        self.check("settle.provider_micros", int(settlement.get("provider_micros", 0)) > 0,
+                   f"provider_micros={settlement.get('provider_micros')} (the ledger's own figure)")
+        self.check("settle.no_quarantine", int(settlement.get("quarantined_windows", 0)) == 0,
+                   f"quarantined_windows={settlement.get('quarantined_windows')}")
+        margin_at_create = int(usage.get("rate_margin_bps_at_create", 0))
+        for window in settlement.get("recent_windows", []):
+            start = window.get("window_start")
+            ident = f"settle.window[{start}]"
+            self.check(f"{ident}.margin_frozen", int(window.get("margin_bps", -1)) == margin_at_create,
+                       f"window margin_bps={window.get('margin_bps')}, rental recorded {margin_at_create}")
+            if window.get("status") == "settled":
+                provider = int(window.get("provider_micros", 0))
+                amount = int(window.get("amount_micros", 0))
+                want = provider + provider * int(window.get("margin_bps", 0)) // 10000
+                self.check(f"{ident}.margin_applied", abs(amount - want) <= 1,
+                           f"amount={amount} provider={provider} expected≈{want}")
+                held = int(window.get("held_micros", 0))
+                self.check(f"{ident}.clamped_to_hold", held == 0 or amount <= held,
+                           f"amount={amount} held={held}")
+        limit = usage.get("spend_limit_micros")
+        if limit is not None:
+            spent = int(settlement.get("captured_micros", 0)) + int(settlement.get("held_micros", 0))
+            self.check("settle.within_spend_limit", spent <= int(limit),
+                       f"captured+held={spent} against spend_limit_micros={limit}")
+
+    def stop(self) -> None:
+        """End the rental. THIS is the whole teardown — no demand to cancel, no
+        `endpoint_tags` query, no conditional force-terminate. The kill set is
+        the deployment id."""
+        self.begin("stop")
+        try:
+            dep, already = self.api.stop(self.leg.org, self.result.deployment_id, self.leg.reason)
+        except ApiError as exc:
+            self.find("stop.accepted", FAILED, f"stop refused: {exc}")
+            self.end()
+            return
+        self.result.deployment = dep
+        self.check("stop.accepted", not already, f"stop accepted (already_stopped={already})")
+        self.check("stop.state", dep.get("state") in (STATE_STOPPING, STATE_STOPPED),
+                   f"state={dep.get('state')!r}")
+        self.check("stop.reason", dep.get("stop_reason") in (STOP_REASON_OWNER, STOP_REASON_ADMIN),
+                   f"stop_reason={dep.get('stop_reason')!r}")
+        err = coherence_error(str(dep.get("state", "")), str(dep.get("stop_reason", "")),
+                              dep.get("stopped_at"))
+        self.check("stop.row_coherent", err is None, err or "state/stop_reason/stopped_at agree")
+        try:
+            repeat, already_again = self.api.stop(self.leg.org, self.result.deployment_id, self.leg.reason)
+        except ApiError as exc:
+            self.find("stop.idempotent", FAILED, f"second stop refused: {exc}")
+            return_early = True
+        else:
+            return_early = False
+            self.check("stop.idempotent",
+                       already_again and repeat.get("config_generation") == dep.get("config_generation"),
+                       f"second stop already_stopped={already_again} "
+                       f"config_generation {dep.get('config_generation')}->{repeat.get('config_generation')}")
+        if not return_early:
+            try:
+                history = self.api.config_history(self.leg.org, self.result.deployment_id)
+            except ApiError:
+                history = []
+            if history:
+                self.result.history = history
+                newest = max(history, key=lambda row: int(row.get("config_generation", 0)))
+                self.check("stop.history_source", newest.get("source") == HISTORY_SOURCE_STOP,
+                           f"newest history row source={newest.get('source')!r}")
+        self.end()
+
+
+def run_leg(api: DeploymentAPI, leg: Leg, *, poll_s: float = 5.0,
+            stall_budget_s: float = 1800.0,
+            log: Callable[[str], None] = lambda _line: None,
+            clock: Callable[[], float] = time.monotonic,
+            sleep: Callable[[float], None] = time.sleep) -> LegResult:
+    """create -> invoke -> read -> stop, with the rental stopped on every path."""
+    leg.validate()
+    run = _Run(api, leg, poll_s=poll_s, stall_budget_s=stall_budget_s,
+               log=log, clock=clock, sleep=sleep)
+    if not run.create():
+        return run.result
+    try:
+        run.provision()
+        run.invoke()
+        run.read()
+    finally:
+        run.stop()
+    return run.result
+
+
+# ---------------------------------------------------------------------------
+# The in-process model, so the driver is testable before the routes exist
+# ---------------------------------------------------------------------------
+
+
+class ContractModel:
+    """A MODEL of the contract, with one switch per unmerged slice.
+
+    A green run here proves the DRIVER reads the contract correctly; it is never
+    evidence about tensorhub. That is precisely why every phase the model cannot
+    reach is reported BLOCKED rather than skipped.
+    """
+
+    def __init__(self, *, provisioning: bool = False, invoke_route: bool = False,
+                 settlement: bool = False, ready_after_reads: int = 1,
+                 margin_bps: int = 2000, pod_rate_micros_per_hour: int = 440_000,
+                 window_s: int = 300, advance_per_read_s: int = 120,
+                 actor: str = "admin:rig@cozy", break_invariant: str = "") -> None:
+        self.provisioning = provisioning
+        self.invoke_route = invoke_route
+        self.settlement = settlement
+        self.ready_after_reads = ready_after_reads
+        self.margin_bps = margin_bps
+        self.pod_rate = pod_rate_micros_per_hour
+        self.window_s = window_s
+        self.advance = advance_per_read_s
+        self.actor = actor
+        self.break_invariant = break_invariant
+        self.now = 0
+        self.rows: Dict[str, Dict[str, Any]] = {}
+        self.requests: Dict[str, Dict[str, Any]] = {}
+        self._seq = 0
+
+    def _id(self) -> str:
+        self._seq += 1
+        return f"00000000-0000-4000-8000-{self._seq:012d}"
+
+    def create(self, org: str, body: Mapping[str, Any]) -> Dict[str, Any]:
+        gpu, lane = parse_pair(str(body["pair"]))
+        if not str(body.get("release_id", "")).strip():
+            raise ApiError("POST", "/create", 400, "invalid_request", "release_id is required")
+        deployment_id = self._id()
+        pods: List[Dict[str, Any]] = []
+        if self.provisioning:
+            chooser = (CHOOSER_ORCHESTRATOR if self.break_invariant == "chooser"
+                       else CHOOSER_PRIVATE_DEPLOYMENT)
+            for index in range(int(body.get("pod_count", 1))):
+                pods.append({"pod_id": f"pod-{deployment_id[-4:]}-{index}", "state": "provisioning",
+                             "gpu_class": gpu, "cost_micros_per_hour": self.pod_rate,
+                             "placement_chooser": chooser, "private_deployment_id": deployment_id})
+        row = {
+            "id": deployment_id, "org_id": self._id(), "created_by": self.actor,
+            "release_id": body["release_id"], "pair": f"{gpu}:{lane}",
+            "gpu_slug": gpu, "execution_lane": lane,
+            "pod_count": int(body.get("pod_count", 1)),
+            "access_mode": body.get("access_mode") or ACCESS_OWNER,
+            "on_pod_failure": body.get("on_pod_failure") or ON_POD_FAILURE_REPLACE,
+            "spend_limit_micros": (int(float(body["spend_limit_usd"]) * 1_000_000)
+                                   if body.get("spend_limit_usd") else None),
+            "rate_margin_bps_at_create": self.margin_bps,
+            "state": STATE_ACTIVE, "stop_reason": STOP_REASON_NONE,
+            "config_generation": 1, "stopped_at": None,
+            "_pods": pods, "_reads": 0, "_started": self.now, "_ended": None,
+            "_history": [{"config_generation": 1, "source": HISTORY_SOURCE_CREATE,
+                          "actor": self.actor, "reason": body.get("reason", ""),
+                          "classes": ["lifecycle"]}],
+        }
+        self.rows[deployment_id] = row
+        return self._view(row)
+
+    @staticmethod
+    def _view(row: Mapping[str, Any]) -> Dict[str, Any]:
+        return {key: value for key, value in row.items() if not key.startswith("_")}
+
+    def _row(self, deployment_id: str) -> Dict[str, Any]:
+        row = self.rows.get(deployment_id)
+        if row is None:
+            raise ApiError("GET", "/get", 404, "private_deployment_not_found", "no such rental")
+        return row
+
+    def get(self, org: str, deployment_id: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+        row = self._row(deployment_id)
+        self.now += self.advance
+        row["_reads"] += 1
+        if self.provisioning and row["state"] == STATE_ACTIVE and row["_reads"] >= self.ready_after_reads:
+            for pod in row["_pods"]:
+                if pod["state"] == "provisioning":
+                    pod["state"] = "ready"
+        return self._view(row), list(row["_pods"])
+
+    def stop(self, org: str, deployment_id: str, reason: str) -> Tuple[Dict[str, Any], bool]:
+        row = self._row(deployment_id)
+        if row["state"] != STATE_ACTIVE:
+            if self.break_invariant == "stop_not_idempotent":
+                row["config_generation"] += 1
+                row["_history"].append({"config_generation": row["config_generation"],
+                                        "source": HISTORY_SOURCE_STOP, "actor": self.actor})
+            return self._view(row), True
+        self.now += self.advance
+        row["stop_reason"] = STOP_REASON_ADMIN
+        row["config_generation"] += 1
+        row["_ended"] = self.now
+        if not [p for p in row["_pods"] if p["state"] not in DEAD_POD_STATES]:
+            row["state"] = STATE_STOPPED
+            row["stopped_at"] = f"t+{self.now}"
+        else:
+            row["state"] = STATE_STOPPING
+            for pod in row["_pods"]:
+                pod["state"] = "terminated"
+            if self.break_invariant == "coherence":
+                row["stopped_at"] = f"t+{self.now}"
+        row["_history"].append({"config_generation": row["config_generation"],
+                                "source": HISTORY_SOURCE_STOP, "actor": self.actor,
+                                "reason": reason})
+        return self._view(row), False
+
+    def config_history(self, org: str, deployment_id: str) -> List[Dict[str, Any]]:
+        return list(self._row(deployment_id)["_history"])
+
+    def usage(self, org: str, deployment_id: str) -> Dict[str, Any]:
+        row = self._row(deployment_id)
+        self.now += self.advance
+        end = row["_ended"] if row["_ended"] is not None else self.now
+        pods = len(row["_pods"])
+        pod_seconds = max(0, end - row["_started"]) * pods
+        return {"deployment_id": deployment_id, "state": row["state"],
+                "pod_rows": pods, "live_pods": len([p for p in row["_pods"]
+                                                    if p["state"] not in DEAD_POD_STATES]),
+                "pod_seconds": pod_seconds,
+                "rate_margin_bps_at_create": row["rate_margin_bps_at_create"],
+                "spend_limit_micros": row["spend_limit_micros"],
+                "settlement": self._settlement(row, pod_seconds)}
+
+    def _settlement(self, row: Mapping[str, Any], pod_seconds: int) -> Dict[str, Any]:
+        pods = max(1, len(row["_pods"]))
+        if not self.settlement or pod_seconds < self.window_s * pods:
+            out: Dict[str, Any] = {"available": False,
+                                   "reason": "no settlement window has opened for this rental yet"}
+            if self.break_invariant == "phantom_figures":
+                out["captured_micros"] = 12345
+            return out
+        margin = row["rate_margin_bps_at_create"]
+        if self.break_invariant == "margin_drift":
+            margin += 500
+        windows: List[Dict[str, Any]] = []
+        captured = provider_total = billed = 0
+        start = int(row["_started"])
+        remaining = pod_seconds
+        while remaining >= self.window_s * pods:
+            seconds = self.window_s * pods
+            provider = self.pod_rate * seconds // 3600
+            amount = provider + provider * margin // 10000
+            windows.append({"window_start": f"t+{start}", "window_end": f"t+{start + self.window_s}",
+                            "status": "settled", "kind": "capture", "margin_bps": margin,
+                            "held_micros": amount, "amount_micros": amount,
+                            "provider_micros": provider, "pod_seconds": seconds})
+            captured += amount
+            provider_total += provider
+            billed += seconds
+            remaining -= seconds
+            start += self.window_s
+        return {"available": True, "windows": len(windows), "open_windows": 0,
+                "pending_windows": 0, "quarantined_windows": 0,
+                "settled_micros": captured, "captured_micros": captured, "held_micros": 0,
+                "provider_micros": provider_total, "billed_pod_seconds": billed,
+                "recent_windows": windows}
+
+    def invoke(self, deployment_id: str, function: str, payload: Mapping[str, Any]) -> str:
+        if not self.invoke_route:
+            raise ApiError("POST", f"/v1/private-deployments/{deployment_id}/{function}",
+                           404, "", "404 page not found")
+        row = self._row(deployment_id)
+        if row["state"] != STATE_ACTIVE:
+            raise ApiError("POST", "/invoke", 409, "private_deployment_stopped", "this rental is stopped")
+        if not [p for p in row["_pods"] if p["state"] in READY_POD_STATES]:
+            raise ApiError("POST", "/invoke", 409, "private_deployment_stopped", "no ready pod")
+        request_id = self._id()
+        self.requests[request_id] = {"id": request_id, "status": "queued", "_reads": 0}
+        return request_id
+
+    def request(self, request_id: str) -> Dict[str, Any]:
+        record = self.requests.get(request_id)
+        if record is None:
+            raise ApiError("GET", "/v1/requests", 404, "request_not_found", "no such request")
+        self.now += self.advance
+        record["_reads"] += 1
+        record["status"] = "completed" if record["_reads"] >= 2 else "running"
+        return {"id": record["id"], "status": record["status"]}
+
+
+#: The exact change `scripts/micro_mint_rig.py` makes when it re-points. Kept
+#: here rather than applied, because the rig is carried by an open PR
+#: (pgw#1214/#761) and its mint modules are rewritten by th#1834 step 4 — the
+#: lane that lands those makes this edit in one place, with no conflict.
+REPOINT_NOTE = """\
+micro_mint_rig legs 2-3 (`mint_process.build_request` -> `mint_process.run_mint`)
+become, once th#1927's invoke route merges:
+
+    from scripts.private_deployment_leg import HttpDeploymentAPI, Leg, run_leg
+
+    outcome = run_leg(
+        HttpDeploymentAPI(hub_url, token),
+        Leg(org=org, endpoint=endpoint, release_id=release_id, pair=parse_pair(pair),
+            function=function, payload=payload, invocations=1,
+            spend_limit_usd=budget_usd, reason="micro mint rig"),
+        log=print,
+    )
+
+and the three-step teardown protocol (cancel own demand -> QUERY endpoint_tags
+-> conditional force-terminate) is DELETED: run_leg stops the rental on every
+path, and the deployment id is the entire kill set. The local child path is not
+kept as a fallback — the hard cut means it has no ground to run on.
+"""
+
+
+def _main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--hub", default="", help="hub base URL")
+    parser.add_argument("--token", default="", help="bearer token (or TENSORHUB_TOKEN in the env)")
+    parser.add_argument("--org", default="tensorhub")
+    parser.add_argument("--endpoint", default="")
+    parser.add_argument("--release", default="", help="release id — PINNED; untagged is fine")
+    parser.add_argument("--pair", default="", help="gpu:lane, e.g. a40:bf16-w16a16+compiled")
+    parser.add_argument("--function", default="generate")
+    parser.add_argument("--payload", default="{}")
+    parser.add_argument("--invocations", type=int, default=1)
+    parser.add_argument("--spend-limit-usd", type=float, default=1.0)
+    parser.add_argument("--json", default="", help="write the JSON report here")
+    parser.add_argument("--confirm", action="store_true", help="required: this buys a real pod")
+    parser.add_argument("--dry", action="store_true", help="run against the in-process model; no hub, no money")
+    parser.add_argument("--state", choices=("resource", "fences", "merged"), default="resource",
+                        help="--dry only: which slices have merged")
+    args = parser.parse_args(argv)
+
+    if args.dry:
+        model = ContractModel(
+            provisioning=args.state in ("fences", "merged"),
+            invoke_route=args.state == "merged",
+            settlement=args.state == "merged",
+        )
+        leg = Leg(org="tensorhub", endpoint="tensorhub/sdxl", release_id="dry-run-release",
+                  pair=("a40", "bf16-w16a16+compiled"), invocations=1)
+        # MODEL seconds, not wall seconds: the model clock advances per read,
+        # so this is "give up after ~15 reads with nothing changing".
+        result = run_leg(model, leg, poll_s=0.0, stall_budget_s=1800.0, log=print,
+                         clock=lambda: float(model.now), sleep=lambda _s: None)
+    else:
+        if not args.hub or not args.endpoint or not args.release or not args.pair:
+            parser.error("--hub, --endpoint, --release and --pair are required without --dry")
+        token = args.token or os.environ.get("TENSORHUB_TOKEN", "")
+        if not token:
+            parser.error("a bearer token is required (--token or TENSORHUB_TOKEN)")
+        leg = Leg(org=args.org, endpoint=args.endpoint, release_id=args.release,
+                  pair=parse_pair(args.pair), function=args.function,
+                  payload=json.loads(args.payload), invocations=args.invocations,
+                  spend_limit_usd=args.spend_limit_usd)
+        leg.validate()
+        if not args.confirm:
+            print("this buys a real pod on a real card; re-run with --confirm once the leg is approved",
+                  file=sys.stderr)
+            return 2
+        result = run_leg(HttpDeploymentAPI(args.hub, token), leg, log=print)
+
+    print(f"\nleg -> {result.status} (deployment {result.deployment_id})")
+    for blocker in result.blockers:
+        print(f"  blocked on {blocker}")
+    for finding in result.findings:
+        if finding.status == FAILED:
+            print(f"  FAILED {finding.ident}: {finding.detail}")
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as handle:
+            json.dump(result.to_json(), handle, indent=2)
+    return 0 if result.status in (OK, BLOCKED) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tests/test_private_deployment_leg_pgw1250.py
+++ b/tests/test_private_deployment_leg_pgw1250.py
@@ -1,0 +1,226 @@
+"""pgw#1250 — the private-deployment mint leg, as a row.
+
+RUNS IN CI, entirely. Pure Python: no GPU, no card, no hub, no network, no
+money. That is the point of the seam — the driver talks to a `DeploymentAPI`,
+and `ContractModel` implements the settled contract in process, so the whole
+leg (create -> invoke -> read -> stop) is provable red/green before tensorhub's
+invoke route and settlement have merged.
+
+What a green here does NOT mean: it is not evidence about tensorhub. It proves
+the DRIVER reads the contract correctly. Every assertion the model cannot reach
+is asserted to be reported BLOCKED — naming the merge that unblocks it — rather
+than skipped, because a skipped assertion on a money-bearing path is how a
+report ends up claiming more than it checked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+from private_deployment_leg import (  # noqa: E402
+    BLOCKED,
+    BLOCKER_INVOKE_ROUTE,
+    BLOCKER_PUBLISH_READ,
+    BLOCKER_RECONCILER,
+    BLOCKER_SETTLEMENT,
+    CHOOSER_PRIVATE_DEPLOYMENT,
+    FAILED,
+    OK,
+    STATE_ACTIVE,
+    STATE_STOPPED,
+    STATE_STOPPING,
+    ContractModel,
+    Leg,
+    coherence_error,
+    parse_pair,
+    run_leg,
+)
+
+
+def _leg(**overrides: Any) -> Leg:
+    base: Dict[str, Any] = dict(
+        org="tensorhub",
+        endpoint="tensorhub/sdxl",
+        release_id="rel-sdxl-0240",
+        pair=("a40", "bf16-w16a16+compiled"),
+        function="generate",
+        payload={"prompt": "a red fox", "seed": 1929},
+        invocations=1,
+        spend_limit_usd=1.0,
+    )
+    base.update(overrides)
+    return Leg(**base)
+
+
+def _run(model: ContractModel, leg: Leg) -> Any:
+    # The model's clock is the leg's clock, so pod-seconds accrue without the
+    # test sleeping and the stall budget measures MODEL time.
+    return run_leg(model, leg, poll_s=0.0, stall_budget_s=10_000.0,
+                   clock=lambda: float(model.now), sleep=lambda _s: None)
+
+
+def _finding(result: Any, ident: str) -> Any:
+    for finding in result.findings:
+        if finding.ident == ident:
+            return finding
+    raise AssertionError(f"no finding {ident!r} among {[f.ident for f in result.findings]}")
+
+
+def test_leg_on_a_fully_merged_hub_runs_every_phase_and_fails_nothing() -> None:
+    model = ContractModel(provisioning=True, invoke_route=True, settlement=True)
+    result = _run(model, _leg())
+
+    assert not [f for f in result.findings if f.status == FAILED], [
+        (f.ident, f.detail) for f in result.findings if f.status == FAILED
+    ]
+    assert [p.name for p in result.phases] == ["create", "provision", "invoke", "read", "stop"]
+    assert result.usage["settlement"]["available"] is True
+    assert result.usage["settlement"]["provider_micros"] > 0
+    assert result.deployment["state"] in (STATE_STOPPING, STATE_STOPPED)
+    # DELIBERATELY still BLOCKED, and on exactly one thing: even with all three
+    # tensorhub slices merged, a completed request is not evidence that a
+    # compiled graph was sealed and published, and this driver has no hub read
+    # that says so. A mint leg that reported OK here would be claiming its own
+    # product without checking it.
+    assert result.status == BLOCKED
+    assert result.blockers == [BLOCKER_PUBLISH_READ]
+
+
+def test_leg_today_is_blocked_and_names_every_missing_merge() -> None:
+    """th#1926 merged, th#1927's reconciler and invoke route and th#1928 not.
+
+    The leg must still create, stop cleanly, and produce a report in which every
+    unreachable assertion is BLOCKED with its issue named.
+    """
+    model = ContractModel()
+    result = _run(model, _leg())
+
+    assert result.status == BLOCKED
+    for blocker in (BLOCKER_RECONCILER, BLOCKER_INVOKE_ROUTE, BLOCKER_SETTLEMENT):
+        assert blocker in result.blockers, result.blockers
+    # The half that IS merged is fully asserted, not deferred with the rest.
+    for ident in ("create.accepted", "create.state_active", "create.row_coherent",
+                  "create.release_pinned", "create.pair_roundtrip",
+                  "create.generation_genesis", "create.owner_recorded",
+                  "read.history_genesis", "settle.honest_absence",
+                  "stop.accepted", "stop.row_coherent", "stop.idempotent",
+                  "stop.history_source"):
+        assert _finding(result, ident).status == OK, _finding(result, ident).detail
+
+
+def test_leg_with_pods_but_no_invoke_route_separates_the_two_halves() -> None:
+    """The state the epic is in the day th#1927's fences merge but its follow-up
+    has not: pods exist, the workload cannot be submitted."""
+    model = ContractModel(provisioning=True)
+    result = _run(model, _leg())
+
+    assert _finding(result, "invoke.route").status == BLOCKED
+    assert _finding(result, "invoke.route").blocker == BLOCKER_INVOKE_ROUTE
+    # Provisioning must read GREEN here, or the report cannot tell "the
+    # reconciler works" from "nothing works".
+    assert _finding(result, "provision.ready").status == OK
+    chooser = [f for f in result.findings if f.ident.startswith("provision.chooser")]
+    assert chooser and all(f.status == OK for f in chooser)
+
+
+@pytest.mark.parametrize(
+    "break_invariant, ident_fragment",
+    [
+        ("coherence", "stop.row_coherent"),
+        ("chooser", "provision.chooser"),
+        ("phantom_figures", "settle.no_phantom_figures"),
+        ("margin_drift", "margin_frozen"),
+        ("stop_not_idempotent", "stop.idempotent"),
+    ],
+)
+def test_every_money_bearing_assertion_is_red_provable(break_invariant: str, ident_fragment: str) -> None:
+    """A guard that has never been seen fail is not a guard.
+
+    Each case severs exactly one invariant in the model and requires the
+    matching assertion to go red — and the leg with it.
+    """
+    merged = break_invariant != "phantom_figures"
+    model = ContractModel(provisioning=merged, invoke_route=merged, settlement=merged,
+                          break_invariant=break_invariant)
+    result = _run(model, _leg())
+
+    reds = [f for f in result.findings if ident_fragment in f.ident and f.status == FAILED]
+    assert reds, (
+        f"severing {break_invariant!r} turned no {ident_fragment!r} assertion red; "
+        f"leg status={result.status}"
+    )
+    assert result.status == FAILED
+
+
+def test_the_rental_is_always_stopped_whatever_the_leg_does() -> None:
+    """The money property. The deployment id is the entire kill set — there is no
+    demand to cancel, no endpoint_tags query, and no conditional terminate."""
+    model = ContractModel(provisioning=True)  # no invoke route: the leg exits early
+    result = _run(model, _leg())
+
+    assert result.deployment_id
+    row, _pods = model.get("tensorhub", result.deployment_id)
+    assert row["state"] != STATE_ACTIVE, row
+    assert coherence_error(row["state"], row["stop_reason"], row["stopped_at"]) is None
+
+
+def test_a_refused_leg_creates_nothing() -> None:
+    model = ContractModel(provisioning=True, invoke_route=True, settlement=True)
+    refusals: List[Tuple[Dict[str, Any], str]] = [
+        ({"release_id": ""}, "release_id is required"),
+        ({"pair": ("", "bf16-w16a16+compiled")}, "must name both a GPU and a lane"),
+        ({"pod_count": 0}, "pod_count must be at least 1"),
+        ({"access_mode": "everyone"}, "must be owner or org"),
+        ({"on_pod_failure": "ignore"}, "must be replace or stop"),
+    ]
+    for bad, expected in refusals:
+        with pytest.raises(ValueError) as caught:
+            _run(model, _leg(**bad))
+        assert expected in str(caught.value)
+    assert not model.rows, "a refused leg created a rental"
+
+
+def test_a_rental_may_not_name_a_bare_lane() -> None:
+    assert parse_pair("a40:bf16-w16a16+compiled") == ("a40", "bf16-w16a16+compiled")
+    assert parse_pair("  A40 : BF16-W16A16+COMPILED ") == ("a40", "bf16-w16a16+compiled")
+    for bad in ("bf16-w16a16+compiled", ":lane", "a40:", ""):
+        with pytest.raises(ValueError):
+            parse_pair(bad)
+
+
+def test_coherence_mirrors_the_schema_checks_exactly() -> None:
+    stamp = "2026-08-14T12:00:00Z"
+    cases: List[Any] = [
+        ((STATE_ACTIVE, "", None), True),
+        ((STATE_STOPPING, "owner_stop", None), True),
+        ((STATE_STOPPED, "owner_stop", stamp), True),
+        # The two CHECKs admit a stopped row with an EMPTY stop_reason, and this
+        # mirror admits exactly what they admit. Refusing an unnamed stop is the
+        # DRIVER's separate `stop.reason` assertion, not a schema invariant.
+        ((STATE_STOPPED, "", stamp), True),
+        ((STATE_ACTIVE, "owner_stop", None), False),
+        ((STATE_ACTIVE, "", stamp), False),
+        ((STATE_STOPPING, "owner_stop", stamp), False),
+        ((STATE_STOPPED, "owner_stop", None), False),
+    ]
+    for (state, reason, stopped_at), ok in cases:
+        assert (coherence_error(state, reason, stopped_at) is None) is ok, (state, reason, stopped_at)
+
+
+def test_a_leg_with_no_invocations_is_a_lifecycle_proof_not_a_silent_pass() -> None:
+    """`invocations=0` is what a mint proof that only needs the pod to BOOT looks
+    like. It must read SKIPPED, which is distinct from OK and from BLOCKED."""
+    model = ContractModel(provisioning=True, invoke_route=True, settlement=True)
+    result = _run(model, _leg(invocations=0))
+
+    invoke = _finding(result, "invoke.workload")
+    assert invoke.status == "skipped"
+    assert _finding(result, "provision.ready").status == OK
+    assert result.pods and result.pods[0]["placement_chooser"] == CHOOSER_PRIVATE_DEPLOYMENT


### PR DESCRIPTION
For tensorhub **th#1929** (epic th#1925 slice 4). Design of record: tracker `research/route2-private-deployments-design.md` §7.

## Why

`scripts/micro_mint_rig.py` proves a mint before a wheel reaches PyPI, and its legs 2–3 spawn a real child interpreter **on this box** and compile there. Paul's 2026-08-10 hard cut removed that ground — all mints and compiles run on remote pods only, no carve-out. The rig's producer has to move off the box.

Before private deployments the replacement was ugly, and this repo's own tracker carries it as a **three-step teardown protocol**: cancel your own demand by request id → QUERY `tensorhub.endpoint_tags` to learn whether the release you just used is tag-routable → force-terminate **only** if that query comes back empty, because a force-terminate against a tag-routable release can take production capacity with it. Plus tagging the release in the first place to manufacture the demand that buys the pod.

**All of it collapses into `stop`.** A rental needs no routing tag (an untagged release is rentable by design), its pod is attributable to one deployment id, and its spend is the owner's — so there is no demand to cancel, no `endpoint_tags` gate, and the kill set is the deployment id.

## What's here

`scripts/private_deployment_leg.py` — a typed, stdlib-only client for th#1926's resource surface plus the th#1927 invoke seam and th#1928's settlement object, and a leg driver that asserts the state sequence, both schema coherence CHECKs on every observation, the pinned release, the pair round-trip, the genesis history row, the `placement_chooser` stamp on every rented pod, stop idempotence, and the settlement window shape (margin frozen against `rate_margin_bps_at_create`, amount checked against the ledger's own provider figure, charge clamped to its hold). The rental is stopped on every path including an early exit; give-up is progress-staleness, never a fixed duration.

**Honest about what it cannot see.** An assertion it cannot reach is `BLOCKED` naming the merge that unblocks it, never skipped. And even with all three tensorhub slices merged the leg still reports `BLOCKED` on exactly one thing: a completed request is not evidence that a compiled graph was sealed and published, and there is no hub read for that from here yet. A mint leg that reported `OK` there would be claiming its own product without checking it.

## Proof

`tests/test_private_deployment_leg_pgw1250.py` — 13 tests, **entirely in CI**: no GPU, no card, no hub, no network, no money. The driver talks to a `DeploymentAPI` protocol and `ContractModel` implements the settled contract in process with one switch per unmerged slice, so "built vs blocked" is itself a tested property (three merge states asserted), and five severed invariants make the money-bearing assertions red-provable. `mypy` strict-clean on both files.

## What it deliberately does NOT touch

**It does not edit the rig.** `scripts/micro_mint_rig.py` is carried by open PR #761 (pgw#1214, draft/HOLD) and its mint modules are rewritten by th#1834 step 4. The rig's own switch to this driver is a separate ~10-line change made by whoever lands those — the exact call is recorded as `REPOINT_NOTE` in the new module, so it lands the same day the invoke route does without a conflict here.

Nothing imports this module yet, so it is inert on merge.

## Sequencing

⚠️ **Not enqueued.** The tracker records a pgw ENQUEUE FREEZE (2026-08-13) whose lift I have no evidence of. Green checks first; the coordinator says when it may merge.