### PR TITLE
pgw#1298: delete the nunchaku SVDQ engine; int4 becomes a typed refusal

### DIFF
--- a/changelog.d/pgw1298.md
+++ b/changelog.d/pgw1298.md
@@ -1,0 +1,23 @@
+- The nunchaku SVDQ engine is deleted. It was slower than our own decoder (843
+  vs 785 ms/step on a 5090, same seeds, same official fp4_r128 bytes, equal
+  peak VRAM), covered strictly less silicon (sm_120/121 against native's
+  sm_100/103/120/121), and — measured, not assumed — was UNREACHABLE: nothing
+  ever passed the `engine=` pin, and for fp4 the ladder put native first on
+  every card nunchaku could serve. Gone with it: `load_svdq_nunchaku_pipeline`,
+  the `(nunchaku, diffusers, torch/cuda)` pin matrix and its `SvdqStackError`,
+  `svdq_stack_reason`, `svdq_precision_for_sm`, the whole engine ladder
+  (`SVDQ_ENGINES`, `svdq_engine_candidates`, `select_svdq_engine`, the
+  per-call `override=`), and `SvdqSnapshotError`. `svdq-int4` — which has no
+  native engine, and which nothing produces (`svdq_produce.py` pins `nvfp4`) —
+  becomes a typed `SvdqInt4Unsupported` refusal raised on the DETECTED
+  artifact, before a weight byte is read, naming the real reason instead of
+  dying on "nunchaku is not installed" three frames deeper.
+- `"nunchaku"` STAYS in `hub_policy.detect_worker_capabilities`' probe list and
+  in `models/ladder.py`'s placement stamp, deliberately. The hub admits an
+  svdq-fp4 row only when the worker reports `nunchaku` in `installed_libs`
+  (tensorhub `precision/ladder.go` `admitted()`), so the probe is now an
+  ADMISSION TOKEN rather than a capability claim — dropping it would stop the
+  one image that carries the wheel from BINDING a flavor it already serves on
+  native. Both die with th#2055 + pgw#1300, not here.
+- Not a FUSE win on its own: `svdq_native.py`'s `safe_open(str(art.file))` is
+  still a real path read on the same file. That moves under pgw#1308.

--- a/src/gen_worker/discovery/decode_set.py
+++ b/src/gen_worker/discovery/decode_set.py
@@ -448,7 +448,7 @@ class FileLayoutUnsupportedError(Exception):
     A third fact, distinct from the handle and from the key convention: the
     bytes may be exactly the right format, addressed in exactly the right
     convention, and still arrive as a shape the decoder's entry point cannot
-    open. Measured case: both svdq engines refuse a bare single-file nunchaku
+    open. Measured case: the svdq engine refuses a bare single-file
     transformer — a servable flavor must be a full diffusers tree with the
     checkpoint under its denoiser directory — and until this axis existed that
     fact lived only in two `raise` statements reached AFTER the CUDA gate, so

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -41,6 +41,17 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
 
     # Known optional libs that affect artifact compatibility.
     # Keep this hardcoded (no env config), per Cozy design.
+    #
+    # "nunchaku" STAYS after pgw#1298 deleted the nunchaku ENGINE, and dropping
+    # it would be a live outage rather than a cleanup. This list is what the
+    # hub admits against: tensorhub stamps every svdq-fp4/int4 row with
+    # `engines=["nunchaku"]` (`precision/placement.go` defaultPlacement, plus
+    # our own `models/ladder.py` stamp) and `precision/ladder.go` admitted()
+    # refuses any row whose engines are not in `installed_libs`. So the probe
+    # is an ADMISSION TOKEN now, not a capability claim — stop reporting it and
+    # `qwen-image-svdq-bench` (the one image carrying the wheel) can no longer
+    # bind the flavor it serves on our native engine. It goes when th#2055
+    # deletes the hub's placement readers, together with pgw#1300's stamp.
     known = ["bitsandbytes", "torchao", "transformer_engine",
              "nunchaku", "deepcompressor", "modelopt"]
     if extra_libs:

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -2293,11 +2293,11 @@ def load_from_pretrained(
             cls, path, dtype=dtype, storage_dtype=storage_dtype,
             components=components, placement_mode=placement_mode,
         )
-    # SVDQuant/nunchaku 4-bit flavors: self-describing snapshots take
-    # the svdq lane — a nunchaku transformer swapped into the standard
-    # pipeline. Detection precedes every other rung; failures are typed
-    # (SvdqStackError / SvdqHardwareError / SvdqSnapshotError), never a
-    # mid-denoise crash.
+    # SVDQuant 4-bit flavors: self-describing snapshots take the svdq lane —
+    # our native decoder wired into the standard pipeline (pgw#1298 deleted
+    # the nunchaku engine; "nunchaku" survives as the FORMAT's name). Detection
+    # precedes every other rung; failures are typed (SvdqInt4Unsupported /
+    # SvdqHardwareError / SvdqNativeError), never a mid-denoise crash.
 
     svdq_art = detect_svdq_artifact(Path(path))
     if svdq_art is not None and callable(getattr(cls, "from_pretrained", None)):

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -1,263 +1,87 @@
-"""SVDQuant/nunchaku 4-bit loader mode.
+"""SVDQuant 4-bit loader mode.
 
 A ``#svdq-fp4-*`` / ``#svdq-int4-*`` flavor is a normal diffusers tree whose
-denoiser directory holds ONE nunchaku-format single-file checkpoint instead of
+denoiser directory holds ONE nunchaku-FORMAT single-file checkpoint instead of
 plain safetensors shards. The file self-describes in its safetensors
