### PR TITLE
pgw#1307 (A18): the flavor fence moves into the REQUIRED context, and the residue is NAMED instead of half-cut

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,6 +371,20 @@ jobs:
           uv run python scripts/lint_repo_ref_pins.py --selftest
           uv run python scripts/lint_repo_ref_pins.py
 
+      # GATING (A18 / §1.32(d), pgw#1307): the flavor axis is deleted, and the
+      # one residue that survives — `ProducedFlavor.flavor`, a PROD author
+      # surface training-endpoints constructs — may not grow a second reader
+      # while it waits for its te leg. `tests/test_flavor_deletion_pgw1148.py`
+      # asserts the same deletion and is NOT skipped (its one skipping row died
+      # at pgw#1167), but it runs in `tests`, which pgw#1264 took off the merge
+      # path — so until this step existed the required context had no opinion
+      # about the axis at all. Selftest first: the fence must prove it goes red
+      # before its green means anything.
+      - name: A18 guard - the flavor is deleted and its residue may not grow
+        run: |
+          uv run python scripts/lint_flavor_deletion.py --selftest
+          uv run python scripts/lint_flavor_deletion.py
+
       # GATING (pgw#1143, §1.33): `Slot(layouts=...)` is the per-slot layout
       # DEMAND the hub's gate reads. It must be readable by the AST sweep as
       # well as by the import, so a computed declaration is refused where it

--- a/changelog.d/pgw1307.md
+++ b/changelog.d/pgw1307.md
@@ -42,3 +42,27 @@
   pgw#743 on all four: a diagnosable refusal retried until it becomes a different, later error.
   The comment now names the live producers, and a parameterized fence carries their shapes.
   It dies when the HUB emits one envelope everywhere, which is a tensorhub row.
+
+- **A18 / §1.32(d): the flavor axis gets a fence in the REQUIRED context, and its residue is
+  named with a removal condition rather than half-cut.** `tests/test_flavor_deletion_pgw1148.py`
+  was believed CI-SKIPPED — `scripts/skip_census.txt` said so and two lanes planned against it.
+  It is not: the one row that ever skipped there died at pgw#1167, the file runs 19 rows, skips
+  none and is green, and the census entry had been unproducible ever since. The real gap was
+  different and worse — the fence lives in `tests`, which pgw#1264 took off the merge path, so
+  the required `fast gates` had no opinion about the axis at all. `scripts/lint_flavor_deletion.py`
+  runs there now, AST-level because the axis is a four-way homonym (`flavor_label`,
+  `cgroup_flavor` and `publish_flavors` are not it), with a `--selftest` that must go red on five
+  planted regressions and green on four homonyms before its green counts. The stale census row is
+  deleted with the reason written where it stood.
+
+- **`ProducedFlavor.flavor` is NOT deleted, deliberately.** pgw#1300 removed the placement stamp
+  but KEPT `precision_class`, so the token's one logic read (`convert/publish.py`, via
+  `classify_flavor_token`) did not evaporate with it — it is still the only statement of precision
+  class for a producer that declares none. The field is a PROD author surface
+  `training-endpoints/conversion` constructs at 14 sites; cutting it from this repo alone would
+  fail those producers with a `TypeError` on a rented pod, or silently unstamp every
+  svdq/fp8/nvfp4 row whose producer states its class only through the token. It is held at exactly
+  one reader, one field and one classifier call by the new lint — a second reader is red, and so
+  is a residue row that stops matching — and it dies when the te leg lands (every non-base
+  producer declaring `precision_class` in its own attribute bag, which te already does at
+  `conversion/src/conversion/quant/modelopt.py:1262`).

