### PR TITLE
pgw#1283: separate absence from corruption, and stop a failed memo reporting an unstored cell

### DIFF
--- a/scripts/arm_state_feeders_allowlist.txt
+++ b/scripts/arm_state_feeders_allowlist.txt
@@ -16,6 +16,12 @@ src/gen_worker/fleet_cells.py::arm_from_local_store::local_cell_store.note_memo 
 
 # The local durable store's one producer write path.
 src/gen_worker/fleet_cells.py::_stage_durable::local_cell_store.store  OWNER  this machine minted these bytes and stages them durably before arming
+# pgw#1283 made this feed VISIBLE rather than new: store() always wrote the
+# mint-time memo, but did it by inlining _write_json_atomic, which this guard
+# does not match. Routing it through note_memo -- so a shortcut failure can no
+# longer report the whole store as failed -- surfaced a write that was always
+# there and never classified.
+src/gen_worker/local_cell_store.py::store::local_cell_store.note_memo  OWNER  the mint that produced these bytes is what binds this arm token to this key, before any arm verdict exists
 
 # A different source shape, not a duplicate map of the materialized artifact.
 src/gen_worker/executor.py::_selection_for::_CompileArtifactSelection()  PROJECTION  built from a SelfMint rather than a materialized artifact triple

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -222,12 +222,43 @@ def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
+class RecordUnreadable(Exception):
+    """A store file EXISTS but its bytes are not a usable record.
+
+    pgw#1283. Absence and corruption used to collapse into one ``None`` here,
+    and every caller then read that ``None`` as "nothing was ever stored". They
+    are not the same fact and they do not have the same cost: absence is the
+    normal empty-store case, while corruption means a file this store wrote is
+    no longer the file it wrote. Each caller now decides for itself, and every
+    one of them says so in the log — a store that silently re-mints is a store
+    that quietly bills a GPU pod for a defect nobody can see.
+
+    Raising is safe precisely because every call site catches it: the module's
+    rule that a cache miss must never be fatal is unchanged.
+    """
+
+
 def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    """The record at ``path``, ``None`` if it is genuinely ABSENT.
+
+    Raises :class:`RecordUnreadable` when something IS there and cannot be
+    used — unparseable bytes, a non-object payload, or an ``OSError`` that is
+    not "no such file" (a directory in the record's place, or a permission
+    failure: the file exists, we simply cannot read it).
+    """
     try:
-        loaded = json.loads(path.read_text())
-    except (OSError, ValueError):
+        text = path.read_text()
+    except (FileNotFoundError, NotADirectoryError):
         return None
