### PR TITLE
pgw#1323: the cross-repo consumer fence stopped reading its biggest consumer, silently — `inference-endpoints` is `serverless-endpoints`

### DIFF
--- a/scripts/author_surface_allowlist.txt
+++ b/scripts/author_surface_allowlist.txt
@@ -43,22 +43,22 @@
 # EXEMPT_TARGETS. A permanent pardon still has to point at something real.
 
 convert.clone.from_civitai	training-endpoints/conversion/src/conversion/mirror.py:185	PROD
-io.read_image	inference-endpoints/flux.2-klein-4b/src/flux2_klein_4b/main.py:569	PROD
-io.write_video	inference-endpoints/wan-2.2/src/wan_2_2/main.py:2134	PROD
-models.loading.apply_block_window_offload	inference-endpoints/ltx-video-2.3/src/ltx_video_23/main.py:128	PROD
+io.read_image	serverless-endpoints/flux.2-klein-4b/src/flux2_klein_4b/main.py:569	PROD
+io.write_video	serverless-endpoints/wan-2.2/src/wan_2_2/main.py:2134	PROD
+models.loading.apply_block_window_offload	serverless-endpoints/ltx-video-2.3/src/ltx_video_23/main.py:128	PROD
 models.svdq_layout.pack_lowrank	training-endpoints/conversion/src/conversion/quant/svdq_produce.py:852	PROD
 models.svdq_layout.pack_qweight	training-endpoints/tests/test_foreign_quant_te134.py:166	TEST
 models.svdq_layout.pack_vector	training-endpoints/conversion/src/conversion/quant/svdq_produce.py:852	PROD
 models.svdq_layout.pack_wscales	training-endpoints/tests/test_foreign_quant_te134.py:166	TEST
-models.w8a8.quantize_tree_w8a8	inference-endpoints/scripts/ie543_batch_bench.py:78	PROD
-models.w8a8.sanitize_w8a8_state_dict	inference-endpoints/anima/src/anima/main.py:327	PROD
+models.w8a8.quantize_tree_w8a8	serverless-endpoints/scripts/ie543_batch_bench.py:78	PROD
+models.w8a8.sanitize_w8a8_state_dict	serverless-endpoints/anima/src/anima/main.py:327	PROD
 request_context.JobContext.mktemp	training-endpoints/vlm_judge/src/vlm_judge/judge.py:166	PROD
 request_context.RequestContext.call_endpoint	private-inference-endpoints/dj-pipeline/src/dj_pipeline/main.py:175	PROD
 request_context.RequestContext.workflow_checkpoint	private-inference-endpoints/dj-pipeline/src/dj_pipeline/main.py:271	PROD
 request_context.JobContext.training_metric	training-endpoints/image_lora_finetuner/src/image_lora_finetuner/diffsynth_loop.py:593	PROD
 request_context._PublisherMixin.checkpoint_dir	training-endpoints/image_lora_finetuner/tests/test_diffsynth.py:1330	TEST
-runtime_config.read_snapshot	inference-endpoints/minimax-h3/tests/test_attn_config_ie678.py:7	TEST
-testing.fake_context	inference-endpoints/qwen3.6-27b-mtp-gguf/tests/test_completion.py:90	TEST
+runtime_config.read_snapshot	serverless-endpoints/minimax-h3/tests/test_attn_config_ie678.py:7	TEST
+testing.fake_context	serverless-endpoints/qwen3.6-27b-mtp-gguf/tests/test_completion.py:90	TEST
 
 
 # pgw#1192 — found only after two widenings of the check, and both are the

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -563,7 +563,11 @@ def reached(d: Definition, reach: Reach) -> bool:
 # consumer's dependency.
 # ---------------------------------------------------------------------------
 
