### PR TITLE
pgw#1268: the required `fast gates` job loses its draft guard — a skipped required check is scored as SATISFIED

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,8 +208,8 @@ on:
     - cron: '17 9 * * *'
   pull_request:
     branches: [master]
-    # `ready_for_review` is NOT a default `pull_request` type, and the jobs below
-    # skip drafts. Without it listed here a lane that opens a draft, pushes, then
+    # `ready_for_review` is NOT a default `pull_request` type, and `tests` below
+    # skips drafts. Without it listed here a lane that opens a draft, pushes, then
     # clicks "Ready for review" gets NO run for the head it actually merges —
     # the same invisible-green this issue exists to remove.
     types: [opened, synchronize, reopened, ready_for_review]
@@ -227,12 +227,16 @@ jobs:
   # behind an 11-minute pytest run.
   gates:
     name: fast gates
-    # `merge_group` is listed FIRST and explicitly: on that event
-    # `github.event.pull_request` is null, so the draft clause alone skips the
-    # job and GitHub scores the skip as a satisfied required check (pgw#1209).
-    # This is the repo's ONLY required context (pgw#1264) — the merge-group arm
-    # of this condition is what the queue actually waits on. Do not weaken it.
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.pull_request.draft == false
+    # pgw#1268: this job has NO `if:` and must never grow one. It is the repo's
+    # only required context, and GitHub scores a SKIPPED required check as
+    # SATISFIED — so any condition here is a false-green generator. Measured on
+    # th#1223 (2026-08-14): a run triggered while the PR was a draft evaluated
+    # `github.event.pull_request.draft == false` as false, the job skipped, and
+    # the PR read fully green having run nothing. Undrafting produced no new run
+    # (the sha already had one) and re-running replays the original draft=true
+    # payload, so the lane escaped only by force-pushing a no-op amend. The same
+    # clause is false on `merge_group`, where `github.event.pull_request` is null.
+    # At ~1m35s the draft guard saved a rounding error; unconditional is the fix.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## The defect, measured live

On tensorhub #1223 (2026-08-14), undrafting a PR produced **no new workflow
run** — the last run on that sha had been triggered while the PR was still a
draft, so the required job's `if:` guard `github.event.pull_request.draft ==
false` was FALSE and the job **skipped**. **GitHub scores a skipped required
check as SATISFIED.** The PR read fully green with the required job never
having executed. Re-running the existing run does not help: a rerun replays the
original event payload, where `draft == true`. The lane escaped only by
force-pushing a no-op amend to mint a new sha.

Two independent routes to it:

1. `on.pull_request` with no `types:` defaults to `[opened, synchronize,
   reopened]` — which **excludes `ready_for_review`**. Undrafting fires nothing.
2. `concurrency` + `cancel-in-progress: true`: a `ready_for_review` run landing
   seconds after a push run collides in the same group and one of them dies.

## The fix

**Delete the draft guard from every REQUIRED job**, so it runs unconditionally
on every event the workflow receives. A job that always runs can never be
skipped-and-satisfied — that closes both routes at once and does not depend on
getting `types:` or concurrency keys subtly right. It also removes the reason
these conditions kept growing explicit `merge_group` / `workflow_call` /
`schedule` arms: on those events `github.event.pull_request` is null.

Non-required jobs (the expensive suites) **keep** their draft guards — that is
where the real saving is, and nothing gates on them, so they cannot produce a
false green. `merge_group:` triggers and PR-scoped `concurrency` are untouched.

The guard existed to save money when required jobs were slow. After th#1965
every required job in this repo is fast, so it now buys a rounding error and
costs a whole class of false green.

## Evidence

Opened as a DRAFT on purpose, and verified through the **jobs API** — the check
rollup cannot distinguish "passed" from "skipped and therefore satisfied",
which is what hid this for so long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