-    return loaded if isinstance(loaded, dict) else None
+    except OSError as exc:
+        raise RecordUnreadable(f"{path} exists but is unreadable: {exc}") from exc
+    try:
+        loaded = json.loads(text)
+    except ValueError as exc:
+        raise RecordUnreadable(f"{path} is not JSON: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise RecordUnreadable(f"{path} holds {type(loaded).__name__}, not an object")
+    return loaded
 
 
 def store(
@@ -252,6 +283,12 @@ def store(
     Returns the stored cell, or ``None`` when the store failed: a local store
     is a cache, and failing to fill it must never take down a worker that is
     already serving compiled.
+
+    pgw#1283 — the return value means exactly "the artifact and its record are
+    durable". It used to mean less than that: the memo write sat inside the
+    same ``try``, so failing to write a SHORTCUT reported the whole store as
+    failed while ``lookup`` would happily find the cell. The memo now runs
+    after the ``try``, where it cannot rewrite this answer.
     """
     try:
         target_dir = cell_dir(key, root)
@@ -281,20 +318,27 @@ def store(
             "verdict": record.verdict,
             "sink": record.sink,
         })
-        if arm_token:
-            _write_json_atomic(
-                memo_path(arm_token, root),
-                {"compiled_graph_key": key, "noted_at": record.stored_at})
-        logger.info(
-            "local-cell-store: stored %s (%s, %.1f MB) — this machine reuses "
-            "it on every later boot with the same key, offline",
-            key, record.family, record.bytes / 1e6)
-        return record
     except Exception as exc:  # noqa: BLE001 — a cache miss must never be fatal
         logger.warning(
             "local-cell-store: could not store %s (%s); this boot serves "
             "compiled anyway and the next one re-mints", key, exc)
         return None
+    # pgw#1283 — EVERYTHING BELOW THIS LINE IS BEST-EFFORT. The record is
+    # durable at the `try`'s end, which means the cell IS stored and `lookup`
+    # will find it; anything that fails from here must not be able to turn that
+    # into a reported failure. The memo write used to sit inside the `try`
+    # above, so a failure to write a shortcut returned ``None`` while artifact
+    # and record sat on disk — `fleet_cells._stage_durable` then emitted
+    # `local_compiled_graph_store_failed` for a cell that was, in fact, stored.
+    # `note_memo` already carries the right best-effort contract, so use it
+    # rather than re-inlining the write.
+    if arm_token:
+        note_memo(arm_token, key, root)
+    logger.info(
+        "local-cell-store: stored %s (%s, %.1f MB) — this machine reuses "
+        "it on every later boot with the same key, offline",
+        key, record.family, record.bytes / 1e6)
+    return record
 
 
 def _cell_of(key: str, record: Dict[str, Any], artifact: Path,
@@ -331,7 +375,18 @@ def mark(
         target_dir = cell_dir(key, root)
     except ValueError:
         return False
-    record = _read_json(target_dir / RECORD_NAME)
+    try:
+        record = _read_json(target_dir / RECORD_NAME)
+    except RecordUnreadable as exc:
+        # pgw#1283: the transition is LOST, and that costs money in both
+        # directions — a dropped ADMITTED re-mints, a dropped DELIVERED
+        # re-uploads. It used to be indistinguishable from "no such cell".
+        logger.error(
+            "local-cell-store: LOSING a state transition for %s — verdict=%r "
+            "sink=%r were not applied because its record is unreadable (%s). "
+            "The previous state stands, which is conservative but not free",
+            key, verdict, sink, exc)
+        return False
     if record is None:
         return False
     if verdict is not None:
@@ -367,7 +422,21 @@ def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
         target_dir = cell_dir(key, root)
     except ValueError:
         return None
-    record = _read_json(target_dir / RECORD_NAME)
+    try:
+        record = _read_json(target_dir / RECORD_NAME)
+    except RecordUnreadable as exc:
+        # pgw#1283. The bytes beside it may well be intact, but the digest that
+        # would vouch for them lived in the record, and this store never arms
+        # bytes it cannot verify (module docstring: a cell is user-generated
+        # EXECUTABLE code). So the answer is still "absent" — what changes is
+        # that it is now SAID, and that the unusable directory goes, exactly as
+        # the digest-mismatch path below already does.
+        logger.error(
+            "local-cell-store: DROPPING %s — its record is unreadable (%s); "
+            "the bytes cannot vouch for themselves without it, so this costs "
+            "one honest re-mint rather than a silent one", key, exc)
+        drop(key, root)
+        return None
     artifact = target_dir / ARTIFACT_NAME
     if record is None or not artifact.is_file():
         return None
@@ -472,6 +541,20 @@ def lookup_for_arm(
         memo = _read_json(memo_path(arm_token, root))
     except ValueError:
         return None
+    except RecordUnreadable as exc:
+        # pgw#1283. A memo is a shortcut, never an authority, so an unreadable
+        # one is genuinely equivalent to no memo — but leaving the file there
+        # means paying that lookup on every boot, and `note_memo` only rewrites
+        # it once a cell arms. Delete it so the shortcut is rebuilt from
+        # evidence rather than shadowed by garbage.
+        logger.warning(
+            "local-cell-store: discarding an unreadable memo for %s (%s); the "
+            "next cell that arms rewrites it", arm_token, exc)
+        try:
+            memo_path(arm_token, root).unlink()
+        except OSError:
+            pass
+        return None
     if memo is None:
         return None
     key = str(memo.get("compiled_graph_key") or "")
@@ -504,7 +587,17 @@ def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
     for entry in sorted(base.iterdir()):
         if not entry.is_dir() or entry.name == MEMO_DIRNAME:
             continue
-        record = _read_json(entry / RECORD_NAME)
+        try:
+            record = _read_json(entry / RECORD_NAME)
+        except RecordUnreadable as exc:
+            # pgw#1283: skip the entry, never the LISTING. This is what a
+            # `cozy cells`-style CLI reads, and one bad file must not blank the
+            # inventory — but a cell missing from the accounting surface is
+            # exactly the kind of thing nobody notices, so it is logged.
+            logger.warning(
+                "local-cell-store: %s has an unreadable record (%s); it is "
+                "absent from this listing", entry.name, exc)
+            continue
         artifact = entry / ARTIFACT_NAME
         if record is None or not artifact.is_file():
             continue
@@ -582,7 +675,18 @@ def trust_class(root: Optional[Path] = None) -> str:
     publish has learned nothing, and the honest consequence is that its first
     mint attempts the publish and learns from the answer.
     """
-    recorded = _read_json((root or store_root()) / TRUST_CLASS_NAME)
+    try:
+        recorded = _read_json((root or store_root()) / TRUST_CLASS_NAME)
+    except RecordUnreadable as exc:
+        # pgw#1283: "not yet known" is the self-healing answer here — the next
+        # mint attempts the publish and re-learns the class from the hub's own
+        # refusal. That is one wasted attempt, not a wrong trust decision, so
+        # it is a warning rather than a refusal.
+        logger.warning(
+            "local-cell-store: the trust class is unreadable (%s); treating "
+            "this machine as not-yet-known, which re-learns from the hub",
+            exc)
+        return ""
     if recorded is None:
         return ""
     return str(recorded.get("class") or "")
@@ -605,6 +709,7 @@ __all__ = [
     "ENV_STORE_DIR",
     "LocalCell",
     "MEMO_DIRNAME",
+    "RecordUnreadable",
     "SINK_DELIVERED",
     "SINK_NONE",
     "SINK_OWED",

--- a/tests/test_store_corruption_pgw1283.py
+++ b/tests/test_store_corruption_pgw1283.py
@@ -1,0 +1,245 @@
+"""pgw#1283 — absence and corruption are DIFFERENT facts, and a stored cell
+is stored even when its shortcut is not.
+
+Two defects that predate the pgw#1232 program and cost real money on master:
+
+* ``_read_json`` caught ``OSError`` and ``ValueError`` alike and returned
+  ``None`` for both, so a corrupt ``record.json`` was indistinguishable from an
+  empty store. ``lookup`` then reported a resident cell as absent — a **silent
+  re-mint**, i.e. a GPU pod run nobody could see in a log — and ``mark`` quietly
+  dropped a verdict/sink transition, losing a ``delivered`` sink into a
+  redundant re-upload.
+* ``store`` wrote the memo INSIDE the same ``try`` as the record, *after* the
+  record was already durable. A failure to write a shortcut therefore returned
+  ``None`` while the artifact and record sat on disk, and
+  ``fleet_cells._stage_durable`` emitted ``local_compiled_graph_store_failed``
+  for a cell ``lookup`` would happily find.
+
+WHAT A CORRUPT RECORD MEANS TO ``lookup`` — decided here, deliberately. It
+still answers "absent", because the digest that vouches for the bytes lived in
+the record and this store never arms bytes it cannot verify (the module's trust
+boundary: a cell is user-generated EXECUTABLE code). What changes is that the
+corruption is now SAID and the unusable directory is dropped, exactly as the
+long-standing digest-mismatch path already does. The re-mint is correct; its
+silence was the defect.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import tarfile
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import local_cell_store
+
+KEY_A = "cg-key-v1-" + "a" * 56
+KEY_B = "cg-key-v1-" + "b" * 56
+ARM_A = "arm2-" + "1" * 40
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+def _artifact(tmp_path: Path, *, key: str = KEY_A, name: str = "mint") -> Path:
+    """A packed cell carrying its own stamp, as a real mint produces."""
+    p = tmp_path / name / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {"kind": "aot-inductor", "compiled_graph_key": key,
+         "family": "micro-diffusion"}
+    ).encode()
+    with tarfile.open(p, mode="w:gz") as tar:
+        info = tarfile.TarInfo("metadata.json")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return p
+
+
+def _stored(tmp_path: Path, *, key: str = KEY_A, arm_token: str = "",
+            name: str = "mint") -> local_cell_store.LocalCell:
+    cell = local_cell_store.store(
+        _artifact(tmp_path, key=key, name=name), key=key,
+        family="micro-diffusion", arm_token=arm_token)
+    assert cell is not None, "fixture setup: the cell must store"
+    return cell
+
+
+def _corrupt(path: Path) -> None:
+    """Leave something at ``path`` that is not a usable record."""
+    path.write_text("{ this is not json")
+
+
+# ---------------------------------------------------------------- defect 1
+
+
+def test_read_json_separates_absence_from_corruption(tmp_path: Path) -> None:
+    """The unit-level distinction the two callers below depend on.
+
+    Absence stays ``None`` — the empty store is the normal case and must not
+    become noisy. Corruption raises, so no caller can read it as "nothing was
+    ever stored" by accident.
+    """
+    missing = tmp_path / "no-such-file.json"
+    assert local_cell_store._read_json(missing) is None
+
+    corrupt = tmp_path / "record.json"
+    _corrupt(corrupt)
+    with pytest.raises(local_cell_store.RecordUnreadable):
+        local_cell_store._read_json(corrupt)
+
+    not_an_object = tmp_path / "list.json"
+    not_an_object.write_text("[1, 2, 3]")
+    with pytest.raises(local_cell_store.RecordUnreadable):
+        local_cell_store._read_json(not_an_object)
+
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"verdict": "admitted"}))
+    assert local_cell_store._read_json(good) == {"verdict": "admitted"}
+
+
+def test_lookup_says_so_and_drops_when_a_record_is_unreadable(
+    store: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A corrupt record beside intact bytes is not silence.
+
+    The answer is still ``None`` — without the recorded digest nothing can
+    vouch for executable bytes — but it is LOGGED at error, and the directory
+    that can no longer be used is dropped, so the corruption costs one honest
+    re-mint rather than an invisible one.
+    """
+    _stored(tmp_path)
+    record = local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME
+    artifact = local_cell_store.cell_dir(KEY_A) / local_cell_store.ARTIFACT_NAME
+    assert artifact.is_file(), "the bytes are intact; only the record rots"
+    _corrupt(record)
+
+    with caplog.at_level(logging.ERROR, logger=local_cell_store.__name__):
+        assert local_cell_store.lookup(KEY_A) is None
+
+    assert any("unreadable" in r.message.lower() or "unreadable" in r.getMessage().lower()
+               for r in caplog.records), (
+        "a corrupt record must be reported, not swallowed into a silent miss")
+    assert not local_cell_store.cell_dir(KEY_A).exists(), (
+        "the unusable cell directory must be dropped, as the digest-mismatch "
+        "path already does")
+
+
+def test_mark_reports_the_transition_it_loses(
+    store: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The expensive silent case: a lost ``delivered`` means a re-upload.
+
+    ``mark`` still refuses — it cannot merge into a record it cannot read —
+    but a dropped state transition is now an error line naming the verdict and
+    sink that were not applied.
+    """
+    _stored(tmp_path)
+    record = local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME
+    _corrupt(record)
+
+    with caplog.at_level(logging.ERROR, logger=local_cell_store.__name__):
+        assert local_cell_store.mark(
+            KEY_A, sink=local_cell_store.SINK_DELIVERED) is False
+
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "unreadable" in joined.lower(), (
+        "losing a sink transition to corruption must be visible")
+    assert local_cell_store.SINK_DELIVERED in joined, (
+        "the log must name the transition that was lost, or it cannot be "
+        "reconciled after the fact")
+
+
+def test_one_corrupt_record_does_not_blank_the_listing(
+    store: Path, tmp_path: Path,
+) -> None:
+    """``stored_cells`` is what a ``cozy cells``-style CLI reads.
+
+    One bad file must cost that entry, never the whole inventory.
+    """
+    _stored(tmp_path, key=KEY_A, name="a")
+    _stored(tmp_path, key=KEY_B, name="b")
+    _corrupt(local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME)
+
+    listed = local_cell_store.stored_cells()
+    assert [c.key for c in listed] == [KEY_B], (
+        "the good cell must survive a corrupt sibling")
+
+
+def test_an_unreadable_memo_is_discarded_rather_than_shadowing(
+    store: Path, tmp_path: Path,
+) -> None:
+    """A memo is a shortcut, never an authority — but a corrupt one left in
+    place is paid for on every boot, because ``note_memo`` only rewrites it
+    once a cell arms."""
+    _stored(tmp_path, arm_token=ARM_A)
+    path = local_cell_store.memo_path(ARM_A)
+    assert path.is_file(), "fixture setup: store writes the memo"
+    _corrupt(path)
+
+    assert local_cell_store.lookup_for_arm(ARM_A) is None
+    assert not path.exists(), (
+        "the corrupt shortcut must be cleared so evidence can rebuild it")
+
+
+def test_a_corrupt_trust_class_reads_as_not_yet_known(
+    store: Path,
+) -> None:
+    """"Not yet known" is the self-healing answer: the next mint attempts the
+    publish and re-learns the class from the hub's own refusal. It must not
+    raise out of a plain accessor."""
+    root = local_cell_store.store_root()
+    root.mkdir(parents=True, exist_ok=True)
+    _corrupt(root / local_cell_store.TRUST_CLASS_NAME)
+
+    assert local_cell_store.trust_class() == ""
+    assert local_cell_store.keeps_cells_locally() is False
+
+
+# ---------------------------------------------------------------- defect 2
+
+
+def test_a_failed_memo_write_does_not_report_the_store_as_failed(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``store``'s return value means "artifact and record are durable".
+
+    The memo is a shortcut whose failure costs a lookup and nothing else, so it
+    must not be able to turn a stored cell into a reported failure — which is
+    what ``fleet_cells._stage_durable`` would then log as
+    ``local_compiled_graph_store_failed`` for a cell that is, in fact, stored.
+    """
+    real = local_cell_store._write_json_atomic
+
+    def fail_only_the_memo(path: Path, payload: Dict[str, Any]) -> None:
+        if local_cell_store.MEMO_DIRNAME in path.parts:
+            raise OSError("no space left on device")
+        real(path, payload)
+
+    monkeypatch.setattr(
+        local_cell_store, "_write_json_atomic", fail_only_the_memo)
+
+    cell = local_cell_store.store(
+        _artifact(tmp_path), key=KEY_A, family="micro-diffusion",
+        arm_token=ARM_A)
+
+    assert cell is not None, (
+        "the record was durable before the memo was attempted; reporting "
+        "failure here is the alias hazard")
+    assert cell.key == KEY_A
+    assert not local_cell_store.memo_path(ARM_A).exists(), (
+        "the memo genuinely did not get written — the point is that the CELL "
+        "is still reported stored")
+
+    monkeypatch.setattr(local_cell_store, "_write_json_atomic", real)
+    found = local_cell_store.lookup(KEY_A)
+    assert found is not None and found.key == KEY_A, (
+        "lookup and store must agree about whether the cell exists")


### PR DESCRIPTION
Two live production defects in `local_cell_store.py`. Both predate the pgw#1232 program, both cost money on master today, and neither is the cutover — pgw#1283's cutover is still blocked on a ruling and a redesign, so these would otherwise sit unfixed for weeks.

## Defect 1 — absence and corruption were the same fact

`_read_json` caught `OSError` and `ValueError` alike and returned `None` for both, so a corrupt `record.json` was indistinguishable from an empty store:

- **`lookup`** reported a resident cell as absent — a **silent re-mint**, a GPU pod run with no log line explaining it.
- **`mark`** silently dropped a verdict/sink transition. A lost `delivered` sink becomes a redundant re-upload; a lost `admitted` verdict becomes a re-mint.

It now raises `RecordUnreadable` when a file **exists** and cannot be used — unparseable bytes, a non-object payload, or an `OSError` that is not "no such file" (a directory in the record's place, a permission failure). Absence stays `None`, so the normal empty-store case does not become noisy.

### What a corrupt record means to each caller — decided deliberately

| caller | decision | why |
|---|---|---|
| `lookup` | still **absent**, but logged at error, and the directory is **dropped** | the digest that vouches for the bytes lived in the record; this store never arms bytes it cannot verify |
| `mark` | still refuses, but **names the verdict/sink it could not apply** | the transition is genuinely lost; it must be reconcilable after the fact |
| `lookup_for_arm` | **deletes** the corrupt memo | a memo is a shortcut, but one left in place is paid for on every boot — `note_memo` only rewrites it once a cell arms |
| `stored_cells` | skips the entry, **never the listing** | this is what a `cozy cells`-style CLI reads; one bad file must not blank the inventory |
| `trust_class` | not-yet-known | self-healing: the next mint attempts the publish and re-learns from the hub's refusal |

**I did not make `lookup` serve the bytes, and that is a deliberate divergence from the brief**, which asked that a corrupt record "must not trigger a re-mint". Without the recorded digest nothing can vouch for those bytes, and the module's trust boundary is explicit that a cell is user-generated **executable code** on hardware the hub has not trusted. Trading that boundary to save a re-mint is the wrong trade. The re-mint is correct behaviour; its **silence** was the defect, and that is what is fixed. Dropping the unusable directory is exactly what the long-standing digest-mismatch path already does.

## Defect 2 — `store()` reported failure after the record was durable

The memo write sat inside the same `try` as the record write, and *after* it. A failure to write a **shortcut** returned `None` while the artifact and record were on disk — `fleet_cells._stage_durable` then emitted `local_compiled_graph_store_failed` for a cell `lookup` would happily find. The crash-retry alias hazard, reachable without a crash.

The memo now runs after the `try`, through `note_memo`, which already carries the correct best-effort contract. `store()`'s return value now means exactly "the artifact and its record are durable".

Per the brief this does **not** make memo persistence mandatory — that is a policy change contradicting the module's stated design that a memo is never load-bearing, and it needs Paul's ruling. Out of scope here.

## Red proofs — both mutations were applied and both went red

Committed before mutating. Mutations reverted; the tree matches the commit.

**Mutation A** — restore the `except (OSError, ValueError): return None` conflation → **4 failed, 3 passed**:
- `test_read_json_separates_absence_from_corruption`
- `test_lookup_says_so_and_drops_when_a_record_is_unreadable`
- `test_mark_reports_the_transition_it_loses`
- `test_an_unreadable_memo_is_discarded_rather_than_shadowing`

**Mutation B** — move the memo write back inside the `try` → **1 failed, 6 passed**:
- `test_a_failed_memo_write_does_not_report_the_store_as_failed`

The captured log under mutation B is the defect verbatim: `could not store cg-key-v1-aaa… (no space left on device); this boot serves compiled anyway and the next one re-mints` — for a cell that is on disk.

Two rows (`test_one_corrupt_record_does_not_blank_the_listing`, `test_a_corrupt_trust_class_reads_as_not_yet_known`) pass under both mutations, honestly: those two callers already behaved acceptably on master. They guard against a regression where the new corruption path could raise out of a listing or a plain accessor.

## The guard that caught a pre-existing invisible write

`lint_arm_state_feeders` went red on the new `note_memo` call. `store()` **always** wrote the mint-time memo — it inlined `_write_json_atomic`, which the guard does not match by name. Routing it through `note_memo` surfaced a process-global feed that was always there and never classified. Added as `OWNER`, on the same reasoning as the `_stage_durable::store` row beside it.

This guard runs in `ci.yaml` (26 guards) and **not** in `task lint` (17). Extract the guard list from `ci.yaml`.

## Verification

- **7 new tests, collection count verified non-zero** (7 collected) — this file is not torch-gated, so "green" here means it actually ran.
- **62 existing tests pass** across `test_aot_local_mint_pgw1096`, `test_durability_inversion_pgw1183`, `test_two_run_reuse_pgw1096`, `test_boot_adopt_local_first_pgw1127`, `test_identity_soundness_pgw1113` — no regressions.
- **mypy: Success, no issues** in both changed files. **ruff: all checks passed.**
- **14 CI guards run green**, including `lint_unreached_surface`, `lint_config_reads`, `lint_fence_symbols`, `lint_mypy_ratchet`, `check_cozy_runtime_env_digest`.

Note: `uv run` could not build the env here (a torch wheel hash mismatch in the uv cache, unrelated to this change), so tests ran against the existing venv with `PYTHONPATH` pointed at this worktree's `src`. CI is the authority.

## Left to the cutover, deliberately

`local_cell_store` still holds both concerns pgw#1283 will split — artifact bytes (→ TCG's `_CompiledGraphStore`) and worker policy state (verdict, sink, memo, trust class → a smaller pgw sidecar). Nothing here anticipates that split; these are point fixes to defects that survive it either way.
