### PR TITLE
pgw#1293 (A15 peer leg 3 of 6): the SDK addresses /vN/, and the endpoint-tag axis is gone from the wire

### DIFF
--- a/changelog.d/pgw1293.md
+++ b/changelog.d/pgw1293.md
@@ -1,0 +1,22 @@
+- **pgw#1293 (BREAKING, th#2044 A15 lockstep): `ctx.call_endpoint` addresses
+  `/vN/`, and the endpoint-tag axis is gone from the SDK.** Endpoint tags die
+  entirely (Paul, 2026-08-16 — canary included), replaced by one serving
+  pointer per `(endpoint, semver_major)`; Route-1 grammar is
+  `POST /{owner}/{name}/v{semver_major}/{function}`, the major a REQUIRED path
+  segment with no default and no `latest`. `RequestContext.call_endpoint` and
+  `callout.CalloutClient.submit` lose `tag: str = "prod"` and gain
+  `semver_major: int`, keyword-only and **required** — no compatibility arm,
+  no both-grammars mode. Endpoint code that passed `tag=` must pass
+  `semver_major=` on the same repin that takes this wheel.
+  The retired URL builder was `{function}:{(tag or 'prod').strip()}`, so an
+  empty or `None` tag silently routed to whatever `prod` pointed at, with no
+  raise and no log; the replacement refuses a non-int (`bool` included — `True`
+  would have rendered `vTrue`) and a negative major **before a socket opens**,
+  and `semver_major_segment` is the one place that spelling exists.
+  The pgw#943 pipelining suite is converted from a fake that could not go red:
+  its platform now REFUSES any submit path outside the `/vN/` grammar and the
+  test asserts the URL that went out rather than the value that came back —
+  reverting the builder reds all 10 of its rows plus 4 grammar rows.
+- **pgw#1293: five unused imports deleted** in `child_contract`, `dispatch`,
+  `models.loading` and `request_context._helpers` — ruff-red on master since
+  PR #850, unowned, and not a gating step.

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -307,15 +307,20 @@ success. Poll `GET /api/v1/endpoint-builds/{id}` to `succeeded`.
 diffusers/transformers/accelerate and its weight-generation layer is ~1 s, so
 the delta is the dependency install).
 
-### 3. Tag `prod` — BEFORE the buy
+### 3. Point semver-major 0 at the release — BEFORE the buy
 
 ```
-PUT /api/v1/endpoints/tensorhub/micro-diffusion/tags/prod  {"release_id": …}
+PUT /api/v1/endpoints/tensorhub/micro-diffusion/serving/0  {"release_id": …}
 ```
 
