### PR TITLE
pgw#1263: the headroom gate never sized the copy it was gating

### DIFF
--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -462,11 +462,20 @@ class CozySnapshotDownloader:
                 missing.append(grant)
             report_residency()
 
-        required = sum(grant.size_bytes for grant in missing) + _DISK_HEADROOM_BYTES
+        # Every resident snapshot occupies disk TWICE: the CAS objects plus the
+        # materialized tree `_publish_snapshot` writes next. Sizing only the
+        # missing objects under-counted by exactly one whole model, and the
+        # `missing and` guard skipped the check entirely when every object was
+        # already resident — the case where the publish is the ONLY writer. A
+        # pod passed this gate and then ENOSPC'd mid-materialize.
+        fetch = sum(grant.size_bytes for grant in missing)
+        publish = sum(entry.size_bytes for entry in entries.values())
+        required = fetch + publish + _DISK_HEADROOM_BYTES
         free = shutil.disk_usage(cas.root).free
-        if missing and required > free:
+        if required > free:
             raise InsufficientDiskError(
-                f"insufficient disk for snapshot download: need {required} bytes, "
+                f"insufficient disk for snapshot: need {required} bytes "
+                f"({fetch} to fetch, {publish} to publish), "
                 f"{free} free at {cas.root}",
                 available_bytes=free,
                 required_bytes=required,

--- a/tests/test_snapshot_disk_headroom_pgw1263.py
+++ b/tests/test_snapshot_disk_headroom_pgw1263.py
@@ -1,0 +1,158 @@
+"""The snapshot headroom gate must size the publish, not only the fetch.
+
+`_publish_snapshot` writes a full second copy of every file in the manifest
+next to the CAS objects, so a snapshot costs ~2x its size on disk. The gate
+sized only the objects still to be fetched, and skipped itself entirely when
+none were missing — which is exactly the case where the publish is the sole
+writer. Both arms below pass a fetch-only gate and fail an honest one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hashrepo import LocalCAS
+
+from gen_worker.capability import InsufficientDiskError
+from gen_worker.models import cozy_snapshot
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef
+
+_HEADROOM = cozy_snapshot._DISK_HEADROOM_BYTES
+
+
+def _ref() -> TensorhubRef:
+    return TensorhubRef(owner="acme", repo="model", release="latest")
+
+
+def _pin_free(monkeypatch: pytest.MonkeyPatch, free: int) -> None:
+    real = shutil.disk_usage
+
+    def fake(path: Any) -> Any:
+        usage = real(path)
+        return type(usage)(total=usage.total, used=usage.used, free=free)
+
+    monkeypatch.setattr(cozy_snapshot.shutil, "disk_usage", fake)
+
+
+def test_a_fully_resident_snapshot_is_still_sized_before_it_is_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing to fetch is not nothing to write.
+
+    Every object is already in the CAS, so `missing` is empty and the old
+    `if missing and ...` guard never evaluated the comparison at all. The
+    publish still writes the whole tree. With free space below the tree size
+    plus the reserve, this must refuse rather than ENOSPC mid-materialize.
+    """
+
+    bodies = [b"weights-" + bytes([index]) * 64 for index in range(3)]
+    store = LocalCAS(tmp_path)
+    digests = [store.put_bytes(body) for body in bodies]
+    tree_bytes = sum(len(body) for body in bodies)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "a" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                f"shard-{index}.safetensors",
+                len(body),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(digest),
+            )
+            for index, (body, digest) in enumerate(zip(bodies, digests, strict=True))
+        ],
+    )
+
+    # Enough for the reserve and every byte but one of the tree.
+    _pin_free(monkeypatch, _HEADROOM + tree_bytes - 1)
+
+    with pytest.raises(InsufficientDiskError) as refusal:
+        asyncio.run(
+            ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
+        )
+    assert refusal.value.required_bytes == _HEADROOM + tree_bytes
+    assert "to publish" in str(refusal.value)
+
+
+def test_the_gate_counts_the_published_tree_on_top_of_the_fetch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pod with room for the download alone still runs out publishing it.
+
+    One object is resident and one must be fetched. Free space covers the
+    reserve plus the fetch exactly — the old arithmetic's whole budget — and
+    is short by the tree. The refusal must name both halves.
+    """
+
+    resident = b"resident-" + b"r" * 128
+    remote = b"remote-" + b"m" * 200
+    store = LocalCAS(tmp_path)
+    resident_digest = store.put_bytes(resident)
+    remote_digest = LocalCAS(tmp_path / "other").put_bytes(remote)
+    tree_bytes = len(resident) + len(remote)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "b" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                "config.json",
+                len(resident),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(resident_digest),
+            ),
+            WorkerResolvedRepoFile(
+                "model.safetensors",
+                len(remote),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(remote_digest),
+            ),
+        ],
+    )
+
+    _pin_free(monkeypatch, _HEADROOM + len(remote))
+
+    with pytest.raises(InsufficientDiskError) as refusal:
+        asyncio.run(
+            ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
+        )
+    assert refusal.value.required_bytes == _HEADROOM + len(remote) + tree_bytes
+    assert refusal.value.available_bytes == _HEADROOM + len(remote)
+
+
+def test_a_snapshot_that_fits_both_copies_still_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate must not refuse a snapshot that genuinely fits.
+
+    Sizing the publish is only correct if it leaves the ordinary path alone;
+    a gate that always refuses would pass both arms above and ship an outage.
+    """
+
+    body = b"small-model-" + b"s" * 32
+    store = LocalCAS(tmp_path)
+    digest = store.put_bytes(body)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "c" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                "model.safetensors",
+                len(body),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(digest),
+            )
+        ],
+    )
+
+    _pin_free(monkeypatch, _HEADROOM + len(body))
+
+    path = asyncio.run(
+        ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
+    )
+    assert (path / "model.safetensors").read_bytes() == body


