### PR TITLE
pgw#1264: the tests suite leaves the merge queue and becomes a nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,10 +139,21 @@ name: CI
 # suite is on the PR trigger and not just the cheap half.
 #
 # pgw#977 (2026-08-05): `dev` is retired and lanes PR straight to `master`, so
-# the trigger names `master` alone. Both jobs here are the master ruleset's
-# REQUIRED contexts (`fast gates`, `tests`) — they gate the merge, and unlike
-# tensorhub this repo keeps its full suite pre-merge because it is public,
-# unmetered, and ~10m rather than ~18m.
+# the trigger names `master` alone.
+#
+# pgw#1264 (2026-08-14, Paul's ruling — SUPERSEDES the paragraph above about both
+# jobs being required): `fast gates` is now the master ruleset's ONLY required
+# context. `tests` gates nothing, and it no longer runs on `merge_group` at all.
+# Measured over ~300 runs before this change: `CI` on `merge_group` p50 911s, of
+# which `fast gates` was 122s and `tests` 868s — so the suite WAS the queue's
+# wall clock while proving nothing about the merge. With the queue widened to ten
+# speculative entries it would also hold ten concurrent 14-minute runners, and
+# the required job would queue behind its own workflow.
+#
+# What replaces it, so nothing is actually lost: `tests` still runs on EVERY PR
+# push (a lane sees its own regression before merging), on `workflow_dispatch`,
+# and NIGHTLY on `master` via the `schedule:` below. Pre-launch, a regression
+# found by tonight's nightly is cheaper than fifteen minutes on every merge.
 # pgw#1209 (2026-08-13): `master` has a MERGE QUEUE. A queued PR is validated on
 # a `gh-readonly-queue/master/...` ref carrying master's tip plus every entry
 # ahead of it — which is the only place the "two PRs green alone, red together"
@@ -152,11 +163,15 @@ name: CI
 #   1. `merge_group:` in the trigger list. Without it no run is created on the
 #      queue ref at all, the required contexts never report, and the queue sits
 #      until `check_response_timeout_minutes` expires and evicts the PR.
-#   2. `github.event_name == 'merge_group'` in each job's `if:`. On a merge_group
-#      event `github.event.pull_request` is NULL, so the draft guard alone
-#      evaluates false and the job SKIPS — and GitHub scores a skipped required
-#      check as satisfied. That failure is worse than the first: the queue merges
-#      having run nothing, and the PR page shows green.
+#   2. `github.event_name == 'merge_group'` in the REQUIRED job's `if:`. On a
+#      merge_group event `github.event.pull_request` is NULL, so the draft guard
+#      alone evaluates false and the job SKIPS — and GitHub scores a skipped
+#      required check as satisfied. That failure is worse than the first: the
+#      queue merges having run nothing, and the PR page shows green.
+#      pgw#1264: this is why the `merge_group:` trigger STAYS even though `tests`
+#      opts out of it. Deleting the trigger to stop `tests` would take `fast
+#      gates` with it and hang every entry to the 15-minute response timeout;
+#      the opt-out belongs in the job's `if:`, never in the trigger list.
 #
 # The trigger is deliberately bare (no `branches:`/`paths:` filter). A filter
 # that excludes a merge group is indistinguishable from case 1.
@@ -182,6 +197,15 @@ name: CI
 on:
   workflow_dispatch: {}
   merge_group:
+  # pgw#1264: the nightly is where the full suite lives now that it is off the
+  # merge path. 09:17 UTC — an odd minute, because the top of an hour is the
+  # busiest slot on GitHub's shared scheduler and a queued cron just runs late.
+  # This is the ONLY cron in the repo (native-kernels, proto-contract and
+  # publish are event-driven), so nothing collides with it.
+  # NOTE: a `schedule` event has no `github.event.pull_request` either — both
+  # jobs' `if:` name it explicitly for the same reason `merge_group` is named.
+  schedule:
+    - cron: '17 9 * * *'
   pull_request:
     branches: [master]
     # `ready_for_review` is NOT a default `pull_request` type, and the jobs below
@@ -192,7 +216,10 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # pgw#1264: superseded PR pushes should stop burning runners, but a merge-queue
+  # run must never be cancellable by group — a cancelled required check reports
+  # nothing, and the entry then sits until the queue's response timeout evicts it.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   # ~1m35s. Everything decidable without running the suite, so a lane learns
@@ -203,7 +230,9 @@ jobs:
     # `merge_group` is listed FIRST and explicitly: on that event
     # `github.event.pull_request` is null, so the draft clause alone skips the
     # job and GitHub scores the skip as a satisfied required check (pgw#1209).
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # This is the repo's ONLY required context (pgw#1264) — the merge-group arm
+    # of this condition is what the queue actually waits on. Do not weaken it.
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -215,6 +244,13 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          # pgw#1264: `setup-uv@v4` does NOT cache by default (the `auto` default
+          # arrived in v6), so every run of the required job re-downloaded the
+          # dev dependency set — 19s of its measured 122s. The key is uv.lock's
+          # hash, so a lock bump misses and repopulates. Only this job asks for
+          # it: `tests` is off the merge path now, and two jobs writing one key
+          # just race to save the same cache.
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -427,14 +463,19 @@ jobs:
       - name: Build package
         run: uv build
 
