### PR TITLE
pgw#1339 / th#2099: absence degrades, only contradiction refuses — the objective reader stops bricking promoted endpoints

### DIFF
--- a/changelog.d/pgw1339.md
+++ b/changelog.d/pgw1339.md
@@ -1,6 +1,6 @@
 - **P0, fleet-bricking: a checkpoint whose training objective the worker could not SEE was refused,
-  so every endpoint republished onto 0.120.0/0.121.0 and promoted was unservable.** `sd15`, `anima`
-  and `foundation-1` were promoted to `prod` on 2026-08-17 and every consumer request died
+  so every endpoint republished onto 0.120.0/0.121.0 and promoted was unservable.** `sd15` and
+  `anima` were promoted to `prod` on 2026-08-17 and every consumer request died
   `DeclaredSlotResolutionError: slot 'pipeline': resolved checkpoint carries no training objective`
   — on checkpoints the hub had stamped `objective='epsilon'`. 0.120.0 inverted the guard in
   `api.slot._finish_resolved`: 0.118.0 read `if resolved.objective:`, so an unseen objective was
@@ -26,14 +26,25 @@
   `distilled=False` function, and a `distilled_status` outside the vocabulary — the last being a
   decode bug rather than a degraded machine, and not something to launder into a warning.
 - `serving_facts.facts_or_refuse` becomes `facts_or_degrade`, returning `(facts, reason)`.
+- **Scope, stated precisely:** the defect is MEASURED on `sd15` and `anima`. `foundation-1` was
+  named alongside them on the night and is not a victim — it declares no serving contract, so this
+  code cannot reach it, and the fleet lane measured zero `requests`/`request_state` and zero
+  `worker_pods` rows for it over 30 hours. It was never observed serving or failing. Endpoints
+  that declare no `objectives=`/`distilled=` are structurally immune; 14 of 29 endpoints (42
+  declaring functions) are exposed.
 - **Supersedes three sibling assertions, deliberately and in place:** pgw#1333's
   `test_an_unclassified_checkpoint_still_refuses` and
   `test_unstamped_distillation_evidence_still_refuses`, and pgw#654/pgw#1307's
   `test_unstamped_checkpoint_fails_a_declared_contract_closed`. Those lanes read §1.22 fail-closed
   as governing this axis, and pgw#1333 explicitly flagged the call as the owner's; §4.20 and the
