### PR TITLE
pgw#1324 (P0): the worker can DISPATCH a job — `execute_job` stops being CLI-only

### DIFF
--- a/changelog.d/pgw1324.md
+++ b/changelog.d/pgw1324.md
@@ -1,0 +1,29 @@
+- **A hub-dispatched `@job` now REACHES ITS BODY.** Until this landed `execute_job`'s only
+  caller in the wheel was `gen-worker job run` (the author dev loop), `Executor.specs` was
+  `Dict[str, EndpointSpec]`, and the wire head resolved `RunJob.function_name` against that
+  table alone — so every job te#218 migrated (27 conversion jobs + 2 trainers) was publishable,
+  submittable and unrunnable, answering `unknown function`. The executor now holds a second
+  table (`Executor.job_specs`, filled by the same `collect_jobs` walk at the same place
+  `collect_endpoints` runs), ONE dispatch head resolves a name against both, and a job routes to
+  `jobs.execute_job` with the declared contract: `publishes`/`emits_media` stamped from the
+  SPEC (never by the head), `RunJob.timeout_ms` carried as `JobDispatch.deadline_s` (recorded —
+  the wall cap stays hub-issued), the group's GPU permit held only by a job declaring
+  `Resources(gpu=True)`, and reserved source/dataset/media inputs materialized exactly as the
+  producer serving path materializes them.
+- **`JobOutcome.recycle_child` is honoured.** After a job's terminal result the compute child
+  exits `procsplit.EXIT_JOB_RECYCLE` (75) and the control parent respawns it — the run-once
+  lifecycle, so nothing survives in-process between jobs. The parent reads that code as neither
+  a crash nor a shutdown: no death dial, no fault booked, no backoff growth, because a recycle
+  per submission is the lifecycle working — proven end to end against a real parent and a real
+  child subprocess (`test_pgw1324_a_job_recycle_respawns_without_booking_a_death`). A process
+  with no control parent (`gen-worker serve`, library use) reports the recycle instead of
+  executing it.
+- **A jobs-only package boots.** `Worker` refused any package with no `@endpoint` class, which
+  is the shape te#218 produced for every conversion package. It now refuses only a package with
+  neither, and refuses at boot when one name is declared as BOTH an endpoint and a job — a
+  dispatch carries a name and nothing else, so one name cannot mean two things.
+- `JobOutcome` carries the failure OBJECT (`exception`), so the hub's infra-vs-body retry split
+  is made from a TYPE through the executor's one classifier rather than re-derived from prose.
+- **Owed by th#2052's protocol leg**: the job dispatch carries no `snapshots` map, so a job's
+  reserved source repos resolve without a pinned digest; and no phase-budget field, so every job
+  runs on `DEFAULT_PHASE_BUDGET_S`. Both are recorded at their call sites, not papered over.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -36,6 +36,7 @@ from . import boot_phases as boot_mod
 from . import cell_adopt
 from . import dispatch
 from . import handler_proof
+from . import procsplit
 from .procsplit import broker as procsplit_broker
 from . import cpu_budget
 from . import measured_posture as posture_mod
@@ -128,7 +129,9 @@ from .topology import (
 from .pb import worker_scheduler_pb2 as pb
 from .redact import sanitize as _sanitize
 from .models.store import ModelStore, _ResidencyIdentity
-from .registry import EndpointSpec
+from . import jobs as jobs_mod
+from .jobs import JobDispatch, JobOutcome, execute_job
+from .registry import EndpointSpec, JobSpec
 from .runtime_config import ConfigStore, extract_job_config
 from .stage_timing import stage_ms_for_metrics
 
@@ -1316,6 +1319,10 @@ class _Job:
     request_id: str
     attempt: int
     spec: Optional[EndpointSpec]
+    # pgw#1324: exactly one of `spec` / `job_spec` is set. A dispatch is one
+    # shape or the other, and the head that admitted it already knows which —
+    # so nothing downstream has to re-derive it from a name.
+    job_spec: Optional[JobSpec] = None
     intent_id: str = ""
     ctx: Optional[RequestContext] = None
     task: Optional[asyncio.Task] = None
@@ -1634,8 +1641,27 @@ class Executor:
         store: Optional[ModelStore] = None,
         gpu_slots: Optional[int] = None,
         topology: Optional[ExecutionTopology] = None,
+        jobs: Optional[List[JobSpec]] = None,
     ) -> None:
         self.specs: Dict[str, EndpointSpec] = {s.name: s for s in specs}
+        # pgw#1324: the OTHER publishable shape this release declares. Two
+        # tables and ONE dispatch head — `RunJob.function_name` is resolved
+        # against both, because the wire carries no intent field to tell them
+        # apart (th#2052 owns that protocol leg) and because a name is unique
+        # across the release either way. Named `job_specs` because `self.jobs`
+        # already means the IN-FLIGHT dispatch map on this class.
+        self.job_specs: Dict[str, JobSpec] = {j.name: j for j in (jobs or [])}
+        collisions = sorted(set(self.specs) & set(self.job_specs))
+        if collisions:
+            # The wire carries a NAME and no intent kind, so a name that is
+            # both is a dispatch nobody can resolve correctly — the head would
+            # silently pick one and the submitter would get the other's
+            # semantics. Refused at boot, where the release can still be fixed.
+            raise ValueError(
+                f"{collisions} declared as BOTH an @endpoint and a @job in one "
+                f"release: a dispatch names a function and nothing else, so one "
+                f"name cannot mean two things. Rename one."
+            )
         self._send = send
         self._settings = settings
         self.store = store or ModelStore(send)
@@ -8771,10 +8797,18 @@ class Executor:
             run.request_id, int(run.attempt), run.function_name)
         if job is None:
             return
+        # pgw#1324: the fork. A JOB skips the whole serving apparatus — no
+        # instance, no setup, no lanes, no compile cell, because a `@job`
+        # declares none of them — and goes straight to the one run-once
+        # harness. Both arms keep the pgw#738 never-silent supervision.
+        runner: Callable[[], Awaitable[None]] = (
+            functools.partial(self._run_job_dispatch, job, run)
+            if job.job_spec is not None
+            else functools.partial(
+                self._run_job, job, functools.partial(self._legacy_order, job, run))
+        )
         job.task = asyncio.create_task(
-            self._supervise_job(
-                job, functools.partial(self._legacy_order, job, run)),
-            name=f"job-{run.request_id}")
+            self._supervise_job(job, runner), name=f"job-{run.request_id}")
         # pgw#674: the serving set may have changed — re-derive what to
         # stage next while this job computes.
         self.preloader.poke()
@@ -8856,19 +8890,28 @@ class Executor:
                 safe_message="worker draining",
             )
             return None
+        # pgw#1324: ONE head, TWO tables. The wire carries no intent kind, so
+        # the NAME is the whole routing key — which is why the refusal below
+        # has to name both inventories: before this, a dispatch naming a
+        # perfectly good JOB and a dispatch naming a typo were the same
+        # sentence, and a 29-job migration shipped unrunnable behind it.
         spec = self.specs.get(function_name)
