### PR TITLE
pgw#1310: the published wheel stops requiring two DELETED PyPI projects — vendor them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -522,6 +522,58 @@ jobs:
       - name: Build package
         run: uv build
 
+      # pgw#1310 / ie#738. BUILDING the wheel is not INSTALLING it, and the
+      # difference is a whole class of defect this workflow could not see: for
+      # two published releases `gen-worker`'s metadata required `hashrepo`, a
+      # PyPI project that had been DELETED, so every unlocked consumer install
+      # died at resolution while every check here stayed green. `uv sync
+      # --locked` cannot catch it — a lock resolves from sources (git pins
+      # included) that a published wheel does not carry.
+      #
+      # Deliberately in `fast gates` and not in `tests`: `tests` is neither
+      # required nor run on the queue ref, so a wheel gate living there proves
+      # nothing about what merges. ~40s, unlocked ON PURPOSE — it must resolve
+      # the artifact's own metadata against the real index, exactly as a
+      # consumer does.
+      - name: pgw#1310 gate - the built wheel installs from a clean venv
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/wheelcheck && mkdir -p /tmp/wheelcheck
+          uv build --wheel --out-dir /tmp/wheelcheck
+          uv venv --python 3.12 /tmp/wheelcheck/venv
+          uv pip install --python /tmp/wheelcheck/venv/bin/python \
+            /tmp/wheelcheck/gen_worker-*.whl
+          /tmp/wheelcheck/venv/bin/python - <<'PY'
+          import threading
+          from gen_worker._vendor.tensorfs import CASRef, LocalCAS, TransferGrant, download
+          from gen_worker._vendor.tensorfs.transfer import _run_parallel
+          from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND
+          from gen_worker._vendor.torch_compiled_graphs.contracts import read_contract
+
+          assert LocalCAS and download and ARTIFACT_KIND
+          assert read_contract("KEY_GRAMMAR_DIGEST")
+
+          # pgw#1287, asserted on the ARTIFACT: the second object cannot finish
+          # until the first object's progress callback has been observed.
+          grants = [TransferGrant(digest=CASRef.parse(f"sha256:{i:064x}"),
+                                  size_bytes=1024, url="https://e/x")
+                    for i in (1, 2)]
+          first, seen = threading.Event(), []
+
+          def worker(grant):
+              if grant.digest == grants[1].digest:
+                  assert first.wait(timeout=10.0), "no mid-batch progress: pgw#1287 fix absent"
+              return False
+
+          def progress(digest, size):
+              seen.append(size)
+              first.set()
+
+          report = _run_parallel(grants, worker, parallel=2, progress=progress)
+          assert report.succeeded == 2 and seen == [1024, 1024], (report, seen)
+          print("wheel installs clean; transfer path present and emitting")
+          PY
+
   # ~14m30s (measured p50 868s). The only job that can catch a behavioural
   # regression — and, since pgw#1264, NOT a required context and NOT part of the
   # merge path.

--- a/changelog.d/pgw1310.md
+++ b/changelog.d/pgw1310.md
@@ -1,0 +1,10 @@
+- The published wheel no longer requires `hashrepo` or `torch-compiled-graphs` from an index.
+  Both PyPI projects are permanently deleted, so every unlocked `pip install gen-worker` died at
+  resolution (ie#738, te#221, e2e#1893) while the repo itself looked fine — a `[tool.uv.sources]`
+  git pin is workspace metadata and is stripped from the artifact. Both packages are now VENDORED
+  at `src/gen_worker/_vendor`, pinned by rev in `_vendor/VENDORED.toml`, and carried inside the
+  wheel. The vendored `tensorfs` is `8bafdfbb`, which includes the pgw#1287 progress-emission fix:
+  a large snapshot download now advances its counter as each object lands instead of reporting
+  `0 / total` until the last byte, so the hub stops condemning pods that are downloading correctly.
+- `fast gates` now proves the built wheel INSTALLS into a clean venv and that the transfer path
+  imports and emits — building a wheel was never evidence that anyone could install it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,10 @@ dependencies = [
     "psutil>=7.0.0",
     "pyyaml>=6.0.0",
     "blake3>=1.0.0",
-    "hashrepo>=0.3,<0.4",
-    # pgw#1232/pgw#1270: TCG owns compiled-graph identity, declaration, call
-    # ingress, artifact format and compile-span attribution. Pure python — it
-    # neither installs nor imports Torch.
-    "torch-compiled-graphs>=0.6,<0.7",
+    # pgw#1310: the CAS/transfer data plane (tensorfs) and the compiled-graph
+    # vocabulary (TCG) are VENDORED at src/gen_worker/_vendor, not required from
+    # an index. Both PyPI projects are permanently deleted and `[tool.uv.sources]`
+    # does not travel in a published wheel. See _vendor/VENDORED.toml.
     "huggingface-hub>=0.26.0",
     # gen_worker.convert (GGUF quantization tooling; small, pure-python)
     "gguf>=0.10.0",
@@ -165,6 +164,13 @@ mypy_path = "src"
 # Generated protobuf modules: no source of ours to fix.
 [[tool.mypy.overrides]]
 module = ["gen_worker.pb.*"]
+ignore_errors = true
+
+# pgw#1310: vendored upstream snapshots. Same class as `gen_worker.pb.*` — the
+# tree is byte-identical to the pinned ref and a digest fence refuses any edit,
+# so a finding here is fixed upstream and re-vendored, never patched in place.
+[[tool.mypy.overrides]]
+module = ["gen_worker._vendor.*"]
 ignore_errors = true
 
 # Modules moved verbatim from the old gen_worker.conversion carry that
@@ -636,9 +642,12 @@ ignore_errors = true
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-# Generated modules are lint-exempt (mirrors the mypy overrides above).
+# Generated and vendored modules are lint-exempt (mirrors the mypy overrides
+# above). `_vendor` is byte-identical to its pinned upstream ref — a lint fix
+# applied here would break the digest fence and diverge the snapshot.
 extend-exclude = [
     "src/gen_worker/pb",
+    "src/gen_worker/_vendor",
 ]
 
 [tool.ruff.lint]
@@ -682,12 +691,8 @@ torch = [
 torchvision = [
   { index = "pytorch-cu130", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-# The hashrepo / torch-compiled-graphs PyPI projects were deleted permanently
-# (DESIGN-RULINGS "Release policy", 2026-08-16): internal consumption is
-# git-pinned, and nothing publishes to PyPI as a side effect of development.
-# These revs are the contents of the last published versions (0.3.1 / 0.6.0),
-# so the resolution is unchanged — only its source is. tensorfs is still
-# pure-python hatchling at this rev, so no Rust toolchain is pulled in.
-# #1297 / #1308 replace these with pins at CURRENT tensorfs / torchcg.
-hashrepo = { git = "https://github.com/cozy-creator/tensorfs", rev = "0d0437570aac241ed234b741e66af8c79492d872" }
-torch-compiled-graphs = { git = "https://github.com/cozy-creator/torchcg", rev = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368" }
+# pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood
+# here. A source pin is workspace-only metadata — it is stripped from a published
+# wheel — so it fixed this repo and left every consumer of the artifact broken
+# (ie#738). Both packages are now vendored: src/gen_worker/_vendor/VENDORED.toml
+# is the single home of the fact, revs included.

--- a/scripts/_lint_scope.py
+++ b/scripts/_lint_scope.py
@@ -1,0 +1,29 @@
+"""Which subtrees of `src/gen_worker` a repo guard may not judge, and why.
+
+ONE HOME for that fact. Each guard used to spell its own exclusion (or forget
+to), so a new such subtree meant finding every scanner by running them.
+
+A directory belongs here only when the code in it is NOT OURS TO CHANGE:
+
+* ``pb`` — generated from the .proto; the fix is in the .proto.
+* ``_vendor`` — byte-identical snapshots of upstream repos, pinned by rev and
+  held to a digest fence (pgw#1310). A guard finding here is fixed upstream and
+  re-vendored; edited in place it would break the fence and diverge the
+  snapshot. It is also not evidence about OUR architecture, which is what these
+  guards measure.
+
+This is not an allowlist for our own debt. Nothing else goes in it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Directory names, matched anywhere in a path under `src/gen_worker`.
+UNOWNED_DIRS = ("pb", "_vendor")
+
+
+def is_unowned(path: Path, root: Path | None = None) -> bool:
+    """True when `path` lies inside a subtree no guard here may judge."""
+    parts = (path.relative_to(root) if root is not None else path).parts
+    return any(name in parts for name in UNOWNED_DIRS)

--- a/scripts/lint_mypy_ratchet.py
+++ b/scripts/lint_mypy_ratchet.py
@@ -93,6 +93,8 @@ HIGH_WATER: Dict[str, Tuple[int, int]] = {
 #: exemption cannot be introduced by adding one line to pyproject.toml.
 DECLARED_WILDCARDS: Dict[str, str] = {
     "gen_worker.pb.*": "generated protobuf; no source of ours to fix",
+    "gen_worker._vendor.*": "vendored upstream snapshot; a digest fence refuses "
+                            "an in-place fix (pgw#1310)",
     "gen_worker.convert.*": "inherited from cozy_convert; bodies ARE checked",
     "tests.*": "test fns may be `def test_x():`; contract checks stay on",
     "tests_v2.*": "test fns may be `def test_x():`; contract checks stay on",

--- a/scripts/lint_settings_writers.py
+++ b/scripts/lint_settings_writers.py
@@ -50,6 +50,9 @@ from typing import Dict, List, Optional, Tuple
 
 REPO = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO / "src" / "gen_worker"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lint_scope import is_unowned  # noqa: E402
 ALLOWLIST = REPO / "scripts" / "settings_writers_allowlist.txt"
 
 CLASSIFICATIONS = {"SCOPED", "PLUMBING", "SCRUB"}
@@ -199,6 +202,8 @@ def scan(root: Path = SRC_ROOT) -> Dict[Tuple[str, str], int]:
     sites: Dict[Tuple[str, str], int] = {}
     for path in sorted(root.rglob("*.py")):
         if path.name in AUTHORITY_FILES and path.parent == root:
+            continue
+        if is_unowned(path, root):
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
         aliases = _Aliases()

--- a/scripts/lint_tcg_vocabulary.py
+++ b/scripts/lint_tcg_vocabulary.py
@@ -51,6 +51,9 @@ import tempfile
 from pathlib import Path
 from typing import Iterator, List, Tuple
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lint_scope import is_unowned  # noqa: E402
+
 REPO = Path(__file__).resolve().parents[1]
 DEFAULT_ROOT = REPO / "src" / "gen_worker"
 
@@ -112,8 +115,9 @@ def _python_files(roots: Iterator[Path]) -> Iterator[Path]:
             yield root
             continue
         for path in sorted(root.rglob("*.py")):
-            # Generated protobuf is owned by the .proto, not by a human.
-            if "pb" in path.relative_to(root).parts:
+            # Generated and vendored subtrees are not ours to respell — and the
+            # vendored TCG IS the authority this guard measures against.
+            if is_unowned(path, root):
                 continue
             yield path
 

--- a/scripts/lint_unbounded_reads.py
+++ b/scripts/lint_unbounded_reads.py
@@ -59,6 +59,9 @@ from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lint_scope import is_unowned  # noqa: E402
+
 # Calls whose result is a length taken from bytes the process did not compute.
 LENGTH_SOURCES = {"unpack", "unpack_from", "from_bytes"}
 
@@ -444,6 +447,8 @@ def scan_file(path: Path, src: str) -> list[str]:
 def main() -> int:
     findings: list[str] = []
     for py in sorted(SRC_ROOT.rglob("*.py")):
+        if is_unowned(py, SRC_ROOT):
+            continue
         findings.extend(scan_file(py, py.read_text(encoding="utf-8")))
 
     if findings:

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -68,6 +68,9 @@ TOOL_ROOTS = (REPO / "scripts", REPO / "examples", REPO / "agents",
 # as reach would exempt half the tree.
 SELF = Path(__file__).resolve()
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _lint_scope import is_unowned  # noqa: E402
+
 # The RATCHET. Every entry is a live hit, recorded rather than silently
 # tolerated: the guard fails on anything NEW, and equally on an entry that has
 # since been wired up and not removed. A baseline nobody has to shrink is a
@@ -440,6 +443,7 @@ def py_files(roots) -> List[Path]:
                        if "__pycache__" not in p.parts
                        and ".venv" not in p.parts
                        and p.name != "conftest.py"
+                       and not is_unowned(p)
                        and p.resolve() != SELF)
     return sorted(out)
 

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -1,0 +1,80 @@
+# Provenance for the vendored upstream snapshots under this directory.
+# THE SINGLE HOME OF THE FACT: nothing else records these revs.
+#
+# Why they are vendored rather than depended on (pgw#1310, ie#738):
+# both PyPI projects were deleted permanently (DESIGN-RULINGS "Release policy",
+# Paul 2026-08-16 — "just use a vendored version of our local library if you
+# need to"), and a `[tool.uv.sources]` git pin is workspace-only metadata that
+# is STRIPPED from a published wheel. So a source pin fixed this repo and left
+# every consumer of the artifact unable to resolve `gen-worker` at all.
+#
+# The snapshots are byte-identical to upstream except for the `rewrites` listed
+# per package. `tests/test_vendored_snapshot_pgw1310.py` refuses any other edit
+# (per-file sha256) and separately proves the BEHAVIOUR the pinned rev exists
+# for, so neither fence can pass on a stale or hand-patched tree.
+#
+# To re-vendor: `git archive <rev> <subdir> | tar -x` into the package
+# directory, re-apply `rewrites`, then regenerate the `files` tables.
+
+[packages.tensorfs]
+repo = "https://github.com/cozy-creator/tensorfs"
+rev = "8bafdfbb112be57cc96c0c71c38fd987091cbf51"
+subdir = "python/src/tensorfs"
+# Why THIS rev and not the tip: upstream `master` is a v0.1.0 genesis restart
+# that deleted this data plane outright (no `transfer`, `journal`, `chunking`);
+# `8bafdfbb` is the merge of tensorfs#41, the last lineage that still carries
+# `LocalCAS` + `download`/`upload` AND the pgw#1287 progress-emission fix
+# (`626a3de` per-object emission + `6c1f2ab` resident objects advance too).
+# A 31.6 GB snapshot reporting `0 / total` for its whole duration is what got
+# correctly-downloading pods condemned by the hub's 6-minute freshness window.
+# The delta from the last published `hashrepo` 0.3.1 (`0d043757`) is exactly:
+# the package rename, the new `daemon` module, and that fix. Nothing else.
+rewrites = []
+
+[packages.torch_compiled_graphs]
+repo = "https://github.com/cozy-creator/torchcg"
+rev = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368"
+subdir = "src/torch_compiled_graphs"
+# The contents of the last published `torch-compiled-graphs` 0.6.0, i.e. what
+# `uv.lock` already resolved — vendoring changes the source, not the code.
+# Upstream `master` is likewise a genesis restart (package renamed `torchcg`).
+rewrites = [
+  "`from hashrepo import ...` -> `from ..tensorfs import ...` in cli.py, engine.py, storage.py (3 lines; upstream's own dependency, vendored beside it)",
+]
+
+[packages.tensorfs.files]
+"__init__.py" = "7cb8f071b7864a92f55e1b4472fc13d4b7e46923db23b063139671ac9fbf6fa2"
+"chunking.py" = "69333dc0836f35b05c420780b7eac205993ebde54c1b91b1afe03e55c313bd7a"
+"daemon.py" = "0af2b1b740dbedd49ff8afdc76d444fb5cd7c66369fe6979528c3d63c1ce5359"
+"journal.py" = "e2da6aa608d1a690f46af8d1ed7b2d61492df093a7866e0fd73894133b5f198e"
+"local.py" = "92ec0d1249115f08eb02fccf554e946d36854a4ae861bde8190590d404695e0e"
+"manifest.py" = "a93ee850992c17dd90a57946441875d282367556703b9e9d1c8be057ea12bed4"
+"py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+"refs.py" = "f3a144543f423a6b01043294b21104ababaafdbfb31798560de678b69f27ac2f"
+"transfer.py" = "5a365ec55d3cedefa088171eb4c9554edf0c951a3b0a1cad390dba486924a143"
+
+[packages.torch_compiled_graphs.files]
+"__init__.py" = "401efd9450c0181f32c64ccee1d21999d78e77dc2be5ef404c27e539e350d4a9"
+"__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
+"_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
+"_wrapper_split.py" = "9cd2cc594f4b2f3a782ecf2d2f9a8204b323c54247f9f7f348ad50c32a3046fd"
+"artifact.py" = "3eb4332d5865ad28b0b9a8fd2be9ea08e0911d0a7b8da55439c8151649f2815d"
+"cli.py" = "18ad75c67ad84eecf92f4470561070a5d07603674aaec59ce91c93a21efb1b4b"
+"compiler.py" = "8450b10e90ca8c6d8c411654d963ebc16dd3580bfe1427cce3966fc2b03972a7"
+"contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"
+"contracts/__init__.py" = "aab5aa1680ac4761f12e7da8695c370c4b4aea0c8fbee849a6a301184b1c7350"
+"contracts/call_ingress_v1.json" = "3af3437ec20b15156892055ab89bf21621378cee9f0f72f63bc4626f69f242dc"
+"contracts/compiled_graph_key_vectors.json" = "a274c5702b8c167ca119758d9fb1f98c40ddfdb3dbf6c58b4aacd580803e8c2b"
+"contracts/graph_class_identity_v3.json" = "f3e947e5c770e0766f7dfe37b753bd8d184b1e8923f5a3995823a8427a637b30"
+"contracts/literal_identity_v1.json" = "50cb80e750a8124a45b982415258d8590c37f90ca804326588dfde1b368c6863"
+"contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
+"declaration.py" = "187be0a12f05b8bbdca01f3c180527abff66ed60a3fb1e6281704d24d9559d79"
+"engine.py" = "3afc7c2a3b94b8852a48e660b62bceebe40156e34f66769f4c590c42f9585e87"
+"host_isa.py" = "8fbdd6250b284408e959c5c07b3ae86289c3d3e50ae46efc46b74ced24c8d725"
+"identity.py" = "6e6bb23b319bd1606bd313d7177877ba79fb16936536cf074d96049bc5a9482f"
+"ingress.py" = "3a679c046236e13965b76b391fb201272aaba297fcc49e64c6c46d41df0575a4"
+"introspection.py" = "99310298249ee2ada91544bcdbd91f06e33a44f136c525cb268ca8d7125aa9e5"
+"py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+"runner.py" = "075d7e743a82555e7ac1b15eb7ca54df9d0bcdc914de649a675fa5d973c8c693"
+"spans.py" = "7a9722b5068c36ce62350e4ffe0eea07aa4ee5506330c9816069054001a10472"
+"storage.py" = "52e785b53f7de6e2fb71d9ac104249e89974d8f1dc3f6081412058aee7b5908f"

--- a/src/gen_worker/_vendor/__init__.py
+++ b/src/gen_worker/_vendor/__init__.py
@@ -1,0 +1,31 @@
+"""Vendored upstream snapshots. See VENDORED.toml for revs and rationale.
+
+Import them by their full path (``gen_worker._vendor.tensorfs``) so nothing can
+confuse a vendored snapshot with a same-named distribution installed beside it —
+which is exactly what the #1295 native-reader cutover will do with the current
+``tensorfs``. Nothing is re-exported here.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from functools import lru_cache
+from pathlib import Path
+
+_MANIFEST = Path(__file__).with_name("VENDORED.toml")
+
+
+@lru_cache(maxsize=None)
+def vendored_rev(package: str) -> str:
+    """The upstream commit a vendored package was taken at.
+
+    The identity a caller used to read from installed distribution metadata.
+    A vendored package HAS no distribution, and `importlib.metadata` answers
+    that by raising — which every caller then swallowed into an empty string,
+    silently dropping the component from whatever key it fed. The rev is
+    strictly more exact than the release string it replaces.
+    """
+    packages = tomllib.loads(_MANIFEST.read_text())["packages"]
+    if package not in packages:
+        raise KeyError(f"{package} is not vendored; see {_MANIFEST}")
+    return str(packages[package]["rev"])

--- a/src/gen_worker/_vendor/tensorfs/__init__.py
+++ b/src/gen_worker/_vendor/tensorfs/__init__.py
@@ -1,0 +1,83 @@
+"""Content-addressed local storage and chunk manifests."""
+
+from typing import TYPE_CHECKING, Any
+
+from .journal import TransferJournal, TransferSession
+from .local import DigestMismatch, LocalCAS, RefConflict
+from .manifest import MAX_CHUNK_SIZE, Chunk, FileEntry, RepositoryManifest
+from .refs import CASRef
+
+if TYPE_CHECKING:
+    from .daemon import (
+        DaemonClient,
+        DaemonError,
+        DaemonHello,
+        DaemonMount,
+        DaemonStatus,
+        MountedPath,
+    )
+    from .transfer import (
+        TransferGrant,
+        TransferReport,
+        download,
+        upload,
+    )
+
+_TRANSFER_EXPORTS = frozenset(
+    (
+        "TransferGrant",
+        "TransferReport",
+        "download",
+        "upload",
+    )
+)
+
+_DAEMON_EXPORTS = frozenset(
+    (
+        "DaemonClient",
+        "DaemonError",
+        "DaemonHello",
+        "DaemonMount",
+        "DaemonStatus",
+        "MountedPath",
+    )
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _TRANSFER_EXPORTS:
+        from . import transfer
+
+        value = getattr(transfer, name)
+    elif name in _DAEMON_EXPORTS:
+        from . import daemon
+
+        value = getattr(daemon, name)
+    else:
+        raise AttributeError(name)
+    globals()[name] = value
+    return value
+
+
+__all__ = [
+    "CASRef",
+    "Chunk",
+    "DaemonClient",
+    "DaemonError",
+    "DaemonHello",
+    "DaemonMount",
+    "DaemonStatus",
+    "DigestMismatch",
+    "FileEntry",
+    "LocalCAS",
+    "MAX_CHUNK_SIZE",
+    "MountedPath",
+    "RefConflict",
+    "RepositoryManifest",
+    "TransferGrant",
+    "TransferJournal",
+    "TransferReport",
+    "TransferSession",
+    "download",
+    "upload",
+]

--- a/src/gen_worker/_vendor/tensorfs/chunking.py
+++ b/src/gen_worker/_vendor/tensorfs/chunking.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from typing import BinaryIO
+
+from .manifest import MAX_CHUNK_SIZE
+
+# 50 GiB / 64 MiB = 800 objects only when boundaries fill perfectly. A greedy
+# small-tensor run of S bytes needs fewer than 2*S/64MiB + 1 packs; large tensors
+# use ceil(size / 64 MiB). On 2026-08-13, 186
+# unique local layouts measured 3,226 aligned objects vs 2,397 fixed (1.346x);
+# 32/16/4 MiB floors cost 2.272x/3.378x/7.988x. Thus 64 MiB controls R2 request
+# count while bounding one changed small-tensor pack to <64 MiB. te#185 phase 4
+# measures the real savings of the automatic policy on a frozen-base LoRA series.
+_FIXED_CHUNK_BYTES = MAX_CHUNK_SIZE
+_TENSOR_FLOOR_BYTES = MAX_CHUNK_SIZE
+_TENSOR_STRIDE_BYTES = MAX_CHUNK_SIZE
+# safetensors 0.8.0's Rust reader refuses header lengths above 100,000,000
+# bytes (MAX_HEADER_SIZE in safetensors/src/tensor.rs). Match that format
+# boundary instead of conflating it with TensorFS's smaller object ceiling;
+# the header region is sub-split below when it exceeds one CAS object.
+_MAX_SAFETENSORS_HEADER_BYTES = 100_000_000
+# TensorFS v1 targets 64-bit Linux/POSIX. Safetensors decodes every shape
+# dimension into Rust usize before it checks tensor byte lengths.
+_MAX_USIZE = (1 << 64) - 1
+
+# This mirrors safetensors::tensor::Dtype::bitsize at upstream 6eb4dc9. Unknown
+# future dtypes take the safe fixed-boundary fallback instead of being guessed here.
+_DTYPE_BITS = {
+    "F4": 4,
+    "F6_E2M3": 6,
+    "F6_E3M2": 6,
+    "BOOL": 8,
+    "U8": 8,
+    "I8": 8,
+    "F8_E5M2": 8,
+    "F8_E4M3": 8,
+    "F8_E8M0": 8,
+    "F8_E5M2FNUZ": 8,
+    "F8_E4M3FNUZ": 8,
+    "I16": 16,
+    "U16": 16,
+    "F16": 16,
+    "BF16": 16,
+    "I32": 32,
+    "U32": 32,
+    "F32": 32,
+    "I64": 64,
+    "U64": 64,
+    "F64": 64,
+    "C64": 64,
+}
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate safetensors header key {key!r}")
+        result[key] = value
+    return result
+
+
+def _fixed_lengths(size: int) -> tuple[int, ...]:
+    if size <= _FIXED_CHUNK_BYTES:
+        return ()
+    full, remainder = divmod(size, _FIXED_CHUNK_BYTES)
+    lengths = (_FIXED_CHUNK_BYTES,) * full
+    return lengths + ((remainder,) if remainder else ())
+
+
+def _tensor_spans(source: BinaryIO, size: int) -> tuple[int, tuple[tuple[int, int], ...]] | None:
+    if size < 10:
+        return None
+    source.seek(0)
+    prefix = source.read(8)
+    if len(prefix) != 8:
+        return None
+    header_length = int.from_bytes(prefix, "little")
+    header_end = 8 + header_length
+    if (
+        header_length < 2
+        or header_length > _MAX_SAFETENSORS_HEADER_BYTES
+        or header_end > size
+    ):
+        return None
+    header_bytes = source.read(header_length)
+    if len(header_bytes) != header_length or not header_bytes.startswith(b"{"):
+        return None
+    try:
+        raw = json.loads(header_bytes, object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    metadata = raw.pop("__metadata__", None)
+    if metadata is not None and (
+        not isinstance(metadata, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in metadata.items()
+        )
+    ):
+        return None
+
+    spans: list[tuple[int, int]] = []
+    for name, value in raw.items():
+        if (
+            not name
+            or not isinstance(value, dict)
+            or set(value) != {"dtype", "shape", "data_offsets"}
+        ):
+            return None
+        dtype = value["dtype"]
+        shape = value["shape"]
+        offsets = value["data_offsets"]
+        if not isinstance(dtype, str) or dtype not in _DTYPE_BITS:
+            return None
+        if not isinstance(shape, list) or any(
+            type(dimension) is not int or not 0 <= dimension <= _MAX_USIZE
+            for dimension in shape
+        ):
+            return None
+        if (
+            not isinstance(offsets, list)
+            or len(offsets) != 2
+            or any(type(offset) is not int for offset in offsets)
+        ):
+            return None
+        start, end = offsets
+        if start < 0 or end < start or end > _MAX_USIZE:
+            return None
+        dtype_bits = _DTYPE_BITS[dtype]
+        body_bits = (end - start) * 8
+        elements = 1
+        for dimension in shape:
+            if dimension and elements > _MAX_USIZE // dimension:
+                return None
+            elements *= dimension
+        if elements and dtype_bits > _MAX_USIZE // elements:
+            return None
+        tensor_bits = elements * dtype_bits
+        if tensor_bits != body_bits:
+            return None
+        spans.append((start, end))
+
+    spans.sort()
+    data_size = size - header_end
+    cursor = 0
+    for start, end in spans:
+        if start != cursor or end > data_size:
+            return None
+        cursor = end
+    if cursor != data_size:
+        return None
+    return header_end, tuple(spans)
+
+
+def _tensor_lengths(header_end: int, spans: tuple[tuple[int, int], ...]) -> tuple[int, ...]:
+    header_chunks, header_remainder = divmod(header_end, MAX_CHUNK_SIZE)
+    lengths = [MAX_CHUNK_SIZE] * header_chunks
+    if header_remainder:
+        lengths.append(header_remainder)
+    packed = 0
+
+    def flush_pack() -> None:
+        nonlocal packed
+        if packed:
+            lengths.append(packed)
+            packed = 0
+
+    for start, end in spans:
+        tensor_bytes = end - start
+        if tensor_bytes == 0:
+            continue
+        if tensor_bytes >= _TENSOR_FLOOR_BYTES:
+            flush_pack()
+            full, remainder = divmod(tensor_bytes, _TENSOR_STRIDE_BYTES)
+            lengths.extend((_TENSOR_STRIDE_BYTES,) * full)
+            if remainder:
+                lengths.append(remainder)
+            continue
+        if packed and packed + tensor_bytes > _TENSOR_FLOOR_BYTES:
+            flush_pack()
+        packed += tensor_bytes
+    flush_pack()
+    return tuple(lengths)
+
+
+def plan_chunks(source: BinaryIO, size: int) -> tuple[int, ...]:
+    """Plan the sole current writer layout for one file.
+
+    Structurally valid safetensors use tensor-stable boundaries. Every other
+    file uses bounded fixed offsets. This decision is automatic and cannot be
+    selected by callers.
+    """
+
+    parsed = _tensor_spans(source, size)
+    if parsed is None:
+        return _fixed_lengths(size)
+    return _tensor_lengths(*parsed)

--- a/src/gen_worker/_vendor/tensorfs/daemon.py
+++ b/src/gen_worker/_vendor/tensorfs/daemon.py
@@ -1,0 +1,216 @@
+"""The pure-Python typed client for the tensorfsd control socket.
+
+This module is a control plane only: length-framed JSON over the daemon's
+mode-0600 Unix socket, eight methods, frames bounded to 1 MiB, and never a
+file, block, or manifest byte. Bulk data moves through the mounted paths the
+daemon returns. There is no parser, hashing, native extension, or fallback
+engine here, and importing it starts nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Any
+
+MAX_FRAME_BYTES = 1024 * 1024
+PROTOCOL = 1
+
+__all__ = [
+    "MAX_FRAME_BYTES",
+    "PROTOCOL",
+    "DaemonClient",
+    "DaemonError",
+    "DaemonHello",
+    "DaemonMount",
+    "DaemonStatus",
+    "MountedPath",
+]
+
+
+class DaemonError(RuntimeError):
+    """One typed daemon refusal carrying the server's stable kebab code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonHello:
+    protocol: int
+    server: str
+    version: str
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonMount:
+    lease: int
+    kind: str
+    target: str
+    mountpoint: str
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonStatus:
+    store: str
+    mounts: tuple[DaemonMount, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MountedPath:
+    lease: int
+    mountpoint: str
+
+
+def _require_str(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise DaemonError("malformed-frame", f"{field} must be a string")
+    return value
+
+
+def _require_int(value: object, field: str) -> int:
+    if type(value) is not int:
+        raise DaemonError("malformed-frame", f"{field} must be an integer")
+    return value
+
+
+class DaemonClient:
+    """One connection to a tensorfsd control socket.
+
+    Leases are connection-bound: every mount opened through this client is
+    torn down by the daemon when the connection closes, so long-lived mounts
+    need a long-lived client.
+    """
+
+    def __init__(self, socket_path: str) -> None:
+        self._path = socket_path
+        self._socket: socket.socket | None = None
+        self._next_id = 0
+
+    def __enter__(self) -> DaemonClient:
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connection.connect(self._path)
+        self._socket = connection
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+
+    def _live(self) -> socket.socket:
+        if self._socket is None:
+            raise DaemonError("not-connected", "use the client as a context manager")
+        return self._socket
+
+    def _read_exact(self, count: int) -> bytes:
+        connection = self._live()
+        chunks = bytearray()
+        while len(chunks) < count:
+            block = connection.recv(count - len(chunks))
+            if not block:
+                raise DaemonError("connection-closed", "the daemon hung up mid-frame")
+            chunks.extend(block)
+        return bytes(chunks)
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        connection = self._live()
+        self._next_id += 1
+        request = json.dumps(
+            {"id": self._next_id, "method": method, "params": params}
+        ).encode()
+        if len(request) > MAX_FRAME_BYTES:
+            raise DaemonError("frame-too-large", "request exceeds the 1 MiB frame bound")
+        connection.sendall(struct.pack("<I", len(request)) + request)
+
+        (length,) = struct.unpack("<I", self._read_exact(4))
+        if length == 0 or length > MAX_FRAME_BYTES:
+            raise DaemonError("frame-too-large", f"daemon frame of {length} bytes refused")
+        raw = json.loads(self._read_exact(length))
+        if not isinstance(raw, dict):
+            raise DaemonError("malformed-frame", "a response is one JSON object")
+        error = raw.get("error")
+        if isinstance(error, dict):
+            raise DaemonError(
+                _require_str(error.get("code"), "error code"),
+                _require_str(error.get("message"), "error message"),
+            )
+        if raw.get("id") != self._next_id:
+            raise DaemonError("malformed-frame", "response id does not match the request")
+        ok = raw.get("ok")
+        if not isinstance(ok, dict):
+            raise DaemonError("malformed-frame", "a success response carries an ok object")
+        return ok
+
+    def hello(self) -> DaemonHello:
+        ok = self._call("hello", {})
+        return DaemonHello(
+            protocol=_require_int(ok.get("protocol"), "protocol"),
+            server=_require_str(ok.get("server"), "server"),
+            version=_require_str(ok.get("version"), "version"),
+        )
+
+    def status(self) -> DaemonStatus:
+        ok = self._call("status", {})
+        rows = ok.get("mounts")
+        if not isinstance(rows, list):
+            raise DaemonError("malformed-frame", "status carries a mounts list")
+        mounts = tuple(
+            DaemonMount(
+                lease=_require_int(row.get("lease"), "lease"),
+                kind=_require_str(row.get("kind"), "kind"),
+                target=_require_str(row.get("target"), "target"),
+                mountpoint=_require_str(row.get("mountpoint"), "mountpoint"),
+            )
+            for row in rows
+            if isinstance(row, dict)
+        )
+        return DaemonStatus(store=_require_str(ok.get("store"), "store"), mounts=mounts)
+
+    def open_snapshot(self, snapshot: str) -> MountedPath:
+        ok = self._call("open_snapshot", {"snapshot": snapshot})
+        return MountedPath(
+            lease=_require_int(ok.get("lease"), "lease"),
+            mountpoint=_require_str(ok.get("mountpoint"), "mountpoint"),
+        )
+
+    def create_workspace(
+        self, workspace: str, *, from_snapshot: str | None = None
+    ) -> MountedPath:
+        params: dict[str, Any] = {"workspace": workspace}
+        if from_snapshot is not None:
+            params["from_snapshot"] = from_snapshot
+        ok = self._call("create_workspace", params)
+        return MountedPath(
+            lease=_require_int(ok.get("lease"), "lease"),
+            mountpoint=_require_str(ok.get("mountpoint"), "mountpoint"),
+        )
+
+    def commit_workspace(self, workspace: str, *, parent: str | None = None) -> str:
+        params: dict[str, Any] = {"workspace": workspace}
+        if parent is not None:
+            params["parent"] = parent
+        ok = self._call("commit_workspace", params)
+        return _require_str(ok.get("snapshot"), "snapshot")
+
+    def push_snapshot(self, snapshot: str) -> None:
+        self._call("push_snapshot", {"snapshot": snapshot})
+
+    def release(self, lease: int) -> None:
+        self._call("release", {"lease": lease})
+
+    def delete_workspace(self, workspace: str) -> None:
+        self._call("delete_workspace", {"workspace": workspace})

--- a/src/gen_worker/_vendor/tensorfs/journal.py
+++ b/src/gen_worker/_vendor/tensorfs/journal.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from .refs import CASRef
+
+
+@dataclass(frozen=True, slots=True)
+class TransferSession:
+    """The remote session that owns one manifest upload in progress."""
+
+    name: str
+    session_id: str
+    manifest: CASRef
+
+    def __post_init__(self) -> None:
+        if not self.name or any(ord(char) < 32 or ord(char) == 127 for char in self.name):
+            raise ValueError("journal name must be non-empty and contain no controls")
+        if not self.session_id or any(
+            ord(char) < 32 or ord(char) == 127 for char in self.session_id
+        ):
+            raise ValueError("session id must be non-empty and contain no controls")
+        object.__setattr__(self, "manifest", CASRef.parse(self.manifest))
+
+
+class TransferJournal:
+    """A process-safe durable map from caller operation names to sessions.
+
+    The caller owns the meaning of ``name`` and obtains grants. TensorFS stores
+    only the remote session and manifest identity needed to ask that service for
+    a resumed plan after a restart.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.lock_path = self.path.with_name(f".{self.path.name}.lock")
+
+    def _read_unlocked(self) -> dict[str, TransferSession]:
+        if not self.path.exists():
+            return {}
+        raw = json.loads(self.path.read_bytes())
+        if not isinstance(raw, dict) or raw.get("format") != 1:
+            raise ValueError(f"transfer journal {self.path} is malformed")
+        sessions = raw.get("sessions")
+        if not isinstance(sessions, list):
+            raise ValueError(f"transfer journal {self.path} is malformed")
+        result: dict[str, TransferSession] = {}
+        for item in sessions:
+            if not isinstance(item, dict) or set(item) != {"name", "session_id", "manifest"}:
+                raise ValueError(f"transfer journal {self.path} is malformed")
+            if not all(isinstance(item[field], str) for field in item):
+                raise ValueError(f"transfer journal {self.path} is malformed")
+            session = TransferSession(
+                name=item["name"],
+                session_id=item["session_id"],
+                manifest=CASRef.parse(item["manifest"]),
+            )
+            if session.name in result:
+                raise ValueError(f"transfer journal {self.path} contains a duplicate name")
+            result[session.name] = session
+        return result
+
+    def _write_unlocked(self, sessions: dict[str, TransferSession]) -> None:
+        payload = json.dumps(
+            {
+                "format": 1,
+                "sessions": [
+                    {
+                        "name": session.name,
+                        "session_id": session.session_id,
+                        "manifest": str(session.manifest),
+                    }
+                    for session in sorted(sessions.values(), key=lambda item: item.name)
+                ],
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, raw_path = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=self.path.parent
+        )
+        temporary = Path(raw_path)
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            directory = os.open(
+                self.path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+            )
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def _lock(self) -> BinaryIO:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        return self.lock_path.open("a+b")
+
+    def find(self, name: str, manifest: str | CASRef) -> TransferSession | None:
+        expected = CASRef.parse(manifest)
+        with self._lock() as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_SH)
+            session = self._read_unlocked().get(name)
+        return session if session is not None and session.manifest == expected else None
+
+    def record(self, session: TransferSession) -> None:
+        with self._lock() as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            sessions = self._read_unlocked()
+            sessions[session.name] = session
+            self._write_unlocked(sessions)
+
+    def clear(self, name: str, *, session_id: str) -> bool:
+        with self._lock() as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            sessions = self._read_unlocked()
+            current = sessions.get(name)
+            if current is None or current.session_id != session_id:
+                return False
+            del sessions[name]
+            self._write_unlocked(sessions)
+            return True

--- a/src/gen_worker/_vendor/tensorfs/local.py
+++ b/src/gen_worker/_vendor/tensorfs/local.py
@@ -1,0 +1,690 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import time
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from .chunking import plan_chunks
+from .manifest import Chunk, FileEntry, RepositoryManifest
+from .refs import CASRef
+
+_COPY_BUFFER = 1 << 20
+
+
+class DigestMismatch(ValueError):
+    """Bytes did not hash to the content reference they were stored under."""
+
+
+class RefConflict(RuntimeError):
+    """A logical ref changed from the value the caller observed."""
+
+
+@dataclass(frozen=True, slots=True)
+class GCReport:
+    """One reachability collection pass."""
+
+    examined: int
+    reachable: int
+    deleted: int
+    bytes_deleted: int
+
+
+class _ObjectWriter:
+    def __init__(self, handle: BinaryIO) -> None:
+        self._handle = handle
+        self._digest = hashlib.sha256()
+        self.size = 0
+
+    def write(self, data: bytes) -> int:
+        written = self._handle.write(data)
+        self._digest.update(data[:written])
+        self.size += written
+        return written
+
+    def flush(self) -> None:
+        self._handle.flush()
+
+    def fileno(self) -> int:
+        return self._handle.fileno()
+
+    @property
+    def ref(self) -> CASRef:
+        return CASRef(self._digest.hexdigest())
+
+
+def _fsync_dir(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _copy_and_hash(
+    source: BinaryIO, destination: BinaryIO, limit: int | None = None
+) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    copied = 0
+    while limit is None or copied < limit:
+        wanted = _COPY_BUFFER if limit is None else min(_COPY_BUFFER, limit - copied)
+        data = source.read(wanted)
+        if not data:
+            break
+        destination.write(data)
+        digest.update(data)
+        copied += len(data)
+    return digest.hexdigest(), copied
+
+
+class LocalCAS:
+    """Authoritative immutable local storage.
+
+    Objects are installed without overwrite. Logical refs are tiny atomic
+    records updated under a process-shared file lock. A new ``LocalCAS``
+    instance can resolve everything written by a previous process.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.objects = self.root / "objects"
+        self.refs = self.root / "refs"
+        self.locks = self.root / "locks"
+        self.tmp = self.root / "tmp"
+        for directory in (self.objects, self.refs, self.locks, self.tmp):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    @contextmanager
+    def _store_lock(self, *, exclusive: bool = False) -> Iterator[None]:
+        """Coordinate collection with object and logical-ref operations."""
+
+        with (self.locks / "store").open("a+b") as handle:
+            mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+            fcntl.flock(handle.fileno(), mode)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def object_path(self, ref: str | CASRef) -> Path:
+        parsed = CASRef.parse(ref)
+        return self.root / parsed.object_key()
+
+    def _verify_object_unlocked(self, parsed: CASRef, size: int | None) -> Path:
+        path = self.object_path(parsed)
+        stat = path.stat()
+        if size is not None and stat.st_size != size:
+            raise DigestMismatch(f"{parsed}: object is {stat.st_size} bytes, expected {size}")
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            while data := handle.read(_COPY_BUFFER):
+                digest.update(data)
+        if digest.hexdigest() != parsed.digest:
+            raise DigestMismatch(f"{parsed}: local object bytes do not match their digest")
+        return path
+
+    def verify_object(self, ref: str | CASRef, *, size: int | None = None) -> Path:
+        parsed = CASRef.parse(ref)
+        with self._store_lock():
+            with self._object_lock(parsed):
+                return self._verify_object_unlocked(parsed, size)
+
+    def contains(self, ref: str | CASRef, *, size: int | None = None) -> bool:
+        try:
+            self.verify_object(ref, size=size)
+        except FileNotFoundError:
+            return False
+        return True
+
+    @staticmethod
+    def _require_identity(path: Path, expected: tuple[int, int]) -> None:
+        try:
+            current = path.stat(follow_symlinks=False)
+        except FileNotFoundError as exc:
+            raise OSError(f"{path} changed after verification") from exc
+        if (current.st_dev, current.st_ino) != expected:
+            raise OSError(f"{path} changed after verification")
+
+    def _commit_temp(
+        self,
+        temporary: Path,
+        ref: CASRef,
+        size: int,
+        *,
+        verified_identity: tuple[int, int] | None = None,
+    ) -> Path:
+        destination = self.object_path(ref)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with self._store_lock():
+            with self._object_lock(ref):
+                try:
+                    if verified_identity is not None:
+                        self._require_identity(temporary, verified_identity)
+                    os.link(temporary, destination, follow_symlinks=False)
+                    if verified_identity is not None:
+                        try:
+                            self._require_identity(destination, verified_identity)
+                        except OSError:
+                            destination.unlink(missing_ok=True)
+                            _fsync_dir(destination.parent)
+                            raise
+                    _fsync_dir(destination.parent)
+                except FileExistsError:
+                    try:
+                        self._verify_object_unlocked(ref, size)
+                    except DigestMismatch:
+                        # The named object is already unusable. Replace it atomically
+                        # with bytes that were verified before reaching this method.
+                        if verified_identity is not None:
+                            self._require_identity(temporary, verified_identity)
+                        os.replace(temporary, destination)
+                        if verified_identity is not None:
+                            try:
+                                self._require_identity(destination, verified_identity)
+                            except OSError:
+                                destination.unlink(missing_ok=True)
+                                _fsync_dir(destination.parent)
+                                raise
+                        _fsync_dir(destination.parent)
+                finally:
+                    temporary.unlink(missing_ok=True)
+        return destination
+
+    def put_bytes(self, data: bytes, *, expected: str | CASRef | None = None) -> CASRef:
+        ref = CASRef.digest_bytes(data)
+        expected_ref = CASRef.parse(expected) if expected is not None else None
+        if expected_ref is not None and ref != expected_ref:
+            raise DigestMismatch(f"bytes hash to {ref}, expected {expected_ref}")
+        with self._store_lock():
+            with self._object_lock(ref):
+                try:
+                    self._verify_object_unlocked(ref, len(data))
+                except (FileNotFoundError, DigestMismatch):
+                    pass
+                else:
+                    return ref
+        fd, raw_path = tempfile.mkstemp(prefix="put-", dir=self.tmp)
+        temporary = Path(raw_path)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._commit_temp(temporary, ref, len(data))
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+        return ref
+
+    @contextmanager
+    def open_writer(
+        self,
+        expected: str | CASRef,
+        *,
+        size: int,
+    ) -> Iterator[_ObjectWriter]:
+        """Hash a byte stream and atomically install its CAS object.
+
+        The object becomes visible only after the context exits successfully,
+        its digest and size match the declaration, and its bytes are durable.
+        """
+
+        expected_ref = CASRef.parse(expected)
+        if type(size) is not int or size < 0:
+            raise ValueError("object size must be a non-negative integer")
+        fd, raw_path = tempfile.mkstemp(prefix="stream-", dir=self.tmp)
+        temporary = Path(raw_path)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                writer = _ObjectWriter(handle)
+                yield writer
+                writer.flush()
+                os.fsync(writer.fileno())
+                written = os.fstat(writer.fileno()).st_size
+                if writer.size != size or written != size:
+                    raise DigestMismatch(
+                        f"{expected_ref}: stream is {written} bytes, expected {size}"
+                    )
+                if writer.ref != expected_ref:
+                    raise DigestMismatch(f"stream hashes to {writer.ref}, expected {expected_ref}")
+            self._commit_temp(temporary, expected_ref, size)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def adopt_file(
+        self,
+        temporary: str | Path,
+        *,
+        expected: str | CASRef,
+        size: int,
+    ) -> CASRef:
+        """Verify and consume a file created in this CAS's temporary directory.
+
+        The verified file itself is linked into the object namespace; its bytes
+        are never copied into another temporary file. The input path is removed
+        after either a successful install or a verification failure.
+        """
+
+        source = Path(temporary)
+        expected_ref = CASRef.parse(expected)
+        if type(size) is not int or size < 0:
+            raise ValueError("object size must be a non-negative integer")
+        if source.parent.resolve() != self.tmp.resolve():
+            raise ValueError(f"adopted files must be direct children of {self.tmp}")
+
+        try:
+            digest = hashlib.sha256()
+            with source.open("rb+") as handle:
+                before = os.fstat(handle.fileno())
+                copied = 0
+                while data := handle.read(_COPY_BUFFER):
+                    digest.update(data)
+                    copied += len(data)
+                os.fsync(handle.fileno())
+                after = os.fstat(handle.fileno())
+            if (
+                copied != size
+                or before.st_size != size
+                or after.st_size != size
+                or after.st_mtime_ns != before.st_mtime_ns
+            ):
+                raise DigestMismatch(f"{source}: file is not the declared {size} bytes")
+            actual_ref = CASRef(digest.hexdigest())
+            if actual_ref != expected_ref:
+                raise DigestMismatch(
+                    f"{source}: bytes hash to {actual_ref}, expected {expected_ref}"
+                )
+            self._commit_temp(
+                source,
+                expected_ref,
+                size,
+                verified_identity=(after.st_dev, after.st_ino),
+            )
+            return expected_ref
+        except BaseException:
+            source.unlink(missing_ok=True)
+            raise
+
+    def put_file(
+        self,
+        source: str | Path,
+        *,
+        expected: str | CASRef | None = None,
+        size: int | None = None,
+    ) -> CASRef:
+        """Install one object from a file after hashing it exactly once."""
+
+        source_path = Path(source)
+        initial = source_path.stat()
+        expected_size = initial.st_size if size is None else size
+        if initial.st_size != expected_size:
+            raise DigestMismatch(
+                f"{source_path}: source is {initial.st_size} bytes, expected {expected_size}"
+            )
+        fd, raw_path = tempfile.mkstemp(prefix="put-", dir=self.tmp)
+        temporary = Path(raw_path)
+        try:
+            with os.fdopen(fd, "wb") as writer:
+                with source_path.open("rb") as reader:
+                    before = os.fstat(reader.fileno())
+                    digest, copied = _copy_and_hash(reader, writer)
+                    after = os.fstat(reader.fileno())
+                writer.flush()
+                os.fsync(writer.fileno())
+            if (
+                copied != expected_size
+                or before.st_size != expected_size
+                or after.st_size != expected_size
+                or after.st_mtime_ns != before.st_mtime_ns
+            ):
+                raise OSError(f"{source_path} changed while it was being ingested")
+            ref = CASRef(digest)
+            expected_ref = CASRef.parse(expected) if expected is not None else None
+            if expected_ref is not None and ref != expected_ref:
+                raise DigestMismatch(f"{source_path}: bytes hash to {ref}, expected {expected_ref}")
+            self._commit_temp(temporary, ref, copied)
+            return ref
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def ingest_file(
+        self,
+        source: str | Path,
+        *,
+        manifest_path: str | None = None,
+    ) -> FileEntry:
+        path = Path(source)
+        initial = path.stat()
+        whole = hashlib.sha256()
+        chunks: list[Chunk] = []
+        copied = 0
+        with path.open("rb") as handle:
+            before = os.fstat(handle.fileno())
+            chunk_lengths = plan_chunks(handle, initial.st_size)
+            if not chunk_lengths:
+                return FileEntry(
+                    manifest_path or path.name,
+                    initial.st_size,
+                    self.put_file(path, size=initial.st_size),
+                )
+            handle.seek(0)
+            for length in chunk_lengths:
+                data = handle.read(length)
+                if len(data) != length:
+                    raise OSError(f"{path} ended while it was being ingested")
+                copied += len(data)
+                whole.update(data)
+                digest = self.put_bytes(data)
+                chunks.append(Chunk(digest, len(data)))
+            if handle.read(1):
+                raise OSError(f"{path} grew while it was being ingested")
+            after = os.fstat(handle.fileno())
+        if (
+            copied != initial.st_size
+            or before.st_size != initial.st_size
+            or after.st_size != initial.st_size
+            or after.st_mtime_ns != before.st_mtime_ns
+        ):
+            raise OSError(f"{path} changed while it was being ingested")
+        return FileEntry(
+            manifest_path or path.name,
+            copied,
+            CASRef(whole.hexdigest()),
+            tuple(chunks),
+        )
+
+    def ingest_repository(
+        self,
+        source: str | Path,
+    ) -> RepositoryManifest:
+        """Ingest every regular file below a directory into one manifest.
+
+        V1 manifests describe files, not symlinks or empty directories. Refusing
+        those filesystem entry types keeps materialization portable and prevents
+        a source-tree link from escaping the repository root.
+        """
+
+        root = Path(source)
+        if not root.is_dir():
+            raise NotADirectoryError(root)
+        entries: list[FileEntry] = []
+        for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+            if path.is_symlink():
+                raise ValueError(f"repository contains a symlink: {path.relative_to(root)}")
+            if path.is_dir():
+                continue
+            if not path.is_file():
+                relative = path.relative_to(root)
+                raise ValueError(f"repository contains a non-regular file: {relative}")
+            entries.append(
+                self.ingest_file(
+                    path,
+                    manifest_path=path.relative_to(root).as_posix(),
+                )
+            )
+        return RepositoryManifest(tuple(entries))
+
+    def materialize(self, entry: FileEntry, destination: str | Path) -> Path:
+        with self._store_lock():
+            return self._materialize_unlocked(entry, Path(destination))
+
+    def _materialize_unlocked(self, entry: FileEntry, target: Path) -> Path:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, raw_path = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+        temporary = Path(raw_path)
+        whole = hashlib.sha256()
+        total = 0
+        try:
+            with os.fdopen(fd, "wb") as writer:
+                for ref, size in entry.objects():
+                    with self._object_lock(ref):
+                        source = self._verify_object_unlocked(ref, size)
+                    with source.open("rb") as reader:
+                        object_hash = hashlib.sha256()
+                        remaining = size
+                        while remaining:
+                            data = reader.read(min(_COPY_BUFFER, remaining))
+                            if not data:
+                                raise DigestMismatch(f"{ref}: object ended before {size} bytes")
+                            writer.write(data)
+                            object_hash.update(data)
+                            whole.update(data)
+                            total += len(data)
+                            remaining -= len(data)
+                        if reader.read(1):
+                            raise DigestMismatch(f"{ref}: object exceeds {size} bytes")
+                    if object_hash.hexdigest() != ref.digest:
+                        raise DigestMismatch(f"{ref}: object changed while materializing")
+                writer.flush()
+                os.fsync(writer.fileno())
+            if total != entry.size_bytes or whole.hexdigest() != entry.digest.digest:
+                raise DigestMismatch(
+                    f"{entry.path}: reconstructed bytes do not match the file manifest"
+                )
+            os.replace(temporary, target)
+            _fsync_dir(target.parent)
+            return target
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def materialize_repository(
+        self, manifest: RepositoryManifest, destination: str | Path
+    ) -> Path:
+        """Atomically publish a complete repository tree at an absent path."""
+
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            raise FileExistsError(target)
+        with self._store_lock():
+            stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
+            try:
+                for entry in manifest.files:
+                    self._materialize_unlocked(entry, stage / entry.path)
+                directories = [stage, *(path for path in stage.rglob("*") if path.is_dir())]
+                for directory in sorted(
+                    directories, key=lambda item: len(item.parts), reverse=True
+                ):
+                    _fsync_dir(directory)
+                os.rename(stage, target)
+                _fsync_dir(target.parent)
+                return target
+            except BaseException:
+                shutil.rmtree(stage, ignore_errors=True)
+                raise
+
+    def store_manifest(self, manifest: RepositoryManifest) -> CASRef:
+        return self.put_bytes(manifest.canonical_bytes())
+
+    def load_manifest(self, ref: str | CASRef) -> RepositoryManifest:
+        parsed = CASRef.parse(ref)
+        with self._store_lock():
+            with self._object_lock(parsed):
+                path = self._verify_object_unlocked(parsed, None)
+                return RepositoryManifest.from_bytes(path.read_bytes())
+
+    @staticmethod
+    def _ref_id(name: str) -> str:
+        if not name or any(ord(char) < 32 or ord(char) == 127 for char in name):
+            raise ValueError("logical ref name must be non-empty and contain no controls")
+        return hashlib.sha256(name.encode("utf-8")).hexdigest()
+
+    def _read_ref_unlocked(self, name: str) -> CASRef | None:
+        path = self.refs / self._ref_id(name)
+        if not path.exists():
+            return None
+        raw = json.loads(path.read_bytes())
+        if (
+            not isinstance(raw, dict)
+            or set(raw) != {"format", "name", "target"}
+            or raw.get("format") != 1
+            or raw.get("name") != name
+        ):
+            raise ValueError(f"logical ref {name!r} is malformed")
+        return CASRef.parse(str(raw.get("target", "")))
+
+    def read_ref(self, name: str) -> CASRef | None:
+        with self._store_lock():
+            return self._read_ref_unlocked(name)
+
+    @contextmanager
+    def _object_lock(self, ref: CASRef) -> Iterator[None]:
+        path = self.locks / f"object-{ref.digest}"
+        with path.open("a+b") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    @contextmanager
+    def _ref_lock(self, name: str) -> Iterator[None]:
+        path = self.locks / self._ref_id(name)
+        with path.open("a+b") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def compare_and_swap_ref(
+        self,
+        name: str,
+        target: str | CASRef | None,
+        *,
+        expected: str | CASRef | None,
+    ) -> CASRef | None:
+        desired = CASRef.parse(target) if target is not None else None
+        expected_ref = CASRef.parse(expected) if expected is not None else None
+        with self._store_lock():
+            if desired is not None:
+                try:
+                    with self._object_lock(desired):
+                        self._verify_object_unlocked(desired, None)
+                except FileNotFoundError:
+                    raise FileNotFoundError(
+                        f"cannot point {name!r} at absent object {desired}"
+                    ) from None
+            with self._ref_lock(name):
+                current = self._read_ref_unlocked(name)
+                if current == desired:
+                    return desired
+                if current != expected_ref:
+                    raise RefConflict(f"logical ref {name!r} is {current}, expected {expected_ref}")
+                destination = self.refs / self._ref_id(name)
+                if desired is None:
+                    destination.unlink(missing_ok=True)
+                    _fsync_dir(self.refs)
+                    return None
+                record = json.dumps(
+                    {"format": 1, "name": name, "target": str(desired)},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                fd, raw_path = tempfile.mkstemp(prefix="ref-", dir=self.tmp)
+                temporary = Path(raw_path)
+                try:
+                    with os.fdopen(fd, "wb") as writer:
+                        writer.write(record)
+                        writer.flush()
+                        os.fsync(writer.fileno())
+                    os.replace(temporary, destination)
+                    _fsync_dir(self.refs)
+                except BaseException:
+                    temporary.unlink(missing_ok=True)
+                    raise
+        return desired
+
+    def _logical_roots_unlocked(self) -> set[CASRef]:
+        roots: set[CASRef] = set()
+        for path in self.refs.iterdir():
+            if not path.is_file():
+                continue
+            if len(path.name) != 64 or any(char not in "0123456789abcdef" for char in path.name):
+                continue
+            raw = json.loads(path.read_bytes())
+            if (
+                not isinstance(raw, dict)
+                or set(raw) != {"format", "name", "target"}
+                or raw.get("format") != 1
+                or not isinstance(raw.get("name"), str)
+                or self._ref_id(raw["name"]) != path.name
+            ):
+                raise ValueError(f"logical ref record {path.name!r} is malformed")
+            roots.add(CASRef.parse(str(raw.get("target", ""))))
+        return roots
+
+    def collect_garbage(
+        self,
+        reachable: Iterable[str | CASRef] = (),
+        *,
+        manifests: Iterable[RepositoryManifest] = (),
+        older_than: float,
+    ) -> GCReport:
+        """Delete unreferenced immutable objects older than a caller cutoff.
+
+        Current logical refs are always roots. Consumers add active byte refs
+        and repository manifests; TensorFS deliberately owns no retention
+        policy. A required age cutoff protects freshly produced bytes during the
+        gap before a consumer installs its logical ref.
+        """
+
+        if older_than <= 0:
+            raise ValueError("garbage collection requires a positive age grace")
+        with self._store_lock(exclusive=True):
+            keep = self._logical_roots_unlocked()
+            keep.update(CASRef.parse(ref) for ref in reachable)
+            for manifest in manifests:
+                for entry in manifest.files:
+                    keep.update(ref for ref, _size in entry.objects())
+
+            # A logical ref commonly targets a stored repository manifest.
+            # Expand valid manifests; arbitrary object bytes simply remain roots.
+            for root in tuple(keep):
+                with self._object_lock(root):
+                    path = self._verify_object_unlocked(root, None)
+                try:
+                    manifest = RepositoryManifest.from_bytes(path.read_bytes())
+                except (OSError, UnicodeDecodeError, ValueError):
+                    continue
+                for entry in manifest.files:
+                    keep.update(ref for ref, _size in entry.objects())
+
+            cutoff = time.time() - older_than
+            examined = deleted = bytes_deleted = 0
+            namespace = self.objects / "sha256"
+            if namespace.exists():
+                for path in namespace.glob("*/*/*"):
+                    if not path.is_file():
+                        continue
+                    try:
+                        ref = CASRef(path.name)
+                    except ValueError:
+                        continue
+                    examined += 1
+                    stat = path.stat()
+                    if ref in keep or stat.st_mtime > cutoff:
+                        continue
+                    with self._object_lock(ref):
+                        try:
+                            current = path.stat()
+                        except FileNotFoundError:
+                            continue
+                        if current.st_mtime > cutoff:
+                            continue
+                        path.unlink()
+                        _fsync_dir(path.parent)
+                        deleted += 1
+                        bytes_deleted += current.st_size
+            return GCReport(examined, len(keep), deleted, bytes_deleted)

--- a/src/gen_worker/_vendor/tensorfs/manifest.py
+++ b/src/gen_worker/_vendor/tensorfs/manifest.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .refs import CASRef
+
+# Every independently addressed object remains at most 64 MiB. This is a wire
+# bound, not a promise that chunk offsets are fixed multiples of this value.
+MAX_CHUNK_SIZE = 64 << 20
+FORMAT = 1
+MAX_SIZE = (1 << 63) - 1
+
+
+def _valid_path(path: str) -> str:
+    try:
+        path.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"manifest path {path!r} must be valid UTF-8") from exc
+    if not path or path.startswith("/") or "\\" in path:
+        raise ValueError(f"manifest path {path!r} must be a relative forward-slash path")
+    if any(ord(char) < 32 or ord(char) == 127 for char in path):
+        raise ValueError(f"manifest path {path!r} contains a control character")
+    parts = path.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise ValueError(f"manifest path {path!r} contains an unsafe component")
+    return path
+
+
+def _require_string(raw: object, field: str) -> str:
+    if not isinstance(raw, str):
+        raise ValueError(f"{field} must be a string")
+    return raw
+
+
+def _require_integer(raw: object, field: str) -> int:
+    if type(raw) is not int:
+        raise ValueError(f"{field} must be an integer")
+    return raw
+
+
+def _require_mapping(raw: object, field: str) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return raw
+
+
+def _ascii_fold(value: str) -> str:
+    return "".join(chr(ord(char) + 32) if "A" <= char <= "Z" else char for char in value)
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    digest: CASRef
+    length: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "digest", CASRef.parse(self.digest))
+        if type(self.length) is not int:
+            raise ValueError("chunk length must be an integer")
+        if not 0 < self.length <= MAX_CHUNK_SIZE:
+            raise ValueError(f"chunk length must be in [1, {MAX_CHUNK_SIZE}], got {self.length}")
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> Chunk:
+        if set(raw) != {"digest", "len"}:
+            raise ValueError("chunk must contain exactly digest and len")
+        return cls(
+            CASRef.parse(_require_string(raw["digest"], "chunk digest")),
+            _require_integer(raw["len"], "chunk length"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {"digest": str(self.digest), "len": self.length}
+
+
+@dataclass(frozen=True, slots=True)
+class FileEntry:
+    path: str
+    size_bytes: int
+    digest: CASRef
+    chunks: tuple[Chunk, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _valid_path(self.path))
+        object.__setattr__(self, "digest", CASRef.parse(self.digest))
+        object.__setattr__(self, "chunks", tuple(self.chunks))
+        if type(self.size_bytes) is not int:
+            raise ValueError("file size must be an integer")
+        if not 0 <= self.size_bytes <= MAX_SIZE:
+            raise ValueError(f"file size must be in [0, {MAX_SIZE}]")
+        if not self.chunks:
+            if self.size_bytes > MAX_CHUNK_SIZE:
+                raise ValueError("files above 64 MiB require chunks")
+            return
+        if sum(chunk.length for chunk in self.chunks) != self.size_bytes:
+            raise ValueError("chunk lengths must sum exactly to the file size")
+        if len(self.chunks) == 1 and self.chunks[0].digest != self.digest:
+            raise ValueError("a whole-file chunk must match the file digest")
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> FileEntry:
+        allowed = {"path", "size_bytes", "digest", "chunks"}
+        if set(raw) - allowed or not {"path", "size_bytes", "digest"}.issubset(raw):
+            raise ValueError("file has missing or unknown fields")
+        chunks_raw = raw.get("chunks", ())
+        if not isinstance(chunks_raw, Sequence) or isinstance(chunks_raw, (str, bytes)):
+            raise ValueError("file chunks must be an array")
+        if "chunks" in raw and not chunks_raw:
+            raise ValueError("file chunks, when present, must not be empty")
+        return cls(
+            path=_require_string(raw["path"], "file path"),
+            size_bytes=_require_integer(raw["size_bytes"], "file size"),
+            digest=CASRef.parse(_require_string(raw["digest"], "file digest")),
+            chunks=tuple(Chunk.from_dict(_require_mapping(item, "chunk")) for item in chunks_raw),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        raw: dict[str, object] = {
+            "path": self.path,
+            "size_bytes": self.size_bytes,
+            "digest": str(self.digest),
+        }
+        if self.chunks:
+            raw["chunks"] = [chunk.to_dict() for chunk in self.chunks]
+        return raw
+
+    def objects(self) -> tuple[tuple[CASRef, int], ...]:
+        if not self.chunks:
+            return ((self.digest, self.size_bytes),)
+        return tuple((chunk.digest, chunk.length) for chunk in self.chunks)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryManifest:
+    files: tuple[FileEntry, ...]
+    format: int = FORMAT
+
+    def __post_init__(self) -> None:
+        if self.format != FORMAT:
+            raise ValueError(f"unsupported manifest format {self.format}; v1 accepts only 1")
+        ordered = tuple(sorted(self.files, key=lambda item: item.path))
+        object.__setattr__(self, "files", ordered)
+        seen: set[str] = set()
+        folded: set[str] = set()
+        for entry in ordered:
+            if entry.path in seen:
+                raise ValueError(f"duplicate manifest path {entry.path!r}")
+            case_key = _ascii_fold(entry.path)
+            if case_key in folded:
+                raise ValueError(f"case-insensitive manifest path collision at {entry.path!r}")
+            seen.add(entry.path)
+            folded.add(case_key)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> RepositoryManifest:
+        if set(raw) != {"format", "files"}:
+            raise ValueError("manifest must contain exactly format and files")
+        files = raw["files"]
+        if not isinstance(files, Sequence) or isinstance(files, (str, bytes)):
+            raise ValueError("manifest files must be an array")
+        return cls(
+            files=tuple(FileEntry.from_dict(_require_mapping(item, "file")) for item in files),
+            format=_require_integer(raw["format"], "manifest format"),
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> RepositoryManifest:
+        raw = json.loads(data)
+        if not isinstance(raw, Mapping):
+            raise ValueError("manifest root must be an object")
+        return cls.from_dict(raw)
+
+    def to_dict(self) -> dict[str, object]:
+        return {"format": self.format, "files": [entry.to_dict() for entry in self.files]}
+
+    def canonical_bytes(self) -> bytes:
+        encoded = json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return encoded.replace(b"\xe2\x80\xa8", b"\\u2028").replace(b"\xe2\x80\xa9", b"\\u2029")
+
+    def digest(self) -> CASRef:
+        return CASRef.digest_bytes(self.canonical_bytes())

--- a/src/gen_worker/_vendor/tensorfs/refs.py
+++ b/src/gen_worker/_vendor/tensorfs/refs.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+_HEX = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class CASRef:
+    """A canonical v1 content reference."""
+
+    digest: str
+
+    def __post_init__(self) -> None:
+        digest = self.digest.lower()
+        if not _HEX.fullmatch(digest):
+            raise ValueError("cas ref: sha256 digest must be 64 hexadecimal characters")
+        object.__setattr__(self, "digest", digest)
+
+    @classmethod
+    def parse(cls, value: str | CASRef) -> CASRef:
+        if isinstance(value, cls):
+            return value
+        text = str(value or "").strip().lower()
+        if not text:
+            raise ValueError("cas ref: empty")
+        if ":" not in text:
+            raise ValueError(
+                'cas ref: not algorithm-tagged (bare hex is refused; write "sha256:<hex>")'
+            )
+        algorithm, digest = text.split(":", 1)
+        if algorithm != "sha256":
+            raise ValueError(f"cas ref: unsupported algorithm {algorithm!r}")
+        return cls(digest)
+
+    @classmethod
+    def digest_bytes(cls, data: bytes) -> CASRef:
+        return cls(hashlib.sha256(data).hexdigest())
+
+    def __str__(self) -> str:
+        return f"sha256:{self.digest}"
+
+    def object_key(self, prefix: str = "objects") -> str:
+        clean = prefix.strip("/")
+        if not clean or any(part in ("", ".", "..") for part in clean.split("/")):
+            raise ValueError("object prefix must contain safe non-empty path components")
+        return str(PurePosixPath(clean, "sha256", self.digest[:2], self.digest[2:4], self.digest))

--- a/src/gen_worker/_vendor/tensorfs/transfer.py
+++ b/src/gen_worker/_vendor/tensorfs/transfer.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import http.client
+import os
+import random
+import re
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+from .local import DigestMismatch, LocalCAS
+from .refs import CASRef
+
+_DEFAULT_PARALLEL = 8
+_PROCESS_TRANSFER_BUDGET = threading.BoundedSemaphore(16)
+_EXPIRY_MARGIN_SECONDS = 120.0
+_RFC3339_UTC = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z"
+)
+
+
+class _GrantExpired(RuntimeError):
+    """The caller should obtain a fresh remote plan, not retry this URL."""
+
+
+class _TransferRefused(RuntimeError):
+    """The remote endpoint rejected the bytes or authorization terminally."""
+
+
+class _TransientTransferError(RuntimeError):
+    """A transport failure that may succeed on the same grant after backoff."""
+
+
+class _HTTPStatusError(RuntimeError):
+    def __init__(self, status: int, detail: str = "") -> None:
+        super().__init__(f"HTTP {status}: {detail}".rstrip())
+        self.status = status
+        self.detail = detail
+
+
+@dataclass(frozen=True, slots=True)
+class TransferGrant:
+    """One opaque, expiring authorization for one exact CAS object."""
+
+    digest: CASRef
+    size_bytes: int
+    url: str
+    staging_key: str = ""
+    headers: Mapping[str, str] = field(default_factory=dict)
+    expires_at: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "digest", CASRef.parse(self.digest))
+        object.__setattr__(self, "headers", dict(self.headers))
+        if type(self.size_bytes) is not int or self.size_bytes < 0:
+            raise ValueError("grant size must be a non-negative integer")
+        if not self.url.strip():
+            raise ValueError("grant URL must not be empty")
+        self.expiry_unix()
+
+    def expiry_unix(self) -> float | None:
+        if self.expires_at is None:
+            return None
+        text = self.expires_at.strip()
+        if not text:
+            raise ValueError("grant expiry must be an RFC 3339 timestamp or None")
+        if _RFC3339_UTC.fullmatch(text) is None:
+            raise ValueError("grant expiry must be an RFC 3339 UTC timestamp ending in Z")
+        try:
+            parsed = datetime.fromisoformat(text[:-1] + "+00:00")
+        except ValueError as exc:
+            raise ValueError(f"invalid grant expiry {self.expires_at!r}") from exc
+        return parsed.timestamp()
+
+    def expired(self, *, now: float | None = None, margin: float = _EXPIRY_MARGIN_SECONDS) -> bool:
+        expiry = self.expiry_unix()
+        return expiry is not None and (time.time() if now is None else now) + margin >= expiry
+
+    @classmethod
+    def from_wire(cls, value: Mapping[str, object]) -> TransferGrant:
+        """Decode the exact v1 upload-grant object emitted by the Go planner."""
+
+        required = {"digest", "size_bytes", "staging_key", "url", "headers", "expires_at"}
+        if set(value) != required:
+            raise ValueError(f"upload grant fields must be exactly {sorted(required)}")
+        headers = value["headers"]
+        if not isinstance(headers, dict) or not all(
+            isinstance(key, str) and isinstance(item, str) for key, item in headers.items()
+        ):
+            raise ValueError("upload grant headers must be a string-to-string object")
+        digest = value["digest"]
+        size_bytes = value["size_bytes"]
+        staging_key = value["staging_key"]
+        url = value["url"]
+        expires_at = value["expires_at"]
+        if not isinstance(digest, str):
+            raise ValueError("upload grant digest must be a string")
+        if type(size_bytes) is not int:
+            raise ValueError("upload grant size_bytes must be an integer")
+        if not isinstance(staging_key, str) or not staging_key:
+            raise ValueError("upload grant staging_key must be a non-empty string")
+        if not isinstance(url, str):
+            raise ValueError("upload grant URL must be a string")
+        if not isinstance(expires_at, str):
+            raise ValueError("upload grant expires_at must be a string")
+        return cls(
+            CASRef.parse(digest),
+            size_bytes,
+            url,
+            staging_key=staging_key,
+            headers=headers,
+            expires_at=expires_at,
+        )
+
+    def to_wire(self) -> dict[str, object]:
+        if not self.staging_key:
+            raise ValueError("wire upload grants require a staging key")
+        if self.expires_at is None:
+            raise ValueError("wire upload grants require an expiry")
+        return {
+            "digest": str(self.digest),
+            "size_bytes": self.size_bytes,
+            "staging_key": self.staging_key,
+            "url": self.url,
+            "headers": dict(self.headers),
+            "expires_at": self.expires_at,
+        }
+
+
+class _GrantTransport(Protocol):
+    def upload(self, grant: TransferGrant, source: Path) -> None: ...
+
+    def download(self, grant: TransferGrant, destination: Path) -> None: ...
+
+
+class _HTTPTransport:
+    """Small stdlib transport for verbatim grant URLs and headers."""
+
+    def __init__(self, *, timeout: float = 120.0, block_bytes: int = 1 << 20) -> None:
+        self.timeout = timeout
+        self.block_bytes = block_bytes
+
+    def _open(self, request: urllib.request.Request) -> object:
+        try:
+            return urllib.request.urlopen(request, timeout=self.timeout)
+        except urllib.error.HTTPError as exc:
+            try:
+                detail = exc.read(1024).decode("utf-8", "replace")
+            finally:
+                exc.close()
+            raise _HTTPStatusError(exc.code, detail) from exc
+        except (OSError, urllib.error.URLError) as exc:
+            raise _TransientTransferError(str(exc)) from exc
+
+    def upload(self, grant: TransferGrant, source: Path) -> None:
+        if source.stat().st_size != grant.size_bytes:
+            raise DigestMismatch(
+                f"{grant.digest}: upload source is {source.stat().st_size} bytes, "
+                f"expected {grant.size_bytes}"
+            )
+
+        def body() -> Iterator[bytes]:
+            with source.open("rb") as handle:
+                while block := handle.read(self.block_bytes):
+                    yield block
+
+        headers = dict(grant.headers)
+        content_lengths = [
+            value for key, value in headers.items() if key.lower() == "content-length"
+        ]
+        if content_lengths and content_lengths != [str(grant.size_bytes)]:
+            raise _TransferRefused(f"{grant.digest}: grant has an incorrect Content-Length")
+        if not content_lengths:
+            headers["Content-Length"] = str(grant.size_bytes)
+        request = urllib.request.Request(
+            grant.url, data=body(), headers=headers, method="PUT"
+        )
+        response = self._open(request)
+        with response:  # type: ignore[attr-defined]
+            status = int(getattr(response, "status", 0))
+            if not 200 <= status < 300:
+                raise _HTTPStatusError(status)
+
+    def download(self, grant: TransferGrant, destination: Path) -> None:
+        request = urllib.request.Request(grant.url, headers=dict(grant.headers), method="GET")
+        response = self._open(request)
+        copied = 0
+        try:
+            with response:  # type: ignore[attr-defined]
+                status = int(getattr(response, "status", 0))
+                if not 200 <= status < 300:
+                    raise _HTTPStatusError(status)
+                with destination.open("wb") as output:
+                    while block := response.read(self.block_bytes):  # type: ignore[attr-defined]
+                        copied += len(block)
+                        if copied > grant.size_bytes:
+                            raise DigestMismatch(
+                                f"{grant.digest}: response exceeds {grant.size_bytes} bytes"
+                            )
+                        output.write(block)
+                    output.flush()
+                    os.fsync(output.fileno())
+        except (http.client.IncompleteRead, OSError, urllib.error.URLError) as exc:
+            raise _TransientTransferError(str(exc)) from exc
+        if copied != grant.size_bytes:
+            raise DigestMismatch(
+                f"{grant.digest}: response is {copied} bytes, expected {grant.size_bytes}"
+            )
+
+
+@dataclass(slots=True)
+class TransferReport:
+    examined: int = 0
+    succeeded: int = 0
+    skipped_resident: int = 0
+    bytes_transferred: int = 0
+    expired: list[CASRef] = field(default_factory=list)
+    failures: list[tuple[CASRef, str]] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return (
+            not self.expired
+            and not self.failures
+            and self.succeeded + self.skipped_resident == self.examined
+        )
+
+    @property
+    def needs_replan(self) -> bool:
+        return bool(self.expired) and not self.failures
+
+
+def _retry(
+    grant: TransferGrant,
+    action: Callable[[], None],
+    *,
+    max_attempts: int,
+    sleep: Callable[[float], None],
+) -> None:
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be positive")
+    last: BaseException | None = None
+    for attempt in range(max_attempts):
+        if grant.expired():
+            raise _GrantExpired(f"grant for {grant.digest} is expired or inside its safety margin")
+        try:
+            action()
+            return
+        except _HTTPStatusError as exc:
+            if exc.status == 403 and grant.expired(margin=0):
+                raise _GrantExpired(f"grant for {grant.digest} expired during transfer") from exc
+            if exc.status not in (408, 425, 429) and exc.status < 500:
+                raise _TransferRefused(f"{grant.digest}: {exc}") from exc
+            last = exc
+        except _TransientTransferError as exc:
+            last = exc
+        if attempt + 1 < max_attempts:
+            ceiling = min(30.0, 0.25 * (2**attempt))
+            sleep(random.uniform(ceiling / 2, ceiling))
+    raise _TransientTransferError(
+        f"{grant.digest}: transfer failed after {max_attempts} attempts: {last}"
+    )
+
+
+def _unique(grants: Sequence[TransferGrant]) -> tuple[TransferGrant, ...]:
+    ordered = tuple(grants)
+    seen: set[CASRef] = set()
+    for grant in ordered:
+        if grant.digest in seen:
+            raise ValueError(f"duplicate grant for {grant.digest}")
+        seen.add(grant.digest)
+    return ordered
+
+
+def _run_parallel(
+    grants: Sequence[TransferGrant],
+    worker: Callable[[TransferGrant], bool],
+    *,
+    parallel: int,
+    progress: Callable[[CASRef, int], None] | None,
+) -> TransferReport:
+    ordered = _unique(grants)
+    if parallel < 1:
+        raise ValueError("parallel must be positive")
+    results: list[tuple[str, str] | None] = [None] * len(ordered)
+
+    def run(index: int, grant: TransferGrant) -> None:
+        with _PROCESS_TRANSFER_BUDGET:
+            try:
+                skipped = worker(grant)
+                results[index] = ("skipped" if skipped else "succeeded", "")
+            except _GrantExpired as exc:
+                results[index] = ("expired", str(exc))
+            except Exception as exc:
+                results[index] = ("failed", f"{type(exc).__name__}: {exc}")
+
+    # `progress` answers "is this transfer advancing toward readiness", so a
+    # RESIDENT object advances it exactly as a fetched one does: verifying an
+    # object already on disk is completed work toward readiness, and callers
+    # size their denominator over every planned object. Counting only fetched
+    # bytes made a resumed transfer — where the previous attempt already landed
+    # most objects — look identical to a dead one, which is how a healthy pod
+    # gets condemned. `bytes_transferred` still counts only what actually moved.
+    #
+    # `progress` fires as each object lands, NOT from the report loop below.
+    # Emitting after the drain means a multi-gigabyte transfer reports nothing
+    # until its last object is on disk, and a caller that watches the counter
+    # for liveness — tensorhub's transfer freshness window, and the worker's
+    # own stall detector — condemns a download that is proceeding correctly.
+    # Objects are capped at 64 MiB, so a live transfer now advances at least
+    # once per 64 MiB.
+    #
+    # It still runs on the CALLER's thread, from the completion loop rather
+    # than from inside `run`. Callers hand this callback shared state that is
+    # not theirs to lock, so moving it onto the pool's threads would fix the
+    # timing by breaking the contract.
+    with ThreadPoolExecutor(max_workers=parallel, thread_name_prefix="tensorfs") as pool:
+        futures = {
+            pool.submit(run, index, grant): index
+            for index, grant in enumerate(ordered)
+        }
+        for future in as_completed(futures):
+            future.result()
+            index = futures[future]
+            result = results[index]
+            assert result is not None
+            if result[0] in ("succeeded", "skipped") and progress is not None:
+                progress(ordered[index].digest, ordered[index].size_bytes)
+
+    report = TransferReport(examined=len(ordered))
+    for grant, result in zip(ordered, results, strict=True):
+        assert result is not None
+        status, detail = result
+        if status == "succeeded":
+            report.succeeded += 1
+            report.bytes_transferred += grant.size_bytes
+        elif status == "skipped":
+            report.skipped_resident += 1
+        elif status == "expired":
+            report.expired.append(grant.digest)
+        else:
+            report.failures.append((grant.digest, detail))
+    return report
+
+
+def _upload(
+    grants: Sequence[TransferGrant],
+    source: LocalCAS,
+    *,
+    transport: _GrantTransport,
+    parallel: int = _DEFAULT_PARALLEL,
+    max_attempts: int = 5,
+    sleep: Callable[[float], None] = time.sleep,
+    progress: Callable[[CASRef, int], None] | None = None,
+) -> TransferReport:
+    """Upload a remote plan's missing objects from an authoritative local CAS."""
+
+    def one(grant: TransferGrant) -> bool:
+        path = source.verify_object(grant.digest, size=grant.size_bytes)
+        _retry(
+            grant,
+            lambda: transport.upload(grant, path),
+            max_attempts=max_attempts,
+            sleep=sleep,
+        )
+        return False
+
+    return _run_parallel(grants, one, parallel=parallel, progress=progress)
+
+
+def upload(
+    grants: Sequence[TransferGrant],
+    source: LocalCAS,
+    *,
+    parallel: int = _DEFAULT_PARALLEL,
+    max_attempts: int = 5,
+    progress: Callable[[CASRef, int], None] | None = None,
+) -> TransferReport:
+    """Upload a remote plan's missing objects through their HTTP grants."""
+
+    return _upload(
+        grants,
+        source,
+        transport=_HTTPTransport(),
+        parallel=parallel,
+        max_attempts=max_attempts,
+        progress=progress,
+    )
+
+
+def _download(
+    grants: Sequence[TransferGrant],
+    destination: LocalCAS,
+    *,
+    transport: _GrantTransport,
+    parallel: int = _DEFAULT_PARALLEL,
+    max_attempts: int = 5,
+    sleep: Callable[[float], None] = time.sleep,
+    progress: Callable[[CASRef, int], None] | None = None,
+) -> TransferReport:
+    """Fetch missing objects; resident verified objects are the resume journal."""
+
+    def one(grant: TransferGrant) -> bool:
+        try:
+            if destination.contains(grant.digest, size=grant.size_bytes):
+                return True
+        except DigestMismatch:
+            # Re-fetch. LocalCAS.adopt_file atomically replaces only the corrupt
+            # object at this same digest after checking the new bytes.
+            pass
+        descriptor, name = tempfile.mkstemp(prefix="download-", dir=destination.tmp)
+        os.close(descriptor)
+        temporary = Path(name)
+        try:
+            _retry(
+                grant,
+                lambda: transport.download(grant, temporary),
+                max_attempts=max_attempts,
+                sleep=sleep,
+            )
+            destination.adopt_file(temporary, expected=grant.digest, size=grant.size_bytes)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return False
+
+    return _run_parallel(grants, one, parallel=parallel, progress=progress)
+
+
+def download(
+    grants: Sequence[TransferGrant],
+    destination: LocalCAS,
+    *,
+    parallel: int = _DEFAULT_PARALLEL,
+    max_attempts: int = 5,
+    progress: Callable[[CASRef, int], None] | None = None,
+) -> TransferReport:
+    """Download missing objects through HTTP grants into an authoritative CAS."""
+
+    return _download(
+        grants,
+        destination,
+        transport=_HTTPTransport(),
+        parallel=parallel,
+        max_attempts=max_attempts,
+        progress=progress,
+    )

--- a/src/gen_worker/_vendor/torch_compiled_graphs/__init__.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/__init__.py
@@ -1,0 +1,71 @@
+"""Mint and reuse verified PyTorch AOTInductor graphs through HashRepo."""
+
+from .artifact import COMPILED_GRAPH_FORMAT, ArtifactError
+from .compiler import CompileError
+from .declaration import (
+    DeclarationError,
+    GraphClassDeclaration,
+    GraphClassSpec,
+    RuntimeCompatibility,
+)
+from .engine import (
+    AdmissionError,
+    Engine,
+    EnsureOutcome,
+    EnsureResult,
+)
+from .identity import (
+    ARTIFACT_KIND,
+    GRAPH_CLASS_BLOCK,
+    REQUIRED_AXES,
+    CompiledGraphKey,
+    IdentityError,
+    is_compiled_graph_key,
+)
+from .ingress import (
+    CallIngress,
+    CallInput,
+    IngressError,
+    build_call_ingress,
+    exported_input_name,
+)
+from .runner import CompiledGraphRunner, ConstantBindingError
+from .storage import (
+    QuarantinedArtifact,
+    StorageError,
+    StoredCompiledGraph,
+    StoreOutcome,
+    StoreResult,
+)
+
+__all__ = [
+    "ARTIFACT_KIND",
+    "AdmissionError",
+    "ArtifactError",
+    "CompileError",
+    "COMPILED_GRAPH_FORMAT",
+    "CompiledGraphKey",
+    "CompiledGraphRunner",
+    "CallIngress",
+    "CallInput",
+    "ConstantBindingError",
+    "DeclarationError",
+    "Engine",
+    "EnsureOutcome",
+    "EnsureResult",
+    "GRAPH_CLASS_BLOCK",
+    "GraphClassDeclaration",
+    "GraphClassSpec",
+    "IdentityError",
+    "REQUIRED_AXES",
+    "IngressError",
+    "QuarantinedArtifact",
+    "RuntimeCompatibility",
+    "StorageError",
+    "StoreOutcome",
+    "StoreResult",
+    "StoredCompiledGraph",
+    "build_call_ingress",
+    "exported_input_name",
+    "is_compiled_graph_key",
+]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/__main__.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/src/gen_worker/_vendor/torch_compiled_graphs/_run_impl_split.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/_run_impl_split.py
@@ -1,0 +1,846 @@
+"""Split AOTI's generated ``run_impl`` across K translation units.
+
+Two independent compiler profiles of the real banked SDXL w8a8 wrapper
+agree: parse is 3-5% of the compile and
+``AOTInductorModel::run_impl`` ALONE is 68% of it (clang attributes 128.84 s
+of a 189.6 s compile to one ``OptFunction``). The cost is superlinear in a
+SINGLE function's size — measured n^1.57 — because both compilers burn in
+the same two per-function algorithms: stack-slot conflict colouring and
+CFG-wide block placement. ``run_impl`` carries 10,032 declarations and 4,231
+dispatch calls in one body. No flag fixes that (the best is -19%, most are
+negative) and no bigger machine fixes it (a 32-core i9 does the TU in
+140.0 s against a 4-vCPU pod's 180.6 s — it is one process on one core
+either way). Reducing per-function size is the only lever, and it wins even
+at zero parallelism: K=8 cuts total CPU 140.0 s -> 32.5 s.
+
+THE SHAPE: a continuation chain. ``run_impl`` keeps its prologue verbatim
+and calls ``part_0``; ``part_k`` ends by calling ``part_{k+1}`` with the
+live set by reference. Chosen over "K calls from run_impl" because it is
+strictly more faithful: no declaration is rewritten (a flat split would have
+to hoist every crossing variable into ``run_impl`` and turn its definition
+into an assignment), and every local's lifetime and destruction order is
+unchanged, because each part's frame stays live for the whole chain.
+
+Each part is a member function of a generated ``_tcg_run_ctx`` that
+carries ``constants_``, ``kernels_``, ``device_idx_`` and ``cubin_dir_``
+under their original names. That is what buys ZERO body rewriting: the
+emitted statements' ``this->device_idx_``, ``this->cubin_dir_``,
+``constants_->at(n)`` and the verbatim ``kernels`` binding all resolve
+against the ctx unmodified.
+
+FAIL-CLOSED BY CONSTRUCTION. :func:`reconstruct` is a self-contained
+mechanical inverse: reading ONLY the split output, it drops
+every generated line, restores every displaced one, splices the part bodies
+back in order, and must reproduce the input byte for byte. It consumes no
+side table from the transform, so it cannot be fooled by the transform's own
+bookkeeping. Anything unrecognised, unbalanced, or untypable declines, and a
+decline compiles inductor's own source unmodified. A slow mint beats a wrong
+artifact.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+#: Every line this module generates carries this suffix, and every line it
+#: displaces is preserved behind :data:`WAS`. Together they are what makes
+#: :func:`reconstruct` self-contained.
+MARK = "  //@tcg"
+#: Re-derivations carry their own marker because the inverse must VERIFY
+#: them rather than drop them: they are copies of a declaration that the
+#: reconstruction still contains, so an altered copy has no original and is
+#: caught. Dropping them blindly lets a mutated ``constants_->at(n)`` binding
+#: through the gate.
+MARK_RD = "  //@tcg:rederived"
+WAS = "//@tcg:was:"
+PARTS = "//@tcg:parts"
+CHUNK_BEGIN = "//@tcg:chunk:begin:"
+CHUNK_END = "//@tcg:chunk:end:"
+
+PREFIX = "_tcg_"
+CTX = f"{PREFIX}run_ctx"
+
+#: Default K. Swept on the real TU: K=8 is the knee — K=16 buys
+#: 0.5 s of wall and costs ~4 s more CPU (8 extra TUs x the 0.8 s per-TU
+#: header floor), and on a 4-vCPU pod parts past K~8 are pure overhead.
+DEFAULT_PARTS = 8
+
+#: Below this the function is not the pathological shape this exists for.
+MIN_COMPUTE_LINES = 4000
+
+
+class Declined(Exception):
+    """The source is not a shape this transform will touch."""
+
+
+# ---------------------------------------------------------------------------
+# Statement recognition
+# ---------------------------------------------------------------------------
+
+#: Declaration forms, in priority order. ``n`` names the declared symbol.
+#: ``kind`` decides how the name crosses a part boundary: ``const_bind`` and
+#: ``array`` are RE-DERIVED (a verbatim copy of the original declaration —
+#: one is a reference into a container we already pass, the other a const
+#: array over parameters), everything else is THREADED by reference.
+_DECLS: Sequence[tuple[str, re.Pattern[str]]] = (
+    # Both bind a reference derived purely from a ctx member, so both are
+    # re-derived verbatim in each part that uses them rather than threaded.
+    (
+        "const_bind",
+        re.compile(r"^\[\[maybe_unused\]\]\s*auto&\s+(?P<n>\w+)\s*=\s*constants_->at\(\d+\);$"),
+    ),
+    (
+        "kernels_bind",
+        re.compile(
+            r"^\[\[maybe_unused\]\]\s*auto&\s+(?P<n>\w+)\s*=\s*"
+            r"static_cast<AOTInductorModelKernels&>\(\*this->kernels_\.get\(\)\);$"
+        ),
+    ),
+    (
+        "array",
+        re.compile(r"^(?:static\s+)?(?:constexpr\s+|const\s+)+int64_t\s+(?P<n>\w+)\[\]\s*=.*;$"),
+    ),
+    ("handle", re.compile(r"^AtenTensorHandle\s+(?P<n>\w+);$")),
+    ("raii", re.compile(r"^RAIIAtenTensorHandle\s+(?P<n>\w+)\(\w+\);$")),
+    ("steal", re.compile(r"^auto\s+(?P<n>\w+)\s*=\s*steal_from_raw_handles_to_raii_handles\(.*;$")),
+    (
+        "move",
+        re.compile(
+            r"^auto\s+(?P<n>\w+)\s*=\s*std::move\((?P<src>\w+)(?P<sub>\[\d+\])?\);(?:\s*//.*)?$"
+        ),
+    ),
+    (
+        "scalar",
+        re.compile(
+            r"^(?:\[\[maybe_unused\]\]\s*)?(?P<t>int64_t|int32_t|uint32_t|size_t|double|float|bool)"
+            r"\s+(?P<n>\w+)\s*=.*;$"
+        ),
+    ),
+    # Only the `AtenTensorHandle` overload of wrap_with_raii_handle_if_needed
+    # returns RAIIAtenTensorHandle; the ArrayRefTensor ones return references
+    # and the ConstantHandle one is `= delete`. reinterpret_tensor_wrapper
+    # returns AtenTensorHandle, so requiring it pins the overload.
+    (
+        "wrap",
+        re.compile(
+            r"^auto\s+(?P<n>\w+)\s*=\s*wrap_with_raii_handle_if_needed\("
+            r"reinterpret_tensor_wrapper\(.*$"
+        ),
+    ),
+    ("auto_int", re.compile(r"^auto\s+(?P<n>\w+)\s*=\s*(?P<rhs>[^;]*);$")),
+)
+
+#: C++ type used for a threaded name of each kind. ``scalar`` reads its own;
+#: ``move`` follows its source.
+_KIND_TYPE = {
+    "handle": "AtenTensorHandle",
+    "raii": "RAIIAtenTensorHandle",
+    "wrap": "RAIIAtenTensorHandle",
+    "steal": "std::vector<RAIIAtenTensorHandle>",
+}
+
+#: Kinds re-emitted verbatim in every part that uses them, instead of
+#: threaded: a reference into a container the ctx already carries, or a
+#: const array over parameters. Both are pure re-derivations.
+_REDERIVED = frozenset({"const_bind", "kernels_bind", "array"})
+
+#: A ``auto x = <expr>;`` whose RHS is pure integer arithmetic over int64_t
+#: names is an int64_t. Anything else is untypable and declines.
+_INT_RHS = re.compile(r"^[\s\d\w()*+/%,<>:.\-]*$")
+_INT_CALLS = ("c10::div_floor_integer", "static_cast<int64_t>")
+
+#: Control flow this transform refuses to cut across. The generated compute
+#: region has none of it — that is verified per-TU, never assumed.
+_CONTROL = re.compile(r"^(for|while|do|switch|goto|try|catch|return|case|default)\b")
+
+#: The declaration table, by kind, for the resolver.
+_RX = {k: rx for k, rx in _DECLS}
+
+_IDENT = re.compile(r"\b[A-Za-z_]\w*\b")
+_GUARD = re.compile(r"^\s*\w*(Guard|RecordFunctionHandle)\s+\w+[({]")
+
+
+def _balanced(line: str) -> bool:
+    code = line
+    return (
+        code.count("(") == code.count(")")
+        and code.count("{") == code.count("}")
+        and code.count("[") == code.count("]")
+        and code.count('"') % 2 == 0
+        and 'R"' not in code
+    )
+
+
+def _strip_comment(line: str) -> str:
+    i = line.find("//")
+    return line if i < 0 else line[:i]
+
+
+# ---------------------------------------------------------------------------
+# Structural anchors
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Anchors:
+    """Half-open [begin, end) line ranges of the regions a part TU needs.
+
+    Every one is found by an anchor inductor's codegen emits verbatim; none
+    is a line number. A missing anchor declines.
+    """
+
+    include: tuple[int, int]
+    driver: tuple[int, int]
+    kernels_class: tuple[int, int]
+    kernels_open: int  # the `namespace {` wrapping the class
+    kernels_close: int  # its `}  // namespace`
+    templates: tuple[int, int]
+    env_fn: tuple[int, int]
+    run_impl: tuple[int, int]  # signature line .. the `} // ...run_impl` line
+
+
+def _find(lines: Sequence[str], pred: Callable[[str], bool], start: int = 0, what: str = "") -> int:
+    for i in range(start, len(lines)):
+        if pred(lines[i]):
+            return i
+    raise Declined(f"anchor not found: {what}")
+
+
+def find_anchors(lines: Sequence[str]) -> Anchors:
+    inc = _find(
+        lines,
+        lambda s: s.startswith("#include <torch/csrc/inductor/aoti_include/"),
+        what="aoti_include",
+    )
+    drv = _find(
+        lines,
+        lambda s: s.startswith("#define CUDA_DRIVER_CHECK"),
+        inc,
+        what="CUDA_DRIVER_CHECK (this transform targets the CUDA wrapper)",
+    )
+    ns1 = _find(lines, lambda s: s == "namespace torch::aot_inductor {", drv, what="namespace #1")
+    kopen = _find(lines, lambda s: s == "namespace {", ns1, what="anonymous namespace")
+    kcls = _find(
+        lines,
+        lambda s: s.startswith("class AOTInductorModelKernels"),
+        kopen,
+        what="AOTInductorModelKernels",
+    )
+    kend = _find(lines, lambda s: s == "};", kcls, what="end of AOTInductorModelKernels")
+    kclose = _find(
+        lines,
+        lambda s: s.startswith("}") and "namespace" in s,
+        kend,
+        what="close of anonymous namespace",
+    )
+    using = _find(
+        lines, lambda s: s == "using namespace torch::aot_inductor;", kclose, what="using namespace"
+    )
+    ns2 = _find(lines, lambda s: s == "namespace torch::aot_inductor {", using, what="namespace #2")
+    env = _find(
+        lines,
+        lambda s: s.startswith("static bool _check_aoti_runtime_check_inputs_env"),
+        ns2,
+        what="_check_aoti_runtime_check_inputs_env",
+    )
+    env_end = _find(lines, lambda s: s == "}", env, what="end of runtime-check helper")
+    run = _find(
+        lines, lambda s: s.startswith("void AOTInductorModel::run_impl("), ns2, what="run_impl"
+    )
+    run_end = _find(
+        lines,
+        lambda s: s.startswith("} // AOTInductorModel::run_impl"),
+        run,
+        what="end of run_impl",
+    )
+    return Anchors(
+        include=(0, inc + 1),
+        driver=(drv, ns1),
+        kernels_class=(kcls, kend + 1),
+        kernels_open=kopen,
+        kernels_close=kclose,
+        templates=(using, ns2),
+        env_fn=(env, env_end + 1),
+        run_impl=(run, run_end + 1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_impl: prologue / compute, declarations, liveness
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Decl:
+    idx: int  # absolute line index of the declaration
+    kind: str
+    ctype: str = ""  # resolved C++ type; "" until the fixpoint runs
+
+
+@dataclass
+class Body:
+    sig: list[str]  # run_impl signature lines, verbatim
+    prologue: tuple[int, int]  # [begin, end) — stays in run_impl
+    compute: tuple[int, int]  # [begin, end) — what gets split
+    decls: dict[str, Decl]
+    uses: dict[str, set[int]]
+    params: dict[str, str] = field(default_factory=dict)  # run_impl params -> type
+
+
+#: One run_impl parameter. The LAST one carries no trailing comma and
+#: its `) {` sits on the next line, so end-of-line has to count too —
+#: a parameter missed here is an undeclared identifier in every part.
+_SIG_PARAM = re.compile(r"^\s*(?P<t>[\w:*]+(?:\s*\*)?)\s+(?P<n>\w+)\s*(?:[,)]|$)")
+
+
+def _parse_signature(lines: Sequence[str], begin: int) -> tuple[int, dict[str, str]]:
+    """Return (index of the line after `) {`, run_impl's parameters)."""
+    params: dict[str, str] = {}
+    i = begin
+    while i < len(lines):
+        stripped = _strip_comment(lines[i]).strip()
+        if stripped.endswith(") {"):
+            return i + 1, params
+        m = _SIG_PARAM.match(_strip_comment(lines[i]))
+        if m and i > begin:
+            params[m.group("n")] = m.group("t")
+        i += 1
+    raise Declined("run_impl signature never closes")
+
+
+def parse_body(lines: Sequence[str], anchors: Anchors) -> Body:
+    begin, end = anchors.run_impl
+    body_begin, params = _parse_signature(lines, begin)
+    body_end = end - 1  # the `} // ...run_impl` line
+
+    # A run_impl parameter is spelled across two lines by the emitter
+    # (`AtenTensorHandle*` then the name); recover those.
+    for i in range(begin + 1, body_begin):
+        raw = _strip_comment(lines[i]).strip()
+        if raw.endswith("*") or raw in ("AtenTensorHandle*",):
+            nxt = _strip_comment(lines[i + 1]).strip().rstrip(",)")
+            if nxt.isidentifier():
+                params[nxt] = raw
+
+    # The prologue ends at the LAST scope guard or the last nested block —
+    # a guard must stay in run_impl, and everything after it must be flat.
+    depth = 0
+    prologue_end = body_begin
+    for i in range(body_begin, body_end):
+        if depth > 0 or _GUARD.match(lines[i]):
+            prologue_end = i + 1
+        depth += lines[i].count("{") - lines[i].count("}")
+    if depth != 0:
+        raise Declined("run_impl body braces do not balance")
+
+    compute = (prologue_end, body_end)
+    if compute[1] - compute[0] < MIN_COMPUTE_LINES:
+        raise Declined(
+            f"compute region is {compute[1] - compute[0]} lines "
+            f"(< {MIN_COMPUTE_LINES}); not the pathological shape"
+        )
+
+    # The compute region must be provably flat straight-line code.
+    for i in range(*compute):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        if not _balanced(line):
+            raise Declined(f"compute line {i + 1} is not a self-contained statement")
+        if _CONTROL.match(stripped):
+            raise Declined(f"compute line {i + 1} carries control flow: {stripped[:60]}")
+        if stripped.startswith("#"):
+            raise Declined(f"compute line {i + 1} is a preprocessor directive")
+
+    decls: dict[str, Decl] = {}
+    for i in range(body_begin, body_end):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        for kind, rx in _DECLS:
+            m = rx.match(stripped)
+            if not m:
+                continue
+            name = m.group("n")
+            if name in decls or name in params:
+                raise Declined(f"{name} is declared more than once (line {i + 1})")
+            decls[name] = Decl(i, kind)
+            break
+
+    uses: dict[str, set[int]] = {n: set() for n in list(decls) + list(params)}
+    for i in range(body_begin, body_end):
+        for name in set(_IDENT.findall(_strip_comment(lines[i]))):
+            if name in uses:
+                uses[name].add(i)
+
+    return Body(
+        sig=list(lines[begin:body_begin]),
+        prologue=(body_begin, prologue_end),
+        compute=compute,
+        decls=decls,
+        uses=uses,
+        params=params,
+    )
+
+
+_INT_WORDS = frozenset({"L", "int64_t", "c10", "div_floor_integer", "static_cast"})
+
+
+def resolve_type(lines: Sequence[str], body: Body, name: str, _seen: set[str] | None = None) -> str:
+    """The C++ type of ``name``, resolved on demand and memoised.
+
+    Only names that actually cross a boundary are ever asked — a wrapper is
+    full of prologue-local ``auto``\\ s (``auto inputs = steal_from_raw…``)
+    that are untypable here and need not be typed, because they never leave
+    ``run_impl``.
+
+    A wrong answer is a HARD COMPILE ERROR at the reference-binding site in
+    the part TU (non-const references admit no conversions), so this map is
+    checked by the compiler as well as by the gate below.
+    """
+    if name in body.params:
+        return body.params[name]
+    d = body.decls.get(name)
+    if d is None:
+        raise Declined(f"{name} crosses a boundary but is never declared")
+    if d.ctype:
+        return d.ctype
+    seen = _seen or set()
+    if name in seen:
+        raise Declined(f"circular type dependency on {name}")
+    seen.add(name)
+
+    stripped = lines[d.idx].strip()
+    if d.kind in _KIND_TYPE:
+        d.ctype = _KIND_TYPE[d.kind]
+    elif d.kind == "move":
+        m = _RX["move"].match(stripped)
+        src = resolve_type(lines, body, m.group("src"), seen)  # type: ignore[union-attr]
+        if m.group("sub"):  # type: ignore[union-attr]
+            if src != "std::vector<RAIIAtenTensorHandle>":
+                raise Declined(f"`auto {name}` subscripts a {src}")
+            src = "RAIIAtenTensorHandle"
+        d.ctype = src
+    elif d.kind == "scalar":
+        d.ctype = _RX["scalar"].match(stripped).group("t")  # type: ignore[union-attr]
+    elif d.kind in _REDERIVED:
+        d.ctype = "<re-derived>"
+    elif d.kind == "auto_int":
+        rhs = _RX["auto_int"].match(stripped).group("rhs")  # type: ignore[union-attr]
+        probe = rhs
+        for call in _INT_CALLS:
+            probe = probe.replace(call, "")
+        if not _INT_RHS.match(probe):
+            raise Declined(f"cannot type `auto {name}` from `{rhs[:60]}`")
+        for ident in _IDENT.findall(probe):
+            if ident in _INT_WORDS:
+                continue
+            if resolve_type(lines, body, ident, seen) not in ("int64_t", "int32_t"):
+                raise Declined(f"`auto {name}` depends on non-integer `{ident}`")
+        d.ctype = "int64_t"
+    else:  # pragma: no cover - _DECLS is exhaustive
+        raise Declined(f"unhandled declaration kind {d.kind}")
+    return d.ctype
+
+
+# ---------------------------------------------------------------------------
+# Cut points and the live set
+# ---------------------------------------------------------------------------
+
+_ALLOC_OPEN = re.compile(r"^AtenTensorHandle\s+(?P<n>\w+);$")
+
+
+def cut_points(lines: Sequence[str], body: Body, parts: int) -> list[int]:
+    """``parts+1`` boundaries over the compute region.
+
+    A boundary never lands inside an allocation group — the
+    ``AtenTensorHandle h;`` / ``...(&h)`` / ``RAIIAtenTensorHandle b(h);``
+    triple — because splitting one would thread a raw, not-yet-owned handle.
+    """
+    begin, end = body.compute
+    open_groups: set[int] = set()
+    pending: str | None = None
+    for i in range(begin, end):
+        stripped = lines[i].strip()
+        m = _ALLOC_OPEN.match(stripped)
+        if m:
+            pending, start = m.group("n"), i
+        elif pending and stripped.startswith(f"RAIIAtenTensorHandle {pending}("):
+            open_groups.update(range(start, i + 1))
+            pending = None
+
+    bounds = [begin]
+    for k in range(1, parts):
+        b = begin + round((end - begin) * k / parts)
+        while b < end and (
+            b in open_groups or not lines[b].strip() or lines[b].strip().startswith("//")
+        ):
+            b += 1
+        if b <= bounds[-1]:
+            raise Declined(f"cannot place cut {k} of {parts}")
+        bounds.append(b)
+    bounds.append(end)
+    return bounds
+
+
+@dataclass
+class Plan:
+    bounds: list[int]
+    threaded: list[list[str]]  # per part, names arriving as by-ref parameters
+    rederived: list[list[str]]  # per part, names re-emitted verbatim
+    parts: int
+
+
+def plan_split(lines: Sequence[str], body: Body, parts: int) -> Plan:
+    bounds = cut_points(lines, body, parts)
+
+    def part_of(idx: int) -> int:
+        if idx < bounds[0]:
+            return -1  # prologue / signature
+        for k in range(parts):
+            if bounds[k] <= idx < bounds[k + 1]:
+                return k
+        return parts - 1
+
+    threaded: list[list[str]] = [[] for _ in range(parts)]
+    rederived: list[list[str]] = [[] for _ in range(parts)]
+
+    names = list(body.params) + list(body.decls)
+    for name in names:
+        decl = body.decls.get(name)
+        used = {part_of(i) for i in body.uses[name]}
+        used.discard(-1)
+        if not used:
+            continue
+        born = part_of(decl.idx) if decl else -1
+        if decl and decl.kind in _REDERIVED:
+            for k in sorted(used):
+                if k > born:
+                    rederived[k].append(name)
+            continue
+        for k in range(born + 1, max(used) + 1):
+            threaded[k].append(name)
+
+    order = {n: (body.decls[n].idx if n in body.decls else -1) for n in names}
+    for k in range(parts):
+        threaded[k].sort(key=lambda n: (order[n], n))
+        rederived[k].sort(key=lambda n: (order[n], n))
+    return Plan(bounds=bounds, threaded=threaded, rederived=rederived, parts=parts)
+
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+_CTX_MEMBERS = (
+    "    const std::shared_ptr<std::vector<ConstantHandle>>& constants_;",
+    "    const std::unique_ptr<AOTInductorModelKernelsBase>& kernels_;",
+    "    int32_t device_idx_;",
+    "    const std::optional<std::string>& cubin_dir_;",
+)
+
+
+def _param(name: str, body: Body) -> str:
+    t = body.decls[name].ctype if name in body.decls else body.params[name]
+    return f"{t} {name}" if t.endswith("*") else f"{t}& {name}"
+
+
+def _signature(k: int, body: Body, plan: Plan, *, defn: bool) -> str:
+    args = ", ".join(_param(n, body) for n in plan.threaded[k])
+    scope = f"{CTX}::" if defn else ""
+    return f"void {scope}{PREFIX}part_{k}({args})"
+
+
+def _ctx_struct(body: Body, plan: Plan) -> list[str]:
+    out = [f"struct {CTX} {{"]
+    out.extend(_CTX_MEMBERS)
+    for k in range(plan.parts):
+        out.append(f"    {_signature(k, body, plan, defn=False)};")
+    out.append("};")
+    return [line + MARK for line in out]
+
+
+def _chunk(lines: Sequence[str], k: int, body: Body, plan: Plan) -> list[str]:
+    out = [CHUNK_BEGIN + str(k)]
+    for name in plan.rederived[k]:
+        out.append(lines[body.decls[name].idx] + MARK_RD)
+    out.extend(lines[plan.bounds[k] : plan.bounds[k + 1]])
+    if k + 1 < plan.parts:
+        call = ", ".join(plan.threaded[k + 1])
+        out.append(f"    this->{PREFIX}part_{k + 1}({call});" + MARK)
+    out.append(CHUNK_END + str(k))
+    return out
+
+
+def _part_tu(lines: Sequence[str], a: Anchors, k: int, body: Body, plan: Plan) -> str:
+    out: list[str] = list(lines[a.include[0] : a.include[1]])
+    out += lines[a.driver[0] : a.driver[1]]
+    out.append("namespace torch::aot_inductor {")
+    out += lines[a.kernels_class[0] : a.kernels_class[1]]
+    out.append("} // namespace torch::aot_inductor")
+    out += lines[a.templates[0] : a.templates[1]]
+    out.append("namespace torch::aot_inductor {")
+    out += lines[a.env_fn[0] : a.env_fn[1]]
+    out += _ctx_struct(body, plan)
+    out.append(_signature(k, body, plan, defn=True) + " {")
+    out += _chunk(lines, k, body, plan)
+    out.append("}")
+    out.append("} // namespace torch::aot_inductor")
+    return "\n".join(out)
+
+
+def _main_tu(lines: Sequence[str], a: Anchors, body: Body, plan: Plan) -> str:
+    out: list[str] = []
+    begin, end = a.run_impl
+    ctx_ctor = (
+        f"    {CTX} {PREFIX}ctx{{this->constants_, this->kernels_, "
+        f"this->device_idx_, this->cubin_dir_}};"
+    )
+    call = ", ".join(plan.threaded[0])
+    for i, line in enumerate(lines):
+        if i == a.kernels_open or i == a.kernels_close:
+            # The class must have EXTERNAL linkage: an anonymous-namespace
+            # type is a different type in every TU, and a part casting the
+            # kernels object to its own copy of it would be UB. (It is also
+            # the trap that silently voided the research lane's first
+            # measurement: gcc emitted nothing for the parts.)
+            out.append(WAS + line)
+            continue
+        if begin <= i < end:
+            if i == begin:
+                out += body.sig
+                out += lines[body.prologue[0] : body.prologue[1]]
+                out.append(ctx_ctor + MARK)
+                out.append(f"    {PREFIX}ctx.{PREFIX}part_0({call});" + " " + PARTS)
+                out.append(lines[end - 1])
+            continue
+        out.append(line)
+        if i == a.env_fn[1] - 1:
+            out += _ctx_struct(body, plan)
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# The gate: a self-contained mechanical inverse
+# ---------------------------------------------------------------------------
+
+_PART_DEFINITION = re.compile(
+    rf"^void {re.escape(CTX)}::{re.escape(PREFIX)}part_(?P<part>\d+)\((?P<params>.*)\) \{{$"
+)
+_PARAMETER_NAME = re.compile(r"(?P<name>[A-Za-z_]\w*)$")
+_CTX_CONSTRUCTION = (
+    f"    {CTX} {PREFIX}ctx{{this->constants_, this->kernels_, "
+    f"this->device_idx_, this->cubin_dir_}};" + MARK
+)
+
+
+def _parameter_names(parameters: str) -> tuple[str, ...]:
+    if not parameters:
+        return ()
+    names: list[str] = []
+    for parameter in parameters.split(", "):
+        match = _PARAMETER_NAME.search(parameter)
+        if match is None:
+            raise Declined(f"cannot read generated parameter {parameter!r}")
+        names.append(match.group("name"))
+    return tuple(names)
+
+
+def _validate_dispatch(main: str, parts: Sequence[str]) -> None:
+    """Prove the generated continuation chain executes every emitted chunk.
+
+    Reconstruction proves statement preservation, but generated calls are
+    intentionally absent from the reconstructed source. Validate those calls
+    independently so a faulty emitter cannot preserve every statement while
+    making some or all of them unreachable.
+    """
+
+    if len(parts) < 2:
+        raise Declined("generated dispatch has fewer than two parts")
+
+    definitions: list[tuple[str, ...]] = []
+    part_lines: list[list[str]] = []
+    for expected_part, text in enumerate(parts):
+        lines = text.split("\n")
+        matches = [match for line in lines if (match := _PART_DEFINITION.match(line))]
+        if len(matches) != 1 or int(matches[0].group("part")) != expected_part:
+            raise Declined(f"part {expected_part} has no unique matching definition")
+        definitions.append(_parameter_names(matches[0].group("params")))
+        part_lines.append(lines)
+
+    main_lines = main.split("\n")
+    if main_lines.count(_CTX_CONSTRUCTION) != 1:
+        raise Declined("main dispatch has no unique exact context construction")
+    expected_main = f"    {PREFIX}ctx.{PREFIX}part_0({', '.join(definitions[0])}); " + PARTS
+    main_dispatches = [line for line in main_lines if line.endswith(PARTS)]
+    if main_dispatches != [expected_main]:
+        raise Declined("main dispatch does not call part 0 with its exact live set")
+
+    for part, lines in enumerate(part_lines):
+        begin = CHUNK_BEGIN + str(part)
+        end = CHUNK_END + str(part)
+        unique_ordered_markers = (
+            lines.count(begin) == 1
+            and lines.count(end) == 1
+            and lines.index(begin) < lines.index(end)
+        )
+        if not unique_ordered_markers:
+            raise Declined(f"part {part} has non-unique or misordered chunk markers")
+        emitted_calls = [line for line in lines if f"this->{PREFIX}part_" in line]
+        if part + 1 == len(parts):
+            if emitted_calls:
+                raise Declined(f"part {part} dispatches after the final chunk")
+            continue
+        expected_call = (
+            f"    this->{PREFIX}part_{part + 1}({', '.join(definitions[part + 1])});" + MARK
+        )
+        if emitted_calls != [expected_call]:
+            raise Declined(
+                f"part {part} dispatch does not call part {part + 1} with its exact live set"
+            )
+
+
+def reconstruct(main: str, parts: Sequence[str]) -> str:
+    """Rebuild the original source from the split output ALONE.
+
+    Reads no side table produced by the transform, so it cannot be fooled by
+    it. Every generated line ends in :data:`MARK` and is dropped; every
+    displaced line is carried behind :data:`WAS` and restored; the single
+    :data:`PARTS` line is replaced by the part bodies in order; and every
+    :data:`MARK_RD` re-derivation must be found, verbatim, in the
+    reconstruction it claims to copy from.
+
+    Raises :class:`Declined` when the output is not a well-formed split.
+    """
+    _validate_dispatch(main, parts)
+
+    rederived: list[str] = []
+    chunks: list[list[str]] = []
+
+    def sift(line: str, into: list[str]) -> None:
+        if line.endswith(MARK_RD):
+            rederived.append(line[: -len(MARK_RD)])
+        elif not line.endswith(MARK):
+            into.append(line)
+
+    for k, text in enumerate(parts):
+        lines = text.split("\n")
+        try:
+            i = lines.index(CHUNK_BEGIN + str(k))
+            j = lines.index(CHUNK_END + str(k))
+        except ValueError as exc:
+            raise Declined(f"part {k} has no chunk markers") from exc
+        chunk: list[str] = []
+        for line in lines[i + 1 : j]:
+            sift(line, chunk)
+        chunks.append(chunk)
+
+    out: list[str] = []
+    for line in main.split("\n"):
+        if line.startswith(WAS):
+            out.append(line[len(WAS) :])
+        elif line.endswith(PARTS):
+            for chunk in chunks:
+                out.extend(chunk)
+        else:
+            sift(line, out)
+
+    original = set(out)
+    for line in rederived:
+        if line not in original:
+            raise Declined(f"re-derived line copies nothing in the original: {line.strip()[:70]}")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunImplSplit:
+    """What the transform did to one wrapper TU."""
+
+    applied: bool
+    reason: str = ""
+    main: str = ""
+    parts: tuple[str, ...] = ()
+    compute_lines: int = 0
+    declarations: int = 0
+    threaded_max: int = 0
+    rederived_max: int = 0
+
+    def detail(self) -> str:
+        if not self.applied:
+            return f"run_impl split declined — {self.reason}"
+        return (
+            f"run_impl: {self.compute_lines} compute lines / {self.declarations} "
+            f"declarations -> {len(self.parts)} parts "
+            f"(max {self.threaded_max} threaded, {self.rederived_max} re-derived)"
+        )
+
+
+def split_run_impl(source: str, *, parts: int = DEFAULT_PARTS) -> RunImplSplit:
+    """Split ``run_impl`` into ``parts`` chained translation units.
+
+    Returns an unapplied :class:`RunImplSplit` — never raises — whenever the
+    wrapper is not the recognised shape or the inverse does not reproduce
+    ``source`` byte for byte. The caller compiles the original in that case.
+    """
+    if parts < 2:
+        return RunImplSplit(False, f"parts={parts} is not a split")
+    lines = source.split("\n")
+    try:
+        anchors = find_anchors(lines)
+        body = parse_body(lines, anchors)
+        plan = plan_split(lines, body, parts)
+        for names in plan.threaded:
+            for name in names:
+                resolve_type(lines, body, name)
+
+        # Every re-derived line must be a COPY of a line that exists in the
+        # original, declaring the name it claims to. The inverse drops these
+        # lines, so this is the forward gate that keeps them honest.
+        for k in range(parts):
+            for name in plan.rederived[k]:
+                decl = lines[body.decls[name].idx]
+                if re.search(rf"\b{re.escape(name)}\b", decl) is None:
+                    raise Declined(f"re-derivation of {name} does not declare it")
+
+        main = _main_tu(lines, anchors, body, plan)
+        part_sources = [_part_tu(lines, anchors, k, body, plan) for k in range(parts)]
+        if reconstruct(main, part_sources) != source:
+            raise Declined(
+                "self-check failed: reconstructing the split did not reproduce "
+                "the original byte for byte"
+            )
+    except Declined as exc:
+        return RunImplSplit(False, str(exc))
+
+    return RunImplSplit(
+        True,
+        main=main,
+        parts=tuple(part_sources),
+        compute_lines=body.compute[1] - body.compute[0],
+        declarations=len(body.decls),
+        threaded_max=max(len(t) for t in plan.threaded),
+        rederived_max=max(len(r) for r in plan.rederived),
+    )
+
+
+__all__ = [
+    "DEFAULT_PARTS",
+    "MIN_COMPUTE_LINES",
+    "Declined",
+    "MARK",
+    "MARK_RD",
+    "RunImplSplit",
+    "reconstruct",
+    "split_run_impl",
+]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/_wrapper_split.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/_wrapper_split.py
@@ -1,0 +1,546 @@
+"""Split AOTI's generated wrapper constructor so g++ stops paying a
+superlinear price for a data table written as code.
+
+Measured, per host invocation: an AOTI mint's entire host cost is ONE
+``g++ -O1 -c wrapper.cpp`` — 180.6 s of a 390 s AOTI compile (46%); linking is
+2.0 s (0.5%), so every classic build lever (mold/lld, ccache, PCH, parallel
+host builds) is measured null or already exhausted. That one
+translation unit is 6.3 MB / 61k lines and is dominated by TWO functions,
+the larger of which is ``AOTInductorModel::AOTInductorModel`` — 26,642
+``constants_info_[i].field = ...;`` statements (2,422 constants x 11
+fields). It is a DATA TABLE spelled as straight-line executable code, it
+runs exactly once at model construction, and it has no runtime significance
+whatsoever. GCC's optimizer is superlinear in statements WITHIN one
+function, so this is a single-function blowup, not a big-file problem.
+
+This module first rewrites that one run of constructor statements into chunked
+helper functions. The same sealed compiler funnel then gives the resulting TU
+to :mod:`_run_impl_split`, whose separate continuation-chain gate may split
+``run_impl`` across translation units. Each transform declines independently;
+an unrecognised shape remains exactly as Inductor emitted it.
+
+Why a mint-path transform and not an inductor config: torch 2.13 exposes no
+knob for constants emission or per-function optimization, and the only
+config that moves this cost (``compile_wrapper_opt_level='O0'``) is DEAD —
+measured at +1.7% per forward, which exceeds AOT's whole 1.4% serving margin,
+and it also re-keys every compiled graph. This transform re-keys nothing (see
+:func:`install`).
+
+FAIL-CLOSED BY CONSTRUCTION. The transform only ever fires when it can
+prove, by textual reconstruction, that it is a pure statement-preserving
+regrouping: :func:`split_constants_constructor` re-inlines its own output
+and refuses unless the reconstruction is byte-identical to the input. Any
+wrapper shape it does not recognise compiles unmodified. A silent no-op is
+correct; a mangled TU is not.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from . import _run_impl_split as runimpl
+from .host_isa import _assert_command_is_clamped
+
+logger = logging.getLogger(__name__)
+
+#: Statements per generated helper. 250 is the measured chunk; the win is flat
+#: across a wide band (the point is "not one 26k-statement function", not any
+#: particular size).
+CHUNK = 250
+
+#: Below this the TU is not the pathological shape this exists for, and the
+#: transform declines rather than adding a mechanism nobody needs.
+MIN_STATEMENTS = 2000
+
+#: Name prefix for every symbol this module introduces.
+PREFIX = "_tcg_constants_info_"
+
+#: The template header line emitted above every helper.
+_TEMPLATE_LINE = "template <typename ConstantsInfoT_>"
+
+#: Banner emitted once, immediately above the first helper.
+_BANNER = (
+    "// torch-compiled-graphs: constants_info_ moved out of the constructor.",
+    "// Same statements, same order; grouped so gcc's superlinear",
+    "// per-function cost stops dominating this translation unit.",
+)
+
+#: The constructor signature inductor emits (``aoti_model_class_name`` is
+#: configurable, so the class name is captured rather than assumed).
+_CTOR_RE = re.compile(
+    r"^(?P<cls>[A-Za-z_]\w*)::(?P=cls)"
+    r"\(std::shared_ptr<ConstantMap> constants_map,\s*$"
+)
+
+#: One ``constants_info_`` field assignment, whole line, one statement.
+_STMT_RE = re.compile(r"^(?P<indent>\s*)constants_info_\[\d+\]\.\w+ = .*;$")
+
+
+class _Declined(Exception):
+    """Internal: the source is not the shape this transform recognises."""
+
+
+@dataclass(frozen=True)
+class SplitOutcome:
+    """What the transform did to one translation unit."""
+
+    applied: bool
+    reason: str  # "" when applied, else why it declined
+    statements: int = 0
+    chunks: int = 0
+    bytes_in: int = 0
+    bytes_out: int = 0
+    source: str = ""
+    #: Set by the run_impl path, whose shape the ctor-split wording cannot
+    #: describe.
+    summary: str = ""
+
+    def detail(self) -> str:
+        name = Path(self.source).name if self.source else "<source>"
+        if self.applied:
+            if self.summary:
+                return f"{name}: {self.summary}"
+            return (
+                f"{name}: {self.statements} constants_info_ statements -> "
+                f"{self.chunks} helper functions "
+                f"({self.bytes_in}B -> {self.bytes_out}B)"
+            )
+        return f"{name}: declined — {self.reason}"
+
+
+def _statement_line(line: str) -> bool:
+    """True when ``line`` is exactly one self-contained ``constants_info_``
+    assignment: balanced brackets, no raw string, terminated. Anything
+    subtler than that is not something this transform will move."""
+    if not _STMT_RE.match(line):
+        return False
+    if 'R"' in line or line.count('"') % 2:
+        return False
+    return (
+        line.count("{") == line.count("}")
+        and line.count("(") == line.count(")")
+        and line.count("[") == line.count("]")
+    )
+
+
+def _find_block(lines: Sequence[str]) -> tuple[int, int, int]:
+    """``(ctor_line, first, last)`` of the constructor and the maximal run
+    of constants_info_ statements inside it. Raises :class:`_Declined`."""
+    ctors = [i for i, line in enumerate(lines) if _CTOR_RE.match(line)]
+    if len(ctors) != 1:
+        raise _Declined(f"expected exactly 1 AOTInductorModel constructor, found {len(ctors)}")
+    ctor = ctors[0]
+    hits = [i for i, line in enumerate(lines) if _statement_line(line)]
+    if not hits:
+        raise _Declined("no constants_info_ assignment statements")
+    first, last = hits[0], hits[-1]
+    if first <= ctor:
+        raise _Declined("constants_info_ statements precede the constructor")
+    if last - first + 1 != len(hits):
+        raise _Declined(
+            f"constants_info_ statements are not contiguous "
+            f"({len(hits)} statements spanning {last - first + 1} lines)"
+        )
+    if len(hits) < MIN_STATEMENTS:
+        raise _Declined(
+            f"only {len(hits)} statements (< {MIN_STATEMENTS}); not the pathological shape"
+        )
+    return ctor, first, last
+
+
+def _helper_attrs(opt_none: bool) -> str:
+    # ``noinline`` is what keeps gcc from folding the chunks straight back
+    # into the constructor at -O1 (-finline-functions-called-once).
+    #
+    # ``optimize("O0")`` resets OPTIMIZATION options for the marked function,
+    # which is the intent and is harmless twice over: these statements are
+    # integer/pointer/vector assignments, so the wrapper command's math flags
+    # (-ffp-contract, -fmath-errno, ...) have nothing to act on; and -fPIC is a
+    # code-generation option the attribute does not touch.
+    attrs = "__attribute__((noinline))"
+    if opt_none:
+        attrs += ' __attribute__((optimize("O0")))'
+    return attrs
+
+
+def split_constants_constructor(
+    source: str, *, chunk: int = CHUNK, opt_none: bool = True
+) -> tuple[str, SplitOutcome]:
+    """Return ``(source', outcome)``.
+
+    ``source'`` differs from ``source`` only in that the constructor's run
+    of ``constants_info_`` assignments has been moved, in order, into
+    ``chunk``-sized static helper functions called in that same order. When
+    ``opt_none`` the helpers additionally carry ``optimize("O0")``: they run
+    once at model construction, so their optimization level is provably
+    without runtime consequence, and pgw#793 measured that as the larger
+    half of the win.
+
+    Declines (returning ``source`` unchanged) whenever the wrapper is not
+    the recognised shape, or whenever re-inlining the result does not
+    reproduce the input byte for byte.
+    """
+    lines = source.split("\n")
+    try:
+        ctor, first, last = _find_block(lines)
+    except _Declined as exc:
+        return source, SplitOutcome(False, str(exc), bytes_in=len(source))
+
+    body = lines[first : last + 1]
+    indent = _STMT_RE.match(body[0]).group("indent")  # type: ignore[union-attr]
+    groups = [body[i : i + chunk] for i in range(0, len(body), chunk)]
+    attrs = _helper_attrs(opt_none)
+
+    helpers: list[str] = list(_BANNER)
+    calls: list[str] = []
+    for idx, group in enumerate(groups):
+        name = f"{PREFIX}{idx}"
+        helpers.append(_TEMPLATE_LINE)
+        helpers.append(f"{attrs} static void {name}(ConstantsInfoT_& constants_info_) {{")
+        helpers.extend(group)
+        helpers.append("}")
+        calls.append(f"{indent}{name}(constants_info_);")
+    helpers.append("")
+
+    out = lines[:ctor] + helpers + lines[ctor:first] + calls + lines[last + 1 :]
+    result = "\n".join(out)
+
+    reconstructed = _reinline(result)
+    if reconstructed != source:
+        return source, SplitOutcome(
+            False,
+            "self-check failed: re-inlining the split source did not "
+            "reproduce the original byte for byte",
+            bytes_in=len(source),
+        )
+    return result, SplitOutcome(
+        True,
+        "",
+        statements=len(body),
+        chunks=len(groups),
+        bytes_in=len(source),
+        bytes_out=len(result),
+    )
+
+
+_CALL_RE = re.compile(rf"^\s*{re.escape(PREFIX)}(\d+)\(constants_info_\);$")
+_DEF_RE = re.compile(rf"^.*static void {re.escape(PREFIX)}(\d+)\(ConstantsInfoT_&")
+
+
+def _reinline(source: str) -> str:
+    """Inverse of the split: substitute each helper's body back at its call
+    site and delete the helper definitions. Used ONLY to self-verify the
+    transform — if this does not reproduce the input exactly, the transform
+    is not a pure regrouping and must not ship."""
+    lines = source.split("\n")
+    bodies: dict[str, list[str]] = {}
+    keep: list[str] = []
+    i = 0
+    start: int | None = None
+    while i < len(lines):
+        match = _DEF_RE.match(lines[i])
+        if match is None:
+            keep.append(lines[i])
+            i += 1
+            continue
+        # A helper definition, preceded by its "template <...>" line; the
+        # three banner comments precede the first one.
+        if not keep or not keep[-1].startswith(_TEMPLATE_LINE):
+            return source  # not our emission shape; force the self-check to fail
+        keep.pop()
+        if start is None:
+            start = len(keep)
+        body: list[str] = []
+        i += 1
+        while i < len(lines) and lines[i] != "}":
+            body.append(lines[i])
+            i += 1
+        i += 1  # the closing brace
+        bodies[match.group(1)] = body
+    if start is not None:
+        span = len(_BANNER)
+        if tuple(keep[start - span : start]) == _BANNER:
+            del keep[start - span : start]
+            start -= span
+        if start < len(keep) and keep[start] == "":
+            del keep[start]
+
+    out: list[str] = []
+    for line in keep:
+        match = _CALL_RE.match(line)
+        if match is None:
+            out.append(line)
+            continue
+        out.extend(bodies.pop(match.group(1), []))
+    if bodies:
+        return source  # unmatched helper: force the caller's self-check to fail
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Compiler-path installation
+# ---------------------------------------------------------------------------
+
+# The outer worker already schedules several graph-class children. Keeping the
+# K+1 host fragments serial avoids a hidden second pool and still preserves the
+# measured total-CPU win from splitting one superlinear function. This is a
+# sealed library policy, not an environment or caller knob.
+HOST_COMPILE_JOBS = 1
+
+_installed = False
+
+
+#: Phase-label prefix for the run_impl lever — a name, never a version number.
+_RUNIMPL = "runimpl"
+
+
+def _emit(outcome: SplitOutcome, lever: str = "") -> None:
+    """Log the private transform outcome without importing product telemetry."""
+
+    state = "applied" if outcome.applied else "declined"
+    logger.debug(
+        "aot-wrapper-split %s%s: %s",
+        f"{lever}_" if lever else "",
+        state,
+        outcome.detail(),
+    )
+
+
+def _split_source_arg(argv: Sequence[str]) -> int | None:
+    """Index of the single ``.cpp`` source in a compile-only command line,
+    or None when this is not a one-source C++ compile (links, the PCH
+    build, the ``.S`` constants object all land here too)."""
+    if "-c" not in argv:
+        return None
+    sources = [i for i, tok in enumerate(argv) if tok.endswith(".cpp") and not tok.startswith("-")]
+    if len(sources) != 1:
+        return None
+    return sources[0]
+
+
+def transform_command(cmd_line: str) -> tuple[str, SplitOutcome | None]:
+    """``(cmd_line', outcome)``. ``outcome`` is None when the command is not
+    a single-source C++ compile at all (nothing to report). Every failure
+    mode — unreadable source, unrecognised shape, write error — returns the
+    ORIGINAL command line."""
+    try:
+        argv = shlex.split(cmd_line)
+    except ValueError:
+        return cmd_line, None
+    index = _split_source_arg(argv)
+    if index is None:
+        return cmd_line, None
+    source = Path(argv[index])
+    try:
+        text = source.read_text()
+    except OSError as exc:
+        return cmd_line, SplitOutcome(False, f"unreadable source: {exc}", source=str(source))
+    split, outcome = split_constants_constructor(text)
+    outcome = replace(outcome, source=str(source))
+    if not outcome.applied:
+        return cmd_line, outcome
+    target = source.with_name(source.name[: -len(".cpp")] + ".tcg.cpp")
+    try:
+        target.write_text(split)
+    except OSError as exc:
+        return cmd_line, replace(outcome, applied=False, reason=f"unwritable transform: {exc}")
+    argv = list(argv)
+    argv[index] = str(target)
+    return shlex.join(argv), outcome
+
+
+# ---------------------------------------------------------------------------
+# run_impl: the K-way split, driven over K+1 real compiles
+# ---------------------------------------------------------------------------
+
+
+def _object_arg(argv: Sequence[str]) -> int | None:
+    """Index of the ``-o`` VALUE in a compile-only command line."""
+    for i, tok in enumerate(argv[:-1]):
+        if tok == "-o":
+            return i + 1
+    return None
+
+
+def _retarget(argv: Sequence[str], src_at: int, obj_at: int, source: Path, obj: Path) -> str:
+    out = list(argv)
+    out[src_at] = str(source)
+    out[obj_at] = str(obj)
+    return shlex.join(out)
+
+
+def _partial_link(argv: Sequence[str], objects: Sequence[Path], target: Path) -> str:
+    """``ld -r`` the part objects into the ONE object torch's link step
+    expects. Driven through the same compiler binary torch chose, so the
+    toolchain stays exactly the one the compiled-graph identity names."""
+    return shlex.join([argv[0], "-r", "-nostdlib", "-o", str(target), *(str(o) for o in objects)])
+
+
+def split_and_compile(
+    cmd_line: str, cwd: str, run: Callable[[str, str], None]
+) -> SplitOutcome | None:
+    """Build ``cmd_line``'s source as K+1 chained TUs, partial-linked into
+    the one object torch's link step expects.
+
+    Returns the outcome on success, or None when the caller should fall back
+    to compiling ``cmd_line`` unmodified. Nothing here may leave a
+    half-written object at the target path: the partial link is the last
+    step and runs only once every part has built.
+    """
+
+    argv = shlex.split(cmd_line)
+    src_at, obj_at = _split_source_arg(argv), _object_arg(argv)
+    if src_at is None or obj_at is None:
+        return None
+    source = Path(argv[src_at])
+    try:
+        text = source.read_text()
+    except OSError as exc:
+        _emit(SplitOutcome(False, f"unreadable source: {exc}", source=str(source)), lever=_RUNIMPL)
+        return None
+    split = runimpl.split_run_impl(text)
+    if not split.applied:
+        _emit(SplitOutcome(False, split.reason, source=str(source)))
+        return None
+
+    stem = source.name[: -len(".cpp")]
+    units: list[tuple[Path, Path]] = []
+    for name, body in [("main", split.main), *((f"part{i}", p) for i, p in enumerate(split.parts))]:
+        cpp = source.with_name(f"{stem}.tcg.{name}.cpp")
+        cpp.write_text(body)
+        units.append((cpp, cpp.with_suffix(".o")))
+
+    def build(unit: tuple[Path, Path]) -> None:
+        run(_retarget(argv, src_at, obj_at, unit[0], unit[1]), cwd)
+
+    for unit in units:
+        build(unit)
+
+    run(_partial_link(argv, [o for _, o in units], Path(argv[obj_at])), cwd)
+    return SplitOutcome(
+        True,
+        "",
+        statements=split.compute_lines,
+        chunks=len(units),
+        bytes_in=len(text),
+        bytes_out=sum(len(b) for b in (split.main, *split.parts)),
+        source=str(source),
+        summary=(
+            f"run_impl {split.compute_lines} statements / {split.declarations} "
+            f"declarations -> {len(split.parts)} chained TUs "
+            f"(max {split.threaded_max} threaded, {split.rederived_max} "
+            f"re-derived), {HOST_COMPILE_JOBS} concurrent compile, partial-linked"
+        ),
+    )
+
+
+def install() -> bool:
+    """Install the transform on torch's single host-compile funnel.
+
+    ``CppBuilder.build()`` reaches ``run_compile_cmd`` through the module
+    global, so wrapping that name covers every host compile inductor
+    performs and nothing else.
+
+    IDENTITY: this changes neither the compiler, its flags, any Inductor
+    config, nor any loaded library. It only regroups generated statements
+    after the compiled-graph key has been derived.
+
+    Returns True when installed, False when already installed.
+    """
+    global _installed
+    if _installed:
+        return False
+    try:
+        from torch._inductor import cpp_builder
+    except Exception:
+        logger.debug("aot-wrapper-split: torch._inductor unavailable")
+        return False
+    original: Callable[..., None] = cpp_builder.run_compile_cmd
+
+    def _patched(cmd_line: str, cwd: str) -> None:
+        # The ISA clamp is asserted at the CONFIG level by host_isa.impose();
+        # this is the argv-level assertion. `run_compile_cmd` is torch's single
+        # host-compile funnel, so every object a mint produces passes through
+        # here exactly once. It raises rather than degrading: an unclamped
+        # object is not slower, it is unportable — a SIGILL-class defect.
+        _assert_command_is_clamped(cmd_line)
+
+        try:
+            new_cmd, outcome = transform_command(cmd_line)
+        except Exception:
+            logger.warning(
+                "aot-wrapper-split: transform raised; compiling unmodified",
+                exc_info=True,
+            )
+            original(cmd_line, cwd)
+            return
+        if outcome is None:
+            original(cmd_line, cwd)  # not a single-source C++ compile
+            return
+        _emit(outcome)
+
+        # The run_impl split works on whatever source the ctor split left —
+        # inductor's own when the ctor split declined, its regrouped one when it
+        # did not. It subsumes the single compile: when it fires it drives every
+        # compile itself and there is no monolith left to run.
+        try:
+            runimpl_outcome = split_and_compile(new_cmd, cwd, original)
+        except Exception as exc:
+            _emit(
+                SplitOutcome(
+                    False,
+                    "split TUs failed to build, retried the whole wrapper: "
+                    f"{type(exc).__name__}: {exc}",
+                    source=outcome.source,
+                ),
+                lever=_RUNIMPL,
+            )
+            logger.warning(
+                "aot-wrapper-split: split failed (%s); recompiling the whole wrapper",
+                type(exc).__name__,
+                exc_info=True,
+            )
+        else:
+            if runimpl_outcome is not None:
+                _emit(runimpl_outcome, lever=_RUNIMPL)
+                return
+
+        if not outcome.applied:
+            original(cmd_line, cwd)
+            return
+        try:
+            original(new_cmd, cwd)
+        except Exception as exc:
+            # The transformed TU did not build. The original command is
+            # untouched and reproducible, so a mint degrades to the slow
+            # path instead of failing. If THAT also fails, the wrapper
+            # itself is broken and the real error propagates.
+            _emit(
+                replace(
+                    outcome,
+                    applied=False,
+                    reason=(
+                        "transformed TU failed to compile, retried the "
+                        f"original: {type(exc).__name__}"
+                    ),
+                )
+            )
+            logger.warning(
+                "aot-wrapper-split: transformed TU failed to compile (%s); "
+                "recompiling inductor's own source",
+                type(exc).__name__,
+            )
+            original(cmd_line, cwd)
+            return
+        _emit(outcome)
+
+    _patched.__wrapped__ = original  # type: ignore[attr-defined]
+    cpp_builder.run_compile_cmd = _patched
+    _installed = True
+    logger.info("aot-wrapper-split: installed on cpp_builder.run_compile_cmd")
+    return True

--- a/src/gen_worker/_vendor/torch_compiled_graphs/artifact.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/artifact.py
@@ -1,0 +1,818 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import os
+import shutil
+import struct
+import tarfile
+import tempfile
+import zlib
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any, BinaryIO, cast
+
+from .declaration import DeclarationError, GraphClassDeclaration, _update_literal_digest
+from .host_isa import HostISAError, _validate_host_facts
+from .identity import (
+    ARTIFACT_KIND,
+    GRAPH_CLASS_BLOCK,
+    from_artifact_metadata,
+    is_compiled_graph_key,
+)
+from .introspection import (
+    PackageIntrospectionError,
+    _package_entry_names,
+    code_only_violations,
+    declared_constants,
+)
+
+COMPILED_GRAPH_FORMAT = 1
+_COMPILED_GRAPH_FORMAT_AXIS = "compiled_graph_format"
+METADATA_NAME = "metadata.json"
+PACKAGE_NAME = "model.pt2"
+LITERALS_NAME = "constants.safetensors"
+_REQUIRED_MEMBERS = frozenset((METADATA_NAME, PACKAGE_NAME))
+_MEMBERS = _REQUIRED_MEMBERS | {LITERALS_NAME}
+_MAX_METADATA_BYTES = 8 << 20
+_MAX_SAFETENSORS_HEADER_BYTES = 8 << 20
+# A code-only AOTI package must not carry model weights. Sixteen GiB is four
+# times ZIP32's 4 GiB boundary: enough for unusually large generated host/CUDA
+# code while still making remote decompression a finite admission operation.
+_MAX_PACKAGE_BYTES = 16 << 30
+# Literal constants are the only tensor bytes this envelope permits. Four GiB
+# is the ZIP32 boundary; larger payloads are model-state in practice and belong
+# in the separately bound repository snapshot, not one compiled graph.
+_MAX_LITERALS_BYTES = 4 << 30
+# The sum, rather than a second convention, is the exact v1 envelope budget.
+_MAX_MEMBER_BYTES = _MAX_METADATA_BYTES + _MAX_PACKAGE_BYTES + _MAX_LITERALS_BYTES
+# Deflate's documented worst-case expansion is well below one percent. That
+# margin plus one canonical tar record bounds the fetched/compressed input too,
+# including concatenated empty gzip members that add CPU without member bytes.
+_MAX_ARCHIVE_BYTES = _MAX_MEMBER_BYTES + _MAX_MEMBER_BYTES // 100 + tarfile.RECORDSIZE
+# Three member headers/padding plus the USTAR terminator fit well within two
+# records. This is the gzip decoder's output ceiling before tar semantics run.
+_MAX_TAR_BYTES = _MAX_MEMBER_BYTES + 2 * tarfile.RECORDSIZE
+_CONSTANT_FIELDS = frozenset(("fqn", "source", "dtype", "shape"))
+_CONSTANT_SOURCES = frozenset(("state_dict", "computed", "literal"))
+_TOP_LEVEL_FIELDS = frozenset(
+    (
+        _COMPILED_GRAPH_FORMAT_AXIS,
+        "kind",
+        "compiled_graph_key",
+        GRAPH_CLASS_BLOCK,
+        "sm",
+        "toolchain",
+        "host_isa",
+        "package_constants_in_so",
+        "constant_folding_fenced",
+    )
+)
+
+_SAFETENSORS_DTYPES: dict[str, tuple[str, int]] = {
+    "BOOL": ("bool", 1),
+    "U8": ("uint8", 1),
+    "I8": ("int8", 1),
+    "I16": ("int16", 2),
+    "U16": ("uint16", 2),
+    "I32": ("int32", 4),
+    "U32": ("uint32", 4),
+    "I64": ("int64", 8),
+    "U64": ("uint64", 8),
+    "F16": ("float16", 2),
+    "BF16": ("bfloat16", 2),
+    "F32": ("float32", 4),
+    "F64": ("float64", 8),
+    "C64": ("complex64", 8),
+    "C128": ("complex128", 16),
+    "F8_E4M3": ("float8_e4m3fn", 1),
+    "F8_E4M3FNUZ": ("float8_e4m3fnuz", 1),
+    "F8_E5M2": ("float8_e5m2", 1),
+    "F8_E5M2FNUZ": ("float8_e5m2fnuz", 1),
+    "F8_E8M0": ("float8_e8m0fnu", 1),
+}
+_GRAPH_CLASS_FIELDS = frozenset(
+    (
+        "name",
+        "target",
+        "class_hash",
+        "graph",
+        "graph_witness",
+        "range_digest",
+        "fork",
+        "class_dims",
+        "strict",
+        "lora_bucket",
+        "literal_values",
+        "literal_payload_values",
+        "placement",
+        "constants",
+    )
+)
+
+
+class ArtifactError(ValueError):
+    """A compiled-graph envelope is malformed or internally inconsistent."""
+
+
+def _fsync_dir(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _validated_constants(graph_class: Mapping[str, Any]) -> list[dict[str, Any]]:
+    constants = graph_class.get("constants")
+    if not isinstance(constants, list):
+        raise ArtifactError("graph_class constants must be an array")
+    checked: list[dict[str, Any]] = []
+    fqns: set[str] = set()
+    for index, row in enumerate(constants):
+        if not isinstance(row, Mapping):
+            raise ArtifactError("graph_class constant must be an object")
+        if set(row) != _CONSTANT_FIELDS:
+            raise ArtifactError(
+                "graph_class constant "
+                f"{index} fields must be exactly {sorted(_CONSTANT_FIELDS)!r}"
+            )
+        fqn = row.get("fqn")
+        source = row.get("source")
+        dtype = row.get("dtype")
+        shape = row.get("shape")
+        if not isinstance(fqn, str) or not fqn or fqn != fqn.strip():
+            raise ArtifactError(f"graph_class constant {index} fqn must be a non-empty string")
+        if fqn in fqns:
+            raise ArtifactError(f"graph_class constants contain duplicate fqn {fqn!r}")
+        if source not in _CONSTANT_SOURCES:
+            raise ArtifactError(
+                "graph_class constant "
+                f"{index} source must be one of {sorted(_CONSTANT_SOURCES)!r}"
+            )
+        if not isinstance(dtype, str) or not dtype or dtype != dtype.strip():
+            raise ArtifactError(
+                f"graph_class constant {index} dtype must be a non-empty string"
+            )
+        if not isinstance(shape, list) or not all(
+            type(dimension) is int and dimension >= 0 for dimension in shape
+        ):
+            raise ArtifactError(
+                "graph_class constant "
+                f"{index} shape must be an array of non-negative integers"
+            )
+        fqns.add(fqn)
+        checked.append({"fqn": fqn, "source": source, "dtype": dtype, "shape": list(shape)})
+    return checked
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for name, value in pairs:
+        if name in result:
+            raise ArtifactError(f"JSON object declares duplicate key {name!r}")
+        result[name] = value
+    return result
+
+
+def _bounded_chunks(source: BinaryIO, offset: int, size: int) -> Iterator[bytes]:
+    source.seek(offset)
+    remaining = size
+    while remaining:
+        chunk = source.read(min(1 << 20, remaining))
+        if not chunk:
+            raise ArtifactError("safetensors tensor data is truncated")
+        remaining -= len(chunk)
+        yield chunk
+
+
+def _verify_literals(path: Path | None, metadata: Mapping[str, Any]) -> None:
+    graph_class = cast(Mapping[str, Any], metadata[GRAPH_CLASS_BLOCK])
+    literal_rows = {
+        cast(str, row["fqn"]): row
+        for row in cast(list[dict[str, Any]], graph_class["constants"])
+        if row["source"] == "literal"
+    }
+    if not literal_rows:
+        if path is not None:
+            raise ArtifactError("artifact carries a literal payload but declares no literals")
+        return
+    if path is None:
+        raise ArtifactError("graph_class declares literal constants but carries no literal payload")
+
+    try:
+        total_size = path.stat().st_size
+        with path.open("rb") as source:
+            prefix = source.read(8)
+            if len(prefix) != 8:
+                raise ArtifactError("safetensors payload has no complete header length")
+            header_size = struct.unpack("<Q", prefix)[0]
+            if (
+                header_size == 0
+                or header_size % 8 != 0
+                or header_size > _MAX_SAFETENSORS_HEADER_BYTES
+                or header_size > total_size - 8
+            ):
+                raise ArtifactError("safetensors payload has an invalid header length")
+            encoded = source.read(header_size)
+            if len(encoded) != header_size:
+                raise ArtifactError("safetensors payload has a truncated header")
+            try:
+                decoded = json.loads(encoded, object_pairs_hook=_unique_object)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ArtifactError(f"safetensors payload has invalid JSON: {exc}") from exc
+            if not isinstance(decoded, dict):
+                raise ArtifactError("safetensors header must be an object")
+            metadata_row = decoded.pop("__metadata__", None)
+            if metadata_row is not None and (
+                not isinstance(metadata_row, dict)
+                or any(
+                    not isinstance(key, str) or not isinstance(value, str)
+                    for key, value in metadata_row.items()
+                )
+            ):
+                raise ArtifactError("safetensors __metadata__ must contain only strings")
+            if set(decoded) != set(literal_rows):
+                missing = sorted(set(literal_rows) - set(decoded))
+                extra = sorted(set(decoded) - set(literal_rows))
+                raise ArtifactError(
+                    "safetensors names do not match declared literals "
+                    f"(missing {missing}, extra {extra})"
+                )
+
+            data_start = 8 + header_size
+            data_size = total_size - data_start
+            tensors: dict[str, tuple[str, tuple[int, ...], int, int]] = {}
+            ranges: list[tuple[int, int, str]] = []
+            for name, raw in decoded.items():
+                if not isinstance(raw, dict) or set(raw) != {"dtype", "shape", "data_offsets"}:
+                    raise ArtifactError(f"safetensors tensor {name!r} has invalid fields")
+                raw_dtype = raw["dtype"]
+                raw_shape = raw["shape"]
+                raw_offsets = raw["data_offsets"]
+                dtype_info = (
+                    _SAFETENSORS_DTYPES.get(raw_dtype) if isinstance(raw_dtype, str) else None
+                )
+                if dtype_info is None:
+                    raise ArtifactError(f"safetensors tensor {name!r} has unsupported dtype")
+                if not isinstance(raw_shape, list) or not all(
+                    type(dimension) is int and dimension >= 0 for dimension in raw_shape
+                ):
+                    raise ArtifactError(f"safetensors tensor {name!r} has invalid shape")
+                if (
+                    not isinstance(raw_offsets, list)
+                    or len(raw_offsets) != 2
+                    or not all(type(offset) is int and offset >= 0 for offset in raw_offsets)
+                ):
+                    raise ArtifactError(f"safetensors tensor {name!r} has invalid data offsets")
+                start, end = raw_offsets
+                shape = tuple(raw_shape)
+                elements = 1
+                for dimension in shape:
+                    elements *= dimension
+                if end < start or end - start != elements * dtype_info[1] or end > data_size:
+                    raise ArtifactError(f"safetensors tensor {name!r} has an invalid byte range")
+                declared = literal_rows[name]
+                if declared["dtype"] != dtype_info[0]:
+                    raise ArtifactError(
+                        f"safetensors tensor {name!r} dtype does not match declaration"
+                    )
+                if tuple(declared["shape"]) != shape:
+                    raise ArtifactError(
+                        f"safetensors tensor {name!r} shape does not match declaration"
+                    )
+                tensors[name] = (dtype_info[0], shape, start, end)
+                ranges.append((start, end, name))
+
+            expected_offset = 0
+            for start, end, name in sorted(ranges):
+                if start != expected_offset:
+                    raise ArtifactError(
+                        f"safetensors tensor {name!r} has overlapping or non-contiguous data"
+                    )
+                expected_offset = end
+            if expected_offset != data_size:
+                raise ArtifactError("safetensors payload has unclaimed trailing data")
+
+            digest = hashlib.sha256()
+            for name in sorted(tensors):
+                canonical_dtype, shape, start, end = tensors[name]
+                _update_literal_digest(
+                    digest,
+                    name=name,
+                    dtype=f"torch.{canonical_dtype}",
+                    shape=shape,
+                    chunks=_bounded_chunks(source, data_start + start, end - start),
+                )
+            if digest.hexdigest()[:32] != graph_class["literal_payload_values"]:
+                raise ArtifactError(
+                    "safetensors values do not match graph_class literal_payload_values"
+                )
+    except OSError:
+        raise
+
+
+def validate_metadata(
+    raw: Mapping[str, Any], *, has_literals: bool | None = None
+) -> dict[str, Any]:
+    """Validate, detach, and return the sole v1 metadata representation."""
+
+    try:
+        decoded: object = json.loads(json.dumps(dict(raw), allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise ArtifactError(f"metadata is not finite JSON: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise ArtifactError("metadata root must be an object")
+    metadata = cast(dict[str, Any], decoded)
+    if set(metadata) != _TOP_LEVEL_FIELDS:
+        raise ArtifactError(f"metadata fields must be exactly {sorted(_TOP_LEVEL_FIELDS)!r}")
+    if (
+        type(metadata.get(_COMPILED_GRAPH_FORMAT_AXIS)) is not int
+        or metadata.get(_COMPILED_GRAPH_FORMAT_AXIS) != COMPILED_GRAPH_FORMAT
+    ):
+        raise ArtifactError(
+            f"{_COMPILED_GRAPH_FORMAT_AXIS} must be {COMPILED_GRAPH_FORMAT}"
+        )
+    if metadata.get("kind") != ARTIFACT_KIND:
+        raise ArtifactError(f"kind must be {ARTIFACT_KIND!r}")
+    if metadata.get("package_constants_in_so") is not False:
+        raise ArtifactError("package_constants_in_so must be false")
+    if metadata.get("constant_folding_fenced") is not True:
+        raise ArtifactError("constant_folding_fenced must be true")
+    sm = metadata.get("sm")
+    if not isinstance(sm, str) or not sm or sm != sm.strip():
+        raise ArtifactError("sm must be a non-empty string")
+    toolchain = metadata.get("toolchain")
+    if (
+        not isinstance(toolchain, dict)
+        or not toolchain
+        or any(
+            not isinstance(name, str)
+            or not name
+            or name != name.strip()
+            or not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            for name, value in toolchain.items()
+        )
+    ):
+        raise ArtifactError("toolchain must contain non-empty string facts")
+    host_isa = metadata.get("host_isa")
+    if not isinstance(host_isa, dict):
+        raise ArtifactError("host_isa must be an object")
+    try:
+        _validate_host_facts(cast(dict[str, str], host_isa))
+    except HostISAError as exc:
+        raise ArtifactError(f"host_isa facts are invalid: {exc}") from exc
+    graph_class = metadata.get(GRAPH_CLASS_BLOCK)
+    if not isinstance(graph_class, dict):
+        raise ArtifactError("metadata must contain one graph_class object")
+    if set(graph_class) != _GRAPH_CLASS_FIELDS:
+        raise ArtifactError(
+            f"graph_class fields must be exactly {sorted(_GRAPH_CLASS_FIELDS)!r}"
+        )
+    for field in ("name", "target", "class_hash", "graph_witness", "range_digest"):
+        if not isinstance(graph_class.get(field), str) or not graph_class[field].strip():
+            raise ArtifactError(f"graph_class {field!r} must be a non-empty string")
+    graph = graph_class.get("graph")
+    if not isinstance(graph, dict) or not graph:
+        raise ArtifactError("graph_class graph must be a non-empty object")
+    literal_values = graph_class.get("literal_values")
+    literal_payload_values = graph_class.get("literal_payload_values")
+    placement = graph_class.get("placement")
+    fork = graph_class.get("fork")
+    class_dims = graph_class.get("class_dims")
+    strict = graph_class.get("strict")
+    lora_bucket = graph_class.get("lora_bucket")
+    if not isinstance(literal_values, str):
+        raise ArtifactError("graph_class literal_values must be a string")
+    if not isinstance(literal_payload_values, str) or (
+        literal_payload_values
+        and (
+            len(literal_payload_values) != 32
+            or any(character not in "0123456789abcdef" for character in literal_payload_values)
+        )
+    ):
+        raise ArtifactError(
+            "graph_class literal_payload_values must be empty or 32 lowercase "
+            "hexadecimal characters"
+        )
+    if not isinstance(placement, list) or not all(
+        isinstance(device, str) and device and device == device.strip() for device in placement
+    ):
+        raise ArtifactError("graph_class placement must be an array of non-empty strings")
+    if not isinstance(fork, list) or not all(
+        isinstance(row, list) and len(row) == 2 and isinstance(row[0], str) for row in fork
+    ):
+        raise ArtifactError("graph_class fork must be an array of name/value pairs")
+    if not isinstance(class_dims, list) or not all(
+        isinstance(row, list)
+        and len(row) == 2
+        and isinstance(row[0], str)
+        and type(row[1]) is int
+        for row in class_dims
+    ):
+        raise ArtifactError("graph_class class_dims must be an array of name/integer pairs")
+    if type(strict) is not bool:
+        raise ArtifactError("graph_class strict must be a boolean")
+    if type(lora_bucket) is not int:
+        raise ArtifactError("graph_class lora_bucket must be an integer")
+    try:
+        declaration = GraphClassDeclaration(
+            graph_class=graph_class["name"],
+            target=graph_class["target"],
+            graph=graph,
+            graph_witness=graph_class["graph_witness"],
+            range_digest=graph_class["range_digest"],
+            fork=tuple((row[0], row[1]) for row in fork),
+            class_dims=tuple((row[0], row[1]) for row in class_dims),
+            strict=strict,
+            lora_bucket=lora_bucket,
+            literal_values=literal_values,
+            placement=tuple(placement),
+        )
+    except DeclarationError as exc:
+        raise ArtifactError(f"graph_class declaration is invalid: {exc}") from exc
+    if (
+        graph_class["name"] != declaration.graph_class
+        or graph_class["target"] != declaration.target
+    ):
+        raise ArtifactError("graph_class name and target must be canonical")
+    if placement != list(declaration.placement):
+        raise ArtifactError("graph_class placement must be sorted and unique")
+    if fork != [[name, value] for name, value in declaration.fork]:
+        raise ArtifactError("graph_class fork must be canonical")
+    if class_dims != [[name, value] for name, value in declaration.class_dims]:
+        raise ArtifactError("graph_class class_dims must be canonical")
+    if graph_class["class_hash"] != declaration.class_hash:
+        raise ArtifactError("graph_class class_hash does not restate its declaration facts")
+    expected = from_artifact_metadata(metadata).value
+    stamped = metadata.get("compiled_graph_key")
+    if not isinstance(stamped, str) or not is_compiled_graph_key(stamped):
+        raise ArtifactError("compiled_graph_key is missing or malformed")
+    if stamped != expected:
+        raise ArtifactError(
+            f"compiled_graph_key {stamped!r} does not restate artifact facts ({expected})"
+        )
+    constants = _validated_constants(graph_class)
+    graph_class["constants"] = constants
+    needs_literals = any(row["source"] == "literal" for row in constants)
+    if needs_literals and not literal_values:
+        raise ArtifactError("graph_class literal constants require a literal_values digest")
+    if needs_literals and not literal_payload_values:
+        raise ArtifactError(
+            "graph_class literal constants require a literal_payload_values digest"
+        )
+    if not needs_literals and literal_payload_values:
+        raise ArtifactError(
+            "graph_class literal_payload_values requires declared literal constants"
+        )
+    if has_literals is not None and has_literals != needs_literals:
+        if needs_literals:
+            raise ArtifactError(
+                "graph_class declares literal constants but carries no literal payload"
+            )
+        raise ArtifactError("artifact carries a literal payload but declares no literals")
+    return metadata
+
+
+def build_metadata(
+    *,
+    graph_class: Mapping[str, Any],
+    sm: str,
+    toolchain: Mapping[str, str],
+    host_isa: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build metadata from recorded facts and stamp the key derived from them."""
+
+    metadata: dict[str, Any] = {
+        _COMPILED_GRAPH_FORMAT_AXIS: COMPILED_GRAPH_FORMAT,
+        "kind": ARTIFACT_KIND,
+        GRAPH_CLASS_BLOCK: dict(graph_class),
+        "sm": str(sm),
+        "toolchain": dict(toolchain),
+        "host_isa": dict(host_isa),
+        "package_constants_in_so": False,
+        "constant_folding_fenced": True,
+    }
+    metadata["compiled_graph_key"] = from_artifact_metadata(metadata).value
+    return validate_metadata(metadata)
+
+
+def _metadata_bytes(metadata: Mapping[str, Any]) -> bytes:
+    checked = validate_metadata(metadata)
+    return json.dumps(
+        checked, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("ascii")
+
+
+def _tarinfo(name: str, size: int) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.size = size
+    info.mode = 0o644
+    info.uid = info.gid = 0
+    info.uname = info.gname = ""
+    info.mtime = 0
+    return info
+
+
+def _member_limit(name: str) -> int:
+    limits = {
+        METADATA_NAME: _MAX_METADATA_BYTES,
+        PACKAGE_NAME: _MAX_PACKAGE_BYTES,
+        LITERALS_NAME: _MAX_LITERALS_BYTES,
+    }
+    return limits[name]
+
+
+def _validate_member_sizes(sizes: Mapping[str, int]) -> None:
+    total = 0
+    for name, size in sizes.items():
+        if type(size) is not int or size < 0:
+            raise ArtifactError(f"artifact member {name!r} has an invalid size")
+        limit = _member_limit(name)
+        if size > limit:
+            raise ArtifactError(f"{name} exceeds the {limit}-byte v1 budget")
+        total += size
+        if total > _MAX_MEMBER_BYTES:
+            raise ArtifactError(
+                f"artifact total uncompressed bytes exceed the {_MAX_MEMBER_BYTES}-byte v1 budget"
+            )
+
+
+def pack_artifact(
+    package: str | Path,
+    output: str | Path,
+    metadata: Mapping[str, Any],
+    *,
+    literals: str | Path | None = None,
+) -> Path:
+    """Create the deterministic v1 tar+gzip envelope."""
+
+    package_path = Path(package)
+    if not package_path.is_file():
+        raise FileNotFoundError(package_path)
+    literal_path = Path(literals) if literals is not None else None
+    if literal_path is not None and not literal_path.is_file():
+        raise FileNotFoundError(literal_path)
+    checked = validate_metadata(metadata, has_literals=literal_path is not None)
+    encoded = _metadata_bytes(checked)
+    sizes = {
+        METADATA_NAME: len(encoded),
+        PACKAGE_NAME: package_path.stat().st_size,
+    }
+    if literal_path is not None:
+        sizes[LITERALS_NAME] = literal_path.stat().st_size
+    _validate_member_sizes(sizes)
+    _verify_literals(literal_path, checked)
+    verify_package(package_path, checked)
+    target = Path(output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    try:
+        with os.fdopen(fd, "wb") as raw:
+            with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as compressed:
+                with tarfile.open(
+                    fileobj=compressed, mode="w", format=tarfile.USTAR_FORMAT
+                ) as archive:
+                    archive.addfile(_tarinfo(METADATA_NAME, len(encoded)), io.BytesIO(encoded))
+                    for name, source in (
+                        (PACKAGE_NAME, package_path),
+                        (LITERALS_NAME, literal_path),
+                    ):
+                        if source is None:
+                            continue
+                        with source.open("rb") as handle:
+                            archive.addfile(_tarinfo(name, source.stat().st_size), handle)
+            raw.flush()
+            os.fsync(raw.fileno())
+        with tempfile.TemporaryDirectory(
+            prefix=f".{target.name}.verify-", dir=target.parent
+        ) as raw_verified:
+            unpack_artifact(temporary_name, Path(raw_verified) / "artifact")
+        os.replace(temporary_name, target)
+        _fsync_dir(target.parent)
+    except BaseException:
+        Path(temporary_name).unlink(missing_ok=True)
+        raise
+    return target
+
+
+def verify_package(package: str | Path, metadata: Mapping[str, Any]) -> None:
+    """Cross-check metadata against one code-only AOTInductor package."""
+
+    package_path = Path(package)
+    checked = validate_metadata(metadata)
+    graph_class = cast(dict[str, Any], checked[GRAPH_CLASS_BLOCK])
+    name = cast(str, graph_class["name"])
+    try:
+        names = _package_entry_names(package_path)
+        if names != (name,):
+            raise ArtifactError(
+                f"package entries {names!r} do not match graph_class {name!r}"
+            )
+        package_constants = [
+            constant.as_manifest_row() for constant in declared_constants(package_path, name)
+        ]
+        if package_constants != graph_class["constants"]:
+            raise ArtifactError("metadata constants do not match the package constant table")
+        violations = code_only_violations(package_path, name)
+    except PackageIntrospectionError as exc:
+        raise ArtifactError(f"cannot verify AOTInductor package: {exc}") from exc
+    if violations:
+        raise ArtifactError("AOTInductor package is not code-only: " + "; ".join(violations))
+
+
+def _validate_single_gzip_member(artifact: Path) -> None:
+    decoder = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
+    uncompressed = 0
+    try:
+        with artifact.open("rb") as source:
+            while compressed := source.read(1 << 16):
+                pending = compressed
+                while pending:
+                    output = decoder.decompress(pending, 1 << 20)
+                    uncompressed += len(output)
+                    if uncompressed > _MAX_TAR_BYTES:
+                        raise ArtifactError(
+                            "artifact decompressed bytes exceed the "
+                            f"{_MAX_TAR_BYTES}-byte v1 budget"
+                        )
+                    pending = decoder.unconsumed_tail
+                    if decoder.eof:
+                        if decoder.unused_data or pending or source.read(1):
+                            raise ArtifactError("artifact must contain exactly one gzip member")
+                        return
+            if not decoder.eof:
+                raise ArtifactError("artifact has a truncated gzip member")
+    except ArtifactError:
+        raise
+    except (OSError, zlib.error) as exc:
+        raise ArtifactError(f"cannot decompress artifact {artifact}: {exc}") from exc
+
+
+def _members(artifact: Path) -> tuple[tarfile.TarFile, dict[str, tarfile.TarInfo]]:
+    archive: tarfile.TarFile | None = None
+    try:
+        artifact_size = artifact.stat().st_size
+        if artifact_size > _MAX_ARCHIVE_BYTES:
+            raise ArtifactError(
+                f"artifact compressed bytes exceed the {_MAX_ARCHIVE_BYTES}-byte v1 budget"
+            )
+        _validate_single_gzip_member(artifact)
+        archive = tarfile.open(artifact, mode="r:*")
+        members: dict[str, tarfile.TarInfo] = {}
+        sizes: dict[str, int] = {}
+        while (row := archive.next()) is not None:
+            if (
+                row.name not in _MEMBERS
+                or not row.isfile()
+                or row.pax_headers
+                or row.name in members
+            ):
+                raise ArtifactError(f"unexpected or duplicate artifact member {row.name!r}")
+            sizes[row.name] = row.size
+            _validate_member_sizes(sizes)
+            members[row.name] = row
+        # The v1 writer closes USTAR with two zero blocks and pads to the next
+        # 20-block record. Consume exactly those canonical bytes, then force one
+        # EOF read so gzip validates its CRC and end marker.
+        expected_end = (
+            (
+                archive.offset
+                + 2 * tarfile.BLOCKSIZE
+                + tarfile.RECORDSIZE
+                - 1
+            )
+            // tarfile.RECORDSIZE
+        ) * tarfile.RECORDSIZE
+        remaining_padding = expected_end - archive.fileobj.tell()
+        if not 0 <= remaining_padding <= tarfile.RECORDSIZE:
+            raise ArtifactError("artifact has a non-canonical USTAR end marker")
+        while remaining_padding:
+            trailer = archive.fileobj.read(min(1 << 20, remaining_padding))
+            if not trailer:
+                raise ArtifactError("artifact has truncated USTAR padding")
+            if trailer.strip(b"\0"):
+                raise ArtifactError("artifact has nonzero bytes after the USTAR end marker")
+            remaining_padding -= len(trailer)
+        if archive.fileobj.read(1):
+            raise ArtifactError("artifact has bytes after the canonical USTAR record")
+        missing = _REQUIRED_MEMBERS - set(members)
+        if missing:
+            raise ArtifactError(f"artifact is missing {sorted(missing)!r}")
+        return archive, members
+    except ArtifactError:
+        if archive is not None:
+            archive.close()
+        raise
+    except (EOFError, OSError, tarfile.TarError) as exc:
+        if archive is not None:
+            archive.close()
+        raise ArtifactError(f"cannot read artifact {artifact}: {exc}") from exc
+
+
+def read_metadata(artifact: str | Path) -> dict[str, Any]:
+    path = Path(artifact)
+    archive, members = _members(path)
+    try:
+        info = members[METADATA_NAME]
+        handle = archive.extractfile(info)
+        if handle is None:
+            raise ArtifactError("metadata member is unreadable")
+        try:
+            raw = json.load(handle, object_pairs_hook=_unique_object)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArtifactError(f"metadata is not valid JSON: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise ArtifactError("metadata root must be an object")
+        return validate_metadata(raw, has_literals=LITERALS_NAME in members)
+    except ArtifactError:
+        raise
+    except (EOFError, OSError, tarfile.TarError) as exc:
+        raise ArtifactError(f"cannot read artifact {path}: {exc}") from exc
+    finally:
+        archive.close()
+
+
+def _verify_materialized(directory: Path) -> dict[str, Any]:
+    if directory.is_symlink() or not directory.is_dir():
+        raise ArtifactError(f"materialized artifact is not a regular directory: {directory}")
+    try:
+        rows = list(directory.iterdir())
+    except OSError:
+        raise
+    names: set[str] = set()
+    for row in rows:
+        if row.name not in _MEMBERS or row.is_symlink() or not row.is_file() or row.name in names:
+            raise ArtifactError(f"unexpected materialized artifact member {row.name!r}")
+        names.add(row.name)
+    missing = _REQUIRED_MEMBERS - names
+    if missing:
+        raise ArtifactError(f"materialized artifact is missing {sorted(missing)!r}")
+    sizes = {name: (directory / name).stat().st_size for name in names}
+    _validate_member_sizes(sizes)
+    metadata_path = directory / METADATA_NAME
+    try:
+        raw = json.loads(metadata_path.read_bytes(), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"metadata is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ArtifactError("metadata root must be an object")
+    checked = validate_metadata(raw, has_literals=LITERALS_NAME in names)
+    verify_package(directory / PACKAGE_NAME, checked)
+    literal_path = directory / LITERALS_NAME if LITERALS_NAME in names else None
+    _verify_literals(literal_path, checked)
+    return checked
+
+
+def _copy_member(
+    archive: tarfile.TarFile,
+    info: tarfile.TarInfo,
+    destination: Path,
+) -> None:
+    extracted = archive.extractfile(info)
+    if extracted is None:
+        raise ArtifactError(f"artifact member {info.name!r} is unreadable")
+    remaining = info.size
+    try:
+        with extracted as source:
+            with destination.open("wb") as output:
+                while remaining:
+                    chunk = source.read(min(1 << 20, remaining))
+                    if not chunk:
+                        raise ArtifactError(f"artifact member {info.name!r} is truncated")
+                    output.write(chunk)
+                    remaining -= len(chunk)
+                output.flush()
+                os.fsync(output.fileno())
+    except ArtifactError:
+        raise
+    except (EOFError, OSError, tarfile.TarError) as exc:
+        raise ArtifactError(f"cannot read artifact member {info.name!r}: {exc}") from exc
+
+
+def unpack_artifact(artifact: str | Path, destination: str | Path) -> dict[str, Any]:
+    """Validate and atomically materialize an artifact into a new directory."""
+
+    target = Path(destination)
+    if target.exists():
+        raise FileExistsError(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    archive, members = _members(Path(artifact))
+    stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
+    try:
+        for name, info in members.items():
+            _copy_member(archive, info, stage / name)
+        metadata = _verify_materialized(stage)
+        _fsync_dir(stage)
+        os.replace(stage, target)
+        _fsync_dir(target.parent)
+        return metadata
+    except BaseException:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+    finally:
+        archive.close()

--- a/src/gen_worker/_vendor/torch_compiled_graphs/cli.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/cli.py
@@ -1,0 +1,54 @@
+"""Operator commands for inspecting and materializing compiled graphs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from ..tensorfs import LocalCAS
+
+from .artifact import read_metadata, unpack_artifact
+from .engine import Engine
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="torch-compiled-graphs")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    inspect = commands.add_parser("inspect", help="print an artifact's validated metadata")
+    inspect.add_argument("artifact", type=Path)
+
+    verify = commands.add_parser("verify", help="fully verify an artifact and its AOTI package")
+    verify.add_argument("artifact", type=Path)
+
+    resolve = commands.add_parser("resolve", help="materialize one exact key from local HashRepo")
+    resolve.add_argument("key")
+    resolve.add_argument("destination", type=Path)
+    resolve.add_argument("--cas-root", type=Path, required=True)
+    return parser
+
+
+def _print(metadata: dict[str, object]) -> None:
+    print(json.dumps(metadata, sort_keys=True, indent=2))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.command == "inspect":
+        _print(read_metadata(args.artifact))
+        return 0
+    if args.command == "verify":
+        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-cli-") as raw:
+            _print(unpack_artifact(args.artifact, Path(raw) / "artifact"))
+        return 0
+    if args.command == "resolve":
+        compiled_graph = Engine(LocalCAS(args.cas_root)).resolve(args.key, args.destination)
+        if compiled_graph is None:
+            parser.error(f"no local compiled graph for {args.key}")
+        _print(compiled_graph.metadata)
+        return 0
+    raise AssertionError(f"unhandled command {args.command!r}")

--- a/src/gen_worker/_vendor/torch_compiled_graphs/compiler.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/compiler.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from importlib import import_module
+from pathlib import Path
+from typing import Any, cast
+
+from . import _wrapper_split
+from .host_isa import HostISAError, _impose_host_policy
+
+_COMPILER_OPTIONS: dict[str, object] = {
+    # pgw#757 measured 32 -> 4 as effectively free while sharply reducing
+    # contention with live serving. A later balanced 16-run 1-vs-4 cold AOTI
+    # comparison put both means inside run-to-run noise (4 was 1.0% lower), so
+    # there is no measured reason to fork the current worker's value. Four is
+    # the one sealed policy; callers cannot select a compiler topology.
+    "compile_threads": 4,
+    "aot_inductor.package_constants_in_so": False,
+    "aot_inductor.use_runtime_constant_folding": True,
+    "aot_inductor.package": True,
+}
+
+
+class CompileError(RuntimeError):
+    """AOTInductor did not produce a packageable code-only graph."""
+
+
+def _compiler_options() -> dict[str, object]:
+    """Return the sole compile policy accepted by pre-launch v1."""
+
+    return dict(_COMPILER_OPTIONS)
+
+
+def _export_context(program: object) -> tuple[object, object]:
+    """Derive the sole FakeTensorMode and ShapeEnv carried by graph metadata."""
+
+    try:
+        pytree = import_module("torch.utils._pytree")
+        fake_tensor = import_module("torch._subclasses.fake_tensor")
+        fake_mode_type = vars(fake_tensor)["FakeTensorMode"]
+    except (ImportError, KeyError) as exc:
+        raise CompileError("PyTorch FakeTensor and pytree support is unavailable") from exc
+    graph_module = getattr(program, "graph_module", None)
+    graph = getattr(graph_module, "graph", None)
+    modes: dict[int, object] = {}
+    environments: dict[int, object] = {}
+    for node in getattr(graph, "nodes", ()):
+        metadata = getattr(node, "meta", None)
+        if not isinstance(metadata, Mapping):
+            continue
+        for name in ("val", "example_value"):
+            if name not in metadata:
+                continue
+            leaves = cast(Any, pytree).tree_leaves(metadata[name])
+            for value in leaves:
+                mode = getattr(value, "fake_mode", None)
+                if mode is not None:
+                    if not isinstance(mode, fake_mode_type):
+                        raise CompileError("exported graph metadata carries a non-FakeTensor mode")
+                    modes[id(mode)] = mode
+                    environment = getattr(mode, "shape_env", None)
+                    if environment is not None:
+                        environments[id(environment)] = environment
+                environment = getattr(getattr(value, "node", None), "shape_env", None)
+                if environment is not None:
+                    environments[id(environment)] = environment
+                shape = getattr(value, "shape", None)
+                if shape is not None:
+                    for dimension in shape:
+                        environment = getattr(getattr(dimension, "node", None), "shape_env", None)
+                        if environment is not None:
+                            environments[id(environment)] = environment
+    if len(modes) != 1:
+        raise CompileError(
+            f"exported graph metadata must carry exactly one FakeTensorMode, found {len(modes)}"
+        )
+    if len(environments) != 1:
+        raise CompileError(
+            f"exported graph metadata must carry exactly one ShapeEnv, found {len(environments)}"
+        )
+    return next(iter(modes.values())), next(iter(environments.values()))
+
+
+@contextmanager
+def _compiling_under_export_context(program: object) -> Iterator[None]:
+    """Restore the FakeTensor tracing context carried by one exported program."""
+
+    mode, environment = _export_context(program)
+    try:
+        guards = import_module("torch._guards")
+        tracing_context = vars(guards)["TracingContext"]
+        tracing = vars(guards)["tracing"]
+    except (ImportError, KeyError) as exc:
+        raise CompileError("PyTorch FakeTensor tracing support is unavailable") from exc
+
+    previous = getattr(mode, "shape_env", None)
+    cast(Any, mode).shape_env = environment
+    try:
+        with cast(Any, tracing)(cast(Any, tracing_context)(mode)):
+            yield
+    finally:
+        cast(Any, mode).shape_env = previous
+
+
+def _aot_compile(
+    graph_module: object,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+    *,
+    options: Mapping[str, object],
+) -> object:
+    try:
+        module = import_module("torch._inductor")
+        compiler = vars(module)["aot_compile"]
+    except (ImportError, KeyError) as exc:  # pragma: no cover - exercised with torch extra
+        raise CompileError("PyTorch with AOTInductor is required to compile") from exc
+    return cast(Any, compiler)(graph_module, args, kwargs, options=options)
+
+
+def _compile_exported_program(program: object) -> tuple[object, ...]:
+    """Compile one ExportedProgram to the loose files used by `package_aoti`.
+
+    FakeTensor and ShapeEnv state is derived only from ``program``. Compile
+    settings are fixed because every setting that can affect generated code
+    must have exactly one v1 identity.
+    """
+    try:
+        _impose_host_policy()
+        _wrapper_split.install()
+    except HostISAError as exc:
+        raise CompileError(f"cannot establish host ISA policy: {exc}") from exc
+
+    exported_module = getattr(program, "module", None)
+    if not callable(exported_module):
+        raise CompileError("program has no callable module(check_guards=False)")
+    try:
+        args, kwargs = program.example_inputs  # type: ignore[attr-defined]
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CompileError("program has no (args, kwargs) example_inputs") from exc
+
+    try:
+        with _compiling_under_export_context(program):
+            result = _aot_compile(
+                exported_module(check_guards=False),
+                tuple(args),
+                dict(kwargs or {}),
+                options=_compiler_options(),
+            )
+    except Exception as exc:
+        raise CompileError(f"AOTInductor compile failed: {type(exc).__name__}: {exc}") from exc
+    if not isinstance(result, list) or not result:
+        raise CompileError("AOTInductor did not return a non-empty loose-file list")
+    return tuple(result)
+
+
+def _package_aoti(output: str, files: Mapping[str, Sequence[object]]) -> object:
+    try:
+        module = import_module("torch._inductor.package")
+        packager = vars(module)["package_aoti"]
+    except (ImportError, KeyError) as exc:  # pragma: no cover - exercised with torch extra
+        raise CompileError("PyTorch with AOTInductor is required to package") from exc
+    return cast(Any, packager)(output, files)
+
+
+def _package_compiled_files(
+    graph_class: str,
+    files: Sequence[object],
+    output: str | Path,
+) -> Path:
+    """Package one named graph class into a `.pt2` file."""
+
+    name = str(graph_class).strip()
+    if not name:
+        raise CompileError("graph_class name must not be empty")
+    if not files:
+        raise CompileError("cannot package a graph_class with no compiled files")
+    target = Path(output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = _package_aoti(str(target), {name: list(files)})
+    except Exception as exc:
+        raise CompileError(f"AOTInductor packaging failed: {type(exc).__name__}: {exc}") from exc
+    return Path(str(result))

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/KEY_GRAMMAR_DIGEST
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/KEY_GRAMMAR_DIGEST
@@ -1,0 +1,6 @@
+# sha256 of testdata/compiled_graph_key_vectors.json — the SHARED compiled-graph
+# key grammar corpus (th#1897). python-gen-worker commits this same digest beside
+# its own byte-identical copy; scripts/grammar-vector-drift.sh proves the two
+# files are equal. Changing the corpus is a coupled cross-repo cut: pgw lands
+# first, then both digests move in one window.
+a274c5702b8c167ca119758d9fb1f98c40ddfdb3dbf6c58b4aacd580803e8c2b

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/__init__.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/__init__.py
@@ -1,0 +1,23 @@
+"""Versioned compiled-graph identity corpora shipped with this package."""
+
+from importlib.resources import files
+from typing import Final
+
+CONTRACT_FILES: Final = (
+    "KEY_GRAMMAR_DIGEST",
+    "call_ingress_v1.json",
+    "compiled_graph_key_vectors.json",
+    "graph_class_identity_v3.json",
+    "literal_identity_v1.json",
+    "toolchain_identity_v1.json",
+)
+
+
+def read_contract(name: str) -> bytes:
+    """Read one canonical contract without depending on a source checkout."""
+    if name not in CONTRACT_FILES:
+        raise ValueError(f"unknown compiled-graph contract: {name!r}")
+    return files(__package__).joinpath(name).read_bytes()
+
+
+__all__ = ["CONTRACT_FILES", "read_contract"]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/call_ingress_v1.json
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/call_ingress_v1.json
@@ -1,0 +1,28 @@
+{
+  "authority": "torch-compiled-graphs CallIngress v1",
+  "digest": "b389f4904367ba113ba552b7076fc2ff",
+  "ingress": {
+    "excluded_inputs": [],
+    "flat_arity": 1,
+    "inputs": [
+      {
+        "dtype": "float32",
+        "exported_name": "value",
+        "name": "value",
+        "param": "value",
+        "param_position": 0,
+        "path": [],
+        "position": 0,
+        "shape": [
+          2,
+          3
+        ]
+      }
+    ],
+    "parameters": [
+      "value"
+    ],
+    "symbols": {},
+    "v": 1
+  }
+}

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/compiled_graph_key_vectors.json
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/compiled_graph_key_vectors.json
@@ -1,0 +1,141 @@
+{
+  "contract": "compiled-graph key grammar (th#1897)",
+  "grammar": "<scheme>-<56 lowercase hex>, whole token <= 96 bytes of [a-z0-9][a-z0-9._-]*",
+  "authorities": [
+    "tensorhub internal/orchestrator/compilecache.IsCompiledGraphKey",
+    "python-gen-worker gen_worker.cell_key.is_key"
+  ],
+  "note": "This file is the CONTRACT between the two, vendored byte-identically in python-gen-worker (tests/testdata/) and fenced by scripts/grammar-vector-drift.sh. th#1897 exists because there was no such file: both implementations were internally consistent, they disagreed about `cg-key-v1`, and nothing in either CI could see it \u2014 the first mint on the new scheme would have compiled for 45+ minutes and been refused at publish. A change to either implementation that is not a change to this file is the same defect again.",
+  "vectors": [
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": true,
+      "note": "DESIGN-RULINGS 1.38's scheme. Hyphenated and digit-free, which is exactly what the pre-th#1897 `ck<1-2 digits>-` shape could not parse; 66 chars, which is what the pre-th#1897 64-char fragment cap could not hold."
+    },
+    {
+      "key": "cg-key-v2-3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0db",
+      "valid": true,
+      "note": "A FUTURE scheme this hub has never seen. th#1183: the hub refuses shape, never scheme, so a newer fleet's key is admitted and ruled on by axes."
+    },
+    {
+      "key": "ck1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": true,
+      "note": "The scheme the 3 purged micro-diffusion rows carried."
+    },
+    {
+      "key": "ck12-3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0db",
+      "valid": true,
+      "note": "Two scheme digits \u2014 the widest the old shape allowed."
+    },
+    {
+      "key": "ek1-8b5b9db0c13db24256c829aa364aa90c6d2eba318b9232a4ab9313b9",
+      "valid": true,
+      "note": "pgw#1176's interim scheme; never minted a real artifact."
+    },
+    {
+      "key": "a-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": true,
+      "note": "One-character scheme. Nothing forbids it."
+    },
+    {
+      "key": "cg.key_v1-3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0db",
+      "valid": true,
+      "note": "'.' and '_' are fragment-charset bytes, so a scheme may carry them."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c02-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": true,
+      "note": "A scheme containing a 20-hex run and three hyphens. THE REGRESSION VECTOR for splitting on '-': the digest is the SUFFIX and the scheme is whatever precedes it, so neither side may split, partition or scan for the first '-'."
+    },
+    {
+      "key": "ccccccccccccccccccccccccccccccccccccccc-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": true,
+      "note": "Exactly refgrammar.MaxFragmentLen (96) \u2014 the boundary, accepted."
+    },
+    {
+      "key": "",
+      "valid": false,
+      "note": "empty"
+    },
+    {
+      "key": "7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "A bare digest carries no scheme."
+    },
+    {
+      "key": "-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "Empty scheme."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add",
+      "valid": false,
+      "note": "55 hex \u2014 one short."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7f",
+      "valid": false,
+      "note": "57 hex \u2014 one long, and it is the tail that is read."
+    },
+    {
+      "key": "cg-key-v1_7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "'_' is not the separator; the separator is '-'."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0addg",
+      "valid": false,
+      "note": "'g' is not hex."
+    },
+    {
+      "key": "cg-key-v1-7692C3AD3540BB803C020B3AEE66CD8887123234EA0C6E7143C0ADDA",
+      "valid": false,
+      "note": "Uppercase hex. The digest is lowercase, byte-wise."
+    },
+    {
+      "key": "CG-KEY-V1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "Uppercase scheme; the fragment charset is lowercase."
+    },
+    {
+      "key": "cg key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "A space is not in the fragment charset."
+    },
+    {
+      "key": "cg/key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "'/' is a ref-grammar separator and can never be inside a fragment."
+    },
+    {
+      "key": "-cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "A fragment may not START with '-'."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7-",
+      "valid": false,
+      "note": "A trailing byte after the digest \u2014 the digest is the suffix."
+    },
+    {
+      "key": "cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7#x",
+      "valid": false,
+      "note": "'#' is a ref-grammar separator."
+    },
+    {
+      "key": "cccccccccccccccccccccccccccccccccccccccc-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "One past refgrammar.MaxFragmentLen (97) \u2014 the boundary, refused."
+    },
+    {
+      "key": "root/family-sdxl#cg-key-v1-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add7",
+      "valid": false,
+      "note": "A cell REF is not a key; KeyRef composes them, KeyFromRef splits them."
+    },
+    {
+      "key": "manifest-7692c3ad3540bb803c020b3aee66cd8887123234",
+      "valid": false,
+      "note": "The manifest digest is deliberately NOT a key (DESIGN-RULINGS 1.38: 'refused by is_key so nothing can resolve, download, verify or arm it')."
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/graph_class_identity_v3.json
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/graph_class_identity_v3.json
@@ -1,0 +1,65 @@
+{
+  "authority": "torch-compiled-graphs GraphClassDeclaration with CallIngress v1",
+  "block": {
+    "class_dims": [
+      [
+        "height",
+        64
+      ],
+      [
+        "width",
+        96
+      ]
+    ],
+    "fork": [
+      [
+        "adapter",
+        false
+      ]
+    ],
+    "graph": {
+      "constant_fqns": [],
+      "lifted_inputs": [],
+      "pytree": {
+        "in": "[1, {\"type\": null, \"context\": null, \"children_spec\": [{\"type\": null, \"context\": null, \"children_spec\": []}]}]",
+        "ingress": {
+          "excluded_inputs": [],
+          "flat_arity": 1,
+          "inputs": [
+            {
+              "dtype": "float32",
+              "exported_name": "value",
+              "name": "value",
+              "param": "value",
+              "param_position": 0,
+              "path": [],
+              "position": 0,
+              "shape": [
+                2,
+                3
+              ]
+            }
+          ],
+          "parameters": [
+            "value"
+          ],
+          "symbols": {},
+          "v": 1
+        },
+        "out": "[1, {\"type\": null, \"context\": null, \"children_spec\": [{\"type\": null, \"context\": null, \"children_spec\": []}]}]"
+      },
+      "specialization": {},
+      "v": 3
+    },
+    "graph_witness": "54ceeee7225e57c9",
+    "placement": [
+      "cuda:0",
+      "cuda:1"
+    ],
+    "range_digest": "b389f4904367ba113ba552b7076fc2ff",
+    "target": "denoiser"
+  },
+  "class_hash": "16509ab34e95cfc7",
+  "lora_bucket": 8,
+  "strict": true
+}

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/literal_identity_v1.json
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/literal_identity_v1.json
@@ -1,0 +1,26 @@
+{
+  "authority": {
+    "repo": "python-gen-worker",
+    "sha": "0a2c33970bd963d3f940d7664a1e96d705af0655"
+  },
+  "constant_fqns": [
+    "table"
+  ],
+  "dtype": "torch.float32",
+  "literal_values": "f0bf7306bf0a83cc13766d1b8f990c00",
+  "name": "table",
+  "shape": [
+    2,
+    2
+  ],
+  "values": [
+    [
+      1.0,
+      2.0
+    ],
+    [
+      3.0,
+      4.0
+    ]
+  ]
+}

--- a/src/gen_worker/_vendor/torch_compiled_graphs/contracts/toolchain_identity_v1.json
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/contracts/toolchain_identity_v1.json
@@ -1,0 +1,20 @@
+{
+  "authority": {
+    "repo": "python-gen-worker",
+    "sha": "0a2c33970bd963d3f940d7664a1e96d705af0655"
+  },
+  "block": {
+    "diffusers": "model-library-is-not-compiler",
+    "loaded_libs": "2222222222222222",
+    "nvidia-cublas-cu13": "5555555555555555",
+    "peft": "model-library-is-not-compiler",
+    "settings_declaration": "1111111111111111",
+    "torch": "3333333333333333",
+    "transformers": "model-library-is-not-compiler",
+    "triton": "4444444444444444"
+  },
+  "graph": "c59210f4ddf6b420",
+  "key": "cg-key-v1-d4c716660ec9c12c079170810bb18d830594a34b875a83beb0ab6150",
+  "sm": "sm_89",
+  "toolchain_axis": "88abf09ce9c69ecb"
+}

--- a/src/gen_worker/_vendor/torch_compiled_graphs/declaration.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/declaration.py
@@ -1,0 +1,591 @@
+"""Canonical declarations for one exported AOTInductor graph class."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .host_isa import HostISAError, _impose_host_policy
+from .identity import CompiledGraphKey, _facts_digest, from_axes, toolchain_axis_digest
+from .ingress import CallIngress, IngressError
+
+_GRAPH_CLASS_CANONICAL_FORMAT = 1
+_GRAPH_DIGEST_HEX = 16
+_GRAPH_INTERFACE_FIELDS = frozenset(
+    ("v", "constant_fqns", "lifted_inputs", "pytree", "specialization")
+)
+
+
+class DeclarationError(ValueError):
+    """A graph or runtime cannot state a complete v1 declaration."""
+
+
+class _Symbols:
+    def __init__(self) -> None:
+        self._ids: dict[str, str] = {}
+
+    def name(self, symbol: Any) -> str:
+        raw = str(symbol)
+        known = self._ids.get(raw)
+        if known is None:
+            known = f"S{len(self._ids)}"
+            self._ids[raw] = known
+        return known
+
+    def known(self) -> tuple[tuple[str, str], ...]:
+        return tuple(sorted(self._ids.items(), key=lambda item: item[1]))
+
+
+def _render_symbol(value: Any, symbols: _Symbols) -> str:
+    expression = getattr(getattr(value, "node", None), "expr", None)
+    free = getattr(expression, "free_symbols", None) or ()
+    if expression is None or not free:
+        return str(expression if expression is not None else value)
+    rendered = str(expression)
+    for symbol in sorted(free, key=lambda item: len(str(item)), reverse=True):
+        rendered = rendered.replace(str(symbol), symbols.name(symbol))
+    return rendered
+
+
+def _render_scalar(value: Any) -> str:
+    import torch
+
+    if isinstance(value, (torch.dtype, torch.device, torch.layout, torch.memory_format)):
+        rendered = str(value)
+        return rendered.split(":", 1)[0] if isinstance(value, torch.device) else rendered
+    if isinstance(value, bool) or value is None:
+        return repr(value)
+    if isinstance(value, float):
+        return value.hex()
+    if isinstance(value, (int, str, bytes)):
+        return repr(value)
+    if isinstance(value, slice):
+        return f"slice({value.start!r},{value.stop!r},{value.step!r})"
+    return f"{type(value).__module__}.{type(value).__qualname__}"
+
+
+def _render_value(value: Any, symbols: _Symbols) -> str:
+    import torch
+
+    if value is None:
+        return "-"
+    if isinstance(value, torch.Tensor):
+        return _render_tensor(value, symbols, include_device=True)
+    if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return f"sym({_render_symbol(value, symbols)})"
+    if isinstance(value, (list, tuple)):
+        body = ",".join(_render_value(item, symbols) for item in value)
+        return f"[{body}]" if isinstance(value, list) else f"({body})"
+    if isinstance(value, dict):
+        body = ",".join(
+            f"{key!r}:{_render_value(item, symbols)}"
+            for key, item in sorted(value.items(), key=lambda pair: repr(pair[0]))
+        )
+        return "{" + body + "}"
+    return _render_scalar(value)
+
+
+def _render_argument(value: Any, names: dict[Any, str], symbols: _Symbols) -> str:
+    import torch
+
+    if isinstance(value, torch.fx.Node):
+        return names.get(value, "%?")
+    if isinstance(value, (list, tuple)):
+        return "(" + ",".join(_render_argument(item, names, symbols) for item in value) + ")"
+    if isinstance(value, dict):
+        body = ",".join(
+            f"{key!r}:{_render_argument(item, names, symbols)}"
+            for key, item in sorted(value.items(), key=lambda pair: repr(pair[0]))
+        )
+        return "{" + body + "}"
+    if isinstance(value, torch.Tensor):
+        return _render_tensor(value, symbols, include_device=False)
+    if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return f"sym({_render_symbol(value, symbols)})"
+    return _render_scalar(value)
+
+
+def _render_tensor(value: Any, symbols: _Symbols, *, include_device: bool) -> str:
+    shape = ",".join(_render_symbol(dimension, symbols) for dimension in value.shape)
+    device = f"|{value.device.type}" if include_device else ""
+    return f"t({value.dtype}|[{shape}]{device})"
+
+
+def _target(node: Any) -> str:
+    if node.op == "placeholder":
+        return ""
+    if node.op in ("call_method", "get_attr", "output"):
+        return str(node.target)
+    module = getattr(node.target, "__module__", "")
+    name = getattr(node.target, "__qualname__", "")
+    return f"{module}.{name}" if module and name else str(node.target)
+
+
+def _node_value(node: Any) -> tuple[bool, Any]:
+    for key in ("val", "example_value", "tensor_meta"):
+        if key in node.meta:
+            return True, node.meta[key]
+    return False, None
+
+
+def _graph_lines(graph: Any, symbols: _Symbols) -> list[str]:
+    names = {node: f"%{index}" for index, node in enumerate(graph.nodes)}
+    lines: list[str] = []
+    for index, node in enumerate(graph.nodes):
+        args = ",".join(_render_argument(item, names, symbols) for item in node.args)
+        kwargs = ",".join(
+            f"{key}={_render_argument(item, names, symbols)}"
+            for key, item in sorted(node.kwargs.items())
+        )
+        present, raw_value = _node_value(node)
+        value = _render_value(raw_value, symbols) if present else "-"
+        placeholder = f"arg{index}" if node.op == "placeholder" else ""
+        lines.append(
+            f"node {index} {node.op} {_target(node)} {placeholder} "
+            f"args=({args}) kwargs=({kwargs}) val={value}"
+        )
+    return lines
+
+
+def _bound(value: Any) -> str:
+    if value is None:
+        return "oo"
+    try:
+        return str(int(value))
+    except (TypeError, ValueError, OverflowError):
+        return str(value).replace("+", "")
+
+
+def _range_lines(ranges: Any, symbols: _Symbols) -> list[str]:
+    if not ranges:
+        return []
+    known = dict(symbols.known())
+    lines = []
+    for symbol, value_range in ranges.items():
+        canonical = known.get(str(symbol))
+        if canonical is not None:
+            lines.append(
+                f"sym {canonical} range=[{_bound(getattr(value_range, 'lower', None))},"
+                f"{_bound(getattr(value_range, 'upper', None))}]"
+            )
+    return sorted(lines)
+
+
+def _signature_lines(program: Any) -> list[str]:
+    signature = getattr(program, "graph_signature", None)
+    lines: list[str] = []
+    for direction, specs in (
+        ("in", getattr(signature, "input_specs", None) or ()),
+        ("out", getattr(signature, "output_specs", None) or ()),
+    ):
+        for index, spec in enumerate(specs):
+            kind_object = getattr(spec, "kind", None)
+            kind = getattr(kind_object, "name", str(kind_object or ""))
+            target = getattr(spec, "target", None) or "-"
+            lines.append(f"sig {direction} {index} kind={kind} target={target}")
+    for attribute, direction in (("_in_spec", "in"), ("_out_spec", "out")):
+        spec = getattr(program, attribute, None)
+        if spec is not None:
+            lines.append(f"spec {direction} {spec!s}".replace("\n", " "))
+    return lines
+
+
+def _canonical_graph(program: object) -> tuple[str, ...]:
+    """Return the sole v1 canonical form for a ``torch.export.ExportedProgram``."""
+
+    import torch
+
+    if not isinstance(program, torch.export.ExportedProgram):
+        raise DeclarationError("v1 declarations require a torch.export.ExportedProgram")
+    symbols = _Symbols()
+    lines = [f"v={_GRAPH_CLASS_CANONICAL_FORMAT} ir=export"]
+    lines.extend(_graph_lines(program.graph_module.graph, symbols))
+    lines.extend(_range_lines(program.range_constraints, symbols))
+    lines.extend(_signature_lines(program))
+    return tuple(lines)
+
+
+def _graph_digest(program: object) -> str:
+    # 64 bits, DERIVED and deliberately kept at v1. This graph-body witness is
+    # one fact folded into GraphClassDeclaration.class_hash, which is itself a
+    # 16-hex choke point. Birthday bound P ~= N^2 / 2^65: about 3e-12 at 10^4
+    # graph classes and 3e-8 at 10^6. Widening only this site rekeys the corpus
+    # while leaving graph-axis collision resistance at 64 bits, so BOTH
+    # choke points move together or neither does.
+    payload = "\n".join(_canonical_graph(program)).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:_GRAPH_DIGEST_HEX]
+
+
+def _literal_names(program: object) -> tuple[str, ...]:
+    signature = getattr(program, "graph_signature", None)
+    state = {
+        str(name)
+        for field in ("parameters", "buffers")
+        for name in (getattr(signature, field, ()) or ())
+    }
+    names = {str(name) for name in getattr(signature, "lifted_tensor_constants", ()) or ()}
+    names.update(str(name) for name in (getattr(program, "constants", {}) or {}))
+    return tuple(sorted(names - state))
+
+
+def _constant_names(program: object) -> tuple[str, ...]:
+    signature = getattr(program, "graph_signature", None)
+    names = {
+        str(name)
+        for field in ("parameters", "buffers", "lifted_tensor_constants")
+        for name in (getattr(signature, field, ()) or ())
+    }
+    names.update(str(name) for name in (getattr(program, "constants", {}) or {}))
+    return tuple(sorted(names))
+
+
+def _literal_digest(program: object) -> str:
+    return _literal_digest_for(program, _literal_names(program))
+
+
+def _literal_digest_for(program: object, names: Iterable[str]) -> str:
+    names = tuple(sorted({str(name) for name in names}))
+    if not names:
+        return ""
+    values = getattr(program, "constants", {}) or {}
+    digest = hashlib.sha256()
+    for name in names:
+        value = values.get(name)
+        if value is None:
+            raise DeclarationError(f"literal constant {name!r} carries no value")
+        try:
+            import torch
+
+            tensor = value.detach().cpu().contiguous().reshape(-1)
+            _update_literal_digest(
+                digest,
+                name=name,
+                dtype=str(value.dtype),
+                shape=tuple(value.shape),
+                chunks=(tensor.view(torch.uint8).numpy().tobytes(),),
+            )
+        except Exception as exc:
+            raise DeclarationError(
+                f"literal constant {name!r} could not be digested: {type(exc).__name__}: {exc}"
+            ) from exc
+    return digest.hexdigest()[:32]
+
+
+def _update_literal_digest(
+    digest: Any,
+    *,
+    name: str,
+    dtype: str,
+    shape: tuple[int, ...],
+    chunks: Iterable[bytes],
+) -> None:
+    """Update a v1 literal digest from canonical facts and bounded byte chunks."""
+
+    digest.update(name.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(dtype.encode("utf-8"))
+    digest.update(str(tuple(shape)).encode("utf-8"))
+    for chunk in chunks:
+        digest.update(chunk)
+
+
+def _placement(program: object) -> tuple[str, ...]:
+    import torch
+
+    devices: set[str] = set()
+
+    def note(value: Any) -> None:
+        if isinstance(value, torch.device):
+            devices.add(f"{value.type}:{value.index}" if value.index is not None else value.type)
+        elif isinstance(value, torch.Tensor):
+            note(value.device)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                note(item)
+        elif isinstance(value, dict):
+            for item in value.values():
+                note(item)
+
+    for node in program.graph_module.graph.nodes:  # type: ignore[attr-defined]
+        present, value = _node_value(node)
+        if present:
+            note(value)
+        note(node.args)
+        note(node.kwargs)
+    return tuple(sorted(devices))
+
+
+@dataclass(frozen=True, slots=True)
+class GraphClassDeclaration:
+    """Immutable graph facts shared by lookup, mint, and admission."""
+
+    graph_class: str
+    target: str
+    graph: Mapping[str, Any]
+    graph_witness: str
+    range_digest: str
+    fork: tuple[tuple[str, Any], ...] = ()
+    class_dims: tuple[tuple[str, int], ...] = ()
+    strict: bool = True
+    lora_bucket: int = 0
+    literal_values: str = ""
+    placement: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        graph_class = self.graph_class.strip()
+        target = self.target.strip()
+        if not graph_class or not target:
+            raise DeclarationError("graph_class and target must be non-empty")
+        if "\\" in graph_class or any(
+            part in ("", ".", "..") for part in graph_class.split("/")
+        ):
+            raise DeclarationError(f"unsafe graph_class name {graph_class!r}")
+        if not isinstance(self.graph, Mapping) or not self.graph:
+            raise DeclarationError("graph_class graph interface must be a non-empty object")
+        try:
+            canonical_graph = json.loads(
+                json.dumps(dict(self.graph), sort_keys=True, allow_nan=False)
+            )
+        except (TypeError, ValueError) as exc:
+            raise DeclarationError(
+                f"graph_class graph interface is not finite JSON: {exc}"
+            ) from exc
+        if not isinstance(canonical_graph, dict) or not canonical_graph:
+            raise DeclarationError("graph_class graph interface must be a non-empty object")
+        graph_fields = set(canonical_graph)
+        if graph_fields not in (
+            _GRAPH_INTERFACE_FIELDS,
+            _GRAPH_INTERFACE_FIELDS | {"literal_values"},
+        ):
+            raise DeclarationError(
+                "graph_class graph interface fields must be exactly "
+                f"{sorted(_GRAPH_INTERFACE_FIELDS)!r}, with literal_values only when present"
+            )
+        if type(canonical_graph.get("v")) is not int or canonical_graph.get("v") != 3:
+            raise DeclarationError("graph_class graph interface v must be 3")
+        for field in ("constant_fqns", "lifted_inputs"):
+            values = canonical_graph.get(field)
+            if not isinstance(values, list) or not all(
+                isinstance(value, str) and value for value in values
+            ) or values != sorted(set(values)):
+                raise DeclarationError(
+                    f"graph_class graph interface {field} must be sorted unique strings"
+                )
+        if not isinstance(canonical_graph.get("pytree"), dict) or not isinstance(
+            canonical_graph.get("specialization"), dict
+        ):
+            raise DeclarationError(
+                "graph_class graph interface pytree and specialization must be objects"
+            )
+        try:
+            ingress = CallIngress.from_graph(canonical_graph)
+        except IngressError as exc:
+            raise DeclarationError(f"graph_class call ingress is invalid: {exc}") from exc
+        if len(self.graph_witness) != _GRAPH_DIGEST_HEX or any(
+            character not in "0123456789abcdef" for character in self.graph_witness
+        ):
+            raise DeclarationError(
+                "graph_witness must be 16 lowercase hexadecimal characters"
+            )
+        if len(self.range_digest) != 32 or any(
+            character not in "0123456789abcdef" for character in self.range_digest
+        ):
+            raise DeclarationError("range_digest must be 32 lowercase hexadecimal characters")
+        if self.range_digest != ingress.digest():
+            raise DeclarationError("range_digest does not restate graph.pytree.ingress")
+        fork = tuple((str(name), value) for name, value in self.fork)
+        if any(not name or name != name.strip() for name, _ in fork):
+            raise DeclarationError("graph_class fork names must be non-empty canonical strings")
+        try:
+            json.dumps([[name, value] for name, value in fork], allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise DeclarationError(f"graph_class fork is not finite JSON: {exc}") from exc
+        if fork != tuple(sorted(fork, key=lambda item: item[0])):
+            raise DeclarationError("graph_class fork must be sorted by name")
+        class_dims = tuple((str(name), value) for name, value in self.class_dims)
+        if any(
+            not name
+            or name != name.strip()
+            or type(value) is not int
+            for name, value in class_dims
+        ):
+            raise DeclarationError("graph_class dimensions must be canonical name/integer pairs")
+        if class_dims != tuple(sorted(class_dims, key=lambda item: item[0])):
+            raise DeclarationError("graph_class dimensions must be sorted by name")
+        if type(self.strict) is not bool:
+            raise DeclarationError("graph_class strict must be a boolean")
+        if type(self.lora_bucket) is not int:
+            raise DeclarationError("graph_class lora_bucket must be an integer")
+        if self.literal_values and (
+            len(self.literal_values) != 32
+            or any(character not in "0123456789abcdef" for character in self.literal_values)
+        ):
+            raise DeclarationError(
+                "literal-values digest must be 32 lowercase hexadecimal characters"
+            )
+        graph_literals = canonical_graph.get("literal_values")
+        if graph_literals != (self.literal_values or None):
+            raise DeclarationError(
+                "graph interface literal_values must exactly match the compiled-graph payload"
+            )
+        object.__setattr__(self, "graph_class", graph_class)
+        object.__setattr__(self, "target", target)
+        object.__setattr__(self, "graph", canonical_graph)
+        object.__setattr__(self, "fork", fork)
+        object.__setattr__(self, "class_dims", class_dims)
+        canonical_placement = tuple(sorted({str(device) for device in self.placement if device}))
+        if len(canonical_placement) == 1:
+            raise DeclarationError("single-device placement must be omitted")
+        object.__setattr__(self, "placement", canonical_placement)
+
+    def facts(self) -> dict[str, object]:
+        facts: dict[str, object] = {
+            "v": 3,
+            "target": self.target,
+            "fork": [[name, value] for name, value in self.fork],
+            "class_dims": [[name, value] for name, value in self.class_dims],
+            "range_digest": self.range_digest,
+            "graph": dict(self.graph),
+            "graph_witness": self.graph_witness,
+            "strict": self.strict,
+            "lora_bucket": self.lora_bucket,
+        }
+        if len(self.placement) > 1:
+            facts["placement"] = list(self.placement)
+        return facts
+
+    @property
+    def class_hash(self) -> str:
+        # 64 bits, DERIVED and deliberately kept at v1. THIS is the `graph`
+        # axis's graph-class identity and the second 16-hex choke point; the
+        # other is _graph_digest, which produces one fact above. The axis has
+        # the MINIMUM of the two. Birthday bound P ~= N^2 / 2^65: about 3e-12
+        # at 10^4 graph classes and 3e-8 at 10^6. Widen both or neither.
+        return _facts_digest(self.facts())[:_GRAPH_DIGEST_HEX]
+
+
+@dataclass(frozen=True, slots=True)
+class GraphClassSpec:
+    """A named exported program ready for local resolution or minting."""
+
+    graph_class: str
+    target: str
+    program: object
+    graph: Mapping[str, Any]
+    fork: tuple[tuple[str, Any], ...] = ()
+    class_dims: tuple[tuple[str, int], ...] = ()
+    strict: bool = True
+    lora_bucket: int = 0
+
+    def declare(self) -> GraphClassDeclaration:
+        graph_witness = _graph_digest(self.program)
+        literals = _literal_digest(self.program)
+        placement = _placement(self.program)
+        graph = dict(self.graph)
+        constant_fqns = list(_constant_names(self.program))
+        stated_constants = graph.get("constant_fqns")
+        if stated_constants not in (None, constant_fqns):
+            raise DeclarationError(
+                "graph interface constant_fqns disagrees with the exported program"
+            )
+        graph["constant_fqns"] = constant_fqns
+        if literals:
+            stated = graph.get("literal_values")
+            if stated not in (None, literals):
+                raise DeclarationError(
+                    "graph interface literal_values disagrees with the exported program"
+                )
+            graph["literal_values"] = literals
+        elif "literal_values" in graph:
+            raise DeclarationError(
+                "graph interface states literal_values but the exported program has none"
+            )
+        try:
+            range_digest = CallIngress.from_graph(graph).digest()
+        except IngressError as exc:
+            raise DeclarationError(f"graph_class call ingress is invalid: {exc}") from exc
+        return GraphClassDeclaration(
+            self.graph_class,
+            self.target,
+            graph,
+            graph_witness,
+            range_digest,
+            fork=self.fork,
+            class_dims=self.class_dims,
+            strict=self.strict,
+            lora_bucket=self.lora_bucket,
+            literal_values=literals,
+            placement=placement if len(placement) > 1 else (),
+        )
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class RuntimeCompatibility:
+    """Recorded compiler facts plus the current host policy for one target."""
+
+    sm: str
+    _toolchain: tuple[tuple[str, str], ...]
+    _host_isa: tuple[tuple[str, str], ...]
+
+    def __init__(self, target: str, *, toolchain: Mapping[str, str]) -> None:
+        requested = str(target).strip().lower()
+        if requested == "cpu":
+            import torch
+
+            architecture = f"cpu-{torch.backends.cpu.get_cpu_capability().lower()}"
+        elif re.fullmatch(r"sm_[0-9]+", requested):
+            import torch
+
+            if not torch.cuda.is_available():
+                raise DeclarationError("CUDA target requires a compatible visible CUDA device")
+            major, minor = torch.cuda.get_device_capability()
+            architecture = f"sm_{major}{minor}"
+            if requested != architecture:
+                raise DeclarationError(
+                    f"requested CUDA target {requested!r} does not match {architecture!r}"
+                )
+        else:
+            raise DeclarationError("runtime target must be 'cpu' or a concrete 'sm_NN'")
+        cleaned = tuple(sorted((str(name), str(value)) for name, value in toolchain.items()))
+        if not cleaned or any(
+            not name or name != name.strip() or not value or value != value.strip()
+            for name, value in cleaned
+        ):
+            raise DeclarationError(
+                "runtime requires a worker-recorded toolchain block of non-empty strings"
+            )
+        try:
+            host_facts = tuple(sorted(_impose_host_policy().items()))
+        except HostISAError as exc:
+            raise DeclarationError(f"cannot establish host ISA policy: {exc}") from exc
+        object.__setattr__(self, "sm", architecture)
+        object.__setattr__(self, "_toolchain", cleaned)
+        object.__setattr__(self, "_host_isa", host_facts)
+
+    @property
+    def toolchain(self) -> dict[str, str]:
+        return dict(self._toolchain)
+
+    @property
+    def host_isa(self) -> dict[str, str]:
+        return dict(self._host_isa)
+
+    def key(self, declaration: GraphClassDeclaration) -> CompiledGraphKey:
+        return from_axes(
+            {
+                "graph": declaration.class_hash,
+                "sm": self.sm,
+                "toolchain": toolchain_axis_digest(self.toolchain),
+            }
+        )
+
+    def canonical(self) -> bytes:
+        return json.dumps(
+            {"sm": self.sm, "toolchain": self.toolchain},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")

--- a/src/gen_worker/_vendor/torch_compiled_graphs/engine.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/engine.py
@@ -1,0 +1,383 @@
+"""Local-first compile, store, resolve, and admission lifecycle."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, cast
+
+from ..tensorfs import LocalCAS
+
+from .artifact import build_metadata, pack_artifact, read_metadata
+from .compiler import _compile_exported_program, _package_compiled_files
+from .declaration import (
+    GraphClassDeclaration,
+    GraphClassSpec,
+    RuntimeCompatibility,
+    _literal_digest_for,
+)
+from .host_isa import HostISAError, _admit_host
+from .identity import GRAPH_CLASS_BLOCK, CompiledGraphKey, toolchain_axis_digest
+from .introspection import DeclaredConstant, declared_constants
+from .runner import CompiledGraphRunner
+from .storage import (
+    QuarantinedArtifact,
+    StorageError,
+    StoredCompiledGraph,
+    StoreOutcome,
+    StoreResult,
+    _CompiledGraphStore,
+)
+
+
+class AdmissionError(StorageError):
+    """Materialized bytes do not exactly satisfy their requested graph plan."""
+
+
+class EnsureOutcome(str, Enum):
+    REUSED = "reused"
+    MINTED = "minted"
+
+
+@dataclass(frozen=True, slots=True)
+class _GraphClassPlan:
+    """The one declaration and exact key used by both resolve and mint."""
+
+    spec: GraphClassSpec
+    declaration: GraphClassDeclaration
+    runtime: RuntimeCompatibility
+    key: CompiledGraphKey
+
+
+@dataclass(frozen=True, slots=True)
+class EnsureResult:
+    outcome: EnsureOutcome
+    compiled_graph: StoredCompiledGraph
+    publication: StoreOutcome | None = None
+
+
+def _literal_value(program: object, constant: DeclaredConstant) -> Any:
+    values = getattr(program, "constants", {}) or {}
+    if constant.fqn in values:
+        return values[constant.fqn]
+    if constant.name in values:
+        return values[constant.name]
+    raise AdmissionError(f"declared literal constant {constant.fqn!r} has no exported value")
+
+
+def _write_literals(
+    program: object, constants: tuple[DeclaredConstant, ...], target: Path
+) -> str:
+    literals = sorted(
+        (constant for constant in constants if constant.source == "literal"),
+        key=lambda constant: constant.fqn,
+    )
+    if not literals:
+        return ""
+    try:
+        from safetensors import TensorSpec, serialize_file
+    except ImportError as exc:  # pragma: no cover - package dependency
+        raise AdmissionError("safetensors is required for literal graph constants") from exc
+    tensors = {
+        constant.fqn: _literal_value(program, constant).detach().cpu().contiguous()
+        for constant in literals
+    }
+    try:
+        specs = {
+            name: TensorSpec(
+                dtype=str(tensor.dtype).removeprefix("torch."),
+                shape=list(tensor.shape),
+                data_ptr=tensor.data_ptr(),
+                data_len=tensor.numel() * tensor.element_size(),
+            )
+            for name, tensor in tensors.items()
+        }
+        serialize_file(specs, str(target))
+    except Exception as exc:
+        raise AdmissionError(f"cannot serialize literal graph constants: {exc}") from exc
+    return _literal_digest_for(program, (constant.fqn for constant in literals))
+
+
+def _compile_package(plan: _GraphClassPlan, workspace: Path) -> Path:
+    files = _compile_exported_program(plan.spec.program)
+    return _package_compiled_files(
+        plan.declaration.graph_class,
+        files,
+        workspace / "model.pt2",
+    )
+
+
+def _program_state_dict_fqns(program: object) -> set[str]:
+    signature = getattr(program, "graph_signature", None)
+    return {
+        str(name)
+        for field in ("parameters", "buffers")
+        for name in (getattr(signature, field, ()) or ())
+    }
+
+
+def _admit_constant_table(plan: _GraphClassPlan, constants: tuple[DeclaredConstant, ...]) -> None:
+    """Prove the package did not invent a constant or compile in a weight."""
+
+    stated = plan.declaration.graph.get("constant_fqns")
+    if not isinstance(stated, list) or not all(isinstance(name, str) for name in stated):
+        raise AdmissionError("graph declaration has no canonical constant FQN table")
+    program = set(stated)
+    package = {constant.fqn for constant in constants}
+    bindable = {constant.fqn for constant in constants if constant.source != "computed"}
+    package_only = sorted(bindable - program)
+    if package_only:
+        raise AdmissionError(
+            f"compiled package declares {len(package_only)} constant(s) the exported "
+            f"program never lifted: {package_only[:6]!r}"
+        )
+    folded_weights = sorted(_program_state_dict_fqns(plan.spec.program) - package)
+    if folded_weights:
+        raise AdmissionError(
+            f"compiled package eliminated {len(folded_weights)} state-dict constant(s): "
+            f"{folded_weights[:6]!r}; their checkpoint values may be compiled into code"
+        )
+
+
+class Engine:
+    """One local compiled-graph engine backed exclusively by HashRepo."""
+
+    def __init__(self, cas: LocalCAS) -> None:
+        self._store = _CompiledGraphStore(cas)
+
+    @staticmethod
+    def _plan(spec: GraphClassSpec, runtime: RuntimeCompatibility) -> _GraphClassPlan:
+        declaration = spec.declare()
+        return _GraphClassPlan(spec, declaration, runtime, runtime.key(declaration))
+
+    @staticmethod
+    def _admit_host_metadata(metadata: Mapping[str, object]) -> None:
+        host_isa = metadata.get("host_isa")
+        if not isinstance(host_isa, Mapping):
+            raise AdmissionError("artifact records no host_isa")
+        try:
+            _admit_host(cast(Mapping[str, str], host_isa))
+        except HostISAError as exc:
+            raise AdmissionError(f"artifact host ISA is unsupported: {exc}") from exc
+
+    @staticmethod
+    def _admit(plan: _GraphClassPlan, compiled_graph: StoredCompiledGraph) -> None:
+        metadata = compiled_graph.metadata
+        graph_class = metadata.get(GRAPH_CLASS_BLOCK)
+        if not isinstance(graph_class, Mapping):
+            raise AdmissionError("compiled graph records no graph_class")
+        expected_graph_class: dict[str, object] = {
+            "name": plan.declaration.graph_class,
+            "target": plan.declaration.target,
+            "class_hash": plan.declaration.class_hash,
+            "graph": dict(plan.declaration.graph),
+            "graph_witness": plan.declaration.graph_witness,
+            "range_digest": plan.declaration.range_digest,
+            "fork": [[name, value] for name, value in plan.declaration.fork],
+            "class_dims": [[name, value] for name, value in plan.declaration.class_dims],
+            "strict": plan.declaration.strict,
+            "lora_bucket": plan.declaration.lora_bucket,
+            "literal_values": plan.declaration.literal_values,
+            "placement": list(plan.declaration.placement),
+        }
+        mismatches = [
+            field
+            for field, expected in expected_graph_class.items()
+            if graph_class.get(field) != expected
+        ]
+        if metadata.get("sm") != plan.runtime.sm:
+            mismatches.append("sm")
+        stored_toolchain = metadata.get("toolchain")
+        if not isinstance(stored_toolchain, Mapping) or toolchain_axis_digest(
+            stored_toolchain
+        ) != toolchain_axis_digest(plan.runtime.toolchain):
+            mismatches.append("toolchain")
+        if metadata.get("compiled_graph_key") != str(plan.key):
+            mismatches.append("compiled_graph_key")
+        if mismatches:
+            raise AdmissionError(
+                "artifact does not satisfy the exact graph plan: " + ", ".join(mismatches)
+            )
+
+    def resolve(
+        self, key: str | CompiledGraphKey, destination: str | Path
+    ) -> StoredCompiledGraph | None:
+        """Resolve and verify an exact key without importing Torch or building a program."""
+
+        graph = self._store.resolve(key, destination)
+        if graph is None:
+            return None
+        self._admit_host_metadata(graph.metadata)
+        return graph
+
+    @staticmethod
+    def _admit_request(
+        compiled_graph: StoredCompiledGraph,
+        *,
+        target: str,
+        toolchain: Mapping[str, str],
+    ) -> None:
+        requested_target = str(target).strip().lower()
+        requested_toolchain = {str(name): str(value) for name, value in toolchain.items()}
+        if (
+            not requested_target
+            or not requested_toolchain
+            or any(
+                not name or name != name.strip() or not value or value != value.strip()
+                for name, value in requested_toolchain.items()
+            )
+        ):
+            raise AdmissionError("ensure requires target and a recorded toolchain block")
+        stored_target = compiled_graph.metadata.get("sm")
+        target_matches = stored_target == requested_target or (
+            requested_target == "cpu"
+            and isinstance(stored_target, str)
+            and stored_target.startswith("cpu-")
+        )
+        if not target_matches:
+            raise AdmissionError(
+                f"stored target {stored_target!r} does not match requested {requested_target!r}"
+            )
+        stored_toolchain = compiled_graph.metadata.get("toolchain")
+        if not isinstance(stored_toolchain, Mapping) or toolchain_axis_digest(
+            stored_toolchain
+        ) != toolchain_axis_digest(requested_toolchain):
+            raise AdmissionError(
+                "stored toolchain axis does not match the requested compiler-content facts"
+            )
+
+    def import_artifact(self, key: str | CompiledGraphKey, artifact: str | Path) -> StoreResult:
+        """Fully verify and attach bytes fetched by HashRepo under one exact key."""
+
+        self._admit_host_metadata(read_metadata(artifact))
+        return self._store.store(key, artifact)
+
+    def export_artifact(self, key: str | CompiledGraphKey, destination: str | Path) -> Path:
+        """Export a fully verified artifact without exposing HashRepo ref layout."""
+
+        return self._store.export_artifact(key, destination)
+
+    def runner(
+        self, key: str | CompiledGraphKey, destination: str | Path
+    ) -> CompiledGraphRunner | None:
+        """Resolve the exact selected artifact and load its gated AOTI runner."""
+
+        graph = self.resolve(key, destination)
+        return None if graph is None else CompiledGraphRunner._from_verified_graph(graph)
+
+    def _mint(self, plan: _GraphClassPlan) -> StoreResult:
+        """Compile, package, verify, and publish one plan into the local CAS."""
+
+        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-mint-") as raw:
+            workspace = Path(raw)
+            package = _compile_package(plan, workspace)
+            constants = declared_constants(package, plan.declaration.graph_class)
+            _admit_constant_table(plan, constants)
+            literals = workspace / "constants.safetensors"
+            literal_payload_values = _write_literals(plan.spec.program, constants, literals)
+            if plan.spec.declare() != plan.declaration:
+                raise AdmissionError(
+                    "exported program changed during compilation, packaging, "
+                    "or literal serialization"
+                )
+            metadata = build_metadata(
+                graph_class={
+                    "name": plan.declaration.graph_class,
+                    "target": plan.declaration.target,
+                    "class_hash": plan.declaration.class_hash,
+                    "graph": dict(plan.declaration.graph),
+                    "graph_witness": plan.declaration.graph_witness,
+                    "range_digest": plan.declaration.range_digest,
+                    "fork": [[name, value] for name, value in plan.declaration.fork],
+                    "class_dims": [[name, value] for name, value in plan.declaration.class_dims],
+                    "strict": plan.declaration.strict,
+                    "lora_bucket": plan.declaration.lora_bucket,
+                    "literal_values": plan.declaration.literal_values,
+                    "literal_payload_values": literal_payload_values,
+                    "placement": list(plan.declaration.placement),
+                    "constants": [constant.as_manifest_row() for constant in constants],
+                },
+                sm=plan.runtime.sm,
+                toolchain=plan.runtime.toolchain,
+                host_isa=plan.runtime.host_isa,
+            )
+            artifact = pack_artifact(
+                package,
+                workspace / "compiled_graph.tar.gz",
+                metadata,
+                literals=literals if literals.is_file() else None,
+            )
+            return self._store.store(plan.key, artifact)
+
+    def compile(
+        self,
+        spec: GraphClassSpec,
+        runtime: RuntimeCompatibility,
+        destination: str | Path,
+    ) -> EnsureResult:
+        """Compile or reuse one self-derived graph class under sealed policy."""
+
+        plan = self._plan(spec, runtime)
+        try:
+            existing = self.resolve(plan.key, destination)
+        except QuarantinedArtifact:
+            existing = None
+        if existing is not None:
+            self._admit(plan, existing)
+            return EnsureResult(EnsureOutcome.REUSED, existing)
+
+        publication = self._mint(plan)
+        resolved = self.resolve(plan.key, destination)
+        if resolved is None:
+            raise StorageError(f"compiled graph {plan.key} disappeared after publication")
+        self._admit(plan, resolved)
+        outcome = (
+            EnsureOutcome.REUSED
+            if publication.outcome == StoreOutcome.DIVERGENT
+            else EnsureOutcome.MINTED
+        )
+        return EnsureResult(outcome, resolved, publication.outcome)
+
+    def ensure(
+        self,
+        key: str | CompiledGraphKey,
+        destination: str | Path,
+        *,
+        target: str,
+        toolchain: Mapping[str, str],
+        recipe: Callable[[], GraphClassSpec],
+    ) -> EnsureResult:
+        """Reuse an admitted exact key, compiling only on a miss or quarantine."""
+
+        requested = str(key)
+        try:
+            existing = self.resolve(requested, destination)
+        except QuarantinedArtifact:
+            existing = None
+        if existing is not None:
+            self._admit_request(
+                existing,
+                target=target,
+                toolchain=toolchain,
+            )
+            return EnsureResult(EnsureOutcome.REUSED, existing)
+
+        spec = recipe()
+        runtime = RuntimeCompatibility(target, toolchain=toolchain)
+        plan = self._plan(spec, runtime)
+        if str(plan.key) != requested:
+            raise AdmissionError(f"lazy recipe derives {plan.key}, not requested key {requested!r}")
+        publication = self._mint(plan)
+        resolved = self.resolve(plan.key, destination)
+        if resolved is None:
+            raise StorageError(f"compiled graph {plan.key} disappeared after publication")
+        self._admit(plan, resolved)
+        outcome = (
+            EnsureOutcome.REUSED
+            if publication.outcome == StoreOutcome.DIVERGENT
+            else EnsureOutcome.MINTED
+        )
+        return EnsureResult(outcome, resolved, publication.outcome)

--- a/src/gen_worker/_vendor/torch_compiled_graphs/host_isa.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/host_isa.py
@@ -1,0 +1,255 @@
+"""Fail-closed host-code policy for every AOTInductor target."""
+
+from __future__ import annotations
+
+import platform
+import shlex
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+_X86_64 = "x86_64"
+_X86_64_V3 = "x86-64-v3"
+_LEVELS: tuple[tuple[str, frozenset[str]], ...] = (
+    ("x86-64", frozenset()),
+    ("x86-64-v2", frozenset({"cx16", "lahf_lm", "popcnt", "sse4_1", "sse4_2", "ssse3"})),
+    (
+        _X86_64_V3,
+        frozenset({"abm", "avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "movbe", "xsave"}),
+    ),
+    (
+        "x86-64-v4",
+        frozenset({"avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl"}),
+    ),
+)
+_RANK = {name: index for index, (name, _) in enumerate(_LEVELS)}
+_X86_FEATURE_SWITCHES = {
+    "abm": "-mabm",
+    "avx": "-mavx",
+    "avx2": "-mavx2",
+    "bmi1": "-mbmi",
+    "bmi2": "-mbmi2",
+    "cx16": "-mcx16",
+    "f16c": "-mf16c",
+    "fma": "-mfma",
+    "lahf_lm": "-msahf",
+    "movbe": "-mmovbe",
+    "popcnt": "-mpopcnt",
+    "sse4_1": "-msse4.1",
+    "sse4_2": "-msse4.2",
+    "ssse3": "-mssse3",
+    "xsave": "-mxsave",
+}
+_HOST_FACTS = frozenset(
+    {"machine", "host_isa_level", "host_isa_features", "cpp_march", "cpp_simdlen"}
+)
+_POLICY_LOCK = threading.RLock()
+
+
+class HostISAError(RuntimeError):
+    """The host cannot state, impose, or satisfy its AOTI ISA contract."""
+
+
+def _required_flags(level: str) -> frozenset[str]:
+    rank = _RANK.get(level)
+    if rank is None:
+        raise HostISAError(f"unknown x86-64 ISA level {level!r}")
+    required: set[str] = set()
+    for _, flags in _LEVELS[: rank + 1]:
+        required.update(flags)
+    return frozenset(required)
+
+
+def _cpu_features() -> frozenset[str]:
+    """Return features shared by every processor described by Linux."""
+
+    try:
+        rows = Path("/proc/cpuinfo").read_text(encoding="ascii", errors="replace").splitlines()
+    except OSError as exc:
+        raise HostISAError(f"cannot read /proc/cpuinfo: {exc}") from exc
+    feature_sets = []
+    for row in rows:
+        name, separator, value = row.partition(":")
+        if separator and name.strip().lower() in {"flags", "features"}:
+            feature_sets.append(set(value.lower().split()))
+    if not feature_sets:
+        raise HostISAError("/proc/cpuinfo states no CPU flags or features")
+    common = feature_sets[0]
+    for features in feature_sets[1:]:
+        common.intersection_update(features)
+    return frozenset(common)
+
+
+def _encoded_features(features: frozenset[str]) -> str:
+    return ",".join(sorted(features)) or "none"
+
+
+def _decoded_features(value: str) -> frozenset[str]:
+    if value == "none":
+        return frozenset()
+    rows = value.split(",")
+    if (
+        not rows
+        or rows != sorted(set(rows))
+        or any(not row or row != row.strip() or row.lower() != row for row in rows)
+    ):
+        raise HostISAError("host_isa_features must be sorted, unique lowercase names")
+    return frozenset(rows)
+
+
+@dataclass(frozen=True, slots=True)
+class _Requirement:
+    machine: str
+    level: str
+    features: frozenset[str]
+    march: str
+    simdlen: str
+
+    def facts(self) -> dict[str, str]:
+        return {
+            "machine": self.machine,
+            "host_isa_level": self.level,
+            "host_isa_features": _encoded_features(self.features),
+            "cpp_march": self.march,
+            "cpp_simdlen": self.simdlen,
+        }
+
+
+def _host_requirement() -> _Requirement:
+    machine = platform.machine().strip().lower()
+    if not machine:
+        raise HostISAError("platform states no host machine")
+    features = _cpu_features()
+    if machine != _X86_64:
+        if not features:
+            raise HostISAError(f"cannot state a native ISA requirement for {machine}")
+        return _Requirement(machine, "native", features, "native", "native")
+
+    level = _LEVELS[0][0]
+    for candidate, _ in _LEVELS[1:]:
+        if _required_flags(candidate) <= features:
+            level = candidate
+        else:
+            break
+    march = _X86_64_V3 if _RANK[level] >= _RANK[_X86_64_V3] else level
+    return _Requirement(
+        machine, march, _required_flags(march), march, "256" if march == _X86_64_V3 else "128"
+    )
+
+
+def _fresh_thread_value(function: Any) -> object:
+    value: list[object] = []
+
+    def read() -> None:
+        value.append(function())
+
+    thread = threading.Thread(target=read, name="torch-compiled-graphs-isa-readback", daemon=True)
+    thread.start()
+    thread.join()
+    if not value:
+        raise HostISAError("fresh-thread ISA readback did not complete")
+    return value[0]
+
+
+def _impose_host_policy() -> dict[str, str]:
+    """Impose the closed host-code policy process-wide and return its key facts."""
+
+    with _POLICY_LOCK:
+        requirement = _host_requirement()
+        try:
+            import torch._inductor.config as config
+        except ImportError as exc:
+            raise HostISAError("PyTorch AOTInductor is required to impose host ISA") from exc
+
+        x86 = requirement.machine == _X86_64
+        march = requirement.march if x86 else None
+        simdlen = int(requirement.simdlen) if x86 else None
+        expected: dict[str, object] = {"cpp.march": march, "cpp.simdlen": simdlen}
+        entries = cast(Mapping[str, Any], getattr(config, "_config", {}))
+        for name, value in expected.items():
+            entry = entries.get(name)
+            if entry is None:
+                raise HostISAError(f"PyTorch config has no process-wide {name!r} default")
+            entry.default = value
+        config.cpp.march = march
+        config.cpp.simdlen = simdlen
+        current = (config.cpp.march, config.cpp.simdlen)
+        wanted = (march, simdlen)
+        if current != wanted:
+            raise HostISAError(f"host ISA clamp reads {current!r}, expected {wanted!r}")
+        foreign = _fresh_thread_value(lambda: (config.cpp.march, config.cpp.simdlen))
+        if foreign != wanted:
+            raise HostISAError(f"host ISA clamp is thread-local: fresh thread reads {foreign!r}")
+        return requirement.facts()
+
+
+def _assert_command_is_clamped(command: str) -> None:
+    """Refuse an x86 host compile that escaped the process-wide ISA clamp."""
+
+    if platform.machine().strip().lower() != _X86_64:
+        return
+    try:
+        arguments = shlex.split(command)
+    except ValueError as exc:
+        raise HostISAError(f"cannot parse host compiler command: {exc}") from exc
+    requirement = _host_requirement()
+    expected_march = f"-march={requirement.march}"
+    marches = [argument for argument in arguments if argument.startswith("-march=")]
+    if marches != [expected_march]:
+        raise HostISAError(
+            "host compiler command violates the ISA clamp: "
+            f"expected exactly {expected_march!r}, found {marches!r}"
+        )
+
+    allowed_features = {
+        _X86_FEATURE_SWITCHES[feature]
+        for feature in requirement.features
+        if feature in _X86_FEATURE_SWITCHES
+    }
+    for argument in arguments:
+        if argument == expected_march or argument in allowed_features:
+            continue
+        if argument == "-m64" or argument.startswith(("-mno-", "-mtune=")):
+            continue
+        if argument.startswith("-m") or argument.startswith("--param=march="):
+            raise HostISAError(f"host compiler command violates the ISA clamp with {argument!r}")
+
+
+def _validate_host_facts(toolchain: Mapping[str, str]) -> _Requirement:
+    missing = sorted(_HOST_FACTS - set(toolchain))
+    if missing:
+        raise HostISAError(f"toolchain is missing host ISA facts {missing!r}")
+    machine = toolchain["machine"]
+    level = toolchain["host_isa_level"]
+    march = toolchain["cpp_march"]
+    simdlen = toolchain["cpp_simdlen"]
+    features = _decoded_features(toolchain["host_isa_features"])
+    if not machine or machine != machine.strip().lower():
+        raise HostISAError("machine must be one canonical lowercase name")
+    if machine == _X86_64:
+        if level not in _RANK or march != level:
+            raise HostISAError("x86-64 host ISA level and cpp_march must match a known level")
+        expected_simdlen = "256" if level == _X86_64_V3 else "128"
+        if level == "x86-64-v4" or simdlen != expected_simdlen:
+            raise HostISAError("x86-64 host ISA exceeds the v3 cap or has an invalid simdlen")
+        if features != _required_flags(level):
+            raise HostISAError("x86-64 host ISA features do not restate its level")
+    elif level != "native" or march != "native" or simdlen != "native" or not features:
+        raise HostISAError("non-x86 host ISA must carry a complete native feature requirement")
+    return _Requirement(machine, level, features, march, simdlen)
+
+
+def _admit_host(toolchain: Mapping[str, str]) -> None:
+    requirement = _validate_host_facts(toolchain)
+    machine = platform.machine().strip().lower()
+    if requirement.machine != machine:
+        raise HostISAError(
+            f"artifact host code is {requirement.machine}, this host is {machine or 'unknown'}"
+        )
+    missing = sorted(requirement.features - _cpu_features())
+    if missing:
+        raise HostISAError(
+            f"artifact requires {requirement.level} but this host lacks {','.join(missing)}"
+        )

--- a/src/gen_worker/_vendor/torch_compiled_graphs/identity.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/identity.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+KEY_SCHEME = "cg-key-v1"
+MAX_KEY_LENGTH = 96
+_DIGEST_HEX = 56
+_TOOLCHAIN_DIGEST_HEX = 16
+
+#: The v1 identity axes, in canonical order. Public because consumers otherwise
+#: re-declare it and fence the copy; a duplicate that drifts is how a correctly
+#: named module computes wrong keys with nothing raising.
+REQUIRED_AXES: tuple[str, ...] = ("graph", "sm", "toolchain")
+
+#: The artifact-metadata block carrying graph-class facts. Public for the same
+#: reason: a consumer reading a block this package no longer writes fails at
+#: run time, not at import, and its fixtures keep the obsolete shape green.
+GRAPH_CLASS_BLOCK = "graph_class"
+
+#: The artifact `kind` this package writes and refuses on read. Public for the
+#: same reason again, and defined HERE rather than in `artifact` because this
+#: module is the dependency root: `artifact` imports from it, so the constant
+#: can have exactly one definition that both readers share.
+ARTIFACT_KIND = "aot-inductor"
+
+_NOT_TOOLCHAIN = frozenset(("diffusers", "transformers", "peft"))
+_KEY_RE = re.compile(rf"[a-z0-9][a-z0-9._-]*-[0-9a-f]{{{_DIGEST_HEX}}}\Z")
+
+
+class IdentityError(ValueError):
+    """A compiled graph cannot state its complete, canonical identity."""
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledGraphKey:
+    """The three identity axes and their deterministic v1 address."""
+
+    axes: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.axes, tuple) or any(
+            not isinstance(axis, tuple) or len(axis) != 2 for axis in self.axes
+        ):
+            raise IdentityError("compiled graph key axes must be canonical name/value tuples")
+        if tuple(name for name, _ in self.axes) != REQUIRED_AXES:
+            raise IdentityError(
+                f"compiled graph key axes must be exactly {list(REQUIRED_AXES)!r}"
+            )
+        for name, value in self.axes:
+            if not isinstance(value, str) or not value or value != value.strip():
+                raise IdentityError(f"compiled graph key requires canonical string {name!r}")
+            if is_compiled_graph_key(value):
+                raise IdentityError(f"{name} is a compiled-graph key, not an identity fact")
+
+    def as_dict(self) -> dict[str, str]:
+        return dict(self.axes)
+
+    def canonical(self) -> bytes:
+        return json.dumps(
+            self.as_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("ascii")
+
+    @property
+    def value(self) -> str:
+        digest = hashlib.sha256(self.canonical()).hexdigest()[:_DIGEST_HEX]
+        return f"{KEY_SCHEME}-{digest}"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def is_compiled_graph_key(value: object) -> bool:
+    """Return whether a boundary value has the compiled-graph key shape.
+
+    The digest is the anchored suffix; never split on ``-`` because schemes may
+    contain hyphens. The grammar refuses shape, not scheme, so a future scheme
+    can reach axis-based admission without teaching every boundary its name.
+    """
+
+    return (
+        isinstance(value, str)
+        and len(value) <= MAX_KEY_LENGTH
+        and _KEY_RE.fullmatch(value) is not None
+    )
+
+
+def _refuse_key_as_fact(name: str, value: str) -> None:
+    if is_compiled_graph_key(value):
+        raise IdentityError(f"{name} is a compiled-graph key, not an identity fact")
+
+
+def from_axes(axes: Mapping[str, str]) -> CompiledGraphKey:
+    unknown = sorted(set(axes) - set(REQUIRED_AXES))
+    if unknown:
+        raise IdentityError(
+            f"unknown identity axes {unknown!r}; v1 is exactly {list(REQUIRED_AXES)!r}"
+        )
+    clean: dict[str, str] = {}
+    for name in REQUIRED_AXES:
+        raw = axes.get(name)
+        if not isinstance(raw, str) or not raw or raw != raw.strip():
+            raise IdentityError(f"compiled graph identity requires canonical string {name!r}")
+        value = raw
+        _refuse_key_as_fact(name, value)
+        clean[name] = value
+    return CompiledGraphKey(tuple(sorted(clean.items())))
+
+
+def _facts_digest(facts: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        dict(facts), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def toolchain_axis_digest(block: Mapping[str, Any]) -> str:
+    """Restate the worker's compiler-content axis from its recorded block."""
+
+    facts = {
+        str(name): str(value)
+        for name, value in block.items()
+        if str(name) not in _NOT_TOOLCHAIN
+    }
+    return _facts_digest(facts)[:_TOOLCHAIN_DIGEST_HEX]
+
+
+def from_artifact_metadata(metadata: Mapping[str, Any]) -> CompiledGraphKey:
+    if metadata.get("kind") != ARTIFACT_KIND:
+        raise IdentityError(
+            f"only an {ARTIFACT_KIND} artifact has compiled-graph identity"
+        )
+    sm = metadata.get("sm")
+    if not isinstance(sm, str) or not sm.strip():
+        raise IdentityError("artifact records no GPU compute capability")
+    graph_class = metadata.get(GRAPH_CLASS_BLOCK)
+    if not isinstance(graph_class, Mapping):
+        raise IdentityError(f"compiled graph records no {GRAPH_CLASS_BLOCK} object")
+    graph = graph_class.get("class_hash")
+    if not isinstance(graph, str) or not graph.strip():
+        raise IdentityError("compiled graph records no graph-class hash")
+    toolchain = metadata.get("toolchain")
+    if (
+        not isinstance(toolchain, Mapping)
+        or not toolchain
+        or any(
+            not isinstance(name, str)
+            or not name
+            or name != name.strip()
+            or not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            for name, value in toolchain.items()
+        )
+    ):
+        raise IdentityError("artifact records no toolchain object")
+    return from_axes({"graph": graph, "sm": sm, "toolchain": toolchain_axis_digest(toolchain)})

--- a/src/gen_worker/_vendor/torch_compiled_graphs/ingress.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/ingress.py
@@ -1,0 +1,493 @@
+"""Canonical call-ingress identity for one exported graph class."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+PathStep = int | str
+_INGRESS_FIELDS = frozenset(
+    ("v", "parameters", "flat_arity", "inputs", "symbols", "excluded_inputs")
+)
+_INPUT_FIELDS = frozenset(
+    ("name", "position", "param", "param_position", "path", "exported_name", "dtype", "shape")
+)
+
+
+class IngressError(ValueError):
+    """A call-ingress declaration is incomplete or noncanonical."""
+
+    def __init__(self, reason: str, detail: str | None = None) -> None:
+        self.reason = str(reason)
+        super().__init__(detail if detail is not None else reason)
+
+
+def _name(param: str, path: Sequence[PathStep]) -> str:
+    name = param
+    for step in path:
+        name = step if isinstance(step, str) else f"{name}.{step}"
+    return name
+
+
+def exported_input_name(param: str, path: Sequence[PathStep] = ()) -> str:
+    """Return the placeholder spelling produced by ``torch.export``."""
+
+    return "_".join((str(param), *(str(step) for step in path)))
+
+
+@dataclass(frozen=True, slots=True)
+class CallInput:
+    """One tensor feed and its exact identity in the unflattened call."""
+
+    name: str
+    position: int
+    param: str
+    param_position: int
+    path: tuple[PathStep, ...]
+    exported_name: str
+    dtype: str
+    shape: tuple[int | str, ...]
+
+    def __post_init__(self) -> None:
+        for field, value in (
+            ("name", self.name),
+            ("param", self.param),
+            ("exported_name", self.exported_name),
+            ("dtype", self.dtype),
+        ):
+            if not isinstance(value, str) or not value or value != value.strip():
+                raise IngressError("input_invalid", f"call input {field} must be canonical")
+        if type(self.position) is not int or self.position < 0:
+            raise IngressError("input_invalid", "call input position must be non-negative")
+        if type(self.param_position) is not int or self.param_position < 0:
+            raise IngressError("input_invalid", "call input param_position must be non-negative")
+        if not isinstance(self.path, tuple) or any(
+            (type(step) is not int and not isinstance(step, str))
+            or (type(step) is int and step < 0)
+            or (isinstance(step, str) and (not step or step != step.strip()))
+            for step in self.path
+        ):
+            raise IngressError("input_invalid", "call input path is not canonical")
+        if self.name != _name(self.param, self.path):
+            raise IngressError("input_invalid", "call input name does not restate param/path")
+        if self.exported_name != exported_input_name(self.param, self.path):
+            raise IngressError(
+                "input_invalid", "call input exported_name does not restate param/path"
+            )
+        if not isinstance(self.shape, tuple) or any(
+            (type(dimension) is not int and not isinstance(dimension, str))
+            or (type(dimension) is int and dimension < 0)
+            or (isinstance(dimension, str) and (not dimension or dimension != dimension.strip()))
+            for dimension in self.shape
+        ):
+            raise IngressError("input_invalid", "call input shape is not canonical")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "position": self.position,
+            "param": self.param,
+            "param_position": self.param_position,
+            "path": list(self.path),
+            "exported_name": self.exported_name,
+            "dtype": self.dtype,
+            "shape": list(self.shape),
+        }
+
+    def resolve(
+        self, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> tuple[bool, object | None]:
+        if self.param in kwargs:
+            value: object = kwargs[self.param]
+        elif self.param_position < len(args):
+            value = args[self.param_position]
+        else:
+            return False, None
+        for step in self.path:
+            if isinstance(step, str):
+                if not isinstance(value, Mapping) or step not in value:
+                    return False, None
+                value = value[step]
+            else:
+                if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+                    return False, None
+                if step >= len(value):
+                    return False, None
+                value = value[step]
+        return True, value
+
+
+@dataclass(frozen=True, slots=True)
+class CallIngress:
+    """The closed, identity-hashed call contract consumed by graph runners."""
+
+    parameters: tuple[str, ...]
+    flat_arity: int
+    inputs: tuple[CallInput, ...]
+    symbols: tuple[tuple[str, tuple[int, int]], ...] = ()
+    excluded_inputs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.parameters, tuple) or not self.parameters or any(
+            not isinstance(name, str) or not name or name != name.strip()
+            for name in self.parameters
+        ):
+            raise IngressError("ingress_invalid", "parameters must be canonical strings")
+        if len(self.parameters) != len(set(self.parameters)):
+            raise IngressError("ingress_invalid", "parameters must be unique")
+        if type(self.flat_arity) is not int or self.flat_arity <= 0:
+            raise IngressError("ingress_invalid", "flat_arity must be a positive integer")
+        if not isinstance(self.inputs, tuple) or not self.inputs:
+            raise IngressError("ingress_invalid", "call ingress must declare tensor inputs")
+        positions = tuple(row.position for row in self.inputs)
+        if positions != tuple(sorted(set(positions))):
+            raise IngressError("ingress_invalid", "input positions must be strictly increasing")
+        if positions[-1] >= self.flat_arity:
+            raise IngressError("ingress_invalid", "input position exceeds flat_arity")
+        param_positions = tuple(row.param_position for row in self.inputs)
+        if param_positions != tuple(sorted(param_positions)):
+            raise IngressError(
+                "ingress_invalid", "input param_position values must be nondecreasing"
+            )
+        for row in self.inputs:
+            if row.param_position >= len(self.parameters):
+                raise IngressError(
+                    "ingress_invalid", f"input {row.name!r} param_position is out of range"
+                )
+            if self.parameters[row.param_position] != row.param:
+                raise IngressError(
+                    "ingress_invalid",
+                    f"input {row.name!r} param does not match parameters[param_position]",
+                )
+        for attribute, values in (
+            ("name", tuple(row.name for row in self.inputs)),
+            ("exported_name", tuple(row.exported_name for row in self.inputs)),
+        ):
+            if len(values) != len(set(values)):
+                raise IngressError("ingress_invalid", f"duplicate input {attribute}")
+
+        if not isinstance(self.symbols, tuple):
+            raise IngressError("ingress_invalid", "symbols must be canonical tuples")
+        names = tuple(name for name, _ in self.symbols)
+        if names != tuple(sorted(set(names))):
+            raise IngressError("ingress_invalid", "symbols must be sorted and unique")
+        for name, bounds in self.symbols:
+            if not isinstance(name, str) or not name or name != name.strip():
+                raise IngressError("ingress_invalid", "symbol name must be canonical")
+            if (
+                not isinstance(bounds, tuple)
+                or len(bounds) != 2
+                or any(type(bound) is not int for bound in bounds)
+                or bounds[1] < bounds[0]
+            ):
+                raise IngressError("ingress_invalid", f"symbol {name!r} bounds are invalid")
+        referenced = {
+            dimension
+            for row in self.inputs
+            for dimension in row.shape
+            if isinstance(dimension, str)
+        }
+        known = set(names)
+        missing = sorted(referenced - known)
+        if missing:
+            raise IngressError(
+                "ingress_invalid", f"symbol {missing[0]!r} has no declared bounds"
+            )
+        unused = sorted(known - referenced)
+        if unused:
+            raise IngressError("ingress_invalid", f"symbol {unused[0]!r} is unreferenced")
+
+        if not isinstance(self.excluded_inputs, tuple) or any(
+            not isinstance(name, str) or not name or name != name.strip()
+            for name in self.excluded_inputs
+        ):
+            raise IngressError("ingress_invalid", "excluded_inputs must be canonical strings")
+        if self.excluded_inputs != tuple(sorted(set(self.excluded_inputs))):
+            raise IngressError("ingress_invalid", "excluded_inputs must be sorted and unique")
+        overlap = sorted(set(self.excluded_inputs) & {row.name for row in self.inputs})
+        if overlap:
+            raise IngressError(
+                "ingress_invalid", f"input {overlap[0]!r} is both declared and excluded"
+            )
+
+    @property
+    def symbol_bounds(self) -> dict[str, tuple[int, int]]:
+        return dict(self.symbols)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "v": 1,
+            "parameters": list(self.parameters),
+            "flat_arity": self.flat_arity,
+            "inputs": [row.as_dict() for row in self.inputs],
+            "symbols": {name: list(bounds) for name, bounds in self.symbols},
+            "excluded_inputs": list(self.excluded_inputs),
+        }
+
+    def digest(self) -> str:
+        encoded = json.dumps(
+            self.as_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("ascii")
+        return hashlib.sha256(encoded).hexdigest()[:32]
+
+    @classmethod
+    def decode(cls, raw: Mapping[str, Any]) -> CallIngress:
+        if not isinstance(raw, Mapping) or set(raw) != _INGRESS_FIELDS:
+            raise IngressError(
+                "ingress_invalid",
+                f"call ingress fields must be exactly {sorted(_INGRESS_FIELDS)!r}",
+            )
+        if type(raw.get("v")) is not int or raw.get("v") != 1:
+            raise IngressError("ingress_invalid", "call ingress v must be 1")
+        parameters = raw.get("parameters")
+        if not isinstance(parameters, list):
+            raise IngressError("ingress_invalid", "call ingress parameters must be an array")
+        rows = raw.get("inputs")
+        if not isinstance(rows, list):
+            raise IngressError("ingress_invalid", "call ingress inputs must be an array")
+        inputs: list[CallInput] = []
+        for index, row in enumerate(rows):
+            if not isinstance(row, Mapping) or set(row) != _INPUT_FIELDS:
+                raise IngressError(
+                    "ingress_invalid",
+                    f"call input {index} fields must be exactly {sorted(_INPUT_FIELDS)!r}",
+                )
+            raw_path = row.get("path")
+            raw_shape = row.get("shape")
+            if not isinstance(raw_path, list) or not isinstance(raw_shape, list):
+                raise IngressError("ingress_invalid", f"call input {index} arrays are malformed")
+            inputs.append(
+                CallInput(
+                    name=row["name"],
+                    position=row["position"],
+                    param=row["param"],
+                    param_position=row["param_position"],
+                    path=tuple(raw_path),
+                    exported_name=row["exported_name"],
+                    dtype=row["dtype"],
+                    shape=tuple(raw_shape),
+                )
+            )
+        raw_symbols = raw.get("symbols")
+        if not isinstance(raw_symbols, Mapping):
+            raise IngressError("ingress_invalid", "call ingress symbols must be an object")
+        symbols: list[tuple[str, tuple[int, int]]] = []
+        for name, bounds in raw_symbols.items():
+            if not isinstance(bounds, list) or len(bounds) != 2:
+                raise IngressError("ingress_invalid", f"symbol {name!r} bounds are malformed")
+            symbols.append((name, (bounds[0], bounds[1])))
+        excluded = raw.get("excluded_inputs")
+        if not isinstance(excluded, list):
+            raise IngressError("ingress_invalid", "excluded_inputs must be an array")
+        return cls(
+            parameters=tuple(parameters),
+            flat_arity=raw["flat_arity"],
+            inputs=tuple(inputs),
+            symbols=tuple(symbols),
+            excluded_inputs=tuple(excluded),
+        )
+
+    @classmethod
+    def from_graph(cls, graph: Mapping[str, Any]) -> CallIngress:
+        pytree = graph.get("pytree")
+        if not isinstance(pytree, Mapping):
+            raise IngressError("ingress_invalid", "graph pytree must be an object")
+        ingress = pytree.get("ingress")
+        if not isinstance(ingress, Mapping):
+            raise IngressError("ingress_invalid", "graph pytree declares no call ingress")
+        return cls.decode(ingress)
+
+    def bind(
+        self, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> dict[str, object]:
+        bound: dict[str, object] = {}
+        for row in self.inputs:
+            found, value = row.resolve(args, kwargs)
+            if not found:
+                path = "".join(f"[{step!r}]" for step in row.path)
+                raise IngressError(
+                    "input_missing",
+                    f"declared input {row.name!r} at argument {row.param!r}{path} is absent",
+                )
+            bound[row.name] = value
+        return bound
+
+    def feeds(
+        self, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> tuple[object, ...]:
+        bound = self.bind(args, kwargs)
+        return tuple(bound[row.name] for row in self.inputs)
+
+
+@dataclass(frozen=True, slots=True)
+class _Leaf:
+    param: str
+    param_position: int
+    path: tuple[PathStep, ...]
+    value: object
+
+    @property
+    def name(self) -> str:
+        return _name(self.param, self.path)
+
+    @property
+    def exported_name(self) -> str:
+        return exported_input_name(self.param, self.path)
+
+
+def _walk(
+    param: str,
+    param_position: int,
+    path: tuple[PathStep, ...],
+    value: object,
+    output: list[_Leaf],
+) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str) or not key or key != key.strip():
+                raise IngressError("call_invalid", "mapping input key is not canonical")
+            _walk(param, param_position, path + (key,), item, output)
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _walk(param, param_position, path + (index,), item, output)
+    else:
+        output.append(_Leaf(param, param_position, path, value))
+
+
+def _flatten_call(
+    param_names: Sequence[str], args: Sequence[object], kwargs: Mapping[str, object]
+) -> tuple[_Leaf, ...]:
+    names = tuple(param_names)
+    if any(
+        not isinstance(name, str) or not name or name != name.strip() for name in names
+    ) or len(names) != len(set(names)):
+        raise IngressError("call_invalid", "call parameter names must be canonical and unique")
+    if len(args) > len(names):
+        raise IngressError("call_invalid", "call has more positional values than parameters")
+    values = list(args)
+    for name in names[len(args) :]:
+        if name not in kwargs:
+            raise IngressError("call_invalid", f"call carries no value for parameter {name!r}")
+        values.append(kwargs[name])
+    output: list[_Leaf] = []
+    for position, (param, value) in enumerate(zip(names, values, strict=True)):
+        _walk(param, position, (), value, output)
+    return tuple(output)
+
+
+def _bound(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise IngressError("range_invalid", f"symbol range bound {value!r} is not finite") from exc
+
+
+def _symbol_ranges(program: object) -> dict[str, tuple[int, int]]:
+    ranges: dict[str, tuple[int, int]] = {}
+    for symbol, interval in (getattr(program, "range_constraints", {}) or {}).items():
+        lower = _bound(getattr(interval, "lower", None))
+        upper = _bound(getattr(interval, "upper", None))
+        ranges[str(symbol)] = (lower, upper)
+    return ranges
+
+
+def _placeholder_values(program: object) -> dict[str, object]:
+    values: dict[str, object] = {}
+    graph = getattr(getattr(program, "graph_module", None), "graph", None)
+    for node in getattr(graph, "nodes", ()) or ():
+        if getattr(node, "op", "") == "placeholder":
+            values[str(node.name)] = node.meta.get("val")
+    return values
+
+
+def _dtype(value: object) -> str:
+    raw = str(getattr(value, "dtype", "") or "")
+    return raw.removeprefix("torch.")
+
+
+def build_call_ingress(
+    program: object,
+    param_names: Sequence[str],
+    args: Sequence[object],
+    kwargs: Mapping[str, object],
+    *,
+    excluded_inputs: Sequence[str] = (),
+) -> CallIngress:
+    """Build the sole v1 ingress declaration from a real exported call."""
+
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise IngressError("torch_missing", "building call ingress requires PyTorch") from exc
+    if not isinstance(program, torch.export.ExportedProgram):
+        raise IngressError("program_invalid", "call ingress requires an ExportedProgram")
+    leaves = _flatten_call(param_names, args, kwargs)
+    signature = getattr(program, "graph_signature", None)
+    user_inputs = tuple(getattr(signature, "user_inputs", ()) or ())
+    if len(user_inputs) != len(leaves):
+        raise IngressError(
+            "call_invalid",
+            f"export records {len(user_inputs)} flat inputs but the call has {len(leaves)} leaves",
+        )
+    placeholders = _placeholder_values(program)
+    ranges = _symbol_ranges(program)
+    used_symbols: dict[str, tuple[int, int]] = {}
+    rows: list[CallInput] = []
+    for position, (leaf, exported) in enumerate(zip(leaves, user_inputs, strict=True)):
+        if not isinstance(exported, str):
+            continue
+        value = placeholders.get(exported)
+        dtype = _dtype(value)
+        shape_value = getattr(value, "shape", None)
+        if not dtype or shape_value is None:
+            continue
+        if exported != leaf.exported_name:
+            raise IngressError(
+                "call_invalid",
+                f"torch.export input {exported!r} does not match call leaf {leaf.exported_name!r}",
+            )
+        shape: list[int | str] = []
+        for dimension in shape_value:
+            text = str(dimension)
+            if text.lstrip("-").isdigit():
+                shape.append(int(text))
+                continue
+            bounds = ranges.get(text)
+            if bounds is None:
+                raise IngressError(
+                    "range_invalid", f"input {leaf.name!r} symbol {text!r} has no finite range"
+                )
+            used_symbols[text] = bounds
+            shape.append(text)
+        rows.append(
+            CallInput(
+                name=leaf.name,
+                position=position,
+                param=leaf.param,
+                param_position=leaf.param_position,
+                path=leaf.path,
+                exported_name=leaf.exported_name,
+                dtype=dtype,
+                shape=tuple(shape),
+            )
+        )
+    return CallIngress(
+        parameters=tuple(param_names),
+        flat_arity=len(leaves),
+        inputs=tuple(rows),
+        symbols=tuple(sorted(used_symbols.items())),
+        excluded_inputs=tuple(sorted(excluded_inputs)),
+    )
+
+
+__all__ = [
+    "CallIngress",
+    "CallInput",
+    "IngressError",
+    "PathStep",
+    "build_call_ingress",
+    "exported_input_name",
+]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/introspection.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/introspection.py
@@ -1,0 +1,489 @@
+"""Read publishability facts from a PyTorch AOTInductor ``.pt2`` package."""
+
+from __future__ import annotations
+
+import io
+import re
+import struct
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, cast
+
+
+class PackageIntrospectionError(RuntimeError):
+    """A compiled package is malformed or does not declare an expected fact."""
+
+
+@dataclass(frozen=True)
+class DeclaredConstant:
+    """One row in the constant table emitted into an AOTInductor wrapper."""
+
+    index: int
+    name: str
+    fqn: str
+    data_size: int
+    kind: str
+    dtype: str
+    shape: tuple[int, ...]
+    from_folded: bool
+
+    @property
+    def source(self) -> str:
+        if self.kind in _STATE_DICT_TYPES:
+            return "state_dict"
+        if self.kind in _COMPUTED_TYPES:
+            return "computed"
+        return "literal"
+
+    def as_manifest_row(self) -> dict[str, object]:
+        return {
+            "fqn": self.fqn,
+            "source": self.source,
+            "dtype": self.dtype,
+            "shape": list(self.shape),
+        }
+
+
+_CONSTANT_FIELD = re.compile(
+    r"constants_info_\[(\d+)\]\.(name|data_size|from_folded|original_fqn)\s*=\s*"
+    r'(?:"([^"]*)"|(\d+)|(true|false))\s*;'
+)
+_CONSTANT_TYPE = re.compile(
+    r"constants_info_\[(\d+)\]\.type\s*=\s*static_cast<int32_t>\s*\(\s*"
+    r"torch::aot_inductor::ConstantType::(\w+)\s*\)\s*;"
+)
+_CONSTANT_DTYPE = re.compile(r"constants_info_\[(\d+)\]\.dtype\s*=\s*cached_torch_dtype_(\w+)\s*;")
+_CONSTANT_SHAPE = re.compile(r"constants_info_\[(\d+)\]\.shape\s*=\s*\{([^}]*)\}\s*;")
+_MODEL_BASE = "AOTInductorModelBase("
+_AOTINDUCTOR_ROOT = "data/aotinductor/"
+_ELF_MAGIC = b"\x7fELF"
+_ELF64_SECTION_HEADER_SIZE = 64
+_SHT_NULL = 0
+_SHT_PROGBITS = 1
+_SHT_STRTAB = 3
+_SHT_NOBITS = 8
+_MAX_SECTION_NAME_TABLE_BYTES = 16 << 20
+_LRODATA = ".lrodata"
+_STATE_DICT_TYPES = frozenset(("Parameter", "Buffer"))
+_COMPUTED_TYPES = frozenset(("FoldedConstant",))
+
+
+def _valid_entry(entry: str) -> bool:
+    return (
+        bool(entry)
+        and "\\" not in entry
+        and "\0" not in entry
+        and all(component not in {"", ".", ".."} for component in entry.split("/"))
+    )
+
+
+def _member_layout(name: str) -> tuple[str, str, str] | None:
+    if name.startswith(_AOTINDUCTOR_ROOT):
+        root = ""
+        rest = name[len(_AOTINDUCTOR_ROOT) :]
+    else:
+        root, separator, rest = name.partition(f"/{_AOTINDUCTOR_ROOT}")
+        if not separator or "/" in root or not _valid_entry(root):
+            return None
+    entry, separator, filename = rest.rpartition("/")
+    if not separator or not filename or not _valid_entry(entry):
+        return None
+    return root, entry, filename
+
+
+def _member_entry(name: str, suffix: str) -> str | None:
+    layout = _member_layout(name)
+    if layout is None or not layout[2].endswith(suffix):
+        return None
+    return layout[1]
+
+
+def _members(package: Path, suffix: str, entry: str = "") -> list[str]:
+    if entry and not _valid_entry(entry):
+        raise PackageIntrospectionError(f"{package}: invalid package entry name {entry!r}")
+    try:
+        with zipfile.ZipFile(package) as archive:
+            layouts = [layout for name in archive.namelist() if (layout := _member_layout(name))]
+            roots = {root for root, _, _ in layouts}
+            if len(roots) > 1:
+                raise PackageIntrospectionError(
+                    f"{package}: package members use multiple AOTInductor roots {sorted(roots)!r}"
+                )
+            names = [
+                name
+                for name in archive.namelist()
+                if (member_entry := _member_entry(name, suffix)) is not None
+                and (not entry or member_entry == entry)
+            ]
+    except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        raise PackageIntrospectionError(f"{package}: invalid .pt2 package: {exc}") from exc
+    return names
+
+
+def _one_member(package: Path, suffix: str, entry: str) -> str:
+    names = _members(package, suffix, entry)
+    if len(names) != 1:
+        scope = f" for entry {entry!r}" if entry else ""
+        raise PackageIntrospectionError(
+            f"{package}: expected exactly one *{suffix} in the package{scope}, found {len(names)}"
+        )
+    return names[0]
+
+
+def _read_member(package: Path, name: str) -> bytes:
+    try:
+        with zipfile.ZipFile(package) as archive:
+            return archive.read(name)
+    except (
+        KeyError,
+        OSError,
+        RuntimeError,
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+    ) as exc:
+        raise PackageIntrospectionError(
+            f"{package}: cannot read package member {name!r}: {exc}"
+        ) from exc
+
+
+@contextmanager
+def _open_member(package: Path, name: str) -> Iterator[tuple[BinaryIO, int]]:
+    try:
+        with zipfile.ZipFile(package) as archive:
+            info = archive.getinfo(name)
+            with archive.open(info) as source:
+                yield cast(BinaryIO, source), info.file_size
+    except PackageIntrospectionError:
+        raise
+    except (
+        KeyError,
+        OSError,
+        RuntimeError,
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+    ) as exc:
+        raise PackageIntrospectionError(
+            f"{package}: cannot read package member {name!r}: {exc}"
+        ) from exc
+
+
+def _wrapper_source(package: Path, entry: str = "") -> str:
+    name = _one_member(package, ".wrapper.cpp", entry)
+    try:
+        return _read_member(package, name).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PackageIntrospectionError(
+            f"{package}: package member {name!r} is not UTF-8: {exc}"
+        ) from exc
+
+
+def _package_entry_names(package: Path) -> tuple[str, ...]:
+    """Return named graph entries discovered from wrapper paths."""
+
+    return tuple(
+        sorted(
+            {
+                entry
+                for member in _members(Path(package), ".wrapper.cpp")
+                if (entry := _member_entry(member, ".wrapper.cpp")) is not None
+            }
+        )
+    )
+
+
+def _call_arguments(source: str, opening: str) -> tuple[str, ...]:
+    start = source.find(opening)
+    if start < 0:
+        raise PackageIntrospectionError(f"generated wrapper has no {opening!r} call")
+    index = start + len(opening)
+    depth = 1
+    argument_start = index
+    arguments: list[str] = []
+    while index < len(source):
+        char = source[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth == 0:
+                arguments.append(source[argument_start:index].strip())
+                return tuple(arguments)
+        elif char == "," and depth == 1:
+            arguments.append(source[argument_start:index].strip())
+            argument_start = index + 1
+        index += 1
+    raise PackageIntrospectionError(f"unbalanced {opening!r} argument list")
+
+
+def _model_base_arguments(source: str) -> tuple[str, ...]:
+    arguments = _call_arguments(source, _MODEL_BASE)
+    if len(arguments) < 4:
+        raise PackageIntrospectionError(
+            f"generated wrapper has an unsupported {_MODEL_BASE[:-1]} signature"
+        )
+    return arguments
+
+
+def _declared_constant_count(source: str) -> int:
+    argument = _model_base_arguments(source)[2]
+    if re.fullmatch(r"\d+", argument) is None:
+        raise PackageIntrospectionError(
+            "generated wrapper has no literal constant count in "
+            f"{_MODEL_BASE[:-1]} argument 3: {argument!r}"
+        )
+    return int(argument)
+
+
+def _constants_in_so(package: Path, entry: str = "") -> bool:
+    """Return the package's declared ``load_constants_from_blob`` value."""
+
+    package = Path(package)
+    argument = _model_base_arguments(_wrapper_source(package, entry))[-1]
+    if argument not in {"true", "false"}:
+        raise PackageIntrospectionError(
+            f"{package}: expected a boolean load_constants_from_blob argument, got {argument!r}"
+        )
+    return argument == "true"
+
+
+def declared_constants(package: Path, entry: str = "") -> tuple[DeclaredConstant, ...]:
+    """Parse the package's generated constant table in declaration order."""
+
+    package = Path(package)
+    source = _wrapper_source(package, entry)
+    expected_count = _declared_constant_count(source)
+    fields: dict[int, dict[str, object]] = {}
+
+    def assign(index: int, field_name: str, value: object) -> None:
+        row = fields.setdefault(index, {})
+        if field_name in row:
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] declares {field_name!r} twice"
+            )
+        row[field_name] = value
+
+    for raw_index, field_name, text, number, boolean in _CONSTANT_FIELD.findall(source):
+        index = int(raw_index)
+        if field_name == "data_size":
+            if not number:
+                raise PackageIntrospectionError(
+                    f"{package}: constants_info_[{index}].data_size is not an integer"
+                )
+            assign(index, field_name, int(number))
+        elif field_name == "from_folded":
+            if not boolean:
+                raise PackageIntrospectionError(
+                    f"{package}: constants_info_[{index}].from_folded is not a boolean"
+                )
+            assign(index, field_name, boolean == "true")
+        else:
+            if number or boolean:
+                raise PackageIntrospectionError(
+                    f"{package}: constants_info_[{index}].{field_name} is not a string"
+                )
+            assign(index, field_name, text)
+    for raw_index, kind in _CONSTANT_TYPE.findall(source):
+        assign(int(raw_index), "kind", kind)
+    for raw_index, dtype in _CONSTANT_DTYPE.findall(source):
+        assign(int(raw_index), "dtype", dtype)
+    for raw_index, dimensions in _CONSTANT_SHAPE.findall(source):
+        index = int(raw_index)
+        try:
+            shape = tuple(
+                int(dimension.strip()) for dimension in dimensions.split(",") if dimension.strip()
+            )
+        except ValueError as exc:
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}].shape is not a literal integer shape"
+            ) from exc
+        if any(dimension < 0 for dimension in shape):
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}].shape has a negative dimension"
+            )
+        assign(index, "shape", shape)
+
+    expected_indices = set(range(expected_count))
+    if set(fields) != expected_indices:
+        missing_indices = sorted(expected_indices - set(fields))
+        unexpected = sorted(set(fields) - expected_indices)
+        raise PackageIntrospectionError(
+            f"{package}: constant table does not match declared count {expected_count} "
+            f"(missing indices {missing_indices}, unexpected indices {unexpected})"
+        )
+
+    constants: list[DeclaredConstant] = []
+    for index in sorted(fields):
+        row = fields[index]
+        required = {"name", "data_size", "from_folded", "kind", "dtype", "shape"}
+        missing_fields = sorted(required - set(row))
+        if missing_fields:
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] is missing required fields {missing_fields}"
+            )
+        name = row["name"]
+        data_size = row["data_size"]
+        kind = row["kind"]
+        dtype = row["dtype"]
+        raw_shape = row["shape"]
+        from_folded = row["from_folded"]
+        if not isinstance(name, str) or not name:
+            raise PackageIntrospectionError(f"{package}: constants_info_[{index}] has no name")
+        if not isinstance(data_size, int) or isinstance(data_size, bool) or data_size < 0:
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] has an invalid data_size"
+            )
+        if not isinstance(kind, str) or not kind:
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] has no constant type"
+            )
+        if not isinstance(dtype, str) or not dtype:
+            raise PackageIntrospectionError(f"{package}: constants_info_[{index}] has no dtype")
+        if not isinstance(raw_shape, tuple):
+            raise PackageIntrospectionError(f"{package}: constants_info_[{index}] has no shape")
+        if not isinstance(from_folded, bool):
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] has no from_folded flag"
+            )
+        fqn = row.get("original_fqn") or name
+        if not isinstance(fqn, str):
+            raise PackageIntrospectionError(
+                f"{package}: constants_info_[{index}] has an invalid original_fqn"
+            )
+        constants.append(
+            DeclaredConstant(
+                index=index,
+                name=name,
+                fqn=fqn,
+                data_size=data_size,
+                kind=kind,
+                dtype=dtype,
+                shape=raw_shape,
+                from_folded=from_folded,
+            )
+        )
+    return tuple(constants)
+
+
+def _read_at(source: BinaryIO, offset: int, size: int, total_size: int, what: str) -> bytes:
+    if offset < 0 or size < 0 or offset + size > total_size:
+        raise PackageIntrospectionError(f"packaged .so has an invalid {what} range")
+    source.seek(offset)
+    data = source.read(size)
+    if len(data) != size:
+        raise PackageIntrospectionError(f"packaged .so has a truncated {what}")
+    return data
+
+
+def _elf_section_sizes(source: BinaryIO, total_size: int) -> dict[str, int]:
+    if total_size < 64:
+        raise PackageIntrospectionError("packaged .so is not an ELF image")
+    header = _read_at(source, 0, 64, total_size, "ELF header")
+    if not header.startswith(_ELF_MAGIC):
+        raise PackageIntrospectionError("packaged .so is not an ELF image")
+    if header[4] != 2 or header[5] != 1:
+        raise PackageIntrospectionError(
+            "packaged .so is not 64-bit little-endian ELF "
+            f"(EI_CLASS={header[4]}, EI_DATA={header[5]})"
+        )
+    if header[6] != 1:
+        raise PackageIntrospectionError("packaged .so has an unsupported ELF version")
+
+    section_offset = struct.unpack_from("<Q", header, 0x28)[0]
+    section_size, section_count, string_table_index = struct.unpack_from("<HHH", header, 0x3A)
+    table_size = section_size * section_count
+    if (
+        section_offset < len(header)
+        or not section_count
+        or section_size < _ELF64_SECTION_HEADER_SIZE
+        or string_table_index >= section_count
+        or section_offset + table_size > total_size
+    ):
+        raise PackageIntrospectionError("packaged .so has an invalid ELF section table")
+
+    def section_header(index: int) -> bytes:
+        return _read_at(
+            source,
+            section_offset + index * section_size,
+            _ELF64_SECTION_HEADER_SIZE,
+            total_size,
+            "ELF section header",
+        )
+
+    string_header = section_header(string_table_index)
+    string_type = struct.unpack_from("<I", string_header, 0x04)[0]
+    string_offset, string_size = struct.unpack_from("<QQ", string_header, 0x18)
+    if string_type != _SHT_STRTAB or not string_size:
+        raise PackageIntrospectionError("packaged .so has an invalid ELF section-name table")
+    if string_size > _MAX_SECTION_NAME_TABLE_BYTES:
+        raise PackageIntrospectionError("packaged .so has an oversized ELF section-name table")
+    string_table = _read_at(
+        source, string_offset, string_size, total_size, "ELF section-name table"
+    )
+
+    sizes: dict[str, int] = {}
+    for index in range(section_count):
+        section = section_header(index)
+        name_offset, section_type = struct.unpack_from("<II", section)
+        file_offset, section_bytes = struct.unpack_from("<QQ", section, 0x18)
+        if (
+            section_type not in {_SHT_NULL, _SHT_NOBITS}
+            and file_offset + section_bytes > total_size
+        ):
+            raise PackageIntrospectionError(
+                f"packaged .so has an invalid file range for ELF section {index}"
+            )
+        if name_offset >= len(string_table):
+            raise PackageIntrospectionError("packaged .so has an invalid ELF section name")
+        end = string_table.find(b"\0", name_offset)
+        if end < 0:
+            raise PackageIntrospectionError("packaged .so has an unterminated ELF section name")
+        try:
+            name = string_table[name_offset:end].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise PackageIntrospectionError(
+                "packaged .so has a non-UTF-8 ELF section name"
+            ) from exc
+        if name == _LRODATA and section_type != _SHT_PROGBITS:
+            raise PackageIntrospectionError(
+                f"packaged .so has {_LRODATA} with unexpected ELF section type {section_type}"
+            )
+        sizes[name] = sizes.get(name, 0) + section_bytes
+    return sizes
+
+
+def _elf_section_sizes_from_bytes(blob: bytes) -> dict[str, int]:
+    """Read section sizes from a 64-bit little-endian ELF image."""
+
+    return _elf_section_sizes(io.BytesIO(blob), len(blob))
+
+
+def code_only_violations(package: Path, entry: str = "") -> list[str]:
+    """Return reasons one package entry has constants embedded in its shared object."""
+
+    package = Path(package)
+    constants = declared_constants(package, entry)
+    declared_bytes = sum(constant.data_size for constant in constants)
+    reasons: list[str] = []
+
+    if _constants_in_so(package, entry):
+        largest = sorted(constants, key=lambda constant: -constant.data_size)[:5]
+        details = ", ".join(f"{constant.fqn} ({constant.data_size}B)" for constant in largest)
+        suffix = f"; largest: {details}" if details else ""
+        reasons.append(
+            "package declares load_constants_from_blob=true: "
+            f"{len(constants)} constants totalling {declared_bytes}B are embedded in the .so"
+            f"{suffix}"
+        )
+
+    shared_object = _one_member(package, ".so", entry)
+    with _open_member(package, shared_object) as (source, size):
+        readonly_data = _elf_section_sizes(source, size).get(_LRODATA, 0)
+    if declared_bytes and readonly_data >= declared_bytes:
+        reasons.append(
+            f"{shared_object}: {_LRODATA} is {readonly_data}B, at least the {declared_bytes}B "
+            f"declared across {len(constants)} constants"
+        )
+    return reasons

--- a/src/gen_worker/_vendor/torch_compiled_graphs/runner.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/runner.py
@@ -1,0 +1,280 @@
+"""Verified loading and constant binding for one compiled graph."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, cast
+
+from .identity import GRAPH_CLASS_BLOCK
+from .storage import StoredCompiledGraph
+
+
+class ConstantBindingError(RuntimeError):
+    """A loaded graph cannot be made safe to call with the supplied constants."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = str(reason)
+        super().__init__(detail)
+
+
+@dataclass(frozen=True, slots=True)
+class _Constant:
+    fqn: str
+    source: str
+
+
+def _constants(graph: StoredCompiledGraph) -> tuple[_Constant, ...]:
+    graph_class = graph.metadata[GRAPH_CLASS_BLOCK]
+    assert isinstance(graph_class, Mapping)  # artifact validation owns this boundary
+    rows = graph_class["constants"]
+    assert isinstance(rows, list)
+    return tuple(
+        _Constant(str(row["fqn"]), str(row["source"])) for row in rows if isinstance(row, Mapping)
+    )
+
+
+def _load_package(path: Path, graph_class: str) -> Any:
+    try:
+        module = import_module("torch._inductor.package")
+        loader = vars(module)["load_package"]
+        return cast(Any, loader)(str(path), model_name=graph_class)
+    except (ImportError, KeyError, RuntimeError, OSError) as exc:
+        raise ConstantBindingError(
+            "package_load_failed",
+            f"cannot load compiled graph {graph_class!r}: {type(exc).__name__}: {exc}",
+        ) from exc
+
+
+def _load_literals(path: Path | None, device: str) -> dict[str, Any]:
+    if path is None:
+        return {}
+    try:
+        module = import_module("safetensors.torch")
+        loader = vars(module)["load_file"]
+        return dict(cast(Any, loader)(str(path), device=device))
+    except (ImportError, KeyError, RuntimeError, OSError) as exc:
+        raise ConstantBindingError(
+            "literal_load_failed",
+            f"cannot load compiled-graph literals: {type(exc).__name__}: {exc}",
+        ) from exc
+
+
+def _is_device_oom(exc: BaseException) -> bool:
+    if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
+        return True
+    if not isinstance(exc, RuntimeError):
+        return False
+    detail = str(exc).lower()
+    return any(
+        phrase in detail
+        for phrase in (
+            "out of memory",
+            "cuda oom",
+            "cublas_status_alloc_failed",
+            "cudnn_status_alloc_failed",
+        )
+    )
+
+
+def _oom_in_chain(exc: BaseException) -> BaseException | None:
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        if _is_device_oom(current):
+            return current
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return None
+
+
+class CompiledGraphRunner:
+    """One exact AOTI package that cannot run before a complete bind.
+
+    The worker owns ingress selection and eager fallback.  This class owns the
+    dangerous AOTI boundary: exact constant-table equality, full update, and
+    the lifetime of every by-reference value.
+    """
+
+    key: str
+    graph_class: str
+    calls: int
+    _graph: StoredCompiledGraph
+    _constants: tuple[_Constant, ...]
+    _package: Any
+    _bound_values: dict[str, Any]
+    _retained_values: dict[str, Any]
+    _bound: bool
+    _failed: bool
+
+    def __init__(self) -> None:
+        raise TypeError("compiled-graph runners are created only by Engine.runner")
+
+    @classmethod
+    def _from_verified_graph(cls, graph: StoredCompiledGraph) -> CompiledGraphRunner:
+        """Load one graph after Engine has resolved and admitted its exact bytes."""
+
+        self = object.__new__(cls)
+        graph_class = graph.metadata[GRAPH_CLASS_BLOCK]
+        assert isinstance(graph_class, Mapping)
+        self.key = graph.key
+        self.graph_class = str(graph_class["name"])
+        self._graph = graph
+        self._constants = _constants(graph)
+        try:
+            self._package = _load_package(graph.package, self.graph_class)
+        except ConstantBindingError as exc:
+            oom = _oom_in_chain(exc)
+            if oom is None:
+                raise
+            raise ConstantBindingError(
+                "out_of_memory",
+                f"loading compiled graph {self.graph_class!r} exhausted device memory "
+                f"({type(oom).__name__}: {oom})",
+            ) from exc
+        self._bound_values = {}
+        self._retained_values = {}
+        self._bound = False
+        self._failed = False
+        self.calls = 0
+        return self
+
+    @property
+    def bound(self) -> bool:
+        return self._bound
+
+    @property
+    def bound_fqns(self) -> tuple[str, ...]:
+        return tuple(sorted(self._bound_values))
+
+    @property
+    def declared_fqns(self) -> tuple[str, ...]:
+        return tuple(constant.fqn for constant in self._constants)
+
+    def bind(self, state: Mapping[str, Any], *, device: str) -> None:
+        """Bind the complete constant table by reference, exactly once."""
+
+        if self._bound:
+            raise ConstantBindingError("already_bound", "compiled graph is already bound")
+        if self._failed:
+            raise ConstantBindingError(
+                "binding_failed",
+                "compiled graph had a failed partial bind and must be loaded again",
+            )
+        requested_device = str(device).strip()
+        if not requested_device:
+            raise ConstantBindingError("device_missing", "constant binding requires a device")
+
+        try:
+            actual = {str(name) for name in self._package.get_constant_fqns()}
+        except Exception as exc:
+            self._failed = True
+            oom = _oom_in_chain(exc)
+            if oom is not None:
+                raise ConstantBindingError(
+                    "out_of_memory",
+                    f"reading the artifact constant table exhausted device memory "
+                    f"({type(oom).__name__}: {oom})",
+                ) from exc
+            raise ConstantBindingError(
+                "constant_table_unreadable",
+                f"artifact will not report its constant FQNs: {type(exc).__name__}: {exc}",
+            ) from exc
+        declared = {constant.fqn for constant in self._constants}
+        if actual != declared:
+            self._failed = True
+            raise ConstantBindingError(
+                "constant_set_mismatch",
+                "artifact constant table != declared manifest; "
+                f"declared-only={sorted(declared - actual)[:6]!r} "
+                f"artifact-only={sorted(actual - declared)[:6]!r}",
+            )
+
+        try:
+            literals = _load_literals(self._graph.literals, requested_device)
+        except Exception as exc:
+            self._failed = True
+            oom = _oom_in_chain(exc)
+            if oom is not None:
+                raise ConstantBindingError(
+                    "out_of_memory",
+                    f"loading literal constants exhausted device memory "
+                    f"({type(oom).__name__}: {oom})",
+                ) from exc
+            if isinstance(exc, ConstantBindingError):
+                raise
+            raise ConstantBindingError(
+                "literal_load_failed",
+                f"cannot load compiled-graph literals: {type(exc).__name__}: {exc}",
+            ) from exc
+        values: dict[str, Any] = {}
+        missing: list[str] = []
+        for constant in self._constants:
+            if constant.source == "computed":
+                continue
+            table = state if constant.source == "state_dict" else literals
+            value = table.get(constant.fqn)
+            if value is None:
+                missing.append(f"{constant.fqn} (source={constant.source})")
+                continue
+            if constant.source == "state_dict":
+                try:
+                    if not bool(value.is_contiguous()):
+                        value = value.detach().contiguous()
+                except AttributeError:
+                    pass
+                except Exception as exc:
+                    self._failed = True
+                    oom = _oom_in_chain(exc)
+                    reason = "out_of_memory" if oom is not None else "normalization_failed"
+                    cause = oom or exc
+                    raise ConstantBindingError(
+                        reason,
+                        f"cannot normalize constant {constant.fqn!r} for by-reference "
+                        f"binding ({type(cause).__name__}: {cause})",
+                    ) from exc
+            values[constant.fqn] = value
+        if missing:
+            self._failed = True
+            raise ConstantBindingError(
+                "constant_unresolved",
+                f"{len(missing)} declared constant(s) have no value: {sorted(missing)[:6]!r}",
+            )
+
+        # AOTI may install some raw pointers before reporting a later failure.
+        # Retain every attempted value even on that failure so no installed
+        # user-managed pointer can outlive its Python owner.
+        self._retained_values = values
+        try:
+            self._package.load_constants(
+                values,
+                check_full_update=True,
+                user_managed=True,
+            )
+        except Exception as exc:
+            self._failed = True
+            oom = _oom_in_chain(exc)
+            reason = "out_of_memory" if oom is not None else "injection_failed"
+            cause = oom or exc
+            raise ConstantBindingError(
+                reason,
+                f"artifact refused its complete constant update ({type(cause).__name__}: {cause})",
+            ) from exc
+
+        self._bound_values = values
+        self._bound = True
+
+    def __call__(self, *feeds: object) -> Any:
+        if not self._bound:
+            raise ConstantBindingError(
+                "constants_unbound",
+                f"refusing to invoke graph {self.graph_class!r} before complete binding",
+            )
+        result = self._package(*feeds)
+        self.calls += 1
+        return result
+
+
+__all__ = ["CompiledGraphRunner", "ConstantBindingError"]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/spans.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/spans.py
@@ -1,0 +1,229 @@
+"""Complete, versioned attribution over one graph-class compile.
+
+The totals form three nested partitions.  Each level has one explicit
+residual so a new or lost phase becomes visible instead of silently changing
+the meaning of a measured span::
+
+    compile_s = child_boot_s + child_wall_s + reap_lag_s + parent_other_s
+    child_wall_s = child_seal_s + child_torch_import_s + child_devlock_s
+        + child_setup_s + child_trace_s + compile_wall_s + child_pack_s
+        + child_other_s
+    compile_wall_s = lowering_s + codegen_s + graph_passes_s
+        + host_compile_s + compile_other_s
+
+Triton, autotune, device-lock wait, and Inductor total are overlays nested
+inside those members.  They are never summed into a partition.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from collections.abc import Iterator, Mapping
+from importlib import import_module
+from typing import Any, cast
+
+# Bump when the partition changes shape.  A reader must never mix tables with
+# different residual meanings.
+SPANS_V = 2
+
+PARTITION_KEYS: dict[str, tuple[str, ...]] = {
+    "lowering_s": ("GraphLowering.run",),
+    "codegen_s": ("GraphLowering.codegen",),
+    "host_compile_s": ("AotCodeCompiler.compile",),
+    "graph_passes_s": (
+        "_recursive_pre_grad_passes",
+        "_recursive_joint_graph_passes",
+        "_recursive_post_grad_passes",
+    ),
+}
+
+OVERLAY_KEYS: dict[str, tuple[str, ...]] = {
+    "inductor_total_s": ("compile_fx.<locals>.fw_compiler_base",),
+    "autotune_s": (
+        "CachingAutotuner.benchmark_all_configs",
+        "CachingAutotuner.coordinate_descent_tuning",
+        "CachingAutotuner.combo_sequential_autotune",
+    ),
+}
+
+PARTITIONS: dict[str, tuple[str, ...]] = {
+    "compile_s": (
+        "child_boot_s",
+        "child_wall_s",
+        "reap_lag_s",
+        "parent_other_s",
+    ),
+    "child_wall_s": (
+        "child_seal_s",
+        "child_torch_import_s",
+        "child_devlock_s",
+        "child_setup_s",
+        "child_trace_s",
+        "compile_wall_s",
+        "child_pack_s",
+        "child_other_s",
+    ),
+    "compile_wall_s": (
+        "lowering_s",
+        "codegen_s",
+        "graph_passes_s",
+        "host_compile_s",
+        "compile_other_s",
+    ),
+}
+
+RESIDUALS = ("parent_other_s", "child_other_s", "compile_other_s")
+
+# Recorded beside the partitions but not members of them.  ``parent_stage_s``
+# and ``parent_spawn_s`` occur outside compile_s; the others nest inside a
+# child member.  Summing any of these into a partition double-counts time.
+SUBSPANS = (
+    "child_interp_s",
+    "triton_s",
+    "autotune_s",
+    "device_lock_wait_s",
+    "inductor_total_s",
+    "parent_stage_s",
+    "parent_spawn_s",
+)
+
+
+def phase_snapshot() -> dict[str, float]:
+    """Return every current Dynamo compilation counter, summed per key."""
+
+    try:
+        dynamo_utils = import_module("torch._dynamo.utils")
+
+        return {
+            str(name): float(sum(values))
+            for name, values in cast(Any, dynamo_utils).compilation_time_metrics.items()
+        }
+    except Exception:  # telemetry must never fail a compile
+        return {}
+
+
+def phase_delta(
+    before: Mapping[str, float], after: Mapping[str, float]
+) -> tuple[dict[str, float], dict[str, float], dict[str, float]]:
+    """Return ``(partition, overlays, raw)`` between two snapshots."""
+
+    raw = {
+        name: round(float(after.get(name, 0.0)) - float(before.get(name, 0.0)), 3)
+        for name in set(after) | set(before)
+    }
+    raw = {name: value for name, value in raw.items() if value > 0.0005}
+    partition = {
+        label: round(sum(raw.get(name, 0.0) for name in names), 3)
+        for label, names in PARTITION_KEYS.items()
+    }
+    overlays = {
+        label: value
+        for label, names in OVERLAY_KEYS.items()
+        if (value := round(sum(raw.get(name, 0.0) for name in names), 3))
+    }
+    triton = round(
+        sum(
+            value
+            for name, value in raw.items()
+            if "async_compile" in name or "triton" in name.lower()
+        ),
+        3,
+    )
+    if triton:
+        overlays["triton_s"] = triton
+    return partition, overlays, raw
+
+
+class SpanLedger:
+    """Small wall-clock ledger whose close operation always names residual."""
+
+    def __init__(self) -> None:
+        self.spans: dict[str, float] = {}
+        self._started = time.monotonic()
+        # Cross-process spans need a clock both parent and child can read.
+        self.start_epoch = time.time()
+
+    @contextlib.contextmanager
+    def span(self, name: str) -> Iterator[None]:
+        started = time.monotonic()
+        try:
+            yield
+        finally:
+            self.spans[name] = round(
+                self.spans.get(name, 0.0) + time.monotonic() - started,
+                3,
+            )
+
+    def mark(self, name: str, seconds: float) -> None:
+        self.spans[name] = round(float(seconds), 3)
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self._started
+
+    def close(self, total_name: str, residual_name: str) -> dict[str, float]:
+        total = self.elapsed()
+        named = sum(
+            value for name, value in self.spans.items() if name not in (total_name, residual_name)
+        )
+        self.spans[total_name] = round(total, 3)
+        self.spans[residual_name] = round(total - named, 3)
+        return dict(self.spans)
+
+
+def check(spans: Mapping[str, float], *, tolerance_s: float = 0.05) -> list[str]:
+    """Return partition violations; an empty list is a closed ledger."""
+
+    problems: list[str] = []
+    for total, members in PARTITIONS.items():
+        if total not in spans:
+            continue
+        present = [member for member in members if member in spans]
+        if not present:
+            continue
+        got = sum(float(spans[member]) for member in present)
+        want = float(spans[total])
+        if abs(got - want) > tolerance_s:
+            problems.append(
+                f"{total}={want:.3f} but its members sum to {got:.3f} "
+                f"(delta {got - want:+.3f}s over {sorted(present)!r}) - "
+                "the partition is not exhaustive"
+            )
+        missing = [member for member in members if member not in spans]
+        if missing:
+            problems.append(
+                f"{total}: partition member(s) {missing!r} were never recorded, "
+                "so the residual silently absorbed them"
+            )
+    for name in RESIDUALS:
+        if float(spans.get(name, 0.0)) < -tolerance_s:
+            problems.append(
+                f"{name}={spans[name]:.3f} is negative - a member of its "
+                "partition is double-counted"
+            )
+    return problems
+
+
+def dark_fraction(spans: Mapping[str, float]) -> float:
+    """Return the fraction of compile_s carried only by residual names."""
+
+    total = float(spans.get("compile_s", 0.0))
+    if total <= 0:
+        return 0.0
+    dark = sum(float(spans.get(name, 0.0)) for name in RESIDUALS)
+    return round(dark / total, 4)
+
+
+__all__ = [
+    "OVERLAY_KEYS",
+    "PARTITIONS",
+    "PARTITION_KEYS",
+    "RESIDUALS",
+    "SPANS_V",
+    "SUBSPANS",
+    "SpanLedger",
+    "check",
+    "dark_fraction",
+    "phase_delta",
+    "phase_snapshot",
+]

--- a/src/gen_worker/_vendor/torch_compiled_graphs/storage.py
+++ b/src/gen_worker/_vendor/torch_compiled_graphs/storage.py
@@ -1,0 +1,449 @@
+"""Exact-key compiled-graph policy over HashRepo's generic local CAS."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from ..tensorfs import CASRef, DigestMismatch, FileEntry, LocalCAS, RefConflict, RepositoryManifest
+
+from .artifact import ArtifactError, _fsync_dir, unpack_artifact
+from .identity import CompiledGraphKey, is_compiled_graph_key
+
+_COMPILED_GRAPH_PATH = "compiled_graph.tar.gz"
+_REF_PREFIX = "torch-compiled-graphs/v1"
+
+
+class StorageError(RuntimeError):
+    """A local compiled-graph record is malformed or unavailable."""
+
+
+class QuarantinedArtifact(StorageError):
+    """An exact-key record failed integrity or admission and cannot be reused."""
+
+
+class StoreOutcome(str, Enum):
+    STORED = "stored"
+    PRESENT = "present"
+    REPAIRED = "repaired"
+    DIVERGENT = "divergent"
+
+
+@dataclass(frozen=True, slots=True)
+class StoreResult:
+    outcome: StoreOutcome
+    key: str
+    manifest: CASRef
+
+
+@dataclass(frozen=True, slots=True)
+class StoredCompiledGraph:
+    """One verified compiled graph materialized for a caller."""
+
+    key: str
+    directory: Path
+    metadata: dict[str, object]
+    manifest: CASRef
+
+    @property
+    def package(self) -> Path:
+        return self.directory / "model.pt2"
+
+    @property
+    def literals(self) -> Path | None:
+        path = self.directory / "constants.safetensors"
+        return path if path.is_file() else None
+
+
+def _key_value(key: str | CompiledGraphKey) -> str:
+    value = str(key)
+    if not is_compiled_graph_key(value):
+        raise StorageError("v1 storage requires a compiled-graph key")
+    return value
+
+
+def _graph_ref(key: str) -> str:
+    return f"{_REF_PREFIX}/graphs/{key}"
+
+
+def _quarantine_ref(key: str, manifest: CASRef) -> str:
+    return f"{_REF_PREFIX}/quarantine/{key}/{manifest.digest}"
+
+
+class _CompiledGraphStore:
+    """Compiled-graph naming, immutability, and quarantine over one ``LocalCAS``."""
+
+    def __init__(self, cas: LocalCAS) -> None:
+        self.cas = cas
+
+    @staticmethod
+    def _file(manifest: RepositoryManifest) -> FileEntry:
+        if len(manifest.files) != 1 or manifest.files[0].path != _COMPILED_GRAPH_PATH:
+            raise StorageError("compiled-graph manifest must contain exactly its v1 artifact")
+        return manifest.files[0]
+
+    def _is_quarantined(self, key: str, manifest: CASRef) -> bool:
+        return self.cas.read_ref(_quarantine_ref(key, manifest)) is not None
+
+    def _clear_quarantine(self, key: str, manifest: CASRef, expected: CASRef) -> bool:
+        """Retire exactly one observed marker, never a newer quarantine."""
+
+        name = _quarantine_ref(key, manifest)
+        try:
+            self.cas.compare_and_swap_ref(name, None, expected=expected)
+            return True
+        except RefConflict:
+            return self.cas.read_ref(name) is None
+
+    def _retire_candidate_quarantine(
+        self, key: str, manifest: CASRef, observed: CASRef | None
+    ) -> None:
+        if observed is not None and self._clear_quarantine(key, manifest, observed):
+            return
+        if observed is None and not self._is_quarantined(key, manifest):
+            return
+        raise QuarantinedArtifact(
+            f"compiled graph {key} received a fresh quarantine during repair"
+        )
+
+    def quarantine(self, key: str | CompiledGraphKey, manifest: CASRef) -> None:
+        value = _key_value(key)
+        name = _quarantine_ref(value, manifest)
+        marker = self.cas.put_bytes(
+            json.dumps(
+                {
+                    "format": 1,
+                    "key": value,
+                    "manifest": str(manifest),
+                    "marker": secrets.token_hex(16),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("ascii")
+        )
+        expected = self.cas.read_ref(name)
+        while True:
+            try:
+                self.cas.compare_and_swap_ref(name, marker, expected=expected)
+                return
+            except RefConflict:
+                expected = self.cas.read_ref(name)
+
+    def store(self, key: str | CompiledGraphKey, artifact: str | Path) -> StoreResult:
+        """Verify and keep the first bytes published under one exact graph key."""
+
+        value = _key_value(key)
+        source = Path(artifact)
+        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-import-") as raw:
+            owned = Path(raw) / _COMPILED_GRAPH_PATH
+            shutil.copyfile(source, owned)
+            with owned.open("rb") as handle:
+                os.fsync(handle.fileno())
+            metadata = unpack_artifact(owned, Path(raw) / "verified")
+            if metadata.get("compiled_graph_key") != value:
+                raise StorageError(
+                    f"artifact states key {metadata.get('compiled_graph_key')!r}, "
+                    f"expected {value!r}"
+                )
+            file = self.cas.ingest_file(owned, manifest_path=_COMPILED_GRAPH_PATH)
+        candidate = self.cas.store_manifest(RepositoryManifest((file,)))
+        candidate_quarantine = self.cas.read_ref(_quarantine_ref(value, candidate))
+        ref_name = _graph_ref(value)
+        current = self.cas.read_ref(ref_name)
+        if current is None:
+            try:
+                self.cas.compare_and_swap_ref(ref_name, candidate, expected=None)
+                self._retire_candidate_quarantine(
+                    value, candidate, candidate_quarantine
+                )
+                outcome = (
+                    StoreOutcome.REPAIRED
+                    if candidate_quarantine is not None
+                    else StoreOutcome.STORED
+                )
+                return StoreResult(outcome, value, candidate)
+            except RefConflict:
+                current = self.cas.read_ref(ref_name)
+        if current is None:
+            raise StorageError(f"exact-key ref {value} disappeared during publication")
+        if current == candidate:
+            if candidate_quarantine is not None:
+                self._retire_candidate_quarantine(value, current, candidate_quarantine)
+                return StoreResult(StoreOutcome.REPAIRED, value, current)
+            if self._is_quarantined(value, current):
+                raise QuarantinedArtifact(
+                    f"compiled graph {value} received a fresh quarantine during publication"
+                )
+            return StoreResult(StoreOutcome.PRESENT, value, current)
+        if self._is_quarantined(value, current):
+            try:
+                self.cas.compare_and_swap_ref(ref_name, candidate, expected=current)
+                self._retire_candidate_quarantine(
+                    value, candidate, candidate_quarantine
+                )
+                return StoreResult(StoreOutcome.REPAIRED, value, candidate)
+            except RefConflict:
+                current = self.cas.read_ref(ref_name)
+                if current == candidate:
+                    self._retire_candidate_quarantine(
+                        value, candidate, candidate_quarantine
+                    )
+                    return StoreResult(StoreOutcome.PRESENT, value, candidate)
+                if current is None:
+                    raise StorageError(f"exact-key ref {value} disappeared during repair") from None
+        self.quarantine(value, candidate)
+        return StoreResult(StoreOutcome.DIVERGENT, value, candidate)
+
+    @staticmethod
+    def _verify_archive(artifact: Path, key: str) -> None:
+        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-export-verify-") as raw:
+            metadata = unpack_artifact(artifact, Path(raw) / "artifact")
+        if metadata.get("compiled_graph_key") != key:
+            raise ArtifactError(
+                f"artifact states key {metadata.get('compiled_graph_key')!r}, expected {key!r}"
+            )
+
+    @staticmethod
+    def _require_exact_file(target: Path, expected: FileEntry) -> None:
+        """Accept an occupied destination only when it is the selected CAS file."""
+
+        try:
+            if target.is_symlink():
+                raise FileExistsError(f"destination {target} is a symbolic link")
+            digest = hashlib.sha256()
+            with target.open("rb") as source:
+                before = os.fstat(source.fileno())
+                if not stat.S_ISREG(before.st_mode):
+                    raise FileExistsError(f"destination {target} is not a regular file")
+                while chunk := source.read(1 << 20):
+                    digest.update(chunk)
+                after = os.fstat(source.fileno())
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise FileExistsError(f"cannot verify occupied destination {target}: {exc}") from exc
+        stable = (
+            before.st_dev == after.st_dev
+            and before.st_ino == after.st_ino
+            and before.st_size == after.st_size
+            and before.st_mtime_ns == after.st_mtime_ns
+        )
+        if (
+            not stable
+            or after.st_size != expected.size_bytes
+            or digest.hexdigest() != expected.digest.digest
+        ):
+            raise FileExistsError(
+                f"destination {target} is not the selected compiled-graph artifact"
+            )
+
+    @staticmethod
+    def _require_exact_directory(target: Path, expected: Path) -> None:
+        """Accept an occupied directory only when every selected artifact byte won."""
+
+        message = f"destination {target} is not the selected compiled-graph artifact"
+        directory_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        target_fd: int | None = None
+        expected_fd: int | None = None
+        try:
+            try:
+                target_fd = os.open(target, directory_flags)
+                expected_fd = os.open(expected, directory_flags)
+            except OSError as exc:
+                raise FileExistsError(f"{message}: {exc}") from exc
+            if target_fd is None or expected_fd is None:  # pragma: no cover - os.open returns int
+                raise FileExistsError(message)
+            target_directory_before = os.fstat(target_fd)
+            if not stat.S_ISDIR(target_directory_before.st_mode):
+                raise FileExistsError(message)
+            target_names = set(os.listdir(target_fd))
+            expected_names = set(os.listdir(expected_fd))
+            if target_names != expected_names:
+                raise FileExistsError(message)
+            for name in sorted(expected_names):
+                target_member = os.open(name, file_flags, dir_fd=target_fd)
+                try:
+                    expected_member = os.open(name, file_flags, dir_fd=expected_fd)
+                    try:
+                        target_before = os.fstat(target_member)
+                        expected_before = os.fstat(expected_member)
+                        if (
+                            not stat.S_ISREG(target_before.st_mode)
+                            or not stat.S_ISREG(expected_before.st_mode)
+                            or target_before.st_size != expected_before.st_size
+                        ):
+                            raise FileExistsError(message)
+                        while True:
+                            target_chunk = os.read(target_member, 1 << 20)
+                            expected_chunk = os.read(expected_member, 1 << 20)
+                            if target_chunk != expected_chunk:
+                                raise FileExistsError(message)
+                            if not target_chunk:
+                                break
+                        target_after = os.fstat(target_member)
+                        expected_after = os.fstat(expected_member)
+                        for before, after in (
+                            (target_before, target_after),
+                            (expected_before, expected_after),
+                        ):
+                            if (
+                                before.st_dev != after.st_dev
+                                or before.st_ino != after.st_ino
+                                or before.st_size != after.st_size
+                                or before.st_mtime_ns != after.st_mtime_ns
+                            ):
+                                raise FileExistsError(message)
+                    finally:
+                        os.close(expected_member)
+                finally:
+                    os.close(target_member)
+            target_directory_after = os.fstat(target_fd)
+            current_path = os.stat(target, follow_symlinks=False)
+            if (
+                target_directory_before.st_dev != target_directory_after.st_dev
+                or target_directory_before.st_ino != target_directory_after.st_ino
+                or target_directory_before.st_mtime_ns != target_directory_after.st_mtime_ns
+                or current_path.st_dev != target_directory_after.st_dev
+                or current_path.st_ino != target_directory_after.st_ino
+            ):
+                raise FileExistsError(message)
+        except FileExistsError:
+            raise
+        except OSError as exc:
+            raise FileExistsError(f"{message}: {exc}") from exc
+        finally:
+            if expected_fd is not None:
+                os.close(expected_fd)
+            if target_fd is not None:
+                os.close(target_fd)
+
+    def _require_selected(self, key: str, manifest: CASRef) -> None:
+        """Fail closed if publication or quarantine moved during resolution."""
+
+        if self.cas.read_ref(_graph_ref(key)) != manifest:
+            raise StorageError(f"compiled graph {key} changed during resolution")
+        if self._is_quarantined(key, manifest):
+            raise QuarantinedArtifact(
+                f"compiled graph {key} received a quarantine during resolution"
+            )
+
+    def export_artifact(self, key: str | CompiledGraphKey, destination: str | Path) -> Path:
+        """Export one exact CAS record as a fully verified artifact envelope."""
+
+        value = _key_value(key)
+        manifest_ref = self.cas.read_ref(_graph_ref(value))
+        if manifest_ref is None:
+            raise StorageError(f"compiled graph {value} is not present")
+        if self._is_quarantined(value, manifest_ref):
+            raise QuarantinedArtifact(f"compiled graph {value} is quarantined")
+
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        try:
+            try:
+                manifest = self.cas.load_manifest(manifest_ref)
+                file = self._file(manifest)
+                self.cas.materialize(file, temporary)
+                self._verify_archive(temporary, value)
+            except (
+                ArtifactError,
+                DigestMismatch,
+                FileNotFoundError,
+                StorageError,
+                ValueError,
+            ) as exc:
+                self.quarantine(value, manifest_ref)
+                raise QuarantinedArtifact(
+                    f"compiled graph {value} failed export verification: {exc}"
+                ) from exc
+            try:
+                os.link(temporary, target)
+            except FileExistsError:
+                self._require_exact_file(target, file)
+            _fsync_dir(target.parent)
+            return target
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def resolve(
+        self, key: str | CompiledGraphKey, destination: str | Path
+    ) -> StoredCompiledGraph | None:
+        """Materialize and fully verify one exact key, or return a clean miss."""
+
+        value = _key_value(key)
+        manifest_ref = self.cas.read_ref(_graph_ref(value))
+        if manifest_ref is None:
+            return None
+        if self._is_quarantined(value, manifest_ref):
+            raise QuarantinedArtifact(f"compiled graph {value} is quarantined")
+
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, raw_archive = tempfile.mkstemp(
+            prefix="graph-", suffix=".tar.gz", dir=target.parent
+        )
+        os.close(descriptor)
+        archive = Path(raw_archive)
+        candidate = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
+        candidate.rmdir()
+        try:
+            try:
+                manifest = self.cas.load_manifest(manifest_ref)
+                file = self._file(manifest)
+                self.cas.materialize(file, archive)
+            except (DigestMismatch, FileNotFoundError, ValueError, StorageError) as exc:
+                self.quarantine(value, manifest_ref)
+                raise QuarantinedArtifact(
+                    f"compiled graph {value} failed CAS verification: {exc}"
+                ) from exc
+            try:
+                metadata = unpack_artifact(archive, candidate)
+            except ArtifactError as exc:
+                self.quarantine(value, manifest_ref)
+                raise QuarantinedArtifact(
+                    f"compiled graph {value} failed artifact verification: {exc}"
+                ) from exc
+            if metadata.get("compiled_graph_key") != value:
+                self.quarantine(value, manifest_ref)
+                raise QuarantinedArtifact(
+                    f"stored artifact states key {metadata.get('compiled_graph_key')!r}, "
+                    f"expected {value!r}"
+                )
+            try:
+                os.rename(candidate, target)
+            except OSError as exc:
+                if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY) or not target.is_dir():
+                    raise
+                self._require_exact_directory(target, candidate)
+                self._require_selected(value, manifest_ref)
+                return StoredCompiledGraph(value, target, metadata, manifest_ref)
+            _fsync_dir(target.parent)
+            self._require_selected(value, manifest_ref)
+            return StoredCompiledGraph(value, target, metadata, manifest_ref)
+        except QuarantinedArtifact:
+            raise
+        except (OSError, ArtifactError):
+            raise
+        except ValueError as exc:
+            self.quarantine(value, manifest_ref)
+            raise QuarantinedArtifact(f"compiled graph {value} failed verification: {exc}") from exc
+        finally:
+            archive.unlink(missing_ok=True)
+            shutil.rmtree(candidate, ignore_errors=True)

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -70,8 +70,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import msgspec
-from torch_compiled_graphs import GRAPH_CLASS_BLOCK
-from torch_compiled_graphs.spans import (
+from gen_worker._vendor.torch_compiled_graphs import GRAPH_CLASS_BLOCK
+from gen_worker._vendor.torch_compiled_graphs.spans import (
     PARTITION_KEYS,
     PARTITIONS,
     SPANS_V,
@@ -396,7 +396,7 @@ def _tcg_runtime(cache_root: Optional[Path] = None) -> Tuple[Any, Any]:
     export — pgw#985. This frame only reports which of the two targets the host
     can state.
     """
-    from torch_compiled_graphs import RuntimeCompatibility
+    from gen_worker._vendor.torch_compiled_graphs import RuntimeCompatibility
 
     from . import compile_cache
     from .models.cache_paths import open_worker_engine

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -70,7 +70,7 @@ from typing import (
 
 import msgspec
 
-from torch_compiled_graphs.spans import check as check_spans
+from gen_worker._vendor.torch_compiled_graphs.spans import check as check_spans
 
 from . import aot_device_lock, env_seal
 from . import compile_posture

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -20,7 +20,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-from hashrepo import (
+from gen_worker._vendor.tensorfs import (
     CASRef,
     Chunk,
     DigestMismatch,
@@ -28,7 +28,7 @@ from hashrepo import (
     TransferGrant,
     download,
 )
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     ARTIFACT_KIND,
     StoreOutcome,
     is_compiled_graph_key,

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -24,14 +24,14 @@ from pathlib import Path
 from typing import (
     Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple)
 
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     GRAPH_CLASS_BLOCK,
     CallIngress,
     IngressError,
     build_call_ingress,
     exported_input_name,
 )
-from torch_compiled_graphs.identity import toolchain_axis_digest
+from gen_worker._vendor.torch_compiled_graphs.identity import toolchain_axis_digest
 
 from . import activity as activity_mod
 from . import aot_compile_pool, aot_serve, boot_phases
@@ -2261,7 +2261,7 @@ def tcg_graph_class_spec(traced: TracedClass, export_spec: ExportSpec) -> Any:
     prevents boot lookup and mint from growing two worker-side descriptions of
     the same graph class.
     """
-    from torch_compiled_graphs import GraphClassSpec
+    from gen_worker._vendor.torch_compiled_graphs import GraphClassSpec
 
     if traced.program is None:
         raise ValueError(f"graph class {traced.name!r} carries no exported program")

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -22,7 +22,7 @@ from typing import (
     Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple,
 )
 
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     GRAPH_CLASS_BLOCK,
     CallIngress,
     CallInput,
@@ -1650,7 +1650,7 @@ def entry_states(pipeline: Any) -> Dict[str, Dict[str, Any]]:
 def _adopt_identity(artifact: Path) -> str:
     """Best-effort exact TCG key for a typed adopt event."""
     try:
-        from torch_compiled_graphs.artifact import read_metadata
+        from gen_worker._vendor.torch_compiled_graphs.artifact import read_metadata
 
         meta = read_metadata(artifact)
     except Exception:  # noqa: BLE001 - identity is diagnostic on a refusal
@@ -1667,7 +1667,7 @@ def _import_and_arm(
     expected: "Optional[aot_identity.ExpectedIdentity]",
     declared: Sequence[str],
 ) -> Dict[str, Any]:
-    from torch_compiled_graphs.artifact import read_metadata
+    from gen_worker._vendor.torch_compiled_graphs.artifact import read_metadata
 
     transfer_staging = (
         artifact.parent.name == ".incoming"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -29,10 +29,10 @@
 * ``runtime="vllm"`` boots an engine-hosting server subprocess before setup.
 
 Checkpoint SELECTION is a runtime payload argument, not a build-time fan-out:
-a handler whose payload declares a field typed with a ``ModelChoice`` subclass
-picks, per request, which curated checkpoint runs against the resident base
-(``gen_worker.api.model``). Divergent WIRE contracts are separate methods;
-only weight-sharing forces one class.
+a ``Slot(selected_by=..., default_checkpoint=...)`` is resolved by the hub per
+request, so one handler serves every curated checkpoint that shares the
+resident base. Divergent WIRE contracts are separate methods; only
+weight-sharing forces one class.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -67,7 +67,6 @@ call with it; a paragraph is not a caller.
 from __future__ import annotations
 
 import hashlib
-import importlib.metadata
 import importlib.util
 import json
 import logging
@@ -81,12 +80,13 @@ from typing import (
 
 import msgspec
 
+from ._vendor import vendored_rev
 from . import boot_phases, compile_cache as cc, graph_facts
 from .child_contract import CompileSpec, MintSlot, slot_subjects
 from . import hostfacts
 
 if TYPE_CHECKING:
-    from torch_compiled_graphs import GraphClassDeclaration
+    from gen_worker._vendor.torch_compiled_graphs import GraphClassDeclaration
 
 logger = logging.getLogger(__name__)
 
@@ -355,11 +355,14 @@ def _endpoint_source_facts(modules: Sequence[str]) -> Tuple[Tuple[str, str], ...
 
 
 def _tcg_version() -> str:
-    """Installed TCG release whose declaration semantics the memo stores."""
-    try:
-        return str(importlib.metadata.version("torch-compiled-graphs"))
-    except importlib.metadata.PackageNotFoundError:
-        return ""
+    """Vendored TCG rev whose declaration semantics the memo stores.
+
+    pgw#1310: TCG is vendored, so it has no distribution metadata to read. The
+    old `importlib.metadata.version(...)` swallowed PackageNotFoundError into
+    `""` — which, once the distribution was gone, would have silently dropped
+    TCG from the memo key and stopped a TCG change from invalidating anything.
+    """
+    return vendored_rev("torch_compiled_graphs")
 
 
 def closure_digest(
@@ -595,7 +598,7 @@ def declaration_hashes(declarations: Mapping[str, str]) -> Dict[str, str]:
     ingress, range, witness, coordinates and literals; comparing its derived
     hash to the child's stated hash catches a corrupt or drifted child wire.
     """
-    from torch_compiled_graphs import GraphClassDeclaration
+    from gen_worker._vendor.torch_compiled_graphs import GraphClassDeclaration
 
     hashes: Dict[str, str] = {}
     for name, canonical in declarations.items():
@@ -685,7 +688,7 @@ def fold(
     This parent supplies only the current ``sm`` and toolchain through TCG's
     public identity functions; no worker graph or key arithmetic remains.
     """
-    from torch_compiled_graphs.identity import from_axes, toolchain_axis_digest
+    from gen_worker._vendor.torch_compiled_graphs.identity import from_axes, toolchain_axis_digest
 
     sm = str(cc.runtime_key().get("sm") or "")
     if not sm:

--- a/src/gen_worker/cell_resolve.py
+++ b/src/gen_worker/cell_resolve.py
@@ -87,7 +87,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 from . import aot_identity, boot_phases
 from .procsplit import broker

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -31,7 +31,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
-from hashrepo import CASRef
+from gen_worker._vendor.tensorfs import CASRef
 
 from ..api.types import Asset
 from ..models.cache_paths import open_worker_cas

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -83,7 +83,7 @@ from typing import (
 
 import sys
 
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 from . import (
     dist_records, env_seal, graph_facts, guard_closure, hot_swap,

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -64,9 +64,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
-from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK, REQUIRED_AXES
-from torch_compiled_graphs import is_compiled_graph_key
-from torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK, REQUIRED_AXES
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
 
 from . import (
     aot_identity,

--- a/src/gen_worker/graph_facts.py
+++ b/src/gen_worker/graph_facts.py
@@ -37,7 +37,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 #: The MANIFEST block recording one declaration's DECLARED ENVELOPE.
 #:

--- a/src/gen_worker/hubio/client.py
+++ b/src/gen_worker/hubio/client.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, cast
 
 import requests
-from hashrepo import (
+from gen_worker._vendor.tensorfs import (
     CASRef,
     RepositoryManifest,
     TransferGrant,

--- a/src/gen_worker/hubio/fetch.py
+++ b/src/gen_worker/hubio/fetch.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Callable, Dict, Optional
 
 import requests
-from hashrepo import CASRef, DigestMismatch
+from gen_worker._vendor.tensorfs import CASRef, DigestMismatch
 
 from ..bounded_stream import StreamTooLarge
 from ..models.errors import UrlExpiredError

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -112,8 +112,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from torch_compiled_graphs import ARTIFACT_KIND, is_compiled_graph_key
-from torch_compiled_graphs.identity import KEY_SCHEME
+from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND, is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs.identity import KEY_SCHEME
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from torch_compiled_graphs import Engine

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -116,7 +116,7 @@ from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND, is_compiled_
 from gen_worker._vendor.torch_compiled_graphs.identity import KEY_SCHEME
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from torch_compiled_graphs import Engine
+    from gen_worker._vendor.torch_compiled_graphs import Engine
 
 logger = logging.getLogger(__name__)
 
@@ -423,7 +423,7 @@ def store(
     holding. Which of TCG's three success outcomes came back is a fact for the
     log, never a branch that skips work.
     """
-    from torch_compiled_graphs.storage import StoreOutcome
+    from gen_worker._vendor.torch_compiled_graphs.storage import StoreOutcome
 
     try:
         target_dir = cell_dir(key, root)
@@ -526,7 +526,7 @@ def materialize(
     so it must NOT be written into this worker's verdict (pgw#1283
     criterion 4).
     """
-    from torch_compiled_graphs.storage import QuarantinedArtifact, StorageError
+    from gen_worker._vendor.torch_compiled_graphs.storage import QuarantinedArtifact, StorageError
 
     try:
         destination = cell_dir(key, root) / ARTIFACT_NAME

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -60,7 +60,7 @@ import msgspec
 from . import activity as activity_mod
 from . import artifact_meta
 from . import boot_phases
-from torch_compiled_graphs import GRAPH_CLASS_BLOCK
+from gen_worker._vendor.torch_compiled_graphs import GRAPH_CLASS_BLOCK
 from . import compile_posture
 from . import mint_workers
 from . import progress as progress_mod

--- a/src/gen_worker/models/cache_paths.py
+++ b/src/gen_worker/models/cache_paths.py
@@ -4,12 +4,12 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from hashrepo import LocalCAS
+from gen_worker._vendor.tensorfs import LocalCAS
 
 from ..config import Settings, current_or
 
 if TYPE_CHECKING:
-    from torch_compiled_graphs import Engine
+    from gen_worker._vendor.torch_compiled_graphs import Engine
 
 _STANDALONE = Settings()
 
@@ -60,7 +60,7 @@ def open_worker_engine(root: Path | None = None) -> Engine:
     no caller can silently introduce a second compiled-graph store.  The import
     stays lazy because model-only commands do not require TCG at startup.
     """
-    from torch_compiled_graphs import Engine
+    from gen_worker._vendor.torch_compiled_graphs import Engine
 
     return Engine(open_worker_cas(root))
 

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -20,7 +20,7 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Sequence
 
-from hashrepo import (
+from gen_worker._vendor.tensorfs import (
     CASRef,
     Chunk,
     DigestMismatch,
@@ -445,8 +445,11 @@ class CozySnapshotDownloader:
             except (DigestMismatch, FileNotFoundError, OSError):
                 return False
 
-        # Every check re-hashes the object — ~1.0s of solid CPU per GiB, and a
-        # resume re-hashes everything earlier attempts landed. On the caller's
+        # Every check re-hashes the object — ~1.0s of solid CPU per GiB WARM,
+        # but that is the fast end of a ~14x spread: measured cold-and-contended
+        # it is ~14s/GiB (tensorfs#42), which is what puts a large resident
+        # snapshot past the hub's window. A resume re-hashes everything earlier
+        # attempts landed. On the caller's
         # loop thread that stranded the heartbeat and every queued event until
         # the scan ended, so each check runs off-thread and only the emission
         # stays on the caller's thread.

--- a/src/gen_worker/models/disk_gc.py
+++ b/src/gen_worker/models/disk_gc.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Optional, Tuple
 
-from hashrepo import RefConflict
+from gen_worker._vendor.tensorfs import RefConflict
 
 from .cache_paths import open_worker_cas
 

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -29,7 +29,7 @@ from typing import (
     Tuple,
 )
 
-from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
+from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
 
 from ..cell_adopt import AdoptOutcome
 from ..component_vocab import denoiser_components
@@ -72,7 +72,7 @@ class ModelResolutionError(Exception):
 def _compiled_graph_metadata(path: Path) -> Optional[Dict[str, Any]]:
     """Read metadata through TCG, returning ``None`` for a non-TCG artifact."""
 
-    from torch_compiled_graphs import artifact as compiled_graph_artifact
+    from gen_worker._vendor.torch_compiled_graphs import artifact as compiled_graph_artifact
 
     try:
         return dict(compiled_graph_artifact.read_metadata(Path(path)))

--- a/src/gen_worker/models/volume_verify.py
+++ b/src/gen_worker/models/volume_verify.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Optional, Sequence, Tuple
 
-from hashrepo import CASRef, DigestMismatch
+from gen_worker._vendor.tensorfs import CASRef, DigestMismatch
 
 from .cozy_snapshot import _norm_rel_path
 

--- a/src/gen_worker/numerics_probe.py
+++ b/src/gen_worker/numerics_probe.py
@@ -49,7 +49,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple
 
-from torch_compiled_graphs import CallIngress
+from gen_worker._vendor.torch_compiled_graphs import CallIngress
 
 from . import numerics_ladder
 from .numerics_ladder import Comparison, Thresholds

--- a/src/gen_worker/warm_spans.py
+++ b/src/gen_worker/warm_spans.py
@@ -41,7 +41,7 @@ import contextlib
 import time
 from typing import Any, Dict, Iterator, List, Mapping, Tuple
 
-from torch_compiled_graphs.spans import phase_delta, phase_snapshot
+from gen_worker._vendor.torch_compiled_graphs.spans import phase_delta, phase_snapshot
 
 #: Bump when the partition changes shape, so a reader never mixes two ledgers.
 WARM_SPANS_V = 1

--- a/tests/convert/test_publish_v2_pgw781.py
+++ b/tests/convert/test_publish_v2_pgw781.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 from fake_hub import _client, _FakeHub
-from hashrepo import MAX_CHUNK_SIZE
+from gen_worker._vendor.tensorfs import MAX_CHUNK_SIZE
 
 from gen_worker.hubio.client import CommitFile, HubPublishError
 

--- a/tests/harness/cell_meta.py
+++ b/tests/harness/cell_meta.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
-from torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
 
 from gen_worker import aot_serve, graph_facts
 

--- a/tests/harness/exported_cell.py
+++ b/tests/harness/exported_cell.py
@@ -26,7 +26,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     CallIngress,
     CallInput,
     CompiledGraphRunner,
@@ -424,7 +424,7 @@ def arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
     truthy/falsy, so `assert outcome` reads exactly as `assert armed` did.
     """
     from gen_worker.models import provision
-    from torch_compiled_graphs import artifact as tcg_artifact
+    from gen_worker._vendor.torch_compiled_graphs import artifact as tcg_artifact
 
     metadata_by_artifact: Dict[Path, Dict[str, Any]] = {}
     metadata_by_key: Dict[str, Dict[str, Any]] = {}

--- a/tests/tcg_artifacts.py
+++ b/tests/tcg_artifacts.py
@@ -27,9 +27,9 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 
-from torch_compiled_graphs import CallIngress, CallInput, GraphClassDeclaration
-from torch_compiled_graphs.artifact import build_metadata, pack_artifact
-from torch_compiled_graphs.host_isa import _host_requirement
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, GraphClassDeclaration
+from gen_worker._vendor.torch_compiled_graphs.artifact import build_metadata, pack_artifact
+from gen_worker._vendor.torch_compiled_graphs.host_isa import _host_requirement
 
 #: The default compiler-content facts. Two artifacts that differ only here get
 #: different ``ck1`` keys, which is how a test asks for a second cell.
@@ -160,6 +160,6 @@ def build(
 
 def key_of(artifact: Path) -> str:
     """The ``ck1`` key the artifact states about itself."""
-    from torch_compiled_graphs.artifact import read_metadata
+    from gen_worker._vendor.torch_compiled_graphs.artifact import read_metadata
 
     return str(read_metadata(artifact).get("compiled_graph_key") or "")

--- a/tests/test_adopted_cell_warm_proof_pgw1141.py
+++ b/tests/test_adopted_cell_warm_proof_pgw1141.py
@@ -65,7 +65,7 @@ from gen_worker.registry import extract_specs
 import test_numerics_gate_pgw868 as rig868  # noqa: E402
 from test_numerics_gate_pgw868 import ROWS, ProbePackage, arm, entry_name  # noqa: E402
 from gen_worker.models import store as store_mod
-from torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
 
 #: pgw#868's fixtures, re-exported so this module collects them: `declared`
 #: registers the real export declaration the probe feed is built from, and

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -25,8 +25,8 @@ from typing import Any, Dict, Iterator
 
 import pytest
 
-from torch_compiled_graphs import identity as ck
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as ck
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 from gen_worker import compile_cache as cc
 from gen_worker import env_seal
 from gen_worker.models import w8a8_lora

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -38,7 +38,7 @@ from gen_worker.models.refs import normalize_model_ref
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 from gen_worker.models import store as store_mod
-from torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
 
 FAMILY = "sdxl"
 

--- a/tests/test_aot_declaration_pgw739.py
+++ b/tests/test_aot_declaration_pgw739.py
@@ -593,7 +593,7 @@ def test_hand_dynamic_rows_are_refused_at_declaration_time() -> None:
 def test_fork_and_row_reach_tcg_graph_class_identity() -> None:
     """Forks and static rows are TCG declaration facts, so either changing
     must change the graph-class hash before ``Engine.compile`` is called."""
-    from torch_compiled_graphs import GraphClassSpec, build_call_ingress
+    from gen_worker._vendor.torch_compiled_graphs import GraphClassSpec, build_call_ingress
 
     class Tiny(torch.nn.Module):
         def forward(self, sample: Any) -> Any:

--- a/tests/test_aot_input_alignment_pgw791.py
+++ b/tests/test_aot_input_alignment_pgw791.py
@@ -34,7 +34,7 @@ torch = pytest.importorskip("torch")
 import torch.nn as nn  # noqa: E402
 
 from gen_worker import activity, aot_serve  # noqa: E402
-from torch_compiled_graphs import (  # noqa: E402
+from gen_worker._vendor.torch_compiled_graphs import (  # noqa: E402
     CallIngress,
     CallInput,
     CompiledGraphRunner,

--- a/tests/test_aot_lifted_arm_pgw822.py
+++ b/tests/test_aot_lifted_arm_pgw822.py
@@ -29,7 +29,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from torch import nn
-from torch_compiled_graphs import CallIngress
+from gen_worker._vendor.torch_compiled_graphs import CallIngress
 
 from gen_worker import (
     aot_declaration,

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -37,7 +37,7 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import pytest
 
 from gen_worker import aot_serve as aot
-from torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
 
 FAMILY = "sdxl-base"
 KEY = "cg-key-v1-" + "7" * 56
@@ -215,7 +215,7 @@ def test_failed_bind_does_not_mutate_the_live_module(
 ) -> None:
     class Refusing(FakeTCGRunner):
         def bind(self, state: dict[str, Any], *, device: str) -> None:
-            from torch_compiled_graphs import ConstantBindingError
+            from gen_worker._vendor.torch_compiled_graphs import ConstantBindingError
 
             raise ConstantBindingError("constant_unresolved", "weight absent")
 

--- a/tests/test_aot_variable_chunks_th1931.py
+++ b/tests/test_aot_variable_chunks_th1931.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from hashrepo import LocalCAS, TransferGrant, TransferReport
-from torch_compiled_graphs import StoreOutcome
+from gen_worker._vendor.tensorfs import LocalCAS, TransferGrant, TransferReport
+from gen_worker._vendor.torch_compiled_graphs import StoreOutcome
 
 from gen_worker import aot_delivery, receipts
 

--- a/tests/test_author_ci_harness_pgw1150.py
+++ b/tests/test_author_ci_harness_pgw1150.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 from gen_worker import author_ci, rigcheck, serve_posture
 from gen_worker.api.decorators import Compile

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -206,7 +206,7 @@ def _derived() -> Any:
     real axes, so the address the boot hands the store is the address the store
     is addressed by everywhere else. Only the TRACE is stood in for (there is no
     card on a CI runner, and `sm` is a key axis)."""
-    from torch_compiled_graphs import identity as ck
+    from gen_worker._vendor.torch_compiled_graphs import identity as ck
 
     del ck  # pgw#1283: the address comes from the artifact this machine HOLDS
     return boot_key.DerivedKey(

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -338,7 +338,7 @@ def test_the_gates_are_pairwise_distinguishable(
 
 
 def _derived(wall_ms: int = 1234) -> Any:
-    from torch_compiled_graphs import identity as ck
+    from gen_worker._vendor.torch_compiled_graphs import identity as ck
 
     return boot_key.DerivedKey(
         # pgw#1176: a boot derives a KEY SET. These declarations trace to one

--- a/tests/test_boot_phases_pgw764.py
+++ b/tests/test_boot_phases_pgw764.py
@@ -26,7 +26,7 @@ from typing import Any, List
 
 import pytest
 
-from torch_compiled_graphs import ARTIFACT_KIND
+from gen_worker._vendor.torch_compiled_graphs import ARTIFACT_KIND
 
 from gen_worker import aot_serve, boot_phases, serving_mode
 from gen_worker.compile_cache import AdoptError

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -52,7 +52,7 @@ GUARD_MANIFEST_BLOCK = "guard_manifest"
 
 
 from harness.cell_meta import exported_cell_meta
-from hashrepo import MAX_CHUNK_SIZE
+from gen_worker._vendor.tensorfs import MAX_CHUNK_SIZE
 
 from gen_worker import fleet_cells as fc
 from gen_worker import http_origin

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 import pytest
 
-from torch_compiled_graphs import identity as ck
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as ck
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 from gen_worker import compile_cache as cc
 
 

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -30,11 +30,11 @@ import uuid
 from pathlib import Path
 
 import pytest
-from hashrepo import TransferReport
+from gen_worker._vendor.tensorfs import TransferReport
 
 import gen_worker.hubio.client as hub_client
-from torch_compiled_graphs import GRAPH_CLASS_BLOCK, REQUIRED_AXES
-from torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import GRAPH_CLASS_BLOCK, REQUIRED_AXES
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
 
 from gen_worker import env_seal, graph_facts, receipts
 from gen_worker import fleet_cells as fc

--- a/tests/test_cell_resolve_pgw1090.py
+++ b/tests/test_cell_resolve_pgw1090.py
@@ -495,7 +495,7 @@ def _attempt_all(monkeypatch, tmp_path, *, derive=None, resolve_batch=None,
 def _derived_multi() -> Any:
     """A declaration that traced THREE graph classes — the shape the batch wire
     exists for, and the one a single-key loop would bill three round trips."""
-    from torch_compiled_graphs import identity as ck
+    from gen_worker._vendor.torch_compiled_graphs import identity as ck
 
     from gen_worker import boot_key
 
@@ -509,7 +509,7 @@ def _derived_multi() -> Any:
 
 
 def _derived(digest: str = KEY) -> Any:
-    from torch_compiled_graphs import identity as ck
+    from gen_worker._vendor.torch_compiled_graphs import identity as ck
 
     from gen_worker import boot_key
 

--- a/tests/test_child_traces_its_own_share_pgw1215.py
+++ b/tests/test_child_traces_its_own_share_pgw1215.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List
 
 import msgspec
 import pytest
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 
 torch = pytest.importorskip("torch")
 

--- a/tests/test_compile_attribution_pgw830.py
+++ b/tests/test_compile_attribution_pgw830.py
@@ -35,7 +35,7 @@ import pytest
 
 from gen_worker import aot_compile_child as child
 from gen_worker import aot_compile_pool as pool
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 

--- a/tests/test_compiled_graph_key_pgw1059.py
+++ b/tests/test_compiled_graph_key_pgw1059.py
@@ -28,7 +28,7 @@ import re
 from pathlib import Path
 
 import pytest
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     GRAPH_CLASS_BLOCK,
     REQUIRED_AXES,
     CallIngress,
@@ -37,12 +37,19 @@ from torch_compiled_graphs import (
     RuntimeCompatibility,
 )
 
-from torch_compiled_graphs import identity as tcg_identity
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 from gen_worker import fleet_cells, graph_facts
 
 from harness.cell_meta import exported_cell_meta
+import sys
+
+# pgw#1310: one home for "which subtrees a guard may not judge" —
+# scripts/_lint_scope.py, shared with the CI lint scanners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
+
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
 
@@ -166,6 +173,12 @@ def _derivation_sites(root: Path, needle: str) -> dict[str, int]:
     sites: dict[str, int] = {}
     for path in sorted(root.rglob("*.py")):
         rel = str(path.relative_to(root))
+        # pgw#1310: `_vendor/torch_compiled_graphs` is the AUTHORITY these
+        # needles name. Counting it as a second derivation site inverts the
+        # rule — the rule is that nothing in gen_worker re-derives what TCG
+        # already computes, and TCG computing it is the premise.
+        if is_unowned(path, root):
+            continue
         count = 0
         for line in path.read_text().splitlines():
             stripped = line.strip()

--- a/tests/test_eager_only_command_pgw1142.py
+++ b/tests/test_eager_only_command_pgw1142.py
@@ -43,7 +43,7 @@ from gen_worker import serving_mode
 from gen_worker.cell_adopt import EagerPhase
 from gen_worker.cli import serve as serve_cli
 from gen_worker.pb import worker_scheduler_pb2 as pb
-from torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, CompiledGraphRunner
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fail_closed_verification_pgw939_pgw940.py
+++ b/tests/test_fail_closed_verification_pgw939_pgw940.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     CallIngress,
     CallInput,
     DeclarationError,

--- a/tests/test_fold_per_entry_pgw1189.py
+++ b/tests/test_fold_per_entry_pgw1189.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker import aot_compile_pool as pool
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 from harness import fake_compile_child
 
 _DECLARED = 6

--- a/tests/test_format_one_derivation_pgw1230.py
+++ b/tests/test_format_one_derivation_pgw1230.py
@@ -46,6 +46,14 @@ import pytest
 
 from gen_worker import aot_serve, compile_cache as cc, env_seal
 from gen_worker import fleet_cells
+import sys
+from pathlib import Path
+
+# pgw#1310: one home for "which subtrees a guard may not judge" —
+# scripts/_lint_scope.py, shared with the CI lint scanners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
+
 
 SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "gen_worker"
 
@@ -155,7 +163,8 @@ def test_exactly_one_module_defines_an_artifact_format(
     definers = sorted(
         path.name
         for path in SRC.rglob("*.py")
-        if re.search(r"^COMPILED_GRAPH_FORMAT\s*=", path.read_text(), re.M)
+        if not is_unowned(path, SRC)
+        and re.search(r"^COMPILED_GRAPH_FORMAT\s*=", path.read_text(), re.M)
     )
     assert definers == ["aot_serve.py"], definers
 

--- a/tests/test_graph_witness_pgw1031.py
+++ b/tests/test_graph_witness_pgw1031.py
@@ -6,7 +6,7 @@ import inspect
 from typing import Any
 
 import pytest
-from torch_compiled_graphs import CallIngress, CallInput, GraphClassSpec
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, GraphClassSpec
 
 from gen_worker import aot_mint, boot_key, boot_trace_child
 from gen_worker.aot_inputs import ExportSpec

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -53,8 +53,8 @@ from torch._dynamo import exc as dexc
 
 import gen_worker.executor as executor_mod
 from gen_worker import Compile, activity as activity_mod
-from torch_compiled_graphs import identity as compiled_graph_key_mod
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as compiled_graph_key_mod
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells, hot_swap
 from gen_worker.api.binding import Hub, wire_ref

--- a/tests/test_handback_key_axes_pgw1042.py
+++ b/tests/test_handback_key_axes_pgw1042.py
@@ -32,14 +32,14 @@ import pytest
 
 from gen_worker import aot_serve, env_seal, fleet_cells, graph_facts
 from gen_worker.compile_cache import AdoptError
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     CallIngress,
     CallInput,
     CompiledGraphRunner,
     ConstantBindingError,
 )
-from torch_compiled_graphs import runner as tcg_runner_mod
-from torch_compiled_graphs.storage import StoredCompiledGraph
+from gen_worker._vendor.torch_compiled_graphs import runner as tcg_runner_mod
+from gen_worker._vendor.torch_compiled_graphs.storage import StoredCompiledGraph
 
 
 def _seal_dict() -> Dict[str, Any]:

--- a/tests/test_host_isa_pgw754.py
+++ b/tests/test_host_isa_pgw754.py
@@ -31,7 +31,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from torch_compiled_graphs import build_call_ingress
+from gen_worker._vendor.torch_compiled_graphs import build_call_ingress
 
 from gen_worker import aot_compile_child, aot_mint, env_seal, host_isa
 

--- a/tests/test_hostfacts_pgw896.py
+++ b/tests/test_hostfacts_pgw896.py
@@ -34,6 +34,13 @@ import pytest
 from gen_worker import aot_compile_pool as pool
 from gen_worker import cpu_budget, cuda_probe, hostfacts, lifecycle, postmortem
 from gen_worker.models.memory import probe_host_ram
+import sys
+
+# pgw#1310: one home for "which subtrees a guard may not judge" —
+# scripts/_lint_scope.py, shared with the CI lint scanners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
+
 
 _GIB = 1024 ** 3
 _SRC = Path(hostfacts.__file__).parent
@@ -47,8 +54,8 @@ def _code_hits(needle: str) -> List[Tuple[str, int]]:
     """
     hits: List[Tuple[str, int]] = []
     for path in sorted(_SRC.rglob("*.py")):
-        if "/pb/" in str(path):
-            continue  # generated
+        if is_unowned(path, _SRC):
+            continue  # generated or vendored (pgw#1310)
         text = path.read_text()
         if needle not in text:
             continue
@@ -107,7 +114,7 @@ def _literal_hits(needle: str, *, exact: bool = False) -> List[str]:
     by one), docstrings excluded — so prose about the rule cannot satisfy it."""
     out: List[str] = []
     for path in sorted(_SRC.rglob("*.py")):
-        if "/pb/" in str(path):
+        if is_unowned(path, _SRC):
             continue
         text = path.read_text()
         if needle not in text:

--- a/tests/test_identity_is_tcg_pgw1277.py
+++ b/tests/test_identity_is_tcg_pgw1277.py
@@ -29,8 +29,8 @@ import pathlib
 from typing import Any
 
 import pytest
-from torch_compiled_graphs import identity as tcg_identity
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 
 from gen_worker import env_seal, fleet_cells, graph_facts
 

--- a/tests/test_import_cycles_pgw981.py
+++ b/tests/test_import_cycles_pgw981.py
@@ -23,6 +23,12 @@ from typing import List, NamedTuple, Optional, Tuple
 
 import pytest
 
+# pgw#1310: one home for "which subtrees a guard may not judge" —
+# scripts/_lint_scope.py, shared with the CI lint scanners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
+
+
 SRC = Path(__file__).resolve().parents[1] / "src"
 PKG = SRC / "gen_worker"
 
@@ -54,6 +60,8 @@ class Outcome(NamedTuple):
 def _modules() -> List[str]:
     out: List[str] = []
     for path in sorted(PKG.rglob("*.py")):
+        if is_unowned(path, PKG):
+            continue
         rel = path.relative_to(SRC)
         parts = list(rel.parts)
         if any(p.startswith((".", "_pycache")) or p == "__pycache__" for p in parts):

--- a/tests/test_ingress_recast_and_closest_entry_pgw1074.py
+++ b/tests/test_ingress_recast_and_closest_entry_pgw1074.py
@@ -41,7 +41,7 @@ torch = pytest.importorskip("torch")
 import torch.nn as nn  # noqa: E402
 
 from gen_worker import activity, aot_serve  # noqa: E402
-from torch_compiled_graphs import (  # noqa: E402
+from gen_worker._vendor.torch_compiled_graphs import (  # noqa: E402
     CallIngress,
     CallInput,
     CompiledGraphRunner,

--- a/tests/test_key_grammar_vectors_th1897.py
+++ b/tests/test_key_grammar_vectors_th1897.py
@@ -27,8 +27,8 @@ import sys
 
 import pytest
 
-from torch_compiled_graphs import identity as tcg_identity
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 from gen_worker.compile_cache import parse_cell_ref
 from gen_worker.models.refs import parse_model_ref
 from gen_worker.refgrammar import MAX_FRAGMENT_LEN

--- a/tests/test_managed_tier_fill_source.py
+++ b/tests/test_managed_tier_fill_source.py
@@ -18,7 +18,7 @@ import hashlib
 import os
 from pathlib import Path
 
-from hashrepo import CASRef, TransferReport
+from gen_worker._vendor.tensorfs import CASRef, TransferReport
 
 import gen_worker.models.cozy_snapshot as snap_mod
 from gen_worker import config as gw_config

--- a/tests/test_micro_endpoint_pgw997.py
+++ b/tests/test_micro_endpoint_pgw997.py
@@ -42,7 +42,7 @@ from micro_diffusion.weights import (  # noqa: E402
 )
 
 from gen_worker import aot_declaration as ad  # noqa: E402
-from torch_compiled_graphs import build_call_ingress  # noqa: E402
+from gen_worker._vendor.torch_compiled_graphs import build_call_ingress  # noqa: E402
 from gen_worker.aot_mint import ExportSpec  # noqa: E402
 
 EXPECTED_ENTRIES = ["decoder", "transformer/cfg=false", "transformer/cfg=true"]

--- a/tests/test_one_safetensors_header_bound_pgw973.py
+++ b/tests/test_one_safetensors_header_bound_pgw973.py
@@ -33,6 +33,13 @@ from gen_worker.models.safetensors_header import MAX_HEADER_BYTES, header_len_ok
 from gen_worker.models.svdq import _read_safetensors_metadata
 from gen_worker.models.w4a4 import _read_header as w4a4_read_header
 from gen_worker.models.w8a8 import _read_header as w8a8_read_header
+import sys
+
+# pgw#1310: one home for "which subtrees a guard may not judge" —
+# scripts/_lint_scope.py, shared with the CI lint scanners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
+
 
 # One tensor of one F32 element, so the header describes something real.
 _HEADER = {"t": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}
@@ -73,7 +80,7 @@ def test_the_bound_is_stated_exactly_once():
     owner = src / "models" / "safetensors_header.py"
     offenders = []
     for py in src.rglob("*.py"):
-        if py == owner:
+        if py == owner or is_unowned(py, src):
             continue
         for i, line in enumerate(py.read_text().splitlines(), 1):
             stripped = line.strip()

--- a/tests/test_p2_residency_reconcile.py
+++ b/tests/test_p2_residency_reconcile.py
@@ -434,7 +434,7 @@ def test_corrupt_load_failure_refetches_and_retries_once(tmp_path, monkeypatch) 
     import json
     import struct
 
-    from hashrepo import TransferReport
+    from gen_worker._vendor.tensorfs import TransferReport
 
     import gen_worker.models.cozy_snapshot as snap_mod
     from gen_worker.api.binding import Hub as HubRef

--- a/tests/test_packed_class_merge_pgw917.py
+++ b/tests/test_packed_class_merge_pgw917.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 import pytest
-from torch_compiled_graphs import CallIngress, CallInput, GraphClassDeclaration
+from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput, GraphClassDeclaration
 
 from gen_worker import aot_mint
 

--- a/tests/test_partial_shape_coverage_pgw844.py
+++ b/tests/test_partial_shape_coverage_pgw844.py
@@ -49,7 +49,7 @@ from gen_worker import (  # noqa: E402
     endpoint,
 )
 from gen_worker import aot_serve  # noqa: E402
-from torch_compiled_graphs import (  # noqa: E402
+from gen_worker._vendor.torch_compiled_graphs import (  # noqa: E402
     CallIngress,
     CallInput,
     CompiledGraphRunner,

--- a/tests/test_reap_lag_residual_pgw1099.py
+++ b/tests/test_reap_lag_residual_pgw1099.py
@@ -25,7 +25,7 @@ from typing import Dict
 
 import pytest
 
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 from gen_worker.aot_compile_pool import EntryCompilePool, EntryReport, _Running
 
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -31,8 +31,8 @@ GUARD_MANIFEST_BLOCK = "guard_manifest"
 
 torch = pytest.importorskip("torch")
 
-from torch_compiled_graphs import identity as ck
-from torch_compiled_graphs import is_compiled_graph_key
+from gen_worker._vendor.torch_compiled_graphs import identity as ck
+from gen_worker._vendor.torch_compiled_graphs import is_compiled_graph_key
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure as gc

--- a/tests/test_ref_and_manifest_fuzz_pgw867.py
+++ b/tests/test_ref_and_manifest_fuzz_pgw867.py
@@ -29,7 +29,7 @@ import pathlib
 from typing import Any
 
 import pytest
-from hashrepo import CASRef
+from gen_worker._vendor.tensorfs import CASRef
 from hypothesis import HealthCheck, example, given, settings
 from hypothesis import strategies as st
 

--- a/tests/test_registry_contract_pgw740.py
+++ b/tests/test_registry_contract_pgw740.py
@@ -22,28 +22,13 @@ REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "check_registry_contract.py"
 
 
-def _vendored_requirements() -> list[str]:
-    """The deps that no longer exist on PyPI, as explicit git requirements.
-
-    Paul deleted the `hashrepo` and `torch-compiled-graphs` PyPI projects
-    permanently (DESIGN-RULINGS "Release policy": internal consumers vendor by
-    git pin). A bare wheel install resolves its declared dependencies from
-    PyPI, so this test must supply those two itself. Derived from
-    `[tool.uv.sources]` at run time rather than hardcoded, so the cutover
-    repin (pgw#1297) moves this test automatically.
-    """
-
-    import tomllib
-
-    with (REPO / "pyproject.toml").open("rb") as fh:
-        sources = tomllib.load(fh).get("tool", {}).get("uv", {}).get("sources", {})
-    reqs = []
-    for name in ("hashrepo", "torch-compiled-graphs"):
-        src = sources.get(name)
-        if src and "git" in src:
-            rev = f"@{src['rev']}" if "rev" in src else ""
-            reqs.append(f"{name} @ git+{src['git']}{rev}")
-    return reqs
+# pgw#1310 deleted the `_vendored_requirements()` helper that stood here. It
+# supplied the two deleted projects as explicit git requirements so this test
+# could go green — which made the ONE test that installs the artifact stop
+# measuring whether the artifact is installable. The wheel stayed unresolvable
+# for every consumer (ie#738, te#221, e2e#1893) with this test passing. The
+# install below is bare ON PURPOSE: it must resolve the wheel's own metadata
+# against the real index, exactly as a consumer does.
 
 
 # The three `uv` calls below build an isolated environment, which means
@@ -83,8 +68,7 @@ def test_contract_holds_from_installed_wheel(tmp_path: Path) -> None:
     venv = tmp_path / "venv"
     _uv([uv, "venv", "--python", "3.12", str(venv)])
     py = venv / "bin" / "python"
-    _uv([uv, "pip", "install", "--python", str(py), str(wheel),
-         *_vendored_requirements()])
+    _uv([uv, "pip", "install", "--python", str(py), str(wheel)])
     env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
     proc = subprocess.run(
         [str(py), str(SCRIPT), "--installed"],

--- a/tests/test_seal_lib_memo_pgw832.py
+++ b/tests/test_seal_lib_memo_pgw832.py
@@ -32,7 +32,7 @@ from typing import Dict, Iterator
 import pytest
 
 from gen_worker import aot_compile_pool as pool
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 from gen_worker import env_seal
 
 torch = pytest.importorskip("torch")

--- a/tests/test_snapshot_disk_headroom_pgw1263.py
+++ b/tests/test_snapshot_disk_headroom_pgw1263.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hashrepo import LocalCAS
+from gen_worker._vendor.tensorfs import LocalCAS
 
 from gen_worker.capability import InsufficientDiskError
 from gen_worker.models import cozy_snapshot

--- a/tests/test_snapshot_residency_progress_pgw1289.py
+++ b/tests/test_snapshot_residency_progress_pgw1289.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hashrepo import CASRef, LocalCAS
+from gen_worker._vendor.tensorfs import CASRef, LocalCAS
 
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile

--- a/tests/test_snapshot_v2_fill_pgw781.py
+++ b/tests/test_snapshot_v2_fill_pgw781.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hashrepo import CASRef, FileEntry, LocalCAS, RepositoryManifest
+from gen_worker._vendor.tensorfs import CASRef, FileEntry, LocalCAS, RepositoryManifest
 
 import gen_worker.models.cozy_snapshot as snapshot_mod
 from gen_worker.models.cozy_snapshot import NetworkBytesScope, ensure_snapshot_async

--- a/tests/test_structure_only_pgw1080.py
+++ b/tests/test_structure_only_pgw1080.py
@@ -110,7 +110,7 @@ def test_a_component_the_tree_does_not_declare_REFUSES_by_name(
 def test_the_structure_EXPORTS_and_TCG_COMPILES(
     tree: Path, tmp_path: Path,
 ) -> None:
-    from torch_compiled_graphs import build_call_ingress
+    from gen_worker._vendor.torch_compiled_graphs import build_call_ingress
 
     from gen_worker import aot_compile_child, aot_mint
 

--- a/tests/test_tcg_compile_child_pgw1270.py
+++ b/tests/test_tcg_compile_child_pgw1270.py
@@ -13,13 +13,13 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     CallIngress,
     CallInput,
     GraphClassDeclaration,
     build_call_ingress,
 )
-from torch_compiled_graphs.spans import SpanLedger
+from gen_worker._vendor.torch_compiled_graphs.spans import SpanLedger
 
 from gen_worker import aot_compile_child as child
 from gen_worker import aot_compile_pool as pool
@@ -344,7 +344,7 @@ def test_retry_filters_held_classes_before_export(
 def test_runtime_uses_the_canonical_worker_cas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import torch_compiled_graphs
+    from gen_worker._vendor import torch_compiled_graphs
 
     from gen_worker import compile_cache
     from gen_worker.models import cache_paths
@@ -397,7 +397,7 @@ def test_the_LANE_CHOICE_is_not_made_here_and_the_decline_is_named(
     before any export (its end-to-end red-proof is
     `test_mint_recipe_parity_pgw984_pgw985`).
     """
-    import torch_compiled_graphs
+    from gen_worker._vendor import torch_compiled_graphs
 
     from gen_worker import compile_cache
     from gen_worker.hostfacts import (

--- a/tests/test_tcg_literal_declaration_pgw1270.py
+++ b/tests/test_tcg_literal_declaration_pgw1270.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from torch_compiled_graphs import (
+from gen_worker._vendor.torch_compiled_graphs import (
     DeclarationError,
     GraphClassSpec,
     build_call_ingress,

--- a/tests/test_tcg_runtime_arm_pgw1270.py
+++ b/tests/test_tcg_runtime_arm_pgw1270.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from gen_worker import aot_delivery, aot_serve, receipts
-from torch_compiled_graphs import StoreOutcome
+from gen_worker._vendor.torch_compiled_graphs import StoreOutcome
 
 FAMILY = "runtime-arm"
 KEY = "cg-key-v1-" + "a" * 56
@@ -96,7 +96,7 @@ def test_delivery_never_imports_an_unkeyed_ref(
 def test_serve_handoff_removes_only_delivery_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from torch_compiled_graphs import artifact as artifact_mod
+    from gen_worker._vendor.torch_compiled_graphs import artifact as artifact_mod
 
     incoming = tmp_path / "compiled-graph-transfer" / ".incoming"
     incoming.mkdir(parents=True)

--- a/tests/test_toolchain_membership_pgw1050.py
+++ b/tests/test_toolchain_membership_pgw1050.py
@@ -24,7 +24,7 @@ from typing import Dict
 
 import pytest
 
-from torch_compiled_graphs import identity as tcg_identity
+from gen_worker._vendor.torch_compiled_graphs import identity as tcg_identity
 
 from gen_worker import compile_cache as cc, dist_records
 

--- a/tests/test_trace_child_placement_pgw1124.py
+++ b/tests/test_trace_child_placement_pgw1124.py
@@ -86,7 +86,7 @@ class _TinyTrace(nn.Module):
 
 def _traced_class(aot_mint: Any) -> Any:
     """One real export crossing the same TCG declaration seam as production."""
-    from torch_compiled_graphs import CallIngress, CallInput
+    from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput
 
     example = torch.ones(2)
     program = torch.export.export(_TinyTrace(), (example,))

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -1,0 +1,125 @@
+"""pgw#1310: the vendored snapshots are what VENDORED.toml says they are.
+
+Two fences, deliberately different in kind, because either one alone passes on
+a tree the other refuses:
+
+1. CONTENT — every vendored file hashes to the digest recorded beside its rev.
+   Catches a hand-patch, a partial re-vendor, and a rev bump whose manifest was
+   not regenerated.
+2. BEHAVIOUR — the pinned `tensorfs` rev is pinned FOR the pgw#1287 progress
+   fix, so the fence asserts the fix runs, not that a string says it should.
+   A digest fence alone would happily certify a correctly-recorded snapshot of
+   the broken tree.
+
+Plus the reason the vendoring exists at all: the built distribution must not
+require either deleted project from an index (ie#738).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import tomllib
+from pathlib import Path
+
+import pytest
+
+VENDOR = Path(__file__).resolve().parents[1] / "src" / "gen_worker" / "_vendor"
+MANIFEST = tomllib.loads((VENDOR / "VENDORED.toml").read_text())
+
+
+def test_every_vendored_file_matches_its_recorded_digest() -> None:
+    for package, spec in MANIFEST["packages"].items():
+        recorded = spec["files"]
+        root = VENDOR / package
+        present = {
+            p.relative_to(root).as_posix()
+            for p in root.rglob("*")
+            if p.is_file() and "__pycache__" not in p.parts
+        }
+        assert present == set(recorded), (
+            f"{package}: vendored file set differs from VENDORED.toml — "
+            f"only on disk {sorted(present - set(recorded))}, "
+            f"only recorded {sorted(set(recorded) - present)}"
+        )
+        for name, digest in recorded.items():
+            actual = hashlib.sha256((root / name).read_bytes()).hexdigest()
+            assert actual == digest, (
+                f"{package}/{name} was edited in place. A vendored snapshot is "
+                f"fixed upstream and re-vendored, never patched here — see "
+                f"VENDORED.toml."
+            )
+
+
+def test_the_pinned_tensorfs_rev_emits_progress_as_each_object_lands() -> None:
+    """pgw#1287: the fix this rev is pinned for, asserted by running it.
+
+    The second object cannot finish until the FIRST object's callback has been
+    observed. Post-drain emission (the defect: a 31.6 GB download reporting
+    `0 / total` until its last byte landed, so the hub's 6-minute freshness
+    window condemned a healthy pod) cannot satisfy that, at any timeout.
+    """
+    from gen_worker._vendor.tensorfs import CASRef, TransferGrant
+    from gen_worker._vendor.tensorfs.transfer import _run_parallel
+
+    grants = [
+        TransferGrant(
+            digest=CASRef.parse(f"sha256:{i:064x}"),
+            size_bytes=1024,
+            url="https://example/x",
+        )
+        for i in range(1, 3)
+    ]
+    first_reported = threading.Event()
+    seen: list[int] = []
+
+    def worker(grant: TransferGrant) -> bool:
+        if grant.digest == grants[1].digest:
+            assert first_reported.wait(timeout=10.0), (
+                "the first object's progress callback never fired while a second "
+                "transfer was still running: this rev emits progress only after "
+                "the whole batch drains (pgw#1287 is NOT in the vendored tree)"
+            )
+        return False
+
+    def progress(digest: object, size: int) -> None:
+        seen.append(size)
+        first_reported.set()
+
+    report = _run_parallel(grants, worker, parallel=2, progress=progress)
+    # The worker runs on a pool thread, so its assertion arrives as a recorded
+    # failure rather than as this test's traceback. Surface it verbatim.
+    assert report.failures == [], report.failures[0][1]
+    assert report.succeeded == 2
+    assert seen == [1024, 1024]
+
+
+def test_no_deleted_project_is_required_from_an_index() -> None:
+    """ie#738: the break this whole cut exists to close.
+
+    Both PyPI projects are permanently deleted, so ANY index requirement on them
+    makes the published wheel unresolvable for every consumer.
+    """
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
+    project = tomllib.loads(text)["project"]
+    requirements = list(project["dependencies"])
+    for extra in project.get("optional-dependencies", {}).values():
+        requirements.extend(extra)
+    dead = [r for r in requirements if r.split()[0].split(">")[0].split("=")[0].strip()
+            in {"hashrepo", "tensorfs", "torch-compiled-graphs", "torchcg"}]
+    assert dead == [], f"deleted PyPI projects required from an index: {dead}"
+    assert "[tool.uv.sources]" in text
+    for name in ("hashrepo =", "torch-compiled-graphs =", "tensorfs =", "torchcg ="):
+        assert name not in text, (
+            f"a `{name}` source pin is back in pyproject.toml. A source pin is "
+            f"workspace-only metadata — it is stripped from the published wheel "
+            f"— so it cannot be the delivery mechanism (ie#738)."
+        )
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["gen_worker._vendor.tensorfs", "gen_worker._vendor.torch_compiled_graphs"],
+)
+def test_the_vendored_packages_import_with_no_third_party_present(module: str) -> None:
+    __import__(module)

--- a/tests/test_warm_spans_pgw989.py
+++ b/tests/test_warm_spans_pgw989.py
@@ -13,7 +13,7 @@ import types
 from typing import Dict, List
 
 import pytest
-from torch_compiled_graphs import spans
+from gen_worker._vendor.torch_compiled_graphs import spans
 
 from gen_worker import warm_spans
 

--- a/tests/test_weight_free_premise_pgw1173.py
+++ b/tests/test_weight_free_premise_pgw1173.py
@@ -146,7 +146,7 @@ class _TinyTrace(nn.Module):
 
 def _traced_class(aot_mint: Any) -> Any:
     """One real export crossing the same TCG declaration seam as production."""
-    from torch_compiled_graphs import CallIngress, CallInput
+    from gen_worker._vendor.torch_compiled_graphs import CallIngress, CallInput
 
     example = torch.ones(2)
     program = torch.export.export(_TinyTrace(), (example,))

--- a/tests/test_wire_vocabulary_hardcut_pgw1278.py
+++ b/tests/test_wire_vocabulary_hardcut_pgw1278.py
@@ -22,6 +22,7 @@ boot phases, and ``compile_cell_failed`` — the last a CLOSED
 from __future__ import annotations
 
 import pathlib
+import sys
 from typing import Dict, List, Tuple
 
 import pytest
@@ -35,7 +36,9 @@ _REPO = pathlib.Path(__file__).resolve().parents[1]
 _SRC = _REPO / "src"
 #: tensorhub's canonical proto and its generated output — a different contract
 #: with a different owner. Everything else in `src/` is this repo's vocabulary.
-_EXCLUDED = (_SRC / "gen_worker" / "pb",)
+# pgw#1310: which subtrees a guard may not judge has ONE home.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+from _lint_scope import is_unowned  # noqa: E402
 
 #: Every dead spelling, with the successor that replaced it. A pair rather than
 #: a bare list so the failure names what to write instead.
@@ -69,7 +72,7 @@ def _src_files() -> List[pathlib.Path]:
     for p in sorted(_SRC.rglob("*")):
         if not p.is_file() or p.suffix not in {".py", ".pyi", ".json", ".txt"}:
             continue
-        if any(ex in p.parents for ex in _EXCLUDED):
+        if is_unowned(p, _SRC):
             continue
         out.append(p)
     assert out, "the source scan found nothing — the fence would be vacuous"

--- a/tests/test_wired_gates_pgw1271.py
+++ b/tests/test_wired_gates_pgw1271.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Tuple, cast
 
 import pytest
 
-from torch_compiled_graphs import GRAPH_CLASS_BLOCK
+from gen_worker._vendor.torch_compiled_graphs import GRAPH_CLASS_BLOCK
 
 from gen_worker import (
     aot_serve,

--- a/uv.lock
+++ b/uv.lock
@@ -571,7 +571,6 @@ dependencies = [
     { name = "c2pa-python" },
     { name = "gguf" },
     { name = "grpcio" },
-    { name = "hashrepo" },
     { name = "huggingface-hub" },
     { name = "msgspec" },
     { name = "protobuf" },
@@ -579,7 +578,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tomli-w" },
-    { name = "torch-compiled-graphs" },
 ]
 
 [package.optional-dependencies]
@@ -642,7 +640,6 @@ requires-dist = [
     { name = "gguf", specifier = ">=0.10.0" },
     { name = "grpcio", specifier = ">=1.82.1" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.82.1" },
-    { name = "hashrepo", git = "https://github.com/cozy-creator/tensorfs?rev=0d0437570aac241ed234b741e66af8c79492d872" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "msgspec", specifier = ">=0.18.6" },
@@ -665,7 +662,6 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'torch'", specifier = ">=2.13.0" },
-    { name = "torch-compiled-graphs", git = "https://github.com/cozy-creator/torchcg?rev=ad5f4cb9f89bbe91d2a30ca218f70d5326630368" },
     { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'vision') or (sys_platform == 'win32' and extra == 'vision')", specifier = ">=0.28.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchvision", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'vision'", specifier = ">=0.28.0" },
     { name = "transformers", marker = "extra == 'dev'", specifier = ">=5.13" },
@@ -781,11 +777,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6f
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
-
-[[package]]
-name = "hashrepo"
-version = "0.3.1"
-source = { git = "https://github.com/cozy-creator/tensorfs?rev=0d0437570aac241ed234b741e66af8c79492d872#0d0437570aac241ed234b741e66af8c79492d872" }
 
 [[package]]
 name = "hf-xet"
@@ -2078,15 +2069,6 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp315-cp315-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:20:00Z" },
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp315-cp315t-manylinux_2_28_aarch64.whl", upload-time = "2026-07-08T11:20:04Z" },
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp315-cp315t-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:20:04Z" },
-]
-
-[[package]]
-name = "torch-compiled-graphs"
-version = "0.6.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=ad5f4cb9f89bbe91d2a30ca218f70d5326630368#ad5f4cb9f89bbe91d2a30ca218f70d5326630368" }
-dependencies = [
-    { name = "hashrepo" },
-    { name = "safetensors" },
 ]
 
 [[package]]


### PR DESCRIPTION
## The break

`gen-worker` 0.117.0 and 0.118.0 publish `Requires-Dist: hashrepo<0.4,>=0.3` and
`Requires-Dist: torch-compiled-graphs<0.7,>=0.6`. **Both PyPI projects are deleted,
permanently.** Every unlocked install of the artifact dies at resolution:

```
Because hashrepo was not found in the package registry and gen-worker==0.118.0
depends on hashrepo>=0.3,<0.4, ... your requirements are unsatisfiable.
```

Three consumer halves were filed separately before the artifact was identified as the
common cause: **ie#738** (every ie PR unmergeable on the required `declarations` gate),
**te#221**, **e2e#1893** (every source-publishing journey dead at image build — measured
green 16:26, dead 16:33 on identical source).

pgw#1297's `[tool.uv.sources]` git pins fixed this repo and could never reach any of them:
a source pin is workspace metadata, stripped at build. The hub's generated image build runs
`uv export --no-sources`, so it consumes the wheel's own metadata and nothing else.

## The cut: vendor

Paul's ruling (DESIGN-RULINGS "Release policy"): *"just use a vendored version of our local
library if you need to."* The alternative — a second install step per image — needs that step
in the hub's generated Dockerfile **and** every author Dockerfile: two more homes for a fact
this puts in one.

It is not a fork. Upstream `master` on **both** repos is a v0.1.0 genesis restart that deleted
the code we import (`tensorfs` dropped `transfer`, `journal`, `chunking`). There is no lineage
left to diverge from, and the #1295 native-reader cutover **deletes** `_vendor/` rather than
repinning it.

| vendored | from | why that rev |
|---|---|---|
| `_vendor/tensorfs` | `cozy-creator/tensorfs@8bafdfbb` | merge of tensorfs#41 → carries the **pgw#1287 progress-emission fix**. Delta from published `hashrepo` 0.3.1 is exactly: the rename, the `daemon` module, that fix. Verified file by file. |
| `_vendor/torch_compiled_graphs` | `cozy-creator/torchcg@ad5f4cb9` | contents of published 0.6.0 — what `uv.lock` already resolved. Byte-identical but for 3 `from hashrepo import` lines. |

`_vendor/VENDORED.toml` is the one home of the revs, rationale and per-file sha256.

## Proofs

1. **Metadata** — built wheel's `Requires-Dist` carries none of `hashrepo` / `tensorfs` /
   `torch-compiled-graphs` / `torchcg`; the four names appear nowhere in `METADATA`.
2. **Install + behaviour** — clean venv, `uv pip install <wheel>` unlocked, then from the
   INSTALLED artifact: `LocalCAS`, `download`, `ARTIFACT_KIND`, `read_contract` import, and
   `_run_parallel` is exercised — the second object cannot finish until the first object's
   progress callback is observed. Green.
3. **Red** — the identical sequence on `origin/master` exits 1 with the verbatim ie#738 error.

## The gate that should have caught it

`fast gates` built the wheel and never installed it; `tests` (where the only wheel-install test
lives) is neither required nor run on the queue ref. Master shipped an uninstallable artifact
with everything green, twice. `fast gates` now builds, installs into a clean venv **unlocked**
(on purpose — it must resolve the artifact's own metadata against the real index), and
exercises the transfer path. Red-verified on the pre-cutover tree.

Also reverted: pgw#1297 (`4114d413`) made `test_contract_holds_from_installed_wheel` supply the
two deleted deps as git requirements so it would stop redding — which removed the only
instrument that could see the defect. The install is bare again.

## Fences, each red-verified under its own mutation

| mutation | fence |
|---|---|
| hand-edit any vendored file | digest fence RED |
| revert `_run_parallel` to post-drain emission | behaviour fence RED, named message |
| re-add either name to `dependencies` / `[tool.uv.sources]` | metadata fence RED |

Guards do not judge vendored code, and that rule has **one home** — `scripts/_lint_scope.py`,
shared by four CI lint scanners and five in-tree fences. Without it the vendored TCG reads as a
second derivation site for the very axes it *defines*.

## Also here

* `boot_key._tcg_version` read `importlib.metadata.version("torch-compiled-graphs")` and
  swallowed `PackageNotFoundError` into `""` — with the distribution gone that silently drops
  TCG from the compile memo key. Now reads the vendored rev (strictly more exact).
* `cozy_snapshot`'s `~1.0s of solid CPU per GiB` is the WARM end of a measured ~14x spread
  (tensorfs#42) — qualified. (pgw#1287 rider.)
* `api/decorators.py` documented checkpoint selection via a `ModelChoice` class in
  `gen_worker.api.model`; neither exists. Replaced with the live `Slot(selected_by=,
  default_checkpoint=)`.

## Gates

`mypy src/gen_worker tests tests_v2` → **Success, 757 files** (master: 730, clean). `ruff` clean.
All **24** `fast gates` guards OK. **461** tree-scanning fence tests pass; 121 TCG-path, 94
tensorfs-path (byte-identical result to master, including its 7 pre-existing xdist
conftest errors), 4490 tests collect.

**No version bump, no wheel** — this rides the coordinated release.
