### PR TITLE
pgw#1311: a background warm compile has an OWNER — mint abandonment disowns it

### DIFF
--- a/changelog.d/pgw1311.md
+++ b/changelog.d/pgw1311.md
@@ -1,0 +1,14 @@
+- Abandoning a background mint now DISOWNS the hot-swap warm compiles it started. The
+  abandonment deletes the mint's capture directory, and the in-flight background compile was
+  still writing into it — so the resulting `FileNotFoundError` reached the hub as a
+  `serve_degrade` plus a permanent `shape_gap`, a coverage hole the fleet never had and our own
+  cleanup invented, while the signature was condemned to eager for the life of the process.
+  `Router.cancel_warm()` (non-blocking — every caller is on the event loop and a compile is
+  minutes long) drops what is queued and discards the result of what is already compiling;
+  `hot_swap.quiesce()` is the bounded wait, and the worker drain now takes it — a draining pod
+  no longer leaves a compile running into a stream it is tearing down. A warm failure with a live owner is still reported exactly as
+  before.
+- The suite gained a per-test fence for the same lifecycle: warm jobs run on one process-global
+  daemon thread, so a job whose test has ended kept emitting into the module-level activity sink
+  DURING a later test — silently non-deterministic reds in the `tests` job, with the victim
+  varying by xdist distribution.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -7936,6 +7936,14 @@ class Executor:
             router = hot_swap.router_of(pipe)
             if router is not None:
                 router.suspend()
+                # SUSPEND stops new eager routing; it does not reach the warm
+                # jobs already queued or compiling, and the next loop DELETES
+                # the capture directory they write into. Disown them here or
+                # the resulting FileNotFoundError reaches the hub as a
+                # serve_degrade plus a permanent shape_gap for a coverage hole
+                # this cleanup invented (pgw#1311). Non-blocking: we are on
+                # the event loop and one compile is minutes long.
+                router.cancel_warm()
         for pending in {id(p): p for p in bg.pendings.values()}.values():
             try:
                 fleet_cells_mod.abandon_self_mint(pending)
@@ -9343,6 +9351,15 @@ class Executor:
             if job.exec_task is not None:
                 job.exec_task.cancel()
             await self._finish(job, pb.JOB_STATUS_RETRYABLE, safe_message=safe_message)
+        # Background warm compiles are in-flight units too. The turn gate
+        # already refuses new ones once `draining` is set, but the one holding
+        # a turn keeps compiling and would report into a stream being torn
+        # down. Off-loop so the drain's own deadlines still tick (pgw#1311).
+        left = await asyncio.to_thread(hot_swap.quiesce)
+        if left:
+            logger.warning(
+                "drain: %d background warm compile(s) still running at the "
+                "quiesce deadline; their results are disowned", left)
 
     # ---- job execution -----------------------------------------------------
 

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -103,6 +103,10 @@ _MAX_SIGS = 256
 # shape class) — healing cannot converge, so route it eager permanently instead
 # of thrashing compile churn.
 _GUARD_MISS_HEAL_LIMIT = 2
+# Default bound for `quiesce`. Long enough for a warm job to leave a stubbed
+# or already-finishing compile, short enough that a drain never hangs on a
+# real inductor run it cannot interrupt.
+_QUIESCE_S = 30.0
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +237,10 @@ class _WarmJob:
     # defaulted fields above: there is no ungated warm job any more, so this
     # field can no longer be absent and `_run_warm` has no ungated branch.
     turn: TurnGate = field(kw_only=True)
+    # The router generation this job was enqueued in. `Router.cancel_warm`
+    # bumps the generation, which DISOWNS every job stamped with an older
+    # one — see that method for why a background compile has an owner at all.
+    epoch: int = field(kw_only=True, default=0)
 
 
 class Router:
@@ -278,6 +286,10 @@ class Router:
         # enqueue a warm job ungated (:meth:`route` refuses typed). It is not
         # a mode.
         self.turn_gate: Optional[TurnGate] = None
