### PR TITLE
pgw#1288: delete the last four TCG constants the worker re-declared

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # pgw#1232/pgw#1270: TCG owns compiled-graph identity, declaration, call
     # ingress, artifact format and compile-span attribution. Pure python — it
     # neither installs nor imports Torch.
-    "torch-compiled-graphs>=0.4,<0.5",
+    "torch-compiled-graphs>=0.6,<0.7",
     "huggingface-hub>=0.26.0",
     # gen_worker.convert (GGUF quantization tooling; small, pure-python)
     "gguf>=0.10.0",

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -48,8 +48,6 @@ from .models.cache_paths import open_worker_engine, tensorhub_cas_dir
 from .models.memory import is_cuda_oom
 
 logger = logging.getLogger(__name__)
-
-ARTIFACT_KIND = "aot-inductor"
 #: pgw#791: an input the artifact was compiled for as 16-byte aligned arrived
 #: unaligned (or non-contiguous) and this ingress realigned it. Typed and
 #: hub-visible because the ALTERNATIVE is what shipped: AOTInductor's own
@@ -1976,7 +1974,6 @@ def unwrap(pipeline: Any) -> bool:
 
 __all__ = [
     "AdoptOutcome",
-    "ARTIFACT_KIND",
     "COMPILED_GRAPH_FORMAT",
     "COMPILED_GRAPH_FORMAT_KEY",
     "ConstantsUnboundError",

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -641,7 +641,7 @@ def _record_guard_miss(
 # with the pgw#1035 dead-code wave) and claimed parity with
 # `aot_serve.IDENTITY_AXES`, which was never true — 5 entries against 3, and
 # pgw#1034 had already ruled the two sets deliberately different. The cell key's
-# axes are `graph_facts.KEY_AXES`; this module's job is `runtime_key()`,
+# axes are `torch_compiled_graphs.REQUIRED_AXES`; this module's job is `runtime_key()`,
 # the ONE probe that states them.
 
 

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -64,6 +64,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
+from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK, REQUIRED_AXES
 from torch_compiled_graphs import is_compiled_graph_key
 from torch_compiled_graphs import identity as tcg_identity
 
@@ -812,7 +813,7 @@ class CellPublisher:
                 raise CellPublishRefused(
                     f"entries[{i}] repeats entries[{seen[key]}]'s key {key}")
             seen[key] = i
-            for axis in graph_facts.KEY_AXES:
+            for axis in REQUIRED_AXES:
                 if not str(entry.identity_axes.get(axis) or "").strip():
                     raise CellPublishRefused(
                         f"entries[{i}].identity_axes states no {axis!r}; an "
@@ -1651,7 +1652,7 @@ def arm_ordered(
     row = CellAdoption(
         ref=delivered_ref,
         snapshot_digest=delivered_digest,
-        artifact_kind=aot_serve.ARTIFACT_KIND,
+        artifact_kind=ARTIFACT_KIND,
         arm_ms=arm_ms,
         armed=outcome.armed,
         reason=outcome.reason,
@@ -2506,7 +2507,7 @@ def adopt_delegated_mint(
             row_meta = {}
         row_key = str(row_meta.get("compiled_graph_key") or "").strip()
         entry_name = str(
-            (row_meta.get(graph_facts.TCG_GRAPH_CLASS_BLOCK) or {}).get("name") or "")
+            (row_meta.get(GRAPH_CLASS_BLOCK) or {}).get("name") or "")
         if not row_armed:
             refusals.append((entry_name or row.name, *row_refusal))
             activity_mod.emit_event(

--- a/src/gen_worker/graph_facts.py
+++ b/src/gen_worker/graph_facts.py
@@ -39,30 +39,6 @@ from typing import Any, Dict, Iterable, Mapping, Tuple
 
 from torch_compiled_graphs import is_compiled_graph_key
 
-#: The three identity axes, restated for the PUBLISH WIRE (pgw#1224 / th#1842).
-#: Every batched entry must restate all three, so the wire needs the
-#: enumeration by name.
-#:
-#: This is a PROJECTION of :mod:`torch_compiled_graphs.identity`, not a second
-#: authority — TCG does not export its required-axis tuple today, and
-#: ``tests/test_identity_is_tcg_pgw1277.py`` fences this copy against TCG's
-#: actual refusal so the two cannot drift silently. Delete this constant the
-#: moment TCG publishes the tuple.
-KEY_AXES: Tuple[str, ...] = ("graph", "sm", "toolchain")
-
-#: The block TCG writes into every artifact's metadata to name the ONE graph
-#: class that artifact carries.
-#:
-#: pgw#1277: the worker used to call this block ``entry`` and read it by that
-#: name. TCG has minted every artifact since pgw#1270 and has never written an
-#: ``entry`` block, so every reader was reading a shape that does not exist —
-#: publish refused outright, held classes recompiled, the boot-key memo
-#: silently disabled. Like :data:`KEY_AXES` this is a PROJECTION of a TCG
-#: constant that TCG does not export yet, and
-#: ``tests/test_identity_is_tcg_pgw1277.py`` fences it against TCG's own
-#: refusal. Delete it the moment TCG publishes the name.
-TCG_GRAPH_CLASS_BLOCK = "graph_class"
-
 #: The MANIFEST block recording one declaration's DECLARED ENVELOPE.
 #:
 #: Naming note (pgw#1059 §F): this is the DECLARED envelope. The OTHER
@@ -210,8 +186,6 @@ def manifest_digest(class_hashes: Iterable[str]) -> str:
 
 __all__ = [
     "EXPORT_ENVELOPE_KEY",
-    "KEY_AXES",
-    "TCG_GRAPH_CLASS_BLOCK",
     "GraphFactsError",
     "SlotSubject",
     "envelope_digest",

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -91,7 +91,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from torch_compiled_graphs import is_compiled_graph_key
+from torch_compiled_graphs import ARTIFACT_KIND, is_compiled_graph_key
 from torch_compiled_graphs.identity import KEY_SCHEME
 
 logger = logging.getLogger(__name__)
@@ -126,11 +126,6 @@ MEMO_DIRNAME = ".memo"
 ARTIFACT_NAME = "cell.tar.gz"
 RECORD_NAME = "record.json"
 TRUST_CLASS_NAME = "trust-class.json"
-
-#: The only artifact class this store holds. pgw#1010/pgw#1059: an exported
-#: cell is the only kind with an identity, so it is the only kind that can be
-#: addressed — a JIT capture has no key and nothing could ever look it up.
-KIND = "aot-inductor"
 
 #: The hub's typed 403 that ASSERTS this machine may not publish. One string,
 #: from ``tensorhub``'s ``worker_cell_publish.go``; a refusal the worker does
@@ -279,7 +274,10 @@ def store(
             "arm_token": record.arm_token,
             "bytes": record.bytes,
             "stored_at": record.stored_at,
-            "kind": KIND,
+            # TCG owns this string; pgw#1010/pgw#1059: an exported cell is
+            # the only kind with an identity, so it is the only kind this
+            # store can hold — a JIT capture has no key to look up.
+            "kind": ARTIFACT_KIND,
             "verdict": record.verdict,
             "sink": record.sink,
         })
@@ -605,7 +603,6 @@ __all__ = [
     "ARTIFACT_NAME",
     "CELLS_DIRNAME",
     "ENV_STORE_DIR",
-    "KIND",
     "LocalCell",
     "MEMO_DIRNAME",
     "SINK_DELIVERED",

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -60,7 +60,7 @@ import msgspec
 from . import activity as activity_mod
 from . import artifact_meta
 from . import boot_phases
-from . import graph_facts
+from torch_compiled_graphs import GRAPH_CLASS_BLOCK
 from . import compile_posture
 from . import mint_workers
 from . import progress as progress_mod
@@ -261,7 +261,7 @@ def rule_on_boot_memo(
     blocks: Dict[str, Dict[str, Any]] = {}
     for row in entries:
         block = dict(getattr(row, "metadata", None) or {}).get(
-            graph_facts.TCG_GRAPH_CLASS_BLOCK)
+            GRAPH_CLASS_BLOCK)
         if not isinstance(block, Mapping):
             return ""
         blocks[str(row.entry)] = dict(block)
@@ -594,7 +594,7 @@ def held_graph_classes(out_dir: Path) -> List[Any]:
     for path in sorted(out_dir.glob("*.tar.gz")):
         try:
             meta = dict(artifact_meta.read_metadata(path))
-            name = str(meta[graph_facts.TCG_GRAPH_CLASS_BLOCK]["name"])
+            name = str(meta[GRAPH_CLASS_BLOCK]["name"])
             key = str(meta.get("compiled_graph_key") or "")
         except Exception:  # noqa: BLE001 — see the docstring
             logger.warning(

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -29,6 +29,8 @@ from typing import (
     Tuple,
 )
 
+from torch_compiled_graphs import ARTIFACT_KIND
+
 from ..cell_adopt import AdoptOutcome
 from ..component_vocab import denoiser_components
 from ..api.binding import ModelRef, wire_ref
@@ -819,7 +821,7 @@ def enable_compiled(
     adopt. Staying eager rolls the branches back — canonical zeroed slots
     cost +21-32% eager (gw#547); the eager adapter path re-enables sparse
     placement per request."""
-    from .. import aot_serve, compile_cache  # lazy: keeps `import gen_worker` off the compile/pb stack
+    from .. import compile_cache  # lazy: keeps `import gen_worker` off the compile/pb stack
     # Deferred: receipts pulls +151 modules onto the `import gen_worker` path.
     from .. import receipts
 
@@ -848,7 +850,7 @@ def enable_compiled(
         # through to the ordinary inductor lane.
         meta = _compiled_graph_metadata(artifact)
         kind = str((meta or {}).get("kind") or "")
-        if kind == aot_serve.ARTIFACT_KIND:
+        if kind == ARTIFACT_KIND:
             aot = arm_aot(pipe, cfg, cache_dir, Path(artifact), bucket, meta)
             if aot.armed:
                 return aot

--- a/tests/harness/cell_meta.py
+++ b/tests/harness/cell_meta.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
 from torch_compiled_graphs import identity as tcg_identity
 
 from gen_worker import aot_serve, graph_facts
@@ -43,10 +44,10 @@ def exported_cell_meta(
     """One exported (``aot-inductor``) cell's metadata, key stamped from it."""
     meta: Dict[str, Any] = {
         "family": family, "sku": sku, "sm": sm, "gen_worker": gen_worker,
-        "kind": aot_serve.ARTIFACT_KIND, "format": "pt2",
+        "kind": ARTIFACT_KIND, "format": "pt2",
         "weight_lane": weight_lane, "lora_bucket": int(lora_bucket),
         "strict_export": True,
-        graph_facts.TCG_GRAPH_CLASS_BLOCK: {
+        GRAPH_CLASS_BLOCK: {
             "name": "unet/main",
             "target": "unet", "fork": [], "class_dims": [],
             "range_digest": "r1", "class_hash": CLASS_HASH, "graph": {"v": 2},

--- a/tests/test_boot_phases_pgw764.py
+++ b/tests/test_boot_phases_pgw764.py
@@ -26,6 +26,8 @@ from typing import Any, List
 
 import pytest
 
+from torch_compiled_graphs import ARTIFACT_KIND
+
 from gen_worker import aot_serve, boot_phases, serving_mode
 from gen_worker.compile_cache import AdoptError
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -158,7 +160,7 @@ def test_a_typed_refusal_is_recorded_as_refused_not_failed() -> None:
     exc = AdoptError("key_mismatch", "cell was minted for sm_90, host is sm_89")
     with boot_phases.span(
         boot_phases.PHASE_CELL_ARM,
-        artifact_kind=aot_serve.ARTIFACT_KIND,
+        artifact_kind=ARTIFACT_KIND,
         artifact_key="ck1_deadbeef",
     ) as arm:
         # The shape aot_serve.enable uses: classified reason token + the
@@ -171,7 +173,7 @@ def test_a_typed_refusal_is_recorded_as_refused_not_failed() -> None:
     assert row.outcome != boot_phases.OUTCOME_FAILED
     assert row.reason == "key_mismatch"
     assert "sm_90" in row.detail
-    assert row.artifact_kind == aot_serve.ARTIFACT_KIND
+    assert row.artifact_kind == ARTIFACT_KIND
     assert row.artifact_key == "ck1_deadbeef"
 
 

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -33,6 +33,7 @@ import pytest
 from hashrepo import TransferReport
 
 import gen_worker.hubio.client as hub_client
+from torch_compiled_graphs import GRAPH_CLASS_BLOCK, REQUIRED_AXES
 from torch_compiled_graphs import identity as tcg_identity
 
 from gen_worker import env_seal, graph_facts, receipts
@@ -245,7 +246,7 @@ META = {
     "family": FAMILY, "sku": "l4", "sm": "89",
     "gen_worker": "0.87.0", "kind": "aot-inductor", "format": "pt2",
     "weight_lane": "w8a8", "lora_bucket": 64, "strict_export": True,
-    graph_facts.TCG_GRAPH_CLASS_BLOCK: {
+    GRAPH_CLASS_BLOCK: {
         "name": "unet/main",
         "target": "unet", "fork": [], "class_dims": [],
         "range_digest": "r1", "class_hash": _CLASS_HASH, "graph": {"v": 2},
@@ -418,6 +419,29 @@ def test_the_pre_fix_fallback_row_shape_can_no_longer_be_published(hub, artifact
         fc._identity_axes(FAMILY, dict(TODAYS_FALLBACK_META))
 
 
+@pytest.mark.parametrize("dropped", REQUIRED_AXES)
+def test_an_entry_that_cannot_restate_every_key_axis_is_refused(hub, dropped):
+    """Each of the three axes is required, and each is checked SEPARATELY.
+
+    pgw#1288 deleted the worker's copy of the axis tuple, so this loop now
+    reads TCG's export directly — which means nothing worker-side pins WHICH
+    axes it iterates. Shortening the tuple to two axes left the suite green:
+    an entry with no ``toolchain`` would have reached the hub, and an entry
+    that cannot restate its own key has no identity outside its own batch.
+
+    Parametrised over the export rather than over a spelled-out list, so this
+    follows a deliberate axis change and fails only on a silent one.
+    """
+    axes = {"graph": "a" * 16, "sm": "sm_89", "toolchain": "b" * 16}
+    del axes[dropped]
+    entry = fc.PublishEntry(compiled_graph_key=COMPILED_GRAPH_KEY,
+                            identity_axes=axes)
+    with pytest.raises(fc.CellPublishRefused, match=repr(dropped)):
+        _publisher(hub).publish_intent(
+            FAMILY, [entry], sku="l4", gen_worker="0.118.0")
+    assert not hub.httpd.calls, "refused before the intent left the pod"
+
+
 def test_a_stamp_that_disagrees_with_the_recorded_axes_is_refused(hub, artifact):
     """A cell whose `compiled_graph_key` does not describe its own blocks is a cell the
     hub would index under one identity and the worker would fence on another."""
@@ -454,8 +478,8 @@ def test_a_cell_with_no_class_hash_is_refused(hub, artifact):
     state its own graph axis has no identity, so it would be stored under a
     flavor nothing can request."""
     hollow = dict(META)
-    hollow[graph_facts.TCG_GRAPH_CLASS_BLOCK] = {
-        **META[graph_facts.TCG_GRAPH_CLASS_BLOCK], "class_hash": ""}
+    hollow[GRAPH_CLASS_BLOCK] = {
+        **META[GRAPH_CLASS_BLOCK], "class_hash": ""}
     with pytest.raises(fc.CellPublishRefused):
         _publisher(hub).publish(FAMILY, artifact, hollow)
     assert not hub.httpd.calls

--- a/tests/test_compiled_graph_key_pgw1059.py
+++ b/tests/test_compiled_graph_key_pgw1059.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 import pytest
 from torch_compiled_graphs import (
+    GRAPH_CLASS_BLOCK,
+    REQUIRED_AXES,
     CallIngress,
     CallInput,
     GraphClassDeclaration,
@@ -64,12 +66,12 @@ def test_membership_axiom_the_key_is_exactly_three_axes():
     digests the UNION of the ladder across the whole declaration, which is a
     property of the collection and not of any computation.
     """
-    assert graph_facts.KEY_AXES == ("graph", "sm", "toolchain")
+    assert REQUIRED_AXES == ("graph", "sm", "toolchain")
     # Asserted against the AUTHORITY, not against a worker-side tuple:
-    # pgw#1277 deleted the duplicate, so the axiom is TCG's to enforce and the
-    # worker's wire enumeration is a fenced projection of it.
-    sample = {name: f"{name}-fact" for name in graph_facts.KEY_AXES}
-    assert tcg_identity.from_axes(sample).as_dict().keys() == set(graph_facts.KEY_AXES)
+    # pgw#1288 deleted the last worker copy, so there is nothing left to fence
+    # — the axiom is TCG's to enforce and the wire reads its export directly.
+    sample = {name: f"{name}-fact" for name in REQUIRED_AXES}
+    assert tcg_identity.from_axes(sample).as_dict().keys() == set(REQUIRED_AXES)
 
 
 def test_adding_an_axis_refuses_with_the_axiom_named():
@@ -233,7 +235,7 @@ def _old_schema_digest(meta: dict) -> str:
         # entry artifact records neither, which is itself the structural
         # reason an orphaned cell can never be re-derived.
         "targets": [str(
-            (meta.get(graph_facts.TCG_GRAPH_CLASS_BLOCK) or {}).get("target") or "")],
+            (meta.get(GRAPH_CLASS_BLOCK) or {}).get("target") or "")],
         "shapes": [[1024, 1024]],
         "text_lens": [77],
         "guidance": [7.5],
@@ -297,7 +299,7 @@ def test_pre_redefinition_artifact_is_structurally_refused():
     than a correctness precondition."""
     meta = _current_worker_meta()
     old = dict(meta)
-    entry = old.pop(graph_facts.TCG_GRAPH_CLASS_BLOCK)
+    entry = old.pop(GRAPH_CLASS_BLOCK)
     old["entries"] = {entry["name"]: entry}
     # fence-symbol-exempt: the pre-atom artifact shape, on purpose — this
     # row proves a format-2 cell cannot restate a per-entry identity.
@@ -343,7 +345,7 @@ def test_worker_publish_projection_matches_public_tcg_key() -> None:
     meta = {
         "kind": "aot-inductor",
         "sm": runtime.sm,
-        graph_facts.TCG_GRAPH_CLASS_BLOCK: {
+        GRAPH_CLASS_BLOCK: {
             "name": declaration.graph_class,
             "class_hash": declaration.class_hash,
         },
@@ -418,8 +420,8 @@ def test_only_the_graph_rekeys_and_the_envelope_no_longer_can():
     assert tcg_identity.from_artifact_metadata(wider).value == key
 
     other_graph = dict(meta)
-    other_graph[graph_facts.TCG_GRAPH_CLASS_BLOCK] = {
-        **meta[graph_facts.TCG_GRAPH_CLASS_BLOCK], "class_hash": "b" * 16}
+    other_graph[GRAPH_CLASS_BLOCK] = {
+        **meta[GRAPH_CLASS_BLOCK], "class_hash": "b" * 16}
     assert tcg_identity.from_artifact_metadata(other_graph).value != key
 
 

--- a/tests/test_identity_is_tcg_pgw1277.py
+++ b/tests/test_identity_is_tcg_pgw1277.py
@@ -182,40 +182,6 @@ def test_the_artifact_derivation_is_pinned_by_value() -> None:
     assert tcg_identity.from_artifact_metadata(KAT_META).value == KAT_META_KEY
 
 
-def test_the_axis_projection_is_fenced_against_tcgs_refusal() -> None:
-    """``graph_facts.KEY_AXES`` is a PROJECTION, so it needs a fence.
-
-    TCG does not export its required-axis tuple, and the publish wire has to
-    name the axes. A copy nobody checks is how two enumerations start
-    disagreeing about what an entry must restate — so assert TCG accepts
-    exactly this set and refuses anything outside it.
-    """
-    sample = {name: f"{name}-fact" for name in graph_facts.KEY_AXES}
-    assert tcg_identity.from_axes(sample).as_dict().keys() == set(graph_facts.KEY_AXES)
-
-    for dropped in graph_facts.KEY_AXES:
-        with pytest.raises(tcg_identity.IdentityError):
-            tcg_identity.from_axes({k: v for k, v in sample.items() if k != dropped})
-
-    with pytest.raises(tcg_identity.IdentityError):
-        tcg_identity.from_axes({**sample, "envelope": "e" * 16})
-
-
-def test_the_graph_class_block_projection_is_fenced() -> None:
-    """``graph_facts.TCG_GRAPH_CLASS_BLOCK`` must name the block TCG reads.
-
-    This is the constant whose drift caused the defect. Prove it against TCG
-    itself rather than against another copy of the same guess: renaming the
-    block makes TCG refuse the artifact.
-    """
-    assert tcg_identity.from_artifact_metadata(TCG_METADATA).value
-
-    renamed = json.loads(json.dumps(TCG_METADATA))
-    renamed["entry"] = renamed.pop(graph_facts.TCG_GRAPH_CLASS_BLOCK)
-    with pytest.raises(tcg_identity.IdentityError):
-        tcg_identity.from_artifact_metadata(renamed)
-
-
 def test_the_worker_holds_no_second_identity_module() -> None:
     """The deletion IS the fix — a correctly-named duplicate computing wrong
     keys with nothing raising is the failure this unit removes."""

--- a/tests/test_wired_gates_pgw1271.py
+++ b/tests/test_wired_gates_pgw1271.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, List, Tuple, cast
 
 import pytest
 
+from torch_compiled_graphs import GRAPH_CLASS_BLOCK
+
 from gen_worker import (
     aot_serve,
     author_ci,
@@ -96,7 +98,7 @@ class _Row:
     def __init__(self, entry: str, block: Dict[str, Any]) -> None:
         self.entry = entry
         self.key = f"cg-{entry}"
-        self.metadata = {graph_facts.TCG_GRAPH_CLASS_BLOCK: block}
+        self.metadata = {GRAPH_CLASS_BLOCK: block}
 
 
 class _Result:

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'torch'", specifier = ">=2.13.0" },
-    { name = "torch-compiled-graphs", specifier = ">=0.4,<0.5" },
+    { name = "torch-compiled-graphs", specifier = ">=0.6,<0.7" },
     { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'vision') or (sys_platform == 'win32' and extra == 'vision')", specifier = ">=0.28.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchvision", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'vision'", specifier = ">=0.28.0" },
     { name = "transformers", marker = "extra == 'dev'", specifier = ">=5.13" },
@@ -2033,15 +2033,15 @@ wheels = [
 
 [[package]]
 name = "torch-compiled-graphs"
-version = "0.4.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hashrepo" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/0d/56e112d872c60d9e32b0002a694acf927f4af485d099a05ae65c94409a51/torch_compiled_graphs-0.4.0.tar.gz", hash = "sha256:167b7c9f0016cd12452077c9c48e3b347220f51e2c618151c0ba4157edda5f8c", size = 70273, upload-time = "2026-08-14T16:22:21.727Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/02/3d9eb0001882cc746c9ce4152637954624a3151a9c3f1c55d5d88c1ef5d5/torch_compiled_graphs-0.6.0.tar.gz", hash = "sha256:07f733547e350b02ee40843bdd978656a18501a40c083cffa3ea08f6a11060b2", size = 73172, upload-time = "2026-08-16T10:58:33.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/7e/71fd20b3ff9920b4d600fcabc5ddfaf5c2fcb569d023ca0c6226e4b7ffd2/torch_compiled_graphs-0.4.0-py3-none-any.whl", hash = "sha256:390d167bd8fcee494f4dc368a63fbbb0f6fff10b6f4e9edab9c2e8738d7ae723", size = 78723, upload-time = "2026-08-14T16:22:20.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/68/8cf29d2c46997e9ed1d4f1ae3cf5bb9ac1e1b84b7a84ea452f0cb16b714d/torch_compiled_graphs-0.6.0-py3-none-any.whl", hash = "sha256:d254e5885e4dec7c97fdc6c76a5ac8d800f87adafdd3c20ada535938b4fc1309", size = 79249, upload-time = "2026-08-16T10:58:31.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
TCG [0.5.0](https://github.com/cozy-creator/torch-compiled-graphs/pull/22) published `REQUIRED_AXES` and `GRAPH_CLASS_BLOCK`; [0.6.0](https://github.com/cozy-creator/torch-compiled-graphs/pull/24) published `ARTIFACT_KIND`. `graph_facts.py`'s own comments said *"Delete this constant the moment TCG publishes the tuple"* / *"the moment TCG publishes the name."* That moment has arrived.

## Four copies, and the two that mattered most had no fence at all

| copy | where | fenced against TCG? |
|---|---|---|
| `KEY_AXES` | `graph_facts.py:51` | yes |
| `TCG_GRAPH_CLASS_BLOCK` | `graph_facts.py:64` | yes |
| `KIND` | `local_cell_store.py:133` | **no** |
| `ARTIFACT_KIND` | `aot_serve.py:52` | **no** |

The `aot-inductor` pair is the point. The fenced pair at least had `test_identity_is_tcg_pgw1277.py` comparing them to TCG's actual refusal. The other two had **nothing** — `test_boot_phases_pgw764.py` only checks `row.artifact_kind == aot_serve.ARTIFACT_KIND`, the worker against itself. TCG renaming its artifact kind would have gone unnoticed: the precondition of the `entry`/`graph_class` outage, one field over and still live. Found while auditing this cleanup, and it is why TCG #24 exists.

## No re-export aliases

`aot_serve.ARTIFACT_KIND` and `local_cell_store.KIND` are gone from `__all__`, and all four readers (`provision.py`, `fleet_cells.py`, `local_cell_store.py`, `test_boot_phases`) import from `torch_compiled_graphs` directly. Keeping the names as re-exports would have been the smaller diff and the wrong one — **a second NAME for one authority is how the first copy started.**

The two fence tests that existed only to guard the copies are deleted with them, and `test_compiled_graph_key_pgw1059`'s membership axiom now reads TCG's export instead of a worker tuple.

## Pin

`>=0.4,<0.5` → **`>=0.6,<0.7`**, `uv.lock` re-resolved 0.4.0 → 0.6.0. Not optional: 0.4.x exports none of these three names, so the deletion breaks the worker at import time without it.

## Red proofs

| mutation | result |
|---|---|
| rename `GRAPH_CLASS_BLOCK` **inside the installed TCG** | 3 worker tests RED — the worker now follows the authority and cannot drift from it |
| re-hardcode `"entry"` at `mint_supervisor`'s two read sites | `test_the_mint_publish_seam_rules_on_a_DISHONEST_boot_memo` + `test_the_dishonest_verdict_reaches_the_wire_as_a_TYPED_EVENT` RED |
| shorten `publish_intent`'s axis loop to two axes | the new parametrised test RED on `[toolchain]` |

## Two unbound read sites found on the way

Repointing every reader meant mutating each one, which exposed two that **no test binds**:

1. **`publish_intent`'s axis loop** (`fleet_cells.py:815`) validates that every entry restates all three key axes. Shortening it to two left the entire suite green — an entry with no `toolchain` would have reached the hub, and *"a row whose identity is only verifiable inside its batch is not an identity."* **Fixed here**, with a test parametrised over `REQUIRED_AXES` so it follows a deliberate axis change and fails only on a silent one.
2. **`adopt_delegated_mint`'s block read** (`fleet_cells.py:2509`) survived re-hardcoding `"entry"`. It feeds a refusal **label**, so a wrong name empties a log string rather than changing a decision. Named rather than given a heavy fixture — say the word if you want it covered.

## Gates

`ruff check src/gen_worker` — **5 findings, byte-identical to the `origin/master` baseline** (all pre-existing; the cut left two dead imports, both removed). 19 fast-gate lint guards rc=0. Targeted suites **109 passed, 1 skipped** (`test_identity_is_tcg_pgw1277`, `test_compiled_graph_key_pgw1059`, `test_cell_publish_v2_pgw807`, `test_wired_gates_pgw1271`, `test_boot_phases_pgw764`).

**mypy is CI's to judge, and I am saying so rather than claiming a pass.** This worktree's venv has no torch (the `dev` extra's torch download fails on this box), which alone produces 68 `Module has type Any` errors in torch-dependent modules. **Zero of them are in any file this PR touches** — I checked the error set against the changed files explicitly — and `origin/master` is `Success: no issues found in 725 source files` in a torch-equipped venv.