### PR TITLE
#1333: the serving facts are resolved once and carried, never re-derived

### DIFF
--- a/changelog.d/pgw1333.md
+++ b/changelog.d/pgw1333.md
@@ -1,0 +1,38 @@
+- **Every AOT mint and every boot adoption of a function that declares `objectives=` refused
+  `slots_unresolvable`, on any catalog data.** `child_contract.MintSlot` carried `(ref, path)` and
+  nothing else, so each child re-derived its slot resolution through
+  `child_preflight.assert_slots_resolvable` -> `warmup.resolved_slots_kwargs(spec, None)` —
+  `slots=None`, hardcoded. With no orders the chain read objective `""` and
+  `api.slot._finish_resolved` refused the moment the invoked function declared a serving contract.
+  Reachable since pgw#1089 on the boot side and since 0.87.0 on the mint side; sdxl has declared
+  `objectives=("epsilon", "v_prediction")` since pgw#654. It cost e2e#1892 leg-A a paid L40S pod,
+  and it cost the blocker its attribution: the refusal reads *"resolved checkpoint carries no
+  training objective"*, so it was filed against the checkpoint — whose stamp was present and
+  correct, read three ways off the standing hub.
+- The serving facts are now a TYPE (`gen_worker.serving_facts`) with two members, because an empty
+  string was standing for two different states: `ServingFacts` is the catalog's answer (an empty
+  objective there is a real "nothing measured this axis", and a declared contract still fails closed
+  against it), and `FactsUnavailable` is *nobody asked*, carrying `owed_by` — the sender or code
+  path that owes the stamp. Neither `MintSlot.facts` nor `SlotOrder.facts` has a default: a
+  resolution that cannot say which of the two it is does not compile.
+- They are resolved ONCE and carried: `dispatch.order_from_binding` is the single projection of a
+  wire `ModelBinding` (the boot path read one of its five fields and built `SlotOrder(ref=ref)`),
+  `executor._dispatched_spec` folds them into `EndpointSpec.slot_facts` by the statement that folds
+  in the ref, and `child_preflight.bind_slots` reinstalls them onto a child's rediscovered spec
+  beside its binding.
+- **Owed by tensorhub:** `hello_ack.go` builds `DesiredInstance.models[]` with `.objective` /
+  `.distilled` / `.distilled_status` left zero, though the proto carries them and the dispatch path
+  stamps the same message. Until it does, a governed boot slot still refuses — §1.22 fail-closed —
+  but with a sentence naming the wire and the repo, never one that reads as a verdict on the
+  checkpoint.
+- The pgw#969 harness endpoint now declares sdxl's serving contract. Without it that regression test
+  was green on a shape that cannot exhibit this class — the same green-by-fixture trap its own
+  docstring warns about one axis over.
+- **pgw#1334, separated by evidence and not a duplicate.** The `load_phase_done ... staged 0.55 GiB
+  of 6.31 GiB` beside the refusal is not a staging metric and the load was not 9% staged: the left
+  number is the process's anon RSS and the right is `os.walk` over a tree already complete on disk.
+  Nor did the refusal tear the staging down — `_materialize_local` completes before `_boot_adopt` is
+  called, by await order and by data dependency, and the boot-trace children are `start_new_session`
+  subprocesses whose `PreflightRefused` never crosses the process boundary. The row now says what
+  its numbers are and which way the load ended (`stop(raised=...)`); the `config.json` fatal itself
+  is a th#1941 manifest-composition gap and is tracked there.

--- a/scripts/boot_key_rig.py
+++ b/scripts/boot_key_rig.py
@@ -73,10 +73,13 @@ def _vehicle(name: str) -> Any:
 def _slots(veh: Any, tree: Path) -> Dict[str, Any]:
     from gen_worker.api.binding import ModelRef
     from gen_worker.child_contract import MintSlot
+    from gen_worker.serving_facts import FactsUnavailable
 
     return {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path=veh.ref_path, tag="prod"),
-        path=str(tree))}
+        path=str(tree),
+        # pgw#1333: no catalog was consulted by a rig.
+        facts=FactsUnavailable(owed_by="boot_key_rig (no catalog)"))}
 
 
 def _declared_hint(family: str) -> int:

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -242,10 +242,15 @@ def _mint_slot(tree: Path, ref_path: str) -> Any:
     """
     from gen_worker.api.binding import ModelRef
     from gen_worker.child_contract import MintSlot
+    from gen_worker.serving_facts import FactsUnavailable
 
     return MintSlot(
         ref=ModelRef(source="tensorhub", path=ref_path, release="prod"),
         path=str(tree),
+        # pgw#1333: a rig resolves no catalog, and says so rather than
+        # asserting an unclassified checkpoint. The micro vehicles declare no
+        # serving contract, so nothing checks these facts.
+        facts=FactsUnavailable(owed_by="micro_mint_rig (no catalog)"),
     )
 
 

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -40,6 +40,7 @@ from typing import Any, Dict, Generic, Mapping, Optional, Sequence, Type, TypeVa
 import msgspec
 
 from .binding import ModelRef
+from ..serving_facts import OBJECTIVES as _OBJECTIVES
 from ..families.base import KIND_LORA, GenerationDefaults, family_for
 from ..models.tensor_layout_contract import (
     LayoutDeclarationError,
@@ -65,7 +66,11 @@ D = TypeVar("D", bound=GenerationDefaults)
 # v-pred fact). Drives the recipe (few steps, CFG off), the graph choice
 # (cfg_off/batch-1 class) and adapter policy (never stack a distillation
 # LoRA onto already-distilled weights).
-OBJECTIVES = ("epsilon", "v_prediction", "flow")
+# pgw#1333: the vocabulary itself lives in ``gen_worker.serving_facts``,
+# beside the type that validates against it, so a struct cannot be built with
+# an objective this gate would later reject as "not in the declared
+# objectives" — a decode bug wearing a compatibility refusal's clothes.
+OBJECTIVES = _OBJECTIVES
 
 # SERVING TASKS — what a handler asks the model to DO, as opposed to
 # what the model IS. Orthogonal to both facts above: qwen-image-edit and

--- a/src/gen_worker/child_contract.py
+++ b/src/gen_worker/child_contract.py
@@ -30,6 +30,7 @@ import msgspec
 
 from . import graph_facts
 from .api.binding import ModelRef, wire_ref
+from .serving_facts import SlotEvidence
 
 #: Every child progress frame is one stdout line with this prefix. Anything
 #: else the child (or a library it imports) prints is diagnostic tail, never
@@ -90,6 +91,18 @@ class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
       the child never touches the network: a mint is compute, and a mint
       process that could download is one that can stall on a lemon host.
 
+    * ``facts`` — WHAT the catalog says the checkpoint IS (pgw#1333). The
+      child re-runs discovery, so it holds the @worker_function
+      ``objectives=``/``distilled=`` DECLARATION and nothing to check it
+      against; before this field the check ran against a hardcoded ``None``
+      slot map, which made every governed slot resolve with objective ``""``
+      and refused EVERY mint of EVERY function that declares a serving
+      contract — on any catalog data, because no catalog data was ever
+      consulted. Like ``ref`` it carries no default: a slot that cannot say
+      whether the facts were answered or never asked cannot be constructed,
+      and :class:`~gen_worker.serving_facts.FactsUnavailable` makes "never
+      asked" a sentence naming its owner rather than an empty string.
+
     th#1941: nothing rides beside them. The hub composes the manifest, so
     ``path`` names a COHERENT tree by construction — there is no second tree
     for the child to be handed and no narrowing for it to detect.
@@ -97,6 +110,7 @@ class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
 
     ref: ModelRef
     path: str
+    facts: SlotEvidence
 
     def __post_init__(self) -> None:
         if not self.path:

--- a/src/gen_worker/child_preflight.py
+++ b/src/gen_worker/child_preflight.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping, Sequence, Tuple
 
 from .child_contract import MintSlot
+from .serving_facts import FactsUnavailable
 
 
 class PreflightRefused(RuntimeError):
@@ -93,11 +94,18 @@ def bind_slots(specs: Sequence[Any], resolved: Mapping[str, MintSlot]) -> None:
     live property over ``spec.models``, so binding the chosen function alone
     would move its key out from under its siblings and silently narrow the
     class-scoped warm plan (pgw#654) to one lane.
+
+    pgw#1333: the SERVING FACTS install in the same statement as the ref. The
+    child holds the ``@worker_function(objectives=...)`` DECLARATION from its
+    own discovery and had nothing to check it against — every governed slot
+    resolved with objective ``""`` and every such mint refused, on any catalog
+    data. A binding without its facts is half a resolution.
     """
     for spec in specs:
         for slot, res in resolved.items():
             if slot in spec.slots or slot in spec.models:
                 spec.models[slot] = res.ref
+                spec.slot_facts[slot] = res.facts
 
 
 def assert_slots_resolvable(
@@ -147,7 +155,19 @@ def assert_slots_resolvable(
         errors = warmup_mod.resolved_slots_kwargs(spec, None)["slot_errors"]
         for name, why in sorted(errors.items()):
             resolved = slots.get(name)
-            if resolved is not None:
+            if resolved is None:
+                continue
+            if isinstance(resolved.facts, FactsUnavailable):
+                # NOT a divergence between the two processes: the parent sent
+                # a ref with no serving facts beside it, so there is nothing
+                # here to check the declaration against. Named separately
+                # because the generic sentence reads as "this checkpoint is
+                # bad" and cost a paid pod's blocker its correct attribution.
+                problems.append(
+                    f"slot {name!r} of {spec.name!r}: the parent's binding "
+                    f"{resolved.ref.path!r} crossed WITHOUT its serving facts "
+                    f"— {why}")
+            else:
                 problems.append(
                     f"slot {name!r} of {spec.name!r}: the parent's binding "
                     f"{resolved.ref.path!r} "

--- a/src/gen_worker/dispatch.py
+++ b/src/gen_worker/dispatch.py
@@ -9,22 +9,80 @@ the head replaceable without touching the driver.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .serving_facts import FactsUnavailable, ServingFacts, SlotEvidence
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .pb import worker_scheduler_pb2 as pb
 
 
-@dataclass(frozen=True)
+#: pgw#1333: WHO owes the serving facts on the BOOT path.
+#: ``DesiredInstance.models`` is the same ``ModelBinding`` message the
+#: dispatch path stamps, but tensorhub's ``hello_ack.go`` leaves
+#: ``objective`` / ``distilled`` / ``distilled_status`` zero on it. Named
+#: here, once, so every boot-side reader refuses with the SAME sentence and
+#: an operator reading it knows which repo owes the fix.
+BOOT_SENDER_OWES = (
+    "the hub's boot sender (tensorhub hello_ack.go leaves "
+    "DesiredInstance.models[].objective / .distilled / .distilled_status "
+    "unset; the dispatch path stamps the same three fields)"
+)
+
+
+@dataclass(frozen=True, kw_only=True)
 class SlotOrder:
     """One dispatched slot binding, as far as the head resolved it.
 
     ``ref`` is a canonical tensorhub-CAS ref or ``""`` (unbound — the driver
     drops an optional slot, and the head may leave a required slot for the
     code-declared default).
+
+    ``facts`` carries NO default (pgw#1333). Every construction site must say
+    whether the catalog answered (:class:`~gen_worker.serving_facts.ServingFacts`)
+    or was never asked (:class:`~gen_worker.serving_facts.FactsUnavailable`),
+    because the three loose defaulted scalars this replaced made those two
+    states one state — and the state they collapsed to reads, at the refusal,
+    as "this checkpoint is unclassified".
     """
 
     ref: str = ""
     inference_defaults: str = ""
-    objective: str = ""
-    distilled: bool = False
-    distilled_status: str = ""
+    facts: SlotEvidence
+
+
+def order_from_binding(
+    binding: "pb.ModelBinding", *, ref: str = "", owed_by: str = "",
+) -> SlotOrder:
+    """THE projection of one wire ``ModelBinding`` into a neutral order.
+
+    One function for every sender (``RunJob.models``, ``DesiredInstance.models``
+    on the boot/preload paths), so a path cannot quietly read fewer fields
+    than another — which is exactly how the boot path came to build
+    ``SlotOrder(ref=ref)`` and drop three fields the message already carried.
+
+    ``owed_by`` names the sender for the case where the message carries no
+    serving facts AT ALL. proto3 scalars have no presence, so a wholly
+    zero-valued triple cannot be distinguished from a genuinely unclassified
+    checkpoint on the wire; with ``owed_by`` given, the zero triple is read as
+    the wire gap it is on senders known not to stamp yet. Pass it ONLY for
+    such a sender — the dispatch path stamps, so its zero triple is an answer
+    and ``owed_by`` must be empty there.
+    """
+    objective = str(getattr(binding, "objective", "") or "")
+    distilled = bool(getattr(binding, "distilled", False))
+    status = str(getattr(binding, "distilled_status", "") or "")
+    facts: SlotEvidence
+    if owed_by and not objective and not distilled and not status:
+        facts = FactsUnavailable(owed_by=owed_by)
+    else:
+        facts = ServingFacts(
+            objective=objective, distilled=distilled, distilled_status=status)
+    return SlotOrder(
+        ref=str(ref or getattr(binding, "ref", "") or "").strip(),
+        inference_defaults=str(getattr(binding, "inference_defaults", "") or ""),
+        facts=facts,
+    )
 
 
 @dataclass(frozen=True)
@@ -36,4 +94,6 @@ class AdapterOrder:
     inference_defaults: str = ""
 
 
-__all__ = ["AdapterOrder", "SlotOrder"]
+__all__ = [
+    "BOOT_SENDER_OWES", "AdapterOrder", "SlotOrder", "order_from_binding",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -45,6 +45,7 @@ from . import settings_authority
 from . import process_role
 from . import progress as progress_mod
 from . import serve_posture
+from . import serving_facts
 from . import serving_mode as serving_mode_mod
 from . import warmup
 from . import worker_credential
@@ -411,6 +412,13 @@ _ALL_COMPONENTS = _AllComponents()
 #: several tests call them here; there is one implementation.
 _resolve_slots_kwargs = warmup.resolved_slots_kwargs
 _spec_root_slot = warmup.spec_root_slot
+
+#: A setup slot that reached ``_setup_locked_inner`` with no order at all —
+#: a hub-less local boot, or a code ``default_checkpoint``. Nothing asked a
+#: catalog, and the sentence says exactly that.
+_UNBOUND_SLOT_FACTS = serving_facts.FactsUnavailable(
+    owed_by="nothing resolved this slot against a catalog (no dispatch order "
+            "and no desired-instance binding reached this setup)")
 
 
 def _hub_binding_for_wire_ref(ref: str) -> ModelRef:
@@ -3933,14 +3941,24 @@ class Executor:
         re-runs for the pick and setup-held state (``self.pipeline``) stays
         coherent per checkpoint while the LRU machinery evicts whole
         instances. Function-shaped (``cls=None``) specs rebind too — their
-        slots inject via ``_handler_kwargs``, which reads ``spec.models``."""
+        slots inject via ``_handler_kwargs``, which reads ``spec.models``.
+
+        pgw#1333: an order's SERVING FACTS are folded in by the same loop that
+        folds in its ref, into ``spec.slot_facts``. They used to be dropped
+        here, and the drop was invisible because the only consumer that
+        noticed was a CHILD process, which re-derived them from a hardcoded
+        ``None`` and got ``""``."""
         if not spec.slots:
             return spec
         run_refs = {
             slot: so.ref for slot, so in slots.items() if slot and so.ref
         }
+        facts = dict(spec.slot_facts)
         effective = dict(spec.models)
         for slot, decl in spec.slots.items():
+            order = slots.get(slot)
+            if order is not None:
+                facts[slot] = order.facts
             if decl.optional and not run_refs.get(slot, ""):
                 # Unbound optional slot: the deploy chose not to serve this
                 # lane, and the deploy decides (th#980/ie#524) — a code
@@ -3952,9 +3970,9 @@ class Executor:
                 effective.pop(slot, None)
                 continue
             effective[slot] = self._bound_slot(spec, slot, run_refs.get(slot, ""))
-        if effective == spec.models:
+        if effective == spec.models and facts == spec.slot_facts:
             return spec
-        return dc_replace(spec, models=effective)
+        return dc_replace(spec, models=effective, slot_facts=facts)
 
     def _effective_config(
         self, spec: EndpointSpec,
@@ -4330,7 +4348,17 @@ class Executor:
                 f"{sorted(spec.models)!r}); got {sorted(bindings)!r}"
             )
 
-        orders = {m.slot: dispatch.SlotOrder(ref=m.ref) for m in remapped}
+        # pgw#1333: the DesiredInstance bindings carry the same
+        # `ModelBinding` fields the dispatch path stamps, and this path read
+        # exactly one of them. It reads all of them now; `owed_by` names the
+        # hub because a wholly zero-valued triple from THIS sender is (today)
+        # the boot gap, and proto3 scalars have no presence to tell it from a
+        # genuinely unclassified row.
+        orders = {
+            m.slot: dispatch.order_from_binding(
+                m, ref=m.ref, owed_by=dispatch.BOOT_SENDER_OWES)
+            for m in remapped
+        }
         effective = self._dispatched_spec(spec, orders)
         mismatched = {
             slot: wire_ref(effective.models[slot])
@@ -5432,7 +5460,12 @@ class Executor:
                 ref, snap, binding=binding)
             slot_identities[slot] = materialized.identity
             resolved_slots[slot] = MintSlot(
-                ref=binding, path=str(materialized.path))
+                ref=binding, path=str(materialized.path),
+                # pgw#1333: the third half of ONE resolution. A slot whose
+                # facts the parent never received says so by name here rather
+                # than defaulting to a blank objective the child would read
+                # as "the catalog classified this checkpoint as nothing".
+                facts=spec.slot_facts.get(slot, _UNBOUND_SLOT_FACTS))
         paths: Dict[str, str] = {
             slot: res.path for slot, res in resolved_slots.items()}
         topology_eager = self._eager_only_reason()
@@ -9048,13 +9081,10 @@ class Executor:
         for b in run.models:
             if not b.slot:
                 continue
-            slots[b.slot] = dispatch.SlotOrder(
-                ref=str(b.ref or "").strip(),
-                inference_defaults=str(b.inference_defaults or ""),
-                objective=str(b.objective or ""),
-                distilled=bool(b.distilled),
-                distilled_status=str(b.distilled_status or ""),
-            )
+            # The dispatch path is the sender that STAMPS: a zero-valued
+            # triple here is the catalog's answer, not a wire gap, so no
+            # `owed_by` (pgw#1333).
+            slots[b.slot] = dispatch.order_from_binding(b)
             if b.loras:
                 adapters[b.slot] = tuple(
                     dispatch.AdapterOrder(

--- a/src/gen_worker/local_serve.py
+++ b/src/gen_worker/local_serve.py
@@ -35,6 +35,7 @@ from . import compile_cache as cc
 from . import compile_posture, fleet_cells, handler_proof
 from . import local_cell_store, mint_supervisor
 from .child_contract import MintFrame, MintSlot
+from .serving_facts import FactsUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -390,13 +391,22 @@ def slot_map(
     a hole in it — ``MintSlot`` refuses to be constructed without both halves,
     and ``child_preflight.assert_slots_resolvable`` refuses a declared,
     non-optional slot that never arrived.
+
+    pgw#1333: a hub-less local serve consults no catalog, so it has no serving
+    facts to forward and says exactly that. A local run of a function that
+    DECLARES ``objectives=`` therefore refuses by name — which is honest: the
+    declaration is checked against evidence, and there is none here.
     """
     out: Dict[str, MintSlot] = {}
     for slot, path in paths.items():
         binding = bindings.get(slot)
         if binding is None or not str(path or ""):
             continue
-        out[slot] = MintSlot(ref=binding, path=str(path))
+        out[slot] = MintSlot(
+            ref=binding, path=str(path),
+            facts=FactsUnavailable(
+                owed_by="a hub-less local serve (no catalog resolves this "
+                        "slot's objective/distilled facts)"))
     return out
 
 

--- a/src/gen_worker/measure_child.py
+++ b/src/gen_worker/measure_child.py
@@ -69,6 +69,7 @@ import msgspec
 
 from . import activity
 from .child_contract import CompileSpec, MintSlot
+from .serving_facts import FactsUnavailable
 from .hostfacts import cuda_ready
 from .child_preflight import (
     PreflightRefused,
@@ -348,6 +349,13 @@ def _parse_slot_flag(raw: str) -> Tuple[str, str, str]:
     return name, value.strip(), tail.strip()
 
 
+#: pgw#1333: a measure run names a tree on this machine; no catalog is
+#: consulted and none is available offline. Saying so by name is what keeps a
+#: declared serving contract from being checked against a fabricated blank.
+_OPERATOR_FACTS = FactsUnavailable(
+    owed_by="a --slot operator argument (a measure run consults no catalog)")
+
+
 def _slot_from_value(name: str, value: str, ref_text: str) -> MintSlot:
     """One resolved slot from ``VALUE`` — a local tree, or a ref already here.
 
@@ -367,7 +375,8 @@ def _slot_from_value(name: str, value: str, ref_text: str) -> MintSlot:
     if Path(value).is_dir():
         return MintSlot(
             ref=ModelRef(source="tensorhub", path=ref_text or f"local/{name}"),
-            path=str(Path(value)))
+            path=str(Path(value)),
+            facts=_OPERATOR_FACTS)
     ref = ModelRef(source="tensorhub", path=value)
     try:
         path = resolve_local_path(
@@ -380,7 +389,7 @@ def _slot_from_value(name: str, value: str, ref_text: str) -> MintSlot:
             f"({type(exc).__name__}: {exc}). A measure run never downloads — "
             f"it is compute, exactly as a mint is — so name a tree this pod "
             f"already fetched: --slot {name}=/path/to/tree") from exc
-    return MintSlot(ref=ref, path=str(path))
+    return MintSlot(ref=ref, path=str(path), facts=_OPERATOR_FACTS)
 
 
 def _target_owner(spec: Any, targets: Sequence[str]) -> str:

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -53,8 +53,12 @@ COUNTER_NAME = "load:staged_bytes"
 #: A load phase STARTED (``duration_ms`` 0 — nothing is measured yet). This
 #: is the row that names the component a hung load is hung on.
 EVENT_PHASE = "load_phase"
-#: A load phase FINISHED, carrying its measured span (the number goes in the
-#: column, never interpolated into the detail).
+#: A load phase ENDED, carrying its measured span (the number goes in the
+#: column, never interpolated into the detail). pgw#1334: "done" here means
+#: the phase is over, NOT that it succeeded and NOT that any tree is complete
+#: — `stop()` fires it from `provision.load_slot`'s `finally`, so the row a
+#: failed load emits is this one. Nothing on this path measures completeness
+#: of anything; the detail says which way it ended.
 EVENT_PHASE_DONE = "load_phase_done"
 #: This phase is RE-READING its own set instead of staging it — the
 #: direct-reclaim crawl, confessed while the worker is still alive.
@@ -160,29 +164,52 @@ class LoadProgressReporter:
 
     # -- phase events -------------------------------------------------------
 
+    def _progress(self) -> str:
+        """This phase's byte line, in words that say what the numbers ARE.
+
+        pgw#1334: it used to read ``staged 0.55 GiB of 6.31 GiB``, and a pod's
+        blocker was filed as "the loader ran against a 9%-staged tree". Neither
+        number is a staging fraction. The left is this PROCESS's resident anon
+        memory (or its /proc read delta, whichever is smaller —
+        :meth:`_tick`); the right is ``os.walk`` over the tree that is ALREADY
+        on disk, measured after staging finished. Their ratio is a
+        memory-residency observation about a complete tree, and it cannot go
+        to 100% for a load that mmaps. Reading it as progress-toward-complete
+        is reading a number that does not exist, so the row no longer offers
+        the words for it.
+        """
+        return (f"resident {_gib(self._staged)} anon; tree on disk "
+                f"{_gib(self.total_bytes)}")
+
     def _announce_phase(self) -> None:
         try:
             sized = f", {_gib(self._phase_bytes)} tree" if self._phase_bytes else ""
             activity_mod.emit_event(
                 EVENT_PHASE,
-                f"{self.label}: {self._phase}{sized}; staged "
-                f"{_gib(self._staged)} of {_gib(self.total_bytes)}",
+                f"{self.label}: {self._phase}{sized}; {self._progress()}",
                 phase=self._phase,
             )
         except Exception:  # noqa: BLE001 - reporting must never break a load
             logger.debug("load-phase event dropped", exc_info=True)
 
-    def _close_phase(self) -> None:
+    def _close_phase(self, outcome: str = "") -> None:
+        """Close the current phase's span.
+
+        ``outcome`` is set only by :meth:`stop` — a mid-load ``set_phase``
+        transition ends a phase but decides nothing about the LOAD, so it
+        says nothing. pgw#1334.
+        """
         try:
             span_ms = int(max(0.0, time.monotonic() - self._phase_started) * 1000)
             # "ended", never "complete": `load_slot` stops the reporter from a
             # `finally`, so this row also closes a phase that RAISED. The span
             # is the honest fact either way; the outcome is the raised error's
-            # to report.
+            # to report. pgw#1334 read one of these as a completion claim,
+            # which is why the sentence now says which way it ended.
             activity_mod.emit_event(
                 EVENT_PHASE_DONE,
-                f"{self.label}: {self._phase} ended; staged "
-                f"{_gib(self._staged)} of {_gib(self.total_bytes)}",
+                f"{self.label}: {self._phase} ended{outcome}; "
+                f"{self._progress()}",
                 phase=self._phase, duration_ms=span_ms,
             )
         except Exception:  # noqa: BLE001 - reporting must never break a load
@@ -205,7 +232,16 @@ class LoadProgressReporter:
         t.start()
         return self
 
-    def stop(self, *, clean: bool) -> None:
+    def stop(self, *, clean: bool, raised: bool = False) -> None:
+        """``clean`` clears the death breadcrumb; ``raised`` says the load
+        this reporter wrapped is unwinding.
+
+        pgw#1334: the two are INDEPENDENT and were conflated by absence.
+        ``load_slot`` stops from a ``finally`` with ``clean=True`` on both
+        paths — the breadcrumb has done its job either way — so ``clean`` was
+        never evidence about the outcome, and the closing row said nothing at
+        all. A pod's `load_phase_done` was then read as a completion claim.
+        """
         global _active
         self._stop.set()
         t = self._thread
@@ -217,7 +253,7 @@ class LoadProgressReporter:
         # The last phase closes on ANY stop: a raise is still a span that
         # ended, and the event names where the time went. Only a kernel kill
         # skips this — that one is the breadcrumb's job.
-        self._close_phase()
+        self._close_phase(" on a RAISE" if raised else " without error")
         try:
             c = activity_mod.scoped_counter(
                 COUNTER_NAME, "bytes", self.total_bytes)

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import logging
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -273,7 +274,11 @@ def load_slot(
             reporter.set_phase("place")
             out.placed = place_pipeline(pipe, mode=mode, ref=ref)
     finally:
-        reporter.stop(clean=True)
+        # pgw#1334: the closing row says which way the load ended. `clean`
+        # only ever meant "clear the breadcrumb" — it is True on both paths —
+        # so without this the raising load and the succeeding one emitted the
+        # same sentence, and a pod's was read as a completion claim.
+        reporter.stop(clean=True, raised=sys.exc_info()[0] is not None)
     return out
 
 

--- a/src/gen_worker/preload.py
+++ b/src/gen_worker/preload.py
@@ -245,7 +245,11 @@ class Preloader:
                 ref = pick[0]
             if not slot or not ref:
                 return None
-            orders[slot] = dispatch.SlotOrder(ref=ref)
+            # pgw#1333: the whole binding, not just its ref — the rotation
+            # preload derives the SAME effective spec the validated warm path
+            # does, and a spec whose slot facts differ is a different spec.
+            orders[slot] = dispatch.order_from_binding(
+                m, ref=ref, owed_by=dispatch.BOOT_SENDER_OWES)
         try:
             return ex._dispatched_spec(spec, orders)
         except Exception:

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -34,6 +34,7 @@ from .warmup import validate_class_warmup
 import dataclasses
 from .api.compile_axis import warm_guidance_values
 from .graph_facts import facts_digest
+from .serving_facts import SlotEvidence
 from .api.export_contract import (
     declares_export_contract, register_export_declaration, registered_entry,
 )
@@ -174,6 +175,14 @@ class EndpointSpec:
     # the handler's derived config schema's @family registration) —
     # precomputed once here so ctx.slots doesn't need EndpointDecl.compile.
     slot_family: Dict[str, str] = field(default_factory=dict)
+    # pgw#1333: per-slot SERVING FACTS — what the catalog says the resolved
+    # checkpoint IS. Never authored and never discovered: `_dispatched_spec`
+    # folds them in from the neutral orders exactly as it folds in `models`,
+    # and `child_preflight.bind_slots` reinstalls them in a child that re-ran
+    # discovery. A slot absent from this map has no EVIDENCE, which is not the
+    # same as a checkpoint the catalog classified as nothing — the two states
+    # were one state before this field, and every governed mint refused.
+    slot_facts: Dict[str, SlotEvidence] = field(default_factory=dict)
     # The handler's DERIVED config schema — the D in `ctx: RequestContext[D]`.
     # None when the handler annotates a bare context. Catalog recipe metadata
     # decodes against this type; code owns the schema, the catalog owns the

--- a/src/gen_worker/serving_facts.py
+++ b/src/gen_worker/serving_facts.py
@@ -1,0 +1,120 @@
+"""What the CATALOG says about a resolved checkpoint — or the honest
+statement that nobody said anything.
+
+pgw#1333. The three serving facts (``objective`` / ``distilled`` /
+``distilled_status``) used to travel as three loose scalars on
+``dispatch.SlotOrder``, every one of them defaulted, and every consumer read
+them with ``.get(name, "")``. That shape has exactly one failure mode and it
+cost a paid pod: a code path that never received the facts is
+INDISTINGUISHABLE from a checkpoint the catalog classified as nothing, so
+``api.slot._finish_resolved`` refused an ``epsilon`` checkpoint by saying
+"resolved checkpoint carries no training objective" — and the refusal was
+read, correctly given its text, as a catalog defect. It was a wire gap.
+
+So the facts get a TYPE, and the gap gets a type of its own:
+
+* :class:`ServingFacts` — the catalog was asked and answered. An empty
+  ``objective`` here is a real answer ("nothing measured this axis"), and a
+  function declaring ``objectives=`` refuses against it exactly as the hub's
+  own two gates do.
+* :class:`FactsUnavailable` — nobody asked. ``owed_by`` names WHO owes the
+  stamp, in the vocabulary of the wire field or the code path that dropped
+  it, so the refusal points at the gap instead of at the checkpoint.
+
+The union is not optional and carries no default anywhere it is stored: a
+slot resolution that cannot say which of the two it is cannot be constructed.
+That is the whole design — an empty string is never again allowed to stand in
+for "we do not know".
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import msgspec
+
+#: Every training objective the platform classifies (mirrors tensorhub's
+#: ``internal/modelfamily``). ``""`` is deliberately NOT a member — an
+#: unclassified checkpoint is ``ServingFacts(objective="")``, a stamped
+#: statement, not a missing one.
+OBJECTIVES = ("epsilon", "v_prediction", "flow")
+
+#: ``distilled``'s evidence axis. ``""`` IS a member: the hub omits the key
+#: whenever the stored column is empty, so "nothing measured the axis" is a
+#: live stamped value distinct from an evidenced ``classified``.
+DISTILLED_STATUSES = ("", "classified", "unclassified", "inconclusive")
+
+
+class ServingFacts(msgspec.Struct, frozen=True, kw_only=True, tag="stamped"):
+    """The resolved checkpoint's stamped facts, as the catalog answered.
+
+    Validated on construction rather than at the gate that reads it: a
+    typo'd objective reaching ``_finish_resolved`` there produces "not in the
+    declared objectives", which reads as a compatibility refusal and is
+    really a decode bug.
+    """
+
+    objective: str = ""
+    distilled: bool = False
+    distilled_status: str = ""
+
+    def __post_init__(self) -> None:
+        if self.objective and self.objective not in OBJECTIVES:
+            raise ValueError(
+                f"unknown training objective {self.objective!r} "
+                f"(valid: {OBJECTIVES}, or '' for unclassified)")
+        if self.distilled_status not in DISTILLED_STATUSES:
+            raise ValueError(
+                f"unknown distilled_status {self.distilled_status!r} "
+                f"(valid: {DISTILLED_STATUSES})")
+
+
+class FactsUnavailable(
+    msgspec.Struct, frozen=True, kw_only=True, tag="unstamped",
+):
+    """No serving facts were ever resolved for this slot.
+
+    NOT "the checkpoint has none" — that is ``ServingFacts(objective="")``.
+    This says the resolution never happened, and ``owed_by`` names the sender
+    or code path that would have supplied it, so a refusal blames the gap by
+    name and an operator knows which side to fix.
+    """
+
+    owed_by: str
+
+    def __post_init__(self) -> None:
+        if not str(self.owed_by).strip():
+            raise ValueError(
+                "FactsUnavailable must name who owes the stamp — an anonymous "
+                "gap is the empty string this type exists to abolish")
+
+
+#: One slot's serving-fact evidence: answered, or explicitly not asked.
+SlotEvidence = Union[ServingFacts, FactsUnavailable]
+
+
+def facts_or_refuse(evidence: SlotEvidence, *, slot: str, what: str) -> ServingFacts:
+    """The stamped facts, or a ``ValueError`` naming the gap.
+
+    The ONE place the union is collapsed, so every caller that needs the
+    three scalars either has real evidence or raises a sentence an operator
+    can act on.
+    """
+    if isinstance(evidence, ServingFacts):
+        return evidence
+    raise ValueError(
+        f"slot {slot!r}: no serving facts were resolved for this checkpoint "
+        f"({what}) — {evidence.owed_by} did not stamp objective/distilled/"
+        f"distilled_status, so there is no evidence to check the invoked "
+        f"function's declared serving contract against. This is a wire gap, "
+        f"NOT a claim about the checkpoint's catalog row.")
+
+
+__all__ = [
+    "DISTILLED_STATUSES",
+    "OBJECTIVES",
+    "FactsUnavailable",
+    "ServingFacts",
+    "SlotEvidence",
+    "facts_or_refuse",
+]

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -87,7 +87,7 @@ from typing import (
 
 import msgspec
 
-from . import dispatch
+from . import dispatch, serving_facts
 from .api.compile_axis import PayloadAxis
 from .api.decorators import EndpointDecl, NoWarmup
 from .api.errors import IllegalCombination
@@ -857,6 +857,16 @@ def resolved_slots_kwargs(
     metadata, so every slot resolves from the spec's own declaration. That is
     what makes this reachable from the delegated mint child, which has the
     spec and no job.
+
+    pgw#1333: the SERVING FACTS come from this dispatch's order when there is
+    one and from ``spec.slot_facts`` otherwise — and those are the SAME value,
+    because ``executor._dispatched_spec`` folds the order's facts into the
+    spec by the same statement that folds in its ref. Before, they came from
+    the orders alone, so the WARM shape (``slots=None``) resolved every
+    governed slot with objective ``""`` and refused every mint and every boot
+    adoption of every function declaring a serving contract, on any catalog
+    data. A slot with no entry on either side has no EVIDENCE and says so by
+    name; it does not pretend the catalog answered "nothing".
     """
     if not spec.slots:
         return {
@@ -872,15 +882,6 @@ def resolved_slots_kwargs(
         name: tuple(a.inference_defaults for a in advs if a.inference_defaults)
         for name, advs in dict(adapters or {}).items()
     }
-    # The resolved checkpoint's stamped objective/distilled facts ride the
-    # binding; the per-function declaration is the backstop (the hub gates
-    # checkpoint<->function compatibility at deploy/dispatch).
-    objectives = {
-        name: so.objective for name, so in slot_orders.items()}
-    distilled_facts = {
-        name: so.distilled for name, so in slot_orders.items()}
-    distilled_statuses = {
-        name: so.distilled_status for name, so in slot_orders.items()}
     resolved: Dict[str, Any] = {}
     errors: Dict[str, str] = {}
     # A FIXED slot's ref is the RELEASE's own declaration, so its resolution
@@ -898,6 +899,41 @@ def resolved_slots_kwargs(
             function_has_selectable_slot=has_selectable,
         )
         try:
+            # The catalog's answer for this slot. A slot no declaration
+            # CHECKS resolves neutrally when there is no answer — nothing
+            # reads the facts, so a gap costs nothing and refusing would
+            # refuse every family that declares no serving contract. A slot a
+            # declaration does check refuses BY NAME when nothing answered,
+            # instead of resolving with `""` and blaming the checkpoint.
+            order = slot_orders.get(name)
+            evidence = (
+                order.facts if order is not None
+                else spec.slot_facts.get(
+                    name,
+                    serving_facts.FactsUnavailable(
+                        owed_by="this spec was never bound to a dispatch or a "
+                                "desired instance"),
+                )
+            )
+            # An UNBOUND slot has no ref, and "which checkpoint" precedes
+            # "what is that checkpoint": pgw#969's sentence must survive, and
+            # complaining about missing facts for a slot nothing bound at all
+            # names the second-order gap.
+            checked = (
+                spec.models.get(name) is not None
+                and governed
+                and (spec.objectives is not None or spec.distilled is not None)
+            )
+            if checked:
+                facts = serving_facts.facts_or_refuse(
+                    evidence, slot=name,
+                    what=f"function {spec.name!r} declares "
+                         f"objectives={spec.objectives!r} "
+                         f"distilled={spec.distilled!r}")
+            elif isinstance(evidence, serving_facts.ServingFacts):
+                facts = evidence
+            else:
+                facts = serving_facts.ServingFacts()
             resolved[name] = resolve_slot(
                 name, slot,
                 ref=spec.models.get(name),
@@ -905,9 +941,9 @@ def resolved_slots_kwargs(
                 family=spec.slot_family.get(name, ""),
                 raw_metadata_json=raw_defaults.get(name, ""),
                 lora_metadata_json=lora_defaults.get(name, ()),
-                objective=objectives.get(name, ""),
-                distilled=distilled_facts.get(name, False),
-                distilled_status=distilled_statuses.get(name, ""),
+                objective=facts.objective,
+                distilled=facts.distilled,
+                distilled_status=facts.distilled_status,
                 allowed_objectives=spec.objectives if governed else None,
                 allowed_distilled=spec.distilled if governed else None,
             )

--- a/tests/harness/mint_catalog_slot_pgw969.py
+++ b/tests/harness/mint_catalog_slot_pgw969.py
@@ -21,6 +21,14 @@ move its key out from under its sibling and silently narrow the mint.
 This module is deliberately isolated (the ``toy_endpoints_slot_only``
 precedent): the mint child walks ``request.modules`` and re-runs discovery
 over it, so what else lives beside it is part of the test.
+
+pgw#1333: ``catalog_generate`` now declares sdxl's EXACT serving contract
+(``objectives=("epsilon", "v_prediction"), distilled=False``). Without it this
+module was the same trap it was written to escape one axis over — a catalog
+slot whose function declared nothing, so the objective backstop never armed
+and the whole "the child re-derives the facts from nothing" class was green by
+fixture. Its sibling deliberately declares NOTHING, because the unrestricted
+arm has to keep working on the same class.
 """
 
 from __future__ import annotations
@@ -30,7 +38,7 @@ from typing import List
 
 import msgspec
 
-from gen_worker import RequestContext, Resources, Slot, endpoint
+from gen_worker import RequestContext, Resources, Slot, endpoint, worker_function
 from gen_worker.api.binding import wire_ref
 from gen_worker.families.base import GenerationDefaults, family
 
@@ -71,6 +79,8 @@ class CatalogSlotEndpoint:
     def setup(self, pipeline: str) -> None:
         self.pipeline_path = pipeline
 
+    # sdxl `generate`'s declaration, character for character.
+    @worker_function(objectives=("epsilon", "v_prediction"), distilled=False)
     def catalog_generate(
         self, ctx: RequestContext[CatalogDefaults], data: CatalogIn,
     ) -> CatalogOut:
@@ -78,7 +88,15 @@ class CatalogSlotEndpoint:
         weights = Path(self.pipeline_path) / "weights.txt"
         return CatalogOut(response=f"{wire}|{weights.read_text()}")
 
+    # The sibling declares NOTHING: the unrestricted arm must survive on a
+    # class whose other handler is governed.
     def catalog_generate_turbo(
         self, ctx: RequestContext[CatalogDefaults], data: CatalogIn,
     ) -> CatalogOut:
         return CatalogOut(response=f"turbo|{_ref_of(ctx)}")
+
+
+#: The catalog row `harness/catalog-pick` stands for: `wai-illustrious`'s real
+#: stamp, read three ways off the standing hub in pgw#1333's filing.
+CATALOG_OBJECTIVE = "epsilon"
+CATALOG_DISTILLED_STATUS = "classified"

--- a/tests/harness/slot_facts.py
+++ b/tests/harness/slot_facts.py
@@ -1,0 +1,18 @@
+"""pgw#1333: the facts stanza a harness resolution carries.
+
+``MintSlot.facts`` has no default — a slot that cannot say whether the catalog
+answered or was never asked is unconstructable. Harness endpoints resolve
+against no catalog, so they say exactly that, once, here. Every one of them
+declares no ``@worker_function(objectives=...)``, so nothing CHECKS these
+facts; a harness that starts declaring a serving contract must pass a real
+:class:`~gen_worker.serving_facts.ServingFacts` instead (see
+``mint_catalog_slot_pgw969``, which does).
+"""
+
+from __future__ import annotations
+
+from gen_worker.serving_facts import FactsUnavailable
+
+TEST_FACTS = FactsUnavailable(owed_by="a test harness (no catalog is involved)")
+
+__all__ = ["TEST_FACTS"]

--- a/tests/test_adopted_cell_warm_proof_pgw1141.py
+++ b/tests/test_adopted_cell_warm_proof_pgw1141.py
@@ -50,6 +50,10 @@ from typing import Any, Dict, List, Tuple, cast
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
+
 import gen_worker
 import gen_worker.executor as ex_mod
 from gen_worker import RequestContext, Resources, Slot, endpoint, worker_function
@@ -379,7 +383,7 @@ def _boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 
     spec = ex.specs["generate"]
     eff = ex._dispatched_spec(
-        spec, {"pipeline": dispatch_mod.SlotOrder(ref=ref)})
+        spec, {"pipeline": dispatch_mod.SlotOrder(ref=ref, facts=_NO_FACTS)})
     snaps = {normalize_model_ref(ref): pb.Snapshot(
         digest="d1" * 16,
         files=[pb.SnapshotFile(

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -29,6 +29,10 @@ from typing import Any, Dict, List, cast
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
+
 import gen_worker
 from gen_worker import aot_serve, compile_cache, fleet_cells
 from gen_worker.api.decorators import Compile
@@ -186,7 +190,7 @@ def _orders(run):
     from gen_worker import dispatch
 
     return {
-        b.slot: dispatch.SlotOrder(ref=b.ref.strip())
+        b.slot: dispatch.SlotOrder(ref=b.ref.strip(), facts=_NO_FACTS)
         for b in run.models if b.slot
     }
 

--- a/tests/test_applied_lane_pgw1104.py
+++ b/tests/test_applied_lane_pgw1104.py
@@ -23,6 +23,10 @@ from typing import Any, List
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
+
 import gen_worker
 import gen_worker.executor as ex_mod
 from gen_worker import (
@@ -125,7 +129,7 @@ def boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     eff = ex._dispatched_spec(
         ex.specs["generate"],
-        {"pipeline": dispatch.SlotOrder(ref=REF)},
+        {"pipeline": dispatch.SlotOrder(ref=REF, facts=_NO_FACTS)},
     )
     snaps = {
         REF: pb.Snapshot(

--- a/tests/test_armed_target_install_pgw1093.py
+++ b/tests/test_armed_target_install_pgw1093.py
@@ -32,6 +32,10 @@ from typing import Any, List
 
 import msgspec
 import pytest
+
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
 import torch
 
 import gen_worker
@@ -200,7 +204,7 @@ def boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     eff = ex._dispatched_spec(
         ex.specs["generate"],
-        {"pipeline": dispatch.SlotOrder(ref=REF)},
+        {"pipeline": dispatch.SlotOrder(ref=REF, facts=_NO_FACTS)},
     )
     snaps = {
         REF: pb.Snapshot(

--- a/tests/test_boot_adopt_observability_pgw1116.py
+++ b/tests/test_boot_adopt_observability_pgw1116.py
@@ -42,6 +42,8 @@ from typing import Any, Dict, Iterator, List
 
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import activity, boot_adopt, boot_key, cell_resolve
 from gen_worker import executor as executor_mod
 from gen_worker.api import export_contract as export_contract_mod
@@ -623,7 +625,7 @@ def test_a_cold_boot_with_a_reachable_hub_actually_issues_the_resolve(
     slots = {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                      release="prod"),
-        path=str(micro_tree))}
+        path=str(micro_tree), facts=_TEST_FACTS)}
 
     # pgw#1176: three declared classes, three outcomes; this row is about
     # the terminus, which every class reaches identically here.
@@ -693,7 +695,7 @@ def test_the_same_boot_derives_a_key_with_accelerate_UNIMPORTABLE(
     slots = {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                      release="prod"),
-        path=str(micro_tree))}
+        path=str(micro_tree), facts=_TEST_FACTS)}
 
     # pgw#1176: three declared classes, three outcomes; this row is about
     # the terminus, which every class reaches identically here.

--- a/tests/test_cgkey_as_data_pgw1327.py
+++ b/tests/test_cgkey_as_data_pgw1327.py
@@ -42,6 +42,8 @@ from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, cast
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import boot_adopt, cell_resolve, compile_cache as cc, keyset
 from gen_worker.child_contract import CompileSpec
 from gen_worker.keyset import document as doc_mod, store as keyset_store
@@ -635,7 +637,7 @@ def test_the_minted_key_set_is_the_key_set_a_fresh_pod_reads(
     slots = {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                      release="prod"),
-        path=str(micro_tree))}
+        path=str(micro_tree), facts=_TEST_FACTS)}
     declaration = export_declaration(str(cfg.family))
     assert declaration is not None
 

--- a/tests/test_child_traces_its_own_share_pgw1215.py
+++ b/tests/test_child_traces_its_own_share_pgw1215.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, List
 
 import msgspec
 import pytest
+
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
 from gen_worker._vendor.torchcg import spans
 
 torch = pytest.importorskip("torch")
@@ -104,7 +106,7 @@ def _request(tmp_path: Path) -> Any:
         report=str(tmp_path / "report.json"),
         cfg=CompileSpec(family=FAMILY, targets=("unet",), shapes=((4, 4),)),
         slots={"pipeline": MintSlot(
-            ref=_ref(), path=str(tmp_path / "tree"))},
+            ref=_ref(), path=str(tmp_path / "tree"), facts=_TEST_FACTS)},
         phases_snapshot=str(tmp_path / "phases.json"),
         compiled_graph_peak_rss_bytes=1024 ** 3,
     )
@@ -289,7 +291,7 @@ def test_compile_spec_and_slots_survive_the_wire() -> None:
     job = pool.EntryJob(
         function="generate", modules=("a", "b"),
         cfg=CompileSpec(family=FAMILY, targets=("unet",), shapes=((4, 4),)),
-        slots={"pipeline": MintSlot(ref=_ref(), path="/tree")},
+        slots={"pipeline": MintSlot(ref=_ref(), path="/tree", facts=_TEST_FACTS)},
         share="share-000", share_index=0, share_count=2,
         out_dir="/out")
     back = msgspec.json.decode(msgspec.json.encode(job), type=pool.EntryJob)

--- a/tests/test_compile_politeness_pgw1137.py
+++ b/tests/test_compile_politeness_pgw1137.py
@@ -47,6 +47,8 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import (
     aot_compile_child, aot_compile_pool, compile_cache, compile_posture,
     local_serve, mint_child, mint_process, mint_supervisor)
@@ -145,7 +147,7 @@ def test_the_local_serve_entry_DECLARES_the_user_machine_posture(
 
     ctx = local_serve.mint_context(
         function="generate", module="micro_diffusion.endpoint",
-        slots={"pipeline": MintSlot(ref="cozy/micro#1", path="/tmp/micro")})
+        slots={"pipeline": MintSlot(ref="cozy/micro#1", path="/tmp/micro", facts=_TEST_FACTS)})
     local_serve._mint_here(object(), _Pending(), ctx)  # type: ignore[arg-type]
 
     assert cap.task is not None, "the local path must build a MintTask"

--- a/tests/test_declaration_refusal_pgw1075.py
+++ b/tests/test_declaration_refusal_pgw1075.py
@@ -34,6 +34,8 @@ from typing import Dict, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import child_preflight
 from gen_worker import child_contract
 from gen_worker import mint_child, mint_process
@@ -84,7 +86,7 @@ def _request(checkpoint: Path, workdir: Path, *, bucket: int) -> mp.MintRequest:
         slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
                          release="prod"),
-            path=str(checkpoint))},
+            path=str(checkpoint), facts=_TEST_FACTS)},
         device=-1, execution_lane="", configs={})
     request = mint_process.build_request(task, workdir=workdir)
     return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)

--- a/tests/test_declared_blockers_pgw1115.py
+++ b/tests/test_declared_blockers_pgw1115.py
@@ -38,6 +38,8 @@ from typing import Any, List, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import child_preflight
 from gen_worker import child_contract
 from gen_worker import Compile, MintBlocker, fleet_cells
@@ -370,7 +372,7 @@ def _blocked_request(tmp_path: Path) -> mp.MintRequest:
         pending=pending, pipe=object(), function="blocked-echo",
         modules=(HARNESS_MODULE,),
         slots={"pipeline": child_contract.MintSlot(
-            ref=blocked.DECLARED_PIPELINE, path=str(tree))},
+            ref=blocked.DECLARED_PIPELINE, path=str(tree), facts=_TEST_FACTS)},
         execution_lane="w8a8", device=-1)
     request = mint_process.build_request(
         task, workdir=tmp_path / "w")

--- a/tests/test_declared_slot_error_pgw763.py
+++ b/tests/test_declared_slot_error_pgw763.py
@@ -27,7 +27,7 @@ from gen_worker.request_context import RequestContext
 
 
 class _FakeSpec:
-    """The two fields ``resolved_slots_kwargs`` reads for this path.
+    """The fields ``resolved_slots_kwargs`` reads for this path.
 
     Neither slot has a ``default_checkpoint`` and the warm shape supplies no
     hub binding, so both fail resolution at ``resolve_slot``'s ``ref is None``
@@ -42,8 +42,13 @@ class _FakeSpec:
         self.models: dict = {}
         self.defaults_type = None
         self.slot_family: dict = {}
+        # pgw#1333: what the catalog said about each slot. Empty here — no
+        # dispatch and no desired instance bound this spec, which is exactly
+        # the shape under test.
+        self.slot_facts: dict = {}
         self.objectives = None
         self.distilled = None
+        self.name = "fake"
 
 
 def _kwargs() -> dict:

--- a/tests/test_entry_blast_radius_pgw1208.py
+++ b/tests/test_entry_blast_radius_pgw1208.py
@@ -26,6 +26,8 @@ from typing import Any, Dict, List
 
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
@@ -138,7 +140,7 @@ def _drive_to_load(
         slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/composed",
                          release="prod"),
-            path=str(tree))},
+            path=str(tree), facts=_TEST_FACTS)},
     )
     with pytest.raises(BaseException):
         mint_child.mint(request)

--- a/tests/test_identity_soundness_pgw1113.py
+++ b/tests/test_identity_soundness_pgw1113.py
@@ -25,6 +25,8 @@ from typing import Any, Dict
 
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import boot_key, fleet_cells, graph_facts, keyset, local_cell_store
 from gen_worker.keyset import document as keyset_doc, store as keyset_store
 
@@ -219,7 +221,7 @@ def _spec() -> CompileSpec:
 
 
 def _slots(ref: Any, path: str = "/cas/a") -> Dict[str, MintSlot]:
-    return {"pipeline": MintSlot(ref=ref, path=path)}
+    return {"pipeline": MintSlot(ref=ref, path=path, facts=_TEST_FACTS)}
 
 
 def test_a_rebinding_forces_a_memo_MISS() -> None:

--- a/tests/test_legacy_arms_pgw1307b.py
+++ b/tests/test_legacy_arms_pgw1307b.py
@@ -25,6 +25,8 @@ from typing import Any
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import ServingFacts
+
 from gen_worker import RequestContext, Slot, endpoint, worker_function  # noqa: E402
 
 
@@ -95,10 +97,11 @@ def test_an_ungoverned_slot_is_never_asked_for_evidence() -> None:
     spec = extract_specs(Gen)[0]
     slots = {
         "pipeline": dispatch.SlotOrder(
-            ref="acme/plain-xl", distilled=False,
-            distilled_status="classified"),
+            ref="acme/plain-xl", facts=ServingFacts(
+                distilled=False, distilled_status="classified")),
         "interpolator": dispatch.SlotOrder(
-            ref="acme/rife", distilled=False, distilled_status="unclassified"),
+            ref="acme/rife", facts=ServingFacts(
+                distilled=False, distilled_status="unclassified")),
     }
 
     result = resolved_slots_kwargs(spec, slots)

--- a/tests/test_load_telemetry_pgw1041.py
+++ b/tests/test_load_telemetry_pgw1041.py
@@ -218,6 +218,41 @@ def test_a_refused_phase_is_closed_as_ended_not_complete(tmp_path, monkeypatch):
     assert all("complete" not in ev.detail for ev in done), [
         ev.detail for ev in done]
     assert done[-1].phase.startswith("hydrate:")
+    # pgw#1334: "ended" was not enough. A pod's `load_phase_done ... staged
+    # 0.55 GiB of 6.31 GiB` was read as "the load finished with 9% of the tree
+    # on disk", and the blocker was filed as an incomplete-stage hazard. The
+    # row must SAY it is the raising path.
+    assert "on a RAISE" in done[-1].detail, done[-1].detail
+    # ...and a mid-load phase transition decides nothing about the LOAD, so
+    # it claims nothing either way.
+    assert all(
+        "on a RAISE" not in ev.detail and "without error" not in ev.detail
+        for ev in done[:-1]), [ev.detail for ev in done[:-1]]
+    assert all("staged" not in ev.detail for ev in done), [
+        ev.detail for ev in done]
+
+
+def test_the_byte_line_says_what_its_numbers_are(tmp_path, monkeypatch):
+    """pgw#1334, the other half. Neither number in the byte line is a staging
+    fraction: the left is this process's anon RSS and the right is `os.walk`
+    over a tree that is ALREADY on disk. Their ratio is a memory-residency
+    observation about a COMPLETE tree, so the row must not offer the word
+    "staged" for someone to read a progress fraction out of."""
+    monkeypatch.setattr(postmortem, "LOAD_PROGRESS_PATH", tmp_path / "m.json")
+    with _PhaseEvents() as events:
+        rep = load_progress.LoadProgressReporter(
+            "pipeline:test/tiny@latest", 6 * 1024 ** 3,
+            marker_path=tmp_path / "m.json", interval_s=0.5).start()
+        rep.stop(clean=True)
+    rows = (events.of_kind(load_progress.EVENT_PHASE)
+            + events.of_kind(load_progress.EVENT_PHASE_DONE))
+    assert rows
+    for ev in rows:
+        assert "staged" not in ev.detail, ev.detail
+        assert "resident" in ev.detail and "tree on disk" in ev.detail, ev.detail
+    done = events.of_kind(load_progress.EVENT_PHASE_DONE)
+    assert all("without error" in ev.detail for ev in done), [
+        ev.detail for ev in done]
 
 
 def test_component_admission_refuses_structural(tmp_path, monkeypatch):