-``__metadata__``: ``model_class`` names the nunchaku transformer class and
+``__metadata__``: ``model_class`` names the transformer class and
 ``quantization_config`` carries ``{"method": "svdquant", "weight": {"dtype":
-"fp4_e2m1_all" | "int4"}, "rank": N}``. Loading swaps the nunchaku module into
-the standard pipeline — same pipeline class, same handler, no new endpoint.
+"fp4_e2m1_all" | "int4"}, "rank": N}``. Loading swaps the decoded denoiser
+into the standard pipeline — same pipeline class, same handler, no new
+endpoint.
 
-Hardware: fp4 kernels exist ONLY on consumer Blackwell (sm_120/121); int4 on
-sm_75–89. No sm_90/100 (no datacenter SVDQ kernels). Version coupling is
-HARD (live-hit): nunchaku wheels are per-(torch minor, CUDA) and each
-nunchaku release calls diffusers transformer forwards positionally against one
-diffusers signature window — 1.2.x/1.3.x require diffusers 0.36/0.37 and crash
-on 0.38+. The pin matrix below is enforced with typed errors both at variant
-selection (fit gating) and at load."""
+"nunchaku" here is a FORMAT LINEAGE, not a runtime. pgw#1298 deleted the
+nunchaku engine: it was slower than our own decoder (843 vs 785 ms/step on a
+5090, same seeds, equal peak VRAM), covered strictly less silicon (sm_120/121
+against native's sm_100/103/120/121), and was UNREACHABLE — the only caller
+(``models/loading.py``) never passed an engine pin, and for fp4 the ladder put
+native first on every card nunchaku could serve. Every svdq load now runs
+through :mod:`gen_worker.models.svdq_native`, which reads the same bytes
+bit-exactly.
+
+ONE fleet image still installs the nunchaku WHEEL — ``inference-endpoints/
+qwen-image-svdq-bench`` (a benchmark fixture pending teardown). That is
+deliberate and must stay until th#2055: the hub admits an svdq-fp4 row only
+when the worker reports ``nunchaku`` in ``installed_libs``
+(``models/hub_policy.py`` probes it; tensorhub ``precision/ladder.go``'s
+``admitted()`` requires it), so removing the wheel — or dropping the probe —
+would stop that endpoint BINDING a flavor it can serve perfectly well on
+native. The wheel is now purely an admission token.
+
+fp4 serves; int4 is a typed refusal (:class:`SvdqInt4Unsupported`) — the
+native module is nvfp4 block-scaled ``_scaled_mm`` and int4 svdq is a
+different (single-level, group-64) scale path. Nothing produces int4
+(``convert/svdq_produce.py`` pins ``nvfp4``), so this is the honest spelling
+of a refusal that already happened."""
 
 from __future__ import annotations
 
 import json
 import logging
-import re
 import struct
 from dataclasses import dataclass
 from pathlib import Path
 from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
 from typing import Any, Optional
-import importlib.metadata as md
-from ..hostfacts import cuda_ready
 
 logger = logging.getLogger(__name__)
 
 SVDQ_METHOD = "svdquant"
-# Nunchaku ships fp4 kernels for consumer Blackwell only and int4 kernels for
-# Turing→Ada. sm_90 (Hopper) and sm_100 (B200) are deliberately absent.
+# The SM windows of nunchaku's kernels. NOT a serving constraint any more —
+# nothing in this module reads them, because the native engine's own window
+# (`svdq_native.SVDQ_NATIVE_FP4_SMS`, a strict superset for fp4) is what
+# decides whether a load can run. They survive for exactly two consumers, both
+# of which die together:
+#   - `models/ladder.py:99-101`, the published placement stamp
+#   - tensorhub's `internal/wirecontract/WORKER_PARSED_CONSTANTS`, which pins
+#     these two symbol names to this file by hand
+# Both go with th#2055 + pgw#1300 (the placement-reader/producer cut). Deleting
+# them here would break that stamp and falsify the hub's peer pin, so they stay
+# until that coordinated cut, and not one line longer.
 SVDQ_FP4_SMS = (120, 121)
 SVDQ_INT4_SMS = (75, 80, 86, 89)
-
 
 
 class SvdqError(RuntimeError):
     """Base class for typed svdq loader-mode failures."""
 
 
-class SvdqStackError(SvdqError):
-    """The (nunchaku, diffusers, torch/cuda) stack violates the pin matrix."""
-
-
 class SvdqHardwareError(SvdqError):
     """The artifact's precision has no kernels on this GPU."""
 
 
