### PR TITLE
pgw#1283: the store unit — bytes to torchcg, policy stays

### DIFF
--- a/changelog.d/pgw1283.md
+++ b/changelog.d/pgw1283.md
@@ -1,0 +1,59 @@
+- **pgw#1283: the store unit — the bytes move to TCG, the policy stays.**
+  `local_cell_store` kept a SECOND copy of every artifact TCG had already
+  admitted to its CAS: `aot_compile_child` packs with `Engine.export_artifact`,
+  and the store then hashed that file, copied it to
+  `<root>/aot-cells/<key>/cell.tar.gz`, and re-hashed it on every lookup —
+  three digest passes over a multi-hundred-megabyte artifact, all re-deriving
+  what the CAS derived on ingest. That duplication is deleted. `store()` now
+  hands the artifact to `Engine.import_artifact` and `lookup()` materializes it
+  back through `Engine.export_artifact`; the module contains no `sha256` and
+  copies no artifact.
+
+  What stays is a policy sidecar: the `verdict`, the `sink` obligation, the
+  arm-token memo and the hub-learned trust class — facts about gates this
+  worker ran and uploads it owes, which TCG has no concept of. The rule that
+  falls out: **bytes are the authority on whether a cell EXISTS; the sidecar is
+  the authority on whether it may be SERVED.** A record with no bytes and bytes
+  with no record are both clean misses, and both heal on the next store.
+
+- **pgw#1283: a cell this worker quarantined can no longer be armed through the
+  CAS.** §1.3.4 keeps a gate-refused cell "quarantined-local for forensics".
+  Before the cutover its bytes lived only in `local_cell_store`, so no load path
+  could reach them; they are now in the very CAS `aot_serve.arm_compiled_graph`
+  resolves runners from, and TCG has no notion of a worker parity/arm refusal.
+  `arm_compiled_graph` asks `local_cell_store.is_quarantined` first and refuses
+  `compiled_graph_worker_quarantined` before the engine is opened. Only the
+  QUARANTINED verdict refuses — an `unverified` row is the normal state of a
+  cell §1.5 stored before the gate that is about to prove it.
+
+- **pgw#1283: TCG's storage quarantine is NOT this worker's verdict, in both
+  directions.** Rot in the CAS makes TCG quarantine its own record; that is
+  repairable by re-storing the bytes, so mirroring it into `verdict` would
+  strand a healthy cell forever on a defect that fixes itself. `drop()` narrowed
+  to match: it forgets the worker's permission to serve and leaves the
+  content-addressed bytes alone, because they may be exactly the bytes another
+  route resolves.
+
+- **pgw#1283: `store()` is idempotent, so a crash-retry loses no alias.** Every
+  step runs on every call — a TCG `PRESENT` (the bytes landed on an attempt that
+  died before the sidecar) still rewrites the record and the memo. Treating it
+  as "already stored, nothing to do" is the crash-retry alias loss: the bytes
+  survive and the arm-token shortcut does not, so a machine with no boot-key
+  route re-mints on every boot forever. `DIVERGENT` is the one outcome that
+  refuses, and it records nothing.
+
+- **pgw#1283: separate absence from corruption, and stop a failed memo reporting
+  an unstored cell.** `_read_json` raises `RecordUnreadable` when a file EXISTS
+  and cannot be used; absence stays `None`. Each of the five call sites decides
+  for itself and every one of them logs — a store that silently re-mints bills a
+  GPU pod for a defect nobody can see. The memo write moved out of `store()`'s
+  `try`, so the return value means exactly "the artifact and its record are
+  durable"; a failed shortcut used to report the whole cell unstored while
+  `lookup` would happily find it.
+
+- **pgw#1283: the memo write is collision-safe; its persistence is still not
+  load-bearing.** The temp name was keyed on the pid alone — one name per
+  PROCESS, which is not a distinct name for two THREADS, and the memo is written
+  from the mint path and the arm path concurrently. It is now per-write, fsynced
+  and atomically replaced. A memo that cannot be written is logged at warning
+  with both the token and the key, and the cell is still reported stored.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -663,7 +663,7 @@ markers = [
 # Prefer the working-tree source so a bare `pytest` never tests a stale wheel.
 # The supported command is still `uv run --extra dev pytest` (pytest is a dev
 # extra); tests/conftest.py hard-fails if gen_worker resolves outside src/.
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 
 # NOTE: the CUDA 13.0 torch pin below is uv-only — it is read by `uv sync` /
 # `uv build` in this repo, NOT by `pip`. `pip install gen-worker[torch]`

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -35,6 +35,7 @@ from torch_compiled_graphs import (
 
 from . import activity as activity_mod
 from . import aot_identity
+from . import local_cell_store
 from .cell_adopt import AdoptOutcome
 from . import serve_posture
 from . import shape_growth
@@ -1490,6 +1491,23 @@ def arm_compiled_graph(
     if not is_compiled_graph_key(key):
         raise AdoptError(
             "compiled_graph_key_invalid", f"not a compiled-graph key: {key!r}"
+        )
+    # pgw#1283 criterion 4 — THE WORKER'S OWN QUARANTINE, asked before the CAS
+    # is. §1.3.4 keeps a refused cell "quarantined-local for forensics"; before
+    # the store cutover those bytes lived only in `local_cell_store`, so no
+    # load path could reach them. They are now in the very CAS this function
+    # resolves from, and TCG has no concept of a worker parity/arm refusal, so
+    # without this the runner loads a cell this worker already refused.
+    #
+    # Only the QUARANTINED verdict refuses. An unverified row is a cell that is
+    # durable but not yet proven — §1.5 stores before the gate runs, and it is
+    # this very arm that proves it — and a key this worker never recorded is
+    # every hub-delivered cell there is.
+    if local_cell_store.is_quarantined(key):
+        raise AdoptError(
+            "compiled_graph_worker_quarantined",
+            f"this worker quarantined {key!r} at its own gate (§1.3.4); its "
+            f"bytes are kept for forensics and are never armed",
         )
     engine = open_worker_engine(cache_dir)
     destination = _tcg_destination(cache_dir, key)

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -342,6 +342,7 @@ def no_compiled_graph_source(hub_absent: str) -> bool:
 
 def _local_answer(
     key: str, derived: "boot_key.DerivedKey", *, family: str, fn: str,
+    cache_dir: Optional[Path] = None,
 ) -> Optional[BootAdoptOutcome]:
     """This machine's own store, asked by the derived key. ``None`` = ask on.
 
@@ -356,7 +357,7 @@ def _local_answer(
     witness to compare.
     """
     try:
-        cell = local_cell_store.lookup(key)
+        cell = local_cell_store.lookup(key, cas_root=cache_dir)
     except Exception as exc:  # noqa: BLE001 — a cache read is never fatal
         logger.debug("boot-adopt: local store lookup failed", exc_info=True)
         logger.warning("boot-adopt: local store unreadable (%s)", exc)
@@ -485,7 +486,8 @@ def attempt(
     settled: Dict[str, BootAdoptOutcome] = {}
     ask: List[str] = []
     for key in keys:
-        local = _local_answer(key, derived, family=family, fn=fn)
+        local = _local_answer(
+            key, derived, family=family, fn=fn, cache_dir=cache_dir)
         if local is not None:
             settled[key] = local
         elif hub_absent:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1339,6 +1339,7 @@ def _mark_publish(key: str, state: str) -> None:
 
 def resume_owed_publishes(
     publisher: Optional[CellPublisher],
+    cas_root: Optional[Path] = None,
 ) -> List[threading.Thread]:
     """Re-attempt every upload this machine still OWES (pgw#1183 / §1.5).
 
@@ -1361,10 +1362,21 @@ def resume_owed_publishes(
         # too. A key whose upload is already running is owed nothing more.
         if cell.key in in_flight:
             continue
-        meta = artifact_meta.try_read_metadata(cell.artifact) or {}
+        # pgw#1283 criterion 5: the SCAN above is metadata-only — sidecar reads
+        # and nothing else — and the bytes are materialized only for the cells
+        # this actually ships. An owed scan that exported every resident
+        # artifact would make "is anything owed?" cost as much as sending it.
+        artifact = local_cell_store.materialize(cell.key, cas_root=cas_root)
+        if artifact is None:
+            logger.warning(
+                "fleet-cells: %s is owed to the sink but its bytes are not "
+                "resolvable from this machine's CAS; the obligation stands and "
+                "a later boot re-attempts it", cell.key)
+            continue
+        meta = artifact_meta.try_read_metadata(artifact) or {}
         threads.append(_publish_async(
             publisher, cell.family or str(meta.get("family") or ""),
-            cell.artifact, dict(meta), compiled_graph_key_digest=cell.key,
+            artifact, dict(meta), compiled_graph_key_digest=cell.key,
             arm_token=cell.arm_token))
     if threads:
         logger.info(
@@ -2303,13 +2315,13 @@ def arm_from_local_store(
     _sweep_superseded_memos_once()
     route = ROUTE_MEMO
     try:
-        local = local_cell_store.lookup_for_arm(arm_key.token)
+        local = local_cell_store.lookup_for_arm(arm_key.token, cas_root=cache_dir)
         if local is None and boot_local_key:
             # The memo is a SHORTCUT, never an authority (§4.28) — so when it
             # has nothing to say, the address the boot derived is asked
             # directly. Same store, same key space, same gate below.
             route = ROUTE_BOOT_KEY
-            local = local_cell_store.lookup(boot_local_key)
+            local = local_cell_store.lookup(boot_local_key, cas_root=cache_dir)
     except Exception as exc:  # noqa: BLE001 — a cache read must never be fatal
         logger.warning("fleet-cells: local cell store unreadable (%s)", exc)
         return None
@@ -2357,7 +2369,13 @@ def arm_from_local_store(
     minted = SelfMint(
         family=family, compiled_graph_key=key,
         ref=f"{cc.system_repo(family)}#{key}",
-        snapshot_digest=local.content_digest,
+        # pgw#1283: the store no longer keeps a digest of its own. It kept one
+        # so it could re-verify its own copy of the bytes, and TCG's CAS
+        # already does that for the copy it owns; the ONE consumer that still
+        # needs a self-attested digest is this advertisement, so it is computed
+        # here, once, exactly where the delegated-mint route already computes
+        # it (`adopt_delegated_mint`, same spelling).
+        snapshot_digest="sha256:" + sha256_file(local.artifact),
         artifact=local.artifact,
     )
     with _PENDING_LOCK:
@@ -2669,6 +2687,7 @@ def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
         verdict=local_cell_store.VERDICT_UNVERIFIED,
         sink=(local_cell_store.SINK_NONE if sink_absent
               else local_cell_store.SINK_OWED),
+        cas_root=pending.cache_dir,
     )
     if stored is None:
         # A local-store write failure is the one thing §1.5 cannot absorb
@@ -2706,7 +2725,7 @@ def _admit_durable(
     if not key or staged_key != key:
         return None
     local_cell_store.mark(key, verdict=local_cell_store.VERDICT_ADMITTED)
-    cell = local_cell_store.lookup(key)
+    cell = local_cell_store.lookup(key, cas_root=pending.cache_dir)
     if cell is None:
         return None
     activity_mod.emit_event(

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -1,4 +1,4 @@
-"""pgw#1096 / §4.28 — the untrusted machine's OWN cell store: AOT cells, ck1-keyed.
+"""pgw#1096 / §4.28 — this machine's OWN cells: TCG holds the bytes, this holds the POLICY.
 
 DESIGN-RULINGS §4.28 (Paul, 2026-08-10): *"Untrusted hardware (community
 cloud, cozy-local) mints for ITSELF: local cell, local repo-CAS, reused
@@ -7,20 +7,49 @@ elaboration: *"download model + code ONCE, compile ONCE, and every
 subsequent run of that code reuses the same compiled cell — same ck1 key
 derivation, same memo shortcut, fully offline-capable."*
 
-ONE IDENTITY, TWO STORES. A cell stored here is addressed by exactly the
-key the hub store addresses it by — ``tcg.identity.from_artifact_metadata``
-stamped on the bytes (pgw#1059's four axes: graph x envelope x sm x
-toolchain). The hub store and this one differ in their SINK, never in their
-addressing, so a cell that later becomes publishable needs no re-keying and a
-local hit is the same artifact a hub hit would have delivered.
+pgw#1283 — THE SPLIT. This module used to keep a SECOND copy of bytes TCG had
+already admitted to its CAS: ``aot_compile_child`` packs with
+``Engine.export_artifact``, and this module then hashed that file, copied it to
+``<root>/aot-cells/<key>/cell.tar.gz``, and re-hashed it on every lookup. Three
+digest passes over a multi-hundred-megabyte artifact, all of them re-deriving
+what the CAS derived when it ingested the bytes. That duplication is deleted.
+The two concerns that were tangled in it are now stated separately:
+
+**EXISTENCE is TCG's.** :func:`store` hands the artifact to
+``Engine.import_artifact``, which unpacks it, checks that its metadata restates
+the key, admits its host ISA, and files it under the exact-key ref.
+:func:`lookup` materializes it back through ``Engine.export_artifact``, which
+verifies the CAS record and the envelope before it hands over a path. This
+module contains no ``sha256`` and copies no artifact.
+
+**PERMISSION is this module's.** A cell's ``verdict`` and its ``sink``
+obligation are worker policy — facts about a gate this worker ran and an upload
+this worker owes — and TCG has no concept of either. They live in a small
+sidecar record beside the export, and nothing else here is load-bearing.
+
+The rule that falls out, and the one to keep: **bytes are the authority on
+whether a cell EXISTS; the sidecar is the authority on whether it may be
+SERVED.** So a record with no bytes is a clean miss, bytes with no record are a
+clean miss, and both heal on the next :func:`store` of the same mint rather
+than needing a repair pass.
+
+TWO QUARANTINES, DELIBERATELY NOT ONE (pgw#1283 criterion 4). TCG quarantines
+a key because its CAS record failed verification; this module quarantines a
+cell because a parity/arm gate refused it. Collapsing them was the reviewed
+NO-SHIP defect in both directions: a TCG CAS repair would leave worker state
+stuck at :data:`VERDICT_QUARANTINED` forever, and — the sharper half, created
+by this very cutover — a worker-quarantined cell's bytes now live in the CAS
+that ``aot_serve.arm_compiled_graph`` loads runners from, so the load path
+would happily arm a cell this worker refused. :func:`is_quarantined` is the
+seam that stops it, and ``aot_serve`` asks it before it resolves.
 
 TRUST BOUNDARY — inherited verbatim from the JIT-era store this replaces
 (``local_cells``). A compile cell is user-generated EXECUTABLE code
 (compiled kernels + generated C++/Triton sources); accepting one from a user
 machine into shared storage would let any user ship arbitrary code into other
 people's GPU workers. Enforcement is STRUCTURAL, not a flag: this module has
-no publish path — it is not a CAS client, imports no upload/transport
-machinery, and writes only under the store root. ``tests/
+no publish path — it imports no upload/transport machinery and writes only
+under the store root and the worker's one CAS. ``tests/
 test_aot_local_mint_pgw1096.py`` pins that structurally, the way
 ``test_local_cells`` pins it for the module this succeeds.
 
@@ -29,18 +58,10 @@ worker-side self-declaration and no env flag — §1.18/§4.28. The class is
 LEARNED from the hub's own typed publish refusal (``compiled_graph_publish_untrusted_tier``,
 403, ``tensorhub internal/orchestrator/http/worker_cell_publish.go``) and
 persisted here so the next boot does not have to pay a mint to rediscover it.
-Before this module existed that refusal was terminal in the worst way: th#1643
-books it as SUNK — *"a sealed cell was produced and thrown away"* — and
-``fleet_cells._publish_async``'s ``finally`` then rmtree'd the bytes.
 
-pgw#1183 / §1.5 — THIS STORE IS THE DURABILITY LAYER, unconditionally, on every
-tier. It used to be written only by a machine with nowhere to ship, which is
-exactly backwards: a trusted fleet pod — the only kind that mints for anyone
-else — kept nothing, and its artifact lived in the temp dir owned by the
-process most likely to die. The ordering is now fixed: **pack -> here ->
-verify -> arm -> publish**, and the hub is a distribution layer reading these
-bytes, never the thing that makes them exist. Two facts ride the record and
-carry that:
+pgw#1183 / §1.5 — THE DURABILITY ORDERING IS UNCHANGED by the split: **pack ->
+here -> verify -> arm -> publish**, on every tier. Two facts ride the sidecar
+record and carry it:
 
 * :data:`VERDICT_UNVERIFIED` -> :data:`VERDICT_ADMITTED` / :data:`VERDICT_QUARANTINED`
   — a cell is durable BEFORE it is proven, so only an ADMITTED one may be
@@ -52,12 +73,16 @@ carry that:
   (:func:`cells_owed_to_sink` is what the next boot reads).
 
 LAYOUT (one directory per cell, so a cell and the facts about it move as a
-unit and a partial write leaves nothing admissible)::
+unit)::
 
-    <root>/aot-cells/<ck1-…>/cell.tar.gz   the packed artifact
-    <root>/aot-cells/<ck1-…>/record.json   {compiled_graph_key, content_digest, family, …}
+    <root>/aot-cells/<ck1-…>/record.json   the POLICY sidecar {verdict, sink, …}
+    <root>/aot-cells/<ck1-…>/cell.tar.gz   TCG's export — a MATERIALIZATION, not custody
     <root>/aot-cells/.memo/<arm1-…>.json   the MEMO: pre-trace identity -> ck1 key
     <root>/trust-class.json                the learned trust class
+
+The layout is preserved on purpose: cozy-local's ``cozy cells`` CLI and
+tensorhub's runtime-env contract both name it, and the cutover changes byte
+CUSTODY, not the cross-repo path contract.
 
 THE MEMO, and why a content-addressed store needs one. The ck1 key's ``graph``
 axis is the traced-graph digest, which does not exist until an export
@@ -66,53 +91,34 @@ What it CAN state in milliseconds is ``fleet_cells.ArmIdentity``: every
 pre-trace-knowable fact (family, format, lane, sm, envelope, env_seal,
 toolchain). The memo maps that token to the ck1 key the last mint of it
 produced. It is a SHORTCUT, never an authority: the artifact it points at is
-verified against its recorded digest and then passes the identical arm gate a
-child-minted cell passes, so a wrong memo can only cost one re-mint. When
-pgw#1089 lands boot-side trace-for-key the derived key addresses the CAS
-directly and the memo stays exactly what §4.28 calls it — the shortcut.
+verified by TCG and then passes the identical arm gate a child-minted cell
+passes, so a wrong memo can only cost one re-mint.
 
 EVICTION: there is none, deliberately (pre-launch). What accumulates is one
-cell per (graph x envelope x sm x toolchain), so every torch upgrade, every
-gen-worker upgrade and every settings change leaves the previous cell resident
-forever. :func:`stored_cells` enumerates them with sizes so a future sweep has
-a fact base; an age-based sweep would be wrong (a cell nobody booted for six
-months is still exactly the cell the next boot wants).
+cell per (graph x sm x toolchain). :func:`stored_cells` enumerates the sidecar
+records with no digest recomputation and no materialization, so a future sweep
+has a fact base that costs a listdir.
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
+import secrets
 import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from torch_compiled_graphs import ARTIFACT_KIND, is_compiled_graph_key
 from torch_compiled_graphs.identity import KEY_SCHEME
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch_compiled_graphs import Engine
+
 logger = logging.getLogger(__name__)
-
-#: Read size for the content digest. The store deliberately hashes with the
-#: stdlib rather than importing the CAS client's helper: this module must not
-#: reach into transport machinery even for a pure function, because "it only
-#: imports it for the hash" is how a boundary enforced by ABSENCE stops being
-#: enforced by absence.
-_DIGEST_CHUNK_BYTES = 4 * 1024 * 1024
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with open(path, "rb") as handle:
-        while True:
-            block = handle.read(_DIGEST_CHUNK_BYTES)
-            if not block:
-                break
-            digest.update(block)
-    return digest.hexdigest()
 
 #: A path relocation, never a behavior knob (§1.18, and the same rule
 #: ``TENSORHUB_CACHE_DIR`` follows). cozy-local exports it from its own
@@ -138,7 +144,7 @@ TRUST_UNTRUSTED = "untrusted"
 
 #: pgw#1183: whether this cell has passed the gate that lets it SERVE. The
 #: store is written before the gate runs (§1.5), so "durable" and "provable"
-#: are two facts and the store records both.
+#: are two facts and the sidecar records both.
 VERDICT_UNVERIFIED = "unverified"
 VERDICT_ADMITTED = "admitted"
 VERDICT_QUARANTINED = "quarantined"
@@ -162,11 +168,7 @@ SINK_REFUSED = "refused"
 
 
 def store_root() -> Path:
-    """The local store root: the stated env path, else the cozy cache dir.
-
-    Moved here from ``local_cells`` by pgw#1096 with its value unchanged so
-    cozy-local's ``cozy cells`` CLI keeps resolving to the same directory.
-    """
+    """The policy sidecar root: the stated env path, else the cozy cache dir."""
     env = os.environ.get(ENV_STORE_DIR, "").strip()
     if env:
         return Path(env).expanduser()
@@ -178,7 +180,7 @@ def cells_root(root: Optional[Path] = None) -> Path:
 
 
 def cell_dir(key: str, root: Optional[Path] = None) -> Path:
-    """The directory holding the cell keyed ``key``.
+    """The directory holding the sidecar for the cell keyed ``key``.
 
     Refuses anything that is not a ``ck1`` key rather than sanitizing it: a
     store addressed by a key-shaped string it did not verify is a store whose
@@ -198,28 +200,79 @@ def memo_path(arm_token: str, root: Optional[Path] = None) -> Path:
     return cells_root(root) / MEMO_DIRNAME / f"{token}.json"
 
 
+def _engine(cas_root: Optional[Path] = None) -> "Engine":
+    """TCG on the worker's ONE CAS.
+
+    The import is function-local and goes through ``cache_paths``, which is the
+    single sanctioned ``LocalCAS`` construction seam (pgw#1277): a second one
+    would be a second compiled-graph store, which is the thing this cutover
+    exists to remove.
+    """
+    from .models.cache_paths import open_worker_engine
+
+    return open_worker_engine(cas_root)
+
+
 @dataclass(frozen=True)
-class LocalCell:
-    """One cell resident in the local store, with the facts recorded beside it."""
+class CellRecord:
+    """The POLICY facts this worker recorded about one cell. No bytes.
+
+    What :func:`stored_cells` yields: a listdir and a small JSON read per
+    entry, with nothing materialized and nothing hashed. pgw#1283 criterion 5
+    — an owed-upload scan must cost a scan.
+    """
 
     key: str
-    artifact: Path
-    content_digest: str  # "sha256:<hex>" of the packed artifact
     family: str
     arm_token: str
     bytes: int
     stored_at: float
-    #: pgw#1183: one of the ``VERDICT_*`` constants.
+    #: One of the ``VERDICT_*`` constants.
     verdict: str = VERDICT_ADMITTED
-    #: pgw#1183: one of the ``PUBLISH_*`` constants.
+    #: One of the ``SINK_*`` constants.
+    sink: str = SINK_NONE
+
+
+@dataclass(frozen=True)
+class LocalCell:
+    """A recorded cell whose bytes TCG has verified and materialized."""
+
+    key: str
+    artifact: Path
+    family: str
+    arm_token: str
+    bytes: int
+    stored_at: float
+    verdict: str = VERDICT_ADMITTED
     sink: str = SINK_NONE
 
 
 def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    """Replace ``path`` with ``payload``, atomically and collision-safely.
+
+    pgw#1283 criterion 6. The temp name used to be keyed on the pid alone,
+    which is not a distinct name for two THREADS of one process — and the memo
+    is written from the mint path and from the arm path, which do run
+    concurrently. Two writers then shared one temp file and could publish a
+    torn interleaving of both payloads under a name that says it is atomic.
+    The random suffix makes the name distinct per WRITE, not per process, and
+    the ``os.replace`` makes the publication atomic; the fsyncs make it
+    survive the crash the ordering is designed around.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + f".tmp-{os.getpid()}")
-    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
-    os.replace(tmp, path)
+    tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}-{secrets.token_hex(8)}")
+    try:
+        with open(tmp, "w") as handle:
+            handle.write(json.dumps(payload, sort_keys=True, indent=2))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 class RecordUnreadable(Exception):
@@ -261,18 +314,95 @@ def _read_json(path: Path) -> Optional[Dict[str, Any]]:
     return loaded
 
 
+def _record_of(key: str, raw: Dict[str, Any]) -> CellRecord:
+    return CellRecord(
+        key=key,
+        family=str(raw.get("family") or ""),
+        arm_token=str(raw.get("arm_token") or ""),
+        bytes=int(raw.get("bytes") or 0),
+        stored_at=float(raw.get("stored_at") or 0.0),
+        verdict=str(raw.get("verdict") or VERDICT_ADMITTED),
+        sink=str(raw.get("sink") or SINK_NONE),
+    )
+
+
+def _record_payload(record: CellRecord) -> Dict[str, Any]:
+    return {
+        "compiled_graph_key": record.key,
+        "family": record.family,
+        "arm_token": record.arm_token,
+        "bytes": record.bytes,
+        "stored_at": record.stored_at,
+        # TCG owns this string; pgw#1010/pgw#1059: an exported cell is the only
+        # kind with an identity, so it is the only kind this store can hold.
+        "kind": ARTIFACT_KIND,
+        "verdict": record.verdict,
+        "sink": record.sink,
+    }
+
+
+def read_record(key: str, root: Optional[Path] = None) -> Optional[CellRecord]:
+    """This worker's recorded policy for ``key``, without touching the bytes.
+
+    ``None`` when nothing was ever recorded. Raises :class:`RecordUnreadable`
+    when a record file exists and cannot be used, so each caller decides.
+    """
+    try:
+        target = cell_dir(key, root)
+    except ValueError:
+        return None
+    raw = _read_json(target / RECORD_NAME)
+    return None if raw is None else _record_of(key, raw)
+
+
+def verdict_of(key: str, root: Optional[Path] = None) -> str:
+    """``key``'s recorded verdict, or ``""`` when this worker recorded none.
+
+    ``""`` is NOT a verdict: it is "this worker has no policy for these bytes",
+    which is the honest answer for a cell that arrived by any route other than
+    this machine's own mint. Callers that gate on it must gate on the
+    QUARANTINED value they refuse, never on the absence of an admission.
+    """
+    try:
+        record = read_record(key, root)
+    except RecordUnreadable as exc:
+        # An unreadable record cannot ASSERT a quarantine, and inventing one
+        # would strand a cell no gate ever refused. It is loud instead.
+        logger.error(
+            "local-cell-store: %s has an unreadable policy record (%s); this "
+            "worker states no verdict for it", key, exc)
+        return ""
+    return "" if record is None else record.verdict
+
+
+def is_quarantined(key: str, root: Optional[Path] = None) -> bool:
+    """True when THIS WORKER refused ``key`` at a parity/arm gate (§1.3.4).
+
+    pgw#1283 criterion 4, and the guard the cutover made necessary. Before it,
+    a quarantined cell's bytes lived only here, so nothing else could reach
+    them; now they are in the CAS ``aot_serve.arm_compiled_graph`` loads
+    runners from, and a load path that does not ask this question arms a cell
+    this worker already refused.
+
+    Deliberately NOT true for a TCG storage quarantine. That is a statement
+    about a CAS record, it is repairable by re-storing the bytes, and reading
+    it as a worker refusal is exactly how a repair would leave a cell stranded
+    forever.
+    """
+    return verdict_of(key, root) == VERDICT_QUARANTINED
+
+
 def store(
     artifact: Path, *, key: str, family: str, arm_token: str = "",
     verdict: str = VERDICT_ADMITTED, sink: str = SINK_NONE,
-    root: Optional[Path] = None,
-) -> Optional[LocalCell]:
-    """Copy ``artifact`` into the store under its STAMPED ``key``.
+    root: Optional[Path] = None, cas_root: Optional[Path] = None,
+) -> Optional[CellRecord]:
+    """Admit ``artifact`` to TCG under its STAMPED ``key`` and record the policy.
 
-    The artifact is written to a temp sibling and ``os.replace``d, and the
-    record — which carries the digest every later lookup is checked against —
-    is written LAST, so a crash mid-store leaves a directory with no record
-    and the next lookup treats it as absent rather than as a short cell. Same
-    ordering rule every crash-safe artifact publication uses.
+    TCG does the byte work: ``import_artifact`` unpacks the envelope, checks
+    that its metadata restates ``key``, admits its host ISA, and files it under
+    the exact-key ref. This module then writes the sidecar — the verdict and
+    the sink obligation, which TCG has no concept of.
 
     ``verdict`` defaults to :data:`VERDICT_ADMITTED` — "the caller vouches for
     these bytes", which is what every route that finds an already-proven cell
@@ -280,103 +410,81 @@ def store(
     promotes with :func:`mark` once its own gate passes, because §1.5 makes the
     store write happen BEFORE the proof.
 
-    Returns the stored cell, or ``None`` when the store failed: a local store
+    Returns the recorded cell, or ``None`` when the store failed: a local store
     is a cache, and failing to fill it must never take down a worker that is
     already serving compiled.
 
-    pgw#1283 — the return value means exactly "the artifact and its record are
-    durable". It used to mean less than that: the memo write sat inside the
-    same ``try``, so failing to write a SHORTCUT reported the whole store as
-    failed while ``lookup`` would happily find the cell. The memo now runs
-    after the ``try``, where it cannot rewrite this answer.
+    pgw#1283 criterion 7 — **IDEMPOTENT, so a crash-retry loses no alias.**
+    Every step runs on every call: a TCG ``PRESENT`` (the bytes were already
+    there, from an earlier attempt that died before the sidecar) still rewrites
+    the record and still rewrites the memo. Skipping them because "it is
+    already stored" is the crash-retry alias loss — the bytes survive, the
+    arm-token alias does not, and every later boot re-mints a cell it is
+    holding. Which of TCG's three success outcomes came back is a fact for the
+    log, never a branch that skips work.
     """
+    from torch_compiled_graphs.storage import StoreOutcome
+
     try:
         target_dir = cell_dir(key, root)
-        target_dir.mkdir(parents=True, exist_ok=True)
-        digest = "sha256:" + _sha256_file(Path(artifact))
-        final = target_dir / ARTIFACT_NAME
-        tmp = target_dir / f".{ARTIFACT_NAME}.tmp-{os.getpid()}"
-        shutil.copy2(str(artifact), str(tmp))
-        os.replace(tmp, final)
-        record = LocalCell(
-            key=key, artifact=final, content_digest=digest,
-            family=str(family or ""), arm_token=str(arm_token or ""),
-            bytes=final.stat().st_size, stored_at=time.time(),
+        outcome = _engine(cas_root).import_artifact(key, artifact).outcome
+        if outcome == StoreOutcome.DIVERGENT:
+            # TCG already binds this exact key to DIFFERENT admitted bytes, and
+            # it quarantined the newcomer rather than choosing between them.
+            # Recording a sidecar now would file worker policy against bytes
+            # nothing will resolve.
+            logger.error(
+                "local-cell-store: REFUSING %s — this machine's CAS already "
+                "binds that key to different admitted bytes; the artifact just "
+                "offered is quarantined by TCG and nothing is recorded here",
+                key)
+            return None
+        record = CellRecord(
+            key=key, family=str(family or ""), arm_token=str(arm_token or ""),
+            bytes=Path(artifact).stat().st_size, stored_at=time.time(),
             verdict=str(verdict), sink=str(sink),
         )
-        _write_json_atomic(target_dir / RECORD_NAME, {
-            "compiled_graph_key": record.key,
-            "content_digest": record.content_digest,
-            "family": record.family,
-            "arm_token": record.arm_token,
-            "bytes": record.bytes,
-            "stored_at": record.stored_at,
-            # TCG owns this string; pgw#1010/pgw#1059: an exported cell is
-            # the only kind with an identity, so it is the only kind this
-            # store can hold — a JIT capture has no key to look up.
-            "kind": ARTIFACT_KIND,
-            "verdict": record.verdict,
-            "sink": record.sink,
-        })
+        _write_json_atomic(target_dir / RECORD_NAME, _record_payload(record))
     except Exception as exc:  # noqa: BLE001 — a cache miss must never be fatal
         logger.warning(
             "local-cell-store: could not store %s (%s); this boot serves "
             "compiled anyway and the next one re-mints", key, exc)
         return None
-    # pgw#1283 — EVERYTHING BELOW THIS LINE IS BEST-EFFORT. The record is
-    # durable at the `try`'s end, which means the cell IS stored and `lookup`
-    # will find it; anything that fails from here must not be able to turn that
-    # into a reported failure. The memo write used to sit inside the `try`
-    # above, so a failure to write a shortcut returned ``None`` while artifact
-    # and record sat on disk — `fleet_cells._stage_durable` then emitted
+    # pgw#1283 — EVERYTHING BELOW THIS LINE IS BEST-EFFORT. The bytes are in
+    # the CAS and the record is durable, which means the cell IS stored and
+    # `lookup` will find it; anything that fails from here must not be able to
+    # turn that into a reported failure. The memo write used to sit inside the
+    # `try` above, so a failure to write a shortcut returned ``None`` while the
+    # cell sat on disk — `fleet_cells._stage_durable` then emitted
     # `local_compiled_graph_store_failed` for a cell that was, in fact, stored.
-    # `note_memo` already carries the right best-effort contract, so use it
-    # rather than re-inlining the write.
     if arm_token:
         note_memo(arm_token, key, root)
     logger.info(
-        "local-cell-store: stored %s (%s, %.1f MB) — this machine reuses "
-        "it on every later boot with the same key, offline",
-        key, record.family, record.bytes / 1e6)
+        "local-cell-store: stored %s (%s, %.1f MB, tcg=%s) — this machine "
+        "reuses it on every later boot with the same key, offline",
+        key, record.family, record.bytes / 1e6, outcome.value)
     return record
-
-
-def _cell_of(key: str, record: Dict[str, Any], artifact: Path,
-             digest: str) -> LocalCell:
-    return LocalCell(
-        key=key, artifact=artifact, content_digest=digest,
-        family=str(record.get("family") or ""),
-        arm_token=str(record.get("arm_token") or ""),
-        bytes=int(record.get("bytes") or artifact.stat().st_size),
-        stored_at=float(record.get("stored_at") or 0.0),
-        # A record written before pgw#1183 carries neither field; it was
-        # written by a route that only ever stored proven bytes, so ADMITTED
-        # is what it meant. `publish` is `none` for the same reason — the old
-        # store existed exactly where there was no sink.
-        verdict=str(record.get("verdict") or VERDICT_ADMITTED),
-        sink=str(record.get("sink") or SINK_NONE),
-    )
 
 
 def mark(
     key: str, *, verdict: Optional[str] = None, sink: Optional[str] = None,
     root: Optional[Path] = None,
 ) -> bool:
-    """Move a stored cell's ``verdict`` and/or ``publish`` state (pgw#1183).
+    """Move a stored cell's ``verdict`` and/or ``sink`` state (pgw#1183).
 
     The two transitions the mint flow makes after the bytes are already
     durable: unverified -> admitted/quarantined once the parity gate and the
-    arm answer, and pending -> done/refused once the upload does. Never fatal:
-    a record that cannot be rewritten leaves the previous state, which is the
-    conservative one in both directions (an unpromoted cell is re-minted; an
-    unresolved publish is re-attempted).
+    arm answer, and owed -> delivered/refused once the upload does. Never
+    fatal: a record that cannot be rewritten leaves the previous state, which
+    is the conservative one in both directions (an unpromoted cell is
+    re-minted; an unresolved upload is re-attempted).
     """
     try:
         target_dir = cell_dir(key, root)
     except ValueError:
         return False
     try:
-        record = _read_json(target_dir / RECORD_NAME)
+        raw = _read_json(target_dir / RECORD_NAME)
     except RecordUnreadable as exc:
         # pgw#1283: the transition is LOST, and that costs money in both
         # directions — a dropped ADMITTED re-mints, a dropped DELIVERED
@@ -387,14 +495,14 @@ def mark(
             "The previous state stands, which is conservative but not free",
             key, verdict, sink, exc)
         return False
-    if record is None:
+    if raw is None:
         return False
     if verdict is not None:
-        record["verdict"] = str(verdict)
+        raw["verdict"] = str(verdict)
     if sink is not None:
-        record["sink"] = str(sink)
+        raw["sink"] = str(sink)
     try:
-        _write_json_atomic(target_dir / RECORD_NAME, record)
+        _write_json_atomic(target_dir / RECORD_NAME, raw)
     except OSError as exc:
         logger.warning(
             "local-cell-store: could not re-record %s (%s)", key, exc)
@@ -402,60 +510,122 @@ def mark(
     return True
 
 
-def lookup(key: str, root: Optional[Path] = None) -> Optional[LocalCell]:
-    """The resident, ADMITTED cell for ``key``, or ``None``.
+def materialize(
+    key: str, root: Optional[Path] = None, cas_root: Optional[Path] = None,
+) -> Optional[Path]:
+    """TCG's verified bytes for ``key``, at this store's stable path.
 
-    The recorded ``content_digest`` is RECOMPUTED over the bytes on disk, so a
-    truncated, half-written or edited artifact refuses here instead of being
-    handed to the arm: persisted bytes cannot vouch for themselves. A refusing
-    entry is dropped, which turns a
-    corrupted cell into exactly one honest re-mint.
+    ``Engine.export_artifact`` re-checks the CAS record and unpacks the
+    envelope before it links the bytes into place, so the path this returns is
+    one TCG vouched for on THIS call — the property the deleted
+    ``content_digest`` re-hash was reaching for, done once by the layer that
+    owns the bytes instead of a second time by the layer that does not.
+
+    ``None`` on any miss, including a TCG storage quarantine: that is a
+    statement about a CAS record and is repairable by re-storing the artifact,
+    so it must NOT be written into this worker's verdict (pgw#1283
+    criterion 4).
+    """
+    from torch_compiled_graphs.storage import QuarantinedArtifact, StorageError
+
+    try:
+        destination = cell_dir(key, root) / ARTIFACT_NAME
+    except ValueError:
+        return None
+    engine = _engine(cas_root)
+    # Two attempts, and the second one only ever runs after the first has
+    # DELETED the thing that refused it — progress, not a retry budget.
+    for discarded_stale_copy in (False, True):
+        try:
+            return engine.export_artifact(key, destination)
+        except FileExistsError as exc:
+            # TCG refuses to clobber an occupied destination that is not the
+            # bytes it selected — correctly, because it cannot know whose file
+            # that is. It is OURS: this path is a materialization of the CAS
+            # record, not custody of it, so a rotted or half-written export is
+            # discarded and re-materialized from bytes that are still intact.
+            # Without this the refusal is TERMINAL — every later lookup
+            # re-refuses the same stale file — and a cell the CAS is holding
+            # perfectly would cost a re-mint on every boot.
+            if discarded_stale_copy:
+                logger.error(
+                    "local-cell-store: %s cannot be materialized even after "
+                    "its stale copy was discarded (%s)", key, exc)
+                return None
+            logger.warning(
+                "local-cell-store: %s's materialized copy is not the artifact "
+                "TCG selected (%s); discarding it and re-exporting from the "
+                "CAS, which still holds the bytes", key, exc)
+            try:
+                destination.unlink(missing_ok=True)
+            except OSError:
+                return None
+        except QuarantinedArtifact as exc:
+            logger.error(
+                "local-cell-store: TCG holds %s QUARANTINED in its CAS (%s) — "
+                "that is a fact about the stored record, not this worker's "
+                "verdict, so the verdict is left exactly as it stands and "
+                "re-storing the bytes repairs it", key, exc)
+            return None
+        except StorageError as exc:
+            logger.debug("local-cell-store: TCG cannot serve %s (%s)", key, exc)
+            return None
+        except OSError as exc:
+            logger.warning(
+                "local-cell-store: could not materialize %s (%s)", key, exc)
+            return None
+    return None
+
+
+def lookup(
+    key: str, root: Optional[Path] = None, cas_root: Optional[Path] = None,
+) -> Optional[LocalCell]:
+    """The resident, ADMITTED cell for ``key``, with its bytes on disk.
 
     pgw#1183: a cell whose verdict is not :data:`VERDICT_ADMITTED` is absent
     HERE and enumerable elsewhere (:func:`quarantined_cells`,
     :func:`stored_cells`). Durability made the bytes exist before the proof
     did, so this is the seam that keeps "we kept it" from meaning "we serve
-    it" — the next boot re-mints that class and overwrites the record, which
-    is how an unverified cell heals.
+    it".
+
+    The permission is checked BEFORE the bytes are materialized: an unverified
+    or quarantined cell must not even be unpacked by the serving path, and
+    exporting first would make the refusal cost an export.
     """
     try:
-        target_dir = cell_dir(key, root)
-    except ValueError:
-        return None
-    try:
-        record = _read_json(target_dir / RECORD_NAME)
+        record = read_record(key, root)
     except RecordUnreadable as exc:
-        # pgw#1283. The bytes beside it may well be intact, but the digest that
-        # would vouch for them lived in the record, and this store never arms
-        # bytes it cannot verify (module docstring: a cell is user-generated
-        # EXECUTABLE code). So the answer is still "absent" — what changes is
-        # that it is now SAID, and that the unusable directory goes, exactly as
-        # the digest-mismatch path below already does.
+        # pgw#1283. The bytes may well be intact in the CAS, but the permission
+        # to serve them lived in this record, and a cell is user-generated
+        # EXECUTABLE code (module docstring). So the answer is "absent" — what
+        # changes is that it is now SAID, and that the unusable sidecar goes so
+        # the next store can rewrite it.
         logger.error(
-            "local-cell-store: DROPPING %s — its record is unreadable (%s); "
-            "the bytes cannot vouch for themselves without it, so this costs "
-            "one honest re-mint rather than a silent one", key, exc)
+            "local-cell-store: DROPPING the policy record for %s — it is "
+            "unreadable (%s); the bytes stay in the CAS, but nothing vouches "
+            "for arming them, so this costs one honest re-mint rather than a "
+            "silent one", key, exc)
         drop(key, root)
         return None
-    artifact = target_dir / ARTIFACT_NAME
-    if record is None or not artifact.is_file():
+    if record is None or record.verdict != VERDICT_ADMITTED:
         return None
-    if str(record.get("verdict") or VERDICT_ADMITTED) != VERDICT_ADMITTED:
+    artifact = materialize(key, root, cas_root)
+    if artifact is None:
         return None
-    want = str(record.get("content_digest") or "")
-    try:
-        have = "sha256:" + _sha256_file(artifact)
-    except OSError as exc:
-        logger.warning("local-cell-store: %s is unreadable (%s)", key, exc)
-        return None
-    if not want or have != want:
-        logger.error(
-            "local-cell-store: DROPPING %s — the stored bytes digest %s, the "
-            "record states %s; a cell that cannot vouch for its own content "
-            "is never armed", key, have, want or "nothing")
-        drop(key, root)
-        return None
-    return _cell_of(key, record, artifact, have)
+    # NOT a place to rebuild the memo, and a test caught the attempt (pgw#1283,
+    # `test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT`). The record names
+    # the token this cell was STORED for, which may belong to a superseded
+    # arm-token scheme that :func:`sweep_superseded_memos` has deliberately
+    # invalidated — rewriting it here resurrects dead vocabulary and silently
+    # undoes the sweep. The alias is rebuilt by the route that just PROVED it,
+    # in the CURRENT scheme's token: `fleet_cells.arm_from_local_store` calls
+    # :func:`note_memo` on the boot-key route, which is the whole cost argument
+    # of pgw#1127 §5. Crash-retry alias loss is closed in :func:`store`
+    # instead, by making every step run on every call.
+    return LocalCell(
+        key=record.key, artifact=artifact, family=record.family,
+        arm_token=record.arm_token, bytes=artifact.stat().st_size,
+        stored_at=record.stored_at, verdict=record.verdict, sink=record.sink)
 
 
 def note_memo(
@@ -467,12 +637,14 @@ def note_memo(
     cell was found by another route and then passed the arm gate — which is the
     only other moment the binding is known to be true. It is what makes an
     arm-token scheme bump (:func:`sweep_superseded_memos`) cost a trace instead
-    of a mint: the sweep deletes the shortcut and leaves the CELLS under their
-    own keys, so the next boot's derived key re-finds the cell and re-writes
-    the shortcut from evidence.
+    of a mint.
 
-    Never fatal, and never a substitute for the arm: a memo is a shortcut, so
-    failing to write one costs a lookup and nothing else.
+    NEVER LOAD-BEARING, and pgw#1283 keeps it that way deliberately. The write
+    is now collision-safe and atomic (:func:`_write_json_atomic`), because a
+    torn memo is a wrong answer rather than a missing one; but a memo that
+    cannot be written costs a lookup and nothing else, so this reports the
+    failure LOUDLY and lets the caller succeed. A store whose success depended
+    on a shortcut would be a store that fails when a cache directory is full.
     """
     if not arm_token or not key:
         return False
@@ -482,9 +654,10 @@ def note_memo(
             {"compiled_graph_key": key, "noted_at": time.time()})
         return True
     except Exception as exc:  # noqa: BLE001 — a shortcut is never load-bearing
-        logger.debug(
-            "local-cell-store: could not memo %s -> %s (%s)",
-            arm_token, key, exc)
+        logger.warning(
+            "local-cell-store: could not memo %s -> %s (%s); the cell is "
+            "stored and addressable by key, and the next boot pays a derive "
+            "instead of a lookup", arm_token, key, exc)
         return False
 
 
@@ -530,11 +703,12 @@ def sweep_superseded_memos(
 
 def lookup_for_arm(
     arm_token: str, root: Optional[Path] = None,
+    cas_root: Optional[Path] = None,
 ) -> Optional[LocalCell]:
     """The cell this machine last minted for pre-trace identity ``arm_token``.
 
     The memo is a shortcut, never an authority (module docstring): the answer
-    it names is digest-verified by :func:`lookup` and then passes the same arm
+    it names is verified by TCG in :func:`lookup` and then passes the same arm
     gate a freshly child-minted cell passes. A stale memo costs one re-mint.
     """
     try:
@@ -544,9 +718,9 @@ def lookup_for_arm(
     except RecordUnreadable as exc:
         # pgw#1283. A memo is a shortcut, never an authority, so an unreadable
         # one is genuinely equivalent to no memo — but leaving the file there
-        # means paying that lookup on every boot, and `note_memo` only rewrites
-        # it once a cell arms. Delete it so the shortcut is rebuilt from
-        # evidence rather than shadowed by garbage.
+        # means paying that read on every boot, and it is only rewritten once a
+        # cell arms. Delete it so the shortcut is rebuilt from evidence rather
+        # than shadowed by garbage.
         logger.warning(
             "local-cell-store: discarding an unreadable memo for %s (%s); the "
             "next cell that arms rewrites it", arm_token, exc)
@@ -560,27 +734,39 @@ def lookup_for_arm(
     key = str(memo.get("compiled_graph_key") or "")
     if not key:
         return None
-    return lookup(key, root)
+    return lookup(key, root, cas_root)
 
 
 def drop(key: str, root: Optional[Path] = None) -> None:
-    """Remove one cell and everything recorded about it."""
+    """Forget this worker's POLICY for one cell. The CAS keeps its bytes.
+
+    pgw#1283 — a deliberate narrowing. This used to delete the only copy of an
+    artifact; the bytes now live in the content-addressed store, where they may
+    be the same bytes another key or another route resolves, so a worker
+    decision about ONE arm identity must not delete them. What this removes is
+    the sidecar that grants permission to serve, and the materialized export
+    beside it, which is exactly what "this cell is stale for us" means. A later
+    :func:`store` of the same artifact re-records it against bytes TCG will
+    report ``PRESENT``, at no mint cost.
+    """
     try:
-        shutil.rmtree(cell_dir(key, root), ignore_errors=True)
+        target = cell_dir(key, root)
     except ValueError:
         return
+    shutil.rmtree(target, ignore_errors=True)
 
 
-def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
-    """Every resident cell, cheaply — NO digest recomputation.
+def stored_cells(root: Optional[Path] = None) -> List[CellRecord]:
+    """Every cell this worker recorded, cheaply — NO bytes, NO digests.
 
     The accounting surface for what accumulates (module docstring: one cell
-    per graph x envelope x sm x toolchain, so every toolchain upgrade leaves
-    its predecessor behind). Deliberately not a verification pass: this is the
-    listing a ``cozy cells``-style CLI and any future sweep read, and making it
-    hash every resident artifact would make listing cost as much as arming.
+    per graph x sm x toolchain, so every toolchain upgrade leaves its
+    predecessor behind), and the scan :func:`cells_owed_to_sink` filters.
+    pgw#1283 criterion 5: it reads sidecars and nothing else — it does not ask
+    TCG to export, verify or hash anything, so listing costs a listdir even
+    when every resident cell is a gigabyte.
     """
-    out: List[LocalCell] = []
+    out: List[CellRecord] = []
     base = cells_root(root)
     if not base.is_dir():
         return out
@@ -588,7 +774,7 @@ def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
         if not entry.is_dir() or entry.name == MEMO_DIRNAME:
             continue
         try:
-            record = _read_json(entry / RECORD_NAME)
+            raw = _read_json(entry / RECORD_NAME)
         except RecordUnreadable as exc:
             # pgw#1283: skip the entry, never the LISTING. This is what a
             # `cozy cells`-style CLI reads, and one bad file must not blank the
@@ -598,34 +784,34 @@ def stored_cells(root: Optional[Path] = None) -> List[LocalCell]:
                 "local-cell-store: %s has an unreadable record (%s); it is "
                 "absent from this listing", entry.name, exc)
             continue
-        artifact = entry / ARTIFACT_NAME
-        if record is None or not artifact.is_file():
+        if raw is None:
             continue
-        out.append(_cell_of(
-            str(record.get("compiled_graph_key") or entry.name), record, artifact,
-            str(record.get("content_digest") or "")))
+        out.append(_record_of(
+            str(raw.get("compiled_graph_key") or entry.name), raw))
     return out
 
 
-def quarantined_cells(root: Optional[Path] = None) -> List[LocalCell]:
-    """Every cell kept for FORENSICS: it existed, and it failed its own gate.
+def quarantined_cells(root: Optional[Path] = None) -> List[CellRecord]:
+    """Every cell kept for FORENSICS: it existed, and it failed OUR gate.
 
     §1.3.4 — *"do not arm, do not publish, keep the artifact quarantined-local
-    for forensics"*. Before pgw#1183 the refusal path rmtree'd the mint root,
-    so the one artifact that could explain a refusal was destroyed by the code
-    reporting it, and the store's own header records what that cost: *"cost a
-    full GPU pod run. Twice."*
+    for forensics"*. These are worker verdicts, never TCG's storage
+    quarantine: a cell whose CAS record failed verification is not a cell a
+    gate refused, and listing the two together is how a repair would look like
+    a refusal (pgw#1283 criterion 4).
     """
     return [c for c in stored_cells(root) if c.verdict == VERDICT_QUARANTINED]
 
 
-def cells_owed_to_sink(root: Optional[Path] = None) -> List[LocalCell]:
+def cells_owed_to_sink(root: Optional[Path] = None) -> List[CellRecord]:
     """Every ADMITTED cell whose upload is still owed — the cross-boot retry.
 
     This is what makes publish a retryable background transfer from durable
     bytes rather than a daemon thread the pod must outlive. Only admitted
     cells are listed: an unverified or quarantined artifact is not something
-    any other pod may adopt, so it is not something to upload.
+    any other pod may adopt, so it is not something to upload. The caller
+    materializes the ones it actually ships (:func:`materialize`), so an owed
+    scan never pays for bytes it does not send.
     """
     return [c for c in stored_cells(root)
             if c.verdict == VERDICT_ADMITTED and c.sink == SINK_OWED]
@@ -697,8 +883,7 @@ def keeps_cells_locally(root: Optional[Path] = None) -> bool:
 
     True exactly when the hub has ASSERTED this hardware may not publish. The
     cozy-local CLI serve path does not consult this — it has no publisher and
-    never will, so it calls :func:`store` directly (pgw#1086 wave 1 re-points
-    it there when it deletes the JIT store).
+    never will, so it calls :func:`store` directly.
     """
     return trust_class(root) == TRUST_UNTRUSTED
 
@@ -706,15 +891,16 @@ def keeps_cells_locally(root: Optional[Path] = None) -> bool:
 __all__ = [
     "ARTIFACT_NAME",
     "CELLS_DIRNAME",
+    "CellRecord",
     "ENV_STORE_DIR",
     "LocalCell",
     "MEMO_DIRNAME",
+    "RECORD_NAME",
     "RecordUnreadable",
     "SINK_DELIVERED",
     "SINK_NONE",
     "SINK_OWED",
     "SINK_REFUSED",
-    "RECORD_NAME",
     "TRUST_CLASS_NAME",
     "TRUST_UNTRUSTED",
     "UNTRUSTED_REFUSAL_CODE",
@@ -722,20 +908,24 @@ __all__ = [
     "VERDICT_QUARANTINED",
     "VERDICT_UNVERIFIED",
     "cell_dir",
+    "cells_owed_to_sink",
     "cells_root",
     "drop",
+    "is_quarantined",
     "keeps_cells_locally",
     "lookup",
     "lookup_for_arm",
     "mark",
+    "materialize",
     "memo_path",
     "note_memo",
     "note_refusal",
-    "cells_owed_to_sink",
     "quarantined_cells",
+    "read_record",
     "store",
     "store_root",
     "stored_cells",
     "sweep_superseded_memos",
     "trust_class",
+    "verdict_of",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,14 +358,35 @@ def _isolated_local_cell_store(tmp_path_factory):
     (`AttributeError: 'function' object has no attribute 'cache_clear'`).
     Save and restore the variable by hand so this fixture adds no ordering
     edge to anything.
+
+    pgw#1283 EXTENSION: the store's BYTES no longer live under that root. They
+    live in the worker's one HashRepo CAS at ``TENSORHUB_CACHE_DIR/cas``, whose
+    default is a real shared directory on a dev box. So the cache root is
+    redirected here too — isolating the policy sidecar while leaving the
+    artifacts in a shared store would isolate exactly the half that stopped
+    holding anything, and one suite run would seed another's "hit".
+
+    It is redirected through the ENV plus a republish rather than by patching
+    ``cache_paths``, because the env is the production knob and a patched
+    function is invisible to any test that imported the name
+    (``test_cozy_runtime_env_contract_pgw1237`` compares the two and caught
+    exactly that).
     """
+    from gen_worker import config as _config
+
     prior = os.environ.get("GEN_WORKER_LOCAL_CELLS_DIR")
+    prior_cache = os.environ.get("TENSORHUB_CACHE_DIR")
     os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = str(
         tmp_path_factory.mktemp("local-cell-store"))
+    os.environ["TENSORHUB_CACHE_DIR"] = str(
+        tmp_path_factory.mktemp("worker-cache"))
+    _config.reload_for_test()
     try:
         yield
     finally:
-        if prior is None:
-            os.environ.pop("GEN_WORKER_LOCAL_CELLS_DIR", None)
-        else:
-            os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = prior
+        for name, value in (("GEN_WORKER_LOCAL_CELLS_DIR", prior),
+                            ("TENSORHUB_CACHE_DIR", prior_cache)):
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/tests/tcg_artifacts.py
+++ b/tests/tcg_artifacts.py
@@ -1,0 +1,165 @@
+"""Real ``torch-compiled-graphs`` artifacts, built without torch (pgw#1283).
+
+The local cell store used to hold OPAQUE bytes — it hashed whatever it was
+handed and re-hashed it on the way out — so every test about it could feed it
+``b"packed-cell-bytes"``. pgw#1283 moved byte custody to TCG, which admits an
+artifact only if it unpacks, restates its own key, and names a host ISA this
+machine can run. Opaque bytes are now correctly refused, so the tests need the
+real envelope.
+
+Building one needs no torch and no GPU: the envelope is a gzip+USTAR tar of a
+metadata block and a code-only AOTInductor ``.pt2`` zip, and TCG's introspection
+reads the wrapper source and the ELF section table rather than loading either.
+The ELF and wrapper shapes below are the minimum ``torch_compiled_graphs``
+accepts; they are ported from TCG's own ``tests/test_artifact.py`` fixture,
+which is the authority on that shape.
+
+``host_isa`` is taken from :func:`torch_compiled_graphs.host_isa._host_requirement`
+— a private symbol, deliberately: an artifact stamped with a hard-coded
+``x86-64-v3`` would be refused on an arm64 runner, and a fixture whose
+admissibility depends on which machine ran it is a flake, not a fence.
+"""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from torch_compiled_graphs import CallIngress, CallInput, GraphClassDeclaration
+from torch_compiled_graphs.artifact import build_metadata, pack_artifact
+from torch_compiled_graphs.host_isa import _host_requirement
+
+#: The default compiler-content facts. Two artifacts that differ only here get
+#: different ``ck1`` keys, which is how a test asks for a second cell.
+TOOLCHAIN: Dict[str, str] = {"torch": "record-digest", "triton": "compiler-digest"}
+
+GRAPH_CLASS = "denoiser/h=64,w=64"
+TARGET = "unet"
+
+
+def host_isa() -> Dict[str, str]:
+    """This machine's own ISA facts — the only ones TCG will admit here."""
+    return _host_requirement().facts()
+
+
+def aoti_package(path: Path, *, graph_class: str = GRAPH_CLASS,
+                 filler: str = "") -> Path:
+    """A code-only AOTInductor package TCG's introspection accepts.
+
+    ``filler`` appends an inert comment to the wrapper source: it changes the
+    package's BYTES without changing a single fact TCG derives from it, which
+    is the only way to build two artifacts that state the same key over
+    different content — i.e. TCG's ``DIVERGENT`` case.
+    """
+    names = b"\0.shstrtab\0.lrodata\0"
+    section_offset = 64
+    section_size = 64
+    section_count = 3
+    string_offset = section_offset + section_size * section_count
+    payload_offset = string_offset + len(names)
+    shared_object = bytearray(payload_offset)
+    shared_object[:4] = b"\x7fELF"
+    shared_object[4:7] = bytes((2, 1, 1))
+    struct.pack_into("<Q", shared_object, 0x28, section_offset)
+    struct.pack_into("<HHH", shared_object, 0x3A, section_size, section_count, 1)
+    struct.pack_into("<II", shared_object, section_offset + section_size, 1, 3)
+    struct.pack_into(
+        "<QQ", shared_object, section_offset + section_size + 0x18,
+        string_offset, len(names))
+    struct.pack_into("<II", shared_object, section_offset + 2 * section_size, 11, 1)
+    struct.pack_into(
+        "<QQ", shared_object, section_offset + 2 * section_size + 0x18,
+        payload_offset, 0)
+    shared_object[string_offset:payload_offset] = names
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        root = f"data/aotinductor/{graph_class}"
+        wrapper = (
+            "AOTInductorModelBase(1, 1, 0, device_str, std::move(cubin_dir), false)")
+        if filler:
+            wrapper += f"\n// {filler}"
+        archive.writestr(f"{root}/model.wrapper.cpp", wrapper)
+        archive.writestr(f"{root}/model.so", bytes(shared_object))
+    return path
+
+
+def metadata(
+    *,
+    graph_class: str = GRAPH_CLASS,
+    witness: str = "fedcba9876543210",
+    sm: str = "sm_89",
+    toolchain: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Any]:
+    """Metadata whose stamped ``compiled_graph_key`` TCG derives from itself."""
+    ingress = CallIngress(
+        parameters=("value",),
+        flat_arity=1,
+        inputs=(CallInput("value", 0, "value", 0, (), "value", "float32", (2,)),),
+    )
+    graph: Dict[str, Any] = {
+        "v": 3,
+        "constant_fqns": [],
+        "lifted_inputs": [],
+        "pytree": {"in": "leaf", "out": "leaf", "ingress": ingress.as_dict()},
+        "specialization": {},
+    }
+    declaration = GraphClassDeclaration(
+        graph_class=graph_class,
+        target=TARGET,
+        graph=graph,
+        graph_witness=witness,
+        range_digest=ingress.digest(),
+        literal_values="",
+    )
+    return build_metadata(
+        graph_class={
+            "name": declaration.graph_class,
+            "target": declaration.target,
+            "class_hash": declaration.class_hash,
+            "graph": dict(declaration.graph),
+            "graph_witness": declaration.graph_witness,
+            "range_digest": declaration.range_digest,
+            "fork": [],
+            "class_dims": [],
+            "strict": True,
+            "lora_bucket": 0,
+            "literal_values": declaration.literal_values,
+            "literal_payload_values": "",
+            "placement": list(declaration.placement),
+            "constants": [],
+        },
+        sm=sm,
+        toolchain=dict(toolchain or TOOLCHAIN),
+        host_isa=host_isa(),
+    )
+
+
+def build(
+    output: Path,
+    *,
+    graph_class: str = GRAPH_CLASS,
+    witness: str = "fedcba9876543210",
+    sm: str = "sm_89",
+    toolchain: Optional[Mapping[str, str]] = None,
+    filler: str = "",
+) -> Path:
+    """One real artifact at ``output``; its key is stamped in its metadata."""
+    package = output.parent / f".{output.name}.pt2"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    aoti_package(package, graph_class=graph_class, filler=filler)
+    try:
+        return pack_artifact(
+            package, output,
+            metadata(graph_class=graph_class, witness=witness, sm=sm,
+                     toolchain=toolchain))
+    finally:
+        package.unlink(missing_ok=True)
+
+
+def key_of(artifact: Path) -> str:
+    """The ``ck1`` key the artifact states about itself."""
+    from torch_compiled_graphs.artifact import read_metadata
+
+    return str(read_metadata(artifact).get("compiled_graph_key") or "")

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -14,15 +14,23 @@ What was RED before this issue, on every one of these:
   is JIT-only and knows no ``ck1`` key);
 * compiled-graph reuse had no single canonical HashRepo/TCG authority.
 
-The store's own guarantees are proven against REAL bytes on disk (digest,
-atomicity, drop-on-corruption). The arm is proven to be the SAME gate the
-child's own cell passes — structurally, so it cannot drift into a weaker one.
+The store's own guarantees are proven against REAL bytes on disk. pgw#1283
+moved WHICH layer holds them: TCG's CAS owns the artifact and its verification,
+this module owns the verdict and the sink obligation. So the fixtures below
+build REAL TCG envelopes (``tests/tcg_artifacts.py``, torch-free) rather than
+opaque bytes — opaque bytes are now correctly refused at the seam, and a test
+that fed them would be testing the refusal instead of the store. The arm is
+proven to be the SAME gate the child's own cell passes — structurally, so it
+cannot drift into a weaker one.
 """
 
 from __future__ import annotations
 
 import ast
+import atexit
 import json
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -31,11 +39,21 @@ import pytest
 
 from torch_compiled_graphs import is_compiled_graph_key
 
+import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
-KEY_A = "cg-key-v1-" + "a" * 56
-KEY_B = "cg-key-v1-" + "b" * 56
+# Two REAL artifacts, built once for the module. Their keys are DERIVED from
+# their own metadata by TCG — a store that files bytes under a key its own
+# stamp does not restate is exactly what `Engine.import_artifact` refuses, so
+# these can no longer be hand-typed constants.
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1283-cells-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT_A = tcg_artifacts.build(_FIXTURE_DIR / "a.tar.gz", witness="a" * 16)
+ARTIFACT_B = tcg_artifacts.build(_FIXTURE_DIR / "b.tar.gz", witness="b" * 16)
+KEY_A = tcg_artifacts.key_of(ARTIFACT_A)
+KEY_B = tcg_artifacts.key_of(ARTIFACT_B)
+assert KEY_A != KEY_B
 # pgw#1113: spelled in the CURRENT token scheme — a predecessor-scheme memo
 # is swept by `fleet_cells._sweep_superseded_memos_once`, which is the point.
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
@@ -44,45 +62,41 @@ ARM_B = fleet_cells.ARM_SCHEME + "-" + "2" * fleet_cells.ARM_DIGEST_HEX
 
 @pytest.fixture()
 def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """The store root, relocated by its env — a PATH knob, never a behavior one."""
+    """The policy root, relocated by its env — a PATH knob, never a behavior one."""
     root = tmp_path / "cozy-cells"
     monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
     return root
 
 
-def _artifact(tmp_path: Path, body: bytes = b"packed-cell-bytes") -> Path:
-    """Opaque bytes. The STORE does not care what a cell is — these tests are
-    about addressing, digests and rot, and they assert the bytes round-trip
-    unchanged, so this deliberately stays raw."""
-    p = tmp_path / "mint" / "cell.tar.gz"
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_bytes(body)
-    return p
+@pytest.fixture()
+def cas(tmp_path: Path) -> Path:
+    """The worker's ONE CAS, scoped to this test.
 
-
-def _armable_artifact(tmp_path: Path, *, key: str = KEY_A) -> Path:
-    """A cell with a READABLE envelope — for the tests that reach the ARM.
-
-    pgw#1098: `_arm_exported_cell` refuses `compiled_graph_envelope_unreadable` before
-    any other gate, for the local store exactly as for a child's fresh mint —
-    which is precisely pgw#1096's "one gate, two sources" intent. Opaque bytes
-    used to reach the arm only because the metadata read swallowed its own
-    failure into `None`, so a test that ARMS has to supply a real envelope
-    while a test that only STORES does not.
+    pgw#1283: it is a SECOND root because it always was one — the CAS lives
+    under ``TENSORHUB_CACHE_DIR`` and the policy sidecar under
+    ``GEN_WORKER_LOCAL_CELLS_DIR``. What the cutover changed is that the store
+    now files its bytes in the first instead of copying them into the second.
     """
-    import io as _io
-    import tarfile as _tarfile
+    return tmp_path / "cas"
 
-    p = tmp_path / "mint" / "cell.tar.gz"
+
+def _artifact(tmp_path: Path, source: Path = ARTIFACT_A) -> Path:
+    """One real TCG artifact, staged where a mint would have left it."""
+    p = tmp_path / "mint" / source.name
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        {"kind": "aot-inductor", "compiled_graph_key": key, "family": "micro-diffusion"}
-    ).encode()
-    with _tarfile.open(p, mode="w:gz") as tar:
-        info = _tarfile.TarInfo("metadata.json")
-        info.size = len(payload)
-        tar.addfile(info, _io.BytesIO(payload))
+    shutil.copyfile(source, p)
     return p
+
+
+def _armable_artifact(tmp_path: Path, *, source: Path = ARTIFACT_A) -> Path:
+    """Identical to :func:`_artifact` since pgw#1283, and kept as a NAME.
+
+    It used to be a separate fixture because the store accepted opaque bytes
+    while the arm needed a readable envelope; every artifact the store will
+    now accept is armable by construction, which is the point of moving byte
+    custody to TCG.
+    """
+    return _artifact(tmp_path, source)
 
 
 # ---------------------------------------------------------------------------
@@ -91,24 +105,28 @@ def _armable_artifact(tmp_path: Path, *, key: str = KEY_A) -> Path:
 
 
 def test_a_cell_is_addressed_by_the_same_ck1_key_the_hub_store_uses(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """§4.28's "one identity, two stores": the local address IS the stamped key.
 
     RED before: no local address existed for an AOT cell at all — `local_cells`
     keys on a flavor LABEL (sku/torch/lane), a space with no `ck1` in it.
     """
+    source = _artifact(tmp_path)
     cell = local_cell_store.store(
-        _artifact(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+        source, key=KEY_A, family="micro-diffusion", arm_token=ARM_A,
+        cas_root=cas)
 
     assert cell is not None
     assert cell.key == KEY_A and is_compiled_graph_key(cell.key)
-    assert cell.artifact == store / "aot-cells" / KEY_A / "cell.tar.gz"
-    assert cell.artifact.read_bytes() == b"packed-cell-bytes"
 
-    found = local_cell_store.lookup(KEY_A)
-    assert found is not None and found.content_digest == cell.content_digest
-    assert found.family == "micro-diffusion"
+    found = local_cell_store.lookup(KEY_A, cas_root=cas)
+    assert found is not None and found.family == "micro-diffusion"
+    assert found.artifact == store / "aot-cells" / KEY_A / "cell.tar.gz"
+    # pgw#1283: the bytes came back from TCG's CAS, not from a second copy this
+    # module made — and they are the bytes that went in, which is the property
+    # the deleted worker-side digest was reaching for.
+    assert found.artifact.read_bytes() == source.read_bytes()
 
 
 def test_the_store_refuses_to_be_addressed_by_anything_that_is_not_a_key(
@@ -126,44 +144,65 @@ def test_the_store_refuses_to_be_addressed_by_anything_that_is_not_a_key(
     assert local_cell_store.lookup("../escape") is None
 
 
-def test_a_record_written_but_never_filled_is_absent_not_short(
-    store: Path, tmp_path: Path,
+def test_a_cell_with_no_policy_record_is_absent_however_intact_its_bytes(
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
-    """The record is written LAST: a crash mid-store leaves
-    a directory the next lookup treats as absent, never as a short cell."""
-    local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f")
+    """pgw#1283's ownership rule, in its strictest direction.
+
+    Bytes are the authority on whether a cell EXISTS; the sidecar is the
+    authority on whether it may be SERVED. So bytes with no sidecar are a clean
+    miss, not a cell — a compile cell is user-generated EXECUTABLE code, and
+    "the CAS has it" is not this worker's permission to arm it.
+    """
+    local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
+                           cas_root=cas)
     (store / "aot-cells" / KEY_A / local_cell_store.RECORD_NAME).unlink()
-    assert local_cell_store.lookup(KEY_A) is None
+
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is None
+    assert local_cell_store.verdict_of(KEY_A) == "", (
+        "no record is no verdict — never an implied admission")
 
 
 # ---------------------------------------------------------------------------
-# 2. RED — a corrupted cell is refused, and costs exactly one re-mint
+# 2. RED — rot in the materialized copy costs a re-export, never a re-mint
 # ---------------------------------------------------------------------------
 
 
-def test_corrupting_a_stored_cell_refuses_admission_and_drops_it(
-    store: Path, tmp_path: Path,
+def test_a_rotted_materialized_copy_is_re_exported_from_the_cas_not_re_minted(
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
-    """A persisted artifact cannot vouch for itself. The digest is RECOMPUTED
-    over the bytes on disk, so a
-    truncated, half-written or edited artifact refuses HERE rather than being
-    handed to an arm that would then serve it.
+    """pgw#1283 — what "TCG owns the bytes" buys, stated as a cost.
 
-    RED before: there was no local store, and the JIT one it succeeds compared
-    only recorded FACTS — nothing ever hashed the bytes.
+    The file under ``aot-cells/<key>/cell.tar.gz`` is now a MATERIALIZATION of
+    a CAS record, not the only copy. So an artifact that rots on disk is no
+    longer a lost cell: TCG refuses to hand back a destination that is not the
+    bytes it selected, this module discards that copy, and the SAME bytes come
+    back out of the CAS.
+
+    RED before this issue in the strong sense: the old store held the only
+    copy, recomputed its own digest over it, and DROPPED the cell — the next
+    boot paid a full GPU mint for one flipped bit.
     """
     cell = local_cell_store.store(
-        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
-    assert cell is not None and local_cell_store.lookup(KEY_A) is not None
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A,
+        cas_root=cas)
+    assert cell is not None
+    first = local_cell_store.lookup(KEY_A, cas_root=cas)
+    assert first is not None
+    good = first.artifact.read_bytes()
 
-    cell.artifact.write_bytes(b"packed-cell-byteZ")  # same length, one bit
+    with open(first.artifact, "r+b") as handle:  # one flipped run of bytes
+        handle.seek(200)
+        handle.write(b"\x00\x00\x00\x00")
 
-    assert local_cell_store.lookup(KEY_A) is None, "a corrupted cell armed"
-    assert not local_cell_store.cell_dir(KEY_A).exists(), (
-        "a refused cell must be DROPPED — leaving it costs a re-verify (and a "
-        "re-hash of every boot) forever, for bytes nothing can ever use")
-    assert local_cell_store.lookup_for_arm(ARM_A) is None, (
-        "the memo must not resurrect a cell the digest refused")
+    healed = local_cell_store.lookup(KEY_A, cas_root=cas)
+    assert healed is not None, "a rotted COPY must not cost the cell"
+    assert healed.artifact.read_bytes() == good
+    assert local_cell_store.verdict_of(KEY_A) == local_cell_store.VERDICT_ADMITTED, (
+        "rot in a materialization is not a gate refusal and must never be "
+        "written into this worker's verdict")
+    memo_hit = local_cell_store.lookup_for_arm(ARM_A, cas_root=cas)
+    assert memo_hit is not None and memo_hit.key == KEY_A
 
 
 # ---------------------------------------------------------------------------
@@ -172,20 +211,21 @@ def test_corrupting_a_stored_cell_refuses_admission_and_drops_it(
 
 
 def test_the_memo_turns_a_pre_trace_identity_into_the_ck1_key(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """The `ck1` graph axis needs a trace; the pre-trace `ArmIdentity` does not.
     The memo is what lets boot 2 address the CAS without paying an export."""
     local_cell_store.store(
-        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A,
+        cas_root=cas)
 
-    hit = local_cell_store.lookup_for_arm(ARM_A)
+    hit = local_cell_store.lookup_for_arm(ARM_A, cas_root=cas)
     assert hit is not None and hit.key == KEY_A
-    assert local_cell_store.lookup_for_arm(ARM_B) is None
+    assert local_cell_store.lookup_for_arm(ARM_B, cas_root=cas) is None
 
 
 def test_a_moved_toolchain_is_an_HONEST_re_mint_and_leaves_the_old_cell_alone(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """Paul: *"the key's toolchain/sm axes make local re-mints honest when the
     user upgrades torch or changes GPU."* The upgraded runtime computes a
@@ -193,33 +233,37 @@ def test_a_moved_toolchain_is_an_HONEST_re_mint_and_leaves_the_old_cell_alone(
     under its own key, because a user who rolls torch back must not have to
     recompile what they already compiled."""
     local_cell_store.store(
-        _artifact(tmp_path, b"cell-under-torch-A"), key=KEY_A, family="f",
-        arm_token=ARM_A)
+        _artifact(tmp_path, ARTIFACT_A), key=KEY_A, family="f",
+        arm_token=ARM_A, cas_root=cas)
 
     # The upgrade: a different toolchain digest => a different arm token.
-    assert local_cell_store.lookup_for_arm(ARM_B) is None, (
+    assert local_cell_store.lookup_for_arm(ARM_B, cas_root=cas) is None, (
         "an upgraded toolchain must not adopt the old toolchain's cell")
 
     local_cell_store.store(
-        _artifact(tmp_path, b"cell-under-torch-B"), key=KEY_B, family="f",
-        arm_token=ARM_B)
+        _artifact(tmp_path, ARTIFACT_B), key=KEY_B, family="f",
+        arm_token=ARM_B, cas_root=cas)
 
     assert {c.key for c in local_cell_store.stored_cells()} == {KEY_A, KEY_B}
-    old = local_cell_store.lookup(KEY_A)
-    assert old is not None and old.artifact.read_bytes() == b"cell-under-torch-A"
+    old = local_cell_store.lookup(KEY_A, cas_root=cas)
+    assert old is not None
+    assert old.artifact.read_bytes() == ARTIFACT_A.read_bytes()
 
 
 def test_a_stale_memo_costs_one_re_mint_and_never_a_wrong_cell(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     local_cell_store.store(
-        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+        _artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A,
+        cas_root=cas)
     local_cell_store.drop(KEY_A)
-    assert local_cell_store.lookup_for_arm(ARM_A) is None
+    assert local_cell_store.lookup_for_arm(ARM_A, cas_root=cas) is None, (
+        "dropping the POLICY makes the cell unservable even though the CAS "
+        "still holds its bytes — which is what a worker drop means now")
 
     (store / "aot-cells" / local_cell_store.MEMO_DIRNAME / f"{ARM_A}.json"
      ).write_text(json.dumps({"compiled_graph_key": "not-a-key"}))
-    assert local_cell_store.lookup_for_arm(ARM_A) is None
+    assert local_cell_store.lookup_for_arm(ARM_A, cas_root=cas) is None
 
 
 # ---------------------------------------------------------------------------
@@ -386,17 +430,17 @@ def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
 
 
 def test_a_second_boot_arms_from_this_machines_own_store_with_no_mint(
-    store: Path, tmp_path: Path, armable: List[Path],
+    store: Path, cas: Path, tmp_path: Path, armable: List[Path],
 ) -> None:
     """The product promise, at the seam that decides a miss: compile once, run
     forever. RED before: no lookup existed, so boot 2 opened a pending and paid
     the whole export again."""
     local_cell_store.store(
         _armable_artifact(tmp_path), key=KEY_A, family="micro-diffusion",
-        arm_token=ARM_A)
+        arm_token=ARM_A, cas_root=cas)
 
     minted = fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion")  # type: ignore[arg-type]
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion")  # type: ignore[arg-type]
 
     assert minted is not None
     assert minted.compiled_graph_key == KEY_A
@@ -408,7 +452,7 @@ def test_a_second_boot_arms_from_this_machines_own_store_with_no_mint(
 
 
 def test_a_local_cell_that_cannot_arm_is_dropped_not_retried_forever(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         fleet_cells.provision, "arm_aot",
@@ -421,16 +465,17 @@ def test_a_local_cell_that_cannot_arm_is_dropped_not_retried_forever(
         fleet_cells.activity_mod, "emit_event",
         lambda kind, detail, phase="", duration_ms=0, **_kw: events.append((kind, phase)))
     local_cell_store.store(
-        _armable_artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A)
+        _armable_artifact(tmp_path), key=KEY_A, family="f", arm_token=ARM_A,
+        cas_root=cas)
 
     assert fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "f") is None  # type: ignore[arg-type]
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "f") is None  # type: ignore[arg-type]
     assert not local_cell_store.cell_dir(KEY_A).exists()
     assert ("local_compiled_graph_refused", "constants_unbound") in events
 
 
 def test_a_local_cell_that_does_not_describe_this_runtime_is_refused_by_FACT(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The pgw#1042 axis gate, on the local path, with NOTHING stubbed out.
 
@@ -451,10 +496,11 @@ def test_a_local_cell_that_does_not_describe_this_runtime_is_refused_by_FACT(
         fleet_cells.activity_mod, "emit_event",
         lambda kind, detail, phase="", duration_ms=0, **_kw: events.append((kind, phase)))
     local_cell_store.store(
-        _artifact(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+        _artifact(tmp_path), key=KEY_A, family="micro-diffusion",
+        arm_token=ARM_A, cas_root=cas)
 
     assert fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None  # type: ignore[arg-type]
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion") is None  # type: ignore[arg-type]
     assert ("local_compiled_graph_refused", "key_axis_divergence") in events
     assert not local_cell_store.cell_dir(KEY_A).exists()
 
@@ -515,7 +561,7 @@ def test_the_miss_path_consults_the_local_store_before_opening_a_mint(
 
 
 def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """th#1643 books the refusal as SUNK — *"a sealed cell was produced and
     thrown away"*. It is no longer thrown away: the machine learns its trust
@@ -529,13 +575,13 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
     refusal still teaches the machine its trust class, and it does not disturb
     the durable copy.
     """
-    artifact = _artifact(tmp_path, b"packed-cell-bytes")
+    artifact = _artifact(tmp_path)
     monkeypatch.setattr(fleet_cells.activity_mod, "emit_event",
                         lambda *a, **k: None)
     monkeypatch.setattr(fleet_cells, "_note_durable", lambda *a, **k: None)
     local_cell_store.store(
         artifact, key=KEY_A, family="micro-diffusion", arm_token=ARM_A,
-        sink=local_cell_store.SINK_OWED)
+        sink=local_cell_store.SINK_OWED, cas_root=cas)
 
     class _Refusing:
         def publish(self, family: str, art: Path, meta: dict,
@@ -546,14 +592,14 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
 
     fleet_cells._publish_async(
         _Refusing(), "micro-diffusion",  # type: ignore[arg-type]
-        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
+        local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
         {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
     assert local_cell_store.trust_class() == local_cell_store.TRUST_UNTRUSTED
-    kept = local_cell_store.lookup_for_arm(ARM_A)
+    kept = local_cell_store.lookup_for_arm(ARM_A, cas_root=cas)
     assert kept is not None and kept.key == KEY_A
-    assert kept.artifact.read_bytes() == b"packed-cell-bytes"
+    assert kept.artifact.read_bytes() == ARTIFACT_A.read_bytes()
     # And the obligation is CLOSED, not left owed: a hub that says "never"
     # must not be re-asked on every boot forever.
     assert kept.sink == local_cell_store.SINK_REFUSED
@@ -657,7 +703,7 @@ def test_a_trusted_fleet_pod_with_a_live_sink_OWES_an_upload(
 
 
 def test_nothing_evicts_and_the_accumulation_is_enumerable(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """No GC in this lane, deliberately: a wrong sweep deletes an hour of
     compile. What accumulates is one cell per (graph x envelope x sm x
@@ -666,8 +712,9 @@ def test_nothing_evicts_and_the_accumulation_is_enumerable(
     toolchain-aware sweep needs. An AGE-based sweep would be wrong: a cell
     nobody booted for six months is still exactly the cell the next boot wants.
     """
-    for key in (KEY_A, KEY_B):
-        local_cell_store.store(_artifact(tmp_path), key=key, family="f")
+    for key, source in ((KEY_A, ARTIFACT_A), (KEY_B, ARTIFACT_B)):
+        local_cell_store.store(
+            _artifact(tmp_path, source), key=key, family="f", cas_root=cas)
 
     resident = local_cell_store.stored_cells()
     assert {c.key for c in resident} == {KEY_A, KEY_B}

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -35,15 +35,16 @@ refusal sites out of the tree would have failed on them.
 
 from __future__ import annotations
 
-import io
-import json
+import atexit
+import shutil
 import socket
-import tarfile
+import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pytest
 
+import tcg_artifacts
 from gen_worker import (
     activity, boot_adopt, boot_key, cell_resolve, fleet_cells, local_cell_store,
 )
@@ -51,13 +52,31 @@ from gen_worker import executor as executor_mod
 from gen_worker.api import export_contract as export_contract_mod
 from gen_worker.cell_adopt import AdoptOutcome
 
-# pgw#1176: `cg-key-v1`, because `local_cell_store.store` refuses anything that is
-# not an entry key and a `ck1`-keyed cell is orphaned by the re-key. These
-# fixtures stored under `ck1-` and the store silently declined them, so
-# `no_compiled_graph_source` short-circuited a machine that WAS holding cells — the §1.34
-# orphaning the re-key predicts, surfacing exactly where it should.
-KEY_A = "cg-key-v1-" + "a" * 56
-KEY_B = "cg-key-v1-" + "b" * 56
+#: The graphs this pod "traced". Real values in the pgw#1031 sense: the boot's
+#: witnesses and the cell's recorded ones are compared entry by entry, and the
+#: floor is fail-closed in both directions (a silent cell is a refusal too).
+WITNESSES = {"transformer": "9f" * 8}
+(_ENTRY, _WITNESS), = WITNESSES.items()
+
+# pgw#1283: the keys are DERIVED from real TCG artifacts rather than typed.
+# `local_cell_store.store` hands its bytes to `Engine.import_artifact`, which
+# refuses an artifact whose own metadata does not restate the key it is filed
+# under — so a hand-typed `cg-key-v1-aaa…` can no longer name a storable cell,
+# and a fixture that pretended otherwise would only ever test the refusal.
+#
+# `KEY_DERIVED` is therefore both "what the boot derives" and "what this
+# machine's own artifact states" — the §4.27 identity this file is about, now
+# ENFORCED by the store instead of asserted by the fixture.
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1127-boot-adopt-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT_LOCAL = tcg_artifacts.build(
+    _FIXTURE_DIR / "local.tar.gz", graph_class=_ENTRY, witness=_WITNESS)
+ARTIFACT_OTHER = tcg_artifacts.build(
+    _FIXTURE_DIR / "other.tar.gz", graph_class=_ENTRY, witness=_WITNESS,
+    sm="sm_90")
+KEY_A = KEY_DERIVED = tcg_artifacts.key_of(ARTIFACT_LOCAL)
+KEY_B = tcg_artifacts.key_of(ARTIFACT_OTHER)
+assert KEY_A != KEY_B
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
 
 
@@ -71,6 +90,19 @@ def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     root = tmp_path / "cozy-cells"
     monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
     return root
+
+
+@pytest.fixture()
+def cas(tmp_path: Path) -> Path:
+    """The CAS the BOOT will address — ``_executor``'s own model-store root.
+
+    pgw#1283: the bytes live in the worker's CAS now, and the boot reaches it
+    through the same ``cache_dir`` the executor threads into every other TCG
+    call (``executor._boot_adopt`` -> ``boot_adopt.attempt(cache_dir=…)``).
+    Storing a cell somewhere the arm cannot resolve it is the bug this fixture
+    keeps the file honest about.
+    """
+    return tmp_path / "cas"
 
 
 @pytest.fixture()
@@ -109,42 +141,20 @@ def no_wire(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
     return attempts
 
 
-#: The graphs this pod "traced". Real values in the pgw#1031 sense: the boot's
-#: witnesses and the cell's recorded ones are compared entry by entry, and the
-#: floor is fail-closed in both directions (a silent cell is a refusal too).
-WITNESSES = {"transformer": "9f" * 8}
-
-
 def _cell(
-    tmp_path: Path, *, key: str = KEY_A, name: str = "cell",
-    witnesses: Optional[Dict[str, str]] = None,
+    tmp_path: Path, *, source: Path = ARTIFACT_LOCAL, name: str = "cell",
 ) -> Path:
-    """An ENTRY artifact with a READABLE envelope AND a recorded graph witness.
+    """One real TCG artifact, staged where an earlier boot's mint left it.
 
-    `_arm_exported_cell` and the boot's own pgw#1031 floor both read the packed
-    metadata, and an entry that records no witness is refused — correctly — so a
-    fixture without one could only ever test the refusal.
-
-    pgw#1176: one artifact carries ONE class, so this records an `entry` block.
-    A multi-witness fixture is deliberately unrepresentable here: production
-    cannot pack one, and a fixture that could would be asserting against a
-    shape nothing can produce.
+    pgw#1283: this used to hand-roll a tarball carrying an ``entry`` block —
+    a shape the identity cut (pgw#1277) had already made unwritable by
+    anything in ``src/``. The envelope is now built by TCG itself, so the
+    witness the boot compares against is the witness TCG records: one shape,
+    one writer.
     """
-    rows = dict(WITNESSES if witnesses is None else witnesses)
-    if len(rows) != 1:
-        raise AssertionError(
-            f"an entry artifact carries ONE graph class; got {sorted(rows)!r}")
-    (entry, digest), = rows.items()
     p = tmp_path / name / "cell.tar.gz"
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps({
-        "kind": "aot-inductor", "compiled_graph_key": key, "family": "micro-diffusion",
-        "entry": {"name": entry, "graph_witness": digest},
-    }).encode()
-    with tarfile.open(p, mode="w:gz") as tar:
-        info = tarfile.TarInfo("metadata.json")
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
+    shutil.copyfile(source, p)
     return p
 
 
@@ -198,21 +208,17 @@ def _derived() -> Any:
     card on a CI runner, and `sm` is a key axis)."""
     from torch_compiled_graphs import identity as ck
 
+    del ck  # pgw#1283: the address comes from the artifact this machine HOLDS
     return boot_key.DerivedKey(
-        entry_keys={"a": ck.from_axes({
-            "graph": "c0ffee0000000000",
-            "sm": "sm_89", "toolchain": "t" * 16}).value},
+        entry_keys={"a": KEY_DERIVED},
         workers=2, width_reason="test", traced=1, memo="miss", wall_ms=7)
 
 
-#: The key that derivation actually produces — what the local store must be
-#: addressed by for a boot to find its own cell.
-#:
-#: pgw#1176: a boot derives a key SET. This declaration traces to one class, so
-#: the set has one member; a caller that wants "the address" takes it from
-#: `keys`, never from a `digest` property that no longer exists because there
-#: is no single key to have one.
-KEY_DERIVED = _derived().keys[0]
+# pgw#1176: a boot derives a key SET. This declaration traces to one class, so
+# the set has one member; a caller that wants "the address" takes it from
+# `keys`, never from a `digest` property that no longer exists because there is
+# no single key to have one.
+assert _derived().keys == (KEY_DERIVED,)
 
 
 @pytest.fixture()
@@ -258,7 +264,7 @@ def test_an_empty_store_and_no_hub_still_skips_the_derivation(
 
 
 def test_a_machine_holding_cells_DERIVES_even_with_no_hub_at_all(
-    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    store: Path, cas: Path, tmp_path: Path, declared: None, events: List[Any],
     no_wire: List[Any], monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The half that was WRONG. §4.28's machine has an answerer: itself.
@@ -267,7 +273,8 @@ def test_a_machine_holding_cells_DERIVES_even_with_no_hub_at_all(
     so the one address that could have been answered was never computed.
     """
     local_cell_store.store(
-        _cell(tmp_path), key=KEY_B, family="other", arm_token=ARM_A)
+        _cell(tmp_path, source=ARTIFACT_OTHER), key=KEY_B, family="other",
+        arm_token=ARM_A, cas_root=cas)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
 
     # pgw#1176: a boot returns ONE outcome per declared graph class. This
@@ -290,7 +297,7 @@ def test_a_machine_holding_cells_DERIVES_even_with_no_hub_at_all(
 
 
 def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
-    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    store: Path, cas: Path, tmp_path: Path, declared: None, events: List[Any],
     no_wire: List[Any], monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """§4.28's *"never requested"*, enforced rather than described.
@@ -300,8 +307,8 @@ def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
     its own store answers, and no connection is attempted by any layer.
     """
     local_cell_store.store(
-        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
-        family="micro-diffusion", arm_token=ARM_A)
+        _cell(tmp_path), key=KEY_DERIVED, family="micro-diffusion",
+        arm_token=ARM_A, cas_root=cas)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
 
     ex = _executor(tmp_path)
@@ -321,14 +328,15 @@ def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
 
 
 def test_the_local_store_is_asked_BEFORE_a_perfectly_reachable_hub(
-    store: Path, tmp_path: Path, declared: None, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, declared: None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ordering is the promise, not availability. A local-SECOND design would
     request what the machine already holds — and on a community-cloud pod that
     is the hub shipping back bytes the pod itself minted."""
     local_cell_store.store(
-        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
-        family="micro-diffusion", arm_token=ARM_A)
+        _cell(tmp_path), key=KEY_DERIVED, family="micro-diffusion",
+        arm_token=ARM_A, cas_root=cas)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
     monkeypatch.setattr(
         cell_resolve, "resolve_batch",
@@ -342,7 +350,7 @@ def test_the_local_store_is_asked_BEFORE_a_perfectly_reachable_hub(
 
 
 def test_a_local_hit_carries_an_ADDRESS_and_never_an_adoption(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A self-minted cell has no hub receipt and no publisher org, so riding the
     ``arm_ordered`` path a hub-resolved cell rides would refuse it
@@ -350,13 +358,13 @@ def test_a_local_hit_carries_an_ADDRESS_and_never_an_adoption(
     ``fleet_cells._arm_exported_cell`` — the gate a child's own mint passes —
     decides."""
     local_cell_store.store(
-        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
-        family="micro-diffusion", arm_token=ARM_A)
+        _cell(tmp_path), key=KEY_DERIVED, family="micro-diffusion",
+        arm_token=ARM_A, cas_root=cas)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
 
     (out,) = boot_adopt.attempt(
         function="generate", modules=("micro_diffusion.main",), cfg=_Cfg(),
-        slots={}, declared_hint=1, work_root=tmp_path,
+        slots={}, declared_hint=1, work_root=tmp_path, cache_dir=cas,
         hub_absent="nobody to ask")
 
     assert out.reason == boot_adopt.LOCAL_HIT
@@ -396,7 +404,7 @@ def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
 
 
 def test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT(
-    store: Path, tmp_path: Path, armable: List[Path],
+    store: Path, cas: Path, tmp_path: Path, armable: List[Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """pgw#1127 §5 item 2 — the strongest argument for S2, measured.
@@ -412,33 +420,36 @@ def test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT(
     40-minute compile for a cell already on their disk.
     """
     local_cell_store.store(
-        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A)
+        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token=ARM_A,
+        cas_root=cas)
     # The upgrade: every memo written under the previous scheme is swept.
     removed = local_cell_store.sweep_superseded_memos("arm99")
     assert removed == 1
-    assert local_cell_store.lookup_for_arm(ARM_A) is None, "memo not swept"
-    assert local_cell_store.lookup(KEY_A) is not None, "the CELL must survive"
+    assert local_cell_store.lookup_for_arm(ARM_A, cas_root=cas) is None, (
+        "memo not swept")
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is not None, (
+        "the CELL must survive")
 
     # WITHOUT the derived key this is a miss, and a miss is a mint.
     assert fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion") is None
 
     # WITH it, the same cell arms — and the shortcut is rewritten from the
     # proven arm, so the boot after this one is a memo hit again.
     minted = fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion",
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion",
         boot_local_key=KEY_A)
 
     assert minted is not None and minted.compiled_graph_key == KEY_A
     assert armable and armable[-1] == local_cell_store.cell_dir(KEY_A) / "cell.tar.gz"
-    repaired = local_cell_store.lookup_for_arm(ARM_A)
+    repaired = local_cell_store.lookup_for_arm(ARM_A, cas_root=cas)
     assert repaired is not None and repaired.key == KEY_A, (
         "the memo must be repaired from the proven arm — otherwise every boot "
         "after a scheme bump pays the trace again")
 
 
 def test_the_boot_key_route_refuses_WITHOUT_dropping_and_the_memo_route_drops(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Two routes, two different things a refusal is allowed to do.
 
@@ -452,16 +463,19 @@ def test_the_boot_key_route_refuses_WITHOUT_dropping_and_the_memo_route_drops(
         lambda *a, **k: (False, None, ("key_axis_divergence", "sm")))
 
     local_cell_store.store(
-        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token="")
+        _cell(tmp_path), key=KEY_A, family="micro-diffusion", arm_token="",
+        cas_root=cas)
     assert fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion",
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion",
         boot_local_key=KEY_A) is None
-    assert local_cell_store.lookup(KEY_A) is not None, "route B must not drop"
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is not None, (
+        "route B must not drop")
 
     local_cell_store.note_memo(ARM_A, KEY_A)
     assert fleet_cells.arm_from_local_store(
-        _Pipe(), _Cfg(), None, 0, _Arm(), "micro-diffusion") is None
-    assert local_cell_store.lookup(KEY_A) is None, "route A must drop a stale cell"
+        _Pipe(), _Cfg(), cas, 0, _Arm(), "micro-diffusion") is None
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is None, (
+        "route A must drop a stale cell")
 
 
 # ---------------------------------------------------------------------------
@@ -518,7 +532,7 @@ def test_every_new_terminus_is_in_the_typed_vocabulary() -> None:
 
 
 def test_each_new_terminus_emits_exactly_one_typed_event(
-    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    store: Path, cas: Path, tmp_path: Path, declared: None, events: List[Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """One decision, one event, ``phase`` = the gate's own token. "adopt
@@ -528,11 +542,12 @@ def test_each_new_terminus_emits_exactly_one_typed_event(
 
     ex._boot_adopt(_Spec(), {})                       # empty store, no hub
     local_cell_store.store(
-        _cell(tmp_path, name="b"), key=KEY_B, family="other", arm_token="")
+        _cell(tmp_path, source=ARTIFACT_OTHER, name="b"), key=KEY_B,
+        family="other", arm_token="", cas_root=cas)
     ex._boot_adopt(_Spec(), {})                       # stored, but not this key
     local_cell_store.store(
-        _cell(tmp_path, key=KEY_DERIVED), key=KEY_DERIVED,
-        family="micro-diffusion", arm_token=ARM_A)
+        _cell(tmp_path), key=KEY_DERIVED, family="micro-diffusion",
+        arm_token=ARM_A, cas_root=cas)
     ex._boot_adopt(_Spec(), {})                       # this machine holds it
 
     phases = [u.phase for u in _adopt_events(events)]
@@ -541,7 +556,7 @@ def test_each_new_terminus_emits_exactly_one_typed_event(
 
 
 def test_a_key_that_missed_locally_is_distinguishable_from_one_never_derived(
-    store: Path, tmp_path: Path, declared: None, events: List[Any],
+    store: Path, cas: Path, tmp_path: Path, declared: None, events: List[Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """pgw#1116's regression box, on the new pair. `derived_key` is what tells
@@ -551,7 +566,8 @@ def test_a_key_that_missed_locally_is_distinguishable_from_one_never_derived(
 
     (never,) = ex._boot_adopt(_Spec(), {})
     local_cell_store.store(
-        _cell(tmp_path, name="b"), key=KEY_B, family="other", arm_token="")
+        _cell(tmp_path, source=ARTIFACT_OTHER, name="b"), key=KEY_B,
+        family="other", arm_token="", cas_root=cas)
     (missed,) = ex._boot_adopt(_Spec(), {})
 
     assert never.reason == "no_compiled_graph_source" and not never.derived_key

--- a/tests/test_config_boundary_pgw931.py
+++ b/tests/test_config_boundary_pgw931.py
@@ -95,6 +95,11 @@ def test_foreign_keys_in_dotenv_are_still_ignored(tmp_path: Path, monkeypatch) -
     hundreds of entries belonging to other tools; refusing those would make the
     worker unusable and the rule would be turned off within a day."""
     monkeypatch.chdir(tmp_path)
+    # A real environment variable outranks the dotenv, correctly — and pgw#1283
+    # made the suite set this one for every test (the local cell store's bytes
+    # live under it now, so it has to be isolated per run). Clear it so this
+    # row still measures the dotenv it is about.
+    monkeypatch.delenv("TENSORHUB_CACHE_DIR", raising=False)
     (tmp_path / ".env").write_text(
         "TENSORHUB_CACHE_DIR=/good\nSOME_OTHER_TOOL=1\nEDITOR=vim\n")
     assert config.load_settings().tensorhub_cache_dir == "/good"

--- a/tests/test_durability_inversion_pgw1183.py
+++ b/tests/test_durability_inversion_pgw1183.py
@@ -20,19 +20,26 @@ Every row here asserts the TARGET ordering and was RED on unmodified
 
 from __future__ import annotations
 
-import io
-import json
-import tarfile
+import atexit
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
+import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
-KEY_A = "cg-key-v1-" + "a" * 56
+# pgw#1283: a REAL TCG envelope — the store hands its bytes to
+# ``Engine.import_artifact`` now, which refuses anything that does not unpack
+# and restate its own key.
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1183-durability-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT_A = tcg_artifacts.build(_FIXTURE_DIR / "a.tar.gz", witness="a" * 16)
+KEY_A = tcg_artifacts.key_of(ARTIFACT_A)
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
 
 
@@ -43,17 +50,17 @@ def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return root
 
 
-def _artifact(tmp_path: Path, *, key: str = KEY_A, name: str = "mint") -> Path:
+@pytest.fixture()
+def cas(tmp_path: Path) -> Path:
+    """This test's worker CAS — where the bytes actually live since pgw#1283."""
+    return tmp_path / "cas"
+
+
+def _artifact(tmp_path: Path, *, name: str = "mint") -> Path:
     """A cell with readable metadata — every gate here reads the stamp."""
     p = tmp_path / name / "cell.tar.gz"
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        {"kind": "aot-inductor", "compiled_graph_key": key, "family": "micro-diffusion"}
-    ).encode()
-    with tarfile.open(p, mode="w:gz") as tar:
-        info = tarfile.TarInfo("metadata.json")
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
+    shutil.copyfile(ARTIFACT_A, p)
     return p
 
 
@@ -96,12 +103,14 @@ class _Sink:
         return "ckpt-1"
 
 
-def _pending(tmp_path: Path, publisher: Any) -> fleet_cells.PendingSelfMint:
+def _pending(tmp_path: Path, publisher: Any,
+             cas: Optional[Path] = None) -> fleet_cells.PendingSelfMint:
     root = tmp_path / "mint"
     return fleet_cells.PendingSelfMint(
         family="micro-diffusion", arm_token=ARM_A, ref="r#x", cfg=_Cfg(),
         target=root / "cell.tar.gz", mint_root=root, publisher=publisher,
         arm_key=_Arm(),  # type: ignore[arg-type]
+        cache_dir=cas,
     )
 
 
@@ -128,9 +137,12 @@ def _arming(monkeypatch: pytest.MonkeyPatch, *, ok: bool,
     def _arm(pipe: Any, cfg: Any, cache_dir: Any, artifact: Path,
              bucket: int, meta: Any = None, **_kw: Any) -> AdoptOutcome:
         if observed is not None:
+            # pgw#1283: the listing is metadata-only, so residency of the BYTES
+            # is asked separately — of TCG, which is what holds them.
             observed.extend(
                 c.verdict for c in local_cell_store.stored_cells()
-                if c.key == KEY_A and c.artifact.is_file())
+                if c.key == KEY_A
+                and local_cell_store.materialize(c.key, cas_root=cache_dir))
         if ok:
             return AdoptOutcome.hit(KEY_A)
         return AdoptOutcome.miss("compile_cell_failed", "the card said no")
@@ -144,7 +156,7 @@ def _arming(monkeypatch: pytest.MonkeyPatch, *, ok: bool,
 
 
 def test_a_trusted_pod_writes_the_cell_to_local_cas(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     quiet: List[Tuple[str, str]],
 ) -> None:
     """RED on master: ``local_cell_store.store`` sat behind
@@ -153,19 +165,19 @@ def test_a_trusted_pod_writes_the_cell_to_local_cas(
     only copy lived in a temp dir owned by the process most likely to die."""
     _arming(monkeypatch, ok=True)
     sink = _Sink()
-    pending = _pending(tmp_path, sink)
+    pending = _pending(tmp_path, sink, cas)
     art = _artifact(tmp_path)
 
     assert fleet_cells.adopt_delegated_mint(_Pipe(), pending, [art]) is not None
 
-    kept = local_cell_store.lookup(KEY_A)
+    kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None, (
         "a trusted pod finished a mint and wrote NO durable copy — the "
         "artifact exists only under the mint root every terminus rmtrees")
 
 
 def test_the_cas_copy_exists_BEFORE_the_arm_runs(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     quiet: List[Tuple[str, str]],
 ) -> None:
     """§1.5's ordering is the whole point: durable BEFORE anything downstream
@@ -178,15 +190,15 @@ def test_the_cas_copy_exists_BEFORE_the_arm_runs(
     seen: List[str] = []
     _arming(monkeypatch, ok=True, observed=seen)
     fleet_cells.adopt_delegated_mint(
-        _Pipe(), _pending(tmp_path, _Sink()), [_artifact(tmp_path)])
+        _Pipe(), _pending(tmp_path, _Sink(), cas), [_artifact(tmp_path)])
     assert seen == [local_cell_store.VERDICT_UNVERIFIED], (
         "the arm ran before the artifact was durable")
-    assert local_cell_store.lookup(KEY_A) is not None, (
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is not None, (
         "the gate passed and the cell was never promoted to admitted")
 
 
 def test_an_arm_refusal_QUARANTINES_the_bytes_instead_of_deleting_them(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     quiet: List[Tuple[str, str]],
 ) -> None:
     """§1.3.4: a refused entry is *kept quarantined-local for forensics*. On
@@ -194,9 +206,9 @@ def test_an_arm_refusal_QUARANTINES_the_bytes_instead_of_deleting_them(
     could explain the refusal was destroyed by the code reporting it."""
     _arming(monkeypatch, ok=False)
     assert fleet_cells.adopt_delegated_mint(
-        _Pipe(), _pending(tmp_path, _Sink()), [_artifact(tmp_path)]) is None
+        _Pipe(), _pending(tmp_path, _Sink(), cas), [_artifact(tmp_path)]) is None
 
-    assert local_cell_store.lookup(KEY_A) is None, (
+    assert local_cell_store.lookup(KEY_A, cas_root=cas) is None, (
         "a cell that failed its arm must never be armable from the store")
     quarantined = local_cell_store.quarantined_cells()
     assert [c.key for c in quarantined] == [KEY_A], (
@@ -209,13 +221,14 @@ def test_an_arm_refusal_QUARANTINES_the_bytes_instead_of_deleting_them(
 
 
 def test_a_failed_publish_does_not_destroy_the_bytes(
-    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+    store: Path, cas: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
 ) -> None:
     """THE MONEY BUG. ``finally: shutil.rmtree(artifact.parent)`` ran on every
     exit path, so one ``connection reset`` deleted a completed mint."""
     art = _artifact(tmp_path)
     local_cell_store.store(art, key=KEY_A, family="micro-diffusion",
-                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED)
+                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED,
+                           cas_root=cas)
 
     class _Broken:
         def publish(self, *a: Any, **k: Any) -> str:
@@ -223,11 +236,11 @@ def test_a_failed_publish_does_not_destroy_the_bytes(
 
     fleet_cells._publish_async(
         _Broken(), "micro-diffusion",  # type: ignore[arg-type]
-        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
+        local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
         {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
-    kept = local_cell_store.lookup(KEY_A)
+    kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None and kept.artifact.is_file(), (
         "a transport failure destroyed the sole copy of a completed mint")
     assert kept.sink == local_cell_store.SINK_OWED, (
@@ -235,65 +248,67 @@ def test_a_failed_publish_does_not_destroy_the_bytes(
 
 
 def test_the_publish_thread_is_not_a_daemon(
-    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+    store: Path, cas: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
 ) -> None:
     """Its own event text stated the defect: *"this pod must survive the upload
     or the cell is lost"*. A daemon thread is killed at interpreter exit with
     no unwinding at all."""
     art = _artifact(tmp_path)
     local_cell_store.store(art, key=KEY_A, family="f", arm_token=ARM_A,
-                           sink=local_cell_store.SINK_OWED)
+                           sink=local_cell_store.SINK_OWED, cas_root=cas)
     t = fleet_cells._publish_async(
         _Sink(), "f",  # type: ignore[arg-type]
-        local_cell_store.lookup(KEY_A).artifact,  # type: ignore[union-attr]
+        local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
         {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A)
     assert t.daemon is False
     t.join(timeout=30)
 
 
 def test_a_pending_publish_is_retried_on_the_NEXT_boot(
-    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+    store: Path, cas: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
 ) -> None:
     """Cross-boot retry is what makes publish failure survivable rather than
     terminal. On master a publish that never completed left nothing behind at
     all — the bytes were gone and no record said an upload was owed."""
     local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
-                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED)
+                           arm_token=ARM_A, sink=local_cell_store.SINK_OWED,
+                           cas_root=cas)
     sink = _Sink()
 
-    for t in fleet_cells.resume_owed_publishes(sink):  # type: ignore[arg-type]
+    for t in fleet_cells.resume_owed_publishes(sink, cas):  # type: ignore[arg-type]
         t.join(timeout=30)
 
     assert [p.name for p in sink.published] == ["cell.tar.gz"]
-    kept = local_cell_store.lookup(KEY_A)
+    kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None
     assert kept.sink == local_cell_store.SINK_DELIVERED, (
         "a completed publish must stop being owed, or every boot re-uploads")
 
 
 def test_a_published_cell_is_not_re_uploaded_next_boot(
-    store: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
+    store: Path, cas: Path, tmp_path: Path, quiet: List[Tuple[str, str]],
 ) -> None:
     local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
-                           arm_token=ARM_A, sink=local_cell_store.SINK_DELIVERED)
+                           arm_token=ARM_A, sink=local_cell_store.SINK_DELIVERED,
+                           cas_root=cas)
     sink = _Sink()
-    assert list(fleet_cells.resume_owed_publishes(sink)) == []  # type: ignore[arg-type]
+    assert list(fleet_cells.resume_owed_publishes(sink, cas)) == []  # type: ignore[arg-type]
     assert sink.published == []
 
 
 def test_a_cell_with_no_sink_by_design_owes_no_publish(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     quiet: List[Tuple[str, str]],
 ) -> None:
     """cozy-local (§4.28) never has a sink, so its cells must be durable AND
     must not accumulate an upload obligation nothing will ever discharge."""
     _arming(monkeypatch, ok=True)
     fleet_cells.adopt_delegated_mint(
-        _Pipe(), _pending(tmp_path, None), [_artifact(tmp_path)])
-    kept = local_cell_store.lookup(KEY_A)
+        _Pipe(), _pending(tmp_path, None, cas), [_artifact(tmp_path)])
+    kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None
     assert kept.sink == local_cell_store.SINK_NONE
-    assert list(fleet_cells.resume_owed_publishes(None)) == []
+    assert list(fleet_cells.resume_owed_publishes(None, cas)) == []
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +317,7 @@ def test_a_cell_with_no_sink_by_design_owes_no_publish(
 
 
 def test_no_terminus_deletes_a_cell_the_store_does_not_hold(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     quiet: List[Tuple[str, str]],
 ) -> None:
     """The mint root is SCRATCH once the CAS write lands, and every terminus
@@ -310,11 +325,11 @@ def test_no_terminus_deletes_a_cell_the_store_does_not_hold(
     a terminus that runs on a pending whose bytes never reached the store is
     the destruction bug rebuilt."""
     _arming(monkeypatch, ok=True)
-    pending = _pending(tmp_path, _Sink())
+    pending = _pending(tmp_path, _Sink(), cas)
     fleet_cells.adopt_delegated_mint(_Pipe(), pending, [_artifact(tmp_path)])
     fleet_cells.publish_self_mint(pending)
 
-    kept = local_cell_store.lookup(KEY_A)
+    kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None and kept.artifact.read_bytes(), (
         "the publish terminus destroyed the durable copy")
 

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -24,23 +24,30 @@ only reason to prefer it to a mock.
 from __future__ import annotations
 
 import ast
-import io
-import json
+import atexit
+import shutil
 import subprocess
 import sys
-import tarfile
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
+import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store, local_serve, mint_supervisor
 from gen_worker.cell_adopt import AdoptOutcome
 from gen_worker.cli import run as cli_run
 from gen_worker.child_contract import MintSlot
 
-KEY_A = "cg-key-v1-" + "a" * 56
+# pgw#1283: a REAL TCG envelope, and a key DERIVED from it. `local_cell_store`
+# hands its bytes to `Engine.import_artifact` now, which refuses an artifact
+# whose metadata does not restate the key it is filed under.
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1127-local-serve-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT_A = tcg_artifacts.build(_FIXTURE_DIR / "a.tar.gz", witness="a" * 16)
+KEY_A = tcg_artifacts.key_of(ARTIFACT_A)
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
 
 SRC = Path(fleet_cells.__file__).parent
@@ -85,18 +92,13 @@ class _Arm:
         return {}
 
 
-def _armable_artifact(tmp_path: Path, *, key: str = KEY_A) -> Path:
+def _armable_artifact(tmp_path: Path) -> Path:
     """A cell with a READABLE envelope — `_arm_exported_cell` refuses an
-    unreadable one before every other gate (pgw#1098), local store included."""
+    unreadable one before every other gate (pgw#1098), local store included.
+    Since pgw#1283 the store refuses one too, so this is TCG's own envelope."""
     p = tmp_path / "mint" / "cell.tar.gz"
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        {"kind": "aot-inductor", "compiled_graph_key": key, "family": "micro-diffusion"}
-    ).encode()
-    with tarfile.open(p, mode="w:gz") as tar:
-        info = tarfile.TarInfo("metadata.json")
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
+    shutil.copyfile(ARTIFACT_A, p)
     return p
 
 
@@ -387,17 +389,19 @@ def test_storing_a_cell_imports_no_transport_at_all(tmp_path: Path) -> None:
     scan of the module cannot see — fails here.
     """
     root = tmp_path / "store"
+    cas = tmp_path / "cas"
     artifact = tmp_path / "cell.tar.gz"
-    artifact.write_bytes(b"packed")
+    shutil.copyfile(ARTIFACT_A, artifact)
     program = f"""
 import os, sys
 os.environ["GEN_WORKER_LOCAL_CELLS_DIR"] = {str(root)!r}
+from pathlib import Path
 from gen_worker import local_cell_store
 cell = local_cell_store.store(
-    {str(artifact)!r}, key={KEY_A!r}, family="micro-diffusion",
-    arm_token={ARM_A!r})
+    Path({str(artifact)!r}), key={KEY_A!r}, family="micro-diffusion",
+    arm_token={ARM_A!r}, cas_root=Path({str(cas)!r}))
 assert cell is not None, "the store refused a well-formed cell"
-assert local_cell_store.lookup({KEY_A!r}) is not None
+assert local_cell_store.lookup({KEY_A!r}, cas_root=Path({str(cas)!r})) is not None
 banned = [
     m for m in sys.modules
     if m in ("httpx", "requests", "urllib3", "boto3", "aiohttp")
@@ -417,7 +421,7 @@ print(",".join(sorted(banned)))
 
 def _store_artifact(tmp_path: Path) -> Path:
     p = tmp_path / "cell.tar.gz"
-    p.write_bytes(b"packed")
+    shutil.copyfile(ARTIFACT_A, p)
     return p
 
 

--- a/tests/test_store_corruption_pgw1283.py
+++ b/tests/test_store_corruption_pgw1283.py
@@ -26,19 +26,28 @@ silence was the defect.
 
 from __future__ import annotations
 
-import io
+import atexit
 import json
 import logging
-import tarfile
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any, Dict
 
 import pytest
 
+import tcg_artifacts
 from gen_worker import local_cell_store
 
-KEY_A = "cg-key-v1-" + "a" * 56
-KEY_B = "cg-key-v1-" + "b" * 56
+# pgw#1283: real TCG envelopes. The store no longer holds opaque bytes, so a
+# hand-typed key and a hand-rolled tarball are refused at the seam — see this
+# file's sibling note in ``tests/tcg_artifacts.py``.
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1283-corruption-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT_A = tcg_artifacts.build(_FIXTURE_DIR / "a.tar.gz", witness="a" * 16)
+ARTIFACT_B = tcg_artifacts.build(_FIXTURE_DIR / "b.tar.gz", witness="b" * 16)
+KEY_A = tcg_artifacts.key_of(ARTIFACT_A)
+KEY_B = tcg_artifacts.key_of(ARTIFACT_B)
 ARM_A = "arm2-" + "1" * 40
 
 
@@ -49,26 +58,26 @@ def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return root
 
 
-def _artifact(tmp_path: Path, *, key: str = KEY_A, name: str = "mint") -> Path:
+@pytest.fixture()
+def cas(tmp_path: Path) -> Path:
+    return tmp_path / "cas"
+
+
+def _artifact(tmp_path: Path, *, source: Path = ARTIFACT_A,
+              name: str = "mint") -> Path:
     """A packed cell carrying its own stamp, as a real mint produces."""
     p = tmp_path / name / "cell.tar.gz"
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        {"kind": "aot-inductor", "compiled_graph_key": key,
-         "family": "micro-diffusion"}
-    ).encode()
-    with tarfile.open(p, mode="w:gz") as tar:
-        info = tarfile.TarInfo("metadata.json")
-        info.size = len(payload)
-        tar.addfile(info, io.BytesIO(payload))
+    shutil.copyfile(source, p)
     return p
 
 
-def _stored(tmp_path: Path, *, key: str = KEY_A, arm_token: str = "",
-            name: str = "mint") -> local_cell_store.LocalCell:
+def _stored(tmp_path: Path, cas: Path, *, source: Path = ARTIFACT_A,
+            key: str = KEY_A, arm_token: str = "",
+            name: str = "mint") -> local_cell_store.CellRecord:
     cell = local_cell_store.store(
-        _artifact(tmp_path, key=key, name=name), key=key,
-        family="micro-diffusion", arm_token=arm_token)
+        _artifact(tmp_path, source=source, name=name), key=key,
+        family="micro-diffusion", arm_token=arm_token, cas_root=cas)
     assert cell is not None, "fixture setup: the cell must store"
     return cell
 
@@ -107,7 +116,7 @@ def test_read_json_separates_absence_from_corruption(tmp_path: Path) -> None:
 
 
 def test_lookup_says_so_and_drops_when_a_record_is_unreadable(
-    store: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+    store: Path, cas: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A corrupt record beside intact bytes is not silence.
 
@@ -116,14 +125,12 @@ def test_lookup_says_so_and_drops_when_a_record_is_unreadable(
     that can no longer be used is dropped, so the corruption costs one honest
     re-mint rather than an invisible one.
     """
-    _stored(tmp_path)
+    _stored(tmp_path, cas)
     record = local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME
-    artifact = local_cell_store.cell_dir(KEY_A) / local_cell_store.ARTIFACT_NAME
-    assert artifact.is_file(), "the bytes are intact; only the record rots"
     _corrupt(record)
 
     with caplog.at_level(logging.ERROR, logger=local_cell_store.__name__):
-        assert local_cell_store.lookup(KEY_A) is None
+        assert local_cell_store.lookup(KEY_A, cas_root=cas) is None
 
     assert any("unreadable" in r.message.lower() or "unreadable" in r.getMessage().lower()
                for r in caplog.records), (
@@ -134,7 +141,7 @@ def test_lookup_says_so_and_drops_when_a_record_is_unreadable(
 
 
 def test_mark_reports_the_transition_it_loses(
-    store: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
+    store: Path, cas: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The expensive silent case: a lost ``delivered`` means a re-upload.
 
@@ -142,7 +149,7 @@ def test_mark_reports_the_transition_it_loses(
     but a dropped state transition is now an error line naming the verdict and
     sink that were not applied.
     """
-    _stored(tmp_path)
+    _stored(tmp_path, cas)
     record = local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME
     _corrupt(record)
 
@@ -159,14 +166,14 @@ def test_mark_reports_the_transition_it_loses(
 
 
 def test_one_corrupt_record_does_not_blank_the_listing(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """``stored_cells`` is what a ``cozy cells``-style CLI reads.
 
     One bad file must cost that entry, never the whole inventory.
     """
-    _stored(tmp_path, key=KEY_A, name="a")
-    _stored(tmp_path, key=KEY_B, name="b")
+    _stored(tmp_path, cas, source=ARTIFACT_A, key=KEY_A, name="a")
+    _stored(tmp_path, cas, source=ARTIFACT_B, key=KEY_B, name="b")
     _corrupt(local_cell_store.cell_dir(KEY_A) / local_cell_store.RECORD_NAME)
 
     listed = local_cell_store.stored_cells()
@@ -175,17 +182,17 @@ def test_one_corrupt_record_does_not_blank_the_listing(
 
 
 def test_an_unreadable_memo_is_discarded_rather_than_shadowing(
-    store: Path, tmp_path: Path,
+    store: Path, cas: Path, tmp_path: Path,
 ) -> None:
     """A memo is a shortcut, never an authority — but a corrupt one left in
     place is paid for on every boot, because ``note_memo`` only rewrites it
     once a cell arms."""
-    _stored(tmp_path, arm_token=ARM_A)
+    _stored(tmp_path, cas, arm_token=ARM_A)
     path = local_cell_store.memo_path(ARM_A)
     assert path.is_file(), "fixture setup: store writes the memo"
     _corrupt(path)
 
-    assert local_cell_store.lookup_for_arm(ARM_A) is None
+    assert local_cell_store.lookup_for_arm(ARM_A, cas_root=cas) is None
     assert not path.exists(), (
         "the corrupt shortcut must be cleared so evidence can rebuild it")
 
@@ -208,7 +215,7 @@ def test_a_corrupt_trust_class_reads_as_not_yet_known(
 
 
 def test_a_failed_memo_write_does_not_report_the_store_as_failed(
-    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``store``'s return value means "artifact and record are durable".
 
@@ -229,7 +236,7 @@ def test_a_failed_memo_write_does_not_report_the_store_as_failed(
 
     cell = local_cell_store.store(
         _artifact(tmp_path), key=KEY_A, family="micro-diffusion",
-        arm_token=ARM_A)
+        arm_token=ARM_A, cas_root=cas)
 
     assert cell is not None, (
         "the record was durable before the memo was attempted; reporting "
@@ -240,6 +247,6 @@ def test_a_failed_memo_write_does_not_report_the_store_as_failed(
         "is still reported stored")
 
     monkeypatch.setattr(local_cell_store, "_write_json_atomic", real)
-    found = local_cell_store.lookup(KEY_A)
+    found = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert found is not None and found.key == KEY_A, (
         "lookup and store must agree about whether the cell exists")

--- a/tests/test_store_split_pgw1283.py
+++ b/tests/test_store_split_pgw1283.py
@@ -1,0 +1,566 @@
+"""pgw#1283 — the STORE split: TCG owns the bytes, the worker owns the policy.
+
+The two NO-SHIP criteria this unit had to CLOSE, and the one whose deviation is
+flagged for a ruling.
+
+**Criterion 4 — TCG's storage quarantine must stay separate from the worker's.**
+Two directions, and the cutover created the second one:
+
+* a TCG CAS quarantine is a fact about a stored record and is repaired by
+  re-storing the bytes, so writing it into this worker's ``verdict`` — which
+  §1.3.4 makes terminal, "kept for forensics, never served" — would strand a
+  healthy cell forever on a defect a re-store fixes;
+* the worker's own quarantine used to be unreachable by anything else, because
+  the refused bytes lived only in ``local_cell_store``. They are now in the CAS
+  ``aot_serve.arm_compiled_graph`` loads runners from, so the load path must ask
+  before it resolves, or it arms a cell this worker refused.
+
+**Criterion 7 — no crash-retry alias loss.** ``store`` is idempotent across
+every one of TCG's success outcomes. A crash between the record write and the
+memo write leaves bytes TCG reports ``PRESENT`` on the retry; if that outcome
+were allowed to skip the rest of the function, the arm-token alias would be
+gone permanently and a machine with no boot-key route would re-mint on every
+boot forever. Which outcome came back is a fact for the log, never a branch.
+
+**Criterion 6 — collision-safe memo persistence.** RESOLVED BY DEFAULT, and
+flagged. The review demanded MANDATORY collision-safe memo persistence; this
+module's stated design is that a memo is a shortcut and never load-bearing.
+What landed: the WRITE is collision-safe (a per-write temp name, fsync, atomic
+replace), and PERSISTENCE stays non-load-bearing — a failed memo write is
+logged loudly and ``store`` still reports the cell stored. Making it mandatory
+would mean a full disk on the cache partition fails a mint that succeeded.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import shutil
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+import tcg_artifacts
+from gen_worker import aot_serve, local_cell_store
+from gen_worker.compile_cache import AdoptError
+
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1283-split-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT = tcg_artifacts.build(_FIXTURE_DIR / "cell.tar.gz", witness="a" * 16)
+KEY = tcg_artifacts.key_of(ARTIFACT)
+ARM = "arm2-" + "1" * 40
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+@pytest.fixture()
+def cas(tmp_path: Path) -> Path:
+    return tmp_path / "cas"
+
+
+def _staged(tmp_path: Path) -> Path:
+    p = tmp_path / "mint" / "cell.tar.gz"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ARTIFACT, p)
+    return p
+
+
+def _cas_blob(cas: Path) -> Path:
+    """The store object holding the artifact — the bytes TCG vouches for."""
+    blobs = sorted((p for p in cas.rglob("*") if p.is_file()),
+                   key=lambda p: p.stat().st_size)
+    assert blobs, f"no CAS objects under {cas}"
+    return blobs[-1]
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4a — the load path must not bypass the WORKER's quarantine
+# ---------------------------------------------------------------------------
+
+
+def test_a_worker_quarantined_key_is_refused_before_the_cas_is_asked(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The defect the cutover would otherwise have created, by name.
+
+    Before the split, a cell this worker quarantined was unreachable by any
+    other route: its bytes lived only in ``local_cell_store`` and nothing else
+    could address them. After it, they are in the CAS
+    ``aot_serve.arm_compiled_graph`` resolves from, and TCG has no concept of a
+    worker parity/arm refusal — so without the guard the runner loads a cell
+    §1.3.4 says must never be served.
+
+    The refusal is TYPED, and it fires before ``open_worker_engine`` is called
+    at all: a quarantined cell must not even be unpacked by the serving path.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="micro-diffusion", arm_token=ARM,
+        cas_root=cas) is not None
+    local_cell_store.mark(KEY, verdict=local_cell_store.VERDICT_QUARANTINED)
+    assert local_cell_store.is_quarantined(KEY)
+
+    with pytest.raises(AdoptError) as raised:
+        aot_serve.arm_compiled_graph(object(), object(), KEY, cas)
+    assert raised.value.reason == "compiled_graph_worker_quarantined", (
+        "the load path reached the CAS for a cell this worker refused")
+
+
+def test_the_guard_refuses_ONLY_a_worker_quarantine_and_not_an_unproven_cell(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The discriminating half — the guard must not become "refuse anything".
+
+    §1.5 stores a cell BEFORE the gate that proves it, so an ``unverified`` row
+    is the normal state of a cell that is about to be armed by the very call
+    this guard sits in front of. And a key this worker never recorded is every
+    hub-delivered cell there is. Refusing either would turn the criterion-4
+    guard into an outage.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="micro-diffusion",
+        verdict=local_cell_store.VERDICT_UNVERIFIED, cas_root=cas) is not None
+
+    def _reason() -> str:
+        """Why the load path refused, or "" when it got past every gate.
+
+        It cannot COMPLETE here — the fixture's ``model.so`` is a shaped ELF
+        with no runnable code — so what is asserted is which refusal came back,
+        never that the arm succeeded. A pass/fail assertion would read green
+        for the wrong reason.
+        """
+        try:
+            aot_serve.arm_compiled_graph(object(), object(), KEY, cas)
+        except AdoptError as exc:
+            return str(exc.reason)
+        except Exception:
+            return "reached-tcg"
+        return ""
+
+    for state in (local_cell_store.VERDICT_UNVERIFIED,
+                  local_cell_store.VERDICT_ADMITTED):
+        local_cell_store.mark(KEY, verdict=state)
+        assert _reason() != "compiled_graph_worker_quarantined", (
+            f"a {state!r} cell was refused as if a gate had rejected it")
+
+    local_cell_store.drop(KEY)
+    assert _reason() != "compiled_graph_worker_quarantined", (
+        "a key this worker never recorded is not a key it quarantined")
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4b — a TCG storage quarantine is NOT this worker's verdict
+# ---------------------------------------------------------------------------
+
+
+def test_cas_rot_never_becomes_the_workers_verdict_and_a_repair_restores_it(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The other direction, and the one the review named outright: *"TCG CAS
+    repair could leave worker state permanently quarantined"*.
+
+    Rot in the CAS makes TCG quarantine its own record. This worker records
+    NOTHING about that — its verdict is a statement about a gate it ran — so
+    re-storing the same artifact repairs TCG and the cell serves again, with no
+    mint and no manual intervention. Had the worker mirrored the quarantine,
+    the repair would be unreachable: :func:`mark` can move the verdict back,
+    but nothing in the tree ever calls it that way, because a worker quarantine
+    is terminal by design.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None
+    assert local_cell_store.lookup(KEY, cas_root=cas) is not None
+
+    blob = _cas_blob(cas)
+    rotted = bytearray(blob.read_bytes())
+    rotted[0] ^= 0xFF
+    blob.write_bytes(bytes(rotted))
+    (store / "aot-cells" / KEY / "cell.tar.gz").unlink()
+
+    assert local_cell_store.lookup(KEY, cas_root=cas) is None, (
+        "bytes TCG cannot verify must not be served")
+    assert local_cell_store.verdict_of(KEY) == local_cell_store.VERDICT_ADMITTED, (
+        "a CAS-storage quarantine was written into this worker's verdict")
+    assert not local_cell_store.is_quarantined(KEY)
+    assert [c.key for c in local_cell_store.quarantined_cells()] == [], (
+        "the forensics listing is the WORKER's refusals; a CAS repair case in "
+        "it is a support ticket about a defect that repaired itself")
+
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None, "re-storing the same artifact must repair"
+    healed = local_cell_store.lookup(KEY, cas_root=cas)
+    assert healed is not None and healed.key == KEY
+    assert healed.artifact.read_bytes() == ARTIFACT.read_bytes()
+
+
+def test_a_worker_quarantine_survives_everything_the_cas_does(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The symmetric guarantee: a gate refusal is not repairable by re-storing.
+
+    §1.3.4 keeps a refused cell for forensics precisely because it is the one
+    object that can explain its own refusal. Re-storing its bytes proves
+    something about the BYTES; it says nothing about the gate that refused
+    them, so it must not clear the verdict.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None
+    local_cell_store.mark(KEY, verdict=local_cell_store.VERDICT_QUARANTINED)
+
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        verdict=local_cell_store.VERDICT_QUARANTINED, cas_root=cas) is not None
+    assert local_cell_store.lookup(KEY, cas_root=cas) is None
+    assert [c.key for c in local_cell_store.quarantined_cells()] == [KEY]
+
+
+# ---------------------------------------------------------------------------
+# Criterion 7 — no crash-retry alias loss
+# ---------------------------------------------------------------------------
+
+
+def test_a_retry_after_a_crash_between_the_record_and_the_memo_restores_the_alias(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The crash-retry alias loss, at the cut where it happens.
+
+    ``store`` is three durable steps: the bytes into TCG, the policy record,
+    the arm-token alias. A crash after step 2 leaves a cell TCG will report
+    ``PRESENT`` for on the retry — and if ``PRESENT`` were treated as "already
+    done, nothing to do", the alias would never be written again. The bytes
+    survive and the SHORTCUT does not, so a machine with no boot-key route
+    (§4.28's cozy-local box, which never traces) pays a full compile on every
+    boot for a cell it is holding.
+
+    Every step therefore runs on every call. This drives the crash by deleting
+    exactly what step 3 wrote, which is the same on-disk state a kill between
+    the two ``os.replace``s leaves.
+    """
+    staged = _staged(tmp_path)
+    assert local_cell_store.store(
+        staged, key=KEY, family="f", arm_token=ARM, cas_root=cas) is not None
+
+    memo = local_cell_store.memo_path(ARM)
+    assert memo.is_file(), "setup: the first store wrote the alias"
+    memo.unlink()                                    # the crash cut
+    assert local_cell_store.lookup_for_arm(ARM, cas_root=cas) is None
+
+    retried = local_cell_store.store(
+        staged, key=KEY, family="f", arm_token=ARM, cas_root=cas)
+
+    assert retried is not None, "the retry must report the cell stored"
+    hit = local_cell_store.lookup_for_arm(ARM, cas_root=cas)
+    assert hit is not None and hit.key == KEY, (
+        "the retry left the arm alias lost — every later boot re-mints a cell "
+        "this machine is holding")
+
+
+def test_a_retry_after_a_crash_before_the_record_restores_the_whole_cell(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """The earlier cut, and the ownership rule that makes it safe.
+
+    Bytes in the CAS with no policy record are a clean MISS, not a half-cell:
+    nothing vouches for arming them, and "the CAS has it" is not this worker's
+    permission. The retry re-records against bytes TCG reports ``PRESENT``, so
+    the recovery costs a metadata write rather than a mint.
+    """
+    staged = _staged(tmp_path)
+    assert local_cell_store.store(
+        staged, key=KEY, family="f", arm_token=ARM, cas_root=cas) is not None
+    shutil.rmtree(local_cell_store.cell_dir(KEY))     # the crash cut
+    local_cell_store.memo_path(ARM).unlink(missing_ok=True)
+
+    assert local_cell_store.lookup(KEY, cas_root=cas) is None
+    assert local_cell_store.verdict_of(KEY) == ""
+
+    assert local_cell_store.store(
+        staged, key=KEY, family="f", arm_token=ARM, cas_root=cas) is not None
+    assert local_cell_store.lookup(KEY, cas_root=cas) is not None
+    assert local_cell_store.lookup_for_arm(ARM, cas_root=cas) is not None
+
+
+def test_store_reports_every_tcg_outcome_and_branches_on_none_of_them(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """Structural half of criterion 7: the outcome is LOGGED, never a branch.
+
+    A reader adding ``if outcome is PRESENT: return record`` recreates the
+    alias loss above, and it reads like an optimisation. The only ``StoreOutcome``
+    comparison in the module is the ``DIVERGENT`` refusal — which is not a
+    success outcome at all.
+    """
+    import ast
+
+    tree = ast.parse(Path(local_cell_store.__file__).read_text())
+    compared = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "StoreOutcome"
+    }
+    assert compared == {"DIVERGENT"}, (
+        f"the store branches on TCG success outcomes {sorted(compared)}; every "
+        f"step must run on every call or a crash-retry loses the alias")
+
+
+def test_a_key_tcg_binds_to_different_bytes_is_refused_and_records_nothing(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """``DIVERGENT`` is the one TCG outcome that is not a success.
+
+    Two artifacts state the SAME key over different bytes — the envelope is
+    deterministic, so this takes an inert change to the wrapper source that
+    moves no fact TCG derives. TCG keeps the first bytes and quarantines the
+    newcomer rather than choosing between them, and this module must then
+    record nothing: a sidecar written here would file worker policy against
+    bytes nothing will ever resolve.
+    """
+    divergent = tcg_artifacts.build(
+        tmp_path / "divergent" / "cell.tar.gz", witness="a" * 16,
+        filler="the same facts, different bytes")
+    assert tcg_artifacts.key_of(divergent) == KEY
+    assert divergent.read_bytes() != ARTIFACT.read_bytes()
+
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None
+    first = local_cell_store.lookup(KEY, cas_root=cas)
+    assert first is not None
+    stored_at = first.stored_at
+
+    assert local_cell_store.store(
+        divergent, key=KEY, family="other", cas_root=cas) is None, (
+        "TCG refused to rebind the key; the store must report that failure")
+
+    kept = local_cell_store.lookup(KEY, cas_root=cas)
+    assert kept is not None, "the resident cell must survive a refused newcomer"
+    assert kept.family == "f" and kept.stored_at == stored_at, (
+        "the refusal rewrote worker policy for bytes TCG did not accept")
+    assert kept.artifact.read_bytes() == ARTIFACT.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Criterion 6 — the memo WRITE is collision-safe; its PERSISTENCE is not
+#               load-bearing. See this module's header: resolved by default.
+# ---------------------------------------------------------------------------
+
+
+def test_two_writes_to_one_memo_never_share_a_temporary_file(
+    store: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Criterion 6's collision-safety half, deterministically.
+
+    The temp name used to be ``<name>.tmp-<pid>`` — one name per PROCESS, which
+    is not a distinct name for two THREADS of one process. The memo is written
+    from the mint path and from the arm path, and those do run concurrently, so
+    two writers shared one temp file: the second truncates and rewrites what
+    the first is still filling, and the first then ``os.replace``s a torn
+    interleaving under a name that says it is atomic.
+
+    Asserted on the NAMES rather than on a race, because a race that only
+    sometimes reproduces is not calibration.
+    """
+    temporaries: List[str] = []
+    real_replace = os.replace
+
+    def _record(src: Any, dst: Any) -> None:
+        temporaries.append(str(src))
+        real_replace(src, dst)
+
+    # The publication point itself is the instrument: whatever name reaches
+    # ``os.replace`` IS the file the two writers were filling. Restored the
+    # instant the two writes are done, so nothing else in the run is observed.
+    monkeypatch.setattr(os, "replace", _record)
+    try:
+        assert local_cell_store.note_memo(ARM, KEY) is True
+        assert local_cell_store.note_memo(ARM, KEY) is True
+    finally:
+        monkeypatch.undo()
+
+    assert len(temporaries) == 2
+    assert temporaries[0] != temporaries[1], (
+        "two writers of one memo shared a temporary file; the 'atomic' replace "
+        "then publishes whatever the loser left behind")
+
+
+def test_concurrent_memo_writers_never_publish_a_torn_memo(
+    store: Path, tmp_path: Path,
+) -> None:
+    """The corroborating end-to-end property: readers only ever see one of the
+    written answers, never a splice of two, and no temp residue survives."""
+    keys = [tcg_artifacts.key_of(ARTIFACT), "cg-key-v1-" + "b" * 56]
+    seen: List[Dict[str, Any]] = []
+    barrier = threading.Barrier(8)
+    stop = threading.Event()
+
+    def _writer(which: int) -> None:
+        barrier.wait()
+        for _ in range(40):
+            local_cell_store.note_memo(ARM, keys[which % 2])
+        stop.set()
+
+    def _reader() -> None:
+        barrier.wait()
+        while not stop.is_set():
+            try:
+                raw = local_cell_store.memo_path(ARM).read_text()
+            except OSError:
+                continue
+            seen.append(json.loads(raw))     # a torn write raises here
+
+    threads = [threading.Thread(target=_writer, args=(i,)) for i in range(4)]
+    threads += [threading.Thread(target=_reader) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert seen, "the readers never observed a published memo"
+    assert {row["compiled_graph_key"] for row in seen} <= set(keys)
+    residue = list((store / "aot-cells" / local_cell_store.MEMO_DIRNAME
+                    ).glob("*.tmp-*"))
+    assert not residue, f"temporary memo files survived: {residue}"
+
+
+def test_a_memo_that_cannot_be_written_is_LOUD_and_still_a_stored_cell(
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Criterion 6's DEVIATION, asserted rather than left implicit.
+
+    The review asked for memo persistence to be MANDATORY — part of store
+    success. It is not, and this is the reason stated as a test: the memo is a
+    shortcut whose absence costs one lookup, while a mandatory memo makes a
+    full cache partition fail a mint that has already succeeded. What the
+    deviation buys instead of silence is VOLUME: the failure is logged at
+    warning with both the token and the key.
+
+    Flagged for Paul in the PR body under "Criterion 6 — resolved by default".
+    """
+    import logging
+
+    real = local_cell_store._write_json_atomic
+
+    def _fail_only_the_memo(path: Path, payload: Dict[str, Any]) -> None:
+        if local_cell_store.MEMO_DIRNAME in path.parts:
+            raise OSError("no space left on device")
+        real(path, payload)
+
+    monkeypatch.setattr(
+        local_cell_store, "_write_json_atomic", _fail_only_the_memo)
+
+    with caplog.at_level(logging.WARNING, logger=local_cell_store.__name__):
+        stored = local_cell_store.store(
+            _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+            cas_root=cas)
+
+    assert stored is not None, (
+        "a failed SHORTCUT reported the whole cell unstored — the defect "
+        "pgw#1283 opened on")
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert ARM in joined and KEY in joined, (
+        "a non-load-bearing failure must still name what was lost, or "
+        "'best-effort' is indistinguishable from 'silent'")
+    monkeypatch.setattr(local_cell_store, "_write_json_atomic", real)
+    assert local_cell_store.lookup(KEY, cas_root=cas) is not None
+
+
+# ---------------------------------------------------------------------------
+# The split itself — the duplication that WAS the unit
+# ---------------------------------------------------------------------------
+
+
+def test_the_store_computes_no_digest_of_its_own(store: Path) -> None:
+    """The unit, stated as an absence.
+
+    ``local_cell_store`` used to hash the artifact on the way in and re-hash it
+    on every lookup — twice re-deriving what the CAS derived when it ingested
+    the bytes, over an artifact measured in hundreds of megabytes. TCG owns the
+    digest now, and the module has no hashing left to drift out of agreement
+    with it.
+    """
+    import ast
+
+    source = Path(local_cell_store.__file__).read_text()
+    tree = ast.parse(source)
+    imported = {
+        alias.name
+        for node in ast.walk(tree) if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert "hashlib" not in imported, (
+        "the store grew a second digest authority over bytes it does not own")
+    names = {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    } | {
+        node.name for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    for word in ("sha256", "hexdigest", "digest"):
+        assert not {n for n in names if word in n.lower()}, (
+            f"{word!r} survives in the store; the duplication IS the unit")
+
+
+def test_the_owed_scan_stays_metadata_only(
+    store: Path, cas: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Criterion 5, re-proved against the NEW custody (it was already met).
+
+    ``cells_owed_to_sink`` reads sidecars. Under the split the tempting bug is
+    new: materializing each candidate to size or verify it would make "is
+    anything owed?" cost an export per resident cell, on every reconnect.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        sink=local_cell_store.SINK_OWED, cas_root=cas) is not None
+
+    def _no_engine(*a: Any, **k: Any) -> Any:
+        raise AssertionError("an owed SCAN asked TCG for bytes")
+
+    monkeypatch.setattr(local_cell_store, "_engine", _no_engine)
+
+    owed = local_cell_store.cells_owed_to_sink()
+    assert [c.key for c in owed] == [KEY]
+    assert not hasattr(owed[0], "artifact"), (
+        "a scan row must not carry a materialized path — that is what makes "
+        "the cheap scan impossible to use expensively by accident")
+
+
+def test_dropping_a_cell_forgets_the_POLICY_and_never_the_cas_bytes(
+    store: Path, cas: Path, tmp_path: Path,
+) -> None:
+    """``drop`` narrowed, deliberately.
+
+    It used to delete the only copy of an artifact. The bytes are now
+    content-addressed and may be exactly the bytes another route resolves, so a
+    worker decision about ONE arm identity must not destroy them. What goes is
+    the permission to serve — and a later store of the same artifact re-records
+    it against a TCG ``PRESENT``, at no mint cost.
+    """
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None
+    blob = _cas_blob(cas)
+
+    local_cell_store.drop(KEY)
+
+    assert not local_cell_store.cell_dir(KEY).exists()
+    assert local_cell_store.lookup(KEY, cas_root=cas) is None
+    assert blob.is_file(), "a worker policy decision deleted CAS bytes"
+    assert local_cell_store.store(
+        _staged(tmp_path), key=KEY, family="f", arm_token=ARM,
+        cas_root=cas) is not None
+    assert local_cell_store.lookup(KEY, cas_root=cas) is not None

--- a/tests/test_two_run_reuse_pgw1096.py
+++ b/tests/test_two_run_reuse_pgw1096.py
@@ -10,13 +10,18 @@ not actually work.
 This one proves the claim it is: TWO fresh OS processes, sharing nothing but a
 directory on disk. Run 1 mints and keeps; run 2 starts cold, with an empty
 `_FINALIZED`, and must arm WITHOUT opening a mint. If the memo, the CAS layout
-or the digest record were wrong in any way that a warm process papers over,
+or the sidecar record were wrong in any way that a warm process papers over,
 run 2 opens a `PendingSelfMint` and this test says so.
 
-WHAT IS REAL HERE: the store (real files, real digests, real atomic replace),
-the memo, `fleet_cells._arming_policy` — the actual production arming brain,
-entered the way the executor enters it — the ordering (local check before the
-pending), and process death between the runs.
+WHAT IS REAL HERE: the store (a real TCG envelope in a real HashRepo CAS, real
+atomic replace), the memo, `fleet_cells._arming_policy` — the actual production
+arming brain, entered the way the executor enters it — the ordering (local
+check before the pending), and process death between the runs.
+
+pgw#1283 — byte custody moved to TCG, and the third run below is what that
+buys. Corruption in the CAS is a TCG STORAGE quarantine, which is repairable;
+it is deliberately NOT this worker's verdict, so a repaired CAS arms again with
+no mint. On master the same rot dropped the cell and cost a full GPU pod run.
 
 WHAT IS FAKED, and why: the COMPILE. Paul's standing rule (2026-08-10) is that
 no mint, compile or AOTI link runs on the shared dev box — those go to a pod.
@@ -40,16 +45,20 @@ REPO = Path(__file__).resolve().parent.parent
 #: under test is that the second run of one program behaves differently only
 #: because the first run left something on disk.
 _PROGRAM = r'''
-import io, json, os, sys, tarfile
+import json, os, sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store
 from gen_worker.cell_adopt import AdoptOutcome
 
 MODE = sys.argv[1]
-KEY = "cg-key-v1-" + "c" * 56
+ARTIFACT = Path(os.environ["PGW1096_ARTIFACT"])
+SOURCE = Path(os.environ["PGW1096_SOURCE"])
+CAS = Path(os.environ["PGW1096_CAS"])
+KEY = tcg_artifacts.key_of(SOURCE)
 ARM = fleet_cells.ARM_SCHEME + "-" + "9" * fleet_cells.ARM_DIGEST_HEX
 FAMILY = "micro-diffusion"
 
@@ -96,38 +105,29 @@ def _spy(*a: Any, **k: Any) -> Any:
 fleet_cells.PendingSelfMint = _spy           # type: ignore[assignment]
 
 if MODE == "mint":
-    # Stand in for the child's packed cell. On a pod this is a real .pt2
-    # tarball out of a real AOTI link. The store itself does not care what the
-    # cell IS — but run 2 ARMS this cell, and since pgw#1098 the arm refuses
-    # `compiled_graph_envelope_unreadable` before any other gate, so the stand-in has to
-    # carry a readable `metadata.json` exactly as the real thing does.
-    art = Path(os.environ["PGW1096_ARTIFACT"])
-    art.parent.mkdir(parents=True, exist_ok=True)
-    _meta = json.dumps(
-        {"kind": "aot-inductor", "compiled_graph_key": KEY, "family": FAMILY}).encode()
-    _body = b"a-real-cell-would-be-here" * 40
-    with tarfile.open(art, mode="w:gz") as _tar:
-        _mi = tarfile.TarInfo("metadata.json")
-        _mi.size = len(_meta)
-        _tar.addfile(_mi, io.BytesIO(_meta))
-        _bi = tarfile.TarInfo("payload.bin")
-        _bi.size = len(_body)
-        _tar.addfile(_bi, io.BytesIO(_body))
+    # Stand in for the child's packed cell. On a pod this comes out of a real
+    # AOTI link; here it is a real TCG envelope built without torch, because
+    # since pgw#1283 the store hands its bytes to `Engine.import_artifact` and
+    # an artifact that does not unpack and restate its own key is refused.
+    ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
+    ARTIFACT.write_bytes(SOURCE.read_bytes())
     reason = fleet_cells.no_publish_sink_reason(None)
     stored = local_cell_store.store(
-        art, key=KEY, family=FAMILY, arm_token=ARM)
+        ARTIFACT, key=KEY, family=FAMILY, arm_token=ARM, cas_root=CAS)
+    materialized = local_cell_store.materialize(KEY, cas_root=CAS)
     print("RESULT " + json.dumps({
         "run": 1, "keep_reason": reason,
         "stored": stored is not None,
-        "stored_at_path": str(stored.artifact) if stored else "",
-        "digest": stored.content_digest if stored else "",
+        "key": KEY,
+        "bytes": stored.bytes if stored else 0,
+        "stored_at_path": str(materialized or ""),
     }))
 else:
     # A COLD process: no `_FINALIZED`, no pending, nothing warm. The only
-    # thing that exists is the directory run 1 wrote.
+    # thing that exists is what run 1 wrote to disk.
     assert not fleet_cells._FINALIZED, "a fresh process must start with no index"
     minted = fleet_cells.arm_from_local_store(
-        Pipe(), Cfg(), None, 0, Arm(), FAMILY)
+        Pipe(), Cfg(), CAS, 0, Arm(), FAMILY)
     print("RESULT " + json.dumps({
         "run": 2,
         "armed": minted is not None,
@@ -135,16 +135,27 @@ else:
         "artifact": str(getattr(minted, "artifact", "")),
         "mints_opened": len(opened_mints),
         "resident": [c.key for c in local_cell_store.stored_cells()],
+        "verdict": local_cell_store.verdict_of(KEY),
     }))
 '''
 
 
-def _run(mode: str, store: Path, artifact: Path) -> dict:
+def _source(tmp_path: Path) -> Path:
+    """One real TCG artifact, built once per test."""
+    import tcg_artifacts
+
+    return tcg_artifacts.build(tmp_path / "source" / "cell.tar.gz")
+
+
+def _run(mode: str, store: Path, artifact: Path, source: Path,
+         cas: Path) -> dict:
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(
         [str(REPO / "src"), str(REPO / "tests"), env.get("PYTHONPATH", "")])
     env["GEN_WORKER_LOCAL_CELLS_DIR"] = str(store)
     env["PGW1096_ARTIFACT"] = str(artifact)
+    env["PGW1096_SOURCE"] = str(source)
+    env["PGW1096_CAS"] = str(cas)
     proc = subprocess.run(
         [sys.executable, "-c", _PROGRAM, mode],
         capture_output=True, text=True, env=env, timeout=300)
@@ -155,34 +166,45 @@ def _run(mode: str, store: Path, artifact: Path) -> dict:
         f"run {mode!r} produced no result\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
 
 
+def _cas_object(cas: Path) -> Path:
+    """The one CAS object holding the artifact — the bytes TCG vouches for."""
+    objects = sorted(
+        (p for p in cas.rglob("*") if p.is_file()),
+        key=lambda p: p.stat().st_size)
+    assert objects, f"no CAS objects under {cas}"
+    return objects[-1]
+
+
 def test_run_one_mints_and_keeps_run_two_reuses_with_no_mint(
     tmp_path: Path,
 ) -> None:
     """Paul's compile-once-run-forever, across process death, measured."""
     store = tmp_path / "cozy-cells"
+    cas = tmp_path / "cas"
     artifact = tmp_path / "mint" / "cell.tar.gz"
+    source = _source(tmp_path)
 
-    one = _run("mint", store, artifact)
+    one = _run("mint", store, artifact, source, cas)
     assert one["stored"] is True
     # cozy-local's reason: no publisher was ever constructed, and no hub will
     # ever refuse this machine, because it never talks to one.
     assert one["keep_reason"] == "no_publish_sink"
-    assert one["digest"].startswith("sha256:")
+    assert one["bytes"] == source.stat().st_size
 
     # The mint's own workdir is gone, exactly as `_publish_async`'s `finally`
     # and `abandon_self_mint` leave it. Only the store survives — which is the
     # point: run 2 must not be reading the mint's leftovers.
     artifact.unlink()
 
-    two = _run("reuse", store, artifact)
+    two = _run("reuse", store, artifact, source, cas)
     assert two["armed"] is True, "the second run did not reuse the stored cell"
     assert two["mints_opened"] == 0, (
         "the second run opened a mint — compile-once-run-forever is the whole "
         "product promise and this is what breaking it looks like")
-    assert two["compiled_graph_key"] == "cg-key-v1-" + "c" * 56
+    assert two["compiled_graph_key"] == one["key"]
     assert two["artifact"].startswith(str(store)), (
         "run 2 must serve the STORE's bytes, not a leftover from the mint")
-    assert two["resident"] == ["cg-key-v1-" + "c" * 56]
+    assert two["resident"] == [one["key"]]
 
 
 def test_a_cold_run_with_an_EMPTY_store_mints_rather_than_inventing_a_hit(
@@ -191,26 +213,55 @@ def test_a_cold_run_with_an_EMPTY_store_mints_rather_than_inventing_a_hit(
     """The negative that makes the positive mean something: with nothing on
     disk the same cold process reports no arm, so `armed=True` above is the
     store's doing and not the stub's."""
-    two = _run("reuse", tmp_path / "empty-store", tmp_path / "unused.tar.gz")
+    two = _run("reuse", tmp_path / "empty-store", tmp_path / "unused.tar.gz",
+               _source(tmp_path), tmp_path / "empty-cas")
     assert two["armed"] is False
     assert two["resident"] == []
 
 
-def test_a_corrupted_store_makes_the_cold_run_refuse_and_drop(
+def test_cas_rot_refuses_the_arm_WITHOUT_becoming_this_workers_verdict(
     tmp_path: Path,
 ) -> None:
-    """RED, across processes: run 1 keeps a cell, the bytes rot on disk, and
-    the cold run refuses it, drops it and is left with an empty store — one
-    honest re-mint, never a wrong arm."""
+    """pgw#1283 criterion 4, across process death — the repairable case.
+
+    Run 1 keeps a cell. The bytes rot IN THE CAS, which is a fact about a
+    storage record: TCG quarantines it and no cold run may arm it. What must
+    NOT happen is the worker recording its own :data:`VERDICT_QUARANTINED` —
+    that verdict means "a parity/arm gate refused these bytes", it is terminal
+    by design (§1.3.4 keeps such a cell for forensics and never serves it), and
+    writing it here would strand a cell forever on a defect a re-store fixes.
+
+    Run 3 proves the repair: the same artifact is stored again, TCG repairs its
+    own record, and the cell arms — with no mint, because the worker's
+    admission was never destroyed.
+    """
     store = tmp_path / "cozy-cells"
+    cas = tmp_path / "cas"
     artifact = tmp_path / "mint" / "cell.tar.gz"
-    one = _run("mint", store, artifact)
-    stored = Path(one["stored_at_path"])
+    source = _source(tmp_path)
 
-    rotted = bytearray(stored.read_bytes())
+    one = _run("mint", store, artifact, source, cas)
+    assert one["stored"] is True
+
+    rotted = bytearray(_cas_object(cas).read_bytes())
     rotted[0] ^= 0xFF          # same length; only the content moved
-    stored.write_bytes(bytes(rotted))
+    _cas_object(cas).write_bytes(bytes(rotted))
+    # The materialized copy goes too, or TCG would hand back the export it
+    # already made instead of re-reading the record that rotted.
+    (store / "aot-cells" / one["key"] / "cell.tar.gz").unlink()
 
-    two = _run("reuse", store, artifact)
-    assert two["armed"] is False, "a corrupted cell armed on a cold boot"
-    assert two["resident"] == [], "the refused cell was not dropped"
+    two = _run("reuse", store, artifact, source, cas)
+    assert two["armed"] is False, "a cell TCG cannot verify armed on a cold boot"
+    assert two["verdict"] == "admitted", (
+        "a CAS-storage quarantine was written into this worker's verdict; a "
+        "repair can then never bring the cell back")
+    assert two["resident"] == [one["key"]], (
+        "the worker's own record must survive rot it did not cause")
+
+    three = _run("mint", store, artifact, source, cas)
+    assert three["stored"] is True, "re-storing the same artifact must repair"
+    four = _run("reuse", store, artifact, source, cas)
+    assert four["armed"] is True, (
+        "a repaired CAS record must arm again — the whole reason the two "
+        "quarantines are kept apart")
+    assert four["mints_opened"] == 0


### PR DESCRIPTION
`local_cell_store` kept a **second copy of every artifact TCG had already
admitted to its CAS**. `aot_compile_child:443` packs with TCG's own
`Engine.export_artifact`; `fleet_cells._stage_durable` — the single
`local_cell_store.store()` call site in the tree — then handed that file to a
module that hashed it, copied it to `<root>/aot-cells/<key>/cell.tar.gz`, and
**re-hashed it on every lookup**. Three digest passes over a
multi-hundred-megabyte artifact, all of them re-deriving what the CAS derived
on ingest. That duplication *is* the unit, and it is gone.

## The split as landed

| concern | before | after |
|---|---|---|
| artifact bytes, digest, storage quarantine | `local_cell_store._sha256_file`, `shutil.copy2`, digest re-verify at `:259`/`:378` | **TCG** — `Engine.import_artifact` / `Engine.export_artifact` |
| verdict, sink obligation, memo, trust class | `local_cell_store` | **stays** — a policy sidecar with no hashing left in it |

**The module got BIGGER, and that is the honest number**: 367 -> 436 code lines
(741 -> 931 total). Deleting the duplication removed ~30 lines; what was added
is the policy surface the split makes explicit — `verdict_of` /
`is_quarantined` (criterion 4a has to be able to ASK), `CellRecord` separated
from `LocalCell` so a scan cannot accidentally carry a materialized path
(criterion 5), `materialize()` with its own repair path, and `cas_root`
threading. "Smaller" was never the goal; **one authority over the bytes** was.

`store()` hands the artifact to `Engine.import_artifact`, which unpacks it,
checks that its metadata restates the key, admits its host ISA, and files it
under the exact-key ref. `lookup()` materializes it back through
`Engine.export_artifact`, which re-verifies the CAS record and the envelope
before it hands over a path. **The module contains no `sha256` and copies no
artifact** — asserted structurally by
`test_the_store_computes_no_digest_of_its_own`, not just observed.

The rule that falls out, and the one worth keeping:

> **Bytes are the authority on whether a cell EXISTS; the sidecar is the
> authority on whether it may be SERVED.**

So a record with no bytes is a clean miss, bytes with no record are a clean
miss, and both heal on the next `store()` of the same mint rather than needing
a repair pass. `drop()` narrowed to match: it forgets the worker's *permission
to serve* and leaves the content-addressed bytes alone, because they may be
exactly the bytes another key or route resolves.

`cas_root` is threaded from every caller that already carries a `cache_dir`
(`_stage_durable`, `_admit_durable`, `arm_from_local_store`,
`boot_adopt._local_answer`, `resume_owed_publishes`). That is not plumbing for
its own sake: `aot_serve.arm_compiled_graph` builds its engine with
`open_worker_engine(cache_dir)`, so a store that filed bytes at
`open_worker_engine(None)` would put them in a CAS the arm does not read.

**Checklist item 1 verified empirically before anything was built on it**
(the tracker asked for exactly this): a TCG-exported artifact re-imports as
`StoreOutcome.PRESENT`, and `export_artifact` round-trips it byte-identically.

## Criterion 4 — the two quarantines stay apart, in both directions

**4a — the load path must not bypass the WORKER's quarantine.** This is the
defect *the cutover creates*. §1.3.4 keeps a gate-refused cell
"quarantined-local for forensics"; before the split those bytes lived only in
`local_cell_store`, so no other path could reach them. They are now in the very
CAS `aot_serve.arm_compiled_graph` resolves runners from, and TCG has no notion
of a worker parity/arm refusal. `arm_compiled_graph` now asks
`local_cell_store.is_quarantined(key)` and refuses
`compiled_graph_worker_quarantined` **before `open_worker_engine` is called at
all** — a quarantined cell must not even be unpacked by the serving path.

Only the QUARANTINED verdict refuses. An `unverified` row is the normal state
of a cell §1.5 stored *before* the gate that is about to prove it, and a key
this worker never recorded is every hub-delivered cell there is; refusing
either would turn the guard into an outage. That half is its own test.

**4b — a TCG storage quarantine is NOT this worker's verdict.** Rot in the CAS
makes TCG quarantine its own record; that is repairable by re-storing the
bytes, and mirroring it into `verdict` — which §1.3.4 makes terminal — would
strand a healthy cell forever on a defect that fixes itself. `materialize()`
logs the TCG quarantine and returns a miss, and writes nothing. Proven with the
repair: re-store the same artifact, TCG repairs, the cell arms again, no mint.

**Evidence (red 5/5 each, re-run against the final rebased tree):**

| mutation | test that goes red | ratio |
|---|---|---|
| delete the `is_quarantined` guard in `arm_compiled_graph` | `test_a_worker_quarantined_key_is_refused_before_the_cas_is_asked` | **5/5** |
| `mark(key, verdict=QUARANTINED)` on TCG's `QuarantinedArtifact` | `test_cas_rot_never_becomes_the_workers_verdict_and_a_repair_restores_it` + `test_cas_rot_refuses_the_arm_WITHOUT_becoming_this_workers_verdict` (cross-process) | **5/5** |

The second one is proven twice: in-process, and across process death in
`test_two_run_reuse_pgw1096` — two fresh interpreters sharing only a directory,
which is where a "repair" that was really a stranding would show up.

## Criterion 7 — no crash-retry alias loss

`store()` is three durable steps: bytes into TCG, the policy record, the
arm-token alias. A crash after step 2 leaves bytes TCG reports `PRESENT` for on
the retry — and if `PRESENT` were allowed to skip the rest of the function the
alias would never be written again. The bytes survive and the **shortcut does
not**, so a machine with no boot-key route (§4.28's cozy-local box, which never
traces) pays a full compile on every boot for a cell it is holding.

Every step therefore runs on every call; which outcome came back is a fact for
the log, never a branch. `DIVERGENT` is the one outcome that refuses, and it
records nothing — a sidecar written there would file worker policy against
bytes nothing will resolve.

| mutation | test that goes red | ratio |
|---|---|---|
| `if outcome != PRESENT and arm_token: note_memo(...)` — i.e. "already stored, nothing to do" | `test_a_retry_after_a_crash_between_the_record_and_the_memo_restores_the_alias` | **5/5** |

Plus a structural fence: the only `StoreOutcome` comparison in the module is
the `DIVERGENT` refusal, asserted by AST, because the skip reads like an
optimisation to the next reader.

## Criterion 6 — resolved by default, Paul may veto

**The conflict.** NO-SHIP Review 1 requires *"collision-safe memo persistence
mandatory"* — memo persistence as part of store success. `local_cell_store`'s
own stated design is the opposite: *"a memo is a SHORTCUT, never an authority"*,
and the module docstring has said so since pgw#1096. The coordinator asked for a
Paul ruling; none was available, so a **coordinator default was applied and is
flagged here rather than buried**.

**What landed:** the memo **WRITE is collision-safe**; the memo's
**PERSISTENCE stays non-load-bearing**.

*Collision-safe half — implemented, and it fixed a real bug.* The temp name was
`<name>.tmp-<pid>`: one name per **process**, which is not a distinct name for
two **threads** of one process. The memo is written from the mint path and from
the arm path, and those do run concurrently — so two writers shared one temp
file, the second truncating and rewriting what the first was still filling, and
the first then `os.replace`d a torn interleaving under a name that says it is
atomic. It is now per-**write** (`pid` + `secrets.token_hex(8)`), fsynced, then
atomically replaced. Red 5/5 by reverting to the pid-only name
(`test_two_writes_to_one_memo_never_share_a_temporary_file`), asserted on the
temp NAMES rather than on a race, because a race that only sometimes reproduces
is not calibration. A 4-writer/4-reader concurrency test corroborates that no
reader ever observes a torn memo and no temp residue survives.

*Mandatory half — deliberately NOT implemented.* Reasoning:

1. **Cost asymmetry.** A memo that cannot be written costs one lookup — the
   next boot pays a derive instead. Making it mandatory means a full cache
   partition **fails a mint that has already succeeded**, i.e. converts a
   free miss into a GPU pod run.
2. **It re-opens the defect this issue was filed on.** pgw#1283's own defect 2
   was precisely that a failed memo write reported an unstored cell, and
   `fleet_cells._stage_durable` then emitted `local_compiled_graph_store_failed`
   for a cell `lookup` would happily find. "Mandatory" is that behaviour by
   another name.
3. **The alias is recoverable from evidence.** pgw#1127's boot-key route
   re-derives the address and `note_memo`s it after a proven arm, which is the
   whole cost argument for S2: a lost shortcut costs a **trace**, not a mint.
4. The review was written against **#807's rewritten `compiled_graph_store.py`**,
   which is dead code; the requirement never bound this module's design.

*What the deviation buys instead of silence is volume:* a failed memo write is
now logged at **warning** naming both the token and the key
(`test_a_memo_that_cannot_be_written_is_LOUD_and_still_a_stored_cell`). It was
`logger.debug`.

**If Paul rules the other way**, the change is small and local: move the
`note_memo` call back inside `store()`'s success path and return `None` when it
fails. The test above is the one that flips.

## A defect this work introduced, caught by an existing test

The first cut of `lookup()` rebuilt a missing arm alias from the record's own
`arm_token`. `test_an_arm_scheme_bump_costs_a_TRACE_and_not_a_MINT` went red:
the recorded token can belong to a **superseded arm-token scheme** that
`sweep_superseded_memos` has deliberately invalidated, so the heal resurrected
dead vocabulary and silently undid the sweep. The heal is deleted; the alias is
rebuilt by the route that just PROVED it, in the current scheme's token
(`fleet_cells.arm_from_local_store` -> `note_memo` on the boot-key route), and
crash-retry alias loss is closed in `store()` instead. The reasoning is a
comment at the site so it does not get re-added.

## Blast radius

**src (5):** `local_cell_store` (rewritten), `aot_serve` (criterion-4a guard),
`fleet_cells` (`cas_root` threading, the owed scan materializes per-cell,
`snapshot_digest` computed at its one consumer), `boot_adopt` (`cache_dir`
threaded to `_local_answer`), `pyproject.toml` (`tests/` on the pytest path).
`executor` and `compile_posture` reference the module only in prose and are
untouched.

**tests (9 + 2 new):** the store fixtures move to **real TCG envelopes** —
`tests/tcg_artifacts.py`, torch-free, ported from TCG's own artifact fixture.
Opaque bytes are now correctly refused at the seam, so a fixture that fed them
would be testing the refusal instead of the store; and keys are **derived from
the artifacts** rather than hand-typed, because filing bytes under a key their
own metadata does not restate is exactly what `Engine.import_artifact` refuses.
`tests/conftest.py`'s existing per-test store isolation is extended to the CAS
root, for its own stated reason: isolating the sidecar while leaving artifacts
in a shared store would isolate exactly the half that stopped holding anything.

## Suites run vs CI-carried

Run locally, `uv run --frozen`, on this final rebased tree:

* `tests/test_store_split_pgw1283.py` (new, 14), `test_store_corruption_pgw1283`
  (7), `test_aot_local_mint_pgw1096` (21), `test_durability_inversion_pgw1183`
  (10), `test_boot_adopt_local_first_pgw1127` (12), `test_local_serve_no_publisher_pgw1127`
  (15), `test_two_run_reuse_pgw1096` (3), `test_config_boundary_pgw931` (14),
  plus the 14 cache-root-adjacent files — **95 passed** in the store set,
  **174 passed / 17 skipped** in the adjacency sweep.
* All 4 red proofs, 5 runs each, re-run against this tree: **RED 5/5** on every
  one, and PASS unmutated. Restore verified by sha256 after every run.
* **24 of the 26 CI guard scripts** pass (the other two take arguments and were
  run separately: `assemble_changelog.py --check` passes;
  `lint_skip_census.py` needs the CI pytest artifact and is a no-op locally).
* `mypy src/gen_worker tests tests_v2`, baselined against an `origin/master`
  worktree: **75 errors / 32 files on both**, 733 sources checked here vs 731
  there — the two new test files, no new errors.

**Carried by CI, not by me:** `fast gates` (the required context) and the full
`tests` job. `torch` is not installed on this control-plane box by policy, so
`test_compile_politeness_pgw1137::test_a_stopped_local_mint_reuses_only_the_canonical_tcg_store`
skips-by-failing locally — **verified to fail identically on an `origin/master`
worktree with the same env**, so it records an env gap, not a regression.

**One pre-existing failure I did not fix and am naming:**
`test_local_serve_no_publisher_pgw1127::test_a_pending_this_process_cannot_drive_is_ended_not_dropped`
fails when run in the same process as `test_boot_adopt_local_first_pgw1127` —
`fleet_cells._PENDING` is not cleared between files (the `_fresh_cell_ledgers`
autouse fixture clears `_FINALIZED` only) and both files use the same `ARM_A`
token. **Reproduced identically on an `origin/master` worktree**, so it predates
this branch; CI's `--dist loadfile` hides it. Passes standalone. Worth its own
one-line fix in that fixture, deliberately not done here.

## Seam note — torchcg

Landed on the pin pgw master currently carries
(`torchcg@ad5f4cb`, distribution `torch-compiled-graphs` 0.6.0). torchcg has
since merged `7b5d639a` (hashrepo -> tensorfs, blobs instead of manifests).
**Checked symbol by symbol against that commit: every surface this split uses
is unchanged** — `Engine.__init__(cas: LocalCAS)`, `import_artifact`,
`export_artifact`, `StoreOutcome`'s four members, `StorageError`,
`QuarantinedArtifact`, and `_require_exact_file` still raising `FileExistsError`
on an occupied destination (which is what the re-export path here handles).
`export_artifact` still quarantines on a failed `verify_object`, so the
criterion-4 tests bind on the new custody path too. This module reaches TCG
only through `open_worker_engine()`, so the cutover costs it an import rename
and nothing else.

**Deliberately not repinned here**, because pgw master's own pin comment names
the owner: *"#1297 / #1308 replace these with pins at CURRENT tensorfs /
torchcg"*. Doing it in this PR would also rename `torch_compiled_graphs` ->
`torchcg` repo-wide and swap `hashrepo` -> `tensorfs` at
`models/cache_paths.py:53`, and current tensorfs is maturin-built where the
pinned rev is "pure-python hatchling ... so no Rust toolchain is pulled in".
Also **not** duplicating torchcg's verify-on-lookup compensation for its
0600 blobs: this module has no digest work at all, and a test asserts it.

## Not in this PR, and why

Tracker items 4, 5 and 6 stay open, honestly:

* **item 4/5 — the `GEN_WORKER_LOCAL_CELLS_DIR` deletion window** is a
  three-repo lockstep (pgw's two vendored corpora + allowlist + loader,
  tensorhub's `localcompiledgraphs`, cozy-local's `serveproc`/`cells`). The
  corpora must end byte-identical across all three, so deleting the row in pgw
  alone breaks `check_cozy_runtime_env_digest`. The layout
  (`aot-cells/<key>/cell.tar.gz` + `record.json`) is deliberately **preserved**
  by this PR so that contract holds while byte custody moves.
* **item 6 — closing `#806` / `#1213` / `#25` as superseded** follows the
  window, not this cut.