### PR TITLE
pgw#1262: the AOT adopt names itself a COMPILE, so its deaths stop bricking the pod

### DIFF
--- a/changelog.d/pgw1262.md
+++ b/changelog.d/pgw1262.md
@@ -1,0 +1,25 @@
+- **pgw#1262: the AOT adopt is named as a COMPILE while it touches the device,
+  so its deaths stop being charged to the tenant.** `attribute_signal_death`
+  has always recorded a signal death against an in-flight `compile` marker
+  rather than the request that happened to be running — *"charging the
+  request's function would refuse serving and condemn the SKU for a software
+  bug"* — and `executor` has always acted on it (pgw#714: a prior
+  compile-attributed death reboots the pod EAGER-ONLY). Neither ever covered
+  the adopt, because `hot_swap` was the SDK's only writer of such a marker.
+  `provision.arm_aot` now holds one across both of its device spans: the load
+  (`aot_serve.enable`) and the §4.32 numerics gate's two forwards. Measured
+  2026-08-14 on the standing master stack: a z-image pod died in `probe_cell`
+  -> `gate_cell_numerics` -> `arm_aot`, reported
+  `native_crash_streaks: {"generate": 1}` against the tenant's function,
+  restarted the same two arm_keys and crash-looped while th#1326's mint hold
+  paid $0.44/hr to keep it. `arm_aot` is the one seam ALL FOUR arm routes pass
+  (boot adopt, local-store adopt, re-arm, self-mint adopt), so one span covers
+  every route — the same reason pgw#1168 put the adopt's measurement there.
+  This is containment, not a budget: no VRAM number is introduced, nothing is
+  predicted, and the pgw#1205 device-peak bank stays measurement-only.
+- **pgw#1262: `postmortem.compile_inflight` is the one way to name a compile
+  span.** A context manager whose `finally` is load-bearing — a leaked marker
+  makes the NEXT unrelated death read as a compile crash, the same
+  misattribution pointed the other way. `hot_swap`'s hand-rolled
+  `note_inflight`/`clear_inflight` pair now uses it, so there is one pattern
+  rather than two.

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal
+from typing import TYPE_CHECKING, Any, Iterable, Iterator
 
 from gen_worker.api.errors import ValidationError
 

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -667,12 +667,8 @@ def _run_warm_gated(job: _WarmJob) -> None:
     # mid-compile attributes to THIS compile marker rather than to whatever
     # tenant request was in flight (which condemns (release, SKU) pairs for a
     # software race).
-    token = postmortem.note_inflight(
-        postmortem.COMPILE_KIND, postmortem.compile_marker(job.label))
-    try:
+    with postmortem.compile_inflight(job.label):
         _run_warm_compile(job)
-    finally:
-        postmortem.clear_inflight(token)
 
 
 def _run_warm_compile(job: _WarmJob) -> None:

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -52,6 +52,7 @@ from .memory import place_pipeline
 from .refs import DEFAULT_REF_TAG, parse_model_ref
 from .. import activity as activity_mod
 from .. import mint_workers
+from .. import postmortem
 
 if TYPE_CHECKING:
     from ..aot_identity import ExpectedIdentity