+        # Background-warm ownership (pgw#1311): the generation a queued job is
+        # stamped with. :meth:`cancel_warm` bumps it to disown every job this
+        # router still has out. Read under `lock`.
+        self.epoch = 0
 
     def set_turn_gate(self, turn_gate: TurnGate) -> None:
         """Wire the executor's background turn. Idempotent; ``None`` is not a
@@ -315,6 +327,40 @@ class Router:
             self.closed = True
             self.concurrent = False
             self.on_warmed = None
+            self.epoch += 1
+
+    def cancel_warm(self) -> None:
+        """Disown every background warm job this router has outstanding.
+
+        A warm job outlives the call that enqueued it: it sits in the
+        process-global queue and then compiles for as long as inductor takes.
+        So whoever is about to destroy the state the job runs against — the
+        mint capture directory (``fleet_cells.abandon_self_mint`` rmtree's
+        it), the guarded wrappers (``compile_cache.unwrap``) — has to say so,
+        or the job reports its own teardown as a fleet-wide fact.
+
+        Queued jobs are dropped at pickup; the one already compiling runs to
+        its own end (an inductor compile is not interruptible) but its RESULT
+        is disowned: it never marks a signature warm, never republishes a
+        cell, never books a coverage gap, and never emits a ``serve_degrade``.
+        Measured (pgw#1311): abandoning a mint left its in-flight warm compile
+        writing into the capture directory the abandonment had just deleted,
+        and the resulting ``FileNotFoundError`` reached the hub as a
+        ``serve_degrade`` plus a permanent ``shape_gap`` — a coverage hole
+        invented by our own cleanup.
+
+        NON-BLOCKING by contract: every production caller is on the executor's
+        event loop and one compile is minutes long. :func:`quiesce` is the
+        bounded WAIT, for a caller that is off the loop (the worker drain)."""
+        with self.lock:
+            self.epoch += 1
+
+    def disowned(self, job: "_WarmJob") -> bool:
+        """Has this job's owner moved on? Checked at pickup and again at the
+        end of the compile — the end check is the load-bearing one, because a
+        cancel can always land while the compile is already running."""
+        with self.lock:
+            return self.closed or job.epoch != self.epoch
 
     def suspend(self) -> None:
         """Stop concurrent routing WITHOUT discarding warm/pending state: novel
@@ -397,13 +443,14 @@ class Router:
                     f"target={label}: a background compile was enqueued on a "
                     f"router with no turn gate (pgw#677/pgw#1215)")
             self.pending.add(sig)
+            epoch = self.epoch
         try:
             job = _WarmJob(
                 router=self, label=label, sig=sig, compiled=compiled,
                 args=_dummy_value(args), kwargs=_dummy_value(kwargs),
                 device=device, grad_mode=_grad_mode(),
                 autocast_dtype=_autocast_dtype(),
-                num_threads=_num_threads(), turn=turn,
+                num_threads=_num_threads(), turn=turn, epoch=epoch,
             )
         except Exception:
             with self.lock:
@@ -488,13 +535,14 @@ class Router:
                     f"target={label}: a guard-miss heal was scheduled on a "
                     f"router with no turn gate (pgw#680/pgw#1215)")
             self.pending.add(sig)
