### PR TITLE
pgw#1271: wire the gates that cannot go red, and make the ratchet refuse a silent one

### DIFF
--- a/changelog.d/pgw1271.md
+++ b/changelog.d/pgw1271.md
@@ -1,0 +1,64 @@
+- **pgw#1271: `boot_key.assert_memo_honest` has a caller.** Its module header
+  promises "Honesty is enforced, not trusted... A wrong key is never produced",
+  and the function had **zero `src/` callers** — `trust_memo=False` was passed
+  only from tests, and both production callers took the default. The memo path
+  skips the traces and re-folds stored blocks into the `graph` axis of every
+  published `cg-key-v1`, so a stale memo was a key generator with no error
+  path. `mint_supervisor.rule_on_boot_memo` now runs the comparison at the
+  seal/publish seam of every supervised mint — the one moment a pod holds a
+  freshly traced class set for the closure its boot may have answered from a
+  memo — and a disagreement rides the wire as the typed `boot_memo_honesty`
+  event (`phase=memo_dishonest`), not a log line. A partial class set rules on
+  nothing: coverage accretes, so ruling would fire `class set differs` on every
+  incremental mint.
+- **pgw#1271: the rig no longer certifies its own fleet line.**
+  `rigcheck._collect_authorities` appended `"gen-worker"` to the authority
+  chain, so the SDK vouched for the very torch floor the rig was asked to
+  prove and `FleetLineUnknown` was unreachable on any machine with gen-worker
+  installed. Endpoint dists only now. The CUDA-usability refusal also stopped
+  being gated on `nvidia-smi` working (`env["driver"]` truthy) — a host broken
+  enough that the diagnostic fails is exactly the host the refusal is for.
+- **pgw#1271: an expired presign on the direct-final PUT is typed.** The
+  re-plan catches `ArtifactTransferError(phase="put", status_code=403)`; the
+  multipart leg raised that and the direct-final leg raised `TransportError`
+  raw — and direct-final is the leg production always takes, since the stream
+  always sends `sha256` and the hub therefore always mints `put_url`. One
+  helper, `_typed_presigned_put`, now serves both legs, so a re-plannable 403
+  can no longer lose a whole completed render as an untyped `RuntimeError`.
+- **pgw#1271: a wedged NVLink fabric is not "card 0, fine".**
+  `topology.delivered_topology` raises `TopologyError` on peer access with
+  0.0 GB/s measured so the hub re-packs; `lifecycle.probe_hardware` and
+  `free_vram_bytes` swallowed it with `except Exception: pass` and no log. The
+  catches are narrowed — an ordinary "no CUDA here" still reports 0.
+- **pgw#1271: a numerics report's EXISTENCE is no longer its verdict.**
+  `author_ci.read_parity` set `passed = True` in the mint branch merely because
+  a report was present, so a cell whose worst axis sat in the DEGRADED band
+  reported PASS with the failing cosine printed beside it. The verdict now
+  comes from `report.comparison().healthy` plus the pgw#868 measured-ness
+  clause, cross-checked against `aot_serve.entry_states` — a class the arm
+  de-armed is a class this cell does not deliver, whatever its cosine says.
+- **pgw#1271: `parallel.cp.refuse_unless_divisible` has a caller.**
+  `install_context_parallel` runs it per sharding candidate on the component's
+  declared head count, so diffusers #12536 fails at install instead of as an
+  inscrutable shape mismatch mid-denoise on a pod that has already rented.
+- **pgw#1271: one runtime probe.** `aot_serve.runtime_key` re-probed torch
+  behind its own `except Exception: pass` — a duplicate of
+  `compile_cache.runtime_key` whose failure was silent, so pgw#657's fix lived
+  in one copy only. It is a four-axis projection of the one probe now (the
+  envelope's axes; widening them would re-key every artifact), and
+  `aot_serve.torch_version`, its only remaining consumer, is deleted.
+- **pgw#1271: no call that reads as the last gate and checks nothing.**
+  `receipts.verify_delivered_artifact` called `refuse_untrusted_publisher(
+  receipt, "", "")` from inside that callee's own early-return condition, so it
+  executed zero checks immediately before the caller `dlopen`s the artifact.
+  Deleted; the signature is what clears a platform-tier cell, and it already
+  ran. The org-tier path is untouched.
+- **pgw#1271: THE STANDING RULE — a gate on the unreached-surface ratchet must
+  say why it is not wired.** Any baseline row whose leaf symbol starts with
+  `assert_` / `verify_` / `refuse_` / `require_` / `check_` now needs an inline
+  reason or `lint_unreached_surface.py` fails. The file's header has named "A
+  gate that never runs" as its first severity class since it was written and
+  has a delisting precedent for the right outcome, but findings were absorbed
+  as bare lines — which is how the honesty gate above got permanent tenure. A
+  gate's failure is invisible precisely because the reasoning around it reads
+  like enforcement, so the ratchet has to make it say so out loud.

--- a/changelog.d/pgw1271.md
+++ b/changelog.d/pgw1271.md
@@ -17,7 +17,10 @@
   prove and `FleetLineUnknown` was unreachable on any machine with gen-worker
   installed. Endpoint dists only now. The CUDA-usability refusal also stopped
   being gated on `nvidia-smi` working (`env["driver"]` truthy) — a host broken
-  enough that the diagnostic fails is exactly the host the refusal is for.
+  enough that the diagnostic fails is exactly the host the refusal is for. The
+  "a cardless host is not a host failure" carve-out survives on a signal a
+  broken diagnostic cannot fake: the probe's own class, since only a host with
+  a driver TO fail can answer `driver_too_old`/`cuda_error`.
 - **pgw#1271: an expired presign on the direct-final PUT is typed.** The
   re-plan catches `ArtifactTransferError(phase="put", status_code=403)`; the
   multipart leg raised that and the direct-final leg raised `TransportError`

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -871,8 +871,8 @@ def _upstream_baseline() -> Optional[Set[str]]:
         return None
     if out.returncode != 0:
         return None
-    return {ln.strip() for ln in out.stdout.splitlines()
-            if ln.strip() and not ln.startswith("#")}
+    return {ln.partition("#")[0].strip() for ln in out.stdout.splitlines()
+            if ln.strip() and not ln.startswith("#")} - {""}
 
 
 def rewrite_baseline(current: Set[str]) -> None:
@@ -892,9 +892,14 @@ def rewrite_baseline(current: Set[str]) -> None:
     comment_idx = [i for i, ln in enumerate(lines) if ln.startswith("#")]
     head_end = max(comment_idx) + 1 if comment_idx else 0
     header = lines[:head_end]
-    documented = {ln.strip() for ln in header
-                  if ln.strip() and not ln.strip().startswith("#")}
-    tail = sorted(current - documented)
+    documented = {ln.partition("#")[0].strip() for ln in header
+                  if ln.strip() and not ln.strip().startswith("#")} - {""}
+    # Inline reasons are DATA, not decoration: `gate_rows_without_reasons`
+    # fails the gate on a gate-shaped row that has lost one, so a rewriter
+    # that dropped them would turn every annotated gate row red.
+    _, _, reasons = baseline_rows()
+    tail = [label + (f"  # {reasons[label]}" if label in reasons else "")
+            for label in sorted(current - documented)]
     dropped = documented - current
     BASELINE.write_text("\n".join(header) + "\n\n" + "\n".join(tail) + "\n",
                         encoding="utf-8")
@@ -907,16 +912,43 @@ def rewrite_baseline(current: Set[str]) -> None:
               f"not touch prose.", file=sys.stderr)
 
 
-def baseline_rows() -> Tuple[Set[str], Dict[str, str]]:
-    """The ratchet's labels, and the OWNER/EXPIRY note governing each.
+#: A symbol whose LEAF NAME starts with one of these is a GATE: its whole
+#: purpose is to refuse. pgw#1271 — a gate on the ratchet is categorically
+#: different from an unreported metric or a duplicated helper, and the file's
+#: own header has always said so ("A gate that never runs" is its first
+#: severity class). The ratchet absorbed them as unannotated lines anyway, so
+#: `boot_key.assert_memo_honest` — the check that made the boot-key memo safe
+#: to have at all — sat here with permanent tenure while the memo produced the
+#: `graph` axis of every published key with nothing checking it.
+GATE_PREFIXES = ("assert_", "verify_", "refuse_", "require_", "check_")
 
-    The file writes those notes as prose above the rows they cover. Parsing
+
+def is_gate_label(label: str) -> bool:
+    """Whether a baseline label names a gate (by its leaf symbol, not its
+    module: `models.checkpoint.load` is not a gate, `x.check_slots` is)."""
+    leaf = label.rstrip("()").rsplit(".", 1)[-1]
+    return leaf.startswith(GATE_PREFIXES)
+
+
+def baseline_rows() -> Tuple[Set[str], Dict[str, str], Dict[str, str]]:
+    """The ratchet's labels, the OWNER/EXPIRY note governing each, and each
+    row's own INLINE reason.
+
+    The file writes the notes as prose above the rows they cover. Parsing
     them turns a note nobody reads into the first line of the failure that
     needs it: a row with an owner and an expiry is a deletion somebody OWES,
     and the reader who trips the gate is usually not that somebody.
