### PR TITLE
pgw#1291 (th#2031 A18 residue): the component-dtype pin gate was SILENTLY OFF for four spellings — 0 bits meant "agree"

### DIFF
--- a/src/gen_worker/convert/dtype_pins.py
+++ b/src/gen_worker/convert/dtype_pins.py
@@ -42,15 +42,58 @@ from ..families.facts import ComponentDtype, component_dtypes_for_classes
 # Storage width per dtype spelling, for the ONE comparison this module makes:
 # is the requested/produced precision NARROWER than the pin? Quant dtypes are
 # all narrower than every pin, which is the answer that matters.
+#
+# pgw#1291: KEYS ARE SEPARATOR- AND CASE-FOLDED before lookup (see
+# :func:`dtype_bits`), so `fp8:e4m3`, `fp8_e4m3`, `fp8-e4m3` and `F8_E4M3` are
+# ONE entry. That is not tidiness — an unknown spelling scores 0 bits, and 0
+# bits makes :func:`is_narrowing` answer False, which turns this whole gate
+# SILENTLY OFF for the artifact it was pointed at. Four live spellings did
+# exactly that: `int8` and `uint8` (which the module docstring claims are
+# caught: "quant dtypes are all narrower than every pin"), and tensorhub's
+# canonical `fp8_e4m3`/`fp8_e5m2`, which is the vocabulary `tensorlayout`
+# derives and the catalog is moving to. Measured before the fix:
+# `dtype_bits("int8") == 0`, `is_narrowing("int8", "fp32") is False`.
+#
+# `_dtype_vocabulary_is_complete` (tests/test_dtype_pins_vocabulary_pgw1291.py)
+# is the fence: every token any producer in this repo can EMIT must have a
+# width here, so the next vocabulary addition fails a test instead of
+# disarming the gate 45 minutes into a conversion.
 DTYPE_BITS: Dict[str, int] = {
     "fp64": 64, "f64": 64, "float64": 64,
     "fp32": 32, "f32": 32, "float32": 32,
     "bf16": 16, "bfloat16": 16, "fp16": 16, "f16": 16, "float16": 16,
-    "fp8": 8, "fp8:e4m3": 8, "fp8:e5m2": 8, "q8_0": 8,
+    "fp8": 8, "fp8:e4m3": 8, "fp8:e5m2": 8, "f8:e4m3": 8, "f8:e5m2": 8,
+    "int8": 8, "uint8": 8, "i8": 8, "u8": 8, "q8_0": 8,
     "q6_k": 6, "q5_k_m": 5, "q5_k_s": 5,
     "nvfp4": 4, "int4": 4, "int4:nf4": 4, "int4:fp4": 4, "nf4": 4, "fp4": 4,
     "q4_k_m": 4, "q4_k_s": 4, "q4_0": 4, "q4_1": 4,
     "q3_k_m": 3, "q3_k_s": 3, "q2_k": 2,
+}
+
+# The separators a dtype flavor is spelled with across the four vocabularies
+# that meet here: `fp8:e4m3` (this module + clone), `fp8_e4m3` (tensorlayout /
+# the catalog), `fp8-e4m3` (producer labels), `F8_E4M3` (the safetensors
+# header). One fact, four spellings; fold them rather than enumerate them.
+_DTYPE_SEPARATORS = ("_", "-")
+
+
+def _fold_dtype(dtype: str) -> str:
+    """The lookup key: lowercased, with every flavor separator folded to ':'.
+
+    Applied to BOTH sides — the table is written with ':' and folded on load —
+    so no entry can be reachable by one spelling and not another.
+    """
+    key = str(dtype or "").strip().lower()
+    for sep in _DTYPE_SEPARATORS:
+        key = key.replace(sep, ":")
+    return key
+
+
+# Fold the table itself, once, so lookups compare like with like. Written with
+# ':' above for readability; `q4_k_m` and friends fold to `q4:k:m` and stay
+# addressable only through the same fold.
+_DTYPE_BITS_FOLDED: Dict[str, int] = {
+    _fold_dtype(k): v for k, v in DTYPE_BITS.items()
 }
 
 
@@ -77,8 +120,13 @@ class ComponentDtypePinError(ValueError):
 
 
 def dtype_bits(dtype: str) -> int:
-    """Storage width of a dtype spelling; 0 when unknown (never compared)."""
-    return DTYPE_BITS.get(str(dtype or "").strip().lower(), 0)
+    """Storage width of a dtype spelling; 0 when unknown (never compared).
+
+    Spelling-insensitive across the separator vocabularies (pgw#1291): a
+    flavored fp8 answers 8 however it is written, because answering 0 disarms
+    the caller's gate instead of failing it.
+    """
+    return _DTYPE_BITS_FOLDED.get(_fold_dtype(dtype), 0)
 
 
 def is_narrowing(requested: str, pin: str) -> bool:

