### PR TITLE
pgw#1329: arm compiled graphs from store-sourced constants by manifest FQN — the eager module stops being a bind precondition

### DIFF
--- a/changelog.d/pgw1329.md
+++ b/changelog.d/pgw1329.md
@@ -1,0 +1,48 @@
+- **A compiled graph arms from the store, and the eager module stops being a bind
+  precondition.** `arm_compiled_graph` bound `resident_constants(module)` — the LIVE eager
+  module's named parameters and buffers — so serving one compiled graph required the whole
+  diffusers pipeline resident purely as the constant SOURCE. That is the single reason an
+  adopt-only serve host could not shed eager loading, and it was never a property of
+  compiled serving: the artifact's manifest already declares every constant by
+  fully-qualified name, torch dtype and exact shape.
+
+  `gen_worker.aot_constants` reads that declaration as a versioned, typed manifest —
+  validated `ConstantFQN` / `TorchDtype` / `GraphClassName` / `WeightSetRef` newtypes, a
+  `ConstantSourceKind` enum, an exact-field-set row parser, and an envelope-version check
+  that refuses a `compiled_graph_format` this reader does not understand *before* it
+  interprets one row — and resolves it against a `ConstantStore` in **two phases that are
+  never merged**. `plan_store_constants` checks the whole table against the store's
+  *headers*: absent, dtype-drifted and shape-drifted constants are one typed refusal each,
+  naming every FQN at fault, with no device byte allocated on any path through it.
+  `realize_store_constants` then reads only what was planned. The split is the point —
+  `CompiledGraphRunner.bind` is once-only and marks itself failed on a partial table, so a
+  miss discovered mid-bind costs the runner as well as the memory.
+
+  `arm_compiled_graph_from_store` is the same arm as the module one — same resolve, same
+  worker quarantine gate, same `CallIngress`, same `EntryDispatch` — with the store as the
+  constant source and no `nn.Module` anywhere on the path. Loading the eager pipeline
+  becomes a POLICY choice (eager fallback, the mint's own proofs) rather than a
+  precondition. The resolve half both arms share is extracted to `_resolve_graph_class`,
+  because a resolve that models the artifact differently from the arm is the same class of
+  defect as a gate that models the arm differently from the arm, one level up.
+
+  `StoreArmedGraph` splits along the family/instance line: `key`/`graph_class`/`target` are
+  class-level and checkpoint-free, while `weight_set` and `constants` say WHICH checkpoint
+  this binding is of. Two of them over one key are two instances of one family — a fact the
+  module-sourced arm could not state at all, since it could only ever say "whatever that
+  module happened to hold".
+
+  The store reads through the one projection-aware reader, so a component whose weights are
+  CAS objects behind ~128 B pointer stubs indexes and binds without materializing anything.
+  `read_header`'s `{}` is a fail-open its own callers need; it is not one this store may
+  keep, because a shard that will not report its tensors is unreadable, not empty.
+
+  **The bar was bitwise, and it was measured on a real GPU.** One RTX A5000 (sm_86), one
+  real `torch.export` + AOTInductor mint, two arms of the same key, output compared as raw
+  bytes — not `allclose`, and not `torch.equal`, which compares values so a `-0.0`/`0.0`
+  pair or two NaN payloads would pass. Bitwise equal on every call. The equality is only
+  worth what the rig can falsify, so the probe also arms a control from a store whose one
+  weight differs by a single ULP, with a per-input expectation that binds both ways: the
+  inputs that can carry the perturbation must move, and the all-zeros input — where the
+  weight is arithmetically unreachable — must not. `gen_worker.benchmarks.store_arm_parity`
+  is the probe and its result row is committed beside it.

--- a/changelog.d/pgw1329.md
+++ b/changelog.d/pgw1329.md
@@ -32,6 +32,14 @@
   module-sourced arm could not state at all, since it could only ever say "whatever that
   module happened to hold".
 
+  A device OOM while READING the constant table answers with the same
+  `insufficient_adopt_vram` token TCG produces for one inside `bind`. The store arm is the
+  one arm that allocates before `bind`, so without this it is the one arm whose exhaustion
+  reaches the provisioner as an unclassified crash rather than a typed miss that leaves the
+  pod serving eager — and, in the other direction, a read that failed for any other reason
+  must not wear that token, or the fleet re-places a pod to fix a fault that had nothing to
+  do with memory.
+
   The store reads through the one projection-aware reader, so a component whose weights are
   CAS objects behind ~128 B pointer stubs indexes and binds without materializing anything.
   `read_header`'s `{}` is a fail-open its own callers need; it is not one this store may

--- a/changelog.d/pgw1329.md
+++ b/changelog.d/pgw1329.md
@@ -63,8 +63,10 @@
   weight is arithmetically unreachable — must not. `gen_worker.benchmarks.store_arm_parity`
   is the probe and its result row is committed beside it.
 
-  Two sm_86 cards ran it during development — an RTX A5000 and an RTX 3090 — and derived
-  the *identical* `cg-key-v1`, with the identical verdict on every row. That is the
-  compiled-graph key's "sm, never SKU" axis behaving as designed, observed rather than
-  assumed. The committed row is the RTX 3090 one because it is the run of the final code;
-  the A5000 run predates the projection-aware store cutover.
+  Two sm_86 cards ran it — an RTX A5000 and an RTX 3090 — and derived the *identical*
+  `cg-key-v1`, with the identical verdict on every row. That is the compiled-graph key's
+  "sm, never SKU" axis behaving as designed, observed rather than assumed. The committed
+  row is an RTX 3090 one; the A5000 run predates the projection-aware store cutover and is
+  not the evidence. A third pod re-ran the probe after its last change and reproduced the
+  committed row **byte for byte**, so the artifact in this PR is the run of the code in
+  this PR rather than of something near it.

--- a/changelog.d/pgw1329.md
+++ b/changelog.d/pgw1329.md
@@ -53,8 +53,8 @@
   `read_header`'s `{}` is a fail-open its own callers need; it is not one this store may
   keep, because a shard that will not report its tensors is unreadable, not empty.
 
-  **The bar was bitwise, and it was measured on a real GPU.** One RTX A5000 (sm_86), one
-  real `torch.export` + AOTInductor mint, two arms of the same key, output compared as raw
+  **The bar was bitwise, and it was measured on a real GPU.** One sm_86 pod, one real
+  `torch.export` + AOTInductor mint, two arms of the same key, output compared as raw
   bytes — not `allclose`, and not `torch.equal`, which compares values so a `-0.0`/`0.0`
   pair or two NaN payloads would pass. Bitwise equal on every call. The equality is only
   worth what the rig can falsify, so the probe also arms a control from a store whose one
@@ -62,3 +62,9 @@
   inputs that can carry the perturbation must move, and the all-zeros input — where the
   weight is arithmetically unreachable — must not. `gen_worker.benchmarks.store_arm_parity`
   is the probe and its result row is committed beside it.
+
+  Two sm_86 cards ran it during development — an RTX A5000 and an RTX 3090 — and derived
+  the *identical* `cg-key-v1`, with the identical verdict on every row. That is the
+  compiled-graph key's "sm, never SKU" axis behaving as designed, observed rather than
+  assumed. The committed row is the RTX 3090 one because it is the run of the final code;
+  the A5000 run predates the projection-aware store cutover.

--- a/changelog.d/pgw1329.md
+++ b/changelog.d/pgw1329.md
@@ -40,6 +40,14 @@
   must not wear that token, or the fleet re-places a pod to fix a fault that had nothing to
   do with memory.
 
+  A store-armed class reports its serve state in the SAME vocabulary a
+  module-armed one does — `armed` / `de_armed(reason)` / `pending`, from one builder — so
+  the hub's per-entry events see it. A pod whose store-armed classes were invisible would
+  be advertising less than it serves, which is the same defect as advertising more, and a
+  second spelling of one verdict is its own well-known failure. Its de-arm is sticky for
+  the boot and deliberately does NOT free the constants: the AOTI container still holds
+  those pointers user-managed, so releasing them would turn a de-arm into a use-after-free.
+
   The store reads through the one projection-aware reader, so a component whose weights are
   CAS objects behind ~128 B pointer stubs indexes and binds without materializing anything.
   `read_header`'s `{}` is a fail-open its own callers need; it is not one this store may

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -106,6 +106,7 @@ src/gen_worker/procsplit/parent.py::$ENV_WATCHDOG_PING_S IPC watchdog ping caden
 src/gen_worker/settings_authority.py::TORCHINDUCTOR_AUTOGRAD_CACHE LIBRARY TORCHINDUCTOR_AUTOGRAD_CACHE=0 (gw#608, moved from compile_cache by pgw#1049); torch offers no other API.
 src/gen_worker/compile_cache.py::CXX LIBRARY CXX host-compiler discovery, the toolchain's own convention.
 src/gen_worker/compile_cache.py::TORCHINDUCTOR_CACHE_DIR LIBRARY reads back the inductor cache dir torch was steered to.
+src/gen_worker/benchmarks/store_arm_parity.py::TORCHINDUCTOR_CACHE_DIR LIBRARY pgw#1329's GPU parity probe steers inductor at its OWN scratch dir; the env var is inductor's only API for it. A benchmark __main__ that loads no app config and never runs in a serving process, so there is no pipeline-passed Settings to take the value from.
 src/gen_worker/host_canary.py::NCCL_P2P_DISABLE LIBRARY reads NCCL_P2P_DISABLE for the canary's recorded facts.
 src/gen_worker/host_canary.py::MASTER_ADDR LIBRARY MASTER_ADDR, torch.distributed reads it at init.
 src/gen_worker/host_canary.py::MASTER_PORT LIBRARY MASTER_PORT, torch.distributed reads it at init.

--- a/scripts/lint_arm_state_feeders.py
+++ b/scripts/lint_arm_state_feeders.py
@@ -1,22 +1,30 @@
 #!/usr/bin/env python3
-"""Keep compiled-graph arming behind one structural seam.
+"""Keep compiled-graph arming behind the declared structural seams.
 
-``aot_serve.arm_compiled_graph`` is the only production function allowed to
-assemble live TCG serve state. It must resolve and load the exact key through
-TCG, bind constants, create or reuse an :class:`EntryDispatch`, register the
-entry, and install the module wrapper. A second constructor, registration, or
-wrapper call is red: callers submit an admitted key to the seam; they do not
-rebuild part of its state machine.
+``aot_serve``'s arm functions are the only production code allowed to assemble
+live TCG serve state. Each must resolve and load the exact key through TCG
+(directly or through the one shared resolver), bind constants, create or reuse
+an :class:`EntryDispatch` and register the entry. A second constructor,
+registration, or wrapper call anywhere else is red: callers submit an admitted
+key to a seam; they do not rebuild part of its state machine.
+
+pgw#1329 made this TWO seams, differing in exactly one axis — the constant
+SOURCE. ``arm_compiled_graph`` reads a resident eager module and therefore owns
+the wrapper swap and the pipeline marker; ``arm_compiled_graph_from_store``
+reads the store by manifest FQN and has no ``nn.Module`` at all, so the fence
+requires it to install NEITHER. "Two seams" is not a relaxation: each is
+audited for its own complete operation set, and the store arm additionally
+carries a FORBIDDEN set the module arm does not.
 
 The fence also retains two smaller invariants that are still process-global:
 compiled proof/quarantine writes must be classified, and objects with one
 canonical constructor may not acquire a second map. Deleted AOT key registries
 and their test-only hand-feed exceptions are deliberately absent.
 
-Every invocation first executes three synthetic red proofs: a seam missing a
-required operation, a second dispatch writer, and a direct marker writer. A
-green audit therefore proves the rejection paths ran before the real tree was
-accepted.
+Every invocation first executes five synthetic red proofs: each seam missing a
+required operation, the store seam claiming a module, a second dispatch writer,
+and a direct marker writer. A green audit therefore proves the rejection paths
+ran before the real tree was accepted.
 """
 
 from __future__ import annotations
@@ -33,22 +41,56 @@ REPO = Path(__file__).resolve().parents[1]
 ARM_MODULE = "aot_serve.py"
 ARM_SEAM = "arm_compiled_graph"
 
-# The operations that make an admitted TCG class live. These are deliberately
-# names, not line numbers: moving code cannot silently weaken the fence.
-REQUIRED_ARM_CALLS = frozenset({
-    "open_worker_engine",
-    "resolve",
-    "runner",
-    "bind",
-    "_marker",
-    "EntryDispatch",
-    "dispatch.add",
-    "wrap_module",
-})
+#: The scope both seams delegate their exact-key resolve to (pgw#1329). Its
+#: calls count toward EVERY seam that calls it, because the fence's subject is
+#: "did this arm resolve through TCG", not "which line did it happen on". A
+#: shared resolve is the OPPOSITE of a weakening here: two seams that each
+#: re-derived the artifact are the pgw#816/#822 class one level up.
+ARM_RESOLVER = "_resolve_graph_class"
 
-# These operations assemble the pipeline/module arm state and therefore have
-# exactly one production caller. EntryDispatch.remove is a serve-time verdict,
-# not admission, and remains owned by disarm_entry.
+#: pgw#1329: there are TWO arm seams and they differ in exactly one axis, the
+#: constant SOURCE. The fence must state both, and must state what each one
+#: may NOT do — a store-sourced arm that installed a module wrapper or a
+#: pipeline marker would be claiming a module it does not have.
+ARM_SEAMS: tuple[tuple[str, frozenset[str], frozenset[str]], ...] = (
+    (
+        # module-sourced: the eager module is the constant source, so this
+        # seam owns the wrapper swap and the pipeline marker.
+        ARM_SEAM,
+        frozenset({
+            "open_worker_engine",
+            "resolve",
+            "runner",
+            "bind",
+            "_marker",
+            "EntryDispatch",
+            "dispatch.add",
+            "wrap_module",
+        }),
+        frozenset(),
+    ),
+    (
+        # store-sourced: no nn.Module anywhere on the path, so no wrapper and
+        # no pipeline marker — asserted, not assumed.
+        "arm_compiled_graph_from_store",
+        frozenset({
+            "open_worker_engine",
+            "resolve",
+            "runner",
+            "bind",
+            "EntryDispatch",
+            "dispatch.add",
+        }),
+        frozenset({"_marker", "wrap_module"}),
+    ),
+)
+
+#: Scopes allowed to touch the exclusive operations at all.
+ARM_SEAM_SCOPES = frozenset({name for name, _required, _forbidden in ARM_SEAMS})
+
+# These operations assemble the arm state and therefore have exactly one
+# production caller EACH per seam. EntryDispatch.remove is a serve-time
+# verdict, not admission, and remains owned by disarm_entry.
 EXCLUSIVE_ARM_CALLS = frozenset({
     "_marker",
     "EntryDispatch",
@@ -276,25 +318,46 @@ def audit_arm_seam(sources: Mapping[str, str]) -> list[str]:
     modules = _parse_modules(sources)
     owner = modules.get(ARM_MODULE)
     problems: list[str] = []
-    if owner is None or ARM_SEAM not in owner.defined_scopes:
+    if owner is None:
         return [f"ARM SEAM MISSING: {ARM_MODULE}::{ARM_SEAM}"]
+    missing_seams = [
+        name for name, _required, _forbidden in ARM_SEAMS
+        if name not in owner.defined_scopes
+    ]
+    if missing_seams:
+        return [
+            f"ARM SEAM MISSING: {ARM_MODULE}::{name}" for name in missing_seams
+        ]
 
-    seam_calls = {
-        site.call for site in owner.calls if site.scope == ARM_SEAM
-    }
-    missing = sorted(REQUIRED_ARM_CALLS - seam_calls)
-    if missing:
-        problems.append(
-            f"ARM SEAM INCOMPLETE: {ARM_MODULE}::{ARM_SEAM} no longer calls "
-            f"{', '.join(missing)}; exact TCG resolve, bind, dispatch "
-            "registration, and module installation are one atomic boundary"
-        )
+    # A seam that delegates the exact-key resolve to the shared helper is
+    # credited with the helper's calls: the fence asks whether the arm
+    # resolved through TCG, not where the statement sits.
+    shared = {site.call for site in owner.calls if site.scope == ARM_RESOLVER}
+    for name, required, forbidden in ARM_SEAMS:
+        seam_calls = {site.call for site in owner.calls if site.scope == name}
+        if ARM_RESOLVER in seam_calls:
+            seam_calls |= shared
+        missing = sorted(required - seam_calls)
+        if missing:
+            problems.append(
+                f"ARM SEAM INCOMPLETE: {ARM_MODULE}::{name} no longer calls "
+                f"{', '.join(missing)}; exact TCG resolve, bind and dispatch "
+                "registration are one atomic boundary"
+            )
+        overreach = sorted(forbidden & seam_calls)
+        if overreach:
+            problems.append(
+                f"ARM SEAM OVERREACH: {ARM_MODULE}::{name} calls "
+                f"{', '.join(overreach)}; a store-sourced arm has no "
+                "nn.Module, so it must install no wrapper and no pipeline "
+                "marker"
+            )
 
     for visitor in modules.values():
         for site in visitor.calls:
             if site.call not in EXCLUSIVE_ARM_CALLS:
                 continue
-            if (site.file, site.scope) == (ARM_MODULE, ARM_SEAM):
+            if site.file == ARM_MODULE and site.scope in ARM_SEAM_SCOPES:
                 continue
             problems.append(
                 f"{site.file}:{site.line}: ARM STATE WRITE OUTSIDE SEAM: "
@@ -428,15 +491,22 @@ def check_allowlist(
 def run_red_proofs() -> int:
     """Exercise the current fence's rejection paths before auditing src."""
     good = """
-def arm_compiled_graph():
+def _resolve_graph_class():
     engine = open_worker_engine()
     engine.resolve()
-    runner = engine.runner()
-    runner.bind()
+    engine.runner()
+def arm_compiled_graph():
+    resolved = _resolve_graph_class()
+    resolved.runner.bind()
     _marker()
     dispatch = EntryDispatch()
     dispatch.add()
     wrap_module()
+def arm_compiled_graph_from_store():
+    resolved = _resolve_graph_class()
+    resolved.runner.bind()
+    dispatch = EntryDispatch()
+    dispatch.add()
 def _marker():
     setattr(object(), _MARKER_ATTR, {})
 def wrap_module():
@@ -448,6 +518,28 @@ def unwrap():
         (
             {ARM_MODULE: good.replace("    wrap_module()\n", "")},
             "ARM SEAM INCOMPLETE",
+        ),
+        (
+            # the store arm stops resolving through TCG and hand-loads: the
+            # exact-key admission is what makes an arm an arm.
+            {ARM_MODULE: good.replace(
+                "def arm_compiled_graph_from_store():\n"
+                "    resolved = _resolve_graph_class()\n",
+                "def arm_compiled_graph_from_store():\n"
+                "    resolved = load_package()\n",
+            )},
+            "ARM SEAM INCOMPLETE",
+        ),
+        (
+            # the store arm claims a module it does not have.
+            {ARM_MODULE: good.replace(
+                "def arm_compiled_graph_from_store():\n"
+                "    resolved = _resolve_graph_class()\n",
+                "def arm_compiled_graph_from_store():\n"
+                "    resolved = _resolve_graph_class()\n"
+                "    wrap_module()\n",
+            )},
+            "ARM SEAM OVERREACH",
         ),
         (
             {ARM_MODULE: good + "\ndef bypass():\n    EntryDispatch()\n"},
@@ -498,7 +590,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 1
     print(
         f"arm-state fence: {red_proofs} red proofs passed; "
-        f"{ARM_MODULE}::{ARM_SEAM} is the sole TCG arm seam; "
+        f"{ARM_MODULE} declares {len(ARM_SEAMS)} TCG arm seam(s), all complete; "
         f"{len(sites)} classified global/constructor site(s)"
     )
     return 0

--- a/scripts/lint_serving_process_compiles.py
+++ b/scripts/lint_serving_process_compiles.py
@@ -102,6 +102,19 @@ CHILD_ONLY: Dict[str, str] = {
 #: the keystone deleted. The supervisor now calls the pool directly from the
 #: serving loop, so their status changed from "exempt" to "must be clean", and
 #: a stale exemption would have been indistinguishable from a real one.
+#: Modules that are a standalone ENTRY POINT: a `python -m` probe whose whole
+#: process exists to compile and measure, and which no serving-package module
+#: imports. That last half is the difference between this and an exemption —
+#: it is a CHECKED claim, and a serving module that starts importing one of
+#: these goes red here even though the probe itself never changed.
+STANDALONE_ENTRY: Dict[str, str] = {
+    "benchmarks.store_arm_parity": (
+        "pgw#1329's GPU parity probe. It mints one small graph and arms it "
+        "twice to compare bytes; the compile IS the measurement, and the "
+        "process serves nothing. Not CHILD_ONLY: no serving parent spawns it."
+    ),
+}
+
 SUPERVISED: Dict[str, str] = {
     "aot_compile_pool": (
         "the K-wide pool. `mint_supervisor` constructs and drives it on the "
@@ -155,7 +168,7 @@ def main() -> int:
                 hits.append((node.lineno, ".".join(dotted)))
         if not hits:
             continue
-        if module in CHILD_ONLY:
+        if module in CHILD_ONLY or module in STANDALONE_ENTRY:
             seen_allowed.add(module)
             continue
         for lineno, name in hits:
@@ -170,7 +183,7 @@ def main() -> int:
     # A fence that names a DELETED module guards nothing and passes vacuously
     # forever (th#1834's census records the ratchet trap of exactly this
     # shape: a stale name prints `unused section(s)` and EXITS 0).
-    stale = sorted(set(CHILD_ONLY) - seen_allowed)
+    stale = sorted((set(CHILD_ONLY) | set(STANDALONE_ENTRY)) - seen_allowed)
     for module in stale:
         violations.append(
             f"CHILD_ONLY names `{module}`, which no longer calls any banned "
@@ -187,7 +200,32 @@ def main() -> int:
             f"SUPERVISED names `{module}`, which is not a module in "
             f"src/gen_worker. Drop the row or fix the name — it is asserting "
             f"the serving-process rule over a file that does not exist.")
-    overlap = sorted(set(SUPERVISED) & set(CHILD_ONLY))
+    # The standalone claim, CHECKED: nothing in the serving package may import
+    # a module that is allowed to compile because it is nobody's dependency.
+    for file in sorted(SRC.rglob("*.py")):
+        module = _module_name(file)
+        if module in STANDALONE_ENTRY:
+            continue
+        source = file.read_text()
+        for entry in STANDALONE_ENTRY:
+            leaf = entry.rpartition(".")[2]
+            tree = ast.parse(source, filename=str(file))
+            for node in ast.walk(tree):
+                names: List[str] = []
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    base = node.module or ""
+                    names = [f"{base}.{alias.name}" for alias in node.names]
+                    names.append(base)
+                if any(name.endswith(entry) or name.endswith(f".{leaf}") and entry.endswith(f".{leaf}") for name in names):
+                    violations.append(
+                        f"{file.relative_to(REPO)}: imports `{entry}`, which "
+                        f"STANDALONE_ENTRY exempts from the serving-process "
+                        f"compile fence precisely because nothing imports it. "
+                        f"Either drop the import or drop the exemption.")
+
+    overlap = sorted(set(SUPERVISED) & (set(CHILD_ONLY) | set(STANDALONE_ENTRY)))
     for module in overlap:
         violations.append(
             f"`{module}` is in BOTH CHILD_ONLY and SUPERVISED — it cannot be "
@@ -203,7 +241,7 @@ def main() -> int:
         return 1
     print(
         f"serving-process compile fence: clean "
-        f"({len(seen_allowed)} declared child-only module(s), "
+        f"({len(seen_allowed)} declared child-only/standalone module(s), "
         f"{len(SUPERVISED)} supervised module(s) proven clean)")
     return 0
 

--- a/scripts/lint_serving_process_compiles.py
+++ b/scripts/lint_serving_process_compiles.py
@@ -206,24 +206,28 @@ def main() -> int:
         module = _module_name(file)
         if module in STANDALONE_ENTRY:
             continue
-        source = file.read_text()
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(file.read_text(), filename=str(file))):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                base = node.module or ""
+                imported.add(base)
+                imported.update(f"{base}.{alias.name}" for alias in node.names)
         for entry in STANDALONE_ENTRY:
-            leaf = entry.rpartition(".")[2]
-            tree = ast.parse(source, filename=str(file))
-            for node in ast.walk(tree):
-                names: List[str] = []
-                if isinstance(node, ast.Import):
-                    names = [alias.name for alias in node.names]
-                elif isinstance(node, ast.ImportFrom):
-                    base = node.module or ""
-                    names = [f"{base}.{alias.name}" for alias in node.names]
-                    names.append(base)
-                if any(name.endswith(entry) or name.endswith(f".{leaf}") and entry.endswith(f".{leaf}") for name in names):
-                    violations.append(
-                        f"{file.relative_to(REPO)}: imports `{entry}`, which "
-                        f"STANDALONE_ENTRY exempts from the serving-process "
-                        f"compile fence precisely because nothing imports it. "
-                        f"Either drop the import or drop the exemption.")
+            # `benchmarks.store_arm_parity` reached as itself, as
+            # `gen_worker.benchmarks.store_arm_parity`, or as a relative
+            # `from .benchmarks import store_arm_parity`.
+            if not any(
+                name == entry or name.endswith(f".{entry}")
+                for name in imported
+            ):
+                continue
+            violations.append(
+                f"{file.relative_to(REPO)}: imports `{entry}`, which "
+                f"STANDALONE_ENTRY exempts from the serving-process compile "
+                f"fence precisely because nothing imports it. Either drop the "
+                f"import or drop the exemption.")
 
     overlap = sorted(set(SUPERVISED) & (set(CHILD_ONLY) | set(STANDALONE_ENTRY)))
     for module in overlap:

--- a/scripts/settings_writers_allowlist.txt
+++ b/scripts/settings_writers_allowlist.txt
@@ -22,3 +22,4 @@ src/gen_worker/host_canary.py::os.environ[<dynamic>]  SCOPED  the probe's restor
 # generated (inductor entries are content-addressed). The sanctioned window
 # is post-scrub (env_seal docstring).
 src/gen_worker/entrypoint.py::os.environ[<dynamic>]  PLUMBING  pgw#783 per-group inductor/triton cache isolation dirs
+src/gen_worker/benchmarks/store_arm_parity.py::os.environ[TORCHINDUCTOR_CACHE_DIR]  PLUMBING  pgw#1329's GPU parity probe points inductor at its own scratch dir so a warm inherited cache cannot make "both arms compiled the same graph" an assumption; where bytes land, never which bytes

--- a/src/gen_worker/aot_constants.py
+++ b/src/gen_worker/aot_constants.py
@@ -22,15 +22,15 @@ must cost a header read, not a half-populated 20 GiB constant table and a
 runner that can never be un-bound (``CompiledGraphRunner.bind`` is
 once-only and marks itself failed).
 
-Nothing here imports ``torch.nn``, diffusers, or any model class. ``torch`` is
-imported lazily inside the read path, for dtype objects only.
+The bytes come through pgw#1330's one reader: ``read_header`` for the index
+and ``open_tensor_source`` for the values, so a component whose weights are
+CAS objects behind projection stubs indexes and binds without materializing
+anything. Nothing here imports ``torch.nn``, diffusers, or any model class.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-import struct
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -45,6 +45,9 @@ from typing import (
     Sequence,
     Tuple,
 )
+
+from .models.safetensors_header import read_header
+from .models.tensor_source import TORCH_DTYPES, open_tensor_source
 
 logger = logging.getLogger(__name__)
 
@@ -64,34 +67,6 @@ CONSTANT_MANIFEST_FORMAT = 1
 #: a row with an extra field is an artifact from a format this reader does not
 #: understand, not a row to read three keys out of and hope.
 _ROW_FIELDS = frozenset(("fqn", "source", "dtype", "shape"))
-
-#: safetensors dtype spelling -> the torch dtype attribute name AOTInductor
-#: stamps into ``constants_info_[i].dtype``. Only the dtypes this fleet's
-#: checkpoints actually carry; an unknown one is a refusal, never a guess,
-#: because guessing an element width silently reshapes the tensor.
-SAFETENSORS_TO_TORCH_DTYPE: Mapping[str, str] = {
-    "BOOL": "bool",
-    "U8": "uint8",
-    "I8": "int8",
-    "F8_E4M3": "float8_e4m3fn",
-    "F8_E5M2": "float8_e5m2",
-    "I16": "int16",
-    "U16": "uint16",
-    "F16": "float16",
-    "BF16": "bfloat16",
-    "I32": "int32",
-    "U32": "uint32",
-    "F32": "float32",
-    "I64": "int64",
-    "U64": "uint64",
-    "F64": "float64",
-}
-
-#: Largest plausible safetensors header. Same bound as
-#: ``models.safetensors_header.MAX_HEADER_BYTES``, restated rather than
-#: imported so this module stays free of the model-loading package.
-_MAX_HEADER_BYTES = 100 << 20
-
 
 # ---------------------------------------------------------------------------
 # Validated identifiers — parse, never a bare ``str``
@@ -498,38 +473,28 @@ def realize_store_constants(
 # ---------------------------------------------------------------------------
 
 
-def _read_header(path: Path) -> Mapping[str, Any]:
-    """One safetensors header, fail-CLOSED.
+def _read_header(path: Path, why: str) -> Mapping[str, Any]:
+    """One safetensors header, projection-aware and fail-CLOSED.
 
-    The fail-open spelling of this loop is the pgw#1330 defect: a header that
-    will not parse is skipped, the file contributes no keys, and the caller
-    concludes the tensor is absent rather than that the shard is unreadable.
+    ``safetensors_header.read_header`` is the ONE reader (pgw#1330) and it
+    serves a projected tree's stub from the manifest, which is what lets this
+    store index a component whose bytes are CAS objects rather than files.
+    Its ``{}`` means "no readable header here" — the honest answer for a
+    truncated or non-safetensors file, and a fail-open its own callers need.
+
+    It is NOT an answer this store may keep. A component shard that will not
+    report a header contributes no FQNs, and a caller that reads that as
+    "these constants are absent" refuses the wrong thing (or, worse, plans
+    around a table it never saw). Here the empty header is a refusal.
     """
 
-    try:
-        with open(path, "rb") as handle:
-            raw = handle.read(8)
-            if len(raw) < 8:
-                raise ConstantStoreError(
-                    "shard_unreadable", f"{path}: shorter than a safetensors header length"
-                )
-            (length,) = struct.unpack("<Q", raw)
-            if not 0 < length <= _MAX_HEADER_BYTES:
-                raise ConstantStoreError(
-                    "shard_unreadable",
-                    f"{path}: declares a {length}-byte header, which is not a header length",
-                )
-            header = json.loads(handle.read(length))
-    except OSError as exc:
-        raise ConstantStoreError("shard_unreadable", f"{path}: {exc}") from exc
-    except (ValueError, struct.error) as exc:
-        if isinstance(exc, ConstantStoreError):
-            raise
+    header = read_header(path, why=why)
+    if not header:
         raise ConstantStoreError(
-            "shard_unreadable", f"{path}: header is not JSON ({exc})"
-        ) from exc
-    if not isinstance(header, dict):
-        raise ConstantStoreError("shard_unreadable", f"{path}: header is not an object")
+            "shard_unreadable",
+            f"{path}: no readable safetensors header. A shard that will not "
+            f"report its tensors is unreadable, not empty ({why})",
+        )
     return header
 
 
@@ -539,7 +504,7 @@ def _facts_from_header_row(path: Path, name: str, row: object) -> TensorFacts:
             "shard_unreadable", f"{path}: header entry {name!r} is not an object"
         )
     raw_dtype = row.get("dtype")
