### PR TITLE
pgw#1251: keep reconnect failures inside the lifecycle

### DIFF
--- a/changelog.d/pgw1251.md
+++ b/changelog.d/pgw1251.md
@@ -1,0 +1,4 @@
+Fixed a reconnect loop that could overflow its attempt arithmetic during a long
+or rapid hub outage even though the jitter delay itself was capped. The test hub
+now also preserves the worker's typed fatal/error report so a lifecycle failure
+shows its root cause instead of a misleading missing-Hello assertion.

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -172,6 +172,26 @@ def normalize_grpc_addr(addr: str, default_tls: Optional[bool] = None) -> Tuple[
     return a, a.endswith(":443")
 
 
+def _backoff_ceiling(base: float, cap: float, attempt: int) -> float:
+    """Return ``min(cap, base * 2**attempt)`` without building ``2**attempt``.
+
+    A cap does not make the original expression safe: Python evaluates the
+    float multiplication before ``min``, and converting a sufficiently large
+    integer exponent to float raises ``OverflowError``. Double only until the
+    ceiling saturates instead. The loop is bounded by the number of doublings
+    between ``base`` and ``cap`` (five for the production 1 s -> 30 s policy),
+    never by ``attempt`` once the cap has been reached.
+    """
+    safe_base = max(0.0, float(base))
+    safe_cap = max(0.0, float(cap))
+    ceiling = min(safe_base, safe_cap)
+    remaining = max(0, int(attempt))
+    while remaining and 0.0 < ceiling < safe_cap:
+        ceiling = min(safe_cap, ceiling * 2.0)
+        remaining -= 1
+    return ceiling
+
+
 def _msg_kind(msg: pb.WorkerMessage) -> str:
     which = msg.WhichOneof("msg")
     if which == "job_result":
@@ -1418,7 +1438,9 @@ class Transport:
                 if now - self._connected_at >= _BACKOFF_RESET_AFTER_S:
                     attempt = 0
 
-            delay = random.uniform(0, min(self._backoff_cap, self._backoff_base * (2 ** attempt)))
+            delay = random.uniform(
+                0, _backoff_ceiling(self._backoff_base, self._backoff_cap, attempt)
+            )
             attempt += 1
             self.reconnect_delays.append(delay)
             logger.info("reconnecting in %.2fs (attempt %d)", delay, attempt)

--- a/tests/harness/hub_double.py
+++ b/tests/harness/hub_double.py
@@ -106,6 +106,10 @@ class Conn:
     def __init__(self) -> None:
         self.hello: Optional[pb.Hello] = None
         self.received: List[pb.WorkerMessage] = []
+        # Shared with the scheduler: fatal/error reporting uses a separate
+        # diagnostic-first Connect, but a failed wait on this primary stream
+        # still needs to print the cause that process delivered.
+        self.diagnostic_reports: List[pb.HardwareUnsuitable] = []
         self._recv_cond = threading.Condition()
         self._out: "queue.Queue[Any]" = queue.Queue()
         self.client_done = threading.Event()
@@ -217,7 +221,10 @@ class Conn:
 
         return self._wait(
             _take,
-            lambda: f"no matching message; got {[_label(m) for m in self.received]}",
+            lambda: (
+                f"no matching message; got {[_label(m) for m in self.received]}; "
+                f"diagnostics={[(r.reason_class, r.detail) for r in self.diagnostic_reports]}"
+            ),
             timeout,
         )
 
@@ -255,6 +262,11 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
         file_base_url: str = "http://127.0.0.1:1/files",
     ) -> None:
         self.connections: List[Conn] = []
+        # HardwareUnsuitable is also the typed worker fatal/error carrier. It
+        # opens its own Connect and is valid in place of Hello (gw#619/th#988).
+        # Keep the whole payload so a primary-stream failure cannot erase the
+        # exception detail that explains it.
+        self.diagnostic_reports: List[pb.HardwareUnsuitable] = []
         self._conn_cond = threading.Condition()
         self.reject_unauthenticated = reject_unauthenticated
         self.file_base_url = file_base_url
@@ -271,10 +283,22 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
             context.abort(grpc.StatusCode.UNAUTHENTICATED, "bad worker jwt")
 
         first = next(request_iterator)
-        assert first.WhichOneof("msg") == "hello", "first message must be Hello"
+        first_kind = first.WhichOneof("msg")
+        if first_kind == "hardware_unsuitable":
+            with self._conn_cond:
+                self.diagnostic_reports.append(first.hardware_unsuitable)
+                self._conn_cond.notify_all()
+            # The client half-closes after this one report. Mirror the real hub:
+            # drain it and end the call with no response.
+            for _ in request_iterator:
+                pass
+            return
+        assert first_kind == "hello", (
+            f"first message must be Hello, got {first_kind!r}")
         conn = Conn()
         conn.hello = first.hello
         conn.boot_cost = self.boot_cost