-        if spec is None:
+        job_spec = self.job_specs.get(function_name) if spec is None else None
+        if spec is None and job_spec is None:
+            detail = (
+                f"unknown function {function_name!r} — this release serves "
+                f"endpoints {sorted(self.specs) or '[]'} and jobs "
+                f"{sorted(self.job_specs) or '[]'}"
+            )
             self._intent_transition(
                 intent_id,
                 pb.LIFECYCLE_INTENT_STATUS_FAILED,
                 pb.LIFECYCLE_INTENT_STAGE_VALIDATING,
-                detail=f"unknown function {function_name!r}",
+                detail=detail,
             )
             await self._send_result(
-                request_id,
-                attempt,
-                pb.JOB_STATUS_INVALID,
-                safe_message=f"unknown function {function_name!r}",
+                request_id, attempt, pb.JOB_STATUS_INVALID,
+                safe_message=detail[:512],
             )
             return None
         if function_name in self.unavailable:
@@ -8891,6 +8934,7 @@ class Executor:
             request_id=request_id,
             attempt=attempt,
             spec=spec,
+            job_spec=job_spec,
             intent_id=intent_id,
         )
         self.jobs[key] = job
@@ -9383,7 +9427,7 @@ class Executor:
     # ---- job execution -----------------------------------------------------
 
     async def _supervise_job(
-        self, job: _Job, make_order: Callable[[], Awaitable[_JobOrder]],
+        self, job: _Job, runner: Callable[[], Awaitable[None]],
     ) -> None:
         """pgw#738 never-silent guarantee: a job task that ends WITHOUT having
         reported terminal state is reaped into one.
@@ -9394,12 +9438,14 @@ class Executor:
         escape from ``_run_job``'s own handlers lands here, as does a plain
         return that somehow skipped ``_finish``.
 
-        ``make_order`` is the wire head's projection (pgw#904): everything
-        from here down reads the neutral ``_JobOrder``, never a wire message.
+        ``runner`` is the admitted dispatch's own execution — the serving path
+        (whose head projects the wire message into a neutral ``_JobOrder``,
+        pgw#904) or, for a `@job`, the run-once harness. The never-silent
+        guarantee is the same guarantee for both shapes.
         """
         escaped: Optional[BaseException] = None
         try:
-            await self._run_job(job, make_order)
+            await runner()
         except asyncio.CancelledError:
             # Worker shutdown / explicit task cancellation. The stream drop is
             # itself a terminal signal to the hub and the loop is going away,
@@ -9445,6 +9491,279 @@ class Executor:
                     f"running: {detail}"
                 ),
             )
