### PR TITLE
pgw#1274: changelog fragment for the SDK release axis

### DIFF
--- a/changelog.d/pgw1274.md
+++ b/changelog.d/pgw1274.md
@@ -1,0 +1,6 @@
+- A publish ATTACHES its artifact to a release. `publish_v2(release=…)` and
+  `publish_flavors(release=…)` state an ALREADY-CUT release on the declare
+  request itself; publishing never cuts one. Naming a release nobody cut raises
+  the typed, non-retryable `HubReleaseNotFoundError`, whose remedy is to cut the
+  release — never to re-upload the bytes. Stating a release through `metadata`
+  was always inert: the hub reads only the first-class field.


### PR DESCRIPTION
The release-notes fragment for PR #831 (merged `032a0289`), which landed while the fragment was still local — the branch was already in the merge queue and locked. Docs only.