--- a/tests/test_dtype_pins_vocabulary_pgw1291.py
+++ b/tests/test_dtype_pins_vocabulary_pgw1291.py
@@ -1,0 +1,126 @@
+"""pgw#1291 — the component-dtype pin gate was SILENTLY OFF for four live
+spellings, and nothing could have told us.
+
+`dtype_pins.dtype_bits` answers 0 for a spelling its table does not carry, and
+`is_narrowing` reads 0 as "not narrower". So an unknown spelling does not make
+the gate refuse or complain — it makes the gate AGREE. That is the exact shape
+of pgw#1133, the invisible-truncation bug this module was built to catch.
+
+Measured on master before this fix:
+
+    dtype_bits("int8")     == 0   is_narrowing("int8", "fp32")     is False
+    dtype_bits("uint8")    == 0   is_narrowing("uint8", "fp32")    is False
+    dtype_bits("fp8_e4m3") == 0   is_narrowing("fp8_e4m3", "fp32") is False
+    dtype_bits("fp8_e5m2") == 0   is_narrowing("fp8_e5m2", "fp32") is False
+
+`int8` and `uint8` are contradicted by the module's own docstring ("Quant
+dtypes are all narrower than every pin, which is the answer that matters").
+`fp8_e4m3`/`fp8_e5m2` is `tensorlayout`'s canonical vocabulary — what tensorhub
+derives from bytes and what th#1994 recorded the catalog as owing a move to.
+
+The fix folds separators and case, so one fact cannot hide behind four
+spellings. THIS FILE IS THE FENCE: every dtype token a producer in this
+repository can EMIT must have a width, so the next vocabulary addition fails
+here instead of disarming a publish gate on a rented pod.
+
+RED-VERIFY, each arm reverted alone and each naming a DIFFERENT test — which is
+the point, because the two halves of this fix fail differently:
+
+  * drop `int8`/`uint8` from DTYPE_BITS
+    -> `eight_bit_integer_storage_is_narrower_than_every_pin` (NOT the fence:
+       neither token is in an emitted set today, which is exactly why the
+       docstring's claim about them went unchecked for so long)
+  * drop `nvfp4`, which `clone._KNOWN_DTYPES` DOES emit
+    -> `the_gate_is_armed_for_every_emitted_dtype`: "1 emitted dtype(s) score
+       0 bits ... ['nvfp4']"
+  * revert `dtype_bits` to the plain `.get(lower())`
+    -> `a_flavor_answers_the_same_width_however_it_is_spelled` on five of its
+       six spellings
+
+Run: uv run pytest tests/test_dtype_pins_vocabulary_pgw1291.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.convert.clone import _KNOWN_DTYPES
+from gen_worker.convert.dtype_pins import DTYPE_BITS, dtype_bits, is_narrowing
+from gen_worker.convert.ingest import _SAFETENSORS_DTYPE_NAMES
+
+#: `"source"` is a MODE ("publish the source's own weights untouched"), not a
+#: dtype — it never reaches a width comparison. Named here so its absence is a
+#: decision rather than an oversight.
+_NOT_A_DTYPE = {"source"}
+
+
+def _emitted_dtype_tokens() -> set[str]:
+    """Every dtype token this repository can put on an artifact or a request.
+
+    Two producers, read rather than restated: the safetensors header projection
+    (`ingest._SAFETENSORS_DTYPE_NAMES`, which is what `detect_snapshot_dtype`
+    reports and therefore what `verify_produced_tree` compares) and the
+    conversion request vocabulary (`clone._KNOWN_DTYPES`, which is what
+    `cast_exempt_components` and `check_explicit_pin_conflict` are handed).
+    """
+    return ({str(v) for v in _SAFETENSORS_DTYPE_NAMES.values() if v}
+            | {str(d) for d in _KNOWN_DTYPES}) - _NOT_A_DTYPE
+
+
+def test_the_gate_is_armed_for_every_emitted_dtype() -> None:
+    """A token a producer can emit but the table cannot price is a gate that
+    silently agrees with whatever it is shown."""
+    unpriced = sorted(d for d in _emitted_dtype_tokens() if dtype_bits(d) == 0)
+    assert not unpriced, (
+        f"{len(unpriced)} emitted dtype(s) score 0 bits, so `is_narrowing` "
+        f"answers False for them and the component-pin gate is OFF: {unpriced}"
+    )
+
+
+@pytest.mark.parametrize("spelling", [
+    "fp8:e4m3", "fp8_e4m3", "fp8-e4m3", "FP8_E4M3", "F8_E4M3", "  fp8_e4m3  ",
+])
+def test_a_flavor_answers_the_same_width_however_it_is_spelled(spelling: str) -> None:
+    """Four vocabularies meet in this module — this one's `:`, tensorlayout's
+    `_`, producer labels' `-`, and the safetensors header's upper case. One
+    fact must not be reachable by some of them and not others."""
+    assert dtype_bits(spelling) == 8, spelling
+    assert is_narrowing(spelling, "fp32") is True, spelling
+    assert is_narrowing(spelling, "bf16") is True, spelling
+
+
+def test_eight_bit_integer_storage_is_narrower_than_every_pin() -> None:
+    """The module docstring's own claim, asserted. It was FALSE for `int8` and
+    `uint8` — the two spellings a bitsandbytes / LLM.int8() tree carries."""
+    for d in ("int8", "uint8", "i8", "u8"):
+        assert dtype_bits(d) == 8, d
+        assert is_narrowing(d, "fp32") is True, d
+
+
+def test_an_unknown_dtype_still_scores_zero() -> None:
+    """The fold must not turn the table into a prefix or fuzzy match: a token
+    nobody emits is still unpriced, and the fence above is what keeps that
+    honest rather than convenient."""
+    assert dtype_bits("definitely-not-a-dtype") == 0
+    assert dtype_bits("") == 0
+    assert is_narrowing("definitely-not-a-dtype", "fp32") is False
+
+
+def test_widening_and_equal_width_are_never_narrowing() -> None:
+    """The comparison this module exists to make, in the direction that must
+    NOT fire — a cast to fp32 of an fp32 pin is a no-op, not a violation."""
+    assert is_narrowing("fp32", "fp32") is False
+    assert is_narrowing("fp32", "bf16") is False
+    assert is_narrowing("bf16", "fp32") is True
+
+
+def test_the_table_has_no_two_entries_that_fold_together_with_different_widths() -> None:
+    """Folding is only safe while it is injective on WIDTH. Two spellings of
+    one fact must not disagree about how wide that fact is."""
+    from gen_worker.convert.dtype_pins import _fold_dtype
+
+    by_key: dict[str, set[int]] = {}
+    for spelling, bits in DTYPE_BITS.items():
+        by_key.setdefault(_fold_dtype(spelling), set()).add(bits)
+    clashes = {k: sorted(v) for k, v in by_key.items() if len(v) > 1}
+    assert not clashes, f"spellings fold together but disagree on width: {clashes}"


### PR DESCRIPTION
Found while cutting **HARDCUT-CHECKLIST A18** (th#2031). A18's second survivor names this module by name: *"pgw's `convert/dtype_pins.py` narrowing gate returns 0 bits — **silently off** — for any spelling outside its collapsed set, which would regress the exact invisible-truncation bug it was built to catch (pgw#1133)."* It is worse than that: two of the failing spellings are **live today**, not hypothetical.

## Measured on master

```
dtype_bits("int8")     == 0   is_narrowing("int8", "fp32")     is False
dtype_bits("uint8")    == 0   is_narrowing("uint8", "fp32")    is False
dtype_bits("fp8_e4m3") == 0   is_narrowing("fp8_e4m3", "fp32") is False
dtype_bits("fp8_e5m2") == 0   is_narrowing("fp8_e5m2", "fp32") is False
```

`is_narrowing` reads 0 as *"not narrower"*, so an unknown spelling does not make the gate refuse or complain — **it makes the gate agree**. `int8`/`uint8` are contradicted by the module's own docstring ("Quant dtypes are all narrower than every pin, which is the answer that matters"), and they are exactly the two spellings a bitsandbytes / LLM.int8() tree carries.

## Why it happened

**Four vocabularies meet in this module and each spells a flavor differently** — this module's `fp8:e4m3`, `tensorlayout`'s `fp8_e4m3`, producer labels' `fp8-e4m3`, the safetensors header's `F8_E4M3`. The table carried one of them. `dtype_bits` now folds separators and case on **both** sides, so one fact cannot be reachable through some spellings and not others, and the table stays written the readable way.

## The durable half

`tests/test_dtype_pins_vocabulary_pgw1291.py` asserts that **every dtype token a producer in this repo can emit** — `ingest._SAFETENSORS_DTYPE_NAMES` values plus `clone._KNOWN_DTYPES`, read rather than restated — has a width. The next vocabulary addition fails there instead of disarming a publish gate 45 minutes into a conversion on a rented pod.

## Red/green — three arms, each naming a DIFFERENT test

| arm reverted | what goes red |
|---|---|
| drop `int8`/`uint8` | `eight_bit_integer_storage_is_narrower_than_every_pin` (**not** the fence — neither token is in an emitted set today, which is precisely why the docstring's claim about them went unchecked) |
| drop `nvfp4`, which `clone._KNOWN_DTYPES` **does** emit | `the_gate_is_armed_for_every_emitted_dtype`: *"1 emitted dtype(s) score 0 bits … ['nvfp4']"* |
| revert the fold to `.get(lower())` | `a_flavor_answers_the_same_width_however_it_is_spelled`, 5 of its 6 spellings |

Green: 11 passed; mypy clean on both touched files; `-k "dtype_pin or clone or convert"` → 162 passed (the one failure, `test_the_incremental_writer_finalizes_ATOMICALLY_and_fsyncs`, is `ModuleNotFoundError: torch` in this box's venv).

**No wire, grammar or serialization surface moves** — this is a lookup that stops missing. No wheel cut is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXFNHRibH4iWjv36Fyt2u