### PR TITLE
pgw#1320: delete the manifest `output_mode` key the hub has never decoded

### DIFF
--- a/changelog.d/pgw1320.md
+++ b/changelog.d/pgw1320.md
@@ -1,0 +1,13 @@
+- **The discovery manifest emitted an `output_mode` key the hub has never decoded.** Every function
+  row carried both `output_mode: "incremental"|"single"` and `incremental_output: <bool>` for one
+  bit of fact. `output_mode` appears nowhere in tensorhub's `internal/builder`: the hub decodes
+  `incremental_output` and republishes it under that name, so the second key was written on every
+  publish and read on none. Deleted. That also collapses a third value space — the same bit was
+  spelled `"single"|"stream"` on `EndpointSpec`, `"incremental"|"single"` on the manifest and a
+  boolean on the wire; two spellings remain, and only one of them crosses a repo boundary.
+- The fence runs `discover_manifest` — the entry point the image build itself runs — and asserts the
+  key is absent from a real manifest, so restoring the emit fails by name rather than by nobody
+  noticing. Its controls are the reason it means anything: an absent-key assertion passes just as
+  well over an empty walk, so the same run proves the walk produced both cardinalities and that
+  `incremental_output` is present and correct on each. That key had no pgw-side coverage at all
+  before this — the one spelling the hub actually reads was asserted nowhere in the repo.

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -796,10 +796,13 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             "input_schema": input_schema,
             "moderation": moderation,
             "expected_outputs": expected_outputs,
-            "output_mode": "incremental" if incremental else "single",
             "output_type": _type_id(output_type),
             "output_schema_sha256": output_sha,
             "output_schema": output_schema,
+            # The output-cardinality fact, in the ONE spelling the hub decodes
+            # (builder/manifest_contract.go). pgw#1320 deleted the sibling
+            # `output_mode: "incremental"|"single"` key beside it — a third
+            # value space for this bit that no hub reader has ever named.
             "incremental_output": incremental,
             "is_async": es.is_async,
         }