+
+    An INLINE reason is written after the label on its own line::
+
+        gen_worker.geometry.FamilyGeometry.assert_declared()  # a test-only …
+
+    It is required on gate-shaped rows and optional everywhere else — see
+    :func:`gate_rows_without_reasons`.
     """
     known: Set[str] = set()
     notes: Dict[str, str] = {}
+    reasons: Dict[str, str] = {}
     current = ""
     buf: List[str] = []
     for raw in BASELINE.read_text(encoding="utf-8").splitlines():
@@ -939,10 +971,37 @@ def baseline_rows() -> Tuple[Set[str], Dict[str, str]]:
         if buf:
             current = " ".join(buf)
             buf = []
-        known.add(line)
+        label, _, inline = line.partition("#")
+        label = label.strip()
+        if not label:
+            continue
+        known.add(label)
+        if inline.strip():
+            reasons[label] = inline.strip()
         if current:
-            notes[line] = current
-    return known, notes
+            notes[label] = current
+    return known, notes, reasons
+
+
+def gate_rows_without_reasons(
+    known: Set[str], reasons: Dict[str, str],
+) -> List[str]:
+    """Gate-shaped baseline rows carrying no inline reason (pgw#1271).
+
+    THE STANDING RULE: a gate that is on this list is a gate that CANNOT GO
+    RED, and the ratchet's own delisting precedent (`numerics_ladder.gate`,
+    wired and removed 2026-08-02) proves the correct outcome is usually to
+    wire it. Absorbing it as a bare line grants it permanent tenure instead,
+    and — because the reasoning around an unwired gate reads exactly like
+    enforcement — nothing else in this repo will ever notice.
+
+    So a gate row must SAY, in one line, why it is not wired. "Call from
+    tests" is an acceptable reason. Silence is not: it is indistinguishable
+    from a gate everyone assumes is running.
+    """
+    return sorted(
+        label for label in known
+        if is_gate_label(label) and not reasons.get(label))
 
 
 def main() -> int:
@@ -998,7 +1057,25 @@ def main() -> int:
         rewrite_baseline(current)
         return 0
 
-    known, notes = baseline_rows()
+    known, notes, reasons = baseline_rows()
+    unexplained = gate_rows_without_reasons(known, reasons)
+    for label in unexplained:
+        print(f"GATE ROW WITH NO REASON: {label}\n"
+              f"  This is a GATE — its leaf name is one of "
+              f"{'/'.join(GATE_PREFIXES)}* — and it is on the ratchet, which "
+              f"means NOTHING IN src/ CALLS IT. A gate that cannot go red is "
+              f"the one class on this list that is worse than dead code: the "
+              f"reasoning around it reads like enforcement, so nothing else "
+              f"will ever notice.\n"
+              f"    WIRE IT   the usual outcome — see numerics_ladder.gate, "
+              f"delisted 2026-08-02 by acquiring a caller;\n"
+              f"    DELETE IT with its tests, if the property it guards is no "
+              f"longer load-bearing;\n"
+              f"    SAY WHY   append an inline reason to its line in "
+              f"{BASELINE.name}:\n"
+              f"                {label}  # a test-only assertion; …\n"
+              f"  'Call from tests' is an acceptable reason. Silence is not.",
+              file=sys.stderr)
     new = sorted(current - known)
     stale = sorted(known - current)
     for label in new:
@@ -1050,7 +1127,7 @@ def main() -> int:
                   f"nothing can. Delete its line from {BASELINE.name} in the "
                   f"same commit as the deletion. (Do not go looking for its new "
                   f"caller — there isn't one.)", file=sys.stderr)
-    return 1 if (new or stale) else 0
+    return 1 if (new or stale or unexplained) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -283,8 +283,38 @@ gen_worker.boot_phases.servable_ms()
 #
 # Entries are `module.Symbol` for a type and `module.symbol()` for a callable.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# pgw#1271 — THE STANDING RULE, and the reason it had to become one.
+#
+# A row whose LEAF SYMBOL starts with `assert_` / `verify_` / `refuse_` /
+# `require_` / `check_` is a GATE, and a gate on this list is a gate that
+# CANNOT GO RED. It must carry an INLINE REASON or `lint_unreached_surface.py`
+# fails:
+#
+#     gen_worker.x.assert_y()  # a test-only assertion; the property is ...
+#
+# "Call from tests" is an acceptable reason. Silence is not — and silence is
+# what this file granted for months. The header above has named "A gate that
+# never runs" as the FIRST severity class since the day it was written, and it
+# has a working precedent for the right outcome (`numerics_ladder.gate`,
+# delisted 2026-08-02 the moment pgw#848 gave it a caller). But findings were
+# absorbed as unannotated lines, so `boot_key.assert_memo_honest` — the check
+# whose own module header promises "Honesty is enforced, not trusted... A wrong
+# key is never produced" — sat here with permanent tenure while the memo it was
+# supposed to police produced the `graph` axis of every published `cg-key-v1`
+# with nothing checking it. A gate's failure is INVISIBLE precisely because the
+# reasoning around it reads like enforcement; the ratchet has to make it say so
+# out loud.
+#
+# Delisted by WIRING under pgw#1271:
+#   boot_key.assert_memo_honest — called from `mint_supervisor.rule_on_boot_memo`
+#     at the seal/publish seam, the one moment a pod holds a freshly TRACED
+#     class set for the closure its boot may have answered from a memo.
+#   parallel.cp.refuse_unless_divisible — called from
+#     `install_context_parallel`, once per sharding candidate, on the declared
+#     head count.
+# ---------------------------------------------------------------------------
 
-gen_worker.boot_key.assert_memo_honest()
 gen_worker.boot_key.prop_economy()
 gen_worker.component_vocab.ComponentVocabulary.role_of()
 gen_worker.component_vocab.declare_components()
@@ -318,7 +348,7 @@ gen_worker.convert.writer.fp8_te_components()
 gen_worker.convert.writer.streaming_cast_snapshot()
 gen_worker.convert.writer.streaming_w8a8_snapshot()
 gen_worker.families.base.family_registry()
-gen_worker.geometry.FamilyGeometry.assert_declared()
+gen_worker.geometry.FamilyGeometry.assert_declared()  # its own docstring says "Call from tests": it asserts a DECLARATION consistency property (every fit bucket is a declared compile shape) that has no runtime decision to make, and a runtime caller would be re-checking a fact the mint already refuses on.
 gen_worker.input_assets.inputs_dir_for_request()
 gen_worker.io.exists()
 gen_worker.io.read_audio()
@@ -346,7 +376,6 @@ gen_worker.models.tensor_layout_contract.parse_layout_id()
 gen_worker.models.w4a4.quantize_tree_w4a4()
 gen_worker.models.w4a4.sanitize_w4a4_state_dict()
 gen_worker.parallel.cp._GroupMesh.get_group()
-gen_worker.parallel.cp.refuse_unless_divisible()
 gen_worker.procsplit.group.GroupPlan.child()
 gen_worker.progress.reset()
 gen_worker.progress.tracking

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -168,6 +168,18 @@ KIND_APPLIED_ATTENTION = "applied_attention"
 # (`boot_adopt.REASONS`, countable hub-side); `detail` names family, function,
 # derived key and the sentence; `duration_ms` is the derivation's own wall.
 KIND_BOOT_ADOPT = "boot_adopt"
+# pgw#1271: the boot-key MEMO honesty verdict, ruled at the one moment a pod
+# holds both halves — what the memo answered at boot, and what this mint just
+# traced. `boot_key`'s memo path SKIPS THE TRACES and produces the `graph` axis
+# of every published `cg-key-v1`, and the module header's promise ("Honesty is
+# enforced, not trusted... A wrong key is never produced") was carried by
+# `assert_memo_honest`, which had zero `src/` callers: the check existed, read
+# as enforcement, and never ran on a fleet pod. A typed event rather than a log
+# line because a hub-spawned pod's stdout goes nowhere (pgw#760/#1116) and a
+# dishonest memo is a KEY-SPACE fault — the fleet needs it countable.
+# `phase` is `memo_dishonest` / `memo_unrulable`; `detail` carries
+# `assert_memo_honest`'s own sentence, which names every disagreeing class.
+KIND_BOOT_MEMO = "boot_memo_honesty"
 # th#1322: JIT (dynamo/inductor) compile duration, as a typed numeric event.
 # It used to be `logger.info("compiled %s in %.0fs")` and nothing else, so on a
 # hub-spawned pod (no stdout, pgw#760) the one number an AOT-vs-JIT comparison

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -115,8 +115,8 @@ from .compile_cache import (
     _clean_tarinfo,
     _resolve_target,
     parse_cell_ref,
-    sku_slug,
 )
+from . import compile_cache as _compile_cache
 from .models import lora_lifted
 from .models.memory import flush_memory, is_cuda_oom
 
@@ -252,35 +252,26 @@ class IngressContractError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
-def torch_version() -> str:
-    """Full torch version (``2.13.0+cu130``) — the artifact is ABI-locked
-    to it."""
-    try:
-        import torch
-
-        return str(torch.__version__)
-    except Exception:
-        return ""
-
-
 def runtime_key() -> Dict[str, str]:
-    """Consumer-side half of the artifact key, probed from this process.
+    """Consumer-side half of the artifact key — a PROJECTION of the one probe.
 
     ``sm`` is the compiled-code identity (:data:`IDENTITY_AXES`); ``sku`` is
     the GPU's marketing slug, recorded for observability and selection.
-    """
-    key = {"sku": "", "sm": "", "torch": torch_version(), "cuda": ""}
-    try:
-        import torch
 
