### PR TITLE
pgw#1275: the rank command channel stops being a pickle.loads gadget

### DIFF
--- a/changelog.d/pgw1275.md
+++ b/changelog.d/pgw1275.md
@@ -1,0 +1,8 @@
+- The rank command channel no longer unpickles. `FollowerChannel.next_command`
+  read `pickle.loads` off an `mp.Queue` whose writer is the process that imports
+  tenant endpoint code and marshals tenant-supplied model-call arguments, so
+  every rank sibling was a deserialization gadget on tenant-reachable input.
+  Commands are now a closed msgspec msgpack union (`gen_worker.parallel.wire`),
+  tensors ride as safetensors bytes, and an argument outside the wire's
+  vocabulary is a typed per-request refusal on rank 0 naming the argument —
+  where pickle crossed any object silently.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -174,9 +174,9 @@ from . import warmup as warmup_mod
 from .api.decorators import ATTR as _DECL_ATTR
 from . import compile_cache as _cc_execution_lane
 from .parallel import ContextParallelUnavailable
-from .parallel import GroupPlan
+from .parallel import BootPlan, GroupPlan
 from .parallel.cp import w8a8_gemm_mode
-from .parallel.runtime import BootPlan, SequenceRuntime, arm_sequence_gate
+from .parallel.runtime import SequenceRuntime, arm_sequence_gate
 from .runtimes.server import RUNTIME_FACTORIES
 from .models.loading import composition_compute_dtype
 from .runtimes.server import ServerHandle

--- a/src/gen_worker/parallel/__init__.py
+++ b/src/gen_worker/parallel/__init__.py
@@ -32,9 +32,10 @@ from .group import (
     RankSpec,
     init_rank,
 )
-from .plan import GroupPlan, RankDivergence
+from .plan import BootPlan, GroupPlan, RankDivergence
 
 __all__ = [
+    "BootPlan",
     "ContextParallelUnavailable",
     "CpComms",
     "FollowerChannel",

--- a/src/gen_worker/parallel/group.py
+++ b/src/gen_worker/parallel/group.py
@@ -26,19 +26,23 @@ process-local default are untouchable by construction.
 **Command channel.** Rank-0 -> follower commands ride per-follower
 mp queues, NOT collectives: an idle follower parks on ``queue.get`` (no
 collective timeout to trip), teardown is a queue put + join/terminate (no
-collective that can block the event loop), and command payloads are pickled
-EAGERLY on rank 0 so an unpicklable argument is a typed per-request error
+collective that can block the event loop), and command payloads are encoded
+EAGERLY on rank 0 so an uncrossable argument is a typed per-request error
 instead of a feeder-thread mystery. Collectives happen only INSIDE the model
 call (the CP hooks) and carry the process group's timeout, so a rank that
 raises mid-call strands its peers for at most ``collective_timeout_s``, after
 which they fail loudly and the group is condemned — never a silent wedge.
+
+The channel's bytes are msgspec msgpack (:mod:`.wire`), NEVER pickle: the
+writer is the process that imports tenant endpoint code and marshals
+tenant-supplied model-call arguments, so a follower that unpickled would be a
+deserialization gadget on tenant-reachable input.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import pickle
 import queue as queue_mod
 import signal
 import time
@@ -48,6 +52,7 @@ from datetime import timedelta
 from typing import Any, Callable, List, Optional, Sequence, Tuple, cast
 import multiprocessing as mp
 
+from . import wire
 from .. import proc_evidence, settings_authority
 from ..stall import SilenceWindow
 
@@ -94,9 +99,6 @@ _FIRST_COMMAND_WAIT_S = 1800.0
 # is not the store-arrival wait, which is `_await_arrivals` above.
 _STORE_CONNECT_TIMEOUT_S = 180.0
 
-_OP_RUN = "run"
-_OP_CLOSE = "close"
-
 
 class RankGroupError(RuntimeError):
     """The group could not form, or a rank died. Fatal for the request; the
@@ -106,9 +108,11 @@ class RankGroupError(RuntimeError):
 @dataclass(frozen=True)
 class RankSpec:
     """What one rank needs to join. Deliberately tiny and picklable — it
-    crosses a spawn boundary. ``group_name`` is unique per arm so a process
-    that arms many groups over its lifetime never collides in the
-    torch.distributed registries."""
+    crosses the SPAWN boundary, which is multiprocessing's own pickle of a
+    fixed struct this process built, not the command queue (that is `wire`,
+    and it carries tenant-reachable payloads). ``group_name`` is unique per
+    arm so a process that arms many groups over its lifetime never collides
+    in the torch.distributed registries."""
 
     rank: int
     world_size: int
@@ -124,12 +128,14 @@ class RankSpec:
 class FollowerChannel:
     """A follower's half of the command plane: commands in, readiness out."""
 
-    commands: Any  # mp.Queue of pickled command bytes
+    commands: Any  # mp.Queue of msgpack-encoded `wire.Command` bytes
     ready: Any     # mp.Queue; follower puts its rank when armed
 
-    def next_command(self, timeout: Optional[float] = None) -> Any:
+    def next_command(self, timeout: Optional[float] = None) -> wire.Command:
+        """The next command, decoded as one of exactly three types. A payload
+        cannot name a class, so it cannot reach a constructor."""
         raw = self.commands.get(timeout=timeout)
-        return pickle.loads(raw)
+        return wire.decode(raw)
 
     def report_ready(self, rank: int) -> None:
         self.ready.put(int(rank))
@@ -457,21 +463,19 @@ class RankGroup:
 
     # ---- command plane (never a collective) --------------------------------
 