--- a/tests/test_local_serve_no_publisher_pgw1127.py
+++ b/tests/test_local_serve_no_publisher_pgw1127.py
@@ -35,6 +35,8 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 import tcg_artifacts
 from gen_worker import fleet_cells, local_cell_store, local_serve, mint_supervisor
 from gen_worker.cell_adopt import AdoptOutcome
@@ -158,7 +160,7 @@ def armable(monkeypatch: pytest.MonkeyPatch) -> List[Path]:
 def _ctx() -> local_serve.LocalMintContext:
     return local_serve.mint_context(
         function="generate", module="micro_diffusion.endpoint",
-        slots={"pipeline": MintSlot(ref="cozy/micro#1", path="/tmp/micro")},
+        slots={"pipeline": MintSlot(ref="cozy/micro#1", path="/tmp/micro", facts=_TEST_FACTS)},
     )
 
 

--- a/tests/test_measure_only_pgw1134.py
+++ b/tests/test_measure_only_pgw1134.py
@@ -46,6 +46,8 @@ from typing import Any, Dict, Iterator, List, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import child_preflight
 from gen_worker import activity, aot_compile_child, boot_trace_child, boot_key
 from gen_worker import measure_child, mint_child
@@ -147,7 +149,7 @@ def _slots(tree: Path) -> Dict[str, MintSlot]:
     return {"pipeline": MintSlot(
         ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                      release="prod"),
-        path=str(tree))}
+        path=str(tree), facts=_TEST_FACTS)}
 
 
 def _measure_job(tree: Path) -> measure_child.MeasureJob:

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -36,8 +36,11 @@ from typing import Any, List, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import child_preflight
 from gen_worker import child_contract
