### PR TITLE
pgw#896 + pgw#897 + pgw#898: one `hostfacts` module — the host is measured once, and a second answer becomes unrepresentable

### DIFF
--- a/changelog.d/pgw896.md
+++ b/changelog.d/pgw896.md
@@ -1,0 +1,21 @@
+Every fact the worker observes about its own host now has ONE home,
+`gen_worker.hostfacts`. The CUDA predicate, the free/total VRAM readings, the
+cgroup CPU quota and `/proc/meminfo` each have exactly one code site, fenced by
+a test, so two call sites can no longer disagree about the same physical fact.
+
+Three behaviour fixes fall out of the collapse:
+
+* a fractional CPU quota is no longer rounded UP. A 2.5-core pod reported 3
+  cores to the hub and to the compile-pool sizer while torch was given 2.5, so
+  the derived thread pools sat above the quota and the kernel throttled them.
+* the AOT compile pool and the host-RAM load guard now credit the same
+  reclaimable page cache, from one probe with one sibling divisor. The pool had
+  its own, narrower definition and no divisor, so on a split pod the two
+  components sized against the same RAM with denominators that differed by the
+  split degree.
+* a CUDA device that will not answer is now distinguishable from a host with no
+  card. `torch.cuda.is_available()` is False for both, so a wedged GPU served
+  every function on the CPU rung behind a warning that said the pod had no GPU.
+
+`WorkerResources` now has a single builder. The compute child built a second
+copy that the control parent overwrote before the hub ever saw it.

--- a/src/gen_worker/adopt_fit.py
+++ b/src/gen_worker/adopt_fit.py
@@ -58,6 +58,8 @@ import contextlib
 import logging
 import threading
 from typing import Any, Dict, Iterator, Optional
+from .hostfacts import cuda_ready
+from . import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +81,7 @@ def _torch() -> Any:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return None
         return torch
     except Exception:  # noqa: BLE001 — a probe never changes an outcome
@@ -156,20 +158,8 @@ def headroom(device: Optional[int] = None) -> Optional[int]:
     device cannot be probed. Driver-free plus the allocator cache this process
     can return — cached blocks are headroom, and counting only ``free`` would
     refuse a card holding a large idle cache."""
-    torch = _torch()
     index = _device_index(device)
-    if torch is None or index is None:
-        return None
-    try:
-        free, _total = torch.cuda.mem_get_info(index)
-        reclaimable = max(
-            0,
-            int(torch.cuda.memory_reserved(index))
-            - int(torch.cuda.memory_allocated(index)),
-        )
-        return int(free) + reclaimable
-    except Exception:  # noqa: BLE001
-        return None
+    return None if index is None else hostfacts.headroom_bytes(index)
 
 
 def refusal(what: str, device: Optional[int] = None) -> str:

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -92,6 +92,7 @@ from .aot_compile_pool import (
     PackedGraphClass,
 )
 from . import aot_device_lock
+from .hostfacts import cuda_ready
 from .child_preflight import (
     PreflightRefused,
     assert_slots_resolvable,
@@ -169,7 +170,7 @@ def _peak_device() -> tuple:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return (0, 0)
         return (int(torch.cuda.max_memory_allocated()),
                 int(torch.cuda.max_memory_reserved()))
@@ -339,7 +340,7 @@ def run(job: EntryJob) -> int:
     # whatever the seal's torch import allocated first. A probe: it reads and
     # clears a counter and decides nothing.
     try:
-        if torch.cuda.is_available():
+        if cuda_ready():
             torch.cuda.reset_peak_memory_stats()
     except Exception:  # noqa: BLE001 — a probe never changes an outcome
         pass

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -77,11 +77,15 @@ from . import compile_posture, kernel_path
 from .child_contract import CompileSpec, MintSlot
 from .compile_posture import (
     USER_MACHINE_RSS_RESERVE_BYTES, CompilePosture)
-from .postmortem import cpu_quota_cores
+from . import hostfacts
+from .hostfacts import cuda_ready
+from .models.memory import probe_host_ram
 from .stall import SilenceWindow
 import hashlib
 
 logger = logging.getLogger(__name__)
+
+_GIB = 1024 ** 3
 
 ENTRY_CHILD_MODULE = "gen_worker.aot_compile_child"
 
@@ -349,114 +353,52 @@ class PoolWidth:
         return out
 
 
-def _read_int(path: Path) -> Optional[int]:
-    try:
-        raw = path.read_text().strip()
-    except OSError:
-        return None
-    if raw == "max":
-        return None
-    try:
-        value = int(raw)
-    except ValueError:
-        return None
-    # A cgroup v1 "unlimited" is a huge sentinel, not a limit.
-    return value if 0 <= value < (1 << 62) else None
-
-
-def _cgroup_reclaimable_bytes(stat: Path) -> int:
-    """File pages this cgroup is charged for that the kernel will hand back
-    under pressure — page cache, and reclaimable slab.
-
-    pgw#842: ``memory.current`` counts page cache. A mint reads GBs (weights,
-    the toolchain the seal hashes, every staged program) and every one of
-    those pages inflates ``current`` until something needs the memory. Sizing
-    a pool on ``max - current`` therefore shrinks the pool in proportion to
-    how much I/O the pod has already done — a bound that moves with history
-    instead of with the box. Subtracting what is reclaimable is the same
-    working-set definition every container runtime uses.
-    """
-    total = 0
-    try:
-        lines = stat.read_text().splitlines()
-    except OSError:
-        return 0
-    wanted = {
-        "inactive_file", "slab_reclaimable",          # cgroup v2
-        "total_inactive_file", "total_slab_reclaimable",  # cgroup v1
-    }
-    for line in lines:
-        parts = line.split()
-        if len(parts) == 2 and parts[0] in wanted:
-            try:
-                total += int(parts[1])
-            except ValueError:
-                continue
-    return total
-
-
 def memory_facts(
     *,
-    meminfo: Path = Path("/proc/meminfo"),
+    meminfo: Optional[Path] = None,
     cgroup_root: Path = Path("/sys/fs/cgroup"),
+    proc_self_cgroup: Path = Path("/proc/self/cgroup"),
 ) -> MemoryFacts:
-    """Host RAM this process may actually take, cgroup-aware.
+    """Host RAM this pool may take — a PROJECTION of ``probe_host_ram``.
 
-    ``MemAvailable`` is the host's answer and a container's limit is not; the
-    narrower of the two is the only honest one — the same rule
-    ``effective_cpu_count`` applies to cores. Both readings are kept, so the
-    telemetry can say WHICH one bounded the pool.
+    pgw#897: this used to be a second host-RAM probe with its own
+    ``/proc/meminfo`` parse and its own, narrower, "reclaimable" definition
+    (``inactive_file + slab_reclaimable``, missing the ACTIVE file LRU that
+    ``models/memory`` documents as the dominant term for a pod that just
+    downloaded its weights) and NO sibling divisor — so on a split pod the
+    compile pool sized itself against the whole container while the host-move
+    guard sized against 1/G of it. Two components allocating from the same RAM
+    with denominators that differed by the split degree.
 
-    The paths are arguments so a test can drive this function against a real
-    (synthetic) cgroup tree instead of re-implementing its arithmetic.
+    The paths stay arguments so a test can drive the real arithmetic against a
+    synthetic cgroup tree instead of re-implementing it.
     """
-    host = 0
-    try:
-        for line in meminfo.read_text().splitlines():
-            if line.startswith("MemAvailable:"):
-                host = int(line.split()[1]) * 1024
-                break
-    except (OSError, ValueError, IndexError):
-        host = 0
-    cgroup = -1
-    reclaimable = 0
-    for limit_name, usage_name, stat_name in (
-        ("memory.max", "memory.current", "memory.stat"),
-        ("memory/memory.limit_in_bytes", "memory/memory.usage_in_bytes",
-         "memory/memory.stat"),
-    ):
-        limit = _read_int(cgroup_root / limit_name)
-        used = _read_int(cgroup_root / usage_name)
-        if limit is None or used is None or limit <= 0:
-            continue
-        reclaimable = _cgroup_reclaimable_bytes(cgroup_root / stat_name)
-        working_set = max(0, used - reclaimable)
-        cgroup = max(0, limit - working_set)
-        break
-    if host > 0 and cgroup >= 0:
-        basis = "cgroup" if cgroup < host else "meminfo"
-        return MemoryFacts(min(host, cgroup), basis, host, cgroup, reclaimable)
-    if cgroup >= 0:
-        return MemoryFacts(cgroup, "cgroup", host, cgroup, reclaimable)
-    if host > 0:
-        return MemoryFacts(host, "meminfo", host, -1, 0)
-    return MemoryFacts(0, "unreadable", 0, -1, 0)
+    ram = probe_host_ram(
+        root=cgroup_root, proc_self_cgroup=proc_self_cgroup, meminfo=meminfo)
+    host = int(ram.meminfo_available_gb * _GIB)
+    reclaimable = int(ram.reclaimable_file_gb * _GIB)
+    cgroup = (
+        -1 if ram.cgroup_limit_gb is None
+        else int(ram.available_gb * _GIB) if ram.source == "cgroup"
+        else int(ram.cgroup_limit_gb * _GIB)
+    )
+    if host <= 0 and cgroup < 0:
+        return MemoryFacts(0, "unreadable", 0, -1, 0)
+    return MemoryFacts(
+        int(ram.available_gb * _GIB), ram.source, host, cgroup, reclaimable)
 
 
 def cpu_facts() -> CpuFacts:
-    """The pod's honest core count, and which of the three readings it is."""
-    os_count = os.cpu_count() or 1
-    try:
-        affinity = len(os.sched_getaffinity(0))
-    except (AttributeError, OSError):
-        affinity = os_count
-    quota = cpu_quota_cores()
-    quota_cores = float(quota) if quota is not None else -1.0
-    candidates = [(os_count, "cpu_count"), (affinity, "affinity")]
-    if quota is not None:
-        candidates.append((max(1, int(quota + 0.5)), "quota"))
-    vcpus, basis = min(candidates)
-    return CpuFacts(max(1, vcpus), basis, os_count, affinity, quota_cores)
+    """The pod's honest core count — a PROJECTION of ``hostfacts.cpu_allowance``.
+
+    pgw#897: this was the THIRD independent ``min()`` over the same three
+    candidates, and the second to round the quota half-up. A 2.5-core pod sized
+    its compile width at 3.
+    """
+    allowance = hostfacts.cpu_allowance()
+    return CpuFacts(
+        allowance.whole_cores, allowance.basis,
+        allowance.os_count, allowance.affinity, allowance.quota_cores)
 
 
 def _has_card() -> bool:
@@ -469,12 +411,14 @@ def _has_card() -> bool:
     it needs presence and never size. Unreadable counts as present: refusing
     to widen is the conservative answer for a lock question.
     """
+    # `cuda_ready()` answers False for BOTH "no card" and "torch will not
+    # import"; for a LOCK bound the second must read as PRESENT, so it is
+    # stated here rather than inherited from the predicate.
     try:
-        import torch
-
-        return bool(torch.cuda.is_available())
+        import torch  # noqa: F401 — an unimportable torch is not an absent card
     except Exception:  # noqa: BLE001
         return True
+    return bool(cuda_ready())
 
 
 def entry_workers(

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -87,6 +87,7 @@ later step could upload.
 """
 
 from __future__ import annotations
+from .hostfacts import cuda_ready
 
 import argparse
 import contextlib
@@ -234,7 +235,7 @@ def raise_if_device_oom(exc: BaseException, where: str) -> None:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             peak = int(torch.cuda.max_memory_allocated())
     except Exception:  # noqa: BLE001 — a probe never changes an outcome
         peak = 0
