### PR TITLE
pgw#1265 (th#1959): the adopt asks whether a SERVE still fits, and can give the arm back

### DIFF
--- a/changelog.d/pgw1265.md
+++ b/changelog.d/pgw1265.md
@@ -1,0 +1,25 @@
+- The ADOPT now asks whether a SERVE still fits before it spends the card, and can give the
+  arm back when the answer is no (pgw#1265, th#1959). Live four times on 2026-08-14 as
+  `ComputeProcessDied: cause=signal:SIGSEGV function=generate` on z-image: 32.01 GiB resident of
+  44.42 GiB, the adopt loads a runner and runs the §4.32 gate's two forwards beside it, and the
+  process dies with 17.9 MiB free — then crash-loops, which the hub reads as demand and buys
+  more pods for. `_bind_headroom` catches a CATCHABLE bind OOM, but this SDK imposes
+  `expandable_segments:True`, under which exhaustion is a native mapping abort no `except` sees,
+  so the leg that actually fires cannot return a refusal at all. `adopt_fit` therefore asks one
+  question first, from two quantities MEASURED at the decision point: usable device memory
+  (`mem_get_info` free plus reclaimable allocator cache) against the largest transient one
+  forward has actually taken in this process on this card. No margin, no factor, no floor, no
+  bank — pgw#1205's device-peak bank stays measurement-only, and pgw#1164's deleted
+  `adopt_headroom` estimate (`2 * activation` off an unmeasured fraction, refusing stickily) is
+  not rebuilt. Nothing measured yet, or an unprobeable device, FITS BY CONSTRUCTION: the gate
+  only ever speaks from evidence this process produced. The verdict is taken before the load,
+  before the parity gate's forwards, before returning an armed outcome, and again at
+  `_advertise_compiled_graphs` before `active_compile_ref` flips — and a negative verdict
+  ABANDONS: the entry de-arms (sticky for the boot, so it cannot become a retry loop), its
+  runner is released, nothing is advertised, and the pod serves EAGER and stays alive. The
+  artifact is neither condemned nor unpublished; a full card is a fact about this pod at this
+  instant. Also fixed alongside: `hot_swap.enable` was called even when every target had just
+  been rolled back to eager for want of a guard revocation signal, and the advertisement — which
+  touches the live compiled objects — now holds pgw#1255/pgw#1262's `postmortem.compile_inflight`
+  marker, so a signal death there is charged to the compile and pgw#714's eager-only reboot
+  fires instead of another crash-loop.

--- a/src/gen_worker/adopt_fit.py
+++ b/src/gen_worker/adopt_fit.py
@@ -37,6 +37,19 @@ the card's.
 FIT BY CONSTRUCTION, exactly like every other budget in this tree. An honest
 under-refusal beats a number invented to look like a bound; the refusal only
 ever fires on evidence this process produced itself.
+
+**THE RESIDENT FLOOR IS NEVER COMPUTED HERE, AND MUST NOT BE.** ``have`` is the
+DRIVER's free figure, so every byte anything holds on this card — this record's
+weights, a sibling instance's, and any component a placement rung kept resident
+rather than offloading (ie#721's exclusion set) — is already subtracted from it
+before this module sees it. There is deliberately no floor term to keep in step
+with `models/memory.place_pipeline`: a second derivation of a quantity the card
+already reports is how two subsystems come to disagree about it. If a future
+change wants the exclusion accounted for, it is accounted for — by observation,
+at the instant of the decision, which is stronger than any published set could
+be. The one thing this cannot see is a floor that rises AFTER the verdict (a
+rung transition, a sibling's rotation); no pre-check can, and that residue is
+exactly what the serve-time allocator-exhaustion ruling covers.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/adopt_fit.py
+++ b/src/gen_worker/adopt_fit.py
@@ -1,0 +1,195 @@
+"""Does a SERVE still fit after this adopt? (pgw#1265)
+
+The adopt raises this pod's residency floor permanently: the loaded runner
+stays resident for the life of the arm, and the §4.32 parity gate runs two
+forwards beside it. Nothing asked whether what it was about to allocate fit.
+Measured 2026-08-14 on z-image, four times in one day: resident 32.01 GiB of
+44.42 GiB before the adopt (three functions, two full pipelines), then
+``ComputeProcessDied: cause=signal:SIGSEGV function=generate`` with 17.9 MiB
+free. The exhaustion is UNCATCHABLE — this SDK imposes
+``expandable_segments:True`` (``settings_authority.py``), under which running
+out is a native mapping abort no ``except`` sees — so ``_bind_headroom``'s
+attempt-and-catch, which is the honest gate for a CATCHABLE bind OOM, cannot
+be the whole answer. A query has to run first.
+
+**What this is NOT.** ``mint_budget.adopt_headroom`` (pgw#1164) was deleted for
+cause in pgw#1175: it PREDICTED the arm's cost as ``2 * activation`` where
+``activation`` was an admittedly unmeasured quarter of a resident set the free
+figure already excluded, and it refused stickily. It could not refuse the
+failure it was written for and did refuse cards that were fine. Nothing here
+predicts the adopt's cost, no bank is read (pgw#1205's device-peak bank stays
+measurement-only), and there is no margin, factor or floor constant to tune.
+
+**The two terms, both measured, both at the decision point.**
+
+``have`` — ``torch.cuda.mem_get_info`` free plus the allocator cache this
+process can hand back (``reserved - allocated``), the identical construction
+``hot_swap._headroom_ok`` already uses.
+
+``need`` — the largest device transient ONE forward has actually taken in this
+process on this card, banked nowhere and bracketed at the seams every forward
+passes (the executor's warm forward and its request invoke). It is keyed by
+DEVICE, not by pipeline, deliberately: a release serving three functions holds
+several pipelines on one card, and the question "can a serve still run here" is
+the card's.
+
+``need == 0`` (nothing has been measured yet) and an unprobeable device both
+FIT BY CONSTRUCTION, exactly like every other budget in this tree. An honest
+under-refusal beats a number invented to look like a bound; the refusal only
+ever fires on evidence this process produced itself.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+#: The typed refusal reason. A CAPACITY verdict about this pod at this instant
+#: — never a contract verdict about the artifact, which is what quarantines a
+#: key (th#1819). Another pod, or this one with less resident, adopts it fine.
+REASON = "insufficient_adopt_headroom"
+
+_GIB = float(1 << 30)
+
+_lock = threading.Lock()
+#: device index -> the largest single-forward device transient measured in this
+#: process. In-process only: it dies with the worker, is never persisted, never
+#: emitted as a bank row, and never read by a width or placement decision.
+_forward_peak: Dict[int, int] = {}
+
+
+def _torch() -> Any:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return torch
+    except Exception:  # noqa: BLE001 — a probe never changes an outcome
+        return None
+
+
+def _device_index(device: Optional[int]) -> Optional[int]:
+    torch = _torch()
+    if torch is None:
+        return None
+    try:
+        return int(torch.cuda.current_device()) if device is None else int(device)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def record_forward_peak(device: Optional[int], transient: int) -> None:
+    """Bank ONE forward's measured device transient, monotonically."""
+    index = _device_index(device)
+    if index is None or transient <= 0:
+        return
+    with _lock:
+        if transient > _forward_peak.get(index, 0):
+            _forward_peak[index] = int(transient)
+
+
+def forward_peak(device: Optional[int] = None) -> int:
+    """The largest single-forward transient measured on this device, or 0."""
+    index = _device_index(device)
+    if index is None:
+        return 0
+    with _lock:
+        return int(_forward_peak.get(index, 0))
+
+
+def reset() -> None:
+    """Forget every measurement (tests; a fresh process starts here anyway)."""
+    with _lock:
+        _forward_peak.clear()
+
+
+@contextlib.contextmanager
+def forward_watermark(device: Optional[int] = None) -> Iterator[None]:
+    """Bracket ONE forward and record what it transiently cost the device.
+
+    ``max_memory_allocated`` is process-monotone and shared with other readers,
+    so it is never reset here (pgw#652's activation learning reads the same
+    counter): the transient is ``peak_after - allocated_at_entry``, which is
+    this span's own high-water above the resident set it started from. A span
+    that allocates nothing new records nothing.
+    """
+    torch = _torch()
+    index = _device_index(device)
+    if torch is None or index is None:
+        yield
+        return
+    try:
+        before = int(torch.cuda.memory_allocated(index))
+    except Exception:  # noqa: BLE001
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            peak = int(torch.cuda.max_memory_allocated(index))
+            record_forward_peak(index, peak - before)
+        except Exception:  # noqa: BLE001 — telemetry never fails a forward
+            logger.debug("adopt-fit: forward watermark failed", exc_info=True)
+
+
+def headroom(device: Optional[int] = None) -> Optional[int]:
+    """Device bytes a new allocation could actually get, or ``None`` when the
+    device cannot be probed. Driver-free plus the allocator cache this process
+    can return — cached blocks are headroom, and counting only ``free`` would
+    refuse a card holding a large idle cache."""
+    torch = _torch()
+    index = _device_index(device)
+    if torch is None or index is None:
+        return None
+    try:
+        free, _total = torch.cuda.mem_get_info(index)
+        reclaimable = max(
+            0,
+            int(torch.cuda.memory_reserved(index))
+            - int(torch.cuda.memory_allocated(index)),
+        )
+        return int(free) + reclaimable
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def refusal(what: str, device: Optional[int] = None) -> str:
+    """``""`` when ``what`` may proceed; else the typed refusal's detail.
+
+    Fits by construction when nothing has been measured on this device yet, or
+    when the device cannot be probed. Both are the deliberate under-refusal:
+    this gate only ever speaks from evidence this process produced.
+    """
+    need = forward_peak(device)
+    if need <= 0:
+        return ""
+    have = headroom(device)
+    if have is None or have >= need:
+        return ""
+    return (
+        f"{what}: this pod has {have / _GIB:.3f} GiB of usable device memory "
+        f"(free + reclaimable cache) and ONE forward on this card has measured "
+        f"a {need / _GIB:.3f} GiB transient in this process, so a serve would "
+        f"not fit beside what the adopt is about to hold. Adoption is "
+        f"abandoned; this pod serves EAGER and stays alive. Nothing is said "
+        f"about the artifact — this is a fact about the card at this instant, "
+        f"and another pod, or this one with less resident, adopts it fine "
+        f"(pgw#1265)"
+    )
+
+
+__all__ = [
+    "REASON",
+    "forward_peak",
+    "forward_watermark",
+    "headroom",
+    "record_forward_peak",
+    "refusal",
+    "reset",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -29,6 +29,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Tupl
 import msgspec
 
 from . import activity as activity_mod
+from . import adopt_fit
 from . import aot_declaration, aot_identity, aot_mint
 from . import boot_adopt
 from . import boot_phases as boot_mod
@@ -5080,19 +5081,24 @@ class Executor:
         inflight_token = postmortem.note_inflight(
             "warmup", spec.name, request_id=str(ctx.request_id or ""))
         try:
-            if spec.is_async_gen:
-                async for _ in bound(**call_kwargs):
-                    pass
-            elif spec.is_async:
-                await bound(**call_kwargs)
-            else:
-                def _consume() -> None:
-                    out = bound(**call_kwargs)
-                    if spec.output_mode == "stream":
-                        for _ in out:
-                            pass
+            # pgw#1265: mint seeds and the boot warm forward go through here
+            # and nowhere else, so this is what gives the adopt's headroom
+            # verdict a measurement on a pod that has not served a tenant
+            # request yet — which is every pod that mints at boot.
+            with adopt_fit.forward_watermark():
+                if spec.is_async_gen:
+                    async for _ in bound(**call_kwargs):
+                        pass
+                elif spec.is_async:
+                    await bound(**call_kwargs)
+                else:
+                    def _consume() -> None:
+                        out = bound(**call_kwargs)
+                        if spec.output_mode == "stream":
+                            for _ in out:
+                                pass
 
-                await _to_thread_complete(_consume)
+                    await _to_thread_complete(_consume)
             # pgw#1199: THE proof, recorded where it already happens. This call
             # is the endpoint's own handler, running on the RESIDENT pipeline
             # with real checkpoint values, and every warm path in this process
@@ -8165,27 +8171,90 @@ class Executor:
         rec.eager_posture = ""
         for pid, outcome in finalized.items():
             pipe = bg.pipes[pid]
-            for target in rec.compile_targets.values():
-                if target.pipeline is not pipe:
-                    continue
-                with target.state_lock:
-                    target.active_compile_ref = str(outcome.ref)
-                    target.active_compile_snapshot_digest = str(
-                        outcome.snapshot_digest)
-                    target.active_self_mint = True
-                # pgw#686: the mint stamped the pipe's lane; re-advertise so
-                # the target's lane/bucket/contract descriptors match what it
-                # now serves.
-                self._refresh_compile_target(target)
-                if not self._bind_compile_guard(rec, target):
+            # pgw#1265: THE FLIP IS CHECKED BEFORE IT HAPPENS. Between the arm
+            # (where `arm_aot` took the same verdict) and here sit the publish
+            # and whatever a sibling instance did to the card meanwhile, so the
+            # question is asked again about the state that actually exists at
+            # the flip. The advertisement is a claim that this pipe SERVES
+            # compiled; making it on a card that can no longer fit a forward is
+            # how a mint's last step became a SIGSEGV and then a crash-loop the
+            # hub read as demand (th#1959).
+            device = mint_workers.device_of(pipe)
+            no_room = adopt_fit.refusal(
+                f"advertising the compiled graphs for {bg.spec.name}", device)
+            if no_room:
+                self._abandon_advertisement(rec, pipe, outcome, no_room)
+                continue
+            armed_here = False
+            # pgw#1262's marker, one question over: binding the guard and
+            # flipping the router touch the live compiled objects, so a signal
+            # death here is a compile's, not the tenant's.
+            with postmortem.compile_inflight(f"advertise:{bg.spec.name}"):
+                for target in rec.compile_targets.values():
+                    if target.pipeline is not pipe:
+                        continue
                     with target.state_lock:
-                        target.active_compile_ref = ""
-                        target.active_compile_snapshot_digest = ""
-                    logger.warning(
-                        "compile target %s has no runtime guard revocation "
-                        "signal; advertising eager", target.incarnation_id)
-                    continue
-            hot_swap.enable(pipe)
+                        target.active_compile_ref = str(outcome.ref)
+                        target.active_compile_snapshot_digest = str(
+                            outcome.snapshot_digest)
+                        target.active_self_mint = True
+                    # pgw#686: the mint stamped the pipe's lane; re-advertise so
+                    # the target's lane/bucket/contract descriptors match what it
+                    # now serves.
+                    self._refresh_compile_target(target)
+                    if not self._bind_compile_guard(rec, target):
+                        with target.state_lock:
+                            target.active_compile_ref = ""
+                            target.active_compile_snapshot_digest = ""
+                        logger.warning(
+                            "compile target %s has no runtime guard revocation "
+                            "signal; advertising eager", target.incarnation_id)
+                        continue
+                    armed_here = True
+                # pgw#1265: eager-while-compiling is turned on for a pipe that
+                # ADVERTISES something. Unconditional, it enabled concurrent
+                # routing on a pipe whose every target had just been rolled
+                # back to eager for want of a revocation signal.
+                if armed_here:
+                    hot_swap.enable(pipe)
+
+    def _abandon_advertisement(
+        self, rec: "_ClassRecord", pipe: Any, outcome: Any, detail: str,
+    ) -> None:
+        """pgw#1265: refuse the flip and GIVE THE ARM BACK.
+
+        Invariants 2 and 3 at the wire seam. Nothing is advertised, so no
+        capability projection claims a compiled tier; the armed entries are
+        de-armed and their runners released, so the residency floor this adopt
+        raised comes back down; and the de-arm is sticky for the boot, so the
+        next request cannot walk into the same refusal. The worker serves
+        eager and stays alive — which is the whole difference between a
+        degraded pod and `ComputeProcessDied`.
+
+        The artifact is not condemned and stays PUBLISHED: it was minted and
+        parity-gated by this process, and a card that is full at this instant
+        says nothing about it.
+        """
+        for target in rec.compile_targets.values():
+            if target.pipeline is not pipe:
+                continue
+            with target.state_lock:
+                target.active_compile_ref = ""
+                target.active_compile_snapshot_digest = ""
+                target.active_self_mint = False
+        for entry in list(aot_serve.entry_states(pipe)):
+            try:
+                aot_serve.disarm_entry(pipe, entry, adopt_fit.REASON)
+            except Exception:  # noqa: BLE001 — the refusal survives its cleanup
+                logger.warning(
+                    "adopt-fit: de-arming %r at the advertisement failed",
+                    entry, exc_info=True)
+        flush_memory()
+        logger.warning("adopt-fit: %s", detail)
+        activity_mod.emit_event(
+            "adopt_headroom_refused", detail, phase=adopt_fit.REASON,
+            cell_key=str(getattr(outcome, "ref", "") or ""),
+        )
 
     async def _supervise_mint(
         self, rec: _ClassRecord, bg: "_BackgroundMint", act: Any,
@@ -10631,7 +10700,11 @@ class Executor:
         # interval runtime_ms measures).
         ctx._stages.handler_open()
         try:
-            with _HandlerEvidence(owner):
+            # pgw#1265: the tenant forward is where "what does one forward cost
+            # this card" is MEASURED. The adopt's headroom verdict has no other
+            # source of truth — and this is the same forward, on the same card,
+            # that a raised residency floor would have to make room for.
+            with adopt_fit.forward_watermark(gpu_index), _HandlerEvidence(owner):
                 while True:
                     try:
                         return await asyncio.wait_for(

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -48,9 +48,10 @@ from .loading import (
     load_from_pretrained,
     model_index_components,
 )
-from .memory import place_pipeline
+from .memory import flush_memory, place_pipeline
 from .refs import DEFAULT_REF_TAG, parse_model_ref
 from .. import activity as activity_mod
+from .. import adopt_fit
 from .. import mint_workers
 from .. import postmortem
 
@@ -270,6 +271,43 @@ def arm_route(mode: str) -> Optional[str]:
     return {
         "": "aot_serve.enable",
     }.get(str(mode or ""))
+
+
+def _abandon_adopt(
+    pipe: Any, meta: Optional[Dict[str, Any]], detail: str, *, entry: str,
+) -> None:
+    """Give the adopt back (pgw#1265): de-arm, RELEASE, say so, serve eager.
+
+    The half `_bind_headroom` never needed. A catchable bind OOM refuses before
+    the first live mutation, so the pipeline is already as eager as it was
+    found; a headroom verdict taken AFTER the arm is looking at a pipeline that
+    has been mutated and at a runner that is holding device memory. Abandoning
+    means both come back: :func:`aot_serve.disarm_entry` drops the runner from
+    the dispatch and restores the target's eager callable, and
+    ``flush_memory`` is what turns a dropped reference into free bytes — the
+    whole point is that the floor this adopt raised comes back down.
+
+    The de-arm is sticky for the boot (§4.31), which is invariant 3: this class
+    cannot be re-armed in this process, so a refused adopt cannot become a
+    retry loop that pays the load again on a card that is already full.
+    """
+    from .. import aot_serve
+
+    family = str((meta or {}).get("family") or "")
+    if entry:
+        try:
+            aot_serve.disarm_entry(pipe, entry, adopt_fit.REASON)
+        except Exception:  # noqa: BLE001 — the refusal must survive its cleanup
+            logger.warning(
+                "adopt-fit: de-arming %r after a headroom refusal failed",
+                entry, exc_info=True)
+        flush_memory()
+    logger.warning("adopt-fit: %s", detail)
+    activity_mod.emit_event(
+        "adopt_headroom_refused", detail, phase=adopt_fit.REASON,
+        family=family, cell_key=str((meta or {}).get("cell_key") or ""),
+        graph_class=entry,
+    )
 
 
 def arm_aot(
@@ -495,6 +533,17 @@ def arm_aot(
     # `settings_authority.py:83`) is a native mapping abort that no `except`
     # sees, so the process dies here. When it does, this marker is what makes
     # the death read as a COMPILE crash rather than as the tenant's.
+    #
+    # pgw#1265: which is exactly why the attempt cannot be the WHOLE gate. An
+    # uncatchable death has no refusal to return, so the one question a query
+    # can settle — is there room for a forward at all — is asked first, from
+    # `adopt_fit`'s two measured terms. It predicts nothing and refuses only on
+    # evidence this process produced; see that module for why pgw#1164's
+    # deleted estimate is not what this is.
+    _no_room = adopt_fit.refusal("the adopt's LOAD", _budget_device)
+    if _no_room:
+        _abandon_adopt(pipe, meta, _no_room, entry="")
+        return AdoptOutcome.miss(adopt_fit.REASON, _no_room)
     with postmortem.compile_inflight(_adopt_label):
         outcome = aot_serve.enable(
             pipe, cfg, cache_dir, artifact, expected=expected, declared=declared)
@@ -510,6 +559,23 @@ def arm_aot(
             + f" — {lifted_install_error}]".strip(),
             outcome.identity)
     if outcome.armed:
+        # pgw#1265: THE RUNNER IS NOW RESIDENT, and everything below runs
+        # beside it. This is where the floor rose, so this is where it is
+        # checked — and, because the arm has already mutated the pipeline, it
+        # is also the first point that needs a way BACK DOWN. Both spans below
+        # are abandonable: the entry de-arms, its runner is released, the
+        # pipeline serves eager and the worker stays alive.
+        _entry_name = str(
+            ((meta or {}).get(cell_key.ENTRY_BLOCK_KEY) or {}).get("name") or "")
+        _no_room = adopt_fit.refusal(
+            "the §4.32 parity gate's forwards" if verify_numerics
+            else "serving through the freshly armed graph class",
+            _budget_device)
+        if _no_room:
+            _emit_adopt_budget(0, False)
+            _abandon_adopt(pipe, meta, _no_room, entry=_entry_name)
+            return AdoptOutcome.miss(
+                adopt_fit.REASON, _no_room, outcome.identity)
         # §4.32: quality is proven at MINT and in author CI, never at adoption.
         # An adopting pod materializes, arms and serves.
         # pgw#1262: the gate runs TWO forwards on a card that is already
@@ -525,6 +591,18 @@ def arm_aot(
             gate_ok = True
         _, _peak_after_verify = mint_workers.adopt_watermark(_budget_device)
         if gate_ok:
+            # pgw#1265: the gate's own forwards have just been paid and freed.
+            # The question this last verdict asks is the one the CALLER is
+            # about to act on — it advertises this arm and serves through it —
+            # so it is asked about the state the arm actually leaves behind,
+            # not about the state before the gate ran.
+            _no_room = adopt_fit.refusal(
+                "serving through the freshly armed graph class", _budget_device)
+            if _no_room:
+                _emit_adopt_budget(_peak_after_verify - _peak_after_load, False)
+                _abandon_adopt(pipe, meta, _no_room, entry=_entry_name)
+                return AdoptOutcome.miss(
+                    adopt_fit.REASON, _no_room, outcome.identity)
             _emit_adopt_budget(_peak_after_verify - _peak_after_load, True)
             return outcome
         _emit_adopt_budget(_peak_after_verify - _peak_after_load, False)

--- a/tests/test_adopt_fit_pgw1265.py
+++ b/tests/test_adopt_fit_pgw1265.py
@@ -1,0 +1,560 @@
+"""The adopt asks whether a SERVE still fits, and can give the arm back.
+
+pgw#1265. Live four times on 2026-08-14 as
+``ComputeProcessDied: cause=signal:SIGSEGV function=generate`` on z-image:
+resident 32.01 GiB of 44.42 GiB (three functions, two full pipelines), the
+adopt loads a runner and runs the §4.32 gate's two forwards beside it, and the
+process dies with 17.9 MiB free. Under ``expandable_segments:True`` that
+exhaustion is a native mapping abort no ``except`` sees, so
+``aot_serve._bind_headroom``'s attempt-and-catch — the honest gate for a
+CATCHABLE bind OOM — cannot be the whole answer.
+
+Three invariants, one per section:
+
+1. every device-touching span of the adopt is preceded by a verdict taken from
+   live free memory against a peak MEASURED in this process;
+2. a negative verdict ABANDONS — the entry de-arms, its runner is released, and
+   the worker keeps serving eager;
+3. an abandoned adopt cannot brick the worker: nothing is advertised, the flip
+   never happens, and the class cannot be re-armed in this process.
+
+These drive the REAL ``provision.arm_aot``, the REAL
+``Executor._advertise_compiled_graphs``, the REAL ``adopt_fit`` arithmetic and
+the REAL ``aot_serve.EntryDispatch``. The doubles are the CUDA device, the load
+and the §4.32 gate — the GPU work this box may not do. Nothing is compiled or
+minted here.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import adopt_fit, mint_workers
+from gen_worker import compile_cache
+from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.models import provision
+
+_GIB = 1 << 30
+
+_META: Dict[str, Any] = {
+    "family": "z-image",
+    "weight_lane": "lora128",
+    "cell_key": "cg-key-v1-" + "0" * 56,
+    "entry": {"name": "transformer/e0", "target": "transformer"},
+}
+
+
+# ---------------------------------------------------------------------------
+# The card, and only the card, is a double.
+# ---------------------------------------------------------------------------
+
+
+class FakeCard:
+    """A CUDA device that answers the three questions `adopt_fit` asks it.
+
+    Everything above it — the free/reclaimable construction, the watermark
+    subtraction, the verdict — is the production code under test.
+    """
+
+    def __init__(self, *, free: int, reserved: int = 0, allocated: int = 0):
+        self.free = int(free)
+        self.reserved = int(reserved)
+        self.allocated = int(allocated)
+        self.peak = int(allocated)
+        self.is_available = lambda: True  # noqa: E731 — attribute, not method
+
+    # -- the torch surface `adopt_fit` uses -------------------------------
+    @property
+    def cuda(self) -> "FakeCard":
+        return self
+
+    def current_device(self) -> int:
+        return 0
+
+    def mem_get_info(self, _index: int) -> tuple:
+        return (self.free, 48 * _GIB)
+
+    def memory_reserved(self, _index: int) -> int:
+        return self.reserved
+
+    def memory_allocated(self, _index: int) -> int:
+        return self.allocated
+
+    def max_memory_allocated(self, _index: int) -> int:
+        return self.peak
+
+    # -- what a forward or a load does to it ------------------------------
+    def run_forward(self, transient: int) -> None:
+        """One forward: allocates `transient`, frees it, moves the peak."""
+        self.peak = max(self.peak, self.allocated + int(transient))
+
+    def take(self, held: int) -> None:
+        """Somebody (a load, a sibling instance) takes `held` bytes for good."""
+        self.allocated += int(held)
+        self.reserved += int(held)
+        self.free -= int(held)
+        self.peak = max(self.peak, self.allocated)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_measurements() -> Iterator[None]:
+    adopt_fit.reset()
+    yield
+    adopt_fit.reset()
+
+
+@pytest.fixture
+def card(monkeypatch: pytest.MonkeyPatch) -> FakeCard:
+    """A card with 40 GiB free that has served one 12 GiB forward."""
+    dev = FakeCard(free=40 * _GIB, reserved=2 * _GIB, allocated=1 * _GIB)
+    monkeypatch.setattr(adopt_fit, "_torch", lambda: dev)
+    with adopt_fit.forward_watermark(0):
+        dev.run_forward(12 * _GIB)
+    assert adopt_fit.forward_peak(0) == 12 * _GIB
+    return dev
+
+
+class _Trace:
+    def __init__(self) -> None:
+        self.load = 0
+        self.gate = 0
+        self.disarmed: List[tuple] = []
+        self.flushed = 0
+        self.events: List[tuple] = []
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    on_load: Optional[Callable[[], None]] = None,
+    on_gate: Optional[Callable[[], None]] = None,
+    armed: bool = True,
+    gate_passes: bool = True,
+) -> _Trace:
+    """Real arm_aot; the load and the §4.32 gate are doubled."""
+    from gen_worker import aot_serve
+
+    trace = _Trace()
+    monkeypatch.setattr(mint_workers, "adopt_watermark", lambda _d=None: (0, 0))
+    monkeypatch.setattr(mint_workers, "device_of", lambda _p: 0)
+
+    def _enable(*_a: Any, **_k: Any) -> AdoptOutcome:
+        trace.load += 1
+        if on_load is not None:
+            on_load()
+        return (AdoptOutcome.hit("armed") if armed
+                else AdoptOutcome.miss("load_failed", "no"))
+
+    def _gate(*_a: Any, **_k: Any) -> bool:
+        trace.gate += 1
+        if on_gate is not None:
+            on_gate()
+        return gate_passes
+
+    monkeypatch.setattr(aot_serve, "enable", _enable)
+    monkeypatch.setattr(aot_serve, "armed_metadata", lambda _p: dict(_META))
+    def _disarm(_p: Any, name: str, reason: str) -> bool:
+        trace.disarmed.append((name, reason))
+        return True
+
+    monkeypatch.setattr(aot_serve, "disarm_entry", _disarm)
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {})
+    monkeypatch.setattr(provision, "gate_cell_numerics", _gate)
+    monkeypatch.setattr(
+        provision, "flush_memory",
+        lambda: trace.__setattr__("flushed", trace.flushed + 1))
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: trace.events.append((kind, kw.get("phase", ""))))
+    return trace
+
+
+def _arm(tmp_path: Path, **kw: Any) -> AdoptOutcome:
+    return provision.arm_aot(
+        object(), type("Cfg", (), {"family": "z-image"})(), None,
+        tmp_path / "cell.tar.gz", 0, dict(_META), **kw)
+
+
+# ===========================================================================
+# INVARIANT 1 — the verdict is taken BEFORE the span that would spend the card.
+# ===========================================================================
+
+
+def test_the_LOAD_is_refused_when_a_measured_forward_no_longer_fits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """A sibling instance took the card down to 1 GiB of usable memory. The
+    adopt must not even start: `aot_serve.enable` is never called."""
+    card.take(39 * _GIB)
+    trace = _install(monkeypatch)
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert trace.load == 0, (
+        "the adopt loaded a runner onto a card that cannot fit a forward — "
+        "this is the allocation that raised the residency floor and killed "
+        "the process")
+    assert not outcome.armed
+    assert outcome.reason == adopt_fit.REASON
+    # The refusal states BOTH measured terms: 1 GiB free + 1 GiB reclaimable
+    # against the 12 GiB forward this process actually ran.
+    assert "2.000 GiB of usable" in outcome.detail, outcome.detail
+    assert "12.000 GiB transient" in outcome.detail, outcome.detail
+
+
+def test_the_VERIFY_FORWARDS_are_refused_when_the_LOAD_ate_the_headroom(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """The exact production shape: the card had room for the load, and the
+    §4.32 gate's two forwards — `probe_cell` -> `gate_cell_numerics`, the frame
+    the z-image pod actually died in — no longer fit beside the runner."""
+    trace = _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert trace.load == 1, "the load itself was affordable and must have run"
+    assert trace.gate == 0, (
+        "the §4.32 gate ran two forwards on a card with no room for one — the "
+        "adopt's peak device moment, unchecked")
+    assert outcome.reason == adopt_fit.REASON
+
+
+def test_an_ADOPTER_that_runs_no_gate_is_still_checked_before_it_serves(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """`verify_numerics=False` is every adopting pod. It runs no gate, so the
+    verdict that protects it is the one about the state the arm LEAVES."""
+    trace = _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=False)
+
+    assert trace.gate == 0
+    assert outcome.reason == adopt_fit.REASON
+    assert trace.disarmed, "the loaded runner was left resident"
+
+
+def test_the_state_the_ARM_LEAVES_is_checked_after_the_gate_has_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """The card had room for the load AND for the §4.32 gate, and by the time
+    the gate finished it no longer had room to SERVE — a sibling instance
+    rotated, or the gate's own forwards left the allocator holding blocks this
+    process cannot hand back. The caller is about to advertise this arm and
+    serve through it, so the last verdict is about the state the arm actually
+    leaves behind."""
+    trace = _install(monkeypatch, on_gate=lambda: card.take(38 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert (trace.load, trace.gate) == (1, 1), (
+        "both spans were affordable when they were asked about")
+    assert outcome.reason == adopt_fit.REASON, (
+        "an arm was returned ARMED on a card that can no longer fit a forward "
+        "— the caller advertises it and the next request is the one that dies")
+    assert trace.disarmed == [("transformer/e0", adopt_fit.REASON)]
+
+
+def test_a_card_that_fits_adopts_exactly_as_before(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """The gate is not allowed to cost a pod that has room."""
+    trace = _install(monkeypatch, on_load=lambda: card.take(2 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert outcome.armed
+    assert (trace.load, trace.gate) == (1, 1)
+    assert trace.disarmed == []
+
+
+# --- the two terms of the verdict, severed one at a time -------------------
+
+
+def test_NOTHING_MEASURED_fits_by_construction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """No forward has run in this process, so there is no evidence to refuse
+    on. An honest under-refusal beats a number invented to look like a bound
+    (pgw#1175's lesson, not re-learned)."""
+    dev = FakeCard(free=1 << 20, reserved=0, allocated=44 * _GIB)
+    monkeypatch.setattr(adopt_fit, "_torch", lambda: dev)
+    trace = _install(monkeypatch)
+
+    assert adopt_fit.forward_peak(0) == 0
+    assert _arm(tmp_path, verify_numerics=True).armed
+    assert trace.load == 1
+
+
+def test_an_UNPROBEABLE_device_fits_by_construction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(adopt_fit, "_torch", lambda: None)
+    trace = _install(monkeypatch)
+
+    assert adopt_fit.refusal("x", 0) == ""
+    assert _arm(tmp_path, verify_numerics=True).armed
+    assert trace.load == 1
+
+
+def test_RECLAIMABLE_CACHE_counts_as_headroom(card: FakeCard) -> None:
+    """Driver-free alone would refuse a card holding a large idle allocator
+    cache, which is memory this process can hand back on demand."""
+    card.free = 4 * _GIB
+    card.reserved = card.allocated + 9 * _GIB
+
+    assert adopt_fit.headroom(0) == 13 * _GIB
+    assert adopt_fit.refusal("x", 0) == "", "13 GiB usable, 12 GiB needed"
+
+
+def test_there_is_no_MARGIN_no_FACTOR_and_no_FLOOR(card: FakeCard) -> None:
+    """Paul's standing rule. The verdict is `have >= need` on two measured
+    quantities: exactly enough is enough, and one byte short refuses."""
+    card.free = 12 * _GIB
+    card.reserved = card.allocated
+    assert adopt_fit.headroom(0) == 12 * _GIB
+    assert adopt_fit.refusal("x", 0) == ""
+
+    card.free -= 1
+    assert adopt_fit.refusal("x", 0) != ""
+
+
+def test_the_verdict_reads_no_BANK() -> None:
+    """pgw#1205's device-peak bank stays measurement-only, and pgw#1164's
+    deleted estimate is not rebuilt: this module's whole input surface is the
+    live device plus this process's own forwards."""
+    source = Path(adopt_fit.__file__).read_text()
+    for forbidden in (
+        "device_peak", "mint_workers", "fleet_cells", "compile_cache",
+        "vram_gb", "resources_vram",
+    ):
+        assert forbidden not in source.split('"""')[2], (
+            f"adopt_fit reads {forbidden!r} — the verdict must come from "
+            f"measurement at the decision point, never a bank or a declaration")
+
+
+def test_the_watermark_never_resets_the_shared_peak_counter(
+    card: FakeCard,
+) -> None:
+    """`max_memory_allocated` is process-monotone and other readers share it
+    (pgw#652's activation learning). A watermark that reset it would zero a
+    measurement the admission ladder is built on."""
+    assert not hasattr(card, "reset_peak_memory_stats_called")
+    assert "reset_peak_memory_stats" not in Path(adopt_fit.__file__).read_text()
+
+
+# ===========================================================================
+# INVARIANT 2 — a negative verdict ABANDONS: de-arm, release, keep serving.
+# ===========================================================================
+
+
+def test_a_refused_adopt_DE_ARMS_the_entry_it_loaded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    trace = _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    _arm(tmp_path, verify_numerics=True)
+
+    assert trace.disarmed == [("transformer/e0", adopt_fit.REASON)], (
+        "the runner stayed armed after the adopt was refused — the residency "
+        "floor it raised is permanent and every later request pays it")
+
+
+def test_a_refused_adopt_RELEASES_the_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """De-arming drops the reference; `flush_memory` is what turns a dropped
+    reference into free bytes. Both terms are load-bearing."""
+    trace = _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    _arm(tmp_path, verify_numerics=True)
+
+    assert trace.flushed == 1, (
+        "the dropped runner was never collected, so the floor did not come "
+        "back down")
+
+
+def test_a_refused_adopt_RETURNS_and_the_worker_keeps_serving(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """The refusal is a returned verdict, never a raise: `adopt_delegated_mint`
+    is documented to return None when nothing adopted, and an escaping
+    exception there destroys the typed refusal and the quarantine."""
+    _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert outcome.armed is False
+    assert outcome.reason == adopt_fit.REASON
+
+
+def test_the_refusal_is_a_CAPACITY_verdict_not_a_contract_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """A contract verdict quarantines a key (th#1819). A full card says
+    nothing about the artifact — another pod adopts it fine."""
+    trace = _install(monkeypatch, on_load=lambda: card.take(35 * _GIB))
+
+    outcome = _arm(tmp_path, verify_numerics=True)
+
+    assert ("adopt_headroom_refused", adopt_fit.REASON) in trace.events
+    assert "another pod" in outcome.detail
+    for reason in ("numerics_refused", "artifact_failed", "contract_invalid"):
+        assert reason not in outcome.reason
+
+
+# ===========================================================================
+# INVARIANT 3 — an abandoned adopt cannot brick the worker.
+# ===========================================================================
+
+
+def test_a_refused_class_cannot_be_RE_ARMED_in_this_process() -> None:
+    """§4.31's de-arm is sticky, which is what stops a refused adopt becoming
+    a retry loop that pays the load again on a card that is already full.
+    This drives the REAL dispatch registry."""
+    from gen_worker import aot_serve
+
+    dispatch = aot_serve.EntryDispatch()
+    runner = type("Runner", (), {"calls": 0})()
+    dispatch.add("transformer/e0", runner)  # type: ignore[arg-type]
+    assert dispatch.remove("transformer/e0", adopt_fit.REASON)
+
+    with pytest.raises(compile_cache.AdoptError) as caught:
+        dispatch.add("transformer/e0", runner)  # type: ignore[arg-type]
+    assert caught.value.reason == "entry_de_armed"
+
+
+# -- the executor's advertisement -------------------------------------------
+
+
+class _FakeTarget:
+    def __init__(self, pipeline: Any) -> None:
+        self.pipeline = pipeline
+        self.state_lock = threading.Lock()
+        self.active_compile_ref = ""
+        self.active_compile_snapshot_digest = ""
+        self.active_self_mint = False
+        self.incarnation_id = "inc-1"
+
+
+def _advertise(
+    monkeypatch: pytest.MonkeyPatch, *, guard_binds: bool = True,
+    probe: Optional[Callable[[], None]] = None,
+) -> tuple:
+    """Drive the REAL `Executor._advertise_compiled_graphs`."""
+    from gen_worker import aot_serve, executor as executor_mod
+    from gen_worker import hot_swap
+
+    pipe = object()
+    target = _FakeTarget(pipe)
+    rec = type("Rec", (), {
+        "compile_targets": {"t": target}, "eager_posture": "declined"})()
+    bg = type("Bg", (), {
+        "pipes": {1: pipe}, "spec": type("Spec", (), {"name": "generate"})()})()
+    act = type("Act", (), {"phase": staticmethod(lambda _p: None)})()
+    outcome = type("Outcome", (), {"ref": "cg-ref", "snapshot_digest": "d"})()
+
+    enabled: List[Any] = []
+    disarmed: List[tuple] = []
+    events: List[tuple] = []
+    monkeypatch.setattr(mint_workers, "device_of", lambda _p: 0)
+    def _enable(p: Any, *_a: Any, **_k: Any) -> bool:
+        enabled.append(p)
+        return True
+
+    def _disarm(_p: Any, name: str, reason: str) -> bool:
+        disarmed.append((name, reason))
+        return True
+
+    monkeypatch.setattr(hot_swap, "enable", _enable)
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {"e0": {}})
+    monkeypatch.setattr(aot_serve, "disarm_entry", _disarm)
+    monkeypatch.setattr(executor_mod, "flush_memory", lambda: None)
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: events.append((kind, kw.get("phase", ""))))
+    monkeypatch.setattr(
+        executor_mod.Executor, "_refresh_compile_target",
+        lambda self, t: probe() if probe is not None else None)
+    monkeypatch.setattr(
+        executor_mod.Executor, "_bind_compile_guard",
+        lambda self, r, t: guard_binds)
+
+    ex = object.__new__(executor_mod.Executor)
+    executor_mod.Executor._advertise_compiled_graphs(
+        ex, rec, bg, act, {1: outcome})
+    return target, enabled, disarmed, events
+
+
+def test_the_ADVERTISEMENT_is_refused_before_active_compile_ref_flips(
+    monkeypatch: pytest.MonkeyPatch, card: FakeCard,
+) -> None:
+    """The named site. Between the arm and here sit the publish and whatever a
+    sibling did to the card, so the flip takes the verdict again — and a claim
+    that this pipe SERVES compiled must not be made on a card that cannot fit
+    a forward."""
+    card.take(39 * _GIB)
+
+    target, enabled, disarmed, events = _advertise(monkeypatch)
+
+    assert target.active_compile_ref == "", (
+        "the target advertises a compiled ref on a card with no room to serve "
+        "one")
+    assert target.active_self_mint is False
+    assert enabled == [], "eager-while-compiling was turned on anyway"
+    assert disarmed == [("e0", adopt_fit.REASON)]
+    assert ("adopt_headroom_refused", adopt_fit.REASON) in events
+
+
+def test_a_fitting_card_advertises_and_enables_exactly_as_before(
+    monkeypatch: pytest.MonkeyPatch, card: FakeCard,
+) -> None:
+    target, enabled, disarmed, _events = _advertise(monkeypatch)
+
+    assert target.active_compile_ref == "cg-ref"
+    assert target.active_self_mint is True
+    assert len(enabled) == 1
+    assert disarmed == []
+
+
+def test_hot_swap_is_NOT_enabled_when_no_target_kept_its_ref(
+    monkeypatch: pytest.MonkeyPatch, card: FakeCard,
+) -> None:
+    """Every target rolled back for want of a guard revocation signal, and the
+    pipe was still switched to concurrent routing. Unconditional was wrong."""
+    target, enabled, _disarmed, _events = _advertise(
+        monkeypatch, guard_binds=False)
+
+    assert target.active_compile_ref == ""
+    assert enabled == [], (
+        "concurrent routing was enabled on a pipe advertising nothing")
+
+
+def test_the_advertisement_span_is_named_as_a_COMPILE(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, card: FakeCard,
+) -> None:
+    """pgw#1262's marker, one question over: a signal death at the flip must be
+    charged to the compile, so pgw#714's eager-only reboot fires instead of the
+    pod re-minting the same key and crash-looping while the hub reads the
+    crashes as demand (th#1959)."""
+    from gen_worker import postmortem
+
+    monkeypatch.setattr(postmortem, "INFLIGHT_PATH", tmp_path / "inflight.json")
+    postmortem.clear_inflight()
+    seen: List[List[Dict[str, Any]]] = []
+
+    def _look() -> None:
+        seen.append([
+            row for row in postmortem.take_inflight(postmortem.INFLIGHT_PATH)
+            if row.get("kind") == postmortem.COMPILE_KIND])
+
+    _advertise(monkeypatch, probe=_look)
+
+    assert seen and seen[0], (
+        "no compile marker was in flight while the advertisement touched the "
+        "live compiled objects")
+    assert seen[0][0]["function"] == "compile:advertise:generate"


### PR DESCRIPTION
## The defect, read at source (this corrects the report)

The report named `executor._advertise_compiled_graphs`, and that function *is*
unguarded — it flips `active_compile_ref` and calls `hot_swap.enable(pipe)`
with no headroom check and no rollback, and it enabled concurrent routing even
when every target had just been rolled back to eager. But **it is not where the
device memory is spent.** By the time it runs, `models/provision.arm_aot` has
already loaded the runner (`aot_serve.enable`) and run §4.32's parity gate
(`gate_cell_numerics`), which pgw#1262's own comment in that function names as
*"the adopt's peak device moment — and it is where the 2026-08-14 z-image death
actually landed (`probe_cell` -> `gate_cell_numerics` -> `arm_aot`)"*.

So the residency floor rises inside `arm_aot`, and the fix belongs at that seam
— **the one seam every arm route passes** (pgw#1168 put the measurement there,
pgw#1262 the attribution) — with the advertise seam checked too, because the
publish and any sibling rotation sit between the arm and the flip.

Second correction: the leg that actually kills the pod is uncatchable.
`aot_serve._bind_headroom` turns a CATCHABLE bind OOM into a typed
`insufficient_adopt_vram` refusal, which is the right gate for that case; but
this SDK imposes `expandable_segments:True` (`settings_authority.py`), under
which exhaustion is a native mapping abort no `except` sees. Attempt-and-catch
therefore cannot be the whole gate. A **query** has to run first.

## Design — invariants 1-3

**`src/gen_worker/adopt_fit.py`** (new, ~195 lines, no dependencies beyond a
lazily imported torch). Two terms, both MEASURED, both at the decision point:

| term | source |
|---|---|
| `have` | `torch.cuda.mem_get_info` free **plus** reclaimable allocator cache (`reserved - allocated`) — the construction `hot_swap._headroom_ok` already uses |
| `need` | the largest device transient **one forward** has actually taken in this process on this card, bracketed at the two seams every forward passes: `Executor._execute` and `_invoke_warmup` |

The verdict is `have >= need`. **No margin, no factor, no floor, no duration.**
`need == 0` (nothing measured yet) and an unprobeable device **fit by
construction** — the gate only ever speaks from evidence this process produced
itself. `need` is keyed by **device**, not pipeline, deliberately: the z-image
release holds several pipelines on one card and the question is the card's.

**This is not pgw#1164 rebuilt.** I read why `mint_budget.adopt_headroom` was
deleted (pgw#1175 / cc6136ca) before writing anything: it PREDICTED the arm at
`2 * activation`, where `activation` was an admittedly unmeasured quarter of a
resident set the free figure already excluded, and its refusal was sticky for
the process — it could not refuse the failure it was written for and could
refuse cards that were fine. Nothing here predicts the adopt's cost. pgw#1205's
device-peak bank is not read (its
`test_no_width_or_placement_decision_reads_the_bank` fence is untouched);
`resources_vram_gb` is gone with th#1867 and is not consulted;
`tests/test_adopt_fit_pgw1265.py::test_the_verdict_reads_no_BANK` fails if any
of those names appears in the module.

1. **Verified before the flip** — the verdict is taken before the load, before
   the parity gate's forwards, before returning an ARMED outcome (that is the
   state the caller advertises and serves through), and again at
   `_advertise_compiled_graphs` before `active_compile_ref` flips.
2. **Abandonable** — `_abandon_adopt` / `_abandon_advertisement` de-arm the
   entry, `flush_memory()` turns the dropped runner into free bytes, the
   refusal is typed `insufficient_adopt_headroom` and rides
   `adopt_headroom_refused` on the wire, and the pod serves **eager** and stays
   alive. Neither the artifact nor the key is condemned — a full card is a fact
   about this pod at this instant, and a contract verdict is what quarantines a
   key (th#1819).
3. **Never bricked** — nothing is advertised, every target's ref is cleared,
   and §4.31's de-arm is sticky for the boot (`EntryDispatch.add` refuses a
   re-arm), so a refused adopt cannot become a retry loop that pays the load
   again on a card that is already full.

Alongside, in the same frame: `hot_swap.enable` is now conditional on some
target actually keeping its ref, and the advertisement — which touches the live
compiled objects — runs inside pgw#1255/pgw#1262's
`postmortem.compile_inflight`, so a death there is a compile's and pgw#714's
eager-only reboot covers it. One pattern, not two.

## Scope boundary, and the pending ruling

`aot_serve.py`'s serve-time `is_cuda_oom -> serve this request eager, stay
armed` branch is **untouched**. What changes if Paul's overturn lands:

* **If the ruling stands** (stay armed on a serve-time OOM), this change is
  what makes that ruling safe rather than fatal: the pod only ever reaches the
  armed state on a card that measurably had room for a forward, so the
  "OOM again on every later request forever" state now requires the card to
  have been taken *after* adoption — which is precisely the case the ruling
  describes and refuses to blame the artifact for.
* **If the overturn lands** (de-arm on a serve-time OOM), nothing here is
  rewritten: the overturn's de-arm is `aot_serve.disarm_entry` + release, which
  is exactly the abandon path this PR builds and hardens. It would call
  `_abandon_adopt`'s two lines from the serve frame.
* **Does this make the overturn moot?** No — and that is useful input. This
  gate cannot see a *sibling* instance or rotation consuming the card after the
  adopt committed, which is the exact scenario the ratified ruling is about. It
  removes the case where the pod itself walked into the wall.

## Red proof — 15 severances, each red alone

Each severance was applied **to the real tree** (the repo's `tests/conftest.py`
refuses any other import root — a scratch-copy harness ran green under every
severance and would have been a false clean), then reverted; the tree is
verified unmodified afterwards.

| # | severed | red |
|---|---|---|
| I1a | pre-LOAD verdict deleted | 1 |
| I1b | pre-VERIFY verdict deleted | 1 |
| I1c | post-ARM verdict deleted | 1 |
| I1d | advertise verdict deleted | 1 |
| I1e | **the `need` term** (no forward ever measured) | 10 |
| I1f | **the `have` term** (free memory never read) | 10 |
| I1g | the watermark (forwards not measured) | 16 |
| I1h | reclaimable cache dropped from `headroom` | 2 |
| I2a | abandon does not de-arm | 3 |
| I2b | abandon does not release | 1 |
| I2c | abandon says nothing on the wire | 1 |
| I3a | advertisement abandon removed | 1 |
| I3b | `hot_swap.enable` unconditional again | 1 |
| I3c | the de-arm stops being sticky | 1 |
| I3d | advertise span not named a compile | 3 |

I1e and I1f are the two-sufficient-terms check: the refusal fires only when
BOTH `need > 0` and `have < need`, so each was severed independently and each
is red on its own. I1c had **no** red on the first pass — the post-gate verdict
was shadowed by the pre-gate one — so a test was added for the case that
distinguishes them (the gate itself consumes the card).

20 tests; they drive the real `provision.arm_aot`, the real
`Executor._advertise_compiled_graphs`, the real `adopt_fit` arithmetic and the
real `aot_serve.EntryDispatch`. **The doubles are the CUDA device, the load and
the §4.32 gate** — the GPU work this box may not do. Nothing is compiled or
minted; no local mint, no inductor/AOTI, no real-model inference.

Also green locally: `mypy` (strict) on the tree, `ruff`, and all ten `fast
gates` lint scripts (`lint_unreached_surface`, `lint_arm_state_feeders`,
`lint_serving_process_compiles`, `lint_ambient_census`, …), plus the
neighbouring suites — `pgw1262`, `pgw1168`, `pgw1175`, `pgw868`, `pgw849`,
`pgw1215`, `pgw622`, `pgw672`, `pgw671`, `pgw680`, `pgw1199`, `pgw894`,
`th1107`, `test_executor_adopt` (166 rows).

## Surviving #807 and the `cell` -> `compiled_graph` sweep

The diff is deliberately seam-local: one new module plus **four** call sites of
1-6 lines each. Seams touched, with what they become in #807's tree:

* `models/provision.arm_aot` — #807 (based on a master that predates pgw#1262)
  currently has no `arm_aot` and calls `aot_serve.enable_compiled_graph` from
  `fleet_cells._arm_compiled_graph`. Whichever survives the rebase, the three
  verdicts move as a block with the load/gate/return they bracket.
* `aot_serve.enable` -> `enable_compiled_graph`, `disarm_entry` and
  `entry_states` keep their names in #807.
* `executor._advertise_compiled_graphs` — unchanged name in #807.
* `Executor._execute` / `_invoke_warmup` — one `with` clause each, untouched by
  #807.
* `adopt_fit` names nothing in the retiring vocabulary (no `cell`, no
  `vram_gb`, no `flavor`).

## Related

pgw#1255 / pgw#1262 (the marker this builds on), pgw#1164 / pgw#1175 (the
deleted estimate, read before writing), pgw#1205 (bank stays
measurement-only), th#1825, th#1867, and **th#1959** — the hub half: act on the
typed crash report, do not count a crash as capacity demand, reclaim the
surplus pods. This PR stops the pod producing the crash; th#1959 stops the
crash being read as demand.

## Seam with ie#721 (offload exclusion)

ie#721 generalizes `_exclude_from_cpu_offload` from the force_upcast VAE to any
component a record does not exclusively hold, which **raises the resident
floor** — the quantity this check is about. The coordination ruling was that
ie#721 publishes the excluded-resident set and this check consumes it rather
than re-deriving it.

**There is nothing to consume, and that is the strongest form of the seam, not
a gap in it.** `have` is the *driver's* free figure (`mem_get_info`), so every
byte anything holds on this card is already subtracted before `adopt_fit` sees
it: this record's weights, a sibling instance's, and any component the
exclusion keeps resident. No floor term exists here to keep in step with
`place_pipeline`, deliberately — a second derivation of a quantity the card
already reports is how two subsystems come to disagree about it three weeks
later. Commit `39094f5f` states that invariant in the module so a later change
does not add the floor term the seam exists to prevent.

Residue, named honestly: a floor that rises **after** the verdict (a rung
transition, a sibling's rotation) is invisible to any pre-check — which is
precisely the case the ratified serve-time allocator-exhaustion ruling covers.
`need` needs no adjustment either: it is a *measured* forward transient, so any
extra transient the exclusion causes is in it by observation rather than by
arithmetic.

## CI

`fast gates` — the repository's only required context since pgw#1264 — is
**green on the final head** (run 31836444685, commit `39094f5f`).

The non-required `tests` suite ran twice on the logic head (`1784c01a`):
`1 failed, 5038 passed` and `1 failed, 5036 passed`, and **the two failures are
different tests** — `test_sigterm_is_forwarded_to_the_worker`
(subprocess/SIGTERM timing) and
`test_sub_phases_do_not_disturb_the_reconciliation_invariant` (a `StageTimer`
wall-clock equality with a 20 ms sleep). Both pass locally, neither touches any
seam in this diff, and each passed in the run the other failed in: runner-load
flakes under `-n 4`, not this change.
