### PR TITLE
pgw#1297: the registry-contract wheel install supplies the vendored deps

### DIFF
--- a/tests/test_registry_contract_pgw740.py
+++ b/tests/test_registry_contract_pgw740.py
@@ -22,6 +22,30 @@ REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "check_registry_contract.py"
 
 
+def _vendored_requirements() -> list[str]:
+    """The deps that no longer exist on PyPI, as explicit git requirements.
+
+    Paul deleted the `hashrepo` and `torch-compiled-graphs` PyPI projects
+    permanently (DESIGN-RULINGS "Release policy": internal consumers vendor by
+    git pin). A bare wheel install resolves its declared dependencies from
+    PyPI, so this test must supply those two itself. Derived from
+    `[tool.uv.sources]` at run time rather than hardcoded, so the cutover
+    repin (pgw#1297) moves this test automatically.
+    """
+
+    import tomllib
+
+    with (REPO / "pyproject.toml").open("rb") as fh:
+        sources = tomllib.load(fh).get("tool", {}).get("uv", {}).get("sources", {})
+    reqs = []
+    for name in ("hashrepo", "torch-compiled-graphs"):
+        src = sources.get(name)
+        if src and "git" in src:
+            rev = f"@{src['rev']}" if "rev" in src else ""
+            reqs.append(f"{name} @ git+{src['git']}{rev}")
+    return reqs
+
+
 # The three `uv` calls below build an isolated environment, which means
 # PyPI — the one remaining third party in this suite. It is the SAME PyPI the
 # job's own `uv sync --locked` already required, so this adds no new dependency;
@@ -59,7 +83,8 @@ def test_contract_holds_from_installed_wheel(tmp_path: Path) -> None:
     venv = tmp_path / "venv"
     _uv([uv, "venv", "--python", "3.12", str(venv)])
     py = venv / "bin" / "python"
-    _uv([uv, "pip", "install", "--python", str(py), str(wheel)])
+    _uv([uv, "pip", "install", "--python", str(py), str(wheel),
+         *_vendored_requirements()])
     env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
     proc = subprocess.run(
         [str(py), str(SCRIPT), "--installed"],


### PR DESCRIPTION
The PyPI deletions made the pgw740 contract test red on every open PR — its clean-venv wheel install resolved `hashrepo`/`torch-compiled-graphs` from PyPI, now permanently 404. The 404 is correctly not in the transient-network skip list (it is not transient), so the fix supplies both as explicit git requirements, **derived at run time from `[tool.uv.sources]`** so the pgw#1297 cutover repin moves this test automatically instead of drifting. Both arms pass locally (2/2); `fast gates` + queue carry the rest.