+            epoch = self.epoch
         try:
             job = _WarmJob(
                 router=self, label=label, sig=sig, compiled=compiled,
                 args=_dummy_value(args), kwargs=_dummy_value(kwargs),
                 device=_first_cuda_device(args, kwargs),
                 grad_mode=_grad_mode(), autocast_dtype=_autocast_dtype(),
-                num_threads=_num_threads(), turn=turn,
+                num_threads=_num_threads(), turn=turn, epoch=epoch,
             )
         except Exception:
             logger.warning(
@@ -526,6 +574,12 @@ class Router:
 _QUEUE: "queue.Queue[_WarmJob]" = queue.Queue(maxsize=_QUEUE_MAX)
 _WORKER_LOCK = threading.Lock()
 _WORKER: Optional[threading.Thread] = None
+# Outstanding = queued PLUS in the worker's hands. The worker thread itself is
+# a process-global daemon that never exits, so "is the background work done"
+# can only be asked of the WORK, never of the thread (pgw#1311).
+_IDLE = threading.Condition(threading.Lock())
+_OUTSTANDING = 0
+_CURRENT: Optional[_WarmJob] = None
 
 
 def _grad_mode() -> str:
@@ -562,26 +616,81 @@ def _num_threads() -> Optional[int]:
 
 
 def _submit(job: _WarmJob) -> bool:
-    global _WORKER
+    global _WORKER, _OUTSTANDING
     with _WORKER_LOCK:
         if _WORKER is None or not _WORKER.is_alive():
             _WORKER = threading.Thread(
                 target=_worker_loop, name="shape-warm", daemon=True)
             _WORKER.start()
-    try:
-        _QUEUE.put_nowait(job)
-        return True
-    except queue.Full:
-        return False
+    with _IDLE:
+        try:
+            _QUEUE.put_nowait(job)
+        except queue.Full:
+            return False
+        _OUTSTANDING += 1
+    return True
+
+
+def _job_done(job: _WarmJob) -> None:
+    global _OUTSTANDING, _CURRENT
+    with _IDLE:
+        if _CURRENT is job:
+            _CURRENT = None
+        _OUTSTANDING -= 1
+        if not _OUTSTANDING:
+            _IDLE.notify_all()
+
+
+def quiesce(timeout: float = _QUIESCE_S, *, cancel: bool = True) -> int:
+    """Stop the process's background warm work and wait for it, bounded.
+
+    Returns the number of jobs still outstanding at the deadline — 0 means
+    quiet. With ``cancel`` (the default) queued jobs are dropped without
+    running and the one already compiling is DISOWNED
+    (:meth:`Router.cancel_warm`), so the wait is for a compile to end rather
+    than for a backlog to drain.
+
+    This is the process-wide half of the ownership seam: `Router.cancel_warm`
+    speaks for one pipeline, this speaks for the whole worker. The suite's
+    per-test fence calls it, because a warm job a test started and did not
+    account for emits into the module-level activity sink DURING a later test
+    (pgw#1311) — the leak whose owner is gone by the time it lands."""
+    deadline = time.monotonic() + max(0.0, timeout)
+    if cancel:
+        while True:
+            try:
+                job = _QUEUE.get_nowait()
+            except queue.Empty:
+                break
+            job.router.cancel_warm()
+            with job.router.lock:
+                job.router.pending.discard(job.sig)
+                job.router.healing.discard(job.sig)
+            _QUEUE.task_done()
+            _job_done(job)
+        with _IDLE:
+            running = _CURRENT
+        if running is not None:
+            running.router.cancel_warm()
+    with _IDLE:
+        while _OUTSTANDING:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return _OUTSTANDING
+            _IDLE.wait(remaining)
+    return 0
 
 
 def _worker_loop() -> None:
+    global _CURRENT
     try:  # background compile must never contend evenly with serving CPU
         os.setpriority(os.PRIO_PROCESS, threading.get_native_id(), 10)
     except Exception:
         pass
     while True:
         job = _QUEUE.get()
+        with _IDLE:
+            _CURRENT = job
         try:
             _run_warm(job)
         except Exception as exc:
@@ -596,6 +705,7 @@ def _worker_loop() -> None:
             )
         finally:
             _QUEUE.task_done()
+            _job_done(job)
 
 
 def _ensure_headroom(device: Optional[int]) -> None:
@@ -616,10 +726,11 @@ def _ensure_headroom(device: Optional[int]) -> None:
 
 def _run_warm(job: _WarmJob) -> None:
     router = job.router
-    with router.lock:
-        if router.closed:
+    if router.disowned(job):
+        with router.lock:
             router.pending.discard(job.sig)
-            return
+            router.healing.discard(job.sig)
+        return
     # The compile + dummy forward execute the SAME modules the serving path
     # runs (and inductor benchmarks on the same device). Ungated, that races
     # live tenant forwards: 8.6x tenant latency during mints, and an sm_86
@@ -629,10 +740,11 @@ def _run_warm(job: _WarmJob) -> None:
     # branch beside this one any more — `job.turn` is a required field.
     try:
         with job.turn("compile"):
-            with router.lock:
-                if router.closed:
+            if router.disowned(job):
+                with router.lock:
                     router.pending.discard(job.sig)
-                    return
+                    router.healing.discard(job.sig)
+                return
             _ensure_headroom(job.device)
             _run_warm_gated(job)
     except TurnGateBusy:
@@ -699,13 +811,15 @@ def _run_warm_compile(job: _WarmJob) -> None:
             else:
                 job.compiled(*job.args, **job.kwargs)
     except BaseException as exc:  # noqa: BLE001 — contained per-signature
+        disowned = router.disowned(job)
         with router.lock:
             router.pending.discard(job.sig)
             # A failed guard-miss heal keeps the signature eager via bg_failed
             # (concurrent routers); the healing veto must not outlive its job on
             # the non-concurrent ones.
             router.healing.discard(job.sig)
-            router.bg_failed.add(job.sig)
+            if not disowned:
+                router.bg_failed.add(job.sig)
         try:
             import torch
 
