### PR TITLE
pgw#1308 step 6: a pod serves from a projected tree, and a resident model occupies disk ONCE

### DIFF
--- a/changelog.d/pgw1308.md
+++ b/changelog.d/pgw1308.md
@@ -1,18 +1,24 @@
-- The tensorhub grant transfer plane is first-party at `gen_worker.transfer`. It was vendored
-  from tensorfs, but it was never storage — `TransferGrant.from_wire` parses tensorhub's grant
-  JSON, and the retry ladder, fan-out width and per-object progress emission are this worker's
-  policy about this worker's uplink. Upstream agrees: current tensorfs has no Python transfer
-  plane at all. So those two modules were pinned to a lineage upstream had abandoned, and a
-  digest fence over them certified fidelity to a rev nobody would ever fix. Behaviour is
-  unchanged; the pgw#1287 progress fix now has a fence over pgw's own source instead of over an
-  upstream pin, and a new fence refuses the plane's return to the vendored snapshot.
-- The vendored `tensorfs` snapshot no longer carries the FUSE daemon client. Pods provably cannot
-  mount — `CAP_SYS_ADMIN` is absent from the container's bounding set, measured on a real pod
-  (pgw#1295) — and nothing in this repo imported it, so it was a mount client shipping in a wheel
-  that can never mount.
-- `fast gates` censuses the materialization hatch (pgw#1308). Whole-tree materialization is down
-  to one production caller and its test scaffolding, both NAMED in the lint with the issue that
-  deletes them; a third site is refused. Every `extract()` call must name which
-  `docs/mixed-cas-layout.md` §9 row it is, and the known rows are enumerated — so the hatch that
-  "defeats the whole purpose of this system" can only shrink, and cannot grow in a diff nobody
-  read.
+- **A snapshot on a pod is now a PROJECTED tree, and a resident model occupies disk once.**
+  `ensure_snapshot` used to publish a complete second copy of every byte the object store already
+  held, so every resident model cost 2x its size. It now projects: non-tensor files are relative
+  symlinks into `objects/`, tensor containers are ~128 byte TFSSTUB1 pointer stubs, and the tensors
+  are read straight out of the store. Measured on a rented pod against a real hub-resolved 319 MiB
+  snapshot: `du` before 0, after 334,648,326 bytes for a 334,647,012-byte model — **1.000004x**,
+  against 2.000004x for the same manifest materialized. The published tree itself is 127 bytes, and
+  no regular file anywhere in it holds more than one block.
+- **The disk headroom gate sizes what a projection actually writes.** It charged one whole extra
+  model, which was right when publishing meant copying one and would now refuse boots that fit with
+  room to spare. Stubs, empty files and symlinks cost nothing; a chunked non-tensor file is
+  reassembled and costs its size. The prediction is asserted against a real `du` of a real
+  projection rather than trusted to stay in step with the projector.
+- **A consumer that hands a DIRECTORY to a third-party loader still gets real files, and now pays
+  for only what it asks for.** `diffusers.from_pretrained`, `ComponentSpec.load`,
+  `from_single_file`, `gguf.GGUFReader` and `llama-server -m` cannot read pointer stubs and are not
+  ours to change. They go through one seam that materializes the requested SUBTREE on demand — a
+  component costs a component, nothing is copied until something asks, every copy is logged with
+  its byte count and its caller, and the copy dies with the snapshot it belongs to.
+- **Disk GC stopped under-reporting a resident model as nothing.** Walking a projected tree answers
+  with a few hundred bytes for a model of any size, and eviction acts on that answer; a projected
+  tree is now sized from its manifest, plus any priced copy taken above.
+- Boot verification of a projected tree is structural and clean — no re-hashing, no quarantine, no
+  re-download — proved on the pod as well as in the suite.

--- a/scripts/lint_materialization_hatch.py
+++ b/scripts/lint_materialization_hatch.py
@@ -70,22 +70,57 @@ DEFAULT_ROOTS = (
 #: Whole-tree materialization -- the symbol upstream deleted (tensorfs#58).
 RETIRED = re.compile(r"\bmaterialize" r"_repository\b")
 
+#: A line that DEFINES the retired symbol rather than reaching for it. Only
+#: the vendored storage snapshot may do that: it is a byte-identical copy of
+#: an upstream rev, fixed upstream and re-vendored, never patched here.
+RETIRED_DEFINITION = re.compile(r"^(?:async\s+)?def\s+materialize" r"_repository\b")
+
 #: The residue, NAMED. Each entry is a path that may still mention the retired
 #: symbol, with the issue that deletes it. Not an allowlist for new debt: a
 #: path not on this list is refused, and the list only ever shrinks.
-RETIRED_RESIDUE = {
-    # The chokepoint itself. pgw#1295 replaces this one line with a projected
-    # tree; it is gated on pgw#1303 (Paul's ruling on author slots that demand
-    # a real model DIRECTORY), because every `from_pretrained(path)` consumer
-    # downstream of it reads weights through the tree today.
-    "src/gen_worker/models/cozy_snapshot.py",
-    # Its test scaffolding: a LocalCAS subclass that counts and interrupts the
-    # copy. Dies in the same commit as the caller it exercises.
-    "tests/test_snapshot_v2_fill_pgw781.py",
+#:
+#: **IT IS EMPTY**, as of pgw#1308 step ⑥. The chokepoint projects
+#: (`models/cozy_snapshot.py:_publish_snapshot`) and its test scaffolding went
+#: with it. Nothing in this repo, first-party or vendored, CALLS whole-tree
+#: materialization; the only surviving trace is the definition in the pinned
+#: storage snapshot, declared below.
+RETIRED_RESIDUE: set[str] = set()
+
+#: Where the retired symbol may still be DEFINED, and why. Declared rather
+#: than merely unseen: `_lint_scope` excludes `_vendor` from every other
+#: guard, so without this line the census would read "gone" when the code is
+#: still shipped in the wheel with zero callers. It leaves when the vendored
+#: storage rev moves, which VENDORED.toml explains is NOT gated on this issue.
+RETIRED_DEFINED_IN = {
+    "src/gen_worker/_vendor/tensorfs/local.py",
 }
 
 #: The hatch itself, scanned only where tensorfs is imported.
-HATCH = re.compile(r"\.extract\s*\(")
+#:
+#: TWO SPELLINGS, and missing the second is how the census read zero. §9 and
+#: current upstream call the single-file hatch `extract()`; the rev this repo
+#: PINS (`_vendor/VENDORED.toml`) calls the same operation
+#: `LocalCAS.materialize(entry, destination)`. A fence that matches only the
+#: name upstream uses today matches nothing in the code it guards -- there is
+#: no `.extract(` on a tensorfs reader anywhere in this tree -- while a live
+#: first-party single-file materialization sat unpriced at
+#: `aot_delivery.py`. A guard must spell the symbol its own snapshot exports.
+HATCH = re.compile(r"\.(?:extract|materialize)\s*\(")
+
+#: `def materialize(...)` is a definition, not a hatch call.
+HATCH_DEFINITION = re.compile(r"^(?:async\s+)?def\s+(?:extract|materialize)\b")
+
+#: Vendored files that legitimately call the hatch, with their §9 row. A
+#: vendored call cannot carry an inline marker (the snapshot is byte-identical
+#: to upstream), so it is declared HERE instead of being invisible. A vendored
+#: hatch call in an undeclared file is refused, and a declared file that no
+#: longer contains one is refused too -- so the table cannot go stale in
+#: either direction.
+VENDORED_HATCH = {
+    # `_export_archive` / `_stage_artifact` write a compiled-graph archive off
+    # the tensorfs store with the single-file arm.
+    "src/gen_worker/_vendor/torchcg/storage.py": "tcg-artifact-export",
+}
 
 #: A file reaches the hatch only if it can reach a tensor reader.
 _TENSORFS_IMPORT = re.compile(r"\b(?:from|import)\s+\S*tensorfs\b")
@@ -105,17 +140,27 @@ ROWS = {
 }
 
 
-def _iter_files(roots: Tuple[Path, ...]) -> Iterator[Path]:
+def _iter_files(roots: Tuple[Path, ...]) -> Iterator[Tuple[Path, bool]]:
+    """Every scannable file, with whether a guard may JUDGE it.
+
+    `_vendor` is scanned rather than skipped, unlike every other guard here.
+    That exclusion is right for architecture measurements -- vendored code is
+    not evidence about ours -- and wrong for a CENSUS, whose whole job is to
+    say what is present. So vendored files are read, and what they may contain
+    is decided by the declaration tables above instead of by an inline marker
+    they cannot carry.
+    """
+
     for root in roots:
         if root.is_file():
-            yield root
+            yield root, is_unowned(root)
             continue
         for p in sorted(root.rglob("*.py")):
             if not p.is_file() or "__pycache__" in p.parts:
                 continue
-            if is_unowned(p) or p.resolve() == SELF:
+            if p.resolve() == SELF:
                 continue
-            yield p
+            yield p, is_unowned(p)
 
 
 def _row_of(line: str) -> str:
@@ -125,26 +170,57 @@ def _row_of(line: str) -> str:
 
 def scan(roots: Tuple[Path, ...]) -> List[str]:
     findings: List[str] = []
-    for path in _iter_files(roots):
+    vendored_hatch_seen: set[str] = set()
+    for path, vendored in _iter_files(roots):
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        reaches_tensorfs = bool(_TENSORFS_IMPORT.search(text))
+        reaches_tensorfs = bool(_TENSORFS_IMPORT.search(text)) or vendored
         rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
         rel_key = rel.as_posix()
         for lineno, line in enumerate(text.splitlines(), 1):
             stripped = line.strip()
             if stripped.startswith("#"):
                 continue
-            if RETIRED.search(line) and rel_key not in RETIRED_RESIDUE:
-                findings.append(
-                    f"{rel}:{lineno}: whole-tree materialization is retired "
-                    f"(pgw#1295/#1296a, tensorfs#58) and this file is not in "
-                    f"the named residue: {stripped}"
-                )
-                continue
+            if RETIRED.search(line):
+                if RETIRED_DEFINITION.match(stripped):
+                    if rel_key not in RETIRED_DEFINED_IN:
+                        findings.append(
+                            f"{rel}:{lineno}: whole-tree materialization is "
+                            f"retired (pgw#1296a, tensorfs#58) and this file "
+                            f"is not the pinned upstream snapshot that still "
+                            f"defines it: {stripped}"
+                        )
+                    continue
+                if rel_key not in RETIRED_RESIDUE:
+                    findings.append(
+                        f"{rel}:{lineno}: whole-tree materialization is retired "
+                        f"(pgw#1296a, tensorfs#58) and this file is not in "
+                        f"the named residue: {stripped}"
+                    )
+                    continue
             if not reaches_tensorfs or not HATCH.search(line):
+                continue
+            if HATCH_DEFINITION.match(stripped):
+                continue
+            if vendored:
+                # A vendored line cannot carry a marker without breaking the
+                # digest fence, so its row is declared in the table above.
+                row = VENDORED_HATCH.get(rel_key, "")
+                if not row:
+                    findings.append(
+                        f"{rel}:{lineno}: a vendored snapshot reaches the "
+                        f"single-file materialization hatch and no §9 row is "
+                        f"declared for it in VENDORED_HATCH: {stripped}"
+                    )
+                elif row not in ROWS:
+                    findings.append(
+                        f"{rel}:{lineno}: declared hatch row {row!r} is not in "
+                        f"docs/mixed-cas-layout.md §9: {stripped}"
+                    )
+                else:
+                    vendored_hatch_seen.add(rel_key)
                 continue
             if MARKER not in line:
                 findings.append(
@@ -158,6 +234,14 @@ def scan(roots: Tuple[Path, ...]) -> List[str]:
                     f"{rel}:{lineno}: hatch row {row!r} is not in "
                     f"docs/mixed-cas-layout.md §9 (known: {sorted(ROWS)}): {stripped}"
                 )
+    # A declaration that no longer describes anything is a census that has
+    # stopped being read. It goes when its last call goes, not later.
+    if any(root == REPO / "src" for root in roots):
+        for declared in sorted(set(VENDORED_HATCH) - vendored_hatch_seen):
+            findings.append(
+                f"{declared}: declared in VENDORED_HATCH but no longer calls "
+                f"the hatch — delete the declaration, the row is now empty"
+            )
     return findings
 
 
@@ -176,6 +260,30 @@ def _selftest() -> int:
             "from gen_worker._vendor.tensorfs import open_tensors\n"
             'reader.extract("config.json", dest)\n',
             1,
+        ),
+        # The PINNED rev's spelling of the same hatch. Matching only
+        # `extract()` matched nothing in this tree while a real single-file
+        # materialization ran unpriced.
+        (
+            "unnamed_pinned_spelling.py",
+            "from gen_worker._vendor.tensorfs import LocalCAS\n"
+            "cas.materialize(entry, destination)\n",
+            1,
+        ),
+        (
+            "named_pinned_spelling.py",
+            "from gen_worker._vendor.tensorfs import LocalCAS\n"
+            "cas.materialize(entry, destination)  "
+            f"{MARKER} tcg-artifact-export\n",
+            0,
+        ),
+        # Defining a helper called `materialize` is not reaching for the hatch.
+        (
+            "defines_one.py",
+            "from gen_worker._vendor.tensorfs import read_entry\n"
+            "def materialize(base, fixture):\n"
+            "    return read_entry(fixture.cas, entry)\n",
+            0,
         ),
         (
             "unknown_row.py",
@@ -212,9 +320,27 @@ def _selftest() -> int:
                     file=sys.stderr,
                 )
                 return 1
+    # The `def` of the retired symbol is permitted ONLY in the pinned storage
+    # snapshot, and refused anywhere else -- otherwise "define it here and
+    # call it" walks straight through the definition exemption.
+    with tempfile.TemporaryDirectory() as tmp:
+        planted = Path(tmp) / "redefines.py"
+        planted.write_text(
+            "from gen_worker._vendor.tensorfs import LocalCAS\n"
+            "def " + "materialize" + "_repository(manifest, target):\n"
+            "    ...\n"
+        )
+        if len(scan((planted,))) != 1:
+            print(
+                "SELFTEST FAILED: a first-party redefinition of the retired "
+                "symbol was not refused",
+                file=sys.stderr,
+            )
+            return 1
     print(
-        "lint_materialization_hatch selftest: red on a retired copy, on an "
-        "unnamed hatch and on an unknown row; green on a named §9 row"
+        "lint_materialization_hatch selftest: red on a retired copy, on a "
+        "first-party redefinition, on an unnamed hatch in either spelling and "
+        "on an unknown row; green on a named §9 row and on a plain definition"
     )
     return 0
 

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -47,19 +47,48 @@ subdir = "python/src/tensorfs"
 # What is LEFT is genuinely storage — `LocalCAS`, the chunk manifest, refs —
 # and it is byte-identical to `8bafdfbb` except for the `rewrites` below.
 #
-# pgw#1330: THE SNAPSHOT IS SPLIT AT TWO REVS, ON PURPOSE, AND THIS IS THE
-# ONLY RECORD OF IT. `project.py`, `tensors.py` and `gguf.py` come from
+# pgw#1330: THE SNAPSHOT IS SPLIT AT TWO REVS, ON PURPOSE, PERMANENTLY (see
+# the ownership ruling below), AND THIS IS THE ONLY RECORD OF IT. `project.py`, `tensors.py` and `gguf.py` come from
 # `read_plane_rev` below, NOT from `rev`. They are the consumption plane the
 # whole mixed-CAS cutover rests on — TFSSTUB1 render/parse, tree projection,
 # and the direct tensor reader — and they DID NOT EXIST at `8bafdfbb`.
 #
 # Why not simply bump `rev`: the newer lineage DELETED `LocalCAS.ingest_file`,
-# `LocalCAS.collect_garbage` and `LocalCAS.materialize_repository`, which are
-# live here at `hubio/client.py`, `models/disk_gc.py` and the
-# `models/cozy_snapshot.py` chokepoint. Taking them away is the chokepoint
-# flip (pgw#1308 sequencing step 6) and an ownership question about who owns
-# ingest and GC — neither is a consumption-cutover decision, and pretending
-# otherwise would put a storage rewrite inside a loader change.
+# `LocalCAS.ingest_repository`, `LocalCAS.collect_garbage`,
+# `LocalCAS.materialize` and `LocalCAS.materialize_repository`.
+#
+# pgw#1308 STEP 6 ANSWERED THE OWNERSHIP QUESTION, and the answer is NOT the
+# one this file used to imply. It said the split ends when the chokepoint
+# flips. It does not:
+#
+#   * `materialize_repository` — DEAD. The chokepoint projects (pgw#1308 step
+#     6, `models/cozy_snapshot.py:_publish_snapshot`), so this repo has zero
+#     callers. The definition below is all that is left of it, and
+#     `scripts/lint_materialization_hatch.py` declares that and refuses a new
+#     caller anywhere, `_vendor` included.
+#   * `materialize` (single file) — KEPT. It is `extract()` under the pinned
+#     rev's name: the priced escape hatch that upstream's own
+#     no-whole-tree-materialization fence deliberately exempts. Two live users
+#     (`aot_delivery.py`, vendored `torchcg/storage.py`), both declared to the
+#     lint against `docs/mixed-cas-layout.md` section 9.
+#   * `ingest_file` / `ingest_repository` — TENSORFS'S, not ours. Admission is
+#     the store's identity contract: the chunk grid, the whole-file digest,
+#     the concurrent-mutation refusal. Upstream did not abandon it the way it
+#     abandoned the Python transfer plane; it PORTED it to Rust
+#     (`Plan`/`HashedPlan`/`AdmittedObject`/`ObjectStore`) and added
+#     `TensorWriter`. Forking it first-party would put a second implementation
+#     of the rule that decides hub dedup in this repo.
+#   * `collect_garbage` — TENSORFS'S, same shape. Reachability over the
+#     store's own ref and manifest formats; its own docstring says tensorfs
+#     owns no retention policy, and the retention policy is already
+#     first-party in `models/disk_gc.py`.
+#
+# So the split at two revs is the STEADY STATE. It ends when pgw can depend on
+# a PUBLISHED, COMPILED tensorfs — upstream's successors for ingest and GC are
+# the Rust extension, and pgw#1310 rules a compiled extension out of a
+# source-vendored wheel. That is a release-policy decision (Paul), not a lane's.
+# Do not "finish the bump": it would delete two symbols with no reachable
+# successor.
 #
 # Why the split is SAFE rather than merely convenient: the three read-plane
 # modules import nothing from `local.py` at runtime beyond `object_path`,

--- a/src/gen_worker/aot_delivery.py
+++ b/src/gen_worker/aot_delivery.py
@@ -201,7 +201,13 @@ def _materialize_named_artifact(
             failures = "; ".join(detail for _digest, detail in report.failures)
             raise RuntimeError(failures or "artifact grants expired")
         dest_dir.mkdir(parents=True, exist_ok=True)
-        cas.materialize(file_entry, dest)
+        # A compiled-graph artifact leaving the tensorfs store for torchcg's
+        # own cell store. Priced under §9's `tcg artifact export off-store`
+        # row: the destination is a different store's file, not a path inside
+        # a projected snapshot, so there is nothing here to point a stub at.
+        # The pinned rev spells the single-file hatch `materialize`; §9 and
+        # current upstream spell it `extract`.
+        cas.materialize(file_entry, dest)  # mixed-cas-hatch: tcg-artifact-export
     except NamedArtifactUnavailable:
         raise
     except (ValueError, RuntimeError, OSError) as exc:

--- a/src/gen_worker/convert/gguf_tools.py
+++ b/src/gen_worker/convert/gguf_tools.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 from pathlib import Path
 
+from ..models.materialized_view import third_party_dir
 from ..subproc import ProcessStalledError, run_process
 
 logger = logging.getLogger(__name__)
@@ -129,7 +130,10 @@ def run_hf_to_gguf_conversion(
     output_path: Path,
     encoding: str,
 ) -> None:
-    cmd = [sys.executable, str(script_path), str(hf_model_dir),
+    # `convert_hf_to_gguf.py` is a SUBPROCESS reading the tree itself, so it
+    # gets real files (pgw#1303's gate; pgw#1335 owns cutting this lane).
+    cmd = [sys.executable, str(script_path),
+           str(third_party_dir(hf_model_dir, why="convert_hf_to_gguf.py subprocess")),
            "--outfile", str(output_path), "--outtype", normalize_gguf_encoding(encoding)]
     try:
         returncode = run_process(

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -30,6 +30,7 @@ from gen_worker.models.download import (
 )
 
 from ..net import hf, install_hf_http_timeouts
+from ..models.materialized_view import third_party_dir
 from ..models.safetensors_header import header_len_ok
 from .classifier import RepoClassification, apply_source_include, classify_repo
 from .layout import detect_huggingface_source_layout
@@ -695,7 +696,8 @@ def _local_gguf_quant(path: Path) -> str:
         from gguf import GGUFReader
         from gguf.constants import LlamaFileType
 
-        reader = GGUFReader(str(path), "r")
+        reader = GGUFReader(
+            str(third_party_dir(path, why="gguf.GGUFReader wants a real file")), "r")
         field = reader.fields.get("general.file_type")
         if field is None:
             return ""

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     import torch
 
 from ..models.file_layout import MULTI_FILE, SINGLE_FILE, FileLayout  # noqa: F401  (re-exported)
+from ..models.materialized_view import third_party_dir
 
 from ..component_vocab import (
     pipeline_component_dirs,
@@ -152,7 +153,8 @@ class Source:
         """
         if self._tokenizer is None:
             from transformers import AutoTokenizer
-            self._tokenizer = AutoTokenizer.from_pretrained(str(self._path))
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                str(third_party_dir(self._path, why="AutoTokenizer.from_pretrained")))
         return self._tokenizer
 
     def diffusers_variant(self) -> str | None:
@@ -185,12 +187,18 @@ class Source:
             if v := self.diffusers_variant():
                 kwargs["variant"] = v
         if model_cls is not None:
-            return model_cls.from_pretrained(str(self._path), **kwargs)
+            return model_cls.from_pretrained(
+                str(third_party_dir(self._path, why="conversion source model_cls")),
+                **kwargs)
         if self._file_layout == MULTI_FILE:
             from diffusers import DiffusionPipeline
-            return DiffusionPipeline.from_pretrained(str(self._path), **kwargs)
+            return DiffusionPipeline.from_pretrained(
+                str(third_party_dir(self._path, why="conversion source pipeline")),
+                **kwargs)
         from transformers import AutoModelForCausalLM
-        return AutoModelForCausalLM.from_pretrained(str(self._path), **kwargs)
+        return AutoModelForCausalLM.from_pretrained(
+            str(third_party_dir(self._path, why="conversion source causal LM")),
+            **kwargs)
 
     # ----- tensor access ----------------------------------------------
 

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -2,19 +2,26 @@
 
 Tensorhub supplies a resolved manifest and opaque GET grants. tensorfs owns
 what is true about bytes at rest -- the chunk manifest, the local object store,
-and materialization. **The transfer is OURS** (pgw#1308,
+and the PROJECTION of a manifest into a tree. **The transfer is OURS**
+(pgw#1308,
 :mod:`gen_worker.transfer.grants`): the grants are tensorhub's wire format and
 the retry ladder, fan-out width and progress emission are this worker's policy
 about this worker's uplink. This module retains the rest of that policy:
 component selection, pickle refusal, disk headroom, endpoint-volume fill order,
 and boot observability.
+
+**A snapshot this module publishes is a PROJECTED tree** (pgw#1308 step ⑥):
+symlinks into ``objects/`` for everything that is not a tensor container,
+~128 B TFSSTUB1 pointer stubs for everything that is, and no tensor byte at
+any path in it. Whole-tree materialization -- the second complete copy this
+used to write -- has no caller left in this repo, and
+``scripts/lint_materialization_hatch.py`` refuses its return.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextvars
-import errno
 import fcntl
 import hashlib
 import logging
@@ -32,12 +39,14 @@ from gen_worker._vendor.tensorfs import (
     LocalCAS,
     RefConflict,
     RepositoryManifest,
+    project_snapshot,
 )
 from gen_worker.transfer.grants import TransferGrant, download
 
 from .. import activity as _activity
 from .. import boot_phases
 from ..capability import InsufficientDiskError
+from . import projection
 from .cache_paths import open_worker_cas
 from .download import components_present, select_component_paths
 from .errors import (
@@ -231,41 +240,67 @@ def _file_matches(path: Path, entry: FileEntry) -> bool:
         return False
 
 
+def _entry_matches(path: Path, entry: FileEntry) -> bool:
+    """Whether the tree already holds this entry, projected or materialized.
+
+    A projected artifact is judged structurally against the manifest
+    (:func:`projection.projection_fault`); anything holding real bytes is
+    hashed. Both arms are live on purpose: a pod that upgrades across the
+    chokepoint flip meets its own pre-flip MATERIALIZED tree under the same
+    key, and converging on it is correct — it holds the bytes the manifest
+    names. This function never WRITES a materialized tree, and nothing else
+    here can either.
+    """
+
+    if projection.is_projection_artifact(path):
+        return (
+            projection.projection_fault(
+                path, digest=entry.digest.digest, size=entry.size_bytes
+            )
+            is None
+        )
+    return _file_matches(path, entry)
+
+
 def _tree_matches(path: Path, manifest: RepositoryManifest) -> bool:
     try:
         actual = {
             candidate.relative_to(path).as_posix()
             for candidate in path.rglob("*")
-            if candidate.is_file()
+            # A symlink into `objects/` IS this entry's file. A BROKEN one is
+            # not, and dropping it here is what makes the set comparison
+            # refuse a tree whose store was swept underneath it.
+            if candidate.is_file() or candidate.is_symlink()
         }
     except OSError:
         return False
     expected = {entry.path for entry in manifest.files}
     return actual == expected and all(
-        _file_matches(path / entry.path, entry) for entry in manifest.files
+        _entry_matches(path / entry.path, entry) for entry in manifest.files
     )
 
 
-def _materialize_repository(
-    cas: LocalCAS, manifest: RepositoryManifest, target: Path
-) -> Path:
-    """Publish or converge on another process's exact winning tree."""
-    try:
-        return cas.materialize_repository(manifest, target)
-    except OSError as exc:
-        if exc.errno not in {errno.EEXIST, errno.ENOTEMPTY}:
-            raise
-        if _tree_matches(target, manifest):
-            return target
-        # The winner is not this manifest. Never delete a tree another process
-        # may own; preserve the publication collision as the failure.
-        raise
-
-
 def _publish_snapshot(
-    cas: LocalCAS, manifest: RepositoryManifest, target: Path
+    cas: LocalCAS,
+    manifest: RepositoryManifest,
+    target: Path,
+    *,
+    symlinks: bool,
 ) -> Path:
-    """Revalidate and publish one target under its process-shared lock."""
+    """Project one snapshot tree under its process-shared lock.
+
+    **This is pgw#1308 step ⑥ — the chokepoint.** It used to ask the store for
+    a whole-tree materialization, writing a complete second copy of every byte
+    the store already held, so a resident model occupied disk twice
+    (pgw#1296(a)). It now projects: non-tensor files are relative symlinks
+    into ``objects/``, tensor containers are ~128 B TFSSTUB1 pointer stubs,
+    and the tensors are read out of the CAS through
+    :func:`gen_worker.models.tensor_source.open_tensor_source`.
+
+    ``symlinks`` is the caller's ONE probe of the target filesystem, passed
+    through rather than re-probed, so the disk check upstream of this sized
+    the tree this writes (:func:`projection.projection_write_bytes`).
+    """
 
     lock_path = target.parent / f".{target.name}.lock"
     with lock_path.open("a+b") as lock:
@@ -277,7 +312,7 @@ def _publish_snapshot(
                 # This exact target is protected by the flock. Never remove a
                 # tree based on validation performed before acquiring it.
                 shutil.rmtree(target)
-            return _materialize_repository(cas, manifest, target)
+            return project_snapshot(cas, manifest, target, symlinks=symlinks)
         finally:
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
@@ -346,6 +381,11 @@ class CozySnapshotDownloader:
                     _TRUSTED_SNAPSHOTS.add(trust_key)
                     return target
 
+            # Probed ONCE, here, and passed to both the disk check and the
+            # projector: the two must agree about what the tree will cost.
+            symlinks = await asyncio.to_thread(
+                projection.symlinks_supported, snapshots
+            )
             await self._ensure_objects(
                 open_worker_cas(base_dir),
                 selected.files,
@@ -355,10 +395,18 @@ class CozySnapshotDownloader:
                     if fill_source_dir is not None
                     else None
                 ),
+                publish_bytes=projection.projection_write_bytes(
+                    manifest, symlinks=symlinks
+                ),
             )
             cas = open_worker_cas(base_dir)
+            # Pinned BEFORE the tree exists: `projection.resolve_projection`
+            # recovers a tree's manifest through this ref, so a tree readable
+            # before its ref is a tree every stub-aware consumer must refuse.
             await asyncio.to_thread(_pin_manifest, cas, key, manifest)
-            await asyncio.to_thread(_publish_snapshot, cas, manifest, target)
+            await asyncio.to_thread(
+                _publish_snapshot, cas, manifest, target, symlinks=symlinks
+            )
             if len(_TRUSTED_SNAPSHOTS) >= _TRUST_CAP:
                 _TRUSTED_SNAPSHOTS.clear()
             _TRUSTED_SNAPSHOTS.add(trust_key)
@@ -379,6 +427,7 @@ class CozySnapshotDownloader:
         *,
         progress: ProgressFn | None,
         fill: LocalCAS | None,
+        publish_bytes: int,
     ) -> None:
         grants = _grants(files)
         entries = {file.path: _manifest_entry(file) for file in files}
@@ -468,14 +517,23 @@ class CozySnapshotDownloader:
                 missing.append(grant)
             report_residency()
 
-        # Every resident snapshot occupies disk TWICE: the CAS objects plus the
-        # materialized tree `_publish_snapshot` writes next. Sizing only the
-        # missing objects under-counted by exactly one whole model, and the
-        # `missing and` guard skipped the check entirely when every object was
-        # already resident — the case where the publish is the ONLY writer. A
-        # pod passed this gate and then ENOSPC'd mid-materialize.
+        # SIZE WHAT IS ACTUALLY WRITTEN, and nothing else. This arithmetic has
+        # been wrong in both directions (pgw#1296(b)): it first sized only the
+        # MISSING objects while `_publish_snapshot` wrote a full second copy
+        # with no check at all, and pgw#1263 then corrected it to
+        # fetch + one whole model. Step ⑥ deleted that second copy — a
+        # projection writes stubs, symlinks and the CAS objects themselves —
+        # so charging a whole model here would now over-reserve by exactly the
+        # model and refuse boots that fit. `publish_bytes` is
+        # `projection.projection_write_bytes` over the SAME symlink probe the
+        # projector is given, so the two cannot disagree.
+        #
+        # The `missing and` guard that once skipped this check entirely stays
+        # gone: fully-resident is still a real case, and it is now the case
+        # where the requirement is genuinely near zero rather than the case
+        # where the publish is the only writer.
         fetch = sum(grant.size_bytes for grant in missing)
-        publish = sum(entry.size_bytes for entry in entries.values())
+        publish = publish_bytes
         required = fetch + publish + _DISK_HEADROOM_BYTES
         free = shutil.disk_usage(cas.root).free
         if required > free:

--- a/src/gen_worker/models/disk_gc.py
+++ b/src/gen_worker/models/disk_gc.py
@@ -144,8 +144,34 @@ class RefIndex:
 
 
 def tree_bytes(path: Path) -> int:
-    """Bytes under ``path`` (file or tree), hardlinked inodes counted once."""
+    """Bytes under ``path`` (file or tree), hardlinked inodes counted once.
+
+    **A PROJECTED snapshot tree is sized from its MANIFEST** (pgw#1308 step
+    ⑥), not by walking it. The walk would answer with the stubs and the
+    symlink targets it happens to reach — a few hundred bytes plus the
+    non-tensor files — for a model of any size. Every caller of this function
+    is asking "how much disk does this ref hold", and the honest answer is the
+    objects the tree's manifest pins, because deleting the tree drops its ref
+    and `sweep_orphan_blobs` then reclaims exactly those. Answering ~0 would
+    make eviction believe a resident 30 GiB model frees nothing, and a pod
+    that cannot reclaim disk does not fail loudly — it fills up.
+    """
     p = Path(path)
+    try:
+        from . import projection
+
+        snapshot = projection.resolve_projection(p)
+    except Exception:  # a probe must never be the thing that fails
+        snapshot = None
+    if snapshot is not None:
+        from .materialized_view import view_root_for
+
+        # The manifest's objects, PLUS any priced copy a pgw#1303-gated site
+        # asked for. Both die when this ref's bytes are deleted, so both are
+        # what deleting it reclaims.
+        return sum(
+            int(entry.size_bytes) for entry in snapshot.manifest.files
+        ) + tree_bytes(view_root_for(p))
     try:
         if p.is_file():
             return int(p.stat().st_size)
@@ -273,6 +299,12 @@ def delete_ref_bytes(ref: str, path: Path, cas_dir: Path) -> None:
                 cas.compare_and_swap_ref(name, None, expected=current)
             except RefConflict:
                 logger.info("disk-gc: snapshot ref %s changed while deleting", name)
+        # The pgw#1303-gated priced copy, if a gated site ever asked for one.
+        # It is keyed by this snapshot and readable only through it, so a view
+        # that outlived its tree would be disk nothing could name or reclaim.
+        from .materialized_view import view_root_for
+
+        shutil.rmtree(view_root_for(unit), ignore_errors=True)
     if unit.is_dir():
         shutil.rmtree(unit, ignore_errors=True)
     else:

--- a/src/gen_worker/models/hf_fp8_blockwise.py
+++ b/src/gen_worker/models/hf_fp8_blockwise.py
@@ -44,6 +44,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import msgspec
 
+from .materialized_view import third_party_dir
 from .safetensors_header import read_header
 from .file_layout import MULTI_FILE, SINGLE_FILE
 from .tensor_layout_contract import (
@@ -406,7 +407,10 @@ def load_hf_fp8_blockwise(
     kwargs: Dict[str, Any] = {"dtype": compute, "quantization_config": quant}
     if device_map is not None:
         kwargs["device_map"] = device_map
-    return model_cls.from_pretrained(str(path), **kwargs)
+    return model_cls.from_pretrained(
+        str(third_party_dir(path, why=f"{model_cls} fp8-blockwise from_pretrained")),
+        **kwargs,
+    )
 
 
 __all__ = [

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -27,6 +27,7 @@ import struct
 
 from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
+from .materialized_view import third_party_dir
 from .file_layout import (
     MULTI_FILE,
     SINGLE_FILE,
@@ -739,14 +740,16 @@ def load_gguf_pipeline(
     denoiser_cls = getattr(importlib.import_module(str(module_name)), str(class_name))
     compute = torch.bfloat16
     denoiser = denoiser_cls.from_single_file(
-        str(gguf_file),
-        config=str(path / component),
+        str(third_party_dir(gguf_file, why="GGUF from_single_file wants a real file")),
+        config=str(third_party_dir(path / component, why="GGUF config dir")),
         quantization_config=GGUFQuantizationConfig(compute_dtype=compute),
         torch_dtype=compute,
     )
     kwargs = dict(components or {})
     kwargs[component] = denoiser
-    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="gguf-denoiser sibling parts from_pretrained")),
+        torch_dtype=compute, **kwargs)
     for name in _fp8_text_encoder_components():
         text_encoder = getattr(pipe, name, None)
         if text_encoder is not None and hasattr(text_encoder, "parameters"):
@@ -1421,7 +1424,9 @@ def load_component(
     if torch_dtype is not None and _accepts_kwarg(
             cls.from_pretrained, "torch_dtype"):
         kwargs["torch_dtype"] = torch_dtype
-    return cls.from_pretrained(str(src), **kwargs)
+    return cls.from_pretrained(
+        str(third_party_dir(src, why="contract_loaded_component from_pretrained")),
+        **kwargs)
 
 
 def contract_loaded_component(
@@ -1940,7 +1945,12 @@ def hydrate_modular_pipeline(
         if _weightless_model_dir(src):
             skipped.append(name)
             continue
-        sources[name] = str(src)
+        # A third-party `ComponentSpec.load` reads this path itself, so it
+        # gets real files. THE #1303 CENSUS MISSED THIS SITE: it counted
+        # literal `from_pretrained(dir)` calls, and modular hydration hands
+        # the directory to diffusers through a spec field instead.
+        sources[name] = str(
+            third_party_dir(src, why=f"ComponentSpec.load({name!r})"))
 
     # Re-point the SPECS first: a later bare `pipe.load_components()` (e.g.
     # endpoint-side) must be equally incapable of reaching the index's repo
@@ -2218,7 +2228,8 @@ def _load_modular_pipeline(
         logger.info(
             "modular slot stages per component onto the device: %s",
             plan.summary())
-    pipe = cls.from_pretrained(path)
+    pipe = cls.from_pretrained(
+        third_party_dir(path, why="modular pipeline shell from_pretrained"))
     if not _is_modular_pipeline(pipe):
         raise ModularHydrationError(
             f"{getattr(cls, '__name__', cls)}.from_pretrained returned "
@@ -2437,7 +2448,9 @@ def load_from_pretrained(
     single = _single_file_checkpoint(Path(path))
     if single is not None and callable(getattr(cls, "from_single_file", None)):
         kwargs.pop("variant", None)
-        pipe = cls.from_single_file(str(single), **kwargs)
+        pipe = cls.from_single_file(
+            str(third_party_dir(single, why="from_single_file wants a real file")),
+            **kwargs)
     else:
         # A part whose dtype opinion is WIDER than the composition's compute
         # dtype must come off disk that way — upcasting a bf16-loaded
@@ -2449,7 +2462,8 @@ def load_from_pretrained(
         if per_component:
             kwargs["torch_dtype"] = per_component
         try:
-            pipe = cls.from_pretrained(path, **kwargs)
+            pipe = cls.from_pretrained(
+                third_party_dir(path, why="pipeline from_pretrained"), **kwargs)
         except (TypeError, ValueError):
             # Not every loader takes variant=/quantization_config= (transformers
             # models, single-file components); retry with the bare essentials.
@@ -2469,7 +2483,8 @@ def load_from_pretrained(
                     "composition's single compute dtype (widened parts will "
                     "load truncated)", path, getattr(cls, "__name__", cls),
                 )
-            pipe = cls.from_pretrained(path, **kwargs)
+            pipe = cls.from_pretrained(
+                third_party_dir(path, why="pipeline from_pretrained"), **kwargs)
 
     unmaterialized = meta_tensors(pipe)
     if unmaterialized:

--- a/src/gen_worker/models/materialized_view.py
+++ b/src/gen_worker/models/materialized_view.py
@@ -1,0 +1,170 @@
+"""A real directory of real files, for a loader that will not read our store.
+
+**This is the pgw#1303 gate's mechanism, and it is the piece pgw#1308 step ⑥
+could not ship without.** The chokepoint now publishes a PROJECTED tree, so a
+consumer that hands a DIRECTORY to a third-party loader — `diffusers`
+`from_pretrained`, `ComponentSpec.load`, `from_single_file`, `gguf.GGUFReader`,
+`llama-server -m` — is handing it pointer stubs. Those loaders fail at their
+own parse site, correctly and loudly, and there is nothing this repo can change
+in them.
+
+pgw#1330 cut every site pgw controls to native reads. What is left is the 23
+sites that hand a path OUT, and pgw#1303 is Paul's ruling on whether they are
+priced or deprecated. **Until that ruling they stay materialized** — and this
+is where the price is paid, named, and made visible.
+
+## What changes even before the ruling
+
+Materialization used to be UNCONDITIONAL and WHOLE-TREE: every snapshot on
+every pod carried a complete second copy, whether or not anything ever handed
+a directory to a third party (pgw#1296(a) measured the 2.000x). Now:
+
+*   nothing is copied until a gated site actually asks;
+*   only the SUBTREE it asks for is copied — a `from_pretrained` on one
+    component costs that component, not the model;
+*   every copy goes through the single-file hatch with its §9 row on the line,
+    so `scripts/lint_materialization_hatch.py` counts it;
+*   the bytes are logged at INFO with the caller's own `why`, so a pod's 2x
+    residency has a name and a call site instead of being the default.
+
+That turns pgw#1303 from "should we allow this?" into a decision with a
+measured price per site, which is what a ruling needs.
+
+## Where the copy lives
+
+``<base>/materialized/<snapshot-key>/<rel>`` — a sibling of ``snapshots/``,
+keyed identically, so :func:`gen_worker.models.disk_gc.delete_ref_bytes` drops
+it with the tree it belongs to and :func:`disk_gc.tree_bytes` counts it. A view
+that outlived its snapshot would be disk nothing could name.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import itertools
+import logging
+import os
+import shutil
+from pathlib import Path
+
+
+from gen_worker._vendor.tensorfs import FileEntry, LocalCAS
+
+from . import projection
+
+_log = logging.getLogger("gen_worker.models.materialized_view")
+_SCRATCH = itertools.count()
+
+VIEWS_DIR = "materialized"
+
+__all__ = ["VIEWS_DIR", "third_party_dir", "view_root_for"]
+
+
+def view_root_for(snapshot_root: Path | str) -> Path:
+    """Where a snapshot's materialized view lives, whether or not it exists."""
+
+    tree = Path(snapshot_root)
+    return tree.parent.parent / VIEWS_DIR / tree.name
+
+
+def _materialize(cas: LocalCAS, entry: FileEntry, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # The single-file hatch. It streams, it is atomic, and it verifies the
+    # reconstruction against the manifest's whole-file digest before the
+    # rename — so a view is known-good bytes, not merely copied ones. The
+    # pinned rev spells `extract()` as `materialize`; see VENDORED.toml.
+    cas.materialize(entry, destination)  # mixed-cas-hatch: author-slot-directory
+
+
+def third_party_dir(path: Path | str, *, why: str) -> Path:
+    """``path``, made real, for a consumer that cannot read the CAS.
+
+    Returns ``path`` UNCHANGED when it is not inside a projected snapshot —
+    an ordinary materialized tree, a bare HF download, a test fixture — so a
+    call site can be unconditional and stays correct on every tree shape. That
+    is deliberate: a caller forced to branch on "is this projected?" is a
+    caller that will get the branch wrong somewhere.
+
+    ``why`` names the third party that needs real files. It is required and it
+    is logged with the byte count, because the whole point of routing these
+    through one seam is that the pgw#1303 ruling can read what it costs and
+    where.
+    """
+
+    target = Path(path)
+    # The tree ROOT is the common case and `snapshot_root_of` cannot see it:
+    # it walks PARENTS looking for `snapshots/`, so it answers for a file
+    # inside a tree and answers `None` for the tree itself. Ask directly
+    # first, then walk. (Getting this backwards is silent — the seam returns
+    # the projected path unchanged and the third party meets a stub.)
+    snapshot = projection.resolve_projection(target)
+    root = target if snapshot is not None else projection.snapshot_root_of(target)
+    if root is None:
+        return target
+    if snapshot is None:
+        snapshot = projection.resolve_projection(root)
+    if snapshot is None:
+        return target
+
+    try:
+        rel = target.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return target
+    rel = "" if rel == "." else rel
+
+    wanted = [
+        entry
+        for entry in snapshot.manifest.files
+        if not rel or entry.path == rel or entry.path.startswith(rel + "/")
+    ]
+    if not wanted:
+        raise projection.UnresolvedProjection(
+            f"{target} is inside the projected tree {root} but its manifest "
+            f"covers no file at {rel!r} ({why}). Refusing to hand a third "
+            f"party a directory this store cannot fill."
+        )
+
+    view = view_root_for(root)
+    out = view / rel if rel else view
+    if out.exists():
+        return out
+
+    view.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = view.parent / f".{view.name}.lock"
+    written = 0
+    with lock_path.open("a+b") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            if out.exists():
+                return out
+            if len(wanted) == 1 and wanted[0].path == rel:
+                # ONE file. The hatch is already atomic — it writes a temp
+                # beside the destination, verifies the whole-file digest, and
+                # renames — so there is no second staging step to add.
+                out.parent.mkdir(parents=True, exist_ok=True)
+                _materialize(snapshot.cas, wanted[0], out)
+                written = wanted[0].size_bytes
+            else:
+                # A DIRECTORY. Built under a scratch name and renamed, so no
+                # reader ever sees a half-filled view — the projector's rule.
+                scratch = view.parent / f".building-{view.name}-{os.getpid()}-{next(_SCRATCH)}"
+                shutil.rmtree(scratch, ignore_errors=True)
+                try:
+                    for entry in wanted:
+                        suffix = entry.path[len(rel) + 1 :] if rel else entry.path
+                        _materialize(snapshot.cas, entry, scratch / suffix)
+                        written += entry.size_bytes
+                    out.parent.mkdir(parents=True, exist_ok=True)
+                    scratch.rename(out)
+                except BaseException:
+                    shutil.rmtree(scratch, ignore_errors=True)
+                    raise
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    _log.info(
+        "materialized_view snapshot=%s rel=%s bytes=%d files=%d why=%s "
+        "(pgw#1303: this is the priced copy, not the default)",
+        root.name, rel or "(whole tree)", written, len(wanted), why,
+    )
+    return out

--- a/src/gen_worker/models/projection.py
+++ b/src/gen_worker/models/projection.py
@@ -26,6 +26,7 @@ tree's own location.
 
 from __future__ import annotations
 
+import itertools
 import logging
 import os
 from dataclasses import dataclass
@@ -39,8 +40,10 @@ from gen_worker._vendor.tensorfs import (
     RepositoryManifest,
     Stub,
     TensorReader,
+    is_tensor_container,
     open_tensors,
     read_stub,
+    stub_bytes,
 )
 
 _log = logging.getLogger("gen_worker.models.projection")
@@ -234,16 +237,131 @@ def object_of_symlink(path: Path | str) -> Optional[CASRef]:
         return None
 
 
+def is_projection_artifact(path: Path | str) -> bool:
+    """Whether this path carries a POINTER instead of the bytes it names.
+
+    A pointer stub or a symlink into the CAS. Not a judgement about whether
+    the pointer is *correct* — that is :func:`projection_fault`.
+    """
+
+    file = Path(path)
+    return file.is_symlink() or read_stub(file) is not None
+
+
+def projection_fault(path: Path | str, *, digest: str, size: int) -> Optional[str]:
+    """Why the projection artifact at ``path`` is not the one the manifest
+    names, or ``None`` when it is exactly right.
+
+    THE SINGLE STATEMENT of what a correct projected artifact is. The boot
+    verifier (:func:`gen_worker.models.volume_verify.verify_projection`) and
+    the snapshot chokepoint's convergence check both read it from here: a
+    second copy of this rule is a second thing to get wrong, which is what the
+    five duplicated fail-open header readers pgw#1330 collapsed already
+    demonstrated in this repo.
+
+    Complete rather than partial. A stub's whole content is a body identity
+    and a logical size, and both are checked; a symlink's whole content is the
+    object it names, and that object's presence and identity are checked. The
+    bytes themselves were hashed at ADMISSION into a pod-local store, so there
+    is nothing further at this path to check.
+
+    Precondition: :func:`is_projection_artifact`. A path holding real bytes
+    has no projection fault — it has a hash, and the caller must take it.
+    """
+
+    file = Path(path)
+    stub = read_stub(file)
+    if stub is not None:
+        if stub.body_sha256 != digest:
+            return (
+                f"stub names body {stub.body_sha256[:16]}…, "
+                f"manifest says {digest[:16]}…"
+            )
+        if size and stub.size != size:
+            return f"stub declares {stub.size} bytes, manifest declares {size}"
+        return None
+    got = object_of_symlink(file)
+    if got is None:
+        return "symlink does not resolve into the CAS objects tree"
+    if got.digest != digest:
+        return f"links to object {got.digest[:16]}…, manifest says {digest[:16]}…"
+    if not file.exists():
+        return f"linked object {got.digest[:16]}… is absent"
+    return None
+
+
+_SYMLINK_PROBE = itertools.count()
+
+
+def symlinks_supported(directory: Path | str) -> bool:
+    """Whether ``directory``'s filesystem can hold the tree's symlinks.
+
+    Probed rather than assumed, and probed ONCE by the caller so the same
+    answer sizes the disk check and drives ``project_snapshot(symlinks=…)``.
+    Letting each side probe independently is how a headroom check comes to
+    size a tree of symlinks while the projector writes a tree of copies.
+    """
+
+    parent = Path(directory)
+    probe = parent / f".symlink-probe-{os.getpid()}-{next(_SYMLINK_PROBE)}"
+    try:
+        os.symlink("probe-target", probe)
+    except (OSError, NotImplementedError):
+        return False
+    finally:
+        try:
+            os.unlink(probe)
+        except OSError:
+            pass
+    return True
+
+
+def projection_write_bytes(
+    manifest: RepositoryManifest, *, symlinks: bool
+) -> int:
+    """Bytes projecting ``manifest`` will actually WRITE at the target path.
+
+    The dispatch mirrors ``tensorfs.project._project_entry`` arm for arm,
+    because a disk check that sizes something other than what the writer
+    writes is worse than no check: on master this sized a whole second copy
+    of the model that a projection never makes, and before pgw#1263 it sized
+    only the MISSING objects while the publish wrote a full copy with no
+    check at all. ``tests/test_projection_headroom_pgw1308.py`` asserts this
+    equals the real ``du`` of a real projection rather than trusting the
+    mirror to stay in step.
+
+    Three arms cost nothing: a tensor container is a ~128 B stub, an empty
+    file is empty, and a single-object non-tensor file is a symlink. The one
+    arm that costs its whole size is a CHUNKED non-tensor file, which has no
+    single object to point at and no tensor reader to serve it — and, when
+    the filesystem cannot hold symlinks, every non-tensor file.
+    """
+
+    total = 0
+    for entry in manifest.files:
+        if is_tensor_container(entry.path):
+            total += len(stub_bytes(entry.digest, entry.size_bytes))
+        elif entry.size_bytes == 0:
+            continue
+        elif len(entry.chunks) > 1 or not symlinks:
+            total += entry.size_bytes
+    return total
+
+
 __all__ = [
     "ProjectedSnapshot",
     "REF_PREFIX",
     "SNAPSHOTS_DIR",
     "UnresolvedProjection",
+    "is_projection_artifact",
     "logical_size",
     "object_of_symlink",
+    "projection_fault",
+    "projection_write_bytes",
     "require_projection",
     "require_projection_for",
     "resolve_projection",
     "snapshot_root_of",
     "stub_at",
+    "symlinks_supported",
 ]

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -53,7 +53,6 @@ from .svdq_layout import (
     split_decoded,
     to_buffers,
 )
-from pathlib import Path
 import json
 import time
 from .w4a4 import w4a4_gemm_mode
@@ -61,6 +60,7 @@ from .w4a4 import _gemm_w4a4
 from .native_kernels import svdq_linear_execution_lane
 from .svdq_fused import build_svdq_fused_linear, fused_shape_supported
 from .svdq import _read_safetensors_metadata
+from .materialized_view import third_party_dir
 from .tensor_source import open_tensor_source
 from .svdq_awq import decode_awq_linear, is_awq_linear
 from .svdq_layout import LOWRANK_QUANT_KEY, LOWRANK_QUANT_SCHEMES, decode_linear
@@ -606,7 +606,9 @@ def load_svdq_native_pipeline(cls: Any, path: Any, art: Any, *,
             f"servable flavor must be a full diffusers tree with the "
             f"checkpoint under its denoiser directory")
     denoiser = load_svdq_native_denoiser(art, compute_dtype=compute)
-    pipe = cls.from_pretrained(str(Path(path)), torch_dtype=compute,
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="svdq non-denoiser parts from_pretrained")),
+        torch_dtype=compute,
                               **{art.component: denoiser})
     try:
         pipe._cozy_weight_lane = (

--- a/src/gen_worker/models/volume_verify.py
+++ b/src/gen_worker/models/volume_verify.py
@@ -185,7 +185,7 @@ def split_projection_targets(
     projected: List[VerifyTarget] = []
     material: List[VerifyTarget] = []
     for t in targets:
-        if t.path.is_symlink() or projection.stub_at(t.path) is not None:
+        if projection.is_projection_artifact(t.path):
             projected.append(t)
         else:
             material.append(t)
@@ -211,54 +211,31 @@ def verify_projection(targets: Sequence[VerifyTarget]) -> VerifyReport:
 
     Re-hashing the objects instead would re-read every resident model on every
     boot to re-derive a fact the store already refused to store wrongly.
+
+    What a correct artifact IS lives in :func:`projection.projection_fault`,
+    which the snapshot chokepoint's convergence check reads too. This function
+    owns the report shape and the wire-digest parse; it does not own a second
+    opinion about the rule.
     """
 
     rep = VerifyReport(expected=len(targets))
     for t in targets:
         label = t.label or t.ref
+        rep.examined += 1
         try:
             want = CASRef.parse(t.ref)
         except ValueError as exc:
-            rep.examined += 1
             rep.bad.append(label)
             rep.findings.append(f"{t.path.name}: unreadable digest {t.ref!r}: {exc}")
             continue
-        stub = projection.stub_at(t.path)
-        if stub is not None:
-            rep.examined += 1
-            if stub.body_sha256 != want.digest:
-                rep.bad.append(label)
-                rep.findings.append(
-                    f"{t.path.name}: stub names body {stub.body_sha256[:16]}…, "
-                    f"manifest says {want.digest[:16]}…"
-                )
-            elif t.size and stub.size != t.size:
-                rep.bad.append(label)
-                rep.findings.append(
-                    f"{t.path.name}: stub declares {stub.size} bytes, "
-                    f"manifest declares {t.size}"
-                )
-            else:
-                rep.projected += 1
-            continue
-        got = projection.object_of_symlink(t.path)
-        rep.examined += 1
-        if got is None:
-            rep.bad.append(label)
-            rep.findings.append(
-                f"{t.path.name}: symlink does not resolve into the CAS objects tree"
-            )
-        elif got.digest != want.digest:
-            rep.bad.append(label)
-            rep.findings.append(
-                f"{t.path.name}: links to object {got.digest[:16]}…, "
-                f"manifest says {want.digest[:16]}…"
-            )
-        elif not t.path.exists():
-            rep.bad.append(label)
-            rep.findings.append(f"{t.path.name}: linked object {got.digest[:16]}… is absent")
-        else:
+        fault = projection.projection_fault(
+            t.path, digest=want.digest, size=t.size
+        )
+        if fault is None:
             rep.projected += 1
+        else:
+            rep.bad.append(label)
+            rep.findings.append(f"{t.path.name}: {fault}")
     _log.info(
         "projection_verify examined=%d/%d projected=%d bad=%d",
         rep.examined, rep.expected, rep.projected, len(rep.bad),

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -47,6 +47,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
+from .materialized_view import third_party_dir
 from .safetensors_header import read_header
 from .tensor_source import load_state_dict, open_tensor_source
 from .tensor_layout_contract import unregistered_decode_path
@@ -608,7 +609,9 @@ def load_w4a4_pipeline(cls: Any, path: Path, art: W4a4Artifact, *,
     denoiser = load_w4a4_denoiser(path, art, compute_dtype=compute, mode=mode)
     kwargs: Dict[str, Any] = dict(components or {})
     kwargs[art.component] = denoiser
-    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="w4a4 quantizer from_pretrained")),
+        torch_dtype=compute, **kwargs)
     try:
         pipe._cozy_weight_lane = (
             "w4a4" if mode != "dequant" else "bf16-resident")
@@ -796,7 +799,9 @@ def load_w4a4_root_pipeline(
 
     compute = compute_dtype or torch.bfloat16
     mode = w4a4_gemm_mode() or "dequant"
-    pipe = cls.from_pretrained(str(path), torch_dtype=compute)
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="w4a4 quantizer from_pretrained")),
+        torch_dtype=compute)
     denoiser = _root_denoiser(pipe)
     if mode != "dequant":
         if not swap_w4a4_linears(denoiser, art, compute_dtype=compute):

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
+from .materialized_view import third_party_dir
 from .safetensors_header import read_header
 from .tensor_source import load_state_dict, open_tensor_source
 from .file_layout import MULTI_FILE, SINGLE_FILE
@@ -735,7 +736,9 @@ def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
     if len(arts) > 1:
         logger.info("w8a8: %d quantized denoisers wired (%s)", len(arts),
                     ", ".join(a.component for a in arts))
-    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="w8a8 quantizer from_pretrained")),
+        torch_dtype=compute, **kwargs)
     try:
         pipe._cozy_weight_lane = "w8a8" if mode != "dequant" else "bf16-resident"
     except Exception:
@@ -941,7 +944,9 @@ def load_w8a8_root_pipeline(
 
     compute = compute_dtype or torch.bfloat16
     mode = w8a8_gemm_mode() or "dequant"
-    pipe = cls.from_pretrained(str(path), torch_dtype=compute)
+    pipe = cls.from_pretrained(
+        str(third_party_dir(path, why="w8a8 quantizer from_pretrained")),
+        torch_dtype=compute)
     denoiser = _root_denoiser(pipe)
     key_map = (getattr(pipe, "_cozy_w8a8_key_map", None)
                or getattr(cls, "_cozy_w8a8_key_map", None))

--- a/src/gen_worker/runtimes/llama.py
+++ b/src/gen_worker/runtimes/llama.py
@@ -22,6 +22,7 @@ import msgspec
 
 from ..api.errors import FatalError
 from ..api.streaming import IncrementalTokenDelta, TokenUsage
+from ..models.materialized_view import third_party_dir
 from ..models.memory import get_available_vram_gb
 
 logger = logging.getLogger(__name__)
@@ -125,7 +126,9 @@ def read_gguf_info(path: Union[str, Path]) -> GGUFInfo:
         ) from exc
 
     gguf_path = Path(path)
-    reader = GGUFReader(str(gguf_path), "r")
+    reader = GGUFReader(
+        str(third_party_dir(gguf_path, why="gguf.GGUFReader wants a real file")),
+        "r")
     arch_field = reader.get_field("general.architecture")
     arch = str(arch_field.contents()) if arch_field is not None else ""
     n_head = _field_int(reader, f"{arch}.attention.head_count")

--- a/tests/harness/boot_ladder_endpoints_pgw797.py
+++ b/tests/harness/boot_ladder_endpoints_pgw797.py
@@ -25,6 +25,26 @@ from gen_worker import Compile, Hub, RequestContext, Resources, endpoint
 from gen_worker.families.base import GenerationDefaults, family
 
 
+def _slot_weight_bytes(slot_dir: object) -> str:
+    """What the slot's weights file HOLDS, on any tree shape.
+
+    A harness endpoint is the closest thing this repo has to a pgw#1303 author
+    slot: it is handed a DIRECTORY and reads raw weight bytes out of it. After
+    pgw#1308 step ⑥ that directory is a projected tree, so the file at the
+    path is a ~128 B pointer stub — which is exactly what a real third-party
+    loader gets, and exactly why #1303 is a ruling rather than a cleanup.
+
+    So these fixtures go through the SAME seam a gated production site now
+    goes through (`models.materialized_view.third_party_dir`), which is what
+    makes them evidence about the gate instead of a workaround for it.
+    """
+
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = third_party_dir(Path(str(slot_dir)), why="harness author slot")
+    return (real / "model.safetensors").read_text()
+
+
 @family("harness-pgw797-testfam")
 class _Defaults(GenerationDefaults, frozen=True):
     steps: int = 3
@@ -48,7 +68,7 @@ class ToyPipeline:
 
     @classmethod
     def from_pretrained(cls, path: str, **_kw: object) -> "ToyPipeline":
-        return cls((Path(path) / "model.safetensors").read_text())
+        return cls(_slot_weight_bytes(path))
 
     def to(self, device: str) -> "ToyPipeline":
         return self

--- a/tests/harness/toy_endpoints.py
+++ b/tests/harness/toy_endpoints.py
@@ -23,6 +23,26 @@ from gen_worker.api.streaming import StreamResult, TokenUsage
 from gen_worker.families.base import GenerationDefaults, family
 
 
+def _slot_weight_bytes(slot_dir: object) -> str:
+    """What the slot's weights file HOLDS, on any tree shape.
+
+    A harness endpoint is the closest thing this repo has to a pgw#1303 author
+    slot: it is handed a DIRECTORY and reads raw weight bytes out of it. After
+    pgw#1308 step ⑥ that directory is a projected tree, so the file at the
+    path is a ~128 B pointer stub — which is exactly what a real third-party
+    loader gets, and exactly why #1303 is a ruling rather than a cleanup.
+
+    So these fixtures go through the SAME seam a gated production site now
+    goes through (`models.materialized_view.third_party_dir`), which is what
+    makes them evidence about the gate instead of a workaround for it.
+    """
+
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = third_party_dir(Path(str(slot_dir)), why="harness author slot")
+    return (real / "model.safetensors").read_text()
+
+
 @family("harness-testfam")
 class _ToyDefaults(GenerationDefaults, frozen=True):
     steps: int = 7
@@ -96,8 +116,7 @@ class ModelBoundEndpoint:
         self.model_path = model
 
     def model_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
-        weights = Path(self.model_path) / "model.safetensors"
-        return EchoOut(response=weights.read_text())
+        return EchoOut(response=_slot_weight_bytes(self.model_path))
 
 
 # Toggled by P2's setup-failure test: True => BrokenSetupEndpoint.setup
@@ -116,8 +135,7 @@ class BrokenSetupEndpoint:
         self.model_path = model
 
     def broken_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
-        weights = Path(self.model_path) / "model.safetensors"
-        return EchoOut(response=weights.read_text())
+        return EchoOut(response=_slot_weight_bytes(self.model_path))
 
 
 class _RamPressurePipeline:
@@ -171,8 +189,7 @@ class SlotBootPrecedenceEndpoint:
         self.vae_path = vae
 
     def slot_boot_precedence(self, ctx: RequestContext[_ToyDefaults], data: EchoIn) -> EchoOut:
-        weights = Path(self.pipeline_path) / "model.safetensors"
-        return EchoOut(response=weights.read_text())
+        return EchoOut(response=_slot_weight_bytes(self.pipeline_path))
 
 
 DECLARED_PIPELINE = Hub("harness/slot-identity-declared", release="prod")
@@ -386,8 +403,8 @@ class OptionalExecutionLaneEndpoint:
         self.edit_path = edit
 
     def optional_t2i(self, ctx: RequestContext[_ToyDefaults], data: EchoIn) -> EchoOut:
-        weights = Path(self.t2i_path) / "model.safetensors"
-        return EchoOut(response=f"t2i:{weights.read_text()}:edit_bound={self.edit_path is not None}")
+        return EchoOut(response=f"t2i:{_slot_weight_bytes(self.t2i_path)}"
+                                f":edit_bound={self.edit_path is not None}")
 
     def optional_edit(self, ctx: RequestContext[_ToyDefaults], data: EchoIn) -> EchoOut:
         if self.edit_path is None:
@@ -395,8 +412,7 @@ class OptionalExecutionLaneEndpoint:
                 "slot 'edit' is not bound on this release — this deploy "
                 "serves the t2i lane only"
             )
-        weights = Path(self.edit_path) / "model.safetensors"
-        return EchoOut(response=f"edit:{weights.read_text()}")
+        return EchoOut(response=f"edit:{_slot_weight_bytes(self.edit_path)}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness/toy_endpoints_slot_only.py
+++ b/tests/harness/toy_endpoints_slot_only.py
@@ -18,6 +18,26 @@ from gen_worker import Hub, RequestContext, Slot, endpoint
 from gen_worker.families.base import GenerationDefaults, family
 
 
+def _slot_weight_bytes(slot_dir: object) -> str:
+    """What the slot's weights file HOLDS, on any tree shape.
+
+    A harness endpoint is the closest thing this repo has to a pgw#1303 author
+    slot: it is handed a DIRECTORY and reads raw weight bytes out of it. After
+    pgw#1308 step ⑥ that directory is a projected tree, so the file at the
+    path is a ~128 B pointer stub — which is exactly what a real third-party
+    loader gets, and exactly why #1303 is a ruling rather than a cleanup.
+
+    So these fixtures go through the SAME seam a gated production site now
+    goes through (`models.materialized_view.third_party_dir`), which is what
+    makes them evidence about the gate instead of a workaround for it.
+    """
+
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = third_party_dir(Path(str(slot_dir)), why="harness author slot")
+    return (real / "model.safetensors").read_text()
+
+
 @family("harness-slot-only-testfam")
 class _ToyDefaults(GenerationDefaults, frozen=True):
     steps: int = 7
@@ -45,5 +65,4 @@ class SlotBootPrecedenceEndpoint:
         self.vae_path = vae
 
     def slot_boot_precedence(self, ctx: RequestContext[_ToyDefaults], data: EchoIn) -> EchoOut:
-        weights = Path(self.pipeline_path) / "model.safetensors"
-        return EchoOut(response=weights.read_text())
+        return EchoOut(response=_slot_weight_bytes(self.pipeline_path))

--- a/tests/projection_fixture.py
+++ b/tests/projection_fixture.py
@@ -188,7 +188,7 @@ def build(
     return Fixture(base=base, source=source, tree=tree, key=key, cas=cas, manifest=manifest)
 
 
-def materialize(base: Path, fixture: Fixture, name: str = "materialized") -> Path:
+def read_entry_tree(base: Path, fixture: Fixture, name: str = "materialized") -> Path:
     """The same manifest as a tree of REAL files, for the control arm.
 
     Built with ``read_entry``, NOT with the single-file materialization hatch:
@@ -196,6 +196,12 @@ def materialize(base: Path, fixture: Fixture, name: str = "materialized") -> Pat
     for it in a test is the example that spreads. ``read_entry`` also verifies
     the reconstruction against the manifest's whole-file digest, so the control
     arm is known-good bytes rather than merely copied ones.
+
+    NAMED for what it uses (pgw#1308 step ⑥). It was called ``materialize``,
+    which made the hatch census report it as an unpriced hatch call the moment
+    the fence learned the pinned rev's spelling — a docstring saying "this is
+    not the hatch" does not reach a grep, and a helper whose name is the thing
+    it is not is the example that spreads just as fast.
     """
 
     target = base / SNAPSHOTS_DIR / name
@@ -205,6 +211,28 @@ def materialize(base: Path, fixture: Fixture, name: str = "materialized") -> Pat
         destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_bytes(read_entry(fixture.cas, entry))
     return target
+
+
+def bytes_at(tree: Path, rel: str) -> bytes:
+    """What ``rel`` HOLDS in a snapshot tree, wherever its bytes really live.
+
+    The one idiom every pre-flip assertion of the form
+    ``(snapshot / "model.safetensors").read_bytes() == payload`` becomes after
+    pgw#1308 step ⑥. Reading the path directly is not a weaker assertion, it
+    is an assertion about a ~128 B pointer stub — and it fails loudly, which
+    is how these tests were found rather than silently kept.
+
+    A symlink or an ordinary file is read at the path, because that is where
+    those bytes are.
+    """
+
+    from gen_worker.models.projection import require_projection, stub_at
+
+    path = tree / rel
+    if stub_at(path) is None:
+        return path.read_bytes()
+    snapshot = require_projection(tree, why=f"test reads {rel} through the tree")
+    return read_entry(snapshot.cas, snapshot.entry(rel))
 
 
 def iter_stubs(tree: Path) -> Iterable[Path]:

--- a/tests/test_chokepoint_projects_pgw1308.py
+++ b/tests/test_chokepoint_projects_pgw1308.py
@@ -1,0 +1,363 @@
+"""pgw#1308 step ⑥: what `ensure_snapshot` publishes is a PROJECTED tree.
+
+Everything else in the mixed-CAS program is machinery that a pod never meets
+until this one call stops materializing. pgw#1330 proved every consumer works
+over a projected tree built by a FIXTURE; these arms run the production
+chokepoint and assert the tree it publishes is that tree.
+
+The measurement that matters is single residency (pgw#1296(a)). It is stated
+as bytes on disk from `du`, against a control arm that materializes the same
+manifest, because "the diff removed a copy" is a reading of a diff and not a
+measurement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from gen_worker._vendor.tensorfs import (
+    CASRef,
+    Chunk,
+    FileEntry,
+    LocalCAS,
+    RepositoryManifest,
+    project_snapshot,
+    read_entry,
+    tree_bytes,
+)
+
+import projection_fixture as fixture
+from gen_worker.models import cozy_snapshot, projection
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef
+from gen_worker.models.store import ModelStore
+from gen_worker.models.volume_verify import (
+    VerifyTarget,
+    split_projection_targets,
+    verify_projection,
+)
+
+#: Big enough that ~128 B stubs are noise against it, small enough to stay a
+#: unit test. A fixture too small to reach the path is its own failure mode
+#: (DONE-STANDARD, "fixture shape").
+_SHARD_TENSOR_BYTES = 1 << 20
+
+
+def _ref() -> TensorhubRef:
+    return TensorhubRef(owner="acme", repo="model", release="latest")
+
+
+def _write_model(source: Path) -> None:
+    """A diffusers-shaped model: JSON, a tokenizer, media, and two shards."""
+
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "model_index.json").write_text(
+        json.dumps({"_class_name": "TinyPipeline", "transformer": ["diffusers", "X"]})
+    )
+    for component in ("transformer", "vae"):
+        directory = source / component
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "config.json").write_text(json.dumps({"_class_name": "X"}))
+        (directory / "diffusion_pytorch_model.safetensors").write_bytes(
+            fixture.safetensors_bytes(
+                {
+                    f"{component}.weight": (
+                        "F32",
+                        (_SHARD_TENSOR_BYTES // 4,),
+                        fixture.varied(_SHARD_TENSOR_BYTES, 7 + len(component)),
+                    )
+                }
+            )
+        )
+    tokenizer = source / "tokenizer"
+    tokenizer.mkdir(parents=True, exist_ok=True)
+    (tokenizer / "tokenizer_config.json").write_text(json.dumps({"model_max_length": 77}))
+    media = source / "dataset"
+    media.mkdir(parents=True, exist_ok=True)
+    (media / "sample.mp4").write_bytes(fixture.varied(4096, 11))
+    (media / "empty.txt").write_bytes(b"")
+
+
+def _resident(base: Path, source: Path) -> WorkerResolvedRepo:
+    """Admit every file as one CAS object and describe it as tensorhub would.
+
+    Resident on purpose: the transfer is pgw#781/#1289's subject, and the
+    publish is this file's.
+    """
+
+    cas = LocalCAS(base)
+    files: list[WorkerResolvedRepoFile] = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        body = path.read_bytes()
+        digest = cas.put_bytes(body)
+        files.append(
+            WorkerResolvedRepoFile(
+                path.relative_to(source).as_posix(),
+                len(body),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(digest),
+            )
+        )
+    return WorkerResolvedRepo(snapshot_digest="sha256:" + "e" * 64, files=files)
+
+
+def _du(root: Path) -> int:
+    """Bytes the files under ``root`` occupy. Never follows a symlink."""
+
+    total = 0
+    for directory, _subdirs, names in os.walk(root, followlinks=False):
+        for name in names:
+            info = os.lstat(os.path.join(directory, name))
+            if not stat.S_ISLNK(info.st_mode):
+                total += info.st_size
+    return total
+
+
+@pytest.fixture
+def published(tmp_path: Path) -> dict[str, Path]:
+    source = tmp_path / "source-model"
+    _write_model(source)
+    base = tmp_path / "store"
+    base.mkdir()
+    resolved = _resident(base, source)
+    tree = asyncio.run(
+        ensure_snapshot_async(base_dir=base, ref=_ref(), resolved=resolved)
+    )
+    return {"base": base, "source": source, "tree": tree}
+
+
+def test_the_chokepoint_publishes_symlinks_and_stubs(published: dict[str, Path]) -> None:
+    """Every file in the tree is a pointer. Nothing in it is a copy."""
+
+    tree, source = published["tree"], published["source"]
+    seen: set[str] = set()
+    for path in sorted(tree.rglob("*")):
+        if path.is_dir() and not path.is_symlink():
+            continue
+        rel = path.relative_to(tree).as_posix()
+        seen.add(rel)
+        original = source / rel
+        if rel.endswith(".safetensors"):
+            stub = projection.stub_at(path)
+            assert stub is not None, f"{rel} is not a pointer stub"
+            assert stub.size == original.stat().st_size
+            assert stub.body_sha256 == hashlib.sha256(original.read_bytes()).hexdigest()
+        elif original.stat().st_size == 0:
+            assert path.read_bytes() == b""
+        else:
+            assert path.is_symlink(), f"{rel} is a copy, not a symlink"
+            assert projection.object_of_symlink(path) is not None
+            # A symlink is only useful if reading through it is the file.
+            assert path.read_bytes() == original.read_bytes()
+    assert seen == {
+        p.relative_to(source).as_posix() for p in source.rglob("*") if p.is_file()
+    }
+
+
+def test_no_tensor_byte_is_at_a_filesystem_path(published: dict[str, Path]) -> None:
+    """The claim the whole layout exists to make true, asserted directly.
+
+    Not "the shards are stubs" — every regular file anywhere in the published
+    tree is under one block, so there is nowhere for a tensor to be hiding.
+    """
+
+    tree = published["tree"]
+    for path in sorted(tree.rglob("*")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        assert path.stat().st_size < 4096, f"{path} holds {path.stat().st_size} bytes"
+    assert tree_bytes(tree) < 4096
+
+
+def test_a_resident_model_occupies_disk_ONCE(published: dict[str, Path]) -> None:
+    """pgw#1296(a), as bytes rather than as a reading of the diff.
+
+    The control arm is the same manifest written out as real files. Both
+    numbers come from the same walk, so the ratio is not an artifact of two
+    different measurements.
+    """
+
+    base, tree = published["base"], published["tree"]
+    snapshot = projection.require_projection(tree, why="pgw#1308 residency arm")
+    objects = _du(base / "objects")
+    projected_total = _du(base)
+
+    control = base / "control-materialized"
+    control.mkdir()
+    for entry in snapshot.manifest.files:
+        destination = control / entry.path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(read_entry(snapshot.cas, entry))
+    materialized_total = projected_total + _du(control)
+
+    model = sum(entry.size_bytes for entry in snapshot.manifest.files)
+    assert objects >= model  # the bytes, stored once
+    assert projected_total < objects + 4096
+    assert materialized_total > objects + model - 4096
+    # The claim, stated the way the issue states it.
+    assert projected_total / model < 1.01
+    assert materialized_total / model > 1.99
+
+
+def test_the_published_tree_resolves_to_its_own_manifest(
+    published: dict[str, Path]
+) -> None:
+    """`resolve_projection` needs the ref the chokepoint pins, and gets it.
+
+    Every stub-aware consumer in this repo recovers `(cas, manifest)` from a
+    bare directory path this way. A tree published without its ref would be an
+    `UnresolvedProjection` at every one of them.
+    """
+
+    tree = published["tree"]
+    snapshot = projection.resolve_projection(tree)
+    assert snapshot is not None
+    assert snapshot.root == tree
+    assert {entry.path for entry in snapshot.manifest.files} == {
+        p.relative_to(published["source"]).as_posix()
+        for p in published["source"].rglob("*")
+        if p.is_file()
+    }
+
+
+def test_weights_read_byte_exact_out_of_the_published_tree(
+    published: dict[str, Path]
+) -> None:
+    """The tree serves the model, or it is a smaller way of serving nothing."""
+
+    tree, source = published["tree"], published["source"]
+    snapshot = projection.require_projection(tree, why="pgw#1308 read-back arm")
+    for component in ("transformer", "vae"):
+        rel = f"{component}/diffusion_pytorch_model.safetensors"
+        # `read_entry` reassembles from the CAS objects AND verifies the
+        # result against the manifest's whole-file digest, so a byte-exact
+        # match here is a statement about the store, not about a copy.
+        assert read_entry(snapshot.cas, snapshot.entry(rel)) == (
+            (source / rel).read_bytes()
+        )
+    # And the tensors themselves, by name, with no file anywhere behind them.
+    with snapshot.open_tensors() as reader:
+        for component in ("transformer", "vae"):
+            view = reader[f"{component}.weight"]
+            assert view.nbytes == _SHARD_TENSOR_BYTES
+            assert view.tobytes() == fixture.varied(
+                _SHARD_TENSOR_BYTES, 7 + len(component)
+            )
+
+
+def test_boot_verification_of_the_published_tree_is_clean(
+    published: dict[str, Path]
+) -> None:
+    """The pgw#1330 defect, closed against the PRODUCTION publish.
+
+    `store._verify_snapshot_tree` runs on first use every boot. Against a
+    materialized tree it hashes; against this one it must verify structurally
+    and report REAL work, or the vacuity guard scores a clean pass as
+    untrustworthy and the pod quarantines the model it just published.
+    """
+
+    tree = published["tree"]
+    snapshot = projection.require_projection(tree, why="pgw#1308 boot arm")
+    targets = [
+        VerifyTarget(
+            path=tree / entry.path,
+            ref=str(entry.digest),
+            size=entry.size_bytes,
+            label=str(entry.digest),
+        )
+        for entry in snapshot.manifest.files
+    ]
+    projected, material = split_projection_targets(targets)
+    # The empty file is the one entry that holds its own (zero) bytes.
+    assert {t.path.name for t in material} <= {"empty.txt"}
+    report = verify_projection(projected)
+    assert report.ok
+    assert report.projected == len(projected)
+    assert report.hashed == 0
+
+    # And the whole-tree verdict the store reaches on first use every boot.
+    ok, bad = ModelStore._verify_snapshot_tree(
+        object.__new__(ModelStore), tree, None
+    )
+    assert (ok, bad) == (True, [])
+
+
+def test_the_headroom_prediction_is_what_the_projection_writes(
+    tmp_path: Path
+) -> None:
+    """pgw#1296(b): the disk check sizes the tree the projector writes.
+
+    `projection_write_bytes` mirrors `tensorfs.project._project_entry` arm for
+    arm, and a mirror drifts. So it is compared against a real `du` of a real
+    projection over a manifest carrying all four arms — stub, empty file,
+    symlink, and the reassembled chunked non-tensor file that is the only one
+    costing its whole size.
+    """
+
+    base = tmp_path / "store"
+    cas = LocalCAS(base)
+    source = tmp_path / "source"
+    _write_model(source)
+    # Give the chunked arm a file whose contents exist only as several objects.
+    parts = [fixture.varied(2048, 3), fixture.varied(2048, 5)]
+    for part in parts:
+        cas.put_bytes(part)
+    chunked = b"".join(parts)
+
+    entries = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        body = path.read_bytes()
+        entries.append(
+            FileEntry(
+                path.relative_to(source).as_posix(),
+                len(body),
+                cas.put_bytes(body),
+            )
+        )
+    entries.append(
+        FileEntry(
+            "dataset/chunked.mp4",
+            len(chunked),
+            CASRef.digest_bytes(chunked),
+            tuple(Chunk(CASRef.digest_bytes(part), len(part)) for part in parts),
+        )
+    )
+    manifest = RepositoryManifest(tuple(entries))
+
+    shapes = {
+        "stub": any(e.path.endswith(".safetensors") for e in manifest.files),
+        "empty": any(e.size_bytes == 0 for e in manifest.files),
+        "symlink": any(
+            not e.chunks and e.size_bytes and not e.path.endswith(".safetensors")
+            for e in manifest.files
+        ),
+        "chunked": any(len(e.chunks) > 1 for e in manifest.files),
+    }
+    assert all(shapes.values()), shapes
+
+    predicted = projection.projection_write_bytes(manifest, symlinks=True)
+    tree = base / "snapshots" / "predicted"
+    project_snapshot(cas, manifest, tree, symlinks=True)
+
+    assert predicted == tree_bytes(tree)
+    # And it is nowhere near the model, which is the point of the restatement.
+    assert predicted < sum(e.size_bytes for e in manifest.files) // 4
+
+
+def test_whole_tree_materialization_is_unreachable_from_the_chokepoint() -> None:
+    """A state assertion, not an intent: the wrapper is GONE, not disabled."""
+
+    assert not hasattr(cozy_snapshot, "_materialize_repository")
+    source = Path(cozy_snapshot.__file__).read_text()
+    assert "materialize" + "_repository" not in source

--- a/tests/test_managed_tier_fill_source.py
+++ b/tests/test_managed_tier_fill_source.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from gen_worker._vendor.tensorfs import CASRef
 from gen_worker.transfer.grants import TransferReport
 
+import projection_fixture
 import gen_worker.models.cozy_snapshot as snap_mod
 from gen_worker import config as gw_config
 from gen_worker.models.cache_paths import open_worker_cas, tensorhub_fill_source_dir
@@ -92,7 +93,7 @@ def test_volume_blob_preferred_over_r2(tmp_path: Path, monkeypatch) -> None:
         snap = asyncio.run(ensure_snapshot_async(
             base_dir=local, ref=ref, resolved=_resolved(), fill_source_dir=volume,
         ))
-    assert (snap / "model.safetensors").read_bytes() == _PAYLOAD
+    assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD
     assert calls == []  # no R2 fetch — the volume already had it
     assert scope.network_bytes == 0
     assert _blob(local).read_bytes() == _PAYLOAD  # copied into local CAS
@@ -109,7 +110,7 @@ def test_r2_fetch_writes_through_to_volume(tmp_path: Path, monkeypatch) -> None:
         snap = asyncio.run(ensure_snapshot_async(
             base_dir=local, ref=ref, resolved=_resolved(), fill_source_dir=volume,
         ))
-    assert (snap / "model.safetensors").read_bytes() == _PAYLOAD
+    assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD
     assert calls == [1]  # exactly one R2 fetch
     assert scope.network_bytes == len(_PAYLOAD)
     assert _blob(volume).read_bytes() == _PAYLOAD  # warmed for the next pod
@@ -129,7 +130,7 @@ def test_no_fill_source_is_byte_identical_to_pre_th850(
         snap = asyncio.run(ensure_snapshot_async(
             base_dir=local, ref=ref, resolved=_resolved(),
         ))
-    assert (snap / "model.safetensors").read_bytes() == _PAYLOAD
+    assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD
     assert calls == [1]
     assert scope.network_bytes == len(_PAYLOAD)
 
@@ -153,7 +154,7 @@ def test_corrupt_volume_blob_falls_through_to_r2(tmp_path: Path, monkeypatch) ->
         snap = asyncio.run(ensure_snapshot_async(
             base_dir=local, ref=ref, resolved=_resolved(), fill_source_dir=volume,
         ))
-    assert (snap / "model.safetensors").read_bytes() == _PAYLOAD  # real bytes
+    assert projection_fixture.bytes_at(snap, "model.safetensors") == _PAYLOAD  # real bytes
     assert calls == [1]  # fell through to R2, not the corrupt volume copy
     assert scope.network_bytes == len(_PAYLOAD)
 

--- a/tests/test_materialized_view_pgw1308.py
+++ b/tests/test_materialized_view_pgw1308.py
@@ -1,0 +1,206 @@
+"""pgw#1308 step ⑥: the pgw#1303 gate's mechanism, and what it costs.
+
+The flip makes every snapshot a projected tree. A site that hands a DIRECTORY
+to a third party (`diffusers.from_pretrained`, `ComponentSpec.load`,
+`from_single_file`, `gguf.GGUFReader`, `llama-server -m`) is handing it pointer
+stubs, and nothing in this repo can change those loaders. Until pgw#1303 rules,
+they stay materialized — through ONE seam, per subtree, priced.
+
+What each arm holds is a property the old unconditional whole-tree copy did
+NOT have, so none of them is a restatement of the status quo.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import projection_fixture as fixture
+from gen_worker.models import disk_gc, materialized_view, projection
+from gen_worker.models.materialized_view import third_party_dir, view_root_for
+
+
+def _du(root: Path) -> int:
+    total = 0
+    for directory, _subdirs, names in os.walk(root, followlinks=False):
+        for name in names:
+            info = os.lstat(os.path.join(directory, name))
+            if not stat.S_ISLNK(info.st_mode):
+                total += info.st_size
+    return total
+
+
+def test_a_gated_site_gets_real_files_out_of_a_projected_tree(
+    tmp_path: Path,
+) -> None:
+    """The whole point: `from_pretrained` can read what it is handed."""
+
+    built = fixture.build(tmp_path)
+    shard = built.tree / "unet" / "diffusion_pytorch_model.safetensors"
+    assert projection.stub_at(shard) is not None, "fixture is not projected"
+
+    real = third_party_dir(built.tree, why="test: diffusers from_pretrained")
+
+    assert real != built.tree
+    for entry in built.manifest.files:
+        made = real / entry.path
+        assert not made.is_symlink()
+        assert projection.stub_at(made) is None
+        assert made.stat().st_size == entry.size_bytes
+        assert made.read_bytes() == (built.source / entry.path).read_bytes()
+
+
+def test_a_component_costs_the_component_and_not_the_model(
+    tmp_path: Path,
+) -> None:
+    """The change that lands BEFORE Paul's ruling, and the reason it matters.
+
+    Materialization used to be unconditional and whole-tree: every snapshot on
+    every pod carried a second complete copy. Now a gated site that wants one
+    component pays for one component. Asserted as bytes, because "it is
+    narrower" is the kind of claim that is true in a diff and false on a pod.
+    """
+
+    built = fixture.build(tmp_path)
+    whole = sum(entry.size_bytes for entry in built.manifest.files)
+    component = sum(
+        entry.size_bytes
+        for entry in built.manifest.files
+        if entry.path.startswith("unet/")
+    )
+    assert 0 < component < whole  # or the arm proves nothing
+
+    made = third_party_dir(built.tree / "unet", why="test: one component")
+
+    assert _du(view_root_for(built.tree)) == component
+    assert _du(view_root_for(built.tree)) < whole
+    assert (made / "config.json").exists()
+    assert not (view_root_for(built.tree) / "vae").exists()
+
+
+def test_the_seam_is_a_no_op_on_a_tree_that_is_not_projected(
+    tmp_path: Path,
+) -> None:
+    """Call sites are unconditional on purpose.
+
+    A caller forced to ask "is this projected?" is a caller that gets the
+    branch wrong somewhere — an HF cache directory, a bare download, a test
+    fixture. So the seam answers with the path it was given, and nothing is
+    copied.
+    """
+
+    ordinary = tmp_path / "hf-cache" / "models--acme--x" / "snapshots" / "abc"
+    ordinary.mkdir(parents=True)
+    (ordinary / "config.json").write_text(json.dumps({"a": 1}))
+
+    assert third_party_dir(ordinary, why="test: not projected") == ordinary
+    assert third_party_dir(
+        ordinary / "config.json", why="test: not projected"
+    ) == (ordinary / "config.json")
+
+
+def test_a_view_is_idempotent_and_built_once(tmp_path: Path) -> None:
+    """A second ask returns the same files without copying them again."""
+
+    built = fixture.build(tmp_path)
+    first = third_party_dir(built.tree, why="test: first")
+    marker = (first / "model_index.json").stat().st_ino
+    before = _du(view_root_for(built.tree))
+
+    second = third_party_dir(built.tree, why="test: second")
+
+    assert second == first
+    assert (second / "model_index.json").stat().st_ino == marker
+    assert _du(view_root_for(built.tree)) == before
+
+
+def test_a_view_dies_with_the_snapshot_it_belongs_to(tmp_path: Path) -> None:
+    """Otherwise it is disk nothing can name.
+
+    `delete_ref_bytes` reclaims a ref by removing its snapshot tree. A view is
+    keyed by that tree and reachable only through it, so a view that survived
+    would be bytes no ref accounts for and no sweep collects.
+    """
+
+    built = fixture.build(tmp_path)
+    third_party_dir(built.tree, why="test: view to be reclaimed")
+    view = view_root_for(built.tree)
+    assert view.is_dir() and _du(view) > 0
+
+    disk_gc.delete_ref_bytes("acme/model", built.tree, tmp_path)
+
+    assert not built.tree.exists()
+    assert not view.exists()
+
+
+def test_disk_gc_sizes_a_projected_tree_from_its_manifest(
+    tmp_path: Path,
+) -> None:
+    """A walk of a projected tree answers ~0 for a model of any size.
+
+    Every caller of `tree_bytes` is asking how much disk a ref holds, and
+    eviction acts on the answer. Answering ~0 does not fail loudly — the pod
+    simply believes a resident model frees nothing, and fills up.
+    """
+
+    built = fixture.build(tmp_path)
+    model = sum(entry.size_bytes for entry in built.manifest.files)
+
+    assert _du(built.tree) < 4096  # what a walk would have reported
+    assert disk_gc.tree_bytes(built.tree) == model
+
+    third_party_dir(built.tree / "unet", why="test: priced copy counts")
+    component = sum(
+        entry.size_bytes
+        for entry in built.manifest.files
+        if entry.path.startswith("unet/")
+    )
+    assert disk_gc.tree_bytes(built.tree) == model + component
+
+
+def test_a_path_the_manifest_does_not_cover_is_a_refusal(tmp_path: Path) -> None:
+    """Refusing to guess, rather than handing back an empty directory.
+
+    An empty directory is what `from_pretrained` reports as "no such model",
+    which sends the investigation to the catalog instead of to the store.
+    """
+
+    built = fixture.build(tmp_path)
+    with pytest.raises(projection.UnresolvedProjection) as refusal:
+        third_party_dir(built.tree / "no-such-component", why="test: absent")
+    assert "no-such-component" in str(refusal.value)
+
+
+def test_one_file_is_a_file_and_not_a_directory_holding_it(
+    tmp_path: Path,
+) -> None:
+    """`from_single_file` and `GGUFReader` name a FILE.
+
+    The directory arm builds under a scratch and renames; a single file must
+    not go through it, or the seam hands back a directory where the caller
+    asked for a checkpoint.
+    """
+
+    built = fixture.build(tmp_path)
+    rel = "unet/diffusion_pytorch_model.safetensors"
+    made = third_party_dir(built.tree / rel, why="test: from_single_file")
+
+    assert made.is_file()
+    assert made.read_bytes() == (built.source / rel).read_bytes()
+
+
+def test_the_seam_is_the_only_way_the_hatch_is_reached(tmp_path: Path) -> None:
+    """A state assertion about the census, not an intent.
+
+    `scripts/lint_materialization_hatch.py` is the enforcement; this pins the
+    fact the lint's `author-slot-directory` row now has exactly one first-party
+    occupant, so a second one is a decision someone makes on purpose.
+    """
+
+    source = Path(materialized_view.__file__).read_text()
+    assert source.count("# mixed-cas-hatch: author-slot-directory") == 1
+    assert "cas.materialize(" in source

--- a/tests/test_p2_residency_reconcile.py
+++ b/tests/test_p2_residency_reconcile.py
@@ -38,6 +38,20 @@ _RAM_PIPELINE_REF = "harness/ram-pressure-pipeline"
 _RAM_VAE_REF = "harness/ram-pressure-shared-vae"
 
 
+def _weights(slot_dir: object) -> bytes:
+    """The slot's weight bytes, on any tree shape.
+
+    A pgw#1303 author slot in miniature: handed a DIRECTORY, reads raw weight
+    bytes. After pgw#1308 step ⑥ that directory is a projected tree, so this
+    goes through the same seam a gated production site goes through.
+    """
+
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = third_party_dir(Path(str(slot_dir)), why="harness author slot")
+    return (real / "model.safetensors").read_bytes()
+
+
 def _decode(data: bytes) -> EchoOut:
     return msgspec.msgpack.decode(data, type=EchoOut)
 
@@ -59,7 +73,7 @@ class _WeightsPipe:
 
     @classmethod
     def from_pretrained(cls, path, **kwargs):
-        data = (Path(path) / "model.safetensors").read_bytes()
+        data = _weights(path)
         if data != cls.expected:
             raise OSError("Unable to load weights from checkpoint file")
         return cls()
@@ -328,7 +342,7 @@ def test_host_ram_failure_precedes_retryable_result_on_wire(tmp_path, monkeypatc
         vae_snap = blobs.one_file_snapshot("ram-vae", "vae", vae_payload)
 
         def _tree_bytes(path) -> int:
-            data = (path / "model.safetensors").read_bytes()
+            data = _weights(path)
             return (6 if data == pipeline_payload else 1) * 1024**3
 
         monkeypatch.setattr(disk_gc, "tree_bytes", _tree_bytes)
@@ -389,7 +403,7 @@ def test_structural_host_ram_shortfall_stops_reselling_the_same_pod(
         vae_snap = blobs.one_file_snapshot("ram-vae", "vae", b"small-shared-vae")
 
         def _tree_bytes(path) -> int:
-            data = (path / "model.safetensors").read_bytes()
+            data = _weights(path)
             # 40GiB of weights on a 31GiB host: no eviction can ever cover it.
             return (40 if data == pipeline_payload else 1) * 1024**3
 
@@ -478,12 +492,18 @@ def test_corrupt_load_failure_refetches_and_retries_once(tmp_path, monkeypatch) 
         store = ModelStore(lambda m: asyncio.sleep(0), cache_dir=tmp_path)
         ex = Executor([spec], lambda m: asyncio.sleep(0), store=store)
         path = await store.ensure_local(ref, snap)
-        (path / "model.safetensors").write_bytes(b"garbage-that-parses-as-nothing")
+        # Corrupt the tree the way a bad disk would. A projection
+        # artifact is installed read-only, so this unlinks first —
+        # the test is about what the STORE concludes from bad bytes,
+        # not about the artifact mode.
+        shard = path / "model.safetensors"
+        shard.unlink()
+        shard.write_bytes(b"garbage-that-parses-as-nothing")
         store._verified.discard(ref)
 
         inst = await ex.ensure_setup(spec, {ref: snap})
         assert isinstance(inst.m, _WeightsPipe)
-        assert (path / "model.safetensors").read_bytes() == content
+        assert _weights(path) == content
 
     asyncio.run(_run())
     assert calls["n"] == 2, "quarantine must trigger exactly one re-download"

--- a/tests/test_projected_tree_pgw1330.py
+++ b/tests/test_projected_tree_pgw1330.py
@@ -127,7 +127,7 @@ def test_a_truncated_materialized_shard_is_still_corrupt(tmp_path: Path) -> None
     mandatory hash."""
 
     built = fixture.build(tmp_path)
-    tree = fixture.materialize(tmp_path, built)
+    tree = fixture.read_entry_tree(tmp_path, built)
     ok, bad = _verify(tmp_path, tree, built.snapshot_message())
     assert ok, f"an intact materialized tree was scored corrupt: {bad}"
 
@@ -174,7 +174,7 @@ def test_dtype_is_identical_projected_and_materialized(tmp_path: Path) -> None:
     """The projection must not change the answer — the point of the layout."""
 
     built = fixture.build(tmp_path)
-    material = fixture.materialize(tmp_path, built)
+    material = fixture.read_entry_tree(tmp_path, built)
     assert detect_on_disk_dtype(built.tree) == detect_on_disk_dtype(material) == "bf16"
 
 
@@ -225,7 +225,7 @@ def test_a_quantized_artifact_is_still_detected_as_quantized(tmp_path: Path) -> 
     from gen_worker.models.w8a8 import detect_w8a8_artifacts
 
     built = fixture.build(tmp_path, fp8=True)
-    material = fixture.materialize(tmp_path, built)
+    material = fixture.read_entry_tree(tmp_path, built)
 
     projected = detect_w8a8_artifacts(built.tree)
     baseline = detect_w8a8_artifacts(material)
@@ -240,7 +240,7 @@ def test_component_weight_bytes_are_the_real_bytes(tmp_path: Path) -> None:
     from gen_worker.models.loading import snapshot_component_weight_bytes
 
     built = fixture.build(tmp_path)
-    material = fixture.materialize(tmp_path, built)
+    material = fixture.read_entry_tree(tmp_path, built)
     projected = snapshot_component_weight_bytes(built.tree)
     assert projected == snapshot_component_weight_bytes(material)
     assert projected and all(v > 0 for v in projected.values())

--- a/tests/test_snapshot_disk_headroom_pgw1263.py
+++ b/tests/test_snapshot_disk_headroom_pgw1263.py
@@ -1,10 +1,21 @@
-"""The snapshot headroom gate must size the publish, not only the fetch.
+"""The snapshot headroom gate must size WHAT IT WRITES — no more, no less.
 
-`_publish_snapshot` writes a full second copy of every file in the manifest
-next to the CAS objects, so a snapshot costs ~2x its size on disk. The gate
-sized only the objects still to be fetched, and skipped itself entirely when
-none were missing — which is exactly the case where the publish is the sole
-writer. Both arms below pass a fetch-only gate and fail an honest one.
+This arithmetic has now been wrong in both directions, which is the reason it
+gets its own file:
+
+*   pgw#1263: it sized only the objects still to be FETCHED, and skipped itself
+    entirely when none were missing — exactly the case where the publish is the
+    sole writer. A pod passed the gate and then ENOSPC'd mid-publish.
+*   pgw#1308 step ⑥: the correction charged one whole extra model, because
+    publishing meant materializing a complete second copy. A projected tree
+    does not, so charging it now would refuse boots that comfortably fit.
+
+What a projection actually writes is three near-free arms and one real one: a
+tensor container is a ~128 B pointer stub, an empty file is empty, a
+single-object non-tensor file is a symlink — and a CHUNKED non-tensor file is
+reassembled, costing its whole size, because it has no single object to point
+at and no tensor reader to serve it. Every arm below is chosen to make one of
+those visible.
 """
 
 from __future__ import annotations
@@ -15,12 +26,16 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from gen_worker._vendor.tensorfs import LocalCAS
+from gen_worker._vendor.tensorfs import CASRef, LocalCAS, stub_bytes
 
 from gen_worker.capability import InsufficientDiskError
-from gen_worker.models import cozy_snapshot
+from gen_worker.models import cozy_snapshot, projection
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
-from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.hub_client import (
+    WorkerResolvedChunk,
+    WorkerResolvedRepo,
+    WorkerResolvedRepoFile,
+)
 from gen_worker.models.refs import TensorhubRef
 
 _HEADROOM = cozy_snapshot._DISK_HEADROOM_BYTES
@@ -40,21 +55,29 @@ def _pin_free(monkeypatch: pytest.MonkeyPatch, free: int) -> None:
     monkeypatch.setattr(cozy_snapshot.shutil, "disk_usage", fake)
 
 
+def _stub_cost(digest: CASRef, size: int) -> int:
+    return len(stub_bytes(digest, size))
+
+
 def test_a_fully_resident_snapshot_is_still_sized_before_it_is_published(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Nothing to fetch is not nothing to write.
 
-    Every object is already in the CAS, so `missing` is empty and the old
-    `if missing and ...` guard never evaluated the comparison at all. The
-    publish still writes the whole tree. With free space below the tree size
-    plus the reserve, this must refuse rather than ENOSPC mid-materialize.
+    Every object is already in the CAS, so `missing` is empty and the
+    pgw#1263 `if missing and ...` guard never evaluated the comparison at all.
+    The publish still writes — three stubs here rather than three shards, but
+    the gate that skips itself skips them too, and that guard staying gone is
+    the property this arm holds.
     """
 
     bodies = [b"weights-" + bytes([index]) * 64 for index in range(3)]
     store = LocalCAS(tmp_path)
     digests = [store.put_bytes(body) for body in bodies]
-    tree_bytes = sum(len(body) for body in bodies)
+    stubs = sum(
+        _stub_cost(digest, len(body))
+        for body, digest in zip(bodies, digests, strict=True)
+    )
 
     resolved = WorkerResolvedRepo(
         snapshot_digest="sha256:" + "a" * 64,
@@ -69,48 +92,57 @@ def test_a_fully_resident_snapshot_is_still_sized_before_it_is_published(
         ],
     )
 
-    # Enough for the reserve and every byte but one of the tree.
-    _pin_free(monkeypatch, _HEADROOM + tree_bytes - 1)
+    # Enough for the reserve and every byte but one of what is written.
+    _pin_free(monkeypatch, _HEADROOM + stubs - 1)
 
     with pytest.raises(InsufficientDiskError) as refusal:
         asyncio.run(
             ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
         )
-    assert refusal.value.required_bytes == _HEADROOM + tree_bytes
+    assert refusal.value.required_bytes == _HEADROOM + stubs
     assert "to publish" in str(refusal.value)
 
 
-def test_the_gate_counts_the_published_tree_on_top_of_the_fetch(
+def test_the_gate_counts_the_projection_on_top_of_the_fetch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A pod with room for the download alone still runs out publishing it.
 
-    One object is resident and one must be fetched. Free space covers the
-    reserve plus the fetch exactly — the old arithmetic's whole budget — and
-    is short by the tree. The refusal must name both halves.
+    The publish half is a CHUNKED non-tensor file — the one arm of a
+    projection that genuinely writes its whole size, because there is no
+    single object to symlink and no tensor reader to serve it. Free space
+    covers the reserve plus the fetch exactly, and is short by that file. The
+    refusal must name both halves.
     """
 
-    resident = b"resident-" + b"r" * 128
     remote = b"remote-" + b"m" * 200
+    first, second = b"clip-header" + b"h" * 40, b"clip-body" + b"b" * 90
     store = LocalCAS(tmp_path)
-    resident_digest = store.put_bytes(resident)
     remote_digest = LocalCAS(tmp_path / "other").put_bytes(remote)
-    tree_bytes = len(resident) + len(remote)
+    chunk_digests = [store.put_bytes(part) for part in (first, second)]
+    whole = CASRef.digest_bytes(first + second)
+    reassembled = len(first) + len(second)
 
     resolved = WorkerResolvedRepo(
         snapshot_digest="sha256:" + "b" * 64,
         files=[
             WorkerResolvedRepoFile(
-                "config.json",
-                len(resident),
-                "http://127.0.0.1:1/must-not-fetch",
-                digest=str(resident_digest),
-            ),
-            WorkerResolvedRepoFile(
                 "model.safetensors",
                 len(remote),
                 "http://127.0.0.1:1/must-not-fetch",
                 digest=str(remote_digest),
+            ),
+            WorkerResolvedRepoFile(
+                "dataset/clip.mp4",
+                reassembled,
+                None,
+                digest=str(whole),
+                chunks=tuple(
+                    WorkerResolvedChunk(
+                        digest.digest, "http://127.0.0.1:1/must-not-fetch", len(part)
+                    )
+                    for digest, part in zip(chunk_digests, (first, second), strict=True)
+                ),
             ),
         ],
     )
@@ -121,17 +153,58 @@ def test_the_gate_counts_the_published_tree_on_top_of_the_fetch(
         asyncio.run(
             ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
         )
-    assert refusal.value.required_bytes == _HEADROOM + len(remote) + tree_bytes
+    stub = _stub_cost(remote_digest, len(remote))
+    assert refusal.value.required_bytes == (
+        _HEADROOM + len(remote) + stub + reassembled
+    )
     assert refusal.value.available_bytes == _HEADROOM + len(remote)
 
 
-def test_a_snapshot_that_fits_both_copies_still_publishes(
+def test_the_gate_does_not_charge_a_whole_second_copy_of_the_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The gate must not refuse a snapshot that genuinely fits.
+    """The pgw#1308 step ⑥ half, and the arm the other two cannot see.
 
-    Sizing the publish is only correct if it leaves the ordinary path alone;
-    a gate that always refuses would pass both arms above and ship an outage.
+    Every arm above passes under the pre-flip arithmetic too — over-reserving
+    only makes a refusal arrive sooner. This one fails under it: the model is
+    resident, the projection costs one stub, and free space is nowhere near a
+    second copy. A gate still sizing `sum(entry.size_bytes)` refuses a boot
+    that fits with room to spare, on every pod, for every model.
+    """
+
+    body = b"a-model-that-fits-" + b"w" * 4096
+    store = LocalCAS(tmp_path)
+    digest = store.put_bytes(body)
+
+    resolved = WorkerResolvedRepo(
+        snapshot_digest="sha256:" + "d" * 64,
+        files=[
+            WorkerResolvedRepoFile(
+                "model.safetensors",
+                len(body),
+                "http://127.0.0.1:1/must-not-fetch",
+                digest=str(digest),
+            )
+        ],
+    )
+
+    stub = _stub_cost(digest, len(body))
+    assert stub < len(body)  # or the arm proves nothing
+    _pin_free(monkeypatch, _HEADROOM + stub)
+
+    path = asyncio.run(
+        ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
+    )
+    assert projection.logical_size(path / "model.safetensors") == len(body)
+
+
+def test_a_snapshot_that_fits_still_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate must leave the ordinary path alone.
+
+    A gate that always refuses would pass both refusal arms above and ship an
+    outage.
     """
 
     body = b"small-model-" + b"s" * 32
@@ -142,7 +215,7 @@ def test_a_snapshot_that_fits_both_copies_still_publishes(
         snapshot_digest="sha256:" + "c" * 64,
         files=[
             WorkerResolvedRepoFile(
-                "model.safetensors",
+                "config.json",
                 len(body),
                 "http://127.0.0.1:1/must-not-fetch",
                 digest=str(digest),
@@ -155,4 +228,4 @@ def test_a_snapshot_that_fits_both_copies_still_publishes(
     path = asyncio.run(
         ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
     )
-    assert (path / "model.safetensors").read_bytes() == body
+    assert (path / "config.json").read_bytes() == body

--- a/tests/test_snapshot_residency_progress_pgw1289.py
+++ b/tests/test_snapshot_residency_progress_pgw1289.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 from gen_worker._vendor.tensorfs import CASRef, LocalCAS
 
+import projection_fixture
 from gen_worker.models.cozy_snapshot import ensure_snapshot_async
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from gen_worker.models.refs import TensorhubRef
@@ -99,7 +100,7 @@ def test_a_resident_grant_advances_progress_before_the_scan_finishes(
     )
 
     assert (path / "config.json").read_bytes() == first
-    assert (path / "weights.safetensors").read_bytes() == second
+    assert projection_fixture.bytes_at(path, "weights.safetensors") == second
     # The total is known before any byte is hashed, and the counter reaches it.
     assert beats[0] == (0, total)
     assert beats[-1] == (total, total)

--- a/tests/test_snapshot_v2_fill_pgw781.py
+++ b/tests/test_snapshot_v2_fill_pgw781.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import errno
 import hashlib
 import http.server
 import multiprocessing
@@ -12,9 +11,16 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from gen_worker._vendor.tensorfs import CASRef, FileEntry, LocalCAS, RepositoryManifest
+from gen_worker._vendor.tensorfs import (
+    CASRef,
+    FileEntry,
+    LocalCAS,
+    RepositoryManifest,
+    read_entry,
+)
 
 import gen_worker.models.cozy_snapshot as snapshot_mod
+from gen_worker.models import projection
 from gen_worker.models.cozy_snapshot import NetworkBytesScope, ensure_snapshot_async
 from gen_worker.models.hub_client import (
     WorkerResolvedChunk,
@@ -111,32 +117,34 @@ def test_grpc_adapter_keeps_ordered_lengths_and_drops_fixed_layout_scalar() -> N
     assert not hasattr(file, "chunk_size_bytes")
 
 
-class _BarrierCAS(LocalCAS):
-    def __init__(self, root: Path, barrier: Any) -> None:
-        super().__init__(root)
-        self._barrier = barrier
-
-    def materialize_repository(
-        self, manifest: RepositoryManifest, destination: str | Path
-    ) -> Path:
-        if Path(destination).exists():
-            raise FileExistsError(destination)
-        self._barrier.wait(30)
-        return super().materialize_repository(manifest, destination)
-
-
-def _materialize_process(
+def _publish_process(
     root: str, target: str, digest: str, size: int, barrier: Any, results: Any
 ) -> None:
-    cas = _BarrierCAS(Path(root), barrier)
+    """One process publishing the snapshot, released with the other.
+
+    The barrier is OUTSIDE `_publish_snapshot`, not inside it: the publish
+    holds an exclusive flock on the target, so a barrier inside would hold the
+    lock while waiting for a process the lock is keeping out, and the test
+    would deadlock rather than race.
+
+    Both arms report what they READ back through the tree, so a loser that
+    converged on the winner's tree is distinguishable from a loser that got a
+    path with nothing behind it.
+    """
+
+    cas = LocalCAS(Path(root))
     manifest = RepositoryManifest(
         (FileEntry("config.json", size, CASRef(digest)),)
     )
     try:
-        path = snapshot_mod._materialize_repository(cas, manifest, Path(target))
-        results.put(("ok", (path / "config.json").read_bytes()))
+        barrier.wait(30)
+        path = snapshot_mod._publish_snapshot(
+            cas, manifest, Path(target), symlinks=True
+        )
+        link = path / "config.json"
+        results.put(("ok", link.is_symlink(), link.read_bytes()))
     except BaseException as exc:
-        results.put(("error", f"{type(exc).__name__}: {exc}"))
+        results.put(("error", False, f"{type(exc).__name__}: {exc}".encode()))
 
 
 def _resident_resolved(digest: str, size: int) -> WorkerResolvedRepo:
@@ -233,16 +241,17 @@ def test_whole_file_downloads_into_tensorfs_and_reuses_it(tmp_path: Path) -> Non
         server.close()
 
 
-def test_two_processes_converge_on_the_same_materialized_tree(tmp_path: Path) -> None:
+def test_two_processes_converge_on_the_same_projected_tree(tmp_path: Path) -> None:
     body = b"cross-process-winner"
     cas = LocalCAS(tmp_path)
     digest = cas.put_bytes(body)
     target = tmp_path / "snapshots" / "same"
+    target.parent.mkdir(parents=True, exist_ok=True)
     barrier = _MP.Barrier(2)
     results = _MP.Queue()
     processes = [
         _MP.Process(
-            target=_materialize_process,
+            target=_publish_process,
             args=(str(tmp_path), str(target), digest.digest, len(body), barrier, results),
         )
         for _ in range(2)
@@ -253,32 +262,68 @@ def test_two_processes_converge_on_the_same_materialized_tree(tmp_path: Path) ->
         process.join(timeout=30)
         assert process.exitcode == 0
     assert [results.get(timeout=5) for _ in processes] == [
-        ("ok", body),
-        ("ok", body),
+        ("ok", True, body),
+        ("ok", True, body),
     ]
 
 
-def test_materialization_collision_refuses_an_invalid_winner(tmp_path: Path) -> None:
-    good = b"expected"
-    digest = CASRef.digest_bytes(good)
-    manifest = RepositoryManifest((FileEntry("config.json", len(good), digest),))
-    target = tmp_path / "snapshot"
+def test_publish_keeps_a_preflip_materialized_tree_it_finds(tmp_path: Path) -> None:
+    """A pod that upgrades ACROSS the flip meets its own old tree.
 
-    class _DivergentCAS(LocalCAS):
-        def materialize_repository(
-            self, _manifest: RepositoryManifest, destination: str | Path
-        ) -> Path:
-            winner = Path(destination)
-            winner.mkdir(parents=True)
-            (winner / "config.json").write_bytes(b"diverged")
-            raise OSError(errno.ENOTEMPTY, "another process published")
+    Under the same snapshot key, because the key is the snapshot digest. That
+    tree holds exactly the bytes the manifest names, so the publish converges
+    on it rather than deleting and re-projecting: `_entry_matches` hashes a
+    path that carries real bytes and checks a projection artifact structurally.
+    Deleting it would be safe but pointless; deleting it while another process
+    reads it would not be, which is why this path never removes a tree it has
+    just found to be correct.
+    """
 
-    with pytest.raises(OSError) as caught:
-        snapshot_mod._materialize_repository(
-            _DivergentCAS(tmp_path / "cas"), manifest, target
-        )
-    assert caught.value.errno == errno.ENOTEMPTY
-    assert (target / "config.json").read_bytes() == b"diverged"
+    body = b"published-before-the-flip"
+    cas = LocalCAS(tmp_path)
+    digest = cas.put_bytes(body)
+    manifest = RepositoryManifest(
+        (FileEntry("config.json", len(body), digest),)
+    )
+    target = tmp_path / "snapshots" / "preflip"
+    target.mkdir(parents=True)
+    (target / "config.json").write_bytes(body)
+    marker = (target / "config.json").stat().st_ino
+
+    published = snapshot_mod._publish_snapshot(
+        cas, manifest, target, symlinks=True
+    )
+
+    assert published == target
+    assert not (target / "config.json").is_symlink()
+    assert (target / "config.json").stat().st_ino == marker
+    assert (target / "config.json").read_bytes() == body
+
+
+def test_publish_replaces_a_tree_that_is_not_this_manifest(tmp_path: Path) -> None:
+    """A tree under this key that does not match is replaced by a projection.
+
+    The flock is held across the check and the replacement, so the decision to
+    remove cannot be taken against a tree someone else has since rebuilt (the
+    stale-validation defect below).
+    """
+
+    body = b"the-real-bytes"
+    cas = LocalCAS(tmp_path)
+    digest = cas.put_bytes(body)
+    manifest = RepositoryManifest(
+        (FileEntry("config.json", len(body), digest),)
+    )
+    target = tmp_path / "snapshots" / "diverged"
+    target.mkdir(parents=True)
+    (target / "config.json").write_bytes(b"not-this-manifest")
+
+    published = snapshot_mod._publish_snapshot(
+        cas, manifest, target, symlinks=True
+    )
+
+    assert (published / "config.json").is_symlink()
+    assert (published / "config.json").read_bytes() == body
 
 
 def test_stale_invalid_validation_cannot_delete_a_rebuilt_tree(
@@ -409,8 +454,17 @@ def test_chunked_file_uses_manifest_recorded_variable_lengths(tmp_path: Path) ->
             ensure_snapshot_async(base_dir=tmp_path, ref=_ref(), resolved=resolved)
         )
         output = path / "weights.safetensors"
-        assert output.stat().st_size == len(first) + len(second)
-        assert hashlib.sha256(output.read_bytes()).hexdigest() == whole
+        # A tensor container is a POINTER STUB after the chokepoint flip
+        # (pgw#1308 step ⑥). Its own `st_size` is the stub's, so the size the
+        # manifest recorded is read from what the stub DECLARES, and the bytes
+        # are reassembled out of the CAS at the recorded variable lengths --
+        # which is this test's actual subject, and is now asserted where the
+        # bytes really are instead of at a path that no longer holds them.
+        assert projection.stub_at(output) is not None
+        assert projection.logical_size(output) == len(first) + len(second)
+        snapshot = projection.require_projection(path, why="pgw#781 chunk test")
+        rebuilt = read_entry(snapshot.cas, snapshot.entry("weights.safetensors"))
+        assert hashlib.sha256(rebuilt).hexdigest() == whole
         assert all(server.hits(digest) == 1 for digest in blobs)
     finally:
         server.close()

--- a/tests/test_store_sourced_arm_pgw1329.py
+++ b/tests/test_store_sourced_arm_pgw1329.py
@@ -635,7 +635,7 @@ def test_the_store_indexes_and_binds_a_projected_tree(tmp_path: Path) -> None:
     from gen_worker.models.projection import stub_at
 
     built = fixture.build(tmp_path / "cas")
-    control = fixture.materialize(tmp_path / "cas", built)
+    control = fixture.read_entry_tree(tmp_path / "cas", built)
 
     shard = built.tree / "unet" / "diffusion_pytorch_model.safetensors"
     assert stub_at(shard) is not None, "the fixture stopped being a projection"

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -95,6 +95,37 @@ def test_the_read_plane_is_recorded_at_its_own_rev() -> None:
         assert name in spec["files"], f"{name} is not digest-fenced"
 
 
+def test_the_storage_half_still_provides_what_the_ownership_ruling_keeps() -> None:
+    """pgw#1308 step ⑥: the split is the STEADY STATE, and this says why.
+
+    The ruling (VENDORED.toml, and the issue's own section) is that admission
+    and GC are TENSORFS'S — upstream ported them to Rust rather than
+    abandoning them, and a source-vendored wheel cannot load Rust (pgw#1310).
+    So they are consumed from the pinned rev indefinitely, and a bump that
+    "finishes the migration" deletes them with no reachable successor.
+
+    A comment saying that goes stale silently. This goes red instead, and it
+    is deliberately NOT a digest check: the digest fence above would refuse
+    the bump too, but only with "a file changed", which is exactly the message
+    that gets a fence regenerated rather than read.
+    """
+
+    from gen_worker._vendor.tensorfs import LocalCAS
+
+    for kept in ("ingest_file", "ingest_repository", "collect_garbage", "materialize"):
+        assert callable(getattr(LocalCAS, kept, None)), (
+            f"LocalCAS.{kept} is gone from the vendored storage snapshot. If "
+            f"this is a `rev` bump: upstream's successor is the compiled Rust "
+            f"extension, which pgw cannot load (pgw#1310). Read the ownership "
+            f"ruling in VENDORED.toml before bumping."
+        )
+
+    # And the one that DID die with the chokepoint flip: still defined by the
+    # pinned upstream snapshot, called by nothing here. The caller census is
+    # `scripts/lint_materialization_hatch.py`, in the required `fast gates`.
+    assert hasattr(LocalCAS, "materialize" + "_repository")
+
+
 def test_the_read_plane_runs_without_the_compiled_extension() -> None:
     """The reason the split is expressible at all: this half is PURE PYTHON.
 

--- a/tests_v2/catalog.py
+++ b/tests_v2/catalog.py
@@ -52,6 +52,22 @@ from gen_worker.api.streaming import StreamResult, TokenUsage
 from gen_worker.api.types import ImageAsset
 from gen_worker.families.base import GenerationDefaults, family
 
+
+def _slot_weight_bytes(slot_dir: object) -> str:
+    """What the slot's weights file HOLDS, on any tree shape.
+
+    A v2 catalog endpoint is a pgw#1303 author slot in miniature: handed a
+    DIRECTORY, reads raw weight bytes. After pgw#1308 step 6 that directory is
+    a projected tree and the file at the path is a ~128 B pointer stub — which
+    is what a real third-party loader gets. So this goes through the SAME seam
+    a gated production site now goes through.
+    """
+
+    from gen_worker.models.materialized_view import third_party_dir
+
+    real = third_party_dir(Path(str(slot_dir)), why="v2 catalog author slot")
+    return (real / "model.safetensors").read_text()
+
 #: The one module string every scenario (and baked manifest) uses.
 MODULE = "tests_v2.catalog"
 
@@ -152,8 +168,7 @@ class HotBound:
         self.model_path = model
 
     def hot_echo(self, ctx: RequestContext, data: Ping) -> Reply:
-        weights = Path(self.model_path) / "model.safetensors"
-        return Reply(response=weights.read_text())
+        return Reply(response=_slot_weight_bytes(self.model_path))
 
 
 @endpoint(models={


### PR DESCRIPTION
**pgw#1308 step ⑥ — the only step that makes the mixed-CAS program observable on a pod.**

pgw#1330 cut every consumer pgw controls to native reads and fixed two fleet-breaking
projected-tree defects, but explicitly did **not** touch the chokepoint, so nothing it
landed changed what a pod does. This flips it.

## Measured on a rented pod, not on a projection

`tensorhub/sdxl-vae-fp16-fix@prod` resolved from the standing hub through the standalone
production path (`resolve_repo` → `ensure_snapshot_async`), on a clean RunPod CPU pod,
`du` from `os.lstat` with symlinks counted as zero:

| | bytes | |
|---|---|---|
| `du` before | 0 | clean pod |
| **`du` after** | **334,648,326** | model is 334,647,012 → **1.000004×** |
| same manifest materialized | 669,295,338 | **2.000004×** |
| the published tree itself | **127** | one stub + two symlinks |
| biggest regular file in the tree | **0** | **no tensor byte at any filesystem path** |

Second pod arm: boot verification of that tree is structural and clean (3 projected, 0
hashed, no quarantine, `_verify_snapshot_tree` → `(True, [])`); `disk_gc.tree_bytes`
answers 334,647,012 rather than ~0; the pgw#1303 seam produces a real 334,643,238-byte
shard whose safetensors header parses to 248 tensors in 0.5 s while the projected shard
is still `TFSSTUB1`; GC removes the tree and the priced view together. Pod terminated,
verified absent twice. ~$0.03.

## ① The vendored-rev ownership question, answered before implementing

The issue and `VENDORED.toml` both framed step ⑥ as "vendor-rev bump + chokepoint flip in
one commit". **Two of the three symbols come out the other way.** Tested against upstream
`origin/master`'s `LocalCAS` symbol by symbol:

| symbol | verdict |
|---|---|
| `materialize_repository` | **dies with the flip.** One caller, the chokepoint. Upstream deleted it and fences its return in three languages |
| `materialize` (single-file) | **stays.** It is `extract()` under the pinned rev's name — the priced hatch upstream's own fence deliberately exempts |
| `ingest_file` / `ingest_repository` | **genuinely tensorfs's.** Unlike the transfer plane, upstream did not ABANDON it, it PORTED it to Rust (`Plan`/`HashedPlan`/`AdmittedObject`). Forking it here would put a second implementation of the store's identity rule — the rule hub dedup depends on — in this repo |
| `collect_garbage` | **genuinely tensorfs's.** Reachability over the store's own formats; the retention policy is already first-party in `disk_gc.py`, so the split is at the right seam |

Consequence: pgw cannot reach either successor (they are the compiled extension; pgw#1310
rules Rust out of a source-vendored wheel), so **the split at two revs is the steady state,
not a waiting room.** It ends when pgw can depend on a published compiled `tensorfs` — a
release-policy decision, not a lane's. `VENDORED.toml` said the opposite and now says this,
with a test that goes red on a bump instead of a comment that goes stale.

## ② The flip could not ship alone

A projected tree breaks every site that hands a **directory** to a third-party loader.
Those are pgw#1303's 23, they are not ours to change, and "they stay materialized until
Paul rules" needs a mechanism. `models/materialized_view.py` is it: one seam, materializing
the requested **subtree** on demand through the single-file hatch with its §9 row on the
line. Before the ruling this already changes four things — nothing is copied until
something asks; a component costs a component instead of the model; every copy is logged
with its bytes and its caller; the copy dies with its snapshot. That turns #1303 from
"should we allow this?" into a decision with a price per site.

## ③ The census missed two things

* **The hatch fence spelled the hatch `extract()`** — upstream's *current* name. The rev
  this repo *pins* spells the same operation `LocalCAS.materialize`, so the regex matched
  **nothing** in the tree it guards while a live first-party single-file materialization
  sat unpriced at `aot_delivery.py:204`. "First-party 0" was a spelling artifact. The fence
  now knows both spellings, scans `_vendor` (declaring what it finds rather than being
  blind to it), permits the retired symbol's *definition* only in the pinned snapshot, and
  refuses a declaration that no longer describes anything.
* **`hydrate_modular_from_local` is a 24th gated site.** The 23 were counted by grepping
  `from_pretrained(dir)`; modular hydration hands the directory to diffusers through a spec
  field. Caught by the flip, not by the grep.

## ④ Two more live consequences, each with its own arm

* **The headroom gate charged one whole extra model.** Correct when publishing meant
  copying one; now it would refuse boots that fit with room to spare. It sizes what a
  projection writes, over the *same* symlink probe the projector is given, asserted against
  a real `du` of a real projection rather than trusted to stay in step.
* **`disk_gc.tree_bytes` walked the projected tree**, so a resident model of any size
  reported a few hundred bytes and eviction believed it could reclaim nothing — which does
  not fail loudly, the pod just fills up. Sized from the manifest now, plus any priced copy.

## Evidence

Full suite: **4776 passed, 24 skipped**, one load-sensitive flake
(`test_compile_steal_is_announced_on_the_wire`, green in isolation, also flaked on the
pre-change run). mypy strict clean over `src` + `tests` + `tests_v2`; `fast gates` linters
green including the rewritten hatch census and its `--selftest`.

**Red 5/5 on each of** `chokepoint-projects`, `headroom-arithmetic`,
`projection-write-bytes`, `gated-seam`, `disk-gc-sizing`, `view-gc` — each reverts one
thing, runs the test five times, and is re-confirmed green after restore.

## What remains gated on #1303

The ruling itself: whether the 24 directory-handing sites are priced (keep the seam) or
deprecated (refuse with "convert to fp8/nvfp4"). Every one of them now runs through a
single seam with a measured cost, which is what the ruling needs and did not have. The
`convert/` writer lane stays **pgw#1335**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