+
+    # ---- pgw#1324: the run-once JOB path -----------------------------------
+
+    async def _run_job_dispatch(self, job: _Job, run: pb.RunJob) -> None:
+        """Execute ONE dispatched ``@job`` and report its terminal outcome.
+
+        The whole difference from the serving path is what a job DOESN'T have:
+        no instance, no ``setup()``, no execution lanes, no compile cell, no
+        slots — a ``JobSpec`` declares none of them, so resolving any of them
+        here would be inventing a contract the decorator does not offer. What
+        it does have is the same admission, the same context surface, the same
+        progress/result envelopes and the same exception classifier, because a
+        job and a request are two harnesses over one body (th#2049 charter,
+        constraint 1) and two classifiers would eventually disagree.
+
+        Everything that decides anything lives in ``jobs.execute_job``: the
+        declaration stamp, the schema decode, the progress watch and the
+        run-once contract. This method is the seam that hands it a dispatch.
+        """
+        spec = job.job_spec
+        assert spec is not None
+        outcome: Optional[JobOutcome] = None
+        try:
+            self._intent_transition(
+                job.intent_id,
+                pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                pb.LIFECYCLE_INTENT_STAGE_VALIDATING,
+            )
+            try:
+                ctx = await self._build_job_context(job, run, spec)
+                dispatch = JobDispatch(
+                    job_name=spec.name,
+                    payload=bytes(run.input_payload),
+                    # The job UUID: th#2050 puts it in `request_id` because a
+                    # job rides the request message. One id, not two.
+                    job_id=str(run.request_id),
+                    attempt=int(run.attempt),
+                    # RECORDED, never armed here — the wall cap is hub-issued
+                    # through the provider API, and a pod-side timer would be a
+                    # second home for one guarantee (jobs.JobDispatch).
+                    deadline_s=(
+                        float(run.timeout_ms) / 1000.0
+                        if int(run.timeout_ms or 0) > 0 else None),
+                    org=str(run.org or ""),
+                    invoker_id=str(run.invoker_id or ""),
+                    capability_token=str(run.capability_token or ""),
+                )
+                outcome = await self._execute_job_body(job, spec, dispatch, ctx)
+            except (asyncio.CancelledError, CanceledError):
+                await self._finish(
+                    job, pb.JOB_STATUS_CANCELED, safe_message="canceled")
+                return
+            except Exception as exc:
+                # Everything BEFORE the body: context build, input
+                # materialization, schema decode. Classified by the same
+                # `_map_exception` a request uses, so the hub's infra-vs-body
+                # retry split reads one vocabulary.
+                status, message = _map_exception(exc)
+                logger.exception("job %s failed before its body ran", spec.name)
+                await self._finish(job, status, safe_message=message)
+                return
+            await self._finish_job_outcome(job, outcome)
+        finally:
+            self._recycle_after_job(job, outcome)
+
+    async def _build_job_context(
+        self, job: _Job, run: pb.RunJob, spec: JobSpec,
+    ) -> JobContext:
+        """The context a job body receives, built ONCE and stamped by
+        ``execute_job``.
+
+        ``publishes``/``emits_media`` are deliberately NOT passed: the
+        declaration is the RELEASE's, ``_stamp_declaration`` is its one
+        projection site, and a head that also set them would be a second home
+        for the same fact — the shape that lets a job hold a valid capability
+        token and still be refused by its own SDK.
+
+        ``kind="job"`` and not a producer kind: the kind-implies-publish escape
+        hatch (`_KIND_IMPLIES_PUBLISH`) exists for pre-declaration endpoints,
+        and a job that inherited it would never reach its own typed refusal.
+        """
+        payload_view = self._job_payload_view(spec, run.input_payload)
+        destination_info = _reserved_repo_info(payload_view, "destination")
+        execution_hints: Dict[str, Any] = {"kind": "job"}
+        dest_repo = _producer_destination_repo(payload_view, destination_info)
+        if dest_repo:
+            # th#2068 rewrote this to the run's scratch repo on the WIRE, so the
+            # repo the job writes to and the repo its token authorizes are one
+            # value rather than two that agree by convention.
+            execution_hints["destination_repo"] = dest_repo
+        dest_release = str(destination_info.get("release") or "").strip()
+        if dest_release:
+            execution_hints["destination_release"] = dest_release
+        ctx = JobContext(
+            request_id=str(run.request_id),
+            job_id=_capability_job_id(run.capability_token),
+            emitter=self._make_ctx_emitter(job),
+            owner=str(run.org or "") or None,
+            invoker_id=str(run.invoker_id or "") or None,
+            file_api_base_url=self.file_base_url or None,
+            worker_capability_token=str(run.capability_token or "") or None,
+            execution_hints=execution_hints,
+            source_info=_reserved_repo_info(payload_view, "source"),
+            destination_info=destination_info,
+            text_encoder_info=_reserved_repo_info(payload_view, "text_encoder"),
+            candidate_info=_reserved_repo_info(payload_view, "candidate"),
+            resume_from_info=_reserved_repo_info(payload_view, "resume_from"),
+            hf_token=getattr(self._settings, "hf_token", "") or "",
+        )
+        job.ctx = ctx
+        if job.cancel_requested:
+            ctx._cancel()
+        await self._materialize_job_inputs(ctx, job, run, payload_view)
+        return ctx
+
+    def _job_payload_view(self, spec: JobSpec, payload: bytes) -> Any:
+        """The dispatch payload decoded against the job's PUBLISHED schema.
+
+        Decoded here as well as inside ``execute_job`` because the reserved
+        repo fields decide what the context is built with, and the context has
+        to exist before the body runs. Same decoder, same schema, so the two
+        reads cannot disagree — and a schema violation surfaces here, typed,
+        before any weight is fetched.
+        """
+        return jobs_mod.decode_payload(spec, payload)
+
+    async def _materialize_job_inputs(
+        self, ctx: JobContext, job: _Job, run: pb.RunJob, payload: Any,
+    ) -> None:
+        """Reserved repos, datasets and request media, exactly as the producer
+        serving path materializes them.
+
+        ⚠️ th#2052 DEPENDENCY, recorded rather than papered over: the job
+        dispatch carries no ``snapshots`` map, so these refs resolve WITHOUT a
+        pinned digest (``snapshots.get(ref)`` is None). The read grants are
+        minted from the payload's reserved bindings hub-side (th#2068), so the
+        fetch is authorized; what is missing is the digest pin, which needs a
+        field on the job dispatch the wire does not carry today.
+        """
+        await _to_thread_complete(
+            materialize_input_assets,
+            payload,
+            str(run.request_id),
+            attempt=int(run.attempt),
+            manifest=manifest_from_run_job(run.input_assets),
+            file_base_url=self.file_base_url or "",
+            capability_token=str(run.capability_token or ""),
+            cancel_check=lambda: ctx.cancelled,
+        )
+        ctx.raise_if_cancelled("canceled")
+        snapshots: Dict[WireRef, pb.Snapshot] = {}
+        for field_name, setter in (
+            ("source", None),
+            ("text_encoder", ctx._set_text_encoder_path),
+            ("candidate", ctx._set_candidate_path),
+            ("resume_from", ctx._set_resume_from_path),
+        ):
+            info = _reserved_repo_info(payload, field_name)
+            if info:
+                await self._materialize_source(
+                    ctx, info, snapshots,
+                    set_path=setter, field_name=field_name)
+        await self._materialize_datasets(ctx, payload)
+        ctx.raise_if_cancelled("canceled")
+
+    async def _execute_job_body(
+        self, job: _Job, spec: JobSpec, dispatch: JobDispatch, ctx: JobContext,
+    ) -> JobOutcome:
+        """Run the body under the run-once harness, holding a card only if the
+        job declared it needs one.
+
+        The GPU-vs-plan rung, as behaviour: ``Resources(gpu=True)`` takes this
+        group's permit for the whole run; a ``plan-*`` job declaring only
+        ``vcpus`` takes none, so the $0 planning half of fail-fast-before-
+        renting never queues behind a card it does not use.
+        """
+        gpu_permit: Optional[asyncio.Semaphore] = None
+        permit_token: Optional[int] = None
+        if spec.needs_gpu:
+            gpu_permit = self._gpu_permit_for_group(current_device_group())
+            await self._intent_await(
+                job.intent_id,
+                gpu_permit.acquire(),
+                operation=f"GPU permit for job {dispatch.job_id}",
+                status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
+                stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_GPU_SLOT,
+                reason=pb.LIFECYCLE_WAIT_REASON_GPU_SLOT,
+            )
+            permit_token = self._permits.take(
+                gpu_permit, f"job {dispatch.job_id}")
+        try:
+            job.executing = True
+            self._intent_transition(
+                job.intent_id,
+                pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                pb.LIFECYCLE_INTENT_STAGE_READY,
+                detail="executing",
+            )
+            logger.info(
+                "job %s dispatched: name=%s gpu=%s deadline_s=%s publishes=%s "
+                "emits_media=%s", dispatch.job_id, spec.name, spec.needs_gpu,
+                dispatch.deadline_s, spec.publishes, spec.emits_media)
+            # The body is a plain function: run it OFF the loop so a job that
+            # computes for hours does not starve the stream the parent holds.
+            return typing.cast(JobOutcome, await _to_thread_complete(
+                execute_job, dispatch, jobs={spec.name: spec}, ctx=ctx))
+        finally:
+            job.handler_thread_done.set()
+            job.executing = False
+            if gpu_permit is not None:
+                if permit_token is not None:
+                    self._permits.drop(gpu_permit, permit_token)
+                gpu_permit.release()
+
+    async def _finish_job_outcome(self, job: _Job, outcome: JobOutcome) -> None:
+        """One ``JobOutcome`` -> one terminal ``JobResult``."""
+        ctx = job.ctx
+        if outcome.status == "succeeded":
+            inline: Optional[bytes] = outcome.result
+            blob_ref: Optional[str] = None
+            if ctx is not None:
+                inline, blob_ref = await self._deliver_result_bytes(
+                    ctx, job.request_id, outcome.result)
+            await self._finish(
+                job, pb.JOB_STATUS_OK, inline=inline, blob_ref=blob_ref)
+            return
+        exc = outcome.exception
+        # The infra-vs-body split is made from the TYPE, never from prose: the
+        # hub retries infra faults and treats a body failure as terminal, so a
+        # RuntimeError from a recipe must not buy a second GPU boot.
+        status, message = (
+            _map_exception(exc) if exc is not None
+            else (pb.JOB_STATUS_FATAL,
+                  _sanitize(outcome.failure or "job failed")))
+        await self._finish(job, status, safe_message=message)
+
+    def _recycle_after_job(self, job: _Job, outcome: Optional[JobOutcome]) -> None:
+        """Honour ``JobOutcome.recycle_child``: leave, so the next job starts
+        on a process that has never imported this one's world.
+
+        "Nothing survives in-process between jobs by contract" is the whole
+        run-once lifecycle, and this is the only place that can enforce it —
+        the executor IS the compute child (procsplit), so the child leaving is
+        the parent forking a fresh one. A dispatch that died before producing
+        an outcome recycles too: it still ran this release's import and
+        materialization side effects in this process.
+        """
+        if outcome is not None and not outcome.recycle_child:
+            logger.info(
+                "job %s asked NOT to recycle its child; keeping the process",
+                job.request_id)
+            return
+        others = [k for k in self.in_flight_keys()
+                  if k != (job.request_id, job.attempt)]
+        if others:
+            # v1 is one job per pod at a time. If that ever stops being true,
+            # recycling here would kill somebody else's in-flight work.
+            logger.warning(
+                "job %s finished but %d other dispatch(es) are in flight; "
+                "skipping the run-once recycle", job.request_id, len(others))
+            return
+        if not procsplit.is_compute_child():
+            # `gen-worker serve` and library use have no control parent to
+            # respawn this process. Exiting there is a dead pod, not a fresh
+            # child, so the contract is REPORTED rather than executed.
+            logger.info(
+                "job %s finished; run-once recycle not executed (no control "
+                "parent in this process)", job.request_id)
+            return
+        logger.info(
+            "job %s finished; recycling this compute child (run-once "
+            "lifecycle)", job.request_id)
+        self._process_exit(procsplit.EXIT_JOB_RECYCLE)
 
     async def _run_job(
         self, job: _Job, make_order: Callable[[], Awaitable[_JobOrder]],
@@ -10898,7 +11217,15 @@ class Executor:
                 "deferred outputs reached serialization un-drained for %s — "
                 "materializing inline", request_id)
             await asyncio.to_thread(ctx._drain_deferred_outputs)
