### PR TITLE
pgw#1299: import TCG's metadata vocabulary instead of respelling it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,6 +350,18 @@ jobs:
           uv run python scripts/lint_pickle_readers.py --selftest
           uv run python scripts/lint_pickle_readers.py
 
+      # GATING (pgw#1299): TCG owns the compiled-graph metadata vocabulary and
+      # exports it. A respelled `"graph_class"` / `"aot-inductor"` does not fail
+      # at import when TCG renames the key — it returns None from a `.get()` on
+      # an artifact-metadata dict, the arm reads an un-armed cell as a cache
+      # miss, and the fleet silently re-mints. Filed three times (pgw#1288,
+      # pgw#1299); remembering failed. AST-based, so prose is not a finding, and
+      # a genuinely different vocabulary is classified at the line.
+      - name: pgw#1299 guard - nobody respells TCG's metadata vocabulary
+        run: |
+          uv run python scripts/lint_tcg_vocabulary.py --selftest
+          uv run python scripts/lint_tcg_vocabulary.py
+
       # GATING (th#1987 / HARDCUT A9): the `:tag` ref production is DELETED.
       # A surviving pin fails on a rented pod at the resolve, not at the line
       # that wrote it. The selftest proves the fence can go red, because a

--- a/changelog.d/pgw1299.md
+++ b/changelog.d/pgw1299.md
@@ -1,0 +1,29 @@
+TCG owns the compiled-graph metadata vocabulary, and the worker now imports it
+everywhere it reads it. Eleven sites spelled the string instead: ten
+`.get("graph_class")` reads of an artifact-metadata dict, across `aot_serve`,
+`aot_mint`, `aot_compile_child` and `models/provision`, plus one
+`artifact_kind="aot-inductor"` in `aot_delivery`. `models/provision` was
+importing `ARTIFACT_KIND` at the top of the file while spelling `"graph_class"`
+three times below it.
+
+The failure mode is why this matters more than tidiness: a TCG-side key rename
+does not raise on a `.get()`. It returns `None`, the arming path reads an
+un-armed cell as a cache miss, and the fleet re-mints — money, silently.
+
+`boot_key`'s four occurrences are deliberately NOT converted, and that is the
+substantive finding. They are `GraphClassDeclaration`'s dataclass FIELD name,
+carrying a class NAME into pgw's own boot-memo wire format; `GRAPH_CLASS_BLOCK`
+is the artifact-metadata BLOCK key. Equal strings, different vocabularies.
+Substituting the block name there would couple pgw's on-disk memo format to a
+rename of something else entirely, and a TCG field rename is already loud at
+those lines (`declaration.graph_class` raises `AttributeError`) — the silent
+`.get()` failure this issue is about cannot occur there. Each is classified at
+the line with a `# tcg-vocab:` reason.
+
+New gating fence in `fast gates`: `scripts/lint_tcg_vocabulary.py`, an AST sweep
+(so prose in a docstring is not a finding) with a `--selftest` that proves it can
+go red. It has no path allowlist — a genuinely different vocabulary is
+recognised by a reason at the line, so a filename cannot hide a real respelling.
+The fence immediately found a fifteenth site the issue's grep-based audit could
+not see: `boot_key.py:621` spells it in single quotes inside an f-string, and the
+audit swept for `"graph_class"` only.