+from gen_worker import serving_facts
 from gen_worker import handler_proof
 from gen_worker import mint_child, mint_process, registry, warmup
 from gen_worker import mint_process as mp
@@ -89,7 +92,15 @@ def served(tmp_path: Path) -> Tuple[Path, ModelRef]:
                 request_id="r-969", attempt=1,
                 function_name="catalog-generate",
                 input_payload=msgspec.msgpack.encode(catalog.CatalogIn()),
-                models=[pb.ModelBinding(slot="pipeline", ref=PICK_REF)],
+                models=[pb.ModelBinding(
+                    slot="pipeline", ref=PICK_REF,
+                    # pgw#1333: the hub's dispatch stamp. `catalog_generate`
+                    # declares objectives=(epsilon, v_prediction) — WITHOUT
+                    # these three fields the parent's own dispatch refuses,
+                    # which is the defect this fixture now proves absent.
+                    objective=catalog.CATALOG_OBJECTIVE,
+                    distilled=False,
+                    distilled_status=catalog.CATALOG_DISTILLED_STATUS)],
                 snapshots={PICK_REF: snap},
             ))
             res = conn.wait_for(is_result_for("r-969")).job_result
@@ -113,8 +124,16 @@ def served(tmp_path: Path) -> Tuple[Path, ModelRef]:
     return trees[0], _hub_binding_for_wire_ref(PICK_REF)
 
 