-    def send(self, command: Any) -> None:
+    def send(self, command: wire.Command) -> None:
         """Deliver one command to every follower.
 
-        Pickled EAGERLY here so an unpicklable payload (a closure callback,
-        a live handle) raises a typed error on THIS thread with the group
-        still coherent — the followers are parked at ``queue.get`` and simply
-        never see the command.
+        Encoded EAGERLY here so an uncrossable payload raises a typed error on
+        THIS thread with the group still coherent — the followers are parked
+        at ``queue.get`` and simply never see the command.
         """
         try:
-            raw = pickle.dumps(command)
+            raw = wire.encode(command)
         except Exception as exc:
             raise RankGroupError(
                 f"command cannot cross the rank boundary: {type(exc).__name__}: "
-                f"{exc} — pass only picklable model-call arguments (closures/"
-                "callbacks cannot be broadcast to follower ranks)"
+                f"{exc}"
             ) from exc
         for channel in self._channels:
             channel.commands.put(raw)
@@ -580,7 +584,7 @@ class RankGroup:
         group are untouched."""
         for channel in self._channels:
             try:
-                channel.commands.put(pickle.dumps({"op": _OP_CLOSE}))
+                channel.commands.put(wire.encode(wire.Close()))
             except Exception:  # noqa: BLE001 — teardown must not raise
                 pass
         deadline = time.monotonic() + grace_s

--- a/src/gen_worker/parallel/plan.py
+++ b/src/gen_worker/parallel/plan.py
@@ -21,12 +21,30 @@ the only place a follower is allowed to disagree is by raising
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BootPlan:
+    """Everything a follower needs to build the SAME pipeline.
+
+    Lives beside :class:`GroupPlan` because they are the same act — rank 0
+    decides, every rank obeys — and they ride the arm command together.
+    """
+
+    modules: Tuple[str, ...] = ()
+    function_name: str = ""
+    slot: str = ""
+    # slot -> the pod-shared CAS path. One copy of the bytes, N mappings.
+    path: str = ""
+    cache_dir: str = ""
+    degree: int = 1
+    dtype: str = ""
+    storage_dtype: str = ""
 
 
 class RankDivergence(RuntimeError):
@@ -76,15 +94,6 @@ class GroupPlan:
     # The sharding degree this plan was decided for.
     sp_degree: int = 1
     extra: Dict[str, Any] = field(default_factory=dict)
-
-    def encode(self) -> bytes:
-        return json.dumps(asdict(self), sort_keys=True).encode()
-
-    @classmethod
-    def decode(cls, raw: bytes) -> "GroupPlan":
-        obj = json.loads(raw.decode())
-        obj["loras"] = tuple(tuple(x) for x in obj.get("loras") or ())
-        return cls(**obj)
 
     def refuse_unless_cp_safe(self) -> None:
         """Refuse a plan that cannot be correct under sharding, BEFORE the

--- a/src/gen_worker/parallel/runtime.py
+++ b/src/gen_worker/parallel/runtime.py
@@ -37,9 +37,9 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
+from . import wire
 from .cp import (
     ContextParallelUnavailable,
     CpComms,
@@ -53,11 +53,9 @@ from .group import (
     RankGroupError,
     RankSpec,
     _FIRST_COMMAND_WAIT_S,
-    _OP_CLOSE,
-    _OP_RUN,
     init_rank,
 )
-from .plan import GroupPlan
+from .plan import BootPlan, GroupPlan
 from .cp import w8a8_gemm_mode
 from ..models import provision
 from ..registry import collect_endpoints
@@ -66,45 +64,10 @@ from ..hostfacts import cuda_ready
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class BootPlan:
-    """Everything a follower needs to build the SAME pipeline. Small and
-    picklable by construction — it crosses a spawn boundary."""
-
-    modules: Tuple[str, ...] = ()
-    function_name: str = ""
-    slot: str = ""
-    # slot -> the pod-shared CAS path. One copy of the bytes, N mappings.
-    path: str = ""
-    cache_dir: str = ""
-    degree: int = 1
-    dtype: str = ""
-    storage_dtype: str = ""
-
-
 # ---------------------------------------------------------------------------
-# Call marshalling: the model call must arrive at every rank IDENTICAL.
+# Call marshalling lives in `wire`: the model call must arrive at every rank
+# IDENTICAL, and its bytes must not be able to execute anything.
 # ---------------------------------------------------------------------------
-
-
-def _dehydrate(value: Any) -> Any:
-    """Make one call argument crossable. CUDA tensors go via CPU (the
-    followers own different cards); a `torch.Generator` is not picklable at
-    all and is replaced by its seed, which is the only part that has to
-    agree — every rank rebuilds an identical one."""
-    import torch
-
-    if isinstance(value, torch.Tensor):
-        return ("__tensor__", value.detach().to("cpu"))
-    if isinstance(value, torch.Generator):
-        return ("__generator__", int(value.initial_seed()))
-    if isinstance(value, (list, tuple)):
-        marshalled = [_dehydrate(v) for v in value]
-        return ("__list__", marshalled) if isinstance(value, list) else (
-            "__tuple__", marshalled)
-    if isinstance(value, dict):
-        return ("__dict__", {k: _dehydrate(v) for k, v in value.items()})
-    return value
 
 
 def _rank_device(device: int) -> str:
@@ -155,25 +118,6 @@ def _force_collectives(value: Any) -> Any:
     return value
 
 
-def _rehydrate(value: Any, device: int) -> Any:
-    import torch
-
-    dev = _rank_device(device)
-    if isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], str):
-        tag, payload = value
-        if tag == "__tensor__":
-            return payload.to(dev)
-        if tag == "__generator__":
-            return torch.Generator(device=dev).manual_seed(int(payload))
-        if tag == "__list__":
-            return [_rehydrate(v, device) for v in payload]
-        if tag == "__tuple__":
-            return tuple(_rehydrate(v, device) for v in payload)
-        if tag == "__dict__":
-            return {k: _rehydrate(v, device) for k, v in payload.items()}
-    return value
-
-
 # The gated-call flag lives with the hooks it guards (cp.py); re-exported here
 # because the gate is what enters it.
 _gated_call = gated_call
