### PR TITLE
pgw#1253: the declared hf.fp8-blockwise@1 decoder now RUNS — registered was not running

### DIFF
--- a/changelog.d/pgw1253.md
+++ b/changelog.d/pgw1253.md
@@ -1,0 +1,28 @@
+- **pgw#1253: the declared `hf.fp8-blockwise@1` decoder is now REACHED — a
+  declaration on code nothing runs is a decode-set that is true by accident.**
+  `load_hf_fp8_blockwise` carried `@implements_contract`, so pgw#1245's derived
+  `[decode_set]` told the hub this image decodes `hf.fp8-blockwise@1`, and no
+  production call site reached it. Measured by driving `load_component` with a
+  real blockwise fixture: `transformers.LlamaForCausalLM.from_pretrained` ran
+  and the declared decoder did not. Nothing failed, which is why it survived —
+  transformers reads `quantization_config` out of `config.json` by itself, so
+  the tree decoded through the GENERIC arm, the one that declares
+  `plain.bf16@1`.
+
+  What was lost with the arm: `inspect_hf_fp8_blockwise`'s verification. A
+  TRANSPOSED scale grid loaded without complaint (every block scale applied to
+  the wrong span — plausible numbers, no exception), and the
+  `cozy.fp8-rowwise@1` refusal this contract exists to make could not fire on
+  the production path. `contract_loaded_component` — the one dispatch the
+  modular and non-modular component entry points share — now detects the
+  contract from the tree's own `quantization_config` claim (`quant_method` fp8
+  with a `[block_m, block_n]` pair), verifies it from headers, and dispatches
+  to the declaring decoder. A tree making the claim that does not verify
+  RAISES rather than falling through, and a tree making no such claim is left
+  alone: `cozy.fp8-rowwise@1` keeps its own arm.
+
+  `scripts/lint_unreached_surface.py` did not miss this — the row was in its
+  ratchet baseline from 2026-08-12, and pgw#1245 later derived a hub-visible
+  capability from the very function the ratchet had recorded as caller-less.
+  The row is delisted by wiring, with that sequence written into the baseline
+  header where the next derivation can read it.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -105,6 +105,22 @@
 #       with NO importer at all"; this deletion is that lesson applied by
 #       hand.
 #
+#   A DECLARED capability derived from a function this file already listed
+#     models.hf_fp8_blockwise.load_hf_fp8_blockwise — ✅ DELISTED 2026-08-14
+#       (pgw#1253) by WIRING: `contract_loaded_component` now detects an
+#       `hf.fp8-blockwise@1` component tree and dispatches to it. Listed
+#       2026-08-12 (pgw#1182) when the fence grew to the whole package.
+#       pgw#1245 then hung `@implements_contract` on this same function and
+#       DERIVED the image's `[decode_set]` from the marker — so the hub was
+#       told this image decodes `hf.fp8-blockwise@1` on the strength of a
+#       function this file had already recorded as caller-less. Nothing broke,
+#       which is the point: transformers reads `quantization_config` out of
+#       config.json itself, so the tree loaded through the generic arm that
+#       declares `plain.bf16@1` and the contract's own verifier never ran.
+#       THIS GUARD DID NOT MISS IT — the row was here the whole time. What is
+#       missing is that a derivation reading the marker does not read this
+#       file.
+#
 #   ⚠️ KNOWN BLIND SPOT — the wrapper exemption clears the WRONG function
 #
 #     MECHANISM: a definition is exempted when its body is a one-line call
@@ -312,7 +328,6 @@ gen_worker.kernel_path.probe()
 gen_worker.models.attention_modes.known_attention_modes()
 gen_worker.models.fp8_storage.castable_leaves()
 gen_worker.models.hf_fp8_blockwise.dequantize_block_scaled()
-gen_worker.models.hf_fp8_blockwise.load_hf_fp8_blockwise()
 gen_worker.models.ladder.Placement.admits_sm()
 gen_worker.models.lora_lifted.LiftedLoraBinding.swap()
 gen_worker.models.lora_lifted.LiftedLoraPlan.views()

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -276,6 +276,37 @@ def inspect_hf_fp8_blockwise(
         modules_to_not_convert=skip, units=tuple(units), files=files)
 
 
