### PR TITLE
pgw#1330: a projected tree stops being read as corruption, and stops being read as absence

### DIFF
--- a/changelog.d/pgw1330.md
+++ b/changelog.d/pgw1330.md
@@ -1,0 +1,62 @@
+- **A projected model tree stops being read as corruption, and stops being read as
+  absence.** Two consumers met a tensorfs pointer stub and drew opposite wrong conclusions
+  from the same correct loud failure.
+
+  `ModelStore._verify_snapshot_tree` runs on **first use every boot**. It hashed every
+  manifest-covered file at its path and ran the structural safetensors check over the rest;
+  a ~128 B `TFSSTUB1` stub is by construction neither, so every weight file scored corrupt,
+  the tree was quarantined — `rmtree` the tree, `delete_blobs` the CAS objects it was built
+  from, `sweep_orphan_blobs` — and the whole model re-downloaded. It never raised and never
+  degraded: it presented as *"the CAS has stopped caching"*, which points the investigation
+  at the store rather than at the projection. Project a tree, reboot the pod, and the pod
+  deletes the model and fetches it again. Every boot. Forever. Boot verification now splits
+  projection artifacts off before hashing and checks them structurally against the manifest
+  — a stub must name its entry's digest and size, a symlink must resolve to the object its
+  entry names and that object must be present. That is not a weakening: the bytes were
+  hashed at CAS **admission**, on a store that is always pod-local, so re-hashing them every
+  boot re-derives a fact the store already refused to store wrongly. The materialized path
+  keeps its mandatory hash, and a truncated shard is still caught.
+
+  `detect_on_disk_dtype` read the stub's first eight bytes as a safetensors header length,
+  correctly judged them implausible, and **`continue`d** — so every weight file was skipped,
+  the count stayed empty, and it returned `""`. Its own docstring states the consequence:
+  *"a bf16 snapshot silently loads via diffusers' fp32 default — 2x the VRAM."* It now reads
+  the header from the manifest, and a stub whose manifest cannot be recovered is an
+  `UnresolvedProjection` refusal naming what it would otherwise have got wrong. `""` still
+  means what it honestly meant — no readable header — and never again means "this is a stub".
+
+- **Five copies of that same fail-open header reader are now one.** `loading.py`,
+  `w8a8.py`, `w4a4.py`, `svdq.py` and `hf_fp8_blockwise.py` each carried a private
+  `open(path,"rb")` + `struct.unpack("<Q")` + `return {}` on failure. A fail-open duplicated
+  per lane cannot be fixed per lane, so they are deleted in favour of
+  `models/safetensors_header.read_header(path, why=…)`, which serves the header from the CAS
+  when the path is a stub. Each had its own silent wrongness: `_quantized_layers` returning
+  `()` routes an fp8 or w4a4 artifact down the plain bf16 lane; `_read_safetensors_metadata`
+  returning `{}` makes an svdq checkpoint stop being an svdq checkpoint;
+  `_safetensors_data_bytes` returning 0 plans VRAM for a model that is not there;
+  `key_topology.tensor_keys` returning nothing classifies a checkpoint's attention topology
+  as neither.
+
+- **The weight lanes read tensors from the CAS.** `models/tensor_source.open_tensor_source`
+  keeps the `safe_open` shape — `keys()`, `get_tensor()`, `metadata()` — and moves the
+  source, so a lane is cut over by changing one `with` line. `svdq_native`'s primary
+  weight-materialization loop, both `w8a8`/`w4a4` state-dict loads and their per-layer
+  handle caches, and the LoRA adapter load now go through it. The svdq lane was the worked
+  example: it already built its shell with `from_config` under `init_empty_weights` and
+  filled by name, so it never wanted a directory and the cut is the source of the tensors
+  and nothing else.
+
+- **`utils/lora` compares adapters by the size they HOLD, not the size of their inode.**
+  Picking "the largest `.safetensors`" and enforcing `MAX_LORA_FILE_BYTES` both read
+  `st_size`, which for a stub is ~128 B regardless of the adapter behind it — so the ceiling
+  stopped bounding anything without ever failing. Both now read the stub's declared size.
+
+- **The vendored `tensorfs` snapshot gains the read plane, at a declared second rev.**
+  `project.py`, `tensors.py` and `gguf.py` — TFSSTUB1 render/parse, tree projection and the
+  direct tensor reader — come from `read_plane_rev`, recorded in `VENDORED.toml` beside the
+  storage half's `rev`. The revs differ on purpose: the newer lineage deleted
+  `LocalCAS.ingest_file`, `collect_garbage` and `materialize_repository`, which are live
+  here, and taking them away is the chokepoint flip rather than a loader change. The split
+  is digest-fenced like any other vendored file, and one test executes the render/parse path
+  with the compiled extension made unimportable, so "pure Python" is run rather than
+  asserted from an import list.

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -46,8 +46,34 @@ subdir = "python/src/tensorfs"
 #
 # What is LEFT is genuinely storage — `LocalCAS`, the chunk manifest, refs —
 # and it is byte-identical to `8bafdfbb` except for the `rewrites` below.
+#
+# pgw#1330: THE SNAPSHOT IS SPLIT AT TWO REVS, ON PURPOSE, AND THIS IS THE
+# ONLY RECORD OF IT. `project.py`, `tensors.py` and `gguf.py` come from
+# `read_plane_rev` below, NOT from `rev`. They are the consumption plane the
+# whole mixed-CAS cutover rests on — TFSSTUB1 render/parse, tree projection,
+# and the direct tensor reader — and they DID NOT EXIST at `8bafdfbb`.
+#
+# Why not simply bump `rev`: the newer lineage DELETED `LocalCAS.ingest_file`,
+# `LocalCAS.collect_garbage` and `LocalCAS.materialize_repository`, which are
+# live here at `hubio/client.py`, `models/disk_gc.py` and the
+# `models/cozy_snapshot.py` chokepoint. Taking them away is the chokepoint
+# flip (pgw#1308 sequencing step 6) and an ownership question about who owns
+# ingest and GC — neither is a consumption-cutover decision, and pretending
+# otherwise would put a storage rewrite inside a loader change.
+#
+# Why the split is SAFE rather than merely convenient: the three read-plane
+# modules import nothing from `local.py` at runtime beyond `object_path`,
+# `load_manifest` and `_store_lock` — all three present and unchanged at
+# `8bafdfbb` — plus `manifest.py` and `refs.py`. `refs.py` is byte-identical
+# across the two revs. `manifest.py` differs ONLY in that the newer rev drops
+# the 64 MiB cap on a chunkless entry; the older, STRICTER parser is the one
+# in force here, so nothing the read plane is handed can be a manifest the
+# storage half would have refused. `tests/test_projected_tree_pgw1330.py`
+# proves the pairing executes rather than asserting it from imports.
+read_plane_rev = "333bb10016c328c5e3a275de2a2a314dbd0abcaf"
+read_plane_files = ["gguf.py", "project.py", "tensors.py"]
 rewrites = [
-  "`__init__.py`: the `transfer`, `journal` and `daemon` re-exports are gone with the modules (pgw#1308). No other file is touched, so the remaining digests are still upstream's.",
+  "`__init__.py`: the `transfer`, `journal` and `daemon` re-exports are gone with the modules (pgw#1308), and the `project`/`tensors` re-exports are added with the read plane (pgw#1330). No other file is touched, so the remaining digests are still upstream's.",
 ]
 
 [packages.torchcg]
@@ -68,12 +94,15 @@ rewrites = [
 ]
 
 [packages.tensorfs.files]
-"__init__.py" = "45e521905b56fa570a61f10c018beb0ee48d3f75587423ba2e4f94b5e8d3cfeb"
+"__init__.py" = "51e60fc07782af7ff738c889be2fb1d9fa81224abfc0dfe546dde9d2191cf21b"
 "chunking.py" = "69333dc0836f35b05c420780b7eac205993ebde54c1b91b1afe03e55c313bd7a"
+"gguf.py" = "458927d1bd86c2c166ed0168e9369f76f85387ac09bbb1eb5ecb095cdec6e055"
 "local.py" = "92ec0d1249115f08eb02fccf554e946d36854a4ae861bde8190590d404695e0e"
 "manifest.py" = "a93ee850992c17dd90a57946441875d282367556703b9e9d1c8be057ea12bed4"
+"project.py" = "2471c26e013b287a7554cecda51ff9b42c09f71cd6d6d57dd33ed4ef242c40cd"
 "py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 "refs.py" = "f3a144543f423a6b01043294b21104ababaafdbfb31798560de678b69f27ac2f"
+"tensors.py" = "b68adf8b95161defb89ed06bdea8a778b54e21a461768a43ae658955ccc6db9d"
 
 [packages.torchcg.files]
 "__init__.py" = "401efd9450c0181f32c64ccee1d21999d78e77dc2be5ef404c27e539e350d4a9"

--- a/src/gen_worker/_vendor/tensorfs/__init__.py
+++ b/src/gen_worker/_vendor/tensorfs/__init__.py
@@ -1,16 +1,58 @@
-"""Content-addressed local storage and chunk manifests."""
+"""Content-addressed local storage, chunk manifests, and direct tensor reads."""
 
 from .local import DigestMismatch, LocalCAS, RefConflict
 from .manifest import MAX_CHUNK_SIZE, Chunk, FileEntry, RepositoryManifest
+from .project import (
+    STUB_MAGIC,
+    TENSOR_SUFFIXES,
+    ProjectionError,
+    Stub,
+    is_tensor_container,
+    parse_stub,
+    project_snapshot,
+    read_stub,
+    stub_bytes,
+    tree_bytes,
+)
 from .refs import CASRef
+from .tensors import (
+    DTYPE_BITS,
+    BlockLayout,
+    FileTooLarge,
+    TensorError,
+    TensorReader,
+    TensorView,
+    dtype_itemsize,
+    open_tensors,
+    read_entry,
+)
 
 __all__ = [
     "CASRef",
     "Chunk",
+    "DTYPE_BITS",
     "DigestMismatch",
+    "BlockLayout",
     "FileEntry",
+    "FileTooLarge",
     "LocalCAS",
     "MAX_CHUNK_SIZE",
+    "ProjectionError",
     "RefConflict",
     "RepositoryManifest",
+    "STUB_MAGIC",
+    "Stub",
+    "TENSOR_SUFFIXES",
+    "TensorError",
+    "TensorReader",
+    "TensorView",
+    "dtype_itemsize",
+    "is_tensor_container",
+    "open_tensors",
+    "parse_stub",
+    "project_snapshot",
+    "read_entry",
+    "read_stub",
+    "stub_bytes",
+    "tree_bytes",
 ]