-class SvdqSnapshotError(SvdqError):
-    """The flavor snapshot is not a loadable svdq tree."""
+class SvdqInt4Unsupported(SvdqError):
+    """svdq-int4: no native engine, and no other engine is installed."""
 
 
-# ---------------------------------------------------------------------------
-# Pin matrix — (nunchaku minor) -> required diffusers window.
-#
-# nunchaku calls ``super().forward(...)`` POSITIONALLY against the diffusers
-# transformer signatures it was released against; a newer diffusers inserts
-# arguments and the call crashes mid-denoise (1.2.1 on 0.38.0.dev0 and 0.39.0
-# -> "TypeError: argument of type 'int' is not iterable"). Torch/CUDA
-# coupling is carried in the wheel's local version tag (e.g.
-# ``1.2.1+cu13.0torch2.11``) and checked against the running interpreter.
-# Re-verify and extend this table on every nunchaku release.
-# ---------------------------------------------------------------------------
-
-@dataclass(frozen=True)
-class SvdqPin:
-    nunchaku_minor: tuple[int, int]
-    diffusers_min: tuple[int, int]
-    diffusers_max_exclusive: tuple[int, int]
-
-
-_PIN_MATRIX: tuple[SvdqPin, ...] = (
-    # 1.2.x: CI-pinned to diffusers 0.36 (verified live).
-    SvdqPin((1, 2), (0, 36), (0, 37)),
-    # 1.3.x <-> diffusers 0.39: UNVERIFIED — static signature check only, live
-    # A/B still owed; inert until a nunchaku 1.3 wheel is actually installed.
-    # Static basis: nunchaku's forward and diffusers 0.39's HAVE drifted
-    # positionally (nunchaku keeps txt_seq_lens, 0.39 dropped it and added
-    # additional_t_cond, so position 6+ misbinds on a positional call), BUT
-    # diffusers 0.39's QwenImagePipeline calls the transformer with keyword
-    # arguments only and never passes either drifted param — so the positional
-    # hazard is void and no unexpected-kwarg error can fire on the t2i path.
-    # Numerical equivalence is NOT established by that check, and
-    # QwenImageEditPlusPipeline was not checked at all.
-    SvdqPin((1, 3), (0, 39), (0, 40)),
+SVDQ_INT4_REFUSAL = (
+    "{path} is svdq-int4. The native engine implements the nvfp4 "
+    "block-scaled path only; int4 svdq is a different (single-level, "
+    "group-64) scale path with no native implementation, so loading it would "
+    "require the nunchaku runtime this worker deliberately does not use "
+    "(pgw#1298 deleted that engine). Serve the fp4 artifact of this family, "
+    "or file int4 native support as a pgw# follow-up."
 )
-
-
-def _version_tuple(raw: str, n: int = 2) -> tuple[int, ...]:
-    """Leading numeric components of a version string ("0.38.0.dev0" ->
-    (0, 38)). Missing/unparseable parts are 0."""
-    parts: list[int] = []
-    for tok in re.split(r"[.+]", str(raw or "").strip()):
-        m = re.match(r"^(\d+)", tok)
-        if m is None:
-            break
-        parts.append(int(m.group(1)))
-        if len(parts) >= n:
-            break
-    while len(parts) < n:
-        parts.append(0)
-    return tuple(parts)
-
-
-def _wheel_local_tag(nunchaku_version: str) -> tuple[str, str]:
-    """(cuda, torch) from a nunchaku wheel version's local tag, e.g.
-    ``1.2.1+cu13.0torch2.11`` -> ("13.0", "2.11"). Empty strings when the
-    tag is absent (source builds)."""
-    if "+" not in str(nunchaku_version or ""):
-        return "", ""
-    local = str(nunchaku_version).split("+", 1)[1]
-    m = re.match(r"^cu([\d.]+)torch([\d.]+)$", local)
-    if m is None:
-        return "", ""
-    return m.group(1), m.group(2)
-
-
-def check_svdq_stack_versions(
-    *, nunchaku_version: str, diffusers_version: str,
-    torch_version: str = "", cuda_version: str = "",
-) -> None:
-    """Pure pin-matrix check over version strings. Raises SvdqStackError with
-    the precise coupling that failed; returns None when the stack is legal."""
-    nv = _version_tuple(nunchaku_version)
-    pin = next((p for p in _PIN_MATRIX if p.nunchaku_minor == nv), None)
-    if pin is None:
-        known = ", ".join(f"{a}.{b}" for a, b in (p.nunchaku_minor for p in _PIN_MATRIX))
-        raise SvdqStackError(
-            f"nunchaku {nunchaku_version} is not in the svdq pin matrix "
-            f"(known: {known}); its diffusers signature window must be "
-            f"verified and added before the svdq rung can serve on it"
-        )
-    dv = _version_tuple(diffusers_version)
-    if not (pin.diffusers_min <= dv < pin.diffusers_max_exclusive):
-        lo = ".".join(map(str, pin.diffusers_min))
-        hi = ".".join(map(str, pin.diffusers_max_exclusive))
-        raise SvdqStackError(
-            f"nunchaku {nunchaku_version} requires diffusers>={lo},<{hi} "
-            f"(positional transformer forward coupling, gw#405); installed "
-            f"diffusers is {diffusers_version}"
-        )
-    wheel_cuda, wheel_torch = _wheel_local_tag(nunchaku_version)
-    if wheel_torch and torch_version and _version_tuple(torch_version) != _version_tuple(wheel_torch):
-        raise SvdqStackError(
-            f"nunchaku wheel {nunchaku_version} was built for torch "
-            f"{wheel_torch}.x; installed torch is {torch_version}"
-        )
-    if wheel_cuda and cuda_version and _version_tuple(wheel_cuda, 1) != _version_tuple(cuda_version, 1):
-        raise SvdqStackError(
-            f"nunchaku wheel {nunchaku_version} was built for CUDA "
-            f"{wheel_cuda}; torch reports CUDA {cuda_version}"
-        )
-
-
-def svdq_stack_reason() -> Optional[str]:
-    """Non-raising stack check against the INSTALLED environment (importlib
-    metadata only — does not import nunchaku's CUDA extension). Returns the
-    failure reason, or None when the svdq lane is servable here."""
-
-    try:
-        nunchaku_version = md.version("nunchaku")
-    except md.PackageNotFoundError:
-        return "nunchaku is not installed"
-    try:
-        diffusers_version = md.version("diffusers")
-    except md.PackageNotFoundError:
-        return "diffusers is not installed"
-    torch_version = cuda_version = ""
-    try:
-        import torch
-
-        torch_version = str(torch.__version__ or "")
-        cuda_version = str(getattr(torch.version, "cuda", "") or "")
-    except ImportError:
-        pass
-    try:
-        check_svdq_stack_versions(
-            nunchaku_version=nunchaku_version,
-            diffusers_version=diffusers_version,
-            torch_version=torch_version,
-            cuda_version=cuda_version,
-        )
-    except SvdqStackError as exc:
-        return str(exc)
-    return None
-
-
-def svdq_precision_for_sm(gpu_sm: int) -> str:
-    """"fp4" / "int4" / "" — which svdq kernel family NUNCHAKU can run here."""
-    if gpu_sm in SVDQ_FP4_SMS:
-        return "fp4"
-    if gpu_sm in SVDQ_INT4_SMS:
-        return "int4"
-    return ""
-
-
-# ---------------------------------------------------------------------------
-# Engine selection: an svdq artifact serves on the native lane or on nunchaku.
-# ---------------------------------------------------------------------------
-
-SVDQ_ENGINES = ("native", "nunchaku")
-
-# th#1887: the GEN_WORKER_SVDQ_ENGINE process-wide pin is deleted. It was a
-# PROCESS-wide override of a PER-ARTIFACT decision, so one incident's pin
-# outlived the incident and silently served every later artifact on the wrong
-# engine. The typed `override=` argument below survives and is the supported
-# way to force one: it is per call, so it cannot leak into the next load.
-
-def svdq_engine_candidates(precision: str) -> tuple[str, ...]:
-    """Engines that could serve this precision, best first.
-
-    NATIVE is preferred for fp4: no nunchaku wheel, no diffusers signature
-    window, no pin-matrix row, no torch downgrade, it compiles, and it covers
-    sm_100/103 which nunchaku never
-    will. int4 has no native implementation — the native module is nvfp4
-    block-scaled ``_scaled_mm``, and int4 svdq is a different (single-level,
-    group-64) scale path."""
-    if str(precision) == "int4":
-        return ("nunchaku",)
-    return ("native", "nunchaku")
-
-
-def select_svdq_engine(precision: str, *, override: str = "",
-                       ) -> tuple[str, dict[str, str]]:
-    """Pick the engine for an svdq artifact on THIS host.
-
-    Returns ``(engine, reasons)`` — ``engine`` is "" when none can serve, and
-    ``reasons`` maps each rejected engine to why, so the caller can raise one
-    error naming every closed door. An explicit ``override`` is honored
-    strictly: if that engine cannot serve, nothing else is substituted."""
-    # Deferred: svdq_native adds +2 modules to the `import gen_worker` path.
-    from .svdq_native import svdq_native_reason
-
-    chosen = str(override or "").strip().lower()
-    if chosen and chosen not in SVDQ_ENGINES:
-        raise SvdqError(f"unknown svdq engine {chosen!r} "
-                        f"({', '.join(SVDQ_ENGINES)})")
-
-    candidates = ((chosen,) if chosen
-                  else svdq_engine_candidates(precision))
-    reasons: dict[str, str] = {}
-    for engine in candidates:
-        if engine == "native":
-            if str(precision) == "int4":
-                reasons[engine] = ("the native engine implements nvfp4 only; "
-                                   "int4 svdq is a different scale path")
-                continue
-            reason = svdq_native_reason()
-        else:
-            reason = svdq_stack_reason()
-        if reason is None:
-            return engine, reasons
-        reasons[engine] = reason
-    return "", reasons
 
 
 # ---------------------------------------------------------------------------
@@ -343,103 +167,52 @@ def detect_svdq_artifact(model_path: Path) -> Optional[SvdqArtifact]:
 
 
 # ---------------------------------------------------------------------------
-# Loading — nunchaku transformer swap into the standard pipeline
+# Loading — the native decoder wired into the standard pipeline
 # ---------------------------------------------------------------------------
 
-def check_svdq_loadable(art: SvdqArtifact) -> None:
-    """All typed gates for actually serving ``art`` on this machine."""
-    reason = svdq_stack_reason()
+def check_svdq_servable(art: SvdqArtifact, path: Any = "") -> None:
+    """Every typed refusal for ``art``, raised on the DETECTED artifact.
+
+    Called before a single weight byte is read, so an unservable flavor is
+    refused by name rather than dying inside a load. int4 is refused on the
+    artifact's own precision — no probing, no environment, no engine ladder,
+    because there is nothing to probe: the refusal is a property of the
+    checkpoint."""
+    if str(art.precision) == "int4":
+        raise SvdqInt4Unsupported(
+            SVDQ_INT4_REFUSAL.format(path=path or art.file))
+    # Deferred: svdq_native adds +2 modules to the `import gen_worker` path.
+    from .svdq_native import svdq_native_reason
+
+    reason = svdq_native_reason()
     if reason is not None:
-        raise SvdqStackError(reason)
-    import torch
-
-    if not cuda_ready():
-        raise SvdqHardwareError("svdq artifacts require a CUDA GPU")
-    major, minor = torch.cuda.get_device_capability()
-    sm = major * 10 + minor
-    expected = svdq_precision_for_sm(sm)
-    if expected != art.precision:
         raise SvdqHardwareError(
-            f"svdq-{art.precision} has no kernels on SM{sm} "
-            f"(fp4: sm_120/121, int4: sm_75-89"
-            + (f"; this GPU runs svdq-{expected}" if expected else "")
-            + ")"
-        )
+            f"cannot serve svdq-{art.precision} here — {reason}")
 
 
-def load_svdq_pipeline(cls: Any, path: Path, art: SvdqArtifact, *,
-                       engine: str = "") -> Any:
-    """Serve an svdq artifact through whichever ENGINE can run it here.
+def load_svdq_pipeline(cls: Any, path: Path, art: SvdqArtifact) -> Any:
+    """Serve an svdq artifact on the native engine.
 
