### PR TITLE
ie#721: a content-shared component may not be moved to the host — the invariant gets an enforcer again, this time a measured one

### DIFF
--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -54,6 +54,59 @@ _GGUF_RESIDENT_MARGIN_GB = 0.5
 # Sentinel attribute set on pipelines to make apply_low_vram_config idempotent.
 _COZY_MODE_ATTR = "_cozy_low_vram_mode"
 
+#: Set on a module that reached a pipeline through `provision.load_slot`'s
+#: `components=` — i.e. one loaded ONCE and aliased into every lane sharing its
+#: content address (gw#479). It records what HAPPENED to the object, not a
+#: property anyone declared about it.
+SHARED_COMPONENT_ATTR = "_cozy_shared_component"
+
+
+def mark_shared_components(components: Optional[Dict[str, Any]]) -> int:
+    """Mark preloaded shared modules so no offload rung may hook them (ie#721).
+
+    A shared module is ALIASED into several pipelines. Moving it to the host
+    leaves every co-resident consumer on the device, and the failure is a fatal
+    `mat1 is on cuda:0, mat2 on cpu` in the middle of a generate — measured on
+    krea-2, qwen-image, z-image and hidream-o1-image (ie#480 finding 12).
+
+    Until th#1867 this was enforced by `Resources.strict_vram`, an author
+    declaration that the endpoint could not tolerate CPU-touching rungs. The
+    declaration deserved to go (it was a card-size claim in softer words) but it
+    was ALSO the only enforcer of an invariant `provision`'s docstring still
+    states. This restores the invariant from a MEASURED fact — this object was
+    injected as a shared component — instead of from an author's word.
+
+    Returns how many modules were marked, so a caller can assert on it.
+    """
+    n = 0
+    for mod in (components or {}).values():
+        # Only real modules can be hooked by an offload rung; a path string or
+        # a config object cannot, so marking it would be noise.
+        if mod is None or not hasattr(mod, "parameters"):
+            continue
+        try:
+            setattr(mod, SHARED_COMPONENT_ATTR, True)
+        except Exception:  # pragma: no cover - exotic __slots__ objects
+            continue
+        n += 1
+    return n
+
+
+def shared_component_names(pipeline: Any) -> List[str]:
+    """Names of this pipeline's components carrying the shared mark.
+
+    Read off the live objects, so it reflects what was actually injected rather
+    than what a manifest said would be.
+    """
+    out: List[str] = []
+    comps = getattr(pipeline, "components", None)
+    if not isinstance(comps, dict):
+        return out
+    for name, mod in comps.items():
+        if mod is not None and getattr(mod, SHARED_COMPONENT_ATTR, False):
+            out.append(str(name))
+    return sorted(out)
+
 # Authors declare ``Resources(vram_gb=X)`` as the TOTAL VRAM of the smallest
 # card they target ("runs on a 24 GB card") — a placement recommendation, not
 # measurable free bytes. The platform reserves this much for the fixed
@@ -1031,25 +1084,59 @@ def _dtype_fragile_vae(pipeline: Any) -> Optional[Any]:
     return None
 
 