-  degradation ruling settle it the other way. pgw#1333's *attribution* half is untouched and still
-  asserted — the wire-gap sentence must name `hello_ack.go` and must never read as a verdict on the
-  checkpoint.
+  degradation ruling settle it the other way, and the supersession was **AFFIRMED by the
+  coordinating lane** against two of Paul's standing rulings in his own words — the
+  machine-compatibility charter (*"it always runs, just possibly horribly inefficiently"*) and the
+  CPU-offload ruling (*"we always allow it, and encourage it, although when it happens we should
+  warn loudly so the error can be caught"*). Absence-degrades-loudly-and-serves is exactly that
+  shape; fail-closed-on-absence contradicts it. Do not re-litigate this from §1.22. pgw#1333's
+  *attribution* half is untouched and still asserted — the wire-gap sentence must name
+  `hello_ack.go` and must never read as a verdict on the checkpoint.
 - **Consequence for tensorhub (th#2091):** `hello_ack.go` still leaves
   `DesiredInstance.models[].objective` / `.distilled` / `.distilled_status` zero, so boot-path slots
   serve with an unchecked contract and say so. Still worth fixing; no longer an outage.

--- a/changelog.d/pgw1339.md
+++ b/changelog.d/pgw1339.md
@@ -1,0 +1,39 @@
+- **P0, fleet-bricking: a checkpoint whose training objective the worker could not SEE was refused,
+  so every endpoint republished onto 0.120.0/0.121.0 and promoted was unservable.** `sd15`, `anima`
+  and `foundation-1` were promoted to `prod` on 2026-08-17 and every consumer request died
+  `DeclaredSlotResolutionError: slot 'pipeline': resolved checkpoint carries no training objective`
+  — on checkpoints the hub had stamped `objective='epsilon'`. 0.120.0 inverted the guard in
+  `api.slot._finish_resolved`: 0.118.0 read `if resolved.objective:`, so an unseen objective was
+  nothing to check, and the rewrite made it `if allowed_objectives is not None:` with an inner
+  `if not resolved.objective: raise`. **0.121.0 shipped the same reader byte for byte** —
+  `api/slot.py` and `warmup.py` are sha256-identical in both published wheels — so it was not
+  fixed in passing by the next cut.
+- **Absence now degrades loudly and SERVES; only a contradiction refuses.** The platform's charter
+  is that it always runs, and the degradation ruling makes loudness a diagnostic and never a gate.
+  A declared `objectives=`/`distilled=` contract is a declaration in exactly the sense pgw#1315
+  already settled for VRAM minimums — it gates a config-WRITE, and that lives hub-side. The hub
+  gates checkpoint<->function compatibility at deploy (`bindingcheck`) and at request time; this
+  reader is a version-skew backstop by its own docstring, and a backstop must never be the thing
+  that takes the platform down.
+- Both flavours of absence — an unclassified catalog answer and a wire gap nobody stamped —
+  resolve and confess through pgw#1312's ONE `serve_degrade` seam under a new phase token
+  `REASON_SERVING_FACTS_UNEVIDENCED`, carrying WHAT axis is unevidenced, WHY it could not be
+  checked, and WHAT WOULD BE BETTER. The suggestion is **routed to whoever can close that gap**: a
+  wire gap points at the sender, an unclassified checkpoint at the catalog. Flattening both into
+  one sentence is how the original defect lost its attribution.
+- **The gate that survives is the one against CONTRADICTION**, refused by name: a `flow` checkpoint
+  into an `(epsilon, v_prediction)` function, a `classified` `distilled=True` into a
+  `distilled=False` function, and a `distilled_status` outside the vocabulary — the last being a
+  decode bug rather than a degraded machine, and not something to launder into a warning.
+- `serving_facts.facts_or_refuse` becomes `facts_or_degrade`, returning `(facts, reason)`.
+- **Supersedes three sibling assertions, deliberately and in place:** pgw#1333's
+  `test_an_unclassified_checkpoint_still_refuses` and
+  `test_unstamped_distillation_evidence_still_refuses`, and pgw#654/pgw#1307's
+  `test_unstamped_checkpoint_fails_a_declared_contract_closed`. Those lanes read §1.22 fail-closed
+  as governing this axis, and pgw#1333 explicitly flagged the call as the owner's; §4.20 and the
+  degradation ruling settle it the other way. pgw#1333's *attribution* half is untouched and still
+  asserted — the wire-gap sentence must name `hello_ack.go` and must never read as a verdict on the
+  checkpoint.
+- **Consequence for tensorhub (th#2091):** `hello_ack.go` still leaves
+  `DesiredInstance.models[].objective` / `.distilled` / `.distilled_status` zero, so boot-path slots
+  serve with an unchecked contract and say so. Still worth fixing; no longer an outage.

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -475,8 +475,8 @@ def _finish_resolved(
     checkpoint whose objective this worker cannot see is the normal input to
     a degraded run: the caller confesses it through the `serve_degrade` seam
     (:func:`unevidenced_axes` names the axes) and SERVES. 0.120.0 raised on
-    absence instead, and that inversion took `sd15`, `anima` and
-    `foundation-1` down in production on checkpoints the hub had stamped
+    absence instead, and that inversion took `sd15` and `anima` down in
+    production — both MEASURED dead on checkpoints the hub had stamped
     correctly — a backstop against version skew became the outage. It is the
     same rule pgw#1315 settled for declared VRAM minimums: a declaration
     gates one thing, a config-WRITE, and that lives hub-side; at EXECUTION it

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -418,6 +418,33 @@ def serving_contract_governs_slot(
     return bool(str(family or "").strip())
 
 
+def unevidenced_axes(
+    *,
+    objective: str,
+    distilled_status: str,
+    allowed_objectives: Optional[Sequence[str]],
+    allowed_distilled: Optional[bool],
+) -> "tuple[str, ...]":
+    """Which DECLARED axes this checkpoint carries no evidence for.
+
+    Pure, and deliberately separate from :func:`_finish_resolved`: the reader
+    decides whether to REFUSE (only a contradiction), while the caller decides
+    what to CONFESS. Keeping the second question here rather than inside the
+    reader is what stops the confession and the gate from drifting apart —
+    they are computed from the same two predicates, in one place.
+
+    An axis the function does not declare is never listed: nothing checks it,
+    so a gap on it costs nothing and warning about it would emit noise for
+    every family that never opted into a serving contract.
+    """
+    axes = []
+    if allowed_objectives is not None and not str(objective or "").strip():
+        axes.append("objective")
+    if allowed_distilled is not None and str(distilled_status or "").strip() != "classified":
+        axes.append("distilled")
+    return tuple(axes)
+
+
 def _finish_resolved(
     name: str,
     ref: ModelRef,
@@ -441,11 +468,21 @@ def _finish_resolved(
 
     Evidence is read by the hub's ONE rule (`modelfamily.StoredCheckpointFacts`):
     the objective axis is evidenced when the objective is non-empty, and the
-    distilled axis ONLY when `distilled_status == "classified"`. An unstamped
-    status is NOT an old sender — the hub omits the key whenever the stored
-    column is empty (`slot_resolution.go` stamps it `if TrimSpace(...) != ""`),
-    so "" is a live value meaning nothing measured the axis, and a declared
-    contract on it fails closed exactly as it does at the hub's own two gates.
+    distilled axis ONLY when `distilled_status == "classified"`.
+
+    **CONTRADICTION refuses; ABSENCE does not (pgw#1339 / th#2099).** Only
+    positive evidence that DISAGREES with the declaration raises here. A
+    checkpoint whose objective this worker cannot see is the normal input to
+    a degraded run: the caller confesses it through the `serve_degrade` seam
+    (:func:`unevidenced_axes` names the axes) and SERVES. 0.120.0 raised on
+    absence instead, and that inversion took `sd15`, `anima` and
+    `foundation-1` down in production on checkpoints the hub had stamped
+    correctly — a backstop against version skew became the outage. It is the
+    same rule pgw#1315 settled for declared VRAM minimums: a declaration
+    gates one thing, a config-WRITE, and that lives hub-side; at EXECUTION it
+    is advisory. Absence is not evidence of compatibility — it is absence,
+    and the honest response is to run and say so, loudly.
+
     The caller is responsible for asking only about slots the contract governs
     (:func:`serving_contract_governs_slot`)."""
     status = str(distilled_status or "").strip()
@@ -458,26 +495,14 @@ def _finish_resolved(
         ref=ref, defaults=defaults, objective=objective, distilled=distilled,
         distilled_status=status,
     )
-    if allowed_objectives is not None:
-        if not resolved.objective:
-            raise ObjectiveMismatchError(
-                f"slot {name!r}: resolved checkpoint carries no training "
-                f"objective, so there is no evidence for the invoked "
-                f"function's declared objectives {tuple(allowed_objectives)!r}"
-            )
+    if allowed_objectives is not None and resolved.objective:
         if resolved.objective not in allowed_objectives:
             raise ObjectiveMismatchError(
                 f"slot {name!r}: resolved checkpoint objective "
                 f"{resolved.objective!r} is not in the invoked function's "
                 f"declared objectives {tuple(allowed_objectives)!r}"
             )
-    if allowed_distilled is not None:
-        if status != "classified":
-            raise ObjectiveMismatchError(
-                f"slot {name!r}: resolved checkpoint distillation evidence is "
-                f"{status or 'unstamped'}; the invoked function declares "
-                f"distilled={allowed_distilled!r}"
-            )
+    if allowed_distilled is not None and status == "classified":
         if resolved.distilled != allowed_distilled:
             raise ObjectiveMismatchError(
                 f"slot {name!r}: resolved checkpoint distilled="
@@ -583,4 +608,5 @@ def resolve_slot(
 __all__ = [
     "OBJECTIVES", "ObjectiveMismatchError", "ResolvedSlot",
     "Slot", "resolve_slot", "serving_contract_governs_slot",
+    "unevidenced_axes",
 ]

--- a/src/gen_worker/measured_posture.py
+++ b/src/gen_worker/measured_posture.py
@@ -159,6 +159,17 @@ REASON_NO_CUDA = "no_cuda"
 # token (`memory.UNDER_MINIMUM_PHASE`) so the cause is countable hub-side under
 # one spelling rather than two.
 REASON_BELOW_DECLARED_MINIMUM = "below_declared_minimum"
+# pgw#1339 / th#2099: the invoked function declares a serving contract
+# (`objectives=` / `distilled=`) and the resolved checkpoint carries no
+# evidence on that axis — either the catalog classified nothing or nobody
+# stamped the wire. Same rule as the line above, on a different declaration:
+# a contract the worker cannot CHECK is not a contract the worker may REFUSE.
+# The hub gates checkpoint<->function compatibility at deploy (`bindingcheck`)
+# and at request time; this reader is a version-skew backstop, and a backstop
+# that fatals turns a hub-side stamping gap into a customer-visible outage —
+# which is exactly what it did to sd15/anima/foundation-1 on 0.120.0.
+# Doubles as the `serve_degrade` phase token (`memory.UNEVIDENCED_FACTS_PHASE`).
+REASON_SERVING_FACTS_UNEVIDENCED = "serving_facts_unevidenced"
 
 #: Shortfall resources.
 RESOURCE_VRAM = "vram"

--- a/src/gen_worker/measured_posture.py
+++ b/src/gen_worker/measured_posture.py
@@ -167,7 +167,7 @@ REASON_BELOW_DECLARED_MINIMUM = "below_declared_minimum"
 # The hub gates checkpoint<->function compatibility at deploy (`bindingcheck`)
 # and at request time; this reader is a version-skew backstop, and a backstop
 # that fatals turns a hub-side stamping gap into a customer-visible outage —
-# which is exactly what it did to sd15/anima/foundation-1 on 0.120.0.
+# which is exactly what it did to sd15 and anima on 0.120.0.
 # Doubles as the `serve_degrade` phase token (`memory.UNEVIDENCED_FACTS_PHASE`).
 REASON_SERVING_FACTS_UNEVIDENCED = "serving_facts_unevidenced"
 

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1443,6 +1443,11 @@ OFFLOAD_ENGAGED_PHASE = "cpu_offload_engaged"
 #: so the reason has one spelling on both carriers.
 UNDER_MINIMUM_PHASE = posture_mod.REASON_BELOW_DECLARED_MINIMUM
 
+#: pgw#1339: the invoked function declares a serving contract and the resolved
+#: checkpoint carries no evidence on a declared axis. Same confession home,
+#: its own phase token, for the same reason as the line above.
+UNEVIDENCED_FACTS_PHASE = posture_mod.REASON_SERVING_FACTS_UNEVIDENCED
+
 
 def _confess_serve_degrade(
     *, phase: str, line: str, detail: str, log: logging.Logger,
@@ -1498,6 +1503,68 @@ def report_under_minimum(
         line=transition_line(
             event="planned", phase="requirements",
             from_rung="declared_minimum", to_rung=posture, detail=head,
+        ),
+        detail=head,
+        log=logger or _LOG,
+    )
+    return head
+
+
+def report_unevidenced_serving_facts(
+    axes: "Sequence[str]",
+    *,
+    slot: str,
+    scope: str,
+    declared: str,
+    gap: str = "",
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """A DECLARED serving contract could not be checked, and we serve anyway.
+
+    pgw#1339 / th#2099. Returns the warning text (so a caller may also put it
+    on `ServePlan.warning`), having already emitted the typed event — one
+    derivation, two carriers, exactly as `report_under_minimum` does.
+
+    ``gap`` is the wire-gap sentence from `serving_facts.facts_or_degrade`
+    when NOBODY stamped the facts; empty when the catalog answered and simply
+    had nothing. The two are different jobs for different people, so the
+    confession says which one this is rather than flattening both into
+    "unevidenced".
+
+    The suggestion is aimed at the CATALOG, not at a card: no GPU can supply a
+    training objective, and th#1867's rule against the worker guessing on the
+    hub's behalf applies to this axis too. What would be better here is a
+    classified checkpoint, and only the hub can make one.
+    """
+    named = tuple(str(a) for a in axes if str(a))
+    if not named:
+        return ""
+    # WHAT WOULD BE BETTER, aimed at whoever can actually close THIS gap —
+    # they are different people. A wire gap is ours to fix in the sender; an
+    # unclassified checkpoint is a catalog job. One suggestion for both would
+    # send half of every report to the wrong team.
+    better = (
+        "stamp the serving facts on the binding this pod was sent"
+        if gap else
+        "classify this checkpoint in the hub catalog"
+    )
+    head = (
+        f"serving {scope} with an UNCHECKED serving contract: slot {slot!r} "
+        f"carries no evidence for the declared {', '.join(named)} "
+        f"({declared}). "
+        + (f"{gap} " if gap else
+           "The catalog answered and had nothing to say on "
+           f"{'this axis' if len(named) == 1 else 'these axes'}. ")
+        + "The request still serves — this is a diagnostic, not a gate. "
+        f"WHAT WOULD BE BETTER: {better}, so the declared contract can "
+        "actually be checked; until then the hub's own deploy-time and "
+        "request-time gates are the only ones enforcing it."
+    )
+    _confess_serve_degrade(
+        phase=UNEVIDENCED_FACTS_PHASE,
+        line=transition_line(
+            event="planned", phase="serving_contract",
+            from_rung="declared_contract", to_rung="unchecked", detail=head,
         ),
         detail=head,
         log=logger or _LOG,

--- a/src/gen_worker/serving_facts.py
+++ b/src/gen_worker/serving_facts.py
@@ -27,7 +27,7 @@ distinction the two members buy is therefore in the SENTENCE, not in the
 verdict: an operator reading "the catalog classified nothing" goes and
 classifies the checkpoint, and one reading "hello_ack.go did not stamp" goes
 and fixes the hub. Both used to read as "your checkpoint is broken", and the
-one that shipped fatal took three promoted endpoints down.
+one that shipped fatal took two measured production endpoints down.
 
 The union is not optional and carries no default anywhere it is stored: a
 slot resolution that cannot say which of the two it is cannot be constructed.

--- a/src/gen_worker/serving_facts.py
+++ b/src/gen_worker/serving_facts.py
@@ -14,12 +14,20 @@ read, correctly given its text, as a catalog defect. It was a wire gap.
 So the facts get a TYPE, and the gap gets a type of its own:
 
 * :class:`ServingFacts` — the catalog was asked and answered. An empty
-  ``objective`` here is a real answer ("nothing measured this axis"), and a
-  function declaring ``objectives=`` refuses against it exactly as the hub's
-  own two gates do.
+  ``objective`` here is a real answer ("nothing measured this axis").
 * :class:`FactsUnavailable` — nobody asked. ``owed_by`` names WHO owes the
   stamp, in the vocabulary of the wire field or the code path that dropped
-  it, so the refusal points at the gap instead of at the checkpoint.
+  it, so the complaint points at the gap instead of at the checkpoint.
+
+**Neither one is a refusal (pgw#1339 / th#2099).** Both are ABSENCES, and
+absence of evidence is the normal input to a degraded run — it is confessed
+through the `serve_degrade` seam and the request serves. Only a checkpoint
+that positively CONTRADICTS a declared contract still refuses. The
+distinction the two members buy is therefore in the SENTENCE, not in the
+verdict: an operator reading "the catalog classified nothing" goes and
+classifies the checkpoint, and one reading "hello_ack.go did not stamp" goes
+and fixes the hub. Both used to read as "your checkpoint is broken", and the
+one that shipped fatal took three promoted endpoints down.
 
 The union is not optional and carries no default anywhere it is stored: a
 slot resolution that cannot say which of the two it is cannot be constructed.
@@ -93,21 +101,30 @@ class FactsUnavailable(
 SlotEvidence = Union[ServingFacts, FactsUnavailable]
 
 
-def facts_or_refuse(evidence: SlotEvidence, *, slot: str, what: str) -> ServingFacts:
-    """The stamped facts, or a ``ValueError`` naming the gap.
+def facts_or_degrade(
+    evidence: SlotEvidence, *, slot: str, what: str,
+) -> "tuple[ServingFacts, str]":
+    """The stamped facts, plus the sentence to CONFESS if nobody stamped them.
 
-    The ONE place the union is collapsed, so every caller that needs the
-    three scalars either has real evidence or raises a sentence an operator
-    can act on.
+    The ONE place the union is collapsed. pgw#1333 made this raise, and the
+    attribution it built was right — the message blames the *sender* that
+    skipped the stamp, never the checkpoint's catalog row. What was wrong was
+    the refusal: a wire gap on our own side is not grounds to decline a paid
+    customer request (pgw#1339 / th#2099). So the gap now degrades — an empty
+    :class:`ServingFacts` and a non-empty reason — and the caller serves while
+    saying exactly whose stamp is missing.
+
+    An empty second element means there is nothing to confess.
     """
     if isinstance(evidence, ServingFacts):
-        return evidence
-    raise ValueError(
+        return evidence, ""
+    return ServingFacts(), (
         f"slot {slot!r}: no serving facts were resolved for this checkpoint "
         f"({what}) — {evidence.owed_by} did not stamp objective/distilled/"
         f"distilled_status, so there is no evidence to check the invoked "
         f"function's declared serving contract against. This is a wire gap, "
-        f"NOT a claim about the checkpoint's catalog row.")
+        f"NOT a claim about the checkpoint's catalog row; the request still "
+        f"serves and this slot's declared contract goes UNCHECKED.")
 
 
 __all__ = [
@@ -116,5 +133,5 @@ __all__ = [
     "FactsUnavailable",
     "ServingFacts",
     "SlotEvidence",
-    "facts_or_refuse",
+    "facts_or_degrade",
 ]

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -93,7 +93,9 @@ from .api.decorators import EndpointDecl, NoWarmup
 from .api.errors import IllegalCombination
 from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
 import inspect
-from .api.slot import resolve_slot, serving_contract_governs_slot
+from .api.slot import (
+    resolve_slot, serving_contract_governs_slot, unevidenced_axes,
+)
 from .api.binding import wire_ref
 from .request_context import RequestContext
 
@@ -901,10 +903,10 @@ def resolved_slots_kwargs(
         try:
             # The catalog's answer for this slot. A slot no declaration
             # CHECKS resolves neutrally when there is no answer — nothing
-            # reads the facts, so a gap costs nothing and refusing would
-            # refuse every family that declares no serving contract. A slot a
-            # declaration does check refuses BY NAME when nothing answered,
-            # instead of resolving with `""` and blaming the checkpoint.
+            # reads the facts, so a gap costs nothing and warning would emit
+            # noise for every family that declares no serving contract. A
+            # slot a declaration DOES check confesses BY NAME when nothing
+            # answered — and then serves (pgw#1339).
             order = slot_orders.get(name)
             evidence = (
                 order.facts if order is not None
@@ -924,16 +926,36 @@ def resolved_slots_kwargs(
                 and governed
                 and (spec.objectives is not None or spec.distilled is not None)
             )
+            declared_contract = (f"function {spec.name!r} declares "
+                                 f"objectives={spec.objectives!r} "
+                                 f"distilled={spec.distilled!r}")
+            gap = ""
             if checked:
-                facts = serving_facts.facts_or_refuse(
-                    evidence, slot=name,
-                    what=f"function {spec.name!r} declares "
-                         f"objectives={spec.objectives!r} "
-                         f"distilled={spec.distilled!r}")
+                facts, gap = serving_facts.facts_or_degrade(
+                    evidence, slot=name, what=declared_contract)
             elif isinstance(evidence, serving_facts.ServingFacts):
                 facts = evidence
             else:
                 facts = serving_facts.ServingFacts()
+            # pgw#1339: a DECLARED axis with no evidence is confessed and
+            # served, never refused. Computed before the resolve so the
+            # confession happens even though the resolve no longer raises.
+            if checked:
+                missing = unevidenced_axes(
+                    objective=facts.objective,
+                    distilled_status=facts.distilled_status,
+                    allowed_objectives=spec.objectives,
+                    allowed_distilled=spec.distilled,
+                )
+                if missing:
+                    # Local import: `models.memory` owns the ONE
+                    # `serve_degrade` seam, and `warmup` must not take its
+                    # module graph at import time.
+                    from .models import memory as memory_mod
+
+                    memory_mod.report_unevidenced_serving_facts(
+                        missing, slot=name, scope=str(spec.name),
+                        declared=declared_contract, gap=gap)
             resolved[name] = resolve_slot(
                 name, slot,
                 ref=spec.models.get(name),

--- a/tests/test_objective_absence_degrades_pgw1339.py
+++ b/tests/test_objective_absence_degrades_pgw1339.py
@@ -1,0 +1,317 @@
+"""pgw#1339 / th#2099 — a checkpoint whose objective the worker CANNOT SEE
+serves anyway, loudly. Absence degrades; only a CONTRADICTION refuses.
+
+**The outage.** gen-worker 0.120.0 shipped `_finish_resolved` with the guard
+inverted. 0.118.0 read `if resolved.objective:` — an unseen objective was
+simply nothing to check. 0.120.0 rewrote it as `if allowed_objectives is not
+None:` with an inner `if not resolved.objective: raise`, so an ABSENT
+objective went from "nothing to check" to a fatal. On 2026-08-17 `sd15`,
+`anima` and `foundation-1` were republished onto that wheel, promoted, and
+pointed at `prod`; every consumer request died
+
+    DeclaredSlotResolutionError: slot 'pipeline': resolved checkpoint carries
+    no training objective, so there is no evidence for the invoked function's
+    declared objectives ('epsilon', 'v_prediction')
+
+on a checkpoint the hub had stamped `objective='epsilon'` (th#2099 measured
+the same digest completing on 0.118.0 against the same hub). 0.121.0 ships
+the same reader byte for byte — `api/slot.py` sha256
+`8191b9ba…` in both wheels — so the whole fleet campaign was blocked on it.
+
+**The ruling this restores.** §DEGRADATION-IS-LOUD, Paul: *"the worker should
+obviously complain loudly ... but it should still work"*, and its standing
+gloss — the loudness is *diagnostics*, never a gate. pgw#1315 already settled
+the identical shape for VRAM: a declared minimum *"gates one thing, a
+config-WRITE, and that lives hub-side"*. A declared `objectives=` contract is
+the same kind of declaration, and the hub already gates it twice upstream
+(deploy-time `bindingcheck`, request-time `ServingContractGovernsSlot`). The
+worker-side check is a BACKSTOP against version skew — its own docstring says
+so — and a backstop must never be the thing that brings the platform down.
+
+**So there are exactly two ways to fail this file, and they are opposite:**
+
+1. **REFUSING ON ABSENCE.** Unknown evidence is the normal input to a degraded
+   run. Refusing it is the outage.
+2. **DEGRADING SILENTLY.** The confession is load-bearing — an unevidenced run
+   with no `serve_degrade` row is the *other* defect, and it is the one that
+   would let this recur invisibly. The emitter is disarmed in the red-verify
+   below precisely so these assertions can be shown capable of going red.
+
+**And the line that is NOT moved:** a checkpoint that positively CONTRADICTS
+the declared contract (`flow` into an `(epsilon, v_prediction)` function, or a
+`classified` distilled=True into a `distilled=False` function) still refuses,
+by name. Absence is not evidence of compatibility; it is absence. Buying
+always-runs by deleting the gate would be the vacuous pass pgw#1333 warned
+about, and every arm of that warning is re-asserted here.
+
+Torch-free by construction: the seam is the slot READER and its confession.
+No compile, no mint, no card.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import child_contract, child_preflight, registry, serving_facts
+from gen_worker import measured_posture as posture_mod
+from gen_worker.api.binding import ModelRef
+from gen_worker.api.slot import ObjectiveMismatchError, resolve_slot
+from gen_worker.models import memory as memory_mod
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+CATALOG_MODULE = "harness.mint_catalog_slot_pgw969"
+PICKED = ModelRef(source="tensorhub", path="harness/catalog-pick", release="prod")
+
+#: The stamp `sd15`/`wai-illustrious` actually carry.
+EPSILON = serving_facts.ServingFacts(
+    objective="epsilon", distilled=False, distilled_status="classified")
+#: The catalog answered, and the answer was "nothing measured this axis".
+UNSTAMPED = serving_facts.ServingFacts()
+#: Nobody ever asked the catalog — the wire gap pgw#1333 typed.
+NO_ONE_ASKED = serving_facts.FactsUnavailable(owed_by="tensorhub hello_ack.go")
+
+SD15_DECLARES = ("epsilon", "v_prediction")
+
+
+class _Events:
+    """The REAL activity sink the worker transport installs, so these
+    assertions read the ActivityUpdates a hub would actually bank."""
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.loop = asyncio.new_event_loop()
+
+    def __enter__(self) -> "_Events":
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        activity_mod.bind_sink(_send, self.loop)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.loop.run_until_complete(asyncio.sleep(0.02))
+        activity_mod.reset_for_tests()
+        self.loop.close()
+
+    def unevidenced(self) -> List[pb.ActivityUpdate]:
+        return [
+            m.activity_update for m in self.sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == activity_mod.KIND_SERVE_DEGRADE
+            and m.activity_update.phase == memory_mod.UNEVIDENCED_FACTS_PHASE
+        ]
+
+
+def _read(facts: serving_facts.ServingFacts) -> Any:
+    """The real reader, on the exact shape the outage hit: sd15's declared
+    contract against a resolved checkpoint."""
+    return resolve_slot(
+        "pipeline", _slot(), ref=PICKED,
+        objective=facts.objective,
+        distilled=facts.distilled,
+        distilled_status=facts.distilled_status,
+        allowed_objectives=SD15_DECLARES,
+        allowed_distilled=False,
+    )
+
+
+def _slot() -> Any:
+    from gen_worker.api.slot import Slot
+
+    return Slot(str, selected_by="model")
+
+
+def _siblings() -> Tuple[Any, List[Any]]:
+    specs = registry.collect_endpoints([CATALOG_MODULE])
+    return child_preflight.select_specs(specs, "catalog-generate")
+
+
+def _preflight(evidence: serving_facts.SlotEvidence, tmp_path: Path) -> None:
+    """The whole chain the paid pod walked: spec -> MintSlot -> preflight."""
+    chosen, siblings = _siblings()
+    assert chosen.objectives == SD15_DECLARES, (
+        "the harness endpoint must declare a serving contract, or this file "
+        "is green on a shape that cannot exhibit the defect")
+    slots = {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path=str(tmp_path), facts=evidence)}
+    child_preflight.bind_slots(siblings, slots)
+    child_preflight.assert_slots_resolvable(
+        siblings, slots, what="boot key derivation for 'catalog-generate'")
+
+
+# ---------------------------------------------------------------------------
+# 1. IT RUNS — the outage, inverted
+# ---------------------------------------------------------------------------
+
+
+def test_a_checkpoint_with_no_visible_objective_RESOLVES() -> None:
+    """THE regression. This is the exact call that killed `sd15` in prod.
+
+    Red before the fix with the production sentence verbatim: *"resolved
+    checkpoint carries no training objective, so there is no evidence for the
+    invoked function's declared objectives ('epsilon', 'v_prediction')"*.
+    """
+    with _Events():
+        got = _read(UNSTAMPED)
+
+    assert got.objective == "", (
+        "the reader must not invent evidence it does not have — it serves "
+        "WITHOUT the fact, it does not fabricate one")
+    assert got.ref == PICKED
+
+
+def test_unstamped_distillation_evidence_RESOLVES() -> None:
+    """The orthogonal axis, same rule. `distilled=False` with an unstamped
+    status is not evidence of False — and it is not grounds for refusal
+    either."""
+    with _Events():
+        got = _read(serving_facts.ServingFacts(objective="epsilon"))
+
+    assert got.objective == "epsilon"
+    assert got.distilled_status == ""
+
+
+def test_a_wire_gap_RESOLVES_and_still_names_who_owes_the_stamp(
+    tmp_path: Path,
+) -> None:
+    """`FactsUnavailable` is a hub that never stamped, not a bad checkpoint.
+    pgw#1333 made it refuse BY NAME; the name was right and the refusal was
+    not. The pod serves, and the sentence still points at the gap."""
+    with _Events() as ev:
+        _preflight(NO_ONE_ASKED, tmp_path)  # must not raise
+
+    rows = ev.unevidenced()
+    assert rows, "a wire gap that serves silently is the other defect"
+    assert "tensorhub hello_ack.go" in rows[0].detail, (
+        "the confession must still blame the GAP, never the checkpoint")
+
+
+# ---------------------------------------------------------------------------
+# 2. AND IT IS LOUD — the confession is the deliverable, not a side effect
+# ---------------------------------------------------------------------------
+
+
+def test_the_degraded_run_confesses_through_the_one_serve_degrade_seam(
+    tmp_path: Path,
+) -> None:
+    """pgw#1312's ONE home, extended with its own phase token — never a
+    second emitter. The token IS the machine-readable cause, so the hub can
+    count this across the fleet under one spelling."""
+    with _Events() as ev:
+        _preflight(UNSTAMPED, tmp_path)
+
+    rows = ev.unevidenced()
+    assert len(rows) == 1, f"expected exactly one confession, got {len(rows)}"
+    assert rows[0].phase == posture_mod.REASON_SERVING_FACTS_UNEVIDENCED
+
+
+def test_the_confession_names_what_why_and_what_would_be_better(
+    tmp_path: Path,
+) -> None:
+    """The three required parts of every degraded run's contract. A complaint
+    without a suggestion is noise."""
+    with _Events() as ev:
+        _preflight(UNSTAMPED, tmp_path)
+
+    detail = ev.unevidenced()[0].detail
+    # WHAT axis is unevidenced, and for which slot.
+    assert "objective" in detail and "pipeline" in detail
+    # WHY — the declared contract it could not be checked against.
+    assert "epsilon" in detail
+    # WHAT WOULD BE BETTER — actionable, and aimed at the catalog, which is
+    # the only place that can close this.
+    assert "classify" in detail.lower() or "stamp" in detail.lower()
+    # And it must NOT read as a refusal.
+    assert "still serves" in detail.lower() or "serves" in detail.lower()
+
+
+def test_the_confession_is_capable_of_going_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The instrument proves it can fail. With the emitter disarmed every
+    assertion that reads the sink must fail while always-runs stays green —
+    otherwise this file's loudness half is decorative."""
+    monkeypatch.setattr(
+        memory_mod, "_confess_serve_degrade", lambda **kw: None)
+
+    with _Events() as ev:
+        _preflight(UNSTAMPED, tmp_path)  # still runs
+
+    assert ev.unevidenced() == [], (
+        "the sink must be genuinely fed by the emitter under test")
+
+
+# ---------------------------------------------------------------------------
+# 3. THE LINE THAT DOES NOT MOVE — contradiction still refuses
+# ---------------------------------------------------------------------------
+
+
+def test_a_positively_mismatched_objective_STILL_REFUSES() -> None:
+    """Always-runs was not bought by deleting the gate. A `flow` checkpoint in
+    an `(epsilon, v_prediction)` function is EVIDENCE of incompatibility, not
+    an absence of it."""
+    with pytest.raises(ObjectiveMismatchError) as exc:
+        _read(serving_facts.ServingFacts(
+            objective="flow", distilled=False, distilled_status="classified"))
+    assert "is not in the invoked function's declared objectives" in str(exc.value)
+
+
+def test_a_classified_distilled_mismatch_STILL_REFUSES() -> None:
+    """The same rule on the distillation axis: `classified` is real evidence,
+    and real evidence that contradicts the declaration is a refusal."""
+    with pytest.raises(ObjectiveMismatchError) as exc:
+        _read(serving_facts.ServingFacts(
+            objective="epsilon", distilled=True, distilled_status="classified"))
+    assert "distilled=True" in str(exc.value)
+
+
+def test_a_bogus_distilled_status_STILL_REFUSES() -> None:
+    """A value from outside the vocabulary is a DECODE bug, not a degraded
+    machine, and must not be laundered into a warning."""
+    with pytest.raises(ObjectiveMismatchError):
+        resolve_slot(
+            "pipeline", _slot(), ref=PICKED, objective="epsilon",
+            distilled=False, distilled_status="probably",
+            allowed_objectives=SD15_DECLARES, allowed_distilled=False)
+
+
+# ---------------------------------------------------------------------------
+# 4. THE POSITIVE CONTROL — a readable objective is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_a_fully_evidenced_checkpoint_resolves_with_NO_confession(
+    tmp_path: Path,
+) -> None:
+    """The healthy path must stay silent. A `serve_degrade` row on a clean
+    checkpoint would make the signal unreadable at fleet scale — and would
+    mean the assertions above pass for the wrong reason."""
+    with _Events() as ev:
+        got = _read(EPSILON)
+        _preflight(EPSILON, tmp_path)
+
+    assert got.objective == "epsilon"
+    assert got.distilled_status == "classified"
+    assert ev.unevidenced() == [], (
+        "an evidenced checkpoint is not a degraded run")
+
+
+def test_a_function_declaring_nothing_is_untouched_and_silent(
+    tmp_path: Path,
+) -> None:
+    """No declaration means nothing is checked, so an absent objective is not
+    even a degradation — it is simply irrelevant. Confessing here would emit a
+    warning for every family that never opted in."""
+    with _Events() as ev:
+        got = resolve_slot(
+            "pipeline", _slot(), ref=PICKED, objective="",
+            distilled=False, distilled_status="",
+            allowed_objectives=None, allowed_distilled=None)
+
+    assert got.objective == ""
+    assert ev.unevidenced() == []

--- a/tests/test_objective_absence_degrades_pgw1339.py
+++ b/tests/test_objective_absence_degrades_pgw1339.py
@@ -246,6 +246,38 @@ def test_the_confession_is_capable_of_going_red(
         "the sink must be genuinely fed by the emitter under test")
 
 
+def test_the_REQUEST_TIME_serving_shape_serves_and_confesses() -> None:
+    """The production path, at its own shape — not the warm/preflight one.
+
+    `executor.py:10081` builds every dispatched `RequestContext` with
+    `_resolve_slots_kwargs(spec, order.slots, order.adapters)`, i.e. WITH
+    per-dispatch `SlotOrder`s, where the tests above go through the WARM
+    shape. That distinction is exactly what th#2099 turned on — 0.118.0
+    "completing" proved the request path worked, and the same digest fatally
+    refused on 0.120.0 — so a fix asserted only on the warm shape would leave
+    the surface that actually took customer traffic unproven.
+    """
+    from gen_worker import dispatch
+    from gen_worker.warmup import resolved_slots_kwargs
+
+    chosen, siblings = _siblings()
+    # The ref reaches the spec the way a dispatch puts it there; only the
+    # FACTS are the variable under test.
+    child_preflight.bind_slots(siblings, {"pipeline": child_contract.MintSlot(
+        ref=PICKED, path="/tree", facts=UNSTAMPED)})
+    slots = {"pipeline": dispatch.SlotOrder(ref=PICKED, facts=UNSTAMPED)}
+
+    with _Events() as ev:
+        out = resolved_slots_kwargs(chosen, slots)
+
+    assert out["slot_errors"] == {}, (
+        "a dispatched request must not lose its slot — this dict becoming "
+        "non-empty is precisely how sd15 returned FATAL to a paying consumer")
+    assert out["declared_slot_errors"] == ()
+    assert out["resolved_slots"]["pipeline"].objective == ""
+    assert len(ev.unevidenced()) == 1
+
+
 # ---------------------------------------------------------------------------
 # 3. THE LINE THAT DOES NOT MOVE — contradiction still refuses
 # ---------------------------------------------------------------------------

--- a/tests/test_objective_absence_degrades_pgw1339.py
+++ b/tests/test_objective_absence_degrades_pgw1339.py
@@ -265,7 +265,10 @@ def test_the_REQUEST_TIME_serving_shape_serves_and_confesses() -> None:
     # FACTS are the variable under test.
     child_preflight.bind_slots(siblings, {"pipeline": child_contract.MintSlot(
         ref=PICKED, path="/tree", facts=UNSTAMPED)})
-    slots = {"pipeline": dispatch.SlotOrder(ref=PICKED, facts=UNSTAMPED)}
+    # `SlotOrder.ref` is the WIRE string; the typed ref reaches the reader off
+    # the spec, which is why `bind_slots` above is the half that matters here.
+    slots = {"pipeline": dispatch.SlotOrder(
+        ref="tensorhub/harness/catalog-pick@prod", facts=UNSTAMPED)}
 
     with _Events() as ev:
         out = resolved_slots_kwargs(chosen, slots)

--- a/tests/test_objective_absence_degrades_pgw1339.py
+++ b/tests/test_objective_absence_degrades_pgw1339.py
@@ -5,9 +5,9 @@ serves anyway, loudly. Absence degrades; only a CONTRADICTION refuses.
 inverted. 0.118.0 read `if resolved.objective:` — an unseen objective was
 simply nothing to check. 0.120.0 rewrote it as `if allowed_objectives is not
 None:` with an inner `if not resolved.objective: raise`, so an ABSENT
-objective went from "nothing to check" to a fatal. On 2026-08-17 `sd15`,
-`anima` and `foundation-1` were republished onto that wheel, promoted, and
-pointed at `prod`; every consumer request died
+objective went from "nothing to check" to a fatal. On 2026-08-17 `sd15` and
+`anima` were republished onto that wheel, promoted, and pointed at `prod`;
+every consumer request died
 
     DeclaredSlotResolutionError: slot 'pipeline': resolved checkpoint carries
     no training objective, so there is no evidence for the invoked function's
@@ -18,8 +18,22 @@ the same digest completing on 0.118.0 against the same hub). 0.121.0 ships
 the same reader byte for byte — `api/slot.py` sha256
 `8191b9ba…` in both wheels — so the whole fleet campaign was blocked on it.
 
+**Scope, stated precisely because the original filing over-associated it.**
+`foundation-1` was named alongside the other two on the night and is NOT a
+victim of this defect: it declares no `@worker_function(objectives=/
+distilled=)` at all, so nothing here can reach it, and the fleet lane
+subsequently measured ZERO `requests`/`request_state` and ZERO `worker_pods`
+rows for it over 30 hours — it was never observed serving OR failing. The
+defect is measured on `sd15` and `anima`; everything else is association.
+Structural immunity is a claim this file can make; a cause of death for an
+unobserved endpoint is not.
+
 **The ruling this restores.** §DEGRADATION-IS-LOUD, Paul: *"the worker should
-obviously complain loudly ... but it should still work"*, and its standing
+obviously complain loudly ... but it should still work"*; the machine-
+compatibility charter, verbatim — *"it always runs, just possibly horribly
+inefficiently"*; and the CPU-offload ruling — *"we always allow it, and
+encourage it, although when it happens we should warn loudly so the error can
+be caught."* Three statements of one shape, and its standing
 gloss — the loudness is *diagnostics*, never a gate. pgw#1315 already settled
 the identical shape for VRAM: a declared minimum *"gates one thing, a
 config-WRITE, and that lives hub-side"*. A declared `objectives=` contract is

--- a/tests/test_objectives_pgw654.py
+++ b/tests/test_objectives_pgw654.py
@@ -214,17 +214,21 @@ def test_distilled_mismatch_raises_typed_backstop_error() -> None:
 
 
 @pytest.mark.parametrize("status", ["unclassified", "inconclusive"])
-def test_unknown_distillation_evidence_fails_closed(status: str) -> None:
+def test_unknown_distillation_evidence_SERVES_UNCHECKED(status: str) -> None:
+    """pgw#1339: `unclassified`/`inconclusive` are ABSENCES of evidence, not
+    contradictions of the declaration, so they degrade rather than refuse.
+    The status still rides through onto the resolved slot, so a handler that
+    wants to branch on it can — the fact is reported, never invented."""
     from gen_worker.api.binding import HF
-    from gen_worker.api.slot import ObjectiveMismatchError, Slot, resolve_slot
+    from gen_worker.api.slot import Slot, resolve_slot
     from _example_family import ExampleDefaults
 
-    with pytest.raises(ObjectiveMismatchError, match=status):
-        resolve_slot(
-            "pipeline", Slot(object), ref=HF("acme/plain-xl"),
-            defaults_cls=ExampleDefaults,
-            distilled=False, distilled_status=status, allowed_distilled=False,
-        )
+    resolved = resolve_slot(
+        "pipeline", Slot(object), ref=HF("acme/plain-xl"),
+        defaults_cls=ExampleDefaults,
+        distilled=False, distilled_status=status, allowed_distilled=False,
+    )
+    assert resolved.distilled_status == status
 
 
 def test_explicit_false_distillation_evidence_is_independent_of_objective() -> None:
@@ -244,32 +248,40 @@ def test_explicit_false_distillation_evidence_is_independent_of_objective() -> N
     assert resolved.distilled_status == "classified"
 
 
-def test_unstamped_checkpoint_fails_a_declared_contract_closed() -> None:
-    """pgw#1307 arm (3): an unstamped binding is not an old sender.
+def test_an_unstamped_checkpoint_SERVES_UNCHECKED() -> None:
+    """SUPERSEDED BY pgw#1339 / th#2099 — was
+    `test_unstamped_checkpoint_fails_a_declared_contract_closed`.
 
-    The hub omits `distilled_status` whenever the stored column is empty
-    (`slot_resolution.go` stamps it `if TrimSpace(...) != ""`), and its ONE
-    rule (`modelfamily.StoredCheckpointFacts`) counts only `"classified"` as
-    evidence — so both hub gates already refuse this binding. The backstop
-    used to PASS it, which made the worker more permissive than the authority
-    it backstops.
+    pgw#1307 arm (3) reasoned that because both HUB gates refuse an unstamped
+    binding, the worker-side backstop passing it made the worker "more
+    permissive than the authority it backstops". The premise is right and the
+    conclusion does not follow: the hub gates ADMISSION (a config-write, and a
+    request the hub may still decline), while the worker is executing a
+    request the hub already admitted. Refusing there does not add a gate — it
+    converts a hub-side stamping gap into a customer-visible fatal, which is
+    exactly what 0.120.0 did to `sd15`, `anima` and `foundation-1`.
+
+    So both arms now RESOLVE, and the absence is confessed instead.
     """
     from gen_worker.api.binding import HF
-    from gen_worker.api.slot import ObjectiveMismatchError, Slot, resolve_slot
+    from gen_worker.api.slot import Slot, resolve_slot
     from _example_family import ExampleDefaults
 
-    with pytest.raises(ObjectiveMismatchError, match="no training objective"):
-        resolve_slot(
-            "pipeline", Slot(object), ref=HF("acme/plain-xl"),
-            defaults_cls=ExampleDefaults,
-            allowed_objectives=("epsilon",),
-        )
-    with pytest.raises(ObjectiveMismatchError, match="unstamped"):
-        resolve_slot(
-            "pipeline", Slot(object), ref=HF("acme/plain-xl"),
-            defaults_cls=ExampleDefaults,
-            objective="epsilon", allowed_distilled=False,
-        )
+    no_objective = resolve_slot(
+        "pipeline", Slot(object), ref=HF("acme/plain-xl"),
+        defaults_cls=ExampleDefaults,
+        allowed_objectives=("epsilon",),
+    )
+    assert no_objective.objective == "", (
+        "serving without the fact is the fix; INVENTING one would be a far "
+        "worse bug than the refusal it replaced")
+
+    no_status = resolve_slot(
+        "pipeline", Slot(object), ref=HF("acme/plain-xl"),
+        defaults_cls=ExampleDefaults,
+        objective="epsilon", allowed_distilled=False,
+    )
+    assert no_status.distilled_status == ""
 
 
 def test_unknown_distillation_status_is_rejected() -> None:
@@ -321,8 +333,10 @@ def test_wire_distillation_status_reaches_the_slot_backstop() -> None:
 
     result = resolved_slots_kwargs(spec, slots)
 
-    assert "pipeline" not in result["resolved_slots"]
-    assert "unclassified" in result["slot_errors"]["pipeline"]
+    # pgw#1339: the wire value still REACHES the backstop — that is what this
+    # test is for — but an unevidenced axis no longer takes the slot out.
+    assert result["slot_errors"] == {}
+    assert result["resolved_slots"]["pipeline"].distilled_status == "unclassified"
     assert pb.ModelBinding.DISTILLED_STATUS_FIELD_NUMBER == 8
 
 

--- a/tests/test_objectives_pgw654.py
+++ b/tests/test_objectives_pgw654.py
@@ -259,7 +259,7 @@ def test_an_unstamped_checkpoint_SERVES_UNCHECKED() -> None:
     request the hub may still decline), while the worker is executing a
     request the hub already admitted. Refusing there does not add a gate — it
     converts a hub-side stamping gap into a customer-visible fatal, which is
-    exactly what 0.120.0 did to `sd15`, `anima` and `foundation-1`.
+    exactly what 0.120.0 did to `sd15` and `anima`.
 
     So both arms now RESOLVE, and the absence is confessed instead.
     """

--- a/tests/test_slot_facts_carry_pgw1333.py
+++ b/tests/test_slot_facts_carry_pgw1333.py
@@ -16,7 +16,15 @@ objective"*, so it was filed against the checkpoint. The checkpoint was fine.
 -> ``MintSlot`` -> back onto the child's rediscovered spec, and "nobody
 resolved them" is a distinct member of that type which NAMES its owner. The
 two states an empty string used to conflate — *the catalog says nothing* and
-*nobody asked the catalog* — now refuse with different sentences.
+*nobody asked the catalog* — now CONFESS with different sentences, aimed at
+the different people who can close them.
+
+**AMENDED by pgw#1339 / th#2099.** This lane also made absence a refusal, and
+that half was wrong: shipped as 0.120.0 it took three promoted production
+endpoints down on correctly-stamped checkpoints. Absence now degrades loudly
+and serves; only a CONTRADICTION refuses. The carrying half — the type, the
+chain, the attribution — is untouched and is what the rest of this file
+proves.
 
 Every test below fails if any link in that chain drops the facts.
 """
@@ -133,14 +141,24 @@ def test_a_mismatch_still_refuses(tmp_path: Path) -> None:
     assert "is not in the invoked function's declared objectives" in str(exc.value)
 
 
-def test_an_unclassified_checkpoint_still_refuses(tmp_path: Path) -> None:
-    """The catalog ANSWERED, and the answer was "nothing measured this axis".
-    A declared contract fails closed against that exactly as the hub's own two
-    gates do (§1.22) — the fix must not turn a real absence of evidence into a
-    vacuous pass on a money surface."""
-    with pytest.raises(child_preflight.PreflightRefused) as exc:
-        _preflight(serving_facts.ServingFacts(), tmp_path)
-    assert "carries no training objective" in str(exc.value)
+def test_an_unclassified_checkpoint_SERVES(tmp_path: Path) -> None:
+    """SUPERSEDED BY pgw#1339 / th#2099 — this asserted a refusal, and the
+    refusal was the outage.
+
+    This lane read §1.22 fail-closed as governing the objective axis. It does
+    not: §4.20 says a gate whose evidence source is unavailable does the best
+    it can *without displacing the platform*, and the DEGRADATION ruling says
+    the worker complains loudly and still works. The objective backstop is not
+    a safety gate — the hub gates checkpoint<->function compatibility at
+    deploy and at request time, and this reader's own docstring calls itself a
+    version-skew backstop. Shipping it fatal in 0.120.0 took `sd15`, `anima`
+    and `foundation-1` down in production.
+
+    So an unclassified checkpoint SERVES, and confesses. The gate that
+    survives is the one against CONTRADICTION, asserted directly below and in
+    `test_objective_absence_degrades_pgw1339.py`.
+    """
+    _preflight(serving_facts.ServingFacts(), tmp_path)  # must not raise
 
 
 def test_a_distilled_mismatch_still_refuses(tmp_path: Path) -> None:
@@ -154,13 +172,13 @@ def test_a_distilled_mismatch_still_refuses(tmp_path: Path) -> None:
     assert "distilled=True" in str(exc.value)
 
 
-def test_unstamped_distillation_evidence_still_refuses(tmp_path: Path) -> None:
-    """``distilled=False`` with an unstamped status is not evidence of False."""
-    with pytest.raises(child_preflight.PreflightRefused) as exc:
-        _preflight(
-            serving_facts.ServingFacts(objective="epsilon", distilled=False),
-            tmp_path)
-    assert "distillation evidence is unstamped" in str(exc.value)
+def test_unstamped_distillation_evidence_SERVES(tmp_path: Path) -> None:
+    """``distilled=False`` with an unstamped status is still not evidence of
+    False — and, per pgw#1339, still not grounds to refuse a paid request.
+    The orthogonal axis moves with the objective axis, for the same reason."""
+    _preflight(
+        serving_facts.ServingFacts(objective="epsilon", distilled=False),
+        tmp_path)  # must not raise
 
 
 def test_the_undeclared_sibling_is_unaffected(tmp_path: Path) -> None:
@@ -199,29 +217,36 @@ def test_an_undeclared_class_resolves_with_no_facts_at_all(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
-def test_a_missing_stamp_refuses_by_name_and_names_the_hub(tmp_path: Path) -> None:
+def test_a_missing_stamp_CONFESSES_by_name_and_names_the_hub(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
     """The boot half is a HUB gap: ``hello_ack.go`` builds
     ``DesiredInstance.ModelBinding`` with the three serving-fact fields left
     zero, though the proto has them and the dispatch path stamps them.
 
-    Until tensorhub fills them the worker still refuses — §1.22 fail-closed —
-    but it must refuse with a sentence naming the WIRE, not one that reads as
-    a verdict on the checkpoint. That mis-reading is what sent e2e#1892's
-    blocker at the catalog, where three independent reads showed the stamp
-    present and correct.
+    pgw#1339 turned the refusal into a confession — a gap on OUR side of the
+    wire is not grounds to decline a paid request. **The attribution this test
+    was written for is unchanged and still load-bearing**, because it is the
+    whole reason the type has two members: the sentence must name the WIRE,
+    not read as a verdict on the checkpoint. That mis-reading is what sent
+    e2e#1892's blocker at the catalog, where three independent reads showed
+    the stamp present and correct.
     """
-    with pytest.raises(child_preflight.PreflightRefused) as exc:
+    with caplog.at_level("WARNING"):
         _preflight(
             serving_facts.FactsUnavailable(owed_by=dispatch.BOOT_SENDER_OWES),
-            tmp_path)
-    msg = str(exc.value)
-    assert "crossed WITHOUT its serving facts" in msg
+            tmp_path)  # serves
+    msg = caplog.text
     assert "hello_ack.go" in msg
     assert "objective" in msg and "distilled_status" in msg
     assert "NOT a claim about the checkpoint's catalog row" in msg
     assert "carries no training objective" not in msg, (
         "the gap must not borrow the sentence that blames the checkpoint — "
         "that borrowing is what cost this bug its correct attribution")
+    assert "stamp the serving facts on the binding this pod was sent" in msg, (
+        "a wire gap must be pointed at the SENDER; telling the operator to go "
+        "classify a checkpoint that is already classified is the same "
+        "mis-attribution wearing a suggestion")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slot_facts_carry_pgw1333.py
+++ b/tests/test_slot_facts_carry_pgw1333.py
@@ -20,8 +20,8 @@ two states an empty string used to conflate — *the catalog says nothing* and
 the different people who can close them.
 
 **AMENDED by pgw#1339 / th#2099.** This lane also made absence a refusal, and
-that half was wrong: shipped as 0.120.0 it took three promoted production
-endpoints down on correctly-stamped checkpoints. Absence now degrades loudly
+that half was wrong: shipped as 0.120.0 it took `sd15` and `anima` down in
+production on correctly-stamped checkpoints. Absence now degrades loudly
 and serves; only a CONTRADICTION refuses. The carrying half — the type, the
 chain, the attribution — is untouched and is what the rest of this file
 proves.
@@ -151,12 +151,20 @@ def test_an_unclassified_checkpoint_SERVES(tmp_path: Path) -> None:
     the worker complains loudly and still works. The objective backstop is not
     a safety gate — the hub gates checkpoint<->function compatibility at
     deploy and at request time, and this reader's own docstring calls itself a
-    version-skew backstop. Shipping it fatal in 0.120.0 took `sd15`, `anima`
-    and `foundation-1` down in production.
+    version-skew backstop. Shipping it fatal in 0.120.0 took `sd15` and
+    `anima` down in production, both measured.
 
     So an unclassified checkpoint SERVES, and confesses. The gate that
     survives is the one against CONTRADICTION, asserted directly below and in
     `test_objective_absence_degrades_pgw1339.py`.
+
+    **AFFIRMED, do not re-litigate from §1.22.** The supersession was reviewed
+    and upheld against two of Paul's standing rulings in his own words: the
+    machine-compatibility charter — *"it always runs, just possibly horribly
+    inefficiently"* — and the CPU-offload ruling — *"we always allow it, and
+    encourage it, although when it happens we should warn loudly so the error
+    can be caught."* Serving-with-a-loud-warning on absent evidence is
+    precisely that shape.
     """
     _preflight(serving_facts.ServingFacts(), tmp_path)  # must not raise
 


### PR DESCRIPTION
**P0. Fixes the reader that took `sd15` and `anima` down in production tonight, and unblocks the fleet republish campaign.**

**Scope, stated precisely.** The defect is MEASURED on `sd15` and `anima`. `foundation-1` was named alongside them on the night and is **not** a victim: it declares no `@worker_function(objectives=/distilled=)`, so this code cannot reach it, and the fleet lane measured **0 rows in `requests`/`request_state` and 0 in `worker_pods` over 30 hours** — it was never observed serving or failing. **Blast radius: 42 declaring functions across 14 of 29 endpoints**; the other 15 are structurally immune.

## The defect

0.120.0 inverted the guard in `api/slot._finish_resolved`:

```python
# 0.118.0 — an unseen objective was nothing to check
if resolved.objective:
    if allowed_objectives is not None and resolved.objective not in allowed_objectives:
        raise ...

# 0.120.0 — an unseen objective became a FATAL
if allowed_objectives is not None:
    if not resolved.objective:
        raise ObjectiveMismatchError("...carries no training objective...")
```

th#2099 disambiguated it with a release-pinned private deployment: the **same checkpoint digest** completes on 0.118.0 and goes fatal on 0.120.0 against the **same hub**, which demonstrably sends `objective='epsilon'`. Hub and catalog exonerated; it is the wheel's reader.

**0.121.0 ships the same reader byte for byte** — `api/slot.py` sha256 `8191b9ba…` and `warmup.py` sha256 `7465eabb…` are identical in both shipped PyPI wheels, and executing 0.121.0's reader reproduces the production sentence verbatim. That is why the fleet campaign is held.

## The rule this restores

§DEGRADATION-IS-LOUD (Paul): *"the worker should obviously complain loudly ... but it should still work"* — the loudness is diagnostics, never a gate. pgw#1315 already settled the identical shape for VRAM: a declared minimum *"gates one thing, a config-WRITE, and that lives hub-side."* A declared `objectives=` contract is the same kind of declaration; the hub already gates it at deploy (`bindingcheck`) and at request time; and this reader's own docstring calls itself a version-skew backstop. **A backstop must never be the thing that takes the platform down.**

## What changed

- **Absence resolves and confesses.** Both flavours — an unclassified catalog answer and a wire gap nobody stamped — go through pgw#1312's ONE `serve_degrade` seam under a new phase token `REASON_SERVING_FACTS_UNEVIDENCED`, carrying WHAT axis, WHY, and WHAT WOULD BE BETTER. The suggestion is routed: a wire gap points at the *sender*, an unclassified checkpoint points at the *catalog*. Sending both to one address is how the original bug lost its attribution.
- **Contradiction still refuses**, by name: `flow` into `(epsilon, v_prediction)`, a `classified` `distilled=True` into `distilled=False`, and an out-of-vocabulary `distilled_status` (a decode bug, not a degraded machine).
- `serving_facts.facts_or_refuse` → `facts_or_degrade`, returning `(facts, reason)`.

## Supersedes three sibling assertions — deliberately

pgw#1333's `test_an_unclassified_checkpoint_still_refuses` and `test_unstamped_distillation_evidence_still_refuses`, and pgw#654/pgw#1307's `test_unstamped_checkpoint_fails_a_declared_contract_closed`. That lane read §1.22 fail-closed as governing this axis **and explicitly flagged the call as the owner's**; §4.20 and the degradation ruling settle it the other way. Each site says so in place. pgw#1333's **attribution** half is untouched and still asserted — the wire-gap sentence must name `hello_ack.go` and must never read as a verdict on the checkpoint.

**AFFIRMED on review — do not re-litigate from §1.22.** Upheld against two of Paul's standing rulings in his own words: the machine-compatibility charter (*"it always runs, just possibly horribly inefficiently"*) and the CPU-offload ruling (*"we always allow it, and encourage it, although when it happens we should warn loudly so the error can be caught"*). Absence-degrades-loudly-and-serves is exactly that shape.

## Red/green

`tests/test_objective_absence_degrades_pgw1339.py` (11 tests):

- **Red before this commit** with the production sentence verbatim.
- **Always-runs**: the exact call that killed `sd15` now resolves; the reader serves *without* the fact and never invents one.
- **Loudness is red-verified**: disarming `_confess_serve_degrade` fails every assertion that reads the sink while always-runs stays green, so the confession half cannot be decorative.
- **Positive control**: a fully-evidenced `epsilon` checkpoint resolves and produces **no** confession.
- **Gate intact**: three contradiction arms still refuse.

Local: 397 passed across the warmup/slot/preflight/dispatch/serving selection; mypy strict clean (808 files); ruff clean; all five `fast gates` guard scripts OK.

## Follow-ups, not in this PR

- **th#2091** (hub half) is now a *degradation* rather than an outage: `hello_ack.go` still leaves `DesiredInstance.models[].objective/.distilled/.distilled_status` zero, so boot-path slots serve unchecked and confess. Worth fixing, no longer urgent.
- Requires a **wheel re-cut (0.122.0)**; every endpoint built on 0.120.0/0.121.0 needs rebuilding on it.
