### PR TITLE
pgw#1282 (HARDCUT A19): a model slot with no consumed tensor-layout contract does not ship

### DIFF
--- a/changelog.d/pgw1282.md
+++ b/changelog.d/pgw1282.md
@@ -1,0 +1,51 @@
+- **pgw#1282 (HARDCUT A19): a model slot that declares no consumed
+  tensor-layout contract does not ship.** `Slot(layouts=...)` was optional and
+  absence was the UNDECLARED tri-state — the hub's gate then fell back to the
+  image-wide decoder census. Measured fleet-wide, that rung was never a
+  considered choice; it was the default, so "this slot has no opinion" and
+  "nobody wrote the line" were one state and no refusal could tell them apart.
+  `discover_manifest` + `validate_endpoint_lock` — the entry point the
+  Dockerfile runs — now REFUSE a model slot carrying neither `layouts=` nor
+  the new `layouts_undeclarable=`, naming the function, the slot and the
+  declaration syntax, and naming every offender in one build rather than one
+  per image. Non-model slots are exempt by construction: every entry of
+  `models={}` is a model slot.
+
+  `layouts_undeclarable="<reason>"` is the explicit third rung and a
+  DECLARATION rather than a default — the reason is required (a blank one is
+  refused where it is written), it is mutually exclusive with `layouts=`, and
+  it travels onto the manifest so the gap is on the record instead of being
+  lost to an absent key. It exists because real slots hold bytes the registry
+  genuinely does not name: a tokenizer tree with no tensors, a GGUF quant axis
+  th#1809 T3 has not registered, a vLLM compressed-tensors checkpoint with no
+  descriptor. Inventing a handle for those is the failure mode, not the fix.
+
+  `scripts/lint_layout_declarations.py` grows the same refusal as an AST
+  fence, so an endpoint repo sees it in the diff — where a layout demand is
+  actually judged — rather than at image build. The eight `micro-diffusion`
+  example endpoints declare theirs (`plain.bf16@1`; the w8a8 arm also names
+  `cozy.fp8-rowwise@1`, which is what `load_w8a8_denoiser` actually reads).
+
+- **pgw#1282: contracts carry their execution REQUIREMENTS.** Paul, same day:
+  "certain contracts can only be executed efficiently if their
+  hardware-requirements are met... other requirements might be kernels or
+  torch versions." `Slot(layout_requirements={handle: "sm100+"})` declares the
+  compute-capability floor for a contract this slot consumes — dual form, the
+  compact term list or `LayoutRequirements(min_sm=100)`. It is per (slot,
+  handle) rather than per handle globally, because one contract has different
+  floors in different code: `cozy.fp8-rowwise@1` is sm89 per-tensor and sm90
+  rowwise (`models/w8a8.py`), and the 4-bit contracts are sm100
+  (`models/w4a4.py`). It feeds — and is deliberately named after —
+  tensorhub's `contractspec.DecodeEntry.MinSM`, which already documents the
+  floor as "an EXECUTION fact [that] lives here rather than on the artifact
+  contract, which describes bytes at rest only", and which
+  `contractspec.Resolve` already reads for the card-executability
+  intersection. **Finding, filed rather than fixed here: nothing sets that
+  field.** `releaseselector.DecodeSetForRelease` builds every `DecodeEntry`
+  with `MinSM: 0`, so the intersection is a fleet-wide no-op — the same
+  unarmed-gate shape A19 exists to close, one layer down.
+
+  Kernel and torch-version terms are named in the ruling and NOT built. The
+  compact grammar is a comma-separated term list so one can be added without
+  re-spelling a declaration, and an unknown term is REFUSED by name: an
+  ignored requirement is a requirement that silently does not hold.

--- a/changelog.d/pgw1282.md
+++ b/changelog.d/pgw1282.md
@@ -45,6 +45,12 @@
   with `MinSM: 0`, so the intersection is a fleet-wide no-op — the same
   unarmed-gate shape A19 exists to close, one layer down.
 
+  It has a real declarer, not only tests: micro-diffusion's w8a8 arm reads a
+  REAL fp8 artifact through `load_w8a8_denoiser` and states `sm89+` — the floor
+  `W8A8_MIN_SM` states, and deliberately not sm90, because the rowwise GEMM
+  wants sm90 while the CONTRACT is still decodable at sm89 through the
+  per-tensor path. The honest floor for the handle, not the fastest one.
+
   Kernel and torch-version terms are named in the ruling and NOT built. The
   compact grammar is a comma-separated term list so one can be added without
   re-spelling a declaration, and an unknown term is REFUSED by name: an

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -386,10 +386,48 @@ class Generate:
   `"*"` is the every-component default; a component key overrides it for that
   component. The map is one level deep, keyed by component. The hub compares an artifact's PROVEN layout against this set at
   rebind and refuses a mismatch with both sides named, before any pod is
