### PR TITLE
pgw#1319 (A18, THE CUT): the flavor token is deleted, the precision class is DECLARED, and an undeclared non-base publish is a REFUSAL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -395,16 +395,17 @@ jobs:
           uv run python scripts/lint_repo_ref_pins.py --selftest
           uv run python scripts/lint_repo_ref_pins.py
 
-      # GATING (A18 / §1.32(d), pgw#1307): the flavor axis is deleted, and the
-      # one residue that survives — `ProducedFlavor.flavor`, a PROD author
-      # surface training-endpoints constructs — may not grow a second reader
-      # while it waits for its te leg. `tests/test_flavor_deletion_pgw1148.py`
-      # asserts the same deletion and is NOT skipped (its one skipping row died
-      # at pgw#1167), but it runs in `tests`, which pgw#1264 took off the merge
-      # path — so until this step existed the required context had no opinion
-      # about the axis at all. Selftest first: the fence must prove it goes red
-      # before its green means anything.
-      - name: A18 guard - the flavor is deleted and its residue may not grow
+      # GATING (A18 / §1.32(d), pgw#1307 -> pgw#1319): the flavor axis is
+      # deleted and the residue is now ZERO — `ProducedFlavor.flavor`, the
+      # `label` read and `classify_flavor_token` are gone, the class is
+      # DECLARED, and the former residue paths get no exemption.
+      # `tests/test_flavor_deletion_pgw1148.py` asserts the same deletion and is
+      # NOT skipped (its one skipping row died at pgw#1167), but it runs in
+      # `tests`, which pgw#1264 took off the merge path — so without this step
+      # the required context would have no opinion about the axis at all.
+      # Selftest first: the fence must prove it goes red before its green means
+      # anything, and its last arm regrows the residue in its own former files.
+      - name: A18 guard - the flavor is deleted and its residue is zero
         run: |
           uv run python scripts/lint_flavor_deletion.py --selftest
           uv run python scripts/lint_flavor_deletion.py

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ fp8-E4M3 storage with per-layer upcast to the compute `dtype` (half the VRAM
 on any card); fp8-stored artifacts get the same treatment automatically.
 Quantization itself is ahead-of-time only — a conversion endpoint produces the
 artifact, never `setup()` (th#1803) — and the `flavor` axis is DELETED
-(§1.32(d), pgw#1148): selection within a tag group is tensor-layout-contract
+(§1.32(d), pgw#1148, finished by pgw#1319: the producer DECLARES a
+`precision_class` and nothing infers one from a label): selection within a tag
+group is tensor-layout-contract
 compatibility, declared per slot as `Slot(layouts=…)` (§1.33, pgw#1143). See
 [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
 

--- a/changelog.d/pgw1319.md
+++ b/changelog.d/pgw1319.md
@@ -1,0 +1,44 @@
+- **`ProducedFlavor.flavor` is deleted, and with it `classify_flavor_token` —
+  the precision class is DECLARED, never inferred from a label (A18 /
+  §1.32(d)).** The token named no catalog row, but it decided
+  `checkpoints.metadata["placement"]["precision_class"]`, which tensorhub's
+  `precision.StoredPrecisionOf` reads as its strongest evidence for a stored
+  class where no tensor-layout contract is proven — so a producer-local string
+  decided how an artifact is served. It also answered wrong in both directions:
+  the classifier matched `fp8` and `fp8-*` and never `*-fp8`, so `coherent-fp8`
+  and `encoder-trunc-fp8` published with NO class and the hub served them as
+  base for as long as they existed. Producers now state the class in their own
+  attribute bag, derived from a structural fact (the svdq artifact's precision,
+  the quantization scheme, the requested dtype, the safetensors header).
+- **`publish_flavors` REFUSES instead of guessing.** A `precision_class`
+  outside `models.ladder.PRECISION_CLASSES` is a typed `PrecisionClassRefusal`
+  rather than prose in checkpoint metadata, and a tree whose own safetensors
+  headers report sub-16-bit weights while declaring no class is refused before
+  a byte moves — the deletion's one real hazard is a row that silently unstamps
+  and serves as base, and that is now the one thing it cannot do. (Packed
+  int4/fp4 weights read as `I8`/`I32` and are invisible to that evidence: the
+  declaration is the mechanism, this is the backstop.)
+- **The cross-repo leg landed first, and the census was wrong twice.**
+  training-endpoints te#225 (`7e5e6196`) declared at seven sites; te#227
+  (`e52ad87d`) took the census to NINE after a third enumeration made from the
+  tree — `fuse_lora`'s fp8 arm passes the literal `"fp8"` (both earlier
+  censuses read it as a free-form label), and the H3 modulation bake splits an
+  fp8 DiT it never decodes, so both of its variants published with no class at
+  all. That is a third live mis-stamp of the `coherent-fp8` shape, closed by
+  declaring. **Eleven of te's twenty production `ProducedFlavor` constructions
+  publish a non-base row**; the other nine are base and correctly declare
+  nothing.
+- `scripts/lint_flavor_deletion.py`'s residue is now **zero**: no field, no
+  reader, no classifier, and the former residue paths get no exemption. Its
+  selftest's last arm regrows all three in `convert/produced.py` and
+  `convert/publish.py` and requires every rule to speak — the arm that would
+  have gone quiet if the cut had removed the code and left the allowance.
+- The publish activity leg reads `artifact=<produced path name>` instead of
+  `flavor=<token>`. A filename is the thing that actually exists, is always
+  present, and still tells one leg of an N-artifact export from another.
+- `convert.svdq.svdq_flavor_label` and the `attrs["flavor"]` key
+  `build_svdq_flavor_tree` writes are pure LABEL now — no pgw logic reads
+  either. They are held, named, in `scripts/author_surface_allowlist.txt`
+  because training-endpoints' committed producers still read both to fill the
+  `flavor=` kwarg this release deletes; they die in the te repin lane, in the
+  commit that drops those kwargs.

--- a/docs/convert.md
+++ b/docs/convert.md
@@ -7,11 +7,14 @@ Cozy Creator's model ETL: hub ingest (HF + Civitai), dtype cast / quantization, 
 > inside an endpoint's `setup()` is deleted, not kept as a fallback (it lengthens every cold boot
 > and wastes transfer — fetch 30 GB of bf16, discard 15 GB).
 >
-> **`flavor` as a selector is dead** (DESIGN-RULINGS §1.33): what a producer emits is an artifact
-> carrying a tensor-layout contract, and consumers select within a tag group by contract
-> compatibility, not by an arbitrary `#flavor` string. The `ProducedFlavor` / `publish_flavors` /
-> `#fp8` spellings below are the current API, not the target one — th#1809 (hub) and pgw#1143 (SDK)
-> own the replacement.
+> **`flavor` is dead, selector AND label** (DESIGN-RULINGS §1.32(d)/§1.33; A18, pgw#1319): what a
+> producer emits is an artifact carrying a tensor-layout contract, and consumers select within a
+> tag group by contract compatibility, not by an arbitrary `#flavor` string. `ProducedFlavor` has
+> no `flavor` field: what the bytes ARE is the `dtype` attribute plus an `artifact_contract`, and
+> what LANE they are on is a `precision_class` attribute the producer DECLARES from a structural
+> fact. A tree of sub-16-bit weights that declares none is a typed refusal, never an unstamped
+> publish — the hub reads an unstamped row as base. The struct's NAME is the last of the word;
+> th#1809 (hub) and pgw#1143 (SDK) own the rest of the replacement.
 
 - **Ingest**: HuggingFace (`HfApi.list_repo_files` + classifier + `snapshot_download(allow_patterns=…)`) and Civitai (bounded provider API).
 - **Convert**: streaming dtype cast + fp8-E4M3 storage cast (`#fp8` flavor), GGUF (llama.cpp toolchain), singlefile↔diffusers repackage.

--- a/scripts/author_surface_allowlist.txt
+++ b/scripts/author_surface_allowlist.txt
@@ -76,5 +76,13 @@ convert.publish.publish_flavors	training-endpoints/conversion/src/conversion/_co
 convert.source.Source	training-endpoints/conversion/src/conversion/_common.py:9	PROD
 convert.svdq.build_svdq_flavor_tree	training-endpoints/conversion/src/conversion/quant/svdq.py:36	PROD
 convert.svdq.fetch_svdq_checkpoint	training-endpoints/conversion/src/conversion/quant/svdq.py:36	PROD
+# A18 RESIDUE, pgw#1319. `svdq_flavor_label` renders the DEAD token
+# (`svdq-fp4-r128`) and `build_svdq_flavor_tree` puts it in the attribute bag
+# as `attrs["flavor"]`. Neither is logic any more — the precision class is
+# DECLARED from `svdq_precision` (te#225) — but te's committed producers still
+# read both to fill the `flavor=` kwarg this repo just deleted, and `src/` is
+# not a delete authority for surface another repo calls. They die in the te
+# repin lane, in the same commit that drops te's `flavor=` kwargs.
+convert.svdq.svdq_flavor_label	training-endpoints/conversion/src/conversion/quant/h3_svdq.py:126	PROD
 convert.writer.streaming_fp8_snapshot	training-endpoints/tests/test_fuse_lora.py:317	TEST
 convert.writer.verify_w8a8_snapshot	training-endpoints/conversion/src/conversion/quant/modelopt.py:872	PROD

--- a/scripts/lint_flavor_deletion.py
+++ b/scripts/lint_flavor_deletion.py
@@ -1,43 +1,32 @@
 #!/usr/bin/env python3
-"""A18 / DESIGN-RULINGS §1.32(d): the flavor dies entirely, and what is left of
-it may not GROW while it waits for its cross-repo leg.
+"""A18 / DESIGN-RULINGS §1.32(d): the flavor is deleted, and the residue is ZERO.
 
 WHY A LINT AND NOT ONLY A TEST. `tests/test_flavor_deletion_pgw1148.py` is a
 good fence and it runs — but it runs in `tests`, which pgw#1264 took off the
-merge path, so nothing in the REQUIRED context (`fast gates`) has an opinion
-about the flavor axis. A rename that regrows a reader merges green and is found
-on a pod. This runs where the merge is decided.
+merge path, so nothing in the REQUIRED context (`fast gates`) would have an
+opinion about the flavor axis. A rename that regrows a reader merges green and
+is found on a pod. This runs where the merge is decided.
 
-WHAT SURVIVES, AND WHY IT IS NOT CUT HERE. `ProducedFlavor.flavor` is a
-PRODUCTION AUTHOR SURFACE: `training-endpoints/conversion` constructs it at 14
-sites and `scripts/author_surface_allowlist.txt` pins `publish_flavors` to
-`conversion/src/conversion/_common.py:9`. The token is not decoration — it is
-the input to `classify_flavor_token`, which derives
-`checkpoints.metadata["placement"]["precision_class"]`, the hub's strongest
-evidence for a stored precision class where no tensor-layout contract is proven
-(tensorhub `precision.StoredPrecisionOf`). Deleting the field from this repo
-alone would either fail every te producer with a `TypeError` on a rented pod, or
-— worse — silently drop the precision class of every svdq/fp8/nvfp4 row whose
-producer states it only through the token. So the residue stays, NAMED, with its
-removal condition, and this fence holds it at exactly the size it is today.
-
-THE REMOVAL CONDITION, so this file states it rather than a tracker page: every
-te producer whose token classifies to a non-base class declares
-`precision_class` in its own attribute bag (te already does this once, at
-`conversion/src/conversion/quant/modelopt.py:1262`). When that lands,
-`classify_flavor_token`, the `label` read and `ProducedFlavor.flavor` all go,
-`RESIDUE` below becomes empty, and this fence becomes a pure deletion check.
+THE RESIDUE IS GONE (pgw#1319, 2026-08-17). `ProducedFlavor.flavor`,
+the `label = flavor.flavor or ...` read and `classify_flavor_token` are all
+DELETED. The cross-repo condition that held them alive is discharged: te#225
+and te#227 made `precision_class` a DECLARATION at every training-endpoints
+producer that publishes a non-base row (eight sites — the census was wrong
+twice before it was made from the tree), and `convert.publish` now REFUSES a
+publish of sub-16-bit bytes that declares no class instead of guessing one from
+a label. So this file no longer holds an allowance at a size; it asserts that
+the axis names nothing at all, and the former residue paths get NO exemption.
 
 Three rules, all AST — a grep cannot tell `X.flavor` from `flavor_label(...)`
 from `cgroup_flavor`, and this axis is a four-way homonym (the compile-cell
 `#`-fragment is the one that must NOT move).
 
   1. DELETED names stay deleted. Nothing in `src/` binds or reads a name the
-     deletion removed.
-  2. A `flavor`-shaped FIELD is declared at exactly one place, the named residue.
-  3. The token is READ at exactly the declared sites. A new reader is red even
-     though it compiles, because a second reader is how a deleted axis comes
-     back.
+     deletion removed — `classify_flavor_token` among them now.
+  2. NO `flavor`-shaped FIELD is declared anywhere. There is no residue row to
+     be excused by.
+  3. The token is READ nowhere. A new reader is red even though it compiles,
+     because a second reader is how a deleted axis comes back.
 
 Usage:
 
@@ -68,18 +57,19 @@ DELETED_NAMES = (
     "WorkerResolvedFlavor",
     "sibling_flavors",
     "default_flavor",
+    "classify_flavor_token",
 )
 
 #: Field names that name the axis. `flavors` is deliberately absent: it is the
 #: parameter of `publish_flavors`, a LIST of produced artifacts, not a selector.
 FIELD_NAMES = ("flavor", "default_flavor", "sibling_flavors")
 
-#: The A18 residue, at the size it is allowed to be. `<relpath>: <what>`.
-#: Every row dies with the te leg described in this module's docstring; a row
-#: that no longer matches anything is red too, so the list cannot outlive it.
-RESIDUE_FIELD = "convert/produced.py"          # ProducedFlavor.flavor
-RESIDUE_READERS = ("convert/publish.py",)      # the one `label = ...` derivation
-RESIDUE_CLASSIFIERS = ("convert/publish.py",)  # the one classify_flavor_token call
+#: The A18 residue, now EMPTY. Kept as named constants rather than deleted so
+#: the rules below read as "at exactly these sites, and there are none" — and
+#: so that a future lane re-adding one has to say so in this file.
+RESIDUE_FIELD = ""       # no module may declare a flavor field
+RESIDUE_READERS: Tuple[str, ...] = ()      # no module may read the token
+RESIDUE_CLASSIFIERS: Tuple[str, ...] = ()  # the classifier is deleted
 
 CLASSIFIER = "classify_flavor_token"
 
@@ -150,35 +140,25 @@ def scan(roots: Tuple[Path, ...]) -> List[str]:
                     seen_readers.append(rel)
                 else:
                     findings.append(
-                        f"{rel}:{node.lineno}: a new read of `.{node.attr}` — the "
-                        "producer-local label has ONE reader and is losing that "
-                        "one; see this script's docstring for the te leg")
+                        f"{rel}:{node.lineno}: a read of `.{node.attr}` — the "
+                        "producer-local label is DELETED and has no readers; "
+                        "the class is declared, not inferred from a label")
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
                     and node.func.id == CLASSIFIER and not is_classifier_def:
                 if rel in RESIDUE_CLASSIFIERS:
                     seen_classifiers.append(rel)
                 else:
                     findings.append(
-                        f"{rel}:{node.lineno}: a new {CLASSIFIER} caller — it is a "
-                        "package-internal choke point that dies with the token; "
-                        "nothing new may grow on it")
+                        f"{rel}:{node.lineno}: a {CLASSIFIER} caller — the "
+                        "classifier is DELETED; declare `precision_class` from a "
+                        "structural fact instead of re-deriving it from a label")
 
-    # A residue row matching nothing is stale, and a stale row reads as a fence.
-    if not seen_field:
-        findings.append(
-            f"RESIDUE_FIELD names {RESIDUE_FIELD!r}, which declares no flavor "
-            "field any more — the te leg landed: delete the row (and probably "
-            "this whole rule)")
-    for row in RESIDUE_READERS:
-        if row not in seen_readers:
-            findings.append(
-                f"RESIDUE_READERS names {row!r}, which no longer reads the token "
-                "— delete the row")
-    for row in RESIDUE_CLASSIFIERS:
-        if row not in seen_classifiers:
-            findings.append(
-                f"RESIDUE_CLASSIFIERS names {row!r}, which no longer calls "
-                f"{CLASSIFIER} — delete the row")
+    # The residue is EMPTY, so there is no staleness rule left: every match
+    # above is already a finding. These stay asserted rather than dropped so a
+    # lane that re-adds a row has to make the allowance visible here.
+    assert not seen_field and not seen_readers and not seen_classifiers, (
+        "the A18 residue is empty; a match here means a residue row was "
+        "re-added without saying so")
     return findings
 
 
@@ -207,16 +187,6 @@ def _selftest() -> int:
         for name, src, expect_red in cases:
             root = Path(tmp) / name
             root.mkdir()
-            # Satisfy the residue rows so only the planted rule can speak.
-            (root / RESIDUE_FIELD).parent.mkdir(parents=True, exist_ok=True)
-            (root / RESIDUE_FIELD).write_text(
-                "import msgspec\n\n\nclass ProducedFlavor(msgspec.Struct):\n"
-                "    flavor: str = ''\n")
-            (root / RESIDUE_READERS[0]).write_text(
-                "def publish_flavors(ctx, flavors):\n"
-                "    for f in flavors:\n"
-                "        label = f.flavor\n"
-                f"        yield {CLASSIFIER}(label)\n")
             (root / "planted.py").write_text(src)
             findings = [f for f in scan((root,)) if f.startswith("planted.py")]
             if bool(findings) != expect_red:
@@ -224,20 +194,32 @@ def _selftest() -> int:
                 verb = "did not go red" if expect_red else "went red"
                 print(f"SELFTEST FAILED: {name} {verb}: {findings}", file=sys.stderr)
 
-        # The staleness rule: a residue row that matches nothing is red.
-        root = Path(tmp) / "stale"
+        # The flip pgw#1319 makes: the residue is ZERO, so the paths that
+        # used to be excused are excused no longer. Regrow all three there and
+        # every one is red — the arm that would have gone quiet if the cut had
+        # deleted the code but left the allowance behind.
+        root = Path(tmp) / "regrown"
         (root / "convert").mkdir(parents=True)
-        (root / RESIDUE_FIELD).write_text("X = 1\n")
-        (root / RESIDUE_READERS[0]).write_text("Y = 2\n")
-        stale = scan((root,))
-        if len(stale) != 3:
+        (root / "convert" / "produced.py").write_text(
+            "import msgspec\n\n\nclass ProducedFlavor(msgspec.Struct):\n"
+            "    flavor: str = ''\n")
+        (root / "convert" / "publish.py").write_text(
+            "def publish_flavors(ctx, flavors):\n"
+            "    for f in flavors:\n"
+            "        label = f.flavor\n"
+            f"        yield {CLASSIFIER}(label)\n")
+        regrown = scan((root,))
+        # field + `.flavor` read + classifier CALL + the classifier's name read
+        # (it is a DELETED name now, so rule 1 speaks too).
+        if len(regrown) != 4:
             ok = False
-            print(f"SELFTEST FAILED: a fully-landed te leg should red all three "
-                  f"residue rows, got {stale}", file=sys.stderr)
+            print("SELFTEST FAILED: regrowing the former residue in its own "
+                  f"files must red every rule, got {regrown}", file=sys.stderr)
     if not ok:
         return 1
     print("lint_flavor_deletion selftest: red on all five regressions, green on "
-          "all four homonyms, red on a stale residue row")
+          "all four homonyms, red on a regrown residue in its own former "
+          "files (the residue is ZERO)")
     return 0
 
 
@@ -247,16 +229,18 @@ def main(argv: List[str]) -> int:
     roots = tuple(Path(a).resolve() for a in argv) or DEFAULT_ROOTS
     findings = scan(roots)
     if findings:
-        print("A18 / §1.32(d): the flavor is deleted and its residue may not "
-              "grow. See scripts/lint_flavor_deletion.py for the residue's "
-              "removal condition (a training-endpoints leg).\n", file=sys.stderr)
+        print("A18 / §1.32(d): the flavor is deleted and names nothing. The "
+              "precision class is DECLARED by the producer (`precision_class`, "
+              "checked against models.ladder.PRECISION_CLASSES); it is never "
+              "inferred from a label.\n", file=sys.stderr)
         for f in findings:
             print(f, file=sys.stderr)
         print(f"\n{len(findings)} finding(s)", file=sys.stderr)
         return 1
     print("lint_flavor_deletion: the flavor axis is deleted; the A18 residue is "
-          f"{len(RESIDUE_READERS)} reader, 1 field, "
-          f"{len(RESIDUE_CLASSIFIERS)} classifier call — unchanged")
+          f"{len(RESIDUE_READERS)} readers, "
+          f"{1 if RESIDUE_FIELD else 0} fields, "
+          f"{len(RESIDUE_CLASSIFIERS)} classifier calls — the token names nothing")
     return 0
 
 

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -64,7 +64,7 @@ from .repack_spec import (
     RepackageFamily,
     SinglefileTarget,
 )
