### PR TITLE
pgw#1315 (deliverables 3+4): an under-minimum machine SERVES and SAYS SO, and the facts pick the lane

### DIFF
--- a/changelog.d/pgw1315.md
+++ b/changelog.d/pgw1315.md
@@ -59,3 +59,59 @@
   Bounded per the local-inference rule: logic only, no compile, no mint, no real model. The new
   guards are deliberately torch-free — they drive `cuda_ready()`, which is what the code under test
   actually asks — so they RUN on the CI runner instead of skipping on it.
+
+- **An under-minimum machine SERVES, and now CONFESSES.** A declared `minimum`
+  (pgw#1313's vocabulary) gates exactly one thing and it is hub-side: a config-WRITE. At
+  EXECUTION it may not gate anything at all — a machine below a declared floor is the *normal*
+  input to a degraded run — but until now it also said NOTHING, so a pod running a lane its author
+  had declared unfit for that card was indistinguishable from one running it as designed. The
+  worker measures its own facts and every missed minimum becomes ONE typed `serve_degrade`
+  (`phase=below_declared_minimum`, the same spelling as the `MeasuredPosture` cause) naming the
+  TERM, the declared floor, this machine's measured fact and the posture taken. It rides pgw#1312's
+  one confession home — `_report_offload_engaged`'s emitter, extracted and shared, never twinned —
+  and the SAME sentence lands on `ServePlan.warning`, which `lifecycle._emit_degraded` sends as
+  `FnDegraded.reason`. One derivation, two carriers, so the operator's line and the hub's row
+  cannot disagree.
+
+  It carries NO suggested card. th#1867 deleted `FnDegraded.recommended_vram_gb` because the
+  worker's suggestion was the author's own guess handed back, and §1.2 measured that guess wrong in
+  BOTH directions on live releases; only the hub knows the catalog (th#2075 clause 3). `ran` also
+  stays out of the hub's exact-match RunMode vocabulary: a requirement shortfall is not a placement
+  demotion, and reporting it as one would make the hub reschedule a pod running natively and fine.
+
+- **Machine facts pick the LANE.** Among the lanes a release binds for a slot — its accepted
+  contract handles, each with its declared `layout_requirements` — the worker now prefers the one
+  whose minimum this machine meets, then the one whose `recommended` it meets, with ties left in
+  the caller's order. Under the minimum on ALL of them it takes the LEAST-BAD and warns:
+  `select_lane` has no arm that returns nothing, because refusing there would re-answer question 1
+  (which this ruling gives to the author) and would break always-runs. Before this,
+  `select_auto_mode` degraded WITHIN one lane and nothing anywhere picked BETWEEN lanes.
+
+  Worker-side by construction, and it never becomes a hub gate: preference has exactly one
+  authority, the author's ordered (GPU, lane) ladder. What the worker holds is the slot's accepted
+  SET, whose order carries NO preference (§1.33 point 2), so the tie-break is determinism and the
+  code says so. Named rather than hidden: an UNDECLARED level contributes no shortfall, so a lane
+  that declares nothing can outrank one whose recommendation this machine misses — NO DEFAULTS
+  applied consistently, and harmless because ranking is not gating.
+
+- **ONE evaluator, ONE vocabulary.** `models/machine_fit.py` derives its term->fact table from
+  `KNOWN_REQUIREMENT_TERMS` (`min_sm`->`sm`, `min_vram_gb`->`vram_gb`, ...), so growing the
+  vocabulary grows the runtime check for free and no term literal appears in the evaluator. The
+  comparison IS `tensor_layout_contract.term_meets` — the same function that refuses `recommended`
+  below `minimum` at declaration, made public rather than re-implemented. `vram_gb` is the card's
+  TOTAL, never its free bytes: free VRAM is a MOMENT and moments are the rung walk's input, not a
+  floor's. An UNMEASURED fact is reported UNEVALUATED, never scored as a shortfall — reading a
+  cardless pod's `sm=0` as "meets no floor" would file a warning about the wrong thing.
+
+  Red-verified two ways, distinguishably. Disarming the confession emitter reds the three
+  under-minimum arms (and pgw#1312's + the CPU rung's own confession arms, which is the proof the
+  home is shared rather than copied) and leaves every always-runs and lane-pick arm green. Making
+  `select_lane` ignore its facts reds the six lane arms and leaves every warning arm green. Both
+  deliverables are asserted through `gate_functions` — the seam that decides what this pod
+  advertises — not through the planner in isolation: EXECUTION, not registration. Torch-free by
+  construction, so the guards RUN on CI. 286 green across the adjacent suites; ruff, mypy (775
+  files) and seventeen lint scanners clean.
+
+  One fixture defect fell out: `test_multi_group_async_gate_pgw778` built `EndpointSpec(slots=)`
+  as a TUPLE of names where the field is `{slot: Slot}`. Nothing read it until a slot was asked
+  for its declared lanes, and `available_functions` only needed it truthy.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -701,6 +701,21 @@ is unenforceable theater; unmet, it is a degrade warning, which is what the
 offload rungs already do. A minimum is refused at the declaration site, naming
 the move.
 
+**What the worker does with a minimum it does not meet: it SERVES, and it says
+so.** (pgw#1315.) The pod measures its own facts — spelled identically to the
+terms, minus the `min_` prefix — and every declared minimum it misses becomes
+one typed `serve_degrade` event (`phase=below_declared_minimum`) plus the same
+sentence on `FnDegraded.reason`, naming the term, the declared floor and the
+measured fact. It never withdraws the function and it never suggests a card:
+only the hub knows the catalog. So a wrong minimum costs a noisy warning, not a
+dark endpoint.
+
+**Where a slot binds several lanes, those facts also pick which one runs.** Among
+the handles in `Slot(layouts=...)` that carry a `layout_requirements` entry, the
+worker prefers the lane whose minimum this machine meets, then the one whose
+`recommended` it meets. Under the minimum on all of them it takes the least-bad
+and warns — it never answers "none". An undeclared lane is not ranked at all.
+
 Declare a minimum ONLY for a genuine incapability — a function that merely runs
 *better* on newer silicon declares `recommended` and lets the ladder choose;
 over-declaring a minimum shrinks the rentable pool for no reason.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -158,6 +158,7 @@ from .preload import Preloader
 from .api.binding import rebind_pick
 from . import hostfacts
 from .models.hub_policy import TensorhubWorkerCapabilities
+from .models import machine_fit
 from .models.serve_fit import (RUN_FP8_STORAGE,
                                    RUN_OFFLOAD, plan_serve)
 from . import postmortem
@@ -2221,6 +2222,12 @@ class Executor:
             torch_version=facts.torch_version,
             installed_libs=list(libs),
         )
+        # pgw#1315: THE machine, measured once for every function this gate
+        # plans. `vram_gb` is the card's TOTAL — a requirement compared
+        # against free VRAM would pass or fail depending on who else was
+        # loading, and moments are the rung walk's input, not a floor's.
+        machine = machine_fit.measure_machine_facts(
+            caps, vram_gb=total_vram_gb)
         # pgw#676: per-pod native-crash streaks (SIGSEGV & friends recorded
         # by the supervisor/boot-record post-mortem). A function that keeps
         # killing the PROCESS on this card is refused here — loudly, typed —
@@ -2311,8 +2318,17 @@ class Executor:
             # Serve-time plan. th#1867: this no longer asks a size question —
             # `plan_serve` returns non-serveable ONLY for the two gates that
             # name our own code.
-            primary = next(iter(spec.models.values()), None)
-            plan = plan_serve(r, caps, free_vram_gb, binding=primary)
+            # pgw#1315 deliverable 4: the lanes THIS release binds for the
+            # function are its primary model slot's accepted contract handles,
+            # and the machine's facts pick among them. The slot's set order
+            # carries no preference (§1.33 point 2), so `select_lane`'s
+            # tie-break is determinism and not a ranking — the author's ladder
+            # is the one authority on preference and it lives hub-side.
+            primary_slot = next(iter(spec.models), "")
+            primary = spec.models.get(primary_slot)
+            lanes = machine_fit.lane_candidates(spec.slots.get(primary_slot))
+            plan = plan_serve(r, caps, free_vram_gb, binding=primary,
+                              lanes=lanes, facts=machine, scope=name)
             self.serve_plans[name] = plan
             self._gate_serve_plans[name] = plan
             if not plan.serveable:

--- a/src/gen_worker/measured_posture.py
+++ b/src/gen_worker/measured_posture.py
@@ -151,6 +151,14 @@ REASON_CUDA_OOM = "cuda_oom"
 REASON_KERNEL_UNAVAILABLE = "kernel_unavailable"
 REASON_LANE_CAST_DROPPED = "lane_cast_dropped"
 REASON_NO_CUDA = "no_cuda"
+# pgw#1315: this machine is below a lane's DECLARED minimum and the request
+# serves anyway. It is a WARNING and never a refusal — a machine below a
+# declared minimum is the normal input to a degraded run, which is what the
+# minimum being advisory-at-EXECUTION means (the minimum gates one thing, a
+# config-WRITE, and that lives hub-side). Doubles as the `serve_degrade` phase
+# token (`memory.UNDER_MINIMUM_PHASE`) so the cause is countable hub-side under
+# one spelling rather than two.
+REASON_BELOW_DECLARED_MINIMUM = "below_declared_minimum"
 
 #: Shortfall resources.
 RESOURCE_VRAM = "vram"

--- a/src/gen_worker/models/machine_fit.py
+++ b/src/gen_worker/models/machine_fit.py
@@ -1,0 +1,376 @@
+"""Q2's evaluator: this machine's measured FACTS against declared requirement
+TERMS (pgw#1315 deliverables 3 and 4).
+
+`research/machine-compatibility-design.md` splits compatibility into two
+questions. Q1 — *"what is a good GPU for this workload?"* — is the endpoint
+AUTHOR's, answered as configuration, and a declared **minimum** gates exactly
+one thing hub-side: a config-WRITE. Q2 — *"given a fixed GPU, how well does
+this endpoint run on this machine?"* — is this worker's, and **the answer is
+always "it runs"**. So nothing in this module refuses anything. It answers two
+questions and nothing else:
+
+1. **which lane** — among the lanes the release binds, the one whose declared
+   requirements this machine best satisfies (:func:`select_lane`);
+2. **how far under** — the terms the machine falls short of, named, so the
+   worker can serve and CONFESS (:func:`under_minimum`, reported through
+   `memory.report_under_minimum`).
+
+**ONE VOCABULARY, ONE EVALUATOR.** A requirement term and the machine fact it
+is compared against carry the same name minus the `min_` prefix, so evaluating
+a requirement is a NAME LOOKUP and never a bespoke comparator per term:
+
+    min_sm -> sm    min_vram_gb -> vram_gb    min_host_ram_gb -> host_ram_gb
+    min_cuda -> cuda                          min_torch -> torch
+
+The comparison itself is `tensor_layout_contract.term_meets`, the same function
+that checks `recommended >= minimum` at declaration. Growing
+`KNOWN_REQUIREMENT_TERMS` grows this module for free; nothing here names a
+term literal.
+
+**AN UNMEASURED FACT IS UNEVALUATED, NEVER A SHORTFALL.** A `kernels` floor
+with no runtime probe behind it is a requirement that silently does not hold,
+which is why the SDK refuses that term outright. The same rule applies to a
+term whose fact this machine could not measure (no card, so no `sm`): it is
+reported as unevaluated, not scored as a pass and not scored as a failure.
+Reading "0" as "meets nothing" would turn a cardless pod's every lane into a
+shortfall report about the wrong thing — the pod already knows it has no card,
+and the CPU rung already says so.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
+
+import msgspec
+
+from .. import hostfacts
+from .tensor_layout_contract import (
+    KNOWN_REQUIREMENT_TERMS,
+    LayoutRequirements,
+    RequirementTerms,
+    # Re-exported deliberately: this module is where a reader looks for the
+    # runtime comparison, and there must be exactly one to find.
+    term_meets as term_meets,
+)
+
+#: term -> the machine fact it is compared against. Derived, not written: the
+#: whole point of the shared vocabulary is that this table cannot drift.
+FACT_OF_TERM: Dict[str, str] = {
+    term: term.removeprefix("min_") for term in KNOWN_REQUIREMENT_TERMS
+}
+
+LEVEL_MINIMUM = "minimum"
+LEVEL_RECOMMENDED = "recommended"
+
+
+class MachineFacts(msgspec.Struct, frozen=True, kw_only=True):
+    """What this machine IS, spelled identically to the requirement terms.
+
+    Every field's zero/empty means NOT MEASURED — the same tri-state the
+    declaration side uses for NOT DECLARED. ``vram_gb`` is the card's TOTAL,
+    never its free bytes: free VRAM is a MOMENT, and the rung walk is what
+    reads moments (`memory.select_auto_mode`). A requirement compared against
+    a moment would pass or fail depending on who else was loading.
+    """
+
+    sm: int = 0
+    vram_gb: float = 0.0
+    host_ram_gb: float = 0.0
+    cuda: str = ""
+    torch: str = ""
+
+    def stated(self, fact: str) -> bool:
+        return bool(getattr(self, fact, None))
+
+    def render(self) -> str:
+        parts = [f"{f}={getattr(self, f)}"
+                 for f in self.__struct_fields__ if self.stated(f)]
+        return ", ".join(parts) or "nothing measured"
+
+
+def measure_machine_facts(
+    caps: Any = None,
+    *,
+    vram_gb: Optional[float] = None,
+    host_ram_gb: Optional[float] = None,
+) -> MachineFacts:
+    """This machine, as facts. ``caps`` is the already-measured
+    :class:`~gen_worker.models.hub_policy.TensorhubWorkerCapabilities` the
+    executor holds; anything it does not carry is measured here.
+
+    There is no second probe: SM/CUDA/torch come from the capabilities the
+    worker already reported to the hub, VRAM from `hostfacts`, and host RAM
+    from `memory.probe_host_ram`, which pgw#973 made the ONE owner of that
+    number (imported lazily because `memory` imports this module for the
+    confession).
+    """
+    sm = int(getattr(caps, "gpu_sm", 0) or 0)
+    cuda = str(getattr(caps, "cuda_version", "") or "")
+    torch_version = str(getattr(caps, "torch_version", "") or "")
+    if vram_gb is None:
+        total = hostfacts.total_vram_bytes()
+        vram_gb = (total / (1 << 30)) if total else 0.0
+    if host_ram_gb is None:
+        from .memory import get_total_ram_gb
+
+        host_ram_gb = get_total_ram_gb()
+    return MachineFacts(
+        sm=sm,
+        vram_gb=float(vram_gb or 0.0),
+        host_ram_gb=float(host_ram_gb or 0.0),
+        cuda=_dotted(cuda),
+        torch=_dotted(torch_version),
+    )
+
+
+def _dotted(value: str) -> str:
+    """A version the way the vocabulary spells it: leading numeric components
+    only. torch reports `2.9.0+cu128`; the declared floor is `2.9`."""
+    head = str(value or "").strip().split("+")[0]
+    parts: list[str] = []
+    for part in head.split("."):
+        if not part.isdigit():
+            break
+        parts.append(part)
+    return ".".join(parts)
+
+
+@dataclass(frozen=True)
+class Shortfall:
+    """One declared term this machine does not meet.
+
+    ``term`` is the vocabulary's name for the axis, ``declared`` the floor the
+    author wrote, ``measured`` what this machine actually has. That triple IS
+    the warning §1.36 asks for — *what was applied, why quantified* — and it
+    carries NO suggested card: th#1867 deleted `FnDegraded.recommended_vram_gb`
+    because the worker's suggestion was the author's own guess handed back.
+    Only the hub knows the catalog (th#2075 clause 3).
+    """
+
+    term: str
+    level: str
+    declared: Any
+    measured: Any
+    lane: str = ""
+
+    @property
+    def fact(self) -> str:
+        return FACT_OF_TERM[self.term]
+
+    def render(self) -> str:
+        where = f"{self.lane}: " if self.lane else ""
+        return (f"{where}{self.term} declares {self.declared} "
+                f"({self.level}); this machine measures "
+                f"{self.fact}={self.measured}")
+
+
+@dataclass(frozen=True)
+class LevelVerdict:
+    """One LEVEL of one requirement, evaluated. Never a pass/fail bool: the
+    unevaluated axes are the third state and dropping them is how a floor
+    silently stops holding."""
+
+    shortfalls: Tuple[Shortfall, ...] = ()
+    unevaluated: Tuple[str, ...] = ()
+
+    @property
+    def met(self) -> bool:
+        return not self.shortfalls
+
+
+def evaluate_terms(
+    terms: RequirementTerms,
+    facts: MachineFacts,
+    *,
+    level: str,
+    lane: str = "",
+) -> LevelVerdict:
+    """Every DECLARED term of one level against the facts, by name lookup."""
+    shortfalls: list[Shortfall] = []
+    unevaluated: list[str] = []
+    for term, declared in terms.declared_terms().items():
+        fact = FACT_OF_TERM[term]
+        if not facts.stated(fact):
+            unevaluated.append(term)
+            continue
+        measured = getattr(facts, fact)
+        if not term_meets(term, measured, declared):
+            shortfalls.append(Shortfall(
+                term=term, level=level, declared=declared,
+                measured=measured, lane=lane))
+    return LevelVerdict(
+        shortfalls=tuple(shortfalls), unevaluated=tuple(unevaluated))
+
+
+def under_minimum(
+    requirement: Optional[LayoutRequirements],
+    facts: MachineFacts,
+    *,
+    lane: str = "",
+) -> LevelVerdict:
+    """The MINIMUM level's verdict. A shortfall here is a WARNING and never a
+    refusal — a machine below a declared minimum is the normal input to a
+    degraded run, which is what the minimum being advisory-at-execution
+    means."""
+    if requirement is None:
+        return LevelVerdict()
+    return evaluate_terms(
+        requirement.min_terms(), facts, level=LEVEL_MINIMUM, lane=lane)
+
+
+def under_recommended(
+    requirement: Optional[LayoutRequirements],
+    facts: MachineFacts,
+    *,
+    lane: str = "",
+) -> LevelVerdict:
+    """The RECOMMENDED level's verdict. It gates NOTHING, ever — it only ranks
+    lanes below, and even there it can never turn into a floor because
+    :func:`select_lane` always returns a lane."""
+    if requirement is None:
+        return LevelVerdict()
+    return evaluate_terms(
+        requirement.recommended_terms(), facts, level=LEVEL_RECOMMENDED,
+        lane=lane)
+
+
+# ---------------------------------------------------------------------------
+# Deliverable 4 — lane selection by machine facts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LaneCandidate:
+    """One lane the release binds, with what its author declared about it.
+
+    ``requirement`` is None for a lane with no declaration: NO DEFAULTS, so an
+    undeclared lane is not evaluated rather than scored as satisfying nothing.
+    """
+
+    lane: str
+    requirement: Optional[LayoutRequirements] = None
+
+
+@dataclass(frozen=True)
+class RankedLane:
+    lane: str
+    minimum: LevelVerdict
+    recommended: LevelVerdict
+    order: int
+
+    @property
+    def key(self) -> Tuple[int, int, int]:
+        """MINIMUM shortfalls first, then RECOMMENDED, then the caller's order.
+
+        One lexicographic key expresses the design's *"recommended first, then
+        minimum"* because the declaration side already refuses a `recommended`
+        below its own `minimum`: a lane whose recommended holds has its minimum
+        holding too, so "fewest minimum shortfalls, then fewest recommended"
+        cannot rank an under-minimum lane above a satisfied one.
+
+        NAMED, NOT HIDDEN: an UNDECLARED level contributes no shortfall, so a
+        lane that declares nothing can outrank one that declares a
+        recommendation this machine misses. That is NO DEFAULTS applied
+        consistently — an undeclared axis is not evaluated, and scoring
+        silence as a failure would be inventing the author's declaration — and
+        it is harmless because ranking is not gating: every lane here runs.
+        An author who wants a lane preferred moves a rung on the ladder, which
+        is preference's one authority.
+        """
+        return (len(self.minimum.shortfalls),
+                len(self.recommended.shortfalls),
+                self.order)
+
+
+@dataclass(frozen=True)
+class LaneChoice:
+    """The pick, and every rejected lane's verdict beside it."""
+
+    lane: str
+    ranked: Tuple[RankedLane, ...] = ()
+
+    @property
+    def picked(self) -> Optional[RankedLane]:
+        for row in self.ranked:
+            if row.lane == self.lane:
+                return row
+        return None
+
+    @property
+    def under_minimum(self) -> Tuple[Shortfall, ...]:
+        row = self.picked
+        return () if row is None else row.minimum.shortfalls
+
+    @property
+    def forced(self) -> bool:
+        """True when EVERY candidate is under its own minimum, so the pick is
+        the least-bad rather than a satisfied one. Still a pick: the worker
+        does not get to answer "none"."""
+        return bool(self.ranked) and all(
+            row.minimum.shortfalls for row in self.ranked)
+
+
+def select_lane(
+    candidates: Sequence[LaneCandidate], facts: MachineFacts,
+) -> LaneChoice:
+    """The best lane these facts afford — and there is ALWAYS one.
+
+    Candidates arrive in the order their holder ranks them, and the sort is
+    stable, so ties keep that order. A caller holding the author's (GPU, lane)
+    ladder passes ladder order and gets the author's tie-break; a caller
+    holding only a slot's accepted SET passes canonical order, which is
+    determinism and explicitly NOT a preference (§1.33 point 2: the set is a
+    compatibility filter whose order carries no preference, and preference has
+    exactly one authority — the ladder).
+
+    Under-minimum on every candidate picks the LEAST-BAD one and the caller
+    warns. Never a refusal: refusing here would re-answer question 1, which
+    this design gives to the author, and would break always-runs.
+    """
+    ranked = tuple(sorted(
+        (
+            RankedLane(
+                lane=c.lane,
+                minimum=under_minimum(c.requirement, facts, lane=c.lane),
+                recommended=under_recommended(
+                    c.requirement, facts, lane=c.lane),
+                order=i,
+            )
+            for i, c in enumerate(candidates)
+        ),
+        key=lambda r: r.key,
+    ))
+    return LaneChoice(lane=ranked[0].lane if ranked else "", ranked=ranked)
+
+
+def lane_candidates(slot: Any) -> Tuple[LaneCandidate, ...]:
+    """A model slot's bound lanes, in the slot's canonical handle order.
+
+    The lanes a release binds for a slot ARE its accepted contract handles
+    (`Slot(layouts=...)`), and their declared requirements are
+    `Slot(layout_requirements=...)`, keyed by the handle they guard. A slot
+    that declares no requirement at all yields no candidates: there is nothing
+    to rank by, and inventing a ranking over undeclared lanes is exactly the
+    guess this program deletes.
+    """
+    layouts = getattr(slot, "layouts", None) or {}
+    requirements = getattr(slot, "layout_requirements", None) or {}
+    if not requirements:
+        return ()
+    seen: list[str] = []
+    for handles in layouts.values():
+        for handle in handles:
+            if handle not in seen:
+                seen.append(handle)
+    return tuple(
+        LaneCandidate(lane=handle, requirement=requirements.get(handle))
+        for handle in seen
+    )
+
+
+def summarize(shortfalls: Iterable[Shortfall]) -> str:
+    """The shortfalls as one line, each naming term, declared floor and
+    measured fact. Empty for no shortfall — a warning with nothing in it is
+    worse than no warning."""
+    return "; ".join(s.render() for s in shortfalls)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -31,11 +31,13 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import msgspec
 
 from .. import activity as activity_mod
+from .. import measured_posture as posture_mod
+from . import machine_fit
 from ..api.errors import HostRamMoveRefusedError
 from ..component_vocab import component_vocabulary
 from .structure_only import STAMP as _STRUCTURE_ONLY
@@ -1435,6 +1437,73 @@ def place_pipeline(
 #: Countable hub-side in `worker_activity_events`.
 OFFLOAD_ENGAGED_PHASE = "cpu_offload_engaged"
 
+#: pgw#1315: the machine is below a lane's DECLARED minimum and it serves
+#: anyway. Same confession home, its own phase token — and the token IS the
+#: machine-readable cause (`measured_posture.REASON_BELOW_DECLARED_MINIMUM`),
+#: so the reason has one spelling on both carriers.
+UNDER_MINIMUM_PHASE = posture_mod.REASON_BELOW_DECLARED_MINIMUM
+
+
+def _confess_serve_degrade(
+    *, phase: str, line: str, detail: str, log: logging.Logger,
+) -> None:
+    """THE seam every degraded-posture confession leaves this pod through.
+
+    Loud line for a human, typed `serve_degrade` event for the hub, derived
+    from the SAME numbers so the two cannot disagree. Never a gate — every
+    caller has already decided to serve. pgw#1312 built this for offload
+    activation and pgw#1315 puts the under-minimum warning through it rather
+    than beside it: a second emitter is a second answer, and the one the hub
+    banks is never the one the operator read.
+    """
+    log.warning(line)
+    activity_mod.emit_event(
+        activity_mod.KIND_SERVE_DEGRADE, detail=detail, phase=phase)
+
+
+def report_under_minimum(
+    shortfalls: "Sequence[machine_fit.Shortfall]",
+    *,
+    scope: str,
+    posture: str,
+    lane: str = "",
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """This machine is under a DECLARED minimum, and it serves anyway.
+
+    Returns the warning text the caller puts on `ServePlan.warning` (which
+    reaches the hub as `FnDegraded.reason`), having already emitted the typed
+    event — one derivation, two carriers.
+
+    It names the TERM, the declared floor, this machine's measured fact and
+    the posture taken, and it names NO card: th#1867 deleted
+    `FnDegraded.recommended_vram_gb` because the worker's suggestion was the
+    author's own guess handed back, and only the hub knows the catalog.
+    """
+    rows = tuple(shortfalls)
+    if not rows:
+        return ""
+    detail = machine_fit.summarize(rows)
+    # `scope` names the function; each ROW names its own lane (function-scope
+    # rows have none), so the head states the lane the facts PICKED rather
+    # than attributing every shortfall to it.
+    head = (
+        f"running BELOW a declared minimum for {scope}"
+        + (f" (lane picked: `{lane}`)" if lane else "")
+        + f": {detail}. The request still serves at posture `{posture}`; "
+        "this pod is serving DEGRADED and a declared floor is not being met."
+    )
+    _confess_serve_degrade(
+        phase=UNDER_MINIMUM_PHASE,
+        line=transition_line(
+            event="planned", phase="requirements",
+            from_rung="declared_minimum", to_rung=posture, detail=head,
+        ),
+        detail=head,
+        log=logger or _LOG,
+    )
+    return head
+
 
 def _report_offload_engaged(
     pipeline: Any, rung: str, applied: Dict[str, Any], log: logging.Logger,
@@ -1457,14 +1526,14 @@ def _report_offload_engaged(
     """
     needed_gb = estimate_pipeline_size_gb(pipeline)
     free_gb = get_available_vram_gb()
-    log.warning(transition_line(
-        event="engaged", phase="load", from_rung="resident", to_rung=rung,
-        needed_gb=needed_gb, free_gb=free_gb,
-        detail=f"CPU offload ENGAGED ({_applied_summary(applied)}); every "
-               f"forward on this pipeline now moves weights over PCIe",
-    ))
-    activity_mod.emit_event(
-        activity_mod.KIND_SERVE_DEGRADE,
+    _confess_serve_degrade(
+        phase=OFFLOAD_ENGAGED_PHASE,
+        line=transition_line(
+            event="engaged", phase="load", from_rung="resident", to_rung=rung,
+            needed_gb=needed_gb, free_gb=free_gb,
+            detail=f"CPU offload ENGAGED ({_applied_summary(applied)}); every "
+                   f"forward on this pipeline now moves weights over PCIe",
+        ),
         detail=(
             f"pipeline={type(pipeline).__name__}: CPU offload ENGAGED at rung "
             f"`{rung}` ({_applied_summary(applied)}) — ~{needed_gb:.1f} GiB of "
@@ -1473,7 +1542,7 @@ def _report_offload_engaged(
             f"the request still serves; this pod is serving DEGRADED and every "
             f"request on it pays the transfer."
         ),
-        phase=OFFLOAD_ENGAGED_PHASE,
+        log=log,
     )
 
 

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -27,6 +27,15 @@ REACTIVE walk used to stop one rung short of CPU, so a pod that OOM'd its way
 down refused where plan time served. Both ends now reach the same bottom rung
 and it EXECUTES (`memory.apply_low_vram_config` mode `cpu`).
 
+WHAT IT DOES DECIDE, AS OF pgw#1315: which LANE. Among the lanes a release
+binds, the machine's measured facts pick the one whose declared requirements
+they best satisfy (`models/machine_fit.select_lane`), and the declared
+MINIMUMS this machine misses become a loud typed warning through pgw#1312's
+one confession home. Both are question 2 in
+`research/machine-compatibility-design.md`, and neither can refuse: a minimum
+gates a config-WRITE hub-side and NOTHING at execution, so an under-minimum
+machine is the normal input to a degraded run rather than an error.
+
 Every degraded plan carries ``wanted`` (what the function declares) and ``ran``
 (what actually runs) so the worker can report the degradation STRUCTURALLY to
 the orchestrator (FnDegraded) as OPERATOR EVIDENCE. It carries no card size:
@@ -37,14 +46,16 @@ the author's own guess, which §1.2 measured wrong in both directions.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Optional
+from typing import Any, Optional, Sequence, Tuple
 
 from .. import hostfacts
+from . import machine_fit
 from .hub_policy import (
     FIT_INCOMPATIBLE,
     TensorhubWorkerCapabilities,
     variant_fit,
 )
+from .memory import report_under_minimum
 
 # Run modes and prices are the One Rung ladder's; re-exported here because
 # this module is the hub-vocabulary projection.
@@ -69,14 +80,32 @@ class ServePlan:
     est_latency_multiplier: float = 1.0
     wanted: str = ""              # what the function declares (flavor, or "bf16")
     ran: str = ""                 # what actually runs (flavor when native, else run_mode)
+    # pgw#1315 deliverable 4: the lane these machine facts picked, among the
+    # ones the release binds. "" when the function binds no lane that declares
+    # a requirement — there is nothing to rank by, and ranking undeclared
+    # lanes would be the guess this program deletes.
+    lane: str = ""
+    # pgw#1315 deliverable 3: the declared MINIMUMS this machine does not meet.
+    # Non-empty means it runs anyway, degraded, having said so.
+    under_minimum: Tuple[machine_fit.Shortfall, ...] = ()
 
     @property
     def degraded(self) -> bool:
         """True when it runs, but not as planned: non-native placement,
-        or a precision pick that could not be applied
-        (``ran`` != ``wanted``, e.g. a dropped fp8 cast serving bf16)."""
+        a precision pick that could not be applied (``ran`` != ``wanted``,
+        e.g. a dropped fp8 cast serving bf16), or a machine under a declared
+        minimum.
+
+        The last one is why an under-minimum run reaches the orchestrator at
+        all: `_emit_degraded` sends `FnDegraded` for exactly the plans this
+        says yes to, carrying ``warning`` as the reason. It stays a WARNING —
+        `ran` keeps its own vocabulary, so no hub arm that switches on a
+        RunMode can read a requirement shortfall as a placement demotion.
+        """
         if not self.serveable:
             return False
+        if self.under_minimum:
+            return True
         if self.run_mode != RUN_NATIVE:
             return True
         return bool(self.wanted) and bool(self.ran) and self.ran != self.wanted
@@ -100,6 +129,9 @@ def plan_serve(
     free_vram_gb: float,
     *,
     binding: Any = None,
+    lanes: Sequence[machine_fit.LaneCandidate] = (),
+    facts: Optional[machine_fit.MachineFacts] = None,
+    scope: str = "",
 ) -> ServePlan:
     """Decide how one function serves on the actual card.
 
@@ -108,9 +140,22 @@ def plan_serve(
     :func:`variant_fit` keeps it: it is the number the deleted comparison was
     made against, and a caller that stops passing it would hide the fact that
     reintroducing the comparison is a one-line edit.
+
+    pgw#1315 adds question 2's other half. ``lanes`` are the lanes this
+    release binds for the function (``machine_fit.lane_candidates`` builds
+    them from the slot's accepted handles and their declared requirements);
+    the machine's own FACTS pick among them, and the declared MINIMUMS this
+    machine misses become a loud typed warning — never a refusal, because
+    "it always runs" is the whole answer to question 2.
+
+    ``facts`` is measured once by the caller (the gate loop plans every
+    function against ONE machine); ``None`` measures here.
     """
     needs_gpu = bool(getattr(resources, "gpu", False))
     wanted = _wanted(binding)
+    if facts is None:
+        facts = machine_fit.measure_machine_facts(caps)
+    choice = machine_fit.select_lane(tuple(lanes), facts)
 
     verdict, detail = variant_fit(resources, caps, free_vram_gb, binding=binding)
 
@@ -138,7 +183,7 @@ def plan_serve(
             f"({state.probe_class}: {state.detail})"
             if state.unreadable else "no CUDA device detected on this pod"
         )
-        return ServePlan(
+        return _confess_under_minimum(ServePlan(
             serveable=True,
             run_mode=RUN_CPU,
             fit=FIT_INCOMPATIBLE,
@@ -146,7 +191,8 @@ def plan_serve(
             est_latency_multiplier=price(RUN_CPU),
             wanted=wanted,
             ran=RUN_CPU,
-        )
+            lane=choice.lane,
+        ), resources=resources, choice=choice, facts=facts, scope=scope)
 
     # A quant library this build does not carry. Names our IMAGE; the
     # executor's own gate reports it as `missing_cuda_library`.
@@ -162,12 +208,53 @@ def plan_serve(
     # Everything else SERVES. Which rung it lands on is measured at load time
     # (models/memory.select_auto_mode) and reported through `replan`, never
     # predicted here.
-    return ServePlan(
+    return _confess_under_minimum(ServePlan(
         serveable=True,
         run_mode=RUN_NATIVE,
         fit=verdict,
         wanted=wanted,
         ran=wanted,
+        lane=choice.lane,
+    ), resources=resources, choice=choice, facts=facts, scope=scope)
+
+
+def _confess_under_minimum(
+    plan: ServePlan,
+    *,
+    resources: Any,
+    choice: machine_fit.LaneChoice,
+    facts: machine_fit.MachineFacts,
+    scope: str,
+) -> ServePlan:
+    """Serve, and SAY that a declared floor is not being met.
+
+    TWO scopes reach a worker and both are evaluated here: the FUNCTION scope
+    (`Resources(requires=)`, for code with no contract to hang a requirement
+    on) and the (slot, handle) scope of the lane the facts just picked. The
+    hub owns the third (the contract's intrinsic floor) and it can only be
+    looser, so nothing here re-derives it.
+
+    The plan is returned SERVEABLE either way — this function has no arm that
+    can refuse. The warning rides `ServePlan.warning` to `FnDegraded.reason`,
+    and the same sentence rides the typed `serve_degrade` event out of
+    pgw#1312's one confession home, so the operator's line and the hub's row
+    are one derivation.
+    """
+    declared = (resources.requirement()
+                if hasattr(resources, "requirement") else None)
+    shortfalls = (
+        machine_fit.under_minimum(declared, facts).shortfalls
+        + choice.under_minimum
+    )
+    if not shortfalls:
+        return plan
+    warning = report_under_minimum(
+        shortfalls, scope=scope or "this function", lane=choice.lane,
+        posture=plan.run_mode)
+    return replace(
+        plan,
+        under_minimum=tuple(shortfalls),
+        warning=f"{plan.warning} {warning}".strip(),
     )
 
 

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -891,9 +891,16 @@ def _version_tuple(value: str) -> tuple[int, ...]:
     return tuple(int(part) for part in value.split("."))
 
 
-def _term_meets(term: str, candidate: Any, floor: Any) -> bool:
+def term_meets(term: str, candidate: Any, floor: Any) -> bool:
     """Is `candidate` at least `floor` for this term? One comparator per
-    KIND, chosen by name — never one per term."""
+    KIND, chosen by name — never one per term.
+
+    PUBLIC because it is THE evaluator for this vocabulary at BOTH ends: the
+    declaration check below (recommended >= minimum) and the runtime check of
+    a measured machine FACT against a declared floor (`models.machine_fit`)
+    are the same comparison, and a second implementation of it is how the two
+    ends start disagreeing about what "meets" means.
+    """
     if term in ("min_cuda", "min_torch"):
         return _version_tuple(str(candidate)) >= _version_tuple(str(floor))
     return float(candidate) >= float(floor)
@@ -1074,7 +1081,7 @@ def parse_layout_requirements(
 
     floor = min_terms.declared_terms()
     for term, value_ in rec_terms.declared_terms().items():
-        if term in floor and not _term_meets(term, value_, floor[term]):
+        if term in floor and not term_meets(term, value_, floor[term]):
             raise LayoutDeclarationError(
                 f"{where}: recommended {term}={value_} is below minimum "
                 f"{term}={floor[term]}. A recommendation below the floor is a "

--- a/tests/test_lane_pick_by_machine_facts_pgw1315.py
+++ b/tests/test_lane_pick_by_machine_facts_pgw1315.py
@@ -1,0 +1,293 @@
+"""pgw#1315 deliverable 4 — the machine's FACTS pick the lane.
+
+`research/machine-compatibility-design.md`, Q2 in force: *"Rank the lanes the
+release binds by how much of their declared `recommended`, then `minimum`, the
+machine satisfies. Ties broken by the author's ladder order. Run the best one,
+degraded as needed."*
+
+Two properties, and both are load-bearing:
+
+* **the facts FLIP the choice.** One two-lane fixture, two machines, and the
+  pick swaps — which no amount of "the first accepted handle" can produce.
+  Red-verify by making the selector ignore its facts: the flip arm reds and
+  the always-picks-something arms stay green.
+* **it is a PICK, never a gate.** Under-minimum on every candidate returns
+  the least-bad lane and the caller warns. `select_lane` has no arm that
+  returns nothing, because refusing here would re-answer question 1 — which
+  this design gives to the author — and would break always-runs.
+
+Worker-side by construction. This never reaches the hub as a gate: preference
+has exactly one authority, the author's ordered (GPU, lane) ladder, which is
+hub config. What the worker holds is the slot's accepted SET, whose order
+carries NO preference (§1.33 point 2) — so the tie-break here is determinism,
+and this file says so out loud.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.api.slot import Slot
+from gen_worker.executor import Executor
+from gen_worker.hostfacts import HostFacts
+from gen_worker.models import machine_fit
+from gen_worker.models.tensor_layout_contract import (
+    CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    CONTRACT_PLAIN_BF16,
+    LayoutRequirements,
+    parse_layout_requirements,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+_WHERE = "test"
+
+
+def _req(value: Any) -> LayoutRequirements:
+    return parse_layout_requirements(value, where=_WHERE)
+
+
+#: THE two-lane fixture. A bf16 lane that wants a big card and a 4-bit lane
+#: that wants a NEW one: neither dominates, so which lane wins is a fact about
+#: the machine and about nothing else.
+_BF16 = machine_fit.LaneCandidate(
+    CONTRACT_PLAIN_BF16,
+    _req(LayoutRequirements(minimum="sm80+, vram48g",
+                            recommended="sm90+, vram80g")))
+_NVFP4 = machine_fit.LaneCandidate(
+    CONTRACT_COZY_SVDQ_NVFP4_LR8, _req("sm100+, vram24g"))
+_LANES = (_BF16, _NVFP4)
+
+#: An H100: new enough for neither 4-bit floor to bite, roomy enough for bf16.
+_H100 = machine_fit.MachineFacts(sm=90, vram_gb=80.0, host_ram_gb=192.0)
+#: A 5090: NEWER than the H100 and far smaller. bf16's 48 GiB floor fails
+#: here and the 4-bit lane's sm100 floor does not.
+_RTX5090 = machine_fit.MachineFacts(sm=120, vram_gb=32.0, host_ram_gb=64.0)
+#: An A6000: old AND small. Under BOTH minimums — the least-bad case.
+_A6000 = machine_fit.MachineFacts(sm=86, vram_gb=24.0, host_ram_gb=128.0)
+
+
+# ---------------------------------------------------------------------------
+# 1. the facts flip the choice
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_two_lanes_pick_DIFFERENTLY_on_two_machines() -> None:
+    """THE arm this deliverable exists for. Same candidates, same order, two
+    machines, opposite picks — the machine's facts are doing the choosing.
+
+    Red-verify by having `select_lane` ignore `facts`: every other arm in this
+    file still passes, and this one cannot.
+    """
+    assert machine_fit.select_lane(_LANES, _H100).lane == CONTRACT_PLAIN_BF16
+    assert machine_fit.select_lane(
+        _LANES, _RTX5090).lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+
+
+def test_the_flip_survives_the_candidates_being_handed_over_reversed() -> None:
+    """The pick is not "the first one that fits". Reversing the input order
+    changes nothing about which lane the facts satisfy."""
+    reversed_lanes = tuple(reversed(_LANES))
+    assert machine_fit.select_lane(
+        reversed_lanes, _H100).lane == CONTRACT_PLAIN_BF16
+    assert machine_fit.select_lane(
+        reversed_lanes, _RTX5090).lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+
+
+def test_a_satisfied_minimum_outranks_a_better_recommended() -> None:
+    """`recommended` ranks WITHIN the satisfied set and can never promote an
+    under-minimum lane above a satisfied one — the declaration side already
+    refuses a `recommended` below its own `minimum`, so one lexicographic key
+    expresses both levels without `recommended` ever becoming a floor."""
+    choice = machine_fit.select_lane(_LANES, _H100)
+    ranked = {row.lane: row for row in choice.ranked}
+    # bf16 is picked despite MISSING its own recommendation (sm90 clears
+    # sm90+, but 80 GiB is exactly the recommended VRAM, so both hold here);
+    # the 4-bit lane is under its minimum and cannot win regardless.
+    assert ranked[CONTRACT_COZY_SVDQ_NVFP4_LR8].minimum.shortfalls
+    assert not ranked[CONTRACT_PLAIN_BF16].minimum.shortfalls
+    assert choice.lane == CONTRACT_PLAIN_BF16
+    assert choice.forced is False
+
+
+def test_recommended_breaks_a_tie_between_two_satisfied_lanes() -> None:
+    """Both minimums hold, so the ONLY thing left to separate them is how much
+    of each `recommended` this machine affords. That is `recommended` doing
+    the one job the design leaves it: informing a pick, gating nothing."""
+    plain = machine_fit.LaneCandidate(
+        CONTRACT_PLAIN_BF16,
+        _req(LayoutRequirements(minimum="sm80+", recommended="sm100+")))
+    nvfp4 = machine_fit.LaneCandidate(
+        CONTRACT_COZY_SVDQ_NVFP4_LR8,
+        _req(LayoutRequirements(minimum="sm80+", recommended="sm86+")))
+    choice = machine_fit.select_lane((plain, nvfp4), _A6000)
+    assert choice.lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+    assert choice.forced is False, (
+        "both minimums hold; a recommendation shortfall is not a shortfall "
+        "against a floor"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. it always picks — under-minimum is a warning, not a veto
+# ---------------------------------------------------------------------------
+
+
+def test_under_minimum_on_EVERY_lane_still_returns_one() -> None:
+    """Always-runs is the answer to question 2, and it does not get an
+    exception for "no lane fits". The pick is the LEAST-BAD and the caller
+    warns; `forced` is how the caller knows to."""
+    choice = machine_fit.select_lane(_LANES, _A6000)
+    assert choice.lane, "select_lane may never answer 'none'"
+    assert choice.forced is True
+    assert choice.under_minimum, (
+        "the pick being forced is exactly when the confession is owed"
+    )
+
+
+def test_the_least_bad_lane_is_the_one_that_misses_LESS() -> None:
+    """Both under their own minimum, one by more. `forced` says the caller
+    owes a warning either way; the pick is still the better of two bad
+    answers, which is what always-runs on a small old card looks like."""
+    starving = machine_fit.LaneCandidate(
+        CONTRACT_PLAIN_BF16, _req("sm100+, vram80g, cuda13.0+"))
+    nearly = machine_fit.LaneCandidate(
+        CONTRACT_COZY_SVDQ_NVFP4_LR8, _req("sm100+"))
+    choice = machine_fit.select_lane((starving, nearly), _A6000)
+    assert choice.lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+    assert choice.forced is True
+    assert len(choice.under_minimum) == 1
+
+
+def test_a_pure_tie_keeps_the_CALLERS_order() -> None:
+    """Identical declarations cannot be separated by any fact, so the caller's
+    order decides — deterministically, and this is NOT a preference (§1.33
+    point 2: the accepted SET's order carries none). A caller holding the
+    author's ladder passes ladder order and gets the author's tie-break; a
+    caller holding only the set is choosing arbitrarily, and honestly."""
+    same = "sm100+, vram80g"
+    lanes = (machine_fit.LaneCandidate(CONTRACT_PLAIN_BF16, _req(same)),
+             machine_fit.LaneCandidate(CONTRACT_COZY_SVDQ_NVFP4_LR8, _req(same)))
+    assert machine_fit.select_lane(lanes, _A6000).lane == CONTRACT_PLAIN_BF16
+    assert machine_fit.select_lane(
+        tuple(reversed(lanes)), _A6000).lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+
+
+def test_an_UNDECLARED_recommendation_is_not_scored_as_a_failure() -> None:
+    """The asymmetry, NAMED rather than left to be discovered: a lane that
+    declares no recommendation contributes no recommended shortfall, so it can
+    outrank a lane whose recommendation this machine misses. That is NO
+    DEFAULTS applied consistently — scoring silence as a failure would invent
+    the author's declaration — and it is harmless because ranking is not
+    gating: both lanes run either way."""
+    choice = machine_fit.select_lane(_LANES, _A6000)
+    assert choice.lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+    ranked = {row.lane: row for row in choice.ranked}
+    assert len(ranked[CONTRACT_PLAIN_BF16].minimum.shortfalls) == 1
+    assert len(ranked[CONTRACT_COZY_SVDQ_NVFP4_LR8].minimum.shortfalls) == 1
+    assert ranked[CONTRACT_COZY_SVDQ_NVFP4_LR8].recommended.shortfalls == ()
+
+
+def test_no_candidates_is_no_lane_and_no_crash() -> None:
+    choice = machine_fit.select_lane((), _H100)
+    assert choice.lane == "" and choice.ranked == ()
+    assert choice.forced is False and choice.under_minimum == ()
+
+
+# ---------------------------------------------------------------------------
+# 3. candidates come from the slot the release binds
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    pass
+
+
+def test_lane_candidates_reads_the_slots_accepted_handles() -> None:
+    slot: Slot[Any] = Slot(
+        _Pipe, selected_by="model",
+        layouts={"*": (CONTRACT_PLAIN_BF16, CONTRACT_COZY_SVDQ_NVFP4_LR8)},
+        layout_requirements={
+            CONTRACT_COZY_SVDQ_NVFP4_LR8: "sm100+, vram24g",
+            CONTRACT_PLAIN_BF16: LayoutRequirements(
+                minimum="sm80+, vram48g", recommended="sm90+, vram80g"),
+        },
+    )
+    candidates = machine_fit.lane_candidates(slot)
+    assert {c.lane for c in candidates} == {
+        CONTRACT_PLAIN_BF16, CONTRACT_COZY_SVDQ_NVFP4_LR8}
+    assert machine_fit.select_lane(
+        candidates, _RTX5090).lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+
+
+def test_a_slot_that_declares_NO_requirement_offers_NO_lanes() -> None:
+    """NO DEFAULTS. Ranking lanes nobody declared anything about would be the
+    platform inventing the author's answer to question 1, which is precisely
+    what this ruling takes away from the platform."""
+    slot: Slot[Any] = Slot(_Pipe, selected_by="model",
+                layouts={"*": (CONTRACT_PLAIN_BF16,)})
+    assert machine_fit.lane_candidates(slot) == ()
+    assert machine_fit.lane_candidates(None) == ()
+
+
+# ---------------------------------------------------------------------------
+# 4. through the production gate
+# ---------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Fake:
+    def generate(self, ctx: Any, payload: _In) -> None:  # pragma: no cover
+        return None
+
+
+def _gate(gpu_sm: str, vram_gb: int) -> Any:
+    async def _send(_msg: pb.WorkerMessage) -> None:  # pragma: no cover
+        return None
+
+    spec = EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": Hub("acme/sdxl")},
+        slots={"pipeline": Slot(
+            _Pipe, selected_by="model",
+            layouts={"*": (CONTRACT_PLAIN_BF16, CONTRACT_COZY_SVDQ_NVFP4_LR8)},
+            layout_requirements={
+                CONTRACT_COZY_SVDQ_NVFP4_LR8: "sm100+, vram24g",
+                CONTRACT_PLAIN_BF16: LayoutRequirements(
+                    minimum="sm80+, vram48g", recommended="sm90+, vram80g"),
+            },
+        )},
+        resources=Resources(gpu=True),
+    )
+    ex = Executor([spec], _send)
+    ex.gate_functions(HostFacts(
+        vram_total_bytes=vram_gb * 1024 ** 3,
+        vram_free_bytes=(vram_gb - 4) * 1024 ** 3,
+        gpu_sm=gpu_sm, cuda_version="12.8", torch_version="2.9.0",
+    ))
+    return ex.serve_plans["generate"]
+
+
+def test_the_EXECUTOR_GATE_records_the_lane_the_facts_picked() -> None:
+    """ASSERT EXECUTION, NOT REGISTRATION: the same fixture, driven through
+    `gate_functions` — the seam that actually decides what this pod serves —
+    picks differently on the two machines and lands the pick on the plan."""
+    assert _gate("90", 80).lane == CONTRACT_PLAIN_BF16
+    assert _gate("120", 32).lane == CONTRACT_COZY_SVDQ_NVFP4_LR8
+
+
+def test_the_gate_never_withdraws_a_function_over_a_lane_pick() -> None:
+    """Even the machine that is under BOTH lanes' minimums keeps serving. A
+    lane pick that could decline would be a gate, and this is a pick."""
+    plan = _gate("86", 24)
+    assert plan.serveable is True
+    assert plan.lane, "a forced pick is still a pick"
+    assert plan.degraded is True and plan.warning

--- a/tests/test_multi_group_async_gate_pgw778.py
+++ b/tests/test_multi_group_async_gate_pgw778.py
@@ -25,6 +25,7 @@ import pytest
 from gen_worker.hostfacts import HostFacts
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker import Hub, Resources
+from gen_worker.api.slot import Slot
 from gen_worker.executor import EndpointSpec, Executor
 from gen_worker.topology import ExecutionTopology
 
@@ -48,7 +49,10 @@ def _specs() -> List[EndpointSpec]:
     common = dict(
         kind="inference", payload_type=_In, output_mode="single", cls=_Fake,
         models={"pipeline": Hub("acme/sdxl")}, resources=Resources(gpu=True),
-        slots=("pipeline",),
+        # `EndpointSpec.slots` is {slot: Slot}. This fixture spelled it as a
+        # tuple of names — truthy, which was all `available_functions` needed,
+        # and wrong the moment pgw#1315 asked the slot for its declared lanes.
+        slots={"pipeline": Slot(_Fake, selected_by="model")},
     )
     return [
         EndpointSpec(name="sync_fn", method=_Fake.sync_gen, **common),

--- a/tests/test_under_minimum_warning_pgw1315.py
+++ b/tests/test_under_minimum_warning_pgw1315.py
@@ -1,0 +1,366 @@
+"""pgw#1315 deliverable 3 — an under-minimum machine SERVES, and CONFESSES.
+
+`research/machine-compatibility-design.md`, verbatim: *"**Under-minimum is a
+WARNING, never a refusal.** A machine below a declared minimum is the *normal*
+input to a degraded run — that is what the minimum being advisory-at-execution
+means. The typed warning names the term, the declared floor, this machine's
+fact, and the posture taken."*
+
+So there are exactly two ways to fail this file, and they are opposite:
+
+1. **REFUSING.** A declared minimum that gates EXECUTION breaks always-runs.
+   The minimum gates one thing and it is hub-side: a config-WRITE.
+2. **SERVING SILENTLY.** The warning is LOAD-BEARING — it is the whole
+   deliverable. An under-minimum run with no confession is the defect, which
+   is why the emitter is disarmed to red-verify these: with
+   `memory._confess_serve_degrade` a no-op, every assertion below that reads
+   the sink fails and the always-runs assertions stay green.
+
+The confession rides pgw#1312's ONE home (`serve_degrade`, its own phase
+token) — extended, never twinned — and the same sentence rides
+`ServePlan.warning` to `FnDegraded.reason`, so the operator's line and the
+hub's row are one derivation.
+
+Torch-free by construction: the seam is the requirement EVALUATOR and the
+report, not a card. Bounded per the local-inference rule — logic only, no
+compile, no mint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+from gen_worker import activity as activity_mod
+from gen_worker import measured_posture as posture_mod
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.api.slot import Slot
+from gen_worker.executor import Executor
+from gen_worker.hostfacts import HostFacts
+from gen_worker.models import machine_fit
+from gen_worker.models import memory as memory_mod
+from gen_worker.models.hub_policy import TensorhubWorkerCapabilities
+from gen_worker.models.serve_fit import RUN_NATIVE, plan_serve
+from gen_worker.models.tensor_layout_contract import (
+    CONTRACT_PLAIN_BF16,
+    LayoutRequirements,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+import msgspec
+
+
+class _Events:
+    """The REAL activity sink the worker transport installs, drained after the
+    plan — so these assertions read exactly the ActivityUpdates a hub would
+    bank, not an in-process spy."""
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.loop = asyncio.new_event_loop()
+
+    def __enter__(self) -> "_Events":
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        activity_mod.bind_sink(_send, self.loop)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.loop.run_until_complete(asyncio.sleep(0.02))
+        activity_mod.reset_for_tests()
+        self.loop.close()
+
+    def under_minimum(self) -> List[pb.ActivityUpdate]:
+        return [
+            m.activity_update for m in self.sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == activity_mod.KIND_SERVE_DEGRADE
+            and m.activity_update.phase == memory_mod.UNDER_MINIMUM_PHASE
+        ]
+
+
+_CAPS = TensorhubWorkerCapabilities(
+    cuda_version="12.8", gpu_sm=86, torch_version="2.9.0+cu128",
+    installed_libs=[],
+)
+
+#: An RTX A6000-shaped machine: sm86, 48 GiB, a roomy host.
+_MACHINE = machine_fit.MachineFacts(
+    sm=86, vram_gb=48.0, host_ram_gb=128.0, cuda="12.8", torch="2.9")
+
+
+def _plan(requires: Any, *, facts: machine_fit.MachineFacts = _MACHINE) -> Any:
+    return plan_serve(
+        Resources(gpu=True, requires=requires), _CAPS, 40.0,
+        facts=facts, scope="generate")
+
+
+# ---------------------------------------------------------------------------
+# 1. it runs — the whole point of question 2
+# ---------------------------------------------------------------------------
+
+
+def test_a_machine_far_under_every_declared_minimum_still_SERVES() -> None:
+    """§1.35 amendment 2: *"'This model does not run on this card' is never an
+    acceptable terminal state."* The minimum gates a config-WRITE hub-side and
+    nothing at execution, so there is no arm here that can decline."""
+    with _Events():
+        plan = _plan("sm100+, vram80g, cuda13.0+, torch2.13+")
+
+    assert plan.serveable is True
+    assert plan.reason == ""
+    assert plan.run_mode == RUN_NATIVE, (
+        "an under-minimum machine is the NORMAL input to this planner; it "
+        "must not be demoted a rung for missing a declared floor — which rung "
+        "it lands on is measured at load time, not predicted from a "
+        "declaration"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. and it confesses — the load-bearing half
+# ---------------------------------------------------------------------------
+
+
+def test_the_under_minimum_warning_names_TERM_FLOOR_and_FACT() -> None:
+    """The three parts §1.36's amendment requires, on the typed carrier.
+
+    A warning that says "degraded" and nothing else is the qualitative
+    degradation this whole program exists to replace.
+    """
+    with _Events() as events:
+        _plan("sm100+, vram80g")
+
+    rows = events.under_minimum()
+    assert len(rows) == 1, (
+        "ONE confession per plan, through pgw#1312's one home — a second "
+        "emitter is a second answer, and the one the hub banks is never the "
+        "one the operator read"
+    )
+    detail = rows[0].detail
+    for fragment in ("min_sm", "100", "sm=86", "min_vram_gb", "80", "vram_gb=48"):
+        assert fragment in detail, (fragment, detail)
+    assert rows[0].phase == posture_mod.REASON_BELOW_DECLARED_MINIMUM, (
+        "the phase token IS the machine-readable cause, so the reason has one "
+        "spelling on both carriers"
+    )
+
+
+def test_the_warning_rides_ServePlan_warning_to_FnDegraded() -> None:
+    """`lifecycle._emit_degraded` sends `FnDegraded(reason=plan.warning)` for
+    exactly the plans `plan.degraded` says yes to. An under-minimum plan that
+    is not `degraded` never reaches the orchestrator at all."""
+    with _Events() as events:
+        plan = _plan("sm100+, vram80g")
+
+    assert plan.degraded is True
+    assert plan.warning
+    assert plan.warning == events.under_minimum()[0].detail, (
+        "one derivation, two carriers: the operator's line and the hub's row "
+        "cannot be allowed to disagree"
+    )
+    assert len(plan.under_minimum) == 2
+
+
+def test_the_warning_suggests_NO_CARD() -> None:
+    """th#1867 deleted `FnDegraded.recommended_vram_gb` because the worker's
+    suggestion was the author's own guess handed back, and §1.2 measured that
+    guess wrong in BOTH directions on live releases. Only the hub knows the
+    catalog (th#2075 clause 3)."""
+    with _Events():
+        plan = _plan("sm100+, vram80g")
+
+    lowered = plan.warning.lower()
+    assert "recommend" not in lowered
+    assert " use a " not in lowered and "upgrade" not in lowered
+
+
+def test_the_ran_token_stays_out_of_the_hubs_RunMode_vocabulary() -> None:
+    """tensorhub matches `FnDegraded.ran` EXACTLY (`degradation_reschedule.go`
+    switches on `offload`/`cpu`). A requirement shortfall is not a placement
+    demotion, so it must not arrive spelled as one — an under-minimum warning
+    that reported `ran="cpu"` would make the hub reschedule a pod that is
+    running natively and fine."""
+    with _Events():
+        plan = _plan("sm100+, vram80g")
+
+    assert plan.ran not in ("offload", "cpu")
+    assert plan.ran == plan.wanted == "bf16"
+
+
+# ---------------------------------------------------------------------------
+# 3. what must NOT warn
+# ---------------------------------------------------------------------------
+
+
+def test_a_machine_that_MEETS_the_minimum_says_nothing() -> None:
+    with _Events() as events:
+        plan = _plan("sm80+, vram24g, cuda12.0+, torch2.5+")
+
+    assert events.under_minimum() == []
+    assert plan.warning == ""
+    assert plan.degraded is False
+    assert plan.under_minimum == ()
+
+
+def test_recommended_gates_NOTHING_and_warns_about_nothing() -> None:
+    """*"A recommended requirement gates nothing at all, ever."*
+    `recommended_vram_gb` was deleted for cause (th#1720: the hub learned a
+    monotone buy floor from it), so a machine below a RECOMMENDED level is not
+    even a warning — it only ranks lanes."""
+    requirement = LayoutRequirements(
+        minimum="sm80+, vram24g", recommended="sm90+, vram80g")
+    with _Events() as events:
+        plan = _plan(requirement)
+
+    assert events.under_minimum() == []
+    assert plan.warning == ""
+    assert plan.degraded is False
+
+
+def test_an_undeclared_axis_is_NOT_EVALUATED() -> None:
+    """NO DEFAULTS. A requirement that names only `min_sm` says nothing about
+    VRAM, and a planner that read the absence as a floor of zero — or as a
+    floor of anything — would be inventing the author's declaration."""
+    with _Events() as events:
+        plan = _plan("sm80+")
+
+    assert events.under_minimum() == []
+    assert plan.under_minimum == ()
+
+
+def test_an_UNMEASURED_fact_is_unevaluated_rather_than_a_shortfall() -> None:
+    """A cardless pod measures no `sm`. Reading that 0 as "meets no floor"
+    would turn every declaration into a shortfall report about the wrong
+    thing — the pod already knows it has no card, and the CPU rung already
+    says so, loudly, through the same confession home."""
+    cardless = machine_fit.MachineFacts(host_ram_gb=64.0)
+    verdict = machine_fit.under_minimum(
+        Resources(gpu=True, requires="sm100+, vram80g").requirement(), cardless)
+
+    assert verdict.shortfalls == ()
+    assert verdict.unevaluated == ("min_sm", "min_vram_gb")
+
+
+# ---------------------------------------------------------------------------
+# 4. through the PRODUCTION gate, not the planner in isolation
+# ---------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Fake:
+    def generate(self, ctx: Any, payload: _In) -> None:  # pragma: no cover
+        return None
+
+
+def _spec(requires: Any) -> EndpointSpec:
+    return EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": Hub("acme/sdxl")},
+        slots={"pipeline": Slot(
+            _Fake, selected_by="model",
+            layouts={"*": (CONTRACT_PLAIN_BF16,)},
+            layout_requirements={CONTRACT_PLAIN_BF16: "sm100+, vram80g"},
+        )},
+        resources=Resources(gpu=True, requires=requires),
+    )
+
+
+def test_the_EXECUTOR_GATE_confesses_and_keeps_the_function_available(
+) -> None:
+    """ASSERT EXECUTION, NOT REGISTRATION. `gate_functions` is the seam that
+    decides what this pod advertises; it is where an under-minimum machine
+    either serves loudly or quietly disappears from the fleet."""
+
+    async def _send(_msg: pb.WorkerMessage) -> None:  # pragma: no cover
+        return None
+
+    with _Events() as events:
+        ex = Executor([_spec("sm100+")], _send)
+        ex.gate_functions(HostFacts(
+            vram_total_bytes=48 * 1024 ** 3,
+            vram_free_bytes=40 * 1024 ** 3,
+            gpu_sm="86", cuda_version="12.8", torch_version="2.9.0",
+        ))
+
+    assert "generate" not in ex.unavailable, (
+        "a declared minimum may never withdraw a function: it gates a "
+        "config-WRITE hub-side and nothing at execution"
+    )
+    plan = ex.serve_plans["generate"]
+    assert plan.serveable is True and plan.degraded is True
+    rows = events.under_minimum()
+    assert len(rows) == 1
+    # BOTH scopes reach the worker and both are evaluated: the function scope
+    # (`Resources(requires=)`) and the (slot, handle) scope of the picked lane.
+    assert "generate" in rows[0].detail
+    assert CONTRACT_PLAIN_BF16 in rows[0].detail
+    assert len(plan.under_minimum) == 3, (
+        "min_sm from the function scope, min_sm + min_vram_gb from the lane "
+        "scope — a scope that is silently dropped is a floor that silently "
+        "does not hold"
+    )
+
+
+def test_the_gate_leaves_a_MEETING_machine_silent() -> None:
+    """The negative control for the arm above: same seam, same spec shape, a
+    machine that clears both scopes."""
+
+    async def _send(_msg: pb.WorkerMessage) -> None:  # pragma: no cover
+        return None
+
+    spec = EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": Hub("acme/sdxl")},
+        slots={"pipeline": Slot(
+            _Fake, selected_by="model",
+            layouts={"*": (CONTRACT_PLAIN_BF16,)},
+            layout_requirements={CONTRACT_PLAIN_BF16: "sm80+, vram24g"},
+        )},
+        resources=Resources(gpu=True, requires="sm80+"),
+    )
+    with _Events() as events:
+        ex = Executor([spec], _send)
+        ex.gate_functions(HostFacts(
+            vram_total_bytes=48 * 1024 ** 3,
+            vram_free_bytes=40 * 1024 ** 3,
+            gpu_sm="86", cuda_version="12.8", torch_version="2.9.0",
+        ))
+
+    assert events.under_minimum() == []
+    assert ex.serve_plans["generate"].degraded is False
+
+
+# ---------------------------------------------------------------------------
+# 5. the vocabulary is shared, so the evaluator cannot drift
+# ---------------------------------------------------------------------------
+
+
+def test_every_requirement_term_has_a_measured_fact_of_the_same_name() -> None:
+    """*"A requirement term and the machine fact it is compared against have
+    the SAME NAME, so evaluation is a name lookup, never a bespoke comparator
+    per term."* Growing `KNOWN_REQUIREMENT_TERMS` must not need an edit here —
+    but a term with no fact behind it is a floor that silently does not hold,
+    which is exactly why `kernels` is refused at declaration."""
+    fields = set(machine_fit.MachineFacts.__struct_fields__)
+    assert set(machine_fit.FACT_OF_TERM.values()) == fields
+
+
+def test_the_comparator_is_the_declaration_sites_own() -> None:
+    """One evaluator. `recommended >= minimum` at declaration and `fact >=
+    floor` at runtime are the same question, and two implementations of it
+    drift into disagreeing about what "meets" means."""
+    from gen_worker.models import tensor_layout_contract as tlc
+
+    assert machine_fit.term_meets is tlc.term_meets
+    # And it is version-aware rather than lexicographic, which is the whole
+    # reason a per-KIND comparator exists: "2.10" is above "2.9".
+    assert tlc.term_meets("min_torch", "2.10", "2.9") is True
+    assert tlc.term_meets("min_torch", "2.9", "2.10") is False


### PR DESCRIPTION
Closes the last two deliverables of pgw#1315. Deliverables 1+2 landed as `c93cbb1f`; this rides pgw#1313's `{minimum, recommended}` vocabulary (`89d2465b`).

Design: `research/machine-compatibility-design.md`. A declared **minimum** gates exactly one thing and it is hub-side — a config-WRITE. At EXECUTION it gates nothing. But until now it also **said** nothing, so a pod running a lane its author had declared unfit for that card was indistinguishable from one running it as designed.

### 3. The under-minimum warning

The worker measures its own facts and every missed minimum becomes ONE typed `serve_degrade` (`phase=below_declared_minimum`, the same spelling as the `MeasuredPosture` cause) naming the TERM, the declared floor, the measured fact and the posture taken. It rides pgw#1312's one confession home — `_report_offload_engaged`'s emitter, extracted and shared, never twinned — and the SAME sentence lands on `ServePlan.warning`, which `lifecycle._emit_degraded` sends as `FnDegraded.reason`. One derivation, two carriers.

It carries **no suggested card** (th#1867 deleted `recommended_vram_gb` because the worker's suggestion was the author's own guess handed back), and `ran` stays out of the hub's exact-match RunMode vocabulary: a requirement shortfall is not a placement demotion, and reporting it as one would make the hub reschedule a pod running natively and fine.

### 4. Lane selection by machine facts

Among the lanes a release binds for a slot — its accepted contract handles, each with its declared `layout_requirements` — the worker prefers the one whose minimum this machine meets, then whose `recommended` it meets, ties left in the caller's order. Under-minimum on ALL of them takes the LEAST-BAD and warns: `select_lane` has no arm that returns nothing, because refusing there would re-answer question 1 (the author's) and break always-runs. Before this, `select_auto_mode` degraded WITHIN one lane and nothing picked BETWEEN lanes.

Worker-side by construction. Preference's one authority stays the author's ladder; the slot set's order carries none (§1.33 point 2), so the tie-break is determinism and the code says so.

### One evaluator

`models/machine_fit.py` derives its term->fact table from `KNOWN_REQUIREMENT_TERMS` (`min_sm`->`sm`, ...), so growing the vocabulary grows the runtime check for free. The comparison IS `tensor_layout_contract.term_meets` — the same function that refuses `recommended` below `minimum` at declaration, made public rather than re-implemented. `vram_gb` is the card's TOTAL, never free bytes: moments are the rung walk's input, not a floor's. An unmeasured fact is UNEVALUATED, never a shortfall.

### Red/green

- Disarming `_confess_serve_degrade` reds the three under-minimum arms **and** pgw#1312's + the CPU rung's own confession arms — the proof the home is shared rather than copied — and leaves every always-runs and lane-pick arm green.
- Making `select_lane` ignore its facts reds the six lane arms and leaves every warning arm green.
- Both deliverables are asserted through `gate_functions`, the seam that decides what this pod advertises — EXECUTION, not registration.
- 286 green across the adjacent suites (incl. the whole pgw#1315 + pgw#1312 + pgw#1313 acceptance sets, untouched). ruff clean on `src/gen_worker`, mypy clean on 775 files, seventeen lint scanners green. Torch-free by construction, so the guards RUN on CI.
- No wheel bump: rides the next cut with pgw#1313's vocabulary.

Also fixes a fixture defect this surfaced: `test_multi_group_async_gate_pgw778` built `EndpointSpec(slots=)` as a tuple of names where the field is `{slot: Slot}` — nothing read it until a slot was asked for its declared lanes, and `available_functions` only needed it truthy.