### PR TITLE
pgw#1317: the pool rounded every microsecond charge to zero before adding it

### DIFF
--- a/changelog.d/pgw1317.md
+++ b/changelog.d/pgw1317.md
@@ -1,0 +1,6 @@
+- The compile pool's parent-serial totals stopped rounding themselves away. `stage_total_s` and
+  `spawn_total_s` rounded every individual charge to milliseconds before adding it, so a share
+  that cost 250 us contributed exactly zero and the total said the pool never staged and never
+  forked — measured on master: `stage_total_s == 0.0` on a run that staged two shares. Both now
+  accumulate raw, like the idle split beside them, and are rounded once at `facts()` and once in
+  the per-entry span table. At a realistic K the figure was off by the whole quantity.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -1280,9 +1280,11 @@ class EntryCompilePool:
         )
         job_path = slot / "job.json"
         job_path.write_bytes(msgspec.json.encode(job))
-        self.entry_stage_seconds[share] = round(time.monotonic() - t0, 3)
-        self.ledger.stage_total_s = round(
-            self.ledger.stage_total_s + self.entry_stage_seconds[share], 3)
+        # pgw#1317: measured RAW, rounded only where it is rendered. Rounding
+        # each charge destroyed it: staging is a json write, so every share
+        # rounded to 0.000 and the total said the pool never staged.
+        self.entry_stage_seconds[share] = time.monotonic() - t0
+        self.ledger.stage_total_s += self.entry_stage_seconds[share]
         return job, job_path
 
     def _spawn(self, job: EntryJob, job_path: Path) -> _Running:
@@ -1300,9 +1302,10 @@ class EntryCompilePool:
         finally:
             handle.close()
         started, spawn_epoch = time.monotonic(), time.time()
-        self.entry_spawn_seconds[job.share] = round(started - t0, 3)
-        self.ledger.spawn_total_s = round(
-            self.ledger.spawn_total_s + (started - t0), 3)
+        # pgw#1317: raw, like every other charge on this ledger — a fork costs
+        # 250-450 us, which `round(x, 3)` discards outright.
+        self.entry_spawn_seconds[job.share] = started - t0
+        self.ledger.spawn_total_s += started - t0
         logger.info(
             "aot-pool: %s (rows[%d::%d]) -> pid %s",
             job.share, job.share_index, job.share_count, proc.pid)
@@ -1965,8 +1968,10 @@ class EntryCompilePool:
         # staging overlaps other children, so summing it into the compile
         # total would invent seconds nobody spent compiling. Its idle FRACTION
         # is `ledger.idle_staging_s`, which is a pool number, not an entry one.
-        spans["parent_stage_s"] = self.entry_stage_seconds.get(row.entry, 0.0)
-        spans["parent_spawn_s"] = self.entry_spawn_seconds.get(row.entry, 0.0)
+        spans["parent_stage_s"] = round(
+            self.entry_stage_seconds.get(row.entry, 0.0), 3)
+        spans["parent_spawn_s"] = round(
+            self.entry_spawn_seconds.get(row.entry, 0.0), 3)
         return spans
 
 def _stderr_tail(path: Path, limit: int = 2048) -> str:

--- a/tests/test_compile_attribution_pgw830.py
+++ b/tests/test_compile_attribution_pgw830.py
@@ -202,10 +202,19 @@ def test_pool_idle_is_accounted_separately_from_child_seconds(
 
     facts = led.facts()
     assert facts["pool_idle_s"] == pytest.approx(
-        facts["idle_staging_s"] + facts["idle_drain_s"]
-        + facts["idle_spawn_s"] + facts["idle_other_s"], abs=0.01)
-    # Spawning is parent-serial and really does hold a freed slot.
-    assert facts["spawn_total_s"] > 0.0
+        facts["idle_staging_s"] + facts["idle_source_s"]
+        + facts["idle_drain_s"] + facts["idle_spawn_s"]
+        + facts["idle_other_s"], abs=0.01)
+    # Spawning and staging are parent-serial and really do hold a freed slot.
+    #
+    # pgw#1317: asserted on the LEDGER, never on `facts()`. `facts()` rounds to
+    # milliseconds for the wire, and both of these are microsecond work — a
+    # fork is 250-450 us, staging is one json write. Read off `facts()` this is
+    # an assertion about how fast the runner is, and it duly went red on master
+    # (`assert 0.0 > 0.0`) with nothing broken. The ledger holds the
+    # measurement; rounding belongs at the render.
+    assert led.spawn_total_s > 0.0
+    assert led.stage_total_s > 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Master-red triage. `tests` failed on `master` at `66706529` ([run 31989016555](https://github.com/cozy-creator/python-gen-worker/actions/runs/31989016555)) — the run's **only** failure, no PR responsible:

```
tests/test_compile_attribution_pgw830.py:208: AssertionError
>       assert facts["spawn_total_s"] > 0.0
E       assert 0.0 > 0.0
```

## Which side was wrong: both, and neither was pgw#1311's

Falsified first: pgw#1311 (`cancel_warm`/`quiesce`) touched `executor.py`, `hot_swap.py`, `conftest.py` and one new test — never `aot_compile_pool.py`. `git log -L` on `_spawn` says its last toucher was pgw#1309, which only appended a telemetry emit *after* the measurement. No landing changed the accounting semantics.

**The test** asserted a strict positive on `facts()`, which rounds to milliseconds for the wire. The quantity is microsecond work — measured on a loaded box, a bare `Popen(start_new_session=True)` costs 252-444 us, all below the 500 us cliff. Off `facts()` that assertion measures how fast the runner is, which is why it survived hundreds of green runs and then went red with nothing broken.

**The product** had a live defect underneath it. `_stage` and `_spawn` rounded each individual charge *and* re-rounded the running total:

```python
self.ledger.stage_total_s = round(self.ledger.stage_total_s + round(delta, 3), 3)
```

A sub-millisecond charge is not *displayed* rounded — it is **destroyed**; the increment never enters the accumulator. Measured on `master`, 8/8 runs: `stage_total_s == 0.0` and every share's `entry_stage_seconds == 0.0`, on a pool that demonstrably staged two shares. The idle split three functions away (`idle_staging_s`, `idle_spawn_s`, `capacity_s`) already accumulates raw and rounds once — these two were the outliers, disagreeing with their own file. At a realistic K the figure is off by the entire quantity (64 forks at 400 us = 26 ms, reported `0.000`).

`ledger.facts()` is splatted into the mint's telemetry row (`aot_mint.py:1809`) and read by the pgw#830 attribution table. "A span that stops being measured" is exactly the attribution rot that file exists to prevent, so the accounting is the side that had to change.

## The change

- `_stage` / `_spawn` accumulate raw; rounding moves to `facts()` and to the per-entry span table (`parent_stage_s` / `parent_spawn_s`), where it always belonged.
- The test asserts `led.spawn_total_s` / `led.stage_total_s` (the measurement), never `facts()` (the render), and the idle-partition assertion gains the `idle_source_s` term that `idle_s` already sums but it omitted.

## Red / green

- **Red**, by disarming the fix in place: same assertion text, `E assert 0.0 > 0.0`, deterministically on the staging term.
- **Green**, 10/10 runs of the whole file (4 passed each).
- 66 neighbouring pool/ledger tests green (`pgw842`, `pgw832`, `pgw1099`, `pgw848`, `pgw809`, `pgw1309`); ruff + mypy clean.

Tracker: `python-gen-worker/progress.md` #1317. No wheel bump — a release lane is cutting 0.119.0 concurrently.