+#: What the parent resolved for the catalog slot — the same triple the hub
+#: stamped on the dispatch above (pgw#1333).
+CATALOG_FACTS = serving_facts.ServingFacts(
+    objective=catalog.CATALOG_OBJECTIVE, distilled=False,
+    distilled_status=catalog.CATALOG_DISTILLED_STATUS)
+
+
 def _request(
     tree: Path, binding: Any, tmp_path: Path, *, function: str = "catalog-generate",
+    facts: serving_facts.SlotEvidence = CATALOG_FACTS,
 ) -> mp.MintRequest:
     """The child's request, built through the REAL parent chain and
     round-tripped through msgspec — the boundary IS a file.
@@ -134,7 +153,8 @@ def _request(
         spec=SimpleNamespace(name=function), instance=object(), snapshots=None,
         pendings={}, pipes={},
         modules=(CATALOG_MODULE,),
-        slots=({"pipeline": child_contract.MintSlot(ref=binding, path=str(tree))}
+        slots=({"pipeline": child_contract.MintSlot(
+                    ref=binding, path=str(tree), facts=facts)}
                if binding is not None else {}),
     )
     task = mint_process.MintTask(
@@ -338,7 +358,7 @@ def test_a_bound_slot_that_still_fails_names_the_divergence(
     request = msgspec.structs.replace(
         request, slots={"nonexistent-slot": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/pick", release="prod"),
-            path=str(tmp_path))})
+            path=str(tmp_path), facts=CATALOG_FACTS)})
     with pytest.raises(child_preflight.PreflightRefused) as exc:
         _child_specs(request)
     assert "sent no resolved binding" in str(exc.value)
@@ -368,7 +388,7 @@ def test_a_code_default_never_stands_in_for_the_parents_pick(
     assert wire_ref(chosen.models["pipeline"]) == declared
 
     child_preflight.bind_slots(siblings, {"pipeline": child_contract.MintSlot(
-        ref=picked, path=str(tmp_path))})
+        ref=picked, path=str(tmp_path), facts=CATALOG_FACTS)})
     with __import__("tempfile").TemporaryDirectory() as tmp:
         ctx = warmup.warm_context(
             chosen, request_id="mint-child-x", local_output_dir=tmp)
@@ -415,15 +435,24 @@ def test_a_slot_with_bytes_and_no_identity_cannot_be_constructed() -> None:
     with two defaults. ``ref`` and ``path`` now have none.
     """
     with pytest.raises(TypeError):
