### PR TITLE
pgw#1286 (HARDCUT M3): the ladder.py census says DELETE, not fence — and the one surviving duplicate is fenced at the wire

### DIFF
--- a/changelog.d/pgw1286.md
+++ b/changelog.d/pgw1286.md
@@ -1,0 +1,27 @@
+- **pgw#1286 (HARDCUT M3, the pgw leg of th's G6): the vendored copies of hub
+  precision policy are DELETED, not fenced.** `models/ladder.py` carried three
+  tables of tensorhub decisions — `FP8_COMPUTE_MIN_SM` (twin of
+  `precision.FP8ComputeMinSM`), `_FAMILY_ROOT_OVERRIDES` (twin of
+  `modelfamily.rootOverrides`) and `CONV_UNET_W8A8_EXCLUDED_ROOTS` — and every
+  one of them lost its last reader when the local AUTO fp8 fold died
+  (pgw#1148 / pgw#1180 cut 2). A fence over dead code would have pinned three
+  values nothing consults; the census also found all three **already drifted**:
+  the hub's root table has grown `wan-22-*`, `ltx-23` and `micro-4d` entries
+  the worker's copy never got, and the named conv-UNet twin
+  (`convUNetW8A8ExcludedRoots`) does not exist hub-side any more — it is
+  `convUNetUpcastRoots` today. The walk, the family root and the family lane
+  policy are hub decisions that reach the worker resolved; the worker restates
+  none of them.
+- **pgw#1286: what survives the deletion is the PRODUCER stamp, and that is
+  what the drift fence covers.** The worker writes
+  `checkpoints.metadata["placement"]` at publish and tensorhub keeps a mirror
+  of the same class defaults as its fallback for unstamped rows
+  (`precision.defaultPlacement`, `svdqFP4SMs` / `svdqINT4SMs`,
+  `PlacementFromMetadata`). Disagreement there admits an unstamped row onto
+  silicon the producer would have excluded, so
+  `tests/convert/test_placement_stamp_pgw1286.py` transcribes the hub table as
+  literals and reads the declared block **off the wire** — every row publishes
+  through the real `publish_flavors` against the fake hub and asserts the exact
+  declare-request metadata, including that a zero-constraint base row sends no
+  block at all and that a producer's explicit `placement_*` override travels
+  whole without leaking the override attrs into metadata as prose.

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -9,12 +9,20 @@ Produced flavors carry their placement in ``checkpoints.metadata["placement"]``
 (stamped at publish by :func:`gen_worker.convert.publish.publish_flavors`).
 Unstamped/mirrored rows fall back to the token-derived defaults here — the
 same defaults the stamping writes, so both paths agree. The ladder WALK
-(rung ordering per arch class) lives hub-side (tensorhub's
-internal/orchestrator/precision resolver) and delivers picks via HelloAck;
-this module is the classification + placement half, plus the family lane
-policy. There is deliberately no local walk and no local AUTO fp8 fold:
-locally, fit is the loading layer's job (runtime fp8 rung + the offload
-ladder), and selection within a tag group is §1.33 contract compatibility.
+(rung ordering per arch class), the family-root table and the family lane
+policy live hub-side (tensorhub's internal/orchestrator/precision resolver
+and internal/modelfamily) and reach the worker in the resolved ref/HelloAck;
+this module is the PRODUCER half only — classification + placement stamp.
+There is deliberately no local walk and no local AUTO fp8 fold: locally, fit
+is the loading layer's job (runtime fp8 rung + the offload ladder), and
+selection within a tag group is §1.33 contract compatibility.
+
+pgw#1286: the vendored copies of hub policy that fed the deleted local fold
+(`FP8_COMPUTE_MIN_SM`, `_FAMILY_ROOT_OVERRIDES`, `CONV_UNET_W8A8_EXCLUDED_ROOTS`)
+are gone — unread since pgw#1148/#1180, and already drifted from their hub
+twins. The one fact both repos still restate is the placement stamp below,
+fenced by ``tests/convert/test_placement_stamp_pgw1286.py`` against
+tensorhub's ``precision.defaultPlacement`` mirror.
 """
 
 from __future__ import annotations
@@ -111,54 +119,18 @@ def placement_to_metadata(p: Placement) -> dict[str, Any]:
     return out
 
 
-
-# Native fp8 tensor-core compute exists on SM >= 89 (sm_89 Ada, sm_90 Hopper,
-# sm_100+/120 Blackwell). Below that, fp8 storage still SERVES (bf16-upcast
-# path) — this floor gates only the fp8-over-bf16 PREFERENCE, never admission.
-FP8_COMPUTE_MIN_SM = 89
-
-
-# --- Family-root policy — twin of tensorhub's modelfamily.Root ----
-
-# Families whose root is not derivable by normalization alone. Roots collapse
-# fine-tune/scheduler/distillation variants that keep the weight envelope.
-_FAMILY_ROOT_OVERRIDES = {
-    "sd14": "sd1", "sd15": "sd1",
-    "sdxl-turbo": "sdxl", "sdxl-pony": "sdxl", "sdxl-illustrious": "sdxl",
-    "sdxl-lightning": "sdxl", "sdxl-hyper": "sdxl", "sdxl-refiner": "sdxl",
-    "sd35-large-turbo": "sd35-large",
-    "flux1-dev": "flux1", "flux1-schnell": "flux1",
-    "flux1-kontext": "flux1", "flux1-krea": "flux1",
-    "flux2-dev": "flux2", "flux2-pro": "flux2",
-    "z-image-turbo": "z-image",
-    "svd-xt": "svd",
-}
-
-
-
-# Conv-UNet roots get no fp8-GEMM win (torch scaled_mm is Linear-only, and
-# SDXL w8a8 measured 1.9-2.7x slower than bf16): their fp8-w8a8 rows
-# are AUTO-ineligible and the scale-free #fp8 row is the family table-best
-# on sm_89+; bf16 stays the sub-floor default. Explicit pins still resolve
-# w8a8. Twin of tensorhub precision.convUNetW8A8ExcludedRoots.
-CONV_UNET_W8A8_EXCLUDED_ROOTS = frozenset({"sd1", "sd2", "sdxl"})
-
-
-
-
 # The flavor-token parses (classify_flavor_token, placement_for_flavor) are
 # package-internal choke points, not public API. They die when typed
 # descriptors are backfilled; nothing new may grow on them.
 __all__ = [
-    "FP8_COMPUTE_MIN_SM",
     "CLASS_BASE",
     "CLASS_FP8",
     "CLASS_NVFP4",
     "CLASS_NVFP4_W4A4",
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
-    "CONV_UNET_W8A8_EXCLUDED_ROOTS",
     "Placement",
+    "classify_flavor_token",
     "default_placement",
     "placement_to_metadata",
 ]

--- a/tests/convert/test_placement_stamp_pgw1286.py
+++ b/tests/convert/test_placement_stamp_pgw1286.py
@@ -1,0 +1,155 @@
+"""pgw#1286 (HARDCUT M3): the ONE precision fact both repos still restate.
+
+`models/ladder.py` used to vendor three tables of tensorhub policy — the fp8
+compute floor, the family-root overrides and the conv-UNet w8a8 exclusion set.
+All three lost their last reader when the local AUTO fold died (pgw#1148 /
+pgw#1180), all three had already drifted from their hub twins, and one named a
+twin that no longer exists (`convUNetW8A8ExcludedRoots` is `convUNetUpcastRoots`
+today). They are deleted, not fenced: the walk, the family root and the lane
+policy are hub decisions that reach the worker resolved.
+
+What SURVIVES the deletion is the placement STAMP — the worker is the producer
+of `checkpoints.metadata["placement"]`, and tensorhub keeps a mirror of these
+same defaults as its fallback for unstamped rows
+(`internal/orchestrator/precision/placement.go`: `defaultPlacement`,
+`svdqFP4SMs`, `svdqINT4SMs`, `PlacementFromMetadata`). Those two tables must
+agree byte for byte or an unstamped row is admitted onto silicon the producer
+would have excluded. THIS is the drift fence, and it is written at the wire:
+every row publishes through the real `publish_flavors` against the fake hub and
+reads the placement block off the declare request the hub actually receives.
+
+Revert-turns-red: change any SM window, floor, engine list or class token in
+`gen_worker.models.ladder.default_placement` (or drop the stamp from
+`convert/publish.py`) and the matching row fails on the exact declared block.
+
+    pytest tests/convert/test_placement_stamp_pgw1286.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fake_hub import _FakeHub
+
+from gen_worker.convert.produced import ProducedFlavor
+from gen_worker.convert.publish import publish_flavors
+from gen_worker.models import ladder
+
+#: Cut by `tests/convert/conftest.py`'s fake repo.
+RELEASE = "2026.08"
+
+#: The hub's `precision.defaultPlacement` twin, transcribed. Written as
+#: literals on purpose: a fence that derived them from `default_placement`
+#: would only ever agree with itself.
+HUB_DEFAULTS: dict[str, dict[str, Any] | None] = {
+    # ClassBase — zero constraints, so the producer sends NO block at all and
+    # the hub's `Placement{PrecisionClass: ClassBase}` fallback is exact.
+    "bf16": None,
+    "fp16": None,
+    # ClassFP8 — fp8 storage serves on any silicon (bf16-upcast path).
+    "fp8": {"precision_class": "fp8"},
+    "fp8-w8a8": {"precision_class": "fp8"},
+    # ClassSvdqINT4 / ClassSvdqFP4 — nunchaku kernel wheels are per-arch, so
+    # the allow-list is fail-closed. `svdqINT4SMs` / `svdqFP4SMs` hub-side.
+    "svdq-int4": {
+        "precision_class": "svdq-int4",
+        "sm_allowed": [75, 80, 86, 89],
+        "engines": ["nunchaku"],
+    },
+    "svdq-fp4": {
+        "precision_class": "svdq-fp4",
+        "sm_allowed": [120, 121],
+        "engines": ["nunchaku"],
+    },
+    # ClassNVFP4W4A4 — Blackwell only, open-ended floor.
+    "nvfp4-w4a4": {"precision_class": "nvfp4-w4a4", "sm_min": 100},
+    # Unrecognized tokens stay opaque and are never ladder rungs.
+    "q4_k_m": None,
+}
+
+
+class _Ctx:
+    def __init__(self, base_url: str) -> None:
+        self._file_api_base_url = base_url
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+
+    def log(self, message: str, **fields: Any) -> None:
+        pass
+
+
+def _tree(tmp_path: Path, name: str) -> Path:
+    out = tmp_path / name
+    out.mkdir()
+    (out / "diffusion.safetensors").write_bytes(b"\x11" * 2048)
+    return out
+
+
+def _publish(fake_hub: Any, tmp_path: Path, flavor: str, **attrs: str) -> dict:
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    publish_flavors(
+        ctx,
+        [ProducedFlavor(
+            path=str(_tree(tmp_path, "out")), flavor=flavor, attributes=dict(attrs),
+        )],
+        destination_repo="acme/qwen-image",
+        release=RELEASE,
+    )
+    return dict(_FakeHub.state["publish_request"].get("metadata") or {})
+
+
+@pytest.mark.parametrize("token", sorted(HUB_DEFAULTS))
+def test_declared_placement_matches_the_hub_fallback_table(
+    fake_hub: Any, tmp_path: Path, token: str
+) -> None:
+    """Each precision class stamps EXACTLY what tensorhub would have assumed
+    for an unstamped row of that class — read off the declare request."""
+    meta = _publish(fake_hub, tmp_path, token)
+
+    expected = HUB_DEFAULTS[token]
+    if expected is None:
+        assert "placement" not in meta, (
+            f"{token!r} constrains nothing; a block here means the hub's "
+            "unstamped fallback and the producer disagree")
+    else:
+        assert meta["placement"] == expected
+
+
+def test_the_stamp_is_the_only_hub_policy_this_module_restates(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """pgw#1286's deletion, asserted rather than remembered: nothing in the
+    ladder module names a family root, a family lane preference or an fp8
+    compute floor. Those live hub-side and arrive resolved."""
+    vendored = [
+        name for name in vars(ladder)
+        if ("FAMILY" in name.upper() or "ROOT" in name.upper()
+            or "MIN_SM" in name.upper())
+    ]
+    assert vendored == [], f"hub policy re-vendored into ladder.py: {vendored}"
+    assert set(ladder.__all__) == {
+        "CLASS_BASE", "CLASS_FP8", "CLASS_NVFP4", "CLASS_NVFP4_W4A4",
+        "CLASS_SVDQ_FP4", "CLASS_SVDQ_INT4", "Placement",
+        "classify_flavor_token", "default_placement", "placement_to_metadata",
+    }
+
+
+def test_a_producer_override_still_wins_over_the_class_default(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """The defaults are a FALLBACK, not a ceiling — a producer that knows its
+    kernel coverage states it, and the override travels whole. (The override
+    attrs themselves must not leak into metadata as prose.)"""
+    meta = _publish(
+        fake_hub, tmp_path, "svdq-int4",
+        placement_sm_allowed="89", placement_engines="nunchaku,triton",
+    )
+
+    assert meta["placement"] == {
+        "precision_class": "svdq-int4",
+        "sm_allowed": [89],
+        "engines": ["nunchaku", "triton"],
+    }
+    assert not [k for k in meta if k.startswith("placement_")]

--- a/tests/convert/test_placement_stamp_pgw1286.py
+++ b/tests/convert/test_placement_stamp_pgw1286.py
@@ -92,7 +92,7 @@ def _publish(fake_hub: Any, tmp_path: Path, flavor: str, **attrs: str) -> dict:
     publish_flavors(
         ctx,
         [ProducedFlavor(
-            path=str(_tree(tmp_path, "out")), flavor=flavor, attributes=dict(attrs),
+            path=_tree(tmp_path, "out"), flavor=flavor, attributes=dict(attrs),
         )],
         destination_repo="acme/qwen-image",
         release=RELEASE,


### PR DESCRIPTION
**HARDCUT M3 (the pgw leg of ledger G6).** The row asked for a drift fence over `models/ladder.py`'s duplication of tensorhub precision policy, written against the policy that survived B5. The census says the better answer for three of the four items is **deletion**.

### Census — what `ladder.py` actually duplicates today (pgw 0.118.0 vs `tensorhub@8ade0782c`)

| value | hub twin | readers in pgw | verdict |
|---|---|---|---|
| `FP8_COMPUTE_MIN_SM = 89` | `precision.FP8ComputeMinSM = 89` (live, 6 call sites) | **0** | delete |
| `_FAMILY_ROOT_OVERRIDES` (14 rows) | `modelfamily.rootOverrides` (live) | **0** | delete |
| `CONV_UNET_W8A8_EXCLUDED_ROOTS` | named twin `precision.convUNetW8A8ExcludedRoots` **no longer exists** — it is `convUNetUpcastRoots` today | **0** | delete |
| `default_placement` + `SVDQ_*_SMS` | `precision.defaultPlacement`, `svdqFP4SMs`/`svdqINT4SMs` (hub comment: *"mirror gen_worker.models.svdq"*) | `convert/publish.py` — LIVE | **fence** |
| offload / degrade-don't-OOM rungs | none | — | worker-local, not a duplicate, untouched |

### Why deletion beats a fence for the three

All three lost their last reader when the local AUTO fp8 fold died — `git log -S` puts it at pgw#1148 (`#flavor` stops being a weight address; every picker that read one is gone) and pgw#1180 cut 2 (five dead model helpers). The module docstring already said *"there is deliberately no local walk and no local AUTO fp8 fold"*; these were its orphaned inputs.

And all three had **already drifted**, which is the argument: the hub's root table has grown `wan-22-t2v-a14b`/`-i2v-a14b`/`-ti2v-5b`, `ltx-23` and `micro-4d` entries the worker's copy never got, and the conv-UNet comment names a hub symbol that was renamed out from under it. A fence over dead, already-drifted values pins three numbers nothing consults and reports drift that costs nothing.

### What survives, and where the fence went

The worker is the PRODUCER of `checkpoints.metadata["placement"]` (`publish.py:_placement_block`), and tensorhub keeps the identical class-defaults table as its fallback for unstamped rows (`precision/placement.go: defaultPlacement`, `PlacementFromMetadata`). Disagreement there admits an unstamped row onto silicon the producer would have excluded. Direction matters: the SM windows are the *worker's* fact (nunchaku kernel-wheel coverage) and the hub vendors them, so the fence belongs producer-side.

`tests/convert/test_placement_stamp_pgw1286.py` (10 rows) drives the **real seam**, not the function: each precision class publishes through the real `publish_flavors` against the fake tensorhub and the placement block is read **off the declare request the hub receives** — base/unrecognized rows send no block at all (matching the hub's zero-constraint fallback exactly), fp8 sends `{"precision_class":"fp8"}`, both svdq classes send their fail-closed `sm_allowed` + `engines=["nunchaku"]`, `nvfp4-w4a4` sends `sm_min=100`, and a producer's explicit `placement_*` override travels whole without leaking the override attrs into metadata as prose. The hub's values are transcribed as literals on purpose — deriving them from `default_placement` would only ever agree with itself.

### Red-verified, three arms

1. `SVDQ_INT4_SMS` + `90` → `[svdq-int4]` red on the exact declared block.
2. re-vendoring `FP8_COMPUTE_MIN_SM` into `ladder.py` → the re-vendoring row red, naming the symbol.
3. dropping `meta["placement"] = placement` from `publish.py` → 6 of 10 red.

Green on the unmutated tree.

### Verified

`mypy src/gen_worker tests tests_v2` Success (725 files) · all 17 `fast gates` lint scripts rc=0 · `assemble_changelog.py --check` rc=0 · ruff unchanged (5 pre-existing, none in the touched files) · `tests/convert/` 116 passed.

Tracker: `python-gen-worker/progress.md` #1286.
