### PR TITLE
pgw#1315: the CPU rung EXECUTES — always-runs holds on a reactive descent, not just at plan time

### DIFF
--- a/changelog.d/pgw1315.md
+++ b/changelog.d/pgw1315.md
@@ -1,0 +1,61 @@
+- **The always-runs guarantee now holds on a REACTIVE descent, not only at plan time.** The degrade
+  ladder declared a `cpu` rung, priced it at 40x, and then refused to hand it out: `rung.descend`
+  stopped one rung ABOVE it and reported `FLOOR_CPU_RUNG_UNEXECUTABLE`, on which the executor
+  emitted a `serve_degrade` event saying *"the next one is `cpu`, which THIS BUILD CANNOT
+  EXECUTE"* and returned the request retryable. So the honest answer to *"does it always run?"* was
+  **yes at plan time, NO on a descent that reached the bottom** — and §1.35 amendment 2 is that
+  *"'This model does not run on this card' is never an acceptable terminal state."* The refusal was
+  correct in FORM (it named our build, never the card), which is exactly what made it actionable.
+  The build executes the rung now, and the token is DELETED rather than repointed.
+
+  `memory.apply_low_vram_config` grows a `cpu` mode: VAE/attention savers, the whole pipeline moved
+  to host RAM, no offload hook armed (every one of them onloads to a device, and this rung's premise
+  is that there is no usable one), rung stamped. `rung.CPU.touches_host_ram` becomes True, which is
+  what the rung IS — a CPU-placed pipeline keeps its whole tree on the host — so it joins
+  `PLACEMENT_LADDER`, is charged host RAM by the pgw#1063 admission, is refused the per-component
+  staging discount, and can be LEARNED as a per-ref degraded floor. That last one is the seam that
+  makes a descent stick: an instance that OOMs on `sequential` is now quarantined with `cpu` as its
+  floor, so the hub's retry reloads onto the rung instead of re-running the same failure.
+
+  Red-verified against `66706529` with nine cases, each failing distinguishably: the acceptance arm
+  (`place_pipeline` walking `off -> model_offload -> group_offload -> sequential -> cpu` and
+  SERVING) died on `RuntimeError: CUDA error: out of memory`, and the executor arm learned no floor
+  at all.
+
+- **A CPU placement is APPLIED, not described.** A cardless pod got a bare `{"mode": "cpu"}` back
+  from `place_pipeline` — a dict nobody had acted on, so `low_vram_mode()` read `""` and the
+  ladder's own view of that pipeline was *never placed*. It routes through the applier now, so plan
+  time and a reactive descent stamp ONE token. The sibling case (an offload rung requested where no
+  CUDA device is usable) stamped `vae_only`, describing a resident placement two rungs above where
+  the weights actually were; it stamps `cpu`.
+
+- **The host-move guard's refusal keeps its TYPE across the rollback seam.**
+  `_move_pipeline_to_cpu` swallowed `HostRamMoveRefusedError` into a DEBUG line, after which
+  `place_pipeline`'s rollback check resurfaced it as a generic
+  `RuntimeError("CUDA OOM left the pipeline mixed-device and CPU rollback failed")`. The one case
+  where `GEN_WORKER_HOST_MOVE_GUARD` legitimately stops a degrade — it refuses only a move that
+  would SIGKILL the worker anyway — was indistinguishable from a bug in our own rollback. The guard
+  is correct and stays ON by default; only the type propagates, carrying the provoking OOM as its
+  cause. The propagation is TYPE-scoped: every other move failure stays swallowed, because
+  `repair_device_placement` is what decides whether the rollback actually worked, and promoting all
+  of them to fatal would turn recoverable descents into refusals. Both halves are red-verified —
+  restoring the swallow reds the typed arm and leaves the untyped arm green.
+
+- **Two silences on the same path, found by touching it.** A mid-inference descent reported
+  `run_mode=RUN_OFFLOAD` hardcoded, so a descent onto the CPU rung would have reached the hub as
+  `ran="offload"` — a wrong measurement, not a coarse one, on a field the hub matches exactly. It
+  reads the rung's own projection (`rung.run_mode_of`) now. And `_record_placement_posture` had a
+  dead `if mode == "cpu"` arm setting `REASON_NO_CUDA`: it appended SECOND, and ledger appends are
+  idempotent per (name, component), so it was always dropped in favour of a `vram_shortfall` that
+  never happened. The reason is selected once, in one place.
+
+- **The new rung reports through pgw#1312's one confession home, not beside it.** `cpu` is a
+  CPU-touching rung by definition and the loudest degradation the ladder has, so it emits the same
+  single `serve_degrade` (`phase=cpu_offload_engaged`) every other host-touching activation does —
+  asserted off the REAL activity sink, so the test reads the `ActivityUpdate` a hub would bank. A
+  bottom rung that served silently would have re-opened the exact hole pgw#1312 closed one commit
+  earlier.
+
+  Bounded per the local-inference rule: logic only, no compile, no mint, no real model. The new
+  guards are deliberately torch-free — they drive `cuda_ready()`, which is what the code under test
+  actually asks — so they RUN on the CI runner instead of skipping on it.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2498,7 +2498,14 @@ class Executor:
                 # The rung ASKED FOR, when a descent moved off it. Absent on a
                 # proactive selection: nothing was asked, the fit decided.
                 wanted=str(placed.get("requested_mode") or ""),
+                # pgw#1315: a PROACTIVE cpu placement is `no_cuda` — there was
+                # no card to be short of. The separate `if mode == "cpu"` block
+                # that used to say so appended SECOND, and appends are
+                # idempotent per (name, component), so it was dropped in favour
+                # of a `vram_shortfall` that never happened. Silence is the
+                # pattern: the dead arm read as coverage.
                 reason=(posture_mod.REASON_CUDA_OOM if reactive
+                        else posture_mod.REASON_NO_CUDA if mode == "cpu"
                         else posture_mod.REASON_VRAM_SHORTFALL))
         if mode == "vae_only":
             # Resident, but NOT the same run: slicing changes the traced decode
@@ -2507,10 +2514,6 @@ class Executor:
             ledger.technique(
                 posture_mod.TECHNIQUE_VAE_SLICING, component="vae",
                 reason=posture_mod.REASON_VRAM_SHORTFALL)