-SIBLINGS = ("training-endpoints", "inference-endpoints",
+# DIRECTORY names, and a missing one is skipped silently at the loop below — so a
+# stale entry here is a consumer repo this fence stops reading without saying so.
+# `inference-endpoints` became `serverless-endpoints` on 2026-08-16;
+# `training-endpoints` becomes `jobs` when its checkout is renamed.
+SIBLINGS = ("training-endpoints", "serverless-endpoints",
             "private-inference-endpoints", "tensorhub", "e2e", "cozy-local")
 def _workspace() -> Path:
     """The directory the sibling repos sit in. Walk up rather than assume

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -150,13 +150,13 @@ CI-SKIPPED tests/test_unbounded_read_guard_pgw1013.py|<hex> not in this checkout
 # ─── LOCAL-ONLY ───────────────────────────────────────────────────────────────
 LOCAL-ONLY tests/test_lora_lifted_pgw725.py|set gen_worker_aot_pack_tests=# (packs a real .pt#; needs g++)
 # pgw#1150. Four rows put the author-CI harness's emitted `author-ci.toml`
-# record through `inference-endpoints/scripts/lint_author_ci.py` ITSELF —
+# record through `serverless-endpoints/scripts/lint_author_ci.py` ITSELF —
 # that script is the AUTHORITY on the record's schema and must never be
 # re-stated here, so where the sibling repo is absent (every CI runner) the
 # round trip cannot run. The schema half IS measured, in that repo's own
 # `lint_author_ci.py --selftest` (23 cases, red on 20), which its CI gates
 # on. Set AUTHOR_CI_LINT=<path to lint_author_ci.py> to run them anywhere.
-LOCAL-ONLY tests/test_author_ci_harness_pgw1150.py|inference-endpoints is not checked out beside this repo
+LOCAL-ONLY tests/test_author_ci_harness_pgw1150.py|serverless-endpoints is not checked out beside this repo
 # pgw#978. The full local mint cycle: a real child spawn, a real torch.export +
 # AOTInductor compile, a real publish over the wire and a real second-process
 # adopt. It is opt-in EVERYWHERE, CI included — not because CI could run it and

--- a/tests/test_author_ci_harness_pgw1150.py
+++ b/tests/test_author_ci_harness_pgw1150.py
@@ -10,7 +10,7 @@ the dispatch, `ctx.stage` -> `stage_ms` timing, the serve-posture order and its
 release, `Compile.blockers` read through `export_contract.open_blockers`, the
 parity gate (`provision.gate_cell_numerics` against pgw#868's real armed cell,
 real ladder, real declared floor), the record's TOML, and — where the sibling
-repo is checked out — `inference-endpoints/scripts/lint_author_ci.py` itself,
+repo is checked out — `serverless-endpoints/scripts/lint_author_ci.py` itself,
 imported and run against what this harness emitted.
 
 WHAT IS FAKED, and why: the COMPILE and the model load. Paul's standing rule is
@@ -433,9 +433,9 @@ def test_median_and_p95_are_both_reported_and_the_tail_is_not_hidden():
 # ---------------------------------------------------------------------------
 
 def _lint() -> Any:
-    """`inference-endpoints/scripts/lint_author_ci.py`, imported for real."""
+    """`serverless-endpoints/scripts/lint_author_ci.py`, imported for real."""
     candidates = [os.environ.get("AUTHOR_CI_LINT", "")]
-    candidates += [str(base / "inference-endpoints" / "scripts"
+    candidates += [str(base / "serverless-endpoints" / "scripts"
                        / "lint_author_ci.py")
                    for base in (REPO.parent, REPO.parents[2], Path.home() / "cozy")
                    if base is not None]
@@ -447,7 +447,7 @@ def _lint() -> Any:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             return module
-    pytest.skip("inference-endpoints is not checked out beside this repo")
+    pytest.skip("serverless-endpoints is not checked out beside this repo")
 
 
 def _through_the_lint(lint: Any, tmp_path: Path, record: Path) -> int:


### PR DESCRIPTION
Paul renamed `cozy-creator/inference-endpoints` → **`cozy-creator/serverless-endpoints`** on 2026-08-16 and the checkout moved to `~/cozy/serverless-endpoints`. Two places here name that **directory**, and neither breaks loudly — both just quietly do less.

## 1. `SIBLINGS` in `scripts/lint_unreached_surface.py`

The scan loop `continue`s past a sibling whose `.git` is absent. So the rename did not break the fence; it made it read one repo fewer **while still printing a confident verdict**. Measured on this workspace, same command, same tree otherwise:

```
old list:  cross-repo check: 5 files/branches scanned across 6 siblings, 0 unlisted consumers
new list:  cross-repo check: 6 files/branches scanned across 6 siblings, 0 unlisted consumers
```

Note the `6 siblings` in both lines — the count that changed is the one nobody reads. The repo it stopped reading is the 29-package endpoint fleet, i.e. exactly the corpus this check exists to protect: its stated job is to go RED *"when somebody is about to delete a cross-repo consumer's dependency."*

## 2. `_lint()` in `tests/test_author_ci_harness_pgw1150.py`

It resolves `<base>/inference-endpoints/scripts/lint_author_ci.py` and calls `pytest.skip` when absent. After the rename that path can never exist — so the row proving the author-CI record round-trips through the **real** sibling lint now skips for a reason that reads exactly like an ordinary un-checked-out workspace. Same class as (1): a green run testing less than it claims.

## Also

The provenance column of `scripts/author_surface_allowlist.txt` (7 rows — message text only; `author_surface()` folds it into a human-readable string, it is never resolved on disk) and two `scripts/skip_census.txt` reason lines.

## Deliberately unchanged

`training-endpoints` stays in `SIBLINGS`. That checkout has a live lane (te#218, the JOBS migration), so its rename to `jobs` is deferred and the entry is **correct** until the directory moves. The comment above `SIBLINGS` now records both facts, and the deferred step is written up in the tracker.

Default `lint_unreached_surface.py` output is byte-identical to master (same three findings). No deletions.