### PR TITLE
pgw#1252: the decode-set constrains file_layout, by IMPORTING the ruled vocabulary

### DIFF
--- a/changelog.d/pgw1252.md
+++ b/changelog.d/pgw1252.md
@@ -1,0 +1,31 @@
+- **pgw#1252: the decode-set constrains `file_layout`, and the vocabulary is
+  IMPORTED rather than transcribed a fourth time.** `DecodeDimensions` gains a
+  required `file_layouts` axis whose tokens come from the one ruled home
+  (th#1937: `multi-file` | `single-file`, no aliases — a dead spelling fails
+  the BUILD where it is written). That home MOVED, `convert/file_layout.py` →
+  `models/file_layout.py`: the load side needs it and `models -> convert` is a
+  hard cycle (`convert/__init__` reaches `api.slot` and back into `models`,
+  measured as an `ImportError`, not assumed). `convert/` imports it from its new
+  home; `publish.validate_file_layout` and the decode-set now resolve to the
+  same function object, which a test asserts by identity.
+
+  **The declarations are what the code does, not what the checkpoint looks
+  like.** The svdq decoders declare `multi-file` ONLY — the nunchaku checkpoint
+  is one flat namespace, but BOTH engines refuse an artifact that is only that
+  file (`load_svdq_nunchaku_pipeline` / `load_svdq_native_pipeline` raise on
+  `not art.component`), and `convert/svdq.py` builds a full diffusers tree.
+  `plain.bf16@1` and `cozy.fp8-rowwise@1` read both shapes and say so;
+  `hf.fp8-blockwise@1` reads a transformers tree, which `classifier.py` stamps
+  `multi-file` as a pipeline subfolder and `single-file` as a root repo.
+
+  **The refusal is new information, not a restatement.** `require_decodable`
+  gains a third check — `decode_set_file_layout_unsupported`, naming the shape
+  observed and the shapes accepted, answered from directory shape before any
+  tensor is read. Before it, a bare single-file svdq snapshot reached the
+  engine selector and reported `no svdq engine can serve svdq-fp4 here … requires
+  a CUDA GPU` — a GPU complaint for an artifact no GPU would have fixed.
+
+  `loading._single_file_checkpoint` now decides its shape test through
+  `file_layout.is_single_file_snapshot`, so the loader's routing and the
+  declared axis cannot disagree about what "single-file" means, and the
+  observation costs no shard reassembly.

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from typing import Mapping, Optional, Sequence
 
 from gen_worker.api.errors import ValidationError