--- a/scripts/lint_tcg_vocabulary.py
+++ b/scripts/lint_tcg_vocabulary.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""pgw#1299: TCG owns the compiled-graph metadata vocabulary; nobody respells it.
+
+`torch_compiled_graphs` exports `GRAPH_CLASS_BLOCK` and `ARTIFACT_KIND` for one
+reason: a consumer that spells the string instead of importing it does not fail
+at import when TCG renames the key. It fails at run time, silently, and in the
+worst possible shape — every one of these sites is a `.get(...)` on an
+artifact-metadata dict, so a rename returns `None`, the arming path reads an
+un-armed cell as a cache miss, and the fleet re-mints. That is money, not a
+warning.
+
+This has now been filed three times (pgw#1288 deleted four sites, pgw#1299
+found fourteen more). Remembering failed; this is the fence.
+
+WHAT IT LOOKS FOR is an AST string CONSTANT equal to `graph_class` or
+`aot-inductor` anywhere under `src/gen_worker/`. AST rather than grep, so prose
+in a docstring or a comment is not a finding — the vocabulary is only at risk
+where it is a value the interpreter compares against.
+
+THERE IS NO PATH ALLOWLIST, deliberately, for the reason
+`lint_repo_ref_pins.py` states: a filename lets a real respelling hide. The one
+legitimate use is recognised by a PROOF AT THE LINE instead — a
+`# tcg-vocab: <reason>` comment. Delete the reason and the line goes red.
+
+The legitimate use is real and worth naming, because conflating it with the
+metadata block would be its own bug. `GraphClassDeclaration.graph_class` is a
+DATACLASS FIELD holding a class NAME; `GRAPH_CLASS_BLOCK` is the
+ARTIFACT-METADATA BLOCK key. They are equal strings from different vocabularies.
+`boot_key.serialize_declaration` writes the field name into pgw's own boot-memo
+wire format, and a TCG field rename there is an `AttributeError` on
+`declaration.graph_class` — LOUD, which is precisely the failure mode this lint
+exists to prevent, already handled by Python. Substituting `GRAPH_CLASS_BLOCK`
+there would invent a coupling that does not exist: a rename of the metadata
+block would silently change pgw's on-disk boot memo format.
+
+Usage:
+
+    python scripts/lint_tcg_vocabulary.py [PATH ...]
+    python scripts/lint_tcg_vocabulary.py --selftest
+
+Defaults to `src/gen_worker/`. Generated protobuf (`pb/`) is skipped: it is
+owned by the `.proto`, not by a human, and regenerating it is the only way to
+change it.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterator, List, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_ROOT = REPO / "src" / "gen_worker"
+
+#: value -> the authority a consumer must import from `torch_compiled_graphs`.
+OWNED: dict[str, str] = {
+    "graph_class": "GRAPH_CLASS_BLOCK",
+    "aot-inductor": "ARTIFACT_KIND",
+}
+
+#: The marker that turns a finding into a classified exemption. It must carry a
+#: reason after the colon — a bare marker is not a proof.
+MARKER = "# tcg-vocab:"
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """`id()` of every Constant that is a module/class/function docstring."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                out.add(id(first.value))
+    return out
+
+
+def scan_text(text: str, where: str) -> List[Tuple[int, str, str]]:
+    """(line, value, authority) for every unexempted respelling in `text`."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:
+        raise SystemExit(f"{where}: cannot parse: {exc}") from exc
+    lines = text.splitlines()
+    skip = _docstring_nodes(tree)
+    found: List[Tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or id(node) in skip:
+            continue
+        if not isinstance(node.value, str) or node.value not in OWNED:
+            continue
+        line = node.lineno
+        source = lines[line - 1] if 0 < line <= len(lines) else ""
+        marker = source.find(MARKER)
+        if marker != -1 and source[marker + len(MARKER):].strip():
+            continue
+        found.append((line, node.value, OWNED[node.value]))
+    return sorted(set(found))
+
+
+def _python_files(roots: Iterator[Path]) -> Iterator[Path]:
+    for root in roots:
+        if root.is_file() and root.suffix == ".py":
+            yield root
+            continue
+        for path in sorted(root.rglob("*.py")):
+            # Generated protobuf is owned by the .proto, not by a human.
+            if "pb" in path.relative_to(root).parts:
+                continue
+            yield path
+
+
+def selftest() -> int:
+    """A sweep that can only ever print 'clean' guards nothing."""
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        bad = Path(tmp) / "bad.py"
+        bad.write_text('x = meta.get("graph_class")\ny = dict(kind="aot-inductor")\n')
+        hits = scan_text(bad.read_text(), str(bad))
+        if len(hits) != 2:
+            print(f"SELFTEST FAIL: expected 2 findings, got {hits}")
+            ok = False
+
+        exempt = Path(tmp) / "exempt.py"
+        exempt.write_text('x = {"graph_class": d.graph_class}  # tcg-vocab: declaration field\n')
+        if scan_text(exempt.read_text(), str(exempt)):
+            print("SELFTEST FAIL: a classified line must not be a finding")
+            ok = False
+
+        bare = Path(tmp) / "bare.py"
+        bare.write_text('x = meta.get("graph_class")  # tcg-vocab:\n')
+        if not scan_text(bare.read_text(), str(bare)):
+            print("SELFTEST FAIL: a marker with no reason is not a proof")
+            ok = False
+
+        prose = Path(tmp) / "prose.py"
+        prose.write_text('"""Reads the graph_class block of an aot-inductor artifact."""\n')
+        if scan_text(prose.read_text(), str(prose)):
+            print("SELFTEST FAIL: prose in a docstring is not a respelling")
+            ok = False
+
+    print("selftest: OK" if ok else "selftest: FAILED")
+    return 0 if ok else 1
+
+
+def main(argv: List[str]) -> int:
+    if "--selftest" in argv:
+        return selftest()
+    roots = [Path(a).resolve() for a in argv] or [DEFAULT_ROOT]
+    findings: List[str] = []
+    for path in _python_files(iter(roots)):
+        for line, value, authority in scan_text(path.read_text(), str(path)):
+            findings.append(
+                f"{path.relative_to(REPO)}:{line}: {value!r} is TCG's vocabulary — "
+                f"import {authority} from torch_compiled_graphs"
+            )
+    if findings:
+        print("pgw#1299: compiled-graph vocabulary respelled as a literal\n")
+        for row in findings:
+            print(f"  {row}")
+        print(
+            f"\n{len(findings)} finding(s). A TCG rename does not raise on these — "
+            "it returns None and the arm reads as a cache miss.\n"
+            f"If a site is genuinely a DIFFERENT vocabulary, say so at the line "
+            f"with `{MARKER} <reason>`."
+        )
+        return 1
+    print("pgw#1299: clean — no compiled-graph vocabulary is respelled")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -70,6 +70,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import msgspec
+from torch_compiled_graphs import GRAPH_CLASS_BLOCK
 from torch_compiled_graphs.spans import (
     PARTITION_KEYS,
     PARTITIONS,
@@ -434,7 +435,7 @@ def _compile_traced_class(
             f"TCG result for {traced.name!r} records key "
             f"{metadata.get('compiled_graph_key')!r}, not selected ref {key!r}"
         )
-    graph_class = metadata.get("graph_class")
+    graph_class = metadata.get(GRAPH_CLASS_BLOCK)
     if not isinstance(graph_class, dict) or graph_class.get("name") != traced.name:
         raise ValueError(
             f"TCG result for {traced.name!r} records the wrong graph_class"

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -28,7 +28,11 @@ from hashrepo import (
     TransferGrant,
     download,
 )
-from torch_compiled_graphs import StoreOutcome, is_compiled_graph_key
+from torch_compiled_graphs import (
+    ARTIFACT_KIND,
+    StoreOutcome,
+    is_compiled_graph_key,
+)
 
 from . import boot_phases, receipts
 from .api.errors import RetryableError
@@ -101,7 +105,7 @@ def materialize_named_artifact(
     with boot_phases.span(
         boot_phases.PHASE_CELL_FETCH,
         ref=cell_ref,
-        artifact_kind="aot-inductor",
+        artifact_kind=ARTIFACT_KIND,
         artifact_key=str(content_digest or ""),
     ) if boot_phases.in_boot() else contextlib.nullcontext() as fetch_span:
         return _materialize_named_artifact(

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -25,6 +25,7 @@ from typing import (
     Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple)
 
 from torch_compiled_graphs import (
+    GRAPH_CLASS_BLOCK,
     CallIngress,
     IngressError,
     build_call_ingress,
@@ -1520,7 +1521,7 @@ def fold_held_graph_classes(
     metas = {str(row.entry): dict(row.metadata) for row in held}
     blocks: Dict[str, Dict[str, Any]] = {}
     for name, meta in metas.items():
-        block = meta.get("graph_class")
+        block = meta.get(GRAPH_CLASS_BLOCK)
         if not isinstance(block, dict):
             raise MintRefused(
                 f"held graph class {name!r} carries no graph_class, so its "
@@ -1632,7 +1633,7 @@ def mint_graph_classes(
                 f"graph class {name!r}: the compile child returned an "
                 f"unreadable envelope ({exc}) — an artifact whose metadata "
                 f"this process cannot parse cannot be published") from exc
-        graph_class = meta.get("graph_class")
+        graph_class = meta.get(GRAPH_CLASS_BLOCK)
         if (
             not isinstance(graph_class, dict)
             or str(graph_class.get("name") or "") != name
@@ -1659,7 +1660,7 @@ def mint_graph_classes(
                 f"reach the child that owns it, so one class would publish "
                 f"two artifacts")
         held_meta = dict(carried.metadata)
-        held_block = held_meta.get("graph_class")
+        held_block = held_meta.get(GRAPH_CLASS_BLOCK)
         if not isinstance(held_block, dict):
             raise MintRefused(
                 f"held graph class {name!r} carries no graph_class, so its "

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 from torch_compiled_graphs import (
+    GRAPH_CLASS_BLOCK,
     CallIngress,
     CallInput,
     CompiledGraphRunner,
@@ -167,7 +168,7 @@ def entry_from_meta(meta: Mapping[str, Any]) -> Dict[str, Any]:
     pgw#1176: the plural ``entries_from_meta`` is GONE with the multi-entry
     artifact. A caller that wants several entries holds several artifacts.
     """
-    graph_class = meta.get("graph_class")
+    graph_class = meta.get(GRAPH_CLASS_BLOCK)
     if not isinstance(graph_class, Mapping):
         raise ValueError("compiled graph metadata has no graph_class")
     graph = graph_class.get("graph")
@@ -1503,7 +1504,7 @@ def arm_compiled_graph(
             "compiled_graph_unavailable", f"TCG could not load {key!r}"
         )
     metadata = dict(compiled_graph.metadata)
-    graph_class = metadata.get("graph_class")
+    graph_class = metadata.get(GRAPH_CLASS_BLOCK)
     if not isinstance(graph_class, Mapping):
         raise AdoptError(
             "contract_invalid",
@@ -1725,7 +1726,7 @@ def enable(
             reason, exc)
         return AdoptOutcome.miss(
             reason, f"{identity}: {type(exc).__name__}: {exc}", identity)
-    entry = dict(meta.get("graph_class") or {})
+    entry = dict(meta.get(GRAPH_CLASS_BLOCK) or {})
     armed = len(armed_entries(pipeline))
     logger.info(
         "aot-serve: armed %s entry %s (sku=%s torch=%s precision=%s, "

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -544,12 +544,18 @@ def assert_memo_honest(
         f"invalidated: " + "; ".join(disagreements[:4]))
 
 
+# pgw#1299: these are `GraphClassDeclaration`'s FIELD names, not TCG's
+# artifact-metadata block. `graph_class` here is the field holding a class NAME;
+# `GRAPH_CLASS_BLOCK` is the metadata block key. Equal strings, different
+# vocabularies — substituting the block name would couple pgw's own boot-memo
+# wire format to a rename of something else entirely. A TCG field rename is
+# already loud here: `declaration.graph_class` below raises AttributeError.
 _DECLARATION_FIELDS = frozenset({
     "class_hash",
     "class_dims",
     "fork",
     "graph",
-    "graph_class",
+    "graph_class",  # tcg-vocab: declaration field name, not the metadata block
     "graph_witness",
     "literal_values",
     "lora_bucket",
@@ -563,7 +569,7 @@ _DECLARATION_FIELDS = frozenset({
 def serialize_declaration(declaration: "GraphClassDeclaration") -> str:
     """Canonical wire form of one already-validated TCG declaration."""
     payload = {
-        "graph_class": declaration.graph_class,
+        "graph_class": declaration.graph_class,  # tcg-vocab: declaration field
         "target": declaration.target,
         "graph": dict(declaration.graph),
         "graph_witness": declaration.graph_witness,
@@ -615,14 +621,14 @@ def declaration_hashes(declarations: Mapping[str, str]) -> Dict[str, str]:
             raise ValueError(
                 f"boot graph class {name!r} declaration is not canonical JSON"
             )
-        if payload.get("graph_class") != name:
+        if payload.get("graph_class") != name:  # tcg-vocab: declaration field
             raise ValueError(
                 f"boot graph class map names {name!r}, declaration names "
-                f"{payload.get('graph_class')!r}"
+                f"{payload.get('graph_class')!r}"  # tcg-vocab: declaration field
             )
         try:
             declaration = GraphClassDeclaration(
-                graph_class=payload["graph_class"],
+                graph_class=payload["graph_class"],  # tcg-vocab: declaration field
                 target=payload["target"],
                 graph=payload["graph"],
                 graph_witness=payload["graph_witness"],

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -29,7 +29,7 @@ from typing import (
     Tuple,
 )
 
-from torch_compiled_graphs import ARTIFACT_KIND
+from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
 
 from ..cell_adopt import AdoptOutcome
 from ..component_vocab import denoiser_components
@@ -409,7 +409,7 @@ def arm_aot(
         # component name (pgw#740: the vocabulary is not repeated in live
         # code; a guessed name on a non-UNet family would silently skip the
         # install and waste the arm).
-        graph_class = (meta or {}).get("graph_class") or {}
+        graph_class = (meta or {}).get(GRAPH_CLASS_BLOCK) or {}
         targets: list[str] = []
         if isinstance(graph_class, Mapping):
             target = str(graph_class.get("target") or "").strip()
@@ -586,7 +586,7 @@ def arm_aot(
         # is also the first point that needs a way BACK DOWN. Both spans below
         # are abandonable: the entry de-arms, its runner is released, the
         # pipeline serves eager and the worker stays alive.
-        graph_class = (meta or {}).get("graph_class") or {}
+        graph_class = (meta or {}).get(GRAPH_CLASS_BLOCK) or {}
         _entry_name = str(
             graph_class.get("name") if isinstance(graph_class, Mapping) else ""
         )
@@ -647,7 +647,7 @@ def arm_aot(
         # condemns that class and says nothing about its siblings. The refused
         # entry de-arms sticky, its siblings keep serving compiled, and it is
         # not published.
-        graph_class = meta.get("graph_class") or {}
+        graph_class = meta.get(GRAPH_CLASS_BLOCK) or {}
         entry = str(
             graph_class.get("name") if isinstance(graph_class, Mapping) else ""
         )


### PR DESCRIPTION
Closes #1299 (tracker `python-gen-worker/progress.md` `# #1299`).

## What changed

Eleven literals replaced with the imported authority:

| file | sites | literal | now |
|---|---|---|---|
| `aot_serve.py` | 171, 1507, 1729 | `"graph_class"` | `GRAPH_CLASS_BLOCK` |
| `aot_mint.py` | 1524, 1636, 1663 | `"graph_class"` | `GRAPH_CLASS_BLOCK` |
| `aot_compile_child.py` | 438 | `"graph_class"` | `GRAPH_CLASS_BLOCK` |
| `models/provision.py` | 412, 589, 650 | `"graph_class"` | `GRAPH_CLASS_BLOCK` |
| `aot_delivery.py` | 108 | `"aot-inductor"` | `ARTIFACT_KIND` |

Import name is `torch_compiled_graphs`, which is what the **current** pin
resolves to (`torch-compiled-graphs>=0.6,<0.7`; the installed package exports
both constants). The `torchcg` rename has landed in the peer repo but the pgw
repin (#1297) has not, so this stays on the current name and becomes a
mechanical module re-spell when #1297 lands.

## Fresh sweep (run in a worktree at `origin/master` 17e60ff3, as the section requires)

`grep -rn '"graph_class"' src/gen_worker/` excluding `pb/`: **14** — matching the
corrected count exactly, with **no new sites** since the audit. `"aot-inductor"`:
**2**, of which one (`fleet_cells.py:2985`) is prose inside a docstring, so **1**
real literal.

**A caveat on that number, found by the new fence: the audit's grep pattern was
double-quote-only.** `boot_key.py:621` spells it in *single* quotes inside an
f-string (`f"{payload.get('graph_class')!r}"`). The true count of `graph_class`
string constants is **15**, not 14. The AST sweep finds it; no grep for
`"graph_class"` ever could.

## The call I made: `boot_key`'s four (now five) are NOT converted

This is the substantive decision in the PR, and I want it reviewed rather than
buried. `boot_key` 552/566/618/621/625 are **not the same vocabulary**:

* `GRAPH_CLASS_BLOCK` is the **artifact-metadata block key**, per TCG's own
  docstring at `identity.py:33`.
* `boot_key`'s occurrences are `GraphClassDeclaration`'s **dataclass field
  name** — a class *name* string — written into **pgw's own boot-memo wire
  format** by `serialize_declaration` and read back by its own reader.

TCG publishes no declaration-field-name vocabulary; `GRAPH_CLASS_BLOCK` is the
only string constant it exports here. Substituting it would invent a coupling
that does not exist: a rename of the *metadata block* would then silently change
pgw's *on-disk boot memo* format.

And the failure mode this issue exists to prevent **cannot occur there**. The
tracker states it precisely — "every one of these is a `.get(\"graph_class\")` on
a metadata dict... a rename does not raise, it returns `None`". At `boot_key`, a
TCG field rename raises `AttributeError` on `declaration.graph_class` and
`TypeError` on the `graph_class=` kwarg. Loud, not silent. The `payload.get(...)`
reads are against a dict pgw itself wrote two functions earlier.

So the tracker's "zero string literals remain" is **not** met literally, on
purpose. Each site is classified in place with a `# tcg-vocab: <reason>` comment.

## The fence (tracker item 3 — "without it this is the third time this issue is filed")

`scripts/lint_tcg_vocabulary.py`, gating in **`fast gates`** (the sole required
context; the `gates` job has no `if:` and `merge_group:` is in the trigger list,
so it runs on the queue ref too).

* **AST, not grep** — a docstring mentioning `graph_class` is not a finding, and
  single-quoted/f-string spellings cannot hide. It found the 15th site on its
  first run.
* **`--selftest`** — four cases (finds real ones, honours a classified line,
  rejects a marker with no reason, ignores prose). A sweep that only ever prints
  "clean" guards nothing.
* **No path allowlist**, following `lint_repo_ref_pins.py`'s stated design: a
  filename would let a real respelling hide. A different vocabulary is
  recognised by a *reason at the line*, so deleting the reason goes red.

## Red proof — caught-by mapping

Method: re-hardcode each site class to `"entry"`, run, record. Baseline green
before each.

| site class | caught | by |
|---|---|---|
| `aot_serve` (3) | YES, 2 tests | `test_aot_serve_pgw721.py::test_arm_resolves_and_loads_the_same_destination_then_binds`, `::test_failed_bind_does_not_mutate_the_live_module` |
| `aot_mint` (3) | YES, 1 test | `test_tcg_mint_parent_pgw1270.py::test_parent_preserves_closed_tcg_metadata_and_records_alias_outside_it` |
| `aot_compile_child` (1) | YES, 2 tests | `test_tcg_compile_child_pgw1270.py::test_tcg_result_is_the_unchanged_minimal_pool_wire`, `::test_tcg_reuse_reports_zero_compile_time` |
| `models/provision` (3) | YES, 4 tests | `test_adopt_fit_pgw1265.py::test_the_state_the_ARM_LEAVES_is_checked_after_the_gate_has_run`, `::test_a_refused_adopt_DE_ARMS_the_entry_it_loaded`, `test_adopted_cell_warm_proof_pgw1141.py::test_the_MINT_gate_is_strict_a_gray_band_cell_does_not_ship`, `::test_the_MINT_gate_refuses_a_cell_below_its_floor` |
| `aot_delivery` (1) | **NO** | — |

`provision` needed a wider net than the pgw#1288 wired-gate suites — the
`test_wired_gates_pgw1271.py` set alone did **not** catch it (115 passed under
mutation); `test_adopt_fit_pgw1265.py` + `test_adopted_cell_warm_proof_pgw1141.py`
do.

### ⚠️ FLAGGED: `aot_delivery.py:108` is caught by no test

Mutated to `artifact_kind="entry"` and ran all six suites that import
`aot_delivery` (`test_tcg_runtime_arm_pgw1270`, `test_cell_resolve_pgw1090`,
`test_aot_variable_chunks_th1931`, `test_measure_only_pgw1134`,
`test_stream_bounds_pgw1013`, `test_cozy_runtime_env_contract_pgw1237`): **96
passed, unchanged from baseline.**

It is a label on the `PHASE_CELL_FETCH` boot span — telemetry, and nothing
asserts its value. Flagging rather than silently fixing, per the issue's own
standard. The new lint fence now covers it statically, which is the appropriate
guard for a value no behavioural assertion can reach; a test that pinned a
telemetry string would be a change-detector. Happy to add one if a reviewer
disagrees.

## Gates run

`test_wired_gates_pgw1271`, `test_aot_serve_pgw721`, `test_tcg_compile_child_pgw1270`,
`test_tcg_mint_parent_pgw1270`, `test_identity_is_tcg_pgw1277`,
`test_cell_publish_v2_pgw807`, `test_aot_selfmint_pgw805`, `test_adopt_fit_pgw1265`,
`test_adopted_cell_warm_proof_pgw1141`, `test_weight_free_premise_pgw1173`,
`test_boot_phases_pgw764`, `test_compiled_graph_key_pgw1059` — **204 passed**.
Plus `lint_tcg_vocabulary.py --selftest` OK and the sweep clean.

I did **not** run the whole tree locally (torch/compile suites are CI's lane on
this shared box). CI covers the rest.

## Related

Peer PR `cozy-creator/torchcg#31` fixes tcg#26 (the `torch_config_digest`
host-dependence). They are independent — that one touches no pgw code, and I kept
them as separate PRs because the digest fix turned out to have **zero** key
blast radius, so bundling would have implied a shared risk that does not exist.