### PR TITLE
pgw#1289: the residency scan reports as it scans, and stops holding the event loop while it does

### DIFF
--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -422,28 +422,45 @@ class CozySnapshotDownloader:
         missing: list[TransferGrant] = []
         done = 0
         total = sum(grant.size_bytes for grant in grants)
-        for grant in grants:
+
+        # Report per grant: a counter frozen at zero reads as a stalled
+        # transfer and the pod is killed mid-progress.
+        def report_residency() -> None:
+            if progress is not None:
+                progress(done, total)
+
+        def resident(grant: TransferGrant) -> bool:
             try:
-                resident = cas.contains(grant.digest, size=grant.size_bytes)
+                return bool(cas.contains(grant.digest, size=grant.size_bytes))
             except DigestMismatch:
-                resident = False
-            if resident:
+                return False
+
+        def filled(grant: TransferGrant) -> bool:
+            if fill is None:
+                return False
+            try:
+                source = fill.verify_object(grant.digest, size=grant.size_bytes)
+                cas.put_file(source, expected=grant.digest, size=grant.size_bytes)
+                return True
+            except (DigestMismatch, FileNotFoundError, OSError):
+                return False
+
+        # Every check re-hashes the object — ~1.0s of solid CPU per GiB, and a
+        # resume re-hashes everything earlier attempts landed. On the caller's
+        # loop thread that stranded the heartbeat and every queued event until
+        # the scan ended, so each check runs off-thread and only the emission
+        # stays on the caller's thread.
+        report_residency()
+        for grant in grants:
+            if await asyncio.to_thread(resident, grant):
                 done += grant.size_bytes
                 settle(grant.digest, boot_phases.SOURCE_LOCAL)
-                continue
-            copied = False
-            if fill is not None:
-                try:
-                    source = fill.verify_object(grant.digest, size=grant.size_bytes)
-                    cas.put_file(source, expected=grant.digest, size=grant.size_bytes)
-                    copied = True
-                except (DigestMismatch, FileNotFoundError, OSError):
-                    copied = False
-            if copied:
+            elif await asyncio.to_thread(filled, grant):
                 done += grant.size_bytes
                 settle(grant.digest, boot_phases.SOURCE_VOLUME)
             else:
                 missing.append(grant)
+            report_residency()
 
         required = sum(grant.size_bytes for grant in missing) + _DISK_HEADROOM_BYTES
         free = shutil.disk_usage(cas.root).free
@@ -455,8 +472,6 @@ class CozySnapshotDownloader:
                 required_bytes=required,
                 path=str(cas.root),
             )
-        if progress is not None:
-            progress(done, total)
 
         sink = _NETWORK_BYTES_SINK.get()
         moved = 0