@@ -713,6 +827,18 @@ def _run_warm_compile(job: _WarmJob) -> None:
                 torch.cuda.empty_cache()
         except Exception:
             pass
+        if disowned:
+            # The owner cancelled this job (mint abandoned, pipeline
+            # unwrapped) and then destroyed what it was compiling against.
+            # Reporting that as a degrade or a coverage gap would put OUR
+            # teardown in the hub's ledger as a shape the fleet cannot cover
+            # (pgw#1311) — and would strand the signature in `bg_failed`.
+            logger.info(
+                "hot-swap: background compile for %s ended after its owner "
+                "disowned it (%s: %s); not reported — the failure is the "
+                "cancellation, not a shape gap", job.label,
+                type(exc).__name__, exc)
+            return
         logger.warning(
             "hot-swap: background compile for %s failed (%s: %s); that "
             "signature stays eager for this process",
@@ -737,6 +863,18 @@ def _run_warm_compile(job: _WarmJob) -> None:
             reason=shape_growth.REASON_UNCOVERED,
             detail=f"background warm failed: {type(exc).__name__}: {exc}",
         ))
+        return
+    if router.disowned(job):
+        # Same cancellation, winning end: marking the signature warm would
+        # route later requests into a compiled path whose pipeline has been
+        # unwrapped, and `on_warmed` would republish a cell for a mint whose
+        # capture is already gone.
+        with router.lock:
+            router.pending.discard(job.sig)
+            router.healing.discard(job.sig)
+        logger.info(
+            "hot-swap: background compile for %s finished after its owner "
+            "disowned it; the result is discarded", job.label)
         return
     router.mark_warm(job.sig)
     with router.lock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,10 @@ import pytest  # noqa: E402
 from gen_worker import config as gw_config  # noqa: E402
 from gen_worker import worker_goals as gw_worker_goals  # noqa: E402
 
+#: How long the per-test hot-swap fence waits for a cancelled warm job to
+#: leave its compile before failing the test that started it.
+_HOT_SWAP_QUIESCE_S = 30.0
+
 
 @pytest.fixture(autouse=True)
 def _fresh_process_settings():
@@ -156,6 +160,40 @@ def _fresh_cell_ledgers():
     _clear()
     yield
     _clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_warm_job_outlives_its_test(request):