-        if mode == "cpu":
-            ledger.technique(
-                posture_mod.TECHNIQUE_CPU, component=str(ref or ""),
-                reason=posture_mod.REASON_NO_CUDA)
         needed_gb = float(placed.get("fit_needed_gb") or 0.0)
         if needed_gb > 0.0:
             ledger.shortfall(posture_mod.ResourceShortfall.from_gb(
@@ -10440,12 +10443,18 @@ class Executor:
         if refused:
             transitions = []
         for ref, from_mode, to_mode, needed_gb in transitions:
+            # pgw#1315: the rung's OWN wire projection. The tail's `offload`
+            # token was hardcoded here, so a descent onto the CPU rung reached
+            # the hub as `ran="offload"` — a wrong measurement, not a coarse
+            # one, on the field the hub matches exactly.
+            run_mode = rungspec.run_mode_of(to_mode) or RUN_OFFLOAD
             self._record_rung_transition(
                 spec, ref=ref, phase="inference",
                 from_rung=from_mode or "resident", to_rung=to_mode,
-                run_mode=RUN_OFFLOAD, needed_gb=needed_gb,
+                run_mode=run_mode, needed_gb=needed_gb,
                 detail=f"CUDA OOM mid-inference ({type(exc).__name__}); "
-                       "quarantining this instance for a clean offloaded reload",
+                       f"quarantining this instance for a clean reload onto "
+                       f"the {to_mode} rung",
             )
         flush_memory()
         rec = self._classes.get(spec.instance_key)
@@ -10469,29 +10478,33 @@ class Executor:
             # proactive fit ladder deleted (an estimate deciding placement
             # before anything is measured — §4.33), this reactive walk is the
             # only ladder, so falling off its bottom must be a typed, visible
-            # refusal naming OUR code — never a silent slide into a rung
-            # nothing can run, which would convert a loud estimate-error into a
-            # quiet execution-error.
+            # event naming OUR code.
+            #
+            # pgw#1315 left exactly ONE floor to report. `cpu` EXECUTES now, so
+            # the walk no longer stops above it and there is no longer any rung
+            # this build declines to run. Reaching here means the pipeline is
+            # already standing on the bottom rung — a CUDA OOM on a pipeline
+            # that is not on the card is host-side pressure, and no further
+            # placement change can answer it.
             floors = {
                 rungspec.descent_floor(low_vram_mode(obj))
                 for obj in (self._slot_pipeline(spec, slot) for slot in spec.models)
                 if obj is not None
             }
             floors.discard(None)
-            if rungspec.FLOOR_CPU_RUNG_UNEXECUTABLE in floors:
+            if rungspec.FLOOR_LADDER_EXHAUSTED in floors:
                 activity_mod.emit_event(
                     activity_mod.KIND_SERVE_DEGRADE,
                     detail=(
-                        f"fn={spec.name}: the placement ladder descended to its "
-                        f"last executable rung (sequential) and the next one is "
-                        f"`cpu`, which THIS BUILD CANNOT EXECUTE — the reactive "
-                        f"walk treats it as plan-time only (pgw#1212). This is a "
-                        f"limitation of our worker, not of the card: §1.35 "
-                        f"requires every model to run on every device, CPU "
-                        f"included. The request returns retryable and the hub "
-                        f"re-places it."
+                        f"fn={spec.name}: the placement ladder is already on its "
+                        f"bottom rung (`cpu` — the whole pipeline is host "
+                        f"resident and serving there), so there is no lower "
+                        f"placement to descend to. The request returns retryable "
+                        f"and the hub re-places it. This names OUR ladder, not "
+                        f"the card: §1.35 requires every model to run on every "
+                        f"device, and on this one it already is."
                     ),
-                    phase=rungspec.FLOOR_CPU_RUNG_UNEXECUTABLE,
+                    phase=rungspec.FLOOR_LADDER_EXHAUSTED,
                 )
             logger.warning(transition_line(
                 event="engaged", fn=spec.name, phase="inference",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -13,6 +13,12 @@ Ladder (auto mode, least-aggressive first):
                   ``enable_model_cpu_offload()``                (~10% slower)
   group_offload : leaf-level group offload with CUDA streams   (~25% slower)
   sequential    : ``enable_sequential_cpu_offload()``          (~50%+ slower)
+  cpu           : the whole pipeline on the host, no device at all (~40x)
+
+``cpu`` is the bottom rung and it EXECUTES (pgw#1315). It is never selected by
+``auto`` — it is where a cardless pod starts and where a reactive descent that
+exhausted every offload rung ends. §1.35 amendment 2: *"even a pod without a
+GPU, heck; we can run it CPU only"*.
 
 Upstream foot-gun: ``enable_sequential_cpu_offload`` must NOT be called on a
 pipeline already moved to CUDA; ``apply_low_vram_config`` moves it back first.
@@ -30,6 +36,7 @@ from typing import Any, Dict, Iterable, List, Optional
 import msgspec
 
 from .. import activity as activity_mod
+from ..api.errors import HostRamMoveRefusedError
 from ..component_vocab import component_vocabulary
 from .structure_only import STAMP as _STRUCTURE_ONLY
 import asyncio
@@ -40,10 +47,11 @@ _LOG = logging.getLogger(__name__)
 
 _GIB = 1024 ** 3
 
-Mode = str  # "auto" | "off" | "vae_only" | "model_offload" | "group_offload" | "sequential"
+Mode = str  # "auto" | "off" | "vae_only" | "model_offload" | "group_offload" | "sequential" | "cpu"
 
 _VALID_MODES: tuple[str, ...] = (
     "auto", "off", "vae_only", "model_offload", "group_offload", "sequential",
+    "cpu",
 )
 
 _DEFAULT_MODEL_OFFLOAD_THRESHOLD_GB = 8.0
@@ -128,7 +136,9 @@ GPU_VRAM_OVERHEAD_GB = 1.0
 # walk, one price. This module keeps the probes and the appliers.
 from .rung import (
     PLACEMENT_LADDER,
+    RUN_CPU,
     descend as _descend_rung,
+    price as _rung_price,
     touches_host_ram,
     transition_line,
 )
@@ -1000,14 +1010,37 @@ def _call_if_present(obj: Any, method: str, **kwargs: Any) -> bool:
         return False
 
 
-def _move_pipeline_to_cpu(pipeline: Any) -> None:
+def _to_host(pipeline: Any) -> None:
+    """Move the pipeline to host RAM — best effort, with ONE failure that is
+    not best effort.
+
+    pgw#1315: ``HostRamMoveRefusedError`` used to be swallowed into a DEBUG
+    line, after which ``place_pipeline``'s rollback check resurfaced it as a
+    generic ``RuntimeError("… mixed-device … rollback failed")``. That erased
+    the one case where ``GEN_WORKER_HOST_MOVE_GUARD`` legitimately stops a
+    degrade — it refuses only a move that would SIGKILL the worker anyway — and
+    made it indistinguishable from a bug in our own rollback.
+
+    Every OTHER move failure stays swallowed, deliberately: this is a hygiene
+    step, and ``repair_device_placement`` is what decides whether the pipeline
+    actually came back coherent. Promoting all of them to fatal would turn
+    recoverable descents into refusals.
+    """
     try:
-        if not cuda_ready():
-            return
         if callable(getattr(pipeline, "to", None)):
             pipeline.to("cpu")
+    except HostRamMoveRefusedError:
+        raise
     except Exception as exc:
         _LOG.debug("low_vram: move-to-cpu failed: %s", exc)
+
+
+def _move_pipeline_to_cpu(pipeline: Any) -> None:
+    """Roll a partially-promoted pipeline back to the host. A no-op without
+    CUDA, where nothing was ever promoted off it."""
+    if not cuda_ready():
+        return
+    _to_host(pipeline)
 
 
 def _apply_vae_and_attention(
@@ -1299,7 +1332,13 @@ def place_pipeline(
     """
     log = logger or _LOG
     if not cuda_ready():
-        return {"mode": "cpu"}
+        # pgw#1315: the CPU rung is APPLIED here, not merely described. The
+        # bare `{"mode": "cpu"}` this used to return left `low_vram_mode()`
+        # reading `""` — the ladder's own view of the pipeline was "never
+        # placed", so a later transition could not tell the bottom rung from an
+        # unprepped object. Plan time and the reactive descent now stamp ONE
+        # token.
+        return apply_low_vram_config(pipeline, mode="cpu", logger=log)
     effective = select_auto_mode(pipeline=pipeline) if mode == "auto" else mode
     if mode == "auto":
         effective = _gguf_resident_override(pipeline, effective, log)
@@ -1364,7 +1403,16 @@ def place_pipeline(
             # component graph before the allocator raised. Offload hooks must
             # start from a coherent CPU object; attaching them to that partial
             # move creates the mixed-device fatal seen on live SDXL.
-            _move_pipeline_to_cpu(pipeline)
+            try:
+                _move_pipeline_to_cpu(pipeline)
+            except HostRamMoveRefusedError as refused:
+                # pgw#1315: the guard refusing this rollback and our rollback
+                # being BROKEN are different facts, and the generic
+                # mixed-device error below reported them as the same one. The
+                # guard is correct — it refuses only a move that would SIGKILL
+                # the worker — so its verdict travels, carrying the OOM that
+                # provoked the rollback as its cause.
+                raise refused from exc
             missed = repair_device_placement(pipeline, "cpu")
             if missed:
                 raise RuntimeError(
@@ -1485,6 +1533,22 @@ def apply_low_vram_config(
         setattr(pipeline, _COZY_MODE_ATTR, "off")
         return applied
 
+    if effective_mode == "cpu":
+        # THE BOTTOM RUNG, AND IT RUNS (pgw#1315). No hook is armed: every
+        # offload rung onloads to a device, and this rung's whole premise is
+        # that there is no usable one — either the pod is cardless or every
+        # rung above OOM'd. The savers still apply, because host RAM is now the
+        # constraint and tiled decode is what keeps a large VAE inside it.
+        _apply_vae_and_attention(pipeline, applied, memory_bound=True)
+        _to_host(pipeline)
+        flush_memory()
+        setattr(pipeline, _COZY_MODE_ATTR, "cpu")
+        # pgw#1312's one confession home. This rung is the LOUDEST degradation
+        # the ladder has — ~40x — so it may not be the one route that reaches a
+        # CPU-touching placement without saying so off the pod.
+        _report_offload_engaged(pipeline, "cpu", applied, log)
+        return applied
+
     _apply_vae_and_attention(
         pipeline, applied, memory_bound=effective_mode != "vae_only"
     )
@@ -1497,8 +1561,21 @@ def apply_low_vram_config(
     cuda_ok = cuda_ready()
 
     if not cuda_ok:
-        setattr(pipeline, _COZY_MODE_ATTR, "vae_only")
-        log.info("low_vram: CUDA unavailable, stopping at vae_only")
+        # An offload rung was asked for on a host with no usable device. Every
+        # such rung onloads to one, so none of them can be armed — but the
+        # honest rung is the BOTTOM one, not `vae_only`. pgw#1315: stamping a
+        # resident flavor here described a placement that was not taken, and
+        # the ladder then read the pipeline as sitting two rungs above where it
+        # actually was.
+        log.warning(
+            "low_vram: %s was requested and no CUDA device is usable; the CPU "
+            "rung serves instead (~%.0fx a native run).",
+            effective_mode, _rung_price(RUN_CPU),
+        )
+        applied["mode"] = "cpu"
+        _to_host(pipeline)
+        setattr(pipeline, _COZY_MODE_ATTR, "cpu")
+        _report_offload_engaged(pipeline, "cpu", applied, log)
         return applied
 
     if offload_to_disk_path is None and _should_auto_disk_offload():

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -63,7 +63,11 @@ FP8_STORAGE = Rung("fp8_storage", "", "fp8", RUN_FP8_STORAGE, 1.05, False)
 MODEL_OFFLOAD = Rung("model_offload", "model_offload", "", RUN_OFFLOAD, 2.5, True)
 GROUP_OFFLOAD = Rung("group_offload", "group_offload", "", RUN_OFFLOAD, 3.0, True)
 SEQUENTIAL = Rung("sequential", "sequential", "", RUN_OFFLOAD, 4.0, True)
-CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, False)
+# touches_host_ram: a CPU-placed pipeline keeps its WHOLE tree in host RAM —
+# that IS the rung. Declaring otherwise handed a CPU-rung load the pgw#1063
+# per-component staging discount, which is an admission lie by the same
+# arithmetic that made ie#615 a certain kernel OOM.
+CPU = Rung("cpu", "cpu", "", RUN_CPU, 40.0, True)
 
 #: The ONE ordering, best first. ``descend`` walks it; nothing else may.
 LADDER: tuple[Rung, ...] = (
@@ -72,7 +76,9 @@ LADDER: tuple[Rung, ...] = (
 
 #: The reactive placement tail, shallowest first (gw#463): a load-time CUDA
 #: OOM rolls back and retries one rung lower; a mid-inference OOM records the
-#: next rung and applies it only during a clean reload.
+#: next rung and applies it only during a clean reload. It ends at ``cpu``
+#: (pgw#1315) — the tail is every rung whose weights live on the host, and the
+#: bottom one is where the always-runs guarantee is actually kept.
 PLACEMENT_LADDER: tuple[str, ...] = tuple(
     r.name for r in LADDER if r.touches_host_ram
 )
@@ -80,10 +86,13 @@ PLACEMENT_LADDER: tuple[str, ...] = tuple(
 _BY_NAME = {r.name: r for r in LADDER}
 
 
-#: Stopped one rung above ``cpu``: it is declared in LADDER and priced, and
-#: this build cannot execute it — the reactive walk treats it as plan-time
-#: only (pgw#1212). Names OUR code, never the card.
-FLOOR_CPU_RUNG_UNEXECUTABLE = "cpu_rung_unexecutable"
+# pgw#1315 DELETED ``FLOOR_CPU_RUNG_UNEXECUTABLE``. It said the reactive walk
+# stopped one rung above ``cpu`` because this build could not execute that rung,
+# which made the always-runs guarantee true at plan time and FALSE on a descent
+# that reached the bottom. The refusal named our own code rather than the card,
+# which is what made it actionable: the fix is to execute the rung
+# (``memory.apply_low_vram_config`` mode ``cpu``), not to soften the wording.
+# A floor whose cause is gone must not be left pointing somewhere else.
 
 #: Standing on the last rung the ladder declares. Nothing is below it.
 FLOOR_LADDER_EXHAUSTED = "placement_ladder_exhausted"
@@ -115,17 +124,16 @@ def _walk(current: Optional[str]) -> tuple[Optional[Rung], Optional[str]]:
         nxt = LADDER[idx] if idx < len(LADDER) else None
     if nxt is None:
         return None, FLOOR_LADDER_EXHAUSTED
-    if nxt is CPU:
-        return None, FLOOR_CPU_RUNG_UNEXECUTABLE
     return nxt, None
 
 
 def descend(current: Optional[str]) -> Optional[Rung]:
-    """The next rung down from ``current``; None when the ladder ends.
+    """The next rung down from ``current``; None only when standing on ``cpu``.
 
     The reactive OOM path descends only through the PLACEMENT tail (a storage
     transform cannot be applied to an already-loaded object), so from any
-    resident token the next reactive rung is ``model_offload``.
+    resident token the next reactive rung is ``model_offload`` and the walk ends
+    at ``cpu``, which serves.
     """
     return _walk(current)[0]
 
@@ -136,17 +144,28 @@ def descent_floor(current: Optional[str]) -> Optional[str]:
     th#1867: A DESCENT THAT RUNS OUT MUST NAME ITS FLOOR. The proactive fit
     ladder (``Resources.vram_gb_hint``, an ESTIMATE deciding placement before
     anything is measured — §4.33) is now DELETED, so this reactive walk is the
-    only ladder and its bottom rung has stopped being theoretical. The failure
-    mode that must not happen is the descent silently falling into a rung
-    nothing can run: that converts a loud estimate-error into a quiet
-    execution-error, which is the trade §1.35 and §1.36 keep rejecting.
+    only ladder.
 
-    The refusal this feeds names OUR CODE ("this build cannot execute a CPU
-    rung"), never the card — the legitimate species under §1.35's second
-    amendment. It also makes pgw#1212's gap visible in production rather than
-    latent, which is the fastest way it gets prioritised on evidence.
+    pgw#1315 left exactly ONE floor. A descent now runs to ``cpu`` and serves
+    there, so the only way out of rungs is to be standing on the bottom one
+    already — a fact about where we are, not a refusal to go further. Nothing
+    here may ever again report that a declared rung cannot be executed: the
+    answer to that is to execute it.
     """
     return _walk(current)[1]
+
+
+def run_mode_of(name: Optional[str]) -> str:
+    """The hub-wire ``RUN_*`` projection of a rung NAME ("" when not a rung).
+
+    tensorhub matches ``FnDegraded.ran`` against its RunMode vocabulary
+    EXACTLY, and ``cpu`` is a member of it in its own right. Reporting a
+    descent onto the CPU rung under the offload tail's token is therefore a
+    wrong measurement, not a coarse one. Read the rung's own projection; never
+    assume the tail's (pgw#1315).
+    """
+    r = _BY_NAME.get(str(name or ""))
+    return r.run_mode if r is not None else ""
 
 
 def price(run_mode: str) -> float:

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -22,10 +22,10 @@ every harness endpoint declares `Resources(gpu=True)` and serves on CPU-only CI,
 and `test_boot_span_ladder_pgw797` boots one and runs a warmup forward through
 it. Withdrawing a function that demonstrably works is the opposite of §1.35
 amendment 2's bar ("the worker either serves, however slowly, or emits a typed
-defect naming what in OUR code failed"). pgw#1212's protection stays where it
-already was and where it is true: the REACTIVE walk in `models/rung` stops one
-rung short of CPU (`FLOOR_CPU_RUNG_UNEXECUTABLE`), so a pod that OOMs its way
-down refuses and names our code. Plan time is not that situation.
+defect naming what in OUR code failed"). pgw#1315 closed the other half: the
+REACTIVE walk used to stop one rung short of CPU, so a pod that OOM'd its way
+down refused where plan time served. Both ends now reach the same bottom rung
+and it EXECUTES (`memory.apply_low_vram_config` mode `cpu`).
 
 Every degraded plan carries ``wanted`` (what the function declares) and ``ran``
 (what actually runs) so the worker can report the degradation STRUCTURALLY to
@@ -123,11 +123,8 @@ def plan_serve(
     # forward. Refusing here would have withdrawn a function that demonstrably
     # WORKS, which is the opposite of §1.35 amendment 2's robustness bar.
     #
-    # pgw#1212's protection is real and stays exactly where it already was: the
-    # REACTIVE walk in `models/rung` stops one rung short of CPU
-    # (FLOOR_CPU_RUNG_UNEXECUTABLE), so a pod that OOMs its way down still
-    # refuses, naming our code. Plan time is not that situation — nothing has
-    # failed here.
+    # pgw#1315: the reactive walk reaches this same rung now, so plan time and
+    # a descent that exhausts every offload rung land on ONE answer.
     #
     # pgw#896: "no CUDA device detected" was said for BOTH a genuinely cardless
     # pod and a pod whose card would not answer, because the predicate behind

--- a/tests/test_cpu_rung_executes_pgw1315.py
+++ b/tests/test_cpu_rung_executes_pgw1315.py
@@ -1,0 +1,360 @@
+"""pgw#1315 — the always-runs guarantee holds on a REACTIVE descent, not only at plan time.
+
+The guarantee (Paul, 2026-08-17): *"the answer should be IT ALWAYS RUNS no
+matter what, just horribly inefficiently"*; §1.35 second amendment: *"even a pod
+without a GPU, heck; we can run it CPU only… 'This model does not run on this
+card' is never an acceptable terminal state."*
+
+Two things falsified it, and both were in OUR code, not in any card:
+
+1. **``FLOOR_CPU_RUNG_UNEXECUTABLE``** — ``rung.descend`` deliberately stopped
+   one rung ABOVE ``cpu`` and the executor turned that into a ``serve_degrade``
+   event plus a retryable request. So the honest answer was *yes at plan time,
+   NO on a reactive descent that reaches the bottom*. The refusal was correct in
+   FORM (it named our build, never the card), which is exactly why it was
+   actionable: make the build execute the rung. That is what this file proves.
+2. **``_move_pipeline_to_cpu`` swallowed ``HostRamMoveRefusedError``** into a
+   DEBUG line, after which the CPU-rollback check resurfaced it as a generic
+   ``RuntimeError("… mixed-device … rollback failed")``. The one case where the
+   host-move guard LEGITIMATELY stops a degrade became indistinguishable from a
+   bug. The guard is correct and stays on; the TYPE now propagates.
+
+RED against 66706529: (1) fails with ``RuntimeError: CUDA error: out of
+memory`` — the walk refuses to hand out ``cpu`` — and (2) fails with the generic
+mixed-device ``RuntimeError``.
+
+Deliberately compile-free and inference-free (workspace local-inference rule):
+the seam under test is the ladder WALK and the placement APPLIER, so the
+diffusers hooks are stubbed exactly as ``test_rung_ladder_pgw1206`` stubs them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker.api.binding import wire_ref
+from gen_worker.api.errors import HostRamMoveRefusedError
+from gen_worker.models import memory as memory_mod
+from gen_worker.models import rung
+from gen_worker.models.memory import apply_low_vram_config, place_pipeline
+
+_LOG = logging.getLogger("pgw1315")
+
+
+# ---------------------------------------------------------------------------
+# 0. the ladder hands out the bottom rung
+# ---------------------------------------------------------------------------
+
+
+def test_the_reactive_walk_reaches_the_cpu_rung() -> None:
+    """``sequential`` descends to ``cpu``; the unexecutable floor is DELETED.
+
+    ``test_descent_floor_th1867`` wrote the deletion condition itself: *"When
+    pgw#1212 makes the rung real the token must be DELETED — a floor that no
+    longer exists must not be left pointing somewhere else."*
+    """
+    nxt = rung.descend("sequential")
+    assert nxt is rung.CPU
+    assert rung.descent_floor("sequential") is None
+    assert not hasattr(rung, "FLOOR_CPU_RUNG_UNEXECUTABLE"), (
+        "the rung executes; a floor saying it cannot is a diagnostic that "
+        "outlived its cause")
+    # The bottom is still a bottom: nothing below it, and it does not climb.
+    assert rung.descend("cpu") is None
+    assert rung.descent_floor("cpu") == rung.FLOOR_LADDER_EXHAUSTED
+
+
+def test_the_cpu_rung_is_charged_host_ram() -> None:
+    """A CPU-placed pipeline keeps its WHOLE tree in host RAM — that is what
+    the rung IS. Declaring otherwise let the loader hand a CPU-rung load the
+    per-component staging discount, which is the pgw#1063 admission lie."""
+    assert rung.touches_host_ram("cpu")
+    assert "cpu" in rung.PLACEMENT_LADDER
+    assert rung.floor_of("sequential", "cpu") == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# 1. THE acceptance: a reactive OOM descent reaches the CPU rung and SERVES
+# ---------------------------------------------------------------------------
+
+
+def _arm(monkeypatch: pytest.MonkeyPatch, serves_at: str) -> List[str]:
+    """The established th#1043 seam: the ladder WALK is under test, the
+    diffusers hooks are not.
+
+    Torch-free on purpose — ``place_pipeline`` asks ``cuda_ready()``, not torch,
+    and CI installs no torch extra. A ladder guard that SKIPS on the runner is
+    a guard that is not there.
+    """
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: True)
+    monkeypatch.setattr(memory_mod, "_move_pipeline_to_cpu", lambda *_: None)
+    monkeypatch.setattr(memory_mod, "repair_device_placement", lambda *_: [])
+    monkeypatch.setattr(memory_mod, "flush_memory", lambda: None)
+    attempted: List[str] = []
+
+    def fake_apply(pipeline: object, *, mode: str, logger: object = None) -> dict:
+        attempted.append(mode)
+        if mode != serves_at:
+            raise RuntimeError("CUDA error: out of memory")
+        return {"mode": mode}
+
+    monkeypatch.setattr(memory_mod, "apply_low_vram_config", fake_apply)
+    return attempted
+
+
+def test_a_reactive_descent_that_reaches_the_bottom_SERVES(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE test this issue exists for.
+
+    A pipeline that OOMs at every offload rung lands on ``cpu`` and RUNS. The
+    old build stopped at ``sequential`` and returned the request retryable —
+    "this model does not run here", said about our own ladder.
+    """
+    attempted = _arm(monkeypatch, serves_at="cpu")
+
+    applied = place_pipeline(object(), mode="off", logger=_LOG)
+
+    assert attempted == ["off", "model_offload", "group_offload", "sequential", "cpu"]
+    assert applied["mode"] == "cpu"
+    assert applied["oom_demotions"] == 4
+    assert applied["requested_mode"] == "off"
+
+
+def test_the_cpu_rung_is_APPLIED_not_merely_named(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EXECUTION, not registration: the applier must actually put the pipeline
+    on the host and stamp the rung, or ``mode="cpu"`` is a label on a pipeline
+    still sitting on a card that just OOM'd."""
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: True)
+
+    pipe = _FakePipeline()
+    applied = apply_low_vram_config(pipe, mode="cpu", logger=_LOG)
+
+    assert applied["mode"] == "cpu"
+    assert pipe.moved_to == ["cpu"], "the weights never left the device"
+    assert memory_mod.low_vram_mode(pipe) == "cpu"
+    # No CUDA-only hook may be armed on the rung whose whole premise is that
+    # there is no usable device to onload to.
+    assert not applied["model_offload"]
+    assert not applied["group_offload"]
+    assert not applied["sequential_offload"]
+
+
+def test_the_cpu_rung_CONFESSES_like_every_other_host_touching_rung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1312 made every CPU-touching activation emit ONE typed
+    `serve_degrade`. The CPU rung is the LOUDEST of them (~40x), so it may not
+    be the one route that reaches a host-resident placement silently.
+
+    Read off the REAL activity sink, so this is the ActivityUpdate a hub would
+    actually bank."""
+    from test_offload_always_allowed_pgw1312 import _Events
+
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: True)
+
+    with _Events() as events:
+        apply_low_vram_config(_FakePipeline(), mode="cpu", logger=_LOG)
+
+    engaged = events.offload_engaged()
+    assert len(engaged) == 1, "expected ONE confession from the CPU rung"
+    assert "`cpu`" in engaged[0].detail
+
+
+def test_a_cardless_pod_stamps_the_SAME_rung_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plan time and the reactive descent must name one rung. A cardless pod
+    used to get a bare ``{"mode": "cpu"}`` describing a placement nobody
+    applied, so ``low_vram_mode()`` read ``""`` — the ladder's own view of that
+    pipeline was "never placed"."""
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: False)
+
+    pipe = _FakePipeline()
+    applied = place_pipeline(pipe, mode="auto", logger=_LOG)
+
+    assert applied["mode"] == "cpu"
+    assert memory_mod.low_vram_mode(pipe) == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# 2. the guard's refusal keeps its TYPE across the rollback seam
+# ---------------------------------------------------------------------------
+
+
+def test_a_guard_refusal_during_rollback_surfaces_TYPED(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``GEN_WORKER_HOST_MOVE_GUARD`` refusing the rollback move is a DIFFERENT
+    fact from "the rollback left the pipeline mixed-device", and it was
+    reported as the second. Red-verified by restoring the swallow."""
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: True)
+    monkeypatch.setattr(memory_mod, "flush_memory", lambda: None)
+    # The refused move is exactly why components are still on the device: the
+    # generic check below then reported THAT, and the guard's verdict was gone.
+    monkeypatch.setattr(
+        memory_mod, "repair_device_placement", lambda *_: ["transformer"])
+
+    refusal = HostRamMoveRefusedError(
+        incoming_bytes=1 << 35, available_bytes=1 << 30,
+        floor_bytes=1 << 33, limit_bytes=1 << 34,
+    )
+
+    def fake_apply(pipeline: object, *, mode: str, logger: object = None) -> dict:
+        raise RuntimeError("CUDA error: out of memory")
+
+    monkeypatch.setattr(memory_mod, "apply_low_vram_config", fake_apply)
+    pipe = _FakePipeline(refuse_move=refusal)
+
+    with pytest.raises(HostRamMoveRefusedError) as caught:
+        place_pipeline(pipe, mode="off", logger=_LOG)
+
+    assert caught.value is refusal
+    assert "mixed-device" not in str(caught.value)
+    # The OOM that provoked the rollback stays attached as the cause.
+    assert isinstance(caught.value.__cause__, RuntimeError)
+    assert "out of memory" in str(caught.value.__cause__)
+
+
+def test_an_untyped_move_failure_still_falls_back_to_the_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The propagation is TYPE-scoped. A best-effort ``.to('cpu')`` that fails
+    for any other reason is still swallowed — ``repair_device_placement`` is the
+    check that decides whether the rollback actually worked, and promoting every
+    move error to fatal would turn recoverable descents into refusals."""
+    monkeypatch.setattr(memory_mod, "cuda_ready", lambda: True)
+    monkeypatch.setattr(memory_mod, "flush_memory", lambda: None)
+    monkeypatch.setattr(memory_mod, "repair_device_placement", lambda *_: [])
+    attempted: List[str] = []
+
+    def fake_apply(pipeline: object, *, mode: str, logger: object = None) -> dict:
+        attempted.append(mode)
+        if mode != "model_offload":
+            raise RuntimeError("CUDA error: out of memory")
+        return {"mode": mode}
+
+    monkeypatch.setattr(memory_mod, "apply_low_vram_config", fake_apply)
+    # The REAL `_move_pipeline_to_cpu` runs here, against a `.to` that raises
+    # something the guard did not produce.
+    pipe = _FakePipeline(refuse_move=ValueError("some driver hiccup"))
+
+    applied = place_pipeline(pipe, mode="off", logger=_LOG)
+
+    assert applied["mode"] == "model_offload"
+    assert attempted == ["off", "model_offload"]
+
+
+# ---------------------------------------------------------------------------
+# 3. the executor's mid-inference walk learns the bottom rung
+# ---------------------------------------------------------------------------
+
+
+def _executor(monkeypatch: pytest.MonkeyPatch, pipe: Any) -> tuple[Any, Any]:
+    from gen_worker.executor import Executor
+    from gen_worker.registry import extract_specs
+
+    from harness.toy_endpoints import ModelBoundEndpoint
+
+    spec = extract_specs(ModelBoundEndpoint)[0]
+
+    async def _send(_msg: Any) -> None:
+        return None
+
+    ex = Executor([spec], _send)
+    monkeypatch.setattr(ex, "_slot_pipeline", lambda _s, _slot: pipe)
+
+    async def _no_refusal(*_a: Any, **_k: Any) -> str:
+        return ""
+
+    monkeypatch.setattr(ex, "_refuse_unfittable_offload", _no_refusal)
+    return ex, spec
+
+
+class _Ctx:
+    cancelled = False
+
+    def log(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+
+def test_the_executor_walk_learns_cpu_as_the_next_rung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production seam that makes the descent STICK: an instance that OOMs
+    on ``sequential`` is quarantined with ``cpu`` as its learned per-ref floor,
+    so the hub's retry reloads onto the CPU rung. Before this it learned
+    nothing and emitted ``cpu_rung_unexecutable``."""
+    pipe = _FakePipeline(mode="sequential")
+    ex, spec = _executor(monkeypatch, pipe)
+    slot = next(iter(spec.models))
+    ref = wire_ref(spec.models[slot])
+
+    asyncio.run(ex._quarantine_for_oom(
+        spec, _Ctx(), RuntimeError("CUDA error: out of memory")))
+
+    assert ex.degraded_floor.get(ref) == "cpu"
+    assert ex._placement_mode(spec, ref) == "cpu"
+
+
+def test_the_degraded_wire_token_for_the_cpu_rung_is_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tensorhub matches ``FnDegraded.ran`` against its RunMode vocabulary
+    EXACTLY, and ``cpu`` is a member in its own right. A descent onto the CPU
+    rung reported as ``offload`` is a wrong measurement, so the rung's own
+    ``run_mode`` travels, not the tail's."""
+    pipe = _FakePipeline(mode="sequential")
+    ex, spec = _executor(monkeypatch, pipe)
+
+    asyncio.run(ex._quarantine_for_oom(
+        spec, _Ctx(), RuntimeError("CUDA error: out of memory")))
+
+    plan = ex.serve_plans.get(spec.name)
+    assert plan is not None
+    assert plan.ran == rung.RUN_CPU
+    assert plan.run_mode == rung.RUN_CPU
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakePipeline:
+    """Carries the three offload capabilities the executor's walk looks for,
+    plus a ``.to`` that records every move — the observable that separates
+    "the rung was applied" from "the rung was named"."""
+
+    def __init__(
+        self, mode: str = "", refuse_move: Optional[BaseException] = None,
+    ) -> None:
+        self.moved_to: List[str] = []
+        self._refuse_move = refuse_move
+        self.hooks: Dict[str, bool] = {}
+        if mode:
+            setattr(self, "_cozy_low_vram_mode", mode)
+
+    def to(self, device: Any, *_a: Any, **_k: Any) -> "_FakePipeline":
+        # Only the HOST move is refusable — that is the guard's whole subject,
+        # and a fake that also refuses `to("cuda")` would pass this file's
+        # rollback arm without the rollback ever being reached.
+        if self._refuse_move is not None and str(device) == "cpu":
+            raise self._refuse_move
+        self.moved_to.append(str(device))
+        return self
+
+    def enable_model_cpu_offload(self, *_a: Any, **_k: Any) -> None:
+        self.hooks["model_offload"] = True
+
+    def enable_group_offload(self, *_a: Any, **_k: Any) -> None:
+        self.hooks["group_offload"] = True
+
+    def enable_sequential_cpu_offload(self, *_a: Any, **_k: Any) -> None:
+        self.hooks["sequential"] = True

--- a/tests/test_descent_floor_th1867.py
+++ b/tests/test_descent_floor_th1867.py
@@ -4,9 +4,11 @@ The proactive fit ladder is being deleted (``Resources.vram_gb_hint`` is an
 ESTIMATE deciding placement before anything is measured — §4.33), which makes
 the reactive OOM walk in :mod:`gen_worker.models.rung` the ONLY ladder. Its
 bottom therefore stops being theoretical, and falling off it must be a typed,
-visible refusal naming OUR code rather than a silent slide into a rung nothing
-can run — the loud-estimate-error-for-quiet-execution-error trade §1.35 and
-§1.36 keep rejecting.
+visible event naming OUR code rather than a silent slide.
+
+pgw#1315 then made the bottom rung EXECUTE, which leaves exactly ONE floor —
+``FLOOR_LADDER_EXHAUSTED``, reported only when the pipeline is already standing
+on ``cpu``. No declared rung is one this build declines to run any more.
 
 Deliberately torch-free: it imports ``rung`` and nothing else, so it runs on a
 CPU-only runner and on a laptop with no CUDA. The floor it guards is exercised
@@ -26,8 +28,11 @@ ALL_TOKENS = (
     + [r.name for r in rung.LADDER]
 )
 
+#: pgw#1315 removed the second one. `FLOOR_CPU_RUNG_UNEXECUTABLE` said the walk
+#: stopped above a rung this build could not execute; the build executes it now,
+#: so the token is DELETED rather than repointed — which is the condition
+#: `test_the_cpu_floor_exists_only_because_cpu_is_unreachable` stated below.
 FLOORS = {
-    rung.FLOOR_CPU_RUNG_UNEXECUTABLE,
     rung.FLOOR_LADDER_EXHAUSTED,
 }
 
@@ -77,31 +82,32 @@ def test_upper_rungs_descend_with_no_floor(token: str) -> None:
 
 # --- the floor itself -------------------------------------------------------
 
-def test_the_last_executable_rung_names_the_cpu_floor() -> None:
-    """``sequential`` is the real bottom; ``cpu`` below it is plan-time only."""
-    assert rung.descend("sequential") is None
-    assert rung.descent_floor("sequential") == rung.FLOOR_CPU_RUNG_UNEXECUTABLE
+def test_the_last_offload_rung_descends_to_cpu() -> None:
+    """``cpu`` is the bottom and it EXECUTES (pgw#1315), so ``sequential`` has
+    somewhere to go and nothing to explain."""
+    assert rung.descend("sequential") is rung.CPU
+    assert rung.descent_floor("sequential") is None
 
 
-def test_the_cpu_floor_exists_only_because_cpu_is_unreachable() -> None:
-    """RED-PROOF FOR pgw#1212's IMPLEMENTER, not a restatement of the ladder.
+def test_the_cpu_unexecutable_floor_is_deleted_with_its_cause() -> None:
+    """The condition this file stated for pgw#1212's implementer, now met.
 
-    ``FLOOR_CPU_RUNG_UNEXECUTABLE`` is a confession that ``cpu`` is declared,
-    priced at 40x and not executable. When pgw#1212 makes the rung real the
-    token must be DELETED — a floor that no longer exists must not be left
-    pointing somewhere else, which is how a diagnostic outlives its cause.
-    This goes red the moment ``descend`` starts handing out ``cpu``.
+    It read: *"When pgw#1212 makes the rung real the token must be DELETED — a
+    floor that no longer exists must not be left pointing somewhere else, which
+    is how a diagnostic outlives its cause."* pgw#1315 made the rung real, so
+    this asserts the deletion instead of the confession.
     """
+    assert not hasattr(rung, "FLOOR_CPU_RUNG_UNEXECUTABLE")
     assert rung.LADDER[-1] is rung.CPU
-    assert rung.PLACEMENT_LADDER[-1] == rung.SEQUENTIAL.name
-    assert rung.CPU.name not in rung.PLACEMENT_LADDER
-    assert all(rung.descend(t) is not rung.CPU for t in ALL_TOKENS)
+    assert rung.PLACEMENT_LADDER[-1] == rung.CPU.name
+    assert any(rung.descend(t) is rung.CPU for t in ALL_TOKENS)
 
 
 def test_standing_on_the_bottom_rung_does_not_climb() -> None:
-    """``cpu`` is below the placement tail, so the resident-token arm must not
-    claim it. Before th#1867 this returned ``model_offload`` — the walk went
-    UP, which under pgw#1212 (where ``cpu`` becomes reachable) is a cycle."""
+    """``cpu`` is the end of the placement tail, so the resident-token arm must
+    not claim it. Before th#1867 this returned ``model_offload`` — the walk went
+    UP, which now that ``cpu`` is REACHABLE (pgw#1315) would be a live cycle,
+    not a latent one."""
     assert rung.descend("cpu") is None
     assert rung.descent_floor("cpu") == rung.FLOOR_LADDER_EXHAUSTED
 

--- a/tests/test_rung_ladder_pgw1206.py
+++ b/tests/test_rung_ladder_pgw1206.py
@@ -60,8 +60,11 @@ def test_one_ordered_ladder() -> None:
     prices = [r.latency for r in rung.LADDER]
     assert prices == sorted(prices), "price must be monotonic down the ladder"
     # Host-RAM-touching == exactly the placement tail (the pgw#1063 whole-tree
-    # host-RAM charge; it was the strict_vram boundary until th#1867).
-    assert rung.PLACEMENT_LADDER == ("model_offload", "group_offload", "sequential")
+    # host-RAM charge; it was the strict_vram boundary until th#1867). pgw#1315
+    # added `cpu`: a CPU-placed pipeline keeps its whole tree on the host, so
+    # excluding it handed that load the per-component staging discount.
+    assert rung.PLACEMENT_LADDER == (
+        "model_offload", "group_offload", "sequential", "cpu")
     for r in rung.LADDER:
         assert r.touches_host_ram == (r.name in rung.PLACEMENT_LADDER)
     # Resident flavors are not rungs: from any of them the reactive walk
@@ -73,7 +76,8 @@ def test_one_ordered_ladder() -> None:
 
 def test_descend_walks_every_rung_and_terminates() -> None:
     """From any resident token the reactive walk visits each placement rung
-    exactly once and ends — it never wraps, never skips to CPU."""
+    exactly once and ends on ``cpu`` — it never wraps and it never stops short
+    of the bottom (pgw#1315)."""
     seen = []
     cur = ""
     while True:
@@ -136,7 +140,8 @@ def _arm(monkeypatch: pytest.MonkeyPatch, serves_at: str) -> list[str]:
     return attempted
 
 
-@pytest.mark.parametrize("serves_at", ["model_offload", "group_offload", "sequential"])
+@pytest.mark.parametrize(
+    "serves_at", ["model_offload", "group_offload", "sequential", "cpu"])
 def test_oom_descends_one_rung_at_a_time_and_serves(
     serves_at: str, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes the two holes in the always-runs guarantee named in `research/machine-compatibility-design.md` (DIES rows 15 and 16). Gates th#2075.

## The hole

The ladder declared a `cpu` rung, priced it at 40x, and refused to hand it out: `rung.descend` stopped one rung ABOVE it and reported `FLOOR_CPU_RUNG_UNEXECUTABLE`, on which the executor emitted a `serve_degrade` saying *"the next one is `cpu`, which THIS BUILD CANNOT EXECUTE"* and returned the request retryable. The honest answer to *"does it always run?"* was **yes at plan time, NO on a descent that reached the bottom** — against §1.35 amendment 2, *"'This model does not run on this card' is never an acceptable terminal state."*

The refusal was correct in FORM — it named our build, never the card — which is exactly what made it actionable. **Fix the build; do not soften the refusal.**

## What changed

- `memory.apply_low_vram_config` grows a `cpu` mode: savers applied, whole pipeline moved to host RAM, no offload hook armed (each one onloads to a device; this rung's premise is that there is none), rung stamped.
- `rung.CPU.touches_host_ram` becomes True, because that is what the rung IS. It joins `PLACEMENT_LADDER`, is charged host RAM by the pgw#1063 admission, is refused the per-component staging discount, and can be **LEARNED as a per-ref degraded floor** — the seam that makes a descent stick across the hub's retry.
- `FLOOR_CPU_RUNG_UNEXECUTABLE` is DELETED, which is the condition `test_descent_floor_th1867` itself stated for this implementer.
- A cardless `place_pipeline` returned a bare `{"mode": "cpu"}` nobody had acted on, so `low_vram_mode()` read `""`. An offload rung requested without CUDA stamped `vae_only` — a resident placement two rungs above the weights. Both stamp `cpu`.
- `_move_pipeline_to_cpu` swallowed `HostRamMoveRefusedError` into DEBUG, after which the rollback check resurfaced it as a generic mixed-device `RuntimeError`. The guard stays ON and correct; only the TYPE propagates, carrying the provoking OOM as its cause. Type-scoped — every other move failure stays swallowed.
- Two silences beside it: a mid-inference descent hardcoded `run_mode=RUN_OFFLOAD` (a CPU-rung descent would reach the hub as `ran="offload"`, wrong on a field matched exactly), and `_record_placement_posture` had a dead `if mode == "cpu"` arm that always lost to the idempotent earlier append.
- The new rung reports through **pgw#1312's one confession home**, not beside it.

## Red/green

Red-verified against `66706529` — nine cases, each failing distinguishably. The acceptance arm (`off -> model_offload -> group_offload -> sequential -> cpu`, SERVING) died on `RuntimeError: CUDA error: out of memory`; the executor arm learned no floor; the guard arm produced the verbatim `CUDA OOM left the pipeline mixed-device and CPU rollback failed (['transformer'])`.

Restoring the swallow reds the typed-refusal arm and leaves the untyped arm green — the propagation discriminates rather than blanket-raising.

Green: 175 across cpu_rung / offload_always_allowed / descent_floor / rung_ladder / degraded_reload_refusal / typed_posture / posture_vectors / host_move_guard / trace_child_placement / hostfacts / torchless_boot. ruff, mypy (769 files) and seven lint scanners clean.

The new guards are deliberately **torch-free** — they drive `cuda_ready()`, which is what the code under test actually asks — so they RUN on the CI runner instead of skipping on it.

Bounded per the local-inference rule: logic only, no compile, no mint, no real model.

## Still open on this issue

Deliverables 3 (the under-minimum warning) and 4 (lane selection by machine facts) need pgw#1313's `{minimum, recommended}` vocabulary, which has not landed. pgw#1315 stays in `progress.md`.