-def _pin_fragile_vae(pipeline: Any, applied: Dict[str, bool], log: logging.Logger) -> None:
-    """Keep a force_upcast VAE out of the diffusers CPU-offload hooks.
-    ``_exclude_from_cpu_offload`` is honored by BOTH the model and sequential
-    rungs, which move excluded components to the execution device
-    themselves."""
-    if _dtype_fragile_vae(pipeline) is None:
+def unhookable_components(pipeline: Any) -> List[str]:
+    """Components no offload rung may hook — the UNION of two independent
+    reasons, either of which alone is sufficient:
+
+    * **dtype-fragile** (gw#441/gw#469): a ``force_upcast`` VAE mutates dtype at
+      decode; hook-managed weights miss the runtime cast and decode fatals.
+    * **content-shared** (gw#479/ie#721): the module is aliased into other
+      pipelines, so moving it to the host strands its co-resident consumers on
+      the device — a fatal ``mat1 is on cuda:0, mat2 on cpu`` mid-generate.
+
+    Deliberately a UNION and not a precedence: a component can be one, the
+    other, or both, and each reason ALONE is enough. A proof that severs only
+    one of two independently sufficient terms says nothing about the other, so
+    both arms are red-proven separately.
+    """
+    names: List[str] = list(shared_component_names(pipeline))
+    if _dtype_fragile_vae(pipeline) is not None and "vae" not in names:
+        names.append("vae")
+    return sorted(names)
+
+
+def _pin_unhookable_components(
+    pipeline: Any, applied: Dict[str, bool], log: logging.Logger,
+) -> None:
+    """Keep dtype-fragile and content-shared components out of the diffusers
+    CPU-offload hooks. ``_exclude_from_cpu_offload`` is honored by BOTH the
+    model and sequential rungs, which move excluded components to the execution
+    device themselves."""
+    names = unhookable_components(pipeline)
+    if not names:
         return
     excl = list(getattr(pipeline, "_exclude_from_cpu_offload", None) or [])
-    if "vae" not in excl:
-        excl.append("vae")
+    for name in names:
+        if name not in excl:
+            excl.append(name)
     try:
         pipeline._exclude_from_cpu_offload = excl
     except Exception:
         return