+def detect_hf_fp8_blockwise(path: Path) -> Optional[HfFp8BlockwiseTree]:
+    """The verified ``hf.fp8-blockwise@1`` tree at ``path``, or ``None``.
+
+    DETECTION is the config's own claim and nothing else: a
+    ``quantization_config`` whose ``quant_method`` is fp8 and whose
+    ``weight_block_size`` is a ``[block_m, block_n]`` pair. A tree that makes
+    no such claim is not this contract and is left to the caller's own lane —
+    a per-tensor or per-row fp8 tree is ``cozy.fp8-rowwise@1``, detected by its
+    own arm.
+
+    A tree that DOES make the claim is verified against its headers before it
+    is returned, so a mis-blocked, transposed or rowwise-scaled grid raises
+    :class:`HfFp8BlockwiseLayoutError` here rather than reaching a generic
+    loader that reads it as something else.
+    """
+    p = Path(path)
+    try:
+        cfg = json.loads((p / "config.json").read_text("utf-8"))
+    except (OSError, ValueError):
+        return None
+    qc = cfg.get("quantization_config") if isinstance(cfg, dict) else None
+    if not isinstance(qc, dict):
+        return None
+    if str(qc.get("quant_method", "")).lower() != QUANT_METHOD:
+        return None
+    raw = qc.get("weight_block_size")
+    if not (isinstance(raw, (list, tuple)) and len(raw) == 2):
+        return None
+    return inspect_hf_fp8_blockwise(p)
+
+
 def dequantize_block_scaled(weight: Any, scale: Any, *, out_dtype: Any = None) -> Any:
     """``hf.fp8_blockwise.dequant@1`` — the contract's reference dequant.
 
@@ -387,6 +418,7 @@ __all__ = [
     "HfFp8BlockwiseTree",
     "REFERENCE_DEQUANT",
     "dequantize_block_scaled",
+    "detect_hf_fp8_blockwise",
     "inspect_hf_fp8_blockwise",
     "load_hf_fp8_blockwise",
 ]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -29,6 +29,7 @@ from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_HF_FP8_BLOCKWISE,
     CONTRACT_NUNCHAKU_V1,
     CONTRACT_PLAIN_BF16,
     ELEMENT_BF16,
@@ -49,6 +50,7 @@ from .memory import (
     meta_tensors,
     probe_host_ram,
 )
+from .hf_fp8_blockwise import detect_hf_fp8_blockwise, load_hf_fp8_blockwise
 from .safetensors_header import header_len_ok
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
 from .w4a4 import (
@@ -1464,6 +1466,23 @@ def contract_loaded_component(
             f"dequantized by the pipeline's own gguf loader, so there is no "
             f"component-level production loader to borrow"
         )
+    # hf.fp8-blockwise@1: a transformers component tree (the conditioner /
+    # text encoder position), so it is detected on the component dir and
+    # after the denoiser lanes above. Without this arm the tree loads
+    # GENERICALLY — transformers reads `quantization_config` out of
+    # config.json by itself, so nothing fails and the image's declared
+    # decoder for this contract never runs. Measured (pgw#1253): the arm the
+    # decode-set declares was reached by nothing, so a transposed or rowwise
+    # scale grid was accepted here instead of refused by name, and the
+    # resident-vs-upcast lane was transformers' default rather than this
+    # image's declaration.
+    blockwise = detect_hf_fp8_blockwise(where)
+    if blockwise is not None:
+        require_decodable(
+            CONTRACT_HF_FP8_BLOCKWISE, weights,
+            component=component if where != weights else "")
+        return load_hf_fp8_blockwise(
+            where, cls=cls, dtype=compute_dtype, tree=blockwise)
     return None
 
 

--- a/tests/test_hf_fp8_blockwise_dispatch_pgw1253.py
+++ b/tests/test_hf_fp8_blockwise_dispatch_pgw1253.py
@@ -1,0 +1,202 @@
+"""pgw#1253: the declared ``hf.fp8-blockwise@1`` decoder must RUN.
+
+An EXECUTION assertion, not a registration one. Asserting that a decoder is
+registered proves nothing about whether it runs, and that was literally the
+defect: ``load_hf_fp8_blockwise`` carried ``@implements_contract``, so the
+image's derived ``[decode_set]`` told the hub it decodes
+``hf.fp8-blockwise@1`` — and no production call site reached it. transformers
+reads ``quantization_config`` out of ``config.json`` by itself, so the tree
+loaded anyway, through the GENERIC arm that declares ``plain.bf16@1``, and
+nothing failed.
+
+Measured on the pre-fix tree by driving :func:`load_component` with a real
+blockwise fixture: ``LlamaForCausalLM.from_pretrained`` ran,
+``load_hf_fp8_blockwise`` did not, the conditioner materialized at **float32**
+(the declaration's compute dtype is bf16), and a TRANSPOSED scale grid — the
+grid this contract's verifier exists to refuse — loaded without complaint.
+
+So these tests drive the production dispatch and name the function that ran.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from safetensors.torch import save_file  # noqa: E402
+from transformers import LlamaConfig, LlamaForCausalLM  # noqa: E402
+
+from gen_worker.models import loading  # noqa: E402
+from gen_worker.models.hf_fp8_blockwise import (  # noqa: E402
+    HfFp8BlockwiseLayoutError,
+    detect_hf_fp8_blockwise,
+    load_hf_fp8_blockwise,
+)
+from gen_worker.models.loading import load_component  # noqa: E402
+
+BLOCK = (128, 128)
+FP8_MAX = 448.0
+COMPONENT = "text_encoder"
+
+
+def _quantize_block(w: Any) -> tuple[Any, Any]:
+    out_f, in_f = w.shape
+    srows, scols = math.ceil(out_f / BLOCK[0]), math.ceil(in_f / BLOCK[1])
+    scale = torch.zeros(srows, scols, dtype=torch.float32)
+    q = torch.zeros(out_f, in_f, dtype=torch.float32)
+    for i in range(srows):
+        for j in range(scols):
+            sl = (slice(i * BLOCK[0], (i + 1) * BLOCK[0]),
+                  slice(j * BLOCK[1], (j + 1) * BLOCK[1]))
+            blk = w[sl].float()
+            s = blk.abs().max().clamp(min=1e-12) / FP8_MAX
+            scale[i, j] = s
+            q[sl] = (blk / s).clamp(-FP8_MAX, FP8_MAX)
+    return q.to(torch.float8_e4m3fn), scale
+
+
+def _tiny_llama(hidden: int = 128, inter: int = 256) -> tuple[Any, Any]:
+    cfg = LlamaConfig(
+        vocab_size=256, hidden_size=hidden, intermediate_size=inter,
+        num_hidden_layers=1, num_attention_heads=4, num_key_value_heads=2,
+        max_position_embeddings=64, tie_word_embeddings=False)
+    torch.manual_seed(1253)
+    return cfg, LlamaForCausalLM(cfg).to(torch.bfloat16)
+
+
+def _write_component(
+    d: Path, *, kind: str = "blockwise", hidden: int = 128, inter: int = 256,
+) -> None:
+    """A real transformers component tree.
+
+    ``blockwise`` is ``hf.fp8-blockwise@1``; ``transposed`` writes the same
+    tree with the scale grid transposed (the silently-wrong-numbers case);
+    ``rowwise`` writes ``cozy.fp8-rowwise@1``'s per-row leaf and declares no
+    ``weight_block_size``; ``dense`` writes plain bf16.
+    """
+    cfg, model = _tiny_llama(hidden, inter)
+    out: dict[str, Any] = {}
+    for key, value in model.state_dict().items():
+        module = key[: -len(".weight")] if key.endswith(".weight") else None
+        eligible = (module is not None and value.ndim == 2
+                    and "embed_tokens" not in key and "lm_head" not in key)
+        if not eligible or kind == "dense":
+            out[key] = value
+            continue
+        if kind == "rowwise":
+            out[key] = value.to(torch.float8_e4m3fn)
+            out[f"{module}.weight_scale"] = torch.ones(
+                value.shape[0], dtype=torch.float32)
+            continue
+        q, s = _quantize_block(value)
+        out[key] = q
+        out[f"{module}.weight_scale_inv"] = s.T.contiguous() \
+            if kind == "transposed" else s
+    d.mkdir(parents=True, exist_ok=True)
+    save_file(out, str(d / "model.safetensors"))
+
+    conf = cfg.to_dict()
+    if kind == "blockwise" or kind == "transposed":
+        conf["quantization_config"] = {
+            "quant_method": "fp8",
+            "activation_scheme": "dynamic",
+            "weight_block_size": list(BLOCK),
+            "fmt": "e4m3",
+            "modules_to_not_convert": ["lm_head"],
+        }
+    elif kind == "rowwise":
+        conf["quantization_config"] = {
+            "quant_method": "fp8", "activation_scheme": "dynamic"}
+    (d / "config.json").write_text(json.dumps(conf), encoding="utf-8")
+
+
+def _tree(tmp_path: Path, kind: str, **kw: Any) -> Path:
+    root = tmp_path / kind
+    _write_component(root / COMPONENT, kind=kind, **kw)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "StableDiffusionPipeline",
+        COMPONENT: ["transformers", "LlamaForCausalLM"],
+    }), encoding="utf-8")
+    return root
+
+
+@pytest.fixture()
+def ran(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record WHICH decoder the production dispatch drove.
+
+    Both spies delegate to the real function — this instruments a real
+    end-to-end load, it does not stand in for one.
+    """
+    seen: list[str] = []
+    explicit = load_hf_fp8_blockwise
+    generic = LlamaForCausalLM.from_pretrained
+
+    def spy_explicit(*a: Any, **kw: Any) -> Any:
+        seen.append("gen_worker.models.hf_fp8_blockwise:load_hf_fp8_blockwise")
+        return explicit(*a, **kw)
+
+    def spy_generic(*a: Any, **kw: Any) -> Any:
+        seen.append("transformers:LlamaForCausalLM.from_pretrained")
+        return generic(*a, **kw)
+
+    monkeypatch.setattr(loading, "load_hf_fp8_blockwise", spy_explicit)
+    monkeypatch.setattr(
+        LlamaForCausalLM, "from_pretrained", staticmethod(spy_generic))
+    return seen
+
+
+def test_production_dispatch_runs_the_declared_blockwise_decoder(
+    tmp_path: Path, ran: list[str],
+) -> None:
+    """RED before pgw#1253: ``ran`` held only the generic from_pretrained."""
+    obj = load_component(_tree(tmp_path, "blockwise"), COMPONENT)
+
+    assert ran[0] == (
+        "gen_worker.models.hf_fp8_blockwise:load_hf_fp8_blockwise"), (
+        f"the declared hf.fp8-blockwise@1 decoder did not run; ran={ran}")
+    # and it produced a materialized module, not a shell.
+    weight = obj.model.layers[0].self_attn.q_proj.weight
+    assert not weight.is_meta and torch.isfinite(weight.float()).all()
+
+
+def test_transposed_scale_grid_refuses_through_the_production_dispatch(
+    tmp_path: Path,
+) -> None:
+    """The refusal that only exists on the explicit arm. No spies: the
+    dispatch either reaches the verifier or it does not.
+
+    RED before pgw#1253: this tree loaded, and every block scale was applied
+    to the wrong span of the wrong row.
+    """
+    root = _tree(tmp_path, "transposed", hidden=128, inter=384)
+    with pytest.raises(HfFp8BlockwiseLayoutError) as excinfo:
+        load_component(root, COMPONENT)
+    assert "mis-blocked" in str(excinfo.value)
+
+
+def test_rowwise_tree_is_not_claimed_by_the_blockwise_arm(
+    tmp_path: Path, ran: list[str],
+) -> None:
+    """Detection is the config's own claim: no ``weight_block_size``, no
+    claim. Over-claiming here would route ``cozy.fp8-rowwise@1`` bytes into a
+    128x128 reader, which is the conflation the two handles exist to stop."""
+    root = _tree(tmp_path, "rowwise")
+    assert detect_hf_fp8_blockwise(root / COMPONENT) is None
+    load_component(root, COMPONENT)
+    assert ran == ["transformers:LlamaForCausalLM.from_pretrained"]
+
+
+def test_dense_component_still_takes_the_generic_path(
+    tmp_path: Path, ran: list[str],
+) -> None:
+    root = _tree(tmp_path, "dense")
+    assert detect_hf_fp8_blockwise(root / COMPONENT) is None
+    load_component(root, COMPONENT)
+    assert ran == ["transformers:LlamaForCausalLM.from_pretrained"]


### PR DESCRIPTION
Closes **pgw#1253**.

## The defect, measured rather than read

`load_hf_fp8_blockwise` carried `@implements_contract(CONTRACT_HF_FP8_BLOCKWISE, …)`, so pgw#1245's derived `[decode_set]` told the hub this image decodes `hf.fp8-blockwise@1`. **Nothing in production called it.**

Resolved by RUNNING it. A real blockwise component fixture (header-only scale; no GPU, no weights on the box) driven through `load_component` — THE production loader for one named pipeline component — recorded:

```
FUNCTIONS THAT RAN: ['transformers:LlamaForCausalLM.from_pretrained']
```

The declared decoder did not execute. transformers reads `quantization_config` out of `config.json` by itself, so the tree decoded through the **generic arm — the one that declares `plain.bf16@1`** — and nothing ever failed to reveal it. The decode-set was true by accident: the contract was decodable, and not by the decoder that declared it.

## What the dead arm was costing

`inspect_hf_fp8_blockwise`'s verification, which is the whole value of the explicit decoder:

- a **TRANSPOSED scale grid** loaded through the production dispatch without complaint — every 128×128 block scale applied to the wrong span, plausible numbers, no exception;
- the `cozy.fp8-rowwise@1` refusal this contract exists to make (same element type, same activation scheme, different scale rank) could not fire on the production path at all.

## The fix

`contract_loaded_component` — the one dispatch the modular and non-modular component entry points share — gains an `hf.fp8-blockwise@1` arm. Detection is the tree's own claim and nothing else (`quantization_config.quant_method == "fp8"` with a `[block_m, block_n]` pair); a tree that makes the claim is then verified from headers before dispatch, so a mis-blocked grid **raises rather than falling through**, and a tree that makes no such claim is left alone so `cozy.fp8-rowwise@1` keeps its own arm.

The declaration now sits on running code. The contract is NOT removed from the set — the capability is real.

## Red-verified, per arm

By neutralizing the detection and re-running the same tests:

| test | with detection disabled |
|---|---|
| `test_production_dispatch_runs_the_declared_blockwise_decoder` | **RED** — `ran=['transformers:LlamaForCausalLM.from_pretrained']` |
| `test_transposed_scale_grid_refuses_through_the_production_dispatch` | **RED** — the tree loads, no refusal |
| `test_rowwise_tree_is_not_claimed_by_the_blockwise_arm` | green either way (it is a guard against over-claiming) |
| `test_dense_component_still_takes_the_generic_path` | green either way (same) |

These are **execution** assertions, not registration assertions: asserting a decoder is registered proves nothing about whether it runs, and that was literally the bug. The spies delegate to the real functions — this instruments a real end-to-end load, it does not stand in for one — and the transposed-grid arm uses no instrumentation at all.

## Did `lint_unreached_surface.py` miss it? No.

The issue guessed the module was exempted or satisfied by its test callers. It was neither. `gen_worker.models.hf_fp8_blockwise.load_hf_fp8_blockwise()` was **in the ratchet baseline**, added 2026-08-12 by pgw#1182 when the fence grew to the whole package. The guard found it and the finding was parked.

The gap is a different one, and it is now written into the baseline header: **pgw#1245 hung a hub-visible declaration on a function this file had already recorded as caller-less.** A derivation that reads the `@implements_contract` marker does not read the ratchet. The row is delisted by wiring — the guard goes red on a stale baseline line, which is how the fix was confirmed rather than assumed.

## Verification

- `mypy src/gen_worker tests tests_v2` — `Success: no issues found in 779 source files`
- all 16 `fast gates` lint scripts + `assemble_changelog.py --check` — exit 0
- targeted suites (decode-set, modular contract loader, component bindings/dtype/miss, th#1803, this file) — **70 passed**