@@ -199,11 +143,10 @@ def sequence_rank_main(spec: RankSpec, channel: FollowerChannel) -> None:  # pra
         torch.cuda.set_device(spec.device)
 
     first = channel.next_command(timeout=_FIRST_COMMAND_WAIT_S)
-    if not isinstance(first, dict) or first.get("op") != "arm":
+    if not isinstance(first, wire.Arm):
         raise RankGroupError(
             f"rank {spec.rank}: expected the arm command first, got {first!r}")
-    boot: BootPlan = first["boot"]
-    plan: GroupPlan = first["plan"]
+    boot, plan = first.boot, first.plan
     plan.refuse_unless_cp_safe()
     pipe = _materialize(boot, spec)
     refuse_unless_shard_invariant_quant(pipe, degree=plan.sp_degree)
@@ -229,14 +172,12 @@ def sequence_rank_main(spec: RankSpec, channel: FollowerChannel) -> None:  # pra
 
     while True:
         cmd = channel.next_command()
-        if not isinstance(cmd, dict) or cmd.get("op") == _OP_CLOSE:
+        if isinstance(cmd, wire.Close):
             return
-        if cmd.get("op") != _OP_RUN:
+        if not isinstance(cmd, wire.Run):
             logger.warning("rank %d: unknown command %r", spec.rank, cmd)
             continue
-        args = tuple(_rehydrate(a, spec.device) for a in cmd.get("args", ()))
-        kwargs = {k: _rehydrate(v, spec.device)
-                  for k, v in (cmd.get("kwargs") or {}).items()}
+        args, kwargs = wire.run_call(cmd, device=_rank_device(spec.device))
         with torch.no_grad(), _gated_call():
             pipe(*args, **kwargs)   # output discarded: rank 0 owns the output
 
@@ -333,7 +274,7 @@ class SequenceRuntime:
         self._group = RankGroup(self.devices, **kwargs)
         try:
             spec0 = self._group.form()
