### PR TITLE
pgw#1340 / th#2098: the arm seam compared three axes no cell can state — every self-mint bought its compile and then refused itself

### DIFF
--- a/changelog.d/pgw1340.md
+++ b/changelog.d/pgw1340.md
@@ -1,0 +1,26 @@
+- **Every self-mint since 0.117.0 compiled for 20-45 minutes and then refused itself.** The
+  handback seam (`fleet_cells.arm_axis_divergence`) compared six axes; three of them —
+  `family`, `lane` (`weight_lane`/`lora_bucket`) and `env_seal` — are not in TCG's artifact
+  metadata vocabulary, which `torchcg.artifact.validate_metadata` has enforced as a CLOSED
+  field set since pgw#1270. So the seam read `None` off every cell TCG ever minted and compared
+  it against a live runtime fact: an arm that could only ever fail. Measured on the standing
+  `master` hub 2026-08-17 — `aot_entry_arm_failed key_axis_divergence — family: child cell
+  states '', this runtime computed 'sd15'`, 224 rows on `sd15` and 28 on `ernie` across wheels
+  0.117.0 and 0.118.0, **zero publishes**, ~$1.00 of L4 per burst against 57.7 GPU-seconds of
+  the inference the compile was meant to accelerate (th#2098). The three axes are now
+  `ARM_OBLIGATION_FACTS`: still in the arm token, so they still split the pending, the
+  delegated child and the local store's memo row — just never compared across a boundary no
+  artifact can carry them over. This is the unfinished half of pgw#1277's sweep, which fixed
+  the same class one block over (`entry` -> `graph_class`).
+- **A mint whose seam cannot be satisfied is now refused for $0, at obligation-open.**
+  `fleet_cells.unstateable_arm_axes()` is a pure function of two compile-time constants — the
+  axes compared, and `torchcg.ARTIFACT_METADATA_FIELDS` (newly exported, the pgw#1299 ruling
+  applied to the field SET) — so "no cell can ever satisfy this comparison" is answerable
+  before a child process is spawned. `enable_compiled` declines with the new typed phase
+  `EagerPhase.ARM_AXES_UNSTATEABLE` and buys nothing; previously the answer cost a full
+  inductor compile on a paid card, per pod, per boot, forever.
+- **The fixtures are the fence.** pgw#1277 recorded why CI stayed green through the identical
+  defect: *"every fixture built the obsolete shape."* `tests/test_arm_axes_are_stateable_pgw1340.py`
+  builds the cell through `torchcg.artifact.build_metadata` (via `tests/tcg_artifacts.py`), so the
+  seam is now exercised against metadata a packed artifact can actually contain. It reproduced
+  the production string character-for-character before the fix.

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -1,6 +1,10 @@
 """Mint and reuse verified PyTorch AOTInductor graphs through HashRepo."""
 
-from .artifact import COMPILED_GRAPH_FORMAT, ArtifactError
+from .artifact import (
+    ARTIFACT_METADATA_FIELDS,
+    COMPILED_GRAPH_FORMAT,
+    ArtifactError,
+)
 from .compiler import CompileError
 from .declaration import (
     DeclarationError,
@@ -40,6 +44,7 @@ from .storage import (
 
 __all__ = [
     "ARTIFACT_KIND",
+    "ARTIFACT_METADATA_FIELDS",
     "AdmissionError",
     "ArtifactError",
     "CompileError",

--- a/src/gen_worker/_vendor/torchcg/artifact.py
+++ b/src/gen_worker/_vendor/torchcg/artifact.py
@@ -71,6 +71,20 @@ _TOP_LEVEL_FIELDS = frozenset(
     )
 )
 
+#: The artifact metadata vocabulary, EXPORTED (pgw#1340). `validate_metadata`
+#: refuses any metadata whose field set is not exactly this, so the set is not
+#: a convention a consumer may extend — it is the closed answer to "what can a
+#: cell state about itself".
+#:
+#: pgw#1299 already ruled that a consumer imports TCG's vocabulary rather than
+#: spelling it, for keys. The FIELD SET needs the same treatment for a sharper
+#: reason: a consumer that assumes a field TCG does not write reads `None`, and
+#: `None` compares unequal to a real runtime fact forever. That is th#2098 —
+#: `fleet_cells.arm_axis_divergence` compared `family`, `weight_lane` and
+#: `env_seal` against a cell that structurally cannot carry them, so every
+#: self-mint refused after its compile: ~$1.00 of L4 per burst, for nothing.
+ARTIFACT_METADATA_FIELDS: frozenset[str] = _TOP_LEVEL_FIELDS
+
 _SAFETENSORS_DTYPES: dict[str, tuple[str, int]] = {
     "BOOL": ("bool", 1),
     "U8": ("uint8", 1),

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -92,6 +92,19 @@ class EagerPhase(StrEnum):
     #: identity must not be re-minted) and was the one that only logged.
     COMPILED_GRAPH_QUARANTINED = "compiled_graph_quarantined"
 
+    #: pgw#1340 / th#2098: the handback seam compares an axis a packed cell
+    #: structurally cannot state, so the arm can only ever refuse. The mint is
+    #: declined at obligation-open, for $0, instead of after 20-45 minutes of
+    #: paid GPU — which is what it cost on `sd15` for two wheels running:
+    #: `family: child cell states '', this runtime computed 'sd15'`, every
+    #: mint, nothing published, ~$1.00 of L4 per burst.
+    #:
+    #: A pod reporting this is reporting a CODE defect with a named owner
+    #: (an axis outside `torchcg.ARTIFACT_METADATA_FIELDS`), never a
+    #: capability, a card or a release — which is why it does not share a
+    #: token with the mint-impossibility exits above.
+    ARM_AXES_UNSTATEABLE = "arm_axes_unstateable"
+
     #: Eager with an END — a delegated mint child is building the cell.
     MINT_IN_PROGRESS = "mint_in_progress"
 

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -64,7 +64,12 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
-from gen_worker._vendor.torchcg import ARTIFACT_KIND, GRAPH_CLASS_BLOCK, REQUIRED_AXES
+from gen_worker._vendor.torchcg import (
+    ARTIFACT_KIND,
+    ARTIFACT_METADATA_FIELDS,
+    GRAPH_CLASS_BLOCK,
+    REQUIRED_AXES,
+)
 from gen_worker._vendor.torchcg import is_compiled_graph_key
 from gen_worker._vendor.torchcg import identity as tcg_identity
 
@@ -218,8 +223,25 @@ class ArmIdentity:
 # whole declaration, not about one graph class — so comparing it here would
 # compare a value the child can no longer state against one the parent can,
 # and refuse every handback by construction.
-ARM_ENVIRONMENT_FACTS = ("family", aot_serve.COMPILED_GRAPH_FORMAT_KEY,
-                         "lane", "sm", "env_seal", "toolchain")
+# pgw#1340 / th#2098: `family`, `lane` and `env_seal` LEFT this comparison for
+# the SAME reason `envelope` did one paragraph up, and the sweep that took
+# `envelope` should have taken them. Since pgw#1270 TCG mints every artifact
+# and `torchcg.artifact.validate_metadata` refuses metadata whose field set is
+# not exactly `ARTIFACT_METADATA_FIELDS` — which contains no `family`, no
+# `weight_lane`/`lora_bucket` and no `env_seal`. So three of the six axes here
+# were read as `None` off every real cell and compared against a live runtime
+# fact: a seam that could only ever refuse.
+#
+# It was not theory. MEASURED on the standing `master` hub (2026-08-17):
+# `aot_entry_arm_failed key_axis_divergence — family: child cell states '',
+# this runtime computed 'sd15'`, 224 rows on sd15 and 28 on ernie across wheels
+# 0.117.0 and 0.118.0. EVERY self-mint that reached the seam, none published,
+# each one paying ~25 minutes of L4 for the compile it then discarded — ~$1.00
+# per burst against 57.7 GPU-seconds of the inference it was meant to speed up.
+#
+# What is left is exactly the three axes TCG keys the artifact ON, which is
+# what makes them the three that can genuinely refuse a foreign cell.
+ARM_ENVIRONMENT_FACTS = (aot_serve.COMPILED_GRAPH_FORMAT_KEY, "sm", "toolchain")
 
 #: The SUBJECT half (pgw#1113): WHAT this obligation compiles, as opposed to
 #: what runtime it compiles on. ``subject`` is the resolved slot identity
@@ -235,8 +257,53 @@ ARM_ENVIRONMENT_FACTS = ("family", aot_serve.COMPILED_GRAPH_FORMAT_KEY,
 #: key, which is the traced computation, is what says the computation matches.
 ARM_SUBJECT_FACTS = ("subject", "targets", "dynamic", "regional")
 
+#: Every fact the obligation states that a CELL never can, and therefore that
+#: nothing compares across the handback boundary (pgw#1340). This is not a
+#: weaker check — it is the same check moved to the side of the boundary that
+#: can perform it. `family`, `lane` and `env_seal` are in the arm TOKEN, and
+#: the token is what splits the pending, the delegated child and the local
+#: store's memo row, so two families or two lanes still never share one mint.
+#: The cell's own `ck1` key is what says the COMPUTATION matches.
+ARM_OBLIGATION_FACTS = ("family", "lane", "env_seal") + ARM_SUBJECT_FACTS
+
 #: Every fact in the token, in report order.
-ARM_FACTS = ARM_ENVIRONMENT_FACTS + ARM_SUBJECT_FACTS
+ARM_FACTS = ARM_ENVIRONMENT_FACTS + ARM_OBLIGATION_FACTS
+
+#: Each arm axis -> the CELL-METADATA fields its child-side derivation reads.
+#: The one table both :func:`arm_axis_divergence` and
+#: :func:`unstateable_arm_axes` consult, so "what this axis is read from" and
+#: "can a cell state it" can never be two answers.
+ARM_AXIS_CELL_SOURCES: Dict[str, Tuple[str, ...]] = {
+    aot_serve.COMPILED_GRAPH_FORMAT_KEY: (aot_serve.COMPILED_GRAPH_FORMAT_KEY,),
+    "sm": ("sm",),
+    "toolchain": ("toolchain",),
+    "family": ("family",),
+    "lane": ("weight_lane", "lora_bucket"),
+    "env_seal": (env_seal.SEAL_KEY,),
+}
+
+
+def unstateable_arm_axes(
+    compared: Sequence[str] = ARM_ENVIRONMENT_FACTS,
+) -> Tuple[str, ...]:
+    """The compared axes a packed cell's metadata CANNOT state — the $0 answer.
+
+    A pure function of two compile-time constants: the axes this seam compares,
+    and TCG's closed artifact vocabulary. So a seam that is unsatisfiable is
+    knowable BEFORE a child process is spawned, before an export, before a
+    single second of inductor — which is the whole of th#2098's second ask.
+    :func:`enable_compiled` refuses the obligation on a non-empty answer; the
+    alternative, measured, is 20-45 minutes of paid GPU per pod per boot ending
+    in `key_axis_divergence` forever.
+
+    An axis with no entry in :data:`ARM_AXIS_CELL_SOURCES` is read as reading
+    the field of its own name — so a NEW axis added without a source entry is
+    checked, never silently admitted.
+    """
+    vocabulary = set(ARTIFACT_METADATA_FIELDS)
+    return tuple(
+        axis for axis in compared
+        if not set(ARM_AXIS_CELL_SOURCES.get(axis, (axis,))) <= vocabulary)
 
 #: The pipeline attribute carrying the resolved :class:`graph_facts.SlotSubject`
 #: set the executor built this object from (pgw#1113). Stamped beside the
@@ -1897,6 +1964,48 @@ def _arming_policy(
             pipe, f"self-mint identity computation failed: {exc}", selection_bug,
             phase=EagerPhase.KEY_COMPUTATION_FAILED)
 
+    # pgw#1340 / th#2098 — THE $0 PREFLIGHT, and it is sited here because this
+    # is the last line before anything is spent. Everything below opens a
+    # pending, spawns a child and buys 20-45 minutes of the card this pod is
+    # paying for; the question "can the cell that child returns ever satisfy
+    # the seam that admits it" is answered by two compile-time constants and
+    # costs nothing to ask.
+    #
+    # It is not hypothetical. pgw#1270 moved the artifact vocabulary to TCG and
+    # left three axes in the comparison that no cell can state, and the fleet
+    # paid the full compile to rediscover it on every boot of every pod for two
+    # wheels: 224 `sd15` rows and 28 `ernie` rows of
+    # `aot_entry_arm_failed key_axis_divergence`, zero publishes, ~$1.00 of L4
+    # per burst against 57.7 GPU-seconds of the inference it was accelerating.
+    #
+    # DEGRADE, never fail the worker (§4.33): the pod serves eager, which is
+    # what it was doing anyway — the only thing this removes is the bill.
+    unstateable = unstateable_arm_axes()
+    if unstateable:
+        named = ", ".join(unstateable)
+        logger.error(
+            "fleet-cells: REFUSING to open a self-mint for %s — the handback "
+            "seam compares %s, which a packed cell cannot state (TCG's "
+            "artifact vocabulary is %s). Every mint under this seam would "
+            "compile for 20-45 minutes and then refuse `key_axis_divergence`. "
+            "Serving eager and spending nothing (pgw#1340)",
+            family, named, sorted(ARTIFACT_METADATA_FIELDS))
+        if bucket:
+            cc.drop_lora_execution_lane(pipe)
+        activity_mod.emit_event(
+            "self_mint_skipped",
+            f"family={family} arm_key={key} axes={named}: the arm-axis "
+            f"comparison demands {named}, which no packed cell can state — "
+            f"this worker refuses the mint at ARM time rather than paying "
+            f"for a compile that provably cannot arm. Nothing is spent, "
+            f"serving stays eager, and this is a code defect (an axis outside "
+            f"the artifact vocabulary), not a property of this pod or release",
+            phase=EagerPhase.ARM_AXES_UNSTATEABLE,
+        )
+        return ArmOutcome(
+            armed=False, selection_bug=selection_bug,
+            eager_reason=EagerPhase.ARM_AXES_UNSTATEABLE)
+
     # pgw#672: consult the process ledgers BEFORE opening a capture.
     #
     # pgw#1033: TWO identities can be quarantined for one arm, and the gate
@@ -2080,24 +2189,21 @@ def arm_axis_divergence(
     against the traced fact was the attempt-28 phantom divergence
     (pgw#1059). Every compared fact uses the SAME derivation on both sides.
 
-    :data:`ARM_SUBJECT_FACTS` are equally deliberately NOT compared
-    (pgw#1113). A cell records no subject and must not: the key is the traced
-    computation, so one cell legally serves every checkpoint whose graph it
-    is, and demanding the cell restate the checkpoint it was minted from
-    would refuse exactly the reuse the membership axiom exists to allow. The
-    subject splits the obligation on THIS side of the boundary; what crosses
-    it is compared here.
+    :data:`ARM_OBLIGATION_FACTS` are equally deliberately NOT compared
+    (pgw#1113 for the subject half, pgw#1340 for `family`/`lane`/`env_seal`).
+    A cell records no subject and must not: the key is the traced computation,
+    so one cell legally serves every checkpoint whose graph it is, and
+    demanding the cell restate the checkpoint it was minted from would refuse
+    exactly the reuse the membership axiom exists to allow. `family`, `lane`
+    and `env_seal` are not in TCG's artifact vocabulary AT ALL, so comparing
+    them read `None` off every real cell — th#2098, one production burst at a
+    time. The obligation facts split the obligation on THIS side of the
+    boundary; what crosses it is compared here.
     """
     child: Dict[str, str] = {
-        "family": str(meta.get("family") or ""),
         aot_serve.COMPILED_GRAPH_FORMAT_KEY: str(
             meta.get(aot_serve.COMPILED_GRAPH_FORMAT_KEY) or ""),
-        "lane": cc.execution_lane_label(
-            str(meta.get("weight_lane") or ""),
-            int(meta.get("lora_bucket") or 0)),
         "sm": str(meta.get("sm") or ""),
-        "env_seal": env_seal.seal_digest(
-            dict(meta.get(env_seal.SEAL_KEY) or {})),
         "toolchain": tcg_identity.toolchain_axis_digest(
             dict(meta.get("toolchain") or {})),
     }

--- a/tests/test_arm_axes_are_stateable_pgw1340.py
+++ b/tests/test_arm_axes_are_stateable_pgw1340.py
@@ -1,0 +1,157 @@
+"""pgw#1340 / th#2098 — the handback seam compares axes a REAL cell cannot state.
+
+MEASURED IN PRODUCTION (standing `master` hub `a35434eb14`, 2026-08-17), and it
+is the whole of th#2098: every `tensorhub/sd15` pod bought for a burst spent
+~25 minutes of paid L4 on an `inductor_compile` and threw it away, ~$1.00 of
+GPU per burst for zero artifacts against 57.7 GPU-seconds of actual inference.
+The wire says exactly which axis, on every single row::
+
+    aot_entry_arm_failed  key_axis_divergence
+      family: child cell states '', this runtime computed 'sd15'
+
+224 occurrences on `sd15`, 28 on `ernie`, wheels 0.117.0 and 0.118.0 — every
+self-mint that reached the seam, zero exceptions, zero publishes.
+
+WHY `family` IS EMPTY. Since pgw#1270 TCG mints every artifact, and
+`torchcg.artifact.validate_metadata` refuses any metadata whose field set is
+not EXACTLY its closed vocabulary::
+
+    compiled_graph_format  kind  compiled_graph_key  graph_class
+    sm  toolchain  host_isa  package_constants_in_so  constant_folding_fenced
+
+`family` is not in it. Neither are `weight_lane`/`lora_bucket` (the `lane`
+axis) or `env_seal`. `arm_axis_divergence` still read all four out of the
+metadata dict, so THREE of its six compared axes were structurally unstateable
+and the comparison could only ever fail — `family` first, because it sorts
+first in `ARM_ENVIRONMENT_FACTS`.
+
+THIS IS THE UNFINISHED HALF OF pgw#1277. That issue found the same class one
+block over (the worker read an `entry` block TCG never writes) and recorded the
+reason it survived CI verbatim: *"CI stayed green because every fixture built
+the obsolete shape."* `tests/test_handback_key_axes_pgw1042.py::_envelope` is
+that fixture — it hand-writes `family`, `weight_lane`, `lora_bucket` and
+`env_seal` into a dict no packed cell can contain. So the fence here is not
+another assertion about the same fixture; it is the fixture built by
+`torchcg.artifact.build_metadata`, through `tests/tcg_artifacts.py`, which has
+existed since pgw#1283.
+
+The two halves this file pins:
+
+1. a cell TCG actually minted ARMS — the axes compared at the seam are exactly
+   the axes a cell can state, and a real one agrees with its own runtime;
+2. the divergence is knowable for $0 BEFORE the compile.
+   :func:`fleet_cells.unstateable_arm_axes` is a pure function of two
+   compile-time constants, so a seam that can never agree is a refusal at
+   obligation-open — not a 25-minute receipt.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import aot_serve, env_seal, fleet_cells, graph_facts
+from gen_worker._vendor.torchcg import identity as tcg_identity
+
+import tcg_artifacts
+
+
+def _real_cell_metadata(**kw: Any) -> Dict[str, Any]:
+    """Metadata from TCG's own builder — the only shape a cell can carry."""
+    return tcg_artifacts.metadata(**kw)
+
+
+def _runtime_arm_key(meta: Dict[str, Any], family: str = "sd15") -> fleet_cells.ArmIdentity:
+    """The parent's obligation identity for the runtime that cell was minted on.
+
+    Every OBLIGATION fact is stated exactly as production states it: the family
+    the release declares, the serving lane, this machine's env seal. The
+    ENVIRONMENT facts are taken from the cell's own metadata, because that is
+    the claim under test — a cell minted on this runtime describes it.
+    """
+    facts = {
+        "family": family,
+        aot_serve.COMPILED_GRAPH_FORMAT_KEY: str(aot_serve.COMPILED_GRAPH_FORMAT),
+        "lane": "bf16-w16a16",
+        "sm": str(meta["sm"]),
+        "env_seal": env_seal.seal_digest(env_seal.effective_seal()),
+        "toolchain": tcg_identity.toolchain_axis_digest(dict(meta["toolchain"])),
+        "subject": graph_facts.subject_digest(()),
+        "targets": "unet",
+        "dynamic": "{}",
+        "regional": "0",
+    }
+    return fleet_cells.ArmIdentity(facts=tuple(sorted(facts.items())))
+
+
+def test_a_cell_TCG_MINTED_arms_on_the_runtime_that_minted_it() -> None:
+    """THE PRODUCTION RED. Before pgw#1340 this returned
+    ``family: child cell states '', this runtime computed 'sd15'`` — the exact
+    string 224 `sd15` rows carry — and $1.00/burst of L4 went to a compile
+    that could never arm.
+    """
+    meta = _real_cell_metadata()
+    assert fleet_cells.arm_axis_divergence(_runtime_arm_key(meta), meta) == ""
+
+
+@pytest.mark.parametrize("axis", ["family", "lane", "env_seal"])
+def test_an_axis_no_cell_can_state_is_not_compared_at_this_seam(axis: str) -> None:
+    """INVERTED, and stated rather than merely dropped (pgw#939: absence is a
+    verdict, never a skipped check).
+
+    These three are OBLIGATION facts, and they keep doing their whole job on
+    THIS side of the boundary: they are in the arm token, so they split the
+    pending, the child, and the local store's memo row — two families or two
+    lanes never share a mint. What they cannot do is cross a boundary a TCG
+    artifact has no field for. This is pgw#1176's own ruling about `envelope`,
+    applied to the axes that cut was not swept for.
+    """
+    assert axis not in fleet_cells.ARM_ENVIRONMENT_FACTS
+    assert axis in fleet_cells.ARM_OBLIGATION_FACTS
+
+
+def test_every_compared_axis_is_stateable_by_a_cell() -> None:
+    """The $0 preflight, evaluated on the real constants.
+
+    A non-empty answer here means the seam is unsatisfiable by construction:
+    every mint under it compiles for 20-45 minutes and refuses. That must be
+    a refusal before the child is spawned, never a discovery after the bill.
+    """
+    assert fleet_cells.unstateable_arm_axes() == ()
+
+
+def test_the_preflight_names_an_axis_that_left_the_vocabulary() -> None:
+    """The fence proves it can go RED — this is what would have caught pgw#1270
+    on a laptop instead of on eight L4s.
+    """
+    got = fleet_cells.unstateable_arm_axes(("sm", "family", "env_seal"))
+    assert got == ("family", "env_seal")
+
+
+@pytest.mark.parametrize("field,value,axis", [
+    ("sm", "sm_80", "sm"),
+    ("toolchain", {"torch": "a-different-compiler"}, "toolchain"),
+])
+def test_a_REAL_divergence_is_still_refused_by_name(
+    field: str, value: Any, axis: str,
+) -> None:
+    """The positive control. Narrowing the compared set must not disarm it:
+    a cell minted on another card or another compiler is exactly what this
+    seam exists to refuse, and it still is.
+    """
+    meta = _real_cell_metadata()
+    arm = _runtime_arm_key(meta)
+    diverged = dict(meta, **{field: value})
+    got = fleet_cells.arm_axis_divergence(arm, diverged)
+    assert got.startswith(f"{axis}: "), got
+
+
+def test_the_compared_set_is_not_empty() -> None:
+    """A comparison narrowed to nothing would pass every cell and read green.
+
+    The three that survive are the runtime axes TCG keys the artifact ON, so
+    they are the three that can genuinely refuse a foreign cell.
+    """
+    assert set(fleet_cells.ARM_ENVIRONMENT_FACTS) == {
+        aot_serve.COMPILED_GRAPH_FORMAT_KEY, "sm", "toolchain"}

--- a/tests/test_handback_key_axes_pgw1042.py
+++ b/tests/test_handback_key_axes_pgw1042.py
@@ -92,21 +92,33 @@ def test_shared_axes_agree_is_empty() -> None:
         _arm_key(seal, TOOLCHAIN), _envelope(seal, TOOLCHAIN)) == ""
 
 
-def test_env_seal_divergence_is_named() -> None:
-    """The pod class: the child's recorded seal differs from the parent's."""
+def test_the_env_seal_is_no_longer_comparable_at_this_seam() -> None:
+    """INVERTED by pgw#1340 (th#2098), and stated rather than deleted.
+
+    This used to assert that a child whose recorded seal differs from the
+    parent's is refused ``env_seal: …`` — the measured pgw#1042 class, where
+    `torch._inductor.aot_compile` mutated global config as a side effect.
+    THE SEAL IS NO LONGER ON THE CELL AT ALL: since pgw#1270 TCG mints every
+    artifact and `validate_metadata` refuses metadata outside its closed
+    vocabulary, which has no `env_seal` field. So this comparison did not
+    catch a diverging seal — it read `{}` off every real cell, digested that,
+    and refused every handback ever made.
+
+    The pgw#1042 root fix survives where it belongs: the seal digest still
+    excludes `aot_inductor.metadata` (pinned below), so the side effect this
+    axis was watching for cannot move a seal in the first place.
+    """
     parent_seal = _seal_dict()
     child_seal = dict(parent_seal, inductor="ffff999988887777")
-    got = fleet_cells.arm_axis_divergence(
-        _arm_key(parent_seal, TOOLCHAIN), _envelope(child_seal, TOOLCHAIN))
-    assert got.startswith("env_seal: ")
-    assert env_seal.seal_digest(child_seal) in got
-    assert env_seal.seal_digest(parent_seal) in got
+    assert "env_seal" not in fleet_cells.ARM_ENVIRONMENT_FACTS
+    assert "env_seal" in fleet_cells.ARM_OBLIGATION_FACTS
+    assert fleet_cells.arm_axis_divergence(
+        _arm_key(parent_seal, TOOLCHAIN), _envelope(child_seal, TOOLCHAIN)) == ""
 
 
 @pytest.mark.parametrize("field,value,axis", [
     ("sm", "sm_80", "sm"),
-    ("family", "other-family", "family"),
-    ("lora_bucket", 0, "lane"),
+    ("toolchain", {"libtorch.so": "0000ffff"}, "toolchain"),
     (aot_serve.COMPILED_GRAPH_FORMAT_KEY, "99",
      aot_serve.COMPILED_GRAPH_FORMAT_KEY),
 ])
@@ -142,14 +154,40 @@ def test_the_envelope_is_deliberately_NOT_compared_at_this_seam() -> None:
         _arm_key(seal, TOOLCHAIN), meta) == ""
 
 
+@pytest.mark.parametrize("axis", ["family", "lane"])
+def test_the_obligation_facts_are_deliberately_NOT_compared_either(
+    axis: str,
+) -> None:
+    """pgw#1340 finished the sweep pgw#1176 started.
+
+    ``family`` and ``lane`` left for the identical reason ``envelope`` did —
+    a cell has no field for them — and leaving them behind cost th#2098:
+    ~$1.00 of L4 per burst, every burst, for two wheels. They still split the
+    obligation on the parent's side, where the arm token carries them.
+    """
+    seal = _seal_dict()
+    assert axis not in fleet_cells.ARM_ENVIRONMENT_FACTS
+    assert axis in fleet_cells.ARM_OBLIGATION_FACTS
+    meta = _envelope(seal, TOOLCHAIN)
+    meta["family"] = "other-family"
+    meta["lora_bucket"] = 0
+    assert fleet_cells.arm_axis_divergence(
+        _arm_key(seal, TOOLCHAIN), meta) == ""
+
+
 def test_adopt_refuses_typed_before_any_arm(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A diverging child cell must fail `key_axis_divergence` at the seam —
-    never reach the arm, whose C++ error was the pod's whole diagnostic."""
+    never reach the arm, whose C++ error was the pod's whole diagnostic.
+
+    pgw#1340 re-aimed this at ``sm``: the seal it used to diverge is no longer
+    a comparable axis (a cell cannot state it), so diverging it now proves
+    nothing. ``sm`` is a genuine cross-runtime divergence and the refusal is
+    unchanged — which is the point of re-aiming rather than deleting.
+    """
     seal = _seal_dict()
-    child_seal = dict(seal, inductor="ffff999988887777")
-    meta = _envelope(child_seal, TOOLCHAIN)
+    meta = dict(_envelope(seal, TOOLCHAIN), sm="sm_80")
 
     from gen_worker import artifact_meta
     from gen_worker.models import provision
@@ -180,7 +218,7 @@ def test_adopt_refuses_typed_before_any_arm(
     assert fleet_cells.adopt_delegated_mint(object(), pending, [artifact]) is None
     reason, detail = fleet_cells.adopt_refusal(pending)
     assert reason == "key_axis_divergence"
-    assert "env_seal: " in detail
+    assert "sm: " in detail
     assert meta["compiled_graph_key"] in detail
 
 

--- a/tests/test_identity_soundness_pgw1113.py
+++ b/tests/test_identity_soundness_pgw1113.py
@@ -189,21 +189,30 @@ def test_the_stamp_accumulates_and_is_order_free() -> None:
     assert _token(a) == _token(b)
 
 
-def test_the_arm_facts_split_into_environment_and_subject() -> None:
+def test_the_arm_facts_split_into_environment_and_obligation() -> None:
     """The two halves are different axioms, so they are different tuples.
 
     ``ARM_ENVIRONMENT_FACTS`` is what a delegated child RECORDS on the cell it
     hands back, and is therefore comparable across the process boundary.
-    ``ARM_SUBJECT_FACTS`` is not on the cell and must not be: the key is the
-    computation, so one cell legally serves every checkpoint whose graph it
-    is. Demanding the cell restate its minting checkpoint would refuse exactly
-    the reuse the membership axiom exists to allow.
+    ``ARM_OBLIGATION_FACTS`` is not on the cell and must not be. For the
+    subject half (pgw#1113) that is an axiom: the key is the computation, so
+    one cell legally serves every checkpoint whose graph it is, and demanding
+    the cell restate its minting checkpoint would refuse exactly the reuse the
+    membership axiom exists to allow. For ``family``/``lane``/``env_seal``
+    (pgw#1340) it is a fact about TCG's closed artifact vocabulary, which has
+    no field for any of them — and comparing them anyway is what made every
+    `sd15` self-mint refuse after a 25-minute compile.
     """
     assert set(fleet_cells.ARM_FACTS) == (
         set(fleet_cells.ARM_ENVIRONMENT_FACTS)
-        | set(fleet_cells.ARM_SUBJECT_FACTS))
+        | set(fleet_cells.ARM_OBLIGATION_FACTS))
     assert not (set(fleet_cells.ARM_ENVIRONMENT_FACTS)
-                & set(fleet_cells.ARM_SUBJECT_FACTS))
+                & set(fleet_cells.ARM_OBLIGATION_FACTS))
+    assert set(fleet_cells.ARM_SUBJECT_FACTS) <= set(
+        fleet_cells.ARM_OBLIGATION_FACTS)
+    # The environment half is exactly what a cell can state — the invariant
+    # pgw#1340's preflight refuses a mint on, asserted here on the constants.
+    assert fleet_cells.unstateable_arm_axes() == ()
     identity = fleet_cells.arm_identity("f", "", 0, _Cfg())
     assert set(identity.facts_dict()) == set(fleet_cells.ARM_FACTS)
     assert "graph" not in identity.facts_dict()

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -196,6 +196,12 @@ def test_the_eager_phase_values_are_a_wire_contract() -> None:
         "JIT_ARM_FAILED": "jit_arm_failed",
         "MANDATORY_LANE_NEEDS_A_COMPILED_GRAPH": "mandatory_lane_needs_a_compiled_graph",
         "COMPILED_GRAPH_QUARANTINED": "compiled_graph_quarantined",
+        # pgw#1340 / th#2098: the seam compares an axis no cell can state, so
+        # the mint is refused for $0 at obligation-open instead of after the
+        # compile. A NEW value, deliberately — grouping it with the
+        # mint-impossibility tokens would put a code defect in the same bucket
+        # as "this pod has no toolchain".
+        "ARM_AXES_UNSTATEABLE": "arm_axes_unstateable",
         "MINT_IN_PROGRESS": "mint_in_progress",
         # The hub's ExecutionSpec ordered eager — the arm obeyed.
         "HUB_ORDERED_EAGER": "hub_ordered_eager",


### PR DESCRIPTION
Closes the pgw half of **th#2098** (🟠 P1 COST).

## The defect, measured live

Standing `master` hub `a35434eb14`, 2026-08-17. One 40-request burst against `tensorhub/sd15` bought 8 L4 pods, served the burst in **23 s**, then every pod opened a self-mint and held itself alive for it. Sampled 34 minutes later, five were still in `inductor_compile`. Every one of them ended the same way:

```
aot_entry_arm_failed  key_axis_divergence
  family: child cell states '', this runtime computed 'sd15'
```

Counted straight off `worker_activity_events` on the standing hub:

| family | wheel | axis | child value | occurrences |
|---|---|---|---|---|
| sd15 | 0.118.0 | `family` | `''` | 224 |
| ernie | 0.117.0 + 0.118.0 | `family` | `''` | 28 |
| z-image | 0.114.0 | `format` | `'3'` | 8 (pgw#1230, already fixed) |

**Zero publishes across the whole window.** ~$1.00 of L4 per burst for zero artifacts, against **57.7 GPU-seconds** of the inference the compile was meant to accelerate — roughly 20x. And `sd15` serves `lane=bf16-w16a16+eager` permanently meanwhile, because the mint can never seal, so the platform pays full compile cost per pod AND gets eager serving.

## Root cause — it is not sd15's, not the card's, not the release's

pgw#1270 moved the artifact envelope to TCG. `torchcg.artifact.validate_metadata` refuses any metadata whose field set is not **exactly** its closed vocabulary:

```
compiled_graph_format  kind  compiled_graph_key  graph_class
sm  toolchain  host_isa  package_constants_in_so  constant_folding_fenced
```

`fleet_cells.ARM_ENVIRONMENT_FACTS` kept demanding six axes, three of which are not in that set and structurally cannot be: **`family`**, **`lane`** (`weight_lane` + `lora_bucket`) and **`env_seal`**. So `arm_axis_divergence` read `None` off every artifact TCG has ever minted and compared it against a live runtime fact. **The comparison could not succeed for any cell, on any card, in any family** — 100% of self-mints, deterministically, since 0.117.0. `family` is merely the axis that reports, because it sorted first.

This is **the unfinished half of pgw#1277**, which found the identical class one block over (the worker read an `entry` block TCG never writes) and recorded why nothing caught it, verbatim: *"CI stayed green because every fixture built the obsolete shape."* `test_handback_key_axes_pgw1042.py::_envelope` is that fixture — it hand-writes `family`, `weight_lane`, `lora_bucket` and `env_seal` into a dict no packed cell can contain.

## RED, at $0

The divergence is a pure key-derivation fact, so it needs no GPU, no compile and no pod (standing no-local-mints rule respected throughout). Building the cell through TCG's own `build_metadata` reproduces the production string **character-for-character**:

```
>       assert fleet_cells.arm_axis_divergence(_runtime_arm_key(meta), meta) == ""
E       assert "family: chil...mputed 'sd15'" == ''
E         + family: child cell states '', this runtime computed 'sd15'
```

## The fix

1. **`family`/`lane`/`env_seal` become `ARM_OBLIGATION_FACTS`.** Not a weakened check — the same check on the side of the boundary that can perform it. They stay in the arm token, so they still split the pending, the delegated child and the local store's memo row: two families or two lanes never share a mint. What crosses the boundary is what TCG keys the artifact ON (`compiled_graph_format`, `sm`, `toolchain`), and those still refuse a foreign cell by name. This is pgw#1176's own ruling about `envelope`, applied to the axes that sweep missed.

2. **`unstateable_arm_axes()` — the $0 preflight** (th#2098's ask 2). A pure function of two compile-time constants: the axes compared, and `torchcg.ARTIFACT_METADATA_FIELDS` (newly exported — pgw#1299's "consumers import TCG's vocabulary" ruling, applied to the field SET). `enable_compiled` asks it on the **last line before anything is spent** and declines with a typed `EagerPhase.ARM_AXES_UNSTATEABLE` rather than opening a pending, spawning a child and buying 20–45 minutes of a paid card to rediscover the same refusal.

   **The hub-side scale-down hold needs no weakening for this** — a mint that never starts is never held, and the mint-hold semantics (th#1299/th#1326) stay exactly as strong for compiles that ARE useful.

3. **The fixture is the fence.** The new test builds its cell through `torchcg.artifact.build_metadata` (via `tests/tcg_artifacts.py`, which has existed since pgw#1283). The pgw#1042 rows for the three retired axes are kept as **inverted rulings**, not silent deletions (pgw#939) — putting an axis back goes red instead of going quiet.

## GREEN, and the positive control

- `tests/test_arm_axes_are_stateable_pgw1340.py` — 9 rows: a real TCG-minted cell arms on the runtime that minted it; the three retired axes are named as obligation facts; the preflight is empty on the real constants; **and the fence proves it can go red** — `unstateable_arm_axes(("sm","family","env_seal")) == ("family","env_seal")`.
- **Positive control, the thing that matters most here:** a genuinely divergent cell is still refused by name. `sm=sm_80` → `sm: …`; a different `toolchain` → `toolchain: …`; a wrong `compiled_graph_format` → `compiled_graph_format: …`. The seam did not become a rubber stamp.
- `pgw#1042 / #1059 / #1113 / #1230 / #1277 / #824` suites green. Two pgw#677 background-compile timeouts and the `torch`-absent rows fail **identically on `origin/master`** in the same venv (baselined in a detached worktree).
- mypy strict (824 files), ruff, and all twelve fast-gate lints clean.

## Wheel

**This does NOT ride the 0.122.0 cut in flight from `6f7ba6df`** — it lands after it and will be the next wheel. Stated plainly rather than squeezed in. Until a wheel carrying it reaches the fleet, every pod on 0.117.0–0.122.0 keeps paying the compile; th#2098's hub half (a `MintValueOracle` signal that refuses to FUND a hold for a release+wheel that has already proven `key_axis_divergence`) is what bounds that window, and lands separately in tensorhub.

## Known remainder, filed not hidden — pgw#1341

The publish path has the same defect one seam later: `_identity_axes` raises `CellPublishRefused("cell records no env_seal block")` for **every** real TCG artifact, and `intent_entry` reads `sku`/`gen_worker`/`manifest_digest` off metadata that cannot carry them. Fixing it properly needs mint provenance stored **durably beside the cell** — `resume_owed_publishes` publishes from the local CAS on a later boot, in a different process, potentially on a different pod, so recomputing from the live runtime is not sound. That is a design change, not a line, and it is filed with its own $0 red rather than bolted on here.

**Consequence to be honest about:** this PR makes a pod arm and serve its own compiled graph — the compile finally pays off for the pod that bought it. pgw#1341 is what lets the *fleet* adopt it instead of every pod re-minting.
