### PR TITLE
pgw#1307 batch B: the slot backstop disagreed with the authority it backstops — in BOTH directions

### DIFF
--- a/changelog.d/pgw1307.md
+++ b/changelog.d/pgw1307.md
@@ -1,0 +1,44 @@
+- **The slot backstop was simultaneously too permissive and too strict, and one ported rule fixes
+  both.** `api.slot._finish_resolved` treated an EMPTY `distilled_status` as evidence whenever an
+  objective happened to be stamped, on the stated ground that empty means "an older sender". It
+  does not: the hub omits the key whenever the stored column is empty
+  (`slot_resolution.go` stamps it `if TrimSpace(...) != ""`), and its own single rule
+  (`modelfamily.StoredCheckpointFacts`) counts ONLY `"classified"` as evidence — so both hub
+  gates already refuse the binding the worker was passing. Meanwhile the backstop applied the
+  function's contract to EVERY slot, while both hub gates scope it
+  (`modelfamily.ServingContractGoverns`) — so an `unclassified` stamp on an auxiliary
+  interpolator/upscaler slot failed the WHOLE warmup for any function declaring `distilled=`.
+  `serving_contract_governs_slot` ports that rule term for term and `warmup` asks only about the
+  slots it admits; a governed slot with no evidence for a declared axis now fails closed, on
+  both axes, exactly as the authority does.
+
+- **`convert.publish` stops restating an absent status as an authored false.** The two lines above
+  it forbid exactly that (*"Never turn unknown/inconclusive into an authored false"*), and an
+  absent `distilled_status` is one of the unknowns for the same reason — only `"classified"` is
+  evidence.
+
+- **A drain projection can no longer carry a fabricated goal id.** `lifecycle_intents.set_drain`
+  kept an `else:` branch minting `legacy-drain-<session>` onto a `DrainProjection` the hub reads.
+  `ensure_intent` is TOTAL — hub-authored work, else a minted `compat-` carrier, never `""` — so
+  the branch was unreachable, and the fence is a source check because an unreachable arm cannot
+  be told from its own deletion by behaviour.
+
+- **A keyless cell record refuses instead of adopting the directory it sits in.**
+  `local_cell_store.stored_cells` read `raw.get("compiled_graph_key") or entry.name`, fabricating
+  a cell identity from a filesystem path — and `cells_owed_to_sink` reads that listing, so the
+  invented key reached an upload scan. `_record_payload` always writes the key, so a sidecar
+  without one is not something this store wrote. It is now skipped with a warning, the same way
+  an unreadable record is (cl#63's sibling shape).
+
+- **The duplicate-function-name error names the DEFINING module.** `_assert_unique_function_names`
+  preferred `module` (where the walk found the object — a package `__init__` for a re-exported
+  handler) over `declared_module`, which is the file the author has to open. The dedup key two
+  hundred lines down already preferred `declared_module`; the two now agree.
+
+- **One arm that is NOT residue, pinned so the next sweep does not cut it.** `http_origin`'s
+  string-code envelope classifier was filed as an old-hub arm. Master's hub still emits that
+  shape from four routes that never moved onto `httperrors.Write` — the binding-check 422, the
+  invoke-time model-override 400, and the capability-upload 403/429 — so deleting it reinstates
+  pgw#743 on all four: a diagnosable refusal retried until it becomes a different, later error.
+  The comment now names the live producers, and a parameterized fence carries their shapes.
+  It dies when the HUB emits one envelope everywhere, which is a tensorhub row.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -522,7 +522,20 @@ def generate(self, ctx, payload: TextToImageInput) -> ImageOutput: ...
 
 `objectives` = which checkpoint training objectives the handler's code
 path serves (omit = unrestricted); `distilled` = True (only distilled) /
-False (only non-distilled) / omit (either). The boot WARM PLAN is DERIVED
+False (only non-distilled) / omit (either).
+
+**A declared axis needs EVIDENCE, and it fails closed without one.** The hub
+gates this at deploy and at dispatch; the worker backstops it at warmup with
+the same rule. A checkpoint whose `distilled_status` is anything but
+`classified` — including unstamped — has no verdict on that axis, so it does
+not satisfy `distilled=`, and a checkpoint with no training objective does not
+satisfy `objectives=`. `distilled=False` means "evidenced non-distilled", never
+"nobody looked". The contract is scoped to the slot the request's model pick
+lands on (or, on a function with no selectable slot, to the slots that declared
+a `family`), so auxiliary slots — interpolators, upscalers — are never asked
+for evidence they cannot carry.
+
+The boot WARM PLAN is DERIVED
 — defaulted fields keep their schema defaults, `CompileAxis` fields
 cross-product their classes' `warm=` representatives, required fields
 synthesize neutral values — so there is no `warmup=` payload dict to

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -303,8 +303,10 @@ class ResolvedSlot(Generic[D]):
 
     ``objective``/``distilled`` are the resolved checkpoint's
     hub-stamped values. ``distilled_status`` distinguishes an evidenced false
-    value from an unclassified or inconclusive one. An empty status means an
-    older hub omitted the additive field. ``ctx.for_request`` applies the
+    value from an unclassified or inconclusive one; ``"classified"`` is the
+    only value that is evidence, and an empty status is one of the unknowns —
+    the hub omits the key whenever the stored column is empty.
+    ``ctx.for_request`` applies the
     objective to the per-request scheduler view automatically; handlers may
     also branch on the distillation value and its evidence status.
     """

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -380,6 +380,33 @@ def _apply_lora_overrides(
     return result
 
 
+def serving_contract_governs_slot(
+    *, selected_by: str, family: str, function_has_selectable_slot: bool,
+) -> bool:
+    """Does the invoked function's serving contract apply to THIS slot?
+
+    The worker-side mirror of the hub's one rule
+    (`modelfamily.ServingContractGoverns`, applied at both hub gates —
+    deploy-time `bindingcheck` via `EffectiveBinding.ServingContractSlot` and
+    request-time `release.ServingContractGovernsSlot`):
+
+      * a `selected_by` slot is always governed — a caller-picked checkpoint is
+        the least-vetted input there is;
+      * otherwise a function that has a selectable slot elsewhere governs only
+        that one;
+      * a function with no selectable slot governs the slots that declared an
+        architecture family — the ones that can carry a training objective.
+
+    Without it the backstop asks a pipeline's tokenizer/VAE/finisher for
+    evidence the hub never demands of them, and refuses the whole warmup.
+    """
+    if str(selected_by or "").strip():
+        return True
+    if function_has_selectable_slot:
+        return False
+    return bool(str(family or "").strip())
+
+
 def _finish_resolved(
     name: str,
     ref: ModelRef,
@@ -399,11 +426,17 @@ def _finish_resolved(
     function's declared objective/distilled contract, enforce the backstop:
     the hub gates checkpoint<->function compatibility at deploy and request
     time upstream — reaching a mismatch here means version skew or a hub
-    bug, never a normal-path outcome. The backstop only fires on STAMPED
-    facts. Explicitly unknown distillation evidence fails closed when the
-    function declares that axis. Empty status preserves the old-sender
-    behavior: objective-stamped bindings treat the bool as known, while fully
-    unstamped bindings pass as they did before the additive field existed."""
+    bug, never a normal-path outcome.
+
+    Evidence is read by the hub's ONE rule (`modelfamily.StoredCheckpointFacts`):
+    the objective axis is evidenced when the objective is non-empty, and the
+    distilled axis ONLY when `distilled_status == "classified"`. An unstamped
+    status is NOT an old sender — the hub omits the key whenever the stored
+    column is empty (`slot_resolution.go` stamps it `if TrimSpace(...) != ""`),
+    so "" is a live value meaning nothing measured the axis, and a declared
+    contract on it fails closed exactly as it does at the hub's own two gates.
+    The caller is responsible for asking only about slots the contract governs
+    (:func:`serving_contract_governs_slot`)."""
     status = str(distilled_status or "").strip()
     if status not in ("", "classified", "unclassified", "inconclusive"):
         raise ObjectiveMismatchError(
@@ -414,25 +447,27 @@ def _finish_resolved(
         ref=ref, defaults=defaults, objective=objective, distilled=distilled,
         distilled_status=status,
     )
-    if resolved.objective:
-        if allowed_objectives is not None and resolved.objective not in allowed_objectives:
+    if allowed_objectives is not None:
+        if not resolved.objective:
+            raise ObjectiveMismatchError(
+                f"slot {name!r}: resolved checkpoint carries no training "
+                f"objective, so there is no evidence for the invoked "
+                f"function's declared objectives {tuple(allowed_objectives)!r}"
+            )
+        if resolved.objective not in allowed_objectives:
             raise ObjectiveMismatchError(
                 f"slot {name!r}: resolved checkpoint objective "
                 f"{resolved.objective!r} is not in the invoked function's "
                 f"declared objectives {tuple(allowed_objectives)!r}"
             )
     if allowed_distilled is not None:
-        if status in ("unclassified", "inconclusive"):
+        if status != "classified":
             raise ObjectiveMismatchError(
                 f"slot {name!r}: resolved checkpoint distillation evidence is "
-                f"{status}; the invoked function declares "
+                f"{status or 'unstamped'}; the invoked function declares "
                 f"distilled={allowed_distilled!r}"
             )
-        # Empty is an old sender. Preserve its pre-field behavior: only an
-        # objective-stamped binding treated the adjacent bool as evidenced.
-        distilled_known = (
-            status == "classified" or (not status and bool(resolved.objective)))
-        if distilled_known and resolved.distilled != allowed_distilled:
+        if resolved.distilled != allowed_distilled:
             raise ObjectiveMismatchError(
                 f"slot {name!r}: resolved checkpoint distilled="
                 f"{resolved.distilled!r} but the invoked function declares "
@@ -475,9 +510,10 @@ def resolve_slot(
 
     ``objective``/``distilled`` are the resolved checkpoint's
     hub-stamped values; ``distilled_status`` distinguishes an evidenced false
-    from unknown evidence (empty means an older sender).
+    from unknown evidence (empty means nothing measured the axis).
     ``allowed_objectives``/``allowed_distilled``, when given, are the
-    invoked function's declared ``@worker_function`` contract — see
+    invoked function's declared ``@worker_function`` contract — pass them
+    only for slots :func:`serving_contract_governs_slot` admits, and see
     :func:`_finish_resolved`.
     """
     if ref is None:
@@ -535,5 +571,5 @@ def resolve_slot(
 
 __all__ = [
     "OBJECTIVES", "ObjectiveMismatchError", "ResolvedSlot",
-    "Slot", "resolve_slot",
+    "Slot", "resolve_slot", "serving_contract_governs_slot",
 ]

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -95,13 +95,15 @@ def _source_stamps(ctx: Any, client: HubClient) -> tuple[str | None, bool | None
         if th is None:
             return None, None
         resolved = resolve_repo(th, base_url=client.base_url, token=client.token)
-        # A new hub tells us whether false is evidence or merely the wire
-        # default. Never turn unknown/inconclusive into an authored false on
-        # the derived checkpoint. Empty status is an old hub, whose behavior
-        # remains unchanged for rolling compatibility.
+        # `distilled_status` tells us whether false is evidence or merely the
+        # wire default. Never turn unknown into an authored false on the
+        # derived checkpoint. Only "classified" is evidence — the hub's own
+        # rule (`modelfamily.StoredCheckpointFacts`), and an EMPTY status is
+        # one of the unknowns: the resolve route omits the key whenever the
+        # stored column is empty, so "" means nothing measured the axis.
         distilled = (
             resolved.distilled
-            if resolved.distilled_status in ("", "classified")
+            if resolved.distilled_status == "classified"
             else None
         )
         return resolved.objective, distilled

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -500,9 +500,12 @@ def _assert_unique_function_names(functions: List[Dict[str, Any]]) -> None:
         return
     lines = []
     for nm, fns in sorted(dupes.items()):
+        # `declared_module` first, like the dedup key below: `module` is where
+        # the WALK found the object, which for a re-exported handler is a
+        # package `__init__` — the wrong file to send an author to.
         where = ", ".join(
             f"{f.get('class_name') or '<module-level>'} in "
-            f"{f.get('module') or f.get('declared_module') or '?'}"
+            f"{f.get('declared_module') or f.get('module') or '?'}"
             for f in fns
         )
         lines.append(f"  {nm!r}: defined {len(fns)}x ({where})")

--- a/src/gen_worker/hardware_report.py
+++ b/src/gen_worker/hardware_report.py
@@ -6,8 +6,8 @@ orchestrator contact kills the pod invisibly to every layer of telemetry. This
 module sends ONE ``HardwareUnsuitable`` ``WorkerMessage`` on the Connect stream, in
 place of Hello, so the hub can attribute the death and reschedule/blacklist
 the host. Bounded best-effort: a couple of short retries, then give up — the
-silent exit remains the fallback (unreachable hub, or an old hub that
-predates this field and rejects the connection for not sending Hello first).
+silent exit remains the fallback when the hub cannot be REACHED at all, which
+is the one condition no report can route around.
 """
 
 from __future__ import annotations
@@ -166,10 +166,9 @@ async def _send_once(
 ) -> bool:
     """One dial attempt: open Connect, write the report, half-close, and wait
     for the hub to end the call. Returns True only on a clean, unrejected
-    round trip (delivered); any exception (unreachable, UNAUTHENTICATED, an old
-    hub rejecting the missing Hello with FAILED_PRECONDITION) is
-    "not delivered" — the caller retries or falls through to the silent
-    exit."""
+    round trip (delivered); any exception (unreachable, UNAUTHENTICATED, a
+    refused connection) is "not delivered" — the caller retries or falls
+    through to the silent exit."""
     channel = (
         grpc.aio.secure_channel(target, grpc.ssl_channel_credentials())
         if use_tls

--- a/src/gen_worker/http_origin.py
+++ b/src/gen_worker/http_origin.py
@@ -82,19 +82,21 @@ def response_is_from_hub(resp: Any) -> bool:
     # Shape 1, the common envelope: {"error": {"code": ..., ...}}.
     if isinstance(err, dict) and "code" in err:
         return True
-    # Shape 2, the PUBLISH envelope: {"error": "<code>", "message": ...}.
-    # `publishError.body()` (tensorhub `internal/api/repo_publish.go`) emits the
-    # code as a STRING, not an object — so every publish refusal was read as
-    # proxy-shaped and RETRIED under the silence window. Measured live on a v2
-    # publish: a 422 from `/publishes/{id}/complete` was retried, the
-    # retry hit the now-terminal session and returned 409 `publish_repudiated`,
-    # and the ORIGINAL 422 — the only response that said WHY — was discarded.
-    # A retry loop that converts a diagnosable refusal into a different, later
+    # Shape 2, the STRING-CODE envelope: {"error": "<code>", "message": ...}.
+    # NOT an old-hub arm — pgw#1307 re-read the hub and master still emits it
+    # from routes that never moved onto `httperrors.Write`: the binding-check
+    # 422 (`internal/api/endpoint_bindings.go`, `bindingWriteError.write`), the
+    # invoke-time model-override 400 (`modelOverrideErrorBody`), and the
+    # capability-upload 403/429 (`internal/api/capability_upload_budget.go`).
+    # Deleting this arm reinstates the pgw#743 defect on all four: measured
+    # live on a v2 publish, a 422 read as proxy-shaped was retried, the retry
+    # hit the now-terminal session and returned 409 `publish_repudiated`, and
+    # the ORIGINAL 422 — the only response that said WHY — was discarded. A
+    # retry loop that converts a diagnosable refusal into a different, later
     # error is worse than one that does not retry at all.
-    # A proxy does not synthesise a string `error` alongside a `message` either,
-    # so this stays a hub-only signature. The hub-side fix is to emit the object
-    # envelope everywhere; this must keep working regardless, because old hubs
-    # exist and the client cannot require a deploy to classify an answer.
+    # A proxy does not synthesise a string `error` alongside a `message`, so
+    # this stays a hub-only signature. It dies when the HUB emits one envelope
+    # everywhere, and not before; that is a tensorhub row, not a pgw one.
     return isinstance(err, str) and bool(err.strip()) and "message" in body
 
 

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -1203,42 +1203,41 @@ class IntentRegistry:
         error_code: "pb.LifecycleErrorCode" = pb.LIFECYCLE_ERROR_CODE_UNSPECIFIED,
     ) -> None:
         now = _now_ms()
+        # `ensure_intent` is TOTAL: it returns hub-authored work when there is
+        # any, and otherwise mints the `compat-` carrier. There is no third
+        # answer, so a drain projection never needs a fabricated goal id.
         intent_id = self.ensure_intent(pb.DESIRED_INTENT_KIND_DRAIN)
-        if intent_id:
-            state = self._intents[intent_id]
-            transition_status = {
-                pb.DRAIN_LIFECYCLE_STATUS_ACCEPTED: pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,
-                pb.DRAIN_LIFECYCLE_STATUS_DRAINING: pb.LIFECYCLE_INTENT_STATUS_WAITING,
-                pb.DRAIN_LIFECYCLE_STATUS_FINALIZING: pb.LIFECYCLE_INTENT_STATUS_RUNNING,
-                pb.DRAIN_LIFECYCLE_STATUS_FLUSHING: pb.LIFECYCLE_INTENT_STATUS_RUNNING,
-                pb.DRAIN_LIFECYCLE_STATUS_DRAINED: pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED,
-                pb.DRAIN_LIFECYCLE_STATUS_FAILED: pb.LIFECYCLE_INTENT_STATUS_FAILED,
-            }.get(status, pb.LIFECYCLE_INTENT_STATUS_FAILED)
-            transition_stage = {
-                pb.DRAIN_LIFECYCLE_STATUS_ACCEPTED: pb.LIFECYCLE_INTENT_STAGE_VALIDATING,
-                pb.DRAIN_LIFECYCLE_STATUS_DRAINING: pb.LIFECYCLE_INTENT_STAGE_DRAINING,
-                pb.DRAIN_LIFECYCLE_STATUS_FINALIZING: pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
-                pb.DRAIN_LIFECYCLE_STATUS_FLUSHING: pb.LIFECYCLE_INTENT_STAGE_FLUSHING,
-                pb.DRAIN_LIFECYCLE_STATUS_DRAINED: pb.LIFECYCLE_INTENT_STAGE_FLUSHING,
-                pb.DRAIN_LIFECYCLE_STATUS_FAILED: pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
-            }.get(status, pb.LIFECYCLE_INTENT_STAGE_FINALIZING)
-            self.transition(
-                intent_id,
-                transition_status,
-                transition_stage,
-                reason=(
-                    pb.LIFECYCLE_WAIT_REASON_TENANT_WORK
-                    if int(status) == pb.DRAIN_LIFECYCLE_STATUS_DRAINING
-                    else pb.LIFECYCLE_WAIT_REASON_UNSPECIFIED
-                ),
-                deadline_at_unix_ms=deadline_at_unix_ms,
-                error_code=error_code,
-                detail=detail,
-            )
-            goal_id = state.goal_id
-        else:
-            goal_id = self._drain.goal_id or f"legacy-drain-{self.worker_session_id}"
-            intent_id = self._drain.intent_id or goal_id
+        state = self._intents[intent_id]
+        transition_status = {
+            pb.DRAIN_LIFECYCLE_STATUS_ACCEPTED: pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,
+            pb.DRAIN_LIFECYCLE_STATUS_DRAINING: pb.LIFECYCLE_INTENT_STATUS_WAITING,
+            pb.DRAIN_LIFECYCLE_STATUS_FINALIZING: pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+            pb.DRAIN_LIFECYCLE_STATUS_FLUSHING: pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+            pb.DRAIN_LIFECYCLE_STATUS_DRAINED: pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED,
+            pb.DRAIN_LIFECYCLE_STATUS_FAILED: pb.LIFECYCLE_INTENT_STATUS_FAILED,
+        }.get(status, pb.LIFECYCLE_INTENT_STATUS_FAILED)
+        transition_stage = {
+            pb.DRAIN_LIFECYCLE_STATUS_ACCEPTED: pb.LIFECYCLE_INTENT_STAGE_VALIDATING,
+            pb.DRAIN_LIFECYCLE_STATUS_DRAINING: pb.LIFECYCLE_INTENT_STAGE_DRAINING,
+            pb.DRAIN_LIFECYCLE_STATUS_FINALIZING: pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
+            pb.DRAIN_LIFECYCLE_STATUS_FLUSHING: pb.LIFECYCLE_INTENT_STAGE_FLUSHING,
+            pb.DRAIN_LIFECYCLE_STATUS_DRAINED: pb.LIFECYCLE_INTENT_STAGE_FLUSHING,
+            pb.DRAIN_LIFECYCLE_STATUS_FAILED: pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
+        }.get(status, pb.LIFECYCLE_INTENT_STAGE_FINALIZING)
+        self.transition(
+            intent_id,
+            transition_status,
+            transition_stage,
+            reason=(
+                pb.LIFECYCLE_WAIT_REASON_TENANT_WORK
+                if int(status) == pb.DRAIN_LIFECYCLE_STATUS_DRAINING
+                else pb.LIFECYCLE_WAIT_REASON_UNSPECIFIED
+            ),
+            deadline_at_unix_ms=deadline_at_unix_ms,
+            error_code=error_code,
+            detail=detail,
+        )
+        goal_id = state.goal_id
         since = int(self._drain.since_unix_ms or now)
         next_drain = pb.DrainProjection(
             goal_id=goal_id,

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -786,8 +786,19 @@ def stored_cells(root: Optional[Path] = None) -> List[CellRecord]:
             continue
         if raw is None:
             continue
-        out.append(_record_of(
-            str(raw.get("compiled_graph_key") or entry.name), raw))
+        key = str(raw.get("compiled_graph_key") or "").strip()
+        if not key:
+            # A record REFUSES rather than borrowing the directory it sits in.
+            # `_record_payload` always writes the key, so a sidecar without one
+            # is not something this store wrote — and a fabricated identity is
+            # worse than an absent one here, because `cells_owed_to_sink` reads
+            # this listing and would hand the invented key to an upload.
+            logger.warning(
+                "local-cell-store: %s holds a record with no "
+                "compiled_graph_key; it is absent from this listing",
+                entry.name)
+            continue
+        out.append(_record_of(key, raw))
     return out
 
 

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -96,7 +96,9 @@ class WorkerResolvedRepo:
     # ...) — drives the local family lane policy. "" on hubs not sending it.
     # resolved objective and distillation value plus the
     # evidence status that distinguishes explicit false from unknown. Empty
-    # status is the backward-compatible shape from an older hub.
+    # status is NOT an old hub: the hub stamps the key only when the stored
+    # column is non-empty, so "" means nothing measured the axis — and only
+    # "classified" is evidence (`modelfamily.StoredCheckpointFacts`).
     objective: str = ""
     distilled: bool = False
     distilled_status: str = ""

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -93,7 +93,7 @@ from .api.decorators import EndpointDecl, NoWarmup
 from .api.errors import IllegalCombination
 from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
 import inspect
-from .api.slot import resolve_slot
+from .api.slot import resolve_slot, serving_contract_governs_slot
 from .api.binding import wire_ref
 from .request_context import RequestContext
 
@@ -887,7 +887,16 @@ def resolved_slots_kwargs(
     # failure is version-independent origin evidence and gets a typed label.
     # `selected_by` slots stay untyped — the payload picks there.
     declared: list = []
+    has_selectable = any(
+        str(getattr(s, "selected_by", "") or "").strip() for s in spec.slots.values())
     for name, slot in spec.slots.items():
+        # The contract governs the slot the pick lands on, not every slot the
+        # class declares — the same scoping both hub gates apply.
+        governed = serving_contract_governs_slot(
+            selected_by=str(getattr(slot, "selected_by", "") or ""),
+            family=spec.slot_family.get(name, ""),
+            function_has_selectable_slot=has_selectable,
+        )
         try:
             resolved[name] = resolve_slot(
                 name, slot,
@@ -899,8 +908,8 @@ def resolved_slots_kwargs(
                 objective=objectives.get(name, ""),
                 distilled=distilled_facts.get(name, False),
                 distilled_status=distilled_statuses.get(name, ""),
-                allowed_objectives=spec.objectives,
-                allowed_distilled=spec.distilled,
+                allowed_objectives=spec.objectives if governed else None,
+                allowed_distilled=spec.distilled if governed else None,
             )
         except ValueError as exc:
             errors[name] = str(exc)

--- a/tests/convert/test_publish_stamps_th1411.py
+++ b/tests/convert/test_publish_stamps_th1411.py
@@ -130,9 +130,16 @@ def test_unknown_source_distillation_is_not_authored_as_false(
     assert "distilled" not in req
 
 
-def test_old_hub_without_status_preserves_legacy_restatement(
+def test_absent_status_is_not_authored_as_false_either(
     fake_hub: Any, tmp_path: Path,
 ) -> None:
+    """pgw#1307 arm (4): an ABSENT `distilled_status` is one of the unknowns.
+
+    The hub omits the key whenever the stored column is empty, so absence
+    means "nothing measured the axis" — not "an old hub". Only `"classified"`
+    is evidence (`modelfamily.StoredCheckpointFacts`), so absence must not be
+    restated as an authored false on the derived checkpoint.
+    """
     body = _resolve_body(objective="", distilled=False)
     body.pop("distilled_status")
     _FakeHub.state["resolve_body"] = body
@@ -141,7 +148,7 @@ def test_old_hub_without_status_preserves_legacy_restatement(
 
     _publish(ctx, _tree(tmp_path))
 
-    assert _FakeHub.state["publish_request"]["distilled"] is False
+    assert "distilled" not in _FakeHub.state["publish_request"]
 
 
 def test_explicit_caller_override_wins(fake_hub: Any, tmp_path: Path) -> None:

--- a/tests/test_legacy_arms_pgw1307b.py
+++ b/tests/test_legacy_arms_pgw1307b.py
@@ -1,0 +1,251 @@
+"""pgw#1307 batch B — the arms deferred as "own lanes", executed.
+
+One test per cut, each red before its change:
+
+  * arm (3)  the serving contract's SCOPE, ported from the hub's one rule, and
+             the empty-status arm that made the backstop more permissive than
+             the authority it backstops;
+  * arm (7)  the fabricated ``legacy-drain-`` goal id on a projection the hub
+             reads — unreachable, because ``ensure_intent`` is total;
+  * arm (10) the duplicate-function-name error naming the WALKED module rather
+             than the declared one;
+  * arm (13) NOT a cut: the string-code error envelope is live on master's
+             hub, so this pins the shapes that keep it load-bearing;
+  * addendum a keyless cell record refuses instead of adopting its directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import msgspec
+import pytest
+
+from gen_worker import RequestContext, Slot, endpoint, worker_function  # noqa: E402
+
+
+class _In(msgspec.Struct, frozen=True):
+    x: str = ""
+    model: str = ""
+
+
+class _Out(msgspec.Struct, frozen=True):
+    y: str = ""
+
+
+# ---------------------------------------------------------------------------
+# arm (3): the serving contract governs the slot the pick lands on
+# ---------------------------------------------------------------------------
+
+
+def test_serving_contract_scope_mirrors_the_hubs_one_rule() -> None:
+    """`modelfamily.ServingContractGoverns`, term for term.
+
+    A selectable slot is always governed; a function that has one elsewhere
+    governs only that one; otherwise the slots that declared a family.
+    """
+    from gen_worker.api.slot import serving_contract_governs_slot as governs
+
+    assert governs(
+        selected_by="model", family="", function_has_selectable_slot=True)
+    assert not governs(
+        selected_by="", family="example", function_has_selectable_slot=True)
+    assert governs(
+        selected_by="", family="example", function_has_selectable_slot=False)
+    assert not governs(
+        selected_by="", family="", function_has_selectable_slot=False)
+
+
+def test_an_ungoverned_slot_is_never_asked_for_evidence() -> None:
+    """The contract governs the slot the pick lands on, not its siblings.
+
+    A function with a selectable slot governs only that one — so an auxiliary
+    slot (an interpolator, an upscaler) resolving to a checkpoint nothing has
+    classified must resolve cleanly. Before the scope was ported, that stamp
+    failed the WHOLE warmup for any function declaring `distilled=`.
+    """
+    from gen_worker import dispatch
+    from gen_worker.api.binding import HF
+    from gen_worker.registry import extract_specs
+    from gen_worker.warmup import resolved_slots_kwargs
+
+    @endpoint(
+        models={
+            "pipeline": Slot(
+                object, family="example", selected_by="model",
+                default_checkpoint=HF("acme/plain-xl")),
+            "interpolator": Slot(
+                object, family="example",
+                default_checkpoint=HF("acme/rife")),
+        }
+    )
+    class Gen:
+        def setup(self, pipeline: object, interpolator: object) -> None:
+            self.pipeline = pipeline
+            self.interpolator = interpolator
+
+        @worker_function(distilled=False)
+        def render(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(y="ok")
+
+    spec = extract_specs(Gen)[0]
+    slots = {
+        "pipeline": dispatch.SlotOrder(
+            ref="acme/plain-xl", distilled=False,
+            distilled_status="classified"),
+        "interpolator": dispatch.SlotOrder(
+            ref="acme/rife", distilled=False, distilled_status="unclassified"),
+    }
+
+    result = resolved_slots_kwargs(spec, slots)
+
+    assert "interpolator" not in result["slot_errors"], result["slot_errors"]
+    assert "interpolator" in result["resolved_slots"]
+    # …and the slot the pick DOES land on is still governed.
+    assert "pipeline" in result["resolved_slots"]
+
+
+# ---------------------------------------------------------------------------
+# arm (7): no fabricated goal id reaches a projection the hub reads
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_intent_is_total_so_a_drain_never_fabricates_a_goal_id() -> None:
+    from gen_worker.lifecycle_intents import IntentRegistry
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+
+    reg = IntentRegistry("release-1", ["render"])
+    # No hub-authored drain command has ever arrived: the worker-local carrier
+    # is what must answer, and it must be a real minted intent.
+    assert reg.ensure_intent(pb.DESIRED_INTENT_KIND_DRAIN)
+
+    reg.set_drain(pb.DRAIN_LIFECYCLE_STATUS_DRAINING)
+    snapshot = reg.snapshot()
+
+    assert snapshot.drain.goal_id
+    assert not snapshot.drain.goal_id.startswith("legacy-drain-")
+    assert snapshot.drain.intent_id in {s.intent_id for s in snapshot.intents}
+
+
+def test_the_legacy_drain_spelling_exists_nowhere_in_the_package() -> None:
+    """The source fence: the arm was UNREACHABLE, so only a text check can
+    tell the cut from the state before it."""
+    import gen_worker
+
+    root = Path(gen_worker.__file__).parent
+    offenders = [
+        str(p) for p in root.rglob("*.py")
+        if "legacy-drain-" in p.read_text(encoding="utf-8", errors="ignore")
+    ]
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# arm (10): the duplicate-name error names the DEFINING module
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_name_error_names_the_declared_module() -> None:
+    from gen_worker.discovery.discover import _assert_unique_function_names
+
+    functions = [
+        {"name": "generate", "class_name": "A",
+         "module": "pkg", "declared_module": "pkg.handlers.a"},
+        {"name": "generate", "class_name": "B",
+         "module": "pkg", "declared_module": "pkg.handlers.b"},
+    ]
+    with pytest.raises(ValueError) as exc:
+        _assert_unique_function_names(functions)
+
+    message = str(exc.value)
+    assert "pkg.handlers.a" in message
+    assert "pkg.handlers.b" in message
+
+
+# ---------------------------------------------------------------------------
+# arm (13): NOT residue — the string-code envelope is live on master's hub
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status: int, body: Any) -> None:
+        self.status_code = status
+        self.headers = {"Content-Type": "application/json"}
+        self._body = body
+
+    def json(self) -> Any:
+        return self._body
+
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        # internal/api/endpoint_bindings.go — bindingWriteError.write
+        (422, {"error": "binding_incompatible", "message": "family mismatch",
+               "issues": []}),
+        # internal/orchestrator/http/model_overrides.go — modelOverrideErrorBody
+        (400, {"error": "model_override_rejected", "code": "reserved_input_field",
+               "message": "resolved_models is reserved", "param": "models"}),
+        # internal/api/capability_upload_budget.go
+        (403, {"error": "forbidden", "code": "no_matching_grant",
+               "message": "no capability grant authorizes this upload"}),
+        (429, {"error": "grant_exhausted", "code": "grant_exhausted",
+               "message": "capability grant budget exhausted"}),
+    ],
+)
+def test_live_string_code_envelopes_are_hub_verdicts(status: int, body: Any) -> None:
+    """These four routes on master's hub emit the code as a STRING. Deleting
+    the shape-2 classifier as "old-hub residue" reinstates pgw#743 on every
+    one of them — a refusal retried until it becomes a different, later error.
+    """
+    from gen_worker.http_origin import is_definite_hub_answer, response_is_from_hub
+
+    resp = _Resp(status, body)
+    assert response_is_from_hub(resp)
+    assert is_definite_hub_answer(resp)
+
+
+# ---------------------------------------------------------------------------
+# addendum (cl#63's sibling): a keyless record refuses
+# ---------------------------------------------------------------------------
+
+
+def test_a_keyless_cell_record_refuses_instead_of_adopting_its_directory(
+    tmp_path: Path,
+) -> None:
+    from gen_worker import local_cell_store as store
+
+    root = tmp_path / "cache"
+    key = "ck1_" + "a" * 40
+    cell = store.cells_root(root) / key
+    cell.mkdir(parents=True)
+    (cell / store.RECORD_NAME).write_text(json.dumps({
+        "family": "example", "bytes": 12, "stored_at": 1.0,
+        "verdict": store.VERDICT_ADMITTED, "sink": store.SINK_OWED,
+    }))
+
+    listed = store.stored_cells(root)
+
+    assert [c.key for c in listed] == []
+    # And the identity never reaches an upload scan either.
+    assert store.cells_owed_to_sink(root) == []
+
+
+def test_a_keyed_record_still_lists(tmp_path: Path) -> None:
+    """The refusal above must not blank a healthy store."""
+    from gen_worker import local_cell_store as store
+
+    root = tmp_path / "cache"
+    key = "ck1_" + "b" * 40
+    cell = store.cells_root(root) / key
+    cell.mkdir(parents=True)
+    (cell / store.RECORD_NAME).write_text(json.dumps({
+        "compiled_graph_key": key, "family": "example", "bytes": 12,
+        "stored_at": 1.0, "verdict": store.VERDICT_ADMITTED,
+        "sink": store.SINK_OWED,
+    }))
+
+    assert [c.key for c in store.stored_cells(root)] == [key]
+    assert [c.key for c in store.cells_owed_to_sink(root)] == [key]

--- a/tests/test_objectives_pgw654.py
+++ b/tests/test_objectives_pgw654.py
@@ -242,19 +242,32 @@ def test_explicit_false_distillation_evidence_is_independent_of_objective() -> N
     assert resolved.distilled_status == "classified"
 
 
-def test_old_sender_unstamped_checkpoint_preserves_legacy_backstop() -> None:
-    # Empty status is only an older sender. Its fully unstamped binding keeps
-    # the rolling-upgrade behavior that predated the additive evidence field.
+def test_unstamped_checkpoint_fails_a_declared_contract_closed() -> None:
+    """pgw#1307 arm (3): an unstamped binding is not an old sender.
+
+    The hub omits `distilled_status` whenever the stored column is empty
+    (`slot_resolution.go` stamps it `if TrimSpace(...) != ""`), and its ONE
+    rule (`modelfamily.StoredCheckpointFacts`) counts only `"classified"` as
+    evidence — so both hub gates already refuse this binding. The backstop
+    used to PASS it, which made the worker more permissive than the authority
+    it backstops.
+    """
     from gen_worker.api.binding import HF
-    from gen_worker.api.slot import Slot, resolve_slot
+    from gen_worker.api.slot import ObjectiveMismatchError, Slot, resolve_slot
     from _example_family import ExampleDefaults
 
-    resolved = resolve_slot(
-        "pipeline", Slot(object), ref=HF("acme/plain-xl"),
-        defaults_cls=ExampleDefaults,
-        allowed_objectives=("epsilon",), allowed_distilled=False,
-    )
-    assert resolved.objective == ""
+    with pytest.raises(ObjectiveMismatchError, match="no training objective"):
+        resolve_slot(
+            "pipeline", Slot(object), ref=HF("acme/plain-xl"),
+            defaults_cls=ExampleDefaults,
+            allowed_objectives=("epsilon",),
+        )
+    with pytest.raises(ObjectiveMismatchError, match="unstamped"):
+        resolve_slot(
+            "pipeline", Slot(object), ref=HF("acme/plain-xl"),
+            defaults_cls=ExampleDefaults,
+            objective="epsilon", allowed_distilled=False,
+        )
 
 
 def test_unknown_distillation_status_is_rejected() -> None:
@@ -279,7 +292,11 @@ def test_wire_distillation_status_reaches_the_slot_backstop() -> None:
 
     @endpoint(
         models={
-            "pipeline": Slot(object, default_checkpoint=HF("acme/plain-xl")),
+            # A slot that opted into the family vocabulary — the serving
+            # contract governs exactly those (pgw#1307 arm (3)).
+            "pipeline": Slot(
+                object, family="example",
+                default_checkpoint=HF("acme/plain-xl")),
         }
     )
     class Gen:


### PR DESCRIPTION
Executes the pgw#1307 arms that were deferred as "own lanes" or as needing a
deployed-hub measurement, under the Paul 2026-08-17 ruling (pre-launch breakage
is free; transition-safety holds buy nothing, correctness and red/green still
bind).

## The finding that carried the batch

Arms (3)+(4) were deferred on *"whether the DEPLOYED hub always stamps
`distilled_status`, which is a fleet fact"*. It is not a fleet fact — it is in
the hub's source, and it says the opposite of what the arms assumed:

| question | authority | answer |
|---|---|---|
| does the hub always stamp it? | `slot_resolution.go:1016` | **no** — stamped only `if TrimSpace(...) != ""`, so `""` is a LIVE value |
| is `""` evidence? | `modelfamily.StoredCheckpointFacts` | **no** — `DistilledKnown` is `status == "classified"`, full stop |
| what does the hub do with it? | `modelfamily.ObjectiveCompatible` | **refuses** — a declared contract without evidence fails closed |
| does the contract govern every slot? | `modelfamily.ServingContractGoverns` | **no** — scoped at BOTH gates (`EffectiveBinding.ServingContractSlot`, `release.ServingContractGovernsSlot`) |

So the worker's backstop was wrong in both directions at once: too permissive on
the axis it was asked about (it passed bindings the hub already refuses), and
too strict on a scope nobody had ported (an `unclassified` stamp on an auxiliary
interpolator/upscaler slot failed the WHOLE warmup for any function declaring
`distilled=`). `serving_contract_governs_slot` ports the hub's rule term for
term; `warmup` asks only about the slots it admits; a governed slot with no
evidence for a declared axis now fails closed on both axes.

## Per-arm disposition

| # | arm | disposition |
|---|---|---|
| (3) | `slot.py` empty `distilled_status` skips the gate | **EXECUTED** + the scope port; objective axis fixed with it |
| (4) | `publish.py` empty status read as EVIDENCED | **EXECUTED** |
| (7) | fabricated `legacy-drain-` goal id | **EXECUTED** — unreachable (`ensure_intent` is total); source fence |
| (8) | protocol-v5 compat (~110 LOC) | **NOT CUT** — `RunJob` is live on the wire and `ensure_local_intent` has live callers in `executor`/`models.store`. Its precondition is the JOBS cut (pgw#1294/#1306), not fleet compat |
| (10) | `module`/`declared_module` precedence | **EXECUTED** — the duplicate-name error named the re-export site |
| (11) | `hardware_report` old-hub degrade | **EXECUTED (docs)** — no code branch existed; the arm was the docstring. The unreachable-hub degrade stays |
| (12) | `cli/local_context.py` untyped `kind` | **NOT MINE** — PR #852 (pgw#1294) is still open and owns the file |
| (13) | shape-2 classifier | **NOT RESIDUE** — see below |
| — | addendum: `stored_cells` `or entry.name` | **EXECUTED** |

## (13) is the one to read before deleting it later

Filed as an old-hub arm. Master's hub still emits `{"error": "<code>", …,
"message": …}` from four routes that never moved onto `httperrors.Write`:
`endpoint_bindings.go` (422), `modelOverrideErrorBody` (400), and
`capability_upload_budget.go` (403 + 429). Deleting the classifier reinstates
pgw#743 on all four — a diagnosable refusal retried until it becomes a
different, later error. The comment now names the live producers and a
parameterized fence carries their shapes. It dies when the HUB emits one
envelope everywhere, which is a tensorhub row.

## Verification

Every cut red-verified with the arm restored from `origin/master`, each red
distinguishable:

- addendum → `Left contains one more item: 'ck1_aaaa…'` (the adopted directory name)
- (7) → the source fence finds `legacy-drain-`
- (10) → `assert 'pkg.handlers.a' in "… (A in pkg, B in pkg)"`
- (3) → `DID NOT RAISE ObjectiveMismatchError` + the scope tests
- (4) → `assert 'distilled' not in {… 'distilled': False …}`

Green: `tests/test_legacy_arms_pgw1307b.py` (11), plus
`test_objectives_pgw654`, `test_publish_stamps_th1411`, `test_proxy_outage_pgw743`,
`test_intent_registry_th1085/th1283`, `test_auxiliary_slot_family_pgw747`,
`test_declared_slot_error_pgw763`, `test_optional_slots_th1226`,
`test_p3_slot_binding_precedence`, `test_p5_discovery_lock`,
`test_warmup_kind_collision_pgw1067`, `test_warmup_oneof_invariant_th1771`,
`test_reconcile_busy_pgw654`, `test_gw640_handler_launder`,
`test_store_split_pgw1283`, `test_identity_soundness_pgw1113`,
`test_wire_vocabulary_hardcut_pgw1278`.

`ruff check src/gen_worker` clean; `mypy` clean on all touched modules;
`lint_fence_symbols`, `lint_unreached_surface`, `lint_config_reads` and
`assemble_changelog --check` all exit 0. No deletions
(`git diff --diff-filter=D origin/master` empty). No version bump — the
coordinated release is the coordinator's.