-  bought. **Omitting `layouts=` leaves the slot UNDECLARED** — the gate then
-  falls back to the image-wide decoder census, and absence is never read as
-  "accepts everything"; an empty mapping or an empty tuple is a
-  decoration-time error. Handles must be registered
+  bought. **The declaration is MANDATORY (A19, Paul 2026-08-15).** Omitting it
+  used to leave the slot UNDECLARED; measured fleet-wide that rung was only
+  ever the default, so "no opinion" and "nobody wrote the line" were one
+  state. Discovery now REFUSES a model slot carrying neither `layouts=` nor
+  `layouts_undeclarable=`, naming the function, the slot and the syntax; an
+  empty mapping or an empty tuple is a decoration-time error. If no registered
+  handle names this slot's bytes — a tokenizer tree with no tensors, a GGUF
+  quant axis (th#1809 T3), a compressed-tensors checkpoint — say so and say
+  why:
+
+  ```python
+  Slot(Path, layouts_undeclarable="tokenizer files only — no tensors")
+  ```
+
+  That is a DECLARATION, not a default: the reason is required, it travels
+  onto the manifest, and it cannot be worn alongside `layouts=`.
+
+- **`layout_requirements=` declares WHAT EXECUTING A CONTRACT NEEDS OF THE
+  MACHINE** (Paul, 2026-08-15) — keyed by the handle it guards, dual form:
+
+  ```python
+  Slot(QwenImagePipeline, selected_by="model",
+       layouts={"*": (CONTRACT_PLAIN_BF16, CONTRACT_COZY_SVDQ_NVFP4_LR8)},
+       layout_requirements={CONTRACT_COZY_SVDQ_NVFP4_LR8: "sm100+"})
+  ```
+
+  A handle names bytes at rest; the floor its kernels need is an EXECUTION
+  fact, which is why it lives on the slot and not on the artifact contract —
+  the same placement and the same name as tensorhub's
+  `contractspec.DecodeEntry.MinSM`, the field it feeds and the one the ladder
+  reads for rung admission. Per (slot, handle), because one contract has
+  different floors in different code (`cozy.fp8-rowwise@1` is sm89 per-tensor
+  and sm90 rowwise). A key naming a handle `layouts=` does not accept is
+  refused — a requirement guarding nothing is never checked. Kernel and
+  torch-version requirements are named in the ruling and NOT built; the
+  compact grammar is a comma-separated term list so they can be added without
+  re-spelling a declaration, and an unknown term is refused rather than
+  ignored. **No defaults on this axis either**: a declared requirement is
+  checked, an undeclared one is not evaluated, and there is no "no floor"
+  value to write.
+
+  Handles must be registered
   (`KNOWN_CONTRACTS`, transcribed from tensorhub's `internal/tensorlayout`)
   and written as LITERALS or as constants imported from that module —
   `scripts/lint_layout_declarations.py` refuses anything the AST sweep cannot

--- a/examples/micro-diffusion/src/micro_diffusion/main.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main.py
@@ -90,7 +90,8 @@ class MicroOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroPipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroPipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer", "decoder"), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_4d.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_4d.py
@@ -45,7 +45,8 @@ class Micro4dOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroGridPipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroGridPipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_conv.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_conv.py
@@ -44,7 +44,8 @@ class MicroConvOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroConvPipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroConvPipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("unet",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_escape.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_escape.py
@@ -44,7 +44,8 @@ class MicroEscapeOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroEscapePipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroEscapePipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_pad32.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_pad32.py
@@ -45,7 +45,8 @@ class MicroPad32Out(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroPad32Pipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroPad32Pipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_pad32_branchy.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_pad32_branchy.py
@@ -44,7 +44,8 @@ class MicroPad32BranchyOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroPad32BranchyPipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroPad32BranchyPipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_rope.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_rope.py
@@ -44,7 +44,8 @@ class MicroRopeOut(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroRopePipeline, selected_by="model")},
+    models={"pipeline": Slot(MicroRopePipeline, selected_by="model",
+        layouts={"*": ("plain.bf16@1",)})},
     compile=Compile(
         family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_w8a8.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_w8a8.py
@@ -66,7 +66,13 @@ class MicroW8a8Out(msgspec.Struct):
         MicroW8a8Pipeline, selected_by="model",
         # The denoiser IS the fp8 artifact `load_w8a8_denoiser` reads; the
         # decoder beside it is dense. Both are in the set this slot executes.
-        layouts={"*": ("cozy.fp8-rowwise@1", "plain.bf16@1")})},
+        layouts={"*": ("cozy.fp8-rowwise@1", "plain.bf16@1")},
+        # And what EXECUTING that contract needs of the card. sm89 is the
+        # floor `models/w8a8.py` states (`W8A8_MIN_SM`) — `_scaled_mm`
+        # per-tensor. The rowwise GEMM wants sm90, but the contract is still
+        # DECODABLE at sm89 through the per-tensor path, so 89 is the honest
+        # floor for the handle rather than the fastest one.
+        layout_requirements={"cozy.fp8-rowwise@1": "sm89+"})},
     compile=Compile(
         family=FAMILY, targets=("transformer", "decoder"), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/examples/micro-diffusion/src/micro_diffusion/main_w8a8.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_w8a8.py
@@ -62,7 +62,11 @@ class MicroW8a8Out(msgspec.Struct):
 
 
 @endpoint(
-    models={"pipeline": Slot(MicroW8a8Pipeline, selected_by="model")},
+    models={"pipeline": Slot(
+        MicroW8a8Pipeline, selected_by="model",
+        # The denoiser IS the fp8 artifact `load_w8a8_denoiser` reads; the
+        # decoder beside it is dense. Both are in the set this slot executes.
+        layouts={"*": ("cozy.fp8-rowwise@1", "plain.bf16@1")})},
     compile=Compile(
         family=FAMILY, targets=("transformer", "decoder"), shapes=PIXEL_ROWS,
         text_len=COND_LEN),

--- a/scripts/lint_layout_declarations.py
+++ b/scripts/lint_layout_declarations.py
@@ -130,6 +130,46 @@ def _check_layouts(
     return problems
 
 
+def _check_undeclarable(path: Path, value: ast.expr) -> List[str]:
+    """The escape is reviewed in the diff like any other declaration, so its
+    REASON has to be a literal too — a computed one is unreadable exactly
+    where it matters."""
+    if isinstance(value, ast.Constant) and isinstance(value.value, str) \
+            and value.value.strip():
+        return []
+    return [
+        f"{path}:{value.lineno}: layouts_undeclarable= must be a non-empty "
+        "string literal saying which bytes this slot holds and why no "
+        "registered handle names them"
+    ]
+
+
+def _check_requirements(
+    path: Path, value: ast.expr, vocabulary: Set[str],
+) -> List[str]:
+    """The requirements axis is reviewed in the diff like the demand it
+    guards, so it is a dict literal of handle -> compact string literal."""
+    where = f"{path}:{value.lineno}"
+    if not isinstance(value, ast.Dict):
+        return [
+            f"{where}: layout_requirements= is a {type(value).__name__}, not "
+            "a dict literal — the AST sweep cannot read it"
+        ]
+    problems: List[str] = []
+    for key, item in zip(value.keys, value.values):
+        if key is None or not _handle_is_readable(key, vocabulary):
+            problems.append(
+                f"{where}: layout_requirements= key must be a handle literal "
+                f"or a constant imported from {VOCABULARY_MODULE}")
+            continue
+        if not (isinstance(item, ast.Constant) and isinstance(item.value, str)):
+            problems.append(
+                f"{path}:{item.lineno}: layout_requirements= value must be "
+                "the compact string form (e.g. \'sm100+\'); a computed "
+                "requirement is unreviewable exactly where it matters")
+    return problems
+
+
 def _call_name(call: ast.Call) -> str:
     func = call.func
     if isinstance(func, ast.Name):
@@ -149,15 +189,32 @@ def scan(path: Path) -> List[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or _call_name(node) != "Slot":
             continue
+        declared = False
         for kw in node.keywords:
             if kw.arg == "layouts":
+                declared = True
                 problems.extend(_check_layouts(path, node, kw.value, vocabulary))
+            elif kw.arg == "layouts_undeclarable":
+                declared = True
+                problems.extend(_check_undeclarable(path, kw.value))
+            elif kw.arg == "layout_requirements":
+                problems.extend(
+                    _check_requirements(path, kw.value, vocabulary))
             elif kw.arg is None:
                 # `Slot(cls, **kwargs)` — a layouts= could be hiding in there.
                 problems.append(
                     f"{path}:{node.lineno}: Slot(**kwargs) may carry a "
                     "layouts= the sweep cannot see; pass the declaration "
                     "explicitly")
+                declared = True   # unknowable; the splat refusal above stands
+        if not declared:
+            problems.append(
+                f"{path}:{node.lineno}: this model slot declares no consumed "
+                "tensor-layout contract. A19 is a hard cut — ABSENT is a "
+                "refusal, never the UNDECLARED tri-state. Write "
+                'layouts={"*": ("plain.bf16@1",)}, or, if no registered '
+                "handle names this slot's bytes, "
+                'layouts_undeclarable="<why>".')
     return problems
 
 
@@ -167,8 +224,8 @@ def main(argv: List[str]) -> int:
     for path in _iter_python_files(roots):
         problems.extend(scan(path))
     if problems:
-        print("pgw#1143: Slot(layouts=...) declarations that the AST sweep "
-              "cannot read:\n", file=sys.stderr)
+        print("pgw#1143 / A19: Slot layout declarations that are missing or "
+              "that the AST sweep cannot read:\n", file=sys.stderr)
         for problem in problems:
             print(f"  {problem}", file=sys.stderr)
         print(

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -41,7 +41,13 @@ import msgspec
 
 from .binding import ModelRef
 from ..families.base import KIND_LORA, GenerationDefaults, family_for
-from ..models.tensor_layout_contract import normalize_layout_demand
+from ..models.tensor_layout_contract import (
+    LayoutDeclarationError,
+    LayoutRequirements,
+    normalize_layout_demand,
+    normalize_layout_requirements,
+    normalize_layout_undeclarable,
+)
 
 D = TypeVar("D", bound=GenerationDefaults)
 
@@ -144,18 +150,55 @@ class Slot(Generic[D]):
     The handles are validated here against the SDK's
     transcribed ``KNOWN_CONTRACTS``; the KEYS are validated at decoration
     against the slot's DERIVED component tree, so a key that would silently
-    match nothing is a build error naming the tree. **Absent is UNDECLARED**
-    — a tri-state, neither "accepts everything" nor "accepts nothing": the
-    hub's gate has no teeth on a slot that declares nothing and falls back to
-    the image-wide decoder census. An empty mapping or an empty tuple is a
-    decoration-time error, because collapsing the tri-state is a fail-open
-    defect.
+    match nothing is a build error naming the tree. An empty mapping or an
+    empty tuple is a decoration-time error, because collapsing the tri-state
+    is a fail-open defect.
+
+    **A19 (Paul, 2026-08-15): the declaration is MANDATORY.** Absence used to
+    be the UNDECLARED tri-state; measured fleet-wide it was only ever the
+    default, so "no opinion" and "nobody wrote the line" were one state.
+    Discovery now REFUSES a model slot carrying neither ``layouts=`` nor
+    ``layouts_undeclarable=`` — see :func:`gen_worker.models.
+    tensor_layout_contract.undeclared_slot_refusal`. The refusal is at
+    discovery/publish, not here: a bare ``Slot(...)`` remains constructible
+    in-process, and it is the IMAGE that may not ship undeclared.
+
+    ``layouts_undeclarable`` is the explicit third rung, and it is a
+    declaration rather than a default: a REASON string, refused when blank,
+    mutually exclusive with ``layouts=``. It exists for slots whose bytes no
+    registered handle names — a tokenizer tree with no tensors, a GGUF quant
+    axis (th#1809 T3), a compressed-tensors checkpoint with no descriptor.
+    Inventing a handle for those is the failure mode, not the fix.
 
     This lives on ``Slot`` and NOT on ``Compile``: ``Compile``'s fields feed
     ``contract_axes()``, a cell-key input, and §1.33 point 5 is that
     conversion is upstream of compute and invisible to cell identity. A
     layout declaration there would either re-key every cell in the fleet or
     sit inside the key struct while deliberately not participating.
+
+    ``layout_requirements`` is the REQUIREMENTS axis (Paul, 2026-08-15): what
+    EXECUTING a declared contract needs of the machine, keyed by the handle it
+    guards. Dual form — the compact ``"sm100+"`` or the structured
+    ``LayoutRequirements(min_sm=100)``::
+
+        Slot(QwenImagePipeline, selected_by="model",
+             layouts={"*": (CONTRACT_PLAIN_BF16, CONTRACT_COZY_SVDQ_NVFP4_LR8)},
+             layout_requirements={CONTRACT_COZY_SVDQ_NVFP4_LR8: "sm100+"})
+
+    A handle names bytes at rest; the floor its kernels need is an EXECUTION
+    fact, which is why it lives here and not on the artifact contract — the
+    same placement, and the same name, as tensorhub's
+    ``contractspec.DecodeEntry.MinSM``, which is the field it feeds. It is per
+    (slot, handle) because one contract has different floors in different
+    code: ``cozy.fp8-rowwise@1`` is sm89 per-tensor and sm90 rowwise.
+
+    NO DEFAULTS, as everywhere else on this surface: a declared requirement is
+    checked, an undeclared one is not evaluated. A key naming a handle
+    ``layouts=`` does not accept is a refusal — a requirement guarding nothing
+    is never checked. Kernel and torch-version requirements are named in the
+    ruling and deliberately NOT built; the compact grammar is a comma-separated
+    term list so they can be added without re-spelling a declaration, and an
+    unknown term is refused rather than ignored.
 
     ``optional`` is DERIVED, never passed: a slot is optional exactly when
     its ``setup()`` parameter carries a default (``edit: Pipe | None =
@@ -167,7 +210,7 @@ class Slot(Generic[D]):
 
     __slots__ = (
         "pipeline_cls", "selected_by", "family", "default_checkpoint", "root",
-        "optional", "layouts",
+        "optional", "layouts", "layouts_undeclarable", "layout_requirements",
     )
 
     def __init__(
@@ -179,6 +222,8 @@ class Slot(Generic[D]):
         default_checkpoint: Optional[ModelRef] = None,
         root: bool = False,
         layouts: Optional[Mapping[str, Sequence[str]]] = None,
+        layouts_undeclarable: str = "",
+        layout_requirements: Optional[Mapping[str, Any]] = None,
     ) -> None:
         if not isinstance(pipeline_cls, type):
             raise TypeError(
@@ -196,21 +241,54 @@ class Slot(Generic[D]):
         self.default_checkpoint = default_checkpoint
         self.root = bool(root)
         self.optional = False  # derived at decoration from setup()'s default
-        # None is UNDECLARED and stays None; anything else normalizes now, at
-        # the declaration site, so the traceback names the Slot the author
-        # wrote rather than a manifest key.
+        where = f"Slot({pipeline_cls.__name__})"
+        if layouts is not None and str(layouts_undeclarable or "").strip():
+            raise LayoutDeclarationError(
+                f"{where}: layouts= and layouts_undeclarable= are mutually "
+                "exclusive — a slot either names the contracts it consumes or "
+                "says why none is nameable, never both."
+            )
+        # None is UNDECLARED at construction and stays None; discovery is what
+        # refuses it (A19). Anything else normalizes now, at the declaration
+        # site, so the traceback names the Slot the author wrote rather than a
+        # manifest key.
         self.layouts: Optional[Dict[str, tuple[str, ...]]] = (
             None if layouts is None
-            else normalize_layout_demand(
-                layouts, where=f"Slot({pipeline_cls.__name__})")
+            else normalize_layout_demand(layouts, where=where)
         )
+        # `""` is the parameter's own default — the author passed nothing, and
+        # discovery is what refuses that. Anything else was WRITTEN, so a
+        # whitespace-only reason is a refusal here rather than a silent escape.
+        self.layouts_undeclarable: str = (
+            "" if layouts_undeclarable == ""
+            else normalize_layout_undeclarable(
+                layouts_undeclarable, where=where)
+        )
+        # The REQUIREMENTS axis, keyed by the handle it guards. Declared
+        # against the accepted SET, so a requirement can never guard a
+        # contract this slot does not consume.
+        if layout_requirements is None:
+            self.layout_requirements: Dict[str, LayoutRequirements] = {}
+        elif self.layouts is None:
+            raise LayoutDeclarationError(
+                f"{where}: layout_requirements= without layouts=. A "
+                "requirement guards a declared contract; there is none here "
+                "to guard."
+            )
+        else:
+            self.layout_requirements = normalize_layout_requirements(
+                layout_requirements, where=where,
+                accepted={h for hs in self.layouts.values() for h in hs},
+            )
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return (
             f"Slot({self.pipeline_cls.__name__}, selected_by={self.selected_by!r}, "
             f"family={self.family!r}, default_checkpoint={self.default_checkpoint!r}, "
             f"root={self.root!r}, optional={self.optional!r}, "
-            f"layouts={self.layouts!r})"
+            f"layouts={self.layouts!r}, "
+            f"layouts_undeclarable={self.layouts_undeclarable!r}, "
+            f"layout_requirements={self.layout_requirements!r})"
         )
 
 

--- a/src/gen_worker/discovery/__init__.py
+++ b/src/gen_worker/discovery/__init__.py
@@ -5,6 +5,8 @@ from .names import slugify_name
 from .project import ProjectConfig, load_project_config
 from .validation import (
     EndpointLockValidationResult,
+    refuse_undeclared_slot_layouts,
+    undeclared_slot_layouts,
     validate_endpoint_lock,
 )
 from .walk import EndpointImportError
@@ -18,5 +20,7 @@ __all__ = [
     "ProjectConfig",
     "load_project_config",
     "EndpointLockValidationResult",
+    "refuse_undeclared_slot_layouts",
+    "undeclared_slot_layouts",
     "validate_endpoint_lock",
 ]

--- a/src/gen_worker/discovery/__init__.py
+++ b/src/gen_worker/discovery/__init__.py
@@ -6,7 +6,6 @@ from .project import ProjectConfig, load_project_config
 from .validation import (
     EndpointLockValidationResult,
     refuse_undeclared_slot_layouts,
-    undeclared_slot_layouts,
     validate_endpoint_lock,
 )
 from .walk import EndpointImportError
@@ -21,6 +20,5 @@ __all__ = [
     "load_project_config",
     "EndpointLockValidationResult",
     "refuse_undeclared_slot_layouts",
-    "undeclared_slot_layouts",
     "validate_endpoint_lock",
 ]

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -447,15 +447,28 @@ def _slot_to_manifest(
             {"name": part, "kind": kind}
             for part, kind in sorted(components.items())
         ]
-    # The per-component DEMAND. Absent means UNDECLARED — the hub's gate falls
-    # back to the image-wide decoder census for this slot, and never reads
-    # absence as "accepts everything". Handles only: the hub resolves each to
-    # its descriptor DIGEST at ingest, against its own registry, which is the
-    # only moment one wheel and one hub are both pinned.
+    # The per-component DEMAND. Handles only: the hub resolves each to its
+    # descriptor DIGEST at ingest, against its own registry, which is the only
+    # moment one wheel and one hub are both pinned. Absence is no longer a
+    # state an image can ship — `validate_endpoint_lock` refuses it (A19).
     if slot.layouts:
         out["layouts"] = {
             path: list(handles) for path, handles in slot.layouts.items()
         }
+    # The explicit third rung: this slot's bytes have no registered handle,
+    # and the REASON travels rather than being lost to an absent key.
+    if getattr(slot, "layouts_undeclarable", ""):
+        out["layouts_undeclarable"] = slot.layouts_undeclarable
+    # The REQUIREMENTS axis, keyed by the handle it guards. Only DECLARED
+    # axes are emitted: an undeclared floor must not arrive at the hub as a
+    # zero, which `contractspec.DecodeEntry.MinSM` reads as "no floor".
+    requirements = {
+        handle: row.manifest_row()
+        for handle, row in (getattr(slot, "layout_requirements", None) or {}).items()
+        if row.declared()
+    }
+    if requirements:
+        out["layout_requirements"] = requirements
     return out
 
 

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -106,6 +106,7 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
             )
         slugs[slug] = py_name
 
+    _check_slot_layout_declarations(lock_dict, errors)
     _check_aot_preconditions(lock_dict, errors, warnings)
 
     return EndpointLockValidationResult(
@@ -113,6 +114,53 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
         errors=tuple(errors),
         warnings=tuple(warnings),
     )
+
+
+def undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> List[str]:
+    """A19 — the model slots in this manifest that declare no consumed
+    tensor-layout contract, each already rendered as its own refusal.
+
+    There is no default and no exemption list: every entry of a function's
+    ``models={}`` is a model slot by construction, so "non-model slots are
+    exempt" needs no test — they are not slots. A slot whose bytes no
+    registered handle names says so with ``layouts_undeclarable="<reason>"``,
+    and the reason travels on the manifest.
+    """
+    from ..models.tensor_layout_contract import undeclared_slot_refusal
+
+    out: List[str] = []
+    functions = lock_dict.get("functions") if isinstance(lock_dict, dict) else None
+    for fn in functions or ():
+        if not isinstance(fn, dict):
+            continue
+        fn_label = str(fn.get("name") or fn.get("python_name") or "<function>")
+        for slot in fn.get("slots") or ():
+            if not isinstance(slot, dict):
+                continue
+            if slot.get("layouts"):
+                continue
+            if str(slot.get("layouts_undeclarable") or "").strip():
+                continue
+            out.append(undeclared_slot_refusal(
+                function=fn_label, slot=str(slot.get("name") or "<slot>")))
+    return out
+
+
+def refuse_undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> None:
+    """:func:`undeclared_slot_layouts` as the typed refusal, for callers that
+    want the exception rather than a build-error list."""
+    from ..models.tensor_layout_contract import UndeclaredSlotLayoutError
+
+    found = undeclared_slot_layouts(lock_dict)
+    if found:
+        raise UndeclaredSlotLayoutError("\n\n".join(found))
+
+
+def _check_slot_layout_declarations(
+    lock_dict: Dict[str, Any], errors: List[str],
+) -> None:
+    """The same refusal as build errors, so one run names every offender."""
+    errors.extend(undeclared_slot_layouts(lock_dict))
 
 
 def _check_aot_preconditions(

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -116,7 +116,7 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
     )
 
 
-def undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> List[str]:
+def _undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> List[str]:
     """A19 — the model slots in this manifest that declare no consumed
     tensor-layout contract, each already rendered as its own refusal.
 
@@ -147,11 +147,12 @@ def undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> List[str]:
 
 
 def refuse_undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> None:
-    """:func:`undeclared_slot_layouts` as the typed refusal, for callers that
-    want the exception rather than a build-error list."""
+    """A19's refusal, typed. Every offender in ONE exception rather than one
+    per build — an author fixing them one image build at a time is why nobody
+    fixed them."""
     from ..models.tensor_layout_contract import UndeclaredSlotLayoutError
 
-    found = undeclared_slot_layouts(lock_dict)
+    found = _undeclared_slot_layouts(lock_dict)
     if found:
         raise UndeclaredSlotLayoutError("\n\n".join(found))
 
@@ -159,8 +160,14 @@ def refuse_undeclared_slot_layouts(lock_dict: Dict[str, Any]) -> None:
 def _check_slot_layout_declarations(
     lock_dict: Dict[str, Any], errors: List[str],
 ) -> None:
-    """The same refusal as build errors, so one run names every offender."""
-    errors.extend(undeclared_slot_layouts(lock_dict))
+    """The typed refusal, as a build error beside the others, so one run
+    surfaces it with everything else the manifest gets wrong."""
+    from ..models.tensor_layout_contract import UndeclaredSlotLayoutError
+
+    try:
+        refuse_undeclared_slot_layouts(lock_dict)
+    except UndeclaredSlotLayoutError as exc:
+        errors.append(str(exc))
 
 
 def _check_aot_preconditions(

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -637,3 +637,233 @@ def _axis_member(text: str, *, axis: str, where: str) -> str | None:
             "internal/tensorlayout with a descriptor and a probe set before "
             f"anything may name it. Known: {', '.join(known_contracts(axis))}")
     return value
+
+
+# ── A19: the declaration is MANDATORY, and absence is not the tri-state ──────
+#
+# `layouts=None` used to mean UNDECLARED — a legitimate third rung that made
+# the hub's gate fall back to the image-wide decoder census. Measured
+# fleet-wide, that rung was not a considered choice anywhere: it was the
+# default, so "this slot has no opinion" and "nobody wrote the line" were one
+# state and no refusal could tell them apart.
+#
+# A19 (Paul, 2026-08-15) cuts the default away. A model slot states what it
+# consumes, or it states — with a reason — that no registered handle describes
+# its bytes. Both are DECLARATIONS. What no longer exists is silence.
+#
+# The escape is not a loophole and not a default: it carries a reason string,
+# it is refused when blank, and it is mutually exclusive with `layouts=`. It
+# exists because real slots hold bytes the registry genuinely does not name —
+# a tokenizer tree with no tensors at all, a GGUF quant axis th#1809 T3 has
+# not registered, a vLLM compressed-tensors checkpoint with no descriptor.
+# Inventing a handle for those would be the failure mode, not the fix.
+
+class UndeclaredSlotLayoutError(LayoutDeclarationError):
+    """A model slot that declares neither a consumed contract nor a reason."""
+
+
+def normalize_layout_undeclarable(reason: object, *, where: str) -> str:
+    """`Slot(layouts_undeclarable=...)` -> the reason, or a refusal."""
+    if not isinstance(reason, str):
+        raise LayoutDeclarationError(
+            f"{where}: layouts_undeclarable= must be a string reason, got "
+            f"{type(reason).__name__}")
+    text = reason.strip()
+    if not text:
+        raise LayoutDeclarationError(
+            f"{where}: layouts_undeclarable= needs a REASON. An empty escape "
+            "is the silence A19 removed — say which bytes this slot holds and "
+            "why no registered handle names them.")
+    return text
+
+
+def undeclared_slot_refusal(*, function: str, slot: str) -> str:
+    """The one sentence both the SDK and the manifest gate speak."""
+    return (
+        f"function {function!r}: model slot {slot!r} declares no consumed "
+        "tensor-layout contract. Every model slot states what its code can "
+        "execute — A19 is a hard cut, so ABSENT is a refusal, never the "
+        "UNDECLARED tri-state:\n"
+        f"    Slot(Pipe, layouts={{\"*\": (\"{CONTRACT_PLAIN_BF16}\",)}})\n"
+        f"Registered quant handles: {', '.join(KNOWN_CONTRACTS)}.\n"
+        "If no registered handle names this slot's bytes (a tokenizer tree "
+        "with no tensors, a GGUF quant axis, a compressed-tensors checkpoint), "
+        "declare that explicitly and say why:\n"
+        "    Slot(Pipe, layouts_undeclarable=\"gguf: the quant axis has no "
+        "registered handle (th#1809 T3)\")"
+    )
+
+
+# ── The REQUIREMENTS axis (Paul, 2026-08-15) ────────────────────────────────
+#
+# "Certain contracts can only be executed efficiently if their
+# hardware-requirements are met... other requirements might be kernels or torch
+# versions."
+#
+# A contract handle describes BYTES AT REST. Executing those bytes is a
+# separate fact, and it belongs to the code that executes them rather than to
+# the artifact — which is exactly where tensorhub already put it:
+# `contractspec.DecodeEntry.MinSM`, "the card floor this loader's kernels
+# need. 0 = no floor. It is an EXECUTION fact and lives here rather than on the
+# artifact contract, which describes bytes at rest only." So this axis speaks
+# that field's name and semantics verbatim; it does not invent a second
+# vocabulary for one fact.
+#
+# The requirement is PER (slot, handle), not per handle globally: one contract
+# has different floors in different code. `cozy.fp8-rowwise@1` is sm89 through
+# `_scaled_mm` per-tensor and sm90 rowwise (`models/w8a8.py`), and the 4-bit
+# contracts need sm100 (`models/w4a4.py: W4A4_MIN_SM = 100`). A global table
+# would have to pick one and be wrong for the other.
+#
+# NO DEFAULTS, and the same rule as every other axis: a declared requirement is
+# checked, an undeclared one is not evaluated at all. `0`/absent is not "no
+# floor asserted by the author" dressed as "runs anywhere" — it is the axis
+# nobody answered.
+#
+# EXTENSIBLE, NOT BUILT: the compact grammar is a comma-separated term list so
+# a kernel or torch-version term can be added without re-spelling every
+# declaration. Only the compute-capability term exists today, and an unknown
+# term is REFUSED by name rather than ignored — an ignored requirement is a
+# requirement that silently does not hold.
+
+#: The requirement terms this SDK understands. Growing this tuple is the whole
+#: cost of adding an axis; nothing else parses a term.
+KNOWN_REQUIREMENT_TERMS: tuple[str, ...] = ("min_sm",)
+
+_SM_TERM_RE = re.compile(r"^sm([1-9][0-9]{1,2})\+$")
+
+
+class LayoutRequirements(msgspec.Struct, frozen=True, kw_only=True):
+    """What EXECUTING one declared contract needs of the machine.
+
+    ``min_sm`` is the compute-capability floor, in tensorhub's own
+    two-or-three digit spelling (``sm_89`` -> 89, ``sm_100`` -> 100), and is
+    the value `contractspec.DecodeEntry.MinSM` compares a card against. ``0``
+    means the axis was not declared and is therefore not evaluated.
+    """
+
+    min_sm: int = 0
+
+    def declared(self) -> bool:
+        return self.min_sm > 0
+
+    def render(self) -> str:
+        """The compact spelling, so one requirement has one text form."""
+        return f"sm{self.min_sm}+" if self.min_sm else ""
+
+    def manifest_row(self) -> dict[str, int]:
+        """Only DECLARED axes reach the manifest — an undeclared axis must not
+        arrive at the hub as a zero it could read as a floor of none."""
+        return {"min_sm": self.min_sm} if self.min_sm else {}
+
+
+def _min_sm_value(value: object, *, where: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise LayoutDeclarationError(
+            f"{where}: min_sm must be an int compute-capability code "
+            f"(89, 90, 100, ...), got {type(value).__name__}")
+    if value <= 0 or value > 999:
+        raise LayoutDeclarationError(
+            f"{where}: min_sm={value} is not a compute-capability code. Use "
+            "tensorhub's spelling — sm_89 is 89, sm_100 is 100. There is no "
+            "'no floor' value: omit the requirement instead, which leaves the "
+            "axis UNDECLARED and unevaluated.")
+    return value
+
+
+def parse_layout_requirements(
+    value: object, *, where: str,
+) -> LayoutRequirements:
+    """Dual form: the compact term list, or the structured object.
+
+    ``"sm100+"`` and ``LayoutRequirements(min_sm=100)`` are the same
+    declaration; the compact form is what an author writes and what
+    :meth:`LayoutRequirements.render` produces, so a round trip is stable.
+    """
+    if isinstance(value, LayoutRequirements):
+        if not value.declared():
+            raise LayoutDeclarationError(
+                f"{where}: LayoutRequirements() declares no axis. A "
+                "requirement that requires nothing is not a declaration — "
+                "omit the entry.")
+        return LayoutRequirements(min_sm=_min_sm_value(
+            value.min_sm, where=where))
+    if isinstance(value, dict):
+        unknown = sorted(set(value) - set(KNOWN_REQUIREMENT_TERMS))
+        if unknown:
+            raise LayoutDeclarationError(
+                f"{where}: unknown requirement term(s) {unknown}. This SDK "
+                f"understands {list(KNOWN_REQUIREMENT_TERMS)}; kernel and "
+                "torch-version requirements are named in the ruling but not "
+                "built, and an ignored requirement is one that silently does "
+                "not hold.")
+        if "min_sm" not in value:
+            raise LayoutDeclarationError(
+                f"{where}: requirement mapping declares no axis; omit the "
+                "entry rather than declaring an empty one.")
+        return LayoutRequirements(
+            min_sm=_min_sm_value(value["min_sm"], where=where))
+    if not isinstance(value, str):
+        raise LayoutDeclarationError(
+            f"{where}: a requirement is the compact form 'sm100+', a "
+            f"LayoutRequirements, or a mapping — got {type(value).__name__}")
+    terms = [t.strip() for t in value.split(",")]
+    if not any(terms) or any(not t for t in terms):
+        raise LayoutDeclarationError(
+            f"{where}: {value!r} is not a requirement. The compact form is a "
+            "comma-separated term list, e.g. 'sm100+'.")
+    min_sm = 0
+    for term in terms:
+        match = _SM_TERM_RE.match(term)
+        if match is None:
+            raise LayoutDeclarationError(
+                f"{where}: unknown requirement term {term!r}. The only term "
+                "this SDK understands is the compute-capability floor "
+                "('sm89+', 'sm90+', 'sm100+'); kernel and torch-version "
+                "requirements are named in the ruling but not built, and an "
+                "ignored requirement is one that silently does not hold.")
+        if min_sm:
+            raise LayoutDeclarationError(
+                f"{where}: {value!r} states the compute-capability floor "
+                "twice")
+        min_sm = _min_sm_value(int(match.group(1)), where=where)
+    return LayoutRequirements(min_sm=min_sm)
+
+
+def normalize_layout_requirements(
+    requirements: object, *, where: str, accepted: Iterable[str],
+) -> dict[str, LayoutRequirements]:
+    """`Slot(layout_requirements=...)` -> `{handle: LayoutRequirements}`.
+
+    Keyed by HANDLE, not by component path: the floor is a property of the
+    code that decodes that contract, and the same decoder serves every
+    component the slot accepts it for.
+
+    A key naming a handle this slot does not accept is a REFUSAL rather than a
+    dead entry — it is a requirement guarding nothing, and the shapes that
+    guard nothing are the ones this whole row exists to remove.
+    """
+    if not isinstance(requirements, dict):
+        raise LayoutDeclarationError(
+            f"{where}: layout_requirements= must be a mapping of contract "
+            f"handle -> requirement, got {type(requirements).__name__}")
+    if not requirements:
+        raise LayoutDeclarationError(
+            f"{where}: layout_requirements={{}} declares nothing. Omit it to "
+            "leave every axis UNDECLARED; an empty mapping is not a statement "
+            "that this slot's contracts run anywhere.")
+    accepted_set = set(accepted)
+    out: dict[str, LayoutRequirements] = {}
+    for raw_handle, raw_value in requirements.items():
+        handle = validate_layout_handle(
+            raw_handle, where=f"{where}: layout_requirements")
+        if handle not in accepted_set:
+            raise LayoutDeclarationError(
+                f"{where}: layout_requirements[{handle!r}] guards a contract "
+                f"this slot does not accept. Its declared set is "
+                f"{sorted(accepted_set)} — add the handle to layouts= or drop "
+                "the requirement; a requirement over nothing is never checked."
+            )
+        out[handle] = parse_layout_requirements(
+            raw_value, where=f"{where}: layout_requirements[{handle!r}]")
+    return out

--- a/tests/test_mint_preconditions_pgw996.py
+++ b/tests/test_mint_preconditions_pgw996.py
@@ -72,7 +72,9 @@ _MAIN = """
             return {{}}
 
     @endpoint(
-        models={{"pipeline": Slot(Pipe, selected_by="model")}},
+        models={{"pipeline": Slot(
+            Pipe, selected_by="model",
+            layouts={{"*": ("plain.bf16@1",)}})}},
         resources=Resources(gpu=True),
         compile=Compile(family="ep996", shapes=((1024, 1024),), text_len=77),
         lora_bucket={bucket},

--- a/tests/test_slot_layout_required_pgw1282.py
+++ b/tests/test_slot_layout_required_pgw1282.py
@@ -1,0 +1,353 @@
+"""pgw#1282 (HARDCUT A19) — a model slot that declares no consumed
+tensor-layout contract does not ship.
+
+Master publishes it SILENTLY: `layouts=` was optional, absence was the
+UNDECLARED tri-state, and the hub's gate then fell back to the image-wide
+decoder census. Measured fleet-wide, absence was never a considered choice —
+it was the default. These tests drive the REAL discovery entry point the
+Dockerfile runs (`discover_manifest` + `validate_endpoint_lock`), so the
+refusal is a property of the built image, not of a unit seam.
+"""
+
+from __future__ import annotations
+
+import itertools
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gen_worker.discovery import (
+    refuse_undeclared_slot_layouts,
+    undeclared_slot_layouts,
+    validate_endpoint_lock,
+)
+from gen_worker.models.tensor_layout_contract import (
+    LayoutDeclarationError,
+    LayoutRequirements,
+    UndeclaredSlotLayoutError,
+    parse_layout_id,
+    parse_layout_requirements,
+    validate_layout_handle,
+)
+
+# The DECLARED demand this fixture states, and the one a hub-side variant of
+# the same family derives. `plain.bf16@1` is the handle every dense
+# safetensors tree in the fleet derives to (th#1937), which is why the
+# fixture's declaration and a live variant's derived contract are comparable
+# at all — one vocabulary, two sides.
+DECLARED = ("cozy.fp8-rowwise@1", "plain.bf16@1")
+
+
+def _endpoint_tree(tmp_path: Path, slot_kwargs: str, pkg: str) -> Path:
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent(f"""
+        [project]
+        name = "{pkg}"
+
+        [tool.gen_worker]
+        main = "{pkg}.main"
+    """))
+    src = tmp_path / pkg
+    src.mkdir()
+    (src / "__init__.py").write_text("")
+    (src / "main.py").write_text(textwrap.dedent(f"""
+        import msgspec
+        from gen_worker import RequestContext, Resources, Slot, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str = ""
+
+        class Pipe:
+            pass
+
+        @endpoint(
+            models={{"pipeline": Slot(Pipe{slot_kwargs})}},
+            resources=Resources(gpu_count=1),
+        )
+        class Gen:
+            def setup(self, pipeline: Pipe) -> None:
+                self.pipeline = pipeline
+
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_()
+    """))
+    return tmp_path
+
+
+_NEXT_PKG = itertools.count()
+
+
+def _manifest(tmp_path: Path, slot_kwargs: str,
+              monkeypatch: pytest.MonkeyPatch) -> dict:
+    """One fresh package name per call — the interpreter caches an imported
+    endpoint module, so reusing one name would hand the second fixture the
+    first fixture's slots and quietly assert nothing."""
+    from gen_worker.discovery.discover import discover_manifest
+
+    pkg = f"ep1282_{next(_NEXT_PKG)}"
+    root = _endpoint_tree(tmp_path, slot_kwargs, pkg)
+    monkeypatch.syspath_prepend(str(root))
+    return discover_manifest(root)
+
+
+def _slot(manifest: dict) -> dict:
+    return manifest["functions"][0]["slots"][0]
+
+
+# ---------------------------------------------------------------------------
+# 1. RED on master: an undeclared model slot publishes silently
+# ---------------------------------------------------------------------------
+
+
+def test_an_undeclared_model_slot_refuses_at_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(tmp_path, "", monkeypatch)
+
+    # The emission is honest — there is no invented default on the manifest.
+    assert "layouts" not in _slot(manifest)
+    assert "layouts_undeclarable" not in _slot(manifest)
+
+    # And the build refuses it. This is the assertion that is RED on master,
+    # where `validate_endpoint_lock` reported ok on exactly this manifest.
+    result = validate_endpoint_lock(manifest)
+    assert not result.ok
+    joined = "\n".join(result.errors)
+    assert "'pipeline'" in joined            # the slot, by name
+    assert "'generate'" in joined            # the function, by name
+    assert 'layouts={"*": ("plain.bf16@1",)}' in joined   # the syntax
+    assert "layouts_undeclarable=" in joined              # and the escape
+
+    with pytest.raises(UndeclaredSlotLayoutError) as excinfo:
+        refuse_undeclared_slot_layouts(manifest)
+    assert "pipeline" in str(excinfo.value)
+
+
+def test_every_offender_is_named_in_one_run() -> None:
+    """A build names every undeclared slot at once — an author fixing them
+    one refusal per image build is the reason nobody fixed them."""
+    manifest = {"functions": [
+        {"name": "generate", "slots": [{"name": "pipeline"},
+                                       {"name": "refiner"}]},
+        {"name": "edit", "slots": [{"name": "pipeline"}]},
+    ]}
+    found = undeclared_slot_layouts(manifest)
+    assert len(found) == 3
+    assert sum("'refiner'" in f for f in found) == 1
+    assert sum("'edit'" in f for f in found) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. a declared contract travels into the manifest VERBATIM
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_contract_travels_verbatim_and_parses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(
+        tmp_path,
+        ', layouts={"*": ("plain.bf16@1", "cozy.fp8-rowwise@1")}',
+        monkeypatch)
+
+    slot = _slot(manifest)
+    # CANONICAL order, not as written: the set is a filter and its order
+    # carries no preference, so two spellings of one set emit one manifest.
+    assert slot["layouts"] == {"*": list(DECLARED)}
+
+    validate_endpoint_lock(manifest)
+    assert validate_endpoint_lock(manifest).ok
+
+    # The emitted handles parse under the SHARED vocabulary — the same
+    # grammar tensorhub's contractspec speaks, and the same one a live
+    # variant's DERIVED contract is expressed in. A handle that only this
+    # side could read would make the two sides incomparable.
+    for handle in slot["layouts"]["*"]:
+        assert validate_layout_handle(handle, where="pgw1282") == handle
+        assert parse_layout_id(handle, where="pgw1282").quant == handle
+
+    # And the declared set MEETS a live variant's derived contract: every
+    # dense safetensors checkpoint in the catalog derives `plain.bf16@1`
+    # (th#1937), so this endpoint can serve at least one variant of its own
+    # repo rather than declaring a set nothing satisfies.
+    derived_of_a_live_variant = "plain.bf16@1"
+    assert derived_of_a_live_variant in slot["layouts"]["*"]
+
+
+def test_partial_declaration_checks_only_its_declared_axes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per the tensor-layout ruling: partial declaration = partial checking.
+
+    A slot naming ONE component key states nothing about the others, and
+    discovery adds no whole-tree default to cover them. ABSENT is what A19
+    refuses; PARTIAL is legal and stays exactly as narrow as it was written.
+    """
+    manifest = _manifest(
+        tmp_path, ', layouts={"*": ("plain.bf16@1",)}', monkeypatch)
+    assert _slot(manifest)["layouts"] == {"*": ["plain.bf16@1"]}
+    assert validate_endpoint_lock(manifest).ok
+
+
+# ---------------------------------------------------------------------------
+# 3. the explicit third rung — declared UNDECLARABLE, with a reason
+# ---------------------------------------------------------------------------
+
+
+def test_undeclarable_carries_its_reason_onto_the_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reason = "gguf: the quant axis has no registered handle (th#1809 T3)"
+    manifest = _manifest(
+        tmp_path, f', layouts_undeclarable="{reason}"', monkeypatch)
+
+    slot = _slot(manifest)
+    assert slot["layouts_undeclarable"] == reason
+    assert "layouts" not in slot
+    assert validate_endpoint_lock(manifest).ok
+    assert undeclared_slot_layouts(manifest) == []
+
+
+def test_the_escape_is_a_declaration_and_not_a_default() -> None:
+    from gen_worker import Slot
+
+    class Pipe:
+        pass
+
+    # A reason that was WRITTEN and says nothing is the silence A19 removed.
+    # `""` is the parameter default — not written at all, and refused by
+    # discovery instead, with the syntax in the message.
+    for blank in ("   ", "\n", "\t "):
+        with pytest.raises(LayoutDeclarationError, match="needs a REASON"):
+            Slot(Pipe, layouts_undeclarable=blank)
+    assert Slot(Pipe, layouts_undeclarable="").layouts_undeclarable == ""
+
+    # and it cannot be worn alongside a real declaration
+    with pytest.raises(LayoutDeclarationError, match="mutually exclusive"):
+        Slot(Pipe, layouts={"*": ("plain.bf16@1",)},
+             layouts_undeclarable="because")
+
+    assert Slot(Pipe, layouts_undeclarable=" why  ").layouts_undeclarable == "why"
+
+
+# ---------------------------------------------------------------------------
+# 4. the same refusal at PR time — the AST fence an endpoint repo runs
+# ---------------------------------------------------------------------------
+
+
+def _run_lint(target: Path) -> subprocess.CompletedProcess:
+    repo = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, str(repo / "scripts" / "lint_layout_declarations.py"),
+         str(target)],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+def test_the_fence_refuses_an_undeclared_slot_in_source(tmp_path: Path) -> None:
+    """Discovery refuses at image build; this refuses in the diff, which is
+    where a layout demand is actually judged. An endpoint repo runs the same
+    script against its own tree."""
+    module = tmp_path / "bare.py"
+    module.write_text('x = Slot(Pipe, selected_by="model")\n', encoding="utf-8")
+    result = _run_lint(module)
+    assert result.returncode == 1
+    assert "declares no consumed tensor-layout contract" in result.stderr
+    assert 'layouts={"*": ("plain.bf16@1",)}' in result.stderr
+
+
+def test_the_fence_wants_a_literal_reason_on_the_escape(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.py"
+    empty.write_text('x = Slot(Pipe, layouts_undeclarable="")\n', encoding="utf-8")
+    assert _run_lint(empty).returncode == 1
+
+    computed = tmp_path / "computed.py"
+    computed.write_text(
+        'x = Slot(Pipe, layouts_undeclarable=REASON)\n', encoding="utf-8")
+    assert _run_lint(computed).returncode == 1
+
+    good = tmp_path / "good.py"
+    good.write_text(
+        'x = Slot(Pipe, layouts_undeclarable="gguf: the quant axis has no '
+        'registered handle (th#1809 T3)")\n', encoding="utf-8")
+    assert _run_lint(good).returncode == 0, _run_lint(good).stderr
+
+
+# ---------------------------------------------------------------------------
+# 5. the REQUIREMENTS axis (Paul, 2026-08-15)
+# ---------------------------------------------------------------------------
+
+
+def test_the_two_forms_of_a_requirement_are_one_declaration() -> None:
+    """Dual form, per the standing input ruling: the compact string an author
+    writes and the structured object are the same value, and `render()` puts
+    the compact form back so a round trip is stable."""
+    compact = parse_layout_requirements("sm100+", where="t")
+    structured = parse_layout_requirements(
+        LayoutRequirements(min_sm=100), where="t")
+    mapping = parse_layout_requirements({"min_sm": 100}, where="t")
+    assert compact == structured == mapping
+    assert compact.render() == "sm100+"
+    assert parse_layout_requirements(compact.render(), where="t") == compact
+
+
+def test_an_unbuilt_requirement_term_is_refused_not_ignored() -> None:
+    """Kernel and torch-version requirements are named in the ruling and NOT
+    built. An ignored one is a requirement that silently does not hold, so
+    the grammar refuses it by name and stays extensible for when it exists."""
+    for term in ("torch>=2.13", "kernels", "sm100", "sm_100+", ""):
+        with pytest.raises(LayoutDeclarationError):
+            parse_layout_requirements(term, where="t")
+    with pytest.raises(LayoutDeclarationError, match="unknown requirement"):
+        parse_layout_requirements({"min_torch": "2.13"}, where="t")
+    # and there is no "no floor" value — absence is the undeclared axis
+    for bad in (0, -1, True, "  "):
+        with pytest.raises(LayoutDeclarationError):
+            parse_layout_requirements({"min_sm": bad}, where="t")
+
+
+def test_a_requirement_guarding_nothing_is_refused() -> None:
+    from gen_worker import Slot
+
+    class Pipe:
+        pass
+
+    with pytest.raises(LayoutDeclarationError, match="does not accept"):
+        Slot(Pipe, layouts={"*": ("plain.bf16@1",)},
+             layout_requirements={"cozy.svdq-nvfp4-lr8@1": "sm100+"})
+    with pytest.raises(LayoutDeclarationError, match="without layouts"):
+        Slot(Pipe, layout_requirements={"plain.bf16@1": "sm90+"})
+    with pytest.raises(LayoutDeclarationError, match="declares nothing"):
+        Slot(Pipe, layouts={"*": ("plain.bf16@1",)}, layout_requirements={})
+
+
+def test_a_declared_requirement_travels_and_an_undeclared_one_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial checking, on this axis too: the guarded handle carries its
+    floor onto the manifest and the unguarded one carries NO key — never a
+    zero, which `contractspec.DecodeEntry.MinSM` reads as 'no floor'."""
+    manifest = _manifest(
+        tmp_path,
+        ', layouts={"*": ("plain.bf16@1", "cozy.svdq-nvfp4-lr8@1")}'
+        ', layout_requirements={"cozy.svdq-nvfp4-lr8@1": "sm100+"}',
+        monkeypatch)
+
+    slot = _slot(manifest)
+    assert slot["layout_requirements"] == {
+        "cozy.svdq-nvfp4-lr8@1": {"min_sm": 100}}
+    assert "plain.bf16@1" not in slot["layout_requirements"]
+    assert validate_endpoint_lock(manifest).ok
+
+
+def test_a_slot_with_no_requirements_emits_no_requirements_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(
+        tmp_path, ', layouts={"*": ("plain.bf16@1",)}', monkeypatch)
+    assert "layout_requirements" not in _slot(manifest)

--- a/tests/test_slot_layout_required_pgw1282.py
+++ b/tests/test_slot_layout_required_pgw1282.py
@@ -21,7 +21,6 @@ import pytest
 
 from gen_worker.discovery import (
     refuse_undeclared_slot_layouts,
-    undeclared_slot_layouts,
     validate_endpoint_lock,
 )
 from gen_worker.models.tensor_layout_contract import (
@@ -136,10 +135,12 @@ def test_every_offender_is_named_in_one_run() -> None:
                                        {"name": "refiner"}]},
         {"name": "edit", "slots": [{"name": "pipeline"}]},
     ]}
-    found = undeclared_slot_layouts(manifest)
-    assert len(found) == 3
-    assert sum("'refiner'" in f for f in found) == 1
-    assert sum("'edit'" in f for f in found) == 1
+    with pytest.raises(UndeclaredSlotLayoutError) as excinfo:
+        refuse_undeclared_slot_layouts(manifest)
+    message = str(excinfo.value)
+    assert message.count("declares no consumed") == 3
+    assert "'refiner'" in message
+    assert "'edit'" in message
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +211,7 @@ def test_undeclarable_carries_its_reason_onto_the_manifest(
     assert slot["layouts_undeclarable"] == reason
     assert "layouts" not in slot
     assert validate_endpoint_lock(manifest).ok
-    assert undeclared_slot_layouts(manifest) == []
+    refuse_undeclared_slot_layouts(manifest)  # does not raise
 
 
 def test_the_escape_is_a_declaration_and_not_a_default() -> None:


### PR DESCRIPTION
Closes the pgw half of HARDCUT checklist row **A19** (Paul, 2026-08-15: *"every endpoint declares its consumed tensor-layout contract — if not they should be"*).

## The state this cuts

The author-declared side was NULL fleet-wide; only DERIVED contracts exist (A12 / th#1994). `Slot(layouts=...)` already existed (pgw#1143) — but it was OPTIONAL, and absence was the UNDECLARED tri-state. Measured fleet-wide, that rung was never a considered choice: it was the default. So *"this slot has no opinion"* and *"nobody wrote the line"* were one state, and no refusal could tell them apart.

## The cut

- **`discover_manifest` + `validate_endpoint_lock` REFUSE** a model slot carrying neither `layouts=` nor the new `layouts_undeclarable=`. That is the entry point the Dockerfile runs, so the refusal is a property of the BUILT IMAGE, not of a unit seam. The message names the function, the slot and the declaration syntax, and one build names **every** offender — an author fixing them one refusal per image build is why nobody fixed them. Typed `UndeclaredSlotLayoutError` for callers that want the exception.
- **Non-model slots are exempt by construction** and need no test: every entry of a function's `models={}` is a model slot. There is no exemption list.
- **`layouts_undeclarable="<reason>"`** is the explicit third rung, and a DECLARATION rather than a default: the reason is required, a blank one is refused where it is written, it is mutually exclusive with `layouts=`, and it TRAVELS onto the manifest so the gap is on the record instead of being lost to an absent key. It exists because real slots hold bytes the registry genuinely does not name — a tokenizer tree with no tensors, a GGUF quant axis th#1809 T3 has not registered, a vLLM compressed-tensors checkpoint with no descriptor. Inventing a handle for those is the failure mode, not the fix.
- **The REQUIREMENTS axis** (Paul, same day: *"certain contracts can only be executed efficiently if their hardware-requirements are met... other requirements might be kernels or torch versions"*): `Slot(layout_requirements={handle: "sm100+"})`. Dual form — the compact term list or `LayoutRequirements(min_sm=100)` — and per **(slot, handle)**, not per handle globally, because one contract has different floors in different code: `cozy.fp8-rowwise@1` is sm89 per-tensor and sm90 rowwise (`models/w8a8.py`), and the 4-bit contracts are sm100 (`models/w4a4.py`). It is named after, and feeds, tensorhub's `contractspec.DecodeEntry.MinSM` — the field that already documents the floor as *"an EXECUTION fact [that] lives here rather than on the artifact contract, which describes bytes at rest only"*. One vocabulary, two sides; the B5 ladder lane (th#1999) reads the same field for rung admission.
  - A key naming a handle `layouts=` does not accept is a REFUSAL — a requirement guarding nothing is never checked.
  - Kernel and torch-version terms are named in the ruling and **not built**. The compact grammar is a comma-separated term list so one can be added without re-spelling a declaration, and an unknown term is refused BY NAME: an ignored requirement is a requirement that silently does not hold.
  - **No defaults, partial checks partially**: a declared requirement is checked, an undeclared one is not evaluated, and there is no "no floor" value to write. Only declared axes reach the manifest — an undeclared floor must never arrive at the hub as a `0`, which `MinSM` reads as "no floor".
- **`scripts/lint_layout_declarations.py`** grows the same refusal as an AST fence, so an endpoint repo sees it in the diff — where a layout demand is actually judged — rather than at image build.
- The eight `micro-diffusion` example endpoints declare theirs: `plain.bf16@1`, and the w8a8 arm also `cozy.fp8-rowwise@1`, which is what `load_w8a8_denoiser` actually reads (`_Fp8ScaledLinear`, `float8_e4m3fn`, per-out-channel scales).

## ⚠️ FINDING, filed not fixed — `contractspec.DecodeEntry.MinSM` has no writer

`contractspec/resolve.go:163` reads it for intersection 4 (card executability) and `spec.go:67` documents it. But `releaseselector.DecodeSetForRelease` (`releaseselector.go:276`) builds **every** entry as `DecodeEntry{Handle, Pattern}` — `MinSM` is 0 on all of them, so that intersection is a fleet-wide no-op. This is the same unarmed-gate shape A19 exists to close, one layer down. Hub-side follow-up: set `MinSM` from the manifest slot's `layout_requirements[handle].min_sm` where the release's decode entry is built, and store `layouts_undeclarable` beside `slot_layout_demand` so an undeclarable slot is legible rather than merely absent.

## Sequencing (deliberate)

The refusal is ON — hard cut, no default, no flag. It lands on `master`, therefore in the **next** wheel (0.118.0), never in 0.117.0. The standing-stack Phase 5 campaign builds against 0.117.0 and is unaffected by construction. Endpoint repos adopt on repin (ie#729).

## Red/green

- **RED-verified**: with `_check_slot_layout_declarations` disarmed, `validate_endpoint_lock` returns `ok=True` on exactly the undeclared manifest — master's behaviour, printed. Rearmed, the same manifest refuses.
- `tests/test_slot_layout_required_pgw1282.py`: 13 tests driving real discovery — the refusal, every-offender-in-one-run, a declared contract travelling VERBATIM and in canonical order and parsing under the shared vocabulary (`validate_layout_handle` / `parse_layout_id`) and meeting a live variant's derived `plain.bf16@1`, partial declaration staying exactly as narrow as written, the escape carrying its reason, the two requirement forms being one declaration, an unbuilt term refused not ignored, a requirement guarding nothing refused, and a declared floor travelling while an undeclared one emits NO key.
- mypy clean (722 files) · ruff clean on changed files · mypy ratchet green · `tests/test_slot_layout_demand_pgw1143.py`, `test_decode_set_pgw1245.py`, `test_mint_preconditions_pgw996.py`, `test_layout_converter_registry_pgw1143.py` green (109 passed); the 462-test slot/discovery/layout/lock/manifest slice green.
- One fixture moved with the cut: `test_mint_preconditions_pgw996.py`'s endpoint template now declares `plain.bf16@1` — the gate firing on a real fixture is the gate working.