### PR TITLE
pgw#888: a dispatch whose pinned compiled graph is gone SERVES, loudly, instead of being refused five times

### DIFF
--- a/changelog.d/pgw888.md
+++ b/changelog.d/pgw888.md
@@ -1,0 +1,28 @@
+- **A dispatch whose pinned compiled graph is gone now SERVES, loudly, instead of being refused
+  five times** (pgw#888). Paul, 2026-08-15: *"a worker should serve-eager if compilation doesn't
+  work. We want our worker to be as robust as possible, although it should loudly report when
+  it's performing in a degraded mode."* The observable, measured on the standing master stack
+  2026-08-02: 11 `request_events` rows reading `request.failed / JOB_STATUS_RETRYABLE /
+  required_compile_missing`, every one terminal at `assignment_attempt_epoch=5` — five retries
+  burned per request across three workers. `_validate_required_compile` folded two different
+  questions into one refusal, and only one of them is about correctness. *Is this the right
+  model?* — incarnation, lane, function, every model binding, and now the execution CONTRACT
+  digest under its own `required_compile_contract_mismatch` token — is identity: there is
+  nothing correct to serve, and it still requeues. *Is the pinned compiled graph still what this
+  pod serves?* — the cell ref/digest half — is SPEED: a cell that de-armed for cause (§4.31),
+  was revoked, or was superseded leaves the pipeline, its weights and its lane exactly as the
+  hub picked them. That half now runs LAST, after every identity fence has passed, and answers
+  the request. The confession is a typed `serve_degrade` event, not a log line a hub-spawned
+  worker exposes to nobody (pgw#760): it carries the degraded mode, the compiled-graph key that
+  was not here, the key the target actually serves, and the request — so the hub banks it in
+  `worker_activity_events` and the republish/re-mint machinery can fix the root cause while
+  users keep getting outputs. The request row is honest about it too: `pinned_cell_unavailable`
+  joins the per-request fallback vocabulary, and it is charged as an EAGER sample only when
+  nothing is armed — a pod serving a *different* cell is degraded but still compiled, and
+  counting it eager is the exact `serving_mode` contamination pgw#764 exists to prevent.
+  **The mandatory-quantized carve-out stands**: on a declared `w8a8`/`w4a4` execution lane the
+  author sanctioned compiled execution and nothing else, so the refusal is kept rather than
+  answered with numerics the endpoint never sanctioned — as is the arm-time
+  `MANDATORY_LANE_NEEDS_A_COMPILED_GRAPH` fail-closed in `fleet_cells` and the missing-pin
+  refusal on those lanes. **Coupled cut:** the public worker-value corpus gains one value, so
+  tensorhub must re-vendor `worker_value_contracts.json` and its digest (PGW lands first).

--- a/src/gen_worker/contracts/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/src/gen_worker/contracts/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-e850b3026d10dd036a28c359d3d66c5b4ff925736b849868c151fc64e7626351
+38c0b3664d4fa5194e539a82031cddf3ad7e400f07860131ca9b35e424459d4f

--- a/src/gen_worker/contracts/worker_value_contracts.json
+++ b/src/gen_worker/contracts/worker_value_contracts.json
@@ -64,7 +64,8 @@
       "guard_miss",
       "ingress_refused",
       "healing",
-      "volatile"
+      "volatile",
+      "pinned_cell_unavailable"
     ],
     "eager_posture_reasons": [
       "arm_pending",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3428,6 +3428,26 @@ class Executor:
         worker-session address, not a durable model identity; vacate/reload,
         mutable-tag republish, or an alias/model mismatch must requeue rather
         than execute on a merely same-family pipeline.
+
+        pgw#888 (Paul, 2026-08-15): *"a worker should serve-eager if
+        compilation doesn't work … although it should loudly report when it's
+        performing in a degraded mode."* So this fence now answers TWO
+        questions that it used to fold into one refusal:
+
+        - **Is this the right model?** — incarnation, lane, function and every
+          model binding. A mismatch is a different object, there is nothing
+          correct to serve, and it still requeues.
+        - **Is the pinned COMPILED GRAPH still what this pod serves?** — the
+          cell ref/digest half. A cell that de-armed for cause (§4.31), was
+          revoked, or was replaced by a newer one is a SPEED fact, not a
+          correctness one: the pipeline, its weights and its lane are exactly
+          what the hub picked. Refusing there is what burned 11 real requests
+          through five retries each. It now serves and confesses.
+
+        The mandatory-quantized carve-out stands: `w8a8`/`w4a4` is a lane the
+        author declared serves only from a cell, so a dispatch that cannot
+        name one is still refused rather than answered with numerics the
+        endpoint never sanctioned.
         """
         setup_slots = self._setup_slots(spec)
         want_execution_lane = self._mandatory_execution_lane_of_bound(
@@ -3479,14 +3499,13 @@ class Executor:
                 "required_compile_function_mismatch: target does not serve "
                 f"{spec.name!r}"
             )
-        if (
-            target_active[0] != identity[1]
-            or target_active[1] != identity[2]
-            or target_active[2] != identity[3]
-        ):
+        if target_active[2] != identity[3]:
+            # The EXECUTION CONTRACT, not the cell. A changed contract digest
+            # means the target's call ingress is not the one the hub validated
+            # this dispatch against, so serving it would run a different
+            # function signature — an identity fault, not a degrade.
             raise RetryableError(
-                "required_compile_identity_mismatch: active cell or execution "
-                "contract changed"
+                "required_compile_contract_mismatch: execution contract changed"
             )
 
         expected: List[Tuple[str, str, str]] = []
@@ -3510,6 +3529,70 @@ class Executor:
             raise RetryableError(
                 "required_compile_binding_mismatch: selected target holds a "
                 "different model ref or snapshot digest"
+            )
+
+        # LAST, and only once every identity fence above has passed: this is
+        # the right pipeline, holding the right models, on the right lane —
+        # and the compiled graph the hub pinned is not the one it serves.
+        if target_active[0] != identity[1] or target_active[1] != identity[2]:
+            if want_execution_lane:
+                raise RetryableError(
+                    f"required_compile_identity_mismatch: {want_execution_lane.upper()} "
+                    "dispatch pinned a compile cell this target no longer "
+                    "serves, and the lane is declared mandatory — eager would "
+                    "serve numerics this endpoint never sanctioned"
+                )
+            self._report_pinned_cell_unavailable(spec, run, identity, target_active)
+
+    def _report_pinned_cell_unavailable(
+        self,
+        spec: EndpointSpec,
+        run: pb.RunJob,
+        identity: Tuple[str, str, str, str],
+        active: Tuple[str, str, str],
+    ) -> None:
+        """pgw#888: SERVE this request, and say loudly that it is degraded.
+
+        A log line is not reporting — a hub-spawned worker exposes no stdout
+        (pgw#760) — so the confession is a typed `serve_degrade` event naming
+        the degraded mode, the compiled-graph key that failed to be here, and
+        the cause. The hub banks it in `worker_activity_events`, which is what
+        lets the fleet's republish/re-mint machinery fix the root cause while
+        users keep getting outputs.
+
+        Two distinguishable degrades share this exit, and conflating them
+        would be the exact `serving_mode` contamination pgw#764 exists to
+        prevent: nothing armed means this request really is served EAGER and
+        the latency sample must be subtractable; a DIFFERENT armed cell still
+        serves compiled, and `serving_mode` reports the cell it actually used.
+        """
+        served_eager = not active[0]
+        detail = (
+            f"fn={spec.name} request={run.request_id or '<unknown>'} "
+            f"attempt={int(run.attempt)} "
+            f"pinned_cell={identity[1]} pinned_digest={identity[2][:16]} "
+            f"active_cell={active[0] or '<none>'} "
+            f"active_digest={active[1][:16] or '<none>'} "
+            f"cause=the pinned compiled graph is not armed on this target "
+            f"(de-armed for cause, revoked, or superseded); serving "
+            f"{'eager' if served_eager else 'the armed cell'} instead of "
+            f"refusing (pgw#888)"
+        )
+        logger.warning(
+            "serving request %s DEGRADED: the hub pinned compile cell %s and "
+            "this target serves %s — answering it anyway",
+            run.request_id or "<unknown>", identity[1], active[0] or "eager",
+        )
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            detail,
+            phase=serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE,
+            compiled_graph_key=identity[1],
+        )
+        if served_eager:
+            self._mark_request_eager_fallback(
+                run.request_id,
+                serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE,
             )
 
     def in_flight_keys(self) -> List[Tuple[str, int]]:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1351,6 +1351,11 @@ class _Job:
     # contaminates every compiled-vs-eager latency comparison with eager data.
     served_eager_fallback: bool = False
     fallback_reason: str = ""
+    # pgw#888: the dispatch fence runs TWICE for one job (at intake, and again
+    # as the last execution fence before the GPU turn), so a degrade that
+    # persists across both would confess twice and double every hub-side count
+    # of it. One request, one confession.
+    pinned_cell_degrade_reported: bool = False
     # pgw#789: (steps, width, height) of the EXECUTED payload, defaults
     # applied — the axes latency is a function of. Stamped beside `lane`,
     # where the resolved payload is in scope; 0 means "not applicable"
@@ -3566,6 +3571,11 @@ class Executor:
         the latency sample must be subtractable; a DIFFERENT armed cell still
         serves compiled, and `serving_mode` reports the cell it actually used.
         """
+        job = self.jobs.get((run.request_id, int(run.attempt)))
+        if job is not None:
+            if job.pinned_cell_degrade_reported:
+                return  # the intake fence already confessed this one
+            job.pinned_cell_degrade_reported = True
         served_eager = not active[0]
         detail = (
             f"fn={spec.name} request={run.request_id or '<unknown>'} "

--- a/src/gen_worker/serving_mode.py
+++ b/src/gen_worker/serving_mode.py
@@ -47,9 +47,18 @@ FALLBACK_GUARD_MISS = "guard_miss"
 FALLBACK_INGRESS_REFUSED = "ingress_refused"
 FALLBACK_HEALING = "healing"
 FALLBACK_VOLATILE = "volatile"
+#: pgw#888: the hub PINNED an exact compile cell and this target no longer
+#: serves it (de-armed for cause, revoked, superseded). The other four classes
+#: all describe a cell that is armed and was skipped for one request; this one
+#: describes a cell that is not here at all — and until the pgw#888 ruling it
+#: was not a fallback reason but a refusal, so the request had no serving mode
+#: to report. It rides here so an eager sample charged to a dispatch the hub
+#: believed was compiled stays subtractable from the compiled measurement.
+FALLBACK_PINNED_CELL_UNAVAILABLE = "pinned_cell_unavailable"
 _PER_REQUEST_FALLBACKS = frozenset({
     FALLBACK_GUARD_MISS, FALLBACK_INGRESS_REFUSED,
     FALLBACK_HEALING, FALLBACK_VOLATILE,
+    FALLBACK_PINNED_CELL_UNAVAILABLE,
 })
 
 # --- eager POSTURE reason classes (pgw#824, wire-shared) ---------------------

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -2216,7 +2216,12 @@ def _required_run(spec: EndpointSpec, target, **overrides) -> pb.RunJob:
         ({"target_incarnation_id": "gone"}, "required_compile_replaced"),
         ({"cell_ref": CACHE_REF + "-other"}, "required_compile_identity_mismatch"),
         ({"cell_snapshot_digest": DIGEST_B}, "required_compile_identity_mismatch"),
-        ({"contract_digest": "bad-contract"}, "required_compile_identity_mismatch"),
+        # pgw#888 split the single `identity_mismatch` refusal in two. The
+        # execution CONTRACT is identity — a different call ingress is a
+        # different function — so it keeps a refusal and gets its own token.
+        # The cell ref/digest above is AVAILABILITY, and still refuses here
+        # only because this fixture's lane is the declared-mandatory w8a8 one.
+        ({"contract_digest": "bad-contract"}, "required_compile_contract_mismatch"),
         ({"cell_ref": ""}, "required_compile_invalid"),
     ],
 )

--- a/tests/test_serve_eager_pinned_cell_pgw888.py
+++ b/tests/test_serve_eager_pinned_cell_pgw888.py
@@ -1,0 +1,304 @@
+"""pgw#888 (Paul, 2026-08-15): *"a worker should serve-eager if compilation
+doesn't work. We want our worker to be as robust as possible, although it
+should loudly report when it's performing in a degraded mode."*
+
+The observable this closes, measured on the standing master stack 2026-08-02:
+11 `tensorhub.request_events` rows reading
+`request.failed / JOB_STATUS_RETRYABLE / required_compile_missing`, all
+terminal, all at `assignment_attempt_epoch=5` — five retries burned per
+request because the dispatch fence refused a pod whose pipeline, weights and
+lane were exactly what the hub picked and whose only defect was that the
+PINNED COMPILED GRAPH had gone (de-armed for cause per §4.31, revoked, or
+superseded). A missing cell is a speed fact, not a correctness one.
+
+Drives the real production fence — `Executor._validate_required_compile`, the
+callable wired as `_JobOrder.fence` and invoked at both intake and the last
+pre-execution GPU turn — and the real `activity.emit_event` path through a
+bound sink, so the assertion is on the `ActivityUpdate` the hub would bank in
+`worker_activity_events`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, cast
+
+import pytest
+
+from gen_worker import Compile, Resources
+from gen_worker import activity as activity_mod
+from gen_worker import serving_mode as serving_mode_mod
+from gen_worker.api.binding import Hub
+from gen_worker.api.errors import RetryableError
+from gen_worker.executor import Executor, _ClassRecord, _CompileTargetRecord
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+BARE = "acme/wai-illustrious"
+PICK = "acme/wai-illustrious@sha256:" + "a1" * 32
+SNAPSHOT = "sha256:" + "b2" * 32
+INCARNATION = "incarnation-7"
+CONTRACT = "contract-digest-1"
+
+#: What the hub pinned.
+PINNED_CELL = "cell:sdxl-1024-sm89"
+PINNED_DIGEST = "sha256:" + "c3" * 32
+
+
+class _Payload:
+    pass
+
+
+class _Endpoint:
+    def setup(self, checkpoint: str) -> None:  # pragma: no cover - shape only
+        pass
+
+    def run(self, ctx, payload):  # pragma: no cover - shape only
+        return None
+
+
+class _LiveJob:
+    """The two fields `_mark_request_eager_fallback` writes, plus the two it
+    reads. A real `_Job` needs an asyncio loop and a hub transport; the fence
+    touches none of that."""
+
+    def __init__(self, request_id: str) -> None:
+        self.request_id = request_id
+        self.finished = False
+        self.served_eager_fallback = False
+        self.fallback_reason = ""
+
+
+class _Fence:
+    """The Executor surface the dispatch fence reaches, and nothing else."""
+
+    def __init__(self, execution_lane: str, target: _CompileTargetRecord) -> None:
+        self._model_resolutions = {BARE: (PICK, "", execution_lane)}
+        rec = _ClassRecord(cls=_Endpoint)
+        rec.ready = True
+        rec.compile_targets[target.incarnation_id] = target
+        self._classes: Dict[Any, _ClassRecord] = {_Endpoint: rec}
+        self.jobs: Dict[Any, _LiveJob] = {}
+
+    _resolved_mandatory_execution_lane = Executor._resolved_mandatory_execution_lane
+    _mandatory_execution_lane_of_bound = Executor._mandatory_execution_lane_of_bound
+    _compile_target = Executor._compile_target
+    _mark_request_eager_fallback = Executor._mark_request_eager_fallback
+    _report_pinned_cell_unavailable = Executor._report_pinned_cell_unavailable
+    _validate_required_compile = Executor._validate_required_compile
+    _setup_slots = staticmethod(Executor._setup_slots)
+
+
+def _serve(fence: "_Fence", spec: EndpointSpec, run: pb.RunJob) -> None:
+    """The production call, through the real unbound method. `_Fence` is a
+    surface, not an `Executor` subclass — an Executor needs a hub transport
+    and an event loop to construct, and the fence touches neither."""
+    Executor._validate_required_compile(cast(Executor, fence), spec, run)
+
+
+def _spec() -> EndpointSpec:
+    return EndpointSpec(
+        name="generate", method=_Endpoint.run, kind="inference",
+        payload_type=_Payload, output_mode="single", cls=_Endpoint,
+        attr_name="run",
+        # The DISPATCHED spec (`_dispatched_spec`): declared slots already
+        # rebound to the hub's picks, which is what the fence always sees.
+        models={"checkpoint": Hub(PICK)},
+        resources=Resources(gpu=True),
+        compile=Compile(family="sdxl", shapes=((1024, 1024),), text_len=0),
+    )
+
+
+def _target(
+    weight_lane: str, active_cell: str, active_digest: str,
+    *, held_ref: str = PICK,
+) -> _CompileTargetRecord:
+    return _CompileTargetRecord(
+        incarnation_id=INCARNATION,
+        spec=_spec(),
+        pipeline=object(),
+        pipeline_weight_lane=weight_lane,
+        lora_bucket=0,
+        contract_digest=CONTRACT,
+        active_compile_ref=active_cell,
+        active_compile_snapshot_digest=active_digest,
+        function_names=("generate",),
+        model_bindings=(("checkpoint", held_ref, SNAPSHOT),),
+    )
+
+
+def _run(
+    *, cell_ref: str = PINNED_CELL, digest: str = PINNED_DIGEST,
+    contract: str = CONTRACT,
+) -> pb.RunJob:
+    run = pb.RunJob(
+        request_id="req-888",
+        attempt=1,
+        function_name="generate",
+        models=[pb.ModelBinding(slot="checkpoint", ref=PICK)],
+        required_compile=pb.RequiredCompileExecution(
+            target_incarnation_id=INCARNATION,
+            cell_ref=cell_ref,
+            cell_snapshot_digest=digest,
+            contract_digest=contract,
+        ),
+    )
+    run.snapshots[PICK].digest = SNAPSHOT
+    return run
+
+
+@pytest.fixture()
+def events() -> Iterator[List[pb.ActivityUpdate]]:
+    captured: List[pb.ActivityUpdate] = []
+    previous = activity_mod._sink  # noqa: SLF001
+    activity_mod._sink = captured.append  # noqa: SLF001
+    try:
+        yield captured
+    finally:
+        activity_mod._sink = previous  # noqa: SLF001
+
+
+def test_pinned_cell_gone_serves_instead_of_refusing(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """RED on master: `required_compile_identity_mismatch` -> RetryableError
+    -> `JOB_STATUS_RETRYABLE` -> the hub's five-retry loop. The pipeline is
+    the right one on the plain lane; nothing about it is wrong except that
+    the cell it was pinned to is not armed."""
+    fence = _Fence("fp8-w8a16+compiled", _target("fp8-w8a16", "", ""))
+    job = _LiveJob("req-888")
+    fence.jobs[("req-888", 1)] = job
+    spec = _spec()
+
+    _serve(fence, spec, _run())  # must not raise
+
+    assert job.served_eager_fallback is True
+    assert job.fallback_reason == (
+        serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE)
+
+
+def test_the_degraded_event_carries_graph_key_mode_and_cause(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """The confession is a TYPED event, not a log line — a hub-spawned worker
+    exposes no stdout (pgw#760), so a log line reaches nobody."""
+    fence = _Fence("fp8-w8a16+compiled", _target("fp8-w8a16", "", ""))
+    fence.jobs[("req-888", 1)] = _LiveJob("req-888")
+
+    _serve(fence, _spec(), _run())
+
+    degrades = [e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+    assert len(degrades) == 1
+    event = degrades[0]
+    # the degraded MODE
+    assert event.phase == serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE
+    # the FAILED GRAPH KEY (proto field 19 is still spelled `cell_key`)
+    assert event.cell_key == PINNED_CELL
+    assert PINNED_CELL in event.detail
+    # the CAUSE, and what was served instead
+    assert "not armed on this target" in event.detail
+    assert "serving eager" in event.detail
+    assert "req-888" in event.detail
+
+
+def test_a_superseded_cell_serves_compiled_and_is_not_an_eager_sample(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """The pod holds a DIFFERENT armed cell. Still degraded — the hub's pin
+    was not honoured — but the request is not an eager latency sample, and
+    charging it one would be the exact `serving_mode` contamination pgw#764
+    exists to prevent."""
+    fence = _Fence(
+        "fp8-w8a16+compiled",
+        _target("fp8-w8a16", "cell:sdxl-1024-sm89-v2", "sha256:" + "d4" * 32),
+    )
+    job = _LiveJob("req-888")
+    fence.jobs[("req-888", 1)] = job
+
+    _serve(fence, _spec(), _run())
+
+    assert job.served_eager_fallback is False
+    assert job.fallback_reason == ""
+    degrades = [e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+    assert len(degrades) == 1
+    assert "serving the armed cell" in degrades[0].detail
+    assert "cell:sdxl-1024-sm89-v2" in degrades[0].detail
+
+
+def test_mandatory_quantized_lane_still_refuses(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """THE CONTROL, and the carve-out `hot_swap`'s docstring draws: on a
+    declared-mandatory w8a8/w4a4 lane the author sanctioned compiled
+    execution and nothing else, so a degrade here would answer with numerics
+    the endpoint never sanctioned. That is a refusal, not a degrade."""
+    fence = _Fence(
+        "fp8-w8a8-dynamic+compiled", _target("w8a8-lora0", "", ""))
+    job = _LiveJob("req-888")
+    fence.jobs[("req-888", 1)] = job
+
+    with pytest.raises(RetryableError, match="required_compile_identity_mismatch"):
+        _serve(fence, _spec(), _run())
+
+    assert job.served_eager_fallback is False
+    assert not [
+        e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+
+
+def test_a_changed_execution_contract_still_requeues(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """Identity, not availability: a different contract digest means the
+    target's call ingress is not the one this dispatch was validated against,
+    so serving it would run a different signature."""
+    fence = _Fence(
+        "fp8-w8a16+compiled", _target("fp8-w8a16", PINNED_CELL, PINNED_DIGEST))
+
+    with pytest.raises(RetryableError, match="required_compile_contract_mismatch"):
+        _serve(fence, _spec(), _run(contract="contract-digest-2"))
+
+
+def test_a_different_model_binding_still_requeues(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """pgw#888 acceptance box 2: the identity fence is SPLIT from cell
+    availability, and its half keeps requeuing. A merely same-family pipeline
+    is not the model the hub picked."""
+    fence = _Fence(
+        "fp8-w8a16+compiled",
+        _target("fp8-w8a16", "", "",
+                held_ref="acme/wai-illustrious@sha256:" + "ee" * 32))
+
+    with pytest.raises(RetryableError, match="required_compile_binding_mismatch"):
+        _serve(fence, _spec(), _run())
+    assert not [
+        e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+
+
+def test_an_exactly_matching_pin_is_silent(
+    events: List[pb.ActivityUpdate],
+) -> None:
+    """The optimization fence still fences: a request the pod can serve on
+    the exact pinned cell must produce no degrade event at all."""
+    fence = _Fence(
+        "fp8-w8a16+compiled", _target("fp8-w8a16", PINNED_CELL, PINNED_DIGEST))
+    job = _LiveJob("req-888")
+    fence.jobs[("req-888", 1)] = job
+
+    _serve(fence, _spec(), _run())
+
+    assert job.served_eager_fallback is False
+    assert not [
+        e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+
+
+def test_pinned_cell_unavailable_is_a_wire_fallback_class() -> None:
+    """A token `resolve()` does not recognise never reaches `metrics.
+    fallback_reason` — the request would report the degrade nowhere."""
+    served = serving_mode_mod.resolve(
+        active_compile_ref="",
+        verdict=serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE,
+    )
+    assert served.served_eager_fallback is True
+    assert served.fallback_reason == (
+        serving_mode_mod.FALLBACK_PINNED_CELL_UNAVAILABLE)

--- a/tests/test_serve_eager_pinned_cell_pgw888.py
+++ b/tests/test_serve_eager_pinned_cell_pgw888.py
@@ -58,15 +58,15 @@ class _Endpoint:
 
 
 class _LiveJob:
-    """The two fields `_mark_request_eager_fallback` writes, plus the two it
-    reads. A real `_Job` needs an asyncio loop and a hub transport; the fence
-    touches none of that."""
+    """The four fields the fence writes and reads on a live job. A real `_Job`
+    needs an asyncio loop and a hub transport; the fence touches neither."""
 
     def __init__(self, request_id: str) -> None:
         self.request_id = request_id
         self.finished = False
         self.served_eager_fallback = False
         self.fallback_reason = ""
+        self.pinned_cell_degrade_reported = False
 
 
 class _Fence:
@@ -290,6 +290,20 @@ def test_an_exactly_matching_pin_is_silent(
     assert job.served_eager_fallback is False
     assert not [
         e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]
+
+
+def test_one_request_confesses_once(events: List[pb.ActivityUpdate]) -> None:
+    """`_JobOrder.fence` is invoked TWICE for one job — at intake, and again
+    as the last execution fence before the GPU turn. A degrade that persists
+    across both must not double every hub-side count of it."""
+    fence = _Fence("fp8-w8a16+compiled", _target("fp8-w8a16", "", ""))
+    fence.jobs[("req-888", 1)] = _LiveJob("req-888")
+
+    _serve(fence, _spec(), _run())   # intake
+    _serve(fence, _spec(), _run())   # last execution fence
+
+    assert len(
+        [e for e in events if e.kind == activity_mod.KIND_SERVE_DEGRADE]) == 1
 
 
 def test_pinned_cell_unavailable_is_a_wire_fallback_class() -> None:

--- a/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
+++ b/tests/testdata/WORKER_VALUE_CONTRACTS_DIGEST
@@ -1,3 +1,3 @@
 # SHA-256 of worker_value_contracts.json.
 # PGW is the public-corpus vendor; peer repositories pin this byte identity.
-e850b3026d10dd036a28c359d3d66c5b4ff925736b849868c151fc64e7626351
+38c0b3664d4fa5194e539a82031cddf3ad7e400f07860131ca9b35e424459d4f

--- a/tests/testdata/worker_value_contracts.json
+++ b/tests/testdata/worker_value_contracts.json
@@ -64,7 +64,8 @@
       "guard_miss",
       "ingress_refused",
       "healing",
-      "volatile"
+      "volatile",
+      "pinned_cell_unavailable"
     ],
     "eager_posture_reasons": [
       "arm_pending",


### PR DESCRIPTION
**RULED by Paul, 2026-08-15, verbatim:** *"a worker should serve-eager if compilation doesn't work. We want our worker to be as robust as possible, although it should loudly report when it's performing in a degraded mode."*

## The observable

Standing master stack, 2026-08-02: **11** `tensorhub.request_events` rows reading `request.failed / JOB_STATUS_RETRYABLE / required_compile_missing`, every one terminal at `assignment_attempt_epoch=5` — five retries burned per request, across three workers, on pods whose pipeline, weights and lane were exactly what the hub picked.

## The split

`_validate_required_compile` folded two different questions into one refusal, and only one of them is about correctness.

| Question | Verdict |
|---|---|
| **Is this the right MODEL?** — incarnation, lane, function, every model binding, and now the execution CONTRACT digest under its own `required_compile_contract_mismatch` token | Identity. Nothing correct to serve. **Still requeues.** |
| **Is the pinned COMPILED GRAPH still what this pod serves?** — the cell ref/digest half | Speed. The pipeline underneath is untouched. **Serves, and confesses.** |

The cell-availability check now runs **last**, after every identity fence has passed.

## The loud report

A typed `serve_degrade` activity event, not a log line a hub-spawned worker exposes to nobody (pgw#760). It carries:

- the **degraded mode** (`phase=pinned_cell_unavailable`),
- the **failed graph key** (`cell_key=<pinned cell>`, plus the key the target actually serves),
- the **cause** and the request id, in `detail`.

The hub banks it in `worker_activity_events`, so the fleet's republish/re-mint machinery can fix the root cause while users keep getting outputs.

The request row is honest too: `pinned_cell_unavailable` joins the per-request fallback vocabulary and is charged as an **eager** sample only when nothing is armed. A pod serving a *different* cell is degraded but still compiled, and counting it eager is the exact `serving_mode` contamination pgw#764 exists to prevent.

## Carve-outs KEPT

- A declared-mandatory `w8a8`/`w4a4` execution lane still **refuses** — the author sanctioned compiled execution and nothing else, so eager there would serve numerics the endpoint never sanctioned.
- `fleet_cells._fail_closed` / `MANDATORY_LANE_NEEDS_A_COMPILED_GRAPH` (arm-time, no cell can ever exist) — untouched.
- `required_compile_missing` on a mandatory lane — untouched.
- `hot_swap.py`'s router posture (mandatory lanes stay sequential rather than being routed eager behind the tenant's back) — untouched; built with, not around.

## Red / green

Driving master's source and this branch's source through the same production fence:

```
--- MASTER ---
PLAIN lane, pinned cell gone:            REFUSED -> RetryableError: required_compile_identity_mismatch
MANDATORY w8a8 lane, pinned cell gone:   REFUSED -> RetryableError: required_compile_identity_mismatch

--- FIX ---
PLAIN lane, pinned cell gone:            SERVED (no raise)   [+ serve_degrade event]
MANDATORY w8a8 lane, pinned cell gone:   REFUSED -> ... the lane is declared mandatory
```

`tests/test_serve_eager_pinned_cell_pgw888.py` (8 tests) drives `Executor._validate_required_compile` — the callable wired as `_JobOrder.fence`, invoked at intake and at the last pre-execution GPU turn — with real `_ClassRecord`/`_CompileTargetRecord`/`RunJob` values and the real `activity.emit_event` path through a bound sink, so assertions are on the `ActivityUpdate` the hub would bank. `test_executor_adopt.py`'s parametrized fence table keeps the mandatory refusals and follows the contract-digest token split.

Local: `mypy src/gen_worker tests tests_v2` clean (722 files); ruff clean on the touched files; all 16 hard lint gates + `assemble_changelog.py --check` pass; 92 passed across the executor/serve/value-contract set.

## Coupled cut

The public worker-value corpus gains one value, so **tensorhub must re-vendor** `internal/wirecontract/testdata/worker_value_contracts.json` and its digest. PGW lands first, per `scripts/worker-value-contract-drift.sh`. The hub treats `per_request_fallback_reasons` as an open producer-owned vocabulary (non-empty check only), so no hub decode changes.

Closes pgw#888. HARDCUT-CHECKLIST row M6.