### PR TITLE
pgw#1276: the seal tripwire refuses when it could not measure, instead of reporting "unchanged"

### DIFF
--- a/changelog.d/pgw1276.md
+++ b/changelog.d/pgw1276.md
@@ -1,0 +1,14 @@
+- The seal tripwire no longer scores an UNMEASURABLE loader map as "unchanged".
+  `assert_seal_unchanged`'s live substitution check reads `/proc/self/maps` — the
+  only surface that can see an `LD_PRELOAD`ed native library, since the sealed
+  manifest is disk-derived and structurally blind to one. When that map could not
+  be read the check compared nothing and the call returned clean, so a process
+  that cannot see its own loaded libraries minted and published anyway. The probe
+  is now tri-state (`loaded_library_probe` → `readable`, `digests`) and an armed
+  manifest plus an unreadable map REFUSES, naming the map and the count of
+  libraries left unchecked. A mapped library whose file cannot be read is named as
+  unverified rather than reported as a substitution — including when both sides
+  digest to the same `<unreadable>` sentinel, which used to compare EQUAL and pass
+  without any comparison having happened. The two deliberate skips
+  stand: an env shipping no toolchain libs has nothing to substitute, and a
+  library the loader never mapped cannot have been swapped in this process.

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -353,18 +353,30 @@ def write_library_memo(path: Path) -> int:
     return len(digests)
 
 
-def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
+class LoadedLibraries(NamedTuple):
+    """The loader-map probe as a TRI-STATE. ``readable`` says whether the map
+    could be read AT ALL: an unreadable map yields no digests, and so does a
+    process that mapped nothing relevant — the absence of a measurement is not
+    a measurement of absence, and the two must not share a verdict
+    (:func:`assert_seal_unchanged`)."""
+
+    readable: bool
+    digests: Tuple[Tuple[str, str], ...]
+
+
+def loaded_library_probe() -> LoadedLibraries:
     """(basename, content digest) of every relevant native library the
-    LOADER actually mapped into this process (``/proc/self/maps``).
-    Deterministic: resolved real paths, sorted basenames. Empty off-Linux
-    (no maps surface — recorded as such).
+    LOADER actually mapped into this process (``/proc/self/maps``), plus
+    whether that map was readable at all. Deterministic: resolved real
+    paths, sorted basenames. Off-Linux there is no maps surface, so the
+    probe reports ``readable=False`` and nothing may be concluded from it.
 
     Resolved through :func:`_identity_digest` like the manifest it is compared
     against, so the comparison stays apples-to-apples and an LD_PRELOAD object
     — which no RECORD covers — is HASHED and therefore named."""
     maps = _MAPS_PATH
     if not maps.is_file():
-        return ()
+        return LoadedLibraries(False, ())
     paths: Dict[str, str] = {}
     try:
         for line in maps.read_text().splitlines():
@@ -379,7 +391,7 @@ def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
                 continue  # host driver: recorded-only, never identity
             paths[base] = os.path.realpath(file_path)
     except OSError:
-        return ()
+        return LoadedLibraries(False, ())
     out: Dict[str, str] = {}
     for base in sorted(paths):
         try:
@@ -388,7 +400,13 @@ def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
                 paths[base], st.st_mtime_ns, st.st_size)
         except OSError:
             out[base] = "<unreadable>"
-    return tuple(sorted(out.items()))
+    return LoadedLibraries(True, tuple(sorted(out.items())))
+
+
+def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
+    """The mapped-library digests alone. Callers that must distinguish an
+    unreadable map from an empty one take :func:`loaded_library_probe`."""
+    return loaded_library_probe().digests
 
 
 # The IDENTITY manifest is enumerated from the python env ON DISK, never from
@@ -401,7 +419,8 @@ def loaded_library_digests() -> Tuple[Tuple[str, str], ...]:
 # shipped in the python env). The maps-based probe above remains the LIVE
 # integrity surface: assert_seal_unchanged compares what is actually mapped
 # against this manifest and refuses, naming the library, when an
-# LD_PRELOAD-style substitution diverges from the sealed disk content.
+# LD_PRELOAD-style substitution diverges from the sealed disk content — or
+# when the map could not be read, since a blind check is not a passing one.
 _TOOLCHAIN_LIB_PACKAGES = ("torch", "triton", "nvidia")
 
 # Test seam: when set, enumerate these directories instead of the resolved
