### PR TITLE
pgw#1274: publish ATTACHES to a named release — the SDK's first-class release axis

### DIFF
--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -143,6 +143,7 @@ def publish_flavors(
     flavors: Iterable[ProducedFlavor],
     *,
     destination_repo: str = "",
+    release: str = "",
     tags: Iterable[str] | None = None,
     mode: str = "replace",
     metadata: Mapping[str, Any] | None = None,
@@ -158,6 +159,13 @@ def publish_flavors(
     ships a quantized checkpoint carrying the base weights. Pass
     ``mode="merge"`` explicitly only for deliberate overlay publishes (e.g. a
     vae swap on top of an existing tree).
+
+    ``release`` names the ALREADY-CUT release each flavor attaches to (th#1980);
+    every flavor of one export lands in the same release and is told apart there
+    by its contract. Publishing never cuts a release, so an unknown identifier is
+    a typed ``HubReleaseNotFoundError`` — cut it and publish again, never
+    re-upload. It is a first-class field on the declare request: stating it in
+    ``metadata`` publishes inert prose the hub never reads.
 
     ``journal_path`` is where the in-flight ``publish_id`` is recorded so a
     retry on this pod re-uploads instead of re-casting. Pass the produced
@@ -236,6 +244,7 @@ def publish_flavors(
         results.append(client.publish_v2(
             destination_repo=dest,
             files=_flavor_files(flavor),
+            release=release,
             tags=list(tags or []),
             mode=mode,
             # The conversion producer's own legs. (The per-object liveness beat

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -149,6 +149,35 @@ class HubPublishError(RuntimeError):
         self.retryable = retryable
 
 
+# The hub's typed refusal for a publish naming a release nobody cut (th#1980).
+RELEASE_NOT_FOUND = "release_not_found"
+
+
+class HubReleaseNotFoundError(HubPublishError):
+    """The named release does not exist, and publishing does not cut one.
+
+    Cutting a release is a deliberate act (``POST
+    /repos/{org}/{name}/releases``); a publish ATTACHES an artifact to one that
+    already exists. So the remedy is to cut the release and publish again — never
+    to re-hash, re-cast or re-upload the bytes, which were never the problem.
+    Typed because "the release is missing" and "the artifact is bad" are the two
+    refusals a producer must not confuse: one is a control-plane act costing
+    nothing, the other is gigabytes.
+    """
+
+
+def _publish_refusal(message: str, *, status: int = 0, code: str = "",
+                     retryable: Optional[bool] = None) -> HubPublishError:
+    """One hub refusal as the narrowest exception that fits its code."""
+    if code == RELEASE_NOT_FOUND:
+        return HubReleaseNotFoundError(
+            f"{message} — cut the release first "
+            "(POST /repos/{org}/{name}/releases), then publish into it; the "
+            "bytes are not at fault, do not re-upload",
+            status=status, code=code, retryable=False)
+    return HubPublishError(message, status=status, code=code, retryable=retryable)
+
+
 def _is_terminal_repudiation(exc: BaseException) -> bool:
     """Should this failure destroy the session's staged bytes?
 
@@ -416,6 +445,14 @@ class HubClient:
         destination_repo: str,
         files: list[CommitFile],
         tags: list[str] | None = None,
+        # The release this artifact ATTACHES to (th#1980). It must ALREADY have
+        # been cut — publishing never cuts one, exactly as uploading a binary to
+        # GitHub never creates the release it lands in. An unknown identifier is
+        # a typed, non-retryable `release_not_found`
+        # (:class:`HubReleaseNotFoundError`), whose remedy is a control-plane
+        # act, never a re-upload. Optional for now; requiredness rides the
+        # repo-tag hard cut.
+        release: str = "",
         # "replace" — a checkpoint is COMPLETE IN ITSELF. "merge" unions this
         # publish with the repo's prior :latest, so a caller that never
         # mentioned a sibling INHERITS its bytes (an fp8 checkpoint carrying
@@ -535,6 +572,7 @@ class HubClient:
                 {"tag": t, **({"head": True} if head else {})} for t in tags
             ]
         for key, val in (
+            ("release", release.strip()),
             ("dtype", _dtype_token(dtype)), ("file_layout", file_layout),
             ("file_type", file_type), ("display_label", display_label),
             ("objective", objective), ("artifact_contract", artifact_contract),
@@ -670,7 +708,7 @@ class HubClient:
         if session is None:
             resp = self._post(f"{repo_path}/publishes", body)
             if resp.status_code < 200 or resp.status_code >= 300:
-                raise HubPublishError(
+                raise _publish_refusal(
                     f"publish declare failed ({resp.status_code}): {resp.text[:800]}",
                     status=resp.status_code, code=_error_code_of(resp))
             session = self._json(resp)
@@ -766,7 +804,7 @@ class HubClient:
                                 stage = str(s.get("stage") or "")
                     except Exception:  # noqa: BLE001 - the stage is a nicety
                         pass
-                    raise HubPublishError(
+                    raise _publish_refusal(
                         f"publish {publish_id} "
                         f"{'repudiated' if not failure.get('retryable') else 'failed'}"
                         f"{f' at {stage}' if stage else ''}: "
@@ -775,7 +813,7 @@ class HubClient:
                         status=done.status_code, code=str(failure.get("code") or ""),
                         retryable=bool(failure.get("retryable")),
                     )
-                raise HubPublishError(
+                raise _publish_refusal(
                     f"publish complete failed ({done.status_code}): {done.text[:800]}",
                     status=done.status_code, code=_error_code_of(done))
             final = self._json(done)
@@ -872,6 +910,8 @@ def files_from_tree(tree: Path, *, prefix: str = "") -> list[CommitFile]:
 __all__ = [
     "HubClient",
     "HubPublishError",
+    "HubReleaseNotFoundError",
+    "RELEASE_NOT_FOUND",
     "CommitFile",
     "CommitResult",
     "files_from_tree",

--- a/tests/convert/fake_hub.py
+++ b/tests/convert/fake_hub.py
@@ -39,6 +39,15 @@ class _FakeHub(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_v2_repudiation(self, pid: str, failure: dict) -> None:
+        """A typed refusal, projection-shaped. The STATUS follows the hub's own
+        split (`failCASPublishV2`): retryable is 409, terminal is 422."""
+        self._send(409 if failure.get("retryable") else 422, {"status": {
+            "publish_id": pid, "stage": "repudiated", "terminal": True,
+            "stages": [{"stage": "verify", "status": "failed"}],
+            "failure": failure,
+        }})
+
     def _send_proxy_page(self, code: int) -> None:
         """Answer as a PROXY would (ngrok offline page): text/html, no hub
         error envelope. pgw#738/#743: origin discrimination must classify
@@ -170,12 +179,21 @@ class _FakeHub(BaseHTTPRequestHandler):
             # (pgw#1002 A) rather than re-derive one from the message.
             verdict = st.get("complete_failure")
             if verdict is not None:
-                self._send(409, {"status": {
-                    "publish_id": pid, "stage": "repudiated", "terminal": True,
-                    "stages": [{"stage": "verify", "status": "failed"}],
-                    "failure": dict(verdict),
-                }})
+                self._send_v2_repudiation(pid, dict(verdict))
                 return
+            # th#1980: the release is resolved INSIDE the publish transaction
+            # and must already have been CUT — publishing never cuts one.
+            # `release_not_found` is outside chunkcas' retryable allowlist, so
+            # the projection is a repudiation the producer must not retry.
+            release = str(req.get("release") or "").strip()
+            if release and release not in st.setdefault("releases", set()):
+                self._send_v2_repudiation(pid, {
+                    "code": "release_not_found", "retryable": False,
+                    "message": f"no release {release} in this repo",
+                })
+                return
+            if release:
+                st.setdefault("attached_releases", {})[pid] = release
             st.setdefault("v2_manifests", {})[pid] = req.get("files") or []
             checkpoint_id = "sha256:" + "ab" * 32
             completed[pid] = checkpoint_id

--- a/tests/convert/test_publish_release_attach_pgw1274.py
+++ b/tests/convert/test_publish_release_attach_pgw1274.py
@@ -1,0 +1,138 @@
+"""pgw#1274 (HARDCUT A2b): a publish ATTACHES its artifact to a NAMED release.
+
+The hub has taken `release` as a first-class declare field since th#1980
+(tensorhub `casPublishV2DeclareRequest.Release`, `json:"release"`). Before this
+lane the SDK had no parameter for it at all, so the only way a producer could
+state one was to smuggle it through `metadata` — where the hub copies it into
+checkpoint metadata and NOTHING reads it. Every release published that way
+attached nothing.
+
+Driven end to end through the real `publish_v2` / `publish_flavors` against the
+fake hub, which resolves the release the way tensorhub does: at completion,
+inside the publish transaction, refusing an uncut one.
+
+Revert-turns-red: drop the `release` parameter and the first two rows fail on
+the missing keyword; collapse the typed refusal back into a bare
+`HubPublishError` and the third fails on the class.
+
+    pytest tests/convert/test_publish_release_attach_pgw1274.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fake_hub import _client, _FakeHub
+
+from gen_worker.convert.produced import ProducedFlavor
+from gen_worker.convert.publish import publish_flavors
+from gen_worker.hubio.client import (
+    CommitFile,
+    HubPublishError,
+    HubReleaseNotFoundError,
+)
+
+RELEASE = "2026-08-14-h3"
+
+
+class _Ctx:
+    """Just enough ctx for `HubClient.from_ctx`."""
+
+    def __init__(self, base_url: str) -> None:
+        self._file_api_base_url = base_url
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+
+    def log(self, message: str, **fields: Any) -> None:
+        pass
+
+
+def _file(tmp_path: Path, data: bytes = b'{"model":"x"}') -> CommitFile:
+    path = tmp_path / "config.json"
+    path.write_bytes(data)
+    return CommitFile(path="config.json", local_path=path, size_bytes=len(data))
+
+
+def _declaration() -> dict:
+    return next(iter(_FakeHub.state["publishes"].values()))
+
+
+def test_the_release_travels_VERBATIM_into_the_declare_request(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    _FakeHub.state["releases"] = {RELEASE}
+
+    result = _client(fake_hub).publish_v2(
+        destination_repo="acme/model", files=[_file(tmp_path)], release=RELEASE,
+    )
+
+    # The hub's own field name, unmangled — and NOT a metadata copy, which is
+    # the inert form this lane exists to replace.
+    assert _declaration()["release"] == RELEASE
+    assert "release" not in (_declaration().get("metadata") or {})
+    assert result.checkpoint_id
+    assert _FakeHub.state["attached_releases"] == {"pub-1": RELEASE}
+
+
+def test_no_release_omits_the_field_rather_than_sending_an_empty_one(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """An empty string is not an identifier. Sending one would make every
+    unattached publish indistinguishable from a publish naming `""`."""
+    _client(fake_hub).publish_v2(
+        destination_repo="acme/model", files=[_file(tmp_path)],
+    )
+    assert "release" not in _declaration()
+
+
+def test_an_UNCUT_release_is_a_typed_NON_RETRYABLE_refusal(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """Cutting is a deliberate act, so the remedy is a control-plane call —
+    never a re-upload of the bytes, which were never at fault."""
+    _FakeHub.state["releases"] = set()
+
+    with pytest.raises(HubReleaseNotFoundError) as caught:
+        _client(fake_hub).publish_v2(
+            destination_repo="acme/model", files=[_file(tmp_path)],
+            release="never-cut",
+        )
+
+    exc = caught.value
+    assert isinstance(exc, HubPublishError)  # still one publish-failure family
+    assert exc.code == "release_not_found"
+    assert exc.retryable is False
+    assert "cut the release first" in str(exc)
+    assert "do not re-upload" in str(exc)
+    # The hub's own vocabulary reaches the fleet unchanged.
+    from gen_worker.executor import _map_exception
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    status, detail = _map_exception(exc)
+    assert status == pb.JOB_STATUS_FATAL
+    assert detail.startswith("release_not_found: ")
+
+
+def test_publish_flavors_threads_the_release_to_every_variant(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """Variants of one export share a release and are told apart INSIDE it by
+    contract — so the producer states the release once."""
+    _FakeHub.state["releases"] = {RELEASE}
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    trees = []
+    for label in ("fp8", "bf16"):
+        out = tmp_path / label
+        out.mkdir()
+        (out / "diffusion.safetensors").write_bytes(label.encode() * 500)
+        (out / "config.json").write_text('{"architectures": ["Fake"]}')
+        trees.append(ProducedFlavor(path=out, flavor=label,
+                                    attributes={"dtype": label}))
+
+    publish_flavors(ctx, trees, destination_repo="acme/quant", release=RELEASE)
+
+    declared = list(_FakeHub.state["publishes"].values())
+    assert [d["release"] for d in declared] == [RELEASE, RELEASE]
+    assert set(_FakeHub.state["attached_releases"].values()) == {RELEASE}


### PR DESCRIPTION
HARDCUT-CHECKLIST **A2b**, the prerequisite for A7 (`repo_tags` death in tensorhub). Hub side landed in tensorhub PR #1249 (`119b22eab`, th#1980).

## The defect

`casPublishV2DeclareRequest` has carried `Release string \`json:"release"\`` since th#1980 — a publish ATTACHES its artifact to an already-cut release, and an unknown identifier is a typed non-retryable `release_not_found`. The SDK had **no parameter for it**, so the only way a producer could state a release was training-endpoints' smuggle (`conversion/_common.py:180`, `metadata={"release": release_id}`).

**Verified at the hub source: that key is inert.** `req.Metadata` is copied verbatim into `checkpointMeta` (`internal/api/repo_publish_v2_th1303.go:1512`) and nothing reads `metadata["release"]`; only `req.Release` reaches `resolvePublishReleaseAttachment`. Every te release published to date attached nothing — the release axis has never once been exercised from a producer.

## The change

- `HubClient.publish_v2(release=...)` → `body["release"]`, the hub's own field name. Omitted when empty: an unattached publish must not be indistinguishable from one naming `""`. (It also joins the declaration digest, so changing the release declares a fresh session rather than silently completing a predecessor's.)
- `publish_flavors(release=...)` threads it — one release per export, variants told apart inside it by contract.
- `release_not_found` now raises the typed `HubReleaseNotFoundError`, non-retryable, naming the remedy: **cut the release, never re-upload.** Master collapsed it into a bare `HubPublishError` whose whole message was `publish pub-1 repudiated at verify: release_not_found: ... (retryable=False)` — nothing telling the producer the bytes were never at fault.
- The fake hub resolves the release the way tensorhub does (at completion, inside the transaction), and its typed-refusal status now follows the hub's own split: 409 retryable, 422 terminal.

Optional for now; requiredness lands with A7. Not touched: the tag axis (A7/A8) and te's own smuggle deletion (A8, its repo).

## Red/green

Reverting only `src/` (tests kept) against `origin/master`:

- `publish_v2(release=...)` → `TypeError: publish_v2() got an unexpected keyword argument 'release'`
- an injected `release_not_found` completion → `HubPublishError`, message `publish pub-1 repudiated at verify: release_not_found: no release r1 in this repo (retryable=False)`; no `HubReleaseNotFoundError`, no remedy
- the test module does not even import: `ImportError: cannot import name 'HubReleaseNotFoundError'`

Green: 4 new rows pass; `tests/convert/` publish surface (56 rows across 9 modules) passes; mypy clean on all four changed files; `lint_unreached_surface` / `lint_fence_symbols` / `lint_http_timeouts` / `lint_config_reads` green.