### PR TITLE
pgw#1249: the gate test asserts that the tenant WAITED, not how long a machine took

### DIFF
--- a/tests/test_magic_timeouts_gw666.py
+++ b/tests/test_magic_timeouts_gw666.py
@@ -768,7 +768,15 @@ _ELAPSED_ASSERT_BURNDOWN = {
                                               # fail it, slowness only raises it
     "test_progress_gw621.py",                 # LOWER bound on the fixture's own
                                               # configured freeze window
-    "test_mint_gate_pgw677.py",               # LOWER bounds on induced seed work
+    # pgw#1249 deleted this file's entry rather than re-justifying it. Its two
+    # "LOWER bounds on induced seed work" (`wall >= 0.1`,
+    # `instance_gate_wait >= 100`) were floors on how long a MACHINE took, and
+    # the review note above — "an order of magnitude of headroom over the
+    # observed value" — was simply false for them: the tenant enters somewhere
+    # INSIDE an 800 ms compile, so the observed value ranges over (0, 800] and
+    # the floor sat at 100. It came in at 90 on a loaded runner and turned a
+    # correct tree red on the release path. The property is causal (the tenant
+    # waited for the instance) and is asserted as ordering now.
     "test_procsplit_pgw763.py",               # hang bound: cancel across the seam
                                               # << 3s against a 50ms handler poll
 }

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -305,6 +305,15 @@ def _stage_ms(res: pb.JobResult, name: str) -> int:
     return int(res.metrics.stage_ms.get(name, 0))
 
 
+#: pgw#1249. Slack for comparing two clocks that measure the SAME run — the
+#: worker's stage map against the tape's own wall — not patience for a slow
+#: machine. It bounds rounding and the few instructions between `t0` and the
+#: first stage opening, so it does NOT grow with load: both sides of every
+#: comparison below stretch together. That is the whole difference between
+#: this and the `>= 100` floor it replaced, which measured the weather.
+_CLOCK_SLOP_MS = 25.0
+
+
 # ---------------------------------------------------------------------------
 # 1 + 4 — the starvation shape, red-verified via the kill switch
 # ---------------------------------------------------------------------------