@@ -424,6 +425,19 @@ def arm_aot(
     _resident_before, _ = mint_workers.adopt_watermark(_budget_device)
     _load_bytes = 0
     _emitted = False
+    # pgw#1262: the same seam, for the same reason, one question over. pgw#1168
+    # put the adopt's MEASUREMENT here because this is the one point every arm
+    # route passes; its ATTRIBUTION was never wired at all. The two device
+    # spans below (the load, and the §4.32 gate's forwards) are the adopt's
+    # whole GPU surface, and until now neither held a compile in-flight marker
+    # — so a signal death in either was charged to whatever tenant request was
+    # running, `postmortem.compile_crash_rows()` stayed empty, and pgw#714's
+    # eager-only reboot never fired. Measured 2026-08-14: a z-image pod booked
+    # its adopt SIGSEGV against `generate`, restarted the same two arm_keys and
+    # crash-looped while th#1326 paid to hold it.
+    _adopt_label = "adopt:" + (
+        str((meta or {}).get("family") or getattr(cfg, "family", "") or "")
+        or "unknown")
 
     def _emit_adopt_budget(verify_bytes: int, armed: bool) -> None:
         """One `cell_adopt_budget` row per arm attempt, whatever the outcome.
@@ -474,8 +488,16 @@ def arm_aot(
     #
     # pgw#1176 makes that refusal cheaper still: the attempt is ONE graph
     # class, so a card that cannot hold it costs that class and no other.
-    outcome = aot_serve.enable(
-        pipe, cfg, cache_dir, artifact, expected=expected, declared=declared)
+    #
+    # pgw#1262: and the attempt is NAMED while it runs. `_bind_headroom` turns
+    # a CATCHABLE device OOM into the typed miss above; a device exhaustion
+    # under `expandable_segments:True` (imposed by this SDK at
+    # `settings_authority.py:83`) is a native mapping abort that no `except`
+    # sees, so the process dies here. When it does, this marker is what makes
+    # the death read as a COMPILE crash rather than as the tenant's.
+    with postmortem.compile_inflight(_adopt_label):
+        outcome = aot_serve.enable(
+            pipe, cfg, cache_dir, artifact, expected=expected, declared=declared)
     _, _peak_after_load = mint_workers.adopt_watermark(_budget_device)
     _load_bytes = max(0, _peak_after_load - _resident_before)
     if not outcome.armed and lifted_install_error:
@@ -490,7 +512,17 @@ def arm_aot(
     if outcome.armed:
         # §4.32: quality is proven at MINT and in author CI, never at adoption.
         # An adopting pod materializes, arms and serves.
-        gate_ok = not verify_numerics or gate_cell_numerics(pipe, cfg, strict=True)
+        # pgw#1262: the gate runs TWO forwards on a card that is already
+        # holding the resident pipeline(s) plus the runner just loaded above,
+        # so it is the adopt's peak device moment — and it is where the
+        # 2026-08-14 z-image death actually landed (`probe_cell` ->
+        # `gate_cell_numerics` -> `arm_aot`). Named, so that death is a
+        # compile's.
+        if verify_numerics:
+            with postmortem.compile_inflight(_adopt_label):
+                gate_ok = gate_cell_numerics(pipe, cfg, strict=True)
+        else:
+            gate_ok = True
         _, _peak_after_verify = mint_workers.adopt_watermark(_budget_device)
         if gate_ok:
             _emit_adopt_budget(_peak_after_verify - _peak_after_load, True)

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -21,6 +21,7 @@ vs ``memory.peak``, and the ``memory.events`` ``oom_kill`` counter delta — so
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -28,7 +29,7 @@ import signal
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 import faulthandler
 from .procsplit import group_ordinal, host_siblings
 
@@ -825,6 +826,29 @@ def compile_marker(label: str) -> str:
     return _COMPILE_FN_PREFIX + str(label or "unknown")
 
 
+@contextlib.contextmanager
+def compile_inflight(
+    label: str, *, path: Optional[Path] = None,
+) -> Iterator[None]:
+    """Name a device-touching COMPILE span before it starts, and retire it on
+    every exit (pgw#1262).
+
+    The `finally` is the load-bearing half: a leaked marker would make the NEXT
+    unrelated signal death read as a compile crash, which is the same
+    misattribution this exists to prevent, pointed the other way.
+
+    Wrapping a span in this is what makes :func:`compile_crash_rows` — and so
+    pgw#714's eager-only reboot — cover it. A device-touching compile/adopt
+    phase that does NOT hold one of these is invisible to that mechanism, and
+    its deaths are charged to whatever tenant request happened to be in flight.
+    """
+    token = note_inflight(COMPILE_KIND, compile_marker(label), path=path)
+    try:
+        yield
+    finally:
+        clear_inflight(token, path=path)
+
+
 def compile_crash_rows(
     path: Optional[Path] = None,
 ) -> Dict[str, Dict[str, Any]]:
@@ -999,6 +1023,7 @@ __all__ = [
     "attribute_all_signal_deaths",
     "attribute_signal_death",
     "compile_crash_rows",
+    "compile_inflight",
     "compile_marker",
     "boot_record_is_volatile",
     "clear_boot_record",

--- a/tests/test_adopt_compile_attribution_pgw1262.py
+++ b/tests/test_adopt_compile_attribution_pgw1262.py
@@ -1,0 +1,264 @@
+"""The ADOPT's device spans are named as COMPILES, so their deaths are not
+charged to the tenant.
+
+`postmortem.attribute_signal_death` already implements the right rule — *"when
+a ``compile`` marker is in flight the streak is recorded ONLY against the
+compile marker(s) … charging the request's function would refuse serving and
+condemn the SKU for a software bug"* — and `executor` already acts on it
+(pgw#714: a prior compile-attributed death reboots the pod EAGER-ONLY instead of
+re-running the native crash). Both were live before this change. What was
+missing is that **the adopt never wrote such a marker**: `hot_swap` was the
+SDK's only writer, so an adopt death fell through to the tenant's function, the
+eager-only reboot never fired, and the pod re-minted the same key and
+crash-looped.
+
+Measured 2026-08-14 on the standing master stack (pgw#1255): a z-image pod died
+in `probe_cell` -> `gate_cell_numerics` -> `arm_aot` and reported
+`native_crash_streaks: {"generate": 1}` — the tenant's function, for a fault in
+the adopt.
+
+These tests drive the REAL `provision.arm_aot` and the REAL postmortem registry.
+The doubles are `aot_serve.enable`, `gate_cell_numerics` and the CUDA reading —
+the GPU work this box may not do (§4.33 local-rig bounds: the compile phase is
+stubbed, nothing is minted or compiled here).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import mint_workers, postmortem
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.models import provision
+
+
+_META: Dict[str, Any] = {
+    "family": "z-image",
+    "weight_lane": "lora128",
+    "cell_key": "cg-key-v1-" + "0" * 56,
+    "entry": {"name": "transformer/e0", "target": "transformer"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> Iterator[None]:
+    """Never touch the real pod paths."""
+    monkeypatch.setattr(postmortem, "INFLIGHT_PATH", tmp_path / "inflight.json")
+    monkeypatch.setattr(
+        postmortem, "CRASH_REGISTRY_PATH", tmp_path / "crashes.json")
+    postmortem.clear_inflight()
+    yield
+    postmortem.clear_inflight()
+
+
+def _live_compile_markers() -> List[Dict[str, Any]]:
+    """The compile markers a dying process would find, WITHOUT consuming them."""
+    import json
+
+    try:
+        raw = json.loads(Path(postmortem.INFLIGHT_PATH).read_text())
+    except (OSError, ValueError):
+        return []
+    return [
+        row for row in (raw.get("active") or [])
+        if isinstance(row, dict)
+        and str(row.get("kind") or "") == postmortem.COMPILE_KIND
+    ]
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    on_enable: Optional[Callable[[], None]] = None,
+    on_gate: Optional[Callable[[], None]] = None,
+    armed: bool = True,
+    gate_passes: bool = True,
+    enable_raises: Optional[BaseException] = None,
+) -> None:
+    """Real arm_aot; doubled CUDA reading, load and §4.32 gate."""
+    from gen_worker import aot_serve
+
+    monkeypatch.setattr(mint_workers, "adopt_watermark", lambda _d=None: (0, 0))
+    monkeypatch.setattr(mint_workers, "device_of", lambda _p: 0)
+
+    def _enable(*_a: Any, **_k: Any) -> AdoptOutcome:
+        if on_enable is not None:
+            on_enable()
+        if enable_raises is not None:
+            raise enable_raises
+        return (AdoptOutcome.hit("armed") if armed
+                else AdoptOutcome.miss("load_failed", "no"))
+
+    def _gate(*_a: Any, **_k: Any) -> bool:
+        if on_gate is not None:
+            on_gate()
+        return gate_passes
+
+    monkeypatch.setattr(aot_serve, "enable", _enable)
+    monkeypatch.setattr(aot_serve, "armed_metadata", lambda _p: dict(_META))
+    monkeypatch.setattr(aot_serve, "unwrap", lambda _p: None)
+    monkeypatch.setattr(aot_serve, "disarm_entry", lambda *a, **k: None)
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {})
+    monkeypatch.setattr(provision, "gate_cell_numerics", _gate)
+    monkeypatch.setattr(activity_mod, "emit_event", lambda *a, **k: None)
+
+
+def _arm(tmp_path: Path, **kw: Any) -> AdoptOutcome:
+    return provision.arm_aot(
+        object(), type("Cfg", (), {"family": "z-image"})(), None,
+        tmp_path / "cell.tar.gz", 0, dict(_META), **kw)
+
+
+# --------------------------------------------------------------------------
+# The two device spans are NAMED while they run.
+# --------------------------------------------------------------------------
+
+
+def test_the_LOAD_span_holds_a_compile_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """`aot_serve.enable` is the adopt's first device touch."""
+    seen: List[List[Dict[str, Any]]] = []
+    _install(monkeypatch, on_enable=lambda: seen.append(_live_compile_markers()))
+    _arm(tmp_path)
+
+    assert seen and seen[0], (
+        "no compile marker was in flight during the adopt's LOAD — a signal "
+        "death here is charged to whatever tenant request is running")
+    assert seen[0][0]["function"] == "compile:adopt:z-image"
+
+
+def test_the_NUMERICS_GATE_span_holds_a_compile_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The §4.32 gate runs two forwards beside the just-loaded runner — the
+    adopt's peak device moment, and where the 2026-08-14 death landed."""
+    seen: List[List[Dict[str, Any]]] = []
+    _install(monkeypatch, on_gate=lambda: seen.append(_live_compile_markers()))
+    _arm(tmp_path, verify_numerics=True)
+
+    assert seen and seen[0], (
+        "no compile marker was in flight during `gate_cell_numerics` — this is "
+        "the exact frame the z-image pod died in")
+    assert seen[0][0]["function"] == "compile:adopt:z-image"
+
+
+# --------------------------------------------------------------------------
+# THE CONSEQUENCE: pgw#714's eager-only reboot now covers the adopt.
+# --------------------------------------------------------------------------
+
+
+def test_a_death_during_the_gate_is_a_COMPILE_crash_not_the_tenant_s(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The production report, reproduced: a tenant request in flight, a fault
+    inside the adopt, and the streak must land on the COMPILE."""
+    registry = tmp_path / "crashes.json"
+    captured: Dict[str, Any] = {}
+
+    def _die() -> None:
+        # The process dies HERE. This is what the parent's post-mortem runs.
+        captured.update(postmortem.attribute_signal_death(
+            signal_name="SIGSEGV",
+            inflight_path=postmortem.INFLIGHT_PATH,
+            registry_path=registry))
+
+    _install(monkeypatch, on_gate=_die)
+    # A tenant request is in flight, exactly as `a4e6f6a4…#1` was.
+    postmortem.note_inflight("request", "generate", request_id="a4e6f6a4")
+    _arm(tmp_path, verify_numerics=True)
+
+    streaks = captured.get("native_crash_streaks") or {}
+    assert "generate" not in streaks, (
+        f"the tenant's serving function was charged for an adopt fault: "
+        f"{streaks} — this is the misattribution that kept pgw#714's "
+        f"eager-only reboot from ever firing")
+    assert "compile:adopt:z-image" in streaks, streaks
+
+    rows = postmortem.compile_crash_rows(registry)
+    assert rows, (
+        "compile_crash_rows() is empty, so executor's "
+        "`disable_process_compiles()` never fires and the pod re-mints the "
+        "same arm_key and crash-loops")
+    assert "compile:adopt:z-image" in rows
+
+
+# --------------------------------------------------------------------------
+# The marker must never LEAK — a stale one misattributes the next death.
+# --------------------------------------------------------------------------
+
+
+def test_the_marker_is_retired_on_a_clean_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    _install(monkeypatch)
+    _arm(tmp_path, verify_numerics=True)
+    assert _live_compile_markers() == []
+
+
+def test_the_marker_is_retired_when_the_load_RAISES(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """A leaked marker would make the NEXT unrelated death read as a compile
+    crash — the same misattribution, pointed the other way."""
+    _install(monkeypatch, enable_raises=RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        _arm(tmp_path)
+    assert _live_compile_markers() == []
+
+
+def test_the_marker_is_retired_when_the_gate_REFUSES(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    _install(monkeypatch, gate_passes=False)
+    _arm(tmp_path, verify_numerics=True)
+    assert _live_compile_markers() == []
+
+
+# --------------------------------------------------------------------------
+# Shape guards.
+# --------------------------------------------------------------------------
+
+
+def test_a_boot_adopt_names_the_load_but_runs_no_gate_span(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """`verify_numerics=False` is every adopter; it pays the load and no gate,
+    so it opens exactly one span and never a vacuous second one."""
+    gate_ran: List[int] = []
+    seen: List[List[Dict[str, Any]]] = []
+    _install(
+        monkeypatch,
+        on_enable=lambda: seen.append(_live_compile_markers()),
+        on_gate=lambda: gate_ran.append(1))
+    _arm(tmp_path, verify_numerics=False)
+
+    assert seen and seen[0], "the boot adopt's load must still be named"
+    assert gate_ran == [], "§4.32: an adopter runs no numerics gate"
+    assert _live_compile_markers() == []
+
+
+def test_the_marker_names_the_FAMILY_so_the_reboot_report_is_legible(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """`disable_process_compiles` prints `last=<marker>`; a nameless marker
+    would make the pod's eager-only reboot unexplainable."""
+    seen: List[List[Dict[str, Any]]] = []
+    _install(monkeypatch, on_enable=lambda: seen.append(_live_compile_markers()))
+    provision.arm_aot(
+        object(), type("Cfg", (), {"family": ""})(), None,
+        tmp_path / "cell.tar.gz", 0, {"entry": _META["entry"]})
+
+    assert seen[0][0]["function"] == "compile:adopt:unknown"
+
+
+def test_the_adopt_marker_is_namespaced_away_from_serving_functions() -> None:
+    """It must never collide with — or refuse — a real function name."""
+    assert postmortem.compile_marker("adopt:z-image").startswith("compile:")
+    assert postmortem.compile_crash_rows.__doc__


### PR DESCRIPTION
Tracker: **pgw#1262**, scoped out of the **pgw#1255** P0 root cause by the coordinator.

## What was wrong

`postmortem.attribute_signal_death` has always recorded a signal death against an in-flight `compile` marker rather than the tenant request that happened to be running — *"charging the request's function would refuse serving and condemn the SKU for a software bug"* — and `executor.py:2229-2243` has always acted on it (pgw#714: a prior compile-attributed death calls `disable_process_compiles()` and the pod reboots **eager-only**).

Both mechanisms were live. Neither ever covered the **adopt**, because `hot_swap._run_warm_gated` was the SDK's **only** writer of a compile marker.

## Measured, user-facing (standing master stack, 2026-08-14)

A z-image pod reached `phase=finalize`, armed the cell onto the live pipeline **an in-flight tenant request was already executing on**, and took SIGSEGV in `probe_cell` → `gate_cell_numerics` → `arm_aot` with **17.9 MiB free of 47.7 GB**. The product owner saw `ComputeProcessDied: cause=signal:SIGSEGV`.

The death reported `native_crash_streaks: {"generate": 1}` — the tenant's function. So `compile_crash_rows()` stayed empty, `disable_process_compiles()` never fired, and at 12:08:08 the pod restarted **the same two arm_keys** and crash-looped, while `th#1326 cell_mint_hold_granted … rent=$0.44/hr` paid to hold it because its doomed mint "reports progress" (the th#1959 paid-pod leak).

## The change

`provision.arm_aot` now holds a compile marker across both of its device spans — the load (`aot_serve.enable`) and the §4.32 numerics gate's two forwards. `arm_aot` is the **one seam all four arm routes pass** (boot adopt, local-store adopt, re-arm, self-mint adopt), so one span covers every route; that is the same reason pgw#1168 put the adopt's *measurement* there.

Adds `postmortem.compile_inflight`, a context manager whose `finally` is load-bearing — a leaked marker would make the next unrelated death read as a compile crash, the same misattribution pointed the other way. `hot_swap`'s hand-rolled note/clear pair now uses it, so there is one pattern rather than two.

## What this is NOT

**Containment, not a budget.** No VRAM number is introduced, nothing is predicted, and the pgw#1205 device-peak bank stays measurement-only — its `test_no_width_or_placement_decision_reads_the_bank` fence is untouched. Re-creating what §4.33/pgw#1175 deleted would be a regression, not a fix.

It does **not** fix the root cause — adoption raising the residency floor with no pre-swap check and no rollback. That is filed as a **requirement against pgw#1232's rebuilt design**, stated against the surviving seam names (`provision.arm_aot`, `aot_serve.arm_entry`/`disarm_entry`, `EntryDispatch`) rather than patched into the runner/bind interior PR #807 is actively replacing.

## Red-first proof

Red-proven against `origin/master` in a throwaway worktree (since `conftest` forces the worktree src, `PYTHONPATH` alone cannot un-apply the fix): **5 of 9 fail there**, including `test_a_death_during_the_gate_is_a_COMPILE_crash_not_the_tenant_s`, whose failure text is:

```
AssertionError: the tenant's serving function was charged for an adopt fault: {'generate': 1}
```

byte-identical to the production report. The 4 that pass unfixed are the leak-guards, vacuously true when no marker exists.

Tests drive the **real** `arm_aot` and the **real** postmortem registry; the doubles are `aot_serve.enable`, `gate_cell_numerics` and the CUDA reading — the compile phase is stubbed and **nothing is minted, compiled or inferred locally** (§4.33 local-rig bounds).

## Verification

- new suite: 9 passed; `test_adopt_seam_budget_pgw1168` + `test_device_peak_bank_pgw1205` + `test_mint_supervisor_pgw1215`: 53 passed
- `-k "postmortem or hot_swap or crash or provision or adopt"`: **271 passed**
- `mypy src/gen_worker tests tests_v2`: **Success, 779 files** (new test fully annotated; no ratchet exemption added)
- `ruff check src/gen_worker`: clean
- `lint_http_timeouts` / `lint_unreached_surface` / `lint_config_reads` / `lint_settings_writers` / `lint_mypy_ratchet`: all OK
- `git merge --no-commit origin/master`: already up to date

## Unrelated one-liner, declared

Removes a dead `typing.Literal` import in `src/gen_worker/convert/source.py`, left behind by th#1937 (`f6ddb3ae`) when it removed the last use. It **fails the required `ruff check src/gen_worker` gate on current master**, so it would otherwise block this PR and every entry behind it in the merge queue.