--- a/tests/test_snapshot_residency_progress_pgw1289.py
+++ b/tests/test_snapshot_residency_progress_pgw1289.py
@@ -1,0 +1,176 @@
+"""The residency scan must be visible WHILE it runs, not only once it ends."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hashrepo import CASRef, LocalCAS
+
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef
+
+_GATE_TIMEOUT_S = 10.0
+
+
+def _ref() -> TensorhubRef:
+    return TensorhubRef(owner="acme", repo="model", release="latest")
+
+
+def test_a_resident_grant_advances_progress_before_the_scan_finishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pgw#1289: `_ensure_objects` emitted `progress` once, AFTER the residency
+    loop. `LocalCAS.contains` is `verify_object`, a full sha256 re-hash of every
+    byte, so a resident 31.6 GB snapshot re-hashed 31.6 GB with the hub-visible
+    counter pinned at zero and `download` never reached — and the hub's 6-minute
+    transfer freshness window killed a pod that had already done all the work.
+
+    Totals were always correct; only their arrival was wrong, so any test that
+    checks the final callback set passes on the broken tree. This asserts the
+    arrival: the second grant's residency check refuses to complete until the
+    first grant's callback has been observed, which is impossible if emission
+    waits for the loop. A regression fails here with a named message on a
+    10 s bound rather than wedging the suite.
+    """
+
+    first = b"resident-first"
+    second = b"resident-second-object"
+    store = LocalCAS(tmp_path)
+    first_digest = store.put_bytes(first)
+    second_digest = store.put_bytes(second)
+    first_reported = threading.Event()
+
+    real_contains = LocalCAS.contains
+
+    def gated_contains(self: Any, ref: Any, *, size: int | None = None) -> bool:
+        if CASRef.parse(ref) == second_digest and not first_reported.wait(
+            _GATE_TIMEOUT_S
+        ):
+            raise AssertionError(
+                "no progress was reported for the first resident object while "
+                "the second was still being verified — the whole residency "
+                "scan is invisible until it ends"
+            )
+        return real_contains(self, ref, size=size)
+
+    monkeypatch.setattr(LocalCAS, "contains", gated_contains)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "d" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                "config.json",
+                len(first),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(first_digest),
+            ),
+            WorkerResolvedRepoFile(
+                "weights.safetensors",
+                len(second),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(second_digest),
+            ),
+        ],
+    )
+
+    total = len(first) + len(second)
+    caller = threading.current_thread()
+    beats: list[tuple[int, int | None]] = []
+    threads: list[threading.Thread] = []
+
+    def progress(done: int, reported: int | None) -> None:
+        beats.append((done, reported))
+        threads.append(threading.current_thread())
+        # The gate opens on a RECORDED mid-scan beat, so it cannot be satisfied
+        # by the leading 0/total or by the final one.
+        if 0 < done < total:
+            first_reported.set()
+
+    path = asyncio.run(
+        ensure_snapshot_async(
+            base_dir=tmp_path, ref=_ref(), resolved=resolved, progress=progress
+        )
+    )
+
+    assert (path / "config.json").read_bytes() == first
+    assert (path / "weights.safetensors").read_bytes() == second
+    # The total is known before any byte is hashed, and the counter reaches it.
+    assert beats[0] == (0, total)
+    assert beats[-1] == (total, total)
+    # And it moved while the scan was still running.
+    assert any(0 < done < total for done, _total in beats)
+    assert set(threads) == {caller}
+
+
+def test_the_scan_yields_the_event_loop_between_grants(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An emission that cannot leave the process is not an emission.
+
+    The residency scan hashes on the worker's own event-loop thread, so
+    without a turn between grants the heartbeat coroutine and the DOWNLOADING
+    events the progress callback queues are stranded until the whole scan
+    ends — measured at 1.0 s of blocked loop per GiB scanned, on a warm page
+    cache. This pins the yield: a ticker task must observe wall time passing
+    while the scan is still in flight.
+    """
+
+    bodies = [b"grant-%d" % index for index in range(4)]
+    store = LocalCAS(tmp_path)
+    digests = [store.put_bytes(body) for body in bodies]
+    ticks: list[float] = []
+    scanned: list[float] = []
+
+    real_contains = LocalCAS.contains
+
+    def slow_contains(self: Any, ref: Any, *, size: int | None = None) -> bool:
+        scanned.append(time.monotonic())
+        time.sleep(0.05)
+        return real_contains(self, ref, size=size)
+
+    monkeypatch.setattr(LocalCAS, "contains", slow_contains)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "e" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                f"part{index}.safetensors",
+                len(body),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(digest),
+            )
+            for index, (body, digest) in enumerate(zip(bodies, digests, strict=True))
+        ],
+    )
+
+    async def scenario() -> None:
+        stop = asyncio.Event()
+
+        async def ticker() -> None:
+            while not stop.is_set():
+                await asyncio.sleep(0.005)
+                ticks.append(time.monotonic())
+
+        beat = asyncio.create_task(ticker())
+        try:
+            await ensure_snapshot_async(
+                base_dir=tmp_path, ref=_ref(), resolved=resolved
+            )
+        finally:
+            stop.set()
+            await beat
+
+    asyncio.run(scenario())
+
+    assert len(scanned) == len(bodies)
+    assert any(scanned[0] < tick < scanned[-1] for tick in ticks), (
+        "the event loop never ran between residency checks — every heartbeat "
+        "and every queued progress event is stranded for the whole scan "
+        f"(scan {scanned[0]:.3f}..{scanned[-1]:.3f}, ticks {ticks})"
+    )


### PR DESCRIPTION
Sibling fix under the **pgw#1287** program. tensorfs #41 fixes the DOWNLOAD half; this is the half in pgw that fix cannot reach.

## The bug

`cozy_snapshot._ensure_objects` filters residency **before** it calls `download()`, and emitted `progress(done, total)` exactly once — *after* the whole filter loop. Every check is `LocalCAS.contains`, which is `verify_object` with `FileNotFoundError` swallowed: a full sha256 re-hash of every byte.

So a mostly-resident snapshot re-hashes tens of GB with the hub-visible counter pinned at zero, and `download()` is never reached. The hub's transfer freshness window is 6 minutes and two zero-progress pods now arm a release-scoped fault brake (th#2014), so a pod that had already done all the work condemns itself. It compounds: the loop re-verifies EVERYTHING on every resume attempt, so the silent window grows with retry count on exactly the pods closest to done.

## The fix

1. `progress` fires **before** the loop (total known up front) and **after every grant**.
2. Each check runs under `asyncio.to_thread`. The scan ran on the caller's event-loop thread — **measured: 1008 MiB resident blocked the loop for 1017 ms continuously**, so the heartbeat coroutine and every `DOWNLOADING` event the callback queues were stranded until the scan ended. An emission that cannot leave the process is not an emission. `await asyncio.sleep(0)` per grant does **not** fix it (measured: the ticker observed zero turns during a four-grant scan). Same probe after the change: **max loop gap 1017 ms → 37 ms**.

Serial as before — no parallelism added. `contains`-means-full-verify is deliberately untouched; that question is **tensorfs#42**.

## Tests

Every pre-existing test passes on the broken tree, because the totals were always right and only their arrival was wrong. Two new tests, each red under its own mutation and green under the other:

| mutation | arrival test | loop-residency test |
|---|---|---|
| unmodified master | RED | RED |
| post-loop emission, off-thread scan kept | **RED** (10 s bound, named message) | pass |
| on-loop scan, in-loop emission kept | pass | **RED** (named message) |
| broken tree, ordering barrier disabled | **RED** on the recorded-beat assertion | — |

The arrival test's barrier is a hard block, not a poll: the second grant's `contains` cannot complete until a **recorded** mid-scan beat exists (`0 < done < total`, so neither the leading `0/total` nor the final one can satisfy it). 10/10 repeat runs stable green.

## Gates

`ruff` clean on both touched files. `mypy src/gen_worker tests tests_v2` error set **byte-identical** to master's on a cleared cache (97/51 both trees; the new module adds a checked file and zero errors). 79 passing in the related modules (`test_snapshot_*`, `test_managed_tier_fill_source`, `test_p2_residency_reconcile`, `test_activity_gw601`, `test_resolved_manifest_pgw1246`, the two pickle-refusal modules).

## Not here

No version bump and no wheel — this rides the upcoming tensorfs-repin release, which the pgw#1287 coordinator holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXFNHRibH4iWjv36Fyt2u