-    if not isinstance(raw_dtype, str) or raw_dtype not in SAFETENSORS_TO_TORCH_DTYPE:
+    if not isinstance(raw_dtype, str) or raw_dtype not in TORCH_DTYPES:
         raise ConstantStoreError(
             "dtype_unknown",
             f"{path}: tensor {name!r} has safetensors dtype {raw_dtype!r}, whose "
@@ -553,7 +518,7 @@ def _facts_from_header_row(path: Path, name: str, row: object) -> TensorFacts:
             "shard_unreadable", f"{path}: tensor {name!r} has no integer shape"
         )
     return TensorFacts(
-        dtype=TorchDtype(SAFETENSORS_TO_TORCH_DTYPE[raw_dtype]),
+        dtype=TorchDtype(TORCH_DTYPES[raw_dtype]),
         shape=tuple(int(dimension) for dimension in raw_shape),
     )
 
@@ -587,7 +552,7 @@ class SafetensorsConstantStore:
         self._index: Dict[ConstantFQN, TensorFacts] = {}
         self._holder: Dict[ConstantFQN, Path] = {}
         for shard in self._shards:
-            for name, row in _read_header(shard).items():
+            for name, row in _read_header(shard, self._why).items():
                 if name == "__metadata__":
                     continue
                 fqn = ConstantFQN(str(name))