-Demand is tag-only (th#1315), and the worker bindings written in step 0b point
-at `tensorhub/micro-diffusion@prod` — an untagged release is a release nothing
-can invoke. **ESTIMATE: seconds.**
+**Endpoint tags are dead (th#2044): serving is one hidden pointer per
+`(endpoint, semver_major)`, moved only by an explicit author act, and demand
+and every other read resolve through it (th#2046).** `0` is the common case —
+the package's version is 0.x, and the invoke grammar in step 5 says so. A
+release no pointer names is a release nothing can invoke. The `"tag"` inside a
+binding (step 0b) is the REPO axis — a model release — and is untouched; the
+`config?tag=` query is the endpoint axis and dies with th#2048.
+**ESTIMATE: seconds.**
 
 ### 4. Buy a SERVING pod
 
@@ -333,9 +338,12 @@ POST /v1/admin/releases/<release_id>/workers?count=1&compute_class=gpu
 ### 5. Drive one request
 
 ```
-POST /tensorhub/micro-diffusion/generate
+POST /tensorhub/micro-diffusion/v0/generate
 {"prompt": "a tiny test", "size": "256x256", "steps": 2}
 ```
+
+The `vN` segment is REQUIRED and has no default (th#2045); it names the
+semver-major whose pointer step 3 wrote.
 
 `size` is an **ENUM** (`"256x256"` / `"384x384"`), not a `{"width":…,"height":…}`
 object — the object form is a `400`, and it cost a pod leg. The rows are an enum

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -55,6 +55,24 @@ DEFAULT_POLL_INTERVAL_S = 2.0
 _HTTP_TIMEOUT_S = 60.0
 
 
+def semver_major_segment(semver_major: int) -> str:
+    """The ``vN`` path segment of a Route-1 address (th#2044/th#2045).
+
+    Endpoint tags are dead: a call names an exact semver-major, there is no
+    default and no ``latest``. Anything that is not a non-negative int raises
+    HERE, before a socket opens — the retired `tag` arm defaulted a `None` to
+    `prod` and silently routed somewhere.
+    """
+    if isinstance(semver_major, bool) or not isinstance(semver_major, int):
+        raise TypeError(
+            "semver_major must be an int naming the endpoint's semver-major "
+            f"(e.g. 0 for /v0/), got {semver_major!r}; there is no default"
+        )
+    if semver_major < 0:
+        raise ValueError(f"semver_major must be >= 0, got {semver_major}")
+    return f"v{semver_major}"
+
+
 def _parse_error_body(text: str) -> tuple[str, str]:
     """Best-effort (code, message) from a platform error response body.
 
@@ -120,12 +138,13 @@ class CalloutClient:
         function: str,
         payload: Dict[str, Any],
         *,
-        tag: str = "prod",
+        semver_major: int,
         tier: Optional[str] = None,
     ) -> str:
         """Submit one child request; returns its request id."""
         import requests  # lazy (all sites): callout is on the `import gen_worker` path; stays requests-free
 
+        version = semver_major_segment(semver_major)
         endpoint = (endpoint or "").strip().strip("/")
         if "/" not in endpoint:
             raise ValueError(
@@ -137,7 +156,7 @@ class CalloutClient:
         body = dict(payload or {})
         if tier:
             body["availability_tier"] = tier
-        url = f"{self._base_url}/{endpoint}/{function}:{(tag or 'prod').strip()}"
+        url = f"{self._base_url}/{endpoint}/{version}/{function}"
         resp = requests.post(url, headers=self._headers(), json=body, timeout=_HTTP_TIMEOUT_S)
         if resp.status_code >= 300:
             self._raise_for_error(resp.status_code, resp.text)

--- a/src/gen_worker/child_contract.py
+++ b/src/gen_worker/child_contract.py
@@ -24,7 +24,7 @@ codes and reports stay with the driver that owns them.
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Optional, Tuple
+from typing import Mapping, Optional, Tuple
 
 import msgspec
 

--- a/src/gen_worker/dispatch.py
+++ b/src/gen_worker/dispatch.py
@@ -9,7 +9,6 @@ the head replaceable without touching the driver.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -10,7 +10,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .. import activity as activity_mod
 from ..component_vocab import (

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -802,13 +802,19 @@ class RequestContext(Generic[D]):
         function: str,
         payload: Dict[str, Any],
         *,
-        tag: str = "prod",
+        semver_major: int,
         wait: bool = True,
         timeout_s: Optional[float] = 3600.0,
         tier: Optional[str] = None,
         poll_interval_s: float = 2.0,
     ) -> Any:
         """Call another endpoint's function as a CHILD request.
+
+        ``semver_major`` addresses the callee's serving pointer for that
+        semver-major (``POST /{owner}/{name}/v{semver_major}/{function}``).
+        It is REQUIRED and has no default: endpoint tags are dead (th#2044),
+        an unassigned semver-major is a typed refusal naming the assigned
+        ones, and there is no ``latest``.
 
         The function must be declared ``@endpoint(child_calls=True)`` — the
         platform then scopes this invocation's credential for child calls.
@@ -836,7 +842,9 @@ class RequestContext(Generic[D]):
         """
         self.raise_if_cancelled()
         client = self._callout_client()
-        request_id = client.submit(endpoint, function, payload, tag=tag, tier=tier)
+        request_id = client.submit(
+            endpoint, function, payload, semver_major=semver_major, tier=tier
+        )
 
         handle = ChildRequest(client, request_id, wait_guard=self._child_call_wait)
         if not wait:

--- a/src/gen_worker/request_context/_helpers.py
+++ b/src/gen_worker/request_context/_helpers.py
@@ -12,7 +12,6 @@ import hashlib
 import ipaddress
 import json
 import logging
-import re
 import socket
 import urllib.parse
 from typing import Any, Dict

--- a/tests/test_call_endpoint_semver_major_pgw1293.py
+++ b/tests/test_call_endpoint_semver_major_pgw1293.py
@@ -1,0 +1,174 @@
+"""pgw#1293 / th#2044: `ctx.call_endpoint` addresses `/vN/`, and nothing else.
+
+Endpoint tags are dead (Paul, 2026-08-16 — canary included). Route-1 grammar
+is `POST /{owner}/{name}/v{semver_major}/{function}`, the semver-major a
+REQUIRED path segment with no default. The retired arm built
+`{function}:{(tag or 'prod')}`, so an empty or `None` tag silently routed to
+whatever `prod` pointed at — no raise, no log. This file fences the
+replacement against inheriting that.
+
+The assertions are about the URL that WENT OUT (a real HTTP server records
+it) and about the published signature, which is a wheel contract that
+inference-endpoints / training-endpoints / private-inference-endpoints call
+at runtime.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, List, Optional, Tuple, cast
+
+import pytest
+
+from gen_worker.callout import CalloutClient, semver_major_segment
+from gen_worker.request_context import RequestContext
+
+
+class _Recorder:
+    """Answers every submit with a request id and records the path."""
+
+    def __init__(self) -> None:
+        self.paths: List[str] = []
+        recorder = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *_args: Any) -> None:
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802
+                recorder.paths.append(self.path)
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                body = json.dumps({"request_id": "child-1"}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "_Recorder":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    @property
+    def base_url(self) -> str:
+        host, port = cast(Tuple[str, int], self._server.server_address[:2])
+        return f"http://{host}:{port}"
+
+
+def _client(base_url: str) -> CalloutClient:
+    return CalloutClient(
+        base_url=base_url, parent_request_id="req-parent", get_token=lambda: "tok"
+    )
+
+
+# -- the wire ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("semver_major,segment", [(0, "v0"), (1, "v1"), (12, "v12")])
+def test_submit_addresses_the_semver_major_segment(
+    semver_major: int, segment: str
+) -> None:
+    """The URL that goes out, over a real socket."""
+    with _Recorder() as rec:
+        _client(rec.base_url).submit(
+            "acme/child", "generate", {"prompt": "x"}, semver_major=semver_major
+        )
+    assert rec.paths == [f"/acme/child/{segment}/generate"]
+    # The retired arm's tail. `:` is outside the whole Route-1 grammar.
+    assert ":" not in rec.paths[0]
+
+
+# -- the S4 fence: no default, and no silent default-on-None ----------------
+
+
+def test_submit_without_semver_major_refuses_naming_the_parameter() -> None:
+    with _Recorder() as rec:
+        client = _client(rec.base_url)
+        with pytest.raises(TypeError, match="semver_major"):
+            client.submit("acme/child", "generate", {})  # type: ignore[call-arg]
+        assert rec.paths == [], "a refused call must not reach the platform"
+
+
+def test_semver_major_none_raises_rather_than_defaulting() -> None:
+    """The direct S4 fence: `(tag or 'prod')` used to swallow exactly this."""
+    with _Recorder() as rec:
+        client = _client(rec.base_url)
+        with pytest.raises(TypeError, match="semver_major"):
+            client.submit("acme/child", "generate", {}, semver_major=None)  # type: ignore[arg-type]
+        assert rec.paths == [], "a refused call must not reach the platform"
+
+
+@pytest.mark.parametrize("bad", ["0", "v0", 1.0, True, False])
+def test_non_int_semver_major_refuses(bad: Any) -> None:
+    """`True` would render `vTrue`; `"v0"` would render `vv0`."""
+    with pytest.raises(TypeError, match="semver_major"):
+        semver_major_segment(bad)
+
+
+def test_negative_semver_major_refuses() -> None:
+    with pytest.raises(ValueError, match="semver_major"):
+        semver_major_segment(-1)
+
+
+# -- the published signature ------------------------------------------------
+
+
+def _param(fn: Any, name: str) -> Optional[inspect.Parameter]:
+    return inspect.signature(fn).parameters.get(name)
+
+
+@pytest.mark.parametrize(
+    "fn", [RequestContext.call_endpoint, CalloutClient.submit], ids=["ctx", "client"]
+)
+def test_semver_major_is_required_keyword_only_and_tag_is_gone(fn: Any) -> None:
+    """The wheel contract ie/te/pie call at runtime."""
+    assert _param(fn, "tag") is None, "the endpoint-tag axis is dead (th#2044)"
+    p = _param(fn, "semver_major")
+    assert p is not None
+    assert p.kind is inspect.Parameter.KEYWORD_ONLY
+    assert p.default is inspect.Parameter.empty, "required, no default, no `latest`"
+
+
+def test_ctx_call_endpoint_addresses_a_non_zero_major_over_the_real_client() -> None:
+    """`ctx` is a pass-through: the major it is handed is the one on the wire.
+
+    Through the production `_callout_client()` -> `CalloutClient` -> HTTP path
+    (the pipelining suite covers v0 end to end; this pins that the major is
+    not re-derived or floored on the way out).
+    """
+    with _Recorder() as rec:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx._canceled = False  # type: ignore[attr-defined]
+        ctx._cancel_event = threading.Event()  # type: ignore[attr-defined]
+        ctx._request_id = "req-parent"  # type: ignore[attr-defined]
+        ctx._worker_capability_token = "tok"  # type: ignore[attr-defined]
+        ctx._file_api_base_url = rec.base_url  # type: ignore[attr-defined]
+
+        handle = ctx.call_endpoint(
+            "acme/child", "generate", {}, semver_major=7, wait=False
+        )
+    assert handle is not None
+    assert rec.paths == ["/acme/child/v7/generate"]
+
+
+# -- the grammar helper itself ----------------------------------------------
+
+
+@pytest.mark.parametrize("n,want", [(0, "v0"), (3, "v3"), (10, "v10")])
+def test_segment_grammar(n: int, want: str) -> None:
+    assert semver_major_segment(n) == want

--- a/tests/test_child_call_pipelining_pgw943.py
+++ b/tests/test_child_call_pipelining_pgw943.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import threading
 from contextlib import asynccontextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -49,6 +50,12 @@ from harness.progress_wait import Cadence, await_count, await_progress
 #: `completed` only after `release()`), so this bounds the observation by work
 #: the system under test performed rather than by elapsed time.
 _OBSERVED_CHILD_POLLS = 100
+
+#: The Route-1 invoke grammar the hub serves after th#2045: the semver-major
+#: is a REQUIRED path segment and no `:tag` tail exists anywhere in it. The
+#: fake platform below REFUSES anything else, so every child call in this file
+#: asserts the outgoing URL rather than only the value that came back.
+_INVOKE_PATH = re.compile(r"^/[^/:]+/[^/:]+/v(?:0|[1-9][0-9]*)/[^/:]+$")
 
 
 class _In(msgspec.Struct):
@@ -103,6 +110,14 @@ class _Platform:
                 if self.path.startswith("/v1/requests/"):
                     self._reply(200, {})
                     return
+                if not _INVOKE_PATH.match(self.path):
+                    # What the hub does with a retired address, so a client
+                    # that still speaks one fails HERE and not in production.
+                    self._reply(404, {"error": {
+                        "code": "endpoint_not_found",
+                        "message": f"not the /vN/ invoke grammar: {self.path}",
+                    }})
+                    return
                 with platform._lock:
                     child_id = f"child-req-{len(platform._children) + 1}"
                     platform._children.append(child_id)
@@ -143,6 +158,14 @@ class _Platform:
     def children(self) -> List[str]:
         with self._lock:
             return list(self._children)
+
+    def submit_paths(self) -> List[str]:
+        """Every URL path a child SUBMIT actually went out on."""
+        with self._lock:
+            return [
+                path for method, path in self.calls
+                if method == "POST" and not path.startswith("/v1/requests/")
+            ]
 
     def release(self, request_id: Optional[str] = None) -> None:
         """Mark one child (or every submitted child) completed."""
@@ -199,7 +222,10 @@ class _Probe:
         self.parent_result: List[Any] = []
 
 
-_CHILD_CALL = dict(poll_interval_s=0.02, timeout_s=60.0)
+#: `semver_major` is REQUIRED on every child call (th#2044: endpoint tags are
+#: dead, there is no default and no `latest`). v0 is the common case — 24 of
+#: 27 served endpoints are on semver-major 0.
+_CHILD_CALL = dict(semver_major=0, poll_interval_s=0.02, timeout_s=60.0)
 
 
 def _endpoints(probe: _Probe, *, gpu: bool) -> List[Any]:
@@ -222,7 +248,8 @@ def _endpoints(probe: _Probe, *, gpu: bool) -> List[Any]:
     def parent_deferred(ctx: Any, payload: _In) -> _Out:
         probe.parent_entered.set()
         handle = ctx.call_endpoint(
-            "harness/child-endpoint", "child", {"tag": payload.tag}, wait=False
+            "harness/child-endpoint", "child", {"tag": payload.tag},
+            semver_major=0, wait=False
         )
         out = handle.result(60.0, poll_interval_s=0.02)
         probe.parent_resumed.set()
@@ -465,6 +492,12 @@ def test_ctx_call_endpoint_actually_reaches_the_platform() -> None:
             assert run.probe.parent_result, "ctx.call_endpoint returned no output"
             assert run.probe.parent_result[0] == ["child-ok:child-req-1"]
             assert statuses.get("req-parent") == pb.JOB_STATUS_OK
+            # th#2044/pgw#1293: assert the URL that WENT OUT. A returned value
+            # cannot tell a correct address from a fake that ignores it.
+            assert run.platform.submit_paths() == [
+                "/harness/child-endpoint/v0/child"
+            ], run.platform.submit_paths()
+            assert ":" not in run.platform.submit_paths()[0]
 
     asyncio.run(_measure())
 


### PR DESCRIPTION
**tracker: pgw#1293** · program charter: [tensorhub th#2044](https://github.com/cozy-creator/tensorhub) · depends on th#2045 (LANDED `48185cd69`) · **gates th#2048**

Paul ruled 2026-08-16 that endpoint tags die entirely (canary included), replaced by one serving pointer per `(endpoint, semver_major)`. Route-1 grammar is `POST /{owner}/{name}/v{semver_major}/{function}`; th#2045 landed it and the hub answers it today, th#2046 re-keyed every read through the pointer.

## The cut

`RequestContext.call_endpoint` and `callout.CalloutClient.submit` lose `tag: str = "prod"` and gain `semver_major: int` — keyword-only and **required**. No transition window, no both-grammars mode (standing rule: hard-cut fleet adoption).

The retired builder was `{function}:{(tag or 'prod').strip()}` — silent-failure S4: an empty or `None` tag routed to the serving pointer with no raise and no log. `semver_major_segment` is now the one place the `vN` spelling exists, and it refuses a non-int (`bool` included — `True` would have rendered `vTrue`) or a negative major **before a socket opens**.

## The fake that could not go red

`tests/test_child_call_pipelining_pgw943.py`'s platform matched only `path.startswith("/v1/requests/")` and never inspected the `:tag` tail, so the whole cut passed it unchanged. Its platform now REFUSES any submit path outside the `/vN/` grammar, and the end-to-end row asserts the **URL that went out**, not the value that came back.

## Red-verified, three arms

| disarm | red |
|---|---|
| restore the `:prod` tail in `callout.submit` | **10/10** pipelining rows + 4 grammar rows (14 failed, 13 passed) |
| `semver_major: int = 0` + `f"v{semver_major or 0}"` | both S4 fences + the client signature row |
| `semver_major: int = 0` on `ctx.call_endpoint` | the ctx signature row |

Green: 27 passed across both files · `mypy src/gen_worker tests tests_v2` clean · `ruff check src/gen_worker` clean · `lint_mypy_ratchet` / `lint_http_timeouts` / `lint_unreached_surface` / `lint_fence_symbols` / `lint_repo_ref_pins` / `lint_config_reads` / `check_registry_contract` pass.

## NO VERSION BUMP

`pyproject [project].version` is untouched. This rides ONE coordinated release the coordinator holds, together with pgw#1294 and the tensorfs repin. `changelog.d/pgw1293.md` carries the fragment.

## The lockstep this creates

The wheel that carries this breaks three call sites that pass `tag=` today, and they are the repin lanes' work (te#217 / the pie leg), not this PR's:

- `training-endpoints` `conversion/src/conversion/quant/parity_judge.py:228`
- `private-inference-endpoints` `dj-pipeline/src/dj_pipeline/main.py:144` and `:524`

`call_endpoint` is the ONLY signature change in the wheel (`scripts/author_surface_allowlist.txt:55` marks it PROD, consumed by pie's dj-pipeline). Sequence stays: publish → repin + rebuild every endpoint image → `lint_fleet_pins` exit 0 → fleet census showing pods that BOOTED it → only then th#2048 merges.

## Also in this PR

- **String-literal sweep.** The only retired *endpoint*-tag grammar left in the tree was `examples/micro-diffusion/README.md` — step 3's `PUT .../tags/prod` is now `PUT .../serving/0` and step 5's invoke is `/v0/generate`. Every other `tag`/`:tag`/`@prod` literal in the tree is the **repo** axis (th#1987's ref grammar) or a docker/git tag; `lint_repo_ref_pins` agrees.
- **Drive-by (second commit):** 5 unused imports that have been ruff-red on master since PR #850 — `child_contract`, `dispatch`, `models/loading`, `request_context/_helpers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)