-        child_contract.MintSlot(path="/cas/snapshots/sha256:cafe")   # type: ignore[call-arg]
+        child_contract.MintSlot(                                     # type: ignore[call-arg]
+            path="/cas/snapshots/sha256:cafe", facts=CATALOG_FACTS)
     with pytest.raises(TypeError):
         child_contract.MintSlot(ref=ModelRef(                        # type: ignore[call-arg]
-            source="tensorhub", path="harness/pick", release="prod"))
+            source="tensorhub", path="harness/pick", release="prod"),
+            facts=CATALOG_FACTS)
+    # pgw#1333: and the third half — a ref and a tree with no statement about
+    # what the checkpoint IS. The child holds the declaration and would have
+    # nothing to check it against.
+    with pytest.raises(TypeError):
+        child_contract.MintSlot(                                     # type: ignore[call-arg]
+            ref=ModelRef(source="tensorhub", path="harness/pick", release="prod"),
+            path="/cas/snapshots/sha256:cafe")
     # ...and the degenerate spelling of the same lie.
     with pytest.raises(ValueError):
         child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="harness/pick", release="prod"),
-            path="")
+            path="", facts=CATALOG_FACTS)
 
 
 def test_the_pods_wire_no_longer_decodes(

--- a/tests/test_mint_recipe_parity_pgw984_pgw985.py
+++ b/tests/test_mint_recipe_parity_pgw984_pgw985.py
@@ -39,6 +39,8 @@ from typing import Any, Dict, List, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 from gen_worker import child_preflight
 from gen_worker import child_contract
 from gen_worker import compile_cache as cc
@@ -179,7 +181,7 @@ def _request(
         slots={"pipeline": child_contract.MintSlot(
             ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
                          release="prod"),
-            path=str(checkpoint))},
+            path=str(checkpoint), facts=_TEST_FACTS)},
         device=-1, execution_lane="", configs={})
     request = mint_process.build_request(task, workdir=workdir)
     # The boundary IS a file: round-trip it exactly as the child decodes it.