+        conn.diagnostic_reports = self.diagnostic_reports
         # Queue the HelloAck BEFORE exposing the connection: the contract says
         # HelloAck precedes all other scheduler->worker traffic.
         conn.send(hello_ack=pb.HelloAck(

--- a/tests/test_hardware_report.py
+++ b/tests/test_hardware_report.py
@@ -8,14 +8,18 @@ carried zero orchestrator-visible evidence. Real gRPC sockets throughout
 from __future__ import annotations
 
 import time
+from concurrent import futures
 
+import grpc
 import pytest
 
 from gen_worker import hardware_report
 from gen_worker.config import Settings
 from gen_worker.cuda_probe import CudaProbeResult, classify_probe_failure
+from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
 
 from harness.hardware_report_hub import closed_port_addr, old_hub, recording_hub
+from harness.hub_double import FakeScheduler
 
 pytestmark = pytest.mark.filterwarnings("ignore")
 
@@ -107,6 +111,32 @@ def test_report_hardware_unsuitable_delivers_to_a_new_hub() -> None:
         assert hw.image_digest == "sha256:deadbeef"
         assert hw.instance_id == "pod-1"
         assert hw.reported_at_unix_ms > 0
+
+
+def test_general_hub_double_preserves_a_diagnostic_first_stream() -> None:
+    """The ordinary hub double mirrors both valid Connect first-message shapes.
+
+    Worker fatal/error reporting deliberately opens a separate Connect whose
+    first and only message is ``HardwareUnsuitable``.  Rejecting that valid
+    shape with a bare "first message must be Hello" assertion erased the
+    exception detail that caused the worker's primary stream to end, which is
+    exactly what the merge-queue failure needed to reveal.
+    """
+    scheduler = FakeScheduler()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    pb_grpc.add_WorkerSchedulerServicer_to_server(scheduler, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    try:
+        settings = _settings(orchestrator_public_addr=f"127.0.0.1:{port}")
+        probe = CudaProbeResult(ok=False, reason="the root failure survives")
+        assert hardware_report.report_hardware_unsuitable(settings, probe) is True
+        assert len(scheduler.diagnostic_reports) == 1
+        report = scheduler.diagnostic_reports[0]
+        assert report.reason_class == "cuda_error"
+        assert report.detail == probe.reason
+    finally:
+        server.stop(grace=0)
 
 
 def test_report_hardware_unsuitable_delivers_with_worker_jwt_identity() -> None:

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -23,6 +23,8 @@ exists.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import List
 
 import pytest
@@ -124,6 +126,49 @@ def test_attempt_outcomes_coalesce_by_count_never_by_dropping() -> None:
     ep.note_outcome("exc_ConnectionError")
 
     assert ep.histogram() == "grpc_unavailable=200, exc_ConnectionError=1"
+
+
+def test_a_long_immediate_outage_stays_inside_the_reconnect_loop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A capped backoff must not overflow before its own stop signal lands.
+
+    The production expression multiplied a float by ``2 ** attempt`` *before*
+    applying the cap.  Rapid connection refusals therefore raised
+    ``OverflowError`` around attempt 1,024 even when both configured delays
+    were zero.  That exception escaped ``Transport.run`` and killed the worker
+    thread; the full suite captured the exact traceback twice.
+
+    This tape drives the real reconnect loop beyond that boundary, then stops
+    it through its normal lifecycle signal.  The old expression goes red with
+    the production ``OverflowError`` before attempt 1,100 can be reached.
+    """
+    from gen_worker.config import load_settings
+    from gen_worker.transport import Transport
+
+    class _Handlers:
+        async def on_disconnect(self) -> None:
+            return None
+
+    class _AlwaysUnavailable(Transport):
+        attempts = 0
+
+        async def _connect_once(self, target: str, use_tls: bool) -> None:
+            del target, use_tls
+            self.attempts += 1
+            if self.attempts == 1_100:
+                self.stop()
+            raise ConnectionError("deliberate immediate refusal")
+
+    caplog.set_level(logging.CRITICAL)
+    transport = _AlwaysUnavailable(
+        load_settings(worker_id="pgw1251-overflow"),
+        _Handlers(),
+        backoff_base_s=0.0,
+        backoff_cap_s=0.0,
+    )
+    asyncio.run(transport.run())
+    assert transport.attempts == 1_100
 
 
 def test_an_episode_starts_when_the_STREAM_ended_not_when_teardown_finished() -> None:


### PR DESCRIPTION
## Outcome

Two merge-queue failures now have executable, non-timing-shaped handling:

- the reconnect jitter ceiling saturates before exponentiation can overflow, so a long/rapid outage remains in `Transport.run` until the ordinary stop signal lands;
- the general scheduler double mirrors the hub's already-valid `HardwareUnsuitable`-first diagnostic stream and preserves the full payload beside primary connections, so a worker fatal/error cannot be replaced by `first message must be Hello`.

This does **not** claim the rare v2 worker death is fixed. Exact failed candidate `8209ced6` passed locally under its complete `tests_v2/ -n 4 --dist loadfile` shape (21/21), and #801's merge-group v2 run was green. The observable defect was that the double erased the dying worker's report; this PR makes the next occurrence carry the real cause.

## Red proofs

Before the implementation, both new focused tests failed:

- `test_a_long_immediate_outage_stays_inside_the_reconnect_loop` drove the real loop to attempt ~1,024 and raised production `OverflowError: int too large to convert to float` before its attempt-1,100 stop;
- `test_general_hub_double_preserves_a_diagnostic_first_stream` made two report attempts, both rejected by the double's Hello assertion, and returned `False`.

After the implementation both pass. The exact earlier v1 queue red is owned separately by merged #801; this PR does not touch its timing test.

## Verification

- Ruff: changed files clean
- mypy: changed source/tests clean
- changelog assembly check: clean
- focused red/green tests: 2 passed
- not-leader teardown regression: passed
- isolated v2 entrypoint regression: passed
- exact failed merge-group tree replay: `tests_v2/ -n 4 --dist loadfile`, 21 passed

Refs: pgw#1251, pgw#1249/#801, pgw#1247/#797, gw#619/th#988.