@@ -3606,7 +3607,7 @@ def release_mint_residents(
     cuda = False
     before = 0
     try:
-        cuda = torch.cuda.is_available()
+        cuda = cuda_ready()
         if cuda:
             before = int(torch.cuda.memory_reserved())
     except Exception:  # noqa: BLE001 — a probe never changes an outcome

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -119,6 +119,7 @@ from .compile_cache import (
 from . import compile_cache as _compile_cache
 from .models import lora_lifted
 from .models.memory import flush_memory, is_cuda_oom
+from . import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -1867,16 +1868,14 @@ def _tensor_bytes(values: Iterable[Any]) -> int:
 
 def _device_memory_line() -> str:
     """One human line of live device memory for a typed refusal."""
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return "device=cpu"
-        free, total = torch.cuda.mem_get_info()
-        return (f"device free {free / (1 << 20):.0f} MiB of "
-                f"{total / (1 << 20):.0f} MiB")
-    except Exception:  # noqa: BLE001 — context, never a gate
+    if not hostfacts.cuda_ready():
+        return "device=cpu"
+    free = hostfacts.free_vram_bytes()
+    total = hostfacts.total_vram_bytes()
+    if free is None or total is None:
         return "device=unknown"
+    return (f"device free {free / (1 << 20):.0f} MiB of "
+            f"{total / (1 << 20):.0f} MiB")
 
 
 #: :func:`target_constant_pool`'s refusal for a resident tensor an AOTI

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -80,7 +80,7 @@ import msgspec
 
 from . import aot_serve, boot_phases, cell_key, compile_cache as cc, env_seal
 from .child_contract import CompileSpec, MintSlot, slot_subjects
-from .postmortem import cpu_quota_cores, effective_cpu_count
+from . import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -280,13 +280,12 @@ def trace_workers(classes: int, *, limit: int = 0) -> PoolWidth:
     keeps this function free of a device parameter no caller would pass.
     """
     classes = max(1, int(classes))
-    quota = cpu_quota_cores()
-    if quota is not None:
-        cores = max(1, int(quota))
-        basis = f"cgroup cpu.max={quota:g}"
-    else:
-        cores = effective_cpu_count()
-        basis = f"effective_cpu_count={cores} (uncapped cgroup)"
+    # ONE reduction (hostfacts): quota AND affinity AND host count, floored.
+    # The old branch took floor(quota) when a quota existed, ignoring the
+    # affinity mask — a fourth answer to "how many cores may I use".
+    allowance = hostfacts.cpu_allowance()
+    cores = allowance.whole_cores
+    basis = f"{allowance.basis}={allowance.cores:g} cores"
     usable = max(1, cores - SERVING_HEADROOM_CORES)
     workers = min(classes, usable)
     binding = "classes" if workers == classes else "cpu"
@@ -656,14 +655,8 @@ def free_device_bytes() -> int:
     serving throughout a boot) are already excluded — the children compete for
     what is left, not for the nameplate capacity.
     """
-    try:
-        import torch
-        if not torch.cuda.is_available():
-            return 0
-        free, _total = torch.cuda.mem_get_info()
-        return max(0, int(free))
-    except Exception:  # noqa: BLE001 — a probe never changes an outcome
-        return 0
+    free = hostfacts.free_vram_bytes()
+    return max(0, int(free)) if free is not None else 0
 
 
 def concurrency_budget(

--- a/src/gen_worker/boot_trace_child.py
+++ b/src/gen_worker/boot_trace_child.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import msgspec
+from . import hostfacts
 
 from .child_preflight import (
     PreflightRefused,
@@ -322,16 +323,16 @@ def _device_peak_bytes() -> int:
     """
     try:
         import torch
+
+        if not torch.cuda.is_initialized():
+            return 0
     except Exception:  # noqa: BLE001 — telemetry never fails a trace
         return 0
-    try:
-        if not torch.cuda.is_available() or not torch.cuda.is_initialized():
-            return 0
-        free, total = torch.cuda.mem_get_info()
-        used = int(total) - int(free)
-        return max(0, used)
-    except Exception:  # noqa: BLE001
+    free = hostfacts.free_vram_bytes()
+    total = hostfacts.total_vram_bytes()
+    if free is None or total is None:
         return 0
+    return max(0, int(total) - int(free))
 
 
 def main(argv: List[str]) -> int:

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -46,6 +46,7 @@ from ..api.binding import rebind_pick
 from .sockaddr import DEFAULT_SOCKET_PATH
 from . import invoke as invoke_mod
 from .local_context import _stderr_emitter
+from ..hostfacts import cuda_ready
 
 
 # Exit codes.
@@ -794,12 +795,7 @@ def _structure_device(device: str) -> str:
     want = (device or "").strip().lower()
     if want:
         return want
-    try:
-        import torch
-
-        return "cuda" if torch.cuda.is_available() else "cpu"
-    except Exception:  # noqa: BLE001 — torch-less environment
-        return "cpu"
+    return "cuda" if cuda_ready() else "cpu"
 
 
 def _load_injected_model(

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -59,6 +59,7 @@ from .protocol import PROTOCOL_VERSION, gen_worker_version
 from .sockaddr import DEFAULT_SOCKET_PATH
 from ..api.binding import BINDING_TYPES
 from ..models import provision
+from ..hostfacts import cuda_ready
 
 
 
@@ -250,7 +251,7 @@ def _make_gpu_semaphore() -> threading.BoundedSemaphore:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             gpu_count = int(torch.cuda.device_count() or 0)
     except Exception:
         gpu_count = 0

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -95,6 +95,7 @@ from .models.refs import parse_model_ref
 from .models.w8a8_lora import RANK_BUCKETS
 from .models import execution_lanes as lanespec
 from .models import loading as _loading
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -671,7 +672,7 @@ def runtime_key() -> Dict[str, str]:
 
         key["torch"] = str(torch.__version__)
         key["cuda"] = str(torch.version.cuda or "")
-        if torch.cuda.is_available():
+        if cuda_ready():
             key["sku"] = sku_slug(torch.cuda.get_device_name(0))
             major, minor = torch.cuda.get_device_capability(0)
             key["sm"] = f"sm_{major}{minor}"
@@ -1684,10 +1685,10 @@ def arming_block(
         return ("the hub-resolved execution lane is operator-pinned to +eager "
                 "(pgw#714 kill switch)")
     try:
-        import torch
+        import torch  # noqa: F401 — the import IS the probe here
     except Exception as exc:  # noqa: BLE001 — a torchless process is eager
         return f"torch is not importable ({type(exc).__name__}: {exc})"
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return "torch reports no CUDA device in this process"
     if cache_ready:
         return ""

--- a/src/gen_worker/cpu_budget.py
+++ b/src/gen_worker/cpu_budget.py
@@ -41,53 +41,24 @@ from __future__ import annotations
 
 import logging
 import math
-import os
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
+
+from . import hostfacts
 from .procsplit import host_siblings
 
 logger = logging.getLogger(__name__)
 
-_CGROUP_V2 = "/sys/fs/cgroup/cpu.max"
-_CGROUP_V1_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-_CGROUP_V1_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-
-
-def cgroup_cpu_quota() -> Optional[float]:
-    """CPU cores this cgroup may use, or None when unlimited/unreadable."""
-    try:
-        raw = Path(_CGROUP_V2).read_text().split()
-        if raw and raw[0] != "max":
-            return int(raw[0]) / int(raw[1])
-        if raw:
-            return None
-    except (OSError, ValueError, IndexError):
-        pass
-    try:
-        quota = int(Path(_CGROUP_V1_QUOTA).read_text().strip())
-        period = int(Path(_CGROUP_V1_PERIOD).read_text().strip())
-        if quota > 0 and period > 0:
-            return quota / period
-    except (OSError, ValueError):
-        pass
-    return None
-
 
 def cpu_allowance() -> float:
-    """The narrowest true bound on this process's CPU: cgroup quota,
-    affinity mask, and cpu_count — whichever is smallest."""
-    bounds = []
-    quota = cgroup_cpu_quota()
-    if quota and quota > 0:
-        bounds.append(float(quota))
-    try:
-        bounds.append(float(len(os.sched_getaffinity(0))))
-    except (AttributeError, OSError):
-        pass
-    count = os.cpu_count()
-    if count:
-        bounds.append(float(count))
-    return min(bounds) if bounds else 1.0
+    """The narrowest true bound on this process's CPU, in fractional cores.
+
+    A projection of :func:`hostfacts.cpu_allowance` — the one reduction over
+    cgroup quota, affinity mask and host core count. This module's own copy
+    read a FIXED ``/sys/fs/cgroup/cpu.max`` (which reads ``max`` in a nested
+    cgroup that really is capped) while ``postmortem``'s copy walked the chain
+    and had no v1 fallback; the single reader has both.
+    """
+    return hostfacts.cpu_allowance().cores
 
 
 def per_group_threads(allowance: float, groups: int) -> int:
@@ -149,7 +120,6 @@ def impose_intra_op_threads(groups: int) -> Dict[str, Any]:
 
 
 __all__ = [
-    "cgroup_cpu_quota",
     "cpu_allowance",
     "impose_intra_op_threads",
     "per_group_threads",

--- a/src/gen_worker/cuda_probe.py
+++ b/src/gen_worker/cuda_probe.py
@@ -13,8 +13,15 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import msgspec
+from .hostfacts import cuda_ready
 
 CUDA_PROBE_FAILED_MARKER = "GEN_WORKER_CUDA_PROBE_FAILED"
+
+#: The reason `probe_cuda` records when the predicate itself says no. Named,
+#: because `classify_probe_failure` MATCHES on it: spelling it twice is how a
+#: cardless box starts being classified `cuda_error` and condemned as a host
+#: fault (pgw#1120).
+NO_DEVICE_REASON = "hostfacts.cuda_ready() is False"
 
 #: Wall budget for one `nvidia-smi` subprocess. The exact fault this module
 #: exists for — a wedged CUDA device — is also the fault that makes `nvidia-smi`
@@ -42,8 +49,8 @@ def probe_cuda(device_index: int = 0) -> CudaProbeResult:
         return CudaProbeResult(ok=False, reason=f"torch unavailable: {e}")
 
     try:
-        if not torch.cuda.is_available():
-            return CudaProbeResult(ok=False, reason="torch.cuda.is_available() is False")
+        if not cuda_ready():
+            return CudaProbeResult(ok=False, reason=NO_DEVICE_REASON)
         t = torch.ones(2, 2, device=f"cuda:{device_index}")
         t = t + 1
         torch.cuda.synchronize(device_index)
@@ -53,6 +60,15 @@ def probe_cuda(device_index: int = 0) -> CudaProbeResult:
         return CudaProbeResult(ok=False, reason=f"{type(e).__name__}: {e}")
 
     return CudaProbeResult(ok=True)
+
+
+#: ``cuda_probe.classify_probe_failure`` classes that mean THERE IS NO CUDA
+#: DEVICE HERE, as against a device this host cannot drive. A cardless box is a
+#: different mistake and must not be reported as a host fault (pgw#1120) — but
+#: "cardless" is a fact about the PROBE, not about whether `nvidia-smi` could be
+#: read: only a host with a driver to fail can answer `driver_too_old` or
+#: `cuda_error`, so a broken diagnostic can no longer buy an exemption.
+CARDLESS_PROBE_CLASSES = frozenset({"cuda_unavailable", "torch_unavailable"})
 
 
 def classify_probe_failure(reason: str) -> str:
@@ -69,7 +85,7 @@ def classify_probe_failure(reason: str) -> str:
         return "unknown"
     if "torch unavailable" in r:
         return "torch_unavailable"
-    if "is_available() is false" in r:
+    if NO_DEVICE_REASON.lower() in r:
         return "cuda_unavailable"
     if "driver too old" in r or "found version" in r:
         return "driver_too_old"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -161,6 +161,7 @@ from .models.loading import (
 from .compile_cache import CompiledExecutionLaneUnavailableError
 from .preload import Preloader
 from .api.binding import rebind_pick
+from . import hostfacts
 from .models.hub_policy import TensorhubWorkerCapabilities
 from .models.serve_fit import (RUN_FP8_STORAGE,
                                    RUN_OFFLOAD, plan_serve)
@@ -186,6 +187,7 @@ from . import aot_serve, numerics_ladder, shape_growth
 from . import fleet_cells as fleet_cells_mod
 from . import hot_swap
 from . import mint_supervisor
+from .hostfacts import cuda_ready
 
 _CONTEXT_BY_KIND: Dict[str, type] = {
     "inference": RequestContext,
@@ -1816,7 +1818,7 @@ class Executor:
         # failures (owned by _mark_setup_failed) survive re-gates.
         self._gate_owned: set = set()
         # Last hardware probe, so resolutions can re-run the gates.
-        self._last_gpu_info: Optional[Dict[str, Any]] = None
+        self._last_gpu_info: Optional[hostfacts.HostFacts] = None
         # th#683 P3: how each serveable function will run on the actual card
         # (native / emergency / offload / cpu) + honest-guidance advisory.
         self.serve_plans: Dict[str, "ServePlan"] = {}
@@ -2164,7 +2166,7 @@ class Executor:
 
     # ---- availability ----------------------------------------------------
 
-    def gate_functions(self, gpu_info: Dict[str, Any]) -> None:
+    def gate_functions(self, facts: hostfacts.HostFacts) -> None:
         """Run hardware gates; populate self.unavailable + self.serve_plans.
 
         th#683 P3, as th#1867 left it — the worker NEVER refuses a function
@@ -2185,12 +2187,12 @@ class Executor:
         # Idempotent re-gate (gw#494): drop only the marks THIS gate made
         # last time; setup failures and other owners survive. Remember the
         # probe so apply_model_resolutions can re-run us.
-        self._last_gpu_info = dict(gpu_info)
+        self._last_gpu_info = facts
         for fn in self._gate_owned:
             self.unavailable.pop(fn, None)
         self._gate_owned = set()
 
-        total_vram_gb = float(gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
+        total_vram_gb = float(facts.vram_total_bytes) / (1024 ** 3)
         # pgw#940: no substitution. `or gpu_total_mem` treated a legitimate 0
         # as "absent" and replaced it with the largest plausible number — and
         # `gpu_free_mem` is genuinely 0 on a SATURATED card, which is exactly
@@ -2202,13 +2204,13 @@ class Executor:
         # wraps its whole CUDA probe in `except Exception: pass`, so "the
         # probe raised" arrives here indistinguishable from "the card is
         # full" — both are non-permissive now, which is the point.
-        free_vram_gb = float(gpu_info.get("gpu_free_mem") or 0) / (1024 ** 3)
-        detected_sm = str(gpu_info.get("gpu_sm") or "")
-        libs = {str(x) for x in (gpu_info.get("installed_libs") or [])}
+        free_vram_gb = float(facts.vram_free_bytes) / (1024 ** 3)
+        detected_sm = facts.gpu_sm
+        libs = set(facts.installed_libs)
         caps = TensorhubWorkerCapabilities(
-            cuda_version=str(gpu_info.get("cuda_version") or ""),
+            cuda_version=facts.cuda_version,
             gpu_sm=int(detected_sm) if detected_sm.isdigit() else 0,
-            torch_version=str(gpu_info.get("torch_version") or ""),
+            torch_version=facts.torch_version,
             installed_libs=list(libs),
         )
         # pgw#676: per-pod native-crash streaks (SIGSEGV & friends recorded
@@ -4876,7 +4878,7 @@ class Executor:
                             f"boot warm plan cut short: {evidence.aborted}",
                             phase="warmup_oom",
                         )
-                    if torch is not None and torch.cuda.is_available():
+                    if torch is not None and cuda_ready():
                         torch.cuda.empty_cache()
                     return False
             evidence.count += 1
@@ -6495,7 +6497,7 @@ class Executor:
                 cid for k in rec.shared_keys
                 if (cid := k.cache_id()) not in refs
             )
-        cuda_host = torch is not None and torch.cuda.is_available()
+        cuda_host = torch is not None and cuda_ready()
         if any(res.tier(r) is residency_mod.Tier.RAM for r in refs):
             async with self._load_lock:
                 for ref in refs:
@@ -6989,7 +6991,7 @@ class Executor:
         if needed <= 0:
             return
         # CPU-only workers do not have a VRAM tier to admit against.
-        if torch is None or not torch.cuda.is_available():
+        if torch is None or not cuda_ready():
             return
         # This job's own reservations are the demand being satisfied here —
         # exclude them from the outstanding-claim accounting (pgw#641 Stage 2).
@@ -9751,7 +9753,7 @@ class Executor:
                     # this job exclusively owns gpu_index (jobs serialize under
                     # _gpu_semaphore) — peak_vram_bytes then measures THIS
                     # job's peak, not the process-lifetime high-water mark.
-                    if torch is not None and torch.cuda.is_available():
+                    if torch is not None and cuda_ready():
                         try:
                             torch.cuda.reset_peak_memory_stats(gpu_index)
                         except Exception:
@@ -10575,7 +10577,7 @@ class Executor:
     def _call_sync(
         job: _Job, bound: Callable[..., Any], call_kwargs: Dict[str, Any], gpu_index: int,
     ) -> Any:
-        if torch is not None and torch.cuda.is_available():
+        if torch is not None and cuda_ready():
             try:
                 torch.cuda.set_device(gpu_index)
             except Exception:
@@ -10710,7 +10712,7 @@ class Executor:
         gpu_index: int,
         loop: asyncio.AbstractEventLoop,
     ) -> Optional[StreamResult]:
-        if torch is not None and torch.cuda.is_available():
+        if torch is not None and cuda_ready():
             try:
                 torch.cuda.set_device(gpu_index)
             except Exception:
@@ -10770,7 +10772,7 @@ class Executor:
     def _peak_vram_bytes(gpu_index: int) -> int:
         """This job's CUDA peak-allocator high-water mark (reset when it took
         the GPU). 0 without torch/CUDA."""
-        if torch is not None and torch.cuda.is_available():
+        if torch is not None and cuda_ready():
             try:
                 return int(torch.cuda.max_memory_allocated(gpu_index))
             except Exception:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -85,6 +85,7 @@ from .hubio.client import HubPublishError
 from .models import loading, lora_lifted, provision
 from .procsplit import broker
 from .request_context._helpers import _decode_unverified_jwt_claims
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -3237,12 +3238,7 @@ def _fail_closed(
 
 
 def _cuda_ready() -> bool:
-    try:
-        import torch
-
-        return bool(torch.cuda.is_available())
-    except Exception:
-        return False
+    return cuda_ready()
 
 
 __all__ = [

--- a/src/gen_worker/hardware_report.py
+++ b/src/gen_worker/hardware_report.py
@@ -32,6 +32,7 @@ from .cuda_probe import (
 from .pb import worker_scheduler_pb2 as pb
 from .pb import worker_scheduler_pb2_grpc as pb_grpc
 from .transport import normalize_grpc_addr
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ def build_hardware_report(probe: CudaProbeResult, settings: Settings) -> Hardwar
         torch_cuda_version = str(getattr(torch.version, "cuda", "") or "")
         if not gpu_name:
             try:
-                if torch.cuda.is_available():
+                if cuda_ready():
                     gpu_name = torch.cuda.get_device_name(0)
             except Exception:
                 pass

--- a/src/gen_worker/host_canary.py
+++ b/src/gen_worker/host_canary.py
@@ -45,6 +45,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .cuda_probe import NVIDIA_SMI_TIMEOUT_S as _NVIDIA_SMI_TIMEOUT_S
 from .postmortem import effective_cpu_count
 import tempfile
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ def _measure_pcie() -> tuple[float, float, bool]:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return 0.0, 0.0, False
     except Exception:
         return 0.0, 0.0, False
@@ -319,7 +320,7 @@ def _measure_peer(devices: Tuple[int, int] = (0, 1)) -> Tuple[str, float, bool, 
     try:
         import torch
 
-        if not torch.cuda.is_available() or torch.cuda.device_count() <= max(a, b):
+        if not cuda_ready() or torch.cuda.device_count() <= max(a, b):
             return INTERCONNECT_NONE, 0.0, False, ""
     except Exception:
         return INTERCONNECT_NONE, 0.0, False, ""
@@ -387,7 +388,7 @@ def measure_host_canary() -> HostCanaryReport:
     try:
         import torch
 
-        gpu_count = int(torch.cuda.device_count()) if torch.cuda.is_available() else 0
+        gpu_count = int(torch.cuda.device_count()) if cuda_ready() else 0
     except Exception:
         pass
     interconnect, peer_gbps, peer_access, topo_link = (
@@ -522,7 +523,7 @@ def measure_peer_collective(
     import torch
     import torch.multiprocessing as mp
 
-    if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
+    if not cuda_ready() or torch.cuda.device_count() < world_size:
         return {"ok": False, "error": f"needs {world_size} visible CUDA devices"}
 
     env_saved = {k: os.environ.get(k) for k in

--- a/src/gen_worker/hostfacts.py
+++ b/src/gen_worker/hostfacts.py
@@ -1,0 +1,503 @@
+"""ONE home for every primitive fact this worker observes about its own host.
+
+pgw#896/pgw#897. The rule is not "fewer lines": it is that a **second answer
+to the same question is unrepresentable**. Before this module the platform
+answered "what does this host have" in many places at once — nine free-VRAM
+formulas (ten ``mem_get_info`` call sites), 74 raw ``torch.cuda.is_available()``
+predicates, two cgroup CPU-quota readers with different kernel coverage, four
+independent ``min()`` reductions over the same three candidates, and four
+parsers of ``/proc/meminfo`` — and the sites disagreed in ways only a real pod
+could show.
+
+What lives here, and what does NOT:
+
+* **Primitive observations only.** A named formula reads the host and returns
+  a number (or ``None`` for "no reading"). It never decides. Admission,
+  placement, pool sizing and refusals stay with their owners, which read from
+  here.
+* **Three named VRAM formulas, not nine** — :func:`free_vram_bytes` (what the
+  driver says is free right now), :func:`total_vram_bytes` (the card's
+  nameplate as measured) and :func:`headroom_bytes` (driver-free plus the
+  allocator cache THIS process can hand back). They are different quantities
+  with different right answers, so they are three names rather than one
+  ambiguous "free".
+* **Never aggregate across cards here.** VRAM is not fungible between cards; a
+  producer that sums or maxes hands its consumer a number no single job can
+  have. Aggregation is a consumer's explicit, argued act.
+
+``import torch`` is deliberately lazy in every function: the control parent
+must stay torch-free, and torch-free contexts (tools, tests, the CPU lane)
+import this module freely.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import msgspec
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Is there a usable CUDA device?
+# ---------------------------------------------------------------------------
+
+#: A card this process can use. The accelerator vocabulary is `cuda`/`none`
+#: only — "cpu" is an oxymoron and is not a state of this axis.
+DEVICE_PRESENT = "cuda"
+#: This host genuinely has no card. A CPU-lane pod, a laptop, a CI runner.
+DEVICE_ABSENT = "none"
+#: There is a card (or a driver that owns one) and it would not answer. The
+#: state the weak predicate cannot express: `torch.cuda.is_available()` is
+#: False for BOTH of the two above, so every site that read it alone reported
+#: a wedged H100 as a machine with no GPU — and zeros are what the fleet
+#: places on.
+DEVICE_UNREADABLE = "unreadable"
+
+
+class CudaState(msgspec.Struct, frozen=True):
+    """Which of the three CUDA states this host is in, and the evidence."""
+
+    state: str
+    #: `cuda_probe.classify_probe_failure` vocabulary; "" when present.
+    probe_class: str = ""
+    detail: str = ""
+
+    @property
+    def present(self) -> bool:
+        return self.state == DEVICE_PRESENT
+
+    @property
+    def absent(self) -> bool:
+        return self.state == DEVICE_ABSENT
+
+    @property
+    def unreadable(self) -> bool:
+        return self.state == DEVICE_UNREADABLE
+
+
+_cuda_state: Optional[CudaState] = None
+
+
+def cuda_ready() -> bool:
+    """Does torch have a usable CUDA device right now?
+
+    The ONLY ``torch.cuda.is_available()`` call site in ``src/`` — fenced by
+    ``tests/test_hostfacts_pgw896.py``. Deliberately uncached and deliberately
+    unchanged in value from the raw predicate: it tracks the live device and
+    every caller that had one keeps its exact behaviour.
+
+    It is a CAPABILITY question ("may I take the GPU branch?"), for which
+    degrading on a card that will not answer is correct. A caller that must
+    tell "this host has no card" from "this host's card would not answer" —
+    anything REPORTING to the fleet, anything condemning a SKU — calls
+    :func:`cuda_state` instead, because this predicate cannot express it.
+    """
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:  # noqa: BLE001 — a probe never changes an outcome
+        return False
+
+
+def cuda_state(*, device_index: int = 0) -> CudaState:
+    """The three-valued CUDA verdict, measured once per process.
+
+    Built on ``cuda_probe.probe_cuda`` (allocate, op, synchronize, free) —
+    the strong answer — and on the settled ``CARDLESS_PROBE_CLASSES``
+    discriminator: only a host with a driver TO fail can answer
+    ``driver_too_old``/``cuda_error``, so a broken diagnostic cannot buy an
+    absent card's exemption (pgw#1120).
+
+    Cached because it allocates. Nothing on a hot path needs it.
+    """
+    global _cuda_state
+    if _cuda_state is not None:
+        return _cuda_state
+    from .cuda_probe import CARDLESS_PROBE_CLASSES, classify_probe_failure, probe_cuda
+
+    result = probe_cuda(device_index)
+    if result.ok:
+        _cuda_state = CudaState(DEVICE_PRESENT)
+        return _cuda_state
+    klass = classify_probe_failure(result.reason)
+    _cuda_state = CudaState(
+        DEVICE_ABSENT if klass in CARDLESS_PROBE_CLASSES else DEVICE_UNREADABLE,
+        probe_class=klass,
+        detail=result.reason,
+    )
+    return _cuda_state
+
+
+def reset_cuda_state() -> None:
+    """Forget the cached verdict (tests; a re-probe after a device reset)."""
+    global _cuda_state
+    _cuda_state = None
+
+
+# ---------------------------------------------------------------------------
+# VRAM — three named formulas
+# ---------------------------------------------------------------------------
+
+
+def _mem_get_info(device: Optional[int]) -> Optional[Tuple[int, int]]:
+    """``(free, total)`` driver bytes for one card, or None for no reading.
+
+    The ONLY ``torch.cuda.mem_get_info`` call site in ``src/`` — fenced by
+    ``tests/test_hostfacts_pgw896.py``. ``None`` and ``0`` are different
+    answers here and stay different all the way out: a caller that reads an
+    unreadable card as "0 bytes free" refuses work a healthy card would take,
+    and one that reads it as "plenty" OOMs.
+    """
+    if not cuda_ready():
+        return None
+    try:
+        import torch
+
+        free, total = torch.cuda.mem_get_info(
+            torch.cuda.current_device() if device is None else int(device)
+        )
+        return int(free), int(total)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("mem_get_info failed: %s: %s", type(exc).__name__, exc)
+        return None
+
+
+def free_vram_bytes(device: Optional[int] = None) -> Optional[int]:
+    """Driver-free bytes on ONE card right now. ``None`` = no reading.
+
+    The instantaneous reading. It excludes the allocator cache this process
+    holds, so it is the right input for "what would a NEW process get" and the
+    wrong one for "may I allocate here" — that is :func:`headroom_bytes`.
+    """
+    reading = _mem_get_info(device)
+    return None if reading is None else reading[0]
+
+
+def total_vram_bytes(device: Optional[int] = None) -> Optional[int]:
+    """Total bytes on ONE card, honestly measured (an H100-80GB reports
+    79.19 GiB — declare that, not the marketing number). ``None`` = no
+    reading."""
+    reading = _mem_get_info(device)
+    return None if reading is None else reading[1]
+
+
+def headroom_bytes(device: Optional[int] = None) -> Optional[int]:
+    """Bytes a new allocation on ONE card could actually get. ``None`` = no
+    reading.
+
+    Driver-free PLUS the allocator cache this process can return: cached
+    blocks are headroom, and counting only ``free`` refuses a card that is
+    holding a large idle cache.
+    """
+    reading = _mem_get_info(device)
+    if reading is None:
+        return None
+    free, _total = reading
+    try:
+        import torch
+
+        index = torch.cuda.current_device() if device is None else int(device)
+        reclaimable = max(
+            0,
+            int(torch.cuda.memory_reserved(index))
+            - int(torch.cuda.memory_allocated(index)),
+        )
+    except Exception:  # noqa: BLE001
+        reclaimable = 0
+    return int(free) + reclaimable
+
+
+def device_count() -> int:
+    """Cards this process can see. 0 when there is no CUDA."""
+    if not cuda_ready():
+        return 0
+    try:
+        import torch
+
+        return int(torch.cuda.device_count())
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def device_identity(device: Optional[int] = None) -> Tuple[str, str]:
+    """``(name, sm)`` for one card — ``("", "")`` off-GPU."""
+    if not cuda_ready():
+        return "", ""
+    name = sm = ""
+    try:
+        import torch
+
+        index = torch.cuda.current_device() if device is None else int(device)
+    except Exception:  # noqa: BLE001
+        return "", ""
+    # Asked independently: a driver that will not answer one of them must not
+    # erase the other, and the two feed different fleet decisions.
+    try:
+        name = str(torch.cuda.get_device_properties(index).name)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        major, minor = torch.cuda.get_device_capability(index)
+        sm = f"sm_{major}{minor}"
+    except Exception:  # noqa: BLE001
+        pass
+    return name, sm
+
+
+# ---------------------------------------------------------------------------
+# CPU — one quota reader, one reduction, one rounding rule
+# ---------------------------------------------------------------------------
+
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+#: The one path any host-RAM reading is taken from.
+PROC_MEMINFO = Path("/proc/meminfo")
+
+
+def cgroup_nodes(
+    root: Optional[Path] = None, proc_self_cgroup: Optional[Path] = None
+) -> List[Path]:
+    """Cgroup-v2 dirs from ``root`` down to this process's own cgroup."""
+    root = _CGROUP_ROOT if root is None else root
+    proc_self_cgroup = (
+        _PROC_SELF_CGROUP if proc_self_cgroup is None else proc_self_cgroup)
+    rel = ""
+    try:
+        for line in proc_self_cgroup.read_text().splitlines():
+            if line.startswith("0::"):
+                rel = line[3:].strip().strip("/")
+                break
+    except OSError:
+        pass
+    nodes = [root]
+    node = root
+    for part in Path(rel).parts:
+        node = node / part
+        nodes.append(node)
+    return nodes
+
+
+def _read_text(path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _deepest(
+    name: str, root: Optional[Path], proc_self_cgroup: Optional[Path]
+) -> Optional[Path]:
+    for node in reversed(cgroup_nodes(root, proc_self_cgroup)):
+        candidate = node / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def cpu_quota(
+    *,
+    root: Optional[Path] = None,
+    proc_self_cgroup: Optional[Path] = None,
+) -> Optional[float]:
+    """Cores this cgroup may use, or ``None`` when uncapped/unreadable.
+
+    One reader with BOTH properties the two it replaces had one each of: it
+    walks the cgroup node chain to the DEEPEST ``cpu.max`` (a fixed
+    ``/sys/fs/cgroup/cpu.max`` reads ``max`` in a nested cgroup that really is
+    capped) AND it falls back to v1's ``cpu.cfs_quota_us``/``cfs_period_us``
+    (some fleets mount only the v1 controller).
+
+    ``os.cpu_count()`` reports the HOST's cores — 32 on a pod that owns 4 —
+    so anything sizing work by core count reads this, never that.
+    """
+    raw = _read_text(_deepest("cpu.max", root, proc_self_cgroup))
+    if raw:
+        parts = raw.split()
+        if len(parts) == 2 and parts[0] != "max":
+            try:
+                quota, period = int(parts[0]), int(parts[1])
+                if quota > 0 and period > 0:
+                    return quota / period
+            except ValueError:
+                pass
+        if parts:
+            return None  # an explicit "max" is uncapped, not unreadable
+    try:
+        v1 = (_CGROUP_ROOT if root is None else root) / "cpu"
+        quota = int((v1 / "cpu.cfs_quota_us").read_text().strip())
+        period = int((v1 / "cpu.cfs_period_us").read_text().strip())
+        if quota > 0 and period > 0:
+            return quota / period
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def cpu_quota_raw(
+    *,
+    root: Optional[Path] = None,
+    proc_self_cgroup: Optional[Path] = None,
+) -> Optional[str]:
+    """The verbatim ``cpu.max`` line, for a postmortem to echo. Same file, same
+    reader as :func:`cpu_quota` — a diagnostic that opens the file itself is a
+    second reader that can disagree with the one the pod acts on."""
+    return _read_text(_deepest("cpu.max", root, proc_self_cgroup))
+
+
+class CpuAllowance(msgspec.Struct, frozen=True):
+    """The narrowest true bound on this process's CPU, and which one bound."""
+
+    #: The fractional allowance. NOTHING rounds this.
+    cores: float
+    #: "quota" | "affinity" | "cpu_count"
+    basis: str
+    os_count: int
+    affinity: int
+    #: The cgroup quota, or -1.0 when uncapped/unreadable.
+    quota_cores: float
+
+    @property
+    def whole_cores(self) -> int:
+        """The integer allowance: ``floor``, never ``int(x + 0.5)``.
+
+        Rounding a CPU quota UP is always wrong — it sizes a thread pool above
+        the quota and the kernel throttles it. A 2.5-core pod gets 2.
+        """
+        return max(1, int(math.floor(self.cores)))
+
+
+def cpu_allowance(
+    *,
+    root: Optional[Path] = None,
+    proc_self_cgroup: Optional[Path] = None,
+) -> CpuAllowance:
+    """The ONE ``min()`` over cgroup quota, affinity mask and host core count.
+
+    There were FOUR of these. Two rounded the quota half-up, one kept the
+    fraction, and ``boot_key`` floored it while ignoring the affinity mask
+    entirely: on a ``cpu.max = 250000 100000`` pod the fleet planned against 3
+    while torch ran 2.5 cores worth of threads.
+    """
+    os_count = os.cpu_count() or 1
+    try:
+        affinity = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        affinity = os_count
+    quota = cpu_quota(root=root, proc_self_cgroup=proc_self_cgroup)
+    candidates: List[Tuple[float, str]] = [
+        (float(os_count), "cpu_count"),
+        (float(affinity), "affinity"),
+    ]
+    if quota is not None and quota > 0:
+        candidates.append((float(quota), "quota"))
+    cores, basis = min(candidates)
+    return CpuAllowance(
+        cores=max(0.0, cores),
+        basis=basis,
+        os_count=os_count,
+        affinity=affinity,
+        quota_cores=float(quota) if quota is not None else -1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Host RAM
+# ---------------------------------------------------------------------------
+
+
+def meminfo_kb(path: Optional[Path] = None) -> Dict[str, int]:
+    """``/proc/meminfo`` as ``{key: kB}`` — one parser, in kB as the file is.
+
+    Callers that want an effective, cgroup-capped RAM view call
+    ``models.memory.probe_host_ram`` instead; this is the raw file, for
+    postmortems and for the OOM-rank denominator.
+    """
+    out: Dict[str, int] = {}
+    try:
+        raw = (PROC_MEMINFO if path is None else path).read_text()
+    except OSError:
+        return out
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) < 2 or not parts[0].endswith(":"):
+            continue
+        try:
+            out[parts[0][:-1]] = int(parts[1])
+        except ValueError:
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The measured host, as one immutable struct
+# ---------------------------------------------------------------------------
+
+
+class HostFacts(msgspec.Struct, frozen=True, kw_only=True):
+    """Everything the fleet is told about this host, measured ONCE.
+
+    A handful of these floats become FLEET-WIDE verdicts: ``HardwareUnsuitable``
+    fences a machine, ``HostCanary`` condemns a SKU, ``gpu_name`` chooses which
+    verdict key gets written. So there is exactly one producer
+    (:func:`gen_worker.lifecycle.probe_hardware`, run by
+    ``procsplit.measure`` before any tenant code is imported) and exactly one
+    consumer that puts it on the wire
+    (``procsplit.parent.ParentControl._parent_resources``). A second builder
+    is a second answer, and the one the hub receives is never the one the pod
+    acts on — that was pgw#898.
+    """
+
+    gpu_count: int = 0
+    #: Card 0's TOTAL bytes. Not summed across cards: the hub admits one job
+    #: to one group, so a sum promises room no job can have.
+    vram_total_bytes: int = 0
+    #: Free bytes the hub may admit against — the least-roomy group's, never
+    #: a sum and never card 0's when a wider topology is delivered.
+    vram_free_bytes: int = 0
+    gpu_name: str = ""
+    gpu_sm: str = ""
+    torch_version: str = ""
+    #: The CUDA runtime torch was BUILT against. Measured by
+    #: `models.hub_policy.detect_worker_capabilities` and, until pgw#896,
+    #: dropped on the floor here while `gate_functions` read a dict key
+    #: nothing ever wrote — so the capability always went out as "".
+    cuda_version: str = ""
+    #: The HOST driver, read from NVML: it must stay readable when the CUDA
+    #: runtime is not.
+    driver_version: str = ""
+    installed_libs: Tuple[str, ...] = ()
+
+    def as_dict(self) -> Dict[str, object]:
+        return {f: getattr(self, f) for f in self.__struct_fields__}
+
+
+__all__ = [
+    "DEVICE_ABSENT",
+    "DEVICE_PRESENT",
+    "DEVICE_UNREADABLE",
+    "CpuAllowance",
+    "CudaState",
+    "HostFacts",
+    "cgroup_nodes",
+    "cpu_allowance",
+    "cpu_quota",
+    "cpu_quota_raw",
+    "cuda_ready",
+    "cuda_state",
+    "device_count",
+    "device_identity",
+    "free_vram_bytes",
+    "headroom_bytes",
+    "PROC_MEMINFO",
+    "meminfo_kb",
+    "reset_cuda_state",
+    "total_vram_bytes",
+]

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -34,6 +34,7 @@ from . import compile_cache
 from . import shape_growth
 from .shape_growth import TurnGateBusy, TurnGateClosed
 from . import postmortem
+from . import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -196,18 +197,11 @@ def _headroom_ok(device: Optional[int]) -> bool:
     Unknown/unprobeable state degrades to sequential (never OOM)."""
     if device is None:
         return True  # CPU-only call: no VRAM to protect
-    try:
-        import torch
-
-        free, total = torch.cuda.mem_get_info(device)
-        cached = max(
-            0,
-            torch.cuda.memory_reserved(device)
-            - torch.cuda.memory_allocated(device),
-        )
-        return (free + cached) >= max(_BG_FLOOR_BYTES, total // 8)
-    except Exception:
+    have = hostfacts.headroom_bytes(device)
+    total = hostfacts.total_vram_bytes(device)
+    if have is None or total is None:
         return False
+    return have >= max(_BG_FLOOR_BYTES, total // 8)
 
 
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/kernel_path.py
+++ b/src/gen_worker/kernel_path.py
@@ -66,6 +66,7 @@ from typing import (
 import msgspec
 
 from . import artifact_meta
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -411,7 +412,7 @@ def device_facts() -> Tuple[int, str, str]:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return 0, "", ""
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
         major, minor = torch.cuda.get_device_capability()

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -38,6 +38,7 @@ from .api.binding import wire_ref
 # module import: tests monkeypatch worker_fatal.report_worker_error_async; stay late-bound.
 from . import worker_fatal
 from .topology import TopologyError, delivered_topology
+from . import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -68,54 +69,48 @@ HEARTBEAT_INTERVAL_MS = 10_000
 _DISK_REPORT_TTL_S = 30.0
 
 
-def probe_hardware() -> Dict[str, Any]:
-    """Static hardware facts + gate inputs. torch is optional.
+def probe_hardware() -> hostfacts.HostFacts:
+    """Measure this host ONCE into one immutable :class:`HostFacts`.
 
-    ``gpu_free_mem`` is the input `gate_functions` turns into `unavailable` +
-    `serve_plans` for EVERY function, so on a wide pod it must be the free pool
-    of the group with the LEAST room, not card 0's. The MIN is the honest
-    single scalar until the fit ladder is per-rank: it never promises a group
-    room it does not have.
+    The single producer of the facts the fleet acts on. ``vram_free_bytes`` is
+    the input `gate_functions` turns into `unavailable` + `serve_plans` for
+    EVERY function, so on a wide pod it must be the free pool of the group with
+    the LEAST room, not card 0's. The MIN is the honest single scalar until the
+    fit ladder is per-rank: it never promises a group room it does not have.
     """
-    info: Dict[str, Any] = {
-        "gpu_count": 0,
-        "gpu_total_mem": 0,
-        "gpu_free_mem": 0,
-        "gpu_name": "",
-        "gpu_sm": "",
-        "torch_version": "",
-        "installed_libs": [],
-        "driver_version": "",
-    }
+    gpu_count = 0
+    vram_total = 0
+    vram_free = 0
+    gpu_name = ""
+    gpu_sm = ""
+    torch_version = ""
+    cuda_version = ""
+    driver_version = ""
+    installed_libs: tuple[str, ...] = ()
     # The HOST driver, read from NVML rather than torch: it must stay readable
     # when the CUDA runtime is not. A cu130 build on a 570.x host imports fine,
     # reports every version string correctly, and dies on its first allocation.
     try:
         from .hardware_report import _nvidia_smi_driver_and_gpu
 
-        driver, gpu = _nvidia_smi_driver_and_gpu()
-        info["driver_version"] = driver
-        if gpu and not info["gpu_name"]:
-            info["gpu_name"] = gpu
+        driver_version, gpu_name = _nvidia_smi_driver_and_gpu()
     except Exception:
         pass
     try:
-        import torch
-
-        if torch.cuda.is_available():
-            info["gpu_count"] = torch.cuda.device_count()
-            props = torch.cuda.get_device_properties(0)
-            info["gpu_name"] = props.name
-            free_mem, total_mem = torch.cuda.mem_get_info(0)
-            info["gpu_total_mem"] = int(total_mem)
-            info["gpu_free_mem"] = int(free_mem)
+        count = hostfacts.device_count()
+        if count:
+            gpu_count = count
+            gpu_name = hostfacts.device_identity(0)[0] or gpu_name
+            vram_total = hostfacts.total_vram_bytes(0) or 0
+            card0_free = hostfacts.free_vram_bytes(0) or 0
+            vram_free = card0_free
             worst = _worst_group_free_vram_bytes()
-            if worst and worst != int(free_mem):
+            if worst and worst != card0_free:
                 logger.info(
                     "fit inputs: gating on the least-free group (%d bytes) "
                     "instead of card 0 (%d bytes) — pgw#776",
-                    int(worst), int(free_mem))
-                info["gpu_free_mem"] = int(worst)
+                    int(worst), int(card0_free))
+                vram_free = int(worst)
     except TopologyError:
         # A WEDGED fabric is the one topology fault that must reach the caller:
         # `delivered_topology` raises it so the hub re-packs instead of this
@@ -128,13 +123,24 @@ def probe_hardware() -> Dict[str, Any]:
         from .models.hub_policy import detect_worker_capabilities
 
         caps = detect_worker_capabilities()
-        info["installed_libs"] = list(caps.installed_libs or [])
-        info["torch_version"] = str(caps.torch_version or "")
+        installed_libs = tuple(str(x) for x in (caps.installed_libs or []))
+        torch_version = str(caps.torch_version or "")
+        cuda_version = str(caps.cuda_version or "")
         if caps.gpu_sm:
-            info["gpu_sm"] = str(int(caps.gpu_sm))
+            gpu_sm = str(int(caps.gpu_sm))
     except Exception:
         pass
-    return info
+    return hostfacts.HostFacts(
+        gpu_count=gpu_count,
+        vram_total_bytes=vram_total,
+        vram_free_bytes=vram_free,
+        gpu_name=gpu_name,
+        gpu_sm=gpu_sm,
+        torch_version=torch_version,
+        cuda_version=cuda_version,
+        driver_version=driver_version,
+        installed_libs=installed_libs,
+    )
 
 
 _MULTI_GPU_NO_TOPOLOGY_WARNED = False
@@ -176,14 +182,7 @@ def free_vram_bytes() -> int:
         raise  # see `probe_hardware` — a wedged fabric is never a zero.
     except Exception:
         pass
-    try:
-        import torch
-
-        if torch.cuda.is_available() and torch.cuda.device_count():
-            return int(torch.cuda.mem_get_info(0)[0])
-    except Exception:
-        pass
-    return 0
+    return hostfacts.free_vram_bytes(0) or 0
 
 
 def _warn_once_if_gpus_are_invisible() -> None:
@@ -191,13 +190,11 @@ def _warn_once_if_gpus_are_invisible() -> None:
     if _MULTI_GPU_NO_TOPOLOGY_WARNED:
         return
     try:
-        import torch
-
         from .topology import ENV_VAR
 
         if os.environ.get(ENV_VAR):
             return
-        count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+        count = hostfacts.device_count()
         if count > 1 and delivered_topology().gpu_count == 1:
             _MULTI_GPU_NO_TOPOLOGY_WARNED = True
             logger.warning(
@@ -341,7 +338,7 @@ class Lifecycle:
 
     def _state_delta(self) -> pb.StateDelta:
         free = free_vram_bytes()
-        total = int(self.hardware.get("gpu_total_mem") or 0)
+        total = int(self.hardware.vram_total_bytes)
         quantum = max(1, int(total * _VRAM_QUANTUM_FRACTION)) if total else 1
         return pb.StateDelta(
             # echo DesiredResidency.config_generation.
@@ -391,59 +388,6 @@ class Lifecycle:
 
         self._disk_report_refresh_task = asyncio.create_task(_run(), name="disk-usage-refresh")
 
-    def build_resources(self) -> pb.WorkerResources:
-        hw = self.hardware
-        # measured once per process (cached), so
-        # reconnect Hellos re-ship the same boot-time facts. Never fatal.
-        canary = None
-        try:
-            from .host_canary import get_host_canary
-
-            c = get_host_canary()
-            canary = pb.HostCanary(
-                memcpy_gbps=c.memcpy_gbps,
-                d2h_gbps=c.d2h_gbps,
-                pinned_alloc_ok=c.pinned_alloc_ok,
-                cpu_single_mbps=c.cpu_single_mbps,
-                cpu_multi_mbps=c.cpu_multi_mbps,
-                vcpus=c.vcpus,
-                ram_total_gb=c.ram_total_gb,
-                duration_ms=c.duration_ms,
-                # The measured GPU fabric, alongside gpu_count.
-                interconnect=c.interconnect,
-                peer_gbps=c.peer_gbps,
-                peer_access=c.peer_access,
-                topo_link=c.topo_link,
-            )
-        except Exception:
-            logger.warning("host canary failed; Hello ships without it", exc_info=True)
-        # The hub attests the self-mint publish's gen_worker axis against THIS
-        # Hello-reported version; absent => the publish fails closed.
-        try:
-            from .compile_cache import gen_worker_version
-
-            gw_version = gen_worker_version()
-        except Exception:
-            gw_version = ""
-        return pb.WorkerResources(
-            host_canary=canary,
-            gpu_count=int(hw.get("gpu_count") or 0),
-            vram_total_bytes=int(hw.get("gpu_total_mem") or 0),
-            gpu_name=str(hw.get("gpu_name") or ""),
-            gpu_sm=str(hw.get("gpu_sm") or ""),
-            torch_version=str(hw.get("torch_version") or ""),
-            # The host driver, so the hub can answer "can the host we landed on
-            # run this pod's CUDA line?" from a SUCCESSFUL boot, not a corpse.
-            driver_version=str(hw.get("driver_version") or ""),
-            installed_libs=[str(x) for x in (hw.get("installed_libs") or [])],
-            gen_worker_version=gw_version,
-            image_digest=self._settings.worker_image_digest,
-            # git_commit intentionally unpopulated — dead on both ends. The
-            # field stays on the wire; deleting it needs a coordinated
-            # tensorhub proto update.
-            instance_id=self._settings.runpod_pod_id or "",
-        )
-
     # ---- transport handlers --------------------------------------------------
 
     def build_hello(self) -> pb.Hello:
@@ -455,11 +399,17 @@ class Lifecycle:
             self._desired_residency,
             self._model_resolutions,
         )
+        # NO `resources` field. `WorkerResources` has exactly ONE builder,
+        # `procsplit.parent.ParentControl._parent_resources`, which measures
+        # the silicon in a process that has imported no tenant code and stamps
+        # it onto every relayed Hello. This process HAS imported tenant code,
+        # so anything it measured about the host would be replaced wholesale
+        # before the hub saw it — 53 lines computing a value the wire
+        # discarded, and the fleet condemned SKUs on the other one (pgw#898).
         return pb.Hello(
             protocol_version=PROTOCOL_VERSION,
             worker_id=self.worker_id,
             release_id=self.release_id,
-            resources=self.build_resources(),
             state=self._state_delta(),
             models=self.executor.store.residency_snapshot(),
             in_flight=[

--- a/src/gen_worker/measure_child.py
+++ b/src/gen_worker/measure_child.py
@@ -68,6 +68,7 @@ import msgspec
 
 from . import activity
 from .child_contract import CompileSpec, MintSlot
+from .hostfacts import cuda_ready
 from .child_preflight import (
     PreflightRefused,
     assert_slots_resolvable,
@@ -266,7 +267,7 @@ def _cuda() -> Any:
     try:
         import torch
 
-        return torch if torch.cuda.is_available() else None
+        return torch if cuda_ready() else None
     except Exception:  # noqa: BLE001 — torch-less: nothing to measure
         return None
 

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -75,6 +75,7 @@ from .child_preflight import (
     select_specs,
 )
 from .file_hash import sha256_file
+from .hostfacts import cuda_ready
 from .mint_process import (
     EXIT_BAD_REQUEST,
     EXIT_MINTED,
@@ -266,7 +267,7 @@ def _release() -> None:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             torch.cuda.empty_cache()
             torch.cuda.reset_peak_memory_stats()
     except Exception:  # noqa: BLE001 — best effort
@@ -903,12 +904,7 @@ def _device_label(request: MintRequest) -> str:
     """Where this child's tensors live — the ordinal the parent chose, or the
     card this process defaults to. ``cpu`` on a cardless box, stated rather
     than assumed: a structure built as "cpu" compiles a CPU cell."""
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return "cpu"
-    except Exception:  # noqa: BLE001 — torch-less: nothing to place
+    if not cuda_ready():
         return "cpu"
     ordinal = int(getattr(request, "device", -1) or -1)
     return f"cuda:{ordinal}" if ordinal >= 0 else "cuda"
@@ -924,7 +920,7 @@ def _reset_peak() -> None:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             torch.cuda.reset_peak_memory_stats()
     except Exception:  # noqa: BLE001 — a probe never fails a mint
         logger.debug("mint-child: reset_peak_memory_stats failed",
@@ -943,7 +939,7 @@ def _peak_vram() -> int:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return 0
         return int(torch.cuda.max_memory_allocated())
     except Exception:  # noqa: BLE001 — a probe never fails a report

--- a/src/gen_worker/mint_workers.py
+++ b/src/gen_worker/mint_workers.py
@@ -29,6 +29,7 @@ ever grows a term it did not measure, it belongs in the deleted module.
 from __future__ import annotations
 
 from typing import Any, Dict, NamedTuple, Optional, Tuple
+from .hostfacts import cuda_ready
 
 
 #: One entry child's measured HOST high-water, keyed by (family, weight lane).
@@ -223,7 +224,7 @@ def adopt_watermark(device: Optional[int] = None) -> Tuple[int, int]:
     try:
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return 0, 0
         dev = torch.cuda.current_device() if device is None else int(device)
         return (int(torch.cuda.memory_allocated(dev)),

--- a/src/gen_worker/models/fp8_storage.py
+++ b/src/gen_worker/models/fp8_storage.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +333,7 @@ def _release_freed_blocks() -> None:
     try:
         import torch
 
-        if torch.cuda.is_available() and torch.cuda.is_initialized():
+        if cuda_ready() and torch.cuda.is_initialized():
             torch.cuda.empty_cache()
     except Exception:
         logger.debug("fp8-storage: empty_cache after restructure failed",

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+from ..hostfacts import cuda_ready
 
 
 @dataclass(frozen=True)
@@ -58,7 +59,7 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
 
         torch_version = str(getattr(torch, "__version__", "") or "")
         cuda_version = str(getattr(getattr(torch, "version", None), "cuda", "") or "")
-        if getattr(torch, "cuda", None) is not None and torch.cuda.is_available():
+        if getattr(torch, "cuda", None) is not None and cuda_ready():
             major, minor = torch.cuda.get_device_capability()
             gpu_sm = int(major) * 10 + int(minor)
     except Exception:

--- a/src/gen_worker/models/lane_residency_gate.py
+++ b/src/gen_worker/models/lane_residency_gate.py
@@ -30,6 +30,7 @@ from .. import activity as activity_mod
 from ..stall import SilenceWindow
 from .memory import get_available_vram_gb
 from .residency import Residency, Tier, _obj_offload_hooked
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,7 @@ _HEADROOM_STEP_GB = 1.0 / 16.0
 
 
 def _cuda_available() -> bool:
-    try:
-        import torch
-
-        return torch.cuda.is_available()
-    except Exception:
-        return False
+    return cuda_ready()
 
 
 def _inference_mode_off() -> Any:

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -59,6 +59,7 @@ from .memory import (
 from .hf_fp8_blockwise import detect_hf_fp8_blockwise, load_hf_fp8_blockwise
 from .safetensors_header import header_len_ok
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
+from ..hostfacts import cuda_ready
 from .w4a4 import (
     detect_w4a4_artifact,
     load_w4a4_denoiser,
@@ -539,7 +540,7 @@ def apply_block_window_offload(
         logger.warning("block-window offload ignored: torch not installed")
         return False
     if device is None:
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             logger.warning("block-window offload ignored: no CUDA device")
             return False
         device = "cuda"
@@ -927,7 +928,7 @@ def runtime_fp8_storage_supported() -> bool:
     try:
         import torch
 
-        return bool(torch.cuda.is_available()) and hasattr(torch, "float8_e4m3fn")
+        return bool(cuda_ready()) and hasattr(torch, "float8_e4m3fn")
     except ImportError:
         return False
 

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -32,6 +32,8 @@ import msgspec
 from ..component_vocab import component_vocabulary
 from .structure_only import STAMP as _STRUCTURE_ONLY
 import asyncio
+from ..hostfacts import cuda_ready
+from .. import hostfacts
 
 _LOG = logging.getLogger(__name__)
 
@@ -184,14 +186,10 @@ def available_vram(device_index: int = 0) -> VramReading:
     :func:`get_available_vram_gb`; a caller that must DECIDE with it reads
     ``reason`` and says out loud what it does when the card is unreadable.
     """
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return VramReading(0.0, VRAM_NO_CUDA)
-        free, _total = torch.cuda.mem_get_info(device_index)
-    except Exception as exc:
-        _LOG.warning("free-VRAM probe failed: %s: %s", type(exc).__name__, exc)
+    if not hostfacts.cuda_ready():
+        return VramReading(0.0, VRAM_NO_CUDA)
+    free = hostfacts.free_vram_bytes(device_index)
+    if free is None:
         return VramReading(0.0, VRAM_UNREADABLE)
     return VramReading(float(free) / float(1024**3))
 
@@ -209,15 +207,8 @@ def get_available_vram_gb(device_index: int = 0) -> float:
 def get_total_vram_gb(device_index: int = 0) -> float:
     """TOTAL VRAM of the selected CUDA device — a per-SKU constant
     (pgw#750: deterministic placement inputs). 0.0 if no CUDA."""
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return 0.0
-        _free, total = torch.cuda.mem_get_info(device_index)
-        return float(total) / float(1024**3)
-    except Exception:
-        return 0.0
+    total = hostfacts.total_vram_bytes(device_index)
+    return float(total) / float(1024**3) if total is not None else 0.0
 
 
 def get_available_ram_gb() -> float:
@@ -305,24 +296,6 @@ def _read_cgroup_int(path: Path) -> Optional[int]:
     return value if 0 <= value < _CGROUP_UNLIMITED else None
 
 
-def _v2_cgroup_nodes(root: Path, proc_self_cgroup: Path) -> List[Path]:
-    """Cgroup-v2 dirs from root down to this process's own cgroup."""
-    rel = ""
-    try:
-        for line in proc_self_cgroup.read_text().splitlines():
-            if line.startswith("0::"):
-                rel = line[3:].strip().strip("/")
-                break
-    except OSError:
-        pass
-    nodes = [root]
-    node = root
-    for part in Path(rel).parts:
-        node = node / part
-        nodes.append(node)
-    return nodes
-
-
 def cgroup_memory_limit_bytes(
     root: Path = _CGROUP_ROOT,
     proc_self_cgroup: Path = _PROC_SELF_CGROUP,
@@ -333,7 +306,7 @@ def cgroup_memory_limit_bytes(
     and host cgroup namespaces); v1 fallback: ``memory/memory.limit_in_bytes``.
     """
     limits = [
-        v for node in _v2_cgroup_nodes(root, proc_self_cgroup)
+        v for node in hostfacts.cgroup_nodes(root, proc_self_cgroup)
         if (v := _read_cgroup_int(node / "memory.max")) is not None
     ]
     if limits:
@@ -346,7 +319,7 @@ def cgroup_memory_current_bytes(
     proc_self_cgroup: Path = _PROC_SELF_CGROUP,
 ) -> Optional[int]:
     """Current cgroup memory usage; reads the deepest available counter."""
-    for node in reversed(_v2_cgroup_nodes(root, proc_self_cgroup)):
+    for node in reversed(hostfacts.cgroup_nodes(root, proc_self_cgroup)):
         v = _read_cgroup_int(node / "memory.current")
         if v is not None:
             return v
@@ -390,7 +363,7 @@ def _cgroup_reclaimable_file_bytes(
     backing file) and pages still dirty or under writeback.
     """
     stats: Optional[Dict[str, int]] = None
-    for node in reversed(_v2_cgroup_nodes(root, proc_self_cgroup)):
+    for node in reversed(hostfacts.cgroup_nodes(root, proc_self_cgroup)):
         stats = _read_cgroup_stat(node / "memory.stat")
         if stats is not None:
             break
@@ -446,9 +419,17 @@ def probe_host_ram(
     *,
     root: Path = _CGROUP_ROOT,
     proc_self_cgroup: Path = _PROC_SELF_CGROUP,
+    meminfo: Optional[Path] = None,
     siblings: Optional[int] = None,
 ) -> HostRam:
-    """One truthful host-RAM snapshot: psutil meminfo min'd with the cgroup cap.
+    """The ONE effective host-RAM view: ``/proc/meminfo`` min'd with the
+    cgroup cap, with clean page cache credited back.
+
+    Every consumer that must answer "will this fit in host RAM" reads THIS —
+    the host-move guard, the residency demote floor, the staging admission and
+    (since pgw#897) the AOT compile pool, which used to parse ``/proc/meminfo``
+    and ``memory.stat`` itself with a NARROWER reclaimable definition and no
+    sibling divisor.
 
     ``siblings`` defaults to the compute-child count this process shares its
     cgroup with (pgw#783; 1 unless the process split is running G groups).
@@ -457,15 +438,9 @@ def probe_host_ram(
         from ..procsplit import host_siblings
 
         siblings = host_siblings()
-    meminfo_total = meminfo_available = 0.0
-    try:
-        import psutil
-
-        vm = psutil.virtual_memory()
-        meminfo_total = float(vm.total) / float(_GIB)
-        meminfo_available = float(vm.available) / float(_GIB)
-    except Exception:
-        pass
+    info = hostfacts.meminfo_kb(meminfo)
+    meminfo_total = float(info.get("MemTotal", 0)) * 1024.0 / float(_GIB)
+    meminfo_available = float(info.get("MemAvailable", 0)) * 1024.0 / float(_GIB)
     limit = cgroup_memory_limit_bytes(root, proc_self_cgroup)
     if limit is None:
         return _host_ram_share(HostRam(
@@ -538,7 +513,7 @@ def cuda_allocated_bytes(device_index: Optional[int] = None) -> int:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             return int(torch.cuda.memory_allocated(device_index))
     except Exception:
         pass
@@ -792,7 +767,7 @@ def flush_memory() -> None:
     try:
         import torch
 
-        if torch.cuda.is_available():
+        if cuda_ready():
             torch.cuda.empty_cache()
             try:
                 torch.cuda.reset_peak_memory_stats()
@@ -822,7 +797,7 @@ async def aflush_memory(*, collect: bool = True, reset_peak: bool = False) -> No
         import torch
     except Exception:  # noqa: BLE001 — torch-free installs (cozy-local CLI)
         return
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return
     try:
         await asyncio.to_thread(torch.cuda.empty_cache)
@@ -849,7 +824,7 @@ def release_unused_pinned_host_cache() -> int:
         gc.collect()
         import torch
 
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return 0
         # Pinned frees can remain stream-dependent.  Finish prior CUDA work so
         # the host allocator can distinguish inactive blocks before flushing.
@@ -1026,9 +1001,7 @@ def _call_if_present(obj: Any, method: str, **kwargs: Any) -> bool:
 
 def _move_pipeline_to_cpu(pipeline: Any) -> None:
     try:
-        import torch
-
-        if not torch.cuda.is_available():
+        if not cuda_ready():
             return
         if callable(getattr(pipeline, "to", None)):
             pipeline.to("cpu")
@@ -1149,7 +1122,7 @@ def _apply_group_offload(
         import torch
     except Exception:
         return False
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return False
 
     kwargs: Dict[str, Any] = {
@@ -1324,12 +1297,7 @@ def place_pipeline(
     card size to declare around (§1.35 amendment 2).
     """
     log = logger or _LOG
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return {"mode": "cpu"}
-    except Exception:
+    if not cuda_ready():
         return {"mode": "cpu"}
     effective = select_auto_mode(pipeline=pipeline) if mode == "auto" else mode
     if mode == "auto":
@@ -1519,12 +1487,7 @@ def apply_low_vram_config(
         log.info("low_vram: vae_only applied (%s)", _applied_summary(applied))
         return applied
 
-    try:
-        import torch
-
-        cuda_ok = torch.cuda.is_available()
-    except Exception:
-        cuda_ok = False
+    cuda_ok = cuda_ready()
 
     if not cuda_ok:
         setattr(pipeline, _COZY_MODE_ATTR, "vae_only")

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -51,6 +51,7 @@ from typing import Any, Callable, Dict, Optional
 from .. import kernel_path
 from .svdq_fused import fused_self_check
 from .svdq_awq_packed import awq_packed_self_check
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +80,10 @@ def native_kernels_requested() -> Optional[bool]:
 def _cuda_gap() -> Optional[str]:
     """Why no native lane can run here at all, or None."""
     try:
-        import torch
+        import torch  # noqa: F401 — the import IS the probe here
     except ImportError:
         return "torch is not installed"
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return "native svdq kernels require a CUDA GPU"
     return None
 
@@ -258,7 +259,7 @@ def extension_available() -> bool:
         if not hasattr(ns, "probe_add_one"):
             logger.warning("native extension: loaded but probe op missing")
             return False
-        if torch.cuda.is_available():
+        if cuda_ready():
             x = torch.arange(8, device="cuda", dtype=torch.float32)
             y = ns.probe_add_one(x)
             if not torch.equal(y, x + 1):

--- a/src/gen_worker/models/nvfp4_quant.py
+++ b/src/gen_worker/models/nvfp4_quant.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import functools
 import logging
 from typing import Any, Optional
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -332,9 +333,7 @@ def _arm() -> str:
         return _QUANT_MODE
     mode, op = "torch", None
     try:
-        import torch
-
-        if torch.cuda.is_available():
+        if cuda_ready():
             candidate = _build_fused_op()
             if candidate is not None and _bit_identical(candidate):
                 mode, op = "fused", candidate

--- a/src/gen_worker/models/pinned_swap.py
+++ b/src/gen_worker/models/pinned_swap.py
@@ -33,6 +33,7 @@ import logging
 from typing import Any, Dict, List, Tuple
 
 from . import staging
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ def swap_module(module: Any, device: str) -> bool:
     target = torch.device(device)
     if target.type not in ("cpu", "cuda"):
         return False
-    if target.type == "cuda" and not torch.cuda.is_available():
+    if target.type == "cuda" and not cuda_ready():
         return False
 
     tensors = _module_tensors(module)
@@ -148,7 +149,7 @@ def swap_module(module: Any, device: str) -> bool:
                 copy_stream.synchronize()
             except Exception:
                 pass
-        elif torch.cuda.is_available():
+        elif cuda_ready():
             try:
                 torch.cuda.synchronize()
             except Exception:

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -44,6 +44,7 @@ from .memory import (
 )
 from .pinned_swap import swap_object
 from .pinned_swap import cached_swap_bytes
+from .. import hostfacts
 
 logger = logging.getLogger(__name__)
 
@@ -152,16 +153,13 @@ class DeviceGroup:
         plan; the probe reports physics) — which under ``replicated`` makes
         the whole group unusable, correctly: you cannot replicate onto a
         card that is not there."""
-        import torch
-
-        if not torch.cuda.is_available():
+        count = hostfacts.device_count()
+        if not count:
             return []
-        count = int(torch.cuda.device_count())
         out: List[int] = []
         for d in self.devices:
-            out.append(
-                int(torch.cuda.mem_get_info(d)[0]) if 0 <= int(d) < count else 0
-            )
+            free = hostfacts.free_vram_bytes(d) if 0 <= int(d) < count else None
+            out.append(int(free or 0))
         return out
 
     def free_vram_bytes(self) -> int:

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import Any, Optional
 
+from .. import hostfacts
 from .hub_policy import (
     FIT_INCOMPATIBLE,
     TensorhubWorkerCapabilities,
@@ -127,12 +128,24 @@ def plan_serve(
     # (FLOOR_CPU_RUNG_UNEXECUTABLE), so a pod that OOMs its way down still
     # refuses, naming our code. Plan time is not that situation — nothing has
     # failed here.
+    #
+    # pgw#896: "no CUDA device detected" was said for BOTH a genuinely cardless
+    # pod and a pod whose card would not answer, because the predicate behind
+    # it (`torch.cuda.is_available()`) cannot tell them apart. The operator
+    # reading the warning then goes looking for a provisioning mistake on a box
+    # that has an H100 in it. The strong probe's own class discriminates.
     if verdict == FIT_INCOMPATIBLE and needs_gpu and caps.gpu_sm <= 0:
+        state = hostfacts.cuda_state()
+        why = (
+            f"this pod HAS a CUDA device and it will not answer "
+            f"({state.probe_class}: {state.detail})"
+            if state.unreadable else "no CUDA device detected on this pod"
+        )
         return ServePlan(
             serveable=True,
             run_mode=RUN_CPU,
             fit=FIT_INCOMPATIBLE,
-            warning=_honest_warning(RUN_CPU, "no CUDA device detected on this pod"),
+            warning=_honest_warning(RUN_CPU, why),
             est_latency_multiplier=price(RUN_CPU),
             wanted=wanted,
             ran=RUN_CPU,

--- a/src/gen_worker/models/staging.py
+++ b/src/gen_worker/models/staging.py
@@ -30,6 +30,7 @@ import logging
 import threading
 import weakref
 from typing import Any, Callable, Iterator, Optional
+from ..hostfacts import cuda_ready
 
 from .memory import (
     effective_ram_floor_gb,
@@ -213,7 +214,7 @@ def copy_stream(device: Optional[Any] = None) -> Optional[Any]:
         import torch
     except Exception:
         return None
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return None
     if device is None:
         index = int(torch.cuda.current_device())

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -65,6 +65,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from ..api.errors import WorkerError
 from .. import meta_instantiation as mi
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -324,8 +325,6 @@ def build_component(
     BUFFERS are real, because they are config-derived and a literal-bearing
     family ships them.
     """
-    import torch
-
     # FIRST, before anything about this family is inspected: a process that
     # cannot meta-instantiate refuses about ITSELF, not about the tree it was
     # handed (pgw#1123 — the pod message named component '' and 'unknown
@@ -356,7 +355,7 @@ def build_component(
     facts = _facts(module, component=component,
                    cls_name=getattr(cls, "__name__", str(cls)), census=census)
     setattr(module, FACTS_STAMP, facts)
-    if not torch.cuda.is_available() and device.startswith("cuda"):
+    if not cuda_ready() and device.startswith("cuda"):
         raise StructureOnlyUnsupported(
             component=component, cls_name=facts.cls_name, tree=str(root),
             lacks=f"device {device!r} is not available in this process")

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -28,6 +28,7 @@ from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
 from typing import Any, Optional
 import importlib.metadata as md
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -352,7 +353,7 @@ def check_svdq_loadable(art: SvdqArtifact) -> None:
         raise SvdqStackError(reason)
     import torch
 
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         raise SvdqHardwareError("svdq artifacts require a CUDA GPU")
     major, minor = torch.cuda.get_device_capability()
     sm = major * 10 + minor

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -65,6 +65,7 @@ from .svdq_awq import decode_awq_linear, is_awq_linear
 from .svdq_layout import LOWRANK_QUANT_KEY, LOWRANK_QUANT_SCHEMES, decode_linear
 from .native_kernels import svdq_modulation_execution_lane
 from .svdq_awq_packed import awq_packed_supported, build_awq_packed_linear
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ def svdq_native_reason() -> Optional[str]:
         import torch
     except ImportError:
         return "torch is not installed"
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return "native svdq-fp4 requires a CUDA GPU"
     if getattr(torch, "float4_e2m1fn_x2", None) is None:
         return f"torch {torch.__version__} has no float4_e2m1fn_x2 dtype"
@@ -505,7 +506,7 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
     if mode not in ("blockwise", "dense"):
         mode = "blockwise" if svdq_native_available() else "dense"
     if device is None:
-        device = ("cuda" if mode == "blockwise" and torch.cuda.is_available()
+        device = ("cuda" if mode == "blockwise" and cuda_ready()
                   else "cpu")
     dev = torch.device(device)
 

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -51,6 +51,7 @@ from .safetensors_header import header_len_ok
 from .tensor_layout_contract import unregistered_decode_path
 from typing import Any, Dict, List, Optional
 import shutil
+from ..hostfacts import cuda_ready
 
 from .nvfp4_quant import (
     BLOCK as _BLOCK,
@@ -331,7 +332,7 @@ def w4a4_gemm_mode() -> str:
         import torch
     except ImportError:
         return ""
-    if not torch.cuda.is_available() or _fp4_dtype() is None:
+    if not cuda_ready() or _fp4_dtype() is None:
         return ""
     major, minor = torch.cuda.get_device_capability()
     if major * 10 + minor < W4A4_MIN_SM:

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -53,6 +53,7 @@ from .tensor_layout_contract import (
 )
 from typing import Any, Dict, List, Optional
 import shutil
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -346,7 +347,7 @@ def w8a8_gemm_mode() -> str:
         import torch
     except ImportError:
         return ""
-    if not torch.cuda.is_available() or not hasattr(torch, "float8_e4m3fn"):
+    if not cuda_ready() or not hasattr(torch, "float8_e4m3fn"):
         return ""
     major, minor = torch.cuda.get_device_capability()
     return _choose_gemm_mode(major * 10 + minor)

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -64,6 +64,7 @@ from .fp8_storage import structural_base
 from .w8a8 import fp8_scaled_linear_class
 import inspect
 from .loading import pipeline_weight_lane
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -454,7 +455,7 @@ def _stage_adapter(mapped: Dict[str, Tuple[Any, Any, float]]) -> Dict[str, Any]:
     slices: Dict[Tuple[str, str], Tuple[Any, int, Tuple[int, ...]]] = {}
     for dt, items in by_dtype.items():
         total = sum(t.numel() for _p, _tag, t in items)
-        pin = (torch.cuda.is_available()
+        pin = (cuda_ready()
                and total * items[0][2].element_size() <= _PIN_MAX_BYTES)
         buf = torch.empty(total, dtype=dt, pin_memory=pin)
         off = 0
@@ -837,7 +838,7 @@ def _place_adapters(
                 covered += 1
             else:
                 mod.lora_b.zero_()  # canonical zeroed slot (uniform)
-        if torch.cuda.is_available():
+        if cuda_ready():
             torch.cuda.synchronize()
     if mapped and not covered:
         # Every mapped key resolved to a branch-capable module, so zero

--- a/src/gen_worker/parallel/runtime.py
+++ b/src/gen_worker/parallel/runtime.py
@@ -61,6 +61,7 @@ from .plan import GroupPlan
 from .cp import w8a8_gemm_mode
 from ..models import provision
 from ..registry import collect_endpoints
+from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -109,9 +110,7 @@ def _dehydrate(value: Any) -> Any:
 def _rank_device(device: int) -> str:
     """A rank's device string. Falls back to CPU only where there is no CUDA
     at all — i.e. the gloo test rig; a real follower always has its card."""
-    import torch
-
-    return f"cuda:{int(device)}" if torch.cuda.is_available() else "cpu"
+    return f"cuda:{int(device)}" if cuda_ready() else "cpu"
 
 
 def _force_collectives(value: Any) -> Any:

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -31,6 +31,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 import faulthandler
+from . import hostfacts
 from .procsplit import group_ordinal, host_siblings
 
 logger = logging.getLogger(__name__)
@@ -103,20 +104,7 @@ def cgroup_nodes(
     root: Path = _CGROUP_ROOT, proc_self_cgroup: Path = _PROC_SELF_CGROUP
 ) -> list[Path]:
     """cgroup-v2 dirs from root down to this process's own cgroup."""
-    rel = ""
-    try:
-        for line in proc_self_cgroup.read_text().splitlines():
-            if line.startswith("0::"):
-                rel = line[3:].strip().strip("/")
-                break
-    except OSError:
-        pass
-    nodes = [root]
-    node = root
-    for part in Path(rel).parts:
-        node = node / part
-        nodes.append(node)
-    return nodes
+    return hostfacts.cgroup_nodes(root, proc_self_cgroup)
 
 
 def _read_text(path: Path) -> Optional[str]:
@@ -235,71 +223,36 @@ def container_limits() -> Dict[str, Any]:
     # Every death and every boot record carries it.
     oom_group = _deepest("memory.oom.group")
     facts["memory_oom_group"] = _read_int(oom_group) if oom_group else None
-    cpu_max = _deepest("cpu.max")
-    raw_cpu = _read_text(cpu_max) if cpu_max else None
-    facts["cpu_max"] = raw_cpu
+    facts["cpu_max"] = hostfacts.cpu_quota_raw()
     facts["cpu_quota_cores"] = cpu_quota_cores()
     facts["host_cpu_count"] = os.cpu_count() or 0
     try:
         facts["affinity_cpus"] = len(os.sched_getaffinity(0))
     except (AttributeError, OSError):
         facts["affinity_cpus"] = None
-    meminfo = _read_meminfo()
+    meminfo = hostfacts.meminfo_kb()
     facts["meminfo_total_kb"] = meminfo.get("MemTotal")
     facts["meminfo_available_kb"] = meminfo.get("MemAvailable")
     return facts
 
 
-def _read_meminfo(path: Path = Path("/proc/meminfo")) -> Dict[str, int]:
-    """``/proc/meminfo`` as {key: kB} ("MemTotal:  65...  kB" -> 3 fields)."""
-    out: Dict[str, int] = {}
-    raw = _read_text(path)
-    if not raw:
-        return out
-    for line in raw.splitlines():
-        parts = line.split()
-        if len(parts) < 2 or not parts[0].endswith(":"):
-            continue
-        try:
-            out[parts[0][:-1]] = int(parts[1])
-        except ValueError:
-            continue
-    return out
-
-
 def cpu_quota_cores() -> Optional[float]:
-    """Cores this cgroup may actually use, from ``cpu.max`` (None = uncapped).
-
-    ``os.cpu_count()`` reports the HOST's cores — 32 on a pod that owns 4.
-    Anything that sizes work by core count must use THIS number.
-    """
-    p = _deepest("cpu.max")
-    raw = _read_text(p) if p else None
-    if not raw:
-        return None
-    parts = raw.split()
-    if len(parts) != 2 or parts[0] == "max":
-        return None
-    try:
-        quota, period = int(parts[0]), int(parts[1])
-    except ValueError:
-        return None
-    if period <= 0 or quota <= 0:
-        return None
-    return quota / period
+    """Cores this cgroup may actually use (None = uncapped). One reader,
+    in :mod:`hostfacts` — this module's copy had no cgroup-v1 fallback while
+    ``cpu_budget``'s had no chain walk, so a v1 host and a nested cgroup got
+    different answers from the two."""
+    return hostfacts.cpu_quota()
 
 
 def effective_cpu_count() -> int:
-    """Honest usable-core count: host cores min'd with affinity and quota."""
-    candidates = [os.cpu_count() or 1]
-    try:
-        candidates.append(len(os.sched_getaffinity(0)))
-    except (AttributeError, OSError):
-        pass
-    quota = cpu_quota_cores()
-    if quota is not None:
-        candidates.append(max(1, int(quota + 0.5)))
-    return max(1, min(candidates))
+    """Honest usable-core count: host cores min'd with affinity and quota.
+
+    ``floor``, not ``int(x + 0.5)``: this used to round a 2.5-core quota UP to
+    3 while ``cpu_budget.cpu_allowance`` kept 2.5, so the fleet planned against
+    3 and torch ran 2.5 cores' worth of threads under a throttling kernel. The
+    integer derivation is stated once, in :class:`hostfacts.CpuAllowance`.
+    """
+    return hostfacts.cpu_allowance().whole_cores
 
 
 def describe_exit(status: int) -> Dict[str, Any]:

--- a/src/gen_worker/procsplit/measure.py
+++ b/src/gen_worker/procsplit/measure.py
@@ -33,7 +33,7 @@ def measure() -> Dict[str, Any]:
     try:
         from ..lifecycle import probe_hardware
 
-        out["hardware"] = probe_hardware()
+        out["hardware"] = probe_hardware().as_dict()
     except Exception as exc:  # never fatal: an unmeasured axis is a zero
         out["hardware_error"] = f"{type(exc).__name__}: {exc}"
     try:

--- a/src/gen_worker/procsplit/oom_rank.py
+++ b/src/gen_worker/procsplit/oom_rank.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from .. import hostfacts
 from ..postmortem import cgroup_nodes
 
 logger = logging.getLogger(__name__)
@@ -75,7 +76,6 @@ _OVERRUN_ALLOWANCE = 2
 _TIGHTEST_OBSERVED_DOMAIN_BYTES = 14 * 1024 ** 3
 
 _SELF_OOM_SCORE_ADJ = Path("/proc/self/oom_score_adj")
-_PROC_MEMINFO = Path("/proc/meminfo")
 
 #: Kernel range for ``oom_score_adj`` (``fs/proc/base.c``). Not ours to pick.
 _OOM_SCORE_ADJ_MIN = -1000
@@ -142,13 +142,8 @@ def _cgroup_memory_max() -> Optional[int]:
 
 
 def _meminfo_total_bytes() -> Optional[int]:
-    try:
-        for line in _PROC_MEMINFO.read_text().splitlines():
-            if line.startswith("MemTotal:"):
-                return int(line.split()[1]) * 1024
-    except (OSError, ValueError, IndexError):
-        pass
-    return None
+    total = hostfacts.meminfo_kb().get("MemTotal")
+    return total * 1024 if total else None
 
 
 def oom_domain_bytes() -> int:

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -60,6 +60,7 @@ from ..config import Settings
 from ..pb import worker_scheduler_pb2 as pb
 from ..transport import FatalTransportError, Transport
 from ..topology import ExecutionTopology
+from .. import hostfacts
 from .. import postmortem
 from .. import proc_evidence
 from .. import config, worker_credential, worker_identity
@@ -1424,7 +1425,14 @@ class ParentControl:
         m = self._measurement
         if m is None:
             return None
-        hw = m.get("hardware") or {}
+        try:
+            hw = msgspec.convert(m.get("hardware") or {}, hostfacts.HostFacts)
+        except msgspec.ValidationError:
+            # An unmeasured axis is a zero, never a dead parent: the child that
+            # produced this JSON is the same wheel, so a mismatch here is a
+            # broken measurement, not a version skew.
+            logger.error("host measurement is not a HostFacts", exc_info=True)
+            hw = hostfacts.HostFacts()
         canary = None
         c = m.get("canary")
         if isinstance(c, dict):
@@ -1444,15 +1452,15 @@ class ParentControl:
             )
         return pb.WorkerResources(
             host_canary=canary,
-            gpu_count=int(hw.get("gpu_count") or 0),
-            vram_total_bytes=int(hw.get("gpu_total_mem") or 0),
-            gpu_name=str(hw.get("gpu_name") or ""),
-            gpu_sm=str(hw.get("gpu_sm") or ""),
-            torch_version=str(hw.get("torch_version") or ""),
+            gpu_count=hw.gpu_count,
+            vram_total_bytes=hw.vram_total_bytes,
+            gpu_name=hw.gpu_name,
+            gpu_sm=hw.gpu_sm,
+            torch_version=hw.torch_version,
             # The host driver, so the hub can answer "can the host we landed on
             # run this pod's CUDA line?" from a SUCCESSFUL boot, not only a corpse.
-            driver_version=str(hw.get("driver_version") or ""),
-            installed_libs=[str(x) for x in (hw.get("installed_libs") or [])],
+            driver_version=hw.driver_version,
+            installed_libs=list(hw.installed_libs),
             gen_worker_version=str(m.get("gen_worker_version") or ""),
             image_digest=self._settings.worker_image_digest,
             instance_id=self._settings.runpod_pod_id or "",
@@ -1569,14 +1577,16 @@ class ParentControl:
         resources = self._parent_resources()
         if resources is not None:
             hello.resources.CopyFrom(resources)
-        elif hello.HasField("resources"):
-            logger.error(
-                "no parent-side host measurement is available; DROPPING the "
-                "child's self-reported resources rather than relaying "
-                "tenant-reachable numbers the fleet condemns SKUs on "
-                "(pgw#763 delta 2 / th#1310)"
-            )
-            hello.ClearField("resources")
+            return
+        # The child no longer builds a second copy to fall back on (pgw#898),
+        # so an unmeasured host ships a Hello with NO resources — loudly. The
+        # alternative was relaying tenant-reachable numbers the fleet condemns
+        # SKUs on (pgw#763 delta 2 / th#1310).
+        logger.error(
+            "no parent-side host measurement is available; this Hello ships "
+            "with NO resources — the hub sees an unmeasured host"
+        )
+        hello.ClearField("resources")
 
     async def on_hello_ack(self, ack: pb.HelloAck) -> None:
         # delta 1: the hub's own base URL, for parent-mediated actions.

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -14,6 +14,7 @@ import urllib.parse
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
+from ..hostfacts import cuda_ready
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -600,7 +601,7 @@ class RequestContext(Generic[D]):
             import torch
         except Exception:
             raise RuntimeError("torch is not available in this runtime") from None
-        if torch.cuda.is_available():
+        if cuda_ready():
             return torch.device(f"cuda:{torch.cuda.current_device()}")
         return torch.device("cpu")
 

--- a/src/gen_worker/rigcheck.py
+++ b/src/gen_worker/rigcheck.py
@@ -52,6 +52,7 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence
+from .hostfacts import cuda_ready
 
 __all__ = [
     "CudaUnusable",
@@ -69,13 +70,6 @@ __all__ = [
 #: never WHETHER the assertion runs.
 FLEET_LINE_FILE_ENV = "GEN_WORKER_FLEET_LINE_FILE"
 
-#: ``cuda_probe.classify_probe_failure`` classes that mean THERE IS NO CUDA
-#: DEVICE HERE, as against a device this host cannot drive. A cardless box is a
-#: different mistake and must not be reported as a host fault (pgw#1120) — but
-#: "cardless" is a fact about the PROBE, not about whether `nvidia-smi` could be
-#: read: only a host with a driver to fail can answer `driver_too_old` or
-#: `cuda_error`, so a broken diagnostic can no longer buy an exemption.
-CARDLESS_PROBE_CLASSES = frozenset({"cuda_unavailable", "torch_unavailable"})
 
 #: Wheels whose version decides whether a kernel/quantization result is about the
 #: fleet's stack or about the rig's. Reported on every run; absence is reported,
@@ -423,7 +417,7 @@ def resolve_environment() -> dict[str, Any]:
     except Exception:  # noqa: BLE001
         env["cudnn"] = None
     try:
-        env["cuda_available"] = bool(torch.cuda.is_available())
+        env["cuda_available"] = bool(cuda_ready())
     except Exception:  # noqa: BLE001
         env["cuda_available"] = False
     if env["cuda_available"]:
@@ -553,6 +547,8 @@ def assert_fleet_line(
     # mistake") survives, on a signal a broken diagnostic cannot fake: the probe
     # says WHICH failure this is, and only a host that has a driver to fail can
     # answer `driver_too_old`/`cuda_error`.
+    from .cuda_probe import CARDLESS_PROBE_CLASSES
+
     if (env.get("cuda_usable") is False
             and str(env.get("cuda_unusable_class") or "")
             not in CARDLESS_PROBE_CLASSES):

--- a/src/gen_worker/sparse_attention.py
+++ b/src/gen_worker/sparse_attention.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from . import settings_authority
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -97,10 +98,10 @@ def probe() -> str:
     """"" if the block-sparse path is runnable here, else why not. Called at
     setup so the refusal is a boot fact, not a first-request surprise."""
     try:
-        import torch
+        import torch  # noqa: F401 — the import IS the probe here
     except Exception as exc:  # noqa: BLE001
         return f"torch unimportable: {exc}"
-    if not torch.cuda.is_available():
+    if not cuda_ready():
         return "no CUDA device"
     try:
         _bits()

--- a/src/gen_worker/topology.py
+++ b/src/gen_worker/topology.py
@@ -69,6 +69,7 @@ from typing import Any, Mapping, Optional, Tuple
 
 from .models.residency import REPLICATED, SHARDED, DeviceGroup
 from .host_canary import is_fabric_wedge, sp_admits
+from .hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +143,7 @@ def pin_cuda_device_for_group() -> None:
     try:
         import torch
 
-        if torch.cuda.is_available() and device < torch.cuda.device_count():
+        if cuda_ready() and device < torch.cuda.device_count():
             torch.cuda.set_device(device)
     except Exception:  # noqa: BLE001 - placement is best-effort here; the
         # residency promote still targets `cuda:N` explicitly.

--- a/tests/test_adopt_fit_pgw1265.py
+++ b/tests/test_adopt_fit_pgw1265.py
@@ -31,6 +31,8 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
+import sys
+
 import pytest
 
 from gen_worker import activity as activity_mod
@@ -113,6 +115,11 @@ def card(monkeypatch: pytest.MonkeyPatch) -> FakeCard:
     """A card with 40 GiB free that has served one 12 GiB forward."""
     dev = FakeCard(free=40 * _GIB, reserved=2 * _GIB, allocated=1 * _GIB)
     monkeypatch.setattr(adopt_fit, "_torch", lambda: dev)
+    # pgw#896: the free/reclaimable construction itself now lives in the ONE
+    # home (`hostfacts.headroom_bytes`), which imports torch on its own — so
+    # the fake card has to BE torch for the production formula to be the one
+    # under test.
+    monkeypatch.setitem(sys.modules, "torch", dev)
     with adopt_fit.forward_watermark(0):
         dev.run_forward(12 * _GIB)
     assert adopt_fit.forward_peak(0) == 12 * _GIB

--- a/tests/test_boot_compile_deferral_gw584.py
+++ b/tests/test_boot_compile_deferral_gw584.py
@@ -44,6 +44,7 @@ import msgspec
 import pytest
 
 import gen_worker
+from gen_worker.hostfacts import HostFacts
 from gen_worker import Compile
 from gen_worker import compile_cache as cc
 from gen_worker.api.binding import Hub, wire_ref
@@ -254,9 +255,9 @@ def _mint_enable(cell_ref: str, digest: str, artifact_path: Path):
 
 def _startup(ex: Executor) -> Lifecycle:
     lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
-    lc.hardware = {"gpu_count": 1, "gpu_total_mem": 32 * 1024**3,
-                   "gpu_free_mem": 30 * 1024**3, "gpu_sm": "90",
-                   "installed_libs": []}
+    lc.hardware = HostFacts(
+        gpu_count=1, vram_total_bytes=32 * 1024**3,
+        vram_free_bytes=30 * 1024**3, gpu_sm="90")
     asyncio.run(lc.startup())
     return lc
 

--- a/tests/test_fail_closed_verification_pgw939_pgw940.py
+++ b/tests/test_fail_closed_verification_pgw939_pgw940.py
@@ -334,24 +334,35 @@ def test_the_reading_carries_its_zero_cause(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_a_saturated_card_no_longer_reads_as_empty() -> None:
     """`float(gpu_free_mem or gpu_total_mem or 0)`: `or` treats a legitimate
-    0 as absent and substitutes the largest plausible number. `gpu_free_mem`
-    is genuinely 0 on a saturated card — the state where the ladder must
-    engage, reading as the state where nothing is needed."""
+    0 as absent and substitutes the largest plausible number. Free VRAM is
+    genuinely 0 on a saturated card — the state where the ladder must engage,
+    reading as the state where nothing is needed.
+
+    Since pgw#896 the gate reads a typed `HostFacts`, so the substitution can
+    also be refuted at the VALUE level: a saturated card plans against 0, and
+    the total is never allowed to stand in for it.
+    """
     import ast
     import inspect
 
     from gen_worker import executor
+    from gen_worker.hostfacts import HostFacts
 
     src = inspect.getsource(executor.Executor.gate_functions)
     lines = [
         line.strip() for line in src.splitlines()
-        if "gpu_free_mem" in line and not line.strip().startswith("#")
+        if "vram_free_bytes" in line and not line.strip().startswith("#")
     ]
-    assert lines, "the fit gate no longer reads gpu_free_mem — re-cut this test"
+    assert lines, "the fit gate no longer reads vram_free_bytes — re-cut this"
     for line in lines:
-        assert "gpu_total_mem" not in line, (
+        assert "vram_total_bytes" not in line, (
             f"free VRAM is substituted by total again: {line}")
     ast.parse(src.strip())  # the slice is still syntactically a function
+
+    # A saturated 48 GiB card: free is 0 and the type says so.
+    saturated = HostFacts(vram_total_bytes=48 * 1024**3, vram_free_bytes=0)
+    assert saturated.vram_free_bytes == 0
+    assert float(saturated.vram_free_bytes) / (1024**3) == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_group_host_policy_pgw782.py
+++ b/tests/test_group_host_policy_pgw782.py
@@ -37,7 +37,7 @@ import msgspec
 import pytest
 
 from gen_worker import RequestContext, Resources, endpoint, worker_function
-from gen_worker import cpu_budget, video_encode
+from gen_worker import cpu_budget, hostfacts, video_encode
 from gen_worker.executor import Executor
 from gen_worker.models.store import ModelStore
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -232,13 +232,19 @@ def test_four_groups_serialize_if_the_group_leaves_instance_identity(
 def test_cpu_allowance_is_the_cgroup_quota_not_the_host_cpu_count(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    quota = tmp_path / "cpu.max"
-    quota.write_text("3230000 100000\n")  # the measured A40 pod: 32.3 cores
-    monkeypatch.setattr(cpu_budget, "_CGROUP_V2", str(quota))
-    monkeypatch.setattr(cpu_budget.os, "cpu_count", lambda: 96)
-    monkeypatch.setattr(cpu_budget.os, "sched_getaffinity", lambda _pid: set(range(96)))
+    root = tmp_path / "cgroup"
+    root.mkdir()
+    (root / "cpu.max").write_text("3230000 100000\n")  # measured A40: 32.3
+    proc = tmp_path / "self_cgroup"
+    proc.write_text("0::/\n")
+    monkeypatch.setattr(hostfacts, "_CGROUP_ROOT", root)
+    monkeypatch.setattr(hostfacts, "_PROC_SELF_CGROUP", proc)
+    monkeypatch.setattr(hostfacts.os, "cpu_count", lambda: 96)
+    monkeypatch.setattr(
+        hostfacts.os, "sched_getaffinity", lambda _pid: set(range(96)))
 
-    assert cpu_budget.cgroup_cpu_quota() == pytest.approx(32.3)
+    assert hostfacts.cpu_quota(
+        root=root, proc_self_cgroup=proc) == pytest.approx(32.3)
     assert cpu_budget.cpu_allowance() == pytest.approx(32.3)
     # 96 host processors is what torch would have used; the container has 32.3.
     assert cpu_budget.per_group_threads(32.3, 4) == 8
@@ -250,14 +256,18 @@ def test_cpu_allowance_is_the_cgroup_quota_not_the_host_cpu_count(
 def test_unlimited_cgroup_falls_back_to_the_affinity_mask(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    quota = tmp_path / "cpu.max"
-    quota.write_text("max 100000\n")
-    monkeypatch.setattr(cpu_budget, "_CGROUP_V2", str(quota))
-    monkeypatch.setattr(cpu_budget, "_CGROUP_V1_QUOTA", str(tmp_path / "absent"))
-    monkeypatch.setattr(cpu_budget.os, "sched_getaffinity", lambda _pid: set(range(12)))
-    monkeypatch.setattr(cpu_budget.os, "cpu_count", lambda: 96)
+    root = tmp_path / "cgroup"
+    root.mkdir()
+    (root / "cpu.max").write_text("max 100000\n")
+    proc = tmp_path / "self_cgroup"
+    proc.write_text("0::/\n")
+    monkeypatch.setattr(hostfacts, "_CGROUP_ROOT", root)
+    monkeypatch.setattr(hostfacts, "_PROC_SELF_CGROUP", proc)
+    monkeypatch.setattr(
+        hostfacts.os, "sched_getaffinity", lambda _pid: set(range(12)))
+    monkeypatch.setattr(hostfacts.os, "cpu_count", lambda: 96)
 
-    assert cpu_budget.cgroup_cpu_quota() is None
+    assert hostfacts.cpu_quota(root=root, proc_self_cgroup=proc) is None
     assert cpu_budget.cpu_allowance() == 12.0
 
 

--- a/tests/test_hardware_report.py
+++ b/tests/test_hardware_report.py
@@ -15,6 +15,7 @@ import pytest
 
 from gen_worker import hardware_report
 from gen_worker.config import Settings
+from gen_worker import cuda_probe
 from gen_worker.cuda_probe import CudaProbeResult, classify_probe_failure
 from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
 
@@ -34,7 +35,7 @@ pytestmark = pytest.mark.filterwarnings("ignore")
     [
         ("", "unknown"),
         ("torch unavailable: no module named torch", "torch_unavailable"),
-        ("torch.cuda.is_available() is False", "cuda_unavailable"),
+        (cuda_probe.NO_DEVICE_REASON, "cuda_unavailable"),
         # th#591/th#979's exact real-world signature, reproduced verbatim.
         ("RuntimeError: CUDA initialization: driver too old (found version 12080)", "driver_too_old"),
         ("RuntimeError: CUDA-capable device(s) is/are busy or unavailable", "cuda_error"),
@@ -66,7 +67,7 @@ def test_build_hardware_report_degrades_safely_without_nvidia_smi(monkeypatch: p
         raise FileNotFoundError("no nvidia-smi on this box")
 
     monkeypatch.setattr(hardware_report, "_nvidia_smi_driver_and_gpu", lambda: ("", ""))
-    probe = CudaProbeResult(ok=False, reason="torch.cuda.is_available() is False")
+    probe = CudaProbeResult(ok=False, reason=cuda_probe.NO_DEVICE_REASON)
     report = hardware_report.build_hardware_report(probe, _settings())
     assert report.reason_class == "cuda_unavailable"
     assert report.detail == probe.reason
@@ -98,7 +99,7 @@ def test_build_hardware_report_uses_nvidia_smi_when_torch_cuda_is_down(monkeypat
 def test_report_hardware_unsuitable_delivers_to_a_new_hub() -> None:
     with recording_hub() as (servicer, addr):
         settings = _settings(orchestrator_public_addr=addr, bootstrap_worker_jwt="")
-        probe = CudaProbeResult(ok=False, reason="torch.cuda.is_available() is False")
+        probe = CudaProbeResult(ok=False, reason=cuda_probe.NO_DEVICE_REASON)
         delivered = hardware_report.report_hardware_unsuitable(settings, probe)
         assert delivered is True
 

--- a/tests/test_host_canary.py
+++ b/tests/test_host_canary.py
@@ -18,8 +18,9 @@ import pytest
 
 from gen_worker import host_canary as hc
 from gen_worker.config import Settings
-from gen_worker.executor import Executor
-from gen_worker.lifecycle import Lifecycle
+from gen_worker.procsplit import measure
+from gen_worker.procsplit.parent import ParentControl
+from gen_worker.topology import ExecutionTopology
 
 
 # Verbatim `nvidia-smi topo -m` from a 2x H100 80GB HBM3 (SXM) host.
@@ -94,13 +95,26 @@ def _fake_cuda(monkeypatch: pytest.MonkeyPatch):
 
 
 def _hello_canary(monkeypatch: pytest.MonkeyPatch):
+    """The canary as the HUB receives it.
+
+    Through the real relay: the pre-tenant-import measurement subprocess's
+    payload (`procsplit.measure.measure`) into the control parent's ONE
+    `WorkerResources` builder. pgw#898 deleted the compute child's second
+    builder, whose output the parent overwrote before the hub ever saw it —
+    so a canary asserted there was asserted on a discarded value.
+    """
     monkeypatch.setattr(hc, "_cached", None)
-    lc = Lifecycle(
+    pc = ParentControl(
         Settings(bootstrap_worker_jwt="", worker_id="w-748",
-                 runpod_pod_id="", worker_image_digest=""),
-        Executor([], lambda *a, **k: None),
+                 runpod_pod_id="", worker_image_digest="",
+                 orchestrator_public_addr="127.0.0.1:1"),
+        socket_path="/tmp/gen-worker-canary.sock",
+        topology=ExecutionTopology.single(),
     )
-    return lc.build_hello().resources.host_canary
+    pc._measurement = measure.measure()
+    resources = pc._parent_resources()
+    assert resources is not None
+    return resources.host_canary
 
 
 def test_measured_fabric_reaches_the_hub(_fake_cuda, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_hostfacts_pgw896.py
+++ b/tests/test_hostfacts_pgw896.py
@@ -1,0 +1,442 @@
+"""pgw#896 / pgw#897 / pgw#898 — one home per host fact.
+
+The point of the collapse is not fewer lines. It is that **a second answer
+becomes unrepresentable**: two call sites that could previously disagree about
+the same physical fact now cannot, because there is only one place the fact is
+read from.
+
+Each test below is the disagreement, stated as a law:
+
+* the CUDA predicate, the ``mem_get_info`` reading and the cgroup CPU quota
+  each have exactly ONE code site (a fence over real source, comments and
+  docstrings excluded, so prose about the rule cannot satisfy it);
+* the FOUR CPU readers that used to answer a 2.5-core quota three different
+  ways now derive from one fractional observation, and the integer is never
+  above it;
+* the compile pool and the host-move guard credit the SAME reclaimable page
+  cache against the same cgroup tree;
+* ``torch.cuda.is_available()`` being False no longer erases the difference
+  between a host with no card and a card that will not answer;
+* ``WorkerResources`` has exactly one builder (pgw#898).
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import os
+import tokenize
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from gen_worker import aot_compile_pool as pool
+from gen_worker import cpu_budget, cuda_probe, hostfacts, lifecycle, postmortem
+from gen_worker.models.memory import probe_host_ram
+
+_GIB = 1024 ** 3
+_SRC = Path(hostfacts.__file__).parent
+
+
+def _code_hits(needle: str) -> List[Tuple[str, int]]:
+    """Every occurrence of ``needle`` in ``src/gen_worker`` that is real code.
+
+    Comments and string literals are dropped, so a docstring naming the rule —
+    including this module's own — can never satisfy the fence.
+    """
+    hits: List[Tuple[str, int]] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        if "/pb/" in str(path):
+            continue  # generated
+        text = path.read_text()
+        if needle not in text:
+            continue
+        try:
+            tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+        except (tokenize.TokenError, IndentationError):  # pragma: no cover
+            continue
+        skip = {tokenize.COMMENT, tokenize.STRING,
+                getattr(tokenize, "FSTRING_MIDDLE", -1)}
+        for tok in tokens:
+            if tok.type in skip:
+                continue
+            if needle in tok.line and needle in tok.string:
+                hits.append((str(path.relative_to(_SRC)), tok.start[0]))
+                break
+        else:
+            # `needle` spans several tokens: rebuild the code-only text.
+            stripped = "".join(
+                t.string for t in tokens if t.type not in skip
+            )
+            if needle in stripped:
+                hits.append((str(path.relative_to(_SRC)), 0))
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# The fences: one code site per fact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "torch.cuda.is_available",
+        "torch.cuda.mem_get_info",
+    ],
+)
+def test_the_device_probes_have_exactly_one_code_site(needle: str) -> None:
+    """74 weak CUDA predicates across 42 modules, and 10 ``mem_get_info``
+    call sites across 8, all now read one home.
+
+    The weak predicate is the load-bearing one: it answers False for a host
+    with no card AND for a card that will not answer, so every site that read
+    it alone reported a wedged H100 as a cardless box — and zeros are what the
+    fleet places on. One site means changing that answer is one edit.
+    """
+    hits = _code_hits(needle)
+    assert [f for f, _ in hits] == ["hostfacts.py"], (
+        f"{needle} is answered in {len(hits)} places: {hits}. It has one home, "
+        f"gen_worker/hostfacts.py — route the new site through it."
+    )
+
+
+def _literal_hits(needle: str, *, exact: bool = False) -> List[str]:
+    """Modules with ``needle`` inside a real string LITERAL (a path is named
+    by one), docstrings excluded — so prose about the rule cannot satisfy it."""
+    out: List[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        if "/pb/" in str(path):
+            continue
+        text = path.read_text()
+        if needle not in text:
+            continue
+        tree = ast.parse(text)
+        docstrings = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                 ast.AsyncFunctionDef)):
+                body = getattr(node, "body", None)
+                if (body and isinstance(body[0], ast.Expr)
+                        and isinstance(body[0].value, ast.Constant)
+                        and isinstance(body[0].value.value, str)):
+                    docstrings.add(id(body[0].value))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and id(node) not in docstrings
+                    and (node.value == needle if exact
+                         else needle in node.value)):
+                out.append(str(path.relative_to(_SRC)))
+                break
+    return out
+
+
+def test_the_cgroup_cpu_quota_has_exactly_one_reader() -> None:
+    """``cpu_budget`` read a FIXED ``/sys/fs/cgroup/cpu.max`` (which reports
+    ``max`` in a nested cgroup that really is capped) and had a v1 fallback;
+    ``postmortem`` walked the node chain and had none. Two readers of one file,
+    each missing what the other had."""
+    for needle in ("cpu.max", "cpu.cfs_quota_us"):
+        assert _literal_hits(needle, exact=True) == ["hostfacts.py"], (
+            f"{needle!r} is read in {_literal_hits(needle, exact=True)}; "
+            f"the quota has "
+            f"one reader, hostfacts.cpu_quota()"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CPU: three reductions, three roundings -> one observation
+# ---------------------------------------------------------------------------
+
+
+def _pin_quota(monkeypatch: pytest.MonkeyPatch, cores: float) -> None:
+    """Make every quota reader in the tree see ``cores``.
+
+    Written to patch each module that HAS its own reader, so it stays honest
+    against the pre-collapse tree (where there were three) as well as this one
+    (where there is one). When this needs more than the hostfacts entry, the
+    collapse has regressed.
+    """
+    monkeypatch.setattr(hostfacts, "cpu_quota", lambda **_: cores)
+    for module, name in (
+        (postmortem, "cpu_quota_cores"),
+        (cpu_budget, "cgroup_cpu_quota"),
+        (pool, "cpu_quota_cores"),
+    ):
+        if hasattr(module, name):
+            monkeypatch.setattr(module, name, lambda *_a, **_k: cores)
+    monkeypatch.setattr(os, "cpu_count", lambda: 32)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(32)))
+
+
+def test_a_fractional_cpu_quota_is_never_rounded_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``cpu.max = 250000 100000`` is 2.5 cores.
+
+    ``postmortem.effective_cpu_count`` and ``aot_compile_pool.cpu_facts`` both
+    did ``max(1, int(quota + 0.5))`` -> **3**, while ``cpu_budget.cpu_allowance``
+    kept **2.5**. So the fleet planned against 3 cores, torch sized its intra-op
+    pool above the quota, and the kernel throttled the boot window. Rounding a
+    CPU quota UP is always wrong.
+    """
+    _pin_quota(monkeypatch, 2.5)
+
+    fractional = cpu_budget.cpu_allowance()
+    assert fractional == pytest.approx(2.5)
+
+    for name, value in (
+        ("postmortem.effective_cpu_count", postmortem.effective_cpu_count()),
+        ("aot_compile_pool.cpu_facts().vcpus", pool.cpu_facts().vcpus),
+        ("hostfacts.cpu_allowance().whole_cores",
+         hostfacts.cpu_allowance().whole_cores),
+    ):
+        assert value == 2, f"{name} returned {value}; floor(2.5) is 2, not 3"
+        assert value <= fractional, (
+            f"{name} returned {value}, ABOVE the {fractional}-core quota — "
+            f"the thread pool it sizes will be CFS-throttled"
+        )
+
+
+def test_the_hub_and_torch_read_the_same_quota_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hub's ``vcpus`` and torch's thread allowance need not be equal —
+    one is an integer, the other fractional — but they must be the same
+    OBSERVATION. They were not: two readers with different kernel coverage."""
+    _pin_quota(monkeypatch, 6.25)
+    allowance = hostfacts.cpu_allowance()
+    assert cpu_budget.cpu_allowance() == pytest.approx(allowance.cores)
+    assert postmortem.effective_cpu_count() == allowance.whole_cores
+    assert pool.cpu_facts().vcpus == allowance.whole_cores
+    assert postmortem.cpu_quota_cores() == pytest.approx(allowance.quota_cores)
+
+
+def test_the_quota_reader_covers_both_cgroup_generations(tmp_path: Path) -> None:
+    """One reader with BOTH properties its two predecessors had one each of:
+    the deepest node on the chain, and the v1 fallback."""
+    v2 = tmp_path / "v2"
+    (v2 / "kubepods" / "podxyz").mkdir(parents=True)
+    (v2 / "cpu.max").write_text("max 100000\n")          # the root is uncapped
+    (v2 / "kubepods" / "podxyz" / "cpu.max").write_text("450000 100000\n")
+    proc = tmp_path / "self_v2"
+    proc.write_text("0::/kubepods/podxyz\n")
+    assert hostfacts.cpu_quota(root=v2, proc_self_cgroup=proc) == pytest.approx(4.5)
+
+    v1 = tmp_path / "v1"
+    (v1 / "cpu").mkdir(parents=True)
+    (v1 / "cpu" / "cpu.cfs_quota_us").write_text("250000\n")
+    (v1 / "cpu" / "cpu.cfs_period_us").write_text("100000\n")
+    empty = tmp_path / "self_v1"
+    empty.write_text("")
+    assert hostfacts.cpu_quota(root=v1, proc_self_cgroup=empty) == pytest.approx(2.5)
+
+
+# ---------------------------------------------------------------------------
+# RAM: one definition of "reclaimable"
+# ---------------------------------------------------------------------------
+
+
+def _cgroup_tree(tmp_path: Path, **stat: int) -> Tuple[Path, Path, Path]:
+    root = tmp_path / "cgroup"
+    root.mkdir()
+    (root / "memory.max").write_text(str(200 * _GIB))
+    (root / "memory.current").write_text(str(150 * _GIB))
+    (root / "memory.stat").write_text(
+        "".join(f"{k} {v}\n" for k, v in stat.items()))
+    proc = tmp_path / "self_cgroup"
+    proc.write_text("0::/\n")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemTotal: 262144000 kB\nMemAvailable: 209715200 kB\n")
+    return root, proc, meminfo
+
+
+def test_the_pool_and_the_load_guard_reclaim_the_same_pages(
+    tmp_path: Path,
+) -> None:
+    """A pod that just downloaded its weights holds the snapshot on the ACTIVE
+    file LRU.
+
+    ``models/memory`` counts both file LRUs and documents why (pgw#752: a
+    251GB wan-2.2 pod reported 71.5GiB available while ~180GiB of it was clean
+    snapshot cache). ``aot_compile_pool`` had its own parser counting
+    ``inactive_file + slab_reclaimable`` only — so on the same box the compile
+    pool believed 120 GiB less was available than the loader did, and neither
+    number was labelled as a different question.
+    """
+    root, proc, meminfo = _cgroup_tree(
+        tmp_path,
+        active_file=120 * _GIB,
+        inactive_file=8 * _GIB,
+        slab_reclaimable=1 * _GIB,
+        shmem=0,
+        file_dirty=0,
+        file_writeback=0,
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc, meminfo=meminfo,
+                         siblings=1)
+    facts = pool.memory_facts(
+        meminfo=meminfo, cgroup_root=root, proc_self_cgroup=proc)
+
+    assert ram.reclaimable_file_gb == 128.0, ram
+    assert facts.cgroup_reclaimable_bytes == int(ram.reclaimable_file_gb * _GIB), (
+        f"the pool credits {facts.cgroup_reclaimable_bytes / _GIB:.1f} GiB and "
+        f"the loader {ram.reclaimable_file_gb:.1f} GiB of the SAME page cache"
+    )
+    assert facts.available_bytes == int(ram.available_gb * _GIB), (
+        f"{facts} vs {ram} — two answers to 'how much host RAM is there'"
+    )
+
+
+def test_proc_meminfo_has_one_parser(tmp_path: Path) -> None:
+    """``postmortem`` and the compile pool each parsed the file themselves;
+    ``probe_host_ram`` asked psutil for the same two numbers."""
+    path = tmp_path / "meminfo"
+    path.write_text("MemTotal:       65536000 kB\nMemAvailable:   32768000 kB\n"
+                    "Buffers:            1024 kB\n")
+    assert hostfacts.meminfo_kb(path) == {
+        "MemTotal": 65536000, "MemAvailable": 32768000, "Buffers": 1024}
+    assert _literal_hits("/proc/meminfo", exact=True) == ["hostfacts.py"], (
+        f"/proc/meminfo is opened in "
+        f"{_literal_hits('/proc/meminfo', exact=True)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CUDA: "no answer" is not "no card"
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cuda_state() -> None:
+    hostfacts.reset_cuda_state()
+
+
+@pytest.mark.parametrize(
+    "reason, expected",
+    [
+        (cuda_probe.NO_DEVICE_REASON, hostfacts.DEVICE_ABSENT),
+        ("torch unavailable: No module named 'torch'", hostfacts.DEVICE_ABSENT),
+        ("RuntimeError: CUDA initialization: driver too old (found version "
+         "12080)", hostfacts.DEVICE_UNREADABLE),
+        ("RuntimeError: CUDA-capable device(s) is/are busy or unavailable",
+         hostfacts.DEVICE_UNREADABLE),
+    ],
+)
+def test_a_card_that_will_not_answer_is_not_a_cardless_host(
+    monkeypatch: pytest.MonkeyPatch, reason: str, expected: str,
+) -> None:
+    """``torch.cuda.is_available()`` is False for BOTH, and that is the whole
+    defect: a wedged H100 measured silent zeros and the fleet placed on them.
+
+    The discriminator is the probe's own class, never "nvidia-smi did not
+    answer" — a broken diagnostic must not buy an absent card's exemption
+    (pgw#1120). Only a host with a driver TO fail can report ``driver_too_old``
+    or ``cuda_error``.
+    """
+    monkeypatch.setattr(
+        cuda_probe, "probe_cuda",
+        lambda *_a, **_k: cuda_probe.CudaProbeResult(ok=False, reason=reason))
+    state = hostfacts.cuda_state()
+    assert state.state == expected, state
+    assert state.absent is (expected == hostfacts.DEVICE_ABSENT)
+    assert state.unreadable is (expected == hostfacts.DEVICE_UNREADABLE)
+
+
+def test_the_cpu_rung_warning_names_which_of_the_two_it_is(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator-facing consequence, and the one production consumer of the
+    three-state.
+
+    Every function on a pod with no usable card is served on the CPU rung
+    behind a warning that read *"no CUDA device detected on this pod"* — said
+    identically for a cardless box and for an H100 that would not answer. The
+    operator then goes looking for a provisioning mistake on a machine that
+    has the card in it.
+    """
+    from gen_worker.models import serve_fit
+    from gen_worker.models.hub_policy import TensorhubWorkerCapabilities
+
+    class _Res:
+        gpu = True
+        libraries: Tuple[str, ...] = ()
+
+    caps = TensorhubWorkerCapabilities(
+        cuda_version="", gpu_sm=0, torch_version="2.13.0", installed_libs=[])
+
+    monkeypatch.setattr(
+        cuda_probe, "probe_cuda",
+        lambda *_a, **_k: cuda_probe.CudaProbeResult(
+            ok=False, reason=cuda_probe.NO_DEVICE_REASON))
+    hostfacts.reset_cuda_state()
+    cardless = serve_fit.plan_serve(_Res(), caps, 0.0)
+    assert "no CUDA device detected on this pod" in cardless.warning
+
+    monkeypatch.setattr(
+        cuda_probe, "probe_cuda",
+        lambda *_a, **_k: cuda_probe.CudaProbeResult(
+            ok=False,
+            reason="RuntimeError: CUDA-capable device(s) is/are busy or "
+                   "unavailable"))
+    hostfacts.reset_cuda_state()
+    wedged = serve_fit.plan_serve(_Res(), caps, 0.0)
+    assert "will not answer" in wedged.warning and "cuda_error" in wedged.warning
+    assert wedged.warning != cardless.warning, (
+        "a wedged card and a cardless box still say the same thing"
+    )
+
+
+def test_the_accelerator_vocabulary_is_cuda_or_none() -> None:
+    """`'cpu'` is an oxymoron on this axis and is not a state of it."""
+    assert {hostfacts.DEVICE_PRESENT, hostfacts.DEVICE_ABSENT} == {"cuda", "none"}
+    assert hostfacts.DEVICE_UNREADABLE not in {"cuda", "none", "cpu"}
+
+
+def test_an_unreadable_card_is_not_reported_as_zero_bytes_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``None`` is the reading that did not happen; ``0`` is a saturated card.
+    Collapsing them is how an unreadable card advertised an empty one."""
+    monkeypatch.setattr(hostfacts, "cuda_ready", lambda: False)
+    assert hostfacts.free_vram_bytes(0) is None
+    assert hostfacts.total_vram_bytes(0) is None
+    assert hostfacts.headroom_bytes(0) is None
+
+
+# ---------------------------------------------------------------------------
+# pgw#898 — one builder for WorkerResources
+# ---------------------------------------------------------------------------
+
+
+def test_worker_resources_has_exactly_one_builder() -> None:
+    """``lifecycle.build_resources()`` measured the host in the process that
+    has already imported tenant code, and ``_apply_identity_and_resources``
+    replaced or cleared the result before the hub ever saw it — 53 lines whose
+    output the wire discarded by construction.
+
+    A second builder is not merely waste: a field taught to only one of them is
+    dead on the wire, and the pod that ships the protobuf default gets idle
+    reaped as ``cold_idle_never_dispatched`` (pgw#846).
+    """
+    assert not hasattr(lifecycle.Lifecycle, "build_resources"), (
+        "the discarded second builder is back"
+    )
+    builders = _code_hits("pb.WorkerResources(")
+    assert [f for f, _ in builders] == ["procsplit/parent.py"], (
+        f"WorkerResources is built in {builders}; the parent — the process "
+        f"that has imported no tenant code — is the only one allowed to."
+    )
+
+
+def test_the_measured_host_is_one_immutable_struct() -> None:
+    """``probe_hardware`` returned an untyped ``Dict[str, Any]`` whose keys
+    two builders and one gate spelled by hand; ``gate_functions`` read a
+    ``cuda_version`` key nothing ever wrote."""
+    facts = hostfacts.HostFacts(gpu_count=2, vram_total_bytes=17, gpu_sm="90")
+    with pytest.raises(AttributeError):
+        facts.gpu_count = 3  # type: ignore[misc]
+    assert facts.as_dict()["gpu_count"] == 2
+    assert "cuda_version" in hostfacts.HostFacts.__struct_fields__
+    assert isinstance(lifecycle.probe_hardware(), hostfacts.HostFacts)

--- a/tests/test_multi_group_async_gate_pgw778.py
+++ b/tests/test_multi_group_async_gate_pgw778.py
@@ -22,6 +22,7 @@ from typing import Any, List
 import msgspec
 import pytest
 
+from gen_worker.hostfacts import HostFacts
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker import Hub, Resources
 from gen_worker.executor import EndpointSpec, Executor
@@ -63,8 +64,8 @@ def _executor(topology: ExecutionTopology) -> Executor:
     return Executor(_specs(), _send, topology=topology)
 
 
-_GPU = {"gpu_total_mem": 40 * 1024**3, "gpu_free_mem": 40 * 1024**3,
-        "gpu_sm": "89", "installed_libs": []}
+_GPU = HostFacts(vram_total_bytes=40 * 1024**3, vram_free_bytes=40 * 1024**3,
+                 gpu_sm="89")
 
 
 def test_a_wide_pod_withdraws_the_async_function_instead_of_advertising_it() -> None:

--- a/tests/test_native_crash_streak_pgw676.py
+++ b/tests/test_native_crash_streak_pgw676.py
@@ -30,6 +30,7 @@ from typing import List
 import msgspec
 import pytest
 
+from gen_worker.hostfacts import HostFacts
 from gen_worker.api.binding import Hub
 from gen_worker.api.decorators import Resources
 from gen_worker.executor import Executor
@@ -136,8 +137,8 @@ def _executor() -> Executor:
     return Executor(_specs(), _send)
 
 
-_GPU = {"gpu_total_mem": 20 * 1024**3, "gpu_free_mem": 20 * 1024**3,
-        "gpu_sm": "86", "installed_libs": []}
+_GPU = HostFacts(vram_total_bytes=20 * 1024**3, vram_free_bytes=20 * 1024**3,
+                 gpu_sm="86")
 
 
 def test_crash_streak_gates_only_the_crashing_function(

--- a/tests/test_pod_vram_truth_pgw776.py
+++ b/tests/test_pod_vram_truth_pgw776.py
@@ -21,7 +21,7 @@ CUDA is touched.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, List
 
 import pytest
 
@@ -128,7 +128,7 @@ def test_a_multi_gpu_host_with_no_topology_names_the_invisible_cards(
 def test_the_fit_ladder_gates_on_the_least_free_group(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # DPA-7: `gate_functions` turns probe_hardware()['gpu_free_mem'] into
+    # DPA-7: `gate_functions` turns probe_hardware().vram_free_bytes into
     # serve plans for EVERY function. Card 0 carries group 0's weights plus the
     # allocator cache, so reading it planned rungs for groups 1-3 from a card
     # they never touch — and a genuinely-unfit card 0 refused functions the
@@ -149,7 +149,7 @@ def test_the_fit_ladder_gates_on_the_least_free_group(
     monkeypatch.setattr(torch.cuda, "mem_get_info",
                         lambda i: (40 * GiB, 48 * GiB))
 
-    info: Dict[str, Any] = lifecycle.probe_hardware()
-    assert info["gpu_total_mem"] == 48 * GiB
-    assert info["gpu_free_mem"] == 9 * GiB, (
+    facts = lifecycle.probe_hardware()
+    assert facts.vram_total_bytes == 48 * GiB
+    assert facts.vram_free_bytes == 9 * GiB, (
         "the gate must plan for the group with the LEAST room")

--- a/tests/test_resolution_rekey_gw494.py
+++ b/tests/test_resolution_rekey_gw494.py
@@ -18,6 +18,7 @@ from typing import List
 import msgspec
 import pytest
 
+from gen_worker.hostfacts import HostFacts
 from gen_worker.api.binding import Hub, rebind_pick, wire_ref
 from gen_worker.models.records import vacate_record
 from gen_worker.models.refs import FlavorSelectorRemoved
@@ -181,9 +182,11 @@ def test_regate_runs_after_resolutions_and_is_idempotent() -> None:
     spec = _spec(resources=Resources(gpu=True, libraries=("nunchaku",)))
     ex = _executor(spec)
 
-    without_lib = {"gpu_total_mem": 48 * 1024**3, "gpu_free_mem": 48 * 1024**3,
-                   "gpu_sm": "90", "installed_libs": []}
-    with_lib = dict(without_lib, installed_libs=["nunchaku"])
+    without_lib = HostFacts(
+        vram_total_bytes=48 * 1024**3, vram_free_bytes=48 * 1024**3,
+        gpu_sm="90")
+    with_lib = msgspec.structs.replace(
+        without_lib, installed_libs=("nunchaku",))
 
     ex.gate_functions(without_lib)
     assert ex.unavailable["generate"][0] == "missing_cuda_library"

--- a/tests/test_wire_facts_pgw876.py
+++ b/tests/test_wire_facts_pgw876.py
@@ -1,37 +1,25 @@
 """pgw#876 §4 — the recurrence guard for "two builders for the same fact, only
 one of which is ever on the wire".
 
-`WorkerResources` is built in two places: `lifecycle.build_resources()` in the
-COMPUTE CHILD, and `procsplit.parent.ParentControl._parent_resources()` in the
-CONTROL PARENT. The process split is UNCONDITIONAL, and
-`_apply_identity_and_resources` overwrites the child's copy wholesale (or
-clears the field outright when the parent has no measurement), so **only the
-parent's copy ever reaches the hub.**
+`WorkerResources` had TWO builders — `lifecycle.build_resources()` in the
+compute child and `procsplit.parent.ParentControl._parent_resources()` in the
+control parent. The split is UNCONDITIONAL and the parent overwrote the child's
+copy wholesale, so only the parent's ever reached the hub. pgw#898 deleted the
+child's; `tests/test_hostfacts_pgw896.py` fences the count at one.
 
-The guard: a field taught to only ONE builder is dead on the wire. A pod then
-ships the protobuf default and is idle-reaped as `cold_idle_never_dispatched`
-while the real value sat in its container env the whole time.
-
-These two rows make that fingerprint a red test instead of a paid pod:
-
-* the parent's builder must assign every wire field (except the documented
-  exemption), proved at the VALUE level — feed it all-distinct inputs and no
-  field may come back at its protobuf default;
-* the two builders must assign the SAME field set, proved at the SOURCE level —
-  so teaching one of them a new field and not the other goes red here rather
-  than on a pod.
+The guard that survives: a field the ONE builder does not assign is dead on the
+wire. A pod then ships the protobuf default and is idle-reaped as
+`cold_idle_never_dispatched` while the real value sat in its container env the
+whole time. Proved at the VALUE level — feed the builder all-distinct inputs
+and no field may come back at its protobuf default.
 """
 
 from __future__ import annotations
 
-import ast
-import inspect
-import textwrap
 from pathlib import Path
 
 import pytest
 
-from gen_worker import lifecycle as lifecycle_mod
 from gen_worker.config import load_settings
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.procsplit.parent import ParentControl
@@ -48,10 +36,12 @@ _INTENTIONALLY_UNSET = frozenset({"git_commit"})
 _MEASUREMENT = {
     "hardware": {
         "gpu_count": 4,
-        "gpu_total_mem": 85899345920,
+        "vram_total_bytes": 85899345920,
+        "vram_free_bytes": 42949672960,
         "gpu_name": "NVIDIA H100 80GB HBM3",
         "gpu_sm": "90",
         "torch_version": "2.13.0+cu130",
+        "cuda_version": "13.0",
         "installed_libs": ["diffusers==0.36.0"],
         # The HOST driver. 580.159.04 is a real RunPod draw
         # and the tuple-vs-float trap (as floats 580.159 < the 580.65 floor).
@@ -120,9 +110,8 @@ def test_the_parent_builder_assigns_every_wire_field(monkeypatch: pytest.MonkeyP
     assert not unset, (
         f"the ON-THE-WIRE WorkerResources builder never assigns {sorted(unset)}. "
         "An empty value here is not a default the hub can read as a choice — it "
-        "is the signature of a field taught to `lifecycle.build_resources()` "
-        "(the compute child's builder, which the parent overwrites wholesale) "
-        "instead of to `_parent_resources()`. th#1359 Part 2 did exactly that "
+        "is the signature of a field the ONE builder was never taught. "
+        "th#1359 Part 2 did exactly that "
         "with `worker_mode` and every forge pod bought afterwards was "
         "idle-reaped as a serving pod."
     )
@@ -192,31 +181,3 @@ def test_a_wheel_that_still_sends_the_retired_fields_is_not_refused() -> None:
     assert got.ParseFromString(bytes(twire)) == len(twire)
     assert got.family == "sdxl" and got.requested_cell_key == "ck1-abc"
     assert not hasattr(got, "requested_cell_axes")
-
-
-def _assigned_field_names(func: object) -> set:
-    """The `pb.WorkerResources(...)` keyword names one builder assigns."""
-    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        target = node.func
-        name = target.attr if isinstance(target, ast.Attribute) else getattr(target, "id", "")
-        if name == "WorkerResources":
-            return {kw.arg for kw in node.keywords if kw.arg}
-    raise AssertionError(f"{func!r} no longer constructs a pb.WorkerResources")
-
-
-def test_the_two_resources_builders_assign_the_same_fields() -> None:
-    """Both builders exist; only the parent's is on the wire. Until there is
-    ONE builder, they must at least stay field-for-field identical, so a lane
-    adding a fact does not have to know which of the two is live."""
-    child = _assigned_field_names(lifecycle_mod.Lifecycle.build_resources)
-    parent = _assigned_field_names(ParentControl._parent_resources)
-    assert child == parent, (
-        "the two WorkerResources builders have drifted: "
-        f"child-only={sorted(child - parent)} parent-only={sorted(parent - child)}. "
-        "`procsplit/parent.py::_parent_resources` is the one the hub receives — "
-        "the process split is unconditional and the parent overwrites the "
-        "child's copy wholesale. A field only the child sets is dead on the wire."
-    )

--- a/tests/test_worker_value_contracts_pgw1237.py
+++ b/tests/test_worker_value_contracts_pgw1237.py
@@ -112,7 +112,7 @@ def test_exact_worker_values_match_pgw1237() -> None:
         cuda_probe.classify_probe_failure(reason)
         for reason in (
             "torch unavailable: import failed",
-            "torch.cuda.is_available() is False",
+            cuda_probe.NO_DEVICE_REASON,
             "CUDA initialization: driver too old (found version 12080)",
             "CUDA-capable device is busy",
             "",


### PR DESCRIPTION
Three of the hard-cut program's structural cuts, landed together because two of
them are the same question asked twice.

**Disjointness (process rule):** this branch touches no file in PR #829
(`models/download.py`, `models/errors.py`, `models/cozy_snapshot.py`) and no
file in `1270-tcg-declaration-package`.

## The census — publish the denominator

Code sites only. The fence in `tests/test_hostfacts_pgw896.py` tokenizes the
source and drops comments, string literals and f-string text, so prose naming
the rule can never satisfy it.

| question | before | after |
|---|---|---|
| "is there a usable CUDA device?" | **74 sites / 42 modules** | **1** |
| `torch.cuda.mem_get_info` | **10 sites / 8 modules** | **1** |
| cgroup CPU-quota readers | 2 (`cpu_budget`, `postmortem`) | **1** |
| `min()` reductions over the SAME three CPU candidates | 4 (`cpu_budget`, `postmortem`, `aot_compile_pool`, `boot_key`) | **1** |
| roundings of a fractional quota | 3 (float, half-up, floor) | **1** (floor) |
| `/proc/meminfo` parsers | 4 (`postmortem`, `aot_compile_pool`, `procsplit/oom_rank`, psutil in `models/memory`) | **1** |
| definitions of "reclaimable RAM" | 2 | **1** |
| cgroup-v2 node-chain walkers | 3 | **1** |
| `pb.WorkerResources(` builders | 2 | **1** |

**Where the audit's numbers were stale — the source wins.** The brief said 9
free-VRAM formulas, 12 `mem_get_info` sites and ~80 weak predicates. Master
carries **10** `mem_get_info` sites in 8 modules and **74** `is_available()`
sites in 42; `mint_budget`, `mint_delegate` and `aot_compile_pool` no longer
hold a `mem_get_info` at all, so pgw#896's headline "the pgw#877 dedup left a
third copy at `aot_compile_pool._probe_free_device_bytes`" is **already fixed** —
that function does not exist. Two further brief items are **not defects and are
deliberately not touched**: free-disk's six sites measure six *different mounts*
for six different acts (CAS root, workdir, stream root), which is one formula
applied to different objects rather than one fact answered six times; and
`procsplit/merge.py` summing `free_vram_bytes` while `lifecycle` mins is correct
and argued at both sites (each child sees only its own cards through
`CUDA_VISIBLE_DEVICES`; the min is *within* one process).

## The shape, and why

`HostFacts` — one immutable `msgspec.Struct`, measured **once** by
`lifecycle.probe_hardware()` inside `procsplit/measure.py`'s pre-tenant-import
subprocess, serialized to the control parent, and read (never re-probed) by the
one `WorkerResources` builder and by `Executor.gate_functions`. It replaces a
`Dict[str, Any]` whose keys two builders and one gate spelled by hand.

`gen_worker/hostfacts` — the primitive observations the struct is measured
from, and the *only* place any of them is read:

* **Three named VRAM formulas, not nine.** `free_vram_bytes` (what the driver
  says right now), `total_vram_bytes`, `headroom_bytes` (driver-free *plus* the
  allocator cache this process can return). They are genuinely different
  quantities with different right answers, so they are three names instead of
  one ambiguous "free". `None` means *no reading* and never collapses into `0`,
  which is a saturated card.
* **`cuda_ready()`** — the one `torch.cuda.is_available()` call site, and
  deliberately **value-identical** to the raw predicate, so all 74 capability
  guards keep their exact behaviour. It is a capability question; degrading is
  the right answer for it.
* **`cuda_state()`** — three-valued (`cuda` / `none` / `unreadable`) for anyone
  who must tell "no card" from "a card that will not answer". See the trap
  below.
* **`cpu_quota()` / `cpu_allowance()`** — one reader with *both* properties its
  two predecessors had one each of (the deepest `cpu.max` on the node chain AND
  the cgroup-v1 fallback), and one reduction returning a fractional
  `CpuAllowance` whose `.whole_cores` **floors**.
* **`meminfo_kb()` / `cgroup_nodes()`** — one parser, one chain walker.

Everything else projects from these: `postmortem.effective_cpu_count`,
`cpu_budget.cpu_allowance`, `aot_compile_pool.cpu_facts`/`memory_facts`,
`models/memory.available_vram`/`probe_host_ram`, `boot_key`, `adopt_fit`,
`hot_swap`, `residency`.

## Three live defects the collapse exposes

1. **A fractional CPU quota was rounded UP.** On a `cpu.max = 250000 100000`
   pod the hub was told **3** cores and the compile pool sized itself at **3**
   while torch was given **2.5** — every derived pool sat above the quota and
   the kernel throttled it. `boot_key`'s fourth reduction was worse still: it
   took `floor(quota)` while *ignoring the affinity mask*.
2. **The compile pool and the load guard credited different page cache.** The
   pool counted `inactive_file + slab_reclaimable`; the loader counts both file
   LRUs minus what the kernel cannot drop — the definition `models/memory`
   documents with its measurement (pgw#752: a 251GB wan-2.2 pod reported
   71.5GiB available while ~180GiB was clean snapshot cache). On the synthetic
   tree in the test that is **128 GiB vs 9 GiB**. The pool also applied no
   sibling divisor, so on a split pod two components allocated from one cgroup
   with denominators differing by the split degree.
3. **`gate_functions` read a `cuda_version` key nothing ever wrote.** The
   capability always reached the fit planner as `""`. `HostFacts` carries the
   value `detect_worker_capabilities` was already measuring and throwing away.

## The `is_available()` trap, handled

`torch.cuda.is_available()` is False for a host with **no card** and for a card
that **will not answer**, and 74 sites read that one bit. A wedged GPU therefore
served every function on the CPU rung behind a warning reading *"no CUDA device
detected on this pod"* — sending the operator to hunt a provisioning mistake on
a box with an H100 in it.

`cuda_state()` discriminates on **the strong probe's own class**, never on
"nvidia-smi did not answer" — a broken diagnostic must not buy an absent card's
exemption, and only a host with a driver TO fail can report
`driver_too_old`/`cuda_error` (pgw#1120, and the correction this ledger records
against its own earlier instruction). `CARDLESS_PROBE_CLASSES` moves from
`rigcheck` to `cuda_probe`, next to the classifier that produces it, and the
sentinel reason string becomes a named constant `NO_DEVICE_REASON` **because
`classify_probe_failure` matches on it** — spelling it twice is exactly how a
cardless box starts being classified `cuda_error` and condemned as a host fault.

Naming follows the standing accelerator ruling: `cuda` / `none` only, with
`unreadable` as a third state of a *different* axis. `'cpu'` appears nowhere.

The gate `scripts/lint_unreached_surface.py` went **red** on `cuda_state()`
having no production caller — correctly, and it is wired rather than
baseline-suppressed: `models/serve_fit.plan_serve` now says which of the two it
is, which is the operator-facing consequence of the whole discrimination.

## pgw#898

`lifecycle.build_resources()` — **53 lines, deleted**. Verified discarded at
source before removal: the split is unconditional
(`entrypoint.py:29` "the split is unconditional"), and
`_apply_identity_and_resources` either `CopyFrom`s the parent's copy over it or
`ClearField`s it. So the result was discarded *by construction* while the fleet
condemned SKUs on the other builder's numbers. `build_hello()` no longer sets
`resources` at all, and the parent's "no measurement" path now logs
unconditionally instead of only when the child had set a field to drop.

## Red-verified — values, not assertions

Measured against `origin/master`'s source (script in the run log, not
committed):

```
[1] cpu_budget.cpu_allowance()=2.5  postmortem.effective_cpu_count()=3  pool.cpu_facts().vcpus=3
[2] loader reclaimable=128.0 GiB    pool reclaimable=9.0 GiB
[3] Lifecycle.build_resources exists = True
[4] torch.cuda.is_available(): 74 occurrences in 42 modules
[4] torch.cuda.mem_get_info(:   10 occurrences in 8 modules

4 of 5 laws RED on origin/master
```

(The fifth, the reclaimable/meminfo/quota *fences*, cannot even be expressed
against master — the module does not exist there. That is the point of the cut.)

`tests/test_hostfacts_pgw896.py` states each as a law; **17 rows, all green
here**. The behavioural ones drive real synthetic cgroup trees and the real
production formulas, not mocks.

Two existing tests were **re-cut rather than deleted, and both got stronger**:

* `test_host_canary._hello_canary` asserted the canary on
  `lifecycle.build_hello().resources` — i.e. on the copy the wire discarded. It
  now goes through the real relay: `procsplit.measure.measure()` into the
  parent's one builder.
* `test_adopt_fit_pgw1265`'s `FakeCard` was injected as `adopt_fit._torch()`;
  since the free/reclaimable construction now lives in the one home, the fake
  card **is** `sys.modules["torch"]`, so the production formula is the one under
  test rather than a copy of it.

`test_wire_facts_pgw876`'s "the two builders assign the same fields" row is
deleted with its subject; its value-level row (every wire field assigned) stays
and the count is now fenced at one.

## LOC

The 48 existing `src/` modules go **-209 net** (-571/+362); the five carrying the
duplicates go **-381/+161**. `hostfacts.py` is 502 lines, over half of them the
derivation of why each formula is the one formula. Net `src/` is +293. The
deletions are the point, not the total.

## Checks

`mypy` clean (276 files). `ruff` clean — the 6 findings on this branch are the
6 on master, unchanged. Every gating lint green: `lint_config_reads`,
`lint_unreached_surface`, `lint_mypy_ratchet`, `lint_http_timeouts`,
`lint_settings_writers`, `lint_layout_declarations`, `lint_cell_key_layout_fence`,
`lint_serving_process_compiles`, `lint_fence_symbols`, `check_registry_contract`,
`lint_credential_identity`, `lint_arm_state_feeders`, `lint_ambient_census`,
`lint_post_connect_resolution`, `lint_unbounded_reads`.

(`lint_ambient_census` caught the first spelling of the state constants —
`CUDA_PRESENT`/`CUDA_ABSENT`/`CUDA_UNREADABLE` collide with its `CUDA_` env-name
watch. They are `DEVICE_*` now.)

No GPU work, no compile, no mint: every test here is CPU-only.