-        data = msgspec.msgpack.encode(output)
+        return await self._deliver_result_bytes(
+            ctx, request_id, msgspec.msgpack.encode(output))
+
+    async def _deliver_result_bytes(
+        self, ctx: RequestContext, request_id: str, data: bytes
+    ) -> Tuple[Optional[bytes], Optional[str]]:
+        """Encoded result -> (inline, blob_ref). Shared by the serving path
+        and the `@job` path (pgw#1324): one size threshold and one envelope
+        upload, so a job's return value is delivered exactly as a request's."""
         if len(data) <= INLINE_RESULT_MAX_BYTES:
             return data, None
         try:

--- a/src/gen_worker/jobs.py
+++ b/src/gen_worker/jobs.py
@@ -84,6 +84,11 @@ class JobOutcome:
     data: whoever drives this dispatch must not reuse the process for a second
     job. It is a field rather than a comment so the caller either honours it or
     visibly ignores it.
+
+    ``exception`` carries the failure OBJECT, not just its name, because the
+    infra-vs-body split the scheduler makes is a TYPE question and the worker
+    already owns one classifier for it (``executor._map_exception``). Rebuilding
+    that decision from ``error_type`` prose would be a second home for it.
     """
 
     job_name: str
@@ -93,6 +98,7 @@ class JobOutcome:
     failure: str = ""
     error_type: str = ""
     recycle_child: bool = True
+    exception: Optional[BaseException] = None
 
 
 class ProgressWatch:
@@ -210,7 +216,7 @@ def _outcome(spec: JobSpec, dispatch: JobDispatch, result: bytes) -> JobOutcome:
 def _failure(spec: JobSpec, dispatch: JobDispatch, exc: BaseException) -> JobOutcome:
     return JobOutcome(
         job_name=spec.name, job_id=dispatch.job_id, status="failed",
-        failure=str(exc), error_type=type(exc).__name__,
+        failure=str(exc), error_type=type(exc).__name__, exception=exc,
     )
 
 

--- a/src/gen_worker/procsplit/__init__.py
+++ b/src/gen_worker/procsplit/__init__.py
@@ -70,6 +70,15 @@ def is_compute_child() -> bool:
     return bool(os.environ.get(ENV_CHILD, "").strip())
 
 
+#: The compute child finished a `@job` and is leaving so the next one starts on
+#: a fresh process (pgw#1324; the run-once lifecycle stated as an exit status).
+#: It is neither a crash nor a shutdown, and the parent must read it as
+#: neither: rc 0 makes the parent stop supervising, and any other non-zero
+#: books a death against the pod's fault ledger. Job pods would then look like
+#: they crash-loop once per submission.
+EXIT_JOB_RECYCLE = 75
+
+
 __all__ = [
     "ENV_CHILD",
     "ENV_CHILD_CMD",
@@ -80,6 +89,7 @@ __all__ = [
     "ENV_SOCKET",
     "ENV_TOPOLOGY",
     "ENV_WATCHDOG_PING_S",
+    "EXIT_JOB_RECYCLE",
     "group_ordinal",
     "host_siblings",
     "is_compute_child",

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -72,6 +72,7 @@ from . import (
     ENV_SESSION_ID,
     ENV_SOCKET,
     ENV_WATCHDOG_PING_S,
+    EXIT_JOB_RECYCLE,
     actions,
     attest,
     capability,
@@ -736,6 +737,22 @@ class _ChildSlot:
             if deliberate:
                 await self._finish_deliberate_exit(rc, lifetime_s=lifetime)
                 return
+            if (rc == EXIT_JOB_RECYCLE and saw_hello and not self.watchdog_fired
+                    and not p._draining):
+                # pgw#1324: a `@job` finished and its child left so the next one
+                # starts clean. Respawn WITHOUT the death dial, without counting
+                # a fault and without backoff growth — a recycle per submission
+                # is the run-once lifecycle working, and booking it as a death
+                # would make every job pod read as a crash-loop to th#2014's
+                # ledger. Anything still in flight genuinely died with the
+                # process, so it is still attributed typed.
+                await self._report_in_flight_dead("job_recycle")
+                postmortem.clear_inflight(path=self.inflight_marker_path)
+                logger.info(
+                    "compute child %s recycled after a job (run-once "
+                    "lifecycle, rc=%s); respawning", self.label, rc)
+                backoff = p._backoff_base
+                continue
             cause = await self._handle_child_death(
                 rc, oom_before=oom_before, lifetime_s=lifetime, saw_hello=saw_hello,
             )

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -18,7 +18,7 @@ from .executor import Executor
 from .models.store import ModelStore
 from .lifecycle import Lifecycle
 from .pb import worker_scheduler_pb2 as pb
-from .registry import collect_endpoints
+from .registry import collect_endpoints, collect_jobs
 from .topology import ExecutionTopology, delivered_topology
 from .transport import (
     DEFAULT_QUEUE_MAXSIZE as _DEFAULT_QUEUE_MAXSIZE,
@@ -130,16 +130,22 @@ class Worker:
             set_provider_index(build_provider_index_from_manifest(manifest))
 
         specs = collect_endpoints(list(user_module_names))
-        if not specs:
+        # pgw#1324: the SAME walk, at the same place, for the other publishable
+        # shape. te#218 re-authored every conversion package as jobs-only, so a
+        # boot that demands an `@endpoint` refuses the packages the jobs program
+        # exists to run.
+        jobs = collect_jobs(list(user_module_names))
+        if not specs and not jobs:
             raise ValueError(
-                f"no endpoint classes found in modules {list(user_module_names)!r}"
+                f"no @endpoint classes and no @job functions found in modules "
+                f"{list(user_module_names)!r}"
             )
         store = ModelStore(
             self._send, hf_home=settings.hf_home, hf_token=settings.hf_token
         )
         self.executor = Executor(
             specs, self._send, settings=settings, store=store,
-            gpu_slots=gpu_slots, topology=self.topology,
+            gpu_slots=gpu_slots, topology=self.topology, jobs=jobs,
         )
         if (settings.config_snapshot_path or "").strip():
             from .runtime_config import ConfigStore
@@ -177,7 +183,8 @@ class Worker:
         # slice unattributed.
         boot_phases.mark_once(
             boot_phases.PHASE_SDK_READY,
-            detail=f"endpoints={len(specs)} modules={len(user_module_names)}")
+            detail=f"endpoints={len(specs)} jobs={len(jobs)} "
+                   f"modules={len(user_module_names)}")
 
     async def _send(self, msg: pb.WorkerMessage) -> None:
         await self.transport.send(msg)

--- a/tests/harness/job_pkg_pgw1324.py
+++ b/tests/harness/job_pkg_pgw1324.py
@@ -1,0 +1,32 @@
+"""A JOBS-ONLY package: `@job` functions and not one `@endpoint`.
+
+This is the shape te#218 produced for every conversion package, so a worker
+that cannot boot on it cannot run any migrated job. Kept in `harness/` rather
+than inline in the test because `Worker` takes MODULE NAMES and walks them.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import JobContext, Resources, job
+
+
+class PlanIn(msgspec.Struct):
+    rung: str = "w8a8"
+
+
+class PlanOut(msgspec.Struct):
+    rung: str
+    vcpus: int
+
+
+@job(name="plan-h3-svdq", resources=Resources(vcpus=4))
+def plan_h3_svdq(ctx: JobContext, payload: PlanIn) -> PlanOut:
+    ctx.progress(position=1, total=1, phase="plan")
+    return PlanOut(rung=payload.rung, vcpus=4)
+
+
+@job(name="bake-h3-modulation", resources=Resources(gpu=True), publishes=True)
+def bake_h3_modulation(ctx: JobContext, payload: PlanIn) -> PlanOut:
+    return PlanOut(rung=payload.rung, vcpus=0)