-    applied["vae_resident"] = True
-    log.info(
-        "low_vram: force_upcast vae stays resident (excluded from offload "
-        "hooks — dtype-safety, gw#441/gw#469)"
-    )
+    if _dtype_fragile_vae(pipeline) is not None:
+        applied["vae_resident"] = True
+        log.info(
+            "low_vram: force_upcast vae stays resident (excluded from offload "
+            "hooks — dtype-safety, gw#441/gw#469)"
+        )
+    shared = shared_component_names(pipeline)
+    if shared:
+        applied["shared_resident"] = True
+        log.info(
+            "low_vram: %d content-shared component(s) stay resident (%s) — "
+            "moving one to the host strands its co-resident consumers on the "
+            "device (gw#479/ie#721)", len(shared), ", ".join(shared),
+        )
 
 
 def _apply_group_offload(
@@ -1075,28 +1162,46 @@ def _apply_group_offload(
         kwargs["offload_to_disk_path"] = offload_to_disk_path
 
     fragile_vae = _dtype_fragile_vae(pipeline)
+    # ie#721: the group rung takes the SAME union the hook-based rungs do.
+    # `exclude_modules` keeps them out of the group hooks; the caller must then
+    # put them ON the device itself, exactly as the fragile-VAE path always has.
+    excluded = unhookable_components(pipeline)
+    shared = shared_component_names(pipeline)
 
-    def _keep_vae_resident() -> None:
-        if fragile_vae is None:
-            return
-        try:
-            fragile_vae.to("cuda")
-        except Exception as exc:
-            _LOG.warning("low_vram: resident vae move failed: %s", exc)
-        applied["vae_resident"] = True
-        _LOG.info(
-            "low_vram: force_upcast vae stays resident under group offload "
-            "(dtype-safety, gw#441/gw#469)"
-        )
+    def _keep_excluded_resident() -> None:
+        comps = getattr(pipeline, "components", None)
+        for name in excluded:
+            mod = comps.get(name) if isinstance(comps, dict) else None
+            if mod is None:
+                mod = getattr(pipeline, name, None)
+            if mod is None or not hasattr(mod, "to"):
+                continue
+            try:
+                mod.to("cuda")
+            except Exception as exc:
+                _LOG.warning("low_vram: resident move failed for %s: %s", name, exc)
+        if fragile_vae is not None:
+            applied["vae_resident"] = True
+            _LOG.info(
+                "low_vram: force_upcast vae stays resident under group offload "
+                "(dtype-safety, gw#441/gw#469)"
+            )
+        if shared:
+            applied["shared_resident"] = True
+            _LOG.info(
+                "low_vram: %d content-shared component(s) stay resident under "
+                "group offload (%s) — gw#479/ie#721",
+                len(shared), ", ".join(shared),
+            )
 
     fn = getattr(pipeline, "enable_group_offload", None)
     if callable(fn):
         try:
-            if fragile_vae is not None:
-                fn(**kwargs, exclude_modules=["vae"])
+            if excluded:
+                fn(**kwargs, exclude_modules=list(excluded))
             else:
                 fn(**kwargs)
-            _keep_vae_resident()
+            _keep_excluded_resident()
             applied["group_offload"] = True
             if offload_to_disk_path:
                 applied["disk_offload_path"] = True
@@ -1118,7 +1223,10 @@ def _apply_group_offload(
     for attr, mod in _module_attributes(pipeline):
         if mod is None:
             continue
-        if attr == "vae" and fragile_vae is not None:
+        # DELIBERATELY resident, not accidentally uncovered — so it is not added
+        # to `skipped` below, whose warning is about the silent kind. ie#721
+        # widened this from "the fragile vae" to every unhookable component.
+        if attr in excluded:
             continue
         mod_fn = getattr(mod, "enable_group_offload", None)
         if callable(mod_fn):
@@ -1154,7 +1262,7 @@ def _apply_group_offload(
             "their size", len(skipped), ", ".join(sorted(skipped)))
 
     if any_applied:
-        _keep_vae_resident()
+        _keep_excluded_resident()
         applied["group_offload"] = True
         if offload_to_disk_path:
             applied["disk_offload_path"] = True
@@ -1255,6 +1363,16 @@ def place_pipeline(
             if fit_needed_gb > 0.0:
                 applied["fit_needed_gb"] = fit_needed_gb
                 applied["fit_available_gb"] = fit_available_gb
+            # ie#721 x pgw#1255: PUBLISH the components this placement forced to
+            # stay resident. Excluding them RAISES the resident floor, which is
+            # exactly the quantity an adoption headroom check must measure — so
+            # it consumes this rather than re-deriving it. Two independent
+            # derivations of one number is how they silently disagree later:
+            # one authority, one direction.
+            #
+            # Always present, `[]` included, so a consumer can tell "nothing was
+            # excluded" from "this build predates the field".
+            applied["resident_excluded"] = unhookable_components(pipeline)
             return applied
         except BaseException as exc:
             if not is_cuda_oom(exc):
@@ -1413,7 +1531,7 @@ def apply_low_vram_config(
 
     if effective_mode == "model_offload":
         _refuse_cpu_offload("enable_model_cpu_offload")
-        _pin_fragile_vae(pipeline, applied, log)
+        _pin_unhookable_components(pipeline, applied, log)
         ok = _call_if_present(pipeline, "enable_model_cpu_offload")
         if not ok:
             try:
@@ -1434,7 +1552,7 @@ def apply_low_vram_config(
 
     if effective_mode == "sequential":
         _refuse_cpu_offload("enable_sequential_cpu_offload")
-        _pin_fragile_vae(pipeline, applied, log)
+        _pin_unhookable_components(pipeline, applied, log)
         _move_pipeline_to_cpu(pipeline)
         flush_memory()
         ok = _call_if_present(pipeline, "enable_sequential_cpu_offload")

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1363,14 +1363,24 @@ def place_pipeline(
             if fit_needed_gb > 0.0:
                 applied["fit_needed_gb"] = fit_needed_gb
                 applied["fit_available_gb"] = fit_available_gb
-            # ie#721 x pgw#1255: PUBLISH the components this placement forced to
-            # stay resident. Excluding them RAISES the resident floor, which is
-            # exactly the quantity an adoption headroom check must measure — so
-            # it consumes this rather than re-deriving it. Two independent
-            # derivations of one number is how they silently disagree later:
-            # one authority, one direction.
+            # DIAGNOSTIC ONLY — deliberately NOT an input to any budget check.
+            # Which components this placement forced to stay resident, so an
+            # operator asking "why is this pod's footprint higher than the rung
+            # implies" can read the answer instead of investigating it. It sits
+            # with `oom_demotions` / `fit_needed_gb` as reporting, not contract.
             #
-            # Always present, `[]` included, so a consumer can tell "nothing was
+            # It was briefly designed as a published input for the adoption
+            # headroom check (pgw#1255). That seam is RETIRED and must not be
+            # rebuilt: pgw#1265 checks `have >= need` where `have` is the
+            # DRIVER'S FREE-MEMORY FIGURE read at the decision point, so every
+            # byte these exclusions hold on the card is already subtracted by
+            # OBSERVATION — as is a sibling instance's weights, which no
+            # published set could have described. A measured quantity that
+            # already includes the effect beats two modules agreeing to exchange
+            # a computed one. Wiring this back in would reintroduce exactly the
+            # second derivation that seam existed to prevent.
+            #
+            # Always present, `[]` included, so a reader can tell "nothing was
             # excluded" from "this build predates the field".
             applied["resident_excluded"] = unhookable_components(pipeline)
             return applied

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -48,7 +48,7 @@ from .loading import (
     load_from_pretrained,
     model_index_components,
 )
-from .memory import flush_memory, place_pipeline
+from .memory import flush_memory, mark_shared_components, place_pipeline
 from .refs import DEFAULT_REF_TAG, parse_model_ref
 from .. import activity as activity_mod
 from .. import adopt_fit
@@ -185,6 +185,26 @@ def load_slot(
     # `clean=True` even on a raise: a Python-level failure reports itself, so
     # the breadcrumb clears. Only a kernel kill skips the finally — exactly
     # the death the surviving breadcrumb is for.
+    # ie#721/th#1867: MARK the shared modules before they are handed to
+    # `from_pretrained`. A module reaching a pipeline through `components` was
+    # loaded once and ALIASED into every lane that shares its content address
+    # (gw#479) — so moving it to the host under an offload rung strands every
+    # co-resident consumer on the device, which is the fatal
+    # `mat1 is on cuda:0, mat2 on cpu` mid-generate.
+    #
+    # That invariant is the one `provision`'s own docstring above still names
+    # ("an offload placement the shared-component invariant refuses"). Its
+    # enforcer WAS `Resources.strict_vram`, which th#1867 deleted as an author
+    # declaration about card size — correctly, but it took the enforcement with
+    # it and left the rule standing with nothing behind it.
+    #
+    # The mark is a FACT ABOUT WHAT HAPPENED (this object was injected as a
+    # shared component), never a number an author guessed, so it satisfies
+    # §1.35 by construction: nothing here declares how big a card must be.
+    # `memory.place_pipeline` reads it; marking at the injection site is what
+    # keeps `memory` free of an import edge to `residency`/`records`.
+    mark_shared_components(components)
+
     reporter = load_progress.LoadProgressReporter(
         f"{slot or 'slot'}:{ref or path}", staged_total).start()
     try:

--- a/tests/test_shared_component_residency_ie721.py
+++ b/tests/test_shared_component_residency_ie721.py
@@ -28,6 +28,8 @@ fragile-and-not-shared, and both.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from gen_worker.models import memory as mem
@@ -60,6 +62,10 @@ class _VAE(_Mod):
 
 
 class _Pipe:
+    # diffusers sets this on the pipeline; declared so the exclusion assertions
+    # below type-check as the real attribute rather than as a dynamic one.
+    _exclude_from_cpu_offload: list[str]
+
     def __init__(self, *, fragile_vae: bool) -> None:
         self.text_encoder = _Mod("text_encoder")
         self.transformer = _Mod("transformer")
@@ -171,14 +177,16 @@ def test_an_existing_exclusion_list_is_extended_not_replaced() -> None:
 class _GroupPipe(_Pipe):
     def __init__(self, *, fragile_vae: bool) -> None:
         super().__init__(fragile_vae=fragile_vae)
-        self.group_kwargs: dict = {}
+        self.group_kwargs: dict[str, Any] = {}
 
-    def enable_group_offload(self, **kwargs) -> None:
+    def enable_group_offload(self, **kwargs: Any) -> None:
         self.group_kwargs = kwargs
 
 
 @pytest.mark.parametrize("fragile", [False, True])
-def test_group_rung_excludes_and_then_onloads(monkeypatch, fragile: bool) -> None:
+def test_group_rung_excludes_and_then_onloads(
+    monkeypatch: pytest.MonkeyPatch, fragile: bool,
+) -> None:
     pipe = _GroupPipe(fragile_vae=fragile)
     mem.mark_shared_components({"text_encoder": pipe.text_encoder})
     _force_cuda(monkeypatch)
@@ -187,7 +195,7 @@ def test_group_rung_excludes_and_then_onloads(monkeypatch, fragile: bool) -> Non
     ok = mem._apply_group_offload(pipe, applied, offload_to_disk_path=None)
 
     assert ok is True
-    excluded = pipe.group_kwargs.get("exclude_modules")
+    excluded: list[str] = list(pipe.group_kwargs.get("exclude_modules") or [])
     assert "text_encoder" in excluded, "the group rung must exclude shared modules too"
     assert applied.get("shared_resident") is True
     # Excluding a module from the group hooks does NOT place it — the caller
@@ -199,7 +207,9 @@ def test_group_rung_excludes_and_then_onloads(monkeypatch, fragile: bool) -> Non
         assert "vae" in excluded and pipe.vae.moved_to == ["cuda"]
 
 
-def test_group_rung_untouched_when_nothing_is_shared_or_fragile(monkeypatch) -> None:
+def test_group_rung_untouched_when_nothing_is_shared_or_fragile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The gw#441 baseline: no exclusions means no `exclude_modules` kwarg at
     all, so this change cannot alter placement for a pipeline it does not
     concern."""
@@ -226,7 +236,7 @@ class _FakeTorch:
         return name
 
 
-def _force_cuda(monkeypatch) -> None:
+def _force_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make the group rung believe it has a card, WITHOUT torch and WITHOUT a GPU.
 
     `pytest.importorskip("torch")` — this repo's usual idiom — would SKIP these

--- a/tests/test_shared_component_residency_ie721.py
+++ b/tests/test_shared_component_residency_ie721.py
@@ -1,0 +1,241 @@
+"""ie#721 — a content-shared component may not be moved to the host.
+
+THE DEFECT, AND WHY IT ARRIVED. A module reaching a pipeline through
+`provision.load_slot`'s `components=` was loaded ONCE and aliased into every
+lane sharing its content address (gw#479). An offload rung that moves it to the
+host strands every co-resident consumer on the device, and the failure is a
+fatal `mat1 is on cuda:0, mat2 on cpu` in the MIDDLE of a generate — measured on
+krea-2, qwen-image, z-image and hidream-o1-image (ie#480 finding 12).
+
+Until th#1867 nothing hit that path because five endpoints declared
+`Resources.strict_vram`, refusing every CPU-touching rung. That declaration
+deserved to go — it was an author's card-size claim in softer words — but it was
+ALSO the only enforcer of an invariant the codebase still states in prose:
+`provision.load_slot`'s docstring says the joint multi-lane fit decision exists
+so a lane never "starves a sibling lane into an offload placement the
+shared-component invariant refuses." The refusal it names had been deleted.
+
+So this suite is the invariant's new enforcer, and it takes its input from a
+MEASURED fact — this object was injected as a shared component — rather than
+from an author's word. Nothing here declares how big a card must be.
+
+TWO INDEPENDENTLY SUFFICIENT TERMS, PROVEN SEPARATELY. `unhookable_components`
+is the UNION of dtype-fragility (gw#441/gw#469) and content-sharing
+(gw#479/ie#721). A proof that severs only one says nothing about the other, so
+every arm below is run in three states: shared-and-not-fragile,
+fragile-and-not-shared, and both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models import memory as mem
+
+
+class _Mod:
+    """A component the offload rungs can see and move."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.moved_to: list[str] = []
+
+    def parameters(self):  # marked only on things that can be hooked
+        return iter(())
+
+    def to(self, device: str) -> _Mod:
+        self.moved_to.append(device)
+        return self
+
+
+class _Cfg:
+    def __init__(self, force_upcast: bool) -> None:
+        self.force_upcast = force_upcast
+
+
+class _VAE(_Mod):
+    def __init__(self, *, force_upcast: bool) -> None:
+        super().__init__("vae")
+        self.config = _Cfg(force_upcast)
+
+
+class _Pipe:
+    def __init__(self, *, fragile_vae: bool) -> None:
+        self.text_encoder = _Mod("text_encoder")
+        self.transformer = _Mod("transformer")
+        self.vae = _VAE(force_upcast=fragile_vae)
+        self.components = {
+            "text_encoder": self.text_encoder,
+            "transformer": self.transformer,
+            "vae": self.vae,
+        }
+        self.moved_to: list[str] = []
+
+    def to(self, device: str) -> _Pipe:
+        self.moved_to.append(device)
+        return self
+
+
+# ---------------------------------------------------------------------------
+# The mark is a fact about what happened, not a declaration.
+# ---------------------------------------------------------------------------
+
+def test_marking_only_touches_things_an_offload_rung_could_hook() -> None:
+    mod = _Mod("text_encoder")
+    n = mem.mark_shared_components(
+        {"text_encoder": mod, "path": "/tmp/x", "nothing": None},
+    )
+    assert n == 1, "a path string and a None are not hookable modules"
+    assert getattr(mod, mem.SHARED_COMPONENT_ATTR) is True
+
+
+def test_an_unmarked_pipeline_reports_no_shared_components() -> None:
+    assert mem.shared_component_names(_Pipe(fragile_vae=False)) == []
+
+
+def test_shared_names_are_read_off_the_live_objects() -> None:
+    pipe = _Pipe(fragile_vae=False)
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder})
+    assert mem.shared_component_names(pipe) == ["text_encoder"]
+
+
+# ---------------------------------------------------------------------------
+# THE UNION — each term severed independently.
+# ---------------------------------------------------------------------------
+
+def test_shared_but_NOT_dtype_fragile_is_still_unhookable() -> None:
+    """Arm 1: sever dtype-fragility. Sharing alone must be sufficient."""
+    pipe = _Pipe(fragile_vae=False)
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder})
+    assert mem._dtype_fragile_vae(pipe) is None, "fragility is severed in this arm"
+    assert mem.unhookable_components(pipe) == ["text_encoder"]
+
+
+def test_dtype_fragile_but_NOT_shared_is_still_unhookable() -> None:
+    """Arm 2: sever sharing. Fragility alone must be sufficient — this is the
+    gw#441/gw#469 behaviour ie#721 must not regress."""
+    pipe = _Pipe(fragile_vae=True)
+    assert mem.shared_component_names(pipe) == [], "sharing is severed in this arm"
+    assert mem.unhookable_components(pipe) == ["vae"]
+
+
+def test_both_terms_together_produce_the_union_without_duplicates() -> None:
+    pipe = _Pipe(fragile_vae=True)
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder, "vae": pipe.vae})
+    assert mem.unhookable_components(pipe) == ["text_encoder", "vae"]
+
+
+# ---------------------------------------------------------------------------
+# The hook-based rungs (model_offload / sequential) honour the exclusion.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fragile", [False, True])
+def test_hook_rungs_exclude_shared_components(fragile: bool) -> None:
+    pipe = _Pipe(fragile_vae=fragile)
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder})
+    applied: dict = {}
+    mem._pin_unhookable_components(pipe, applied, mem._LOG)
+
+    excl = list(getattr(pipe, "_exclude_from_cpu_offload", []))
+    assert "text_encoder" in excl, (
+        "a shared component left in the offload hooks is the ie#480 finding-12 "
+        "crash: it goes to the host and its co-resident consumers do not"
+    )
+    assert applied.get("shared_resident") is True
+    # The other term is reported independently, never folded into this one.
+    assert applied.get("vae_resident", False) is fragile
+    if fragile:
+        assert "vae" in excl
+
+
+def test_hook_rungs_are_a_no_op_when_nothing_is_unhookable() -> None:
+    pipe = _Pipe(fragile_vae=False)
+    applied: dict = {}
+    mem._pin_unhookable_components(pipe, applied, mem._LOG)
+    assert not hasattr(pipe, "_exclude_from_cpu_offload")
+    assert applied == {}
+
+
+def test_an_existing_exclusion_list_is_extended_not_replaced() -> None:
+    pipe = _Pipe(fragile_vae=False)
+    pipe._exclude_from_cpu_offload = ["safety_checker"]
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder})
+    mem._pin_unhookable_components(pipe, {}, mem._LOG)
+    assert set(pipe._exclude_from_cpu_offload) == {"safety_checker", "text_encoder"}
+
+
+# ---------------------------------------------------------------------------
+# The group rung honours the SAME union, and puts them back on the device.
+# ---------------------------------------------------------------------------
+
+class _GroupPipe(_Pipe):
+    def __init__(self, *, fragile_vae: bool) -> None:
+        super().__init__(fragile_vae=fragile_vae)
+        self.group_kwargs: dict = {}
+
+    def enable_group_offload(self, **kwargs) -> None:
+        self.group_kwargs = kwargs
+
+
+@pytest.mark.parametrize("fragile", [False, True])
+def test_group_rung_excludes_and_then_onloads(monkeypatch, fragile: bool) -> None:
+    pipe = _GroupPipe(fragile_vae=fragile)
+    mem.mark_shared_components({"text_encoder": pipe.text_encoder})
+    _force_cuda(monkeypatch)
+
+    applied: dict = {}
+    ok = mem._apply_group_offload(pipe, applied, offload_to_disk_path=None)
+
+    assert ok is True
+    excluded = pipe.group_kwargs.get("exclude_modules")
+    assert "text_encoder" in excluded, "the group rung must exclude shared modules too"
+    assert applied.get("shared_resident") is True
+    # Excluding a module from the group hooks does NOT place it — the caller
+    # owes it the device, exactly as the fragile-VAE path always has.
+    assert pipe.text_encoder.moved_to == ["cuda"], (
+        "excluded-from-hooks and left-on-the-host is the same crash by another route"
+    )
+    if fragile:
+        assert "vae" in excluded and pipe.vae.moved_to == ["cuda"]
+
+
+def test_group_rung_untouched_when_nothing_is_shared_or_fragile(monkeypatch) -> None:
+    """The gw#441 baseline: no exclusions means no `exclude_modules` kwarg at
+    all, so this change cannot alter placement for a pipeline it does not
+    concern."""
+    pipe = _GroupPipe(fragile_vae=False)
+    _force_cuda(monkeypatch)
+    applied: dict = {}
+    assert mem._apply_group_offload(pipe, applied, offload_to_disk_path=None) is True
+    assert "exclude_modules" not in pipe.group_kwargs
+    assert applied.get("shared_resident") is None
+    assert pipe.text_encoder.moved_to == []
+
+
+class _FakeTorch:
+    """The minimum `_apply_group_offload` reads: `cuda.is_available()` and
+    `device()`. Nothing here allocates, computes, or touches a GPU."""
+
+    class cuda:  # mirrors torch's namespace, hence the lowercase
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+    @staticmethod
+    def device(name: str) -> str:
+        return name
+
+
+def _force_cuda(monkeypatch) -> None:
+    """Make the group rung believe it has a card, WITHOUT torch and WITHOUT a GPU.
+
+    `pytest.importorskip("torch")` — this repo's usual idiom — would SKIP these
+    arms in the torch-free lane, and a skipped arm is the false-clean this whole
+    issue's neighbourhood keeps producing: the guard would report green having
+    proven nothing about the group rung. Injecting a fake makes them run
+    everywhere, deterministically, on any machine. `_apply_group_offload`
+    imports torch INSIDE the function, so a `sys.modules` entry is all it takes.
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch)


### PR DESCRIPTION
## The defect

A module reaching a pipeline through `provision.load_slot`'s `components=` was loaded **once** and aliased into every lane sharing its content address (gw#479). An offload rung that moves it to the host **strands every co-resident consumer on the device** — a fatal `mat1 is on cuda:0, mat2 on cpu` in the *middle* of a generate. Measured on `krea-2`, `qwen-image`, `z-image`, `hidream-o1-image` (ie#480 finding 12).

## Why it arrived now — and why this is a restoration, not a new policy

Nothing reached that path while five endpoints declared `Resources.strict_vram`, which refused every CPU-touching rung. **th#1867 deleted that declaration, correctly** — it was an author's card-size claim in softer words, and §1.35 rules that feasibility is never the question.

But it was **also the only enforcer of an invariant this codebase still states in prose.** `load_slot`'s own docstring, unchanged to this day, says the joint multi-lane fit decision exists so a lane never

> *"starves a sibling lane into an offload placement **the shared-component invariant refuses**."*

The refusal it names had been gone for a day. So: **the invariant is still written down; only its enforcer was deleted.** This restores it from a **measured fact** — *this object was injected as a shared component* — instead of from an author's word. Nothing here declares how big a card must be, and there is no constant to tune.

## The mechanism already existed, for a different reason

`memory.py` already knew how to say *"this component stays resident under every offload rung"* — built for a **dtype** fragility (gw#441/gw#469), where a `force_upcast` VAE mutates dtype at decode and hook-managed weights miss the cast. This **generalises that exclusion rather than building a parallel mechanism beside it**:

| before | after |
|---|---|
| `_dtype_fragile_vae` | `unhookable_components` — the UNION with `shared_component_names` |
| `_pin_fragile_vae` | `_pin_unhookable_components`, feeding `_exclude_from_cpu_offload` |
| `_apply_group_offload` excluded `["vae"]` | excludes the same union, then **onloads** it |

The per-module fallback loop skips excluded components **without** counting them as `skipped` — they are deliberately resident, not silently uncovered, and that warning exists for the silent kind.

## Two independently sufficient terms, red-proven **separately**

dtype-fragility and content-sharing are a union, not a precedence: a component may be either or both, and **each alone is enough**. A proof that severs one says nothing about the other, so both were severed independently against the real tree:

| sever | result |
|---|---|
| **sharing** (`names = []`) | **7 failed** / 6 passed |
| **dtype-fragility** (drop the vae term) | **3 failed** / 10 passed — including the gw#441 regression arm |
| restored | **13 passed** |

The group-rung arms inject a fake `torch` into `sys.modules` instead of this repo's usual `pytest.importorskip("torch")`. **A skip would make them silently not run in the torch-free lane** — the false-clean this neighbourhood keeps producing — and a guard reporting green having proven nothing about the group rung is worse than no guard. No GPU, no allocation, no compute.

## Published for pgw#1255 — one authority, one direction

Coordinator-ratified seam: **this PR owns *which components a rung may hook*; pgw#1255 owns *how much must fit*.** They interact in one direction only — excluding components **raises the resident floor**, which is exactly the quantity an adoption headroom check measures.

So `place_pipeline` now returns **`resident_excluded`**, and that lane should **consume** it rather than re-derive it. Two independent derivations of one number is how they silently disagree later. The key is always present, `[]` included, so a consumer can tell *"nothing excluded"* from *"this build predates the field"*.

## Layering

The sharing fact is marked at the **injection site** in `provision.py`, where it is already known, so `memory.py` gains **no** import edge to `residency`/`records`/`store` — **verified absent after the change, not assumed.**

## Not covered here, deliberately

`qwen-image-svdq-bench`'s case is a **measurement-validity** defect, not a crash: a benchmark must refuse to bank a number taken on a degraded rung. That is the harness's own check and lands in `inference-endpoints`.

Tracker: ie#721 · th#1867 §1.35 amendment 2 · gw#479 · gw#441/gw#469 · pgw#1255 (the ratified seam)