--- a/tests/test_objectives_pgw654.py
+++ b/tests/test_objectives_pgw654.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import ServingFacts
+
 
 @pytest.fixture()
 def tmp_pkg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -313,8 +315,7 @@ def test_wire_distillation_status_reaches_the_slot_backstop() -> None:
     slots = {
         "pipeline": dispatch.SlotOrder(
             ref="acme/plain-xl",
-            distilled=False,
-            distilled_status="unclassified",
+            facts=ServingFacts(distilled=False, distilled_status="unclassified"),
         )
     }
 

--- a/tests/test_resolved_manifest_pgw1246.py
+++ b/tests/test_resolved_manifest_pgw1246.py
@@ -106,9 +106,18 @@ def test_the_wire_has_no_syntax_left_for_subtraction() -> None:
 def test_the_child_contract_carries_no_second_tree() -> None:
     """A composed manifest names a COHERENT tree, so there is no second tree
     for four child processes to be handed — and no field for them to speak
-    that the parent stopped sending."""
+    that the parent stopped sending.
+
+    Pinned as "exactly ONE location field", not as a field count: pgw#1333
+    added `facts` (what the catalog says the checkpoint IS), which is neither
+    a tree nor a narrowing of one. A count would have gone red for it and
+    said "second tree", which is the wrong sentence.
+    """
     assert "component_paths" not in MintSlot.__struct_fields__
-    assert MintSlot.__struct_fields__ == ("ref", "path")
+    located = [f for f in MintSlot.__struct_fields__
+               if f in ("path", "component_paths", "paths", "trees", "root")]
+    assert located == ["path"], MintSlot.__struct_fields__
+    assert set(MintSlot.__struct_fields__) == {"ref", "path", "facts"}
 
 
 def test_a_binding_pins_exactly_one_ref() -> None:

--- a/tests/test_rotation_preload_pgw674.py
+++ b/tests/test_rotation_preload_pgw674.py
@@ -34,6 +34,10 @@ import hashlib
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
+
 from gen_worker.models.refs import WireRef
 from gen_worker import Hub, RequestContext, Slot, endpoint, worker_function
 from gen_worker.executor import Executor, _Job
@@ -186,7 +190,7 @@ def _orders(run):
     from gen_worker import dispatch
 
     return {
-        b.slot: dispatch.SlotOrder(ref=b.ref.strip())
+        b.slot: dispatch.SlotOrder(ref=b.ref.strip(), facts=_NO_FACTS)
         for b in run.models if b.slot
     }
 

--- a/tests/test_slot_facts_carry_pgw1333.py
+++ b/tests/test_slot_facts_carry_pgw1333.py
@@ -1,0 +1,321 @@
+"""pgw#1333: the serving facts are RESOLVED once and CARRIED, never re-derived.
+
+**The defect.** ``child_contract.MintSlot`` was ``(ref, path)``. Every mint and
+boot-trace child re-derived its slot resolution through
+``child_preflight.assert_slots_resolvable`` ->
+``warmup.resolved_slots_kwargs(spec, None)`` — ``slots=None``, hardcoded — so
+the objective the chain read was ``""`` and ``api.slot._finish_resolved``
+refused the moment the invoked function declared ``objectives=``. Every AOT
+mint and every boot adoption of every such function, on any catalog data,
+forever. It cost e2e#1892 leg-A run 3 a paid L40S pod and cost the blocker its
+correct attribution: the refusal says *"resolved checkpoint carries no training
+objective"*, so it was filed against the checkpoint. The checkpoint was fine.
+
+**The shape of the fix.** The facts are a TYPE
+(:mod:`gen_worker.serving_facts`), they ride ``SlotOrder`` -> ``spec.slot_facts``
+-> ``MintSlot`` -> back onto the child's rediscovered spec, and "nobody
+resolved them" is a distinct member of that type which NAMES its owner. The
+two states an empty string used to conflate — *the catalog says nothing* and
+*nobody asked the catalog* — now refuse with different sentences.
+
+Every test below fails if any link in that chain drops the facts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Tuple, cast
+
+import msgspec
+import pytest
+
+from gen_worker import child_contract, child_preflight, dispatch, registry, serving_facts
+from gen_worker import warmup
+from gen_worker.api.binding import ModelRef
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+CATALOG_MODULE = "harness.mint_catalog_slot_pgw969"
+#: `wai-illustrious`' real stamp, read three ways off the standing hub when
+#: pgw#1333 was filed: objective=epsilon, distilled=f, status=classified.
+EPSILON = serving_facts.ServingFacts(
+    objective="epsilon", distilled=False, distilled_status="classified")
+PICKED = ModelRef(source="tensorhub", path="harness/catalog-pick", release="prod")
+
+
+def _siblings() -> Tuple[Any, List[Any]]:
+    """Exactly what a child does first: a FRESH discovery, holding the
+    declaration and nothing the parent resolved."""
+    specs = registry.collect_endpoints([CATALOG_MODULE])
+    return child_preflight.select_specs(specs, "catalog-generate")
+
+
+def _preflight(facts: serving_facts.SlotEvidence, tmp_path: Path) -> None:
+    chosen, siblings = _siblings()
+    assert chosen.objectives == ("epsilon", "v_prediction"), (
+        "the harness endpoint must declare sdxl's serving contract, or this "
+        "whole file is green on a shape that cannot exhibit the defect")
+    slots = {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path=str(tmp_path), facts=facts)}
+    child_preflight.bind_slots(siblings, slots)
+    child_preflight.assert_slots_resolvable(
+        siblings, slots, what="boot key derivation for 'catalog-generate'")
+
+
+# ---------------------------------------------------------------------------
+# 1. The type: a resolved slot cannot be written down without its facts
+# ---------------------------------------------------------------------------
+
+
+def test_a_slot_cannot_be_constructed_without_a_facts_stanza() -> None:
+    """``ref`` and ``path`` alone are the pod's request. It must not decode.
+
+    pgw#974 made bytes-without-identity unconstructable for the same reason
+    and by the same means; this is the third half of one resolution.
+    """
+    with pytest.raises(TypeError):
+        child_contract.MintSlot(ref=PICKED, path="/tree")  # type: ignore[call-arg]
+
+
+def test_the_wire_carries_the_facts_and_which_kind_they_are() -> None:
+    """The parent/child boundary is a JSON file, so the constructor is only
+    half the guard. Both members of the union must survive the round trip
+    DISTINGUISHABLY — collapsing them back to one is the defect."""
+    for facts in (EPSILON, serving_facts.FactsUnavailable(owed_by="a sender")):
+        slot = child_contract.MintSlot(ref=PICKED, path="/tree", facts=facts)
+        back = msgspec.json.decode(
+            msgspec.json.encode(slot), type=child_contract.MintSlot)
+        assert back == slot
+        assert type(back.facts) is type(facts)
+
+
+def test_an_anonymous_gap_is_not_expressible() -> None:
+    """``FactsUnavailable`` must name WHO owes the stamp. A blank owner is the
+    empty string this type exists to abolish, wearing a struct."""
+    with pytest.raises(ValueError):
+        serving_facts.FactsUnavailable(owed_by="  ")
+
+
+def test_a_bogus_objective_is_refused_at_construction() -> None:
+    """Validated where it is built, not at the gate that reads it: a typo
+    reaching ``_finish_resolved`` produces "not in the declared objectives",
+    which reads as a compatibility refusal and is really a decode bug."""
+    with pytest.raises(ValueError):
+        serving_facts.ServingFacts(objective="epsilion")
+    with pytest.raises(ValueError):
+        serving_facts.ServingFacts(distilled_status="probably")
+
+
+# ---------------------------------------------------------------------------
+# 2. The defect itself: the carried facts RESOLVE the child's preflight
+# ---------------------------------------------------------------------------
+
+
+def test_the_parents_facts_resolve_the_childs_preflight(tmp_path: Path) -> None:
+    """THE regression. An sdxl-shaped spec + an epsilon checkpoint resolves.
+
+    Red without the fix: ``assert_slots_resolvable`` re-derived the objective
+    from ``resolved_slots_kwargs(spec, None)`` and got ``""``, so this raised
+    ``PreflightRefused`` on catalog data that satisfies the contract exactly.
+    """
+    _preflight(EPSILON, tmp_path)  # must not raise
+
+
+def test_a_mismatch_still_refuses(tmp_path: Path) -> None:
+    """The gate was not bought by deleting it. A ``flow`` checkpoint into an
+    ``(epsilon, v_prediction)`` function is a real incompatibility and must
+    still be a named refusal."""
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        _preflight(
+            serving_facts.ServingFacts(
+                objective="flow", distilled=False,
+                distilled_status="classified"),
+            tmp_path)
+    assert "is not in the invoked function's declared objectives" in str(exc.value)
+
+
+def test_an_unclassified_checkpoint_still_refuses(tmp_path: Path) -> None:
+    """The catalog ANSWERED, and the answer was "nothing measured this axis".
+    A declared contract fails closed against that exactly as the hub's own two
+    gates do (§1.22) — the fix must not turn a real absence of evidence into a
+    vacuous pass on a money surface."""
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        _preflight(serving_facts.ServingFacts(), tmp_path)
+    assert "carries no training objective" in str(exc.value)
+
+
+def test_a_distilled_mismatch_still_refuses(tmp_path: Path) -> None:
+    """The orthogonal axis, on the same carried stanza."""
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        _preflight(
+            serving_facts.ServingFacts(
+                objective="epsilon", distilled=True,
+                distilled_status="classified"),
+            tmp_path)
+    assert "distilled=True" in str(exc.value)
+
+
+def test_unstamped_distillation_evidence_still_refuses(tmp_path: Path) -> None:
+    """``distilled=False`` with an unstamped status is not evidence of False."""
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        _preflight(
+            serving_facts.ServingFacts(objective="epsilon", distilled=False),
+            tmp_path)
+    assert "distillation evidence is unstamped" in str(exc.value)
+
+
+def test_the_undeclared_sibling_is_unaffected(tmp_path: Path) -> None:
+    """``catalog_generate_turbo`` declares nothing, so no facts are CHECKED
+    for it — including when there are none. Refusing here would refuse every
+    family that never opted into the serving contract."""
+    specs = registry.collect_endpoints([CATALOG_MODULE])
+    chosen, siblings = child_preflight.select_specs(
+        specs, "catalog-generate-turbo")
+    assert chosen.objectives is None and chosen.distilled is None
+    # The sibling set includes the GOVERNED handler, so a gap still refuses —
+    # the class is minted as a class (pgw#654). Resolve the governed one and
+    # the ungoverned one must ride along.
+    slots = {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path=str(tmp_path), facts=EPSILON)}
+    child_preflight.bind_slots(siblings, slots)
+    child_preflight.assert_slots_resolvable(siblings, slots, what="turbo")
+
+
+def test_an_undeclared_class_resolves_with_no_facts_at_all(tmp_path: Path) -> None:
+    """A family that declares NOTHING must mint with a bare
+    ``FactsUnavailable`` — the unrestricted arm reads no facts, so a gap costs
+    it nothing and must not refuse."""
+    specs = registry.collect_endpoints(["harness.toy_endpoints"])
+    chosen, siblings = child_preflight.select_specs(specs, "juggle-echo")
+    assert chosen.objectives is None
+    slots = {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path=str(tmp_path),
+        facts=serving_facts.FactsUnavailable(owed_by="nothing asked"))}
+    child_preflight.bind_slots(siblings, slots)
+    child_preflight.assert_slots_resolvable(siblings, slots, what="juggle")
+
+
+# ---------------------------------------------------------------------------
+# 3. The gap fails LOUD, and blames the right repo
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_stamp_refuses_by_name_and_names_the_hub(tmp_path: Path) -> None:
+    """The boot half is a HUB gap: ``hello_ack.go`` builds
+    ``DesiredInstance.ModelBinding`` with the three serving-fact fields left
+    zero, though the proto has them and the dispatch path stamps them.
+
+    Until tensorhub fills them the worker still refuses — §1.22 fail-closed —
+    but it must refuse with a sentence naming the WIRE, not one that reads as
+    a verdict on the checkpoint. That mis-reading is what sent e2e#1892's
+    blocker at the catalog, where three independent reads showed the stamp
+    present and correct.
+    """
+    with pytest.raises(child_preflight.PreflightRefused) as exc:
+        _preflight(
+            serving_facts.FactsUnavailable(owed_by=dispatch.BOOT_SENDER_OWES),
+            tmp_path)
+    msg = str(exc.value)
+    assert "crossed WITHOUT its serving facts" in msg
+    assert "hello_ack.go" in msg
+    assert "objective" in msg and "distilled_status" in msg
+    assert "NOT a claim about the checkpoint's catalog row" in msg
+    assert "carries no training objective" not in msg, (
+        "the gap must not borrow the sentence that blames the checkpoint — "
+        "that borrowing is what cost this bug its correct attribution")
+
+
+# ---------------------------------------------------------------------------
+# 4. The parent half: one projection, and it reads every field
+# ---------------------------------------------------------------------------
+
+
+def test_the_dispatch_sender_stamps_so_its_zero_triple_is_an_answer() -> None:
+    """``RunJob.models`` comes from the hub's catalog stamp, so an empty
+    objective there is the catalog saying "unclassified" — a real answer, and
+    a refusal against it is a real refusal."""
+    order = dispatch.order_from_binding(
+        pb.ModelBinding(slot="pipeline", ref="tensorhub/x@prod"))
+    assert order.facts == serving_facts.ServingFacts()
+
+
+def test_every_wire_field_is_read(tmp_path: Path) -> None:
+    """The boot path built ``SlotOrder(ref=ref)`` and dropped three fields the
+    message already carried. One projection now, for every sender."""
+    order = dispatch.order_from_binding(pb.ModelBinding(
+        slot="pipeline", ref="tensorhub/x@prod",
+        inference_defaults='{"steps": 4}',
+        objective="v_prediction", distilled=True,
+        distilled_status="classified"))
+    assert order.facts == serving_facts.ServingFacts(
+        objective="v_prediction", distilled=True,
+        distilled_status="classified")
+    assert order.inference_defaults == '{"steps": 4}'
+
+
+def test_the_boot_sender_zero_triple_reads_as_the_gap_it_is() -> None:
+    """proto3 scalars have no presence, so a sender KNOWN not to stamp yet is
+    read as the wire gap rather than as an unclassified row. The distinction
+    is the whole point of ``owed_by``."""
+    order = dispatch.order_from_binding(
+        pb.ModelBinding(slot="pipeline", ref="tensorhub/x@prod"),
+        owed_by=dispatch.BOOT_SENDER_OWES)
+    assert isinstance(order.facts, serving_facts.FactsUnavailable)
+    assert "hello_ack.go" in order.facts.owed_by
+    # ...but the moment the hub DOES stamp, the same call reads the answer.
+    stamped = dispatch.order_from_binding(
+        pb.ModelBinding(
+            slot="pipeline", ref="tensorhub/x@prod", objective="epsilon",
+            distilled_status="classified"),
+        owed_by=dispatch.BOOT_SENDER_OWES)
+    assert stamped.facts == EPSILON
+
+
+def test_an_order_cannot_be_built_without_saying_which_kind() -> None:
+    """No default on ``SlotOrder.facts``: a construction site that has not
+    thought about the facts is a compile error, not a blank objective."""
+    with pytest.raises(TypeError):
+        dispatch.SlotOrder(ref="tensorhub/x@prod")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# 5. The seam between them: the parent's spec carries what it resolved
+# ---------------------------------------------------------------------------
+
+
+def test_the_dispatched_spec_folds_the_facts_in_beside_the_ref() -> None:
+    """``_dispatched_spec`` is where the order becomes the spec every
+    downstream consumer reads. It folded in the ref and dropped the facts —
+    invisibly, because the only consumer that noticed was a child process."""
+    from types import SimpleNamespace
+
+    from gen_worker.executor import Executor
+
+    specs = registry.collect_endpoints([CATALOG_MODULE])
+    chosen, _ = child_preflight.select_specs(specs, "catalog-generate")
+    order = dispatch.order_from_binding(pb.ModelBinding(
+        slot="pipeline", ref="tensorhub/catalog-pick@prod",
+        objective="epsilon", distilled_status="classified"))
+    ex = object.__new__(Executor)
+    ex._hub_bindings = {}
+    ex.store = cast(Any, SimpleNamespace(register_binding=lambda *a, **k: None))
+    effective = Executor._dispatched_spec(ex, chosen, {"pipeline": order})
+    assert effective.slot_facts["pipeline"] == EPSILON
+    # ...and the resolution chain now reads them from there, on the WARM
+    # shape (`slots=None`) that every child uses.
+    kwargs = warmup.resolved_slots_kwargs(effective, None)
+    assert not kwargs["slot_errors"], kwargs["slot_errors"]
+    assert kwargs["resolved_slots"]["pipeline"].objective == "epsilon"
+
+
+def test_bind_slots_reinstalls_the_facts_in_a_rediscovered_child() -> None:
+    """The child re-runs discovery, so ``spec.slot_facts`` comes back EMPTY —
+    exactly as ``spec.models`` does. A binding installed without its facts is
+    half a resolution, and the half that was missing."""
+    _, siblings = _siblings()
+    for spec in siblings:
+        assert not spec.slot_facts
+    child_preflight.bind_slots(siblings, {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path="/tree", facts=EPSILON)})
+    for spec in siblings:
+        assert spec.slot_facts["pipeline"] == EPSILON
+        assert spec.models["pipeline"] == PICKED