@@ -654,7 +673,8 @@ def assert_seal_unchanged(label: str = "") -> None:
     derives from the declaration and cannot follow the drift). The
     boot-frozen library snapshot is re-digested LIVE here: a substituted
     native lib (LD_PRELOAD-style, post-boot) is named even though the seal
-    fact itself is frozen."""
+    fact itself is frozen. Refuses too when that check could not RUN —
+    unmeasurable is its own outcome, never folded into "unchanged"."""
     global _BOOT_READBACK
     live = settings_readback()
     if _BOOT_READBACK is None:
@@ -662,12 +682,33 @@ def assert_seal_unchanged(label: str = "") -> None:
         return
     diffs = _seal_diff(_BOOT_READBACK, live)
     snapshot = dict(frozen_library_digests())
+    # An env shipping no toolchain libs has nothing to substitute — the
+    # torchless boot, not an unmeasured one.
     if snapshot:
-        current = dict(loaded_library_digests())
+        probe = loaded_library_probe()
+        if not probe.readable:
+            # UNMEASURABLE, not unchanged: the loader map is the only surface
+            # that sees a substitution (the manifest is disk-derived and
+            # structurally blind to LD_PRELOAD), so a map we cannot read
+            # leaves every sealed library unchecked and must refuse.
+            diffs.append(
+                f"loader map {_MAPS_PATH} unreadable: {len(snapshot)} sealed "
+                "libraries could not be checked for substitution")
+        current = dict(probe.digests)
         shipped = _shipped_digest_sets()
         for base in sorted(snapshot):
             now = current.get(base)
-            if now is None or now == snapshot[base]:
+            # Never mapped: nothing was loaded that could have been swapped.
+            if now is None:
+                continue
+            if "<unreadable>" in (snapshot[base], now):
+                # Two `<unreadable>` sides are equal without being a
+                # comparison; naming that is the whole point of this row.
+                diffs.append(
+                    f"loaded lib {base}: content unverified (boot "
+                    f"{snapshot[base]}, now {now}) — no comparison happened")
+                continue
+            if now == snapshot[base]:
                 continue
             if now in shipped.get(base, ()):
                 continue  # the env's own alternate copy, not a substitution
@@ -676,7 +717,8 @@ def assert_seal_unchanged(label: str = "") -> None:
                 "(native library substituted after boot)")
     if diffs:
         raise EnvSealError(
-            f"environment drifted since boot ({label or 'point-of-use'}): "
+            "environment not verifiably unchanged since boot "
+            f"({label or 'point-of-use'}): "
             + "; ".join(diffs))
 
 
