### PR TITLE
pgw#1316: the suite stops forking an interpreter that has gRPC's threads in it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,6 +350,14 @@ jobs:
           uv run python scripts/lint_pickle_readers.py --selftest
           uv run python scripts/lint_pickle_readers.py
 
+      # GATING (pgw#1316): a test that forks this interpreter inherits gRPC's
+      # poller from whichever grpc.aio file shared its xdist worker, and the
+      # child SIGABRTs. It reads as a suite failure nobody caused, on master.
+      - name: pgw#1316 guard - no test forks this interpreter
+        run: |
+          uv run python scripts/lint_test_fork_start_method.py --selftest
+          uv run python scripts/lint_test_fork_start_method.py
+
       # GATING (pgw#1299): TCG owns the compiled-graph metadata vocabulary and
       # exports it. A respelled `"graph_class"` / `"aot-inductor"` does not fail
       # at import when TCG renames the key — it returns None from a `.get()` on

--- a/changelog.d/pgw1316.md
+++ b/changelog.d/pgw1316.md
@@ -1,0 +1,20 @@
+- **The suite stops forking a process that has gRPC's threads in it.** Three tests reached a
+  second process through `multiprocessing.get_context("fork")`; under `-n 4 --dist loadfile` an
+  xdist worker reuses one process across files, so a worker that had already run a `grpc.aio` file
+  still had gRPC's event-engine threads live. gRPC skips its `pthread_atfork` handlers whenever
+  another thread is inside gRPC (`fork_posix.cc:71`), and the child then inherits a poller gRPC
+  never reset and dies on `ev_epoll1_linux.cc: Check failed: next_worker->state == KICKED`. That is
+  a `SIGABRT` in tests whose subject is CAS convergence and ref-index merging, not fork semantics
+  — and it sat RED ON MASTER with no PR responsible (five of eight failing `ci.yaml` runs,
+  2026-08-17). They use `spawn` now; the property each test asserts is unchanged, and the
+  cross-process barrier still proves two real processes race.
+
+- **A lint keeps it gone.** `scripts/lint_test_fork_start_method.py` (self-testing, in `gates`)
+  refuses `get_context("fork")`, `set_start_method("fork")`, a bare `multiprocessing.Process`/`Pool`
+  (whose default start method is `fork` on Linux) and `os.fork()` anywhere under `tests/` or
+  `tests_v2/`. It is red on master's own three sites and green on this tree.
+
+  The production fork-after-gRPC hazard is **not** this issue and is untouched here: the compute
+  child still spawns through `create_subprocess_exec` with a `preexec_fn`
+  (`procsplit/parent.py:586`), which forces `fork()` over `posix_spawn()` while the parent's
+  `grpc.aio` transport is live. That is pgw#932, which owns its exec-first launcher.

