### PR TITLE
pgw#1297: consume hashrepo and torch-compiled-graphs from git, not PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -682,3 +682,12 @@ torch = [
 torchvision = [
   { index = "pytorch-cu130", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
+# The hashrepo / torch-compiled-graphs PyPI projects were deleted permanently
+# (DESIGN-RULINGS "Release policy", 2026-08-16): internal consumption is
+# git-pinned, and nothing publishes to PyPI as a side effect of development.
+# These revs are the contents of the last published versions (0.3.1 / 0.6.0),
+# so the resolution is unchanged — only its source is. tensorfs is still
+# pure-python hatchling at this rev, so no Rust toolchain is pulled in.
+# #1297 / #1308 replace these with pins at CURRENT tensorfs / torchcg.
+hashrepo = { git = "https://github.com/cozy-creator/tensorfs", rev = "0d0437570aac241ed234b741e66af8c79492d872" }
+torch-compiled-graphs = { git = "https://github.com/cozy-creator/torchcg", rev = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ requires-dist = [
     { name = "gguf", specifier = ">=0.10.0" },
     { name = "grpcio", specifier = ">=1.82.1" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.82.1" },
-    { name = "hashrepo", specifier = ">=0.3,<0.4" },
+    { name = "hashrepo", git = "https://github.com/cozy-creator/tensorfs?rev=0d0437570aac241ed234b741e66af8c79492d872" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "msgspec", specifier = ">=0.18.6" },
@@ -665,7 +665,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'torch'", specifier = ">=2.13.0" },
-    { name = "torch-compiled-graphs", specifier = ">=0.6,<0.7" },
+    { name = "torch-compiled-graphs", git = "https://github.com/cozy-creator/torchcg?rev=ad5f4cb9f89bbe91d2a30ca218f70d5326630368" },
     { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'vision') or (sys_platform == 'win32' and extra == 'vision')", specifier = ">=0.28.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchvision", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'vision'", specifier = ">=0.28.0" },
     { name = "transformers", marker = "extra == 'dev'", specifier = ">=5.13" },
@@ -785,11 +785,7 @@ wheels = [
 [[package]]
 name = "hashrepo"
 version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/5a/50245200737dea160cf162de44ce3aeaa100084a9dfc429f14befabe72fd/hashrepo-0.3.1.tar.gz", hash = "sha256:b08f5c8c31427d5a0aa981002c50e4d601041e5031c145ffaa22ffe720e5eab4", size = 23520, upload-time = "2026-08-14T09:24:23.029Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/67/61fb63a28e7ea6243d6a3bc4e520850f59afdf794d7c41631f02ba5a503d/hashrepo-0.3.1-py3-none-any.whl", hash = "sha256:c9450e07c96b0a060db5ab420b9202f0e1efabaa1690c66f03f56ff7b7b3847a", size = 23348, upload-time = "2026-08-14T09:24:21.734Z" },
-]
+source = { git = "https://github.com/cozy-creator/tensorfs?rev=0d0437570aac241ed234b741e66af8c79492d872#0d0437570aac241ed234b741e66af8c79492d872" }
 
 [[package]]
 name = "hf-xet"
@@ -2087,14 +2083,10 @@ wheels = [
 [[package]]
 name = "torch-compiled-graphs"
 version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=ad5f4cb9f89bbe91d2a30ca218f70d5326630368#ad5f4cb9f89bbe91d2a30ca218f70d5326630368" }
 dependencies = [
     { name = "hashrepo" },
     { name = "safetensors" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/02/3d9eb0001882cc746c9ce4152637954624a3151a9c3f1c55d5d88c1ef5d5/torch_compiled_graphs-0.6.0.tar.gz", hash = "sha256:07f733547e350b02ee40843bdd978656a18501a40c083cffa3ea08f6a11060b2", size = 73172, upload-time = "2026-08-16T10:58:33.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/68/8cf29d2c46997e9ed1d4f1ae3cf5bb9ac1e1b84b7a84ea452f0cb16b714d/torch_compiled_graphs-0.6.0-py3-none-any.whl", hash = "sha256:d254e5885e4dec7c97fdc6c76a5ac8d800f87adafdd3c20ada535938b4fc1309", size = 79249, upload-time = "2026-08-16T10:58:31.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why now

The `hashrepo` and `torch-compiled-graphs` PyPI projects were **deleted permanently** (Paul, 2026-08-16). `pyproject.toml:31,35` resolved both from PyPI, so every fresh `uv sync --locked`, CI run and worker-image build breaks as the deletion propagates. This restores installability.

## What this is — and what it is not

Git pins are **the standing internal consumption mechanism**, not a stopgap waiting on a republish. Per DESIGN-RULINGS "Release policy: vendored internally, PyPI only for deliberate releases" (tracker `e62fd84f`):

> "just use a vendored version of our local library if you need to. I like that solution better than spamming a bunch of buggy incomplete versions into pypi like we've been doing."

Nothing publishes to PyPI as a side effect of development, and the deleted names are gone by choice.

These pins are interim **only in their revs**: they sit at the last-published contents, and the real cutover repins (pgw#1297/#1308 onto current `tensorfs`; tcg#28 onto `torchcg`) replace them with pins at *current*. They are never replaced by PyPI versions. Update the revs when that lands; do not delete the source entries.

This is not legacy support. The hard-cut policy governs product code — keeping CI installable through a live deletion is a different thing.

## The revs

| dep | rev | name at rev |
|---|---|---|
| `hashrepo` | `0d043757` (tensorfs) | `hashrepo` 0.3.1 — pre-rename, pure-python hatchling |
| `torch-compiled-graphs` | `ad5f4cb9` (torchcg) | `torch-compiled-graphs` 0.6.0 |

**Correction to the restore map.** `research/deleted-tags-2026-08-16.md` records **tag-object** SHAs, not commits. Its `13a1b45d…` for v0.3.1 is an annotated tag object, which is *not* resolvable as a uv `rev`; it peels to commit `0d043757`. The torchcg entry `ad5f4cb9` happens to already be a commit. Both commits are ancestors of their `origin/main`, so they resolve without the deleted tags.

Two properties worth noting:
- `tensorfs` at `0d043757` is still **pure-python hatchling**, so this pin pulls in **no Rust toolchain** — the cost the ruling flags for a maturin pin at current does not apply yet.
- The repo rename `torch-compiled-graphs` → `torchcg` landed mid-flight. The pin uses the **real** name; resolution was verified against it directly, not via the redirect.

## Verification

- `uv lock` — 102 packages, **versions unchanged** (0.3.1 / 0.6.0). Minimal diff: source lines swapped, PyPI sdist/wheel hashes dropped. No other package moved.
- `uv sync --frozen` — clean install, both from git.
- `python -c "import hashrepo, torch_compiled_graphs"` — both import.

Version specifiers in `dependencies` are left as-is; uv sources satisfy them.

CI carries `fast gates` (required) plus the merge-queue rerun against master's tip.