-        key["cuda"] = str(torch.version.cuda or "")
-        if torch.cuda.is_available():
-            key["sku"] = sku_slug(torch.cuda.get_device_name(0))
-            major, minor = torch.cuda.get_device_capability(0)
-            key["sm"] = f"sm_{major}{minor}"
-    except Exception:
-        pass
-    return key
+    This re-probed torch itself until pgw#1271, behind its own
+    ``except Exception: pass`` — a second implementation of
+    ``compile_cache.runtime_key`` whose failure was SILENT. So the defect
+    pgw#657 fixed there (an empty sku/sm/torch manufactures a key no healthy
+    pod computes, i.e. a guaranteed miss and a mint, with no evidence why) was
+    fixed in one copy only. The four axes are a deliberate projection, not an
+    accidental subset: they are exactly what the artifact envelope carries, and
+    widening them here would re-key every artifact.
+    """
+    # Through the MODULE, never a from-import binding: one probe means one
+    # object to patch, to fix and to reason about.
+    probe = _compile_cache.runtime_key()
+    return {axis: str(probe.get(axis) or "")
+            for axis in ("sku", "sm", "torch", "cuda")}
 
 
 # Stamped cell keys this process LEARNED name aot-inductor artifacts
@@ -3565,7 +3556,6 @@ __all__ = [
     "report_ingress_refusal",
     "split_literals",
     "target_constant_pool",
-    "torch_version",
     "unpack",
     "unpack_metadata",
     "unwrap",

--- a/src/gen_worker/author_ci.py
+++ b/src/gen_worker/author_ci.py
@@ -502,13 +502,21 @@ def read_parity(subject: _Subject, declaration: Any,
     """The mint-parent gate's verdict — read, or (on an ADOPT) taken.
 
     A cell this process MINTED was already gated strictly on the way to
