### PR TITLE
pgw#1250: the seal assertion names th#1955 and states how much weaker its claim is than it sounds

### DIFF
--- a/scripts/private_deployment_leg.py
+++ b/scripts/private_deployment_leg.py
@@ -692,8 +692,11 @@ class _Run:
         self.check("seal.sku_matches_rented_card", bool(matched),
                    f"{len(matched)} graph(s) on sku={want!r} (from pod gpu_class {observed!r}); "
                    f"the store holds {sorted({str(c.get('sku', '')) for c in mine})} for this "
-                   f"release [note: the pod view exposes no gpu_class provenance, so a "
-                   f"provider-reported card and an echoed ask are indistinguishable from here]")
+                   f"release [CAVEAT: the pod view exposes no gpu_class PROVENANCE, so a card the "
+                   f"provider confirmed it delivered and the ask echoed back are indistinguishable "
+                   f"here; this claim is 'the card the pod row records', which is weaker than 'the "
+                   f"card actually rented' sounds. th#1955 closes it, and this becomes a refusal "
+                   f"on source=requested]")
         if not matched:
             return
         # Sealed means an ARTIFACT exists, not merely that a key was computed.


### PR DESCRIPTION
Message-only change; no assertion logic moves. Mirrors e2e [#347](https://github.com/cozy-creator/e2e/pull/347).

The finding said "the card actually rented". **It cannot know that.** tensorhub persists the provenance — `gpu_class_source`, `gpu_class_requested`, `gpu_type_actual` in `worker_pods.provider_metadata_json` — but the private-deployment pod view does not SELECT it, so a card the provider *confirmed it delivered* and the ask *echoed back* read identically here.

The assertion remains sound (it compares the store against what the pod row **records**, which is the delivered card whenever the provider reported one). What it cannot do is distinguish the pathological case, where the leg checks the graph against the card it *asked for* while calling that "the card actually rented".

That gap was silent; it now travels in the finding's own detail text and names **th#1955** — a projection onto one query and one view, no migration — which turns the hedge into an outright **refusal** on `source=requested`.

21 tests green.