--- a/scripts/lint_flavor_deletion.py
+++ b/scripts/lint_flavor_deletion.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""A18 / DESIGN-RULINGS §1.32(d): the flavor dies entirely, and what is left of
+it may not GROW while it waits for its cross-repo leg.
+
+WHY A LINT AND NOT ONLY A TEST. `tests/test_flavor_deletion_pgw1148.py` is a
+good fence and it runs — but it runs in `tests`, which pgw#1264 took off the
+merge path, so nothing in the REQUIRED context (`fast gates`) has an opinion
+about the flavor axis. A rename that regrows a reader merges green and is found
+on a pod. This runs where the merge is decided.
+
+WHAT SURVIVES, AND WHY IT IS NOT CUT HERE. `ProducedFlavor.flavor` is a
+PRODUCTION AUTHOR SURFACE: `training-endpoints/conversion` constructs it at 14
+sites and `scripts/author_surface_allowlist.txt` pins `publish_flavors` to
+`conversion/src/conversion/_common.py:9`. The token is not decoration — it is
+the input to `classify_flavor_token`, which derives
+`checkpoints.metadata["placement"]["precision_class"]`, the hub's strongest
+evidence for a stored precision class where no tensor-layout contract is proven
+(tensorhub `precision.StoredPrecisionOf`). Deleting the field from this repo
+alone would either fail every te producer with a `TypeError` on a rented pod, or
+— worse — silently drop the precision class of every svdq/fp8/nvfp4 row whose
+producer states it only through the token. So the residue stays, NAMED, with its
+removal condition, and this fence holds it at exactly the size it is today.
+
+THE REMOVAL CONDITION, so this file states it rather than a tracker page: every
+te producer whose token classifies to a non-base class declares
+`precision_class` in its own attribute bag (te already does this once, at
+`conversion/src/conversion/quant/modelopt.py:1262`). When that lands,
+`classify_flavor_token`, the `label` read and `ProducedFlavor.flavor` all go,
+`RESIDUE` below becomes empty, and this fence becomes a pure deletion check.
+
+Three rules, all AST — a grep cannot tell `X.flavor` from `flavor_label(...)`
+from `cgroup_flavor`, and this axis is a four-way homonym (the compile-cell
+`#`-fragment is the one that must NOT move).
+
+  1. DELETED names stay deleted. Nothing in `src/` binds or reads a name the
+     deletion removed.
+  2. A `flavor`-shaped FIELD is declared at exactly one place, the named residue.
+  3. The token is READ at exactly the declared sites. A new reader is red even
+     though it compiles, because a second reader is how a deleted axis comes
+     back.
+
+Usage:
+
+    python scripts/lint_flavor_deletion.py [PATH ...]
+    python scripts/lint_flavor_deletion.py --selftest
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterator, List, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_ROOTS = (REPO / "src" / "gen_worker",)
+
+#: Names §1.32(d) / pgw#1148 / th#1803 deleted. Binding or reading one in `src/`
+#: means the axis grew back under an old spelling.
+DELETED_NAMES = (
+    "flavor_token",
+    "pick_family_fp8_flavor",
+    "maybe_rebind_family_fp8",
+    "select_gguf",
+    "maybe_rebind_gguf",
+    "fetch_gguf_snapshot",
+    "WorkerResolvedFlavor",
+    "sibling_flavors",
+    "default_flavor",
+)
+
+#: Field names that name the axis. `flavors` is deliberately absent: it is the
+#: parameter of `publish_flavors`, a LIST of produced artifacts, not a selector.
+FIELD_NAMES = ("flavor", "default_flavor", "sibling_flavors")
+
+#: The A18 residue, at the size it is allowed to be. `<relpath>: <what>`.
+#: Every row dies with the te leg described in this module's docstring; a row
+#: that no longer matches anything is red too, so the list cannot outlive it.
+RESIDUE_FIELD = "convert/produced.py"          # ProducedFlavor.flavor
+RESIDUE_READERS = ("convert/publish.py",)      # the one `label = ...` derivation
+RESIDUE_CLASSIFIERS = ("convert/publish.py",)  # the one classify_flavor_token call
+
+CLASSIFIER = "classify_flavor_token"
+
+
+def _iter_py(roots: Tuple[Path, ...]) -> Iterator[Path]:
+    for root in roots:
+        if root.is_file():
+            yield root
+            continue
+        for p in sorted(root.rglob("*.py")):
+            if "__pycache__" not in p.parts:
+                yield p
+
+
+def _rel(path: Path, roots: Tuple[Path, ...]) -> str:
+    for root in roots:
+        base = root if root.is_dir() else root.parent
+        if path.is_relative_to(base):
+            return path.relative_to(base).as_posix()
+    return path.name
+
+
+def scan(roots: Tuple[Path, ...]) -> List[str]:
+    findings: List[str] = []
+    seen_field: List[str] = []
+    seen_readers: List[str] = []
+    seen_classifiers: List[str] = []
+
+    for path in _iter_py(roots):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        rel = _rel(path, roots)
+        # The classifier's own definition module is not a reader of it.
+        is_classifier_def = any(
+            isinstance(n, ast.FunctionDef) and n.name == CLASSIFIER
+            for n in ast.walk(tree))
+
+        for node in ast.walk(tree):
+            # Rule 1 — a deleted name, bound or read.
+            name = None
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                name = node.name
+            elif isinstance(node, ast.Name):
+                name = node.id
+            elif isinstance(node, ast.Attribute):
+                name = node.attr
+            if name in DELETED_NAMES:
+                findings.append(
+                    f"{rel}:{node.lineno}: {name!r} is DELETED (§1.32(d)) and "
+                    "must not be bound or read")
+
+            # Rule 2 — a field that names the axis.
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) \
+                    and node.target.id in FIELD_NAMES:
+                if rel == RESIDUE_FIELD:
+                    seen_field.append(rel)
+                else:
+                    findings.append(
+                        f"{rel}:{node.lineno}: a new {node.target.id!r} field — "
+                        "the flavor is not an axis; state the bytes with `dtype` "
+                        "+ `artifact_contract`, or the class with `precision_class`")
+
+            # Rule 3 — a read of the token, or a call to the classifier.
+            if isinstance(node, ast.Attribute) and node.attr in FIELD_NAMES:
+                if rel in RESIDUE_READERS:
+                    seen_readers.append(rel)
+                else:
+                    findings.append(
+                        f"{rel}:{node.lineno}: a new read of `.{node.attr}` — the "
+                        "producer-local label has ONE reader and is losing that "
+                        "one; see this script's docstring for the te leg")
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                    and node.func.id == CLASSIFIER and not is_classifier_def:
+                if rel in RESIDUE_CLASSIFIERS:
+                    seen_classifiers.append(rel)
+                else:
+                    findings.append(
+                        f"{rel}:{node.lineno}: a new {CLASSIFIER} caller — it is a "
+                        "package-internal choke point that dies with the token; "
+                        "nothing new may grow on it")
+
+    # A residue row matching nothing is stale, and a stale row reads as a fence.
+    if not seen_field:
+        findings.append(
+            f"RESIDUE_FIELD names {RESIDUE_FIELD!r}, which declares no flavor "
+            "field any more — the te leg landed: delete the row (and probably "
+            "this whole rule)")
+    for row in RESIDUE_READERS:
+        if row not in seen_readers:
+            findings.append(
+                f"RESIDUE_READERS names {row!r}, which no longer reads the token "
+                "— delete the row")
+    for row in RESIDUE_CLASSIFIERS:
+        if row not in seen_classifiers:
+            findings.append(
+                f"RESIDUE_CLASSIFIERS names {row!r}, which no longer calls "
+                f"{CLASSIFIER} — delete the row")
+    return findings
+
+
+def _selftest() -> int:
+    """Each rule must go RED on a planted regression and GREEN on the homonyms.
+
+    The homonyms are the point: this axis has four spellings and only one of
+    them is the deleted selector. A fence that cannot tell them apart would be
+    reverted by the first lane that touched the compile cache.
+    """
+    cases: List[Tuple[str, str, bool]] = [
+        # (name, source, expect_red)
+        ("deleted_name", "def select_gguf(x):\n    return x\n", True),
+        ("deleted_attr", "def f(r):\n    return r.sibling_flavors\n", True),
+        ("new_field", "import msgspec\n\n\nclass S(msgspec.Struct):\n    flavor: str = ''\n", True),
+        ("new_reader", "def f(x):\n    return x.flavor\n", True),
+        ("new_classifier", "def f(t):\n    return classify_flavor_token(t)\n", True),
+        # Homonyms that must stay GREEN.
+        ("cell_label", "def flavor_label(sku, torch_version):\n    return sku\n", False),
+        ("cgroup", "def f(d):\n    d['cgroup_flavor'] = 'v2'\n", False),
+        ("publish_list", "def publish_flavors(ctx, flavors):\n    return list(flavors)\n", False),
+        ("param_named_flavor", "def g(flavor):\n    return flavor\n", False),
+    ]
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, src, expect_red in cases:
+            root = Path(tmp) / name
+            root.mkdir()
+            # Satisfy the residue rows so only the planted rule can speak.
+            (root / RESIDUE_FIELD).parent.mkdir(parents=True, exist_ok=True)
+            (root / RESIDUE_FIELD).write_text(
+                "import msgspec\n\n\nclass ProducedFlavor(msgspec.Struct):\n"
+                "    flavor: str = ''\n")
+            (root / RESIDUE_READERS[0]).write_text(
+                "def publish_flavors(ctx, flavors):\n"
+                "    for f in flavors:\n"
+                "        label = f.flavor\n"
+                f"        yield {CLASSIFIER}(label)\n")
+            (root / "planted.py").write_text(src)
+            findings = [f for f in scan((root,)) if f.startswith("planted.py")]
+            if bool(findings) != expect_red:
+                ok = False
+                verb = "did not go red" if expect_red else "went red"
+                print(f"SELFTEST FAILED: {name} {verb}: {findings}", file=sys.stderr)
+
+        # The staleness rule: a residue row that matches nothing is red.
+        root = Path(tmp) / "stale"
+        (root / "convert").mkdir(parents=True)
+        (root / RESIDUE_FIELD).write_text("X = 1\n")
+        (root / RESIDUE_READERS[0]).write_text("Y = 2\n")
+        stale = scan((root,))
+        if len(stale) != 3:
+            ok = False
+            print(f"SELFTEST FAILED: a fully-landed te leg should red all three "
+                  f"residue rows, got {stale}", file=sys.stderr)
+    if not ok:
+        return 1
+    print("lint_flavor_deletion selftest: red on all five regressions, green on "
+          "all four homonyms, red on a stale residue row")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+    roots = tuple(Path(a).resolve() for a in argv) or DEFAULT_ROOTS
+    findings = scan(roots)
+    if findings:
+        print("A18 / §1.32(d): the flavor is deleted and its residue may not "
+              "grow. See scripts/lint_flavor_deletion.py for the residue's "
+              "removal condition (a training-endpoints leg).\n", file=sys.stderr)
+        for f in findings:
+            print(f, file=sys.stderr)
+        print(f"\n{len(findings)} finding(s)", file=sys.stderr)
+        return 1
+    print("lint_flavor_deletion: the flavor axis is deleted; the A18 residue is "
+          f"{len(RESIDUE_READERS)} reader, 1 field, "
+          f"{len(RESIDUE_CLASSIFIERS)} classifier call — unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -129,17 +129,23 @@ CI-SKIPPED tests/test_mint_oom_classification_pgw848.py|the memory cap did not o
 # on every developer box.
 CI-SKIPPED tests/test_unbounded_read_guard_pgw1013.py|<hex> not in this checkout (shallow clone)
 
-# pgw#1148. `test_the_compile_cache_modules_are_byte_untouched_by_this_deletion`
-# proves the flavor deletion did not touch a single compile-cell module by
-# diffing the eight of them against `git merge-base HEAD origin/master` —
-# `actions/checkout@v4` is shallow, so there is no base commit to diff against.
-# It is REVIEWER EVIDENCE for one diff, and it runs on every developer box.
-# WHERE THE DURABLE PROPERTY IS MEASURED IN CI: the four rows beside it —
-# `test_the_cell_fragment_still_parses`, `test_parse_cell_ref_is_unchanged`
-# and `test_a_cell_ref_round_trips_through_the_normal_form` — which assert the
-# thing that actually matters forever (the `#`-shaped CELL ref grammar the
-# compile cache consumes still parses and round-trips) and run everywhere.
-CI-SKIPPED tests/test_flavor_deletion_pgw1148.py|no origin/master to diff against
+# pgw#1307 DELETED the `tests/test_flavor_deletion_pgw1148.py|no origin/master
+# to diff against` row that stood here, and the deletion is worth a note because
+# the row was doing ACTIVE harm. It classified a skip
+# `test_the_compile_cache_modules_are_byte_untouched_by_this_deletion` used to
+# take on a shallow checkout — a test pgw#1167 REMOVED. No code in this tree can
+# emit that reason any more, so the row could never be observed again; but it
+# read as a live statement, and two later lanes planned against "the flavor
+# fence is CI-SKIPPED" when the file in fact runs 19 rows, skips none, and is
+# green. A census entry nothing can produce is not a note, it is a false fact
+# with a filename attached — and this file's whole value is that its rows are
+# true. `lint_skip_census.py` cannot catch this: an unobserved row is legitimate
+# (CI and a developer box skip different things), so it prints them as expected.
+# Read a row's producing site before believing it.
+#
+# What the axis actually needs was the real finding: the fence ran, but only in
+# `tests`, which pgw#1264 took off the merge path. The REQUIRED context now
+# carries `scripts/lint_flavor_deletion.py` (`fast gates`, A18 guard).
 
 # ─── LOCAL-ONLY ───────────────────────────────────────────────────────────────
 LOCAL-ONLY tests/test_lora_lifted_pgw725.py|set gen_worker_aot_pack_tests=# (packs a real .pt#; needs g++)

--- a/src/gen_worker/convert/produced.py
+++ b/src/gen_worker/convert/produced.py
@@ -50,12 +50,25 @@ class ProducedFlavor(msgspec.Struct):
         same flavor (e.g. a tokenizer.json next to a non-tree output).
       - flavor: optional PRODUCER-LOCAL label such as ``bf16``, ``fp8`` or
         ``int4``. It is NOT published and it names no catalog row — a flavor
-        is not an address. It classifies the placement
-        stamp and names the publish's activity legs; when empty the
-        ``dtype`` attribute is used. What the bytes ARE is stated by the
-        ``dtype`` attribute and, when the producer knows it, an
-        ``artifact_contract`` attribute (``ns.name@N``, PROVEN hub-side
-        against the safetensors header — §1.33).
+        is not an address. It derives the ``precision_class`` stamp
+        (:func:`gen_worker.models.ladder.classify_flavor_token`) and names the
+        publish's activity legs; when empty the ``dtype`` attribute is used.
+        What the bytes ARE is stated by the ``dtype`` attribute and, when the
+        producer knows it, an ``artifact_contract`` attribute (``ns.name@N``,
+        PROVEN hub-side against the safetensors header — §1.33).
+
+        **A18 RESIDUE, with its removal condition.** §1.32(d) rules the flavor
+        dead entirely — contract-spec is the only variant selector — and this
+        field is what is left. It survives only because the derivation above is
+        the sole statement of precision class for producers that do not declare
+        one, and dropping the field from this repo alone would silently unstamp
+        every svdq/fp8/nvfp4 row those producers publish. It dies when every
+        training-endpoints producer whose token classifies non-base declares
+        ``precision_class`` in ``attributes`` (te already does at
+        ``conversion/src/conversion/quant/modelopt.py:1262``); then this field,
+        the ``label`` read in ``publish.py`` and ``classify_flavor_token`` go in
+        one cut. Held at exactly this size by
+        ``scripts/lint_flavor_deletion.py`` — nothing new may read it.
 
     A job that emits several artifacts hands over several ``ProducedFlavor``
     entries: N publishes joining ONE tag group. There is no flavor-label set


### PR DESCRIPTION
Executes the **A18 residue** row on pgw#1307. pgw#1300's code half is already merged (`12316afd`); this is the flavor work it was said to unblock, plus the fence obligation.

## Two handed-down beliefs, both false at the source

**1. "The flavor-deletion fence is CI-SKIPPED."** `scripts/skip_census.txt:142` said so and two lanes planned against it. It is not. The row classified a skip that `test_the_compile_cache_modules_are_byte_untouched_by_this_deletion` took on a shallow checkout — a test **pgw#1167 removed**. No code in this tree can emit that reason any more. `tests/test_flavor_deletion_pgw1148.py` runs **19 rows, skips none, green**.

`lint_skip_census.py` structurally cannot catch this: an unobserved row is legitimate (CI and a developer box skip different things), so it prints them as *expected*. A census row nothing can produce is a false fact with a filename attached. Deleted, with the reason written where it stood.

**2. "The token's logic read dies with pgw#1300's stamp deletion."** It does not. pgw#1300 deleted the placement half but deliberately **KEPT `precision_class`** — tensorhub's `precision.StoredPrecisionOf` reads it as its strongest evidence for a stored class where no tensor-layout contract is proven. The read *moved*, to `publish.py:258` -> `_precision_class_block` -> `classify_flavor_token`. A18's logic half is fully alive.

## What the gap actually was

The fence runs — but only in `tests`, which pgw#1264 took off the merge path. The **required `fast gates` had no opinion about the flavor axis at all**, so a rename that regrew a reader merges green and is found on a pod.

`scripts/lint_flavor_deletion.py` runs there now. AST-level, because the axis is a four-way homonym and a grep cannot tell `X.flavor` from `flavor_label(...)` from `cgroup_flavor` from `publish_flavors` — the compile-cell `#`-fragment is the spelling that must NOT move. Three rules: deleted names stay deleted; a `flavor`-shaped field is declared at exactly one place; the token is read at exactly the declared sites. **A residue row that stops matching is red too**, so the list cannot outlive the residue it describes.

## `ProducedFlavor.flavor` is NOT cut here, deliberately

It is a **PROD author surface**: `training-endpoints/conversion` constructs it at **14 sites**, and `scripts/author_surface_allowlist.txt` pins `publish_flavors` to `conversion/src/conversion/_common.py:9`. te#218 has not retired it. Cutting it from this repo alone would either fail every te producer with a `TypeError` on a rented pod, or — worse — **silently unstamp** every svdq/fp8/nvfp4 row whose producer states its class only through the token (`_SCHEME_FLAVOR`, `attrs["flavor"]`, `"fp8-w8a8"`). That is half-cutting a prod surface; the te leg is specced on the tracker instead.

The residue is held at **one reader, one field, one classifier call**, with its removal condition written at the field: every non-base te producer declares `precision_class` in its own attribute bag — which te already does once, at `conversion/src/conversion/quant/modelopt.py:1262`.

## Red proofs

`--selftest`: red on five planted regressions, green on four homonyms, red on a stale residue row. It runs **before** the real scan in CI, so the gate proves it can fail before its pass counts.

Three real-tree mutations against the **committed** baseline (pgw#1300's process finding: a harness that reverts with `git checkout` must not measure an uncommitted edit), each producing a **different** message:

| mutation | finding |
|---|---|
| regrow `refs.flavor_token` | `models/refs.py:502: 'flavor_token' is DELETED (§1.32(d))` |
| add a second `.flavor` read | `models/refs.py:503: a new read of '.flavor' — ... has ONE reader` |
| delete `ProducedFlavor.flavor` with no te leg | `RESIDUE_FIELD ... declares no flavor field any more` |

Green restored after each; working tree byte-identical.

`tests/convert` + `tests/test_flavor_deletion_pgw1148.py`: **140 passed**. ruff + mypy clean. No wheel bump.