--- a/tests/harness/procsplit_fake_child.py
+++ b/tests/harness/procsplit_fake_child.py
@@ -12,6 +12,11 @@ Behaviour is chosen by PGW763_FAKE_MODE:
                     immediately (frame and death adjacent).
   result_then_exit: accept + OK result, then exit 0 (deliberate exit with a
                     result the parent still owes the hub).
+  result_then_recycle
+                  : accept + OK result, then exit EXIT_JOB_RECYCLE (pgw#1324's
+                    run-once lifecycle). The parent must RESPAWN — this is
+                    neither a crash nor a shutdown, and rc 0 or a plain
+                    non-zero would give the wrong one.
   ignore_sigterm  : serve nothing, ignore SIGTERM forever (TimeoutStopSec).
   spontaneous_result_then_exit
                   : write one JobResult on connect and exit 0 immediately, so
@@ -42,7 +47,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__))), "src"))
 
 from gen_worker.pb import worker_scheduler_pb2 as pb  # noqa: E402
-from gen_worker.procsplit import frames  # noqa: E402
+from gen_worker.procsplit import EXIT_JOB_RECYCLE, frames  # noqa: E402
 
 MODE = os.environ.get("PGW763_FAKE_MODE", "result_then_die")
 WORKER_ID = os.environ.get("PGW763_WORKER_ID", "split-fake-child")
@@ -158,6 +163,8 @@ async def main() -> int:
             os.kill(os.getpid(), signal.SIGKILL)
         if MODE == "result_then_exit":
             os._exit(0)
+        if MODE == "result_then_recycle":
+            os._exit(EXIT_JOB_RECYCLE)
     return 0
 
 