### PR DESCRIPTION
## What

`_publish_snapshot` (`src/gen_worker/models/cozy_snapshot.py:262`) writes a full
second copy of every file in the manifest next to the CAS objects it was built
from, so a resident snapshot costs roughly **twice** its size on disk. The gate
immediately ahead of it sized only the objects still to be *fetched*.

It was also spelled `if missing and required > free`, so when every object was
already resident — a warm pod, a volume fill, a retry — the comparison **never
ran at all**. That is precisely the case where the publish is the only writer.
A pod passed the gate and then hit ENOSPC part-way through materializing.

The gate now sizes `fetch + publish + reserve` and always evaluates. The refusal
names both halves so an operator can tell a download that will not fit from a
publish that will not fit.

## Evidence

`tests/test_snapshot_disk_headroom_pgw1263.py`, three arms:

| arm | old code | new code |
|---|---|---|
| fully-resident snapshot, free space one byte short of the tree | passes (gate skipped) | refuses |
| one resident + one to fetch, free space covers the fetch exactly | passes | refuses, naming both halves |
| snapshot that genuinely fits both copies | publishes | publishes |

Red proof: with the fix reverted, **2 failed / 1 passed, 5 runs of 5**. The
third arm is a positive control — it stays green under the mutation, so a gate
that simply always refused could not pass this suite.

Run locally: `pytest tests/test_snapshot_disk_headroom_pgw1263.py
tests/test_snapshot_residency_progress_pgw1289.py tests/test_snapshot_v2_fill_pgw781.py
tests/test_snapshot_verify_pgw781.py` — 23 passed.

**Not run locally:** mypy and ruff (installing the `dev` extra pulls torch on a
box already at load ~55). CI's fast-gates job must prove those.

## What this does NOT do

This is the honest accounting of the second copy, not its removal. Removing it
means mounting the snapshot instead of materializing it, which is blocked — see
the plan filed on pgw#1263. Once the mount lands, `publish` becomes zero and
this gate reduces to exactly the fetch it always claimed to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)