-from .file_layout import MULTI_FILE, SINGLE_FILE
+from ..models.file_layout import MULTI_FILE, SINGLE_FILE
 
 _PICKLE_EXTS = {".bin", ".pt", ".pth", ".ckpt", ".pickle", ".pkl"}
 _JUNK_EXTS = {

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -81,7 +81,7 @@ _KNOWN_DTYPES = {
     "q4_0", "q4_1", "q3_k_m", "q3_k_s", "q2_k",
 }
 from ..component_vocab import quant_candidate_components
-from .file_layout import KNOWN_FILE_LAYOUTS, MULTI_FILE, SINGLE_FILE
+from ..models.file_layout import KNOWN_FILE_LAYOUTS, MULTI_FILE, SINGLE_FILE
 
 _KNOWN_FILE_LAYOUTS = set(KNOWN_FILE_LAYOUTS)
 _KNOWN_FILE_TYPES = {"safetensors", "gguf"}

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -37,7 +37,7 @@ from .writer import streaming_dtype_cast
 from .writer import streaming_fp8_storage_cast
 from ..subproc import ProcessStalledError, run_process
 from .gguf_tools import (GGUF_TOOLCHAIN_STALL_WINDOW_S, prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
-from .file_layout import SINGLE_FILE
+from ..models.file_layout import SINGLE_FILE
 
 logger = logging.getLogger(__name__)
 

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -33,7 +33,7 @@ from ..net import hf, install_hf_http_timeouts
 from ..models.safetensors_header import header_len_ok
 from .classifier import RepoClassification, apply_source_include, classify_repo
 from .layout import detect_huggingface_source_layout
-from .file_layout import SINGLE_FILE
+from ..models.file_layout import SINGLE_FILE
 from huggingface_hub.errors import EntryNotFoundError, GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError
 
 

--- a/src/gen_worker/convert/layout.py
+++ b/src/gen_worker/convert/layout.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from .layout_spec import LayoutSignals, normalize_letters_digits
 from .registry import registered_layouts
-from .file_layout import MULTI_FILE, SINGLE_FILE
+from ..models.file_layout import MULTI_FILE, SINGLE_FILE
 
 _DEFAULT_SIGNALS = LayoutSignals()
 

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -28,7 +28,7 @@ from ..models.ladder import (
 from .dtype_pins import verify_produced_tree
 from .produced import ProducedFlavor
 from .writer import assert_one_file_per_component
-from .file_layout import validate_file_layout
+from ..models.file_layout import validate_file_layout
 
 _PLACEMENT_ATTR_KEYS = ("placement_sm_allowed", "placement_sm_min", "placement_engines")
 

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -24,7 +24,7 @@ from .writer import iter_source_tensors
 if TYPE_CHECKING:
     import torch
 
-from .file_layout import MULTI_FILE, SINGLE_FILE, FileLayout  # noqa: F401  (re-exported)
+from ..models.file_layout import MULTI_FILE, SINGLE_FILE, FileLayout  # noqa: F401  (re-exported)
 
 
 # Default set of component subdirs that the iter_hf_components passthrough

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -230,7 +230,7 @@ def _tensor_to_bytes(t: "torch.Tensor") -> Any:
 
 
 # ---------------------------------------------------------------------------
-from .file_layout import MULTI_FILE, SINGLE_FILE
+from ..models.file_layout import MULTI_FILE, SINGLE_FILE
 from ..component_vocab import (
     denoiser_components,
     text_encoder_components,

--- a/src/gen_worker/discovery/decode_set.py
+++ b/src/gen_worker/discovery/decode_set.py
@@ -52,6 +52,7 @@ DEFAULT_DECODER_PACKAGES: tuple[str, ...] = ("gen_worker.models",)
 REFUSAL_CONTRACT_UNDECLARED = "decode_set_contract_undeclared"
 REFUSAL_KEY_TOPOLOGY_UNSUPPORTED = "decode_set_key_topology_unsupported"
 REFUSAL_KEY_TOPOLOGY_UNCLASSIFIED = "decode_set_key_topology_unclassified"
+REFUSAL_FILE_LAYOUT_UNSUPPORTED = "decode_set_file_layout_unsupported"
 REFUSAL_DECODE_SET_DRIFT = "decode_set_drift"
 
 
@@ -188,6 +189,7 @@ def manifest_block(ds: DecodeSet) -> Dict[str, Any]:
                 "elements": list(e.decodes.elements),
                 "scales": list(e.decodes.scales),
                 "key_topologies": list(e.decodes.key_topologies),
+                "file_layouts": list(e.decodes.file_layouts),
                 "bakes": list(e.decodes.bakes),
             }
             for e in ds.entries
@@ -440,6 +442,57 @@ class KeyTopologyUnclassifiedError(Exception):
         )
 
 
+class FileLayoutUnsupportedError(Exception):
+    """The artifact's on-disk SHAPE is one no decoder of this contract reads.
+
+    A third fact, distinct from the handle and from the key convention: the
+    bytes may be exactly the right format, addressed in exactly the right
+    convention, and still arrive as a shape the decoder's entry point cannot
+    open. Measured case: both svdq engines refuse a bare single-file nunchaku
+    transformer — a servable flavor must be a full diffusers tree with the
+    checkpoint under its denoiser directory — and until this axis existed that
+    fact lived only in two `raise` statements reached AFTER the CUDA gate, so
+    a host without a GPU reported "svdq artifacts require a CUDA GPU" for an
+    artifact no GPU would have helped.
+    """
+
+    code = REFUSAL_FILE_LAYOUT_UNSUPPORTED
+
+    def __init__(
+        self,
+        contract: str,
+        *,
+        observed: str,
+        accepted: tuple[str, ...],
+        where: str = "",
+    ) -> None:
+        self.contract = contract
+        self.observed = observed
+        self.accepted = accepted
+        self.where = where
+        subject = f" at {where}" if where else ""
+        super().__init__(
+            f"the artifact{subject} is in file layout {observed!r}, which "
+            f"this image's {contract} decoder does not read (it accepts: "
+            f"{', '.join(accepted) or 'none'}). The bytes may be the right "
+            f"format in the right key convention and still be the wrong "
+            f"SHAPE — bind a variant published in an accepted layout, or ship "
+            f"an image whose decoder opens this one."
+        )
+
+
+def accepted_file_layouts(contract: str, ds: DecodeSet) -> tuple[str, ...]:
+    """Every on-disk shape this image's decoders of ``contract`` read."""
+    out: list[str] = []
+    for entry in ds.entries:
+        if entry.contract != contract:
+            continue
+        for token in entry.decodes.file_layouts:
+            if token not in out:
+                out.append(token)
+    return tuple(sorted(out))
+
+
 def accepted_key_topologies(contract: str, ds: DecodeSet) -> tuple[str, ...]:
     """Every key convention this image's decoders of ``contract`` ingest."""
     out: list[str] = []
@@ -458,17 +511,25 @@ def require_decodable(
     decode_set: Optional[DecodeSet] = None,
     where: str = "",
     keys: Optional["SnapshotKeys"] = None,
+    layout: str = "",
 ) -> None:
-    """Refuse, typed, unless this image can decode the artifact. Three checks,
-    three codes, all answered from headers before any tensor is read:
+    """Refuse, typed, unless this image can decode the artifact. Four checks,
+    four codes, all answered from headers and directory shape before any
+    tensor is read:
 
     1. ``contract`` is in the image's decode-set, else
        ``decode_set_contract_undeclared``;
-    2. the artifact's key convention was CLASSIFIED — a DENOISER tree matching
+    2. a decoder of ``contract`` reads the artifact's on-disk SHAPE, else
+       ``decode_set_file_layout_unsupported``;
+    3. the artifact's key convention was CLASSIFIED — a DENOISER tree matching
        no registered topology is ``decode_set_key_topology_unclassified``,
        never a hopeful pass;
-    3. a decoder of ``contract`` ingests that convention, else
+    4. a decoder of ``contract`` ingests that convention, else
        ``decode_set_key_topology_unsupported``.
+
+    ``layout`` is an OBSERVATION (``models.file_layout.observed_file_layout``),
+    and an empty one is an unclassifiable shape: not evaluated, the same
+    UNDECLARED rung an unconstrained axis takes.
 
     **What "unknown" does, stated so it cannot be misread:** for the DENOISER
     it REFUSES (check 2). For every other component — vae, text encoder,
@@ -487,6 +548,11 @@ def require_decodable(
             unregistered=ds.unregistered,
             where=where,
         )
+    if layout:
+        readable = accepted_file_layouts(contract, ds)
+        if readable and layout not in readable:
+            raise FileLayoutUnsupportedError(
+                contract, observed=layout, accepted=readable, where=where)
     if keys is None:
         return
     accepted = accepted_key_topologies(contract, ds)

--- a/src/gen_worker/models/file_layout.py
+++ b/src/gen_worker/models/file_layout.py
@@ -27,10 +27,18 @@ name on a layout value — a second collision on top of the first.  There are no
 aliases: tensorhub refuses a dead spelling at DECLARE with
 ``file_layout_unknown_token``, so this module is what keeps this repo's publishes
 speaking the language the hub accepts.
+
+It lives under ``models/`` rather than ``convert/`` (pgw#1252) because the LOAD
+side now reads it too: ``tensor_layout_contract`` declares a ``file_layouts``
+axis from these tokens. ``convert`` already imports ``models`` freely and the
+reverse is a hard cycle — measured, not assumed: ``convert/__init__`` reaches
+``api.slot`` and back into ``models``, so a ``models -> convert`` edge raises at
+import. One home, imported by both, and no copy in either.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Final, Literal
 
 #: A component-directory tree, read through a multi-component loader entry
@@ -79,11 +87,52 @@ def validate_file_layout(token: str) -> str:
     )
 
 
+def is_single_file_snapshot(path: Path) -> bool:
+    """The single-file SHAPE, from names alone.
+
+    The predicate half of ``loading._single_file_checkpoint``, split out of it
+    so the load-side observation and the loader's own routing decide from ONE
+    rule — and so the observation costs no shard reassembly.
+    """
+    if path.is_file():
+        return path.suffix == ".safetensors"
+    if not path.is_dir():
+        return False
+    if (path / "model_index.json").exists() or (path / "config.json").exists():
+        return False
+    singles = [p for p in path.glob("*.safetensors") if p.is_file()]
+    if len(singles) == 1:
+        return True
+    return bool(singles) and len(list(path.glob("*.safetensors.index.json"))) == 1
+
+
+def observed_file_layout(path: Path) -> str:
+    """The layout a tree ON DISK is in, or :data:`NOT_APPLICABLE`.
+
+    The same two shapes ``convert/classifier.py`` stamps at publish, read back
+    off the tree at load: a component-directory tree (``model_index.json`` /
+    ``config.json`` at the root of what is being read) is ``multi-file``;
+    a loose checkpoint is ``single-file``. Anything else states NOTHING rather
+    than guessing — an unclassifiable shape is not evaluated, which is the
+    tri-state's UNDECLARED rung and not a fail-open, since the contract handle
+    has already been checked by the time this is consulted.
+    """
+    p = Path(path)
+    if is_single_file_snapshot(p):
+        return SINGLE_FILE
+    if p.is_dir() and (
+            (p / "model_index.json").exists() or (p / "config.json").exists()):
+        return MULTI_FILE
+    return NOT_APPLICABLE
+
+
 __all__ = [
     "FileLayout",
     "KNOWN_FILE_LAYOUTS",
     "MULTI_FILE",
     "NOT_APPLICABLE",
     "SINGLE_FILE",
+    "is_single_file_snapshot",
+    "observed_file_layout",
     "validate_file_layout",
 ]

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -46,6 +46,7 @@ from typing import Any, Dict, Optional, Tuple
 import msgspec
 
 from .safetensors_header import header_len_ok
+from .file_layout import MULTI_FILE, SINGLE_FILE
 from .tensor_layout_contract import (
     CONTRACT_HF_FP8_BLOCKWISE,
     ELEMENT_BF16,
@@ -356,6 +357,12 @@ def _hf_model_class(path: Path, cls: Any) -> Any:
         scales=(SCALE_BLOCK_128X128,),
         # transformers' own loader, so transformers' own key convention.
         key_topologies=(KEYS_TRANSFORMERS_SPLIT_QKV,),
+        # BOTH, because this axis is about the ARTIFACT and `classifier.py`
+        # stamps a transformers tree either way: a component subfolder of a
+        # pipeline is `multi-file`, a root transformers repo is `single-file`.
+        # `AutoModel.from_pretrained` reads both, and `inspect_hf_fp8_blockwise`
+        # refuses by name in either shape if the bytes disagree.
+        file_layouts=(MULTI_FILE, SINGLE_FILE),
         bakes=(),
     ),
     why="th#1803: transformers' FineGrainedFP8 reads this layout natively — "

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -27,6 +27,12 @@ import struct
 
 from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
+from .file_layout import (
+    MULTI_FILE,
+    SINGLE_FILE,
+    is_single_file_snapshot,
+    observed_file_layout,
+)
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
     CONTRACT_HF_FP8_BLOCKWISE,
@@ -631,9 +637,10 @@ def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
     """Refuse, typed, before handing bytes to a decoder this IMAGE does not
     declare (pgw#1245).
 
-    Two questions, both answered from HEADERS, both before any tensor is read:
-    is this contract in the image's decode-set, and is the artifact's tensor-KEY
-    convention one a decoder of that contract ingests. The second is not the
+    Three questions, all answered from HEADERS and directory shape, all before
+    any tensor is read: is this contract in the image's decode-set, is the
+    artifact's on-disk SHAPE one a decoder of that contract opens, and is its
+    tensor-KEY convention one that decoder ingests. The third is not the
     first: `plain.bf16@1` minimax-native weights (fused `blocks.N.attn.qkv_proj`)
     and `plain.bf16@1` diffusers weights (split `to_q/to_k/to_v`) are the same
     contract, the same file topology and one key in common, and the diffusers
@@ -653,10 +660,12 @@ def require_decodable(contract: str, path: Any, *, component: str = "") -> None:
     from ..discovery.decode_set import require_decodable as _require
     from .key_topology import classify_snapshot
 
+    tree = Path(path) / component if component else Path(path)
     _require(
         contract,
         where=str(path),
         keys=classify_snapshot(Path(path), component),
+        layout=observed_file_layout(tree),
     )
 
 
@@ -744,13 +753,15 @@ def _single_file_checkpoint(path: Path) -> Optional[Path]:
     ``*.safetensors.index.json`` (the HF shard convention), so a big
     single-file checkpoint arrives as N shards. Those are reassembled once
     into the original file (mmap-backed, ~disk-copy cost) and cached in the
-    snapshot dir — ``from_single_file`` only takes one file."""
+    snapshot dir — ``from_single_file`` only takes one file.
+
+    The SHAPE test is :func:`file_layout.is_single_file_snapshot`, shared with
+    the load-side layout observation so the routing decision and the declared
+    axis cannot disagree about what "single-file" means."""
+    if not is_single_file_snapshot(path):
+        return None
     if path.is_file():
-        return path if path.suffix == ".safetensors" else None
-    if not path.is_dir():
-        return None
-    if (path / "model_index.json").exists() or (path / "config.json").exists():
-        return None
+        return path
     singles = sorted(p for p in path.glob("*.safetensors") if p.is_file())
     if len(singles) == 1:
         return singles[0]
@@ -2407,6 +2418,10 @@ def _load_modular_pipeline(
         # here: a minimax-native tree offered to this loader is refused by
         # name rather than dying as an md5 miss inside a detection helper.
         key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_SPLIT_QKV),
+        # BOTH, and each by its own entry point: a component-directory tree
+        # goes to `from_pretrained`, and `_single_file_checkpoint` routes a
+        # loose checkpoint to `from_single_file` (:2583).
+        file_layouts=(MULTI_FILE, SINGLE_FILE),
         bakes=(),
     ),
     why="the dense-weights path: plain bf16 bytes are read as stored "

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
+from .file_layout import MULTI_FILE
 from .tensor_layout_contract import (
     BAKE_LOW_RANK_BRANCH,
     CONTRACT_COZY_SVDQ_NVFP4_LR8,
@@ -504,6 +505,14 @@ def _decode_quantized_lowrank(
         # fixes the keys, so the fact lives on the HANDLE and a synonym for it
         # here would be a second home (th#1937 declined `contract.native`).
         key_topologies=(),
+        # MULTI-FILE ONLY, and it is the artifact that is constrained, not the
+        # checkpoint: the nunchaku file is one flat namespace, but BOTH svdq
+        # engines refuse an artifact that is only that file —
+        # `load_svdq_nunchaku_pipeline` and `load_svdq_native_pipeline` each
+        # raise on `not art.component` ("a servable flavor must be a full
+        # diffusers tree with the checkpoint under its denoiser directory"),
+        # and `convert/svdq.py` builds exactly that.
+        file_layouts=(MULTI_FILE,),
         bakes=(BAKE_LOW_RANK_BRANCH,),
     ),
     why="pgw#685: this is THE decoder of the nunchaku v1 single-file layout. "
@@ -518,6 +527,7 @@ def _decode_quantized_lowrank(
         elements=(ELEMENT_NVFP4, ELEMENT_INT4, ELEMENT_FP8_E4M3, ELEMENT_BF16),
         scales=(SCALE_GROUP_16, SCALE_PER_CHANNEL_OUT, SCALE_PER_TENSOR),
         key_topologies=(),
+        file_layouts=(MULTI_FILE,),   # same two engine refusals as above
         # The QUANTIZED low-rank branch is what separates this handle from
         # nunchaku.v1@1, and the handle is where that fact lives — the ruled
         # tensor-set registry names the SET, not the scheme it is stored in.

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -30,6 +30,7 @@ from typing import Any, Callable, Iterable, TypeVar
 import msgspec
 
 from .execution_lanes import known_execution_lane_bodies
+from .file_layout import KNOWN_FILE_LAYOUTS
 
 # The registered handles, transcribed from tensorhub's seeded registry. A
 # decoder naming anything else fails the BUILD: an unregistered contract is
@@ -61,7 +62,7 @@ _HANDLE_RE = re.compile(r"^([a-z0-9]+)\.([a-z0-9][a-z0-9._-]*)@([1-9][0-9]*)$")
 # shapes a given decoder reads, and the shapes are exactly where decoders
 # branch: `cozy.fp8-rowwise@1` is one handle whether or not the tree carries
 # the optional `input_scale` leaf, and a decoder that ignores it serves
-# different bytes than one that consumes it. So a declaration carries four
+# different bytes than one that consumes it. So a declaration carries five
 # axes, and th#1938's `resolve()` intersects a variant's derived contract
 # against them rather than against the handle alone.
 #
@@ -94,12 +95,11 @@ KNOWN_SCALES: tuple[str, ...] = (
     SCALE_STATIC_ACTIVATION, SCALE_BLOCK_128X128, SCALE_GROUP_16,
 )
 
-# NO file-layout axis here, deliberately. `file_layout` is RULED
-# (`multi-file` | `single-file`, th#1937) and its pgw home is the
-# `1937-file-layout-vocabulary` lane's `gen_worker/convert/file_layout.py`.
-# Transcribing those tokens here would be the second vocabulary this whole
-# programme exists to delete; the decode-set constrains the axis in a
-# follow-up that IMPORTS that module, once it is on master.
+# FILE LAYOUT — which on-disk shape the decoder's ENTRY POINT can read.
+# The tokens are th#1937's ruling and are IMPORTED from `models/file_layout.py`
+# (pgw#1252), never transcribed: that module is the same one `convert/` publishes
+# through, so the load side and the publish side cannot drift into two
+# spellings of one axis. `KNOWN_FILE_LAYOUTS` is `multi-file` | `single-file`.
 #
 # `pre_sharded` / `shard_axis` are likewise publish-side dimensions. No decoder
 # in this image branches on an SP-sharded tree and none can detect one, so the
@@ -158,7 +158,7 @@ KNOWN_KEY_TOPOLOGIES: tuple[str, ...] = (
 # constrain, rather than a synonym for its own handle.
 
 DECODE_AXES: tuple[str, ...] = (
-    "elements", "scales", "key_topologies", "bakes",
+    "elements", "scales", "key_topologies", "file_layouts", "bakes",
 )
 
 
@@ -167,8 +167,9 @@ class DecodeDimensions(msgspec.Struct, frozen=True, kw_only=True):
 
     Every axis is REQUIRED — there is no default, so a declaration cannot be
     written by omission. `elements` and `scales` must be non-empty: a decoder
-    that states nothing there has declared nothing. `key_topologies` and
-    `bakes` MAY be empty, and empty is a statement rather than a silence —
+    that states nothing there has declared nothing. `key_topologies`,
+    `file_layouts` and `bakes` MAY be empty, and empty is a statement rather
+    than a silence —
     "this decoder does not constrain the axis" (the tri-state's UNDECLARED
     rung), which is the honest answer for a decoder whose quant handle already
     fixes its keys, and the answer that makes a baked variant refuse.
@@ -177,6 +178,7 @@ class DecodeDimensions(msgspec.Struct, frozen=True, kw_only=True):
     elements: tuple[str, ...]
     scales: tuple[str, ...]
     key_topologies: tuple[str, ...]
+    file_layouts: tuple[str, ...]
     bakes: tuple[str, ...]
 
 
@@ -224,6 +226,10 @@ def _validate_dimensions(dims: object, *, where: str) -> DecodeDimensions:
                              known=KNOWN_KEY_TOPOLOGIES,
                              axis="key_topologies", where=where,
                              allow_empty=True),
+        file_layouts=_axis(dims.file_layouts,
+                           known=tuple(sorted(KNOWN_FILE_LAYOUTS)),
+                           axis="file_layouts", where=where,
+                           allow_empty=True),
         bakes=_axis(dims.bakes, known=KNOWN_BAKES, axis="bakes",
                     where=where, allow_empty=True),
     )

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
+from .file_layout import MULTI_FILE, SINGLE_FILE
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
     ELEMENT_BF16,
@@ -605,6 +606,10 @@ def _denoiser_class(root: Path, component: str) -> Any:
         # NAME, so the key convention it can ingest is whichever one that
         # class declares — the diffusers repackaging or a transformers tree.
         key_topologies=(KEYS_DIFFUSERS_SPLIT_QKV, KEYS_TRANSFORMERS_SPLIT_QKV),
+        # BOTH: `detect_w8a8_artifacts` scans the denoiser component dirs of a
+        # `model_index.json` tree, and otherwise the ROOT weight set — the
+        # singlefile / sharded-transformers layouts, per its own docstring.
+        file_layouts=(MULTI_FILE, SINGLE_FILE),
         bakes=(),
     ),
     why="gw#547: Fp8ScaledLinear reads lora_a/lora_b non-persistent buffers "

--- a/tests/convert/test_file_layout_vocabulary_th1937.py
+++ b/tests/convert/test_file_layout_vocabulary_th1937.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker.convert.clone import OutputSpec, normalize_outputs
-from gen_worker.convert.file_layout import (
+from gen_worker.models.file_layout import (
     KNOWN_FILE_LAYOUTS,
     MULTI_FILE,
     NOT_APPLICABLE,

--- a/tests/test_decode_set_file_layouts_pgw1252.py
+++ b/tests/test_decode_set_file_layouts_pgw1252.py
@@ -1,0 +1,189 @@
+"""pgw#1252: the decode-set's `file_layouts` axis — IMPORTED, and enforced.
+
+Two claims, each tested rather than asserted in prose.
+
+**One home.** The tokens come from `models/file_layout.py`, the same module
+`convert/` publishes through. The `models -> convert` direction the issue
+proposed is a HARD CYCLE (`convert/__init__` reaches `api.slot` and back into
+`models`), so the vocabulary moved rather than being copied — a transcription
+here would have been the fourth spelling of one axis.
+
+**A declaration nothing enforces is a declaration nothing can be wrong about.**
+The svdq decoders declare `multi-file` ONLY, and that is measured, not
+inherited from the checkpoint's shape: the nunchaku file is one flat namespace,
+but BOTH engines refuse an artifact that is only that file
+(`load_svdq_nunchaku_pipeline` / `load_svdq_native_pipeline`, `not
+art.component`). Before this axis that fact lived only in those two `raise`
+statements — reached AFTER the CUDA gate, so a GPU-less host reported "svdq
+artifacts require a CUDA GPU" for an artifact no GPU would have helped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from safetensors.torch import save_file  # noqa: E402
+
+from gen_worker.discovery.decode_set import (  # noqa: E402
+    REFUSAL_FILE_LAYOUT_UNSUPPORTED,
+    FileLayoutUnsupportedError,
+    accepted_file_layouts,
+    runtime_decode_set,
+)
+from gen_worker.models import file_layout as fl  # noqa: E402
+from gen_worker.models.loading import load_from_pretrained  # noqa: E402
+from gen_worker.models.svdq import detect_svdq_artifact  # noqa: E402
+from gen_worker.models.tensor_layout_contract import (  # noqa: E402
+    CONTRACT_NUNCHAKU_V1,
+    KNOWN_ELEMENTS,
+)
+
+SVDQ_META = {
+    "model_class": "NunchakuFluxTransformer2dModel",
+    "quantization_config": json.dumps({
+        "method": "svdquant",
+        "weight": {"dtype": "fp4_e2m1_all"},
+        "rank": 32,
+    }),
+}
+
+
+class _Pipe:
+    """A pipeline class shaped like the ones the loader dispatches on. Never
+    constructed: every arm under test refuses before any load."""
+
+    @staticmethod
+    def from_pretrained(*a: Any, **kw: Any) -> Any:  # pragma: no cover
+        raise AssertionError("the layout gate should have refused first")
+
+
+def _svdq_file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_file({"x": torch.zeros(4, dtype=torch.uint8)}, str(path),
+              metadata=SVDQ_META)
+
+
+# ── one home, imported ───────────────────────────────────────────────────────
+
+def test_the_axis_is_the_imported_vocabulary_not_a_transcription() -> None:
+    """Every declared token is a member of the ONE ruled set, and the publish
+    side validates through the same module object — not a same-looking copy."""
+    from gen_worker.convert import publish
+
+    assert getattr(publish, "validate_file_layout") is fl.validate_file_layout
+
+    declared = {
+        token
+        for entry in runtime_decode_set().entries
+        for token in entry.decodes.file_layouts
+    }
+    assert declared, "no decoder declares a file layout"
+    assert declared <= fl.KNOWN_FILE_LAYOUTS
+    # and the axis is not silently borrowing another axis's tokens
+    assert not (declared & set(KNOWN_ELEMENTS))
+
+
+def test_a_dead_spelling_cannot_be_declared() -> None:
+    """No aliases: the pre-th#1937 spellings fail the BUILD where they are
+    written, which is what stops a fourth one appearing."""
+    from gen_worker.models.tensor_layout_contract import (
+        CONTRACT_PLAIN_BF16,
+        DecodeDimensions,
+        implements_contract,
+    )
+
+    for dead in ("singlefile", "diffusers", "single_file"):
+        with pytest.raises(ValueError, match="is not registered"):
+            @implements_contract(
+                contract=CONTRACT_PLAIN_BF16, serves=("bf16-w16a16",),
+                composes_lora=False,
+                decodes=DecodeDimensions(
+                    elements=("bf16",), scales=("none",), key_topologies=(),
+                    file_layouts=(dead,), bakes=()),
+            )
+            def _dead(x: Any) -> Any:
+                return x
+
+    with pytest.raises(TypeError):
+        DecodeDimensions(  # type: ignore[call-arg]
+            elements=("bf16",), scales=("none",), key_topologies=(), bakes=())
+
+
+def test_every_decoder_declares_the_axis() -> None:
+    missing = [e.decoder for e in runtime_decode_set().entries
+               if not e.decodes.file_layouts]
+    assert missing == [], f"decoders with no file_layouts declaration: {missing}"
+
+
+# ── the observation agrees with what publish stamps ──────────────────────────
+
+def test_observed_layout_matches_the_publish_side_shapes(tmp_path: Path) -> None:
+    pipeline = tmp_path / "pipeline"
+    (pipeline / "transformer").mkdir(parents=True)
+    (pipeline / "model_index.json").write_text("{}", encoding="utf-8")
+    assert fl.observed_file_layout(pipeline) == fl.MULTI_FILE
+
+    loose = tmp_path / "loose"
+    loose.mkdir()
+    save_file({"x": torch.zeros(2)}, str(loose / "model.safetensors"))
+    assert fl.observed_file_layout(loose) == fl.SINGLE_FILE
+    assert fl.observed_file_layout(loose / "model.safetensors") == fl.SINGLE_FILE
+
+    # An unclassifiable shape states NOTHING rather than guessing.
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    assert fl.observed_file_layout(bare) == fl.NOT_APPLICABLE
+
+
+# ── the refusal, through the production dispatch ─────────────────────────────
+
+def test_single_file_svdq_snapshot_refuses_by_layout(tmp_path: Path) -> None:
+    """RED before pgw#1252: this reached the svdq lane and died on the CUDA
+    gate — `svdq artifacts require a CUDA GPU`, which is not the reason."""
+    snapshot = tmp_path / "bare-svdq"
+    _svdq_file(snapshot / "svdq-fp4_r32-flux.safetensors")
+    # The artifact really is detected as svdq, so the arm under test is reached.
+    art = detect_svdq_artifact(snapshot)
+    assert art is not None and art.component == ""
+
+    with pytest.raises(FileLayoutUnsupportedError) as excinfo:
+        load_from_pretrained(_Pipe, snapshot)
+    err = excinfo.value
+    assert err.code == REFUSAL_FILE_LAYOUT_UNSUPPORTED
+    assert err.observed == fl.SINGLE_FILE
+    assert err.accepted == (fl.MULTI_FILE,)
+    assert CONTRACT_NUNCHAKU_V1 in str(err)
+
+
+def test_multi_file_svdq_tree_passes_the_layout_gate(tmp_path: Path) -> None:
+    """The shape `convert/svdq.py` actually builds is admitted — the guard has
+    to let the real artifact through or it is just a refusal."""
+    snapshot = tmp_path / "flavor"
+    _svdq_file(snapshot / "transformer" / "svdq-fp4_r32-flux.safetensors")
+    (snapshot / "model_index.json").write_text(
+        json.dumps({"_class_name": "FluxPipeline"}), encoding="utf-8")
+    assert fl.observed_file_layout(snapshot) == fl.MULTI_FILE
+
+    art = detect_svdq_artifact(snapshot)
+    assert art is not None and art.component == "transformer"
+    # It gets past the layout gate and fails later, on the engine — which is
+    # the honest cause on a host with no CUDA.
+    with pytest.raises(Exception) as excinfo:
+        load_from_pretrained(_Pipe, snapshot)
+    assert not isinstance(excinfo.value, FileLayoutUnsupportedError)
+
+
+def test_an_unconstrained_contract_is_not_evaluated() -> None:
+    """`accepted_file_layouts` on a contract nothing declares returns (), and
+    an empty accepted set is the UNDECLARED rung — not a refusal of every
+    artifact."""
+    ds = runtime_decode_set()
+    assert accepted_file_layouts("plain.bf16@1", ds) == (
+        fl.MULTI_FILE, fl.SINGLE_FILE)
+    assert accepted_file_layouts("nope.nothing@9", ds) == ()

--- a/tests/test_decode_set_pgw1245.py
+++ b/tests/test_decode_set_pgw1245.py
@@ -74,7 +74,8 @@ from gen_worker.models.tensor_layout_contract import (
 @implements_contract(
     contract="{contract}", serves=("{body}",), composes_lora=False,
     decodes=DecodeDimensions(
-        elements=("{element}",), scales=("{scale}",), key_topologies=(), bakes=()),
+        elements=("{element}",), scales=("{scale}",), key_topologies=(),
+        file_layouts=(), bakes=()),
     why="fake decoder",
 )
 def decode(tensors):
@@ -228,7 +229,7 @@ def test_a_declaration_cannot_be_written_by_omission() -> None:
             composes_lora=False,
             decodes=DecodeDimensions(
                 elements=(), scales=("none",), key_topologies=(),
-                bakes=()),
+                file_layouts=(), bakes=()),
         )
         def _empty_axis(x):
             return x
