### PR TITLE
pgw#1273 (SECURITY): the HF lane could select and load a pickle weight

### DIFF
--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -37,7 +37,11 @@ from .. import boot_phases
 from ..capability import InsufficientDiskError
 from .cache_paths import open_worker_cas
 from .download import components_present, select_component_paths
-from .errors import PickleWeightRefused
+from .errors import (
+    PICKLE_WEIGHT_EXTENSIONS,
+    PickleWeightRefused,
+    first_pickle_weight_path,
+)
 from .hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from .refs import TensorhubRef
 
@@ -92,15 +96,8 @@ def _component_of(path: str) -> str:
     return head if separator else "(root)"
 
 
-PICKLE_WEIGHT_EXTENSIONS = (".bin", ".ckpt", ".pt", ".pth", ".pkl", ".pickle")
-
-
-def first_pickle_weight_path(paths: Iterable[str]) -> str:
-    for raw in paths:
-        base = str(raw or "").strip().lower().rsplit("/", 1)[-1]
-        if base.endswith(PICKLE_WEIGHT_EXTENSIONS):
-            return raw
-    return ""
+# PICKLE_WEIGHT_EXTENSIONS and first_pickle_weight_path moved to .errors
+# (pgw#1273) so the HF lane refuses on the same list this one does.
 
 
 def _manifest_entry(file: WorkerResolvedRepoFile) -> FileEntry:

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -34,6 +34,7 @@ from ..config import Settings, current_or
 _STANDALONE = Settings()
 from ..stall import ProgressFloor, SilenceWindow
 from .cache_paths import tensorhub_cas_dir
+from .errors import PickleWeightRefused, first_pickle_weight_path
 from .refs import HuggingFaceRef, TensorhubRef, fold_ref, parse_model_ref
 import hashlib
 from fnmatch import fnmatch