--- a/tests/test_job_dispatch_pgw1324.py
+++ b/tests/test_job_dispatch_pgw1324.py
@@ -1,0 +1,475 @@
+"""pgw#1324 (JOBS program): a hub-dispatched `@job` REACHES ITS BODY.
+
+The defect this closes, measured at `origin/master` `45711990` and in the
+published `gen_worker-0.119.0` wheel: `execute_job`'s only caller was
+`cli/job.py`, `Executor.specs` was `Dict[str, EndpointSpec]`, and the one wire
+head resolved `RunJob.function_name` against that table alone. Every job te#218
+migrated (27 conversion jobs + 2 trainers) was publishable, submittable and
+UNRUNNABLE — a dispatch naming one resolved to nothing and came back
+`unknown function`, indistinguishable from a typo.
+
+Each section names the one-line edit that turns it RED:
+
+1. **THE HEADLINE.** A real `RunJob` frame naming a JOB, through the real
+   `Executor.handle_run_job`, reaches the body and returns a `JobResult` whose
+   inline bytes decode as the job's declared result struct. RED by resolving
+   `function_name` against `self.specs` alone in `_admit_dispatch` — which is
+   exactly what master did.
+2. **Two tables, one head, and a refusal that can tell them apart.** A name in
+   NEITHER table is refused INVALID naming both inventories, and a name in BOTH
+   is refused at boot — a dispatch carries a name and no intent kind, so one
+   name cannot mean two things. RED by dropping the job inventory from the
+   refusal message, or by allowing the collision.
+3. **The declaration is the RELEASE's.** `execute_job._stamp_declaration` — not
+   the dispatch head — projects `publishes`/`emits_media` onto the context, so
+   an undeclared job's `save_checkpoint` refuses typed before a byte moves.
+   RED by having the head build the context with `publishes=True`.
+4. **The deadline is CARRIED.** `RunJob.timeout_ms` reaches
+   `JobDispatch.deadline_s`. RED by dropping the conversion.
+5. **GPU-vs-plan rung.** A `Resources(gpu=True)` job holds its group's GPU
+   permit for the whole run; a `plan-*` `Resources(vcpus=N)` job holds none, so
+   a CPU plan job cannot queue behind a card. RED by making the permit
+   unconditional (or never taken).
+6. **`recycle_child` is HONOURED, not ignored.** The run-once lifecycle is a
+   fresh child per job: after the terminal result the compute child asks to be
+   recycled. RED by deleting the `_recycle_after_job` call, or by clearing
+   `recycle_child` on the outcome — the field then goes back to being one
+   nobody reads.
+7. **A jobs-only package BOOTS.** te#218's packages carry no `@endpoint` at
+   all. RED by restoring `if not specs: raise` in `worker.py`.
+8. **A body failure is TERMINAL, not infra.** The hub retries infra faults
+   only; a typed exception from the body must not buy a second GPU boot.
+
+Everything drives production code: the real `Executor`, the real registry
+walk, the real `jobs.execute_job` harness, the real `JobContext`. The doubles
+are a send-sink and a payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from typing import Any, Dict, List, Optional, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import JobContext, Resources, endpoint, job
+from gen_worker import procsplit
+from gen_worker.api.errors import PublishNotDeclaredError
+from gen_worker.executor import Executor
+from gen_worker.jobs import JobDispatch, execute_job as _real_execute_job
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec, extract_job_spec
+
+
+class In(msgspec.Struct):
+    rung: str = "w8a8"
+
+
+class Out(msgspec.Struct):
+    rung: str
+    saw: str = ""
+
+
+# ---- the jobs under dispatch ----------------------------------------------
+# Declared with the REAL decorator and extracted with the REAL registry walk,
+# so what the executor holds is what a published release holds.
+
+_SEEN: Dict[str, Any] = {}
+
+
+@job(name="plan-h3-svdq", resources=Resources(vcpus=4))
+def plan_h3_svdq(ctx: JobContext, payload: In) -> Out:
+    _SEEN["ctx_class"] = type(ctx).__name__
+    _SEEN["publishes"] = ctx.publishes
+    _SEEN["emits_media"] = ctx.emits_media
+    _SEEN["request_id"] = ctx.request_id
+    ctx.progress(position=1, total=2, phase="plan")
+    ctx.progress(position=2, total=2, phase="plan")
+    return Out(rung=payload.rung, saw="planned")
+
+
+@job(name="clone-huggingface", resources=Resources(gpu=True), publishes=True)
+def clone_huggingface(ctx: JobContext, payload: In) -> Out:
+    _SEEN["publishes"] = ctx.publishes
+    _SEEN["gpu_permit_held"] = _permit_probe()
+    return Out(rung=payload.rung, saw="cloned")
+
+
+@job(name="score-benchmark", resources=Resources(vcpus=2), emits_media=True)
+def score_benchmark(ctx: JobContext, payload: In) -> Out:
+    _SEEN["emits_media"] = ctx.emits_media
+    # Undeclared publisher surface: the refusal is the SDK's, before a byte
+    # moves, because the hub minted no write grant for this release.
+    weights = ctx.mktemp() / "adapter.safetensors"
+    weights.write_bytes(b"\x00" * 8)
+    try:
+        ctx.save_checkpoint("model.safetensors", weights)
+    except PublishNotDeclaredError as exc:
+        _SEEN["publish_refusal"] = type(exc).__name__
+    return Out(rung=payload.rung, saw="scored")
+
+
+@job(name="explode", resources=Resources(vcpus=1))
+def explode(ctx: JobContext, payload: In) -> Out:
+    raise RuntimeError("the recipe is wrong and re-running it is money burnt")
+
+
+_PERMIT_PROBE: List[Any] = []
+
+
+def _permit_probe() -> Optional[bool]:
+    return _PERMIT_PROBE[0].locked() if _PERMIT_PROBE else None
+
+
+def _job_specs() -> List[Any]:
+    return [
+        extract_job_spec(fn)
+        for fn in (plan_h3_svdq, clone_huggingface, score_benchmark, explode)
+    ]
+
+
+# ---- an endpoint, so the two tables are genuinely both populated -----------
+
+
+def _serve(ctx: Any, payload: In) -> Out:
+    return Out(rung=payload.rung, saw="served")
+
+
+def _endpoint_spec() -> EndpointSpec:
+    return EndpointSpec(
+        name="generate", method=_serve, kind="inference",
+        payload_type=In, output_mode="single",
+    )
+
+
+# ---- harness ---------------------------------------------------------------
+
+
+class _Harness:
+    """A real Executor with BOTH tables populated, and a send sink."""
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.exits: List[int] = []
+        self.ex = Executor(
+            [_endpoint_spec()], self._send, jobs=_job_specs())
+        self.ex._process_exit = self.exits.append
+        _PERMIT_PROBE[:] = [self.ex._gpu_permit_for_group(0)]
+
+    async def _send(self, msg: pb.WorkerMessage) -> None:
+        self.sent.append(msg)
+
+    def frame(self, name: str, **kw: Any) -> pb.RunJob:
+        return pb.RunJob(
+            request_id=kw.pop("request_id", "job-uuid-1"),
+            attempt=int(kw.pop("attempt", 0)),
+            function_name=name,
+            input_payload=msgspec.msgpack.encode(In(rung=kw.pop("rung", "w8a8"))),
+            **kw,
+        )
+
+    async def dispatch(self, name: str, **kw: Any) -> pb.JobResult:
+        run = self.frame(name, **kw)
+        await self.ex.handle_run_job(run)
+        record = self.ex.jobs.get((run.request_id, run.attempt))
+        if record is not None and record.task is not None:
+            await record.task
+        return self.results()[-1]
+
+    def results(self) -> List[pb.JobResult]:
+        return [m.job_result for m in self.sent
+                if m.WhichOneof("msg") == "job_result"]
+
+    def accepted(self) -> List[pb.JobAccepted]:
+        return [m.job_accepted for m in self.sent
+                if m.WhichOneof("msg") == "job_accepted"]
+
+    def progress(self) -> List[pb.JobProgress]:
+        return [m.job_progress for m in self.sent
+                if m.WhichOneof("msg") == "job_progress"]
+
+
+@pytest.fixture(autouse=True)
+def _clean() -> Any:
+    _SEEN.clear()
+    yield
+    _SEEN.clear()
+    _PERMIT_PROBE.clear()
+
+
+# ---- 1. THE HEADLINE: a dispatched job reaches its body --------------------
+
+
+def test_a_dispatched_job_reaches_its_body_and_returns_a_result() -> None:
+    """The whole issue, in one dispatch: master answered `unknown function`."""
+
+    async def scenario() -> Tuple[pb.JobResult, _Harness]:
+        h = _Harness()
+        result = await h.dispatch("plan-h3-svdq", rung="fp8")
+        return result, h
+
+    result, h = asyncio.run(scenario())
+
+    assert result.status == pb.JOB_STATUS_OK, result.safe_message
+    assert msgspec.msgpack.decode(result.inline, type=Out) == Out(
+        rung="fp8", saw="planned")
+    # The BODY ran — registration alone is the shape that let this ship.
+    assert _SEEN["ctx_class"] == "JobContext"
+    assert _SEEN["request_id"] == "job-uuid-1"
+    # Accepted before result, and the body's positions rode the wire.
+    assert [a.request_id for a in h.accepted()] == ["job-uuid-1"]
+    assert len(h.progress()) >= 2
+
+
+def test_an_endpoint_still_dispatches_through_the_same_head() -> None:
+    """Two tables, one head: the endpoint path is untouched."""
+
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        return await h.dispatch("generate")
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_OK
+    assert msgspec.msgpack.decode(result.inline, type=Out).saw == "served"
+
+
+# ---- 2. a name in NEITHER table is distinguishable -------------------------
+
+
+def test_a_name_in_neither_table_names_both_inventories() -> None:
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        return await h.dispatch("no-such-thing")
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_INVALID
+    msg = result.safe_message
+    assert "no-such-thing" in msg
+    # BOTH inventories, so "unknown name" and "known job name" stop looking
+    # identical — which is how this stayed quiet for a whole migration.
+    assert "generate" in msg and "plan-h3-svdq" in msg
+
+
+def test_one_name_cannot_be_both_an_endpoint_and_a_job() -> None:
+    """The wire carries a name and no intent kind, so a colliding name is a
+    dispatch nobody can resolve. Refused at BOOT, where it is still fixable —
+    not at 3am on a rented pod."""
+
+    async def send(msg: pb.WorkerMessage) -> None:  # pragma: no cover
+        raise AssertionError("nothing should be sent")
+
+    collide = EndpointSpec(
+        name="plan-h3-svdq", method=_serve, kind="inference",
+        payload_type=In, output_mode="single",
+    )
+    with pytest.raises(ValueError, match="BOTH an @endpoint and a @job"):
+        Executor([collide], send, jobs=_job_specs())
+
+
+# ---- 3. the declaration is the RELEASE's -----------------------------------
+
+
+def test_the_publish_declaration_is_stamped_from_the_spec_not_the_head() -> None:
+    async def scenario() -> Tuple[pb.JobResult, pb.JobResult]:
+        h = _Harness()
+        declared = await h.dispatch("clone-huggingface", request_id="job-a")
+        seen_declared = dict(_SEEN)
+        undeclared = await h.dispatch("score-benchmark", request_id="job-b")
+        _SEEN["declared_publishes"] = seen_declared["publishes"]
+        return declared, undeclared
+
+    declared, undeclared = asyncio.run(scenario())
+    assert declared.status == pb.JOB_STATUS_OK
+    assert undeclared.status == pb.JOB_STATUS_OK
+    assert _SEEN["declared_publishes"] is True
+    # The undeclared job saw publishes=False and was refused TYPED at the SDK.
+    assert _SEEN["publish_refusal"] == "PublishNotDeclaredError"
+    assert _SEEN["emits_media"] is True
+
+
+def test_a_job_that_declares_nothing_gets_no_media_grant_either() -> None:
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        return await h.dispatch("plan-h3-svdq")
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_OK
+    assert _SEEN["publishes"] is False
+    assert _SEEN["emits_media"] is False
+
+
+# ---- 4. the deadline is carried --------------------------------------------
+
+
+def test_the_wire_deadline_reaches_the_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`RunJob.timeout_ms` is the hub's per-attempt deadline. It is RECORDED
+    on the dispatch (the wall cap is hub-issued through the provider API), so
+    losing it here loses the only statement of it the pod ever sees."""
+    seen: List[JobDispatch] = []
+
+    def spy(dispatch: JobDispatch, **kw: Any) -> Any:
+        seen.append(dispatch)
+        return _real_execute_job(dispatch, **kw)
+
+    monkeypatch.setattr("gen_worker.executor.execute_job", spy)
+
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        return await h.dispatch("plan-h3-svdq", timeout_ms=1_800_000)
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_OK
+    assert len(seen) == 1
+    assert seen[0].deadline_s == 1800.0
+    assert seen[0].job_name == "plan-h3-svdq"
+    assert seen[0].job_id == "job-uuid-1"
+
+
+# ---- 5. GPU-vs-plan rung ---------------------------------------------------
+
+
+def test_a_gpu_job_holds_the_permit_and_a_plan_job_does_not() -> None:
+    async def scenario() -> None:
+        h = _Harness()
+        await h.dispatch("clone-huggingface", request_id="gpu-job")
+        gpu_held = _SEEN["gpu_permit_held"]
+        await h.dispatch("plan-h3-svdq", request_id="cpu-job")
+        _SEEN["gpu_held"] = gpu_held
+
+    asyncio.run(scenario())
+    assert _SEEN["gpu_held"] is True
+    # And the permit is released again — a plan job never queues behind a card.
+    assert _PERMIT_PROBE[0].locked() is False
+
+
+def test_a_plan_job_runs_while_the_gpu_permit_is_taken() -> None:
+    """The rung, stated as behaviour: a CPU plan job does not wait for a card
+    another holder is using. Fail-fast-before-renting is a property of the
+    inventory only if the runtime honours it."""
+
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        permit = h.ex._gpu_permit_for_group(0)
+        await permit.acquire()
+        try:
+            return await asyncio.wait_for(h.dispatch("plan-h3-svdq"), timeout=20)
+        finally:
+            permit.release()
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_OK
+
+
+# ---- 6. recycle_child is honoured ------------------------------------------
+
+
+def test_the_child_is_recycled_after_a_job_and_not_after_a_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(procsplit, "is_compute_child", lambda: True)
+
+    async def scenario() -> Tuple[List[int], List[int]]:
+        h = _Harness()
+        await h.dispatch("plan-h3-svdq", request_id="job-x")
+        after_job = list(h.exits)
+        await h.dispatch("generate", request_id="req-x")
+        return after_job, list(h.exits)
+
+    after_job, after_request = asyncio.run(scenario())
+    assert after_job == [procsplit.EXIT_JOB_RECYCLE]
+    # A serving REQUEST recycles nothing: the run-once lifecycle is the job's.
+    assert after_request == after_job
+
+
+def test_the_recycle_is_read_off_the_outcome_not_assumed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`recycle_child` was a field nobody read. It is load-bearing only if
+    clearing it actually keeps the process — otherwise the recycle is a habit
+    that happens to agree with the contract."""
+    monkeypatch.setattr(procsplit, "is_compute_child", lambda: True)
+
+    def no_recycle(dispatch: JobDispatch, **kw: Any) -> Any:
+        outcome = _real_execute_job(dispatch, **kw)
+        return dataclasses.replace(outcome, recycle_child=False)
+
+    monkeypatch.setattr("gen_worker.executor.execute_job", no_recycle)
+
+    async def scenario() -> Tuple[pb.JobResult, List[int]]:
+        h = _Harness()
+        result = await h.dispatch("plan-h3-svdq")
+        return result, list(h.exits)
+
+    result, exits = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_OK
+    assert exits == []
+
+
+def test_a_worker_that_is_not_a_compute_child_does_not_kill_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`gen-worker serve` has no control parent to respawn it, so the recycle
+    is REPORTED rather than executed — a process exit with nobody to notice is
+    a dead pod, not a fresh child."""
+    monkeypatch.setattr(procsplit, "is_compute_child", lambda: False)
+
+    async def scenario() -> List[int]:
+        h = _Harness()
+        await h.dispatch("plan-h3-svdq")
+        return list(h.exits)
+
+    assert asyncio.run(scenario()) == []
+
+
+# ---- 7. a jobs-only package boots ------------------------------------------
+
+
+def test_a_package_with_jobs_and_no_endpoints_boots() -> None:
+    """te#218 left every conversion package jobs-only. A worker that refuses
+    to boot on one cannot run a single migrated job."""
+    from gen_worker.config import load_settings
+    from gen_worker.worker import Worker
+
+    settings = load_settings(
+        orchestrator_public_addr="127.0.0.1:1",
+        worker_id="pgw1324-jobs-only",
+        worker_jwt="",
+    )
+    worker = Worker(settings, ["harness.job_pkg_pgw1324"])
+    assert sorted(worker.executor.job_specs) == [
+        "bake-h3-modulation", "plan-h3-svdq"]
+    assert worker.executor.specs == {}
+
+
+def test_a_package_with_neither_still_refuses() -> None:
+    from gen_worker.config import load_settings
+    from gen_worker.worker import Worker
+
+    settings = load_settings(
+        orchestrator_public_addr="127.0.0.1:1",
+        worker_id="pgw1324-empty",
+        worker_jwt="",
+    )
+    with pytest.raises(ValueError, match="no @endpoint classes and no @job"):
+        Worker(settings, ["harness.blob_host"])
+
+
+# ---- 8. a body failure is terminal, not infra ------------------------------
+
+
+def test_a_body_exception_is_terminal_never_retryable() -> None:
+    """`max_retries` counts INFRA faults only — re-running a deterministic
+    failure is money burnt (the jobs-system ruling, k8s semantics)."""
+
+    async def scenario() -> pb.JobResult:
+        h = _Harness()
+        return await h.dispatch("explode")
+
+    result = asyncio.run(scenario())
+    assert result.status == pb.JOB_STATUS_FATAL
+    assert result.status != pb.JOB_STATUS_RETRYABLE
+    assert "recipe is wrong" in result.safe_message