-            self._group.send({"op": "arm", "boot": boot, "plan": plan})
+            self._group.send(wire.Arm(boot=boot, plan=plan))
             installed = install_context_parallel(
                 pipe, degree=self.degree,
                 comms=CpComms(
@@ -371,11 +312,15 @@ class SequenceRuntime:
         group = self._group
         assert group is not None
         group.check_alive()
-        group.send({
-            "op": _OP_RUN,
-            "args": tuple(_dehydrate(a) for a in args),
-            "kwargs": {k: _dehydrate(v) for k, v in kwargs.items()},
-        })
+        # Marshalled BEFORE the queue, on this thread: an argument outside the
+        # wire's vocabulary is a typed per-request error with the group
+        # coherent, never a follower that decoded half a command.
+        try:
+            command = wire.run_command(args, kwargs)
+        except wire.UncrossableArgument as exc:
+            raise RankGroupError(
+                f"command cannot cross the rank boundary: {exc}") from exc
+        group.send(command)
         try:
             with _gated_call():
                 out = _force_collectives(base_call(pipe, *args, **kwargs))

--- a/src/gen_worker/parallel/wire.py
+++ b/src/gen_worker/parallel/wire.py
@@ -1,0 +1,167 @@
+"""The rank command wire: what rank 0 may say to a follower, and in what bytes.
+
+**Why this module exists.** The command channel's writer is rank 0 — the
+compute process that imports TENANT endpoint code and marshals tenant-supplied
+model-call arguments into every RUN. Its readers are the D−1 followers.
+Unpickling that queue makes every follower a deserialization gadget driven by
+tenant-reachable input, so the wire is msgspec msgpack and the
+decoder never names a class the payload chose: commands decode as a CLOSED
+tagged union, and a RUN's leaves decode as plain msgpack data (scalars, lists,
+maps, bytes). There is no constructor reachable from a payload.
+
+**Tensors ride this queue, so msgspec alone does not close it.** The model call
+is the SPMD unit and its arguments are latents, embeddings and masks. Tensors
+therefore travel as **safetensors** bytes — the org's mandated tensor container,
+already a hard dependency, and not a second serialization format: msgspec owns
+the envelope, safetensors owns the tensor.
+
+**The value vocabulary is CLOSED.** msgpack scalars, list, tuple, str-keyed
+dict, `torch.Tensor` and `torch.Generator` — that is all. Anything else is a
+typed refusal raised on rank 0 at send time, with the group still coherent and
+the followers still parked at ``queue.get``. Under pickle the vocabulary was
+open by construction (a PIL image, a numpy array or an endpoint's own class
+crossed silently), and "it pickled" is not the same question as "every rank can
+rebuild it identically".
+
+A `torch.Generator` is not crossable at all and is carried as its seed: the
+seed is the only part that has to agree, and every rank rebuilds an identical
+generator on its own device.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple, Union, cast
+
+import msgspec
+
+from .plan import BootPlan, GroupPlan
+
+# The one key that distinguishes an envelope from a plain value. A model-call
+# argument that happens to use it as a dict key is refused rather than
+# escaped — an escape scheme is a second grammar to get wrong.
+_TAG = "__sp__"
+_VAL = "v"
+
+
+class UncrossableArgument(TypeError):
+    """A model-call argument outside the wire's value vocabulary."""
+
+
+class Arm(msgspec.Struct, tag="arm", tag_field="op"):
+    """Build the SAME pipeline, then obey THIS plan. Sent once per group."""
+
+    boot: BootPlan
+    plan: GroupPlan
+
+
+class Run(msgspec.Struct, tag="run", tag_field="op"):
+    """One model call, marshalled. Leaves are wire values, never objects."""
+
+    args: Tuple[Any, ...] = ()
+    kwargs: Dict[str, Any] = {}
+
+
+class Close(msgspec.Struct, tag="close", tag_field="op"):
+    """Teardown. The only way a follower is supposed to exit."""
+
+
+Command = Union[Arm, Run, Close]
+
+_ENCODER = msgspec.msgpack.Encoder()
+_DECODER = msgspec.msgpack.Decoder(Command)
+
+
+def encode(command: Command) -> bytes:
+    return _ENCODER.encode(command)
+
+
+def decode(raw: bytes) -> Command:
+    """Bytes -> one of exactly three commands. Never anything else."""
+    return cast(Command, _DECODER.decode(raw))
+
+
+# ---------------------------------------------------------------------------
+# values
+# ---------------------------------------------------------------------------
+
+
+def marshal(value: Any, *, path: str = "") -> Any:
+    """One call argument -> msgpack-native tagged data, or refuse by name."""
+    import torch
+
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return value
+    if isinstance(value, torch.Tensor):
+        from safetensors.torch import save
+
+        return {_TAG: "tensor",
+                _VAL: save({"t": value.detach().to("cpu").contiguous()})}
+    if isinstance(value, torch.Generator):
+        return {_TAG: "generator", _VAL: int(value.initial_seed())}
+    if isinstance(value, tuple):
+        return {_TAG: "tuple",
+                _VAL: [marshal(v, path=f"{path}[{i}]")
+                       for i, v in enumerate(value)]}
+    if isinstance(value, list):
+        return [marshal(v, path=f"{path}[{i}]") for i, v in enumerate(value)]
+    if isinstance(value, dict):
+        out: Dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise UncrossableArgument(
+                    f"{path or 'argument'}: dict key {key!r} is "
+                    f"{type(key).__name__}, and only str keys cross the rank "
+                    "boundary")
+            if key == _TAG:
+                raise UncrossableArgument(
+                    f"{path or 'argument'}: {_TAG!r} is the wire's own tag key "
+                    "and cannot be a model-call dict key")
+            out[key] = marshal(item, path=f"{path}.{key}" if path else key)
+        return out
+    raise UncrossableArgument(
+        f"{path or 'argument'} is a {type(value).__name__}, which cannot cross "
+        "the rank boundary. Rank commands carry msgpack scalars, lists, "
+        "tuples, str-keyed dicts, torch tensors (as safetensors) and "
+        "torch.Generator (as its seed) — a closure, a callback or a live "
+        "handle cannot be broadcast to follower ranks")
+
+
+def unmarshal(value: Any, *, device: str) -> Any:
+    """Wire data -> the argument, on THIS rank's device."""
+    import torch
+
+    if isinstance(value, dict):
+        tag = value.get(_TAG)
+        if tag is None:
+            return {k: unmarshal(v, device=device) for k, v in value.items()}
+        payload = value.get(_VAL)
+        if tag == "tensor" and isinstance(payload, bytes):
+            from safetensors.torch import load
+
+            return load(payload)["t"].to(device)
+        if tag == "generator" and isinstance(payload, int):
+            return torch.Generator(device=device).manual_seed(payload)
+        if tag == "tuple" and isinstance(payload, list):
+            return tuple(unmarshal(v, device=device) for v in payload)
+        raise UncrossableArgument(
+            f"malformed wire envelope: tag={tag!r} payload="
+            f"{type(payload).__name__}")
+    if isinstance(value, list):
+        return [unmarshal(v, device=device) for v in value]
+    return value
+
+
+def run_command(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Run:
+    """Marshal a model call. Raises `UncrossableArgument` naming the argument
+    — on rank 0, before anything is queued."""
+    return Run(
+        args=tuple(marshal(a, path=f"args[{i}]") for i, a in enumerate(args)),
+        kwargs={k: marshal(v, path=k) for k, v in kwargs.items()},
+    )
+
+
+def run_call(command: Run, *, device: str) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+    """A follower's side of `run_command`."""
+    args: List[Any] = [unmarshal(a, device=device) for a in command.args]
+    kwargs = {k: unmarshal(v, device=device) for k, v in command.kwargs.items()}
+    return tuple(args), kwargs

--- a/tests/test_rank_command_wire_pgw1275.py
+++ b/tests/test_rank_command_wire_pgw1275.py
@@ -1,0 +1,199 @@
+"""The rank command channel is not a deserialization gadget (pgw#1275).
+
+The channel's writer is rank 0 — the compute process that imports TENANT
+endpoint code and marshals tenant-supplied model-call arguments — and its
+readers are the spawned rank siblings. While ``FollowerChannel.next_command``
+unpickled, every follower executed whatever the bytes on that queue described.
+
+Every row here drives the REAL channel: a real ``spawn`` process reading a real
+``mp.Queue`` through the production ``FollowerChannel``. The full formed group
+(TCPStore rendezvous, gloo process group, arm/run/close over the same wire) is
+exercised by ``test_sp_group_isolation_pgw773_774.py``.
+
+RED before the fix: row 1's marker file appears, because the poisoned payload's
+``__reduce__`` runs inside the follower.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import pickle
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.parallel import wire  # noqa: E402
+from gen_worker.parallel.group import FollowerChannel  # noqa: E402
+
+
+def _touch(path: str) -> str:
+    """The payload's effect. It proves EXECUTION and does nothing harmful."""
+    Path(path).write_text("executed", encoding="utf-8")
+    return path
+
+
+class _Poisoned:
+    """A tenant-shaped object whose mere DESERIALIZATION runs code."""
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __reduce__(self) -> Any:
+        return (_touch, (self.marker,))
+
+
+def _read_one(channel: FollowerChannel, out: Any) -> None:  # pragma: no cover - spawned
+    try:
+        out.put(("decoded", type(channel.next_command(timeout=60)).__name__))
+    except BaseException as exc:  # noqa: BLE001 — the refusal is the result
+        out.put(("refused", type(exc).__name__))
+
+
+def _echo_one(channel: FollowerChannel, out: Any) -> None:  # pragma: no cover - spawned
+    """A follower's real decode, reported back as plain describable facts."""
+    try:
+        cmd = channel.next_command(timeout=60)
+        assert isinstance(cmd, wire.Run), cmd
+        args, kwargs = wire.run_call(cmd, device="cpu")
+        out.put(("ok", _describe(args), _describe(kwargs)))
+    except BaseException as exc:  # noqa: BLE001
+        out.put(("raised", f"{type(exc).__name__}: {exc}", None))
+
+
+def _describe(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return ("tensor", str(value.dtype), tuple(value.shape),
+                value.flatten().tolist())
+    if isinstance(value, torch.Generator):
+        return ("generator", int(value.initial_seed()))
+    if isinstance(value, tuple):
+        return ("tuple", [_describe(v) for v in value])
+    if isinstance(value, list):
+        return ("list", [_describe(v) for v in value])
+    if isinstance(value, dict):
+        return ("dict", {k: _describe(v) for k, v in value.items()})
+    return value
+
+
+def _drive(target: Any, raw: bytes) -> Any:
+    """Put RAW bytes on a real command queue and let a real follower read."""
+    ctx = mp.get_context("spawn")
+    channel = FollowerChannel(commands=ctx.Queue(), ready=ctx.Queue())
+    out = ctx.Queue()
+    proc = ctx.Process(target=target, args=(channel, out), daemon=True)
+    proc.start()
+    try:
+        channel.commands.put(raw)
+        result = out.get(timeout=120)
+    finally:
+        proc.join(timeout=30)
+        if proc.is_alive():  # pragma: no cover - the follower must exit
+            proc.kill()
+            proc.join(timeout=10)
+    return result
+
+
+def test_a_pickle_on_the_command_queue_executes_nothing(tmp_path: Path) -> None:
+    """RED before pgw#1275: `next_command` did `pickle.loads(raw)`, so this
+    marker was written by the follower. The payload is exactly what rank 0
+    would have produced from a hostile model-call argument."""
+    marker = tmp_path / "executed-in-the-follower"
+    outcome, detail = _drive(_read_one, pickle.dumps(_Poisoned(str(marker))))
+
+    assert not marker.exists(), (
+        "a pickle payload on the rank command queue EXECUTED inside the "
+        "follower — the channel is a deserialization gadget again"
+    )
+    assert outcome == "refused", (outcome, detail)
+
+
+def test_the_wire_carries_tensors_generators_and_nesting() -> None:
+    """What actually flows: model-call arguments, tensors included. The
+    ledger's "msgspec closes it for free" is half the story — a tensor is not
+    msgpack-native, so it travels as safetensors bytes and must arrive
+    bit-identical, with tuple/list nesting preserved (a pipeline that gets a
+    list where rank 0 had a tuple is a silent divergence)."""
+    latents = torch.arange(8, dtype=torch.float32).reshape(2, 4) / 3.0
+    mask = torch.tensor([[True, False]], dtype=torch.bool)
+    half = torch.ones(3, dtype=torch.bfloat16)
+    gen = torch.Generator().manual_seed(1234)
+
+    command = wire.run_command(
+        (latents, "a prompt", 30),
+        {
+            "generator": gen,
+            "sizes": (512, 512),
+            "steps": [1, 2, 3],
+            "extra": {"mask": mask, "guidance": 3.5, "half": half},
+            "flags": (True, None, b"raw"),
+        },
+    )
+    outcome, described_args, described_kwargs = _drive(
+        _echo_one, wire.encode(command))
+    assert outcome == "ok", described_args
+
+    assert described_args == ("tuple", [
+        ("tensor", "torch.float32", (2, 4), latents.flatten().tolist()),
+        "a prompt",
+        30,
+    ])
+    kind, kwargs = described_kwargs
+    assert kind == "dict"
+    assert kwargs["generator"] == ("generator", 1234)
+    # tuple stays a tuple, list stays a list — msgpack has one array type, so
+    # this is a property of the wire, not of msgpack.
+    assert kwargs["sizes"] == ("tuple", [512, 512])
+    assert kwargs["steps"] == ("list", [1, 2, 3])
+    assert kwargs["flags"] == ("tuple", [True, None, b"raw"])
+    assert kwargs["extra"] == ("dict", {
+        "mask": ("tensor", "torch.bool", (1, 2), [True, False]),
+        "guidance": 3.5,
+        "half": ("tensor", "torch.bfloat16", (3,), [1.0, 1.0, 1.0]),
+    })
+
+
+class _TenantObject:
+    """Picklable, and therefore silently crossable before pgw#1275."""
+
+    def __init__(self) -> None:
+        self.value = 1
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        pytest.param(_TenantObject(), id="an-endpoint-class"),
+        pytest.param(lambda *a: None, id="a-callback-closure"),
+        pytest.param({1: "int-key"}, id="a-non-str-dict-key"),
+        pytest.param({"__sp__": "shadowing-the-tag"}, id="the-wire-tag-key"),
+    ],
+)
+def test_an_argument_outside_the_vocabulary_is_refused_by_name(
+    argument: Any,
+) -> None:
+    """The vocabulary is CLOSED, and the refusal names the argument. Only the
+    closure was refused before — a plain picklable object crossed silently,
+    which is the open-by-construction half of the defect."""
+    with pytest.raises(wire.UncrossableArgument) as excinfo:
+        wire.run_command((), {"callback": argument})
+    assert "callback" in str(excinfo.value)
+
+
+def test_every_command_decodes_to_its_own_closed_type() -> None:
+    """A payload never names a class, so it can never reach a constructor:
+    the decoder admits exactly three shapes and nothing else."""
+    from gen_worker.parallel.plan import BootPlan, GroupPlan
+
+    arm = wire.Arm(boot=BootPlan(function_name="f", degree=2),
+                   plan=GroupPlan(sp_degree=2, loras=(("l", 0.5),)))
+    assert wire.decode(wire.encode(arm)) == arm
+    assert isinstance(wire.decode(wire.encode(wire.Close())), wire.Close)
+    assert isinstance(wire.decode(wire.encode(wire.Run())), wire.Run)
+
+    import msgspec
+
+    with pytest.raises(msgspec.ValidationError):
+        wire.decode(msgspec.msgpack.encode({"op": "exec", "code": "boom"}))

--- a/tests/test_sequence_parallel_pgw748.py
+++ b/tests/test_sequence_parallel_pgw748.py
@@ -27,6 +27,7 @@ from typing import Any
 import pytest
 
 from gen_worker.parallel import (
+    BootPlan,
     ContextParallelUnavailable,
     FollowerChannel,
     GroupPlan,
@@ -38,6 +39,7 @@ from gen_worker.parallel import (
     install_context_parallel,
     refuse_unless_divisible,
     refuse_unless_shard_invariant_quant,
+    wire,
 )
 
 torch = pytest.importorskip("torch")
@@ -58,7 +60,8 @@ def _follower_echo(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no
 
     pg = init_rank(spec)
     cmd = chan.next_command(timeout=120)
-    plan = cmd["plan"]
+    assert isinstance(cmd, wire.Arm), cmd
+    plan = cmd.plan
     assert plan.precision_execution_lane == "w8a8"
     assert plan.gemm_mode == "rowwise"
     chan.report_ready(spec.rank)
@@ -72,8 +75,9 @@ def _follower_disagrees(spec: RankSpec, chan: FollowerChannel) -> None:  # pragm
     against the delivered plan)."""
     init_rank(spec)
     cmd = chan.next_command(timeout=120)
+    assert isinstance(cmd, wire.Arm), cmd
     mine = GroupPlan(precision_execution_lane="bf16", sp_degree=2)
-    mine.assert_agrees(cmd["plan"], rank=spec.rank)
+    mine.assert_agrees(cmd.plan, rank=spec.rank)
 
 
 def _follower_dies_before_joining(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no cover - spawned
@@ -100,7 +104,7 @@ def test_rank_zero_decides_and_every_rank_obeys() -> None:
             precision_execution_lane="w8a8", gemm_mode="rowwise", sp_degree=2,
             loras=(("style", 0.8),),
         )
-        group.send({"op": "arm", "plan": plan})
+        group.send(wire.Arm(boot=BootPlan(), plan=plan))
         group.wait_armed()
         group.barrier()
     finally:
@@ -114,8 +118,9 @@ def test_a_follower_that_disagrees_fails_the_group() -> None:
     group = _cpu_group(_follower_disagrees)
     group.form()
     try:
-        group.send({"op": "arm",
-                    "plan": GroupPlan(precision_execution_lane="w8a8", sp_degree=2)})
+        group.send(wire.Arm(
+            boot=BootPlan(),
+            plan=GroupPlan(precision_execution_lane="w8a8", sp_degree=2)))
         with pytest.raises(RankGroupError):
             for _ in range(200):
                 group.check_alive()
@@ -277,7 +282,9 @@ def _follower_echo4(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: n
     import torch.distributed as dist
 
     pg = init_rank(spec)
-    plan = chan.next_command(timeout=120)["plan"]
+    cmd = chan.next_command(timeout=120)
+    assert isinstance(cmd, wire.Arm), cmd
+    plan = cmd.plan
     assert plan.sp_degree == 4, plan
     assert plan.gemm_mode == "rowwise"
     assert plan.loras == (("style", 0.8),)
@@ -303,7 +310,7 @@ def test_degree_four_group_forms_and_every_rank_obeys_rank_zero() -> None:
             precision_execution_lane="w8a8", gemm_mode="rowwise", sp_degree=4,
             compile_armed=False, loras=(("style", 0.8),),
         )
-        group.send({"op": "arm", "plan": plan})
+        group.send(wire.Arm(boot=BootPlan(), plan=plan))
         group.wait_armed()
         group.barrier()   # all four ranks reached it
     finally:
@@ -319,7 +326,7 @@ def test_one_dead_rank_of_four_fails_the_whole_group() -> None:
     group = _cpu_group(_follower_rank3_dies, degree=4)
     group.form()
     try:
-        group.send({"op": "arm", "plan": GroupPlan(sp_degree=4)})
+        group.send(wire.Arm(boot=BootPlan(), plan=GroupPlan(sp_degree=4)))
         with pytest.raises(RankGroupError):
             for _ in range(300):
                 group.check_alive()
@@ -385,12 +392,10 @@ def test_the_call_gate_routes_the_pipeline_through_the_group() -> None:
 
 
 def test_call_marshalling_survives_the_wire() -> None:
-    # The model call must arrive at every rank IDENTICAL. CUDA tensors go via
-    # CPU (the followers own other cards) and a Generator is not picklable at
-    # all — only its seed has to agree.
-    import pickle
-
-    from gen_worker.parallel.runtime import _dehydrate, _rehydrate
+    # The model call must arrive at every rank IDENTICAL. Tensors go via CPU
+    # (the followers own other cards) as safetensors bytes; a Generator cannot
+    # cross at all — only its seed has to agree.
+    from gen_worker.parallel import wire
 
     payload = {
         "latents": torch.ones(2, 3),
@@ -399,9 +404,11 @@ def test_call_marshalling_survives_the_wire() -> None:
         "generator": torch.Generator().manual_seed(1234),
         "sigmas": [torch.zeros(2), 0.5],
     }
-    wire = _dehydrate(payload)
-    pickle.loads(pickle.dumps(wire))          # must cross the command channel
-    back = _rehydrate(wire, device=0)
+    # The real crossing: marshal -> encode -> bytes -> decode, as the queue
+    # does it.
+    command = wire.decode(wire.encode(wire.run_command((), payload)))
+    assert isinstance(command, wire.Run)
+    _args, back = wire.run_call(command, device="cpu")
     assert torch.equal(back["latents"].cpu(), payload["latents"])
     assert back["steps"] == 4 and back["prompt"] == "a cat"
     assert back["generator"].initial_seed() == 1234

--- a/tests/test_sp_group_isolation_pgw773_774.py
+++ b/tests/test_sp_group_isolation_pgw773_774.py
@@ -38,10 +38,10 @@ pytestmark = pytest.mark.skipif(
     reason="needs torch.distributed with the gloo backend",
 )
 
-from gen_worker.parallel import RankGroupError  # noqa: E402
+from gen_worker.parallel import RankGroupError, wire  # noqa: E402
 from gen_worker.parallel.group import FollowerChannel, RankSpec, init_rank  # noqa: E402
-from gen_worker.parallel.runtime import BootPlan, SequenceRuntime  # noqa: E402
-from gen_worker.parallel.plan import GroupPlan  # noqa: E402
+from gen_worker.parallel.plan import BootPlan, GroupPlan  # noqa: E402
+from gen_worker.parallel.runtime import SequenceRuntime  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -95,13 +95,13 @@ def _make_toy_pipe() -> Any:
 
 def _rig_entry(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no cover - spawned
     """A follower that mirrors sequence_rank_main against the toy pipe."""
+    from gen_worker.parallel import wire
     from gen_worker.parallel.cp import CpComms, gated_call, install_context_parallel
-    from gen_worker.parallel.runtime import _rehydrate
 
     pg = init_rank(spec)
     first = chan.next_command(timeout=120)
-    assert first["op"] == "arm", first
-    plan: GroupPlan = first["plan"]
+    assert isinstance(first, wire.Arm), first
+    plan: GroupPlan = first.plan
     plan.refuse_unless_cp_safe()
     pipe = _make_toy_pipe()
     install_context_parallel(
@@ -111,9 +111,9 @@ def _rig_entry(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no cov
     chan.report_ready(spec.rank)
     while True:
         cmd = chan.next_command()
-        if not isinstance(cmd, dict) or cmd.get("op") == "close":
+        if not isinstance(cmd, wire.Run):
             return
-        args = tuple(_rehydrate(a, spec.device) for a in cmd.get("args", ()))
+        args, _kwargs = wire.run_call(cmd, device="cpu")
         # Same gate `sequence_rank_main` enters: a follower's forward IS
         # rank-symmetric, so it is inside the gate.
         with torch.no_grad(), gated_call():
@@ -129,13 +129,15 @@ def _rig_entry_never_ready(spec: RankSpec, chan: FollowerChannel) -> None:  # pr
 def _rig_entry_skips_collectives(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no cover
     """Armed and alive, but never joins a RUN's collectives — the follower-
     hang case. Rank 0 must time out TYPED, not park forever."""
+    from gen_worker.parallel import wire
+
     init_rank(spec)
     first = chan.next_command(timeout=120)
-    assert first["op"] == "arm"
+    assert isinstance(first, wire.Arm)
     chan.report_ready(spec.rank)
     while True:
         cmd = chan.next_command()
-        if not isinstance(cmd, dict) or cmd.get("op") == "close":
+        if not isinstance(cmd, wire.Run):
             return
         time.sleep(600)  # a RUN arrived; ignore it
 
@@ -270,11 +272,11 @@ def test_a_follower_that_skips_the_collective_times_out_typed() -> None:
         rt.close()
 
 
-def test_an_unpicklable_argument_is_typed_and_does_not_condemn() -> None:
+def test_an_uncrossable_argument_is_typed_and_does_not_condemn() -> None:
     # DPA-28's shape: a `callback_on_step_end` closure cannot cross the rank
     # boundary. The old broadcast_object_list raised AFTER the followers
-    # were already in _recv, desynchronizing the group. Now the pickle runs
-    # eagerly on rank 0: typed error, group coherent, next call serves.
+    # were already in _recv, desynchronizing the group. Now the marshalling
+    # runs eagerly on rank 0: typed error, group coherent, next call serves.
     rt, pipe = _armed_runtime((0, 1))
     try:
         with pytest.raises(RankGroupError, match="cannot cross the rank"):
@@ -321,7 +323,7 @@ def test_close_is_never_a_collective_and_completes_against_a_wedged_follower() -
                               timeout_s=5.0)
     # A RUN the follower ignores: it is now parked in a 600s sleep.
     parked_s = 600.0
-    rt._group.send({"op": "run", "args": (), "kwargs": {}})
+    rt._group.send(wire.Run())
     start = time.monotonic()
     rt.close()   # must join/terminate, never broadcast
     # The property is that close() does NOT wait out the parked follower.

--- a/tests/test_untrusted_pickle_and_secret_sources_pgw498_pgw884.py
+++ b/tests/test_untrusted_pickle_and_secret_sources_pgw498_pgw884.py
@@ -208,6 +208,49 @@ def test_there_is_no_pickle_reader_in_the_tree() -> None:
     )
 
 
+#: Modules permitted to deserialize a pickle. It starts EMPTY and it stays
+#: empty: an entry here is a decision that some byte stream in this process may
+#: name a class and reach its constructor. There is no such stream.
+_PICKLE_DESERIALIZER_ALLOWLIST: frozenset = frozenset()
+
+_PICKLE_DESERIALIZERS = ("pickle.loads", "pickle.load(", "Unpickler")
+
+
+def test_no_module_deserializes_a_pickle_directly() -> None:
+    """The scan above reads `torch.load(` ONLY — it was blind to the direct
+    `pickle` API, and `parallel/group.py` unpickled off an `mp.Queue` whose
+    writer is the process that imports tenant endpoint code and marshals
+    tenant-supplied model-call arguments (pgw#1275). Every rank-sibling
+    follower reading that queue was a deserialization gadget on
+    tenant-reachable input, and nothing in the tree could go red about it.
+
+    Scanned as a SHAPE, because that is what stops one coming back: a new site
+    is silently a gadget, and no test of the surrounding feature notices.
+    `pickle.dumps` is deliberately not scanned — writing a pickle executes
+    nothing; reading one does.
+    """
+    src_root = Path(writer.__file__).resolve().parent.parent
+    offenders: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        rel = str(path.relative_to(src_root))
+        if rel in _PICKLE_DESERIALIZER_ALLOWLIST:
+            continue
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if not any(name in stripped for name in _PICKLE_DESERIALIZERS):
+                continue
+            offenders.append(f"{rel}:{lineno}: {stripped}")
+    assert offenders == [], (
+        "a pickle DESERIALIZER is back. Whatever the stream is, its writer is "
+        "reachable from tenant code; carry the payload as msgspec (see "
+        "`gen_worker/parallel/wire.py`) instead:\n" + "\n".join(offenders)
+    )
+
+
 # ---------------------------------------------------------------------------
 # refused key material, at every source that can deliver it
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HARDCUT-CHECKLIST **E3**. `parallel/group.py` held the only `pickle.loads` /
`pickle.load(` site in all of `src/`.

## The defect

`FollowerChannel.next_command` did `pickle.loads(raw)` on bytes off an
`mp.Queue` whose **writer is rank 0** — the compute process that imports tenant
endpoint code and marshals **tenant-supplied model-call arguments** into every
RUN command. Every rank-sibling follower was therefore a deserialization gadget
driven by tenant-reachable input, and the module docstring presented eager
pickling as a FEATURE.

## Verified payload inventory — the ledger claim is only half right

The ledger says *"the payload is model-call arguments; msgspec closes it for
free."* Traced at source; three command shapes ride the queue:

| command | contents |
|---|---|
| `arm` | `BootPlan` + `GroupPlan` dataclasses (str/int/bool/tuple) — msgpack-native |
| `run` | `args`/`kwargs` after `runtime._dehydrate` |
| `close` | a bare op marker |

**`_dehydrate` emitted `("__tensor__", <CPU torch.Tensor>)`.** Tensors DO ride
this queue — the model call is the SPMD unit and its arguments are latents,
embeddings and masks — so msgspec alone does **not** close it. Worse, the
vocabulary was **open by construction**: `_dehydrate` returned any unrecognized
value untouched, so a PIL image, a numpy array or an endpoint's own class
crossed silently as long as it pickled.

## The split

- **msgspec msgpack owns the envelope** (`parallel/wire.py`). Commands are a
  closed tagged union `Arm | Run | Close`; a RUN's leaves decode as `Any`, i.e.
  plain msgpack scalars/lists/maps/bytes. **A payload never names a class, so it
  cannot reach a constructor.**
- **safetensors owns the tensor.** Not a new serialization format — it is the
  container the org already mandates and already a hard dependency
  (`safetensors>=0.8.0`). One blob per tensor, round-tripped bit-identical
  (fp32/bf16/bool/int64/0-dim/empty all covered by a test row).
- **`torch.Generator`** stays what it always was: its seed, which is the only
  part that has to agree.
- **Everything else is a typed refusal on rank 0**, naming the argument, before
  anything is queued — group coherent, followers still parked at `queue.get`,
  next call serves. That closes the open half of the vocabulary.

Also: `BootPlan` moves to `plan.py` (it is a plan; the wire needs both without
an import cycle), and `GroupPlan.encode/decode` — an unused *second* json
serialization of the same record — dies. One home per value.

**Out of scope, deliberately:** `mp.Process(args=…)` still pickles `RankSpec`
and the entry function. That is multiprocessing's own spawn mechanism carrying
a fixed struct THIS process built, not a queue anything tenant-reachable writes
to. The `RankSpec` docstring now says so, so a reader cannot mistake it for a
surviving hole.

## Red evidence

Both rows verified RED on `origin/master@6af29f04` (a throwaway detached
worktree, since removed):

1. **The fence.** `test_no_module_deserializes_a_pickle_directly` scans
   `src/gen_worker` for `pickle.loads` / `pickle.load(` / `Unpickler` with an
   allowlist that **starts EMPTY**. On master:
   `AssertionError: … parallel/group.py:132: return pickle.loads(raw)`.
   The standing guard next to it reads `torch.load(` only and passed the whole
   time — it was structurally blind. (E5 broadens the rest separately.)
2. **The gadget executes.** A payload whose `__reduce__` writes a marker file,
   put on a real `mp.Queue` and read by a real spawned follower through the
   production `FollowerChannel`: on master the marker **exists** — arbitrary
   code ran inside the follower. On this branch the follower refuses and the
   marker never appears.

## Tests

`tests/test_rank_command_wire_pgw1275.py` — real `spawn` followers, real
`mp.Queue`s, the production `FollowerChannel`: the gadget row above, a
tensor/generator/nesting round trip decoded by the follower and echoed back
(tuple stays a tuple, list stays a list — msgpack has one array type, so that is
a property of the wire), the four out-of-vocabulary refusals, and a closed-union
decode row.

The full formed group — TCPStore rendezvous, gloo process group, arm/run/close
over the same wire, degree 2 and degree 4 — is
`test_sp_group_isolation_pgw773_774.py` + `test_sequence_parallel_pgw748.py`,
both migrated to the wire and green.

`143 passed` across the 12 parallel-touching modules · `mypy` Success (742
files) · fence-symbol / config-read / settings-writer / unreached-surface /
ambient-census / unbounded-read guards green · changelog fragment added.