@@ -546,6 +547,24 @@ def _run_with_stall_watchdog(
     return str(holder["local"])
 
 
+def _refuse_pickles_on_disk(root: Path, label: str) -> None:
+    """Refuse if any pickle-format weight is materialized under ``root``.
+
+    Used where there is no listing to refuse against ahead of time. Symlinks
+    are not followed: the HF cache materializes snapshots as symlinks into
+    ``blobs/``, and the name that matters is the one a loader will open.
+    """
+    try:
+        names = [p.name for p in root.rglob("*") if p.is_file() or p.is_symlink()]
+    except OSError:
+        return
+    if bad := first_pickle_weight_path(names):
+        raise PickleWeightRefused(
+            f"refusing {label}: {bad!r} is a pickle-format weight. "
+            "Unpickling is arbitrary code execution in this process."
+        )
+
+
 def _hf_progress_dir(hf_home: Optional[str], ref: HuggingFaceRef) -> Path:
     base = Path(hf_home) if hf_home else Path.home() / ".cache" / "huggingface"
     safe = ref.repo_id.replace("/", "--").replace(":", "_")
@@ -602,10 +621,16 @@ def download_hf(
             # No repo listing available offline to narrow precisely — fall
             # back to component-subfolder + root-json glob patterns.
             patterns = [f"{c}/" for c in comps] + ["*.json"]
-        return Path(snapshot_download(
+        offline = Path(snapshot_download(
             repo_id=repo_id, revision=ref.revision, local_files_only=True,
             allow_patterns=patterns or None, **kwargs,
         ))
+        # pgw#1273: this path returns before the selection-time refusal below,
+        # and offline there is no listing to refuse against — so refuse on what
+        # is actually on disk. A cache populated by an earlier build (or by
+        # hand) is exactly the "reaches a worker by another path" case.
+        _refuse_pickles_on_disk(offline, f"{repo_id}@{ref.revision or 'main'} (cached)")
+        return offline
 
     api = HfApi(token=hf_token)
     repo_files = list(api.list_repo_files(repo_id=repo_id, repo_type="model", revision=ref.revision))
@@ -639,6 +664,34 @@ def download_hf(
             # rather than silently reverting to the whole repo.
             selected = set(repo_files)
             kwargs["allow_patterns"] = repo_files
+
+    # pgw#1273 — REFUSE PICKLES BEFORE A BYTE MOVES.
+    #
+    # `selection` is the final resolved set across all three selection paths
+    # (files= patterns, select_hf_files, or the narrowed listing), so this is
+    # the one chokepoint that sees every HF fetch.
+    #
+    # The gap was structural, not an oversight: `_pick` prefers safetensors but
+    # falls back to the whole group when a component has none
+    # (`pool = st or group`), `select_hf_files` returns None -> full repo on an
+    # unrecognized layout, and `select_component_paths` — which calls itself
+    # "the ONE filter both sources apply" — filters by COMPONENT and never by
+    # extension. Nothing downstream re-checked: `use_safetensors=True` appears
+    # nowhere in this tree, so a selected `pytorch_model.bin` reaches
+    # `from_pretrained` and is unpickled in the process holding hub credentials.
+    #
+    # The tensorhub lane already refuses on the resolved manifest
+    # (cozy_snapshot._validate_resolved); the civitai lane is an allow-list.
+    # This is the same refusal on the same list, for the third provider —
+    # exactly the case PickleWeightRefused's docstring already named:
+    # "defence in depth for blobs that ... reach a worker by another path."
+    selection = selected if selected is not None else set(repo_files)
+    if bad := first_pickle_weight_path(sorted(selection)):
+        raise PickleWeightRefused(
+            f"refusing {repo_id}@{ref.revision or 'main'}: {bad!r} is a pickle-format "
+            "weight. Unpickling is arbitrary code execution in this process. "
+            "Use a safetensors revision, or ingest through the conversion endpoint."
+        )
 
     # Best-effort size guard against accidental huge downloads.
     total_hint: Optional[int] = None

--- a/src/gen_worker/models/errors.py
+++ b/src/gen_worker/models/errors.py
@@ -1,6 +1,8 @@
 """Typed download-failure errors (CONTRACT §9 ModelEvent.error vocabulary)."""
 from __future__ import annotations
 
+from typing import Iterable
+
 
 class UrlExpiredError(RuntimeError):
     """A presigned download URL was rejected with a permanent 4xx (expired
@@ -30,4 +32,33 @@ class PickleWeightRefused(RuntimeError):
     for blobs that predate that refusal or reach a worker by another path."""
 
 
-__all__ = ["UrlExpiredError", "MissingSnapshotError", "PickleWeightRefused"]
+# ONE home for the extension set, beside the refusal it feeds (pgw#1273).
+#
+# There were five independent copies of this list in the tree and they had
+# already drifted: convert/writer.py carried four entries where every other
+# copy carried six, so a component holding only `weights.pkl` yielded ZERO
+# tensors instead of raising. A list that decides whether arbitrary code runs
+# must not be re-typed per call site.
+PICKLE_WEIGHT_EXTENSIONS = (".bin", ".ckpt", ".pt", ".pth", ".pkl", ".pickle")
+
+
+def first_pickle_weight_path(paths: Iterable[str]) -> str:
+    """The first pickle-format weight in ``paths``, or "" if there is none.
+
+    Matches on the BASENAME so a directory component that happens to end in a
+    pickle extension cannot mask a real one further along the path.
+    """
+    for raw in paths:
+        base = str(raw or "").strip().lower().rsplit("/", 1)[-1]
+        if base.endswith(PICKLE_WEIGHT_EXTENSIONS):
+            return raw
+    return ""
+
+
+__all__ = [
+    "UrlExpiredError",
+    "MissingSnapshotError",
+    "PickleWeightRefused",
+    "PICKLE_WEIGHT_EXTENSIONS",
+    "first_pickle_weight_path",
+]

--- a/tests/test_hf_pickle_refusal_pgw1273.py
+++ b/tests/test_hf_pickle_refusal_pgw1273.py
@@ -166,7 +166,7 @@ def test_basename_matching_does_not_mask_a_later_pickle():
     assert first_pickle_weight_path(["notes.pt/readme.md", "a/b.bin"]) == "a/b.bin"
 
 
-def test_refuse_pickles_on_disk_walks_symlinks(tmp_path: Path):
+def test_refuse_pickles_on_disk_walks_symlinks(tmp_path: Path) -> None:
     """The HF cache materializes snapshots as symlinks into blobs/, so a
     check that only counted regular files would see an empty directory."""
     blob = tmp_path / "blobs" / "deadbeef"

--- a/tests/test_hf_pickle_refusal_pgw1273.py
+++ b/tests/test_hf_pickle_refusal_pgw1273.py
@@ -1,0 +1,185 @@
+"""pgw#1273 — the HF lane must refuse pickle weights before a byte moves.
+
+These drive the REAL selection functions and the real `download_hf` body. The
+only fakes are the two huggingface_hub network calls (`HfApi.list_repo_files`
+and `snapshot_download`) — a test that faked the selection would be testing
+nothing, since the selection IS the defect.
+
+Red against master: `select_hf_files` picks `pytorch_model.bin` when a
+component ships no safetensors (`pool = st or group`), `download_hf` has no
+deny-list, and `use_safetensors=True` appears nowhere in the tree — so the file
+reaches `from_pretrained` and is unpickled in the process holding hub
+credentials.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.models import download as dl
+from gen_worker.models.errors import (
+    PICKLE_WEIGHT_EXTENSIONS,
+    PickleWeightRefused,
+    first_pickle_weight_path,
+)
+from gen_worker.models.refs import HuggingFaceRef
+
+
+# --- the selection defect, stated as data ---------------------------------
+
+# A diffusers-shaped repo whose UNet ships only a pickle. This is the shape
+# `_pick`'s `pool = st or group` fallback selects, and it is common upstream.
+PICKLE_ONLY_UNET = [
+    "model_index.json",
+    "unet/config.json",
+    "unet/diffusion_pytorch_model.bin",
+    "vae/config.json",
+    "vae/diffusion_pytorch_model.safetensors",
+]
+
+ALL_SAFETENSORS = [
+    "model_index.json",
+    "unet/config.json",
+    "unet/diffusion_pytorch_model.safetensors",
+    "vae/config.json",
+    "vae/diffusion_pytorch_model.safetensors",
+]
+
+
+def test_selection_still_picks_the_pickle_when_a_component_has_none():
+    """Pin the actual behaviour the refusal defends against.
+
+    This asserts the SELECTOR is unchanged — the fix is a refusal, not a
+    silent narrowing. Narrowing would fetch a component with no weights at
+    all, which fails later and further away.
+    """
+    selected = dl.select_hf_files(PICKLE_ONLY_UNET)
+    assert selected is not None
+    assert "unet/diffusion_pytorch_model.bin" in selected, (
+        "if this stops holding, the selector changed and the refusal below is "
+        "no longer proving what it claims to prove"
+    )
+
+
+# --- the refusal ----------------------------------------------------------
+
+def _fake_hf(monkeypatch, repo_files):
+    """Replace ONLY the huggingface_hub module the code resolves at call time.
+
+    `download_hf` does `hub = hf()` then pulls `HfApi`/`snapshot_download` off
+    it, so this substitutes at that seam and leaves every line of selection,
+    narrowing and refusal running as production.
+    """
+    class _Api:
+        def __init__(self, *a, **k):
+            pass
+
+        def list_repo_files(self, **_k):
+            return list(repo_files)
+
+        def list_repo_tree(self, **_k):
+            return []
+
+    calls: list[dict] = []
+
+    def _snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return "/nonexistent/should-not-be-reached"
+
+    class _Hub:
+        HfApi = _Api
+        snapshot_download = staticmethod(_snapshot_download)
+
+    # download_hf does a function-local `from ..net import hf`, so the seam is
+    # on gen_worker.net, not on this module.
+    import gen_worker.net as net
+
+    monkeypatch.setattr(net, "hf", lambda: _Hub)
+    return calls
+
+
+def test_download_hf_refuses_a_pickle_before_downloading(monkeypatch):
+    calls = _fake_hf(monkeypatch, PICKLE_ONLY_UNET)
+    ref = HuggingFaceRef(repo_id="org/pickled", revision="main")
+
+    with pytest.raises(PickleWeightRefused) as excinfo:
+        dl.download_hf(ref)
+
+    assert "diffusion_pytorch_model.bin" in str(excinfo.value)
+    assert calls == [], (
+        "snapshot_download was invoked — the refusal must land BEFORE a byte "
+        "moves, not after"
+    )
+
+
+def test_download_hf_admits_an_all_safetensors_repo(monkeypatch):
+    """The control. A refusal that refuses everything proves nothing."""
+    calls = _fake_hf(monkeypatch, ALL_SAFETENSORS)
+    ref = HuggingFaceRef(repo_id="org/clean", revision="main")
+
+    dl.download_hf(ref)
+    assert len(calls) == 1, "the clean repo must still download"
+
+
+def test_download_hf_refuses_a_pickle_reached_through_files_patterns(monkeypatch):
+    """The `files=` path bypasses select_hf_files entirely, so it needs the
+    same chokepoint — an explicit pattern is not consent to unpickle."""
+    calls = _fake_hf(monkeypatch, PICKLE_ONLY_UNET)
+    ref = HuggingFaceRef(repo_id="org/pickled", revision="main")
+
+    with pytest.raises(PickleWeightRefused):
+        dl.download_hf(ref, allow_patterns=["unet/*"])
+    assert calls == []
+
+
+# --- the shared list ------------------------------------------------------
+
+def test_one_home_for_the_extension_set():
+    """Five copies of this list existed and had already drifted — convert's
+    carried four entries where the others carried six, so a `.pkl`-only
+    component yielded zero tensors instead of raising."""
+    assert set(PICKLE_WEIGHT_EXTENSIONS) == {
+        ".bin", ".ckpt", ".pt", ".pth", ".pkl", ".pickle"
+    }
+
+    # cozy_snapshot must consume the shared list, not redeclare one.
+    import gen_worker.models.cozy_snapshot as cs
+
+    assert cs.PICKLE_WEIGHT_EXTENSIONS is PICKLE_WEIGHT_EXTENSIONS
+    assert cs.first_pickle_weight_path is first_pickle_weight_path
+
+
+@pytest.mark.parametrize("ext", PICKLE_WEIGHT_EXTENSIONS)
+def test_every_listed_extension_is_refused(ext, monkeypatch):
+    repo = ["model_index.json", "unet/config.json", f"unet/weights{ext}"]
+    calls = _fake_hf(monkeypatch, repo)
+    with pytest.raises(PickleWeightRefused):
+        dl.download_hf(HuggingFaceRef(repo_id="org/x", revision="main"))
+    assert calls == []
+
+
+def test_basename_matching_does_not_mask_a_later_pickle():
+    """A directory whose name ends in an extension must not shadow a real
+    weight further along the path."""
+    assert first_pickle_weight_path(["notes.pt/readme.md"]) == ""
+    assert first_pickle_weight_path(["notes.pt/readme.md", "a/b.bin"]) == "a/b.bin"
+
+
+def test_refuse_pickles_on_disk_walks_symlinks(tmp_path: Path):
+    """The HF cache materializes snapshots as symlinks into blobs/, so a
+    check that only counted regular files would see an empty directory."""
+    blob = tmp_path / "blobs" / "deadbeef"
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"not really a pickle")
+    snap = tmp_path / "snapshots" / "rev" / "unet"
+    snap.mkdir(parents=True)
+    (snap / "diffusion_pytorch_model.bin").symlink_to(blob)
+
+    with pytest.raises(PickleWeightRefused):
+        dl._refuse_pickles_on_disk(tmp_path / "snapshots", "org/x (cached)")
+
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    (clean / "model.safetensors").write_bytes(b"ok")
+    dl._refuse_pickles_on_disk(clean, "org/y (cached)")


### PR DESCRIPTION
> **The pickle ban is absolute — reading IS the banned act.** The Hugging Face direct-download lane had no refusal. Every link below verified at source.

## The chain

| | |
|---|---|
| `download.py:300` | `_WEIGHT_SUFFIXES` admits `.bin`, `.pt`, `.pth`, `.ckpt` |
| `download.py:353` | `_pick` does **`pool = st or group`** — a component with no safetensors falls back to the whole group and **selects the pickles** |
| `download.py:345` | `select_hf_files` returns `None` → **whole repo** on an unrecognized layout |
| `download_hf` | applies these as `allow_patterns` with **no deny-list and no post-download check** |
| whole `src/` tree | **`use_safetensors=True` appears ZERO times** — so a selected `pytorch_model.bin` reaches `from_pretrained` and is unpickled in the process holding hub credentials |

The gap is structural rather than an oversight: `select_component_paths` describes itself as *"the ONE filter both sources apply"* and filters by **component**, never by extension.

**The org already does this correctly, twice.** The tensorhub lane refuses on the resolved manifest *before a byte moves* (`cozy_snapshot._validate_resolved`); the civitai lane is a clean allow-list. Only HF had nothing — exactly the case `PickleWeightRefused`'s own docstring already named: *"defence in depth for blobs that … reach a worker by another path."*

## The fix — two layers

1. **Selection-time refusal** at the one chokepoint that sees every HF fetch. `selection` is the final resolved set across all three paths (`files=` patterns, `select_hf_files`, narrowed listing). Refuses **before a byte moves**.
2. **A materialized-directory refusal** for `local_files_only`, which returns before that chokepoint and has no listing to refuse against. Follows symlinks, because the HF cache materializes snapshots as symlinks into `blobs/`.

**The selector is deliberately unchanged.** Narrowing `_pick` would fetch a component with no weights at all and fail later and further away; refusing names the file.

## One home for the extension set

There were **five copies** and they had already drifted — `convert/writer.py` carried four entries where every other copy carried six, so a `.pkl`-only component yielded **zero tensors instead of raising**. `PICKLE_WEIGHT_EXTENSIONS` and `first_pickle_weight_path` now live beside `PickleWeightRefused` in `models/errors.py`; `cozy_snapshot` consumes them.

## Verification

**Red-verified.** With only `download.py` reverted to master (shared list kept so the module still collects), **9 of 13 fail** — every refusal case plus the on-disk check.

The 4 that pass are the controls, and one of them matters: `test_selection_still_picks_the_pickle_when_a_component_has_none` pins that the selector really does choose the `.bin`, so the refusal tests prove a real defect rather than a hypothetical.

Tests drive the **real** selection and the real `download_hf` body — the only substitution is the `huggingface_hub` module at the `net.hf()` seam the code already resolves through.

- `mypy` clean on all three modules
- `lint_config_reads`, `lint_unreached_surface` green
- 105 passed / 1 skipped across the download, snapshot and pickle suites

Found by the convert/quantization greenfield re-derivation.