@@ -352,17 +361,42 @@ def test_compile_and_tenant_forward_never_overlap_and_red_verifies(
         while not h_on.in_compile.is_set():
             assert time.monotonic() < deadline, "no background compile ran"
             await asyncio.sleep(0.005)
+        t_admit = time.monotonic()
+        # The moment the in-flight compile RELEASES, watched from beside the
+        # dispatch. `in_compile` is the same signal the loop above already
+        # trusts to know a compile is holding the instance, so the ordering
+        # assertions rest on nothing new.
+        released: Dict[str, float] = {}
+
+        async def _watch_release() -> None:
+            while h_on.in_compile.is_set():
+                await asyncio.sleep(0.001)
+            released["at"] = time.monotonic()
+
+        watcher = asyncio.ensure_future(_watch_release())
         res, wall = await h_on.dispatch("r-safe", aspect="1:1")
+        t_done = time.monotonic()
+        await watcher
         assert res.status == pb.JOB_STATUS_OK, res.safe_message
-        # It waited for the in-flight compile (bounded by ONE unit)...
-        assert wall >= 0.1
-        # ...the wait is attributed, and runtime_ms excludes it.
-        assert _stage_ms(res, "instance_gate_wait") >= 100
-        # The gate wait it must EXCLUDE is the compile it waited on,
-        # so that is the anchor — a runtime that absorbed the wait could not
-        # come in under it.
-        assert res.metrics.runtime_ms < h_on.compile_delay_s * 1000, (
-            res.metrics.runtime_ms, h_on.compile_delay_s)
+        # The wait is ATTRIBUTED: present, and not zero.
+        #
+        # pgw#1249: this was `wall >= 0.1` and `instance_gate_wait >= 100`.
+        # Both are floors on how long a MACHINE took, and how long a machine
+        # takes is not the property under test — it is the weather. Neither
+        # had a defensible value either: the tenant enters somewhere INSIDE
+        # an 800 ms sleep, so the true wait is anywhere in (0, 800]. On a
+        # loaded runner it came in at 90 ms and turned a correct tree red on
+        # the release path. What the test MEANS is causal — it waited for the
+        # instance — and that is asserted as ordering below.
+        gate_wait_ms = _stage_ms(res, "instance_gate_wait")
+        assert gate_wait_ms > 0, dict(res.metrics.stage_ms)
+        # ...and runtime EXCLUDES it. Measured against this run's OWN
+        # end-to-end wall rather than against `compile_delay_s`: a slow runner
+        # stretches both sides together, so the relation holds exactly where a
+        # constant cannot, and a runtime that had absorbed the gate wait would
+        # overshoot the wall it was measured inside.
+        assert res.metrics.runtime_ms + gate_wait_ms <= wall * 1000 + _CLOCK_SLOP_MS, (
+            res.metrics.runtime_ms, gate_wait_ms, wall)
         # th#1111 invariant survives the new pre-handler stage: the map
         # still closes against runtime_ms with a large gate wait present.
         from gen_worker.stage_timing import reconciliation
@@ -371,6 +405,21 @@ def test_compile_and_tenant_forward_never_overlap_and_red_verifies(
         assert total == res.metrics.runtime_ms
         assert abs(attributed - total) <= 5, dict(res.metrics.stage_ms)
         await h_on.wait_mint()
+
+        # ORDERING — the causal claim, and the reason none of this needs a
+        # threshold. Timestamps THIS run produced, compared only to each
+        # other: the tenant was admitted while the compile still held the
+        # instance, and it did not complete until after that compile let go.
+        # A slow machine moves all of them together, so there is nothing here
+        # for load to falsify.
+        assert "at" in released, "the in-flight compile never released"
+        t_release = released["at"]
+        assert t_admit < t_release, (
+            "inconclusive tape: the tenant was admitted after the compile had "
+            "already released the instance, so nothing here was a wait")
+        assert t_release <= t_done + _CLOCK_SLOP_MS / 1000.0, (
+            "the tenant completed before the compile released the instance — "
+            "it was not gated at all", t_release - t_done)
 
     asyncio.run(_on())
     assert not h_on.overlaps, h_on.overlaps


### PR DESCRIPTION
`tests/test_mint_gate_pgw677.py` asserted `wall >= 0.1` and `_stage_ms(res, "instance_gate_wait") >= 100` — two floors on measured wall time inside the required `tests` context. One of them flaked the pgw#1247 lockstep run at **`assert 90 >= 100`** on a loaded runner, and it would have kept biting every release-path run including the 0.115.0 cut.

## Neither floor had a defensible value — that is the real finding

The tenant is admitted somewhere **inside** an 800 ms compile, so the wait it observes ranges over `(0, 800]`. The burn-down note in `test_magic_timeouts_gw666.py` justifying these two entries claims *"at least an order of magnitude of headroom over the observed value"* — that was simply **false** for them. A threshold cannot be chosen correctly here, because the quantity is not a property of the code; it is the weather.

## What the test means, and now says

The property is causal: the tenant that arrived mid-compile **waited for the instance**, and its wait was attributed to `instance_gate_wait` rather than billed as runtime.

- **ORDERING** — a watcher beside the dispatch records when the in-flight compile releases (`in_compile`, the same signal the surrounding loop already trusts). The tenant was admitted *before* that release and completed *after* it. Three timestamps from one run, compared only to each other.
- **ATTRIBUTION** — `instance_gate_wait` is present and non-zero. Its magnitude is no longer anybody's business.
- **EXCLUSION** — `runtime_ms + instance_gate_wait <= wall`, measured against this run's **own** end-to-end wall instead of against `compile_delay_s`. A slow machine stretches both sides together, so the relation holds exactly where a constant cannot, and a runtime that had absorbed the gate wait would overshoot the wall it was measured inside. `reconciliation` cannot catch that on its own — `instance_gate_wait` is a `PRE_HANDLER_STAGES` member and is excluded from `attributed` by construction.

The one constant left is `_CLOCK_SLOP_MS = 25`, and it is a different kind: slack between two clocks measuring the **same** run, so it bounds rounding, not patience, and does not grow with load.

## The doctrine's own ratchet turns one notch

The file comes off `_ELAPSED_ASSERT_BURNDOWN` in `test_magic_timeouts_gw666.py` — that guard *demanded* it once the assertions were gone (`AssertionError: fixed! remove ['test_mint_gate_pgw677.py'] from the list`). It stays on `_DEADLINE_BURNDOWN`: that entry is the `while not in_compile: assert monotonic() < deadline` **wait loop**, a different class, owned by pgw#795's follow-up and deliberately untouched here.

## Siblings swept

The file's only other measured-time comparisons are the 10 s wait-loop deadline (the `_DEADLINE_BURNDOWN` entry above, another owner's burn-down), `wait_mint(timeout=60)` (a hang bound), and `abs(attributed - total) <= 5` (a tolerance on an identity that is equal by construction, measured-vs-measured). None is a floor on how long the machine took. No semantics changed: the harness, the overlap ledger and the th#1111 reconciliation invariant are exactly as they were.

## Verification

- The reshaped tape passes **8/8 under a synthetic load average of 52** on a 32-core box, and the whole file passes repeatedly at idle.
- Note on red-proofing honestly: I could **not** reproduce the CI flake by loading this box — master's assertions also passed 8/8 under the same load, because a 32-core machine under load still gives the test's own threads a core, whereas a 4-core runner slows the whole process. The argument is therefore made from the CI evidence directly: the observed failing value was **90 ms**, and the new predicates all accept 90 ms (`> 0` ✓, ordering ✓, `runtime + gate <= wall` ✓) while the old one rejects it.
- `mypy src/gen_worker tests tests_v2` clean over 780 files; the gw#666 fence plus the mint-gate, mint-reopen and eager-first suites green (39 passed); `assemble_changelog --check` OK. No changelog fragment: this is a test-only fix with no user-visible behaviour.

Refs: pgw#1249, pgw#1247 (the run it flaked), gw#666 (the doctrine and its fence), pgw#795 (the wait-loop burn-down that keeps its entry).