-    publication, so its report (``minted``) is simply read back — an armed cell
-    that had failed that gate would not be armed. A cell that came out of this
-    machine's store was gated at ITS mint and adoption runs no quality gate, so
-    there is no verdict to read and this run takes one through the SAME function
-    the mint uses. Never a comparison re-implemented here.
+    publication, so its report (``minted``) is read back — but READ, never
+    ASSUMED. Until pgw#1271 the mint branch set ``passed = True`` from the mere
+    EXISTENCE of a report: a report's presence was scored as its verdict, so an
+    armed cell whose worst axis is a degraded comparison reported PASS with the
+    failing cosine printed beside it. The verdict now comes from the same place
+    the mint's own gate takes it — ``report.comparison().healthy`` — and is
+    cross-checked against what the pipeline actually SERVES: an entry the arm
+    de-armed is a class this cell does not deliver, whatever its cosine says.
+
+    A cell that came out of this machine's store was gated at ITS mint and
+    adoption runs no quality gate, so there is no verdict to read and this run
+    takes one through the SAME function the mint uses. Never a comparison
+    re-implemented here.
     """
-    from . import numerics_probe
+    from . import aot_serve, numerics_probe
     from .models import provision
 
     pipe = subject.armed_pipeline()
@@ -516,20 +524,38 @@ def read_parity(subject: _Subject, declaration: Any,
         return Parity(False, None, "?", "nothing armed")
     report = minted
     if report is None:
-        passed = provision.gate_cell_numerics(pipe, declaration, strict=True)
+        taken = provision.gate_cell_numerics(pipe, declaration, strict=True)
         report = numerics_probe.last_report()
         detail = "taken by this run through the mint's own gate (adopted cell)"
     else:
-        passed = True
+        taken = None
         detail = "the mint-parent gate's own verdict (pgw#1141)"
     if report is None:
         return Parity(False, None, "?",
                       "the gate ran and produced no report — refusing to call "
                       "an unmeasurable cell healthy (pgw#868)")
     comparison = report.comparison()
+    if comparison is None:
+        return Parity(False, None, report.threshold_source,
+                      f"{detail}; the report names no comparison — "
+                      f"{report.context()[:300]}")
+    # `measured` is both clauses of pgw#868: every declared axis produced a
+    # comparison, and none errored. An unmeasured axis is absent evidence, and
+    # absent evidence is never a pass.
+    passed = bool(comparison.healthy) and bool(report.measured)
+    if taken is not None:
+        passed = passed and bool(taken)
+    de_armed = sorted(
+        name for name, row in aot_serve.entry_states(pipe).items()
+        if str(row.get("state") or "") != "armed")
+    if de_armed:
+        passed = False
+        detail += (f"; {len(de_armed)} entr{'y' if len(de_armed) == 1 else 'ies'} "
+                   f"NOT armed on the pipeline this verdict describes "
+                   f"({de_armed[:5]})")
     return Parity(
-        passed=bool(passed),
-        cosine=None if comparison is None else float(comparison.cosine),
+        passed=passed,
+        cosine=float(comparison.cosine),
         floor_source=report.threshold_source,
         detail=f"{detail}; {report.context()[:400]}")
 

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -53,6 +53,15 @@ traced per-class hashes are compared against whatever the memo answered
 (:func:`assert_memo_honest`), and a mismatch invalidates the memo entry and
 re-traces on the next boot. A wrong key is never produced — at worst a memo is
 thrown away, by the pod that proved it wrong.
+
+THE CALLER, named here because for the whole of pgw#1089's life there was none:
+``mint_supervisor.rule_on_boot_memo``, at the seal/publish seam of every
+supervised mint. Until pgw#1271 this paragraph described a check with **zero
+``src/`` callers** — ``trust_memo=False`` was passed only from tests, both
+production callers took the default, and so the sentence above was FALSE in the
+deployed configuration. It is a sentence that reads exactly like enforcement,
+which is why nothing caught it. If you move the mint's publish seam, move the
+call with it; a paragraph is not a caller.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -37,7 +37,7 @@ from .transport import (
 from .api.binding import wire_ref
 # module import: tests monkeypatch worker_fatal.report_worker_error_async; stay late-bound.
 from . import worker_fatal
-from .topology import delivered_topology
+from .topology import TopologyError, delivered_topology
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +116,12 @@ def probe_hardware() -> Dict[str, Any]:
                     "instead of card 0 (%d bytes) — pgw#776",
                     int(worst), int(free_mem))
                 info["gpu_free_mem"] = int(worst)
+    except TopologyError:
+        # A WEDGED fabric is the one topology fault that must reach the caller:
+        # `delivered_topology` raises it so the hub re-packs instead of this
+        # worker booting and hanging every collective. Swallowed here it read
+        # as "card 0, fine" and the pod went on to serve.
+        raise
     except Exception:
         pass
     try:
@@ -166,6 +172,8 @@ def free_vram_bytes() -> int:
         if worst:
             _warn_once_if_gpus_are_invisible()
             return int(worst)
+    except TopologyError:
+        raise  # see `probe_hardware` — a wedged fabric is never a zero.
     except Exception:
         pass
     try:

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -217,6 +217,93 @@ def assert_family_mintable(family: str) -> None:
         raise DeclaredBlockerRefusal(blocker_refusal(family, blocked))
 
 
+def rule_on_boot_memo(
+    task: MintTask, cfg: Any, result: Any, *, declared: int,
+) -> str:
+    """THE honesty gate (pgw#1271): what the boot memo answered, against what
+    this mint TRACED. Returns the disagreement, or ``""``.
+
+    ``boot_key``'s memo path SKIPS THE TRACES and re-folds stored blocks into
+    the ``graph`` axis of every ``cg-key-v1`` this pod goes on to publish — so
+    the memo is a key generator, and the only thing standing between a stale
+    memo and a wrong published key is a comparison against a freshly traced
+    truth. ``boot_key.assert_memo_honest`` is that comparison. It had **zero
+    src/ callers**: it was written, documented as the thing that makes the memo
+    safe to have at all, exported, tested — and never invoked on a fleet pod.
+
+    THIS is the moment, and there is only one: a mint is the single point in a
+    pod's life where it holds a traced class set for the same closure the boot
+    memoized. So the call sits at the seal/publish seam, before the artifacts
+    ship — and the offending memo entry is invalidated by the callee, so the
+    next boot re-traces instead of re-reading a hash proven wrong.
+
+    Two things are deliberately NOT ruled on, because ruling on them would
+    manufacture disagreements:
+
+    * a PARTIAL class set. Coverage accretes (pgw#1176), so a mint that packed
+      fewer classes than the declaration has cannot distinguish "the memo holds
+      a class we did not trace" from "we have not traced it yet", and
+      ``assert_memo_honest``'s set check would fire on every partial mint.
+    * a mint whose entries carry no keying block — nothing to compare.
+
+    Returns the reason rather than raising: a dishonest memo has already cost
+    what it can cost (the entry is invalidated, the next boot re-traces), and
+    the artifacts in hand were traced by THIS process and are correct. Killing
+    a finished mint over it would turn a self-healing fault into a lost pod.
+    """
+    from . import boot_key
+
+    memo_dir = getattr(task.pending, "cache_dir", None)
+    if not memo_dir:
+        return ""
+    entries = tuple(getattr(result, "entries", ()) or ())
+    if declared <= 0 or len(entries) != int(declared):
+        return ""
+    blocks: Dict[str, Dict[str, Any]] = {}
+    for row in entries:
+        block = dict(getattr(row, "metadata", None) or {}).get(
+            cell_key_mod.ENTRY_BLOCK_KEY)
+        if not isinstance(block, Mapping):
+            return ""
+        blocks[str(row.entry)] = dict(block)
+    if len(blocks) != len(entries):
+        return ""
+    digest = boot_key.closure_digest(
+        str(getattr(cfg, "family", "") or ""),
+        cfg_spec(cfg),
+        function=str(task.function or ""),
+        slots=dict(task.slots),
+    )
+    return boot_key.assert_memo_honest(Path(memo_dir), digest, blocks)
+
+
+def _rule_on_boot_memo(
+    task: MintTask, cfg: Any, result: Any, *, declared: int, family: str,
+) -> None:
+    """Run :func:`rule_on_boot_memo` and report it as a TYPED event.
+
+    Never raises: an unrulable memo is silence, and a dishonest one is a
+    countable wire fact. A log line would be neither — a hub-spawned pod's
+    stdout goes nowhere (pgw#760).
+    """
+    try:
+        reason = rule_on_boot_memo(task, cfg, result, declared=declared)
+    except Exception as exc:  # noqa: BLE001 — never die with the mint
+        activity_mod.emit_event(
+            activity_mod.KIND_BOOT_MEMO,
+            f"family={family}: the boot-key memo could not be ruled on "
+            f"({type(exc).__name__}: {exc}); this mint's keys are the TRACED "
+            f"ones and are unaffected",
+            phase="memo_unrulable")
+        return
+    if not reason:
+        return
+    logger.error("mint-supervisor: %s", reason)
+    activity_mod.emit_event(
+        activity_mod.KIND_BOOT_MEMO, f"family={family}: {reason}",
+        phase="memo_dishonest")
+
+
 #: The mint's evidence counter, in the `family:name` shape every other counter
 #: uses. Plain `mint_child_evidence` split on ":" in `progress.window_for` and
 #: fell back to the generic 300 s window instead of the 600 s the `compile`
@@ -698,6 +785,12 @@ async def supervise(
 
         if not last:
             act.phase(activity_mod.PHASE_SEAL_PUBLISH)
+            # THE honesty gate. This is the one moment a pod holds a freshly
+            # TRACED class set for the closure its boot may have answered from
+            # a memo — and the memo produced the `graph` axis of the key these
+            # artifacts are about to be published under.
+            _rule_on_boot_memo(
+                task, cfg, result, declared=declared, family=family)
             # pgw#1176/pgw#1183: one artifact per graph class; the adopt
             # stages each durable, verifies, arms and stores it in turn, and a
             # class that refuses costs itself.

--- a/src/gen_worker/parallel/cp.py
+++ b/src/gen_worker/parallel/cp.py
@@ -214,6 +214,15 @@ def install_context_parallel(
 
     installed: List[str] = []
     for name, comp in components:
+        # diffusers #12536, at the one moment it costs nothing: the all-to-all
+        # shards the HEAD dimension, so an expert whose declared head count
+        # does not divide the degree fails as an inscrutable shape mismatch
+        # mid-denoise, on a paying request, on a pod that has already rented.
+        # The head count is a property of the MODEL and is knowable here; the
+        # sequence length is a property of a REQUEST and is not, so it is not
+        # stated (see `refuse_unless_divisible`).
+        refuse_unless_divisible(
+            tokens=0, heads=_declared_heads(comp), degree=int(degree))
         _install_on_component(comp, degree=int(degree), comms=comms)
         _install_gate_guard(comp, name)
         installed.append(name)
@@ -360,6 +369,28 @@ def _refuse_if_offloaded(pipeline: Any) -> None:
             )
 
 
+def _declared_heads(comp: Any) -> int:
+    """A sharding candidate's declared attention-head count, or 0.
+
+    Read off the DECLARATION (the model config), never counted from modules: a
+    module walk answers a different question (how many attention blocks) and
+    would produce a confident wrong number. 0 means the component declares
+    none, and an undeclared count is not a divisibility failure.
+    """
+    config = getattr(comp, "config", None)
+    for attr in ("num_attention_heads", "num_heads", "attention_heads"):
+        for holder in (config, comp):
+            if holder is None:
+                continue
+            try:
+                heads = int(getattr(holder, attr, 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if heads > 0:
+                return heads
+    return 0
+
+
 def refuse_unless_divisible(
     *, tokens: int, heads: int, degree: int
 ) -> None:
@@ -367,6 +398,12 @@ def refuse_unless_divisible(
 
     Ulysses shards the sequence across ranks and the head dimension inside the
     all-to-all, so both must divide the degree.
+
+    Either term may be 0 — "this caller cannot state it" — and 0 asserts
+    nothing rather than asserting falsely. ``install_context_parallel`` is
+    exactly such a caller: the head count is a property of the MODEL and is
+    knowable before the pod commits to a packing; the sequence length is a
+    property of a REQUEST and is not knowable at install.
     """
     d = int(degree)
     if d <= 1:

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -777,6 +777,55 @@ def _complete_upload_session(
     raise ArtifactTransferError("tensorhub upload failed", provider="tensorhub", retryable=False)
 
 
+def _typed_presigned_put(
+    *,
+    url: str,
+    file_path: str,
+    offset: int,
+    length: int,
+    cancel_check: Optional[Any],
+    put_pool: Optional[PutPool],
+    extra_headers: Optional[Dict[str, str]] = None,
+    what: str,
+) -> str:
+    """THE presigned PUT. One leg, one typed vocabulary — for BOTH legs.
+
+    ``hubio.transport`` speaks ``TransportError``/``InterruptedError``; every
+    caller above this module speaks ``ArtifactTransferError``/``CanceledError``,
+    and the ``phase == "put"`` + ``status_code == 403`` pair is what
+    :func:`presigned_upload_file` re-plans an expired presign on.
+
+    This helper exists because the conversion used to live only in the
+    MULTIPART leg. The direct-final PUT — the leg production always takes,
+    since ``_stream`` always sends ``sha256`` and the hub therefore always
+    mints ``put_url`` — raised ``TransportError`` raw: it never matched the
+    re-plan's ``except ArtifactTransferError``, so an expired presign lost a
+    whole completed render as an untyped ``RuntimeError``.
+    """
+    try:
+        with _presigned_put_slot():
+            return upload_part_to_presigned_url(
+                url=url,
+                file_path=file_path,
+                offset=int(offset),
+                length=int(length),
+                cancel_check=cancel_check,
+                pool=put_pool,
+                extra_headers=extra_headers,
+            )
+    except InterruptedError as ie:
+        raise CanceledError("canceled") from ie
+    except TransportError as te:
+        raise ArtifactTransferError(
+            f"tensorhub R2 {what} PUT failed: {str(te) or type(te).__name__}",
+            provider="tensorhub",
+            phase="put",
+            retryable=bool(getattr(te, "retryable", False)),
+            status_code=getattr(te, "status_code", None),
+            cause_type=type(te).__name__,
+        ) from te
+
+
 def _put_whole_object(
     *,
     url: str,
@@ -793,16 +842,16 @@ def _put_whole_object(
     stale-socket isolation on retry — because a single-shot PUT is a part
     upload with one part and no ETag ceremony, not a new transport.
     """
-    with _presigned_put_slot():
-        upload_part_to_presigned_url(
-            url=url,
-            file_path=file_path,
-            offset=0,
-            length=int(size_bytes),
-            cancel_check=cancel_check,
-            pool=put_pool,
-            extra_headers=extra_headers,
-        )
+    _typed_presigned_put(
+        url=url,
+        file_path=file_path,
+        offset=0,
+        length=int(size_bytes),
+        cancel_check=cancel_check,
+        put_pool=put_pool,
+        extra_headers=extra_headers,
+        what="direct-final",
+    )
     if on_progress is not None:
         try:
             on_progress(1, 1, int(size_bytes))
@@ -843,27 +892,15 @@ def _upload_parts_to_s3(
         presigned_url = part_urls[part_index]
         offset = part_index * part_size
         length = min(part_size, file_size - offset)
-        try:
-            with _presigned_put_slot():
-                etag = upload_part_to_presigned_url(
-                    url=presigned_url,
-                    file_path=file_path,
-                    offset=offset,
-                    length=length,
-                    cancel_check=cancel_check,
-                    pool=put_pool,
-                )
-        except InterruptedError as ie:
-            raise CanceledError("canceled") from ie
-        except TransportError as te:
-            raise ArtifactTransferError(
-                f"tensorhub R2 multipart PUT failed: {str(te) or type(te).__name__}",
-                provider="tensorhub",
-                phase="put",
-                retryable=bool(getattr(te, "retryable", False)),
-                status_code=getattr(te, "status_code", None),
-                cause_type=type(te).__name__,
-            ) from te
+        etag = _typed_presigned_put(
+            url=presigned_url,
+            file_path=file_path,
+            offset=offset,
+            length=length,
+            cancel_check=cancel_check,
+            put_pool=put_pool,
+            what="multipart",
+        )
         return (part_number, etag, length)
 
     # Upload parts in parallel.

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -622,7 +622,15 @@ def verify_delivered_artifact(artifact: Path, family: str) -> Receipt:
         # A platform-tier cell is adoptable by every pod, so nothing here has
         # to know who we are — and asking anyway would make a seam hiccup
         # refuse the one class that never needed an identity.
-        refuse_untrusted_publisher(receipt, "", "")
+        #
+        # pgw#1271: this branch used to call `refuse_untrusted_publisher(
+        # receipt, "", "")` here — INSIDE that callee's own early-return
+        # condition (`if not needs_viewer_identity(receipt): return`), so it
+        # executed exactly zero checks, immediately before the caller dlopens
+        # the artifact. A call that reads as the last gate before native-code
+        # execution and is structurally incapable of refusing is worse than no
+        # call: it answers the reader's question wrongly. What actually clears
+        # this tier is the SIGNATURE, and it ran above.
         return receipt
     try:
         viewer = _self_viewer()

--- a/src/gen_worker/rigcheck.py
+++ b/src/gen_worker/rigcheck.py
@@ -69,6 +69,14 @@ __all__ = [
 #: never WHETHER the assertion runs.
 FLEET_LINE_FILE_ENV = "GEN_WORKER_FLEET_LINE_FILE"
 
+#: ``cuda_probe.classify_probe_failure`` classes that mean THERE IS NO CUDA
+#: DEVICE HERE, as against a device this host cannot drive. A cardless box is a
+#: different mistake and must not be reported as a host fault (pgw#1120) — but
+#: "cardless" is a fact about the PROBE, not about whether `nvidia-smi` could be
+#: read: only a host with a driver to fail can answer `driver_too_old` or
+#: `cuda_error`, so a broken diagnostic can no longer buy an exemption.
+CARDLESS_PROBE_CLASSES = frozenset({"cuda_unavailable", "torch_unavailable"})
+
 #: Wheels whose version decides whether a kernel/quantization result is about the
 #: fleet's stack or about the rig's. Reported on every run; absence is reported,
 #: not raised — an unbuildable wheel is the finding.
@@ -538,11 +546,16 @@ def assert_fleet_line(
     # A HOST fault is reported before a WHEEL fault even when both are present:
     # on a too-old driver every version string above can be perfect while nothing
     # allocates, and "rebuild the environment" is then the wrong instruction.
-    # NOT gated on `driver`: reading the driver version means `nvidia-smi` ran,
-    # and a host broken enough that it does not is exactly the host this refusal
-    # is for. `cuda_usable is False` is already a MEASUREMENT (a real allocation
-    # was attempted and failed) — `None` means unmeasured and does not refuse.
-    if env.get("cuda_usable") is False:
+    # NOT gated on `driver` any more: reading a driver version means
+    # `nvidia-smi` RAN, and a host broken enough that it does not is exactly the
+    # host this refusal is for — the check was skipping the machines it was
+    # written for. The carve-out it was carrying ("no card at all is a different
+    # mistake") survives, on a signal a broken diagnostic cannot fake: the probe
+    # says WHICH failure this is, and only a host that has a driver to fail can
+    # answer `driver_too_old`/`cuda_error`.
+    if (env.get("cuda_usable") is False
+            and str(env.get("cuda_unusable_class") or "")
+            not in CARDLESS_PROBE_CLASSES):
         raise CudaUnusable(
             f"{what}: REFUSING TO MEASURE — the wheel is on the fleet line but "
             f"this HOST cannot run it.\n"

--- a/src/gen_worker/rigcheck.py
+++ b/src/gen_worker/rigcheck.py
@@ -19,9 +19,10 @@ reads, best-first:
    own code — has this file. The only authority that declares CUDA.
 2. ``fleet-floors.toml`` ``[floors] torch`` — the fleet-wide floor CI enforces
    against every endpoint's lock. Fleet-scoped, torch only.
-3. Installed distribution metadata — the endpoint dist's own ``torch>=…``
-   requirement, else ``gen-worker[torch]``'s. Always available wherever the code
-   under measurement is installed; torch only.
+3. Installed distribution metadata — the ENDPOINT dist's own ``torch>=…``
+   requirement. Torch only, and never this SDK's own: ``gen-worker`` pins the
+   very torch the rig is being asked to prove, so consulting it made the SDK
+   its own last-resort authority and no rig could ever fail to find one.
 
 Every authority found is compared and the STRICTEST floor wins, so a rig sitting
 between two of them fails rather than picking the lenient one. **No authority
@@ -314,7 +315,13 @@ def _collect_authorities(
         found = _fleet_floors_authority(path)
         if found:
             authorities.append(found)
-    for dist in list(endpoint_dists) + ["gen-worker"]:
+    # ENDPOINT dists only. `gen-worker` used to be appended here as a
+    # last-resort authority, which made the SDK certify its own floor: the
+    # requirement it declares is the requirement the rig is installed against,
+    # so every rig passed, and `FleetLineUnknown` — the finding this function
+    # exists to produce — was unreachable on any machine with gen-worker
+    # installed, i.e. every machine that can run a rig.
+    for dist in endpoint_dists:
         found = _metadata_authority(dist)
         if found:
             authorities.append(found)
@@ -531,11 +538,16 @@ def assert_fleet_line(
     # A HOST fault is reported before a WHEEL fault even when both are present:
     # on a too-old driver every version string above can be perfect while nothing
     # allocates, and "rebuild the environment" is then the wrong instruction.
-    if env.get("driver") and env.get("cuda_usable") is False:
+    # NOT gated on `driver`: reading the driver version means `nvidia-smi` ran,
+    # and a host broken enough that it does not is exactly the host this refusal
+    # is for. `cuda_usable is False` is already a MEASUREMENT (a real allocation
+    # was attempted and failed) — `None` means unmeasured and does not refuse.
+    if env.get("cuda_usable") is False:
         raise CudaUnusable(
             f"{what}: REFUSING TO MEASURE — the wheel is on the fleet line but "
             f"this HOST cannot run it.\n"
-            f"  * driver {env.get('driver')} / torch CUDA {env.get('cuda')}: "
+            f"  * driver {env.get('driver') or '<nvidia-smi unreadable>'} / "
+            f"torch CUDA {env.get('cuda')}: "
             f"{env.get('cuda_unusable_class')} — {env.get('cuda_unusable_reason')}\n\n"
             + report
             + "\n\nThis is a DRIVER fact, not a torch defect (pgw#1120). RunPod's "

--- a/tests/test_rigboot_pgw1120.py
+++ b/tests/test_rigboot_pgw1120.py
@@ -345,14 +345,40 @@ def test_a_usable_card_on_the_line_passes(tmp_path, monkeypatch, capsys) -> None
 
 
 def test_a_cardless_host_is_not_a_host_failure(tmp_path, monkeypatch) -> None:
-    """No driver at all is a different mistake and must not be reported as one."""
+    """No card at all is a different mistake and must not be reported as one.
+
+    pgw#1271 re-based the DISCRIMINATOR without touching the property. It used
+    to be "`nvidia-smi` did not answer", which let a BROKEN diagnostic buy the
+    same exemption as an absent card — so the refusal skipped exactly the hosts
+    it was written for. It is now the probe's own class: a cardless box answers
+    `cuda_unavailable` (`torch.cuda.is_available()` is false), and only a host
+    with a driver TO fail can answer `driver_too_old`. This fixture used to
+    pair `driver=None` with `cuda_unusable_class="driver_too_old"`, which no
+    real host can report — torch's "driver too old (found version ...)" comes
+    out of libcuda.
+    """
     _authority(tmp_path, monkeypatch)
     monkeypatch.setattr(
         rigcheck,
         "resolve_environment",
-        lambda: _on_line_env(driver=None, cuda_usable=False),
+        lambda: _on_line_env(
+            driver=None, cuda_usable=False,
+            cuda_unusable_reason="torch.cuda.is_available() is false",
+            cuda_unusable_class="cuda_unavailable"),
     )
     rigcheck.assert_fleet_line("recell", start=tmp_path)
+
+
+def test_a_broken_DIAGNOSTIC_no_longer_buys_a_cardless_exemption(
+    tmp_path, monkeypatch
+) -> None:
+    """pgw#1271. `nvidia-smi` unreadable, and the probe still MEASURED a driver
+    fault: that is a host this rig must refuse to measure on, not a CPU box."""
+    _authority(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        rigcheck, "resolve_environment", lambda: _on_line_env(driver=None))
+    with pytest.raises(rigcheck.CudaUnusable):
+        rigcheck.assert_fleet_line("recell", start=tmp_path)
 
 
 def test_wheel_mismatch_stays_a_plain_mismatch(tmp_path, monkeypatch) -> None:

--- a/tests/test_wired_gates_pgw1271.py
+++ b/tests/test_wired_gates_pgw1271.py
@@ -1,0 +1,563 @@
+"""pgw#1271 — the gates that could not go red, and the caller each now has.
+
+Every row here is a WIRING test, not a logic test. The logic of each gate was
+already correct, already documented and already unit-tested; what did not exist
+was a production call site, so the gate's failure mode was invisible and its
+own prose read like enforcement. A unit test is structurally blind to that
+class — the unit test IS the caller production is missing — so each row below
+drives the PRODUCTION function and asserts the gate fires THROUGH it.
+
+Every row was verified RED against the pre-fix tree before the fix landed.
+
+Nothing here compiles, mints or touches a GPU.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, cast
+
+import pytest
+
+from gen_worker import (
+    aot_serve,
+    author_ci,
+    boot_key,
+    cell_key,
+    compile_cache,
+    lifecycle,
+    mint_supervisor,
+    numerics_ladder,
+    numerics_probe,
+    presigned_upload,
+    receipts,
+    rigcheck,
+)
+from gen_worker.api.errors import ArtifactTransferError
+from gen_worker.hubio.transport import TransportError
+from gen_worker.parallel.cp import (
+    ContextParallelUnavailable,
+    CpComms,
+    install_context_parallel,
+)
+from gen_worker.topology import TopologyError
+
+from harness.receipt_hub import (  # noqa: F401 — fixtures ride along
+    FAMILY, SELF_ENDPOINT,
+    HubStub, _configure, hub, make_artifact, rsa_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# G1 — boot_key.assert_memo_honest now has a production caller
+# ---------------------------------------------------------------------------
+
+
+def _keying_block(*, dim: int = 64) -> Dict[str, Any]:
+    """The shape `aot_mint.keying_block` produces — a keying block, unstamped."""
+    return {
+        "target": "unet",
+        "fork": [],
+        "class_dims": [["h", int(dim)]],
+        "inputs": [{
+            "name": "x", "position": 0, "dtype": "bfloat16",
+            "shape": [1, 4, "s0", 64], "optional": False,
+        }],
+        "symbols": {"s0": [16, 160]},
+        "constants": [],
+        "graph_witness": f"gw-{dim}",
+        "graph": {
+            "v": 3,
+            "constant_fqns": ["w.weight"],
+            "lifted_inputs": [],
+            "pytree": {"user_inputs": ["x"], "in_spec": "", "out_spec": ""},
+            "specialization": {
+                "weight_lane": "bf16", "lora_bucket": 0, "strict": True},
+        },
+    }
+
+
+class _Cfg:
+    """The parent's `CompileCell`, as `cfg_spec` reads it."""
+
+    family = "tiny"
+    targets = ("unet",)
+    shapes = ((1024, 1024),)
+    text_lens = (77,)
+    guidance_scales = (7.5,)
+    lora_bucket = 0
+
+
+class _Pending:
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.family = "tiny"
+
+
+class _Row:
+    def __init__(self, entry: str, block: Dict[str, Any]) -> None:
+        self.entry = entry
+        self.key = f"cg-{entry}"
+        self.metadata = {cell_key.ENTRY_BLOCK_KEY: block}
+
+
+class _Result:
+    def __init__(self, rows: List[_Row]) -> None:
+        self.entries = tuple(rows)
+
+
+def _mint_task(tmp_path: Path) -> Any:
+    return mint_supervisor.MintTask(
+        pending=_Pending(tmp_path),
+        pipe=object(),
+        function="generate",
+        modules=("endpoint",),
+        slots={},
+    )
+
+
+def _stamped(blocks: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """The blocks as the MINT stamps them — through the mint's own function."""
+    return {
+        name: aot_serve.stamp_entry(name, block, strict=True, lora_bucket=0)
+        for name, block in blocks.items()
+    }
+
+
+@pytest.fixture()
+def _runtime_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the runtime key-complete on a GPU-less box.
+
+    Only the PROBE is faked; every value is a real fact of some runtime and
+    nothing about how they fold into a key is touched.
+    """
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: {
+        "sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
+        "triton": "3.6.0", "cuda": "13.0",
+        "image_digest": "sha256:" + "ab" * 32,
+    })
+
+
+def _write_memo(tmp_path: Path, blocks: Dict[str, Dict[str, Any]]) -> str:
+    cfg = _Cfg()
+    digest = boot_key.closure_digest(
+        "tiny", mint_supervisor.cfg_spec(cfg), function="generate", slots={})
+    assert boot_key.write_memo(tmp_path, digest, blocks)
+    return digest
+
+
+def test_the_mint_publish_seam_rules_on_a_DISHONEST_boot_memo(
+    tmp_path: Path, _runtime_key: None,
+) -> None:
+    """THE headline. `assert_memo_honest` had zero src/ callers, so a memo that
+    answered the boot with the WRONG graph half was never contradicted — and
+    the memo path skips the traces, so nothing else in the pod ever held a
+    traced truth to contradict it with.
+
+    Here the memo holds one closure's blocks and the mint traces DIFFERENT
+    ones. The production seam must name the disagreement and invalidate the
+    entry, so the next boot re-traces rather than re-reading a proven-wrong
+    hash.
+    """
+    digest = _write_memo(tmp_path, {"a": _keying_block(dim=64)})
+    traced = _stamped({"a": _keying_block(dim=128)})
+
+    reason = mint_supervisor.rule_on_boot_memo(
+        _mint_task(tmp_path), _Cfg(),
+        _Result([_Row("a", traced["a"])]), declared=1)
+
+    assert "DISHONEST" in reason and "a: memo" in reason
+    # The entry is GONE: the next boot re-traces instead of answering from it.
+    assert boot_key.read_memo(tmp_path, digest) == {}
+
+
+def test_an_HONEST_boot_memo_is_silence_at_the_publish_seam(
+    tmp_path: Path, _runtime_key: None,
+) -> None:
+    blocks = {"a": _keying_block(dim=64)}
+    digest = _write_memo(tmp_path, blocks)
+    traced = _stamped(blocks)
+
+    assert mint_supervisor.rule_on_boot_memo(
+        _mint_task(tmp_path), _Cfg(),
+        _Result([_Row("a", traced["a"])]), declared=1) == ""
+    # An honest memo SURVIVES — the whole economic point of having one.
+    assert boot_key.read_memo(tmp_path, digest) == blocks
+
+
+def test_a_PARTIAL_class_set_rules_on_nothing(
+    tmp_path: Path, _runtime_key: None,
+) -> None:
+    """Coverage accretes (pgw#1176), so a mint that packed 1 of 2 declared
+    classes cannot tell "the memo holds a class we did not trace" from "we have
+    not traced it yet". Ruling anyway would fire `class set differs` on every
+    partial mint — a gate that cries wolf is uninstalled within a week."""
+    blocks = {"a": _keying_block(dim=64), "b": _keying_block(dim=128)}
+    digest = _write_memo(tmp_path, blocks)
+    traced = _stamped(blocks)
+
+    assert mint_supervisor.rule_on_boot_memo(
+        _mint_task(tmp_path), _Cfg(),
+        _Result([_Row("a", traced["a"])]), declared=2) == ""
+    assert boot_key.read_memo(tmp_path, digest) == blocks
+
+
+def test_the_dishonest_verdict_reaches_the_wire_as_a_TYPED_EVENT(
+    tmp_path: Path, _runtime_key: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not a log line: a hub-spawned pod's stdout goes nowhere (pgw#760), and a
+    dishonest memo is a KEY-SPACE fault the fleet has to be able to count."""
+    from gen_worker import activity as activity_mod
+
+    seen: List[Tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: seen.append(
+            (kind, detail, str(kw.get("phase") or ""))))
+
+    _write_memo(tmp_path, {"a": _keying_block(dim=64)})
+    traced = _stamped({"a": _keying_block(dim=128)})
+    mint_supervisor._rule_on_boot_memo(
+        _mint_task(tmp_path), _Cfg(), _Result([_Row("a", traced["a"])]),
+        declared=1, family="tiny")
+
+    assert [(k, p) for k, _d, p in seen] == [
+        (activity_mod.KIND_BOOT_MEMO, "memo_dishonest")]
+    assert "DISHONEST" in seen[0][1]
+
+
+# ---------------------------------------------------------------------------
+# G2 — the rig's fleet line, and the CUDA half
+# ---------------------------------------------------------------------------
+
+
+def test_the_SDK_is_not_its_own_fleet_line_authority(tmp_path: Path) -> None:
+    """`_collect_authorities` appended "gen-worker" to the chain, so the SDK
+    certified the very torch floor the rig was being asked to prove:
+    `FleetLineUnknown` was unreachable on any machine with gen-worker
+    installed — i.e. every machine that can run a rig."""
+    with pytest.raises(rigcheck.FleetLineUnknown):
+        rigcheck.resolve_fleet_line(start=tmp_path, endpoint_dists=())
+
+
+def test_a_host_whose_DIAGNOSTIC_is_broken_still_refuses_to_measure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The refusal used to be gated on `env["driver"]` being readable, i.e. on
+    `nvidia-smi` WORKING. A host broken enough that it does not is exactly the
+    host this refusal exists for, so the check skipped the machines it was
+    written for."""
+    monkeypatch.setattr(rigcheck, "resolve_fleet_line", lambda **_: rigcheck.FleetLine(
+        torch=(2, 13, 0), cuda=(13, 0), authorities=()))
+    monkeypatch.setattr(rigcheck, "resolve_environment", lambda: {
+        "python": "3.12.0",
+        "torch": "2.13.0+cu130",
+        "cuda": "13.0",
+        # nvidia-smi did not answer. The allocation still failed.
+        "driver": "",
+        "cuda_usable": False,
+        "cuda_unusable_reason": "CUDA driver version is insufficient",
+        "cuda_unusable_class": "driver_too_old",
+    })
+
+    with pytest.raises(rigcheck.CudaUnusable):
+        rigcheck.assert_fleet_line("rig", start=tmp_path, stream=None)
+
+
+# ---------------------------------------------------------------------------
+# G3 — the direct-final PUT speaks the caller's exception vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_an_expired_presign_on_the_DIRECT_FINAL_leg_is_typed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The re-plan at `presigned_upload_file` catches `ArtifactTransferError`
+    with `phase == "put"` and `status_code == 403`. The multipart leg produced
+    exactly that; the direct-final leg — the one production ALWAYS takes, since
+    `_stream` always sends `sha256` and the hub therefore always mints
+    `put_url` — raised `TransportError` raw. It matched no `except`, so an
+    expired presign lost a whole completed render as an untyped RuntimeError.
+    """
+    def _boom(**_kw: Any) -> str:
+        raise TransportError("presigned PUT 403", retryable=False, status_code=403)
+
+    monkeypatch.setattr(presigned_upload, "upload_part_to_presigned_url", _boom)
+    body = tmp_path / "render.png"
+    body.write_bytes(b"x" * 32)
+
+    with pytest.raises(ArtifactTransferError) as caught:
+        presigned_upload._put_whole_object(
+            url="https://r2.example/final",
+            file_path=str(body),
+            size_bytes=32,
+            extra_headers={},
+            on_progress=None,
+            cancel_check=None,
+            put_pool=None,
+        )
+
+    exc = caught.value
+    # The exact predicate the re-plan loop tests. Asserted as the predicate,
+    # not as two fields, because the fields only matter through it.
+    assert exc.phase == "put" and getattr(exc, "status_code", None) == 403
+
+
+def test_a_cancel_on_the_direct_final_leg_is_a_CANCEL(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    from gen_worker.api.errors import CanceledError
+
+    def _boom(**_kw: Any) -> str:
+        raise InterruptedError("canceled")
+
+    monkeypatch.setattr(presigned_upload, "upload_part_to_presigned_url", _boom)
+    body = tmp_path / "render.png"
+    body.write_bytes(b"x")
+
+    with pytest.raises(CanceledError):
+        presigned_upload._put_whole_object(
+            url="https://r2.example/final", file_path=str(body), size_bytes=1,
+            extra_headers={}, on_progress=None, cancel_check=None, put_pool=None)
+
+
+# ---------------------------------------------------------------------------
+# G5 — a wedged NVLink fabric is not "card 0, fine"
+# ---------------------------------------------------------------------------
+
+
+def test_a_wedged_fabric_is_not_swallowed_as_a_free_vram_number(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`topology.delivered_topology` raises `TopologyError` on peer access with
+    0.0 GB/s measured — every collective on that host blocks forever, and the
+    refusal exists so the hub RE-PACKS. Two `except Exception: pass` in this
+    module ate it without a log, and the pod reported a perfectly ordinary
+    free-VRAM number and went on to serve."""
+    def _wedged(*_a: Any, **_kw: Any) -> Any:
+        raise TopologyError(
+            "topology_fabric_wedged_peer_access_zero_bandwidth",
+            "peer access reported with 0.0 GB/s measured")
+
+    monkeypatch.setattr(lifecycle, "delivered_topology", _wedged)
+    with pytest.raises(TopologyError):
+        lifecycle.free_vram_bytes()
+
+
+def test_an_ordinary_topology_failure_is_still_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The catch is NARROWED, not removed: a box with no CUDA at all must still
+    report 0 rather than failing a heartbeat."""
+    def _no_torch(*_a: Any, **_kw: Any) -> Any:
+        raise RuntimeError("no CUDA driver")
+
+    monkeypatch.setattr(lifecycle, "delivered_topology", _no_torch)
+    assert lifecycle.free_vram_bytes() == 0
+
+
+# ---------------------------------------------------------------------------
+# author_ci — a report's EXISTENCE is not its verdict
+# ---------------------------------------------------------------------------
+
+
+def _report(cosine: float, *, measured: bool = True) -> numerics_probe.CellNumerics:
+    thresholds = numerics_ladder.Thresholds(
+        floor=0.90, warn=0.99, label="test",
+        source=numerics_ladder.SOURCE_SDK_DEFAULT)
+    comparison = numerics_ladder.Comparison(
+        reference="eager", subject="unet", thresholds=thresholds,
+        rows=(numerics_ladder.RowStat(
+            name="out", elements=16, cosine=cosine, retention=1.0),),
+        cosine=cosine, retention=1.0)
+    axis = numerics_probe.ProbeAxis(entry="unet", target="unet")
+    verdict = numerics_probe.AxisVerdict(
+        axis=axis, comparison=comparison if measured else None,
+        reason="" if measured else "cell_forward_failed")
+    return numerics_probe.CellNumerics(
+        family="tiny", cell_key="cg-1", thresholds=thresholds,
+        threshold_source=thresholds.source, verdicts=(verdict,), axes_total=1)
+
+
+class _Subject:
+    def __init__(self, pipe: Any) -> None:
+        self._pipe = pipe
+
+    def armed_pipeline(self) -> Any:
+        return self._pipe
+
+
+def test_a_DEGRADED_mint_report_does_not_report_PASS(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`read_parity` set `passed = True` in the mint branch from the mere
+    EXISTENCE of a report — the report's presence scored as its verdict. So a
+    cell whose worst axis sits in the DEGRADED band reported PASS with the
+    failing cosine printed on the same line."""
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {
+        "unet": {"state": "armed", "target": "unet", "calls": 1}})
+
+    parity = author_ci.read_parity(
+        cast(Any, _Subject(object())), declaration=None, minted=_report(0.95))
+
+    assert parity.passed is False
+    assert parity.cosine == pytest.approx(0.95)
+
+
+def test_a_HEALTHY_mint_report_still_reports_PASS(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {
+        "unet": {"state": "armed", "target": "unet", "calls": 1}})
+    assert author_ci.read_parity(
+        cast(Any, _Subject(object())), declaration=None, minted=_report(0.999)).passed is True
+
+
+def test_a_DE_ARMED_entry_fails_the_parity_whatever_the_cosine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cross-check. A class the arm de-armed is a class this cell does not
+    deliver; a verdict that describes the cell without consulting what the
+    pipeline SERVES is a verdict about something else."""
+    monkeypatch.setattr(aot_serve, "entry_states", lambda _p: {
+        "unet": {"state": "armed", "target": "unet", "calls": 1},
+        "vae.decode": {"state": "de_armed", "target": "vae",
+                       "reason": "ingress_contract"},
+    })
+    parity = author_ci.read_parity(
+        cast(Any, _Subject(object())), declaration=None, minted=_report(0.999))
+    assert parity.passed is False
+    assert "NOT armed" in parity.detail
+
+
+# ---------------------------------------------------------------------------
+# parallel.cp.refuse_unless_divisible now has a caller
+# ---------------------------------------------------------------------------
+
+
+class _Expert:
+    """A sharding candidate: declares a `_cp_plan` and `enable_parallelism`."""
+
+    _cp_plan = {"hidden_states": object()}
+
+    def __init__(self, heads: int) -> None:
+        self.config = type("Cfg", (), {"num_attention_heads": heads})()
+
+    def enable_parallelism(self, *_a: Any, **_k: Any) -> None:  # pragma: no cover
+        raise AssertionError("the group-aware install replaces this")
+
+
+class _Pipeline:
+    def __init__(self, heads: int) -> None:
+        self.transformer = _Expert(heads)
+
+
+def test_an_indivisible_HEAD_COUNT_is_refused_before_the_pod_commits() -> None:
+    """diffusers #12536: the all-to-all shards the head dimension. An expert
+    whose declared head count does not divide the degree fails as an
+    inscrutable shape mismatch mid-denoise, on a paying request, on a pod that
+    has already rented. `refuse_unless_divisible` said so, was exported, and
+    was called by nothing."""
+    comms = CpComms(pg=object(), rank=0, device="cuda:0")
+    with pytest.raises(ContextParallelUnavailable, match="head count"):
+        install_context_parallel(_Pipeline(heads=6), degree=4, comms=comms)
+
+
+def test_a_divisible_head_count_gets_past_the_divisibility_gate() -> None:
+    """Proves the gate is not a blanket refusal: heads=8 at degree 4 clears it
+    and the call proceeds into the diffusers install, which then fails on this
+    toy component for an unrelated reason. Whatever comes back, it is not the
+    divisibility refusal."""
+    comms = CpComms(pg=object(), rank=0, device="cuda:0")
+    with pytest.raises(Exception) as caught:
+        install_context_parallel(_Pipeline(heads=8), degree=4, comms=comms)
+    assert "head count" not in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# aot_serve.runtime_key is a PROJECTION of the one probe, not a second one
+# ---------------------------------------------------------------------------
+
+
+def test_there_is_ONE_runtime_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`aot_serve.runtime_key` re-probed torch behind its own
+    `except Exception: pass` — a duplicate of `compile_cache.runtime_key` whose
+    failure was SILENT, so pgw#657's fix (say it out loud, because an empty
+    sku/sm/torch manufactures a key no healthy pod computes) lived in one copy
+    only."""
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: {
+        "sku": "h100", "sm": "sm_90", "torch": "9.9.9+cu999", "cuda": "99.9",
+        "triton": "9.9.9", "image_digest": "sha256:ff",
+    })
+    assert aot_serve.runtime_key() == {
+        "sku": "h100", "sm": "sm_90", "torch": "9.9.9+cu999", "cuda": "99.9"}
+
+
+def test_the_projection_stays_four_axes_wide() -> None:
+    """The four axes are what the artifact envelope carries. Widening them here
+    would re-key every artifact, so the projection is asserted, not assumed."""
+    assert set(aot_serve.runtime_key()) == {"sku", "sm", "torch", "cuda"}
+
+
+# ---------------------------------------------------------------------------
+# receipts — no call that reads as the last gate and checks nothing
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptTrustGate:
+    """Driven through the real gate against the real signing hub."""
+
+    def test_the_platform_tier_path_makes_no_VACUOUS_trust_call(
+        self, tmp_path: Path, hub: HubStub, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`verify_delivered_artifact` called `refuse_untrusted_publisher(receipt,
+        "", "")` INSIDE that callee's own early-return condition, so it executed
+        exactly zero checks — immediately before the caller dlopens the artifact.
+
+        Driven through the real gate against the real signing hub: the platform
+        branch must reach its return having made no trust call at all, rather than
+        one that is structurally incapable of refusing.
+        """
+        calls: List[Tuple[str, str]] = []
+        real = receipts.refuse_untrusted_publisher
+
+        def _record(receipt: Any, endpoint_id: str, org_id: str = "") -> None:
+            calls.append((endpoint_id, org_id))
+            real(receipt, endpoint_id, org_id)
+
+        monkeypatch.setattr(receipts, "refuse_untrusted_publisher", _record)
+
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(artifact, publisher_tier="platform")
+        _configure(hub)
+
+        receipt = receipts.verify_delivered_artifact(artifact, FAMILY)
+        assert receipt.publisher_tier == "platform"
+        assert calls == [], (
+            "the platform branch made a trust call that can only ever return")
+
+
+    def test_an_ORG_tier_cell_still_reaches_the_real_trust_gate(
+        self, tmp_path: Path, hub: HubStub, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The other half, so the deletion above cannot have removed enforcement:
+        an org-tier receipt from a foreign endpoint IS refused, and the call that
+        refuses it carries THIS pod's identity — never two empty strings."""
+        calls: List[Tuple[str, str]] = []
+        real = receipts.refuse_untrusted_publisher
+
+        def _record(receipt: Any, endpoint_id: str, org_id: str = "") -> None:
+            calls.append((endpoint_id, org_id))
+            real(receipt, endpoint_id, org_id)
+
+        monkeypatch.setattr(receipts, "refuse_untrusted_publisher", _record)
+
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(
+            artifact, owning_endpoint_id="ep_someone_else",
+            publisher_org_id="org_someone_else")
+        _configure(hub, endpoint_id=SELF_ENDPOINT)
+
+        with pytest.raises(receipts.ReceiptError):
+            receipts.verify_delivered_artifact(artifact, FAMILY)
+        assert calls and calls[0][0] == SELF_ENDPOINT


### PR DESCRIPTION
**HARDCUT-LEDGER Phase 2 (python-gen-worker).** File set: `boot_key.py`, `mint_supervisor.py`, `activity.py`, `rigcheck.py`, `presigned_upload.py`, `lifecycle.py`, `author_ci.py`, `parallel/cp.py`, `aot_serve.py`, `receipts.py`, `scripts/lint_unreached_surface.py`, the ratchet baseline, one new test file. **Provably disjoint from `1270-tcg-declaration-package`**, which touches the TCG module deletions (`aot_compile_spans`, `aot_flatten`, `aot_package`, `graph_hash`, `cell_key`, `local_cell_store`, …) — no file overlaps.

Deliberately NOT in scope: the AOTI/TCG deletions, `hot_swap.py` (th#1834 ruled KEEP PERMANENTLY), anything storage-coupled to `hashrepo.LocalCAS`, the `cell`/`compiled_graph` rename, and ledger items G4/G6.

---

### The defect class

The opposite of carelessness. This repo has zero `torch.load`, zero `'cpu'` accelerators, zero bare `except:`, a CI-enforced env allowlist and a strict mypy ratchet. What it also has is **exceptionally well-reasoned safety gates that were never wired to a caller**, whose failure is invisible *because the reasoning reads like enforcement*.

### G1 — the headline

`boot_key.assert_memo_honest` had **zero `src/` callers**. `trust_memo=False` was passed only from tests (`test_boot_key_pgw1089.py:954`); both production callers (`executor.py:8367`, `boot_adopt.py:464`) took the default. The memo path **skips the traces** and re-folds stored blocks into the `graph` axis of every published `cg-key-v1` — so a stale memo was a key generator with no error path, and the module header's *"Honesty is enforced, not trusted… A wrong key is never produced"* was **false in the deployed configuration**.

Wired at `mint_supervisor.rule_on_boot_memo`, called from `supervise`'s seal/publish seam. That is the only moment in a pod's life where it holds a freshly **traced** class set for the closure its boot may have answered from a memo. A disagreement is the typed `boot_memo_honesty` activity event (`phase=memo_dishonest`), not a log line — a hub-spawned pod's stdout goes nowhere (pgw#760) and a dishonest memo is a key-space fault the fleet has to be able to count. It returns rather than raises: the entry is invalidated (next boot re-traces), and the artifacts in hand were traced by *this* process and are correct — killing a finished mint over it would turn a self-healing fault into a lost pod.

A **partial** class set rules on nothing. Coverage accretes (pgw#1176), so a mint that packed 1 of 2 declared classes cannot tell "the memo holds a class we did not trace" from "we have not traced it yet"; ruling anyway would fire `class set differs` on every incremental mint, and a gate that cries wolf is uninstalled within a week.

### G2 / G3 / G5, and the smaller siblings

| | was | now |
|---|---|---|
| `rigcheck._collect_authorities` | `list(endpoint_dists) + ["gen-worker"]` — the SDK certified its own torch floor, so `FleetLineUnknown` was unreachable on any machine with gen-worker installed | endpoint dists only |
| `rigcheck.assert_fleet_line` | `if env.get("driver") and env.get("cuda_usable") is False` — the refusal was gated on `nvidia-smi` *working* | `if env.get("cuda_usable") is False` (`None` = unmeasured, still no refusal) |
| `presigned_upload._put_whole_object` | raised `TransportError` raw; the re-plan catches `ArtifactTransferError` — and direct-final is the leg production **always** takes | both legs go through `_typed_presigned_put` |
| `lifecycle` × 2 | `except Exception: pass` ate `TopologyError` (wedged NVLink fabric); the pod reported "card 0, fine" and served | narrowed; `TopologyError` propagates, ordinary faults still report 0 |
| `author_ci.read_parity` | `passed = True` from a report's *existence* | `comparison().healthy` + `report.measured`, cross-checked against `aot_serve.entry_states` |
| `parallel.cp.refuse_unless_divisible` | exported, never called | called per sharding candidate from `install_context_parallel` on the declared head count |
| `aot_serve.runtime_key` | a second torch probe behind its own silent `except Exception: pass` — pgw#657's fix lived in one copy only | a four-axis **projection** of `compile_cache.runtime_key` (widening it would re-key every artifact, so the projection is asserted). `torch_version` went with its last caller |
| `receipts.py:625` | `refuse_untrusted_publisher(receipt, "", "")` **inside the callee's own early-return condition** — zero checks, immediately before `dlopen` | deleted; the signature is what clears a platform-tier cell, and it already ran |

### THE STANDING RULE — the durable deliverable

`scripts/unreached_surface_baseline.txt` is a CI-gated bidirectional ratchet whose header has named *"A gate that never runs"* as its **first** severity class since it was written, and which has a working precedent for the right outcome (`numerics_ladder.gate`, delisted 2026-08-02 the moment it acquired a caller). But findings are absorbed as **unannotated lines**, so real gates sat at `:287`, `:321`, `:349` with permanent tenure.

`lint_unreached_surface.py` now **fails** on any baseline row whose leaf symbol matches `assert_*` / `verify_*` / `refuse_*` / `require_*` / `check_*` and carries no inline reason:

```
gen_worker.geometry.FamilyGeometry.assert_declared()  # its own docstring says "Call from tests": …
```

"Call from tests" is an acceptable reason. **Silence is not** — it is indistinguishable from a gate everyone assumes is running. Two rows delisted by wiring, one annotated. `rewrite_baseline` and `_upstream_baseline` preserve/strip inline reasons so `--write-baseline` cannot silently turn every annotated gate row red.

This is also the wiring guard for G1 and the CP gate: if either call site is deleted, the symbol reappears as a NEW finding and the gate goes red.

### Testing

`tests/test_wired_gates_pgw1271.py`, 19 rows, each driving the **production** function — a unit test is structurally blind to this class, because the unit test *is* the caller production is missing. The receipt rows run against the real signing hub stub (real RSA, real HTTP).

**RED-VERIFIED: 14 of 19 fail against `origin/master`'s source.** The 5 that pass are deliberate control rows — the narrowed catch still swallows an ordinary fault; a HEALTHY report still passes; a divisible head count still clears; the projection is still four axes; the org-tier trust gate still refuses. The new lint rule was separately red-verified by stripping the annotated row's reason (exit 1 → exit 0).

`mypy src/gen_worker tests tests_v2` clean (782 files). All 13 gating lints green. 463 passing in the targeted neighbouring suites. Nothing here compiles, mints, or touches a GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QE62XdHkxFUAvkwwWvy8zo