--- a/tests/test_stranded_family_still_mints_pgw1215.py
+++ b/tests/test_stranded_family_still_mints_pgw1215.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 torch = pytest.importorskip("torch")
 
 from gen_worker import aot_compile_child as child  # noqa: E402
@@ -72,7 +74,7 @@ def _job(checkpoint: Path, tmp_path: Path) -> pool.EntryJob:
         slots={"pipeline": MintSlot(
             ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
                          release="prod"),
-            path=str(checkpoint))},
+            path=str(checkpoint), facts=_TEST_FACTS)},
         share="share-000", share_index=0, share_count=1,
         out_dir=str(tmp_path / "artifacts"), work=str(tmp_path / "work"),
         report=str(tmp_path / "report.json"))

--- a/tests/test_trace_child_placement_pgw1124.py
+++ b/tests/test_trace_child_placement_pgw1124.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, List, Tuple
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
@@ -276,7 +278,7 @@ def _job(micro_tree: Path, report: Path) -> Any:
         slots={"pipeline": MintSlot(
             ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                          release="prod"),
-            path=str(micro_tree))},
+            path=str(micro_tree), facts=_TEST_FACTS)},
         report=str(report),
         code_digest=boot_key.CODE_DIGEST,
     )

--- a/tests/test_warm_tax_pgw654.py
+++ b/tests/test_warm_tax_pgw654.py
@@ -32,6 +32,10 @@ from typing import Annotated, Any, List, Optional, Tuple
 import msgspec
 import pytest
 