-  # ~15m15s. The only job that can catch a behavioural regression — see the
-  # header on why that is worth a dev trigger rather than master-only.
+  # ~14m30s (measured p50 868s). The only job that can catch a behavioural
+  # regression — and, since pgw#1264, NOT a required context and NOT part of the
+  # merge path.
   tests:
     name: tests
-    # `merge_group` is listed FIRST and explicitly: on that event
-    # `github.event.pull_request` is null, so the draft clause alone skips the
-    # job and GitHub scores the skip as a satisfied required check (pgw#1209).
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    # pgw#1264: `!= 'merge_group'` is the whole change. This job proved nothing
+    # about a merge (it is not required) while costing the queue ~868s of its
+    # ~911s p50, and ten speculative entries would have held ten 14-minute
+    # runners in front of the required `fast gates`. It still runs on every PR
+    # push, on `workflow_dispatch`, and nightly on `master` via `schedule:`.
+    # `schedule` is named explicitly for the same null-`pull_request` reason
+    # `merge_group` was: without it the nightly would skip this job silently.
+    if: github.event_name != 'merge_group' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:

--- a/changelog.d/pgw1264.md
+++ b/changelog.d/pgw1264.md
@@ -1,0 +1,5 @@
+CI only, no runtime change: the full `tests` suite no longer runs on merge-queue
+groups, where it gated nothing and accounted for roughly 868s of the queue's 911s
+median. It still runs on every pull-request push, on manual dispatch, and nightly
+on `master`. The required `fast gates` job is unchanged apart from a uv download
+cache, and merge-queue runs are now exempt from concurrency cancellation.


### PR DESCRIPTION
Paul's ruling (2026-08-14): pre-launch, a merge must complete in minutes. `fast gates` is already the master ruleset's **only** required context (`tests` was removed from it before this PR), so the 14-minute suite was pure queue latency.

Measured over the last ~300 runs of the Actions API:

| context | p50 |
|---|---|
| `CI` on `merge_group` | **911s** |
| ↳ `fast gates` | 122s |
| ↳ `tests` | 868s |

`tests` is not required, so on the queue ref it proved nothing about the merge while being the entire wall clock — and with the queue widened to `max_entries_to_build=10` it would hold ten concurrent 14-minute runners in front of the required job.

## What changed

- **`tests` gets `github.event_name != 'merge_group'`.** That is the whole latency fix.
- **The `merge_group:` trigger STAYS.** Removing it to stop `tests` would take `fast gates` with it; a required context that never reports holds the entry until `check_response_timeout_minutes` (15) evicts it.
- **`fast gates`'s `if:` verified** — it still names `merge_group` explicitly (pgw#1209). A draft-guard-only condition is false on `merge_group` (`github.event.pull_request` is null) and GitHub scores the skip as a *satisfied* required check, which is worse than a stall.
- **Nothing is lost.** `tests` still runs on every PR push and on `workflow_dispatch`, and now **nightly on `master`** via `schedule: '17 9 * * *'` — the repo's only cron (native-kernels, proto-contract and publish are event-driven), on an odd minute because the top of the hour is GitHub's busiest scheduler slot. Both jobs' `if:` learned `schedule`, since that event has a null `pull_request` for the same reason `merge_group` does — without it the nightly would silently skip both jobs.
- **`cancel-in-progress` becomes `${{ github.event_name != 'merge_group' }}`.** Superseded PR pushes still stop burning runners; a queue run is never cancelled into a reports-nothing required check. (`native-kernels` and `proto-contract` already have PR-scoped cancel-in-progress; `publish` is tag-push and correctly has none.)
- **`fast gates` cache**: `setup-uv@v4` does not cache by default (the `auto` default landed in v6), so the required job re-downloaded the dev dependency set every run — 19s of its 122s. Only this job asks for the cache; two jobs writing one lock-hash key just race to save it.

## `fast gates` step breakdown (run 31827528117), and why the rest is left alone

```
68s  Type check (mypy, strict by default, src + tests)
19s  Install dependencies          <- addressed here
 6s  pgw#931 guard - config reads outside the pipeline
 3s  pgw#849 guard 2 / pgw#1152 guard / pgw#1013 guard  (3s each)
 2s  Build package, pgw#1049, pgw#1143 x1
 ~1s each  checkout, uv, python, and the remaining ~15 guards/gates
```

mypy is 68s and there is no cheap win in it: a cross-branch `.mypy_cache` restored by `actions/cache` risks a stale-cache false green on the one context that now gates every merge, which is exactly the trade this repo refuses elsewhere. The ~20 tree-scanning guards are ~1-6s each and worth their seconds. Expected `fast gates` after this PR: **~105-110s**, and expected `CI` on `merge_group`: **~2m instead of ~15m**.

Tracker: pgw#1264.