-    Engine choice is :func:`select_svdq_engine` (native preferred for fp4);
-    ``engine`` pins it explicitly. Callers need no engine awareness — this is
-    the single entry point the loading layer already uses."""
-    chosen, reasons = select_svdq_engine(art.precision, override=engine)
-    if not chosen:
-        detail = "; ".join(f"{k}: {v}" for k, v in sorted(reasons.items()))
-        raise SvdqHardwareError(
-            f"no svdq engine can serve svdq-{art.precision} here — {detail}")
-    if chosen == "native":
-        from .svdq_native import load_svdq_native_pipeline
+    The single entry point the loading layer uses. There is one engine, so
+    there is nothing to select: the artifact is either servable here or it is
+    a typed refusal."""
+    check_svdq_servable(art, path)
+    from .svdq_native import load_svdq_native_pipeline
 
-        logger.info("svdq engine: native (%s %s r%d, file %s)",
-                    art.precision, art.component, art.rank, art.file.name)
-        return load_svdq_native_pipeline(cls, path, art)
-    return load_svdq_nunchaku_pipeline(cls, path, art)
-
-
-def load_svdq_nunchaku_pipeline(cls: Any, path: Path, art: SvdqArtifact) -> Any:
-    """Build the pipeline with the nunchaku transformer swapped in.
-
-    Compute dtype is pinned to bf16 — nunchaku's kernels and the surrounding
-    scales are bf16-oriented (every upstream example and our own probe used
-    bf16); honoring an fp16 binding here would change numerics silently."""
-    check_svdq_loadable(art)
-    import nunchaku
-    import torch
-
-    if not art.component:
-        raise SvdqSnapshotError(
-            f"svdq snapshot {path} is a bare single-file transformer; a "
-            f"servable #svdq flavor must be a full diffusers tree with the "
-            f"nunchaku file under its denoiser directory"
-        )
-    ncls = getattr(nunchaku, art.model_class, None)
-    if ncls is None:
-        raise SvdqStackError(
-            f"installed nunchaku has no {art.model_class} (artifact needs a "
-            f"newer nunchaku release / unsupported family)"
-        )
-    dtype = torch.bfloat16
-    logger.info(
-        "svdq loader mode: %s %s r%d via %s (file %s)",
-        art.precision, art.component, art.rank, art.model_class, art.file.name,
-    )
-    denoiser = ncls.from_pretrained(str(art.file), torch_dtype=dtype)
-    # low_cpu_mem_usage=False is nunchaku's documented requirement for the
-    # component-swap pipeline build (meta-device init breaks its buffers).
-    return cls.from_pretrained(
-        str(path), torch_dtype=dtype, low_cpu_mem_usage=False,
-        **{art.component: denoiser},
-    )
+    logger.info("svdq: native engine (%s %s r%d, file %s)",
+                art.precision, art.component, art.rank, art.file.name)
+    return load_svdq_native_pipeline(cls, path, art)
 
 
 __all__ = [
-    "SVDQ_ENGINES",
     "SVDQ_FP4_SMS",
+    "SVDQ_INT4_REFUSAL",
     "SVDQ_INT4_SMS",
     "SvdqArtifact",
     "SvdqError",
     "SvdqHardwareError",
-    "SvdqSnapshotError",
-    "SvdqStackError",
-    "check_svdq_loadable",
-    "check_svdq_stack_versions",
+    "SvdqInt4Unsupported",
+    "check_svdq_servable",
     "detect_svdq_artifact",
-    "load_svdq_nunchaku_pipeline",
     "load_svdq_pipeline",
-    "select_svdq_engine",
-    "svdq_engine_candidates",
-    "svdq_precision_for_sm",
-    "svdq_stack_reason",
 ]

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -506,12 +506,12 @@ def _decode_quantized_lowrank(
         # here would be a second home (th#1937 declined `contract.native`).
         key_topologies=(),
         # MULTI-FILE ONLY, and it is the artifact that is constrained, not the
-        # checkpoint: the nunchaku file is one flat namespace, but BOTH svdq
-        # engines refuse an artifact that is only that file —
-        # `load_svdq_nunchaku_pipeline` and `load_svdq_native_pipeline` each
-        # raise on `not art.component` ("a servable flavor must be a full
-        # diffusers tree with the checkpoint under its denoiser directory"),
-        # and `convert/svdq.py` builds exactly that.
+        # checkpoint: the nunchaku-format file is one flat namespace, but the
+        # svdq engine refuses an artifact that is only that file —
+        # `load_svdq_native_pipeline` raises on `not art.component` ("a
+        # servable flavor must be a full diffusers tree with the checkpoint
+        # under its denoiser directory"), and `convert/svdq.py` builds exactly
+        # that.
         file_layouts=(MULTI_FILE,),
         bakes=(BAKE_LOW_RANK_BRANCH,),
     ),