+from gen_worker.serving_facts import FactsUnavailable as _FU
+
+_NO_FACTS = _FU(owed_by="a test that resolves no catalog")
+
 from gen_worker import (
     AxisClass,
     CompileAxis,
@@ -131,7 +135,7 @@ def _orders(run):
     from gen_worker import dispatch
 
     return {
-        b.slot: dispatch.SlotOrder(ref=b.ref.strip())
+        b.slot: dispatch.SlotOrder(ref=b.ref.strip(), facts=_NO_FACTS)
         for b in run.models if b.slot
     }
 

--- a/tests/test_weight_free_premise_pgw1173.py
+++ b/tests/test_weight_free_premise_pgw1173.py
@@ -32,6 +32,8 @@ from typing import Any, Dict
 import msgspec
 import pytest
 
+from harness.slot_facts import TEST_FACTS as _TEST_FACTS
+
 torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
@@ -433,7 +435,7 @@ def _job(micro_tree: Path, report: Path, *, extra_targets: tuple = ()) -> Any:
         slots={"pipeline": MintSlot(
             ref=ModelRef(source="tensorhub", path="cozy/micro-diffusion",
                          release="prod"),
-            path=str(micro_tree))},
+            path=str(micro_tree), facts=_TEST_FACTS)},
         report=str(report),
         code_digest=boot_key.CODE_DIGEST,
     )


### PR DESCRIPTION
Fixes the pgw#1232 acceptance blocker, and disposes of pgw#1334.

## pgw#1333 — the mechanism

`child_contract.MintSlot` was `(ref, path)`. Every mint and boot-trace child
re-derived its slot resolution through `child_preflight.assert_slots_resolvable`
-> `warmup.resolved_slots_kwargs(spec, None)` — `slots=None`, **hardcoded**. With
no orders the chain read objective `""`, and `api/slot.py:_finish_resolved`
refuses the moment the invoked function declares `objectives=`.

So **every AOT mint and every boot adoption of every function that declares a
serving contract refused `slots_unresolvable`, on any catalog data.** sdxl has
declared `objectives=("epsilon","v_prediction")` since pgw#654; z-image was next
in line and dies identically. It cost e2e#1892 leg-A a paid L40S pod — and it
cost the blocker its attribution, because the refusal reads *"resolved checkpoint
carries no training objective"* and was filed against a checkpoint whose stamp is
present and correct.

## The shape of the fix

The facts are a **type** now (`gen_worker/serving_facts.py`), with two members,
because an empty string was standing for two different states:

- `ServingFacts` — the catalog was asked and answered. An empty objective *here*
  is a real answer, and a declared contract still fails closed against it.
- `FactsUnavailable(owed_by=...)` — **nobody asked**, carrying who owes the stamp.

Neither `MintSlot.facts` nor `SlotOrder.facts` has a default: a resolution that
cannot say which of the two it is does not compile. They are resolved once and
carried — `dispatch.order_from_binding` is the single projection of a wire
`ModelBinding` (the boot path read one of five fields and built
`SlotOrder(ref=ref)`), `executor._dispatched_spec` folds them onto
`EndpointSpec.slot_facts` by the statement that folds in the ref, and
`child_preflight.bind_slots` reinstalls them onto a child's rediscovered spec.

## Owed by tensorhub

`hello_ack.go` builds `DesiredInstance.models[]` leaving **`.objective`,
`.distilled`, `.distilled_status`** zero, though the proto carries them
(`ModelBinding` fields 6/7/8) and the dispatch path stamps the same message.
Until it lands, a governed boot slot still refuses — §1.22 fail-closed — but with
a sentence naming the wire field and the repo (`dispatch.BOOT_SENDER_OWES`),
never one that reads as a verdict on the checkpoint.

## pgw#1334 — separated by evidence, NOT a duplicate

Both candidate causes are refuted at source:

- **"the #1333 refusal tore down staging"** — dead. `_materialize_local`
  completes at `executor.py:5402` before `_boot_adopt` is called at `:5463`, by
  await order *and* by data dependency (`resolved_slots`); the boot-trace
  children are `start_new_session=True` subprocesses whose `PreflightRefused`
  never crosses the process boundary.
- **"`load_phase_done` fired at 9% staged"** — the load was never 9% staged.
  That row's left number is the process's anon RSS and its right is `os.walk`
  over a tree already complete on disk; the ratio cannot express incompleteness.
  The row now says what its numbers are, and `stop(raised=...)` says which way
  the load ended.

The `config.json` fatal itself is a **th#1941 manifest-composition** gap: the
composed manifest omitted the file, and every worker-side check
(`_tree_matches`, `_verify_snapshot_tree`, `refetch_corrupt`) validates the tree
*against that manifest* and therefore passes.

## Tests

`tests/test_slot_facts_carry_pgw1333.py` (18) plus the pgw#969 harness endpoint,
which now declares sdxl's serving contract — without it that regression test was
green on a shape that cannot exhibit this class, the same green-by-fixture trap
its own docstring warns about one axis over.

Red 5/5 on the pre-fix tree for the refusal; green = the same spec + carried
facts mints. Mismatch, unclassified-catalog and unstamped-distillation arms all
still refuse — the gate was not bought by deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)