--- a/tests/test_dead_output_mode_emit_pgw1320.py
+++ b/tests/test_dead_output_mode_emit_pgw1320.py
@@ -1,0 +1,118 @@
+"""pgw#1320 — the manifest carries ONE spelling of output cardinality.
+
+`discover.py` used to emit `output_mode: "incremental"|"single"` beside
+`incremental_output: bool`. The hub has never decoded the first one:
+`output_mode` appears nowhere in tensorhub's `internal/builder`, which
+decodes `incremental_output` (`builder/domain.go`,
+`builder/manifest_contract.go`) and republishes it under that name.
+
+Three spellings existed for one bit — `EndpointSpec.output_mode`
+("single"|"stream") in process, `output_mode` ("incremental"|"single") on
+the manifest, `incremental_output` (bool) on the wire. The middle one was
+read by nobody and is gone.
+
+The fence runs `discover_manifest` — the exact entry point the image's
+build step runs — so it is a property of the manifest a real build emits,
+not of a fixture somebody kept in sync by hand.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# The one spelling the hub decodes, and the one it never has.
+LIVE_KEY = "incremental_output"
+DEAD_KEY = "output_mode"
+
+
+def _endpoint_tree(root: Path) -> None:
+    """A toy endpoint with BOTH cardinalities — a struct-returning function
+    and an Iterator-returning one, which is what `_inspect_return` turns
+    into "single" vs "stream"."""
+    (root / "pyproject.toml").write_text(textwrap.dedent("""
+        [project]
+        name = "ep1320"
+
+        [tool.gen_worker]
+        main = "ep1320.main"
+    """))
+    src = root / "ep1320"
+    src.mkdir()
+    (src / "__init__.py").write_text("")
+    (src / "main.py").write_text(textwrap.dedent("""
+        from typing import Iterator
+
+        import msgspec
+        from gen_worker import RequestContext, Resources, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str = ""
+
+        @endpoint(resources=Resources(gpu=False))
+        class Both:
+            def setup(self) -> None: ...
+
+            def whole(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_()
+
+            def streamed(self, ctx: RequestContext, data: In_) -> Iterator[Out_]:
+                yield Out_()
+    """))
+
+
+@pytest.fixture()
+def functions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    from gen_worker.discovery.discover import discover_manifest
+
+    _endpoint_tree(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return list(discover_manifest(tmp_path)["functions"])
+
+
+def test_the_walk_is_not_vacuous(functions: list[dict]) -> None:
+    """The control for the absence assertion below. An absent-key fence
+    passes just as well when the discovery walk found nothing, so prove
+    the walk produced BOTH cardinalities before believing a "not in"."""
+    by_name = {fn["name"]: fn for fn in functions}
+    assert set(by_name) == {"whole", "streamed"}, by_name.keys()
+    assert by_name["whole"][LIVE_KEY] is False
+    assert by_name["streamed"][LIVE_KEY] is True
+
+
+def test_the_manifest_carries_no_output_mode(functions: list[dict]) -> None:
+    """pgw#1320: the dead key is gone from a REAL discovery manifest.
+
+    Restoring the emit fails here by name — and the hub could not tell,
+    because it has no decoder for it to fail in."""
+    carriers = [fn["name"] for fn in functions if DEAD_KEY in fn]
+    assert carriers == [], (
+        f"{DEAD_KEY!r} is back on {carriers} — the hub has never decoded it "
+        f"({DEAD_KEY} appears nowhere in tensorhub/internal/builder); "
+        f"{LIVE_KEY} is the fact and the only spelling the hub reads"
+    )
+
+
+def test_no_manifest_block_reintroduces_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scoped to the function rows above, the fence would miss the key
+    reappearing on a sibling manifest block (jobs, lanes, decode set).
+    Assert it against the whole document instead."""
+    import json
+
+    from gen_worker.discovery.discover import discover_manifest
+
+    _endpoint_tree(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    doc = json.dumps(discover_manifest(tmp_path))
+
+    assert LIVE_KEY in doc, "the walk emitted no cardinality at all"
+    assert f'"{DEAD_KEY}"' not in doc, (
+        f"{DEAD_KEY!r} reappeared somewhere in the manifest document"
+    )


### PR DESCRIPTION
`discovery/discover.py` emitted `output_mode: "incremental"|"single"` beside `incremental_output: <bool>` — two keys for one bit. **`output_mode` appears nowhere in tensorhub's `internal/builder`.** The hub decodes `incremental_output` (`builder/domain.go`, `builder/manifest_contract.go`) and republishes it under that name on public discovery. The key was written on every publish and read on none, and never has been.

Hard cut, pre-launch. It also collapses a third value space for the same bit: `"single"|"stream"` on `EndpointSpec`, `"incremental"|"single"` on the manifest, boolean on the wire. Two spellings remain, one of which crosses a repo boundary.

## Verified before cutting, at source (not carried from the filing)

- pgw: `output_mode` as a dict key/literal occurs exactly ONCE tree-wide — the emit site. No test, fixture, or reader names it.
- tensorhub: zero occurrences in `internal/builder` other than the fixture mirror (that half is th#2087).
- Peer census re-run 2026-08-17: e2e 0, cozy-local 0, cozy-art 0, private-inference-endpoints 0, training-endpoints 0. serverless-endpoints has 3 — all `assert spec.output_mode == "stream"` on the **in-process `EndpointSpec`**, unrelated to the manifest key.

## The fence, and why its controls are the point

`tests/test_dead_output_mode_emit_pgw1320.py` runs **`discover_manifest`** — the entry point the image build runs — so it asserts a property of the manifest a real build emits, not of a hand-synced fixture.

An absent-key assertion passes just as well over a walk that found nothing, so the same run proves the walk produced *both* cardinalities and that `incremental_output` is present and correct on each. **Before this, the one spelling the hub actually reads was asserted nowhere in this repository** — `incremental_output` occurred exactly once tree-wide, at the emit site.

### Reds observed, controls green in the same run

| mutation | red |
|---|---|
| restore the emit | both absence arms fail by name — master's exact pre-landing state |
| `incremental = False` hard-wired | cardinality control: *`assert False is True`* |
| remove the `@endpoint` decorator (empty walk) | both controls fail — **while the absence arm passes VACUOUSLY**, which is the demonstration that the controls are load-bearing |

## Verification

`tests/test_dead_output_mode_emit_pgw1320.py` green (3/3). Targeted discovery set (`test_discovery_source_only_pgw833`, `test_decode_set_pgw1245`, `test_micro_family_registration_pgw1084`, `test_mint_preconditions_pgw996`, `test_input_manifest_v4`, `test_p5_discovery_lock`, `test_variant_th1004`) **baselined against master's own source**: identical 12 failed / 2 errors either way — all missing local optional extras (`torch`, image decoder) — and this branch adds 3 passes on top. `assemble_changelog.py --check` clean. Rebased onto `3c4d29c3`.

## Not in scope, decided rather than punted

Renaming `EndpointSpec.output_mode` → `output_cardinality` is **declined**, with reasoning and the exact three serverless-endpoints sites recorded on pgw#1320. `"single"|"stream"` is an accurate name for what that field holds; the collision it would avoid is being removed from the *other* side by th#2082, which renames the genuinely misnamed `RunJob.output_mode` (a media-delivery preference). Renaming a correctly-named field to dodge a collision another lane is already deleting is churn plus a three-site cross-repo lockstep.

Hub half: th#2087.