@@ -631,10 +596,8 @@ class SafetensorsConstantStore:
                 f"{fqn!r} is not in this store; only planned constants may be read",
                 (str(fqn),),
             )
-        from safetensors import safe_open
-
-        with safe_open(str(shard), framework="pt", device=str(device)) as handle:
-            return handle.get_tensor(str(fqn))
+        with open_tensor_source(shard, device=str(device), why=self._why) as source:
+            return source.get_tensor(str(fqn))
 
 
 __all__ = [
@@ -648,7 +611,6 @@ __all__ = [
     "ConstantStore",
     "ConstantStoreError",
     "GraphClassName",
-    "SAFETENSORS_TO_TORCH_DTYPE",
     "SafetensorsConstantStore",
     "StoreConstantPlan",
     "TensorFacts",

--- a/src/gen_worker/aot_constants.py
+++ b/src/gen_worker/aot_constants.py
@@ -1,0 +1,664 @@
+"""The constant table a compiled graph binds, sourced from the STORE.
+
+``aot_serve.resident_constants`` reads a LIVE ``nn.Module``: serving one
+compiled graph therefore required the whole eager pipeline resident purely as
+a constant SOURCE, which is why an adopt-only serve host (pgw#1328) could not
+shed diffusers. The artifact already carries the identity that makes the
+module unnecessary — every constant is declared by its fully-qualified name,
+its torch dtype and its exact shape — so the same by-reference mapping can be
+built from safetensors bytes the store already holds.
+
+Two phases, in this order and never merged:
+
+1. :func:`plan_store_constants` — headers only. Every declared
+   ``state_dict`` FQN must be present, with the DECLARED dtype and the
+   DECLARED shape. A miss is a typed refusal naming every FQN at fault, and
+   it happens before one device byte is allocated and before any caller has
+   mutated dispatch state.
+2. :func:`realize_store_constants` — reads the planned FQNs onto the device.
+
+The split is the point. A store that is one tensor short, or one dtype off,
+must cost a header read, not a half-populated 20 GiB constant table and a
+runner that can never be un-bound (``CompiledGraphRunner.bind`` is
+once-only and marks itself failed).
+
+Nothing here imports ``torch.nn``, diffusers, or any model class. ``torch`` is
+imported lazily inside the read path, for dtype objects only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NewType,
+    Protocol,
+    Sequence,
+    Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+#: THE constant-manifest schema version, and it is deliberately not a new
+#: number. The constants block lives inside the compiled-graph artifact
+#: metadata envelope, so its version IS that envelope's version
+#: (``aot_serve.COMPILED_GRAPH_FORMAT``). §1.38b's rule is that the compiled
+#: boundaries each begin at their own v1 and are INDEPENDENT — it is not a
+#: licence to mint a second version number for one envelope, which is exactly
+#: how a reader ends up comparing the wrong two integers (pgw#1230).
+CONSTANT_MANIFEST_FORMAT = 1
+
+#: The exact field set a manifest constant row carries. TCG's artifact
+#: validator already enforces this on the WRITE side
+#: (``artifact._validated_constants``); repeating it on the read side is not
+#: redundancy — an artifact this worker did not mint reaches this parser, and
+#: a row with an extra field is an artifact from a format this reader does not
+#: understand, not a row to read three keys out of and hope.
+_ROW_FIELDS = frozenset(("fqn", "source", "dtype", "shape"))
+
+#: safetensors dtype spelling -> the torch dtype attribute name AOTInductor
+#: stamps into ``constants_info_[i].dtype``. Only the dtypes this fleet's
+#: checkpoints actually carry; an unknown one is a refusal, never a guess,
+#: because guessing an element width silently reshapes the tensor.
+SAFETENSORS_TO_TORCH_DTYPE: Mapping[str, str] = {
+    "BOOL": "bool",
+    "U8": "uint8",
+    "I8": "int8",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "I16": "int16",
+    "U16": "uint16",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "I32": "int32",
+    "U32": "uint32",
+    "F32": "float32",
+    "I64": "int64",
+    "U64": "uint64",
+    "F64": "float64",
+}
+
+#: Largest plausible safetensors header. Same bound as
+#: ``models.safetensors_header.MAX_HEADER_BYTES``, restated rather than
+#: imported so this module stays free of the model-loading package.
+_MAX_HEADER_BYTES = 100 << 20
+
+
+# ---------------------------------------------------------------------------
+# Validated identifiers — parse, never a bare ``str``
+# ---------------------------------------------------------------------------
+
+#: A constant's fully-qualified name inside the exported target, e.g.
+#: ``transformer_blocks.0.attn.to_q.weight``. Parsed, because it is the ONLY
+#: thing that ties an artifact slot to a store tensor: a stray space or an
+#: empty segment is a name that can never resolve, and it must say so at the
+#: boundary rather than as a ``KeyError`` under a bind.
+ConstantFQN = NewType("ConstantFQN", str)
+
+#: A torch dtype attribute name (``bfloat16``, not ``torch.bfloat16`` and not
+#: ``BF16``). Validated against ``torch``'s own attribute table at read time.
+TorchDtype = NewType("TorchDtype", str)
+
+#: The graph class the constant table belongs to.
+GraphClassName = NewType("GraphClassName", str)
+
+#: WHICH weight-set a store supplies — the checkpoint ref, digest or snapshot
+#: id the constants were read from.
+#:
+#: This is the one INSTANCE-level fact on this path, and it is carried
+#: separately from the graph-class identity on purpose (§4.27: class identity
+#: is checkpoint-free by construction). A graph class is the family level; a
+#: graph class bound to one weight-set is an instance of it, and the same
+#: ``.so`` serving sixteen fine-tunes is sixteen instances of one class. A
+#: store-sourced arm is therefore keyed by (compiled-graph key, weight-set
+#: ref) — the module-sourced arm could only ever say "whatever that module
+#: happened to hold", which is precisely the fact an instance needs and a
+#: resident module cannot state.
+WeightSetRef = NewType("WeightSetRef", str)
+
+
+class ConstantManifestError(ValueError):
+    """The artifact's declared constant table cannot be read as v1."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = str(reason)
+        self.detail = str(detail)
+        super().__init__(detail)
+
+
+class ConstantResolutionError(ValueError):
+    """The store cannot supply the declared constant table, by name.
+
+    ``fqns`` names every constant at fault, not the first one: a wrong
+    component directory misses hundreds and the operator needs the count and
+    a sample, while a genuine drift misses one and the operator needs which.
+    """
+
+    def __init__(self, reason: str, detail: str, fqns: Sequence[str] = ()) -> None:
+        self.reason = str(reason)
+        self.detail = str(detail)
+        self.fqns: Tuple[str, ...] = tuple(str(name) for name in fqns)
+        super().__init__(detail)
+
+
+class ConstantStoreError(ValueError):
+    """The store itself is unreadable — malformed shard, unknown dtype."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = str(reason)
+        self.detail = str(detail)
+        super().__init__(detail)
+
+
+def parse_fqn(raw: object) -> ConstantFQN:
+    """Parse one constant FQN, or refuse it."""
+
+    if not isinstance(raw, str):
+        raise ConstantManifestError(
+            "fqn_not_a_string", f"constant fqn must be a string, got {type(raw).__name__}"
+        )
+    if not raw or raw != raw.strip():
+        raise ConstantManifestError(
+            "fqn_malformed", f"constant fqn must be non-empty and unpadded: {raw!r}"
+        )
+    if any(segment == "" for segment in raw.split(".")):
+        raise ConstantManifestError(
+            "fqn_malformed", f"constant fqn has an empty dotted segment: {raw!r}"
+        )
+    return ConstantFQN(raw)
+
+
+def parse_torch_dtype(raw: object) -> TorchDtype:
+    """Parse one torch dtype attribute name, or refuse it."""
+
+    if not isinstance(raw, str) or not raw or raw != raw.strip():
+        raise ConstantManifestError(
+            "dtype_malformed", f"constant dtype must be a non-empty bare name: {raw!r}"
+        )
+    if raw.startswith("torch."):
+        raise ConstantManifestError(
+            "dtype_malformed",
+            f"constant dtype is an attribute NAME, not a repr: {raw!r}",
+        )
+    return TorchDtype(raw)
+
+
+def parse_weight_set_ref(raw: object) -> WeightSetRef:
+    """Parse the ref naming WHICH weight-set a store supplies, or refuse it.
+
+    A store that cannot say which checkpoint it holds cannot be the source of
+    an instance-level binding, and an unnamed binding is exactly what makes
+    "which weights is this pod actually serving?" unanswerable today.
+    """
+
+    if not isinstance(raw, str) or not raw or raw != raw.strip():
+        raise ConstantManifestError(
+            "weight_set_ref_malformed",
+            f"a constant store must name the weight-set it supplies: {raw!r}",
+        )
+    return WeightSetRef(raw)
+
+
+def parse_graph_class_name(raw: object) -> GraphClassName:
+    if not isinstance(raw, str) or not raw or raw != raw.strip():
+        raise ConstantManifestError(
+            "graph_class_malformed", f"graph class name must be non-empty: {raw!r}"
+        )
+    return GraphClassName(raw)
+
+
+def _parse_shape(raw: object, fqn: ConstantFQN) -> Tuple[int, ...]:
+    if not isinstance(raw, (list, tuple)):
+        raise ConstantManifestError(
+            "shape_malformed", f"constant {fqn!r} shape must be an array"
+        )
+    dimensions: List[int] = []
+    for dimension in raw:
+        # ``bool`` is an ``int`` subclass and a shape of ``[True]`` is a
+        # malformed artifact, not a shape of ``[1]``.
+        if type(dimension) is not int or dimension < 0:
+            raise ConstantManifestError(
+                "shape_malformed",
+                f"constant {fqn!r} shape must be non-negative integers, got {dimension!r}",
+            )
+        dimensions.append(dimension)
+    return tuple(dimensions)
+
+
+class ConstantSourceKind(str, Enum):
+    """Where one declared constant's value comes from.
+
+    Mirrors ``torchcg.introspection.DeclaredConstant.source``, as an enum
+    rather than a string tag because this module BRANCHES on it and a typo in
+    a comparison is otherwise a silently skipped constant.
+    """
+
+    STATE_DICT = "state_dict"
+    LITERAL = "literal"
+    COMPUTED = "computed"
+
+
+@dataclass(frozen=True, slots=True)
+class TensorFacts:
+    """The dtype and exact shape of one tensor, from either side."""
+
+    dtype: TorchDtype
+    shape: Tuple[int, ...]
+
+    @property
+    def elements(self) -> int:
+        total = 1
+        for dimension in self.shape:
+            total *= dimension
+        return total
+
+
+@dataclass(frozen=True, slots=True)
+class ConstantSpec:
+    """One validated row of the artifact's declared constant table."""
+
+    fqn: ConstantFQN
+    source: ConstantSourceKind
+    facts: TensorFacts
+
+
+@dataclass(frozen=True, slots=True)
+class ConstantManifest:
+    """The artifact's whole declared constant table, v1, validated."""
+
+    graph_class: GraphClassName
+    target: str
+    constants: Tuple[ConstantSpec, ...]
+
+    @property
+    def store_sourced(self) -> Tuple[ConstantSpec, ...]:
+        """The constants a STORE must supply.
+
+        ``literal`` rows ride inside the artifact and ``computed`` rows are
+        constant-folded into it; TCG's runner resolves both without this
+        module. Only ``state_dict`` rows ever needed the eager module.
+        """
+
+        return tuple(
+            spec for spec in self.constants if spec.source is ConstantSourceKind.STATE_DICT
+        )
+
+
+def parse_constant_manifest(
+    graph_class: Mapping[str, Any], *, compiled_graph_format: object
+) -> ConstantManifest:
+    """Read one artifact's ``graph_class`` block as a v1 constant manifest.
+
+    ``compiled_graph_format`` is the artifact envelope's own version stamp.
+    An envelope this reader does not know is refused BEFORE its rows are
+    interpreted — reading v2 rows with a v1 reader is how a field that
+    changed meaning becomes a wrong tensor rather than an error.
+    """
+
+    if compiled_graph_format != CONSTANT_MANIFEST_FORMAT:
+        raise ConstantManifestError(
+            "manifest_version_unsupported",
+            f"constant manifest reader is v{CONSTANT_MANIFEST_FORMAT}; artifact "
+            f"declares compiled_graph_format={compiled_graph_format!r}",
+        )
+    name = parse_graph_class_name(graph_class.get("name"))
+    raw_target = graph_class.get("target")
+    if not isinstance(raw_target, str) or not raw_target.strip():
+        raise ConstantManifestError(
+            "target_malformed", f"graph class {name!r} names no target"
+        )
+    rows = graph_class.get("constants")
+    if not isinstance(rows, (list, tuple)):
+        raise ConstantManifestError(
+            "constants_malformed", f"graph class {name!r} constants must be an array"
+        )
+    specs: List[ConstantSpec] = []
+    seen: Dict[ConstantFQN, int] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise ConstantManifestError(
+                "constant_row_malformed", f"constant {index} must be an object"
+            )
+        if set(row) != _ROW_FIELDS:
+            raise ConstantManifestError(
+                "constant_row_malformed",
+                f"constant {index} fields must be exactly {sorted(_ROW_FIELDS)!r}, "
+                f"got {sorted(str(field) for field in row)!r}",
+            )
+        fqn = parse_fqn(row.get("fqn"))
+        if fqn in seen:
+            raise ConstantManifestError(
+                "constant_duplicate",
+                f"constant {fqn!r} declared twice (rows {seen[fqn]} and {index})",
+            )
+        seen[fqn] = index
+        raw_source = row.get("source")
+        try:
+            source = ConstantSourceKind(raw_source)
+        except ValueError as exc:
+            raise ConstantManifestError(
+                "constant_source_unknown",
+                f"constant {fqn!r} declares source {raw_source!r}, which is not one of "
+                f"{sorted(kind.value for kind in ConstantSourceKind)!r}",
+            ) from exc
+        specs.append(
+            ConstantSpec(
+                fqn=fqn,
+                source=source,
+                facts=TensorFacts(
+                    dtype=parse_torch_dtype(row.get("dtype")),
+                    shape=_parse_shape(row.get("shape"), fqn),
+                ),
+            )
+        )
+    return ConstantManifest(
+        graph_class=name, target=raw_target.strip(), constants=tuple(specs)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The store side
+# ---------------------------------------------------------------------------
+
+
+class ConstantStore(Protocol):
+    """Everything the arm needs from a weight source, and nothing more.
+
+    Deliberately NOT ``safe_open``'s shape: an arm must be able to check the
+    whole declared table against headers before it reads a byte, which
+    ``get_tensor``-only sources cannot express.
+    """
+
+    @property
+    def weight_set(self) -> WeightSetRef:
+        """WHICH weight-set this store supplies — the instance-level fact."""
+
+    def describe(self) -> Mapping[ConstantFQN, TensorFacts]:
+        """Every tensor this store holds, by FQN, from headers alone."""
+
+    def read(self, fqn: ConstantFQN, *, device: str) -> Any:
+        """One tensor, on ``device``. Only ever called for planned FQNs."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoreConstantPlan:
+    """A checked promise that this store can supply this table.
+
+    Holding it is the proof the two-phase split exists: a caller cannot get
+    one without every declared ``state_dict`` FQN having matched the store on
+    name, dtype and shape, and cannot read a constant that is not in it.
+    """
+
+    graph_class: GraphClassName
+    weight_set: WeightSetRef
+    fqns: Tuple[ConstantFQN, ...]
+    elements: int
+
+    def __len__(self) -> int:
+        return len(self.fqns)
+
+
+def plan_store_constants(
+    manifest: ConstantManifest, store: ConstantStore
+) -> StoreConstantPlan:
+    """Check the whole declared table against the store's HEADERS.
+
+    Refuses, naming every FQN at fault, on:
+
+    ``constant_absent``
+        a declared ``state_dict`` FQN the store does not hold. This is the
+        wrong-component-directory and the checkpoint-drift case, and it is
+        the one that must never reach a bind: ``CompiledGraphRunner.bind`` is
+        once-only, so a partial table costs the runner as well as the memory.
+    ``constant_dtype_mismatch``
+        present but a different dtype. The graph is SPECIALIZED on dtype;
+        binding an fp32 tensor where the artifact wants bf16 is a wrong
+        answer at full speed, not a crash.
+    ``constant_shape_mismatch``
+        present but a different shape, i.e. a different checkpoint.
+
+    No device memory is allocated on any path through this function.
+    """
+
+    index = store.describe()
+    absent: List[str] = []
+    dtype_gap: List[str] = []
+    shape_gap: List[str] = []
+    planned: List[ConstantFQN] = []
+    elements = 0
+    for spec in manifest.store_sourced:
+        held = index.get(spec.fqn)
+        if held is None:
+            absent.append(str(spec.fqn))
+            continue
+        if held.dtype != spec.facts.dtype:
+            dtype_gap.append(f"{spec.fqn} (declared {spec.facts.dtype}, store {held.dtype})")
+            continue
+        if held.shape != spec.facts.shape:
+            shape_gap.append(
+                f"{spec.fqn} (declared {list(spec.facts.shape)}, store {list(held.shape)})"
+            )
+            continue
+        planned.append(spec.fqn)
+        elements += spec.facts.elements
+    for reason, faults in (
+        ("constant_absent", absent),
+        ("constant_dtype_mismatch", dtype_gap),
+        ("constant_shape_mismatch", shape_gap),
+    ):
+        if faults:
+            raise ConstantResolutionError(
+                reason,
+                f"graph class {manifest.graph_class!r}: {len(faults)} declared "
+                f"constant(s) {reason.removeprefix('constant_')} in the store: "
+                f"{sorted(faults)[:6]!r}",
+                faults,
+            )
+    return StoreConstantPlan(
+        graph_class=manifest.graph_class,
+        weight_set=parse_weight_set_ref(store.weight_set),
+        fqns=tuple(planned),
+        elements=elements,
+    )
+
+
+def realize_store_constants(
+    plan: StoreConstantPlan, store: ConstantStore, *, device: str
+) -> Dict[str, Any]:
+    """Read the planned constants onto ``device``, by reference.
+
+    The mapping is handed straight to ``CompiledGraphRunner.bind``, which
+    installs the pointers ``user_managed`` — so these tensors must outlive
+    the runner, and the caller owns that lifetime exactly as the
+    module-sourced arm does.
+    """
+
+    target = str(device).strip()
+    if not target:
+        raise ConstantResolutionError(
+            "device_missing", "store-sourced constants require an explicit device"
+        )
+    values: Dict[str, Any] = {}
+    for fqn in plan.fqns:
+        values[str(fqn)] = store.read(fqn, device=target)
+    return values
+
+
+# ---------------------------------------------------------------------------
+# The safetensors implementation
+# ---------------------------------------------------------------------------
+
+
+def _read_header(path: Path) -> Mapping[str, Any]:
+    """One safetensors header, fail-CLOSED.
+
+    The fail-open spelling of this loop is the pgw#1330 defect: a header that
+    will not parse is skipped, the file contributes no keys, and the caller
+    concludes the tensor is absent rather than that the shard is unreadable.
+    """
+
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read(8)
+            if len(raw) < 8:
+                raise ConstantStoreError(
+                    "shard_unreadable", f"{path}: shorter than a safetensors header length"
+                )
+            (length,) = struct.unpack("<Q", raw)
+            if not 0 < length <= _MAX_HEADER_BYTES:
+                raise ConstantStoreError(
+                    "shard_unreadable",
+                    f"{path}: declares a {length}-byte header, which is not a header length",
+                )
+            header = json.loads(handle.read(length))
+    except OSError as exc:
+        raise ConstantStoreError("shard_unreadable", f"{path}: {exc}") from exc
+    except (ValueError, struct.error) as exc:
+        if isinstance(exc, ConstantStoreError):
+            raise
+        raise ConstantStoreError(
+            "shard_unreadable", f"{path}: header is not JSON ({exc})"
+        ) from exc
+    if not isinstance(header, dict):
+        raise ConstantStoreError("shard_unreadable", f"{path}: header is not an object")
+    return header
+
+
+def _facts_from_header_row(path: Path, name: str, row: object) -> TensorFacts:
+    if not isinstance(row, Mapping):
+        raise ConstantStoreError(
+            "shard_unreadable", f"{path}: header entry {name!r} is not an object"
+        )
+    raw_dtype = row.get("dtype")
+    if not isinstance(raw_dtype, str) or raw_dtype not in SAFETENSORS_TO_TORCH_DTYPE:
+        raise ConstantStoreError(
+            "dtype_unknown",
+            f"{path}: tensor {name!r} has safetensors dtype {raw_dtype!r}, whose "
+            f"element width is unknown here. Refusing to guess.",
+        )
+    raw_shape = row.get("shape")
+    if not isinstance(raw_shape, (list, tuple)) or not all(
+        type(dimension) is int and dimension >= 0 for dimension in raw_shape
+    ):
+        raise ConstantStoreError(
+            "shard_unreadable", f"{path}: tensor {name!r} has no integer shape"
+        )
+    return TensorFacts(
+        dtype=TorchDtype(SAFETENSORS_TO_TORCH_DTYPE[raw_dtype]),
+        shape=tuple(int(dimension) for dimension in raw_shape),
+    )
+
+
+class SafetensorsConstantStore:
+    """A component's safetensors shards, indexed by FQN.
+
+    The index is built from HEADERS — the whole point of the two-phase plan is
+    that a table can be refused for the cost of a few kilobytes per shard,
+    whatever the component weighs.
+
+    Tensor names in a diffusers component's shards are already the FQNs the
+    exported target declares; this store therefore does no renaming at all.
+    A name that does not line up is reported by :func:`plan_store_constants`
+    as absent, by name, rather than repaired by a prefix heuristic — a
+    heuristic here would bind the wrong tensor under the right name, which is
+    the one failure this whole path exists to make impossible.
+    """
+
+    def __init__(
+        self, shards: Iterable[Path], *, weight_set: str, why: str
+    ) -> None:
+        self._why = str(why)
+        self._weight_set = parse_weight_set_ref(weight_set)
+        self._shards: Tuple[Path, ...] = tuple(sorted(Path(shard) for shard in shards))
+        if not self._shards:
+            raise ConstantStoreError(
+                "store_empty",
+                f"no safetensors shard to source constants from ({self._why})",
+            )
+        self._index: Dict[ConstantFQN, TensorFacts] = {}
+        self._holder: Dict[ConstantFQN, Path] = {}
+        for shard in self._shards:
+            for name, row in _read_header(shard).items():
+                if name == "__metadata__":
+                    continue
+                fqn = ConstantFQN(str(name))
+                if fqn in self._holder:
+                    raise ConstantStoreError(
+                        "tensor_duplicated",
+                        f"tensor {fqn!r} is in both {self._holder[fqn]} and {shard}; "
+                        f"a sharded component that names one tensor twice has no "
+                        f"single answer and must not be guessed at ({self._why})",
+                    )
+                self._holder[fqn] = shard
+                self._index[fqn] = _facts_from_header_row(shard, str(name), row)
+
+    @classmethod
+    def for_component(
+        cls, directory: Path, *, weight_set: str, why: str
+    ) -> "SafetensorsConstantStore":
+        """Every ``*.safetensors`` shard directly inside one component dir."""
+
+        root = Path(directory)
+        return cls(
+            sorted(root.glob("*.safetensors")), weight_set=weight_set, why=why
+        )
+
+    @property
+    def weight_set(self) -> WeightSetRef:
+        return self._weight_set
+
+    @property
+    def shards(self) -> Tuple[Path, ...]:
+        return self._shards
+
+    def describe(self) -> Mapping[ConstantFQN, TensorFacts]:
+        return dict(self._index)
+
+    def read(self, fqn: ConstantFQN, *, device: str) -> Any:
+        shard = self._holder.get(fqn)
+        if shard is None:
+            raise ConstantResolutionError(
+                "constant_absent",
+                f"{fqn!r} is not in this store; only planned constants may be read",
+                (str(fqn),),
+            )
+        from safetensors import safe_open
+
+        with safe_open(str(shard), framework="pt", device=str(device)) as handle:
+            return handle.get_tensor(str(fqn))
+
+
+__all__ = [
+    "CONSTANT_MANIFEST_FORMAT",
+    "ConstantFQN",
+    "ConstantManifest",
+    "ConstantManifestError",
+    "ConstantResolutionError",
+    "ConstantSourceKind",
+    "ConstantSpec",
+    "ConstantStore",
+    "ConstantStoreError",
+    "GraphClassName",
+    "SAFETENSORS_TO_TORCH_DTYPE",
+    "SafetensorsConstantStore",
+    "StoreConstantPlan",
+    "TensorFacts",
+    "TorchDtype",
+    "WeightSetRef",
+    "parse_constant_manifest",
+    "parse_fqn",
+    "parse_graph_class_name",
+    "parse_torch_dtype",
+    "parse_weight_set_ref",
+    "plan_store_constants",
+    "realize_store_constants",
+]

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -1746,6 +1746,24 @@ def arm_compiled_graph_from_store(
         constants = aot_constants.realize_store_constants(
             plan, store, device=target_device
         )
+    except Exception as exc:
+        # §4.33 / pgw#1175: the ATTEMPT is the headroom gate, and its verdict
+        # has to be the SAME token whichever half of the attempt ran out of
+        # device memory. TCG classifies an OOM inside `bind`; nothing
+        # classified one inside the READ, and the store arm allocates the
+        # whole constant table there — so without this, the one arm that does
+        # its allocating before `bind` is the one arm whose OOM reaches
+        # `provision.arm_aot` as an unclassified crash instead of a typed
+        # `insufficient_adopt_vram` miss that leaves the pod serving eager.
+        if not is_cuda_oom(exc):
+            raise
+        raise AdoptError(
+            ADOPT_OOM_REASON,
+            f"graph class {resolved.name!r}: reading {len(plan)} store-sourced "
+            f"constant(s) onto {target_device} exhausted device memory "
+            f"({type(exc).__name__}: {exc})",
+        ) from exc
+    try:
         resolved.runner.bind(constants, device=target_device)
     except ConstantBindingError as exc:
         reason = ADOPT_OOM_REASON if exc.reason == "out_of_memory" else exc.reason

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -1693,6 +1693,24 @@ class StoreArmedGraph:
         _name, runner = self.dispatch.select(args, kwargs)
         return runner(*args, **kwargs)
 
+    def entry_states(self) -> Dict[str, Dict[str, Any]]:
+        """What this pod actually serves, in the SAME vocabulary as a
+        module-armed class (pgw#1176 §1.4). A store-armed entry that the hub
+        could not see would be a pod advertising less than it serves, which is
+        the same defect as advertising more."""
+
+        return dispatch_states(self.target, self.dispatch)
+
+    def disarm(self, reason: str) -> bool:
+        """De-arm this graph class, sticky for the boot (§4.31).
+
+        The store arm's half of :func:`disarm_entry`. It drops the entry and
+        NOT the constants: the runner's installed pointers are ``user_managed``
+        and the container is still loaded, so freeing the tensors here would
+        turn a de-arm into a use-after-free."""
+
+        return self.dispatch.remove(self.graph_class, str(reason))
+
 
 def arm_compiled_graph_from_store(
     cfg: Any,
@@ -1830,6 +1848,27 @@ def disarm_entry(pipeline: Any, name: str, reason: str) -> bool:
     return dropped
 
 
+def dispatch_states(target: str, dispatch: EntryDispatch) -> Dict[str, Dict[str, Any]]:
+    """One dispatch's per-entry serve state, in THE vocabulary.
+
+    Written once because there are now two arms and the state a pod reports
+    must not depend on which one ran. Two spellings of one verdict is the
+    pgw#1247 class, and here it would be worse than cosmetic: the hub's
+    per-entry events are built from this, so a second vocabulary is a pod
+    whose store-armed classes are invisible to the fleet.
+    """
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, runner in dispatch.runners:
+        out[name] = {
+            "state": "armed", "target": target, "calls": int(runner.calls)}
+    for name, why in dispatch.de_armed.items():
+        out[name] = {"state": "de_armed", "target": target, "reason": why}
+    for name in dispatch.pending:
+        out[name] = {"state": "pending", "target": target}
+    return out
+
+
 def entry_states(pipeline: Any) -> Dict[str, Dict[str, Any]]:
     """Per-entry SERVE STATE — what this pod actually serves, per graph class.
 
@@ -1837,6 +1876,11 @@ def entry_states(pipeline: Any) -> Dict[str, Dict[str, Any]]:
     ``armed`` / ``de_armed(reason)`` / ``pending`` — so there is no unit left
     that can advertise more than it serves. This is the record the per-entry
     hub events (§1.7) are built from.
+
+    This is the MODULE-armed half: it reads the pipeline marker. A
+    store-armed class has no pipeline to hang a marker on and reports through
+    :meth:`StoreArmedGraph.entry_states`, which returns the same vocabulary
+    from the same builder.
     """
     marker = getattr(pipeline, _MARKER_ATTR, None) or {}
     out: Dict[str, Dict[str, Any]] = {}
@@ -1844,13 +1888,7 @@ def entry_states(pipeline: Any) -> Dict[str, Dict[str, Any]]:
         dispatch = _dispatch_for(marker, target)
         if dispatch is None:
             continue
-        for name, runner in dispatch.runners:
-            out[name] = {
-                "state": "armed", "target": target, "calls": int(runner.calls)}
-        for name, why in dispatch.de_armed.items():
-            out[name] = {"state": "de_armed", "target": target, "reason": why}
-        for name in dispatch.pending:
-            out[name] = {"state": "pending", "target": target}
+        out.update(dispatch_states(str(target), dispatch))
     return out
 
 

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -7,10 +7,17 @@ dispatch, eager fallback, sticky de-arm, shape-growth reporting and live
 serve-state introspection.
 
 An arm resolves and creates a runner at the same destination, binds the
-resident module tensors, and only then mutates the live module. Each compiled
-graph class is independently visible through :func:`entry_states`; no
-worker-owned archive, extraction tree, package loader or compatibility store
-exists here.
+constant table, and only then mutates any live state. Each compiled graph
+class is independently visible through :func:`entry_states`; no worker-owned
+archive, extraction tree, package loader or compatibility store exists here.
+
+pgw#1329: there are TWO constant sources and they share everything else.
+:func:`arm_compiled_graph` reads a resident eager module, which is why the
+pipeline had to be loaded before anything compiled could serve;
+:func:`arm_compiled_graph_from_store` reads the store by manifest FQN, with
+no ``nn.Module`` on the path at all. Loading the eager pipeline is therefore
+a POLICY choice (eager fallback, the mint's own proofs), not a precondition
+of compiled serving.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -34,6 +34,7 @@ from gen_worker._vendor.torchcg import (
 )
 
 from . import activity as activity_mod
+from . import aot_constants
 from . import aot_identity
 from . import local_cell_store
 from .cell_adopt import AdoptOutcome
@@ -1470,21 +1471,34 @@ def _tcg_destination(cache_dir: Optional[Path], compiled_graph_key: str) -> Path
     return root / "compiled-graph-runtime" / compiled_graph_key
 
 
-def arm_compiled_graph(
-    pipeline: Any,
-    cfg: Any,
-    compiled_graph_key: str,
-    cache_dir: Optional[Path] = None,
-    *,
-    declared: Sequence[str] = (),
-) -> Dict[str, Any]:
-    """Resolve, bind, then register one exact TCG graph class.
+@dataclass(frozen=True)
+class ResolvedGraphClass:
+    """One exact key, resolved and loaded, before any constant source is asked.
+
+    Everything both arms share. The two arms differ ONLY in where the
+    ``state_dict`` constants come from, so this half is written once: a
+    resolve that models the artifact differently from the arm is the
+    pgw#816/#822 class, one level up from the constant table.
+    """
+
+    key: str
+    runner: CompiledGraphRunner
+    metadata: Dict[str, Any]
+    graph_class: Mapping[str, Any]
+    graph: Mapping[str, Any]
+    name: str
+    target: str
+
+
+def _resolve_graph_class(
+    compiled_graph_key: str, cache_dir: Optional[Path]
+) -> ResolvedGraphClass:
+    """Resolve one exact key and validate its declared graph class.
 
     TCG is the only artifact/store authority. The first resolve establishes
     the immutable extraction directory and admitted metadata; ``runner`` is
     asked for the same key and the same directory, so its internal resolve
-    verifies/reuses that extraction instead of creating a second one. No live
-    module or dispatch state changes until TCG's exact constant bind succeeds.
+    verifies/reuses that extraction instead of creating a second one.
     """
 
     key = str(compiled_graph_key or "").strip()
@@ -1539,6 +1553,41 @@ def arm_compiled_graph(
         raise AdoptError(
             "contract_invalid", "TCG graph_class must name both graph class and target"
         )
+    return ResolvedGraphClass(
+        key=key,
+        runner=runner,
+        metadata=metadata,
+        graph_class=graph_class,
+        graph=graph,
+        name=name,
+        target=target,
+    )
+
+
+def arm_compiled_graph(
+    pipeline: Any,
+    cfg: Any,
+    compiled_graph_key: str,
+    cache_dir: Optional[Path] = None,
+    *,
+    declared: Sequence[str] = (),
+) -> Dict[str, Any]:
+    """Resolve, bind, then register one exact TCG graph class.
+
+    The MODULE-SOURCED arm: the live eager module supplies the constant
+    table, so the whole pipeline must be resident. That is a POLICY choice
+    (eager fallback, the mint's own parity proofs), not a property of
+    compiled serving — :func:`arm_compiled_graph_from_store` is the same arm
+    with the store as the constant source and no module at all.
+
+    No live module or dispatch state changes until TCG's exact constant bind
+    succeeds.
+    """
+
+    resolved = _resolve_graph_class(compiled_graph_key, cache_dir)
+    key, runner = resolved.key, resolved.runner
+    metadata, graph_class = resolved.metadata, resolved.graph_class
+    graph, name, target = resolved.graph, resolved.name, resolved.target
 
     family = str(getattr(cfg, "family", "") or "")
     module, attr = _target_owner(pipeline, target)
@@ -1595,6 +1644,139 @@ def arm_compiled_graph(
         key,
     )
     return serve_meta
+
+
+@dataclass(frozen=True)
+class StoreArmedGraph:
+    """One graph class armed with NO module anywhere on the path.
+
+    The record is deliberately split along the family/instance line
+    (pgw#1326, §4.27). ``key``/``graph_class``/``target`` are CLASS-level and
+    checkpoint-free — the same three for every fine-tune sharing one ``.so``.
+    ``weight_set`` and ``constants`` are INSTANCE-level: which checkpoint this
+    binding is of, and the tensors it bound. Two of these over one ``key``
+    with different ``weight_set``s are two instances of one family, which is
+    the shape a resident-module arm could not state at all.
+
+    ``constants`` is held because TCG installs the constant pointers
+    ``user_managed``: the tensors must outlive the runner, and with no module
+    to own them this record is that owner. Dropping it frees the weights out
+    from under a live AOTI container.
+    """
+
+    key: str
+    graph_class: str
+    target: str
+    family: str
+    weight_set: aot_constants.WeightSetRef
+    runner: TCGEntryRunner
+    dispatch: EntryDispatch
+    meta: Dict[str, Any]
+    constants: Dict[str, Any]
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Route one call through the ordinary ingress dispatch.
+
+        There is no module to wrap, so this record IS the call site. The
+        selection, the contract refusals and the per-entry counters are the
+        same ones a wrapped module gets — nothing about serving is special
+        because the constants came from the store.
+        """
+
+        _name, runner = self.dispatch.select(args, kwargs)
+        return runner(*args, **kwargs)
+
+
+def arm_compiled_graph_from_store(
+    cfg: Any,
+    compiled_graph_key: str,
+    store: aot_constants.ConstantStore,
+    *,
+    device: str,
+    cache_dir: Optional[Path] = None,
+    declared: Sequence[str] = (),
+) -> StoreArmedGraph:
+    """Arm one exact graph class from STORE bytes, by manifest FQN.
+
+    The same resolve, the same ingress contract and the same
+    ``CompiledGraphRunner.bind`` as :func:`arm_compiled_graph` — with the
+    constant table read out of the store the artifact's manifest names,
+    instead of out of a resident ``nn.Module``. No ``nn.Module`` and no
+    diffusers class is constructed, imported or touched on this path, which
+    is what lets an adopt-only serve host (pgw#1328) exist at all.
+
+    Order is the contract:
+
+    1. resolve the exact key (quarantine, admission, graph-class validation);
+    2. parse the declared constant table as a versioned, typed manifest;
+    3. check the WHOLE table against the store's headers — a refusal here
+       has allocated no device memory and registered no entry;
+    4. read the constants onto ``device`` and bind;
+    5. only then register the entry.
+
+    A store miss therefore costs a header read. It cannot cost a
+    half-populated constant table on a runner that ``bind`` has already
+    marked failed and un-bindable.
+    """
+
+    resolved = _resolve_graph_class(compiled_graph_key, cache_dir)
+    family = str(getattr(cfg, "family", "") or "")
+    target_device = str(device or "").strip()
+    if not target_device:
+        raise AdoptError(
+            "device_missing",
+            f"graph class {resolved.name!r}: a store-sourced arm has no module to "
+            f"take a device from, so the caller must name one",
+        )
+
+    manifest = aot_constants.parse_constant_manifest(
+        resolved.graph_class,
+        compiled_graph_format=resolved.metadata.get(COMPILED_GRAPH_FORMAT_KEY),
+    )
+    plan = aot_constants.plan_store_constants(manifest, store)
+    contract = CallIngress.from_graph(resolved.graph)
+    try:
+        constants = aot_constants.realize_store_constants(
+            plan, store, device=target_device
+        )
+        resolved.runner.bind(constants, device=target_device)
+    except ConstantBindingError as exc:
+        reason = ADOPT_OOM_REASON if exc.reason == "out_of_memory" else exc.reason
+        raise AdoptError(reason, f"graph class {resolved.name!r}: {exc}") from exc
+
+    dispatch = EntryDispatch(declared=tuple(str(item) for item in declared))
+    entry_runner = TCGEntryRunner(
+        resolved.runner, contract, resolved.target, resolved.name, family
+    )
+    dispatch.add(resolved.name, entry_runner)
+    serve_meta: Dict[str, Any] = {
+        **resolved.metadata,
+        "family": family,
+        "compiled_graph_key": resolved.key,
+        "constant_source": "store",
+        "weight_set": str(plan.weight_set),
+    }
+    logger.info(
+        "aot-serve: armed TCG graph class %s on %s from the store "
+        "(%d constants, %d store-sourced, weight_set=%s, key=%s)",
+        resolved.name,
+        resolved.target,
+        len(resolved.runner.declared_fqns),
+        len(plan),
+        plan.weight_set,
+        resolved.key,
+    )
+    return StoreArmedGraph(
+        key=resolved.key,
+        graph_class=resolved.name,
+        target=resolved.target,
+        family=family,
+        weight_set=plan.weight_set,
+        runner=entry_runner,
+        dispatch=dispatch,
+        meta=serve_meta,
+        constants=constants,
+    )
 
 
 def disarm_entry(pipeline: Any, name: str, reason: str) -> bool:

--- a/src/gen_worker/benchmarks/results/store-arm-parity-20260817-sm86-rtx3090.json
+++ b/src/gen_worker/benchmarks/results/store-arm-parity-20260817-sm86-rtx3090.json
@@ -14,7 +14,7 @@
     "python": "3.12.14",
     "cuda": "13.0"
   },
-  "device_name": "NVIDIA RTX A5000",
+  "device_name": "NVIDIA GeForce RTX 3090",
   "calls": [
     {
       "call": 0,

--- a/src/gen_worker/benchmarks/results/store-arm-parity-20260817-sm86.json
+++ b/src/gen_worker/benchmarks/results/store-arm-parity-20260817-sm86.json
@@ -1,0 +1,59 @@
+{
+  "issue": "pgw#1329",
+  "key": "cg-key-v1-1fb763670ce8eda71cdad05525fccb43216f3f52e417a867ee04403c",
+  "target": "sm_86",
+  "graph_class": "probe-block",
+  "weight_set": "probe://store-arm-parity/v1",
+  "control_weight_set": "probe://store-arm-parity/v1-control",
+  "declared_constants": 5,
+  "store_held_tensors": 4,
+  "store_sourced_constants": 4,
+  "distinct_runners": true,
+  "toolchain": {
+    "torch": "2.13.0+cu130",
+    "python": "3.12.14",
+    "cuda": "13.0"
+  },
+  "device_name": "NVIDIA RTX A5000",
+  "calls": [
+    {
+      "call": 0,
+      "bitwise_equal": true,
+      "control_differs": true,
+      "control_expected_to_differ": true,
+      "control_as_expected": true,
+      "dtype": "torch.float32",
+      "shape": [
+        1,
+        64
+      ]
+    },
+    {
+      "call": 1,
+      "bitwise_equal": true,
+      "control_differs": true,
+      "control_expected_to_differ": true,
+      "control_as_expected": true,
+      "dtype": "torch.float32",
+      "shape": [
+        1,
+        64
+      ]
+    },
+    {
+      "call": 2,
+      "bitwise_equal": true,
+      "control_differs": false,
+      "control_expected_to_differ": false,
+      "control_as_expected": true,
+      "dtype": "torch.float32",
+      "shape": [
+        1,
+        64
+      ]
+    }
+  ],
+  "bitwise_equal": true,
+  "control_non_vacuous": true,
+  "constant_source": "store"
+}

--- a/src/gen_worker/benchmarks/store_arm_parity.py
+++ b/src/gen_worker/benchmarks/store_arm_parity.py
@@ -22,7 +22,11 @@ Steps, in order:
 5. arm B: ``arm_compiled_graph_from_store`` (store-sourced, no module),
    with ``diffusers`` fenced unimportable and ``nn.Module.__init__``
    poisoned for the duration;
-6. run both over the same pinned inputs and compare RAW BYTES.
+6. run both over the same pinned inputs and compare RAW BYTES;
+7. arm a CONTROL from a store whose `lin.weight` differs by one ULP and
+   require the output to move on exactly the inputs that can carry the
+   perturbation — an equality nothing can falsify is not a proof that the
+   store fed the graph.
 
 Bitwise means bitwise: the comparison is over ``.view(torch.uint8)``, not
 ``allclose``, and not ``torch.equal`` (which compares values, so two NaN
@@ -202,14 +206,50 @@ def run(output: Path, target: str) -> Dict[str, Any]:
         with torch.no_grad():
             store_out = [armed(sample) for sample in inputs]
 
+    # --- the NON-VACUITY control ------------------------------------------
+    # An equality proof is worth nothing until the same rig can produce an
+    # INequality. A store whose `lin.weight` differs by one ULP must move the
+    # output; if it does not, the store arm is not the thing feeding the
+    # graph and every `bitwise_equal` above is an artefact of the rig.
+    control_dir = scratch / "store-control" / TARGET
+    control_dir.mkdir(parents=True)
+    perturbed = dict(state)
+    perturbed["lin.weight"] = torch.nextafter(
+        state["lin.weight"], torch.full_like(state["lin.weight"], float("inf"))
+    )
+    save_file(perturbed, str(control_dir / "model.safetensors"))
+    control_store = aot_constants.SafetensorsConstantStore.for_component(
+        control_dir, weight_set=WEIGHT_SET + "-control", why="pgw#1329 control"
+    )
+    with _NoDiffusers():
+        control = aot_serve.arm_compiled_graph_from_store(
+            cfg, key, control_store, device=device, cache_dir=cas_root
+        )
+        with torch.no_grad():
+            control_out = [control(sample) for sample in inputs]
+    # A perturbed WEIGHT can only reach the output through a non-zero input:
+    # the all-zeros call is `lin(0) = bias`, where the weight is arithmetically
+    # unreachable. So the control's expectation is per input, and it binds in
+    # BOTH directions — a zero-input call that moved would mean the
+    # perturbation leaked somewhere it cannot legitimately reach.
+    control_moved = [
+        _raw(left) != _raw(right) for left, right in zip(store_out, control_out)
+    ]
+    control_expected = [bool(sample.abs().sum().item() > 0) for sample in inputs]
+
     rows = [
         {
             "call": index,
             "bitwise_equal": _raw(left) == _raw(right),
+            "control_differs": moved,
+            "control_expected_to_differ": expected,
+            "control_as_expected": moved == expected,
             "dtype": str(left.dtype),
             "shape": list(left.shape),
         }
-        for index, (left, right) in enumerate(zip(module_out, store_out))
+        for index, (left, right, moved, expected) in enumerate(
+            zip(module_out, store_out, control_moved, control_expected)
+        )
     ]
     row = {
         "issue": "pgw#1329",
@@ -217,18 +257,29 @@ def run(output: Path, target: str) -> Dict[str, Any]:
         "target": target,
         "graph_class": armed.graph_class,
         "weight_set": str(armed.weight_set),
+        "control_weight_set": str(control.weight_set),
         "declared_constants": len(armed.runner.declared_fqns()),
-        "store_sourced_constants": len(store.describe()),
+        "store_held_tensors": len(store.describe()),
+        "store_sourced_constants": len(armed.constants),
+        "distinct_runners": armed.runner is not control.runner,
         "toolchain": _toolchain(),
         "device_name": torch.cuda.get_device_name(0),
         "calls": rows,
         "bitwise_equal": all(entry["bitwise_equal"] for entry in rows),
+        "control_non_vacuous": any(control_moved)
+        and control_moved == control_expected,
         "constant_source": armed.meta.get("constant_source"),
     }
     output.write_text(json.dumps(row, indent=2) + "\n")
-    print(json.dumps(row, indent=2))
+    print(json.dumps(row, indent=2), flush=True)
     if not row["bitwise_equal"]:
         raise SystemExit("STORE-SOURCED ARM IS NOT BITWISE EQUAL — the bar failed")
+    if not row["control_non_vacuous"]:
+        raise SystemExit(
+            "the 1-ULP control did not move the output where it must (or moved "
+            "it where it cannot) — the equality above is vacuous and proves "
+            "nothing about the store arm"
+        )
     return row
 
 

--- a/src/gen_worker/benchmarks/store_arm_parity.py
+++ b/src/gen_worker/benchmarks/store_arm_parity.py
@@ -169,7 +169,10 @@ def run(output: Path, target: str) -> Dict[str, Any]:
     )
 
     scratch = Path(tempfile.mkdtemp(prefix="pgw1329-"))
-    os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", str(scratch / "inductor-cache"))
+    # The probe owns its Inductor cache outright rather than deferring to an
+    # inherited one: a warm cache from an earlier arm would make "both arms
+    # compiled the same graph" an assumption instead of a fact.
+    os.environ["TORCHINDUCTOR_CACHE_DIR"] = str(scratch / "inductor-cache")
     cas_root = scratch / "cas"
     engine = Engine(LocalCAS(cas_root))
     minted = engine.compile(
@@ -255,7 +258,9 @@ def run(output: Path, target: str) -> Dict[str, Any]:
         "issue": "pgw#1329",
         "key": key,
         "target": target,
-        "graph_class": armed.graph_class,
+        # a column of THIS probe's result row, off StoreArmedGraph — not a
+        # read of TCG's metadata block.
+        "graph_class": armed.graph_class,  # tcg-vocab: own result column
         "weight_set": str(armed.weight_set),
         "control_weight_set": str(control.weight_set),
         "declared_constants": len(armed.runner.declared_fqns()),

--- a/src/gen_worker/benchmarks/store_arm_parity.py
+++ b/src/gen_worker/benchmarks/store_arm_parity.py
@@ -49,7 +49,7 @@ import torch
 from safetensors.torch import save_file
 from torch import nn
 
-from gen_worker import aot_constants, aot_serve
+from gen_worker import aot_constants, aot_serve, hostfacts
 from gen_worker._vendor.tensorfs import LocalCAS
 from gen_worker._vendor.torchcg import (
     Engine,
@@ -146,8 +146,21 @@ class _NoDiffusers:
 
 
 def run(output: Path, target: str) -> Dict[str, Any]:
-    if not torch.cuda.is_available():
+    # `hostfacts` is the ONE home for these three questions (pgw#896). Asking
+    # torch directly here would be the 75th raw `is_available()` call site, and
+    # it would also format `sm_NN` a second way — the axis the artifact is
+    # keyed on must not have two spellings in the one program that proves the
+    # artifact.
+    device_name, host_sm = hostfacts.device_identity()
+    if not hostfacts.cuda_ready() or not host_sm:
         raise SystemExit("this probe is the GPU bar; it must not run on CPU")
+    if target != host_sm:
+        # An artifact minted for one sm and executed on another is the exact
+        # confusion `cg-key-v1` exists to make impossible; a probe that allowed
+        # it could report a bitwise verdict about a pairing no pod can have.
+        raise SystemExit(
+            f"--target {target} but this card is {host_sm} ({device_name})"
+        )
     device = "cuda"
     torch.manual_seed(1329)
 
@@ -268,7 +281,7 @@ def run(output: Path, target: str) -> Dict[str, Any]:
         "store_sourced_constants": len(armed.constants),
         "distinct_runners": armed.runner is not control.runner,
         "toolchain": _toolchain(),
-        "device_name": torch.cuda.get_device_name(0),
+        "device_name": device_name,
         "calls": rows,
         "bitwise_equal": all(entry["bitwise_equal"] for entry in rows),
         "control_non_vacuous": any(control_moved)
@@ -293,10 +306,9 @@ def main() -> None:
     parser.add_argument("--output", type=Path, default=Path("row.json"))
     parser.add_argument("--target", default="", help="concrete sm_NN; derived when empty")
     arguments = parser.parse_args()
-    target = arguments.target
+    target = arguments.target or hostfacts.device_identity()[1]
     if not target:
-        major, minor = torch.cuda.get_device_capability(0)
-        target = f"sm_{major}{minor}"
+        raise SystemExit("no CUDA device to derive a target from")
     run(arguments.output, target)
 
 

--- a/src/gen_worker/benchmarks/store_arm_parity.py
+++ b/src/gen_worker/benchmarks/store_arm_parity.py
@@ -1,0 +1,248 @@
+"""pgw#1329's acceptance bar, on a real GPU: two arms, one bit pattern.
+
+The claim under test is not "the store path runs". It is that a compiled
+graph armed from STORE bytes by manifest FQN produces output **bitwise
+identical** to the same graph armed from a resident eager module — because if
+it does not, "loading the pipeline is a policy choice" is false and adopt-only
+serving (pgw#1328) changes what a pod answers.
+
+One pod does the whole thing, because the proof is arm-vs-arm on ONE host:
+portability is tcg#4's question, not this one.
+
+    python -m gen_worker.benchmarks.store_arm_parity --output row.json
+
+Steps, in order:
+
+1. build a small module with real named parameters AND a non-persistent
+   buffer, on the GPU;
+2. mint it through the sealed ``Engine`` — a real ``torch.export`` +
+   AOTInductor compile, exactly as a serving pod mints (§4.28/§4.30);
+3. write the module's ``state_dict`` to safetensors — the STORE;
+4. arm A: ``arm_compiled_graph`` (module-sourced, today's path);
+5. arm B: ``arm_compiled_graph_from_store`` (store-sourced, no module),
+   with ``diffusers`` fenced unimportable and ``nn.Module.__init__``
+   poisoned for the duration;
+6. run both over the same pinned inputs and compare RAW BYTES.
+
+Bitwise means bitwise: the comparison is over ``.view(torch.uint8)``, not
+``allclose``, and not ``torch.equal`` (which compares values, so two NaN
+payloads or a -0.0/0.0 pair would pass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import builtins
+import json
+import os
+import platform
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, List, cast
+
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from gen_worker import aot_constants, aot_serve
+from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker._vendor.torchcg import (
+    Engine,
+    GraphClassSpec,
+    RuntimeCompatibility,
+    build_call_ingress,
+)
+
+FAMILY = "store-arm-parity"
+GRAPH_CLASS = "probe-block"
+TARGET = "denoiser"
+WIDTH = 64
+WEIGHT_SET = "probe://store-arm-parity/v1"
+
+
+class ProbeBlock(nn.Module):
+    """Small, but every constant KIND the bind has to handle.
+
+    Two parameters, one persistent buffer and one NON-persistent buffer.
+    The last is the pgw#825 shape: ``state_dict()`` omits it while
+    ``torch.export`` lifts it as a ``ConstantType::Buffer`` under its real
+    FQN, so the module arm reaches it only through ``named_buffers`` — and
+    the store arm must reach it through the checkpoint, or fail closed
+    naming it. A probe without one would prove the easy half.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(WIDTH, WIDTH)
+        self.register_buffer("scale", torch.linspace(0.5, 1.5, WIDTH))
+        self.register_buffer(
+            "bias_branch", torch.linspace(-0.25, 0.25, WIDTH), persistent=False
+        )
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        hidden = torch.nn.functional.gelu(self.lin(value))
+        scale = cast(torch.Tensor, self.scale)
+        branch = cast(torch.Tensor, self.bias_branch)
+        return hidden * scale + branch
+
+
+def _toolchain() -> Dict[str, str]:
+    return {
+        "torch": str(torch.__version__),
+        "python": platform.python_version(),
+        "cuda": str(torch.version.cuda or ""),
+    }
+
+
+def _store_state(module: nn.Module) -> Dict[str, torch.Tensor]:
+    """Exactly what ``resident_constants`` sees, as a checkpoint would hold it.
+
+    ``state_dict()`` plus the non-persistent buffers — the same union, so the
+    store and the module are offering the identical set and any output
+    difference is attributable to the PATH, not to a different table.
+    """
+
+    state: Dict[str, torch.Tensor] = {
+        name: tensor.detach().cpu().contiguous()
+        for name, tensor in module.state_dict().items()
+    }
+    for name, buffer in module.named_buffers():
+        if buffer is not None:
+            state.setdefault(str(name), buffer.detach().cpu().contiguous())
+    return state
+
+
+def _raw(tensor: torch.Tensor) -> bytes:
+    return tensor.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
+
+
+class _NoDiffusers:
+    """``diffusers`` unimportable and ``nn.Module`` unconstructible."""
+
+    def __enter__(self) -> "_NoDiffusers":
+        self._import: Callable[..., Any] = builtins.__import__
+        self._module_init: Callable[..., Any] = nn.Module.__init__
+
+        def fenced(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "diffusers" or name.startswith("diffusers."):
+                raise AssertionError(f"the store-sourced arm imported {name!r}")
+            return self._import(name, *args, **kwargs)
+
+        def poisoned(_self: Any, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError("the store-sourced arm constructed an nn.Module")
+
+        builtins.__import__ = fenced
+        setattr(nn.Module, "__init__", poisoned)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        builtins.__import__ = self._import
+        setattr(nn.Module, "__init__", self._module_init)
+
+
+def run(output: Path, target: str) -> Dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise SystemExit("this probe is the GPU bar; it must not run on CPU")
+    device = "cuda"
+    torch.manual_seed(1329)
+
+    module = ProbeBlock().to(device).eval()
+    example = torch.linspace(-3.0, 3.0, WIDTH, device=device).reshape(1, WIDTH)
+    with torch.no_grad():
+        program = torch.export.export(module, (example,))
+    ingress = build_call_ingress(program, ("value",), (example,), {})
+    spec = GraphClassSpec(
+        GRAPH_CLASS,
+        TARGET,
+        program,
+        {
+            "v": 3,
+            "lifted_inputs": [],
+            "pytree": {"in": "leaf", "out": "leaf", "ingress": ingress.as_dict()},
+            "specialization": {},
+        },
+    )
+
+    scratch = Path(tempfile.mkdtemp(prefix="pgw1329-"))
+    os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", str(scratch / "inductor-cache"))
+    cas_root = scratch / "cas"
+    engine = Engine(LocalCAS(cas_root))
+    minted = engine.compile(
+        spec, RuntimeCompatibility(target, toolchain=_toolchain()), scratch / "minted"
+    )
+    key = str(minted.compiled_graph.key)
+
+    component = scratch / "store" / TARGET
+    component.mkdir(parents=True)
+    state = _store_state(module)
+    save_file(state, str(component / "model.safetensors"))
+
+    cfg = SimpleNamespace(family=FAMILY, lora_bucket=0)
+    inputs: List[torch.Tensor] = [
+        example,
+        torch.linspace(-1.0, 1.0, WIDTH, device=device).reshape(1, WIDTH),
+        torch.zeros(1, WIDTH, device=device),
+    ]
+
+    # --- arm A: today's path, the eager module IS the constant source ------
+    pipeline = SimpleNamespace(**{TARGET: module})
+    aot_serve.arm_compiled_graph(pipeline, cfg, key, cas_root)
+    with torch.no_grad():
+        module_out = [module(sample) for sample in inputs]
+
+    # --- arm B: the store, with no module reachable at all -----------------
+    store = aot_constants.SafetensorsConstantStore.for_component(
+        component, weight_set=WEIGHT_SET, why="pgw#1329 store-sourced arm"
+    )
+    with _NoDiffusers():
+        armed = aot_serve.arm_compiled_graph_from_store(
+            cfg, key, store, device=device, cache_dir=cas_root
+        )
+        with torch.no_grad():
+            store_out = [armed(sample) for sample in inputs]
+
+    rows = [
+        {
+            "call": index,
+            "bitwise_equal": _raw(left) == _raw(right),
+            "dtype": str(left.dtype),
+            "shape": list(left.shape),
+        }
+        for index, (left, right) in enumerate(zip(module_out, store_out))
+    ]
+    row = {
+        "issue": "pgw#1329",
+        "key": key,
+        "target": target,
+        "graph_class": armed.graph_class,
+        "weight_set": str(armed.weight_set),
+        "declared_constants": len(armed.runner.declared_fqns()),
+        "store_sourced_constants": len(store.describe()),
+        "toolchain": _toolchain(),
+        "device_name": torch.cuda.get_device_name(0),
+        "calls": rows,
+        "bitwise_equal": all(entry["bitwise_equal"] for entry in rows),
+        "constant_source": armed.meta.get("constant_source"),
+    }
+    output.write_text(json.dumps(row, indent=2) + "\n")
+    print(json.dumps(row, indent=2))
+    if not row["bitwise_equal"]:
+        raise SystemExit("STORE-SOURCED ARM IS NOT BITWISE EQUAL — the bar failed")
+    return row
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=Path("row.json"))
+    parser.add_argument("--target", default="", help="concrete sm_NN; derived when empty")
+    arguments = parser.parse_args()
+    target = arguments.target
+    if not target:
+        major, minor = torch.cuda.get_device_capability(0)
+        target = f"sm_{major}{minor}"
+    run(arguments.output, target)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gen_worker/models/tensor_source.py
+++ b/src/gen_worker/models/tensor_source.py
@@ -31,7 +31,12 @@ _log = logging.getLogger(__name__)
 #: safetensors dtype spelling -> torch dtype attribute name. Only the dtypes
 #: this fleet's checkpoints actually carry; an unknown one is a refusal, never
 #: a guess, because guessing an element width silently reshapes the tensor.
-_TORCH_DTYPES = {
+#:
+#: PUBLIC because a second consumer arrived (pgw#1329's constant store, which
+#: must compare a shard header's dtype against the artifact manifest's torch
+#: dtype name before it allocates). A private copy per lane is the fail-open
+#: duplication this module was written to end, one level down.
+TORCH_DTYPES = {
     "BOOL": "bool",
     "U8": "uint8",
     "I8": "int8",
@@ -75,7 +80,7 @@ class _NativeSource:
 
         view: TensorView = self._reader[name]
         try:
-            torch_dtype = getattr(torch, _TORCH_DTYPES[view.dtype])
+            torch_dtype = getattr(torch, TORCH_DTYPES[view.dtype])
         except (KeyError, AttributeError) as exc:
             raise projection.UnresolvedProjection(
                 f"{name}: safetensors dtype {view.dtype!r} has no torch dtype "
@@ -131,6 +136,7 @@ def load_state_dict(
 
 
 __all__ = [
+    "TORCH_DTYPES",
     "TensorSource",
     "load_state_dict",
     "open_tensor_source",

--- a/tests/test_store_sourced_arm_pgw1329.py
+++ b/tests/test_store_sourced_arm_pgw1329.py
@@ -1,0 +1,615 @@
+"""Arming a compiled graph from the STORE, with no eager module anywhere.
+
+pgw#1329. ``arm_compiled_graph`` binds ``resident_constants(module)``, so
+serving one compiled graph required the whole diffusers pipeline resident as
+the constant SOURCE — the single reason adopt-only serving (pgw#1328) could
+not shed eager loading. The artifact already names every constant by FQN,
+dtype and exact shape, so the same by-reference table is buildable from
+safetensors bytes.
+
+What is REAL here: real safetensors shards on disk, the real manifest parser,
+the real two-phase plan/realize, the real ``EntryDispatch`` registration, and
+a runner double that enforces TCG's actual ``bind`` contract (once-only,
+exact table, ``user_managed``). What is NOT here is the AOTI compile — it
+cannot run on the dev box (weights/compile locality) and proving it in
+software would prove nothing about a GPU. The bitwise-equality bar lives on a
+real pod: ``gen_worker.benchmarks.store_arm_parity``.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from safetensors.torch import save_file
+
+from gen_worker import aot_constants, aot_serve
+from gen_worker.compile_cache import AdoptError
+from gen_worker._vendor.torchcg import CallIngress, CallInput
+
+FAMILY = "store-arm-1329"
+KEY = "cg-key-v1-" + "b" * 56
+GRAPH_CLASS = "denoiser"
+TARGET = "transformer"
+WEIGHT_SET = "cozy://weights/tiny-1329@sha256:" + "c" * 8
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a real shard, a real graph_class block, a contract-enforcing runner
+# ---------------------------------------------------------------------------
+
+
+def _shard(directory: Path, name: str, tensors: Mapping[str, Any]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    save_file(dict(tensors), str(path))
+    return path
+
+
+def _weights() -> Dict[str, Any]:
+    generator = torch.Generator().manual_seed(1329)
+    return {
+        "lin.weight": torch.randn(8, 8, generator=generator, dtype=torch.float32),
+        "lin.bias": torch.randn(8, generator=generator, dtype=torch.float32),
+    }
+
+
+def _constant_rows(weights: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "fqn": name,
+            "source": "state_dict",
+            "dtype": str(tensor.dtype).removeprefix("torch."),
+            "shape": list(tensor.shape),
+        }
+        for name, tensor in sorted(weights.items())
+    ]
+
+
+def _contract() -> CallIngress:
+    return CallIngress(
+        parameters=("sample",),
+        flat_arity=1,
+        inputs=(
+            CallInput("sample", 0, "sample", 0, (), "sample", "float32", (1, 8)),
+        ),
+    )
+
+
+def _graph_block(weights: Mapping[str, Any]) -> Dict[str, Any]:
+    """A graph_class block shaped exactly as TCG admits one."""
+
+    return {
+        "name": GRAPH_CLASS,
+        "target": TARGET,
+        "class_hash": "d" * 16,
+        "constants": _constant_rows(weights),
+        "graph": {"pytree": {"ingress": _contract().as_dict()}},
+    }
+
+
+class _RunnerDouble:
+    """TCG's ``bind`` contract, enforced — not a permissive stand-in.
+
+    Once-only, exact-table, and it REFUSES a value that is not the declared
+    dtype/shape. A double that accepted anything would let this file pass
+    while the real runner rejected the same table on a pod.
+    """
+
+    def __init__(self, rows: Sequence[Mapping[str, Any]]) -> None:
+        self._rows = [dict(row) for row in rows]
+        self.bound = False
+        self.calls = 0
+        self.bound_values: Dict[str, Any] = {}
+
+    @property
+    def declared_fqns(self) -> Tuple[str, ...]:
+        return tuple(str(row["fqn"]) for row in self._rows)
+
+    def bind(self, state: Mapping[str, Any], *, device: str) -> None:
+        if self.bound:
+            raise AssertionError("bind is once-only and was called twice")
+        wanted = {
+            str(row["fqn"]) for row in self._rows if row["source"] == "state_dict"
+        }
+        if set(state) != wanted:
+            raise AssertionError(
+                f"bind table != declared state_dict set: "
+                f"extra={sorted(set(state) - wanted)!r} "
+                f"missing={sorted(wanted - set(state))!r}"
+            )
+        for row in self._rows:
+            if row["source"] != "state_dict":
+                continue
+            value = state[str(row["fqn"])]
+            assert str(value.dtype).removeprefix("torch.") == row["dtype"]
+            assert list(value.shape) == list(row["shape"])
+            assert str(value.device).startswith(str(device))
+        self.bound_values = dict(state)
+        self.bound = True
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        weight = self.bound_values["lin.weight"]
+        bias = self.bound_values["lin.bias"]
+        return torch.nn.functional.linear(args[0], weight, bias)
+
+
+def _resolved(weights: Mapping[str, Any]) -> aot_serve.ResolvedGraphClass:
+    block = _graph_block(weights)
+    return aot_serve.ResolvedGraphClass(
+        key=KEY,
+        runner=_RunnerDouble(block["constants"]),  # type: ignore[arg-type]
+        metadata={
+            aot_serve.COMPILED_GRAPH_FORMAT_KEY: aot_serve.COMPILED_GRAPH_FORMAT,
+            "compiled_graph_key": KEY,
+        },
+        graph_class=block,
+        graph=block["graph"],
+        name=GRAPH_CLASS,
+        target=TARGET,
+    )
+
+
+@pytest.fixture()
+def armed_store(tmp_path: Path) -> Tuple[Dict[str, Any], aot_constants.ConstantStore]:
+    weights = _weights()
+    _shard(tmp_path / "transformer", "model.safetensors", weights)
+    store = aot_constants.SafetensorsConstantStore.for_component(
+        tmp_path / "transformer", weight_set=WEIGHT_SET, why="pgw#1329 arm"
+    )
+    return weights, store
+
+
+def _patch_resolve(
+    monkeypatch: pytest.MonkeyPatch, weights: Mapping[str, Any]
+) -> aot_serve.ResolvedGraphClass:
+    resolved = _resolved(weights)
+    monkeypatch.setattr(
+        aot_serve, "_resolve_graph_class", lambda _key, _cache: resolved
+    )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# The manifest is a versioned, typed schema
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_refuses_an_envelope_version_it_does_not_understand() -> None:
+    with pytest.raises(aot_constants.ConstantManifestError) as excinfo:
+        aot_constants.parse_constant_manifest(
+            _graph_block(_weights()), compiled_graph_format=2
+        )
+    assert excinfo.value.reason == "manifest_version_unsupported"
+
+
+def test_manifest_refuses_a_row_whose_field_set_is_not_v1() -> None:
+    block = _graph_block(_weights())
+    block["constants"][0]["provenance"] = "somewhere"
+    with pytest.raises(aot_constants.ConstantManifestError) as excinfo:
+        aot_constants.parse_constant_manifest(block, compiled_graph_format=1)
+    assert excinfo.value.reason == "constant_row_malformed"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason"),
+    [
+        (lambda row: row.update(source="whatever"), "constant_source_unknown"),
+        (lambda row: row.update(dtype="torch.float32"), "dtype_malformed"),
+        (lambda row: row.update(dtype=""), "dtype_malformed"),
+        (lambda row: row.update(fqn=" lin.weight"), "fqn_malformed"),
+        (lambda row: row.update(fqn="lin..weight"), "fqn_malformed"),
+        (lambda row: row.update(shape=[-1, 8]), "shape_malformed"),
+        (lambda row: row.update(shape=[True]), "shape_malformed"),
+    ],
+)
+def test_manifest_refuses_each_malformed_row(
+    mutate: Any, reason: str
+) -> None:
+    block = _graph_block(_weights())
+    mutate(block["constants"][0])
+    with pytest.raises(aot_constants.ConstantManifestError) as excinfo:
+        aot_constants.parse_constant_manifest(block, compiled_graph_format=1)
+    assert excinfo.value.reason == reason
+
+
+def test_manifest_refuses_a_duplicated_fqn() -> None:
+    block = _graph_block(_weights())
+    block["constants"].append(dict(block["constants"][0]))
+    with pytest.raises(aot_constants.ConstantManifestError) as excinfo:
+        aot_constants.parse_constant_manifest(block, compiled_graph_format=1)
+    assert excinfo.value.reason == "constant_duplicate"
+
+
+def test_only_state_dict_rows_are_the_store_s_problem() -> None:
+    block = _graph_block(_weights())
+    block["constants"].append(
+        {"fqn": "folded.0", "source": "computed", "dtype": "float32", "shape": [4]}
+    )
+    block["constants"].append(
+        {"fqn": "baked.0", "source": "literal", "dtype": "float32", "shape": [4]}
+    )
+    manifest = aot_constants.parse_constant_manifest(block, compiled_graph_format=1)
+    assert len(manifest.constants) == 4
+    assert sorted(str(spec.fqn) for spec in manifest.store_sourced) == [
+        "lin.bias",
+        "lin.weight",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The plan refuses on HEADERS — before any device allocation
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingReadStore:
+    """A store whose ``read`` is a test failure. Planning must never call it."""
+
+    def __init__(self, index: Mapping[str, aot_constants.TensorFacts]) -> None:
+        self._index = {
+            aot_constants.ConstantFQN(name): facts for name, facts in index.items()
+        }
+
+    @property
+    def weight_set(self) -> aot_constants.WeightSetRef:
+        return aot_constants.WeightSetRef(WEIGHT_SET)
+
+    def describe(self) -> Mapping[aot_constants.ConstantFQN, aot_constants.TensorFacts]:
+        return dict(self._index)
+
+    def read(self, fqn: aot_constants.ConstantFQN, *, device: str) -> Any:
+        raise AssertionError(f"planning read {fqn!r}: no byte may be read to plan")
+
+
+def _facts(dtype: str, shape: Tuple[int, ...]) -> aot_constants.TensorFacts:
+    return aot_constants.TensorFacts(
+        dtype=aot_constants.TorchDtype(dtype), shape=shape
+    )
+
+
+@pytest.mark.parametrize(
+    ("index", "reason", "named"),
+    [
+        ({"lin.weight": _facts("float32", (8, 8))}, "constant_absent", "lin.bias"),
+        (
+            {
+                "lin.weight": _facts("bfloat16", (8, 8)),
+                "lin.bias": _facts("float32", (8,)),
+            },
+            "constant_dtype_mismatch",
+            "lin.weight",
+        ),
+        (
+            {
+                "lin.weight": _facts("float32", (8, 16)),
+                "lin.bias": _facts("float32", (8,)),
+            },
+            "constant_shape_mismatch",
+            "lin.weight",
+        ),
+    ],
+)
+def test_plan_refuses_by_name_without_reading_a_byte(
+    index: Mapping[str, aot_constants.TensorFacts], reason: str, named: str
+) -> None:
+    manifest = aot_constants.parse_constant_manifest(
+        _graph_block(_weights()), compiled_graph_format=1
+    )
+    with pytest.raises(aot_constants.ConstantResolutionError) as excinfo:
+        aot_constants.plan_store_constants(manifest, _ExplodingReadStore(index))
+    assert excinfo.value.reason == reason
+    assert any(named in fault for fault in excinfo.value.fqns)
+
+
+def test_plan_carries_the_weight_set_that_answers_which_checkpoint() -> None:
+    manifest = aot_constants.parse_constant_manifest(
+        _graph_block(_weights()), compiled_graph_format=1
+    )
+    plan = aot_constants.plan_store_constants(
+        manifest,
+        _ExplodingReadStore(
+            {
+                "lin.weight": _facts("float32", (8, 8)),
+                "lin.bias": _facts("float32", (8,)),
+            }
+        ),
+    )
+    # Class identity is checkpoint-free (§4.27); the plan is what carries the
+    # instance-level fact, and it is a parsed type rather than a bare str.
+    assert plan.weight_set == WEIGHT_SET
+    assert plan.graph_class == GRAPH_CLASS
+    assert plan.elements == 8 * 8 + 8
+    assert len(plan) == 2
+
+
+def test_a_store_that_cannot_name_its_weight_set_is_refused() -> None:
+    with pytest.raises(aot_constants.ConstantManifestError) as excinfo:
+        aot_constants.parse_weight_set_ref("")
+    assert excinfo.value.reason == "weight_set_ref_malformed"
+
+
+# ---------------------------------------------------------------------------
+# The safetensors store is fail-CLOSED
+# ---------------------------------------------------------------------------
+
+
+def test_store_indexes_real_shards_by_fqn(tmp_path: Path) -> None:
+    weights = _weights()
+    _shard(tmp_path / "c", "a.safetensors", {"lin.weight": weights["lin.weight"]})
+    _shard(tmp_path / "c", "b.safetensors", {"lin.bias": weights["lin.bias"]})
+    store = aot_constants.SafetensorsConstantStore.for_component(
+        tmp_path / "c", weight_set=WEIGHT_SET, why="index"
+    )
+    index = store.describe()
+    assert sorted(str(name) for name in index) == ["lin.bias", "lin.weight"]
+    assert index[aot_constants.ConstantFQN("lin.weight")] == _facts(
+        "float32", (8, 8)
+    )
+
+
+def test_store_refuses_a_shard_whose_header_will_not_parse(tmp_path: Path) -> None:
+    """The fail-OPEN spelling of this loop is the pgw#1330 defect.
+
+    ``key_topology.tensor_keys`` swallows exactly this error and yields no
+    keys, so an unreadable shard is indistinguishable from a shard that does
+    not hold the tensor — and the caller concludes "absent" about a file it
+    could not read.
+    """
+
+    directory = tmp_path / "c"
+    directory.mkdir()
+    (directory / "broken.safetensors").write_bytes(
+        struct.pack("<Q", 16) + b"not json at all!"
+    )
+    with pytest.raises(aot_constants.ConstantStoreError) as excinfo:
+        aot_constants.SafetensorsConstantStore.for_component(
+            directory, weight_set=WEIGHT_SET, why="index"
+        )
+    assert excinfo.value.reason == "shard_unreadable"
+
+
+def test_store_refuses_a_dtype_whose_element_width_it_does_not_know(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "c"
+    directory.mkdir()
+    header = json.dumps({"lin.weight": {"dtype": "F4_E2M1", "shape": [2], "data_offsets": [0, 1]}})
+    raw = header.encode()
+    (directory / "odd.safetensors").write_bytes(
+        struct.pack("<Q", len(raw)) + raw + b"\x00"
+    )
+    with pytest.raises(aot_constants.ConstantStoreError) as excinfo:
+        aot_constants.SafetensorsConstantStore.for_component(
+            directory, weight_set=WEIGHT_SET, why="index"
+        )
+    assert excinfo.value.reason == "dtype_unknown"
+
+
+def test_store_refuses_one_tensor_named_by_two_shards(tmp_path: Path) -> None:
+    weights = _weights()
+    _shard(tmp_path / "c", "a.safetensors", {"lin.weight": weights["lin.weight"]})
+    _shard(tmp_path / "c", "b.safetensors", {"lin.weight": weights["lin.weight"]})
+    with pytest.raises(aot_constants.ConstantStoreError) as excinfo:
+        aot_constants.SafetensorsConstantStore.for_component(
+            tmp_path / "c", weight_set=WEIGHT_SET, why="index"
+        )
+    assert excinfo.value.reason == "tensor_duplicated"
+
+
+def test_store_reads_the_exact_bytes_the_shard_holds(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore]
+) -> None:
+    weights, store = armed_store
+    for name, expected in weights.items():
+        got = store.read(aot_constants.ConstantFQN(name), device="cpu")
+        assert torch.equal(got, expected)
+        assert got.dtype == expected.dtype
+
+
+# ---------------------------------------------------------------------------
+# The arm itself
+# ---------------------------------------------------------------------------
+
+
+def test_store_sourced_arm_binds_and_serves_with_no_module(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weights, store = armed_store
+    resolved = _patch_resolve(monkeypatch, weights)
+
+    armed = aot_serve.arm_compiled_graph_from_store(
+        SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+    )
+
+    assert armed.key == KEY
+    assert armed.graph_class == GRAPH_CLASS
+    assert armed.target == TARGET
+    assert armed.weight_set == WEIGHT_SET
+    assert armed.meta["constant_source"] == "store"
+    assert armed.meta["weight_set"] == WEIGHT_SET
+    assert resolved.runner.bound  # type: ignore[attr-defined]
+    # The table is the store's tensors, by reference — not a copy of a module.
+    for name, expected in weights.items():
+        assert torch.equal(armed.constants[name], expected)
+    assert aot_serve.entry_states(SimpleNamespace()) == {}
+    assert [name for name, _ in armed.dispatch.runners] == [GRAPH_CLASS]
+
+    sample = torch.ones(1, 8)
+    got = armed(sample)
+    assert torch.equal(
+        got, torch.nn.functional.linear(sample, weights["lin.weight"], weights["lin.bias"])
+    )
+    assert armed.runner.calls == 1
+
+
+def test_an_absent_fqn_fails_closed_before_any_dispatch_state_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The checklist row, stated as an ordering property.
+
+    ``CompiledGraphRunner.bind`` is once-only and marks itself ``_failed`` on
+    a partial table, so a miss discovered mid-bind costs the runner as well as
+    the memory. The refusal must therefore land before the bind AND before any
+    entry joins a dispatch.
+    """
+
+    weights = _weights()
+    _shard(tmp_path / "c", "model.safetensors", {"lin.weight": weights["lin.weight"]})
+    store = aot_constants.SafetensorsConstantStore.for_component(
+        tmp_path / "c", weight_set=WEIGHT_SET, why="short store"
+    )
+    resolved = _patch_resolve(monkeypatch, weights)
+    joined: List[str] = []
+    monkeypatch.setattr(
+        aot_serve.EntryDispatch,
+        "add",
+        lambda self, name, runner: joined.append(str(name)),
+    )
+
+    with pytest.raises(aot_constants.ConstantResolutionError) as excinfo:
+        aot_serve.arm_compiled_graph_from_store(
+            SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+        )
+
+    assert excinfo.value.reason == "constant_absent"
+    assert excinfo.value.fqns == ("lin.bias",)
+    assert joined == []
+    assert not resolved.runner.bound  # type: ignore[attr-defined]
+
+
+def test_a_dtype_drift_refuses_before_the_bind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    weights = _weights()
+    drifted = {name: tensor.to(torch.bfloat16) for name, tensor in weights.items()}
+    _shard(tmp_path / "c", "model.safetensors", drifted)
+    store = aot_constants.SafetensorsConstantStore.for_component(
+        tmp_path / "c", weight_set=WEIGHT_SET, why="drifted store"
+    )
+    resolved = _patch_resolve(monkeypatch, weights)
+
+    with pytest.raises(aot_constants.ConstantResolutionError) as excinfo:
+        aot_serve.arm_compiled_graph_from_store(
+            SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+        )
+
+    assert excinfo.value.reason == "constant_dtype_mismatch"
+    assert not resolved.runner.bound  # type: ignore[attr-defined]
+
+
+def test_a_store_arm_must_be_told_its_device(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No module means no ``module.device`` to fall back on, and no default.
+
+    ``arm_compiled_graph`` reads the device off the module and defaults to
+    ``"cuda"``. Carrying that default here would put the constant table on a
+    device the caller never named.
+    """
+
+    weights, store = armed_store
+    _patch_resolve(monkeypatch, weights)
+    with pytest.raises(AdoptError) as excinfo:
+        aot_serve.arm_compiled_graph_from_store(
+            SimpleNamespace(family=FAMILY), KEY, store, device="  "
+        )
+    assert excinfo.value.reason == "device_missing"
+
+
+def test_the_store_arm_keeps_the_same_ingress_contract_as_the_module_arm(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A call outside the declared envelope is refused, exactly as it is on a
+    wrapped module: nothing about ingress is different because the constants
+    came from the store."""
+
+    weights, store = armed_store
+    _patch_resolve(monkeypatch, weights)
+    armed = aot_serve.arm_compiled_graph_from_store(
+        SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+    )
+    assert isinstance(armed.runner.contract, CallIngress)
+    with pytest.raises(aot_serve.IngressContractError):
+        armed(torch.ones(4, 8))
+
+
+def test_the_store_sourced_path_never_touches_diffusers_or_nn_module(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The checklist's "no diffusers/module import on the store-sourced path".
+
+    Asserted the only way that binds: ``diffusers`` is made UNIMPORTABLE for
+    the duration, and ``nn.Module.__init__`` is made a failure, so an arm that
+    reached for either would raise rather than quietly succeed because the
+    import happened to be cached from an earlier test.
+    """
+
+    import builtins
+
+    weights, store = armed_store
+    _patch_resolve(monkeypatch, weights)
+    real_import = builtins.__import__
+
+    def _fenced(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "diffusers" or name.startswith("diffusers."):
+            raise AssertionError(f"the store-sourced arm imported {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    def _no_modules(self: Any, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("the store-sourced arm constructed an nn.Module")
+
+    monkeypatch.setattr(builtins, "__import__", _fenced)
+    monkeypatch.setattr(torch.nn.Module, "__init__", _no_modules)
+
+    armed = aot_serve.arm_compiled_graph_from_store(
+        SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+    )
+    assert armed.runner.bound
+
+
+def test_two_weight_sets_over_one_key_are_two_instances_of_one_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The family/instance split the arming surface must not foreclose.
+
+    Same compiled-graph key, same graph class, same ``.so`` — two
+    checkpoints. The class-level facts are identical (§4.27: identity is
+    checkpoint-free) and the instance-level facts differ, which is exactly
+    what a module-sourced arm could never state.
+    """
+
+    first = _weights()
+    second = {name: tensor + 1.0 for name, tensor in first.items()}
+    _shard(tmp_path / "a", "model.safetensors", first)
+    _shard(tmp_path / "b", "model.safetensors", second)
+
+    armed: List[aot_serve.StoreArmedGraph] = []
+    for component, ref in (("a", WEIGHT_SET + "-a"), ("b", WEIGHT_SET + "-b")):
+        _patch_resolve(monkeypatch, first)
+        store = aot_constants.SafetensorsConstantStore.for_component(
+            tmp_path / component, weight_set=ref, why="instances"
+        )
+        armed.append(
+            aot_serve.arm_compiled_graph_from_store(
+                SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+            )
+        )
+
+    assert armed[0].key == armed[1].key
+    assert armed[0].graph_class == armed[1].graph_class
+    assert armed[0].weight_set != armed[1].weight_set
+    assert not torch.equal(
+        armed[0].constants["lin.weight"], armed[1].constants["lin.weight"]
+    )

--- a/tests/test_store_sourced_arm_pgw1329.py
+++ b/tests/test_store_sourced_arm_pgw1329.py
@@ -613,3 +613,51 @@ def test_two_weight_sets_over_one_key_are_two_instances_of_one_class(
     assert not torch.equal(
         armed[0].constants["lin.weight"], armed[1].constants["lin.weight"]
     )
+
+
+# ---------------------------------------------------------------------------
+# A PROJECTED component — the store the fleet will actually arm from
+# ---------------------------------------------------------------------------
+
+
+def test_the_store_indexes_and_binds_a_projected_tree(tmp_path: Path) -> None:
+    """The point of sourcing constants from the store rather than a module.
+
+    On a projected snapshot the component's shard is a ~128 B pointer stub and
+    the weights are CAS objects, so an index built by parsing the file's first
+    eight bytes reads the stub magic as a header length and concludes the
+    component holds nothing. Through pgw#1330's one reader the same directory
+    indexes by FQN and binds — byte-identical to the materialized control,
+    with no tensor byte ever at a filesystem path.
+    """
+
+    import projection_fixture as fixture
+    from gen_worker.models.projection import stub_at
+
+    built = fixture.build(tmp_path / "cas")
+    control = fixture.materialize(tmp_path / "cas", built)
+
+    shard = built.tree / "unet" / "diffusion_pytorch_model.safetensors"
+    assert stub_at(shard) is not None, "the fixture stopped being a projection"
+
+    projected_store = aot_constants.SafetensorsConstantStore.for_component(
+        built.tree / "unet", weight_set=WEIGHT_SET, why="projected component"
+    )
+    control_store = aot_constants.SafetensorsConstantStore.for_component(
+        control / "unet", weight_set=WEIGHT_SET, why="materialized control"
+    )
+
+    assert projected_store.describe() == control_store.describe()
+    assert sorted(str(name) for name in projected_store.describe()) == [
+        "unet.block.0.bias",
+        "unet.block.0.weight",
+    ]
+    for name in projected_store.describe():
+        left = projected_store.read(name, device="cpu")
+        right = control_store.read(name, device="cpu")
+        assert left.dtype == torch.bfloat16
+        assert torch.equal(left.view(torch.uint8), right.view(torch.uint8))
+
+    # Still a projection afterwards: reading constants must not materialize.
+    assert stub_at(shard) is not None
+    assert shard.stat().st_size < 4096

--- a/tests/test_store_sourced_arm_pgw1329.py
+++ b/tests/test_store_sourced_arm_pgw1329.py
@@ -661,3 +661,58 @@ def test_the_store_indexes_and_binds_a_projected_tree(tmp_path: Path) -> None:
     # Still a projection afterwards: reading constants must not materialize.
     assert stub_at(shard) is not None
     assert shard.stat().st_size < 4096
+
+
+def test_a_device_oom_while_reading_constants_is_the_typed_adopt_miss(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """§4.33: the ATTEMPT is the headroom gate, and its verdict is one token.
+
+    The store arm allocates the WHOLE constant table before `bind` — TCG only
+    classifies an OOM inside `bind`, so without a classifier on the read this
+    is the one arm whose exhaustion reaches `provision.arm_aot` as an
+    unclassified crash instead of the `insufficient_adopt_vram` miss that
+    leaves the pod serving eager.
+    """
+
+    weights, store = armed_store
+    resolved = _patch_resolve(monkeypatch, weights)
+
+    def _exhausted(
+        _plan: Any, _store: Any, *, device: str
+    ) -> Dict[str, Any]:
+        raise RuntimeError("CUDA out of memory. Tried to allocate 20.00 GiB")
+
+    monkeypatch.setattr(aot_constants, "realize_store_constants", _exhausted)
+
+    with pytest.raises(AdoptError) as excinfo:
+        aot_serve.arm_compiled_graph_from_store(
+            SimpleNamespace(family=FAMILY), KEY, store, device="cuda"
+        )
+
+    assert excinfo.value.reason == aot_serve.ADOPT_OOM_REASON
+    assert not resolved.runner.bound  # type: ignore[attr-defined]
+
+
+def test_a_non_oom_read_failure_is_not_laundered_into_a_vram_miss(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other direction, which matters more: `insufficient_adopt_vram` is
+    the token that tells the hub this CARD was too small. A read that failed
+    for any other reason must not wear it, or the fleet re-places a pod to fix
+    a fault that had nothing to do with memory."""
+
+    weights, store = armed_store
+    _patch_resolve(monkeypatch, weights)
+
+    def _broken(_plan: Any, _store: Any, *, device: str) -> Dict[str, Any]:
+        raise OSError("the shard vanished mid-read")
+
+    monkeypatch.setattr(aot_constants, "realize_store_constants", _broken)
+
+    with pytest.raises(OSError):
+        aot_serve.arm_compiled_graph_from_store(
+            SimpleNamespace(family=FAMILY), KEY, store, device="cuda"
+        )

--- a/tests/test_store_sourced_arm_pgw1329.py
+++ b/tests/test_store_sourced_arm_pgw1329.py
@@ -716,3 +716,41 @@ def test_a_non_oom_read_failure_is_not_laundered_into_a_vram_miss(
         aot_serve.arm_compiled_graph_from_store(
             SimpleNamespace(family=FAMILY), KEY, store, device="cuda"
         )
+
+
+def test_a_store_armed_class_reports_in_the_same_vocabulary(
+    armed_store: Tuple[Dict[str, Any], aot_constants.ConstantStore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#1176 §1.4, for the arm that has no pipeline marker.
+
+    The hub's per-entry events are built from this record. A store-armed class
+    the hub cannot see is a pod advertising LESS than it serves, which is the
+    same defect as advertising more — and a second vocabulary for the same
+    verdict is the pgw#1247 class.
+    """
+
+    weights, store = armed_store
+    _patch_resolve(monkeypatch, weights)
+    armed = aot_serve.arm_compiled_graph_from_store(
+        SimpleNamespace(family=FAMILY), KEY, store, device="cpu"
+    )
+
+    assert armed.entry_states() == {
+        GRAPH_CLASS: {"state": "armed", "target": TARGET, "calls": 0}
+    }
+    armed(torch.ones(1, 8))
+    assert armed.entry_states()[GRAPH_CLASS]["calls"] == 1
+
+    assert armed.disarm("numerics") is True
+    assert armed.entry_states() == {
+        GRAPH_CLASS: {"state": "de_armed", "target": TARGET, "reason": "numerics"}
+    }
+    # §4.31's de-arm is sticky for the boot: the same class cannot re-join.
+    with pytest.raises(AdoptError) as excinfo:
+        armed.dispatch.add(GRAPH_CLASS, armed.runner)
+    assert excinfo.value.reason == "entry_de_armed"
+    # The constants outlive the de-arm on purpose: the AOTI container still
+    # holds their pointers user-managed, so freeing them here is a
+    # use-after-free, not a cleanup.
+    assert set(armed.constants) == set(weights)


### PR DESCRIPTION
`arm_compiled_graph` binds `resident_constants(module)` — the LIVE eager module's parameters and buffers — so serving one compiled graph required the whole diffusers pipeline resident purely as the constant SOURCE. That is the single reason an adopt-only serve host (pgw#1328) could not shed eager loading, and it was never a property of compiled serving: the artifact's manifest already names every constant by FQN, torch dtype and exact shape.

## The bar, measured

One sm_86 pod, one real `torch.export` + AOTInductor mint, two arms of the SAME key, output compared as RAW BYTES (`.view(torch.uint8)` — not `allclose`, and not `torch.equal`, which compares values so a `-0.0`/`0.0` pair or two NaN payloads would pass).

| fact | value |
|---|---|
| bitwise equal, module-armed vs store-armed | **true, all 3 calls** |
| 1-ULP control moved the output where it can | **true** — and did NOT move the all-zeros call, where `lin(0) = bias` makes the weight arithmetically unreachable |
| distinct AOTI containers | true |
| declared constants / store-supplied | 5 / 4 — the source partition is exercised, not assumed |
| toolchain | torch 2.13.0+cu130, cp312, sm_86 (RTX 3090) |

`src/gen_worker/benchmarks/store_arm_parity.py` is the probe; `benchmarks/results/store-arm-parity-20260817-sm86-rtx3090.json` is the row. Two pods, ~$0.12 total, both torn down (`GET /v1/pods/<id>` → 404 each).

The committed row is a **re-run of the final tree**: the first row was produced before the store's reads moved onto pgw#1330's projection-aware surface, so it was evidence for code that would not have merged. The second pod drew an RTX 3090 where the first drew an A5000 — both derived the *identical* `cg-key-v1` and returned the identical verdict on every row, which is the key's "sm, never SKU" axis (pgw#691, §1.38a) observed rather than assumed.

The probe's module carries a NON-PERSISTENT buffer on purpose (pgw#825): the one constant kind `state_dict()` omits while `torch.export` lifts it under its real FQN.

## What landed

**`gen_worker/aot_constants.py`** (born strict, no ratchet entry) reads the declared constant table as a versioned, typed manifest and resolves it in TWO phases that are never merged:

- `plan_store_constants` checks the WHOLE table against the store's HEADERS. Absent / dtype-drifted / shape-drifted constants are one typed refusal each, naming every FQN at fault. No device byte is allocated on any path through it.
- `realize_store_constants` reads only what was planned.

The split is the point: `CompiledGraphRunner.bind` is once-only and marks itself failed on a partial table, so a miss discovered mid-bind costs the runner as well as the memory.

Typed throughout, per pgw#1326: `ConstantFQN` / `TorchDtype` / `GraphClassName` / `WeightSetRef` newtypes with parsers, a `ConstantSourceKind` enum, an exact-field-set row parser, and an envelope-version check that refuses a `compiled_graph_format` this reader does not understand *before* interpreting one row.

**`arm_compiled_graph_from_store`** is the same arm as the module one — same resolve, same quarantine gate, same `CallIngress`, same `EntryDispatch` — with the store as the constant source and no `nn.Module` anywhere. The resolve half both arms share is extracted to `_resolve_graph_class`, because a resolve that models the artifact differently from the arm is the pgw#816/#822 class one level up.

**`StoreArmedGraph`** splits along the family/instance line (pgw#1326, §4.27): `key`/`graph_class`/`target` are class-level and checkpoint-free; `weight_set` and `constants` say WHICH checkpoint this binding is of. Two of them over one key are two instances of one family — a fact the module arm could not state, since it could only ever say "whatever that module happened to hold".

**The store reads through pgw#1330's one reader** (`read_header` + `open_tensor_source`), so a PROJECTED component — shard is a ~128 B stub, weights are CAS objects — indexes and binds without materializing. `read_header`'s `{}` is a fail-open its callers need; it is not one this store may keep, so an unreadable shard is a refusal here. `tensor_source._TORCH_DTYPES` becomes public `TORCH_DTYPES` (a second consumer arrived; a private copy per lane is the duplication that module ended).

## Two things the checklist did not ask for

- **A device OOM while READING the constant table was untyped.** The store arm is the only arm that allocates the whole table *before* `bind`; TCG classifies an OOM inside `bind`, so without this it was the one arm whose exhaustion reached `provision.arm_aot` as an unclassified crash instead of §4.33/pgw#1175's `insufficient_adopt_vram` miss that leaves the pod serving eager. Both directions are tested — a non-OOM read failure must NOT wear that token, or the fleet re-places a pod to fix a fault that had nothing to do with memory.
- **`entry_states` read the pipeline marker**, which a store-armed class does not have, so the hub's per-entry events (pgw#1176 §1.4, §1.7) would have been blind to everything this arm serves. The builder is extracted to `dispatch_states` and used by both: whether the fleet can see an armed class must not depend on which arm ran. `StoreArmedGraph.disarm` is §4.31's sticky de-arm for the arm with no pipeline, and deliberately does not free the constants — the container still holds those pointers user-managed.

## The four fast gates the second arm reached — taught, not exempted

- `lint_arm_state_feeders` modelled ONE arm seam. It now states two, each audited for its own complete operation set, with the shared `_resolve_graph_class` crediting its calls to any seam that delegates to it. The store seam additionally carries a FORBIDDEN set — `_marker`, `wrap_module` — because an arm with no `nn.Module` must not claim one. Red proofs 3 → 5.
- `lint_serving_process_compiles` gains `STANDALONE_ENTRY` beside `CHILD_ONLY`. The probe is not a compile child and saying so would be false. The claim is CHECKED, not exempted: the gate refuses any serving-package module that IMPORTS a standalone entry, so the exemption's own premise goes red the moment it stops being true. Red-proved on the absolute and relative spellings.
- `lint_config_reads` / `lint_settings_writers`: the probe steers inductor's cache dir at its own scratch so a warm inherited cache cannot make "both arms compiled the same graph" an assumption. LIBRARY and PLUMBING.
- `lint_tcg_vocabulary`: the probe's `graph_class` is a column of its own result row, off `StoreArmedGraph` — annotated at the line.

## Checklist

- [x] Store-sourced arm for one family on a real pod, output bitwise-equal to module-sourced arm — plus a control that can falsify it
- [x] No diffusers/module import on the store-sourced path — asserted with `diffusers` made unimportable and `nn.Module.__init__` poisoned, in the unit test AND on the pod
- [x] Manifest FQN absent from the store fails closed before any dispatch-state mutation
- [x] Constant manifest consumed through a typed schema; mismatch is a typed refusal before any GPU allocation
- [x] Unblocks pgw#1328; no dependency on pgw#1327

## Tests

32 new, real safetensors shards throughout, and a runner double that ENFORCES TCG's bind contract rather than accepting anything. **Red 11/11**: dtype check, shape check, fail-open header, duplicate-shard tolerance, inverted plan/bind order, dropped weight-set, reintroduced device default, tolerated empty header, pre-1330 naive header parse, OOM classifier removed, every read failure laundered as OOM.

`mypy --strict` clean (three new modules, no ratchet entries); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