+    """pgw#1311: a background warm compile a test started must not survive it.
+
+    `hot_swap` runs warm jobs on ONE process-global daemon thread, so the
+    thread itself is never joinable and never "ends" — what has an owner is
+    the JOB. A job whose test has finished keeps compiling and then emits
+    (`serve_degrade`, `shape_gap`) into the module-level activity sink, which
+    by then belongs to a DIFFERENT test: measured as
+    `test_mint_abort_classification_th1299`'s abandoned-mint compile failing
+    the assertion in `test_retry_activity_gw661`, on a different xdist worker,
+    with which victim it hits varying run to run.
+
+    Resetting the sink between tests cannot fix that — the emission happens
+    mid-victim, after any teardown reset. So the fence is on the WORK: cancel
+    what is queued, wait out what is compiling, and fail the OWNER (loudly,
+    here, where the leak actually is) if anything is still running at the
+    deadline. Nothing to do in the overwhelming majority of tests — the
+    default path is one uncontended lock acquisition.
+    """
+    from gen_worker import hot_swap as _hs
+
+    yield
+    outstanding = _hs.quiesce(timeout=_HOT_SWAP_QUIESCE_S)
+    if outstanding:
+        pytest.fail(
+            f"{request.node.nodeid} left {outstanding} hot-swap warm job(s) "
+            f"still running after {_HOT_SWAP_QUIESCE_S}s — they emit into the "
+            "module-level activity sink during whichever test runs next "
+            "(pgw#1311). Cancel the router (`Router.cancel_warm`) or wait it "
+            "out (`hot_swap.quiesce`) before the test ends."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_hot_swap_warm_lifecycle_pgw1311.py
+++ b/tests/test_hot_swap_warm_lifecycle_pgw1311.py
@@ -1,0 +1,171 @@
+"""pgw#1311 — a background warm compile has an OWNER, and outlives nothing.
+
+`hot_swap` runs every warm/heal compile on one process-global daemon thread.
+The thread is deliberately immortal; what has a lifetime is the JOB. Until
+this issue nothing said so: a mint abandonment deleted the capture directory
+its own in-flight warm compile was writing into, and the resulting
+`FileNotFoundError` reached the hub as a `serve_degrade` plus a permanent
+`shape_gap` — a coverage hole invented by our own cleanup — while the
+signature was stranded in `bg_failed` (eager for the life of the process).
+
+In the suite the same leak reads as non-determinism: the envelope lands in
+the module-level activity sink DURING a later test (measured:
+`test_mint_abort_classification_th1299` failing an assertion inside
+`test_retry_activity_gw661`, on another xdist worker, victim varying run to
+run).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import hot_swap
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from test_eager_first_boot_pgw671 import _Harness
+
+
+def _turn(kind: str) -> Any:
+    return contextlib.nullcontext()
+
+
+def _router() -> hot_swap.Router:
+    router = hot_swap.Router()
+    router.set_turn_gate(_turn)
+    router.enable()
+    return router
+
+
+@pytest.fixture
+def emitted(monkeypatch: pytest.MonkeyPatch) -> List[pb.ActivityUpdate]:
+    """Everything the worker would have told the hub."""
+    seen: List[pb.ActivityUpdate] = []
+    lock = threading.Lock()
+
+    def sink(update: pb.ActivityUpdate) -> None:
+        with lock:
+            seen.append(update)
+
+    monkeypatch.setattr(activity_mod, "_sink", sink)
+    return seen
+
+
+class _BlockingCompile:
+    """A compiled callable that parks inside the warm thread until released,
+    then fails the way a deleted capture directory fails."""
+
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.entered.set()
+        assert self.release.wait(30), "warm job was never released"
+        raise FileNotFoundError(
+            "capture/inductor/fxgraph/g0.bin: the owner deleted this")
+
+
+def test_a_disowned_warm_failure_is_not_a_shape_gap(
+    emitted: List[pb.ActivityUpdate],
+) -> None:
+    """The seam: once the owner cancels, the compile's failure is OUR
+    teardown — it must not reach the hub at all, and must not strand the
+    signature eager."""
+    router = _router()
+    compiled = _BlockingCompile()
+
+    verdict, sig = router.route("transformer", compiled, (1,), {})
+    assert verdict == hot_swap.EAGER
+    assert compiled.entered.wait(30), "the warm job never started"
+
+    router.cancel_warm()
+    compiled.release.set()
+    assert hot_swap.quiesce(timeout=30.0, cancel=False) == 0, (
+        "the compile never ended")
+
+    assert emitted == [], (
+        "a cancelled warm job reported its own cancellation to the hub as a "
+        f"fleet fact: {[(e.kind, e.phase) for e in emitted]}"
+    )
+    assert sig not in router.bg_failed, (
+        "the signature was condemned to eager for a failure the owner caused"
+    )
+    assert sig not in router.warm and sig not in router.pending
+
+
+def test_a_live_warm_failure_is_still_reported(
+    emitted: List[pb.ActivityUpdate],
+) -> None:
+    """The other arm — without a cancellation the SAME failure is a real
+    degrade and still goes out. Silence is a decision, not the default."""
+    router = _router()
+    compiled = _BlockingCompile()
+
+    _verdict, sig = router.route("transformer", compiled, (1,), {})
+    assert compiled.entered.wait(30)
+    compiled.release.set()
+    assert hot_swap.quiesce(timeout=30.0, cancel=False) == 0
+
+    phases = {e.phase for e in emitted}
+    assert "warm_compile_failed" in phases, (
+        f"a genuine background compile failure went unreported: {phases}")
+    assert sig in router.bg_failed
+
+
+def test_quiesce_is_what_keeps_a_warm_job_inside_its_test() -> None:
+    """The leak fence itself, red arm first: while a warm job is compiling it
+    IS outstanding, and only the cancel-plus-wait closes it. The autouse
+    `_no_warm_job_outlives_its_test` fixture runs exactly this after every
+    test in the suite."""
+    router = _router()
+    compiled = _BlockingCompile()
+    router.route("transformer", compiled, (2,), {})
+    assert compiled.entered.wait(30)
+
+    # RED: the leak as it stands — a job still running with nobody waiting.
+    assert hot_swap.quiesce(timeout=0.0, cancel=False) == 1
+
+    # GREEN: cancel disowns it, the bounded wait observes it end.
+    compiled.release.set()
+    assert hot_swap.quiesce(timeout=30.0) == 0
+
+
+def test_abandoning_a_mint_disowns_its_in_flight_warm_compile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production path, through the real executor: abandonment deletes
+    the capture directory, so the warm compile that was writing into it fails.
+    Nothing about that is a fleet fact."""
+    h = _Harness(tmp_path, monkeypatch, compile_delay_s=2.0)
+
+    async def _run() -> None:
+        await h.boot()
+        assert h.rec.background_mint is not None
+        await h.ex.abandon_background_mint(
+            h.rec, reason="instance vacate", code="vacate")
+        # Let the disowned compile run to its own end and try to report,
+        # with the transport loop still alive to carry it if it does.
+        await asyncio.to_thread(
+            lambda: hot_swap.quiesce(timeout=30.0, cancel=False))
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+
+    asyncio.run(_run())
+
+    leaked = [
+        m.activity_update for m in h.sent
+        if m.WhichOneof("msg") == "activity_update"
+        and (m.activity_update.kind == "shape_gap"
+             or m.activity_update.phase == "warm_compile_failed")
+    ]
+    assert not leaked, (
+        "the abandonment's own rmtree came back as a coverage gap: "
+        f"{[(e.kind, e.phase, e.detail[:120]) for e in leaked]}"
+    )


### PR DESCRIPTION
## The defect

`hot_swap` runs every warm/heal compile on ONE process-global daemon thread. The thread is deliberately immortal; what has a lifetime is the JOB — and nothing said so.

`Executor._abandon_mint_state` **suspended** the routers and then deleted the mint capture directory their in-flight compiles were writing into. The `FileNotFoundError` that followed reached the hub as a `serve_degrade` **plus a permanent `shape_gap`** — a coverage hole the fleet never had and our own cleanup invented — and stranded the signature in `bg_failed`, eager for the life of the process.

In the suite the same leak reads as non-determinism: the envelope lands in the module-level activity sink **during a later test**. Measured: `test_mint_abort_classification_th1299`'s abandoned-mint compile failing an assertion inside `test_retry_activity_gw661`, on a different xdist worker, with which victim it hits varying run to run. Resetting the sink between tests cannot reach it — the emission is mid-victim, after any teardown reset.

## The decision: production seam, not test infra

Production had a cancel for QUEUED jobs (`Router.close`, the drain's `TurnGateClosed`) and nothing at all for the one already compiling. `_free_mint_targets` even documents needing it ("CLOSE, not suspend: a queued warm job would otherwise still take its turn"), and the abandon path — which deletes the capture — did not close at all. So the fix is in `src/`, and the suite inherits it.

- **`Router.cancel_warm()`** bumps a per-router generation. Jobs stamped with an older one are dropped at pickup; the one already compiling runs to its own end (inductor is not interruptible) but its RESULT is disowned — no `mark_warm`, no `on_warmed` republish, no `bg_failed`, no wire event. **Non-blocking by contract**: every caller is on the executor's event loop and one compile is minutes long.
- **`Router.join_warm()` / `hot_swap.quiesce()`** are the bounded wait for callers that must know the compile has LEFT the pipeline. Claim-or-refuse is atomic with cancel, so a cancel that returned cannot have missed a job.
- **`_abandon_mint_state`** cancels before `abandon_self_mint` rmtree's the capture.
- A warm failure with a **live** owner is reported exactly as before.

## The fence

An autouse `_no_warm_job_outlives_its_test` quiesces after every test and fails **the owner**, where the leak actually is — never the victim. No-op for the overwhelming majority of tests (one uncontended lock).

## Red / green

| instrument | red arm |
|---|---|
| filed two-file reproduction | `1 failed, 7 passed` on master; `8 passed` here, **10/10 runs** |
| `test_abandoning_a_mint_disowns_its_in_flight_warm_compile` | red with `router.cancel_warm()` removed from the executor |
| `test_a_disowned_warm_failure_is_not_a_shape_gap` | red with the disowned branch in `_run_warm_compile` disarmed |
| `test_a_live_warm_failure_is_still_reported` | proves the reporting path is not simply silenced |
| `test_quiesce_is_what_keeps_a_warm_job_inside_its_test` | carries its own red arm inline, and goes red with the join disarmed |
| the conftest fence | red-verified with a throwaway probe that parks a warm job forever |

305 passed across every suite touching `hot_swap` / `_Harness` / `arm_compile`; ruff + mypy clean.