--- a/src/gen_worker/_vendor/tensorfs/gguf.py
+++ b/src/gen_worker/_vendor/tensorfs/gguf.py
@@ -1,0 +1,256 @@
+"""Enumerate a GGUF file's tensors from its directory, reading no tensor bytes.
+
+The seal planner gives GGUF the same tensor-aligned object treatment
+safetensors gets, so a GGUF tensor is addressable exactly the same way once its
+name, geometry and data offset are known. Recovering those means walking the
+GGUF header, which is what this module does.
+
+Every bound and the GGML block table below mirror
+``crates/tensorfs-core/src/planner/gguf.rs`` so the two implementations accept
+and reject the same files.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+
+MAGIC = b"GGUF"
+DEFAULT_ALIGNMENT = 32
+MAX_METADATA_COUNT = 1_000_000
+MAX_TENSOR_COUNT = 1_000_000
+MAX_SYMBOL_BYTES = 64 * 1024 * 1024
+MAX_ARRAY_ELEMENTS = 16_000_000
+MAX_ARRAY_DEPTH = 16
+MAX_TENSOR_NAME_LEN = 63
+MAX_DIMENSIONS = 4
+
+_ALIGNMENT_KEY = b"general.alignment"
+
+# (elements per encoded block, bytes per encoded block), keyed by ggml type id.
+# Pinned against ggml-org/llama.cpp 7e4c0a96880dae4fc4268ad441f8a6446bd5460a;
+# ids 4, 5, 31..33 and 36..38 are removed upstream and deliberately absent.
+GGML_LAYOUT: dict[int, tuple[int, int]] = {
+    0: (1, 4),
+    1: (1, 2),
+    2: (32, 18),
+    3: (32, 20),
+    6: (32, 22),
+    7: (32, 24),
+    8: (32, 34),
+    9: (32, 40),
+    10: (256, 84),
+    11: (256, 110),
+    12: (256, 144),
+    13: (256, 176),
+    14: (256, 210),
+    15: (256, 292),
+    16: (256, 66),
+    17: (256, 74),
+    18: (256, 98),
+    19: (256, 50),
+    20: (32, 18),
+    21: (256, 110),
+    22: (256, 82),
+    23: (256, 136),
+    24: (1, 1),
+    25: (1, 2),
+    26: (1, 4),
+    27: (1, 8),
+    28: (1, 8),
+    29: (256, 56),
+    30: (1, 2),
+    34: (256, 54),
+    35: (256, 66),
+    39: (32, 17),
+    40: (64, 36),
+    41: (128, 18),
+    42: (64, 18),
+}
+
+GGML_NAME: dict[int, str] = {
+    0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 7: "Q5_1",
+    8: "Q8_0", 9: "Q8_1", 10: "Q2_K", 11: "Q3_K", 12: "Q4_K", 13: "Q5_K",
+    14: "Q6_K", 15: "Q8_K", 16: "IQ2_XXS", 17: "IQ2_XS", 18: "IQ3_XXS",
+    19: "IQ1_S", 20: "IQ4_NL", 21: "IQ3_S", 22: "IQ2_S", 23: "IQ4_XS",
+    24: "I8", 25: "I16", 26: "I32", 27: "I64", 28: "F64", 29: "IQ1_M",
+    30: "BF16", 34: "TQ1_0", 35: "TQ2_0", 39: "MXFP4", 40: "NVFP4",
+    41: "Q1_0", 42: "Q2_0",
+}
+
+# GGUF metadata value type ids -> fixed width, for the ones that have one.
+_FIXED_WIDTH = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
+_TYPE_STRING = 8
+_TYPE_ARRAY = 9
+
+
+class GGUFError(ValueError):
+    """A byte stream did not parse as the GGUF structure it claimed to be."""
+
+
+@dataclass(frozen=True, slots=True)
+class GGUFTensor:
+    name: str
+    ggml_type: int
+    dtype: str
+    shape: tuple[int, ...]
+    offset: int
+    nbytes: int
+    block_elements: int
+    block_bytes: int
+
+
+class _Cursor:
+    """A forward reader over a byte range supplier, refilled in bounded blocks."""
+
+    __slots__ = ("_at", "_block", "_buffer", "_read", "_start", "_size")
+
+    def __init__(self, read: Callable[[int, int], bytes], size: int) -> None:
+        self._read = read
+        self._size = size
+        self._at = 0
+        self._buffer = b""
+        self._start = 0
+        self._block = 1 << 20
+
+    @property
+    def position(self) -> int:
+        return self._at
+
+    def take(self, length: int) -> bytes:
+        if length < 0 or self._at + length > self._size:
+            raise GGUFError("GGUF header runs past the end of the file")
+        end = self._at + length
+        if not (self._start <= self._at and end <= self._start + len(self._buffer)):
+            span = min(max(length, self._block), self._size - self._at)
+            self._buffer = self._read(self._at, span)
+            self._start = self._at
+        begin = self._at - self._start
+        self._at = end
+        return self._buffer[begin : begin + length]
+
+    def skip(self, length: int) -> None:
+        if length < 0 or self._at + length > self._size:
+            raise GGUFError("GGUF header runs past the end of the file")
+        self._at += length
+
+    def u32(self) -> int:
+        return int(struct.unpack("<I", self.take(4))[0])
+
+    def u64(self) -> int:
+        return int(struct.unpack("<Q", self.take(8))[0])
+
+    def symbol(self, limit: int) -> bytes:
+        length = self.u64()
+        if length > limit:
+            raise GGUFError("GGUF symbol exceeds its bound")
+        return self.take(length)
+
+
+def _skip_value(cursor: _Cursor, value_type: int, depth: int) -> None:
+    if depth > MAX_ARRAY_DEPTH:
+        raise GGUFError("GGUF metadata nests too deeply")
+    width = _FIXED_WIDTH.get(value_type)
+    if width is not None:
+        cursor.skip(width)
+        return
+    if value_type == _TYPE_STRING:
+        cursor.symbol(MAX_SYMBOL_BYTES)
+        return
+    if value_type != _TYPE_ARRAY:
+        raise GGUFError(f"unknown GGUF metadata value type {value_type}")
+    element_type = cursor.u32()
+    count = cursor.u64()
+    if count > MAX_ARRAY_ELEMENTS:
+        raise GGUFError("GGUF metadata array exceeds its bound")
+    element_width = _FIXED_WIDTH.get(element_type)
+    if element_width is not None:
+        # Fixed-width elements are a flat run; skipping avoids touching them.
+        cursor.skip(element_width * count)
+        return
+    for _ in range(count):
+        _skip_value(cursor, element_type, depth + 1)
+
+
+def _tensor_nbytes(shape: tuple[int, ...], elements: int, block_bytes: int) -> int:
+    """Rows are encoded blockwise, so only dimension zero divides by the block."""
+
+    if shape[0] % elements:
+        raise GGUFError("GGUF tensor row is not a whole number of blocks")
+    total = (shape[0] // elements) * block_bytes
+    for dimension in shape[1:]:
+        total *= dimension
+    return total
+
+
+def parse(read: Callable[[int, int], bytes], size: int) -> Iterator[GGUFTensor]:
+    """Yield every tensor a GGUF file declares, in declaration order.
+
+    ``read(offset, length)`` supplies bytes; no tensor body is ever requested.
+    """
+
+    cursor = _Cursor(read, size)
+    if size < 24 or cursor.take(4) != MAGIC:
+        raise GGUFError("not a GGUF file")
+    version = cursor.u32()
+    if version not in (2, 3):
+        raise GGUFError(f"unsupported GGUF version {version}")
+    tensor_count = cursor.u64()
+    metadata_count = cursor.u64()
+    if tensor_count > MAX_TENSOR_COUNT or metadata_count > MAX_METADATA_COUNT:
+        raise GGUFError("GGUF directory exceeds its bounds")
+
+    alignment = DEFAULT_ALIGNMENT
+    for _ in range(metadata_count):
+        key = cursor.symbol(MAX_SYMBOL_BYTES)
+        value_type = cursor.u32()
+        if key == _ALIGNMENT_KEY and value_type == 4:
+            alignment = int(struct.unpack("<I", cursor.take(4))[0])
+            if alignment == 0 or alignment & (alignment - 1):
+                raise GGUFError("general.alignment must be a power of two")
+            continue
+        _skip_value(cursor, value_type, 0)
+
+    declared: list[GGUFTensor] = []
+    for _ in range(tensor_count):
+        name = cursor.symbol(MAX_TENSOR_NAME_LEN).decode("utf-8", "strict")
+        dimensions = cursor.u32()
+        if not 1 <= dimensions <= MAX_DIMENSIONS:
+            raise GGUFError(f"GGUF tensor {name!r} declares {dimensions} dimensions")
+        shape = tuple(cursor.u64() for _ in range(dimensions))
+        ggml_type = cursor.u32()
+        offset = cursor.u64()
+        layout = GGML_LAYOUT.get(ggml_type)
+        if layout is None:
+            raise GGUFError(f"GGUF tensor {name!r} uses unsupported ggml type {ggml_type}")
+        elements, block_bytes = layout
+        declared.append(
+            GGUFTensor(
+                name=name,
+                ggml_type=ggml_type,
+                dtype=GGML_NAME.get(ggml_type, f"GGML_{ggml_type}"),
+                shape=shape,
+                offset=offset,
+                nbytes=_tensor_nbytes(shape, elements, block_bytes),
+                block_elements=elements,
+                block_bytes=block_bytes,
+            )
+        )
+
+    # Tensor offsets are relative to the aligned start of the data section.
+    data_start = (cursor.position + alignment - 1) & ~(alignment - 1)
+    for tensor in declared:
+        absolute = data_start + tensor.offset
+        if absolute + tensor.nbytes > size:
+            raise GGUFError(f"GGUF tensor {tensor.name!r} runs past the end of the file")
+        yield GGUFTensor(
+            name=tensor.name,
+            ggml_type=tensor.ggml_type,
+            dtype=tensor.dtype,
+            shape=tensor.shape,
+            offset=absolute,
+            nbytes=tensor.nbytes,
+            block_elements=tensor.block_elements,
+            block_bytes=tensor.block_bytes,
+        )

--- a/src/gen_worker/_vendor/tensorfs/project.py
+++ b/src/gen_worker/_vendor/tensorfs/project.py
@@ -1,0 +1,322 @@
+"""Project a manifest into a snapshot tree, in pure Python.
+
+`Layout::project` (`crates/tensorfs-core/src/layout.rs`) is the Rust half of
+this, and it is the half that cannot travel: python-gen-worker VENDORS
+`python/src/tensorfs` as source (pgw#1310 -- both PyPI projects were deleted,
+and a git pin is workspace-only metadata that a published wheel strips), so a
+PyO3 extension is not reachable from pgw's wheel. Everything a consumer needs
+to STOP materializing therefore has to exist here, without `_tensorfs`:
+
+* :func:`stub_bytes` / :func:`parse_stub` -- TFSSTUB1, byte for byte;
+* :func:`project_snapshot` -- the tree itself.
+
+A projected tree derives entirely from the manifest, pins nothing, and can be
+thrown away and rebuilt byte for byte. It costs one inode per file and no
+tensor bytes at all: a blob is a relative symlink into ``objects/``, a tensor
+container is a ~128 B pointer stub, and the real bytes are read through
+:mod:`tensorfs.tensors`.
+
+The one place this module writes real bytes is a CHUNKED non-tensor file --
+a file whose contents exist only as several objects, so there is no inode to
+point at and no tensor reader to serve it. That is bounded by the CAS scope
+ruling (repos only; large non-tensor files do not belong in the chunked
+store), and it is stated here rather than hidden because a projection that
+silently copied would defeat the point of the layout.
+
+## `body_sha256` per manifest dialect
+
+`spec/v1/TFSSTUB1.md` defines the field as the TFM1 file-*body* hash and
+argues the negative -- *"not the SHA-256 of the file's content"* -- from a
+TFM1 fact: TFM1 gives a tensor container no whole-file hash, so demanding one
+would force the projector to read every tensor byte. The v1 JSON manifest
+(:mod:`tensorfs.manifest`, the dialect tensorhub speaks) does not share that
+fact: every :class:`~tensorfs.manifest.FileEntry` already carries a whole-file
+digest, derivable from the manifest alone at zero read cost. So in this
+dialect the entry digest IS the body identity, and the spec says so.
+"""
+
+from __future__ import annotations
+
+import errno
+import itertools
+import json
+import os
+import re
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .manifest import FileEntry, RepositoryManifest
+from .refs import CASRef
+
+if TYPE_CHECKING:
+    from .local import LocalCAS
+
+__all__ = [
+    "STUB_MAGIC",
+    "TENSOR_SUFFIXES",
+    "ProjectionError",
+    "Stub",
+    "is_tensor_container",
+    "parse_stub",
+    "project_snapshot",
+    "read_stub",
+    "stub_bytes",
+    "tree_bytes",
+]
+
+#: The first eight bytes of every pointer stub, so a tool classifies one
+#: without parsing JSON. Neither a safetensors `u64` header length nor the
+#: GGUF magic -- a naive `open()` fails loudly at the parse site.
+STUB_MAGIC = b"TFSSTUB1"
+
+#: A file is a tensor container when its name says so. This is the same
+#: suffix dispatch `TensorReader._parse_container` uses to decide what it can
+#: serve, and the two must agree: a stub is a promise that the reader will
+#: answer for that path.
+TENSOR_SUFFIXES = (".safetensors", ".gguf")
+
+_LOWER_HEX = re.compile(r"^[0-9a-f]{64}$")
+_ARTIFACT_MODE = 0o444
+_SCRATCH_SEQUENCE = itertools.count()
+_COPY_BLOCK = 1 << 20
+
+
+class ProjectionError(RuntimeError):
+    """A tree could not be projected from the manifest it was given."""
+
+
+@dataclass(frozen=True, slots=True)
+class Stub:
+    """What one pointer stub says: a body identity and a logical size."""
+
+    body_sha256: str
+    size: int
+
+
+def stub_bytes(body_sha256: str | CASRef, size: int) -> bytes:
+    """One pointer stub's bytes: the magic, one space, one line of JSON.
+
+    Emitted by hand rather than by a serializer, because the bytes are the
+    contract (`spec/v1/TFSSTUB1.md`, `spec/v1/tfsstub1-vectors/`): key order,
+    no whitespace, one trailing line feed.
+    """
+
+    digest = CASRef.parse(body_sha256) if ":" in str(body_sha256) else CASRef(str(body_sha256))
+    if type(size) is not int or not 0 <= size < (1 << 64):
+        raise ValueError(f"stub size must be a u64, got {size!r}")
+    body = f'{{"body_sha256":"{digest.digest}","size":{size},"read":"tensorfs"}}'
+    return STUB_MAGIC + b" " + body.encode("ascii") + b"\n"
+
+
+def parse_stub(data: bytes) -> Stub | None:
+    """Read one pointer stub, or ``None`` when the bytes are not one."""
+
+    if not data.startswith(STUB_MAGIC + b" ") or not data.endswith(b"\n"):
+        return None
+    try:
+        raw = json.loads(data[len(STUB_MAGIC) + 1 : -1])
+    except ValueError:
+        return None
+    if not isinstance(raw, dict) or set(raw) != {"body_sha256", "size", "read"}:
+        return None
+    if raw["read"] != "tensorfs" or type(raw["size"]) is not int:
+        return None
+    # `CASRef` normalises case for a caller's convenience; a stub's bytes are
+    # a contract, so the reader refuses what the writer would never emit.
+    if not _LOWER_HEX.fullmatch(str(raw["body_sha256"])):
+        return None
+    if not 0 <= raw["size"] < (1 << 64):
+        return None
+    return Stub(str(raw["body_sha256"]), raw["size"])
+
+
+def read_stub(path: str | Path) -> Stub | None:
+    """The stub at ``path``, or ``None`` when that file is not one.
+
+    Reads a bounded prefix, so pointing this at a real multi-gigabyte file
+    costs one block rather than the file.
+    """
+
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(512)
+    except OSError:
+        return None
+    return parse_stub(head)
+
+
+def is_tensor_container(path: str) -> bool:
+    """Whether a manifest path names a file the tensor reader can serve."""
+
+    return path.endswith(TENSOR_SUFFIXES)
+
+
+def _single_object(entry: FileEntry) -> CASRef | None:
+    """The one CAS object holding this entry's whole contents, if there is one.
+
+    A chunkless entry is one whole blob. A one-chunk entry is the same blob
+    under a grid the manifest happens to spell out -- `FileEntry` already
+    refuses a one-chunk entry whose digest disagrees, so the two are the same
+    object and a symlink is exact.
+    """
+
+    if not entry.chunks:
+        return entry.digest
+    if len(entry.chunks) == 1:
+        return entry.digest
+    return None
+
+
+def _relative_object_target(link: Path, object_path: Path) -> Path:
+    """The symlink body: ``objects/…`` reached from the link's own directory.
+
+    Computed from the two real paths rather than from the manifest path's
+    depth, so a tree projected anywhere -- not only at
+    ``<root>/snapshots/<id>`` -- gets a correct relative link.
+    """
+
+    return Path(os.path.relpath(object_path, link.parent))
+
+
+def _install_bytes(target: Path, data: bytes) -> None:
+    """Install a projection artifact -- a stub or an empty blob -- immutable."""
+
+    with open(target, "wb") as handle:
+        handle.write(data)
+    os.chmod(target, _ARTIFACT_MODE)
+
+
+def _copy_entry(cas: LocalCAS, entry: FileEntry, target: Path) -> None:
+    """Reassemble a chunked non-tensor file: the one real copy this makes."""
+
+    from .tensors import TensorReader
+
+    reader = TensorReader(cas, RepositoryManifest((entry,)))
+    try:
+        with open(target, "wb") as handle:
+            offset = 0
+            while offset < entry.size_bytes:
+                span = min(_COPY_BLOCK, entry.size_bytes - offset)
+                handle.write(reader.read_range(entry.path, offset, span))
+                offset += span
+    finally:
+        reader.close()
+    os.chmod(target, _ARTIFACT_MODE)
+
+
+def _project_entry(cas: LocalCAS, entry: FileEntry, target: Path, *, symlinks: bool) -> None:
+    """One entry's projection.
+
+    The dispatch is on what the ENTRY says and nothing else -- never on a
+    source file that may not exist, which is what makes a projection cost no
+    tensor bytes.
+    """
+
+    if is_tensor_container(entry.path):
+        _install_bytes(target, stub_bytes(entry.digest, entry.size_bytes))
+        return
+    if entry.size_bytes == 0:
+        _install_bytes(target, b"")
+        return
+    ref = _single_object(entry)
+    if ref is None:
+        _copy_entry(cas, entry, target)
+        return
+    source = cas.object_path(ref)
+    if symlinks:
+        os.symlink(_relative_object_target(target, source), target)
+    else:
+        # No symlinks on this filesystem: the tree carries a copy. Local
+        # dedup is lost, correctness is kept.
+        shutil.copyfile(source, target)
+        os.chmod(target, _ARTIFACT_MODE)
+
+
+def _fill(cas: LocalCAS, manifest: RepositoryManifest, root: Path, *, symlinks: bool) -> None:
+    for entry in manifest.files:
+        target = root / entry.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        _project_entry(cas, entry, target, symlinks=symlinks)
+
+
+def _supports_symlinks(directory: Path) -> bool:
+    probe = directory / f".symlink-probe-{os.getpid()}-{next(_SCRATCH_SEQUENCE)}"
+    try:
+        os.symlink("probe-target", probe)
+    except (OSError, NotImplementedError):
+        return False
+    finally:
+        try:
+            os.unlink(probe)
+        except OSError:
+            pass
+    return True
+
+
+def project_snapshot(
+    cas: LocalCAS,
+    manifest: RepositoryManifest | CASRef | str,
+    target: str | Path,
+    *,
+    symlinks: bool | None = None,
+) -> Path:
+    """Project one manifest as a tree at ``target`` and return that path.
+
+    The tree is built under a private scratch name beside ``target`` and
+    renamed into place, so no reader ever sees a half-built projection.
+    Projection is idempotent and racy-safe in the same breath: an existing
+    tree wins, and the loser's scratch is removed. Two projectors of the same
+    manifest produce the same tree by construction, so a lost race costs
+    nothing but the scratch.
+
+    ``symlinks`` defaults to probing the target's filesystem once.
+    """
+
+    if not isinstance(manifest, RepositoryManifest):
+        manifest = cas.load_manifest(manifest)
+    final = Path(target)
+    if final.exists():
+        return final
+    parent = final.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if symlinks is None:
+        symlinks = _supports_symlinks(parent)
+
+    scratch = parent / f".building-{final.name}-{os.getpid()}-{next(_SCRATCH_SEQUENCE)}"
+    shutil.rmtree(scratch, ignore_errors=True)
+    scratch.mkdir()
+    try:
+        _fill(cas, manifest, scratch, symlinks=symlinks)
+        os.rename(scratch, final)
+    except OSError as error:
+        shutil.rmtree(scratch, ignore_errors=True)
+        # Another projector of the same manifest won the race. Its tree has
+        # the same content by construction.
+        if error.errno in (errno.EEXIST, errno.ENOTEMPTY) and final.exists():
+            return final
+        raise
+    except Exception:
+        shutil.rmtree(scratch, ignore_errors=True)
+        raise
+    return final
+
+
+def tree_bytes(root: str | Path) -> int:
+    """Bytes the tree ITSELF occupies -- stubs and symlinks, never targets.
+
+    The measurement the layout exists to make small, and the one a caller
+    proving single-residency wants: `du` over a projected tree must be O(the
+    number of files), not O(the model).
+    """
+
+    total = 0
+    for directory, _subdirs, files in os.walk(root, followlinks=False):
+        for name in files:
+            path = os.path.join(directory, name)
+            info = os.lstat(path)
+            if not stat.S_ISLNK(info.st_mode):
+                total += info.st_size
+    return total

--- a/src/gen_worker/_vendor/tensorfs/tensors.py
+++ b/src/gen_worker/_vendor/tensorfs/tensors.py
@@ -1,0 +1,617 @@
+"""Read individual tensors out of a committed manifest without building a file.
+
+The seal-time planner already gives a safetensors file a tensor-aligned object
+grid, so "load tensor X" is "read these CAS objects". This module is the
+reference implementation of that read path: a lazy ``Mapping`` from tensor name
+to a handle that fetches only the objects its own bytes live in.
+
+This is the executable specification for the Rust/PyO3 reader described in
+``docs/direct-tensor-reads.md``; the byte-exactness properties it proves are
+properties of the object layout, not of this language.
+"""
+
+from __future__ import annotations
+
+import bisect
+import hashlib
+import json
+import math
+import mmap
+import os
+import tempfile
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from . import gguf
+from .manifest import FileEntry, RepositoryManifest
+from .refs import CASRef
+
+if TYPE_CHECKING:
+    from .local import LocalCAS
+
+__all__ = [
+    "DTYPE_BITS",
+    "BlockLayout",
+    "FileTooLarge",
+    "TensorError",
+    "TensorReader",
+    "TensorView",
+    "dtype_itemsize",
+    "open_tensors",
+    "read_entry",
+]
+
+_SAFETENSORS_SUFFIX = ".safetensors"
+_GGUF_SUFFIX = ".gguf"
+_SAFETENSORS_FORMAT = "safetensors-v1"
+_GGUF_FORMAT = "gguf-v1"
+_PREFIX_SIZE = 8
+# safetensors 0.8.0's own reader refuses header lengths above this. Matching it
+# keeps a malformed prefix from provoking a huge allocation here.
+_MAX_HEADER_BYTES = 100_000_000
+
+# Mirrors safetensors::tensor::Dtype::bitsize at upstream 6eb4dc9, and the Rust
+# planner's dtype_bits (crates/tensorfs-core/src/planner/safetensors.rs).
+DTYPE_BITS = {
+    "F4": 4,
+    "F6_E2M3": 6,
+    "F6_E3M2": 6,
+    "BOOL": 8,
+    "U8": 8,
+    "I8": 8,
+    "F8_E5M2": 8,
+    "F8_E4M3": 8,
+    "F8_E8M0": 8,
+    "F8_E5M2FNUZ": 8,
+    "F8_E4M3FNUZ": 8,
+    "I16": 16,
+    "U16": 16,
+    "F16": 16,
+    "BF16": 16,
+    "I32": 32,
+    "U32": 32,
+    "F32": 32,
+    "I64": 64,
+    "U64": 64,
+    "F64": 64,
+    "C64": 64,
+}
+
+
+class TensorError(ValueError):
+    """A manifest did not describe the tensors a caller asked for."""
+
+
+class FileTooLarge(TensorError):
+    """A caller tried to extract a file the escape hatch must not carry."""
+
+
+
+
+def dtype_itemsize(dtype: str) -> float:
+    """Bytes per element, which is fractional for the sub-byte float types."""
+
+    try:
+        return DTYPE_BITS[dtype] / 8
+    except KeyError:
+        raise TensorError(f"unknown safetensors dtype {dtype!r}") from None
+
+
+def _safetensors_block(dtype: str) -> BlockLayout:
+    """Express a safetensors dtype in the same block shape GGUF needs.
+
+    Whole-byte dtypes are one element per block. The sub-byte float types pack
+    several elements into a byte, which is the same relationship a quantized
+    GGUF block describes, so one vocabulary covers both.
+    """
+
+    bits = DTYPE_BITS[dtype]
+    if bits >= 8:
+        return BlockLayout(1, bits // 8)
+    elements = 8 // math.gcd(bits, 8)
+    return BlockLayout(elements, elements * bits // 8)
+
+
+@dataclass(frozen=True, slots=True)
+class BlockLayout:
+    """How many elements one encoded block holds, and how many bytes it takes.
+
+    This is the one shape that describes both formats without the caller
+    branching. A plain safetensors ``F32`` is ``(1, 4)``; its sub-byte ``F4`` is
+    ``(2, 1)``; a GGUF ``Q4_K`` is ``(256, 144)``. A caller that needs to know
+    whether it must build a quantized parameter asks :attr:`quantized`.
+    """
+
+    elements: int
+    nbytes: int
+
+    @property
+    def quantized(self) -> bool:
+        return self.elements > 1
+
+
+@dataclass(frozen=True, slots=True)
+class TensorView:
+    """A lazy handle on one tensor. No tensor bytes are read to create it."""
+
+    name: str
+    file: str
+    format: str
+    dtype: str
+    shape: tuple[int, ...]
+    nbytes: int
+    offset: int
+    block: BlockLayout
+    _reader: TensorReader = field(repr=False, compare=False)
+
+    def pieces(self) -> Iterator[memoryview]:
+        """Yield this tensor's bytes as ordered zero-copy views.
+
+        Each view is a slice of one mmapped CAS object, so nothing is copied
+        and no more than one object is resident per step. A tensor that spans
+        several objects yields several views; concatenating them is the
+        caller's choice, and it is the only place a copy becomes unavoidable.
+        """
+
+        return self._reader._pieces(self.file, self.offset, self.nbytes)
+
+    def tobytes(self) -> bytes:
+        """The whole tensor as one contiguous buffer. Copies, by definition."""
+
+        if self.nbytes == 0:
+            return b""
+        parts = list(self.pieces())
+        if len(parts) == 1:
+            return bytes(parts[0])
+        # join sizes the result once and copies each piece in exactly once;
+        # a bytearray followed by bytes() would copy the whole tensor twice.
+        return b"".join(parts)
+
+    def readinto(self, buffer: memoryview | bytearray) -> int:
+        """Copy this tensor into caller-owned memory, e.g. a pinned buffer."""
+
+        target = memoryview(buffer).cast("B")
+        if len(target) < self.nbytes:
+            raise TensorError(
+                f"{self.name}: buffer holds {len(target)} bytes, tensor needs {self.nbytes}"
+            )
+        at = 0
+        for piece in self.pieces():
+            target[at : at + len(piece)] = piece
+            at += len(piece)
+        return at
+
+
+class TensorReader(Mapping[str, TensorView]):
+    """Every tensor in a manifest, addressable without materializing a file.
+
+    Opening reads only the safetensors header of each contributing file. A
+    tensor's own bytes are read when a :class:`TensorView` is asked for them,
+    so one tensor of a 50 GiB checkpoint costs that tensor and nothing else.
+    """
+
+    def __init__(
+        self,
+        cas: LocalCAS,
+        manifest: RepositoryManifest,
+        *,
+        verify: bool = True,
+    ) -> None:
+        self._cas = cas
+        self._manifest = manifest
+        self._verify = verify
+        self._entries = {entry.path: entry for entry in manifest.files}
+        # (file path) -> (object start offsets, (ref, length) pairs)
+        self._grid: dict[str, tuple[list[int], tuple[tuple[CASRef, int], ...]]] = {}
+        self._maps: dict[str, mmap.mmap] = {}
+        self._verified: set[str] = set()
+        self._index: dict[str, TensorView] | None = None
+        self._closed = False
+
+    # -- Mapping ---------------------------------------------------------
+
+    def __getitem__(self, name: str) -> TensorView:
+        return self._tensors()[name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._tensors())
+
+    def __len__(self) -> int:
+        return len(self._tensors())
+
+    # -- lifecycle -------------------------------------------------------
+
+    def close(self) -> None:
+        """Drop this reader's mappings.
+
+        A mapping the caller still holds a ``memoryview`` into is *not*
+        force-unmapped — that would invalidate live buffers. It is released
+        instead, so the mapping survives exactly as long as the last view of
+        it. This is the same ownership rule the Rust reader gets from holding
+        each object in an ``Arc<Mmap>``; here refcounting supplies it.
+        """
+
+        self._closed = True
+        for handle in self._maps.values():
+            try:
+                handle.close()
+            except BufferError:
+                pass
+        self._maps.clear()
+
+    def __enter__(self) -> TensorReader:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # -- generic byte access ---------------------------------------------
+
+    def files(self) -> tuple[str, ...]:
+        return tuple(self._entries)
+
+    def read_range(self, path: str, offset: int, length: int) -> bytes:
+        """Read an arbitrary byte range, touching only overlapping objects.
+
+        This is the primitive the whole module rests on, and the honest
+        replacement for whole-file materialization: materializing a file was
+        only ever ``read_range(path, 0, size)`` with a write and two extra
+        hash passes bolted on.
+        """
+
+        if length == 0:
+            return b""
+        parts = list(self._pieces(path, offset, length))
+        if len(parts) == 1:
+            return bytes(parts[0])
+        return b"".join(parts)
+
+    def read_file(self, path: str) -> bytes:
+        """A whole small file, e.g. ``config.json`` or ``model_index.json``."""
+
+        entry = self._entry(path)
+        return self.read_range(path, 0, entry.size_bytes)
+
+    def extract(
+        self,
+        path: str,
+        destination: str | Path,
+        *,
+        limit: int | None = None,
+    ) -> Path:
+        """Write ONE non-tensor file to disk, for consumers that need a path.
+
+        This is the whole remaining reason to create a file: config JSON a
+        third-party constructor insists on reading from a directory, or any
+        other non-tensor member of a repo. Tensors never come through here --
+        they are read with :class:`TensorView`.
+
+        There is NO size cap -- ruled by Paul, 2026-08-16: "no hard-cap on
+        materialization size; we just want to avoid large non-tensor files
+        being in tensorfs (our chunked CAS system)." The control is scope at
+        ingestion (CAS holds repos only; datasets and compiled-graph artifacts
+        never enter it -- DESIGN-RULINGS "CAS scope: repos only"), not a limit
+        here. The stream is O(one block) of memory regardless of file size, so
+        extraction itself has no reason to refuse. ``limit`` remains for a
+        caller that wants to bound ITS OWN request; when given, exceeding it
+        raises :class:`FileTooLarge`.
+
+        The write is atomic: the destination either does not exist or is
+        complete, and its bytes are verified on the way out.
+        """
+
+        entry = self._entry(path)
+        if limit is not None and entry.size_bytes > limit:
+            raise FileTooLarge(
+                f"{path} is {entry.size_bytes} bytes, above the caller-supplied "
+                f"{limit}-byte bound"
+            )
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        handle, raw = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+        temporary = Path(raw)
+        try:
+            digest = hashlib.sha256()
+            with os.fdopen(handle, "wb") as sink:
+                for piece in self._pieces(path, 0, entry.size_bytes):
+                    sink.write(piece)
+                    digest.update(piece)
+                sink.flush()
+                os.fsync(sink.fileno())
+            if digest.hexdigest() != entry.digest.digest:
+                raise TensorError(f"{path}: extracted bytes do not match the manifest")
+            os.replace(temporary, target)
+            return target
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def object_span(self, view: TensorView) -> tuple[tuple[CASRef, int], ...] | None:
+        """The objects this tensor occupies, if it occupies them exactly.
+
+        Returns ``None`` when the tensor starts or ends mid-object, because
+        then it has no digest of its own and cannot be carried into a new
+        snapshot by reference -- its bytes would have to be rewritten.
+
+        This is the property that decides whether a conversion can leave a
+        tensor untouched. The Rust seal planner — the only chunker — gives
+        every tensor its own object, so it always holds for grids it planned.
+        The manifest wire allows arbitrary grids, so snapshots committed under
+        the retired packing chunker may not satisfy it.
+        """
+
+        starts, objects = self._file_grid(view.file)
+        begin = bisect.bisect_left(starts, view.offset)
+        if begin == len(starts) or starts[begin] != view.offset:
+            return None
+        span: list[tuple[CASRef, int]] = []
+        total = 0
+        index = begin
+        while total < view.nbytes and index < len(objects):
+            ref, size = objects[index]
+            span.append((ref, size))
+            total += size
+            index += 1
+        if total != view.nbytes:
+            return None
+        return tuple(span)
+
+    def rekeyed(self, names: Mapping[str, str]) -> Mapping[str, TensorView]:
+        """Serve these tensors under other names, admitting nothing.
+
+        The zero-storage half of a re-key: a consumer on the native read path
+        who only wants the other naming scheme -- ComfyUI's spelling of a
+        diffusers checkpoint, say -- needs no second snapshot at all. Composing
+        one (``tensorfs.native.rekey``) is for handing the other spelling to a
+        foreign tool that opens files.
+
+        ``names`` maps a stored name to the name it is served under; a tensor
+        it does not name keeps its own. Two tensors may not land on one name.
+        """
+
+        index = self._tensors()
+        unknown = sorted(set(names) - set(index))
+        if unknown:
+            raise TensorError(f"this manifest holds no tensor named {unknown[0]!r}")
+        translated: dict[str, TensorView] = {}
+        for name, view in index.items():
+            served = names.get(name, name)
+            if served in translated:
+                raise TensorError(f"two tensors would both be served as {served!r}")
+            translated[served] = replace(view, name=served)
+        return MappingProxyType(translated)
+
+    # -- internals -------------------------------------------------------
+
+    def _entry(self, path: str) -> FileEntry:
+        try:
+            return self._entries[path]
+        except KeyError:
+            raise TensorError(f"{path!r} is not in this manifest") from None
+
+    def _file_grid(self, path: str) -> tuple[list[int], tuple[tuple[CASRef, int], ...]]:
+        """Object start offsets and (ref, length) pairs, in file order."""
+
+        cached = self._grid.get(path)
+        if cached is not None:
+            return cached
+        objects = self._entry(path).objects()
+        starts: list[int] = []
+        position = 0
+        for _ref, length in objects:
+            starts.append(position)
+            position += length
+        built = (starts, objects)
+        self._grid[path] = built
+        return built
+
+    def _map(self, ref: CASRef, size: int) -> memoryview:
+        """An mmap of one CAS object, verified at most once per reader."""
+
+        key = ref.digest
+        handle = self._maps.get(key)
+        if handle is None:
+            # Opening under the shared store lock keeps collection from
+            # unlinking the object between path resolution and open. Once the
+            # mapping exists the bytes are pinned by the inode, so the lock is
+            # not held for the lifetime of the view.
+            with self._cas._store_lock():
+                path = self._cas.object_path(ref)
+                with path.open("rb") as source:
+                    handle = mmap.mmap(source.fileno(), 0, prot=mmap.PROT_READ)
+            self._maps[key] = handle
+        view = memoryview(handle)
+        if len(view) != size:
+            raise TensorError(f"{ref}: object is {len(view)} bytes, manifest says {size}")
+        if self._verify and key not in self._verified:
+            # Hashing the mapping is a single pass and copies nothing.
+            if hashlib.sha256(view).hexdigest() != key:
+                raise TensorError(f"{ref}: object bytes do not match their digest")
+            self._verified.add(key)
+        return view
+
+    def _pieces(self, path: str, offset: int, length: int) -> Iterator[memoryview]:
+        if self._closed:
+            raise TensorError("this reader is closed")
+        entry = self._entry(path)
+        if offset < 0 or length < 0 or offset + length > entry.size_bytes:
+            raise TensorError(
+                f"{path}: range [{offset}, {offset + length}) escapes a "
+                f"{entry.size_bytes}-byte file"
+            )
+        if length == 0:
+            return
+        starts, objects = self._file_grid(path)
+        end = offset + length
+        index = bisect.bisect_right(starts, offset) - 1
+        while index < len(objects):
+            start = starts[index]
+            if start >= end:
+                break
+            ref, size = objects[index]
+            view = self._map(ref, size)
+            begin = max(offset, start) - start
+            stop = min(end, start + size) - start
+            yield view[begin:stop]
+            index += 1
+
+    # -- tensor index ----------------------------------------------------
+
+    def _tensors(self) -> dict[str, TensorView]:
+        if self._index is not None:
+            return self._index
+        index: dict[str, TensorView] = {}
+        for path in self._entries:
+            for view in self._parse_container(path):
+                if view.name in index:
+                    raise TensorError(
+                        f"tensor {view.name!r} appears in both "
+                        f"{index[view.name].file!r} and {path!r}"
+                    )
+                index[view.name] = view
+        self._index = index
+        return index
+
+    def _parse_container(self, path: str) -> Iterator[TensorView]:
+        """Dispatch on what the file actually is, not on what it is called."""
+
+        if path.endswith(_GGUF_SUFFIX):
+            yield from self._parse_gguf(path)
+        elif path.endswith(_SAFETENSORS_SUFFIX):
+            yield from self._parse_header(path)
+
+    def _parse_gguf(self, path: str) -> Iterator[TensorView]:
+        """Enumerate a GGUF file from its directory, reading no tensor bytes.
+
+        GGUF carries its quantization block geometry per tensor, which is the
+        one thing safetensors has no equivalent for and the one thing a
+        consumer building a quantized parameter needs.
+        """
+
+        entry = self._entry(path)
+
+        def read(offset: int, length: int) -> bytes:
+            return self.read_range(path, offset, length)
+
+        try:
+            declared = list(gguf.parse(read, entry.size_bytes))
+        except gguf.GGUFError as error:
+            raise TensorError(f"{path}: {error}") from None
+        for tensor in declared:
+            yield TensorView(
+                name=tensor.name,
+                file=path,
+                format=_GGUF_FORMAT,
+                dtype=tensor.dtype,
+                shape=tensor.shape,
+                nbytes=tensor.nbytes,
+                offset=tensor.offset,
+                block=BlockLayout(tensor.block_elements, tensor.block_bytes),
+                _reader=self,
+            )
+
+    def _parse_header(self, path: str) -> Iterator[TensorView]:
+        """Recover names, dtypes and shapes, which the plan itself discards.
+
+        The planner sorts tensor spans and keeps only offsets, so the name to
+        byte-range mapping lives in the safetensors header. The header is read
+        through the same range primitive as everything else; object zero is
+        not special-cased.
+        """
+
+        entry = self._entry(path)
+        if entry.size_bytes < _PREFIX_SIZE + 2:
+            return
+        header_size = int.from_bytes(self.read_range(path, 0, _PREFIX_SIZE), "little")
+        if not 2 <= header_size <= _MAX_HEADER_BYTES:
+            return
+        header_end = _PREFIX_SIZE + header_size
+        if header_end > entry.size_bytes:
+            return
+        raw = self.read_range(path, _PREFIX_SIZE, header_size)
+        try:
+            header = json.loads(raw)
+        except ValueError:
+            return
+        if not isinstance(header, dict):
+            return
+        for name, descriptor in header.items():
+            if name == "__metadata__":
+                continue
+            if not isinstance(descriptor, dict):
+                raise TensorError(f"{path}: tensor {name!r} has a malformed header entry")
+            dtype = descriptor.get("dtype")
+            shape = descriptor.get("shape")
+            offsets = descriptor.get("data_offsets")
+            if (
+                not isinstance(dtype, str)
+                or not isinstance(shape, list)
+                or not isinstance(offsets, list)
+                or len(offsets) != 2
+            ):
+                raise TensorError(f"{path}: tensor {name!r} has a malformed header entry")
+            start, stop = offsets
+            nbytes = stop - start
+            elements = 1
+            for dimension in shape:
+                elements *= dimension
+            # The header states the byte span twice over: explicitly, and
+            # implicitly through dtype and shape. Disagreement means the
+            # offsets cannot be trusted to slice with.
+            if elements * DTYPE_BITS[dtype] != nbytes * 8:
+                raise TensorError(
+                    f"{path}: tensor {name!r} declares {nbytes} bytes but "
+                    f"{dtype}{list(shape)} needs {elements * DTYPE_BITS[dtype] / 8:.0f}"
+                )
+            yield TensorView(
+                name=name,
+                file=path,
+                format=_SAFETENSORS_FORMAT,
+                dtype=dtype,
+                shape=tuple(shape),
+                nbytes=nbytes,
+                offset=header_end + start,
+                block=_safetensors_block(dtype),
+                _reader=self,
+            )
+
+
+def open_tensors(
+    cas: LocalCAS,
+    manifest: RepositoryManifest | CASRef | str,
+    *,
+    verify: bool = True,
+) -> TensorReader:
+    """Open every tensor in a manifest, by value or by stored reference."""
+
+    if not isinstance(manifest, RepositoryManifest):
+        manifest = cas.load_manifest(manifest)
+    return TensorReader(cas, manifest, verify=verify)
+
+
+def read_entry(cas: LocalCAS, entry: FileEntry, *, verify: bool = True) -> bytes:
+    """One committed file's whole contents, straight from its CAS objects.
+
+    This is what whole-file materialization was actually asked for whenever the
+    caller only wanted the bytes: no temporary, no copy on disk, no fsync.
+
+    Because this reads the entire file it can also confirm the reconstruction
+    against the manifest's whole-file digest, which a partial tensor read
+    cannot. Per-tensor reads therefore verify objects only, and that is the
+    point -- the whole-file hash is exactly the cost direct reads exist to
+    stop paying on every load.
+    """
+
+    reader = TensorReader(cas, RepositoryManifest((entry,)), verify=verify)
+    try:
+        data = reader.read_range(entry.path, 0, entry.size_bytes)
+    finally:
+        reader.close()
+    if verify and hashlib.sha256(data).hexdigest() != entry.digest.digest:
+        raise TensorError(
+            f"{entry.path}: reconstructed bytes do not match the file manifest"
+        )
+    return data

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -39,13 +39,12 @@ from __future__ import annotations
 
 import json
 import math
-import struct
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import msgspec
 
-from .safetensors_header import header_len_ok
+from .safetensors_header import read_header
 from .file_layout import MULTI_FILE, SINGLE_FILE
 from .tensor_layout_contract import (
     CONTRACT_HF_FP8_BLOCKWISE,
@@ -117,20 +116,13 @@ class HfFp8BlockwiseTree(msgspec.Struct, frozen=True, kw_only=True):
 
 
 def _read_header(path: Path) -> Dict[str, Any]:
-    """Safetensors header only — bytes read are the declared length, capped
-    by §4.24's bound. No tensor data is touched."""
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(8)
-            if len(raw) < 8:
-                return {}
-            (n,) = struct.unpack("<Q", raw)
-            if not header_len_ok(n):
-                return {}
-            header = json.loads(f.read(n))
-    except (OSError, ValueError):
-        return {}
-    return header if isinstance(header, dict) else {}
+    """One shared, stub-aware reader — see `safetensors_header.read_header`."""
+
+    return read_header(
+        path,
+        why="an fp8-blockwise artifact whose dtypes and shapes go unseen is "
+            "routed to the plain bf16 lane and loads as the wrong model",
+    )
 
 
 def _weight_files(d: Path) -> Tuple[Path, ...]:

--- a/src/gen_worker/models/key_topology.py
+++ b/src/gen_worker/models/key_topology.py
@@ -25,15 +25,13 @@ distinction becomes a refusal or a pass.
 
 from __future__ import annotations
 
-import json
 import re
-import struct
 from pathlib import Path
 from typing import Iterable
 
 import msgspec
 
-from .safetensors_header import header_len_ok
+from .safetensors_header import read_header
 from .tensor_layout_contract import (
     KEYS_DIFFUSERS_SPLIT_QKV,
     KEYS_NATIVE_FUSED_QKV,
@@ -110,17 +108,11 @@ def tensor_keys(files: Iterable[Path]) -> tuple[str, ...]:
     for count, path in enumerate(files):
         if count >= _MAX_FILES:
             break
-        try:
-            with open(path, "rb") as handle:
-                raw = handle.read(8)
-                if len(raw) < 8:
-                    continue
-                (length,) = struct.unpack("<Q", raw)
-                if not header_len_ok(length):
-                    continue
-                header = json.loads(handle.read(length))
-        except (OSError, ValueError, struct.error):
-            continue
+        header = read_header(
+            path,
+            why="the tensor key names classify this checkpoint's attention "
+                "topology; an empty set silently classifies it as neither",
+        )
         if isinstance(header, dict):
             keys.extend(k for k in header if k != "__metadata__")
     return tuple(keys)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -57,7 +57,7 @@ from .memory import (
     probe_host_ram,
 )
 from .hf_fp8_blockwise import detect_hf_fp8_blockwise, load_hf_fp8_blockwise
-from .safetensors_header import header_len_ok
+from .safetensors_header import header_len_ok, read_header
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
 from ..hostfacts import cuda_ready
 from .w4a4 import (
@@ -164,28 +164,38 @@ def detect_on_disk_dtype(model_path: Path) -> str:
     carry no dtype and mirrored repos use unsuffixed filenames, so without
     this a bf16 snapshot silently loads via diffusers' fp32 default — 2x the
     VRAM. "fp8" marks an fp8-E4M3-stored flavor whose storage precision must
-    be preserved (see :func:`apply_fp8_storage`)."""
+    be preserved (see :func:`apply_fp8_storage`).
+
+    **On a projected tree the answer comes from the MANIFEST, and a tree whose
+    manifest cannot be recovered is a refusal, never a ""** (pgw#1308). A
+    TFSSTUB1 stub carries a body digest and a size and no dtype at all, and
+    its first eight bytes are ASCII magic that ``header_len_ok`` correctly
+    rejects — so on master every weight file was skipped by a ``continue``,
+    ``counts`` stayed empty, and this returned "", i.e. exactly the silent
+    fp32 default the docstring above was written to prevent. The stub failed
+    loudly at the parse site as designed; this caller read the loud failure as
+    "no information". A guarantee about how a read fails constrains nothing
+    about what the caller concludes, so the branch has to live here."""
 
     counts: Dict[str, int] = {}
     try:
-        for p in sorted(Path(model_path).rglob("*.safetensors")):
-            with open(p, "rb") as f:
-                raw = f.read(8)
-                if len(raw) < 8:
-                    continue
-                (n,) = struct.unpack("<Q", raw)
-                if not header_len_ok(n):
-                    continue
-                header = json.loads(f.read(n))
-            for value in header.values():
-                if isinstance(value, dict) and "dtype" in value:
-                    counts[str(value["dtype"])] = counts.get(str(value["dtype"]), 0) + 1
-    except (OSError, ValueError):
+        paths = sorted(Path(model_path).rglob("*.safetensors"))
+    except OSError:
         return ""
+    for p in paths:
+        for value in read_header(p, why=_DTYPE_WHY).values():
+            if isinstance(value, dict) and "dtype" in value:
+                counts[str(value["dtype"])] = counts.get(str(value["dtype"]), 0) + 1
     if not counts:
         return ""
     top = max(counts, key=lambda k: counts[k])
     return _SAFETENSORS_DTYPE_NAMES.get(top, "")
+
+
+_DTYPE_WHY = (
+    "the weight dtype decides whether this model loads in its stored precision "
+    "or via diffusers' fp32 default, at 2x the VRAM"
+)
 
 
 def read_on_disk_quant_config(model_path: Path) -> bool:
@@ -2068,14 +2078,11 @@ def hydrate_modular_pipeline(
 
 def _safetensors_data_bytes(p: Path) -> int:
 
-    with open(p, "rb") as f:
-        raw = f.read(8)
-        if len(raw) < 8:
-            return 0
-        (n,) = struct.unpack("<Q", raw)
-        if not header_len_ok(n):
-            return 0
-        header = json.loads(f.read(n))
+    header = read_header(
+        p,
+        why="tensor bytes per component size the VRAM plan; a stub read as "
+            "zero bytes plans a model that is not there",
+    )
     total = 0
     for value in header.values():
         if isinstance(value, dict) and "data_offsets" in value:

--- a/src/gen_worker/models/projection.py
+++ b/src/gen_worker/models/projection.py
@@ -1,0 +1,249 @@
+"""What a projected snapshot tree is, and how this worker reads one.
+
+A projected tree carries no tensor bytes. A non-tensor file (config, tokenizer,
+dataset media, ``.so``) is a relative symlink into the CAS ``objects/``; a
+tensor container is a ~128 B TFSSTUB1 pointer stub; the tensors themselves are
+read straight out of the CAS objects through :func:`open_tensors`.
+
+THE LESSON THIS MODULE EXISTS TO ENCODE (pgw#1308 finding 3, and it
+generalises): the stub format's safety property is that a naive ``open()``
+fails LOUDLY at the parse site. **That guarantee constrains nothing about what
+the caller concludes from the failure.** Two callers on master read the exact
+same correct loud failure and reached opposite wrong conclusions —
+``store.py`` read it as CORRUPTION and deleted the model on every boot;
+``detect_on_disk_dtype`` read it as ABSENCE and silently doubled VRAM. Neither
+is a format bug and no change to the format can fix either. So every consumer
+that can meet a projected tree needs its own stub-aware branch built on this
+module, or an explicit :class:`UnresolvedProjection` refusal. Falling back to
+a default is the defect.
+
+Recovering ``(cas, manifest)`` from a bare directory path needs no sidecar:
+:func:`gen_worker.models.cozy_snapshot.ensure_snapshot` publishes a tree at
+``<base>/snapshots/<key>`` and pins that exact manifest in the same store
+under the ref ``snapshot:<key>``, so the two are already addressable from the
+tree's own location.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from gen_worker._vendor.tensorfs import (
+    CASRef,
+    FileEntry,
+    LocalCAS,
+    RepositoryManifest,
+    Stub,
+    TensorReader,
+    open_tensors,
+    read_stub,
+)
+
+_log = logging.getLogger("gen_worker.models.projection")
+
+SNAPSHOTS_DIR = "snapshots"
+REF_PREFIX = "snapshot:"
+
+
+class UnresolvedProjection(RuntimeError):
+    """A projected tree was met where its manifest could not be recovered.
+
+    Raised INSTEAD of degrading to a default. Every site that raises this had
+    a fall-through on master that silently produced a wrong answer.
+    """
+
+
+def stub_at(path: Path | str) -> Optional[Stub]:
+    """The pointer stub at ``path``, or ``None`` when that file is not one.
+
+    Bounded read: pointing this at a real 20 GiB shard costs one block.
+    """
+
+    return read_stub(path)
+
+
+@dataclass(frozen=True)
+class ProjectedSnapshot:
+    """A projected tree together with the store and manifest that back it."""
+
+    root: Path
+    cas: LocalCAS
+    manifest: RepositoryManifest
+
+    def entry(self, rel: str) -> FileEntry:
+        for entry in self.manifest.files:
+            if entry.path == rel:
+                return entry
+        raise UnresolvedProjection(
+            f"{self.root}: {rel!r} is not in the manifest that backs this tree"
+        )
+
+    def entry_for(self, path: Path | str) -> FileEntry:
+        """The manifest entry for an absolute path inside this tree."""
+
+        rel = Path(path).resolve().relative_to(self.root.resolve()).as_posix()
+        return self.entry(rel)
+
+    def open_tensors(self, *, verify: bool = True) -> TensorReader:
+        """Every tensor in this snapshot, read from CAS objects, no file."""
+
+        return open_tensors(self.cas, self.manifest, verify=verify)
+
+def resolve_projection(root: Path | str) -> Optional[ProjectedSnapshot]:
+    """The ``(cas, manifest)`` backing a snapshot tree, or ``None``.
+
+    ``None`` means "this path is not a snapshot tree this worker published" —
+    an ordinary materialized directory, a bare HF download, a test fixture.
+    It never means "the manifest is missing but the tree is projected"; that
+    case is an :class:`UnresolvedProjection` at :func:`require_projection`.
+    """
+
+    tree = Path(root)
+    if tree.parent.name != SNAPSHOTS_DIR:
+        return None
+    base = tree.parent.parent
+    # Constructing a LocalCAS CREATES its directories. Only do that where one
+    # already lives, so probing an ordinary path never leaves a store behind.
+    if not (base / "refs").is_dir() or not (base / "objects").is_dir():
+        return None
+    try:
+        cas = LocalCAS(base)
+        ref = cas.read_ref(REF_PREFIX + tree.name)
+    except (OSError, ValueError):
+        return None
+    if ref is None:
+        return None
+    try:
+        manifest = cas.load_manifest(ref)
+    except (OSError, ValueError) as exc:
+        raise UnresolvedProjection(
+            f"{tree}: manifest {ref} is pinned but unreadable: {exc}"
+        ) from exc
+    return ProjectedSnapshot(tree, cas, manifest)
+
+
+def snapshot_root_of(path: Path | str) -> Optional[Path]:
+    """The snapshot tree a file lives in, or ``None``.
+
+    A tree is the directory directly under ``snapshots/``, at any depth of
+    component nesting below it.
+    """
+
+    try:
+        resolved = Path(path).resolve()
+    except OSError:
+        return None
+    for parent in resolved.parents:
+        if parent.parent.name == SNAPSHOTS_DIR:
+            return parent
+    return None
+
+
+def require_projection(root: Path | str, *, why: str) -> ProjectedSnapshot:
+    """:func:`resolve_projection`, or a loud refusal naming what needed it.
+
+    ``why`` is the consumer's own sentence about what it was about to get
+    wrong. It is required because a bare "cannot resolve" traceback is what
+    sends the investigation to the store instead of to the projection.
+    """
+
+    resolved = resolve_projection(root)
+    if resolved is None:
+        raise UnresolvedProjection(
+            f"{root} holds tensorfs pointer stubs, so its tensor bytes are in "
+            f"the CAS and not at any file path, but the manifest backing it "
+            f"cannot be recovered ({why}). Refusing to guess: on master this "
+            f"path fell through to a default answer."
+        )
+    return resolved
+
+
+def require_projection_for(
+    path: Path | str, *, why: str
+) -> tuple[ProjectedSnapshot, FileEntry]:
+    """The snapshot and manifest entry backing ONE stubbed file, or a refusal.
+
+    The single seam every consumer holding a file path goes through. It
+    refuses in three distinguishable ways — the file is not in a snapshot
+    tree, the tree's manifest is unrecoverable, the manifest does not cover
+    this file — because each sends the investigation somewhere different, and
+    the defect this replaces sent it nowhere at all.
+    """
+
+    file = Path(path)
+    root = snapshot_root_of(file)
+    if root is None:
+        raise UnresolvedProjection(
+            f"{file} is a tensorfs pointer stub, so its bytes are in the CAS "
+            f"and not at this path, but it is not inside a snapshot tree this "
+            f"worker published, so its manifest cannot be found ({why}). "
+            f"Refusing to guess."
+        )
+    snapshot = require_projection(root, why=why)
+    return snapshot, snapshot.entry_for(file)
+
+
+def logical_size(path: Path | str) -> int:
+    """How many bytes this file HOLDS, whether or not they are at this path.
+
+    A stub's own ``st_size`` is ~128 B regardless of the model behind it, so
+    any size comparison over a projected tree collapses to a tie and the
+    choice becomes arbitrary sort order (pgw#1308's `utils/lora.py:309`
+    finding: "discovery-only is not the same as unaffected"). The stub
+    DECLARES the real size; read it.
+    """
+
+    stub = read_stub(path)
+    if stub is not None:
+        return stub.size
+    try:
+        return Path(path).stat().st_size
+    except OSError:
+        return 0
+
+
+def object_of_symlink(path: Path | str) -> Optional[CASRef]:
+    """The CAS object a projected symlink points at, or ``None``.
+
+    Judged from the object path's own shape —
+    ``…/objects/sha256/<aa>/<bb>/<digest>`` — so it holds for any store root
+    and needs none passed in. ``None`` for a link that is not an object path;
+    a projection never emits one, so a caller may treat that as a finding
+    rather than as absence.
+    """
+
+    link = Path(path)
+    if not link.is_symlink():
+        return None
+    try:
+        parts = Path(os.path.realpath(link)).parts
+    except OSError:
+        return None
+    if len(parts) < 5 or parts[-5] != "objects" or parts[-4] != "sha256":
+        return None
+    digest = parts[-1]
+    if (parts[-3], parts[-2]) != (digest[:2], digest[2:4]):
+        return None
+    try:
+        return CASRef(digest)
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "ProjectedSnapshot",
+    "REF_PREFIX",
+    "SNAPSHOTS_DIR",
+    "UnresolvedProjection",
+    "logical_size",
+    "object_of_symlink",
+    "require_projection",
+    "require_projection_for",
+    "resolve_projection",
+    "snapshot_root_of",
+    "stub_at",
+]

--- a/src/gen_worker/models/safetensors_header.py
+++ b/src/gen_worker/models/safetensors_header.py
@@ -1,4 +1,4 @@
-"""The one bound on a safetensors declared header length.
+"""The one way to read a safetensors header, and the one bound on its length.
 
 A safetensors file opens with an 8-byte
 little-endian header length taken straight from the file. It is attacker- or
@@ -27,6 +27,11 @@ count per shard grew by an order of magnitude.
 
 from __future__ import annotations
 
+import json
+import struct
+from pathlib import Path
+from typing import Any, Dict
+
 MAX_HEADER_BYTES: int = 100 << 20
 
 
@@ -40,4 +45,56 @@ def header_len_ok(n: int) -> bool:
     return 0 < n <= MAX_HEADER_BYTES
 
 
-__all__ = ["MAX_HEADER_BYTES", "header_len_ok"]
+def read_header(path: Path | str, *, why: str) -> Dict[str, Any]:
+    """The parsed safetensors header at ``path``, served from the MANIFEST when
+    that path is a projection stub.
+
+    ``{}`` still means "there is no readable header here", and it is still the
+    honest answer for a real file that is truncated, empty, or not
+    safetensors. What it must NEVER mean again is "this file is a pointer
+    stub". pgw#1308 counted 39 header readers in this repo that treated a
+    parse failure as no-information and fell back to a default; a stub makes
+    every one of them wrong at once, silently, on the serving path
+    (``detect_on_disk_dtype`` -> fp32 at 2x VRAM; ``_quantized_layers`` -> an
+    fp8 artifact routed to the plain bf16 lane; ``_svdq_from_file`` -> an svdq
+    checkpoint that stops being an svdq checkpoint).
+
+    ``why`` is the caller's own sentence about what it would otherwise get
+    wrong, and it appears in the refusal. Three copies of this function were
+    deleted to write this one: a fail-open that is duplicated per lane cannot
+    be fixed per lane.
+    """
+
+    from . import projection
+
+    file = Path(path)
+    if projection.stub_at(file) is not None:
+        snapshot, entry = projection.require_projection_for(file, why=why)
+        with snapshot.open_tensors(verify=False) as reader:
+            (n,) = struct.unpack("<Q", reader.read_range(entry.path, 0, 8))
+            if not header_len_ok(n) or 8 + n > entry.size_bytes:
+                return {}
+            header = json.loads(reader.read_range(entry.path, 8, n))
+        return header if isinstance(header, dict) else {}
+    try:
+        with open(file, "rb") as handle:
+            raw = handle.read(8)
+            if len(raw) < 8:
+                return {}
+            (n,) = struct.unpack("<Q", raw)
+            if not header_len_ok(n):
+                return {}
+            header = json.loads(handle.read(n))
+    except (OSError, ValueError):
+        return {}
+    return header if isinstance(header, dict) else {}
+
+
+def read_metadata(path: Path | str, *, why: str) -> Dict[str, Any]:
+    """A safetensors file's ``__metadata__`` block, stub-aware."""
+
+    meta = read_header(path, why=why).get("__metadata__")
+    return meta if isinstance(meta, dict) else {}
+
+
+__all__ = ["MAX_HEADER_BYTES", "header_len_ok", "read_header", "read_metadata"]

--- a/src/gen_worker/models/store.py
+++ b/src/gen_worker/models/store.py
@@ -28,7 +28,7 @@ from ..lifecycle_intents import IntentRegistry
 from ..pb import worker_scheduler_pb2 as pb
 from ..redact import sanitize as _sanitize
 from ..topology import current_device_group
-from . import cozy_snapshot, disk_gc, disk_telemetry
+from . import cozy_snapshot, disk_gc, disk_telemetry, projection
 from . import residency as residency_mod
 from . import staging as staging_mod
 from .cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
@@ -44,7 +44,12 @@ from .hub_client import (
 from .loading import safetensors_file_valid
 from .refs import WireRef
 from .residency import Residency
-from .volume_verify import snapshot_verify_targets, verify_files
+from .volume_verify import (
+    snapshot_verify_targets,
+    split_projection_targets,
+    verify_files,
+    verify_projection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1578,15 +1583,26 @@ class ModelStore:
     def _verify_snapshot_tree(
         self, path: Path, snapshot: Optional[pb.Snapshot]
     ) -> Tuple[bool, List[str]]:
-        """Integrity of a materialized snapshot (worker thread; blocking IO).
+        """Integrity of a snapshot tree (worker thread; blocking IO).
 
-        With a resolved manifest every regular file is checked against its
-        declared size AND their CONTENT DIGEST, hashed under the algorithm the
-        manifest named; files the manifest cannot cover (reassembled chunked
-        originals, merged single-file checkpoints) plus manifest-less trees
-        (hf/civitai) get the structural safetensors check (header parses +
-        every declared tensor byte present). Returns ``(ok, bad_digests)`` —
-        the digests name blobs to quarantine."""
+        With a resolved manifest every regular file holding real bytes is
+        checked against its declared size AND its CONTENT DIGEST, hashed under
+        the algorithm the manifest named; files the manifest cannot cover
+        (reassembled chunked originals, merged single-file checkpoints) plus
+        manifest-less trees (hf/civitai) get the structural safetensors check
+        (header parses + every declared tensor byte present). Returns
+        ``(ok, bad_digests)`` — the digests name blobs to quarantine.
+
+        **A PROJECTED tree is verified structurally and is NEVER hashed here**
+        (pgw#1308). Its files are pointer stubs and CAS symlinks that by
+        construction do not hold the bytes their manifest entries name, so
+        every byte-level check on them fails — and this function's caller
+        deletes the tree AND its CAS blobs and re-downloads. On master that
+        made a projected tree an infinite re-download: every boot, forever,
+        presenting as "the CAS has stopped caching". The stub format's loud
+        parse failure worked exactly as designed; it was read as corruption by
+        a handler built to trust it. See :func:`volume_verify.verify_projection`
+        for why structural is COMPLETE here rather than weaker."""
 
         p = Path(path)
         bad: List[str] = []
@@ -1612,27 +1628,42 @@ class ModelStore:
             for t in targets:
                 covered.add(t.path)
             if targets:
-                rep = verify_files(targets)
+                # Projection artifacts are split off BEFORE hashing: a stub or
+                # a CAS symlink does not hold the bytes its entry names, so
+                # hashing it at its path is not a weaker check, it is a check
+                # of the wrong thing that fails every time.
+                projected, material = split_projection_targets(targets)
+                rep = verify_files(material)
+                if projected:
+                    proj = verify_projection(projected)
+                    rep.expected += proj.expected
+                    rep.examined += proj.examined
+                    rep.projected += proj.projected
+                    rep.bad.extend(proj.bad)
+                    rep.findings.extend(proj.findings)
                 bad.extend(rep.bad)
                 for finding in rep.findings:
                     logger.warning("snapshot %s: %s", p.name, finding)
                 # DENOMINATOR GUARD, and it applies only to an otherwise-CLEAN
                 # report: a verdict that found nothing wrong is trustworthy only
                 # if it actually read the bytes. `examined` must cover every
-                # target handed in, and a clean run that hashed nothing read
-                # nothing at all. (A report that already names bad files is not
-                # vacuous -- it did its job, and folding it in here would
-                # double-report the same digest.)
+                # target handed in, and a clean run that neither hashed a byte
+                # nor checked a projection artifact read nothing at all. (A
+                # report that already names bad files is not vacuous -- it did
+                # its job, and folding it in here would double-report the same
+                # digest.)
                 vacuous = (
                     not rep.bad
                     and not rep.findings
                     and rep.hashed == 0
+                    and rep.projected == 0
                 )
                 if rep.examined != rep.expected or vacuous:
                     logger.error(
                         "snapshot %s verification is not trustworthy: examined=%d "
-                        "expected=%d hashed=%d bytes=%d -- treating as corrupt",
-                        p.name, rep.examined, rep.expected, rep.hashed, rep.bytes_hashed,
+                        "expected=%d hashed=%d projected=%d bytes=%d -- treating as corrupt",
+                        p.name, rep.examined, rep.expected, rep.hashed,
+                        rep.projected, rep.bytes_hashed,
                     )
                     already = set(bad)
                     bad.extend(t.ref for t in targets if t.ref not in already)
@@ -1642,6 +1673,11 @@ class ModelStore:
             candidates = []
         for st in candidates:
             if st in covered or st.suffix != ".safetensors":
+                continue
+            # A stub IS a valid projection artifact, not a truncated shard.
+            # `safetensors_file_valid` correctly refuses it -- and concluding
+            # "corrupt" from that correct refusal is the pgw#1308 defect.
+            if projection.stub_at(st) is not None:
                 continue
             if not safetensors_file_valid(st):
                 logger.warning("snapshot file %s structurally invalid (truncated?)", st)

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -37,11 +37,10 @@ from __future__ import annotations
 
 import json
 import logging
-import struct
 from dataclasses import dataclass
 from pathlib import Path
 from ..component_vocab import denoiser_components
-from .safetensors_header import header_len_ok
+from .safetensors_header import read_metadata
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -91,19 +90,19 @@ class SvdqArtifact:
 
 
 def _read_safetensors_metadata(path: Path) -> dict:
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(8)
-            if len(raw) < 8:
-                return {}
-            (n,) = struct.unpack("<Q", raw)
-            if not header_len_ok(n):
-                return {}
-            header = json.loads(f.read(n))
-    except (OSError, ValueError):
-        return {}
-    meta = header.get("__metadata__") if isinstance(header, dict) else None
-    return meta if isinstance(meta, dict) else {}
+    """One shared, stub-aware reader — see `safetensors_header.read_metadata`.
+
+    Fail-open here is the loudest of the three: this metadata is what makes an
+    svdq checkpoint AN SVDQ CHECKPOINT. `{}` means `_svdq_from_file` returns
+    None, the artifact is not detected, and a W4A4 model is loaded down the
+    plain lane.
+    """
+
+    return read_metadata(
+        path,
+        why="a checkpoint whose __metadata__ goes unread stops being detected "
+            "as svdq and is loaded down the plain bf16 lane",
+    )
 
 
 def _svdq_from_file(component: str, path: Path) -> Optional[SvdqArtifact]:

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -61,6 +61,7 @@ from .w4a4 import _gemm_w4a4
 from .native_kernels import svdq_linear_execution_lane
 from .svdq_fused import build_svdq_fused_linear, fused_shape_supported
 from .svdq import _read_safetensors_metadata
+from .tensor_source import open_tensor_source
 from .svdq_awq import decode_awq_linear, is_awq_linear
 from .svdq_layout import LOWRANK_QUANT_KEY, LOWRANK_QUANT_SCHEMES, decode_linear
 from .native_kernels import svdq_modulation_execution_lane
@@ -70,6 +71,11 @@ from ..hostfacts import cuda_ready
 logger = logging.getLogger(__name__)
 
 SVDQ_ENGINE_NATIVE = "native"
+
+_SVDQ_WHY = (
+    "the svdq denoiser's every W4A4 linear, AWQ modulation layer and plain "
+    "tensor comes from this one read; without it the model cannot be built"
+)
 
 # Blackwell fp4 tensor cores — the SAME silicon window as the #nvfp4-w4a4 lane
 # (both are block-scaled nvfp4 through torch._scaled_mm / cuBLASLt). torch's own
@@ -474,7 +480,6 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
 
     import torch
     from accelerate import init_empty_weights
-    from safetensors import safe_open
 
     compute = compute_dtype or torch.bfloat16
     meta = _read_safetensors_metadata(art.file)
@@ -516,7 +521,12 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
     t0 = time.perf_counter()
     plain: Dict[str, Any] = {}
     swapped = awq = awq_packed = 0
-    with safe_open(str(art.file), framework="pt", device=str(dev)) as fh:
+    # pgw#1330, THE WORKED EXAMPLE for the weights column. This is the svdq
+    # lane's PRIMARY weight-materialization loop, and it was already the shape
+    # the cutover targets: `from_config` on meta four lines above, then fill by
+    # NAME. It never wanted a directory, so it is independent of #1303 — the
+    # whole cut is the source of the tensors, and nothing else moves.
+    with open_tensor_source(art.file, device=str(dev), why=_SVDQ_WHY) as fh:
         groups = _group_by_prefix(fh.keys())
         for prefix, leaves in sorted(groups.items()):
             tensors = {leaf: fh.get_tensor(f"{prefix}.{leaf}") for leaf in leaves}

--- a/src/gen_worker/models/tensor_source.py
+++ b/src/gen_worker/models/tensor_source.py
@@ -1,0 +1,137 @@
+"""One way to read tensors, whether or not their bytes are at a file path.
+
+``safetensors.safe_open(path)`` is the shape every weight-loading lane in this
+repo was written against, and it is exactly the shape a projected tree cannot
+serve: the bytes are CAS objects, and the path holds a ~128 B pointer stub.
+:func:`open_tensor_source` keeps the shape and moves the source — ``keys()``,
+``get_tensor()`` and ``metadata()`` behave the same either way, so a lane is
+cut over by changing one ``with`` line rather than by being rewritten.
+
+The native arm is not a fallback; on a projected tree it is the ONLY arm, and
+a lane that reaches this module with a stub and no recoverable manifest gets a
+:class:`~gen_worker.models.projection.UnresolvedProjection` refusal instead of
+a wrong model. What it must never do is what master did — read the stub's
+first eight bytes as a header length, fail, and carry on with a default.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Protocol
+
+from gen_worker._vendor.tensorfs import RepositoryManifest, TensorReader, TensorView
+
+from . import projection
+from .safetensors_header import read_metadata
+
+_log = logging.getLogger(__name__)
+
+#: safetensors dtype spelling -> torch dtype attribute name. Only the dtypes
+#: this fleet's checkpoints actually carry; an unknown one is a refusal, never
+#: a guess, because guessing an element width silently reshapes the tensor.
+_TORCH_DTYPES = {
+    "BOOL": "bool",
+    "U8": "uint8",
+    "I8": "int8",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "I16": "int16",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "I32": "int32",
+    "F32": "float32",
+    "I64": "int64",
+    "F64": "float64",
+}
+
+
+class TensorSource(Protocol):
+    """The ``safe_open`` shape, satisfied by a file and by a manifest alike."""
+
+    def keys(self) -> List[str]: ...
+    def get_tensor(self, name: str) -> Any: ...
+    def metadata(self) -> Dict[str, Any]: ...
+
+
+class _NativeSource:
+    """Tensors read straight out of CAS objects. No file, no materialization."""
+
+    def __init__(self, reader: TensorReader, files: set[str], device: str, meta: Dict[str, Any]):
+        self._reader = reader
+        self._files = files
+        self._device = device
+        self._meta = meta
+
+    def keys(self) -> List[str]:
+        return [name for name, view in self._reader.items() if view.file in self._files]
+
+    def metadata(self) -> Dict[str, Any]:
+        return self._meta
+
+    def get_tensor(self, name: str) -> Any:
+        import torch
+
+        view: TensorView = self._reader[name]
+        try:
+            torch_dtype = getattr(torch, _TORCH_DTYPES[view.dtype])
+        except (KeyError, AttributeError) as exc:
+            raise projection.UnresolvedProjection(
+                f"{name}: safetensors dtype {view.dtype!r} has no torch dtype "
+                f"here, so its element width is unknown. Refusing to guess."
+            ) from exc
+        raw = torch.empty(view.nbytes, dtype=torch.uint8)
+        view.readinto(memoryview(raw.numpy()))
+        tensor = raw.view(torch_dtype).reshape(view.shape)
+        return tensor.to(self._device) if self._device != "cpu" else tensor
+
+
+@contextlib.contextmanager
+def open_tensor_source(
+    path: Path | str, *, device: str = "cpu", why: str
+) -> Iterator[TensorSource]:
+    """Read the tensors of ``path``, from the file or from the manifest.
+
+    ``why`` is the caller's sentence about what it would otherwise get wrong;
+    it appears verbatim in the refusal when a stub's manifest is unrecoverable.
+    """
+
+    file = Path(path)
+    if projection.stub_at(file) is None:
+        from safetensors import safe_open
+
+        with safe_open(str(file), framework="pt", device=device) as handle:
+            yield handle
+        return
+
+    snapshot, entry = projection.require_projection_for(file, why=why)
+    meta = read_metadata(file, why=why)
+    reader = TensorReader(snapshot.cas, RepositoryManifest((entry,)), verify=False)
+    try:
+        _log.info("native tensor read: %s (%d bytes) served from the CAS", entry.path, entry.size_bytes)
+        yield _NativeSource(reader, {entry.path}, device, meta)
+    finally:
+        reader.close()
+
+
+def load_state_dict(
+    path: Path | str, *, device: str = "cpu", why: str
+) -> Dict[str, Any]:
+    """One file's whole state dict, from the file or from the manifest.
+
+    The ``safetensors.torch.load_file`` replacement. It is NOT a
+    materialization: each tensor is copied once out of mmapped CAS objects
+    into the tensor that ends up in the model, which is the same number of
+    copies ``load_file`` makes and one fewer than materialize-then-load.
+    """
+
+    with open_tensor_source(path, device=device, why=why) as source:
+        return {name: source.get_tensor(name) for name in source.keys()}
+
+
+__all__ = [
+    "TensorSource",
+    "load_state_dict",
+    "open_tensor_source",
+]

--- a/src/gen_worker/models/volume_verify.py
+++ b/src/gen_worker/models/volume_verify.py
@@ -41,13 +41,16 @@ from typing import Any, List, Optional, Sequence, Tuple
 
 from gen_worker._vendor.tensorfs import CASRef, DigestMismatch
 
+from . import projection
 from .cozy_snapshot import _norm_rel_path
 
 __all__ = [
     "VerifyReport",
     "VerifyTarget",
     "snapshot_verify_targets",
+    "split_projection_targets",
     "verify_files",
+    "verify_projection",
 ]
 
 _log = logging.getLogger(__name__)
@@ -78,6 +81,11 @@ class VerifyReport:
     # expected is what the caller believed it was checking. When it disagrees
     # with `examined`, the reader is wrong and the verdict is not trustworthy.
     expected: int = 0
+    # Projection artifacts checked structurally rather than by hashing. They
+    # count as REAL work for the vacuity guard: a projected tree legitimately
+    # hashes nothing, and scoring that as "read nothing at all" is what turned
+    # boot verification into an infinite re-download (pgw#1308).
+    projected: int = 0
 
     @property
     def ok(self) -> bool:
@@ -159,6 +167,101 @@ def verify_files(
     _log.info(
         "volume_verify examined=%d/%d hashed=%d bytes=%d bad=%d",
         rep.examined, rep.expected, rep.hashed, rep.bytes_hashed, len(rep.bad),
+    )
+    return rep
+
+
+def split_projection_targets(
+    targets: Sequence[VerifyTarget],
+) -> Tuple[List[VerifyTarget], List[VerifyTarget]]:
+    """Split targets into ``(projection artifacts, files holding real bytes)``.
+
+    A projection artifact is a TFSSTUB1 pointer stub or a symlink into the CAS
+    ``objects/``. Neither holds the bytes its manifest entry names, so hashing
+    it at its path is not a weaker check — it is a check of the wrong thing,
+    and it fails 100% of the time.
+    """
+
+    projected: List[VerifyTarget] = []
+    material: List[VerifyTarget] = []
+    for t in targets:
+        if t.path.is_symlink() or projection.stub_at(t.path) is not None:
+            projected.append(t)
+        else:
+            material.append(t)
+    return projected, material
+
+
+def verify_projection(targets: Sequence[VerifyTarget]) -> VerifyReport:
+    """Verify projection artifacts against the manifest, WITHOUT hashing.
+
+    This is deliberately not a weakening of the mandatory-hash rule above; it
+    is the same rule applied where the bytes actually are. A projected tree's
+    bytes live in CAS objects that were hashed at ADMISSION (``LocalCAS``
+    commits an object only after its content hashes to its own name), on a
+    store that is always pod-local — a shared volume is a fill SOURCE whose
+    fills cross that same admission check, never the store itself. So the
+    only things a boot can still get wrong are structural, and they are
+    exactly what is checked here:
+
+    * a stub must name its entry's digest and size — the whole content of a
+      stub, so this is complete, not partial;
+    * a symlink must resolve to the object its entry names, and that object
+      must be present.
+
+    Re-hashing the objects instead would re-read every resident model on every
+    boot to re-derive a fact the store already refused to store wrongly.
+    """
+
+    rep = VerifyReport(expected=len(targets))
+    for t in targets:
+        label = t.label or t.ref
+        try:
+            want = CASRef.parse(t.ref)
+        except ValueError as exc:
+            rep.examined += 1
+            rep.bad.append(label)
+            rep.findings.append(f"{t.path.name}: unreadable digest {t.ref!r}: {exc}")
+            continue
+        stub = projection.stub_at(t.path)
+        if stub is not None:
+            rep.examined += 1
+            if stub.body_sha256 != want.digest:
+                rep.bad.append(label)
+                rep.findings.append(
+                    f"{t.path.name}: stub names body {stub.body_sha256[:16]}…, "
+                    f"manifest says {want.digest[:16]}…"
+                )
+            elif t.size and stub.size != t.size:
+                rep.bad.append(label)
+                rep.findings.append(
+                    f"{t.path.name}: stub declares {stub.size} bytes, "
+                    f"manifest declares {t.size}"
+                )
+            else:
+                rep.projected += 1
+            continue
+        got = projection.object_of_symlink(t.path)
+        rep.examined += 1
+        if got is None:
+            rep.bad.append(label)
+            rep.findings.append(
+                f"{t.path.name}: symlink does not resolve into the CAS objects tree"
+            )
+        elif got.digest != want.digest:
+            rep.bad.append(label)
+            rep.findings.append(
+                f"{t.path.name}: links to object {got.digest[:16]}…, "
+                f"manifest says {want.digest[:16]}…"
+            )
+        elif not t.path.exists():
+            rep.bad.append(label)
+            rep.findings.append(f"{t.path.name}: linked object {got.digest[:16]}… is absent")
+        else:
+            rep.projected += 1
+    _log.info(
+        "projection_verify examined=%d/%d projected=%d bad=%d",
+        rep.examined, rep.expected, rep.projected, len(rep.bad),
     )
     return rep
 

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -42,12 +42,13 @@ import functools
 import importlib
 import json
 import logging
-import struct
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
-from .safetensors_header import header_len_ok
+from .safetensors_header import read_header
+from .tensor_source import load_state_dict, open_tensor_source
 from .tensor_layout_contract import unregistered_decode_path
 from typing import Any, Dict, List, Optional
 import shutil
@@ -97,19 +98,20 @@ class W4a4Artifact:
     static_input_scales: bool
 
 
+_TENSOR_WHY = (
+    "the w4a4 denoiser's packed weights and scales come from this read"
+)
+
+_HEADER_WHY = (
+    "a w4a4 artifact whose contract triple goes unseen is routed to "
+    "the plain bf16 lane and loads as the wrong model"
+)
+
+
 def _read_header(path: Path) -> dict:
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(8)
-            if len(raw) < 8:
-                return {}
-            (n,) = struct.unpack("<Q", raw)
-            if not header_len_ok(n):
-                return {}
-            header = json.loads(f.read(n))
-    except (OSError, ValueError):
-        return {}
-    return header if isinstance(header, dict) else {}
+    """One shared, stub-aware reader — see `safetensors_header.read_header`."""
+
+    return read_header(path, why=_HEADER_WHY)
 
 
 def _quantized_layers(files: tuple[Path, ...]) -> tuple[tuple[str, ...], bool]:
@@ -518,7 +520,6 @@ def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
-    from safetensors.torch import load_file
 
     compute = compute_dtype or torch.bfloat16
     if mode not in ("blockwise", "dequant"):
@@ -533,7 +534,7 @@ def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
 
     sd: Dict[str, Any] = {}
     for f in art.files:
-        sd.update(load_file(str(f)))
+        sd.update(load_state_dict(f, why=_TENSOR_WHY))
 
     lin_cls = w4a4_linear_class()
     swapped = 0
@@ -668,7 +669,6 @@ def swap_w4a4_linears(
     dequantized weights. Returns swapped count."""
     import torch
     import torch.nn as nn
-    from safetensors import safe_open
 
     compute = compute_dtype or torch.bfloat16
     lin_cls = w4a4_linear_class()
@@ -677,6 +677,10 @@ def swap_w4a4_linears(
         for name in _read_header(f):
             if name != "__metadata__":
                 where[name] = f
+    # pgw#1330: one seam for both sources. On a projected tree `src` is a
+    # ~128 B stub and the tensors come from CAS objects; the lazy per-shard
+    # open and the caching are unchanged.
+    stack = ExitStack()
     handles: Dict[Path, Any] = {}
 
     def _tensor(name: str) -> Any:
@@ -685,7 +689,9 @@ def swap_w4a4_linears(
             raise W4a4SnapshotError(f"artifact tensor {name!r} missing from shards")
         fh = handles.get(src)
         if fh is None:
-            fh = handles[src] = safe_open(str(src), framework="pt", device="cpu")
+            fh = handles[src] = stack.enter_context(
+                open_tensor_source(src, why=_TENSOR_WHY)
+            )
         return fh.get_tensor(name)
 
     swapped = 0
@@ -749,11 +755,7 @@ def swap_w4a4_linears(
             setattr(parent, leaf, new)
             swapped += 1
     finally:
-        for fh in handles.values():
-            try:
-                fh.__exit__(None, None, None)
-            except Exception:  # noqa: BLE001
-                pass
+        stack.close()
     logger.info("w4a4 swap: %d/%d quantized Linears on fp4 scaled_mm",
                 swapped, len(art.quantized))
     if skipped:

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -33,12 +33,13 @@ import functools
 import importlib
 import json
 import logging
-import struct
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
-from .safetensors_header import header_len_ok
+from .safetensors_header import read_header
+from .tensor_source import load_state_dict, open_tensor_source
 from .file_layout import MULTI_FILE, SINGLE_FILE
 from .tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
@@ -86,19 +87,20 @@ class W8a8Artifact:
     static_input_scales: bool
 
 
+_TENSOR_WHY = (
+    "the w8a8 denoiser's fp8 weights and scales come from this read"
+)
+
+_HEADER_WHY = (
+    "an fp8 w8a8 artifact whose scales go unseen is routed to the "
+    "plain bf16 lane and loads as the wrong model"
+)
+
+
 def _read_header(path: Path) -> dict:
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(8)
-            if len(raw) < 8:
-                return {}
-            (n,) = struct.unpack("<Q", raw)
-            if not header_len_ok(n):
-                return {}
-            header = json.loads(f.read(n))
-    except (OSError, ValueError):
-        return {}
-    return header if isinstance(header, dict) else {}
+    """One shared, stub-aware reader — see `safetensors_header.read_header`."""
+
+    return read_header(path, why=_HEADER_WHY)
 
 
 def _quantized_layers(files: tuple[Path, ...]) -> tuple[tuple[str, ...], bool]:
@@ -629,7 +631,6 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
-    from safetensors.torch import load_file
 
     compute = compute_dtype or torch.bfloat16
     if mode not in ("rowwise", "pertensor", "dequant"):
@@ -644,7 +645,7 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
 
     sd: Dict[str, Any] = {}
     for f in art.files:
-        sd.update(load_file(str(f)))
+        sd.update(load_state_dict(f, why=_TENSOR_WHY))
 
     lin_cls = fp8_scaled_linear_class()
     swapped = 0
@@ -810,7 +811,6 @@ def swap_w8a8_linears(
     modules."""
     import torch
     import torch.nn as nn
-    from safetensors import safe_open
 
     compute = compute_dtype or torch.bfloat16
     lin_cls = fp8_scaled_linear_class()
@@ -819,6 +819,10 @@ def swap_w8a8_linears(
         for name in _read_header(f):
             if name != "__metadata__":
                 where[name] = f
+    # pgw#1330: one seam for both sources. On a projected tree `src` is a
+    # ~128 B stub and the tensors come from CAS objects; the lazy per-shard
+    # open and the caching are unchanged.
+    stack = ExitStack()
     handles: Dict[Path, Any] = {}
 
     def _tensor(name: str) -> Any:
@@ -827,7 +831,9 @@ def swap_w8a8_linears(
             raise W8a8SnapshotError(f"artifact tensor {name!r} missing from shards")
         fh = handles.get(src)
         if fh is None:
-            fh = handles[src] = safe_open(str(src), framework="pt", device="cpu")
+            fh = handles[src] = stack.enter_context(
+                open_tensor_source(src, why=_TENSOR_WHY)
+            )
         return fh.get_tensor(name)
 
     swapped = 0
@@ -888,11 +894,7 @@ def swap_w8a8_linears(
             setattr(parent, leaf, new)
             swapped += 1
     finally:
-        for fh in handles.values():
-            try:
-                fh.__exit__(None, None, None)
-            except Exception:  # noqa: BLE001
-                pass
+        stack.close()
     logger.info("w8a8 swap: %d/%d quantized Linears on scaled_mm",
                 swapped, len(art.quantized))
     if skipped:

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -32,6 +32,8 @@ from ..component_vocab import denoiser_components, text_encoder_components
 from ..api.errors import RefCompatibilitySurprise, ValidationError
 from dataclasses import replace
 from ..models import lora_lifted, w8a8_lora
+from ..models.projection import logical_size
+from ..models.tensor_source import load_state_dict
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +308,10 @@ def find_adapter_file(snapshot_path: Path, *, ref: str = "") -> Path:
                 ref=ref, axis="component_missing",
             )
         return p
-    files = sorted(p.rglob("*.safetensors"), key=lambda f: f.stat().st_size, reverse=True)
+    # pgw#1330: the LOGICAL size, not the inode's. Under a projected tree
+    # every candidate is a ~128 B stub, so `st_size` makes them all tie and
+    # "the largest adapter" silently becomes "whichever sorted first".
+    files = sorted(p.rglob("*.safetensors"), key=logical_size, reverse=True)
     if not files:
         raise RefCompatibilitySurprise(
             "adapter snapshot contains no .safetensors file",
@@ -365,16 +370,18 @@ def load_adapter_state_dict(path: Path, *, ref: str = "") -> Dict[str, Any]:
     keys (alpha = rank) so diffusers doesn't error. Zero-delta extractions
     are refused here — every consumer (executor overlays, BYO per-request
     loras, endpoint code) inherits the guard from this one seam."""
-    from safetensors.torch import load_file as load_safetensors
     import torch
 
-    size = Path(path).stat().st_size
+    # The DECLARED size: a stub whose model is 40 GiB must still trip the cap.
+    size = logical_size(path)
     if size > MAX_LORA_FILE_BYTES:
         raise ValidationError(
             f"lora adapter too large: {size} bytes (max {MAX_LORA_FILE_BYTES}) (ref={ref})"
         )
     try:
-        state_dict = load_safetensors(str(path))
+        state_dict = load_state_dict(
+            path, why="the adapter's every low-rank matrix comes from this read"
+        )
     except Exception as exc:
         raise RefCompatibilitySurprise(
             f"unreadable adapter safetensors: {exc}", ref=ref, axis="state_dict"

--- a/tests/projection_fixture.py
+++ b/tests/projection_fixture.py
@@ -19,6 +19,7 @@ from gen_worker._vendor.tensorfs import (
     LocalCAS,
     RepositoryManifest,
     project_snapshot,
+    read_entry,
 )
 from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR
 
@@ -188,14 +189,21 @@ def build(
 
 
 def materialize(base: Path, fixture: Fixture, name: str = "materialized") -> Path:
-    """The same manifest as a tree of REAL files, for the control arm."""
+    """The same manifest as a tree of REAL files, for the control arm.
+
+    Built with ``read_entry``, NOT with the single-file materialization hatch:
+    the hatch is the thing this whole program is retiring, and new code reaching
+    for it in a test is the example that spreads. ``read_entry`` also verifies
+    the reconstruction against the manifest's whole-file digest, so the control
+    arm is known-good bytes rather than merely copied ones.
+    """
 
     target = base / SNAPSHOTS_DIR / name
     target.mkdir(parents=True, exist_ok=True)
     for entry in fixture.manifest.files:
         destination = target / entry.path
         destination.parent.mkdir(parents=True, exist_ok=True)
-        fixture.cas.materialize(entry, destination)
+        destination.write_bytes(read_entry(fixture.cas, entry))
     return target
 
 

--- a/tests/projection_fixture.py
+++ b/tests/projection_fixture.py
@@ -1,0 +1,207 @@
+"""A real CAS, a real manifest, and a real projected tree — no mocks.
+
+Everything under pgw#1330 is about what a consumer does when it meets a tree
+whose tensor bytes are not at any file path. A fake tree proves nothing about
+that, so this builds the article: bytes ingested into a real ``LocalCAS``, the
+manifest pinned exactly as ``cozy_snapshot.ensure_snapshot`` pins it, and the
+tree projected by the same ``project_snapshot`` the chokepoint will call.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence, Tuple
+
+from gen_worker._vendor.tensorfs import (
+    LocalCAS,
+    RepositoryManifest,
+    project_snapshot,
+)
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR
+
+# safetensors dtype -> (itemsize, struct format for one element)
+_DTYPES: dict[str, int] = {"BF16": 2, "F16": 2, "F32": 4, "F8_E4M3": 1}
+
+
+def safetensors_bytes(
+    tensors: Mapping[str, Tuple[str, Sequence[int], bytes]]
+) -> bytes:
+    """One safetensors file, written by hand so the fixture owns the bytes.
+
+    ``tensors`` maps name -> (dtype, shape, payload). The payload is real
+    content, never a constant fill: a byte-exactness assertion over a constant
+    cannot see a wrong offset (DONE-STANDARD, "fixture shape").
+    """
+
+    header: dict[str, object] = {}
+    body = bytearray()
+    for name, (dtype, shape, payload) in tensors.items():
+        expected = _DTYPES[dtype]
+        for dim in shape:
+            expected *= dim
+        assert len(payload) == expected, f"{name}: {len(payload)} bytes, want {expected}"
+        start = len(body)
+        body += payload
+        header[name] = {
+            "dtype": dtype,
+            "shape": list(shape),
+            "data_offsets": [start, len(body)],
+        }
+    blob = json.dumps(header, separators=(",", ":")).encode()
+    return struct.pack("<Q", len(blob)) + blob + bytes(body)
+
+
+def varied(nbytes: int, seed: int) -> bytes:
+    """Non-constant, deterministic payload bytes."""
+
+    return bytes(((seed * 31 + i * 17 + (i >> 3)) & 0xFF) for i in range(nbytes))
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """A projected snapshot and everything needed to check it."""
+
+    base: Path
+    source: Path
+    tree: Path
+    key: str
+    cas: LocalCAS
+    manifest: RepositoryManifest
+
+    def snapshot_message(self) -> "_Snapshot":
+        """The duck-typed ``pb.Snapshot`` the store's verifier consumes."""
+
+        return _Snapshot(
+            digest="sha256:" + self.key,
+            files=tuple(
+                _SnapshotFile(
+                    path=entry.path,
+                    digest=str(entry.digest),
+                    size_bytes=entry.size_bytes,
+                )
+                for entry in self.manifest.files
+            ),
+        )
+
+    def weight_paths(self) -> List[Path]:
+        return sorted(self.tree.rglob("*.safetensors"))
+
+
+@dataclass(frozen=True)
+class _SnapshotFile:
+    path: str
+    digest: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    digest: str
+    files: Tuple[_SnapshotFile, ...]
+
+
+def write_model(source: Path, *, dtype: str = "BF16") -> None:
+    """A three-component diffusers-shaped model: configs plus real shards."""
+
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "model_index.json").write_text(
+        json.dumps(
+            {
+                "_class_name": "TinyPipeline",
+                "unet": ["diffusers", "UNet2DConditionModel"],
+                "text_encoder": ["transformers", "CLIPTextModel"],
+                "vae": ["diffusers", "AutoencoderKL"],
+            },
+            indent=2,
+        )
+    )
+    item = _DTYPES[dtype]
+    for component, shards in (
+        ("unet", ("diffusion_pytorch_model.safetensors",)),
+        ("text_encoder", ("model.safetensors",)),
+        ("vae", ("diffusion_pytorch_model.safetensors",)),
+    ):
+        directory = source / component
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "config.json").write_text(
+            json.dumps({"_class_name": component, "hidden": 8}, indent=2)
+        )
+        for index, shard in enumerate(shards):
+            seed = abs(hash((component, shard))) % 251 + 1
+            payload = {
+                f"{component}.block.{index}.weight": (
+                    dtype, (4, 8), varied(4 * 8 * item, seed)
+                ),
+                f"{component}.block.{index}.bias": (
+                    dtype, (8,), varied(8 * item, seed + 1)
+                ),
+            }
+            (directory / shard).write_bytes(safetensors_bytes(payload))
+
+
+def write_fp8_model(source: Path) -> None:
+    """A w8a8 artifact: an fp8 ``transformer`` with the weight/scale pairing.
+
+    This is the shape ``_quantized_layers`` sniffs for. Under stubs its header
+    read returned ``{}``, ``quantized`` came back empty, and the artifact
+    stopped being detected as quantized at all — routed to the plain bf16 lane.
+    """
+
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "model_index.json").write_text(
+        json.dumps({"_class_name": "TinyPipeline", "transformer": ["diffusers", "X"]})
+    )
+    directory = source / "transformer"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "config.json").write_text(json.dumps({"_class_name": "X"}))
+    payload: dict[str, Tuple[str, Sequence[int], bytes]] = {}
+    for index in range(2):
+        name = f"blocks.{index}.linear"
+        payload[f"{name}.weight"] = ("F8_E4M3", (8, 8), varied(64, 3 + index))
+        payload[f"{name}.weight_scale"] = ("F32", (8,), varied(32, 9 + index))
+    (directory / "diffusion_pytorch_model.safetensors").write_bytes(
+        safetensors_bytes(payload)
+    )
+
+
+def build(
+    base: Path, *, dtype: str = "BF16", key: str = "a" * 64, fp8: bool = False
+) -> Fixture:
+    """Ingest a model, pin its manifest, project the tree. No materialization."""
+
+    source = base / "source-model"
+    if fp8:
+        write_fp8_model(source)
+    else:
+        write_model(source, dtype=dtype)
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    # Exactly what `cozy_snapshot._pin_manifest` does, so `resolve_projection`
+    # is exercised against the production pinning and not a test convention.
+    cas.compare_and_swap_ref(REF_PREFIX + key, cas.store_manifest(manifest), expected=None)
+    tree = base / SNAPSHOTS_DIR / key
+    project_snapshot(cas, manifest, tree)
+    return Fixture(base=base, source=source, tree=tree, key=key, cas=cas, manifest=manifest)
+
+
+def materialize(base: Path, fixture: Fixture, name: str = "materialized") -> Path:
+    """The same manifest as a tree of REAL files, for the control arm."""
+
+    target = base / SNAPSHOTS_DIR / name
+    target.mkdir(parents=True, exist_ok=True)
+    for entry in fixture.manifest.files:
+        destination = target / entry.path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        fixture.cas.materialize(entry, destination)
+    return target
+
+
+def iter_stubs(tree: Path) -> Iterable[Path]:
+    from gen_worker.models.projection import stub_at
+
+    for path in sorted(tree.rglob("*")):
+        if path.is_file() and not path.is_symlink() and stub_at(path) is not None:
+            yield path

--- a/tests/test_pod_projected_load_pgw1330.py
+++ b/tests/test_pod_projected_load_pgw1330.py
@@ -1,0 +1,295 @@
+"""pgw#1330: the POD-SHAPED test — pgw's own loader, over a projected tree.
+
+pgw#1308's last open acceptance item, stated verbatim: *"a pod-shaped
+integration test (no FUSE, no CAP_SYS_ADMIN) loads a real multi-component model
+where configs arrive via symlinks and weights via native reads; no tensor byte
+touches a filesystem path."* Its close-out marked that PARTIAL and named the
+clause that did not hold: the storage half ran in tensorfs CI, but it was not
+pgw's loader, so *"no tensor byte touches a filesystem path" is unproven for a
+pod.*
+
+This is that clause. One real multi-component diffusers-shaped tree — a
+nunchaku-format svdq ``transformer`` (a real ``QwenImageTransformer2DModel``
+config, fused W4A4, AWQ modulation), plus ``text_encoder`` and ``vae`` — is
+ingested into a real ``LocalCAS``, pinned, and projected. Then the WORKER runs
+over it: the store's boot verification, the dtype and artifact detection that
+route the load, and finally ``load_svdq_native_denoiser`` building the model.
+
+Constraints held, and each is an assertion rather than a claim:
+
+* **no FUSE, no CAP_SYS_ADMIN** — nothing mounts; a projection is symlinks,
+  stubs and ordinary directories.
+* **no GPU** — the whole thing runs ``mode="dense"`` on CPU.
+* **no tensor byte at a filesystem path** — asserted over every file in the
+  tree, and the tree's own ``du`` is checked against the model's size.
+* **configs via symlinks** — asserted to be the ORIGINAL bytes, through the link.
+
+The control arm throughout is the same manifest materialized: every answer the
+worker computes must be identical, or the projection changed the model.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+import projection_fixture as fixture  # noqa: E402
+from gen_worker._vendor.tensorfs import (  # noqa: E402
+    LocalCAS,
+    project_snapshot,
+    tree_bytes,
+)
+from gen_worker.models import projection  # noqa: E402
+from gen_worker.models import svdq_native as native  # noqa: E402
+from gen_worker.models.loading import (  # noqa: E402
+    detect_on_disk_dtype,
+    snapshot_component_weight_bytes,
+)
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.models.store import ModelStore  # noqa: E402
+from gen_worker.models.svdq import detect_svdq_artifact  # noqa: E402
+from test_svdq_load_device import _Art, _write_multiunit  # noqa: E402
+
+KEY = "d" * 64
+
+
+def _restamp_nunchaku(checkpoint: Path) -> bytes:
+    """The same tensors, with the __metadata__ a nunchaku artifact carries."""
+
+    import struct
+
+    raw = checkpoint.read_bytes()
+    (n,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + n])
+    meta = dict(header.get("__metadata__") or {})
+    meta["model_class"] = "NunchakuQwenImageTransformer2DModel"
+    meta["quantization_config"] = json.dumps(
+        {"method": "svdquant", "weight": {"dtype": "fp4_e2m1_all"}, "rank": 128}
+    )
+    header["__metadata__"] = meta
+    blob = json.dumps(header, separators=(",", ":")).encode()
+    # The data block is unchanged; only the header length and offsets' BASE
+    # move, and safetensors offsets are relative to the data block, so the
+    # tensors are byte-identical.
+    return struct.pack("<Q", len(blob)) + blob + raw[8 + n :]
+
+
+def _same_bytes(a: Any, b: Any) -> bool:
+    a, b = a.detach().cpu().contiguous(), b.detach().cpu().contiguous()
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    return bool(torch.equal(a.reshape(-1).view(torch.uint8), b.reshape(-1).view(torch.uint8)))
+
+
+@pytest.fixture(scope="module")
+def pod(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
+    """One multi-component model: the source tree, the CAS, both projections."""
+
+    root = tmp_path_factory.mktemp("pod")
+    source = root / "source-model"
+    scratch = root / "scratch"
+    scratch.mkdir()
+
+    # A real svdq denoiser, built from a real diffusers model's own config,
+    # then re-stamped with the nunchaku metadata the DETECTOR reads. That
+    # metadata read is itself one of the cut sites, so the fixture has to be
+    # the real article for the detection leg to mean anything.
+    checkpoint, _state, _dim = _write_multiunit(scratch)
+    (source / "transformer").mkdir(parents=True)
+    (source / "transformer" / "diffusion_pytorch_model.safetensors").write_bytes(
+        _restamp_nunchaku(checkpoint)
+    )
+    (source / "transformer" / "config.json").write_text(
+        json.dumps({"_class_name": "QwenImageTransformer2DModel"}, indent=2)
+    )
+    (source / "model_index.json").write_text(
+        json.dumps(
+            {
+                "_class_name": "QwenImagePipeline",
+                "transformer": ["diffusers", "QwenImageTransformer2DModel"],
+                "text_encoder": ["transformers", "Qwen2_5_VLForConditionalGeneration"],
+                "vae": ["diffusers", "AutoencoderKLQwenImage"],
+            },
+            indent=2,
+        )
+    )
+    for component, seed in (("text_encoder", 5), ("vae", 7)):
+        directory = source / component
+        directory.mkdir(parents=True)
+        (directory / "config.json").write_text(
+            json.dumps({"_class_name": component, "hidden_size": 8}, indent=2)
+        )
+        (directory / "model.safetensors").write_bytes(
+            fixture.safetensors_bytes(
+                {
+                    f"{component}.weight": ("BF16", (4, 8), fixture.varied(64, seed)),
+                    f"{component}.bias": ("BF16", (8,), fixture.varied(16, seed + 1)),
+                }
+            )
+        )
+    (source / "tokenizer").mkdir()
+    (source / "tokenizer" / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 1024})
+    )
+
+    base = root / "store"
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    cas.compare_and_swap_ref(
+        REF_PREFIX + KEY, cas.store_manifest(manifest), expected=None
+    )
+    projected = base / SNAPSHOTS_DIR / KEY
+    project_snapshot(cas, manifest, projected)
+
+    materialized = base / SNAPSHOTS_DIR / "materialized"
+    materialized.mkdir(parents=True)
+    for entry in manifest.files:
+        target = materialized / entry.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        cas.materialize(entry, target)
+
+    return {
+        "base": base,
+        "source": source,
+        "cas": cas,
+        "manifest": manifest,
+        "projected": projected,
+        "materialized": materialized,
+        "snapshot": fixture.Fixture(
+            base=base, source=source, tree=projected, key=KEY, cas=cas, manifest=manifest
+        ).snapshot_message(),
+    }
+
+
+# --------------------------------------------------------------------------
+# The constraints, asserted
+# --------------------------------------------------------------------------
+
+
+def test_no_tensor_byte_touches_a_filesystem_path(pod: Dict[str, Any]) -> None:
+    """The claim pgw#1308 could not make for a pod. Every weight container in
+    the tree is a pointer stub, and the tree costs inodes, not the model."""
+
+    tree: Path = pod["projected"]
+    source: Path = pod["source"]
+    weights = sorted(tree.rglob("*.safetensors"))
+    assert weights, "the fixture has no weight files at all"
+    for path in weights:
+        stub = projection.stub_at(path)
+        assert stub is not None, f"{path} holds real tensor bytes"
+        assert path.lstat().st_size < 512
+        rel = path.relative_to(tree).as_posix()
+        assert stub.size == (source / rel).stat().st_size, rel
+
+    model_bytes = sum(e.size_bytes for e in pod["manifest"].files)
+    assert tree_bytes(tree) * 50 < model_bytes, (
+        f"the projected tree costs {tree_bytes(tree)} B against a "
+        f"{model_bytes} B model — that is a materialization"
+    )
+
+
+def test_configs_arrive_via_symlinks_as_the_original_bytes(pod: Dict[str, Any]) -> None:
+    source: Path = pod["source"]
+    tree: Path = pod["projected"]
+    configs = ["model_index.json", "transformer/config.json", "vae/config.json",
+               "tokenizer/tokenizer_config.json"]
+    for rel in configs:
+        link = tree / rel
+        assert link.is_symlink(), f"{rel} is not a symlink into the CAS"
+        assert projection.object_of_symlink(link) is not None, rel
+        assert link.read_bytes() == (source / rel).read_bytes(), rel
+        # A plain reader needs no help: json.load through the link just works.
+        assert json.loads(link.read_text())
+
+
+def test_nothing_mounted_and_nothing_privileged(pod: Dict[str, Any]) -> None:
+    """No FUSE, no CAP_SYS_ADMIN: a projection is directories, symlinks and
+    small regular files, and this asserts the tree contains nothing else."""
+
+    for path in sorted(pod["projected"].rglob("*")):
+        assert path.is_symlink() or path.is_dir() or path.is_file(), path
+        if path.is_file() and not path.is_symlink():
+            assert path.lstat().st_size < 4096, f"{path} holds bulk data"
+
+
+# --------------------------------------------------------------------------
+# The worker, running over it
+# --------------------------------------------------------------------------
+
+
+def test_the_store_trusts_the_tree_on_first_use(pod: Dict[str, Any]) -> None:
+    """The boot path. Before pgw#1330 this quarantined the tree, deleted the
+    CAS blobs behind it and re-downloaded the model — every boot, forever."""
+
+    store = ModelStore.__new__(ModelStore)
+    ok, bad = ModelStore._verify_snapshot_tree(
+        store, pod["projected"], pod["snapshot"]
+    )
+    assert ok, f"the store scored a healthy projected tree corrupt: {bad}"
+
+
+def test_the_routing_facts_are_identical_projected_and_materialized(
+    pod: Dict[str, Any],
+) -> None:
+    """Everything the worker reads to DECIDE how to load. Each of these fell
+    open to a default on master; a wrong answer here loads the wrong model
+    without raising anything."""
+
+    projected, material = pod["projected"], pod["materialized"]
+    assert detect_on_disk_dtype(projected) == detect_on_disk_dtype(material)
+    assert snapshot_component_weight_bytes(projected) == snapshot_component_weight_bytes(
+        material
+    )
+
+    art_projected = detect_svdq_artifact(projected)
+    art_material = detect_svdq_artifact(material)
+    assert art_material is not None, "the fixture is not an svdq artifact at all"
+    assert art_projected is not None, "the svdq artifact vanished under stubs"
+    assert art_projected.component == art_material.component == "transformer"
+    assert art_projected.model_class == art_material.model_class
+    assert art_projected.precision == art_material.precision
+    assert art_projected.rank == art_material.rank
+
+
+def test_the_denoiser_built_from_the_projected_tree_is_bit_identical(
+    pod: Dict[str, Any],
+) -> None:
+    """THE POD-SHAPED CLAUSE. pgw's own loader, from detection through to a
+    built model, over a tree whose weights are CAS objects — and the result is
+    the same model, bit for bit, as the materialized tree yields."""
+
+    art_projected = detect_svdq_artifact(pod["projected"])
+    art_material = detect_svdq_artifact(pod["materialized"])
+    assert art_projected is not None and art_material is not None
+    assert projection.stub_at(art_projected.file) is not None, (
+        "the loader was handed a real file, so this proves nothing"
+    )
+
+    from_tree = native.load_svdq_native_denoiser(
+        _Art(art_projected.file), mode="dense", device="cpu"
+    )
+    from_file = native.load_svdq_native_denoiser(
+        _Art(art_material.file), mode="dense", device="cpu"
+    )
+
+    want: Dict[str, Any] = dict(from_file.named_parameters())
+    want.update(dict(from_file.named_buffers()))
+    got: Dict[str, Any] = dict(from_tree.named_parameters())
+    got.update(dict(from_tree.named_buffers()))
+    assert want and set(want) == set(got)
+    for name in sorted(want):
+        assert got[name].device.type != "meta", f"{name} never got filled"
+        assert _same_bytes(want[name], got[name]), name
+
+
+def test_the_tree_is_still_a_projection_after_the_load(pod: Dict[str, Any]) -> None:
+    """The load must not have quietly materialized anything behind our back."""
+
+    for path in sorted(pod["projected"].rglob("*.safetensors")):
+        assert projection.stub_at(path) is not None, f"{path} was materialized"

--- a/tests/test_pod_projected_load_pgw1330.py
+++ b/tests/test_pod_projected_load_pgw1330.py
@@ -43,6 +43,7 @@ import projection_fixture as fixture  # noqa: E402
 from gen_worker._vendor.tensorfs import (  # noqa: E402
     LocalCAS,
     project_snapshot,
+    read_entry,
     tree_bytes,
 )
 from gen_worker.models import projection  # noqa: E402
@@ -149,10 +150,13 @@ def pod(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
 
     materialized = base / SNAPSHOTS_DIR / "materialized"
     materialized.mkdir(parents=True)
+    # read_entry, not the materialization hatch: the control arm's bytes come
+    # back through the CAS reader and are verified against the manifest's
+    # whole-file digest on the way.
     for entry in manifest.files:
         target = materialized / entry.path
         target.parent.mkdir(parents=True, exist_ok=True)
-        cas.materialize(entry, target)
+        target.write_bytes(read_entry(cas, entry))
 
     return {
         "base": base,

--- a/tests/test_projected_tree_pgw1330.py
+++ b/tests/test_projected_tree_pgw1330.py
@@ -1,0 +1,353 @@
+"""pgw#1330: the two ways a consumer got a projected tree catastrophically wrong.
+
+Both defects are the SAME shape and neither is a format bug. A TFSSTUB1 stub
+fails loudly at the parse site exactly as designed; these two callers read that
+correct loud failure and concluded, respectively, CORRUPTION and ABSENCE:
+
+* ``ModelStore._verify_snapshot_tree`` ran on first use EVERY BOOT, scored
+  every stub structurally invalid, quarantined the tree — which deletes the
+  tree, the CAS blobs it was built from, and re-downloads. Project a tree,
+  reboot the pod, lose the model. Every boot. Forever.
+* ``detect_on_disk_dtype`` skipped every stub via ``continue``, returned "",
+  and its own docstring states the consequence: *"a bf16 snapshot silently
+  loads via diffusers' fp32 default — 2x the VRAM."*
+
+Every arm here runs against a real ``LocalCAS``, a real pinned manifest and a
+real projected tree (``tests/projection_fixture.py``). The control arms matter
+as much as the fixed arms: a "fix" that merely stops verifying, or that stops
+detecting dtypes, would pass the first half of this file and fail the second.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import projection_fixture as fixture
+from gen_worker._vendor.tensorfs import parse_stub, stub_bytes
+from gen_worker.models import projection
+from gen_worker.models.loading import detect_on_disk_dtype
+from gen_worker.models.store import ModelStore
+
+
+def _store(base: Path) -> ModelStore:
+    return ModelStore.__new__(ModelStore)
+
+
+def _verify(base: Path, tree: Path, snapshot: Any) -> tuple[bool, list[str]]:
+    # The verifier duck-types its protobuf argument (path / digest /
+    # size_bytes), so the fixture's message stands in for it exactly.
+    return ModelStore._verify_snapshot_tree(_store(base), tree, snapshot)
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — boot verification over a projected tree
+# --------------------------------------------------------------------------
+
+
+def test_boot_verification_of_a_projected_tree_is_clean(tmp_path: Path) -> None:
+    """THE RED PROOF for the infinite re-download.
+
+    Before the fix this returns ``(False, [<every weight digest>])``, and the
+    caller at ``store.py`` turns that into rmtree + delete_blobs + a fresh
+    download of the whole model, on every boot.
+    """
+
+    built = fixture.build(tmp_path)
+    ok, bad = _verify(tmp_path, built.tree, built.snapshot_message())
+    assert ok, f"a projected tree was scored corrupt: {bad}"
+    assert bad == []
+
+
+def test_boot_verification_reads_no_tensor_bytes(tmp_path: Path) -> None:
+    """It must be clean because it checked the right thing, not because it
+    skipped: hashing a stub at its path is a check of the wrong bytes."""
+
+    from gen_worker.models.volume_verify import (
+        snapshot_verify_targets,
+        split_projection_targets,
+        verify_projection,
+    )
+
+    built = fixture.build(tmp_path)
+    targets, skipped = snapshot_verify_targets(built.snapshot_message().files, built.tree)
+    assert skipped == []
+    projected, material = split_projection_targets(targets)
+    assert material == [], "a projected tree has no file holding real bytes"
+    assert len(projected) == len(built.manifest.files)
+    report = verify_projection(projected)
+    assert report.bad == [] and report.findings == []
+    assert report.projected == len(targets) and report.hashed == 0
+    assert report.bytes_hashed == 0
+
+
+def test_a_stub_naming_the_wrong_body_is_still_corrupt(tmp_path: Path) -> None:
+    """The fix must still DISCRIMINATE. A stub is checked against the manifest,
+    so a stub pointing at other bytes is caught — without reading a byte."""
+
+    built = fixture.build(tmp_path)
+    victim = next(iter(fixture.iter_stubs(built.tree)))
+    original = parse_stub(victim.read_bytes())
+    assert original is not None
+    victim.chmod(0o644)
+    victim.write_bytes(stub_bytes("f" * 64, original.size))
+    ok, bad = _verify(tmp_path, built.tree, built.snapshot_message())
+    assert not ok and bad, "a stub naming the wrong body passed verification"
+
+
+def test_a_stub_declaring_the_wrong_size_is_still_corrupt(tmp_path: Path) -> None:
+    built = fixture.build(tmp_path)
+    victim = next(iter(fixture.iter_stubs(built.tree)))
+    original = parse_stub(victim.read_bytes())
+    assert original is not None
+    victim.chmod(0o644)
+    victim.write_bytes(stub_bytes(original.body_sha256, original.size + 1))
+    ok, bad = _verify(tmp_path, built.tree, built.snapshot_message())
+    assert not ok and bad
+
+
+def test_a_symlink_pointing_out_of_the_store_is_still_corrupt(tmp_path: Path) -> None:
+    built = fixture.build(tmp_path)
+    victim = built.tree / "model_index.json"
+    assert victim.is_symlink()
+    elsewhere = tmp_path / "elsewhere.json"
+    elsewhere.write_text(json.dumps({"_class_name": "Impostor"}))
+    victim.unlink()
+    victim.symlink_to(elsewhere)
+    ok, bad = _verify(tmp_path, built.tree, built.snapshot_message())
+    assert not ok and bad
+
+
+def test_a_truncated_materialized_shard_is_still_corrupt(tmp_path: Path) -> None:
+    """THE CONTROL ARM. A fix that simply stopped verifying would pass every
+    arm above; this is the one it cannot pass. The materialized path keeps its
+    mandatory hash."""
+
+    built = fixture.build(tmp_path)
+    tree = fixture.materialize(tmp_path, built)
+    ok, bad = _verify(tmp_path, tree, built.snapshot_message())
+    assert ok, f"an intact materialized tree was scored corrupt: {bad}"
+
+    victim = sorted(tree.rglob("*.safetensors"))[0]
+    victim.chmod(0o644)
+    data = victim.read_bytes()
+    victim.write_bytes(data[: len(data) - 4])
+    ok, bad = _verify(tmp_path, tree, built.snapshot_message())
+    assert not ok and bad, "a truncated real shard passed verification"
+
+
+def test_a_manifestless_projected_tree_is_not_scored_corrupt(tmp_path: Path) -> None:
+    """The structural sweep runs on trees the manifest cannot cover (hf,
+    civitai, single-file). It must not call a stub a truncated shard."""
+
+    built = fixture.build(tmp_path)
+    ok, bad = _verify(tmp_path, built.tree, None)
+    assert ok, f"the structural sweep scored a projected tree corrupt: {bad}"
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — dtype detection over a projected tree
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "safetensors_dtype,expected", [("BF16", "bf16"), ("F16", "fp16"), ("F8_E4M3", "fp8")]
+)
+def test_dtype_over_a_projected_tree_comes_from_the_manifest(
+    tmp_path: Path, safetensors_dtype: str, expected: str
+) -> None:
+    """THE RED PROOF for the silent 2x VRAM.
+
+    Before the fix every stub is skipped by ``continue``, ``counts`` stays
+    empty and this returns "" — which the loader reads as "no dtype known" and
+    hands to diffusers' fp32 default.
+    """
+
+    built = fixture.build(tmp_path, dtype=safetensors_dtype)
+    assert detect_on_disk_dtype(built.tree) == expected
+
+
+def test_dtype_is_identical_projected_and_materialized(tmp_path: Path) -> None:
+    """The projection must not change the answer — the point of the layout."""
+
+    built = fixture.build(tmp_path)
+    material = fixture.materialize(tmp_path, built)
+    assert detect_on_disk_dtype(built.tree) == detect_on_disk_dtype(material) == "bf16"
+
+
+def test_an_unresolvable_projection_REFUSES_rather_than_defaulting(
+    tmp_path: Path,
+) -> None:
+    """The half that matters most: when the manifest cannot be recovered the
+    answer is an exception, NOT "". Silence here is the whole defect."""
+
+    built = fixture.build(tmp_path)
+    orphan = tmp_path / "orphan"
+    orphan.mkdir()
+    (orphan / "model.safetensors").write_bytes(
+        stub_bytes("b" * 64, 4096)
+    )
+    with pytest.raises(projection.UnresolvedProjection):
+        detect_on_disk_dtype(orphan)
+
+
+def test_a_projected_tree_whose_pin_is_gone_REFUSES(tmp_path: Path) -> None:
+    """Same refusal via the production path: the tree is where it belongs but
+    its manifest ref has been collected."""
+
+    built = fixture.build(tmp_path)
+    (tmp_path / "refs").rename(tmp_path / "refs-gone")
+    (tmp_path / "refs").mkdir()
+    with pytest.raises(projection.UnresolvedProjection):
+        detect_on_disk_dtype(built.tree)
+
+
+def test_dtype_of_a_tree_with_no_weights_is_still_empty(tmp_path: Path) -> None:
+    """"" survives where it is HONEST: nothing to read is not a stub."""
+
+    empty = tmp_path / "configs-only"
+    empty.mkdir()
+    (empty / "model_index.json").write_text("{}")
+    assert detect_on_disk_dtype(empty) == ""
+
+
+# --------------------------------------------------------------------------
+# The rest of the B2 column — the 39 header readers that fail OPEN
+# --------------------------------------------------------------------------
+
+
+def test_a_quantized_artifact_is_still_detected_as_quantized(tmp_path: Path) -> None:
+    """``_quantized_layers`` returning () routes an fp8 artifact to the plain
+    bf16 lane. Nothing raises; the model is simply the wrong model."""
+
+    from gen_worker.models.w8a8 import detect_w8a8_artifacts
+
+    built = fixture.build(tmp_path, fp8=True)
+    material = fixture.materialize(tmp_path, built)
+
+    projected = detect_w8a8_artifacts(built.tree)
+    baseline = detect_w8a8_artifacts(material)
+    assert baseline, "the fixture is not a w8a8 artifact at all"
+    assert [a.quantized for a in projected] == [a.quantized for a in baseline]
+    assert [a.component for a in projected] == [a.component for a in baseline]
+
+
+def test_component_weight_bytes_are_the_real_bytes(tmp_path: Path) -> None:
+    """A stub read as zero data bytes plans VRAM for a model that is not there."""
+
+    from gen_worker.models.loading import snapshot_component_weight_bytes
+
+    built = fixture.build(tmp_path)
+    material = fixture.materialize(tmp_path, built)
+    projected = snapshot_component_weight_bytes(built.tree)
+    assert projected == snapshot_component_weight_bytes(material)
+    assert projected and all(v > 0 for v in projected.values())
+
+
+def test_adapter_sizes_are_the_LOGICAL_sizes(tmp_path: Path) -> None:
+    """pgw#1308's "discovery-only is not the same as unaffected".
+
+    ``utils/lora.py`` compares ``.safetensors`` files by size twice — to pick
+    the largest adapter, and to enforce ``MAX_LORA_FILE_BYTES``. A stub's own
+    ``st_size`` is ~128 B no matter how large the adapter behind it is, so both
+    comparisons stop being about the adapter.
+    """
+
+    from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot
+    from gen_worker.models.projection import logical_size
+    from gen_worker.utils.lora import find_adapter_file
+
+    base = tmp_path / "store"
+    source = base / "source-model"
+    source.mkdir(parents=True)
+    (source / "aaa-small.safetensors").write_bytes(
+        fixture.safetensors_bytes({"w": ("BF16", (2, 8), fixture.varied(32, 4))})
+    )
+    (source / "zzz-large.safetensors").write_bytes(
+        fixture.safetensors_bytes({"w": ("BF16", (64, 8), fixture.varied(1024, 3))})
+    )
+
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    cas.compare_and_swap_ref(
+        projection.REF_PREFIX + "e" * 64, cas.store_manifest(manifest), expected=None
+    )
+    tree = base / projection.SNAPSHOTS_DIR / ("e" * 64)
+    project_snapshot(cas, manifest, tree)
+
+    for name in ("aaa-small.safetensors", "zzz-large.safetensors"):
+        assert logical_size(tree / name) == (source / name).stat().st_size, name
+        assert (tree / name).stat().st_size < 512, "the fixture is not projected"
+    assert logical_size(tree / "aaa-small.safetensors") < logical_size(
+        tree / "zzz-large.safetensors"
+    )
+    assert find_adapter_file(tree, ref="x").name == "zzz-large.safetensors"
+
+
+def test_the_adapter_size_cap_still_REFUSES_over_a_stub(tmp_path: Path) -> None:
+    """The consumer-level half, and the one with teeth.
+
+    ``MAX_LORA_FILE_BYTES`` exists so a caller cannot hand this worker an
+    arbitrarily large adapter. Measured at the stub's inode that ceiling is
+    ~128 B against a cap of gigabytes, so EVERY adapter passes — the guard
+    stops guarding without failing.
+    """
+
+    from gen_worker.api.errors import ValidationError
+    from gen_worker.utils.lora import MAX_LORA_FILE_BYTES, load_adapter_state_dict
+
+    tree = tmp_path / "snapshots" / ("f" * 64)
+    tree.mkdir(parents=True)
+    oversize = tree / "adapter.safetensors"
+    oversize.write_bytes(stub_bytes("a" * 64, MAX_LORA_FILE_BYTES + 1))
+    assert oversize.stat().st_size < 512
+
+    with pytest.raises(ValidationError, match="too large"):
+        load_adapter_state_dict(oversize, ref="x")
+
+
+# --------------------------------------------------------------------------
+# The projection resolver itself
+# --------------------------------------------------------------------------
+
+
+def test_resolve_projection_recovers_the_manifest_from_the_tree_path(
+    tmp_path: Path,
+) -> None:
+    built = fixture.build(tmp_path)
+    resolved = projection.resolve_projection(built.tree)
+    assert resolved is not None
+    assert resolved.manifest == built.manifest
+
+
+def test_resolve_projection_of_an_ordinary_directory_creates_no_store(
+    tmp_path: Path,
+) -> None:
+    """Probing must not leave a CAS behind — it runs on every consumer path."""
+
+    plain = tmp_path / "snapshots" / "not-a-snapshot"
+    plain.mkdir(parents=True)
+    assert projection.resolve_projection(plain) is None
+    assert not (tmp_path / "objects").exists()
+    assert not (tmp_path / "refs").exists()
+
+
+def test_tensors_read_through_the_manifest_are_byte_exact(tmp_path: Path) -> None:
+    """No tensor byte is at a file path, and the bytes are still the originals."""
+
+    built = fixture.build(tmp_path)
+    resolved = projection.require_projection(built.tree, why="test")
+    with resolved.open_tensors() as reader:
+        assert reader
+        for name, view in reader.items():
+            source = built.source / view.file
+            raw = source.read_bytes()
+            header_len = int.from_bytes(raw[:8], "little")
+            header = json.loads(raw[8 : 8 + header_len])
+            start, end = header[name]["data_offsets"]
+            assert view.tobytes() == raw[8 + header_len + start : 8 + header_len + end]
+    for path in built.weight_paths():
+        assert projection.stub_at(path) is not None, f"{path} holds real bytes"

--- a/tests/test_projected_tree_pgw1330.py
+++ b/tests/test_projected_tree_pgw1330.py
@@ -184,7 +184,6 @@ def test_an_unresolvable_projection_REFUSES_rather_than_defaulting(
     """The half that matters most: when the manifest cannot be recovered the
     answer is an exception, NOT "". Silence here is the whole defect."""
 
-    built = fixture.build(tmp_path)
     orphan = tmp_path / "orphan"
     orphan.mkdir()
     (orphan / "model.safetensors").write_bytes(

--- a/tests/test_svdq_native_reads_pgw1330.py
+++ b/tests/test_svdq_native_reads_pgw1330.py
@@ -1,0 +1,142 @@
+"""pgw#1330: the svdq lane serves a projected tree, through its REAL consumer.
+
+`svdq_native.load_svdq_native_denoiser` is the worked example for the weights
+column. It was already the shape the cutover targets — ``from_config`` on meta,
+then fill by NAME — so the whole cut is where the tensors come from:
+``safe_open(art.file)`` became ``open_tensor_source(art.file)``, which serves
+CAS objects when the path holds a TFSSTUB1 stub. Nothing else about the lane
+moves, and it never asks for a directory, so it is independent of #1303.
+
+The test is the same consumer twice over the same manifest — once from the real
+file, once from a projected tree where no tensor byte is at any file path — and
+the two denoisers must be BIT-IDENTICAL. Weakening the reader would show up as
+a numeric difference; skipping it would show up as a meta tensor, which the
+loader itself refuses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.models import projection  # noqa: E402
+from gen_worker.models import svdq_native as native  # noqa: E402
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.models.svdq import _read_safetensors_metadata  # noqa: E402
+from gen_worker.models.tensor_source import open_tensor_source  # noqa: E402
+from test_svdq_load_device import _Art, _write_multiunit  # noqa: E402
+
+
+def _same_bytes(a: Any, b: Any) -> bool:
+    """Bit equality that also holds for 0-dim and non-float tensors."""
+
+    a, b = a.detach().cpu().contiguous(), b.detach().cpu().contiguous()
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    # reshape BEFORE the byte view: a 0-dim tensor cannot be viewed as uint8.
+    return bool(
+        torch.equal(
+            a.reshape(-1).view(torch.uint8), b.reshape(-1).view(torch.uint8)
+        )
+    )
+
+
+def _project(checkpoint: Path, base: Path, key: str = "c" * 64) -> Path:
+    """Ingest ONE checkpoint into a real CAS and project it as a snapshot."""
+
+    cas = LocalCAS(base)
+    entry = cas.ingest_file(checkpoint, manifest_path=checkpoint.name)
+    from gen_worker._vendor.tensorfs import RepositoryManifest
+
+    manifest = RepositoryManifest((entry,))
+    cas.compare_and_swap_ref(
+        REF_PREFIX + key, cas.store_manifest(manifest), expected=None
+    )
+    tree = base / SNAPSHOTS_DIR / key
+    project_snapshot(cas, manifest, tree)
+    return tree / entry.path
+
+
+def test_the_projected_checkpoint_holds_no_tensor_bytes(tmp_path: Path) -> None:
+    checkpoint, _state, _dim = _write_multiunit(tmp_path)
+    stubbed = _project(checkpoint, tmp_path / "store")
+    stub = projection.stub_at(stubbed)
+    assert stub is not None, "the projected checkpoint is not a stub"
+    assert stubbed.stat().st_size < 512
+    assert stub.size == checkpoint.stat().st_size
+
+
+def test_metadata_is_served_from_the_manifest(tmp_path: Path) -> None:
+    """The metadata read that DECIDES this is an svdq checkpoint at all.
+
+    Fail-open here does not raise: it returns ``{}``, `_svdq_from_file`
+    returns None, and a W4A4 model loads down the plain bf16 lane.
+    """
+
+    checkpoint, _state, _dim = _write_multiunit(tmp_path)
+    stubbed = _project(checkpoint, tmp_path / "store")
+    from_file = _read_safetensors_metadata(checkpoint)
+    from_stub = _read_safetensors_metadata(stubbed)
+    assert from_file and from_file == from_stub
+    assert from_stub["model_class"] == "QwenImageTransformer2DModel"
+    assert json.loads(from_stub["config"])
+
+
+def test_tensor_source_serves_the_same_tensors_from_both(tmp_path: Path) -> None:
+    checkpoint, _state, _dim = _write_multiunit(tmp_path)
+    stubbed = _project(checkpoint, tmp_path / "store")
+    with open_tensor_source(checkpoint, why="test") as direct:
+        with open_tensor_source(stubbed, why="test") as native_source:
+            assert sorted(direct.keys()) == sorted(native_source.keys())
+            for name in sorted(direct.keys()):
+                a, b = direct.get_tensor(name), native_source.get_tensor(name)
+                assert a.dtype == b.dtype and a.shape == b.shape, name
+                assert _same_bytes(a, b), name
+
+
+def test_the_denoiser_from_a_projected_tree_is_bit_identical(tmp_path: Path) -> None:
+    """THE CUT, through the real consumer.
+
+    One checkpoint, two sources, one loader. Every SvdqLinear buffer and every
+    plain assigned tensor must agree bit for bit, and the projected load must
+    leave nothing on meta — which `load_svdq_native_denoiser` enforces itself.
+    """
+
+    checkpoint, _state, _dim = _write_multiunit(tmp_path)
+    stubbed = _project(checkpoint, tmp_path / "store")
+
+    from_file = native.load_svdq_native_denoiser(
+        _Art(checkpoint), mode="dense", device="cpu"
+    )
+    from_tree = native.load_svdq_native_denoiser(
+        _Art(stubbed), mode="dense", device="cpu"
+    )
+
+    want: Dict[str, Any] = dict(from_file.named_parameters())
+    want.update(dict(from_file.named_buffers()))
+    got: Dict[str, Any] = dict(from_tree.named_parameters())
+    got.update(dict(from_tree.named_buffers()))
+    assert want and set(want) == set(got)
+    for name in sorted(want):
+        assert got[name].device.type != "meta", name
+        assert _same_bytes(want[name], got[name]), name
+
+
+def test_a_stub_outside_a_snapshot_tree_REFUSES(tmp_path: Path) -> None:
+    """No silent fallback: a stub whose manifest cannot be found is an error,
+    not an empty key list that yields an all-meta model."""
+
+    checkpoint, _state, _dim = _write_multiunit(tmp_path)
+    stubbed = _project(checkpoint, tmp_path / "store")
+    orphan = tmp_path / "orphan.safetensors"
+    orphan.write_bytes(stubbed.read_bytes())
+    with pytest.raises(projection.UnresolvedProjection):
+        with open_tensor_source(orphan, why="test") as source:
+            source.keys()

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -81,11 +81,11 @@ def test_the_read_plane_is_recorded_at_its_own_rev() -> None:
     """pgw#1330: the snapshot is SPLIT at two revs, and the split is declared.
 
     `project.py`, `tensors.py` and `gguf.py` come from a rev the storage half
-    is deliberately NOT at, because the newer lineage deleted `ingest_file`,
-    `collect_garbage` and `materialize_repository` — all three live here. A
-    split that is only in a comment is a split nobody can audit, so the rev is
-    a field and the file list is a field, and the digest fence above covers
-    them like any other vendored file.
+    is deliberately NOT at: the newer lineage deleted three `LocalCAS` methods
+    this repo still calls (ingest, GC, and the whole-tree copy the chokepoint
+    uses — VENDORED.toml names them). A split that is only in a comment is a
+    split nobody can audit, so the rev is a field and the file list is a
+    field, and the digest fence above covers them like any other vendored file.
     """
 
     spec = MANIFEST["packages"]["tensorfs"]

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -77,6 +77,79 @@ def test_the_vendored_tensorfs_carries_no_transfer_plane() -> None:
         )
 
 
+def test_the_read_plane_is_recorded_at_its_own_rev() -> None:
+    """pgw#1330: the snapshot is SPLIT at two revs, and the split is declared.
+
+    `project.py`, `tensors.py` and `gguf.py` come from a rev the storage half
+    is deliberately NOT at, because the newer lineage deleted `ingest_file`,
+    `collect_garbage` and `materialize_repository` — all three live here. A
+    split that is only in a comment is a split nobody can audit, so the rev is
+    a field and the file list is a field, and the digest fence above covers
+    them like any other vendored file.
+    """
+
+    spec = MANIFEST["packages"]["tensorfs"]
+    assert spec["read_plane_rev"] != spec["rev"]
+    assert set(spec["read_plane_files"]) == {"gguf.py", "project.py", "tensors.py"}
+    for name in spec["read_plane_files"]:
+        assert name in spec["files"], f"{name} is not digest-fenced"
+
+
+def test_the_read_plane_runs_without_the_compiled_extension() -> None:
+    """The reason the split is expressible at all: this half is PURE PYTHON.
+
+    `Layout::project` is Rust and cannot travel into a source-vendored wheel,
+    so a stub that only the extension could render or parse would leave every
+    consumer here unable to read a projected tree. Proved by EXECUTING the
+    render/parse/read path with `tensorfs._tensorfs` made unimportable, not by
+    reading the import list.
+    """
+
+    import os
+    import subprocess
+    import sys
+
+    program = """
+import sys
+
+
+class Refuse:
+    # find_spec, not find_module: the latter was REMOVED in 3.12, so a finder
+    # defining it is silently ignored and the guard proves nothing.
+    def find_spec(self, name, path=None, target=None):
+        if name.rpartition(".")[2] == "_tensorfs":
+            raise AssertionError("the read plane reached the compiled extension")
+        return None
+
+
+sys.meta_path.insert(0, Refuse())
+
+# The guard must be LIVE, or everything below is vacuous.
+try:
+    __import__("_tensorfs")
+except AssertionError:
+    pass
+else:
+    raise SystemExit("the meta_path guard never fired -- this test proves nothing")
+
+from gen_worker._vendor.tensorfs import parse_stub, stub_bytes
+
+body = "ab" * 32
+stub = parse_stub(stub_bytes(body, 4096))
+assert stub is not None and stub.body_sha256 == body and stub.size == 4096
+print("ok")
+"""
+    root = VENDOR.parents[1]
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("ok")
+
+
 def test_the_transfer_plane_emits_progress_as_each_object_lands() -> None:
     """pgw#1287, now asserted against pgw's OWN code rather than a pinned rev.
 


### PR DESCRIPTION
Executes pgw#1308's sequencing steps ③④⑤ — the B column, minus the sites that need Paul's #1303 ruling. **Does NOT touch step ⑥** (vendor-rev bump + chokepoint flip): the chokepoint still materializes, so nothing here changes what a pod does today. It changes what a pod will do the moment the chokepoint flips — and on `master` that flip would have been catastrophic.

## The two fleet-breaking defects

Both are #1308's own findings, and both are the same shape: a stub fails LOUDLY at the parse site exactly as designed, and the caller draws a wrong conclusion from that correct failure.

**`store.py` boot verification turned a projected tree into an infinite re-download.** It runs on first use *every boot*. A ~128 B `TFSSTUB1` stub is neither hashable at its path nor structurally valid safetensors, so every weight file scored corrupt and the tree was quarantined — `rmtree` the tree, `delete_blobs` the CAS objects it was built from, sweep orphans, re-download the whole model. It never raised: it presented as *"the CAS has stopped caching"*, which points the investigation at the store rather than at the projection. Project a tree, reboot the pod, lose the model. Every boot. Forever.

Boot verification now splits projection artifacts off **before** hashing and checks them against the manifest — a stub must name its entry's digest and size, a symlink must resolve to the object its entry names and that object must be present. That is not a weakening: CAS objects are hashed at **admission**, on a store that is always pod-local (a shared volume is a fill *source* whose fills cross that same check, never the store root), so re-hashing every resident model every boot re-derives a fact the store already refused to store wrongly. The materialized path keeps its mandatory hash, and a control arm truncates a real shard and requires it caught.

**`detect_on_disk_dtype` failed OPEN into a silent 2x VRAM.** It read the stub magic as a u64 header length, `header_len_ok` correctly refused it, and the file was skipped by `continue` — every weight file, so `counts` stayed empty and it returned `""`. Its own docstring already stated the consequence: *"a bf16 snapshot silently loads via diffusers' fp32 default — 2x the VRAM."* It now reads the header from the manifest, and a stub whose manifest cannot be recovered is an `UnresolvedProjection` **refusal** naming what it would otherwise have got wrong.

## Five copies of one fail-open, now one

`loading.py`, `w8a8.py`, `w4a4.py`, `svdq.py` and `hf_fp8_blockwise.py` each carried a private `open(path,"rb")` + `struct.unpack("<Q")` + `return {}`. A fail-open duplicated per lane cannot be fixed per lane, so they are deleted in favour of `safetensors_header.read_header(path, why=…)`, which serves the header from the CAS when the path is a stub. Each had its own silent wrongness: `_quantized_layers` → an fp8/w4a4 artifact routed to the plain bf16 lane; `_read_safetensors_metadata` → an svdq checkpoint that stops being an svdq checkpoint; `_safetensors_data_bytes` → VRAM planned for a model that is not there; `key_topology.tensor_keys` → attention topology classified as neither.

## The weight lanes read tensors from the CAS

`models/tensor_source.open_tensor_source` keeps the `safe_open` shape — `keys()`, `get_tensor()`, `metadata()` — and moves the source, so a lane is cut over by changing one `with` line. `svdq_native`'s primary weight loop (#1308's worked example; it already built its shell with `from_config` under `init_empty_weights` and filled by name, so it never wanted a directory), both `w8a8`/`w4a4` state-dict loads and their per-layer handle caches, and the LoRA adapter load all go through it.

`utils/lora` now compares adapters by the size they **hold**: `st_size` on a stub is ~128 B whatever the adapter behind it, so both "pick the largest" and `MAX_LORA_FILE_BYTES` had stopped meaning anything — the ceiling stopped bounding without ever failing.

## Sites cut vs sites gated

| class | ours (cut in place) | third-party path/dir (#1303-gated) | total |
|---|---|---|---|
| B1 payload bytes | 22 | 21 | 43 |
| B2 header/metadata | 16 | 2 | 18 |
| C discovery/stat whose behaviour changes | 15 | 0 | 15 |
| | **53** | **23** | **76** |

The 23 are gated on exactly one thing and it is #1303: 17 hand a DIRECTORY to `from_pretrained` (or to `convert_hf_to_gguf.py`), 6 hand a single FILE (`from_single_file`, `GGUFReader`, `llama-server -m`). None can move without materializing or an upstream API change; each is enumerated in the tracker.

Not cut and **not** gated on #1303 either — named rather than lost: the `convert/` writer and layout-converter lane (22 of the 53). It runs on conversion pods over materialized source trees, so it cannot meet a projected tree until the conversion input is projected too. Filed as its own follow-on rather than smuggled into a loader change.

## The pod-shaped test #1308 left PARTIAL

`tests/test_pod_projected_load_pgw1330.py`. One real multi-component diffusers tree — a nunchaku-format svdq `transformer` with a real `QwenImageTransformer2DModel` config, plus `text_encoder`, `vae`, `tokenizer` — ingested into a real `LocalCAS`, pinned exactly as `ensure_snapshot` pins, projected by the landed `project_snapshot`. Then pgw's own path runs over it: boot verification, dtype detection, component weight bytes, `detect_svdq_artifact`, and `load_svdq_native_denoiser` building the model.

Every constraint is an assertion, not a claim: no tensor byte at any file path (every weight container is a stub whose declared size equals the source file's), configs read through symlinks as the ORIGINAL bytes, nothing over 4 KiB anywhere in the tree, no mount, no `CAP_SYS_ADMIN`, no GPU (`mode="dense"`, CPU). The control arm is the same manifest materialized, and the denoiser built from the projected tree is **bit-identical**, parameter by parameter and buffer by buffer.

## The vendored snapshot is split at two revs, deliberately

`project.py`, `tensors.py`, `gguf.py` come from `read_plane_rev = 333bb10`; the storage half stays at `8bafdfbb`. **Why not simply bump:** the newer lineage deleted `LocalCAS.ingest_file`, `collect_garbage` and `materialize_repository`, all three live here (`hubio/client.py:567`, `models/disk_gc.py:286`, `cozy_snapshot.py:254`). Taking them away *is* #1308's step ⑥ plus an ownership question about who owns ingest and GC — neither is a consumption decision, and folding a storage rewrite into a loader change is how a lane stops being reviewable. The split is a declared field, digest-fenced like any other vendored file, and one test executes the render/parse path with `_tensorfs` made unimportable (with a live-guard self-check, because `find_module` was removed in 3.12 and a finder defining it is silently ignored).

## Evidence

Nine mutations, each re-run 5x with the fix reverted and re-confirmed green after restore:

```
defect1-store-verifier:   red 5/5, restored -> green
defect2-dtype-fail-open:  red 5/5, restored -> green
defect3-svdq-file-read:   red 5/5, restored -> green
defect4-svdq-metadata:    red 5/5, restored -> green
defect5-header-readers:   red 5/5, restored -> green
pod-store-verifier:       red 5/5, restored -> green
pod-native-reads:         red 5/5, restored -> green
pod-tensor-source:        red 5/5, restored -> green
lora-logical-size:        red 5/5, restored -> green
```

`lora-logical-size` was **red 0/5 on its first fixture and rewritten**: a stub's byte length grows with the decimal width of its declared size, so comparing two stubs by `st_size` happened to order them correctly and the test was green under its own mutation. Replaced by an assertion on the declared size itself plus the `MAX_LORA_FILE_BYTES` refusal, which binds.

`mypy src/gen_worker tests tests_v2` clean (785 files); every `fast gates` lint green, including `lint_unreached_surface` — which caught three public helpers this PR added with no production caller, deleted rather than baselined. 650 passed across the affected suites locally.

Tracker: `python-gen-worker/progress.md` #1330.