@@ -239,7 +240,7 @@ def test_a_declaration_cannot_be_written_by_omission() -> None:
             composes_lora=False,
             decodes=DecodeDimensions(
                 elements=("fp6_e3m2",), scales=("none",),
-                key_topologies=(), bakes=()),
+                key_topologies=(), file_layouts=(), bakes=()),
         )
         def _invented_token(x):
             return x

--- a/tests/test_derived_execution_lanes_th1580.py
+++ b/tests/test_derived_execution_lanes_th1580.py
@@ -35,7 +35,7 @@ from gen_worker.models.tensor_layout_contract import (
 
 _DIMS = DecodeDimensions(
     elements=("bf16",), scales=("none",),
-    key_topologies=("diffusers.split-qkv@1",), bakes=())
+    key_topologies=("diffusers.split-qkv@1",), file_layouts=(), bakes=())
 
 _GOOD_A = '''
 from gen_worker.models.tensor_layout_contract import (
@@ -46,7 +46,7 @@ from gen_worker.models.tensor_layout_contract import (
     contract="nunchaku.v1@1", serves=("svdq-fp4-w4a4",), composes_lora=False,
     decodes=DecodeDimensions(
         elements=("nvfp4",), scales=("group_16",), key_topologies=(),
-        bakes=()),
+        file_layouts=(), bakes=()),
     why="fake svdq decoder",
 )
 def decode_svdq(tensors):
@@ -63,7 +63,7 @@ from gen_worker.models.tensor_layout_contract import (
     composes_lora=True,
     decodes=DecodeDimensions(
         elements=("fp8_e4m3",), scales=("per_channel_out",),
-        key_topologies=("diffusers.split-qkv@1",), bakes=()),
+        key_topologies=("diffusers.split-qkv@1",), file_layouts=(), bakes=()),
     why="fake fp8 decoder",
 )
 def decode_fp8(tensors):
@@ -84,7 +84,7 @@ from gen_worker.models.tensor_layout_contract import (
     composes_lora=False,
     decodes=DecodeDimensions(
         elements=("nvfp4",), scales=("per_tensor",), key_topologies=(),
-        bakes=()),
+        file_layouts=(), bakes=()),
     why="never reached",
 )
 def decode_nvfp4(tensors):


### PR DESCRIPTION
Closes **pgw#1252**.

`DecodeDimensions` gains a required `file_layouts` axis. The tokens come from the ONE ruled home (th#1937: `multi-file` | `single-file`, no aliases — a dead spelling fails the BUILD where it is written).

## The home moved, and that was measured

The issue proposed importing `convert/file_layout.py` from `models/`, and named the fallback if that direction was wrong. It is wrong, and it is a hard cycle — probed, not assumed:

```
from gen_worker.convert.file_layout import KNOWN_FILE_LAYOUTS
  -> gen_worker/convert/__init__.py:21  from .clone import CloneResult
  -> gen_worker/convert/clone.py:28     from ..api.slot import OBJECTIVES
ImportError: cannot import name 'OBJECTIVES' from partially initialized module
             'gen_worker.api.slot' (most likely due to a circular import)
```

So the module moved to `models/file_layout.py` — which `convert/` already depends on freely — and all eight `convert/` importers were repointed. **One home, imported by both sides, no copy:** the test asserts it by object identity (`publish.validate_file_layout is file_layout.validate_file_layout`), which a transcription cannot satisfy.

What I would have transcribed if I had not imported: `MULTI_FILE`, `SINGLE_FILE`, `NOT_APPLICABLE`, `KNOWN_FILE_LAYOUTS`, `validate_file_layout` and the six dead-spelling remedies — i.e. the fourth spelling of an axis that already had three.

## The declarations are what the code does, not what the checkpoint looks like

The issue's sketch said *"svdq reads single-file"*. **Measured against the installed code, it does not.** The nunchaku checkpoint is one flat namespace, but both svdq engines refuse an artifact that is only that file:

> `svdq snapshot {path} is a bare single-file transformer; a servable flavor must be a full diffusers tree with the checkpoint under its denoiser directory`
> — `load_svdq_nunchaku_pipeline` and `load_svdq_native_pipeline`, both on `not art.component`

and `convert/svdq.py:build_svdq_flavor_tree` builds exactly that tree (it refuses a base without `model_index.json`). So svdq declares **`multi-file` only**. Had I taken the sketch as written, every svdq flavor we produce would have been refused by th#1938.

The derived set:

| contract | decoder | `file_layouts` | why |
|---|---|---|---|
| `plain.bf16@1` | `load_from_pretrained` | multi-file, single-file | component tree → `from_pretrained`; `_single_file_checkpoint` routes a loose checkpoint → `from_single_file` |
| `cozy.fp8-rowwise@1` | `load_w8a8_denoiser` | multi-file, single-file | `detect_w8a8_artifacts` scans denoiser component dirs, else the ROOT weight set |
| `nunchaku.v1@1` | `decode_linear` | multi-file | both engines refuse `not art.component` |
| `cozy.svdq-nvfp4-lr8@1` | `decode_linear` | multi-file | same two refusals |
| `hf.fp8-blockwise@1` | `load_hf_fp8_blockwise` | multi-file, single-file | `classifier.py` stamps a transformers tree `multi-file` as a pipeline subfolder and `single-file` as a root repo |

## The refusal is new information, not a restatement

`require_decodable` gains a third check: `decode_set_file_layout_unsupported`, naming the shape observed and the shapes accepted, answered from directory shape before any tensor is read.

**Red-verified** by neutralizing the check and re-running — a bare single-file svdq snapshot today reaches the engine selector:

> `no svdq engine can serve svdq-fp4 here — native: native svdq-fp4 requires a CUDA GPU; nunchaku: nunchaku is not installed`

A GPU complaint for an artifact no GPU would have fixed. With the axis it is `decode_set_file_layout_unsupported`, `observed='single-file'`, `accepted=('multi-file',)`. The multi-file arm passes the gate either way, which is what makes it a guard rather than a second copy of the refusal.

`loading._single_file_checkpoint` now decides its shape through `file_layout.is_single_file_snapshot`, so the loader's routing and the declared axis cannot disagree about what "single-file" means — and the observation costs no shard reassembly.

## Note for th#1937 / th#1938

`file_layout.py`'s docstring defines `single-file` as *"one flat key namespace, read through a single-file entry point (`from_single_file`)"*, but `convert/classifier.py` stamps `single-file` on a **root transformers repo**, which is read by `AutoModel.from_pretrained`. Both uses are live; the declarations here are written against what the classifier stamps, since that is what th#1938 intersects. Flagging rather than re-ruling — the vocabulary is th#1937's.

## Verification

- `mypy src/gen_worker tests tests_v2` — `Success: no issues found in 781 source files`
- all 16 `fast gates` lint scripts + `assemble_changelog.py --check` — exit 0
- targeted suites: decode-set, execution lanes, th#1937 vocabulary, th#1803, pgw#1253 dispatch, svdq layout, layout converters, slot demand, modular loader, component bindings — **130 passed**; plus the convert/publish/classifier/clone/ingest/writer/loading selection — **342 passed**
- pre-existing `DecodeDimensions(...)` fixtures in `test_decode_set_pgw1245.py` and `test_derived_execution_lanes_th1580.py` updated for the new required axis — that they had to be is the axis working as designed