### PR TITLE
pgw#1269: master-health asserts at the JOB level — an all-skipped run concludes `success`

### DIFF
--- a/.github/workflows/master-health.yaml
+++ b/.github/workflows/master-health.yaml
@@ -117,8 +117,8 @@ jobs:
               | jq -r --arg t "$1" '.[] | select(.title == $t) | .number' | head -1
           }
 
-          report() { # $1 = run id
-            local run name branch sha url concl ev job_list title body num
+          report() { # $1 = run id, $2 = verdict line (optional), $3 = dedup kind (optional)
+            local run name branch sha url concl ev job_list title body num reason key
             run=$(gh api "/repos/$REPO/actions/runs/$1")
             name=$(jq -r .name        <<<"$run")
             branch=$(jq -r .head_branch <<<"$run")
@@ -127,9 +127,16 @@ jobs:
             concl=$(jq -r .conclusion <<<"$run")
             ev=$(jq -r .event         <<<"$run")
 
+            # pgw#1269: "a required job FAILED" and "a required job never RAN"
+            # are different causes with different fixes, so the issue says which.
+            reason="${2:-the run concluded \`$concl\`}"
+            # Dedup key, not the run URL: one run can be reported for two
+            # distinct reasons and the second must not be swallowed as a repeat.
+            key="master-health-key: $1/${3:-failed}"
+
             job_list=$(gh api --paginate "/repos/$REPO/actions/runs/$1/jobs" \
               -q '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "- `" + .name + "` (" + .conclusion + ")"')
-            [ -n "$job_list" ] || job_list="- (no job reported a failure; the run itself concluded \`$concl\`)"
+            [ -n "$job_list" ] || job_list="- (none reported a failure — read the verdict above, not this list)"
 
             if [ "$branch" = "master" ]; then
               title="$RED_TITLE"
@@ -146,6 +153,7 @@ jobs:
 
           | | |
           |---|---|
+          | verdict | **$reason** |
           | workflow | **$name** (run event \`$ev\`, concluded \`$concl\`) |
           | commit | [\`$sha\`](https://github.com/$REPO/commit/$sha) |
           | run | $url |
@@ -157,19 +165,20 @@ jobs:
 
           Required contexts on this repository: $REQUIRED.
 
-          <sub>Opened by \`.github/workflows/master-health.yaml\` (pgw#1267). A MONITOR, not a merge
-          gate: \`master_health\` is not a required context and never runs on \`pull_request\` or
-          \`merge_group\`. Closed automatically by the next tick that finds every watched workflow
-          green on \`master\`.</sub>
+          <sub>Opened by \`.github/workflows/master-health.yaml\` (pgw#1267, job-level assertion
+          pgw#1269). A MONITOR, not a merge gate: \`master_health\` is not a required context and
+          never runs on \`pull_request\` or \`merge_group\`. Closed automatically by the next tick
+          that finds every watched workflow green on \`master\`.
+          <!-- $key --></sub>
           EOF
           )
 
             num=$(open_issue "$title")
             if [ -n "$num" ]; then
-              # One comment per distinct failing run, not one per tick.
+              # One comment per distinct (run, reason), not one per tick.
               if gh issue view "$num" -R "$REPO" --json body,comments \
-                   -q '.body, (.comments[].body)' | grep -qF "$url"; then
-                echo "::notice::already reported on issue #$num: $url"
+                   -q '.body, (.comments[].body)' | grep -qF "$key"; then
+                echo "::notice::already reported on issue #$num: $key"
                 return 0
               fi
               gh issue comment "$num" -R "$REPO" --body "$body"
@@ -178,6 +187,67 @@ jobs:
               num=$(gh issue create -R "$REPO" --title "$title" --body "$body" | tail -1)
               echo "::error::$title — opened $num ($url)"
             fi
+          }
+
+          report_absent() { # $1 = workflow file with no decided master run at all
+            local title body num key
+            title="$RED_TITLE"
+            key="master-health-key: $1/absent"
+
+          body=$(cat <<EOF
+          **\`master\` has NO decided run of \`$1\` at all.** Not a red run — the absence of one.
+          A watched workflow that stops running against \`master\` is indistinguishable from a
+          healthy one to anything that only reads run conclusions, which is exactly the blindness
+          this monitor exists to remove.
+
+          | | |
+          |---|---|
+          | verdict | **no completed \`master\` run of \`$1\` with a success/failure conclusion** |
+          | detected | $(date -u '+%Y-%m-%d %H:%M UTC') |
+
+          Likely causes: the workflow's triggers no longer admit a \`master\` run, it was renamed
+          or deleted, or every recent run was cancelled. This tick dispatched it, so if the
+          trigger is intact the next tick closes this by itself.
+
+          Required contexts on this repository: $REQUIRED.
+
+          <sub>Opened by \`.github/workflows/master-health.yaml\` (pgw#1269). A MONITOR, not a
+          merge gate.
+          <!-- $key --></sub>
+          EOF
+          )
+
+            num=$(open_issue "$title")
+            if [ -n "$num" ]; then
+              if gh issue view "$num" -R "$REPO" --json body,comments \
+                   -q '.body, (.comments[].body)' | grep -qF "$key"; then
+                echo "::notice::already reported on issue #$num: $key"
+                return 0
+              fi
+              gh issue comment "$num" -R "$REPO" --body "$body"
+              echo "::error::$title — no decided master run of $1, commented on issue #$num"
+            else
+              num=$(gh issue create -R "$REPO" --title "$title" --body "$body" | tail -1)
+              echo "::error::$title — no decided master run of $1, opened $num"
+            fi
+          }
+
+          # Jobs that MUST have RUN and SUCCEEDED on a `master` dispatch/schedule
+          # run of each watched workflow. `|`-separated because display names
+          # contain spaces.
+          #
+          # NOTHING IS DELIBERATELY OMITTED HERE, and that is a statement, not an
+          # oversight: on a `master` tick `ci.yaml` has no legitimately-skipping
+          # job. `gates` (display name `fast gates`) carries no `if:` at all
+          # since pgw#1268, and `tests` guards only against `merge_group` and
+          # draft pull requests, neither of which a `master` tick is. If a job is
+          # ever added that DOES skip legitimately on master, list it in this
+          # comment rather than silently leaving it out — a reader has to be able
+          # to tell "deliberately not asserted" from "forgotten".
+          assert_jobs_for() {
+            case "$1" in
+              ci.yaml) echo "fast gates|tests" ;;
+            esac
           }
 
           # ---- alert mode: a watched run just failed, or a verification dispatch.
@@ -193,17 +263,55 @@ jobs:
           # ---- reconcile mode: the standing verdict, independent of the cascade.
           red=0
           for wf in $WATCH; do
+            # `|| true` so a DELETED or renamed watched workflow 404s into the
+            # absent branch below — a loud issue — instead of killing the job
+            # under `set -e` and leaving nothing but a red run nobody reads.
             rid=$(gh api "/repos/$REPO/actions/workflows/$wf/runs?branch=master&status=completed&per_page=10" \
-                    -q '[.workflow_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "timed_out")][0].id // empty')
+                    -q '[.workflow_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "timed_out")][0].id // empty' 2>/dev/null || true)
+            # On a 404 `gh` prints the error BODY to stdout, so `$rid` comes
+            # back as a JSON blob rather than empty and sails past a bare -z
+            # test straight into a nonsense follow-up call. Measured, not
+            # theorised (pgw#1269 test (e)). A run id is digits or it is nothing.
+            case "$rid" in ''|*[!0-9]*) rid="" ;; esac
             if [ -z "$rid" ]; then
-              echo "$wf: no decided master run yet"
+              # pgw#1269: absence is RED. `continue` here used to mean a watched
+              # workflow that stopped running on master read as healthy forever.
+              echo "$wf: NO decided master run"
+              red=1
+              report_absent "$wf"
               continue
             fi
             concl=$(gh api "/repos/$REPO/actions/runs/$rid" -q .conclusion)
             echo "$wf: $concl (run $rid)"
             if [ "$concl" != "success" ]; then
               red=1
-              report "$rid"
+              report "$rid" "the run concluded \`$concl\`" failed
+              continue
+            fi
+
+            # pgw#1269 — THE RUN-LEVEL CONCLUSION IS NOT A HEALTH VERDICT.
+            # A run in which every required job SKIPPED also concludes
+            # `success`, so "required set skipped and scored satisfied" — the
+            # exact state this monitor exists to catch — was indistinguishable
+            # from a healthy master. Verified 2026-08-14 against real runs:
+            # pgw run 31835266128 concluded `success` with jobs
+            # [success, skipped]. So assert at the JOB level: every job that
+            # must run on a master tick has to be present AND `success` —
+            # `skipped` and absent are both red.
+            jobs=$(gh api "/repos/$REPO/actions/runs/$rid/jobs?per_page=100")
+            missing=""
+            OLD_IFS=$IFS; IFS='|'
+            for j in $(assert_jobs_for "$wf"); do
+              IFS=$OLD_IFS
+              c=$(jq -r --arg j "$j" '[.jobs[] | select(.name == $j) | .conclusion] | .[0] // "absent"' <<<"$jobs")
+              [ "$c" = "success" ] || missing="$missing \`$j\`($c)"
+              IFS='|'
+            done
+            IFS=$OLD_IFS
+            if [ -n "$missing" ]; then
+              echo "$wf: run $rid concluded success but required jobs did not run:$missing"
+              red=1
+              report "$rid" "the run concluded \`success\`, but required jobs did NOT run:$missing" didnotrun
             fi
           done
 


### PR DESCRIPTION
## The gap (found by a peer session, verified before acting on it)

The reconcile loop read the **run-level** conclusion and treated `success` as healthy:

```sh
concl=$(gh api ".../runs/$rid" -q .conclusion)
if [ "$concl" != "success" ]; then red=1; report "$rid"; fi
```

**A run in which every required job SKIPPED also concludes `success`.** So "the required set was
skipped and scored satisfied" — the exact state this monitor exists to catch — was
indistinguishable from a healthy master.

Confirmed against real runs on 2026-08-14, not taken on trust:

| run | conclusion | jobs |
|---|---|---|
| pgw `31835266128` | `success` | `fast gates`=success, `tests`=**skipped** |
| ie `31834255563` | `success` | 4 success, **3 skipped** |

## The fix

Assert at the **job** level: every job that must run on a `master` tick is present AND `success`;
`skipped` and absent are both red. The assert list sits next to a comment naming what is
**deliberately not asserted and why**, so a reader can tell that apart from an oversight.

`report()` now takes a verdict line and a dedup key, so the issue says **"a required job FAILED"**
vs **"a required job never RAN"** — different causes, different fixes — and one run reported for
two distinct reasons is no longer swallowed as a repeat.

Two further holes closed in the same pass:

- **An ABSENT decided `master` run is red**, with its own message. The old `continue` meant a
  watched workflow that stopped running on master read as healthy forever.
- **A deleted/renamed watched workflow 404s, and `gh` prints the error BODY to stdout** — so the
  run id came back as a JSON blob, sailed past a bare `-z` test, and produced a nonsense
  follow-up call that killed the job under `set -e`. Found by testing case (e) below rather than
  by reading. A run id is digits or it is nothing, and a 404 now lands in the absent branch as a
  loud issue.

## Verified — every branch, against the live API

| # | case | result |
|---|---|---|
| a | real green `master` run, full assert list | green, **no false positive** |
| b | real run concluding `success` with `tests` **skipped** | RED, "required jobs did NOT run: `tests`(skipped)" — pgw#821 |
| c | same run again | **deduplicated** on the new `(run, reason)` key |
| d | watched workflow that never ran on master | RED "no decided master run" — pgw#822 |
| e | **deleted/nonexistent** watched workflow | first attempt CRASHED — bug found and fixed |
| e2 | same, after the fix | RED absent, no crash |
| f | green again | issue commented and **CLOSED** |

Both proof issues are closed; neither was a real incident. Green-path re-verified per repo
against each repo's own latest decided `master` run before pushing.

Still not a merge gate and still cannot become one: no `pull_request`/`merge_group` trigger,
`master_health` is not a required context name, and no existing workflow is modified.
