### PR TITLE
pgw#1307 follow-up: the scipy fence asserted an import CI does not carry

### DIFF
--- a/tests/test_legacy_arm_register_pgw1307.py
+++ b/tests/test_legacy_arm_register_pgw1307.py
@@ -126,10 +126,13 @@ def test_the_advertised_resampler_is_the_one_that_runs() -> None:
     """scipy was declared NOWHERE — not in `dependencies`, not in an extra, not
     in dev — so `from scipy.signal import resample_poly` always raised and every
     tenant got naive `np.interp` while the docstring advertised polyphase.
-    RED before pgw#1307: scipy was not importable from this package's deps.
-    """
-    from scipy.signal import resample_poly  # noqa: F401
 
+    The DELETION is asserted on the source, not on an import: CI installs the
+    base wheel without the `audio` extra, and requiring scipy here would only
+    prove which extras the runner happens to carry. That scipy is GUARANTEED
+    wherever `read_audio` can run is the next test's job — it reads the
+    manifest, which is the fact that was missing.
+    """
     import gen_worker.io as gw_io
 
     src = __import__("inspect").getsource(gw_io.read_audio)


### PR DESCRIPTION
Follow-up to #853, which merged one commit short.

`test_the_advertised_resampler_is_the_one_that_runs` did `from scipy.signal import resample_poly` before asserting the deletion. CI's `tests` job installs the base wheel **without the `audio` extra**, so that import proves which extras the runner happens to carry — not that the arm is gone. It went red on master's post-merge `tests`.

The deletion is now asserted on `read_audio`'s **source** (no `np.interp`, no `except ImportError`), which needs no scipy. That scipy is *guaranteed* wherever `read_audio` can run is `test_scipy_is_declared_by_the_audio_extra`'s job — it reads `pyproject.toml`, and that missing manifest entry was the original defect.

Red-verified: reintroducing an `except ImportError` / `np.interp` arm in `io.py` fails the test with the `audio` extra absent, exactly as CI runs it. 14 tests green in a bare `uv run --frozen` env.