--- a/tests/test_decode_set_file_layouts_pgw1252.py
+++ b/tests/test_decode_set_file_layouts_pgw1252.py
@@ -10,12 +10,12 @@ here would have been the fourth spelling of one axis.
 
 **A declaration nothing enforces is a declaration nothing can be wrong about.**
 The svdq decoders declare `multi-file` ONLY, and that is measured, not
-inherited from the checkpoint's shape: the nunchaku file is one flat namespace,
-but BOTH engines refuse an artifact that is only that file
-(`load_svdq_nunchaku_pipeline` / `load_svdq_native_pipeline`, `not
-art.component`). Before this axis that fact lived only in those two `raise`
-statements — reached AFTER the CUDA gate, so a GPU-less host reported "svdq
-artifacts require a CUDA GPU" for an artifact no GPU would have helped.
+inherited from the checkpoint's shape: the nunchaku-FORMAT file is one flat
+namespace, but the engine refuses an artifact that is only that file
+(`load_svdq_native_pipeline`, `not art.component`). Before this axis that fact
+lived only in a `raise` reached AFTER the CUDA gate, so a GPU-less host
+reported "svdq artifacts require a CUDA GPU" for an artifact no GPU would have
+helped. (pgw#1298 deleted the second engine; the axis is unchanged.)
 """
 
 from __future__ import annotations

--- a/tests/test_svdq_native_pgw685.py
+++ b/tests/test_svdq_native_pgw685.py
@@ -9,6 +9,7 @@ no GPU: the fp4 GEMM is the only GPU-only piece and it is gated.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -305,71 +306,79 @@ def test_native_sm_window_is_blackwell_only() -> None:
         assert native.svdq_native_sm_supported(sm)
 
 
-def test_int4_has_no_native_engine() -> None:
-    assert svdq_mod.svdq_engine_candidates("int4") == ("nunchaku",)
-    assert svdq_mod.svdq_engine_candidates("fp4") == ("native", "nunchaku")
-    engine, reasons = svdq_mod.select_svdq_engine("int4")
-    assert engine != "native"
-    engine, reasons = svdq_mod.select_svdq_engine("int4", override="native")
-    assert engine == "" and "nvfp4 only" in reasons["native"]
+# pgw#1298 deleted the engine LADDER along with the nunchaku engine, so the
+# five selection tests that used to live here (candidate order, native
+# preference, nunchaku fallback, every-closed-door reasons, strict `override=`)
+# are gone with their subject. What replaces them is the one behaviour a
+# one-engine module still has: which artifacts it refuses, and how.
+#
+# The th#1887 `GEN_WORKER_SVDQ_ENGINE`-is-inert test also died here — its
+# subject was `select_svdq_engine`. The env is still fenced repo-wide by
+# `tests/test_behaviour_gate_visitor_th1887.py:133`, which asserts the name
+# appears in no behaviour gate anywhere; that fence is stronger than the one
+# deleted and needs no svdq-specific companion.
 
 
-def test_native_is_preferred_for_fp4_when_it_can_serve(monkeypatch) -> None:
-    """Native first: no nunchaku wheel, no diffusers window, no pin matrix."""
+def _art(precision: str) -> Any:
+    from gen_worker.models.svdq import SvdqArtifact
+
+    return SvdqArtifact(component="transformer", file=Path("m.safetensors"),
+                        model_class="NunchakuQwenImageTransformer2DModel",
+                        precision=precision, rank=128)
+
+
+def test_int4_is_a_typed_refusal_on_the_detected_artifact() -> None:
+    """int4 has no native engine and no other engine is installed, so it is
+    refused BY NAME on the artifact — not by failing to find a loader.
+
+    Behaviourally this is what already happened (the nunchaku lane died on
+    "nunchaku is not installed"); what changed is that the message now names
+    the real reason, and the type is specific enough to catch."""
+    with pytest.raises(svdq_mod.SvdqInt4Unsupported) as exc:
+        svdq_mod.check_svdq_servable(_art("int4"), "some/flavor")
+    msg = str(exc.value)
+    assert "svdq-int4" in msg
+    assert "no native implementation" in msg
+    assert "some/flavor" in msg
+    # The refusal must not depend on the host: no CUDA probe, no importlib
+    # metadata, nothing that could make it pass on a different machine.
+    assert issubclass(svdq_mod.SvdqInt4Unsupported, svdq_mod.SvdqError)
+
+
+def test_int4_is_refused_before_any_native_probe(monkeypatch) -> None:
+    """The int4 arm must precede the silicon check, so an int4 artifact on a
+    Blackwell card still gets the int4 message rather than a hardware one."""
     monkeypatch.setattr(native, "svdq_native_reason", lambda: None)
-    engine, reasons = svdq_mod.select_svdq_engine("fp4")
-    assert engine == "native", reasons
+    with pytest.raises(svdq_mod.SvdqInt4Unsupported):
+        svdq_mod.check_svdq_servable(_art("int4"))
 
 
-def test_nunchaku_is_used_when_native_cannot_serve(monkeypatch) -> None:
-    monkeypatch.setattr(native, "svdq_native_reason", lambda: "sm_89, no fp4")
-    monkeypatch.setattr(svdq_mod, "svdq_stack_reason", lambda: None)
-    engine, reasons = svdq_mod.select_svdq_engine("fp4")
-    assert engine == "nunchaku"
-    assert reasons["native"] == "sm_89, no fp4"
-
-
-def test_no_engine_reports_every_closed_door(monkeypatch) -> None:
-    monkeypatch.setattr(native, "svdq_native_reason", lambda: "no fp4 silicon")
-    monkeypatch.setattr(svdq_mod, "svdq_stack_reason",
-                        lambda: "nunchaku is not installed")
-    engine, reasons = svdq_mod.select_svdq_engine("fp4")
-    assert engine == ""
-    assert reasons == {"native": "no fp4 silicon",
-                       "nunchaku": "nunchaku is not installed"}
-
-
-def test_explicit_override_is_strict_never_substituted(monkeypatch) -> None:
-    """An operator who pins nunchaku gets nunchaku or an error — never a
-    silent switch to the other engine."""
+def test_fp4_passes_when_the_native_engine_can_serve(monkeypatch) -> None:
     monkeypatch.setattr(native, "svdq_native_reason", lambda: None)
-    monkeypatch.setattr(svdq_mod, "svdq_stack_reason",
-                        lambda: "nunchaku is not installed")
-    engine, reasons = svdq_mod.select_svdq_engine("fp4", override="nunchaku")
-    assert engine == ""
-    assert reasons == {"nunchaku": "nunchaku is not installed"}
-    with pytest.raises(svdq_mod.SvdqError, match="unknown svdq engine"):
-        svdq_mod.select_svdq_engine("fp4", override="cutlass")
+    assert svdq_mod.check_svdq_servable(_art("fp4")) is None
 
 
-def test_th1887_the_deleted_engine_env_changes_nothing(
-        monkeypatch: pytest.MonkeyPatch) -> None:
-    """th#1887: GEN_WORKER_SVDQ_ENGINE is deleted — exporting it must be inert.
+def test_fp4_carries_the_native_engine_reason_when_it_cannot(monkeypatch) -> None:
+    """One engine, one reason — and it is the NATIVE one, named verbatim, so
+    an operator reads about silicon rather than about a missing wheel."""
+    monkeypatch.setattr(native, "svdq_native_reason", lambda: "this GPU is sm_89")
+    with pytest.raises(svdq_mod.SvdqHardwareError, match="this GPU is sm_89"):
+        svdq_mod.check_svdq_servable(_art("fp4"))
 
-    Asserted against a value that WOULD have changed the outcome under the old
-    code: int4's only candidate is nunchaku, so pinning "native" used to force
-    an engine that cannot serve it and produce a different result. If the env
-    ever regains meaning, this test fails.
-    """
-    monkeypatch.delenv("GEN_WORKER_SVDQ_ENGINE", raising=False)
-    before = svdq_mod.select_svdq_engine("int4")
-    monkeypatch.setenv("GEN_WORKER_SVDQ_ENGINE", "native")
-    assert svdq_mod.select_svdq_engine("int4") == before
-    monkeypatch.setenv("GEN_WORKER_SVDQ_ENGINE", "not-an-engine")
-    assert svdq_mod.select_svdq_engine("int4") == before
-    # The TYPED per-call override survives and is still honoured strictly.
-    with pytest.raises(svdq_mod.SvdqError, match="unknown svdq engine"):
-        svdq_mod.select_svdq_engine("fp4", override="cutlass")
+
+def test_the_nunchaku_engine_is_gone() -> None:
+    """pgw#1298: the deletion, asserted rather than described. Nothing may
+    reintroduce a second engine here without this test noticing."""
+    for gone in ("load_svdq_nunchaku_pipeline", "check_svdq_stack_versions",
+                 "svdq_stack_reason", "svdq_precision_for_sm", "SvdqPin",
+                 "SvdqStackError", "SVDQ_ENGINES", "svdq_engine_candidates",
+                 "select_svdq_engine", "_PIN_MATRIX"):
+        assert not hasattr(svdq_mod, gone), f"{gone} came back"
+    # `load_svdq_pipeline` takes no engine pin: there is nothing to pin.
+    import inspect
+
+    params = inspect.signature(svdq_mod.load_svdq_pipeline).parameters
+    assert "engine" not in params
 
 
 # --- the fp4 module (CUDA) ------------------------------------------------


### PR DESCRIPTION
## What

Deletes the nunchaku SVDQ fallback from `models/svdq.py`. Turns `svdq-int4` into a typed refusal raised on the detected artifact.

**Deleted:** `load_svdq_nunchaku_pipeline`, `check_svdq_stack_versions`, `svdq_stack_reason`, `_PIN_MATRIX`, `SvdqPin`, `SvdqStackError`, `svdq_precision_for_sm`, `SVDQ_ENGINES`, `svdq_engine_candidates`, `select_svdq_engine` (and its `override=`), `check_svdq_loadable`, `SvdqSnapshotError`, plus the five engine-selection tests and the th#1887 env-inertness test whose subject was `select_svdq_engine` (that env is still fenced repo-wide at `tests/test_behaviour_gate_visitor_th1887.py:133`, a strictly stronger fence).

**Added:** `SvdqInt4Unsupported` + `SVDQ_INT4_REFUSAL` + `check_svdq_servable`, wording modelled on `training-endpoints`' `foreign_quant.py:_NUNCHAKU_INT4_REFUSAL`.

## Why it is safe — the sequencing question, verified rather than assumed

pgw#1298 was recorded BLOCKED on th#2055/#1300: *"the hub still READS `engines=(\"nunchaku\",)` … deleting the engine while a live reader demands it is an outage."* **That block was wrong, and its supporting premise was wrong in the other direction too.** Both were checked against the trees:

**1. `engines` IS enforced.** Exactly two readers in tensorhub, no flag, no dead code:
- `internal/orchestrator/precision/ladder.go:193` in `admitted()` — reached from `fourBitCandidates` (`:209`), `storedW4A4` (`lane.go:735`), `storedFP8` (`lane.go:663`), `PinnedRefusalDeviation` (`sm_constraint.go:237`), and `ResolvePinned` (`lane.go:391+`).
- `internal/orchestrator/precision/literal_th1940.go:54` in `AdmitLiteral()` — the BYOM named-pick path, live from `scheduler_dispatch.go:2059`.

Both compare the stamp against the worker's `InstalledLibs`, which pgw computes in `models/hub_policy.py` from `importlib.util.find_spec`.

**2. The tracker's "nunchaku is installed NOWHERE in the fleet" is FALSE.** `inference-endpoints/qwen-image-svdq-bench/pyproject.toml:30` pins a nunchaku wheel. That is the *entire* explanation for how svdq-fp4 binds today, and there was never a contradiction to resolve — the endpoint uses a **bare binding + `svdq-fp4-w4a4+eager` lane pin**, which goes straight through `ResolvePinned` → `fourBitCandidates` → `admitted()`, and passes because that one image reports `nunchaku`.

**3. Therefore this deletion changes NO binding outcome.** The hub gates on an *installed Python package*, not on pgw's engine code. Deleting our use of nunchaku does not uninstall the wheel; `installed_libs` still carries it, `admitted()` still passes, the stamp still resolves. And what that endpoint actually *serves* is already native — `select_svdq_engine("fp4")` has put native first on every card since pgw#685, and nothing ever passed `engine="nunchaku"`. **The deleted branch was unreachable in production.**

Two things are therefore kept ON PURPOSE, and removing either IS an outage:
- **`SVDQ_FP4_SMS` / `SVDQ_INT4_SMS` survive.** `models/ladder.py:33` imports them for the placement stamp, and tensorhub's `internal/wirecontract/WORKER_PARSED_CONSTANTS` pins these two symbol *names* to `src/gen_worker/models/svdq.py` by hand (`compiledgraphreceipt.go:62`, `svdq_sm_windows_th2030_test.go`). They are not nunchaku *code*; they are the stamp's data.
- **`"nunchaku"` stays in `hub_policy.py`'s probe list.** It is an admission token now, not a capability claim. Commented in place so the next lane does not "clean it up".

## Explicitly NOT in this PR

- **`models/ladder.py:99-101` is untouched.** The placement stamp dies with th#2055's coordinated cut (pgw#1300 is its producer half), not here — regardless of the above.
- **This is NOT a FUSE / non-path win.** `models/svdq_native.py:519` still does `safe_open(str(art.file), framework="pt", device=str(dev))` — a real path, on the same file. Converting *that* to a native tensor read is pgw#1308, separately. Anyone reading this as "svdq no longer needs a filesystem" is reading it wrong.

## Proof

- **Red 5/5** on the int4 typed refusal: deleting the `if str(art.precision) == "int4"` arm gives **2 failed / 3 passed**, identically across 5 runs. The 3 passing are positive controls (`test_the_nunchaku_engine_is_gone`, and both fp4 arms), so an always-refusing gate could not have produced this.
- `tests/test_svdq_native_pgw685.py` 22 passed / 1 skipped.
- Adjacent suites, unchanged: `test_svdq_load_device`, `test_svdq_official_layout_pgw770`, `test_svdq_awq_pgw685`, `test_decode_set_pgw1245`, `test_decode_set_file_layouts_pgw1252`, `convert/test_placement_stamp_pgw1286`, `test_derived_execution_lanes_th1580`, `test_behaviour_gate_visitor_th1887`, `test_svdq_lowrank_quant_te148`, `convert/test_passthrough_deshard_th1362`, `test_resolution_rekey_gw494` — **130 passed**.
- `lint_fence_symbols` (every symbol a fence names still exists), `lint_config_reads`, `lint_layout_declarations`: clean. `lint_unreached_surface`: byte-identical finding set to master (line-number drift only), exit 0.
- `ruff check src/gen_worker`: identical findings to master (5 pre-existing local ruff-version F401s, none in touched files). `mypy --follow-imports=silent` on the three touched modules: clean.
- Torch/GPU suites are CI's.

## Survivor grep

`grep -rn nunchaku src/ tests/ scripts/ docs/` after the cut — every survivor is one of:
1. **Format lineage** (`svdq_layout.py`, `svdq_native.py`, `svdq_awq*.py`, `convert/svdq.py`, `tensor_layout_contract.py:CONTRACT_NUNCHAKU_V1`, `csrc/README.md`) — the on-disk format is *named* nunchaku.v1 and our decoder is its decoder. Correct as written.
2. **The placement stamp** (`models/ladder.py:37-38, 99, 101`, `tests/convert/test_placement_stamp_pgw1286.py`) — out of scope, dies with th#2055/#1300.
3. **The admission token** (`models/hub_policy.py`) — deliberate, commented, dies with th#2055.
4. **`scripts/svdq_bench/bench_arm.py`** — the A/B harness that produced the 785-vs-843 measurement. It `import nunchaku` directly, not through `models/svdq`, so it is untouched by this deletion and still runs as the reproducer.
5. **`discovery/project.py:10`** — a docstring example of `discovery_heavy_deps`, where `"nunchaku"` is still a genuine heavy dep for the one endpoint that has it.

Stale references to a *second engine* were corrected: `discovery/decode_set.py:451`, `models/loading.py:2296-2300`, `models/svdq_layout.py:509`, `tests/test_decode_set_file_layouts_pgw1252.py`.

## Follow-ups found, not fixed here

- **`inference-endpoints/z-image/pyproject.toml:12` pins `diffusers==0.36.0` solely because "nunchaku 1.2.x requires diffusers 0.36.x"** — and z-image installs no nunchaku. That pin now has no reason. ie# follow-up.
- **th#2055's deletion table omits `admitted()` itself** (`ladder.go:185-199`). It deletes `defaultPlacement` and `PlacementFromMetadata`'s consumers, which *starves* `admitted()` rather than removing the engine check. Worth naming explicitly in that cut.
- **`qwen-image-svdq-bench` must not drop its nunchaku wheel before th#2055 lands**, or it stops binding.

Closes pgw#1298.