### PR TITLE
pgw#1309: the compile child's pid rides the wire

### DIFF
--- a/changelog.d/pgw1309.md
+++ b/changelog.d/pgw1309.md
@@ -1,0 +1,15 @@
+- **pgw#1309: the compile child's pid is a wire fact, not a pod log line.**
+  The pgw#1232 acceptance legs ask whether a compile ran in a CHILD or on the
+  serving process, and every half of the answer was pod-local: the child pid
+  was one `aot-pool: ... -> pid N` line and the serving pid lived in
+  `entrypoint._startup_payload`, on a pod that exposes no logs (pgw#760).
+  `EntryCompilePool` now emits `compile_child` events at spawn and at collect
+  (`phase=child:start` / `child:finish`), detail carrying `child_pid`,
+  `child_ppid`, `serving_pid`, `role`, the share and the packed
+  `compiled_graph_keys`; the FINISH row is emitted before every gate that can
+  raise, so a share that refused or OOM'd still leaves its pid evidence. The
+  serving process states its own pid and role once per sink bind as
+  `process_role`. `process_role.serving_pid()` answers 0 in any interpreter
+  that did not DECLARE itself serving — a compile child cannot pass its own pid
+  off as the serving one. No hub schema change: detail is free text and the
+  th#1839 route already serves it.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -206,6 +206,21 @@ KIND_AOT_MINT = "aot_mint_phases"
 # `measure_child.REASONS` token), `duration_ms` the run's wall, `detail` the
 # peaks in the mint's own vocabulary.
 KIND_MEASURE_ONLY = "measure_only"
+# pgw#1309: ONE compile child, at spawn and at collect. Same shape as
+# `aot_mint_phases`' child rows (`phase=child:start` / `child:finish`), its own
+# KIND because the two questions the pgw#1232 legs ask of it are PRESENCE
+# questions — "a compile ran, in a child, under this serving pid" on leg A and
+# "no compile ran at all" on B/C — and an absence assertion over a kind that
+# also carries width, ledger and per-class rows answers neither. `detail`
+# carries `child_pid` / `child_ppid` / `serving_pid` / `role` plus the packed
+# `compiled_graph_keys`, because no ActivityUpdate field holds a pid and the
+# th#1839 route serves `detail` verbatim (no hub change).
+KIND_COMPILE_CHILD = "compile_child"
+# pgw#1309: this process's own pid and role, stated once per sink bind. The
+# serving pid used to exist only in `entrypoint._startup_payload` and
+# `postmortem.write_boot_record`, both pod-local, so "no compile under the
+# serving PID" was unassertable off-pod even with the child rows above.
+KIND_PROCESS_ROLE = "process_role"
 # th#1322: the roll-up phase both mint routes report their TOTAL under. A
 # reader groups on (kind, phase) and must never sum a roll-up together with
 # its own children.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -731,6 +731,12 @@ class EntryReport(msgspec.Struct, frozen=True, kw_only=True):
 COMPILED = "compiled"
 REFUSED = "refused"
 
+#: pgw#1309: the two compile-child pid rows. START at `Popen`, FINISH at
+#: collect — before any gate can raise, so a share that refused, OOM'd or was
+#: reaped at its terminus still leaves the pid evidence the pgw#1232 legs read.
+PHASE_CHILD_START = "child:start"
+PHASE_CHILD_FINISH = "child:finish"
+
 EXIT_COMPILED = 0
 EXIT_REFUSED = 2
 EXIT_BAD_JOB = 4
@@ -1300,9 +1306,14 @@ class EntryCompilePool:
         logger.info(
             "aot-pool: %s (rows[%d::%d]) -> pid %s",
             job.share, job.share_index, job.share_count, proc.pid)
-        return _Running(
+        row = _Running(
             entry=job.share, proc=proc, job=job,
             started=started, stderr_path=stderr_path, spawn_epoch=spawn_epoch)
+        self._emit_child_pids(
+            row, PHASE_CHILD_START,
+            extra=f"rows[{job.share_index}::{job.share_count}] "
+                  f"function={job.function or '?'}")
+        return row
 
     # -- the run ----------------------------------------------------------
 
@@ -1576,6 +1587,36 @@ class EntryCompilePool:
         except Exception:  # pragma: no cover — telemetry never fails a mint
             logger.debug("aot-pool: width emission failed", exc_info=True)
 
+    def _emit_child_pids(
+        self, row: _Running, phase: str, *,
+        extra: str = "", duration_ms: int = 0,
+    ) -> None:
+        """pgw#1309: this compile child's pids, hub-visible.
+
+        ``aot-pool: %s -> pid %s`` proved nothing off a serve pod (pgw#760),
+        so "the compile ran in a child and not on the serving process" — the
+        pgw#1232 legs' whole PID axis — could not be checked without pod logs.
+        ``child_ppid`` and ``serving_pid`` are separate facts on purpose: the
+        first is this process by construction (it called ``Popen``), the second
+        is 0 unless this process DECLARED itself the serving one, so a pool
+        driven from anywhere else cannot silently pass as serving evidence.
+        """
+        try:
+            from . import activity as activity_mod
+            from . import process_role
+
+            activity_mod.emit_event(
+                activity_mod.KIND_COMPILE_CHILD,
+                f"share={row.entry} child_pid={row.proc.pid} "
+                f"child_ppid={os.getpid()} {process_role.facts()}"
+                + (f" {extra}" if extra else ""),
+                phase=phase,
+                family=str(row.job.cfg.family or ""),
+                duration_ms=duration_ms,
+            )
+        except Exception:  # pragma: no cover — telemetry never fails a mint
+            logger.debug("aot-pool: child pid event failed", exc_info=True)
+
     def _emit_ledger(self) -> None:
         """The pool's own typed event. Separate from the mint's roll-up on
         purpose: pool idle is not a mint phase, and a reader who groups them
@@ -1712,6 +1753,15 @@ class EntryCompilePool:
             # that packed every one of its graph classes would be reported as
             # a signal death and its artifacts thrown away.
             code = EXIT_COMPILED if report.status == COMPILED else EXIT_REFUSED
+        # pgw#1309: BEFORE the gates below, every one of which can raise.
+        keys = [str(c.key) for c in (report.classes if report else ())]
+        self._emit_child_pids(
+            row, PHASE_CHILD_FINISH,
+            extra=(
+                f"status={report.status if report else 'no_report'} "
+                f"exit={code} classes={len(keys)} "
+                f"compiled_graph_keys={','.join(keys) or '-'}"),
+            duration_ms=int(round(elapsed * 1000)))
         if report is not None:
             # pgw#877: banked BEFORE any gate can raise, and on the failure
             # path too — pgw#848's rule for the host half applies unchanged

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -41,6 +41,7 @@ from . import cpu_budget
 from . import measured_posture as posture_mod
 from . import mint_workers
 from . import settings_authority
+from . import process_role
 from . import progress as progress_mod
 from . import serve_posture
 from . import serving_mode as serving_mode_mod
@@ -4410,6 +4411,13 @@ class Executor:
             activity_mod.bind_sink(self._send, asyncio.get_running_loop())
         except RuntimeError:
             pass
+        else:
+            # pgw#1309: THIS is the serving process — it holds the session the
+            # compile children's pid rows are read beside. Declared where the
+            # transport is bound, so the fact and the wire that carries it
+            # arrive together.
+            process_role.declare(process_role.ROLE_SERVING)
+            process_role.emit_boot_role()
         rec = self._class_record(spec)
         async with self._setup_singleflight(spec, rec) as intent_id:
             if rec.ready and not rec.stale:

--- a/src/gen_worker/process_role.py
+++ b/src/gen_worker/process_role.py
@@ -1,0 +1,68 @@
+"""pgw#1309: WHICH process this interpreter is, and its pid, as a wire fact.
+
+The pgw#1232 acceptance legs have to answer one question off-pod: did the
+inductor compile run in a CHILD, or on the process that serves tenants? Every
+half of the answer was pod-local — the compile child's pid is one
+``aot_compile_pool`` log line and the serving pid lives in
+``entrypoint._startup_payload`` — and a serve pod exposes no logs (pgw#760).
+
+The role is DECLARED by the process that knows it (the serving loop, at sink
+bind), never inferred. An interpreter that never declared answers ``unknown``
+and a serving pid of ``0``: a compile child volunteering its own pid as the
+serving one is exactly the confusion the legs exist to rule out.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+#: The process that holds the orchestrator session, serves tenant requests and
+#: supervises compile children (`mint_supervisor`, two tiers since pgw#1215).
+ROLE_SERVING = "serving"
+ROLE_UNKNOWN = "unknown"
+
+_role = ROLE_UNKNOWN
+
+
+def declare(role: str) -> None:
+    global _role
+    _role = str(role or ROLE_UNKNOWN)
+
+
+def role() -> str:
+    return _role
+
+
+def serving_pid() -> int:
+    """This process's pid IF it is the serving one, else 0 (== not known here)."""
+    return os.getpid() if _role == ROLE_SERVING else 0
+
+
+def facts() -> str:
+    """The pid half of every pgw#1309 event, in one spelling."""
+    return f"serving_pid={serving_pid()} role={_role}"
+
+
+def emit_boot_role() -> None:
+    """One event stating the serving pid and this process's role.
+
+    Emitted at every sink bind rather than once per interpreter: the fact is
+    boot-scoped but the transport is not, and a reconnect must not cost the
+    fleet the one row legs B/C assert "no compile ran under this pid" against.
+    Never raises — telemetry never breaks the process it describes.
+    """
+    try:
+        from . import activity as activity_mod
+
+        activity_mod.emit_event(
+            activity_mod.KIND_PROCESS_ROLE,
+            f"{facts()} pid={os.getpid()} ppid={os.getppid()} "
+            f"boot_unix={time.time():.0f}",
+            phase=_role,
+        )
+    except Exception:  # pragma: no cover — telemetry never fails a boot
+        logger.debug("process role event failed", exc_info=True)

--- a/tests/test_activity_gw601.py
+++ b/tests/test_activity_gw601.py
@@ -83,8 +83,11 @@ def test_executor_setup_emits_monotonic_activity_phases():
     # The boot-forward roll-up is a self-contained EVENT under its
     # own kind, not part of this activity's phase envelope. This assertion
     # read as "one activity" only because the two used to share a kind.
+    # pgw#1309's boot row (this process's pid and role) rides the same bind
+    # and is likewise not part of the phase envelope.
     assert {u.kind for u in ups} <= {
-        activity.KIND_WARMUP, activity.KIND_WARMUP_SUMMARY}
+        activity.KIND_WARMUP, activity.KIND_WARMUP_SUMMARY,
+        activity.KIND_PROCESS_ROLE}
     ups = [u for u in ups if u.kind == activity.KIND_WARMUP]
     seqs = [u.seq for u in ups]
     assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), seqs

--- a/tests/test_compile_child_pids_pgw1309.py
+++ b/tests/test_compile_child_pids_pgw1309.py
@@ -1,0 +1,257 @@
+"""pgw#1309: the compile child's pids have to reach the hub, not a pod log.
+
+The pgw#1232 acceptance legs ask one question the fleet could not answer off a
+serve pod (pgw#760): did this compile run in a CHILD, or on the process that
+serves tenants? The child pid lived in one ``aot-pool: ... -> pid N`` log line
+and the serving pid in ``entrypoint._startup_payload``, both pod-local, and
+``worker_activity_events`` — the one channel a leg harness reads — carried no
+pid at all.
+
+Both halves are driven for real here. The pool half spawns REAL child
+processes through the real ``EntryCompilePool`` (the compile INTERIOR is
+``harness.fake_compile_child``, a separate executable: this box forbids local
+inductor, and a mocked spawn would produce no second pid to compare against)
+and reads the events back off a bound sink as ``ActivityUpdate`` envelopes. The
+boot half runs the real ``Executor.ensure_setup``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+import msgspec
+import pytest
+
+from gen_worker import Resources, activity, endpoint, process_role
+from gen_worker import aot_compile_pool as pool
+from gen_worker.child_contract import CompileSpec
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+from harness import fake_compile_child
+
+torch = pytest.importorskip("torch")
+
+_DECLARED = 4
+
+
+@pytest.fixture(autouse=True)
+def _isolated_role():
+    """The role is process-global by design; a suite must not leak it."""
+    before = process_role.role()
+    yield
+    process_role.declare(before)
+    activity.reset_for_tests()
+
+
+class _In(msgspec.Struct):
+    prompt: str = "x"
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+def _detail(update: pb.ActivityUpdate) -> Dict[str, str]:
+    """``k=v`` pairs out of one event's detail — the harness's own read."""
+    return dict(re.findall(r"(\w+)=(\S+)", update.detail))
+
+
+def _run_pool_with_a_bound_sink(tmp_path: Path, workers: int) -> List[Any]:
+    """Drive a real K-wide pool with the wire bound, return the updates."""
+    sent: List[pb.ActivityUpdate] = []
+    loop = asyncio.new_event_loop()
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        if msg.WhichOneof("msg") == "activity_update":
+            sent.append(msg.activity_update)
+
+    width = pool.entry_workers(
+        _DECLARED, limit=workers, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    assert width.workers == workers, width.reason
+    box = pool.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=fake_compile_child.script(tmp_path))
+    try:
+        activity.bind_sink(_send, loop)
+        packed = box.compile(pool.EntryJob(
+            function="generate",
+            cfg=CompileSpec(family="sdxl"),
+            modules=("harness.toy_endpoints",),
+            out_dir=str(tmp_path / "artifacts")))
+        assert len(packed) == _DECLARED, packed
+        loop.run_until_complete(asyncio.sleep(0.05))
+    finally:
+        activity.reset_for_tests()
+        loop.close()
+    return sent
+
+
+def test_a_compile_childs_pids_reach_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every share emits START and FINISH rows naming the REAL child pid, the
+    parent that spawned it, and the serving pid it is not.
+
+    The pids are checked against the ones the pool actually spawned — a spy on
+    the real ``_spawn``, not a stub of it — because an event carrying a
+    plausible-looking number that belongs to no process would satisfy
+    ``child_pid != serving_pid`` while proving nothing.
+    """
+    monkeypatch.setenv("PGW_FAKE_CHILD", "ok")
+    monkeypatch.setenv("PGW_FAKE_DECLARED", str(_DECLARED))
+    process_role.declare(process_role.ROLE_SERVING)
+
+    spawned: List[int] = []
+    real_spawn = pool.EntryCompilePool._spawn
+
+    def _spy(self: Any, job: Any, job_path: Path) -> Any:
+        row = real_spawn(self, job, job_path)
+        spawned.append(row.proc.pid)
+        return row
+
+    monkeypatch.setattr(pool.EntryCompilePool, "_spawn", _spy)
+
+    updates = _run_pool_with_a_bound_sink(tmp_path, workers=2)
+
+    rows = [u for u in updates if u.kind == activity.KIND_COMPILE_CHILD]
+    starts = [u for u in rows if u.phase == pool.PHASE_CHILD_START]
+    finishes = [u for u in rows if u.phase == pool.PHASE_CHILD_FINISH]
+    assert len(spawned) == 2 and len(set(spawned)) == 2, spawned
+    assert len(starts) == 2 and len(finishes) == 2, (
+        f"the compile children's pids did not reach the wire: "
+        f"{[(u.kind, u.phase) for u in updates]}")
+
+    serving = os.getpid()
+    for row in starts + finishes:
+        facts = _detail(row)
+        assert int(facts["serving_pid"]) == serving > 0, facts
+        assert facts["role"] == process_role.ROLE_SERVING, facts
+        # The point of the whole issue: the compile did not run here.
+        assert int(facts["child_pid"]) != int(facts["serving_pid"]), facts
+        assert int(facts["child_ppid"]) == serving, facts
+        assert row.family == "sdxl", row.family
+    assert {int(_detail(u)["child_pid"]) for u in starts} == set(spawned)
+    assert {int(_detail(u)["child_pid"]) for u in finishes} == set(spawned)
+    # Graph-keyed: a leg can join a pid row to the artifact it produced.
+    for row in finishes:
+        facts = _detail(row)
+        assert facts["status"] == pool.COMPILED, facts
+        keys = facts["compiled_graph_keys"].split(",")
+        assert keys and all(k.startswith("ek1-") for k in keys), facts
+        assert int(facts["classes"]) == len(keys), facts
+        assert row.duration_ms > 0, "the child's wall is the span this measures"
+    # The union of the pid rows' keys is the cell the mint packed.
+    assert sorted(
+        k for u in finishes
+        for k in _detail(u)["compiled_graph_keys"].split(",")
+    ) == sorted(f"ek1-cls-dim={i}" for i in range(_DECLARED))
+
+
+def test_a_refusing_share_still_leaves_its_pid_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The FINISH row is emitted before every gate that can raise.
+
+    A share that died is exactly the one whose pid a leg needs — and
+    ``_collect`` raises on that path, so an event emitted after the gates would
+    exist only for mints that succeeded.
+    """
+    monkeypatch.setenv("PGW_FAKE_CHILD", "die")
+    monkeypatch.setenv("PGW_FAKE_DECLARED", str(_DECLARED))
+    process_role.declare(process_role.ROLE_SERVING)
+
+    sent: List[pb.ActivityUpdate] = []
+    loop = asyncio.new_event_loop()
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        if msg.WhichOneof("msg") == "activity_update":
+            sent.append(msg.activity_update)
+
+    width = pool.entry_workers(
+        _DECLARED, limit=2, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    box = pool.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=fake_compile_child.script(tmp_path))
+    try:
+        activity.bind_sink(_send, loop)
+        with pytest.raises(pool.EntryCompileFailed):
+            box.compile(pool.EntryJob(
+                function="generate",
+                cfg=CompileSpec(family="sdxl"),
+                modules=("harness.toy_endpoints",),
+                out_dir=str(tmp_path / "artifacts")))
+        loop.run_until_complete(asyncio.sleep(0.05))
+    finally:
+        activity.reset_for_tests()
+        loop.close()
+
+    finishes = [
+        u for u in sent
+        if u.kind == activity.KIND_COMPILE_CHILD
+        and u.phase == pool.PHASE_CHILD_FINISH]
+    assert finishes, (
+        "the share that FAILED left no pid row — the one case a leg needs")
+    facts = _detail(finishes[0])
+    assert int(facts["child_pid"]) != os.getpid(), facts
+    assert int(facts["serving_pid"]) == os.getpid(), facts
+
+
+def test_the_serving_pid_and_role_are_stated_at_boot() -> None:
+    """One event per sink bind, off the REAL executor setup path.
+
+    Legs B and C assert "no compile ran under the serving PID". Without this
+    row they have no PID to assert it about: the number existed only in the
+    startup log payload and the postmortem boot record, both pod-local.
+    """
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    @endpoint(resources=Resources(gpu=True))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx: Any, payload: _In) -> _Out:
+            return _Out(y="ok")
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _send)
+
+    async def _go() -> None:
+        await ex.ensure_setup(specs[0])
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+    process_role.declare(process_role.ROLE_UNKNOWN)
+    asyncio.run(_go())
+
+    rows = [
+        m.activity_update for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == activity.KIND_PROCESS_ROLE]
+    assert rows, "the serving process never stated its pid or its role"
+    facts = _detail(rows[0])
+    assert int(facts["serving_pid"]) == os.getpid(), facts
+    assert facts["role"] == process_role.ROLE_SERVING == rows[0].phase, facts
+    assert int(facts["ppid"]) == os.getppid(), facts
+    # And the declaration is what the pool's rows then read.
+    assert process_role.serving_pid() == os.getpid()
+
+
+def test_an_undeclared_process_never_passes_itself_off_as_serving() -> None:
+    """A compile child that emitted one of these must answer 0, not its own
+    pid — otherwise "child_pid != serving_pid" is satisfiable by a compile
+    running in the wrong process entirely."""
+    process_role.declare(process_role.ROLE_UNKNOWN)
+    assert process_role.serving_pid() == 0
+    assert "serving_pid=0" in process_role.facts()

--- a/tests/test_progress_gw621.py
+++ b/tests/test_progress_gw621.py
@@ -199,8 +199,13 @@ def test_hub_sees_cpu_quiet_download_then_confession(monkeypatch):
 
         # Local behavior unchanged (the hub owns the kill): setup finishes
         # after the freeze and the activity completes normally.
+        # KIND-scoped, because a self-contained EVENT is also a COMPLETED
+        # envelope: this used to match whichever landed first, and pgw#1309's
+        # `process_role` row (emitted at sink bind, before setup runs at all)
+        # made "an activity completed" true while setup was still going.
         conn.wait_for(
             lambda m: m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == activity.KIND_WARMUP
             and m.activity_update.state
             == pb.ActivityState.ACTIVITY_STATE_COMPLETED,
             timeout=20,


### PR DESCRIPTION
Unblocks the pgw#1232 three-leg acceptance, which hard-stops at preflight (6):
*"Capture the serving PID/role before inference and enable graph-keyed
compile-child start/finish telemetry carrying child PID and PPID."* Both halves
were pod-local, on a pod that exposes no logs (pgw#760) — the child pid was one
`aot-pool: ... -> pid N` line, the serving pid lived in
`entrypoint._startup_payload` / `postmortem.write_boot_record`, and
`worker_activity_events` (the one channel a leg harness reads) carried no pid.

## What lands

**`compile_child`** — one row per compile child at `Popen` and at collect,
`phase=child:start` / `child:finish` (the shape `aot_mint_phases`' child rows
already use). Detail: `share=<share-NNN> child_pid=<n> child_ppid=<n>
serving_pid=<n> role=<role>`, plus on start `rows[i::K] function=<fn>` and on
finish `status=<compiled|refused|no_report> exit=<code> classes=<n>
compiled_graph_keys=<k1,k2,...>`. Typed `family` field; `duration_ms` carries
the child's wall.

Its own KIND rather than a phase of `aot_mint_phases`: legs B/C assert an
ABSENCE ("no compile ran under the serving pid"), and an absence over a kind
that also carries width, ledger and per-class rows answers nothing. The FINISH
row is emitted BEFORE every gate in `_collect` that can raise, so the share that
refused or OOM'd — the one a leg most needs — still leaves its pid evidence.

**`process_role`** — this process's pid and role, stated once per sink bind
(`phase=<role>`, detail `serving_pid=<n> role=serving pid=<n> ppid=<n>
boot_unix=<t>`). Declared by the serving loop where the transport is bound,
never inferred: `process_role.serving_pid()` answers `0` in any interpreter that
did not declare itself serving, so a compile child cannot pass its own pid off
as the serving one and satisfy `child_pid != serving_pid` vacuously.

No hub schema change — detail is free text and the th#1839 route already serves
it.

## Evidence

`tests/test_compile_child_pids_pgw1309.py` drives a real K-wide
`EntryCompilePool` through REAL child processes (`harness.fake_compile_child` —
the compile INTERIOR is stubbed because this box forbids local inductor; the
spawn, the reap and the report decode are not) with the wire bound, and reads
the events back as `ActivityUpdate` envelopes. The emitted pids are checked
against the ones the pool actually spawned (a spy on the real `_spawn`, not a
stub), because a plausible number belonging to no process would satisfy
`child_pid != serving_pid` while proving nothing. The boot row is asserted off a
real `Executor.ensure_setup`.

Mutation audit, each re-run 5 times:

| mutation | result |
|---|---|
| `_emit_child_pids` returns immediately | red 5/5 (2 tests) |
| `process_role.emit_boot_role()` deleted from `ensure_setup` | red 5/5 |
| `serving_pid()` returns `os.getpid()` unconditionally | red 5/5 |
| FINISH row emitted only when `code == EXIT_COMPILED` | red 5/5 (the refusal test) |

Local: mypy clean (761 files), ruff clean, all eight `fast gates` script guards
pass, and the 24 `ensure_setup`- and pool-touching test files re-run green
(`test_activity_gw601`'s kind-set assertion widened for the new boot row).
`tests/test_finalize_wedge_pgw1243.py` did not finish locally — it does not
finish on unmodified `master` either on this box under load ~138, so it is not
this branch's; CI carries it.

**No release is cut here** (pgw#1309 item 4): a leg runs only a PUBLISHED wheel
through an endpoint image, so this rides the next cut + image-rebuild train.