-from .publish import publish_flavors
+from .publish import PrecisionClassRefusal, publish_flavors
 from .source import Source
 from .svdq import build_svdq_flavor_tree, fetch_svdq_checkpoint
 from .writer import (
@@ -97,6 +97,7 @@ __all__ = [
     "ingest_civitai",
     "clone",
     "CloneResult",
+    "PrecisionClassRefusal",
     "publish_flavors",
     # Family declarations: the endpoint declares, the SDK executes.
     "CIVITAI",

--- a/src/gen_worker/convert/produced.py
+++ b/src/gen_worker/convert/produced.py
@@ -48,27 +48,17 @@ class ProducedFlavor(msgspec.Struct):
         what belongs here vs what belongs in the orchestrator job record.
       - extra_files: rare escape hatch — sibling artifacts attached to the
         same flavor (e.g. a tokenizer.json next to a non-tree output).
-      - flavor: optional PRODUCER-LOCAL label such as ``bf16``, ``fp8`` or
-        ``int4``. It is NOT published and it names no catalog row — a flavor
-        is not an address. It derives the ``precision_class`` stamp
-        (:func:`gen_worker.models.ladder.classify_flavor_token`) and names the
-        publish's activity legs; when empty the ``dtype`` attribute is used.
-        What the bytes ARE is stated by the ``dtype`` attribute and, when the
-        producer knows it, an ``artifact_contract`` attribute (``ns.name@N``,
-        PROVEN hub-side against the safetensors header — §1.33).
 
-        **A18 RESIDUE, with its removal condition.** §1.32(d) rules the flavor
-        dead entirely — contract-spec is the only variant selector — and this
-        field is what is left. It survives only because the derivation above is
-        the sole statement of precision class for producers that do not declare
-        one, and dropping the field from this repo alone would silently unstamp
-        every svdq/fp8/nvfp4 row those producers publish. It dies when every
-        training-endpoints producer whose token classifies non-base declares
-        ``precision_class`` in ``attributes`` (te already does at
-        ``conversion/src/conversion/quant/modelopt.py:1262``); then this field,
-        the ``label`` read in ``publish.py`` and ``classify_flavor_token`` go in
-        one cut. Held at exactly this size by
-        ``scripts/lint_flavor_deletion.py`` — nothing new may read it.
+    **A18 / §1.32(d), pgw#1319: there is no ``flavor`` field.** It was the last
+    of the axis — a producer-local label that named no catalog row but still
+    decided the ``precision_class`` stamp through
+    ``classify_flavor_token``, which is deleted with it. What the bytes ARE is
+    stated by the ``dtype`` attribute and, when the producer knows it, an
+    ``artifact_contract`` attribute (``ns.name@N``, PROVEN hub-side against the
+    safetensors header — §1.33); what LANE they are on is stated by a
+    ``precision_class`` attribute, DECLARED from a structural fact and checked
+    against :data:`gen_worker.models.ladder.PRECISION_CLASSES`. A tree of
+    sub-16-bit bytes that declares none is a refusal, not an unstamped publish.
 
     A job that emits several artifacts hands over several ``ProducedFlavor``
     entries: N publishes joining ONE tag group. There is no flavor-label set
@@ -78,7 +68,6 @@ class ProducedFlavor(msgspec.Struct):
     path: _PathField
     attributes: dict = msgspec.field(default_factory=dict)
     extra_files: list[_PathField] = msgspec.field(default_factory=list)
-    flavor: str = ""
 
 
 __all__ = ["ProducedFlavor"]

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -16,10 +16,11 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from .. import activity as _activity
+from ..api.errors import ValidationError
 from ..hubio.client import CommitFile, CommitResult, HubClient, files_from_tree
 from ..hubio.publish_state import JOURNAL_NAME
-from ..models.ladder import CLASS_BASE, classify_flavor_token
-from .dtype_pins import verify_produced_tree
+from ..models.ladder import CLASS_BASE, PRECISION_CLASSES
+from .dtype_pins import dtype_bits, verify_produced_tree
 from .produced import ProducedFlavor
 from .writer import assert_one_file_per_component
 from ..models.file_layout import validate_file_layout
@@ -34,19 +35,65 @@ from ..models.file_layout import validate_file_layout
 _DEAD_PLACEMENT_ATTRS = ("placement_sm_allowed", "placement_sm_min", "placement_engines")
 
 
-def _precision_class_block(attrs: Mapping[str, str], label: str) -> dict[str, Any] | None:
+#: A base row is bf16/fp16/fp32 — 16 bits or wider. Anything narrower is on a
+#: quantization lane, and only its producer knows which one (fp4 bytes are
+#: svdq-fp4 or nvfp4-w4a4 depending on how they were made).
+_BASE_STORAGE_BITS = 16
+
+
+class PrecisionClassRefusal(ValidationError):
+    """A publish whose precision class cannot be recorded as the hub reads it.
+
+    A18 / pgw#1319 replaced ``classify_flavor_token`` — which guessed the class
+    from a producer-local label — with a DECLARATION. A guess that missed
+    published a row with no class at all, and the hub's fallback for an
+    unstamped row is `ClassBase`: an fp8 checkpoint served as though it were
+    bf16, invisibly, for as long as nobody looked (te#225 found two such rows
+    live). So the failure mode is now a refusal at the call site, before a byte
+    moves, naming the attribute to declare.
+    """
+
+
+def _precision_class_block(
+    attrs: Mapping[str, str], produced_dtypes: Mapping[str, str],
+) -> dict[str, Any] | None:
     """The ONE surviving key of ``checkpoints.metadata["placement"]``.
 
     pgw#1300 / th#2055: card admission is gone — pod purchase depends only on
     the endpoint owner's (GPU, lane) ladder — but `precision_class` survives,
     because tensorhub's `precision.StoredPrecisionOf` reads it as its strongest
     evidence for a stored class where no tensor-layout contract is proven.
-    Taken from the producer's explicit ``precision_class`` attr, else derived
-    from the flavor token. Base rows stay unstamped: the hub's own fallback for
-    an unstamped row is `ClassBase`, so a block would restate it.
+
+    It is the producer's own ``precision_class`` attribute and nothing else.
+    Base rows stay unstamped: the hub's own fallback for an unstamped row is
+    `ClassBase`, so a block would restate it. Two refusals stand where the
+    token classifier used to guess — a class outside the vocabulary, and narrow
+    bytes nobody classified. ``produced_dtypes`` is read off the published
+    tree's own safetensors headers, so the second one is decided by the bytes
+    rather than by anything the producer says about them.
     """
     cls = str(attrs.get("precision_class", "") or "").strip().lower()
-    cls = cls or classify_flavor_token(label)
+    if cls and cls not in PRECISION_CLASSES:
+        raise PrecisionClassRefusal(
+            f"precision_class={cls!r} is not a class tensorhub reads "
+            f"({', '.join(sorted(PRECISION_CLASSES))}). Publishing it would "
+            "record prose in the checkpoint metadata and the row would serve "
+            "as base."
+        )
+    if not cls:
+        narrow = sorted(
+            f"{comp}={dt}" for comp, dt in produced_dtypes.items()
+            if 0 < dtype_bits(dt) < _BASE_STORAGE_BITS
+        )
+        if narrow:
+            raise PrecisionClassRefusal(
+                f"this tree carries sub-{_BASE_STORAGE_BITS}-bit weights "
+                f"({', '.join(narrow)}) and declares no precision class. "
+                "Declare `precision_class` in the flavor's attributes (one of "
+                f"{', '.join(sorted(PRECISION_CLASSES))}) — the bytes name the "
+                "width but only the producer knows the lane, and an unstamped "
+                "row is served as base."
+            )
     if not cls or cls == CLASS_BASE:
         return None
     return {"precision_class": cls}
@@ -116,17 +163,22 @@ def _journal_beside(flavor: ProducedFlavor) -> Path:
     return Path(flavor.path).parent / JOURNAL_NAME
 
 
-def _publish_leg(dest: str, label: str, stage: str, facts: Mapping[str, Any]) -> None:
+def _publish_leg(dest: str, artifact: str, stage: str, facts: Mapping[str, Any]) -> None:
     """One typed `convert_publish` event per LEG of the publish protocol.
 
     Without these, the highest-volume producer on the platform emits ZERO
     `worker_activity_events` legs for a multi-hour publish, and "declared 590
     objects and is moving 37 GB" is indistinguishable from "was refused before
     a byte left". Mirrors ``fleet_cells._publish_leg``.
+
+    ``artifact`` is the produced path's own name — what tells one leg of an
+    N-artifact export from another. It was the flavor token, which A18 deleted;
+    a filename is the thing that actually exists, and it is always present.
     """
     detail = " ".join(f"{k}={v}" for k, v in sorted(dict(facts).items()))
     _activity.emit_event(
-        "convert_publish", f"repo={dest} flavor={label}: {detail}", phase=stage)
+        "convert_publish", f"repo={dest} artifact={artifact}: {detail}",
+        phase=stage)
 
 
 def destination_release(ctx: Any, explicit: str = "") -> str:
@@ -258,10 +310,6 @@ def publish_flavors(
         # precision is published either way.
         produced_dtypes = verify_produced_tree(Path(flavor.path))
         attrs = {str(k): str(v) for k, v in (flavor.attributes or {}).items()}
-        # A PRODUCER-LOCAL label. It classifies the precision class and names
-        # the activity leg; it is NOT sent to the hub and does not name a
-        # catalog row — `dtype` + `artifact_contract` state what the bytes are.
-        label = str(flavor.flavor or attrs.get("dtype") or "").strip()
         # Worker-addable provenance stamp fields. Producers declare quant
         # identity in the flavor attribute bag; it rides the commit's
         # `provenance` object onto the checkpoint's node stamp (parents /
@@ -271,7 +319,7 @@ def publish_flavors(
             for k in ("quantization_method", "quantization_library")
             if attrs.get(k)
         }
-        placement = _precision_class_block(attrs, label)
+        placement = _precision_class_block(attrs, produced_dtypes)
         meta = {**(dict(metadata) if metadata else {}), **attrs}
         for k in _DEAD_PLACEMENT_ATTRS:
             meta.pop(k, None)
@@ -300,7 +348,8 @@ def publish_flavors(
             # The conversion producer's own legs. (The per-object liveness beat
             # lives in tensorfs's transfer progress callback, so it
             # cannot be lost by a caller who forgets to pass a callback.)
-            on_stage=functools.partial(_publish_leg, dest, label),
+            on_stage=functools.partial(
+                _publish_leg, dest, Path(flavor.path).name),
             journal_path=journal_path or _journal_beside(flavor),
             # When the producer declares one, the hub PROVES it against the
             # header before recording it.
@@ -316,4 +365,9 @@ def publish_flavors(
     return results
 
 
-__all__ = ["destination_ref", "destination_release", "publish_flavors"]
+__all__ = [
+    "PrecisionClassRefusal",
+    "destination_ref",
+    "destination_release",
+    "publish_flavors",
+]

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -1,13 +1,26 @@
-"""Precision classes — the producer's classification of a flavor token.
+"""Precision classes — the VOCABULARY a producer declares its class from.
 
-A quant token's *precision class* names its quantization lane (``fp8``,
+A *precision class* names an artifact's quantization lane (``fp8``,
 ``svdq-int4``, ...). Produced flavors carry it in
 ``checkpoints.metadata["placement"]["precision_class"]`` (written at publish by
 :func:`gen_worker.convert.publish.publish_flavors`), which is the hub's
 strongest evidence for a stored class where no tensor-layout contract is proven
 (tensorhub ``precision.StoredPrecisionOf``). The ladder WALK, the family-root
 table and the family lane policy live hub-side and reach the worker in the
-resolved ref/HelloAck; this module is the PRODUCER half only — classification.
+resolved ref/HelloAck; this module is the PRODUCER half only.
+
+A18 / §1.32(d), pgw#1319: ``classify_flavor_token`` is DELETED with
+``ProducedFlavor.flavor``. The token was never an address, and inferring a
+precision class from a producer-local LABEL was the last thing that made it
+behave like one — it also got the answer wrong in both directions, matching
+``fp8``/``fp8-*`` but never ``*-fp8``, so ``coherent-fp8`` and
+``encoder-trunc-fp8`` published as base for as long as they existed (te#225).
+**The class is DECLARED now**, in the producer's own attribute bag, derived
+from a structural fact (the artifact's precision field, the quantization
+scheme, the requested dtype, the safetensors header). What remains here is the
+vocabulary those declarations are checked against: one home, and the publish
+gate refuses a value outside it rather than forwarding prose the hub cannot
+read.
 
 pgw#1300 / th#2055: the PLACEMENT half of this module is deleted. ``Placement``,
 ``default_placement`` and ``placement_to_metadata`` stamped an SM allow-list, an
@@ -19,7 +32,7 @@ or refuse a card. **Pod purchase now depends only on the endpoint owner's
 merely unread — it was WRONG and vetoing: `sm_allowed=(120, 121)` plus
 `engines=("nunchaku",)` for svdq-fp4 described a kernel window and a wheel the
 native engine has not needed since pgw#685, so a B200 (sm_100) could not bind a
-flavor it serves. Correcting it was rejected: a correct allow-list still vetoes
+variant it serves. Correcting it was rejected: a correct allow-list still vetoes
 an owner's own rung. There is no local walk and no local AUTO fp8 fold; locally,
 fit is the loading layer's job and selection within a tag group is §1.33
 contract compatibility.
@@ -34,30 +47,20 @@ CLASS_SVDQ_INT4 = "svdq-int4"  # SVDQuant int4 — no native engine; a typed ref
 CLASS_NVFP4 = "nvfp4"  # plain nvfp4 artifact — no serving lane (not a diffusers rung)
 CLASS_NVFP4_W4A4 = "nvfp4-w4a4"  # calibrated nvfp4, two-level scales — fp4 scaled_mm lane
 
-_BASE_TOKENS = ("", "bf16", "fp16", "fp32")
+#: Every class a producer may declare. A publish naming anything else is
+#: refused at the call site (`convert.publish`): the hub maps these and only
+#: these, so an unrecognized value would land in checkpoint metadata as prose
+#: and the row would serve as base — the silent outcome A18 exists to end.
+PRECISION_CLASSES = frozenset({
+    CLASS_BASE,
+    CLASS_FP8,
+    CLASS_NVFP4,
+    CLASS_NVFP4_W4A4,
+    CLASS_SVDQ_FP4,
+    CLASS_SVDQ_INT4,
+})
 
 
-def classify_flavor_token(flavor: str) -> str:
-    """Flavor token -> precision class; "" when unrecognized (gguf/etc.
-    stay opaque — never ladder rungs)."""
-    token = str(flavor or "").strip().lower()
-    if token in _BASE_TOKENS:
-        return CLASS_BASE
-    if token.startswith("svdq-fp4"):
-        return CLASS_SVDQ_FP4
-    if token.startswith("svdq-int4"):
-        return CLASS_SVDQ_INT4
-    if token == "fp8" or token.startswith("fp8-"):
-        return CLASS_FP8
-    if token == "nvfp4-w4a4" or token.startswith("nvfp4-w4a4-"):
-        return CLASS_NVFP4_W4A4
-    if token == "nvfp4" or token.startswith("nvfp4-"):
-        return CLASS_NVFP4
-    return ""
-
-
-# `classify_flavor_token` is a package-internal choke point, not public API. It
-# dies when typed descriptors are backfilled; nothing new may grow on it.
 __all__ = [
     "CLASS_BASE",
     "CLASS_FP8",
@@ -65,5 +68,5 @@ __all__ = [
     "CLASS_NVFP4_W4A4",
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
-    "classify_flavor_token",
+    "PRECISION_CLASSES",
 ]

--- a/tests/convert/test_flavor_token_deleted_pgw1319.py
+++ b/tests/convert/test_flavor_token_deleted_pgw1319.py
@@ -1,0 +1,308 @@
+"""A18 / §1.32(d), pgw#1319: the flavor token is DELETED, and the precision
+class is DECLARED at every producer that publishes a non-base row.
+
+`ProducedFlavor.flavor` was the last of the axis. It named no catalog row, but
+`classify_flavor_token` turned it into `checkpoints.metadata["placement"]
+["precision_class"]` — the hub's strongest evidence for a stored class where no
+tensor-layout contract is proven — so a producer-local LABEL decided how the
+artifact is served. It also got the answer wrong in both directions: the
+classifier matched `fp8` and `fp8-*` and never `*-fp8`, so `coherent-fp8` and
+`encoder-trunc-fp8` published as base for as long as they existed.
+
+The cross-repo leg landed first, in two parts, because pgw cannot drop the
+inference while a producer's only statement of class is a token: te#225
+(`7e5e6196`) declared at seven sites, and te#227 (`e52ad87d`) took the census
+to NINE after a third one made from the tree — `fuse`'s fp8 arm passes the
+literal `"fp8"`, and the H3 modulation bake splits an fp8 DiT it never decodes.
+Eleven of te's twenty production constructions publish a non-base row.
+
+What is fenced here:
+
+  1. Every one of those producer SHAPES publishes its declared class, through
+     the real `publish_flavors` against the fake hub. The bags are transcribed
+     literals: a fence that derived them from the code under test would agree
+     with itself.
+  2. The two refusals that replace the guess. An unclassifiable declaration and
+     a tree of narrow bytes nobody classified are typed errors, never an
+     unstamped publish — the hub's fallback for an unstamped row is `ClassBase`,
+     which is exactly how the two live mis-stamps stayed invisible.
+  3. The deletion itself: no field, no reader, no classifier.
+
+    pytest tests/convert/test_flavor_token_deleted_pgw1319.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fake_hub import _FakeHub
+
+from gen_worker.convert.produced import ProducedFlavor
+from gen_worker.convert.publish import PrecisionClassRefusal, publish_flavors
+from gen_worker.models import ladder
+
+#: Cut by `tests/convert/conftest.py`'s fake repo.
+RELEASE = "2026.08"
+
+#: Every training-endpoints producer shape that publishes a NON-BASE row, as
+#: its attribute bag reaches `publish_flavors` — transcribed from te
+#: `origin/master` after te#227, not derived. The `dtype`/`file_layout` keys
+#: are server-inferred and ride along; what matters is that the class arrives.
+PRODUCER_SHAPES: dict[str, tuple[dict[str, str], dict[str, Any] | None]] = {
+    # modelopt `produce_quant_flavor`, both schemes.
+    "modelopt-fp8": (
+        {"precision_class": "fp8", "quantization_method": "w8a8",
+         "quantization_library": "modelopt", "dtype": "fp8"},
+        {"precision_class": "fp8"}),
+    "modelopt-nvfp4": (
+        {"precision_class": "nvfp4-w4a4", "quantization_method": "nvfp4",
+         "quantization_library": "modelopt"},
+        {"precision_class": "nvfp4-w4a4"}),
+    # svdq `mirror_svdq` / `produce_svdq_flavor` — `svdq_precision` is the
+    # artifact's own field, and the class is derived from it, not from the
+    # `svdq-fp4-r128` token that used to be the only statement.
+    "svdq-fp4": (
+        {"precision_class": "svdq-fp4", "svdq_precision": "fp4",
+         "svdq_rank": "128", "quantization_library": "nunchaku"},
+        {"precision_class": "svdq-fp4"}),
+    "svdq-int4": (
+        {"precision_class": "svdq-int4", "svdq_precision": "int4",
+         "svdq_rank": "32", "quantization_library": "nunchaku"},
+        {"precision_class": "svdq-int4"}),
+    # h3_svdq `produce_h3_svdq` — the site pgw#1307's census missed entirely.
+    "h3-svdq-fp4": (
+        {"precision_class": "svdq-fp4", "svdq_precision": "fp4",
+         "h3_native": "true"},
+        {"precision_class": "svdq-fp4"}),
+    # transform `cast_dtype`, both arms.
+    "cast-w8a8": (
+        {"precision_class": "fp8", "dtype": "fp8",
+         "quantization_method": "w8a8"},
+        {"precision_class": "fp8"}),
+    "cast-fp8": ({"precision_class": "fp8", "dtype": "fp8"},
+                 {"precision_class": "fp8"}),
+    # The two LIVE mis-stamps te#225 closed: fp8 artifacts whose token
+    # classified to "" because it ended in `-fp8` instead of starting with it.
+    "coherent-fp8": (
+        {"precision_class": "fp8", "dtype": "fp8",
+         "coherent_checkpoint": "true"},
+        {"precision_class": "fp8"}),
+    "encoder-trunc-fp8": (
+        {"precision_class": "fp8", "dtype": "fp8", "kept_layers": "20"},
+        {"precision_class": "fp8"}),
+    # te#227's two: `fuse`'s fp8 arm and both H3 modulation-bake variants.
+    "fuse-fp8": (
+        {"precision_class": "fp8", "fuse_component": "transformer",
+         "fuse_scale": "1.0"},
+        {"precision_class": "fp8"}),
+    "adaln-full": (
+        {"precision_class": "fp8", "component_set": "transformer",
+         "adaln_projections": "present"},
+        {"precision_class": "fp8"}),
+    "adaln-baked": (
+        {"precision_class": "fp8", "component_set": "transformer",
+         "modulation_tables": "present"},
+        {"precision_class": "fp8"}),
+    # And the base rows, which declare NOTHING on purpose: the hub's own
+    # fallback for an unstamped row is ClassBase, so a stamp would restate it.
+    "fuse-bf16": ({"fuse_component": "transformer"}, None),
+    "prompt-corpus": ({"corpus_rows": "512"}, None),
+    "lora-card": ({"output_kind": "lora", "lora_rank": "32"}, None),
+}
+
+
+class _Ctx:
+    def __init__(self, base_url: str) -> None:
+        self._file_api_base_url = base_url
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+
+    def log(self, message: str, **fields: Any) -> None:
+        pass
+
+
+def _opaque_tree(tmp_path: Path, name: str = "out") -> Path:
+    """A tree whose bytes state nothing: no readable safetensors header, so
+    `component_dtypes_on_disk` reports nothing and only the DECLARATION can
+    speak. That is the shape every row above is asserted in."""
+    out = tmp_path / name
+    out.mkdir()
+    (out / "diffusion.safetensors").write_bytes(b"\x11" * 2048)
+    return out
+
+
+def _fp8_tree(tmp_path: Path, name: str, *, dtype: Any) -> Path:
+    """A tree whose bytes DO state their width — a real safetensors header the
+    publish gate reads back off disk."""
+    torch = pytest.importorskip("torch")
+    from safetensors.torch import save_file
+
+    out = tmp_path / name
+    (out / "transformer").mkdir(parents=True)
+    save_file({"proj_out.weight": torch.zeros(8, 8).to(dtype)},
+              str(out / "transformer" / "diffusion_pytorch_model.safetensors"))
+    return out
+
+
+def _publish(fake_hub: Any, tree: Path, attrs: dict[str, str]) -> dict:
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    publish_flavors(
+        ctx,
+        [ProducedFlavor(path=tree, attributes=dict(attrs))],
+        destination_repo="acme/qwen-image",
+        release=RELEASE,
+    )
+    return dict(_FakeHub.state["publish_request"].get("metadata") or {})
+
+
+# ---------------------------------------------------------------------------
+# 1. every producer shape, through the real publish path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", sorted(PRODUCER_SHAPES))
+def test_every_producer_shape_publishes_the_class_it_declared(
+    fake_hub: Any, tmp_path: Path, shape: str
+) -> None:
+    """Read off the declare request the fake hub actually receives. With the
+    token gone the attribute bag is the ONLY statement of class, so a shape
+    that stopped declaring lands as `ClassBase` — silently, which is the
+    failure this row exists to make loud."""
+    attrs, expected = PRODUCER_SHAPES[shape]
+    meta = _publish(fake_hub, _opaque_tree(tmp_path), attrs)
+
+    if expected is None:
+        assert "placement" not in meta, (
+            f"{shape} is a base row and must publish unstamped; a block here "
+            "restates the hub's own ClassBase fallback")
+        return
+    assert meta.get("placement") == expected, (
+        f"{shape} declared {attrs.get('precision_class')!r} and published "
+        f"{meta.get('placement')!r}")
+    assert set(meta["placement"]) == {"precision_class"}
+
+
+def test_the_token_is_not_published_as_metadata_under_any_spelling(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """A18's end state: the word names nothing at the wire either."""
+    attrs, _ = PRODUCER_SHAPES["svdq-fp4"]
+    meta = _publish(fake_hub, _opaque_tree(tmp_path), attrs)
+    assert "flavor" not in meta
+    assert "flavor" not in _FakeHub.state["publish_request"]
+
+
+# ---------------------------------------------------------------------------
+# 2. the two refusals that replace the guess
+# ---------------------------------------------------------------------------
+
+
+def test_narrow_bytes_with_no_declaration_are_REFUSED_not_published_unstamped(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """The regression the te legs exist to prevent, asserted from pgw's side.
+
+    Before A18 an fp8 tree whose producer declared nothing was stamped by the
+    token classifier; after it, nothing would stamp it and the hub would serve
+    it as base. So the publish REFUSES, naming the attribute to declare, before
+    a byte moves.
+    """
+    torch = pytest.importorskip("torch")
+    tree = _fp8_tree(tmp_path, "undeclared", dtype=torch.float8_e4m3fn)
+
+    with pytest.raises(PrecisionClassRefusal) as exc:
+        _publish(fake_hub, tree, {"dtype": "fp8"})
+
+    msg = str(exc.value)
+    assert "transformer=fp8" in msg, msg
+    assert "precision_class" in msg, msg
+
+
+def test_the_same_narrow_tree_publishes_once_its_class_is_declared(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """The refusal is about the SILENCE, not about the bytes: declare the class
+    and the identical tree publishes, carrying it."""
+    torch = pytest.importorskip("torch")
+    tree = _fp8_tree(tmp_path, "declared", dtype=torch.float8_e4m3fn)
+
+    meta = _publish(fake_hub, tree, {"dtype": "fp8", "precision_class": "fp8"})
+
+    assert meta["placement"] == {"precision_class": "fp8"}
+    assert meta["component_dtypes"] == {"transformer": "fp8"}
+
+
+def test_a_base_tree_needs_no_declaration(fake_hub: Any, tmp_path: Path) -> None:
+    """bf16 is 16 bits and every ladder rung is narrower, so the backstop stays
+    silent for the rows that are correctly unstamped — otherwise it would
+    refuse every base publish on the platform."""
+    torch = pytest.importorskip("torch")
+    tree = _fp8_tree(tmp_path, "base", dtype=torch.bfloat16)
+
+    meta = _publish(fake_hub, tree, {"dtype": "bf16"})
+
+    assert "placement" not in meta
+    assert meta["component_dtypes"] == {"transformer": "bf16"}
+
+
+@pytest.mark.parametrize("bad", ["fp8-w8a8", "svdq-fp4-r128", "int4", "q4_k_m"])
+def test_a_class_outside_the_vocabulary_is_REFUSED(
+    fake_hub: Any, tmp_path: Path, bad: str
+) -> None:
+    """te#225's rule, on pgw's side of the seam: unclassifiable is a refusal,
+    not an unstamped publish. `fp8-w8a8` and `svdq-fp4-r128` are the two most
+    likely mistakes — they are TOKENS, and the token is what died."""
+    with pytest.raises(PrecisionClassRefusal) as exc:
+        _publish(fake_hub, _opaque_tree(tmp_path), {"precision_class": bad})
+    assert "not a class tensorhub reads" in str(exc.value)
+
+
+def test_a_class_is_matched_case_and_whitespace_insensitively(
+    fake_hub: Any, tmp_path: Path
+) -> None:
+    """The declaration is a producer's literal; `"FP8"` is the same statement
+    as `"fp8"` and refusing it would be a spelling gate, not a class gate."""
+    meta = _publish(fake_hub, _opaque_tree(tmp_path), {"precision_class": " FP8"})
+    assert meta["placement"] == {"precision_class": "fp8"}
+
+
+# ---------------------------------------------------------------------------
+# 3. the deletion itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_produced_struct_has_no_flavor_field() -> None:
+    assert "flavor" not in ProducedFlavor.__struct_fields__
+    with pytest.raises(TypeError):
+        ProducedFlavor(path=Path("/nonexistent"), flavor="fp8")  # type: ignore[call-arg]
+
+
+def test_the_classifier_is_deleted_and_the_vocabulary_survives() -> None:
+    """The vocabulary is what a DECLARATION is checked against, so it stays —
+    one home, in this repo, which te imports rather than re-listing."""
+    assert not hasattr(ladder, "classify_flavor_token")
+    assert ladder.PRECISION_CLASSES == frozenset({
+        "base", "fp8", "nvfp4", "nvfp4-w4a4", "svdq-fp4", "svdq-int4"})
+
+
+def test_the_publish_leg_names_the_artifact_not_a_flavor(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The leg's label was the token. A produced path's own name is the thing
+    that actually exists, is always present, and tells one leg of an
+    N-artifact export from another."""
+    import gen_worker.activity as activity
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        activity, "emit_event",
+        lambda kind, detail, **kw: seen.append(f"{kind}: {detail}"))
+
+    _publish(fake_hub, _opaque_tree(tmp_path, "svdq-tree"), {})
+
+    legs = [s for s in seen if s.startswith("convert_publish:")]
+    assert legs, "the publish emitted no legs at all"
+    assert all("artifact=svdq-tree" in leg for leg in legs), legs
+    assert not any("flavor=" in leg for leg in legs), legs

--- a/tests/convert/test_passthrough_deshard_th1362.py
+++ b/tests/convert/test_passthrough_deshard_th1362.py
@@ -108,8 +108,7 @@ def _publish_svdq_flavor(fake_hub: Any, tmp_path: Path, *, sharded: bool):
         tmp_path / "flavor")
     ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
     results = publish_flavors(
-        ctx, [ProducedFlavor(path=str(tree), flavor=attrs["flavor"],
-                             attributes=attrs)],
+        ctx, [ProducedFlavor(path=str(tree), attributes=attrs)],
         destination_repo="cozy/qwen-image", release="r1")
     paths = sorted(f["path"] for f in _FakeHub.state["publish_request"]["files"])
     return base, tree, te, paths, results
@@ -203,7 +202,7 @@ def test_publish_still_refuses_a_shard_set_the_copy_cannot_collapse(
     ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
     with pytest.raises(ConversionImplementationError,
                        match="sharded_producer_output"):
-        publish_flavors(ctx, [ProducedFlavor(path=str(tree), flavor="x")],
+        publish_flavors(ctx, [ProducedFlavor(path=str(tree))],
                         destination_repo="cozy/qwen-image", release="r1")
 
 

--- a/tests/convert/test_precision_class_stamp_pgw1300.py
+++ b/tests/convert/test_precision_class_stamp_pgw1300.py
@@ -41,20 +41,20 @@ from gen_worker.models import ladder
 #: Cut by `tests/convert/conftest.py`'s fake repo.
 RELEASE = "2026.08"
 
-#: The block the hub must receive, per flavor token. Written as literals: a
-#: fence that derived them from `classify_flavor_token` would agree with itself.
-#: `None` = no block at all, which is exact — the hub's fallback for an
-#: unstamped row is `ClassBase`.
+#: The block the hub must receive, per DECLARED class (A18 / pgw#1319: the
+#: flavor token is deleted and the class is stated by the producer). Written as
+#: literals: a fence that derived them from the module under test would agree
+#: with itself. `None` = no block at all, which is exact — the hub's fallback
+#: for an unstamped row is `ClassBase`, so `base` and "declared nothing" are
+#: the same wire shape on purpose.
 EXPECTED: dict[str, dict[str, Any] | None] = {
-    "bf16": None,
-    "fp16": None,
+    "": None,
+    "base": None,
     "fp8": {"precision_class": "fp8"},
-    "fp8-w8a8": {"precision_class": "fp8"},
     "svdq-int4": {"precision_class": "svdq-int4"},
     "svdq-fp4": {"precision_class": "svdq-fp4"},
+    "nvfp4": {"precision_class": "nvfp4"},
     "nvfp4-w4a4": {"precision_class": "nvfp4-w4a4"},
-    # Unrecognized tokens stay opaque and are never ladder rungs.
-    "q4_k_m": None,
 }
 
 #: The keys th#2055 stopped reading. Any of them at the wire is the regression.
@@ -78,12 +78,14 @@ def _tree(tmp_path: Path, name: str) -> Path:
     return out
 
 
-def _publish(fake_hub: Any, tmp_path: Path, flavor: str, **attrs: str) -> dict:
+def _publish(fake_hub: Any, tmp_path: Path, cls: str, **attrs: str) -> dict:
     ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    if cls:
+        attrs = {"precision_class": cls, **attrs}
     publish_flavors(
         ctx,
         [ProducedFlavor(
-            path=_tree(tmp_path, "out"), flavor=flavor, attributes=dict(attrs),
+            path=_tree(tmp_path, "out"), attributes=dict(attrs),
         )],
         destination_repo="acme/qwen-image",
         release=RELEASE,
@@ -91,19 +93,19 @@ def _publish(fake_hub: Any, tmp_path: Path, flavor: str, **attrs: str) -> dict:
     return dict(_FakeHub.state["publish_request"].get("metadata") or {})
 
 
-@pytest.mark.parametrize("token", sorted(EXPECTED))
+@pytest.mark.parametrize("cls", sorted(EXPECTED))
 def test_the_declared_block_is_precision_class_and_nothing_else(
-    fake_hub: Any, tmp_path: Path, token: str
+    fake_hub: Any, tmp_path: Path, cls: str
 ) -> None:
     """Read off the declare request the fake hub actually receives: every
     laddered class carries its `precision_class`, and no class carries an
     admission key the hub deleted."""
-    meta = _publish(fake_hub, tmp_path, token)
+    meta = _publish(fake_hub, tmp_path, cls)
 
-    expected = EXPECTED[token]
+    expected = EXPECTED[cls]
     if expected is None:
         assert "placement" not in meta, (
-            f"{token!r} is not a ladder rung; a block here restates the hub's "
+            f"{cls!r} is not a ladder rung; a block here restates the hub's "
             "own ClassBase fallback")
         return
     assert meta["placement"] == expected
@@ -112,28 +114,26 @@ def test_the_declared_block_is_precision_class_and_nothing_else(
         "unread JSON at best and a resurrected purchase veto at worst")
 
 
-@pytest.mark.parametrize("token", ["svdq-fp4", "svdq-int4", "nvfp4-w4a4", "fp8"])
+@pytest.mark.parametrize("cls", ["svdq-fp4", "svdq-int4", "nvfp4-w4a4", "fp8"])
 def test_no_admission_key_survives_at_the_wire(
-    fake_hub: Any, tmp_path: Path, token: str
+    fake_hub: Any, tmp_path: Path, cls: str
 ) -> None:
     """The pgw#1300 defect, stated as the thing that must not come back: the
     svdq-fp4 row used to declare `sm_allowed=[120, 121]` + `engines=
     ["nunchaku"]`, which refused a B200 (sm_100) the native engine serves."""
-    block = _publish(fake_hub, tmp_path, token)["placement"]
+    block = _publish(fake_hub, tmp_path, cls)["placement"]
     present = [k for k in DELETED_ADMISSION_KEYS if k in block]
-    assert present == [], f"{token!r} re-stamped deleted admission keys: {present}"
+    assert present == [], f"{cls!r} re-stamped deleted admission keys: {present}"
 
 
-def test_a_producer_precision_class_attr_still_wins_over_the_token(
+def test_the_dead_placement_override_attrs_are_dropped_not_published(
     fake_hub: Any, tmp_path: Path
 ) -> None:
-    """A producer that knows its class states it; the token is the fallback.
-    The DELETED `placement_*` override attrs are dropped rather than published
-    as prose — `training-endpoints`' modelopt quantizer still writes
+    """The DELETED `placement_*` override attrs are dropped rather than
+    published as prose — `training-endpoints`' modelopt quantizer still writes
     `placement_sm_allowed`, and an attr pgw no longer reads is not metadata."""
     meta = _publish(
-        fake_hub, tmp_path, "q4_k_m",
-        precision_class="nvfp4-w4a4",
+        fake_hub, tmp_path, "nvfp4-w4a4",
         placement_sm_allowed="89", placement_engines="nunchaku,triton",
     )
 
@@ -151,7 +151,7 @@ def test_the_ladder_module_no_longer_exports_a_placement() -> None:
 
     assert set(ladder.__all__) == {
         "CLASS_BASE", "CLASS_FP8", "CLASS_NVFP4", "CLASS_NVFP4_W4A4",
-        "CLASS_SVDQ_FP4", "CLASS_SVDQ_INT4", "classify_flavor_token",
+        "CLASS_SVDQ_FP4", "CLASS_SVDQ_INT4", "PRECISION_CLASSES",
     }
     leftovers = [n for n in vars(ladder) if "PLACEMENT" in n.upper()]
     assert leftovers == [], f"placement survived the cut: {leftovers}"

--- a/tests/convert/test_producer_flip_th1303.py
+++ b/tests/convert/test_producer_flip_th1303.py
@@ -56,8 +56,9 @@ def _publish(ctx: _Ctx, tree: Path, **kw: Any) -> Any:
     return publish_flavors(
         ctx,
         [ProducedFlavor(
-            path=str(tree), flavor="fp8-w8a8",
-            attributes={"dtype": "fp8", "quantization_method": "w8a8",
+            path=str(tree),
+            attributes={"dtype": "fp8", "precision_class": "fp8",
+                        "quantization_method": "w8a8",
                         "quantization_library": "llm-compressor"},
         )],
         destination_repo="acme/quant",

--- a/tests/convert/test_publish_release_attach_pgw1274.py
+++ b/tests/convert/test_publish_release_attach_pgw1274.py
@@ -141,8 +141,7 @@ def test_publish_flavors_threads_the_release_to_every_variant(
         out.mkdir()
         (out / "diffusion.safetensors").write_bytes(label.encode() * 500)
         (out / "config.json").write_text('{"architectures": ["Fake"]}')
-        trees.append(ProducedFlavor(path=out, flavor=label,
-                                    attributes={"dtype": label}))
+        trees.append(ProducedFlavor(path=out, attributes={"dtype": label}))
 
     publish_flavors(ctx, trees, destination_repo="acme/quant", release=RELEASE)
 

--- a/tests/convert/test_publish_stamps_th1411.py
+++ b/tests/convert/test_publish_stamps_th1411.py
@@ -71,7 +71,7 @@ def _publish(ctx: _Ctx, tree: Path, **kw: Any) -> Any:
     kw.setdefault("release", RELEASE)
     return publish_flavors(
         ctx,
-        [ProducedFlavor(path=str(tree), flavor="fp8")],
+        [ProducedFlavor(path=str(tree), attributes={"precision_class": "fp8"})],
         destination_repo="acme/qwen-image",
         **kw,
     )


### PR DESCRIPTION
**The last cross-repo thread of A18.** `ProducedFlavor.flavor` named no catalog row, but `classify_flavor_token` turned it into `checkpoints.metadata["placement"]["precision_class"]` — the hub's strongest evidence for a stored class where no tensor-layout contract is proven — so a **producer-local string decided how an artifact is served.** It also answered wrong in both directions: the classifier matched `fp8`/`fp8-*` and never `*-fp8`, so `coherent-fp8` and `encoder-trunc-fp8` published with no class and were served as base for as long as they existed.

Deleted: the field, the `label = flavor.flavor or attrs["dtype"]` read, `_precision_class_block`'s token arm, `classify_flavor_token`. The class VOCABULARY stays (`ladder.PRECISION_CLASSES`) — it is what a declaration is checked against, one home, which te imports rather than re-listing.

## The re-enumeration — pgw#1307's record ordered it, and it paid a third time

Made from the te tree, not from either table: **20 production `ProducedFlavor` construction sites, EIGHT publishing a non-base row.** Five in the first census, seven in the second, eight now.

| found by | site | why it was missed |
|---|---|---|
| census 3 (this lane) | `fuse.py:664` | `name` is the LITERAL `"fp8"` on two of its three values; both censuses filed it among the nine "already unstamped" rows by reading `name` as free-form |
| census 3 (this lane) | `h3_modulation_bake.py:534,544` | splits an fp8 DiT and decodes nothing, so both variants carry fp8 bytes and published **no class at all** — a third live mis-stamp of the `coherent-fp8` shape |

Both closed by **te#227** (PR cozy-creator/training-endpoints#281), which lands first — pgw cannot drop the inference while a producer's only statement of class is a token.

## The refusals that replace the guess

`PrecisionClassRefusal` (a `ValidationError`), at the call site, before a byte moves:

1. a `precision_class` outside the vocabulary — instead of forwarding prose the hub cannot read;
2. a tree whose **own safetensors headers** report sub-16-bit weights while declaring no class.

The deletion's one real hazard is a row that silently unstamps and serves as base. That is now the one thing it cannot do. Honest limit, stated in the code: packed int4/fp4 reads as `I8`/`I32` and is invisible to that evidence — the declaration is the mechanism, this is the backstop.

## The label-vs-logic verdict (the mandate asked for it explicitly)

* **LOGIC — cut**, as above.
* **LABEL — renamed, word deleted.** The publish activity leg was the token's only non-classifying consumer (`repo=… flavor=<token>`). It is now `artifact=<produced path name>`: the thing that actually exists, always present, and still separating the legs of an N-artifact export. Nothing parses that detail string.
* **LABEL — held, NAMED, with a removal condition.** `convert.svdq.svdq_flavor_label` and the `attrs["flavor"]` key `build_svdq_flavor_tree` writes are pure label with no pgw reader left — but te's committed producers read both to fill the `flavor=` kwarg this deletes, and `src/` is not a delete authority for another repo's surface (the rule pgw#1180 restored). Added to `scripts/author_surface_allowlist.txt`, which did not list `svdq_flavor_label` at all — a real gap this census found.

## The fence flips

`scripts/lint_flavor_deletion.py`'s residue goes **1 field / 1 reader / 1 classifier call → ZERO**, the former residue paths lose their exemption, `classify_flavor_token` joins `DELETED_NAMES`, and the stale-residue selftest arm is replaced by a **regrown-residue** arm: it plants the field in `convert/produced.py` and the reader + classifier call in `convert/publish.py` and requires every rule to speak. That is the arm that would have gone quiet if the cut had removed the code and left the allowance behind.

## Red/green

* **GREEN**: `tests/convert/` + `tests/test_flavor_deletion_pgw1148.py` — **166 passed** (105s), including the new `tests/convert/test_flavor_token_deleted_pgw1319.py` (27 rows). `lint_flavor_deletion.py --selftest` green and the real-tree scan reports `0 readers, 0 fields, 0 classifier calls`. `lint_unreached_surface.py` rc=0. ruff clean on every changed file; mypy clean on the three source files.
* **RED**: `test_flavor_token_deleted_pgw1319.py` on pristine master — pending re-run under the box's thermal hold; the deletion rows (`flavor` in `__struct_fields__`, `hasattr(ladder, "classify_flavor_token")`) and the two refusal rows are red there by construction.

## ⚠️ The repin obligation this creates

te still passes `flavor=` at ~20 production and ~25 test `ProducedFlavor` sites. Harmless today (te runs the pinned `gen-worker==0.118.0`); a `TypeError` the moment te repins past this release. **The te repin lane drops those kwargs, `svdq_flavor_label`, and the `attrs["flavor"]` read in one commit.** Recorded on pgw#1319 and te#227.

No wheel bump — this rides the next cut.