@@ -760,6 +802,7 @@ __all__ = [
     "LAST_ESTABLISH_SPANS",
     "DigestSources",
     "EnvSealError",
+    "LoadedLibraries",
     "SCRUB_PREFIXES",
     "SEAL_KEY",
     "SEAL_LIB_MEMO_ENV",
@@ -772,6 +815,7 @@ __all__ = [
     "inductor_config_digest",
     "frozen_library_digests",
     "loaded_library_digests",
+    "loaded_library_probe",
     "scrub_env",
     "seal_digest",
     "settings_readback",

--- a/tests/test_seal_unmeasurable_pgw1276.py
+++ b/tests/test_seal_unmeasurable_pgw1276.py
@@ -1,0 +1,145 @@
+"""pgw#1276: an UNMEASURABLE loader map must not score as "unchanged".
+
+`assert_seal_unchanged`'s library half is the only surface that can see a
+native library substituted after boot — the seal's own toolchain axis comes
+from the DISK manifest, which cannot see an LD_PRELOADed object. The live
+comparison reads `/proc/self/maps`. When that map cannot be read, the check
+measured nothing; folding that into the passing verdict disarms the tripwire
+silently. These tests drive the REAL establish -> assert_seal_unchanged path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+
+from gen_worker import env_seal
+
+_LIBS: Tuple[Tuple[str, bytes], ...] = (
+    ("libtorch_cuda.so", b"torch-image-bytes"),
+    ("libcudart.so.12", b"cudart-image-bytes"),
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_seal_globals() -> Iterator[None]:
+    boot, snapshot = env_seal._BOOT_READBACK, env_seal._LIB_SNAPSHOT
+    try:
+        yield
+    finally:
+        env_seal._BOOT_READBACK = boot
+        env_seal._LIB_SNAPSHOT = snapshot
+
+
+def _toolchain_dir(tmp_path: Path, name: str,
+                   libs: Tuple[Tuple[str, bytes], ...] = _LIBS) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    for base, content in libs:
+        (root / base).write_bytes(content)
+    return root
+
+
+def _maps(tmp_path: Path, name: str, mapped: Tuple[Path, ...]) -> Path:
+    path = tmp_path / name
+    lines = [
+        f"7f{i:010x}000-7f{i:010x}fff r-xp 00000000 08:01 {i + 1} {lib}"
+        for i, lib in enumerate(mapped)
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _arm(monkeypatch: pytest.MonkeyPatch, disk: Path, maps: Path) -> None:
+    """Point the seal at a controlled env: `disk` is what the env ships,
+    `maps` is what the loader mapped. The boot read-back is adopted first
+    (the manifest freezes here), so the next call runs the library check."""
+    monkeypatch.setattr(env_seal, "_TOOLCHAIN_LIB_DIRS_OVERRIDE", (disk,))
+    monkeypatch.setattr(env_seal, "_LIB_SNAPSHOT", None)
+    monkeypatch.setattr(env_seal, "_MAPS_PATH", maps)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
+    env_seal.assert_seal_unchanged("adopt")  # first call adopts, checks nothing
+    assert dict(env_seal.frozen_library_digests()), "manifest must be armed"
+
+
+def test_unreadable_loader_map_refuses_instead_of_scoring_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The pgw#1276 red test: the env ships libraries to check and the map
+    that says what is loaded cannot be read. Nothing was measured, so the
+    verdict cannot be "unchanged"."""
+    disk = _toolchain_dir(tmp_path, "disk")
+    _arm(monkeypatch, disk, _maps(tmp_path, "maps", tuple(disk.iterdir())))
+    monkeypatch.setattr(env_seal, "_MAPS_PATH", tmp_path / "no-such-maps")
+
+    with pytest.raises(env_seal.EnvSealError) as excinfo:
+        env_seal.assert_seal_unchanged("mint")
+    message = str(excinfo.value)
+    assert "no-such-maps" in message
+    assert "mint" in message
+    assert "2" in message  # the libraries left unchecked are counted
+
+
+def test_readable_map_matching_the_manifest_passes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The green control: the same arming, a map that CAN be read, contents
+    that match — no refusal. Unmeasurable and unchanged are different."""
+    disk = _toolchain_dir(tmp_path, "disk")
+    _arm(monkeypatch, disk, _maps(tmp_path, "maps", tuple(disk.iterdir())))
+    env_seal.assert_seal_unchanged("mint")
+
+
+def test_shipped_but_never_mapped_library_is_not_drift(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The deliberate skip stays: a library the loader never mapped cannot
+    have been substituted in this process — no fact to measure, as opposed
+    to a fact we failed to measure."""
+    disk = _toolchain_dir(tmp_path, "disk")
+    _arm(monkeypatch, disk, _maps(tmp_path, "maps",
+                                  (disk / "libtorch_cuda.so",)))
+    env_seal.assert_seal_unchanged("mint")
+
+
+def test_mapped_library_whose_file_cannot_be_read_is_named_unverified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """A mapped library the process cannot stat digests to `<unreadable>` on
+    BOTH sides once the manifest hits the same file — equal strings that are
+    not a comparison. The refusal says unverified, not "substituted"."""
+    disk = _toolchain_dir(tmp_path, "disk")
+    _arm(monkeypatch, disk, _maps(tmp_path, "maps", tuple(disk.iterdir())))
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    monkeypatch.setattr(env_seal, "_MAPS_PATH", _maps(
+        tmp_path, "maps2",
+        (disk / "libtorch_cuda.so", gone / "libcudart.so.12")))
+
+    with pytest.raises(env_seal.EnvSealError) as excinfo:
+        env_seal.assert_seal_unchanged("mint")
+    message = str(excinfo.value)
+    assert "libcudart.so.12" in message
+    assert "content unverified" in message
+    assert "substituted" not in message
+
+
+def test_substituted_mapped_library_still_refuses_by_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The arm itself works under this fixture: swap the bytes of a mapped
+    library and the same call names it. Without this the unreadable-map test
+    could pass against a check that was never armed."""
+    disk = _toolchain_dir(tmp_path, "disk")
+    _arm(monkeypatch, disk, _maps(tmp_path, "maps", tuple(disk.iterdir())))
+    preload = tmp_path / "preload"
+    preload.mkdir()
+    (preload / "libcudart.so.12").write_bytes(b"SUBSTITUTED-cudart")
+    monkeypatch.setattr(env_seal, "_MAPS_PATH", _maps(
+        tmp_path, "maps2",
+        (disk / "libtorch_cuda.so", preload / "libcudart.so.12")))
+
+    with pytest.raises(env_seal.EnvSealError, match="libcudart.so.12"):
+        env_seal.assert_seal_unchanged("mint")


### PR DESCRIPTION
HARDCUT-CHECKLIST **M4** (`env_seal.py:665` "unmeasurable" scored as "unchanged"). Audited, and the claim holds.

## What env_seal seals, and who reads the verdict

`assert_seal_unchanged` is the point-of-use tripwire called from `aot_mint.py:1990`, **before any trace or export**. Two halves:

1. settings read-back vs the boot read-back (boot verified that against the declaration, so a trip is a declaration mismatch by transitivity);
2. the boot-frozen library manifest vs what the loader **actually mapped** (`/proc/self/maps`).

Half 2 is the only surface in the process that can see an `LD_PRELOAD`ed native library: the seal's `toolchain` key axis is derived from the env's DISK manifest (`frozen_library_digests`), which is structurally blind to an object no wheel RECORD covers. A clean verdict is what lets the mint proceed to produce an artifact keyed to that toolchain identity.

## The defect

`loaded_library_digests()` returned `()` for three different states — the maps surface missing (`is_file()` false, off-Linux or a masked `/proc`), an `OSError` reading it, and a genuine read that mapped nothing relevant. Only the third is a measurement. The comparison loop then found `now is None` for every library, appended zero diffs, and the call returned **unchanged**. A process that cannot read its own loader map minted and published anyway, and the refusal that exists for exactly this case never fired. Same fold one level down: a library that digests to `<unreadable>` on BOTH sides compared **equal**, which is a passing verdict reached without any comparison happening.

Standing doctrine: absence is its own state (pgw#830 hostfacts — `None` means no reading, never `0`; the cardless-probe rule — only a host with a driver TO fail can answer `driver_too_old`).

## The fix

`loaded_library_probe() -> LoadedLibraries(readable, digests)`. `loaded_library_digests()` keeps its signature and returns `.digests`. An armed manifest plus `readable=False` refuses, naming the map path and the count of sealed libraries left unchecked; `<unreadable>` on either side is named as unverified instead of being called a substitution or passing as equal. The refusal prefix is now "not verifiably unchanged since boot", because two of its rows are no longer drift.

Two skips are **deliberate** and now say so at the site:
- `if snapshot:` — an env shipping no toolchain libs has nothing to substitute (the torchless/bare-wheel boot; `frozen_library_digests` already classifies it as its own `no_libs` phase token).
- per-library `now is None` when the map WAS read — a library the loader never mapped cannot have been swapped in this process. No fact to measure, as opposed to a fact we failed to measure.

## Red/green

`tests/test_seal_unmeasurable_pgw1276.py`, driving the real `establish()` → `assert_seal_unchanged()` path with a controlled disk manifest and a controlled maps file.

- against master's `env_seal.py`: **2 failed, 3 passed** — `DID NOT RAISE EnvSealError` on the unreadable map, and the `<unreadable>` case reported "native library substituted after boot".
- with the fix: **5 passed**.
- the three controls are green on both trees, and one of them is a real substitution refusing by name — without it the unreadable-map test could pass against a check that was never armed.

Wider: every test file that touches `env_seal` (32 files) — 394 passed, 3 skipped. mypy strict clean on both changed files; ruff clean.

## Noted, NOT fixed here

`toolchain_library_digests` records the literal `<unreadable>` for a shipped lib it cannot stat, and that sentinel rides `loaded_libs_digest` → the `toolchain` KEY axis: two envs each with an unstatable lib of the same basename compute the same axis value. Same doctrine, but fixing it re-keys, so it stays out of a tripwire-scoped PR — pgw#1276 carries the note.