--- a/scripts/lint_test_fork_start_method.py
+++ b/scripts/lint_test_fork_start_method.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""pgw#1316: no test may create a process by forking this interpreter.
+
+Under `-n 4 --dist loadfile` an xdist worker reuses one process across files.
+A worker that already ran a grpc.aio file still has gRPC's event-engine
+threads live, and gRPC skips its `pthread_atfork` handlers whenever another
+thread is inside gRPC (`fork_posix.cc:71`). The child then inherits a poller
+gRPC never got to reset and dies on
+`ev_epoll1_linux.cc: Check failed: next_worker->state == KICKED` — a SIGABRT
+in a test whose subject is not fork semantics, red on master with no PR
+responsible.
+
+`multiprocessing.get_context("spawn")` is the only sanctioned way for a test
+to reach a second process. Bare `multiprocessing.Process`/`Pool` count: their
+default start method is `fork` on Linux.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_ROOTS = (REPO / "tests", REPO / "tests_v2")
+
+#: Attributes of `multiprocessing` (or a context) that start a process.
+_STARTERS = {"Process", "Pool"}
+
+
+def _mp_attr(node: ast.AST) -> str | None:
+    """Name of a `multiprocessing.<attr>` access, else None."""
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        if node.value.id in {"multiprocessing", "mp"}:
+            return node.attr
+    return None
+
+
+def _literal_method(call: ast.Call) -> str | None:
+    if call.args and isinstance(call.args[0], ast.Constant):
+        value = call.args[0].value
+        return value if isinstance(value, str) else None
+    for kw in call.keywords:
+        if kw.arg == "method" and isinstance(kw.value, ast.Constant):
+            return kw.value.value if isinstance(kw.value.value, str) else None
+    return None
+
+
+def check_file(path: Path) -> List[Tuple[int, str]]:
+    problems: List[Tuple[int, str]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        attr = _mp_attr(node.func)
+        if attr in {"get_context", "set_start_method"}:
+            method = _literal_method(node)
+            if method != "spawn":
+                problems.append(
+                    (node.lineno, f'multiprocessing.{attr}({method!r})')
+                )
+        elif attr in _STARTERS:
+            problems.append(
+                (node.lineno, f"bare multiprocessing.{attr} (defaults to fork)")
+            )
+        elif isinstance(node.func, ast.Attribute) and node.func.attr == "fork":
+            if _mp_attr(node.func) is None and isinstance(node.func.value, ast.Name):
+                if node.func.value.id == "os":
+                    problems.append((node.lineno, "os.fork()"))
+    return problems
+
+
+def scan(roots: Tuple[Path, ...]) -> List[str]:
+    findings: List[str] = []
+    for root in roots:
+        files = [root] if root.is_file() else sorted(root.rglob("*.py"))
+        for path in files:
+            for lineno, why in check_file(path):
+                rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+                findings.append(f"{rel}:{lineno}: {why}")
+    return findings
+
+
+def _selftest() -> int:
+    """RED on every fork-shaped spawn; GREEN only on an explicit spawn context."""
+    red = {
+        "fork_ctx": 'import multiprocessing\nc = multiprocessing.get_context("fork")\n',
+        "start_method": 'import multiprocessing\nmultiprocessing.set_start_method("fork")\n',
+        "default_ctx": 'import multiprocessing\nc = multiprocessing.get_context()\n',
+        "bare_process": 'import multiprocessing\np = multiprocessing.Process(target=f)\n',
+        "os_fork": "import os\npid = os.fork()\n",
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for name, body in red.items():
+            path = root / f"{name}.py"
+            path.write_text(body)
+            if len(scan((path,))) != 1:
+                print(f"SELFTEST FAILED: {name} not caught", file=sys.stderr)
+                return 1
+        green = root / "green.py"
+        green.write_text(
+            'import multiprocessing\n'
+            'c = multiprocessing.get_context("spawn")\n'
+            'p = c.Process(target=f)\nq = c.Queue()\n'
+        )
+        if scan((green,)):
+            print("SELFTEST FAILED: a spawn context was flagged", file=sys.stderr)
+            return 1
+    print("lint_test_fork_start_method selftest: red on fork, green on spawn")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+    roots = tuple(Path(a).resolve() for a in argv) or DEFAULT_ROOTS
+    findings = scan(tuple(r for r in roots if r.exists()))
+    if findings:
+        print(
+            "pgw#1316: a test forks this interpreter. gRPC's threads outlive the "
+            "file that started them under `--dist loadfile`, its fork handlers are "
+            "skipped while any thread is inside gRPC, and the child aborts on an "
+            "inherited poller. Use `multiprocessing.get_context(\"spawn\")` and keep "
+            "everything crossing the boundary picklable.\n",
+            file=sys.stderr,
+        )
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+    print("lint_test_fork_start_method: no test forks this interpreter")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_fixed_name_temp_paths_pgw945.py
+++ b/tests/test_fixed_name_temp_paths_pgw945.py
@@ -159,7 +159,10 @@ def test_a_failing_writer_cannot_destroy_a_concurrent_one(shard_server, tmp_path
 def test_two_ref_index_processes_merge_without_losing_an_owner(tmp_path):
     cache = tmp_path / "cache"
     cache.mkdir()
-    context = multiprocessing.get_context("fork")
+    # pgw#1316: SPAWN, never fork — an xdist worker that already ran a
+    # grpc.aio file forks with gRPC's threads live, and the child inherits a
+    # poller gRPC never got to reset.
+    context = multiprocessing.get_context("spawn")
     barrier = context.Barrier(2)
     processes = [
         context.Process(

--- a/tests/test_snapshot_v2_fill_pgw781.py
+++ b/tests/test_snapshot_v2_fill_pgw781.py
@@ -26,6 +26,18 @@ from gen_worker.models.store import _snapshot_to_resolved
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
 
+#: pgw#1316: SPAWN, never fork. These tests need two real OS processes racing
+#: on one CAS tree; they do not need the parent's address space. Under
+#: `-n 4 --dist loadfile` an xdist worker that already ran a grpc.aio file
+#: still has gRPC's event-engine threads live, and gRPC skips its
+#: `pthread_atfork` handlers whenever another thread is inside gRPC
+#: (`fork_posix.cc:71`) — the child then inherits a poller in an inconsistent
+#: state and dies on `ev_epoll1_linux.cc: Check failed: next_worker->state ==
+#: KICKED`. Spawn shares no such state. Everything crossing the boundary must
+#: stay picklable.
+_MP = multiprocessing.get_context("spawn")
+
+
 def _sha(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -226,11 +238,10 @@ def test_two_processes_converge_on_the_same_materialized_tree(tmp_path: Path) ->
     cas = LocalCAS(tmp_path)
     digest = cas.put_bytes(body)
     target = tmp_path / "snapshots" / "same"
-    context = multiprocessing.get_context("fork")
-    barrier = context.Barrier(2)
-    results = context.Queue()
+    barrier = _MP.Barrier(2)
+    results = _MP.Queue()
     processes = [
-        context.Process(
+        _MP.Process(
             target=_materialize_process,
             args=(str(tmp_path), str(target), digest.digest, len(body), barrier, results),
         )
@@ -281,13 +292,12 @@ def test_stale_invalid_validation_cannot_delete_a_rebuilt_tree(
     target.mkdir(parents=True)
     (target / "config.json").write_bytes(b"invalid-old-target")
 
-    context = multiprocessing.get_context("fork")
-    stale_checked = context.Event()
-    rebuilt = context.Event()
-    ensure_entered = context.Event()
-    allow_ensure = context.Event()
-    results = context.Queue()
-    stale = context.Process(
+    stale_checked = _MP.Event()
+    rebuilt = _MP.Event()
+    ensure_entered = _MP.Event()
+    allow_ensure = _MP.Event()
+    results = _MP.Queue()
+    stale = _MP.Process(
         target=_stale_invalid_process,
         args=(
             str(tmp_path),


### PR DESCRIPTION
Fixes the `tests` job that has been RED ON MASTER ITSELF with no PR responsible — five of eight failing `ci.yaml` runs on 2026-08-17, including master's own `workflow_dispatch` (run 31989016555).

## Diagnosis, reproduced at source

The abort is not flake-adjacent noise; it is a hard gRPC assertion:

```
I fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
F ev_epoll1_linux.cc:1125] Check failed: next_worker->state == KICKED
assert -6 == 0   # ForkProcess-1 exitcode=-SIGABRT
```

Under `-n 4 --dist loadfile` an xdist worker PROCESS is reused across files, so a worker that already ran a `grpc.aio` file still has gRPC's event-engine threads live when a later file forks. gRPC skips its `pthread_atfork` handlers whenever another thread is inside gRPC, so the child inherits a poller gRPC never reset and aborts on it.

**Reproduced locally with the exact signature** (live `grpc.aio` channel + traffic in a background thread, then `multiprocessing` fork children): `fork_posix.cc:71` skipped handlers, then `F ev_epoll1_linux.cc:1125] Check failed: next_worker->state == KICKED`, child exitcode `-6`. A single-file run of the suite file passes either way and proves nothing — the hazard is the co-tenant.

## Test infra, not a new production defect

Production's fork-after-gRPC hazard is real and **already filed as pgw#932** — the compute child still spawns through `create_subprocess_exec` with a `preexec_fn` (`procsplit/parent.py:586`), which forces `fork()` over `posix_spawn()` while the parent's `grpc.aio` transport is live. That issue owns its exec-first launcher and is untouched here. Everything else in `src/` already avoids the hazard deliberately: `aot_compile_pool.arm_parent_death_signal` documents why it refuses `preexec_fn`, `mint_process` spawns with no `preexec_fn`, and `supervisor.py`'s `os.fork()` runs *before the worker's heavy imports*, with no gRPC in the process.

## The fix

Three tests reached a second process by forking. None is about fork semantics — two are CAS convergence (`test_snapshot_v2_fill_pgw781.py`), one is ref-index merging (`test_fixed_name_temp_paths_pgw945.py`). They use `spawn`, which shares no gRPC state.

**The property each test asserts is unchanged.** Two real OS processes still race through a cross-process `Barrier(2)`, and a mutant that neuters `_materialize_repository`'s converge branch (`if _tree_matches(...)` -> `if False`) makes the spawn version FAIL — the instrument still goes red.

`scripts/lint_test_fork_start_method.py` keeps it gone: self-testing, wired into `gates`, refusing `get_context("fork")`, `set_start_method("fork")`, a bare `multiprocessing.Process`/`Pool` (default start method is `fork` on Linux) and `os.fork()` under `tests/`/`tests_v2/`. It is **red on master's own three sites** and green on this tree.

## Evidence

| | before | after |
|---|---|---|
| `pytest test_p1_stream_lifecycle.py test_snapshot_v2_fill_pgw781.py test_fixed_name_temp_paths_pgw945.py` (a grpc.aio file sharing the process, the CI shape) | 33 passed, **5** `os.fork()` multi-threaded DeprecationWarnings | 33 passed, **0** |
| the two files, 10 consecutive runs | — | **10/10 green**, 15 passed each |
| `lint_test_fork_start_method.py` on master's tests | **exit 1**, 3 sites | exit 0 |
| mutation (`_tree_matches` branch neutered) | — | **FAILED**, as it must |

`mypy` clean on the changed files; `ruff check` clean.