--- a/tests/test_procsplit_pgw763.py
+++ b/tests/test_procsplit_pgw763.py
@@ -629,6 +629,62 @@ def test_result_written_just_before_death_is_neither_lost_nor_blamed(
         h.close()
 
 
+def test_pgw1324_a_job_recycle_respawns_without_booking_a_death(
+    tmp_path, captured_dials,
+):
+    """pgw#1324: the run-once lifecycle's PARENT half.
+
+    A `@job` finishes and its compute child leaves with `EXIT_JOB_RECYCLE` so
+    the next job starts on a process that has never imported this one's world.
+    The parent must read that as neither a crash nor a shutdown, and the two
+    neighbouring codes give the wrong answer in opposite directions: rc 0 makes
+    the parent STOP SUPERVISING (`_finish_deliberate_exit` returns), and any
+    other non-zero books a death — a dial, a fault against the pod, and growing
+    backoff. A job pod would then read as crash-looping once per submission to
+    th#2014's ledger, which is the kind of self-inflicted fault signal that
+    gets healthy pods condemned.
+
+    RED by deleting the `rc == EXIT_JOB_RECYCLE` branch in
+    `parent.py::_supervise` — the respawn still happens, but `_handle_child_death`
+    dials a `compute_process_exit` post-mortem carrying `cause=exit:75` for a
+    process that left on purpose.
+    """
+    h = SplitHarness(
+        tmp_path,
+        child_cmd=[sys.executable, str(FAKE_CHILD)],
+        extra_child_env={"PGW763_FAKE_MODE": "result_then_recycle"},
+    )
+    try:
+        conn = h.scheduler.wait_connection(0, timeout=30.0)
+        conn.send(run_job=pb.RunJob(
+            request_id="r-recycle", attempt=1, function_name="echo",
+            input_payload=_payload("x")))
+        res = conn.wait_for(is_result_for("r-recycle"), timeout=30.0)
+        assert res.job_result.status == pb.JOB_STATUS_OK, res.job_result.safe_message
+        # A FRESH CHILD: the whole point of the exit.
+        await_count(
+            lambda: h.pc._spawn_count, 2,
+            what="respawn after the run-once job recycle",
+            cadence=Cadence(),
+            gone=lambda: None if h.alive else f"parent exited code={h.exit_code}",
+        )
+        # ...and the parent is still alive supervising it, which rc 0 would not
+        # have left true.
+        assert h.alive, f"parent exited code={h.exit_code}"
+        # No death was booked against the pod for a deliberate departure:
+        # `_handle_child_death` would have dialled `cause=exit:75`.
+        assert not any("exit:75" in d for d in captured_dials), captured_dials
+        # And the completed job was never re-reported as a death.
+        assert not any(
+            m.WhichOneof("msg") == "job_result"
+            and m.job_result.request_id == "r-recycle"
+            and m.job_result.status == pb.JOB_STATUS_FATAL
+            for m in conn.received
+        )
+    finally:
+        h.close()
+
+
 def test_parent_exit_with_unretired_results_is_reported_typed(
     tmp_path, captured_dials,
 ):


### PR DESCRIPTION
**The defect, observed on master's own behavior** (real `Executor`, real spec table, real `@job`, real `RunJob` frame):

```
RESULT status=JOB_STATUS_INVALID safe_message="unknown function 'clone-huggingface'"
```

`execute_job`'s only caller in the shipped wheel was `cli/job.py`, `Executor.specs` was `Dict[str, EndpointSpec]`, and the wire head resolved `RunJob.function_name` against that table alone. Every job te#218 migrated — 27 conversion jobs plus both trainers — was publishable, submittable and **unrunnable**, and an unknown name and a known JOB name were the same sentence.

## What lands

- **Two tables, ONE dispatch head.** `Executor.job_specs` is filled by the same `collect_jobs` walk at the same place `collect_endpoints` runs; `_admit_dispatch` resolves against both and refuses INVALID **naming both inventories** when a name is in neither. One name declared as both an endpoint and a job is refused at BOOT.
- **The declared contract.** `publishes`/`emits_media` are stamped by `jobs._stamp_declaration` from the SPEC and never by the head; `RunJob.timeout_ms` is carried as `JobDispatch.deadline_s` (recorded, not armed — the wall cap is hub-issued); the group's GPU permit is held only by a job declaring `Resources(gpu=True)`, so a `plan-*` job never queues behind a card; reserved source/dataset/media inputs materialize through the same helpers the producer serving path uses.
- **`JobOutcome.recycle_child` is honoured.** After the terminal result the compute child exits `procsplit.EXIT_JOB_RECYCLE` (75) and the control parent respawns it. The parent reads 75 as neither a crash nor a shutdown — rc 0 stops supervision and any other non-zero books a death, so a job pod would otherwise read as crash-looping once per submission.
- **A jobs-only package boots.** `Worker` refused any package with no `@endpoint`, which is exactly te#218's shape.

## Red/green

`tests/test_job_dispatch_pgw1324.py` — 15 rows, all driving the real executor, the real registry walk and the real `execute_job` harness. Nine mutation families were applied and observed RED, including master's own shape (resolve against `self.specs` alone).

## Owed by th#2052's protocol leg

Recorded at the call sites rather than papered over: the job dispatch carries **no `snapshots` map** (a job's reserved source repos resolve without a pinned digest — the read grants are minted hub-side from the payload's reserved bindings, so the fetch is authorized; the digest pin is what is missing) and **no phase-budget field** (every job runs on `DEFAULT_PHASE_BUDGET_S`). The wire also carries no job intent kind, which is why the NAME is the whole routing key here.

Unblocks th#2052, e2e#1890 and te#218's "one real submit per package" obligation.