### PR TITLE
pgw#1342/tcg#39: the vendored torchcg is one rev again, and the store's address moves with it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -390,8 +390,11 @@ jobs:
       # fence and not a sweep. Text-based on purpose, unlike the AST fence
       # above: here the prose IS the defect, because a docstring naming a module
       # nobody can import sends the reader nowhere. `_vendor/` is exempt
-      # structurally — the vendored ref namespace still carries the old spelling
-      # on disk and must NEVER be respelled, or every stored graph is orphaned.
+      # structurally: a vendored file is fixed upstream and re-vendored, never
+      # respelled here, and the digest fence refuses a hand-patch. pgw#1342: the
+      # vendored ref namespace is `torchcg/v1` now — the re-key that renaming it
+      # would have caused was taken deliberately under tcg#39 and is frozen
+      # upstream, so this exemption no longer stands in for an old spelling.
       # The script's own spellings are listed in `RETIRED`; see its docstring.
       - name: pgw#1297 guard - no retired package name survives
         run: |

--- a/changelog.d/pgw1342.md
+++ b/changelog.d/pgw1342.md
@@ -20,6 +20,18 @@
   `scripts/lint_materialization_hatch.py` is now EMPTY, and the §9 `tcg-artifact-export`
   row has exactly one live caller, first-party in `aot_delivery.py`.
 
+- **The bump's real fleet cost is the CLOSURE DIGEST, not the ref prefix.** `tcg_version()`
+  returns `vendored_rev("torchcg")` and is a component of `closure_digest`, the compile
+  memo's key — so moving the rev misses every boot memo on the fleet and re-mints every
+  family, whatever the ref prefix does. `test_the_vendored_table_rename_did_not_move_the_compile_memo_key`
+  pinned the old rev to make that loud, and it was the ONLY test in 4,901 that this bump
+  turned red. It is rewritten rather than re-pinned: a literal saying "this rev, forever"
+  asserts something a ruling has decided is false, and a fence a ruling falsifies gets
+  edited into agreement instead of read. What it states now is pgw#1297's actual invariant,
+  structurally — the derivation folds a 40-hex REV, never the VENDORED.toml TABLE NAME, and
+  it agrees with the file that calls itself the single home of that fact. The money sentence
+  moved into the docstring, where the next lane to consider a bump will read it.
+
 - **The address is fenced on both sides now.** Upstream froze `_REF_PREFIX`, both emitted
   ref shapes, the quarantine marker's on-disk keys and the `artifact` field (torchcg #41),
   with the cost written at the assertion — a re-key plus a fleet-wide re-mint, not an edit.

--- a/changelog.d/pgw1342.md
+++ b/changelog.d/pgw1342.md
@@ -39,3 +39,14 @@
   prefix could not reach a pod through here. The lesson the rename taught is now
   enforceable rather than remembered: an old-name literal sweep must EXEMPT storage and
   wire identity strings.
+
+- **An UNDECLARED vendored rewrite is gone, not merely declared.** Re-vendoring byte-for-byte
+  deleted `ARTIFACT_METADATA_FIELDS`, which `fleet_cells` imports — because pgw#1340 had added
+  it to the vendored `artifact.py` and `__init__.py` **by hand** and listed it in no `rewrites`
+  row. The digest fence passed because the digests were regenerated after the patch: an
+  identity surface forked underneath the fence that exists to prevent exactly that. torchcg#42
+  (tcg#40) gave the closed metadata vocabulary its real home — public for the same reason
+  `REQUIRED_AXES` is — so this snapshot takes it from upstream like every other symbol and the
+  rewrite list is back to ONE row, a relative import. The vendored `tensorfs` was audited the
+  same way and is clean: every file byte-identical to its declared rev, `__init__.py` excepted,
+  which is declared.

--- a/changelog.d/pgw1342.md
+++ b/changelog.d/pgw1342.md
@@ -1,0 +1,29 @@
+- **The vendored `torchcg` snapshot is ONE REV again, and the compiled-graph store's
+  address moves with it.** Two lanes had grafted a newer file over an older storage half —
+  pgw#1328's `selection_rev` and pgw#1332's `recipe_rev` — each because the tip carried a
+  storage re-key its own lane was not entitled to take as a line item:
+  `_REF_PREFIX` moved from `torch-compiled-graphs/v1` to `torchcg/v1`, <!-- retired-name: the retired ref prefix IS this entry's subject; naming the address that moved is the point -->
+  `StoreResult.manifest` became `.artifact`, and underneath both, custody changed shape —
+  an exact-key ref used to point at a one-entry `RepositoryManifest` and now points
+  straight at the artifact blob. Paul ruled it (tcg#39): the compiled-graph store is a
+  CACHE, this is pre-launch, and an orphaned ref is a miss that re-mints on demand. So the
+  snapshot took the tip whole, both graft fields are deleted, and the fence that used to
+  assert each split now refuses ANY second rev instead — a graft records perfectly well
+  under a digest fence, so the digest fence can never be what notices one. `recipe_v1.json`
+  comes along with `recipe.py` this time, so the corpus the SDK generates against ships too.
+
+- **A stored compiled graph is a whole blob, not a manifest wrapping one file.** `resolve`
+  untars straight out of the store — acquiring an artifact copies nothing — and only
+  `export_artifact`, which hands a caller an independent file on the caller's own device,
+  writes the bytes twice. The visible consequence here is that the vendored snapshot
+  stopped reaching the single-file materialization hatch: `VENDORED_HATCH` in
+  `scripts/lint_materialization_hatch.py` is now EMPTY, and the §9 `tcg-artifact-export`
+  row has exactly one live caller, first-party in `aot_delivery.py`.
+
+- **The address is fenced on both sides now.** Upstream froze `_REF_PREFIX`, both emitted
+  ref shapes, the quarantine marker's on-disk keys and the `artifact` field (torchcg #41),
+  with the cost written at the assertion — a re-key plus a fleet-wide re-mint, not an edit.
+  This repo carries the consumer-side half, so a future rev bump that quietly moved the
+  prefix could not reach a pod through here. The lesson the rename taught is now
+  enforceable rather than remembered: an old-name literal sweep must EXEMPT storage and
+  wire identity strings.

--- a/changelog.d/pgw1342.md
+++ b/changelog.d/pgw1342.md
@@ -40,13 +40,17 @@
   enforceable rather than remembered: an old-name literal sweep must EXEMPT storage and
   wire identity strings.
 
-- **An UNDECLARED vendored rewrite is gone, not merely declared.** Re-vendoring byte-for-byte
-  deleted `ARTIFACT_METADATA_FIELDS`, which `fleet_cells` imports — because pgw#1340 had added
-  it to the vendored `artifact.py` and `__init__.py` **by hand** and listed it in no `rewrites`
-  row. The digest fence passed because the digests were regenerated after the patch: an
-  identity surface forked underneath the fence that exists to prevent exactly that. torchcg#42
-  (tcg#40) gave the closed metadata vocabulary its real home — public for the same reason
-  `REQUIRED_AXES` is — so this snapshot takes it from upstream like every other symbol and the
-  rewrite list is back to ONE row, a relative import. The vendored `tensorfs` was audited the
-  same way and is clean: every file byte-identical to its declared rev, `__init__.py` excepted,
-  which is declared.
+- **The undeclared vendored rewrite is gone, and its repair is completed rather than
+  contested.** Re-vendoring byte-for-byte deleted `ARTIFACT_METADATA_FIELDS`, which pgw#1340
+  had added to the vendored `artifact.py` and `__init__.py` **by hand** with no `rewrites` row
+  — the digest fence passed only because the digests were regenerated after the patch, and it
+  is what later turned master red (pgw#1345). pgw#1345 repaired it by reading the private
+  `_TOP_LEVEL_FIELDS` and named the real fix in its own docstring: *"when the public name is
+  wanted it is added UPSTREAM and re-vendored."* torchcg#42 (tcg#40) did that, so
+  `artifact_meta.cell_metadata_fields()` reads the public name and the `getattr` shim on a
+  private one is gone. That is not tidiness: a public name is fenced upstream against the
+  behaviour it claims — torchcg asserts the set against `validate_metadata`'s real refusals —
+  so a drift between vocabulary and validator goes red there, before it reaches a pod as a
+  $1.00-a-burst unstateable-axis bug. The vendored `tensorfs` was audited the same way and is
+  clean: every file byte-identical to its declared rev, `__init__.py` excepted, which is
+  declared.

--- a/scripts/lint_materialization_hatch.py
+++ b/scripts/lint_materialization_hatch.py
@@ -130,11 +130,16 @@ HATCH_DEFINITION = re.compile(r"^(?:async\s+)?def\s+(?:extract|materialize)\b")
 #: hatch call in an undeclared file is refused, and a declared file that no
 #: longer contains one is refused too -- so the table cannot go stale in
 #: either direction.
-VENDORED_HATCH = {
-    # `_export_archive` / `_stage_artifact` write a compiled-graph archive off
-    # the tensorfs store with the single-file arm.
-    "src/gen_worker/_vendor/torchcg/storage.py": "tcg-artifact-export",
-}
+#
+# EMPTY, and that is a result rather than an omission. pgw#1342 bumped the
+# vendored torchcg to a rev whose store keeps artifacts as whole blobs, so
+# `resolve` untars straight out of the store and only `export_artifact` — a
+# plain `copyfile` to a destination the store does not own — writes bytes
+# twice. The vendored snapshot no longer reaches the hatch at all, and the
+# check below refuses a declaration that outlives its last call. The one live
+# §9 `tcg-artifact-export` caller is first-party and carries an inline marker
+# (`aot_delivery.py`).
+VENDORED_HATCH: dict = {}
 
 #: A file reaches the hatch only if it can reach a tensor reader.
 _TENSORFS_IMPORT = re.compile(r"\b(?:from|import)\s+\S*tensorfs\b")

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -156,8 +156,21 @@ subdir = "src/torchcg"
 # untars straight out of the store. `scripts/lint_materialization_hatch.py` and
 # tensorfs's own no-whole-tree-materialization exemption now cover exactly one
 # caller here, `aot_delivery.py`.
+#
+# AN UNDECLARED REWRITE WAS FOUND WHILE DOING THIS, and it is declared below.
+# pgw#1340 added `ARTIFACT_METADATA_FIELDS` to the vendored `artifact.py` and
+# `__init__.py` BY HAND and listed it nowhere; the digest fence passed because
+# the digests were regenerated after the patch. That is a fork of an identity
+# surface hiding under the fence that exists to prevent one — this file's own
+# header says the snapshots are byte-identical to upstream except for the
+# rewrites listed here, and for that symbol it had quietly stopped being true.
+# It is declared now, and torchcg#42 (tcg#40) gives it its real home: the field
+# set is torchcg's own closed vocabulary, public for the same reason
+# `REQUIRED_AXES` is. When that lands, RE-VENDOR AT IT AND DELETE THE SECOND
+# ROW — it is a rewrite with an expiry, not a permanent one.
 rewrites = [
   "`from tensorfs import ...` -> `from ..tensorfs import ...` in cli.py, engine.py, storage.py (3 lines; upstream's own dependency, vendored beside it). Upstream itself dropped `hashrepo` for `tensorfs` at tcg#28, so this rewrite is now only the relative-import prefix.",
+  "`ARTIFACT_METADATA_FIELDS = _TOP_LEVEL_FIELDS` added to artifact.py and exported from `__init__.py` (pgw#1340, undeclared until pgw#1342). `fleet_cells` imports it: a consumer that re-declares the closed metadata vocabulary reads `None` for a field TCG does not write, and `None` compares unequal to a real runtime fact forever (th#2098). EXPIRES at torchcg#42 — re-vendor and delete this row.",
 ]
 
 [packages.tensorfs.files]
@@ -172,11 +185,11 @@ rewrites = [
 "tensors.py" = "b68adf8b95161defb89ed06bdea8a778b54e21a461768a43ae658955ccc6db9d"
 
 [packages.torchcg.files]
-"__init__.py" = "c35ba12adf0f260437ececce13ba30bf7ea921b279147a1970b373562f558378"
+"__init__.py" = "97baadd78d99056f2d4d1cc6bb36900db85f9d0e5daaa137f490809a72153255"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "f21e644e5345c7e2b7fd2b8f5b3ce4ac8216f263fc38768d45609469feb20870"
-"artifact.py" = "dd1ab586fb7c0edaf02ae5bff48028d5123063ad5f0ffff14f81ecdaa58e326c"
+"artifact.py" = "815a6048419b89687df3d96447eb303148bc98e02fe65ea117ad7941dc66e736"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "8450b10e90ca8c6d8c411654d963ebc16dd3580bfe1427cce3966fc2b03972a7"
 "contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -115,13 +115,14 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "94a7872870274dc59de9be2c272ce8bdd208a3ef"
+rev = "15b32a2ae59794b387feefec0e1ab990f657382c"
 subdir = "src/torchcg"
-# THE REV THAT FROZE THE ADDRESS (torchcg PR #41). Its `src/` tree is
-# byte-identical to `41e38a2` — the freeze added only tests and docs — so the
-# digests below are the same either way. It is recorded as the rev because
-# this snapshot is only safe at ONE rev while upstream fences the identity,
-# and that is the first commit where it does.
+# THE REV THAT FROZE THE ADDRESS AND GAVE THE METADATA VOCABULARY ITS HOME —
+# torchcg PR #41 (tcg#39) then PR #42 (tcg#40). The first is why one rev is safe
+# at all: upstream now fences `_REF_PREFIX`, both emitted ref shapes, the
+# quarantine marker's on-disk keys and the `artifact` field, so a later rev
+# cannot re-key this store without going red upstream first. The second deletes
+# a rewrite instead of adding one — see below.
 #
 # ONE REV. Both grafts over the older storage half are DELETED here —
 # pgw#1328's `selection_rev` and pgw#1332's `recipe_rev` — and pgw#1342/tcg#39
@@ -157,20 +158,20 @@ subdir = "src/torchcg"
 # tensorfs's own no-whole-tree-materialization exemption now cover exactly one
 # caller here, `aot_delivery.py`.
 #
-# AN UNDECLARED REWRITE WAS FOUND WHILE DOING THIS, and it is declared below.
-# pgw#1340 added `ARTIFACT_METADATA_FIELDS` to the vendored `artifact.py` and
-# `__init__.py` BY HAND and listed it nowhere; the digest fence passed because
-# the digests were regenerated after the patch. That is a fork of an identity
-# surface hiding under the fence that exists to prevent one — this file's own
-# header says the snapshots are byte-identical to upstream except for the
-# rewrites listed here, and for that symbol it had quietly stopped being true.
-# It is declared now, and torchcg#42 (tcg#40) gives it its real home: the field
-# set is torchcg's own closed vocabulary, public for the same reason
-# `REQUIRED_AXES` is. When that lands, RE-VENDOR AT IT AND DELETE THE SECOND
-# ROW — it is a rewrite with an expiry, not a permanent one.
+# AN UNDECLARED REWRITE WAS FOUND WHILE DOING THIS, AND IT IS GONE RATHER THAN
+# DECLARED. pgw#1340 had added `ARTIFACT_METADATA_FIELDS` to the vendored
+# `artifact.py` and `__init__.py` BY HAND and listed it nowhere; the digest fence
+# passed because the digests were regenerated after the patch, so an identity
+# surface was forked underneath the fence that exists to prevent exactly that.
+# torchcg#42 (tcg#40) gave it its real home — the closed metadata vocabulary is
+# torchcg's own, public for the same reason `REQUIRED_AXES` is — and this
+# snapshot takes it from upstream like every other symbol. `fleet_cells` imports
+# it because a consumer that re-declares the set reads `None` for a field TCG
+# does not write, and `None` compares unequal to a real runtime fact forever
+# (th#2098). The rewrite list is back to ONE row, and that row is a relative
+# import.
 rewrites = [
   "`from tensorfs import ...` -> `from ..tensorfs import ...` in cli.py, engine.py, storage.py (3 lines; upstream's own dependency, vendored beside it). Upstream itself dropped `hashrepo` for `tensorfs` at tcg#28, so this rewrite is now only the relative-import prefix.",
-  "`ARTIFACT_METADATA_FIELDS = _TOP_LEVEL_FIELDS` added to artifact.py and exported from `__init__.py` (pgw#1340, undeclared until pgw#1342). `fleet_cells` imports it: a consumer that re-declares the closed metadata vocabulary reads `None` for a field TCG does not write, and `None` compares unequal to a real runtime fact forever (th#2098). EXPIRES at torchcg#42 — re-vendor and delete this row.",
 ]
 
 [packages.tensorfs.files]
@@ -185,11 +186,11 @@ rewrites = [
 "tensors.py" = "b68adf8b95161defb89ed06bdea8a778b54e21a461768a43ae658955ccc6db9d"
 
 [packages.torchcg.files]
-"__init__.py" = "97baadd78d99056f2d4d1cc6bb36900db85f9d0e5daaa137f490809a72153255"
+"__init__.py" = "df715b9d245945db3edb6b65cc92c5dc195e89bbf5df1c53f47fe8471eb8e004"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
 "_wrapper_split.py" = "f21e644e5345c7e2b7fd2b8f5b3ce4ac8216f263fc38768d45609469feb20870"
-"artifact.py" = "815a6048419b89687df3d96447eb303148bc98e02fe65ea117ad7941dc66e736"
+"artifact.py" = "e9281e4bae4154f93694efa994133e001362c5db271855e03e921110b1fee019"
 "cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "8450b10e90ca8c6d8c411654d963ebc16dd3580bfe1427cce3966fc2b03972a7"
 "contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -115,13 +115,19 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "41e38a2ad1c3e21ceda775490f102c9359b16499"
+rev = "94a7872870274dc59de9be2c272ce8bdd208a3ef"
 subdir = "src/torchcg"
+# THE REV THAT FROZE THE ADDRESS (torchcg PR #41). Its `src/` tree is
+# byte-identical to `41e38a2` — the freeze added only tests and docs — so the
+# digests below are the same either way. It is recorded as the rev because
+# this snapshot is only safe at ONE rev while upstream fences the identity,
+# and that is the first commit where it does.
+#
 # ONE REV. Both grafts over the older storage half are DELETED here —
-# pgw#1328's `selection_rev` and pgw#1332's `recipe_rev` — and
-# pgw#1342/tcg#39 is why. Each was taken because the tip carried a storage
-# migration its own lane was not entitled to take; a third one would have
-# been the same trade a third time.
+# pgw#1328's `selection_rev` and pgw#1332's `recipe_rev` — and pgw#1342/tcg#39
+# is why. Each was taken because the tip carried a storage migration its own
+# lane was not entitled to take; a third one would have been the same trade a
+# third time.
 #
 # The split existed because the tip carried a storage RE-KEY that the serve-role
 # lane was not entitled to take as a line item: `_REF_PREFIX` moved from

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -74,9 +74,11 @@ subdir = "python/src/tensorfs"
 #     `.extract(` is refused outright by
 #     `scripts/lint_materialization_hatch.py`. It is tier 3 of the access
 #     ladder — permanent, not separately priced — and upstream's own
-#     no-whole-tree-materialization fence exempts it by name. Two live users
-#     (`aot_delivery.py`, vendored `torchcg/storage.py`), both declared to the
-#     lint against `docs/mixed-cas-layout.md` section 9.
+#     no-whole-tree-materialization fence exempts it by name. ONE live user
+#     since pgw#1342 — `aot_delivery.py`, declared to the lint against
+#     `docs/mixed-cas-layout.md` section 9 with an inline marker. The vendored
+#     `torchcg/storage.py` was the second until its blob cutover; it untars
+#     straight out of the store now and reaches no hatch.
 #   * `ingest_file` / `ingest_repository` — TENSORFS'S, not ours. Admission is
 #     the store's identity contract: the chunk grid, the whole-file digest,
 #     the concurrent-mutation refusal. Upstream did not abandon it the way it
@@ -113,62 +115,44 @@ rewrites = [
 
 [packages.torchcg]
 repo = "https://github.com/cozy-creator/torchcg"
-rev = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368"
-subdir = "src/torch_compiled_graphs"
-# The contents of the last published `torch-compiled-graphs` 0.6.0, i.e. what
-# `uv.lock` already resolved — vendoring changes the source, not the code.
-# Upstream `master` is likewise a genesis restart (package renamed `torchcg`).
-# pgw#1297/#1299: the LOCAL directory is `torchcg` — upstream's current name,
-# so #1295's deletion of `_vendor/` changes only the import PREFIX. `subdir` is
-# still the old path because that is where the code lived AT `ad5f4cb9`; the
-# snapshot is byte-identical to it and the file digests below are unchanged by
-# the directory rename (this package self-imports relatively, so no file
-# mentions its own package name).
+rev = "41e38a2ad1c3e21ceda775490f102c9359b16499"
+subdir = "src/torchcg"
+# ONE REV. Both grafts over the older storage half are DELETED here —
+# pgw#1328's `selection_rev` and pgw#1332's `recipe_rev` — and
+# pgw#1342/tcg#39 is why. Each was taken because the tip carried a storage
+# migration its own lane was not entitled to take; a third one would have
+# been the same trade a third time.
+#
+# The split existed because the tip carried a storage RE-KEY that the serve-role
+# lane was not entitled to take as a line item: `_REF_PREFIX` moved from
+# `torch-compiled-graphs/v1` to `torchcg/v1`, `StoreResult.manifest` became
+# `.artifact`, and underneath both, custody changed shape — an exact-key ref
+# used to point at a one-entry `RepositoryManifest` and now points straight at
+# the artifact blob (`put_file`/`verify_object` instead of
+# `ingest_file`/`store_manifest`). Every one of those changes the ADDRESS a
+# stored graph lives at, so bumping orphans whatever a store already holds.
+#
+# Paul ruled it on 2026-08-17 (tcg#39), verbatim: "you can delete all of the
+# existing compiled graphs from db / filesystem if you want; we're pre-launch.
+# We can also recompile everything again." So the re-key is ACCEPTED. The
+# orphaned refs are cache misses, a miss re-mints on demand, and minting is a
+# side effect of serving — the fleet repairs itself without anyone driving it.
+#
+# What makes this bump safe to leave at one rev going forward: upstream FROZE
+# the identity it just moved. torchcg PR #41 pins `_REF_PREFIX`, both emitted
+# ref shapes, the quarantine marker's on-disk keys and the `artifact` field on
+# `StoreResult`/`StoredCompiledGraph`, with the cost written at the assertion.
+# A future rev cannot re-key this store without going red upstream first, which
+# is the property the two-rev split was standing in for.
+#
+# The bump also RETIRES a `materialize` caller: the old vendored storage half
+# materialized a manifest entry to a temp file before untarring, and the new one
+# untars straight out of the store. `scripts/lint_materialization_hatch.py` and
+# tensorfs's own no-whole-tree-materialization exemption now cover exactly one
+# caller here, `aot_delivery.py`.
 rewrites = [
-  "`from hashrepo import ...` -> `from ..tensorfs import ...` in cli.py, engine.py, storage.py (3 lines; upstream's own dependency, vendored beside it)",
-  "`ingress_selection_v1.json` added to CONTRACT_FILES in contracts/__init__.py (1 line; the registration the selection corpus needs, taken from the same upstream rev as the corpus itself)",
+  "`from tensorfs import ...` -> `from ..tensorfs import ...` in cli.py, engine.py, storage.py (3 lines; upstream's own dependency, vendored beside it). Upstream itself dropped `hashrepo` for `tensorfs` at tcg#28, so this rewrite is now only the relative-import prefix.",
 ]
-# pgw#1328: THE SNAPSHOT IS SPLIT AT TWO REVS, like tensorfs's above and for the
-# same class of reason. `selection.py` and `contracts/ingress_selection_v1.json`
-# come from `selection_rev` (tcg#37's merge), NOT from `rev`. gen-worker's
-# `aot_serve` ADOPTS that contract as its ranking authority — tcg#37 recorded
-# the adoption as a pgw-side follow-on — and the two files are purely additive:
-# `selection.py` imports only `.ingress`, which is BYTE-IDENTICAL across the
-# two revs, so the graft cannot change any existing behaviour.
-#
-# Why not re-vendor the whole package at that rev: the tip carries an unrelated
-# storage migration — `_REF_PREFIX` moves from `torch-compiled-graphs/v1` to
-# `torchcg/v1` and `StoreResult.manifest` becomes `.artifact` — which would
-# ORPHAN every compiled-graph ref this fleet has already stored. That is a
-# migration with its own evidence bar, not a line item inside a serve-role
-# change, so the storage half stays where it is until somebody takes it
-# deliberately.
-selection_rev = "bbad172c8bb14dd703dba82d30679b08bc8a4696"
-selection_files = ["selection.py", "contracts/ingress_selection_v1.json"]
-# pgw#1332: A THIRD GRAFT, beside pgw#1328's `selection_rev` above and for the
-# same reason. `recipe.py` is tcg#38's `recipe_v1`
-# vocabulary — the class-level composition document pgw#1332's typed Family SDK
-# generates bindings against (G1-G16 in torchcg's `docs/RECIPE.md`). It did not
-# exist at `ad5f4cb9`.
-#
-# Why not simply bump `rev`: the newer lineage is a genesis restart whose
-# `storage.py`, `artifact.py`, `engine.py` and `identity.py` all moved, and this
-# repo's compiled-graph adoption path (aot_serve, aot_mint, local_cell_store,
-# boot_key) is live on the older ones. Re-vendoring the whole package is a
-# compiled-graph-adoption decision, not an authoring-SDK one, and putting it
-# inside an SDK change would hide a storage rewrite behind a codegen diff.
-#
-# Why the split is SAFE rather than merely convenient: `recipe.py` imports
-# exactly two sibling modules — `.identity` (`CompiledGraphKey`, `from_axes`,
-# `toolchain_axis_digest`) and `.ingress` (`CallIngress`, `CallInput`,
-# `IngressError`, `PathStep`). `ingress.py` is BYTE-IDENTICAL across the two
-# revs; `identity.py` differs only by ten lines of comment (verified by diff at
-# vendoring time). It imports no Torch and no `.contracts`, so nothing else in
-# the snapshot is reachable from it. `tests/test_vendored_snapshot_pgw1310.py`
-# proves the pairing EXECUTES against the vendored identity/ingress rather than
-# asserting it from the import list.
-recipe_rev = "41e38a2ad1c3e21ceda775490f102c9359b16499"
-recipe_files = ["recipe.py"]
 
 [packages.tensorfs.files]
 "__init__.py" = "51e60fc07782af7ff738c889be2fb1d9fa81224abfc0dfe546dde9d2191cf21b"
@@ -182,25 +166,26 @@ recipe_files = ["recipe.py"]
 "tensors.py" = "b68adf8b95161defb89ed06bdea8a778b54e21a461768a43ae658955ccc6db9d"
 
 [packages.torchcg.files]
-"__init__.py" = "401efd9450c0181f32c64ccee1d21999d78e77dc2be5ef404c27e539e350d4a9"
+"__init__.py" = "c35ba12adf0f260437ececce13ba30bf7ea921b279147a1970b373562f558378"
 "__main__.py" = "935a1c1166b0c1ea35a82256345000bf2c73ded718d77773bc27a71ecce28f7d"
 "_run_impl_split.py" = "c14db7289ae566ca2cfd636efce1b5b6e0d2f8f6069d993d5acc40bc0ef333b3"
-"_wrapper_split.py" = "9cd2cc594f4b2f3a782ecf2d2f9a8204b323c54247f9f7f348ad50c32a3046fd"
-"artifact.py" = "3eb4332d5865ad28b0b9a8fd2be9ea08e0911d0a7b8da55439c8151649f2815d"
-"cli.py" = "18ad75c67ad84eecf92f4470561070a5d07603674aaec59ce91c93a21efb1b4b"
+"_wrapper_split.py" = "f21e644e5345c7e2b7fd2b8f5b3ce4ac8216f263fc38768d45609469feb20870"
+"artifact.py" = "dd1ab586fb7c0edaf02ae5bff48028d5123063ad5f0ffff14f81ecdaa58e326c"
+"cli.py" = "94a4328c72fa7821f31447883de0a36196b6429ae5e93c239a12699f190f592f"
 "compiler.py" = "8450b10e90ca8c6d8c411654d963ebc16dd3580bfe1427cce3966fc2b03972a7"
 "contracts/KEY_GRAMMAR_DIGEST" = "0503f3251f2eb48b794961736f021915cd56c14930798ac844c90112fa2af69d"
-"contracts/__init__.py" = "3c5d61ca8f65a70af44cbe9acb0e834d9adf25bbea2cfdc924c9fa613f0931c5"
+"contracts/__init__.py" = "1a07e101e98c75111af3f40f6e1c011821abd07737934f0a9f389097f5c36d3f"
 "contracts/call_ingress_v1.json" = "3af3437ec20b15156892055ab89bf21621378cee9f0f72f63bc4626f69f242dc"
 "contracts/compiled_graph_key_vectors.json" = "a274c5702b8c167ca119758d9fb1f98c40ddfdb3dbf6c58b4aacd580803e8c2b"
 "contracts/graph_class_identity_v3.json" = "f3e947e5c770e0766f7dfe37b753bd8d184b1e8923f5a3995823a8427a637b30"
 "contracts/ingress_selection_v1.json" = "a0a8fc83c8c467f23b6ab81af1899547b43dabfd9c726e446cc9ef8b899c1714"
 "contracts/literal_identity_v1.json" = "50cb80e750a8124a45b982415258d8590c37f90ca804326588dfde1b368c6863"
+"contracts/recipe_v1.json" = "5806ac79b6d61ed15bdc1cf3c244f2d741b5269e714a774df41a7b95476e1cfe"
 "contracts/toolchain_identity_v1.json" = "f4114c38ae373f62ddcb2aae5498ffbee30630e80adf11fee99e68bcbdb24282"
 "declaration.py" = "187be0a12f05b8bbdca01f3c180527abff66ed60a3fb1e6281704d24d9559d79"
-"engine.py" = "3afc7c2a3b94b8852a48e660b62bceebe40156e34f66769f4c590c42f9585e87"
-"host_isa.py" = "8fbdd6250b284408e959c5c07b3ae86289c3d3e50ae46efc46b74ced24c8d725"
-"identity.py" = "6e6bb23b319bd1606bd313d7177877ba79fb16936536cf074d96049bc5a9482f"
+"engine.py" = "f9953f6039460214511ea5dad40ce62b3bd51b3d6400f31e9e9339cc5b1c2d64"
+"host_isa.py" = "679aa81547be2d60ae6593b6e8f75dd29dcd56ab85d8e858e219b5af5d0eadc4"
+"identity.py" = "ea309c7e24c7cbb0609c720742e16991ab263d772b1876bccda9b1e9fd725262"
 "ingress.py" = "3a679c046236e13965b76b391fb201272aaba297fcc49e64c6c46d41df0575a4"
 "introspection.py" = "99310298249ee2ada91544bcdbd91f06e33a44f136c525cb268ca8d7125aa9e5"
 "py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -208,4 +193,4 @@ recipe_files = ["recipe.py"]
 "runner.py" = "075d7e743a82555e7ac1b15eb7ca54df9d0bcdc914de649a675fa5d973c8c693"
 "selection.py" = "ddc1b64f36a2e9d119b2d55ac6962d0e589825a1046c1b6e7b34d90d8f2bfadb"
 "spans.py" = "7a9722b5068c36ce62350e4ffe0eea07aa4ee5506330c9816069054001a10472"
-"storage.py" = "52e785b53f7de6e2fb71d9ac104249e89974d8f1dc3f6081412058aee7b5908f"
+"storage.py" = "ccc9d6f8ac1a242b493028eaeed6a1fcd3a02a885c99ba2223bc71df7b69efe4"

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -1,6 +1,6 @@
 """Mint and reuse verified PyTorch AOTInductor graphs through tensorfs."""
 
-from .artifact import COMPILED_GRAPH_FORMAT, ArtifactError
+from .artifact import ARTIFACT_METADATA_FIELDS, COMPILED_GRAPH_FORMAT, ArtifactError
 from .compiler import CompileError
 from .declaration import (
     DeclarationError,
@@ -56,6 +56,7 @@ from .storage import (
 
 __all__ = [
     "ARTIFACT_KIND",
+    "ARTIFACT_METADATA_FIELDS",
     "AdmissionError",
     "ArtifactError",
     "CompileError",

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -1,4 +1,4 @@
-"""Mint and reuse verified PyTorch AOTInductor graphs through HashRepo."""
+"""Mint and reuse verified PyTorch AOTInductor graphs through tensorfs."""
 
 from .artifact import COMPILED_GRAPH_FORMAT, ArtifactError
 from .compiler import CompileError
@@ -30,6 +30,22 @@ from .ingress import (
     exported_input_name,
 )
 from .runner import CompiledGraphRunner, ConstantBindingError
+from .selection import (
+    ClassReport,
+    FeedNormalization,
+    GraphClassCandidate,
+    IngressMiss,
+    MissReason,
+    NormalizationKind,
+    PresentedCall,
+    PresentedValue,
+    RealignReason,
+    Selection,
+    SelectionError,
+    SelectionOutcome,
+    describe_call,
+    select,
+)
 from .storage import (
     QuarantinedArtifact,
     StorageError,
@@ -48,24 +64,38 @@ __all__ = [
     "CompiledGraphRunner",
     "CallIngress",
     "CallInput",
+    "ClassReport",
     "ConstantBindingError",
     "DeclarationError",
     "Engine",
     "EnsureOutcome",
     "EnsureResult",
+    "FeedNormalization",
     "GRAPH_CLASS_BLOCK",
+    "GraphClassCandidate",
     "GraphClassDeclaration",
     "GraphClassSpec",
     "IdentityError",
     "REQUIRED_AXES",
     "IngressError",
+    "IngressMiss",
+    "MissReason",
+    "NormalizationKind",
+    "PresentedCall",
+    "PresentedValue",
     "QuarantinedArtifact",
+    "RealignReason",
     "RuntimeCompatibility",
+    "Selection",
+    "SelectionError",
+    "SelectionOutcome",
     "StorageError",
     "StoreOutcome",
     "StoreResult",
     "StoredCompiledGraph",
     "build_call_ingress",
+    "describe_call",
     "exported_input_name",
     "is_compiled_graph_key",
+    "select",
 ]

--- a/src/gen_worker/_vendor/torchcg/_wrapper_split.py
+++ b/src/gen_worker/_vendor/torchcg/_wrapper_split.py
@@ -65,7 +65,7 @@ _TEMPLATE_LINE = "template <typename ConstantsInfoT_>"
 
 #: Banner emitted once, immediately above the first helper.
 _BANNER = (
-    "// torch-compiled-graphs: constants_info_ moved out of the constructor.",
+    "// torchcg: constants_info_ moved out of the constructor.",
     "// Same statements, same order; grouped so gcc's superlinear",
     "// per-function cost stops dominating this translation unit.",
 )

--- a/src/gen_worker/_vendor/torchcg/artifact.py
+++ b/src/gen_worker/_vendor/torchcg/artifact.py
@@ -72,6 +72,20 @@ _TOP_LEVEL_FIELDS = frozenset(
     )
 )
 
+#: The artifact-metadata vocabulary, PUBLIC. `validate_metadata` refuses any
+#: metadata whose field set is not exactly this, so it is not a convention a
+#: consumer may extend — it is the closed answer to "what can a compiled graph
+#: state about itself".
+#:
+#: Public for the same reason `REQUIRED_AXES` and `GRAPH_CLASS_BLOCK` are: a
+#: consumer that re-declares the set fences a COPY, and the copy drifts. The
+#: field set needs it more sharply than the axes do, because the failure is
+#: silent — a consumer that assumes a field this package does not write reads
+#: `None`, and `None` compares unequal to a real runtime fact forever. That is
+#: gen-worker's th#2098, where an arm seam compared three axes no artifact can
+#: carry and refused every self-mint AFTER paying for its compile.
+ARTIFACT_METADATA_FIELDS: frozenset[str] = _TOP_LEVEL_FIELDS
+
 _SAFETENSORS_DTYPES: dict[str, tuple[str, int]] = {
     "BOOL": ("bool", 1),
     "U8": ("uint8", 1),

--- a/src/gen_worker/_vendor/torchcg/artifact.py
+++ b/src/gen_worker/_vendor/torchcg/artifact.py
@@ -12,7 +12,7 @@ import tempfile
 import zlib
 from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import IO, Any, BinaryIO, cast
 
 from .declaration import DeclarationError, GraphClassDeclaration, _update_literal_digest
 from .host_isa import HostISAError, _validate_host_facts
@@ -36,6 +36,7 @@ PACKAGE_NAME = "model.pt2"
 LITERALS_NAME = "constants.safetensors"
 _REQUIRED_MEMBERS = frozenset((METADATA_NAME, PACKAGE_NAME))
 _MEMBERS = _REQUIRED_MEMBERS | {LITERALS_NAME}
+_COPY_BUFFER = 1 << 20
 _MAX_METADATA_BYTES = 8 << 20
 _MAX_SAFETENSORS_HEADER_BYTES = 8 << 20
 # A code-only AOTI package must not carry model weights. Sixteen GiB is four
@@ -181,7 +182,7 @@ def _bounded_chunks(source: BinaryIO, offset: int, size: int) -> Iterator[bytes]
     source.seek(offset)
     remaining = size
     while remaining:
-        chunk = source.read(min(1 << 20, remaining))
+        chunk = source.read(min(_COPY_BUFFER, remaining))
         if not chunk:
             raise ArtifactError("safetensors tensor data is truncated")
         remaining -= len(chunk)
@@ -633,7 +634,7 @@ def _validate_single_gzip_member(artifact: Path) -> None:
             while compressed := source.read(1 << 16):
                 pending = compressed
                 while pending:
-                    output = decoder.decompress(pending, 1 << 20)
+                    output = decoder.decompress(pending, _COPY_BUFFER)
                     uncompressed += len(output)
                     if uncompressed > _MAX_TAR_BYTES:
                         raise ArtifactError(
@@ -692,7 +693,7 @@ def _members(artifact: Path) -> tuple[tarfile.TarFile, dict[str, tarfile.TarInfo
         if not 0 <= remaining_padding <= tarfile.RECORDSIZE:
             raise ArtifactError("artifact has a non-canonical USTAR end marker")
         while remaining_padding:
-            trailer = archive.fileobj.read(min(1 << 20, remaining_padding))
+            trailer = archive.fileobj.read(min(_COPY_BUFFER, remaining_padding))
             if not trailer:
                 raise ArtifactError("artifact has truncated USTAR padding")
             if trailer.strip(b"\0"):
@@ -768,30 +769,42 @@ def _verify_materialized(directory: Path) -> dict[str, Any]:
     return checked
 
 
+def _read_member(source: IO[bytes], info: tarfile.TarInfo, remaining: int) -> bytes:
+    """Read one chunk of an archive member, naming a read failure as bad bytes."""
+
+    try:
+        return source.read(min(_COPY_BUFFER, remaining))
+    except (EOFError, OSError, tarfile.TarError) as exc:
+        raise ArtifactError(f"cannot read artifact member {info.name!r}: {exc}") from exc
+
+
 def _copy_member(
     archive: tarfile.TarFile,
     info: tarfile.TarInfo,
     destination: Path,
 ) -> None:
+    """Write one archive member out, keeping read and write failures distinct.
+
+    A failure reading the archive means the stored bytes are bad and raises
+    ``ArtifactError``, which callers treat as grounds to quarantine. A failure
+    writing the destination -- ENOSPC above all -- is the caller's disk and stays
+    an ``OSError``, because it is no evidence at all about the stored bytes.
+    """
+
     extracted = archive.extractfile(info)
     if extracted is None:
         raise ArtifactError(f"artifact member {info.name!r} is unreadable")
     remaining = info.size
-    try:
-        with extracted as source:
-            with destination.open("wb") as output:
-                while remaining:
-                    chunk = source.read(min(1 << 20, remaining))
-                    if not chunk:
-                        raise ArtifactError(f"artifact member {info.name!r} is truncated")
-                    output.write(chunk)
-                    remaining -= len(chunk)
-                output.flush()
-                os.fsync(output.fileno())
-    except ArtifactError:
-        raise
-    except (EOFError, OSError, tarfile.TarError) as exc:
-        raise ArtifactError(f"cannot read artifact member {info.name!r}: {exc}") from exc
+    with extracted as source:
+        with destination.open("wb") as output:
+            while remaining:
+                chunk = _read_member(source, info, remaining)
+                if not chunk:
+                    raise ArtifactError(f"artifact member {info.name!r} is truncated")
+                output.write(chunk)
+                remaining -= len(chunk)
+            output.flush()
+            os.fsync(output.fileno())
 
 
 def unpack_artifact(artifact: str | Path, destination: str | Path) -> dict[str, Any]:

--- a/src/gen_worker/_vendor/torchcg/cli.py
+++ b/src/gen_worker/_vendor/torchcg/cli.py
@@ -15,7 +15,7 @@ from .engine import Engine
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="torch-compiled-graphs")
+    parser = argparse.ArgumentParser(prog="torchcg")
     commands = parser.add_subparsers(dest="command", required=True)
 
     inspect = commands.add_parser("inspect", help="print an artifact's validated metadata")
@@ -24,7 +24,9 @@ def _parser() -> argparse.ArgumentParser:
     verify = commands.add_parser("verify", help="fully verify an artifact and its AOTI package")
     verify.add_argument("artifact", type=Path)
 
-    resolve = commands.add_parser("resolve", help="materialize one exact key from local HashRepo")
+    resolve = commands.add_parser(
+        "resolve", help="unpack one exact key from the local tensorfs store"
+    )
     resolve.add_argument("key")
     resolve.add_argument("destination", type=Path)
     resolve.add_argument("--cas-root", type=Path, required=True)
@@ -42,7 +44,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print(read_metadata(args.artifact))
         return 0
     if args.command == "verify":
-        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-cli-") as raw:
+        with tempfile.TemporaryDirectory(prefix="torchcg-cli-") as raw:
             _print(unpack_artifact(args.artifact, Path(raw) / "artifact"))
         return 0
     if args.command == "resolve":

--- a/src/gen_worker/_vendor/torchcg/contracts/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/contracts/__init__.py
@@ -10,6 +10,7 @@ CONTRACT_FILES: Final = (
     "graph_class_identity_v3.json",
     "ingress_selection_v1.json",
     "literal_identity_v1.json",
+    "recipe_v1.json",
     "toolchain_identity_v1.json",
 )
 

--- a/src/gen_worker/_vendor/torchcg/contracts/recipe_v1.json
+++ b/src/gen_worker/_vendor/torchcg/contracts/recipe_v1.json
@@ -1,0 +1,833 @@
+{
+  "authority": "torchcg recipe v1",
+  "axis": "CLASS-LEVEL only, and checkpoint-free by closed field sets: buckets, graph classes, signatures, loop and scheduler are family facts identical for every checkpoint that family serves. Weight sets, checkpoint refs, tuned values and per-request defaults are unrepresentable, so a generated family class is a TYPE whose callables are reached through a fully resolved instance (family x weight-set); two handler parameters of one family type are two independent instances. See docs/RECIPE.md G11-G16.",
+  "digest": "935d16b97cdc444ce6b837051b9ebfc4",
+  "digest_rule": "first 32 lowercase hex of SHA-256 over the recipe document as sorted, compact, ASCII, finite JSON -- the same rule CallIngress v1 uses",
+  "host_loop_digest": "ab0c40a70740ffad33708fd9fc1b49eb",
+  "host_loop_note": "The second document. LLMs and VLMs are first class and their iteration is data-dependent -- it runs until the model says stop -- so `loop.kind` is `host`: the recipe states the per-step graph classes in order and who owns the state threaded between them, and states outright that the iteration is the host's. A counted stage under a host loop is refused. The vocabulary never pretends to describe a loop it cannot express.",
+  "host_loop_recipe": {
+    "buckets": [],
+    "family": "toy_llm",
+    "loop": {
+      "kind": "host",
+      "session_state": "host",
+      "stages": [
+        {
+          "repeat": "once",
+          "runner": "prefill"
+        },
+        {
+          "repeat": "once",
+          "runner": "decode"
+        }
+      ]
+    },
+    "parameters": [],
+    "runners": [
+      {
+        "axes": [],
+        "name": "decode",
+        "variants": [
+          {
+            "bucket": {},
+            "class_hash": "7809c4d21be3f6a5",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 3,
+              "inputs": [
+                {
+                  "dtype": "int64",
+                  "exported_name": "input_ids",
+                  "name": "input_ids",
+                  "param": "input_ids",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    1
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "kv_cache_0",
+                  "name": "kv_cache.0",
+                  "param": "kv_cache",
+                  "param_position": 1,
+                  "path": [
+                    0
+                  ],
+                  "position": 1,
+                  "shape": [
+                    1,
+                    8,
+                    "context",
+                    64
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "kv_cache_1",
+                  "name": "kv_cache.1",
+                  "param": "kv_cache",
+                  "param_position": 1,
+                  "path": [
+                    1
+                  ],
+                  "position": 2,
+                  "shape": [
+                    1,
+                    8,
+                    "context",
+                    64
+                  ]
+                }
+              ],
+              "parameters": [
+                "input_ids",
+                "kv_cache"
+              ],
+              "symbols": {
+                "context": [
+                  1,
+                  4096
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "d336a6217cf5d6dbf768340d65b73418",
+            "layout": "bf16"
+          }
+        ]
+      },
+      {
+        "axes": [],
+        "name": "prefill",
+        "variants": [
+          {
+            "bucket": {},
+            "class_hash": "6f7a3b1c8d20e594",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 1,
+              "inputs": [
+                {
+                  "dtype": "int64",
+                  "exported_name": "input_ids",
+                  "name": "input_ids",
+                  "param": "input_ids",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    "prompt_tokens"
+                  ]
+                }
+              ],
+              "parameters": [
+                "input_ids"
+              ],
+              "symbols": {
+                "prompt_tokens": [
+                  1,
+                  4096
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "78e9000acf3c493edffceb2878605a20",
+            "layout": "bf16"
+          }
+        ]
+      }
+    ],
+    "v": 1
+  },
+  "identifier_grammar": "[a-z][a-z0-9_]*, 1..48 bytes",
+  "note": "recipe_v1 is a VOCABULARY, not a DSL: it names which graph classes compose one family, the loop between them, and the scheduler block that loop runs under. It pins class identity (class hash + CallIngress v1) and never a cg-key-v1 value, so one digest is valid on every SKU; the exact key is folded at adopt from the pod's own sm and toolchain axes. Selecting a bucket for a live call is ingress_selection_v1, not this contract. Each class row also NAMES the tensor-layout contract it was traced against (an fp8-rowwise trace and a bf16 trace are different graphs); per-checkpoint layout metadata is a separate hub document, and the hub JOINS the two for the ahead-of-time compatibility verdict. Typed bindings generate from the DECLARATION-time export, and this document asserts the mint did not drift from it.",
+  "recipe": {
+    "buckets": [
+      {
+        "name": "resolution",
+        "values": [
+          64,
+          128
+        ]
+      }
+    ],
+    "family": "toy_diffusion",
+    "loop": {
+      "kind": "staged",
+      "session_state": "none",
+      "stages": [
+        {
+          "repeat": "once",
+          "runner": "text_encoder"
+        },
+        {
+          "parameter": "steps",
+          "repeat": "counted",
+          "runner": "denoiser"
+        },
+        {
+          "repeat": "once",
+          "runner": "decoder"
+        }
+      ]
+    },
+    "parameters": [
+      {
+        "maximum": 100,
+        "minimum": 1,
+        "name": "steps"
+      }
+    ],
+    "runners": [
+      {
+        "axes": [
+          "resolution"
+        ],
+        "name": "decoder",
+        "variants": [
+          {
+            "bucket": {
+              "resolution": 64
+            },
+            "class_hash": "4d5c1e93b6720af8",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 1,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    64,
+                    64
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents"
+              ],
+              "symbols": {},
+              "v": 1
+            },
+            "ingress_digest": "d2700be6cfafda5f2d40994eb9f21cc4",
+            "layout": "bf16"
+          },
+          {
+            "bucket": {
+              "resolution": 128
+            },
+            "class_hash": "5e6f2a08c9143b7d",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 1,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    128,
+                    128
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents"
+              ],
+              "symbols": {},
+              "v": 1
+            },
+            "ingress_digest": "f2e9f616da2c4dddd97634c9957c70c3",
+            "layout": "bf16"
+          }
+        ]
+      },
+      {
+        "axes": [
+          "resolution"
+        ],
+        "name": "denoiser",
+        "variants": [
+          {
+            "bucket": {
+              "resolution": 64
+            },
+            "class_hash": "2f91b8c40ae7d135",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 4,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    64,
+                    64
+                  ]
+                },
+                {
+                  "dtype": "float32",
+                  "exported_name": "timestep",
+                  "name": "timestep",
+                  "param": "timestep",
+                  "param_position": 1,
+                  "path": [],
+                  "position": 1,
+                  "shape": [
+                    1
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_prompt",
+                  "name": "prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "prompt"
+                  ],
+                  "position": 2,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_negative_prompt",
+                  "name": "negative_prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "negative_prompt"
+                  ],
+                  "position": 3,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents",
+                "timestep",
+                "conditioning"
+              ],
+              "symbols": {
+                "tokens": [
+                  1,
+                  77
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "f68ee5d7671799b69ebecf9d9112bbd3",
+            "layout": "bf16"
+          },
+          {
+            "bucket": {
+              "resolution": 64
+            },
+            "class_hash": "8b1d5f36c07a294e",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 4,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    64,
+                    64
+                  ]
+                },
+                {
+                  "dtype": "float32",
+                  "exported_name": "timestep",
+                  "name": "timestep",
+                  "param": "timestep",
+                  "param_position": 1,
+                  "path": [],
+                  "position": 1,
+                  "shape": [
+                    1
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_prompt",
+                  "name": "prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "prompt"
+                  ],
+                  "position": 2,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_negative_prompt",
+                  "name": "negative_prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "negative_prompt"
+                  ],
+                  "position": 3,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents",
+                "timestep",
+                "conditioning"
+              ],
+              "symbols": {
+                "tokens": [
+                  1,
+                  77
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "f68ee5d7671799b69ebecf9d9112bbd3",
+            "layout": "fp8_rowwise"
+          },
+          {
+            "bucket": {
+              "resolution": 128
+            },
+            "class_hash": "3ab47de205c1986f",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 4,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    128,
+                    128
+                  ]
+                },
+                {
+                  "dtype": "float32",
+                  "exported_name": "timestep",
+                  "name": "timestep",
+                  "param": "timestep",
+                  "param_position": 1,
+                  "path": [],
+                  "position": 1,
+                  "shape": [
+                    1
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_prompt",
+                  "name": "prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "prompt"
+                  ],
+                  "position": 2,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_negative_prompt",
+                  "name": "negative_prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "negative_prompt"
+                  ],
+                  "position": 3,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents",
+                "timestep",
+                "conditioning"
+              ],
+              "symbols": {
+                "tokens": [
+                  1,
+                  77
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "3a719ed0979e308917ff4eee1cc081bd",
+            "layout": "bf16"
+          },
+          {
+            "bucket": {
+              "resolution": 128
+            },
+            "class_hash": "9c2e604718fb35a0",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 4,
+              "inputs": [
+                {
+                  "dtype": "float16",
+                  "exported_name": "latents",
+                  "name": "latents",
+                  "param": "latents",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    4,
+                    128,
+                    128
+                  ]
+                },
+                {
+                  "dtype": "float32",
+                  "exported_name": "timestep",
+                  "name": "timestep",
+                  "param": "timestep",
+                  "param_position": 1,
+                  "path": [],
+                  "position": 1,
+                  "shape": [
+                    1
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_prompt",
+                  "name": "prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "prompt"
+                  ],
+                  "position": 2,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                },
+                {
+                  "dtype": "float16",
+                  "exported_name": "conditioning_negative_prompt",
+                  "name": "negative_prompt",
+                  "param": "conditioning",
+                  "param_position": 2,
+                  "path": [
+                    "negative_prompt"
+                  ],
+                  "position": 3,
+                  "shape": [
+                    1,
+                    "tokens",
+                    768
+                  ]
+                }
+              ],
+              "parameters": [
+                "latents",
+                "timestep",
+                "conditioning"
+              ],
+              "symbols": {
+                "tokens": [
+                  1,
+                  77
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "3a719ed0979e308917ff4eee1cc081bd",
+            "layout": "fp8_rowwise"
+          }
+        ]
+      },
+      {
+        "axes": [],
+        "name": "text_encoder",
+        "variants": [
+          {
+            "bucket": {},
+            "class_hash": "1c0e7a4b39d5f682",
+            "ingress": {
+              "excluded_inputs": [],
+              "flat_arity": 1,
+              "inputs": [
+                {
+                  "dtype": "int64",
+                  "exported_name": "input_ids",
+                  "name": "input_ids",
+                  "param": "input_ids",
+                  "param_position": 0,
+                  "path": [],
+                  "position": 0,
+                  "shape": [
+                    1,
+                    "tokens"
+                  ]
+                }
+              ],
+              "parameters": [
+                "input_ids"
+              ],
+              "symbols": {
+                "tokens": [
+                  1,
+                  77
+                ]
+              },
+              "v": 1
+            },
+            "ingress_digest": "e144f3ba52634672875ce8e0205d76ce",
+            "layout": "bf16"
+          }
+        ]
+      }
+    ],
+    "scheduler": {
+      "name": "euler_discrete",
+      "parameters": {
+        "num_train_timesteps": 1000,
+        "shift": 3.0,
+        "use_karras_sigmas": false
+      }
+    },
+    "v": 1
+  },
+  "reference": {
+    "digest": "935d16b97cdc444ce6b837051b9ebfc4",
+    "family": "toy_diffusion",
+    "v": 1
+  },
+  "refusals": [
+    {
+      "note": "A bucket axis declares no values, a non-positive value, or values that are not sorted and unique.",
+      "reason": "bucket_axis_invalid"
+    },
+    {
+      "note": "A runner leaves some combination of its axes' declared values unbuilt. Coverage must be total, because a generated closed type (Literal, enum) selects from the axis values and every selection must resolve.",
+      "reason": "bucket_coverage_incomplete"
+    },
+    {
+      "note": "A variant does not pin exactly its runner's declared axes, pins a value the axis does not declare, duplicates a bucket, is out of bucket order, or is looked up with a bucket no variant declares.",
+      "reason": "bucket_invalid"
+    },
+    {
+      "note": "The mint-emitted recipe does not match the declaration typed bindings were generated from: a runner is missing, extra, or was minted against a different call. The declaration is the binding source; this document is the drift assertion.",
+      "reason": "declaration_drift"
+    },
+    {
+      "note": "A class hash (16 hex), ingress digest (32 hex), or recipe digest (32 hex) is not exactly that many lowercase hexadecimal characters.",
+      "reason": "digest_invalid"
+    },
+    {
+      "note": "A family, runner, bucket-axis, call-parameter, scheduler, or scheduler-parameter name is outside the identifier grammar, so a generator would have to mangle it.",
+      "reason": "identifier_invalid"
+    },
+    {
+      "note": "A name is reserved in Python or Rust. Refused at the recipe, not at codegen: there is no escaping rule to get wrong twice.",
+      "reason": "identifier_reserved"
+    },
+    {
+      "note": "`ingress_digest` does not restate the digest of the ingress beside it. The redundancy is deliberate: the generated signature and the artifact's admission expectation must be two readings of one identity.",
+      "reason": "ingress_digest_mismatch"
+    },
+    {
+      "note": "A variant's embedded CallIngress v1 value is not decodable, or one of its parameters mixes container kinds and therefore has no generatable type.",
+      "reason": "ingress_invalid"
+    },
+    {
+      "note": "A layout token is outside the identifier grammar, or a variant lookup left the layout unnamed on a runner that has classes for more than one. Choosing a layout is the hub's join of this document with per-checkpoint layout metadata (a SEPARATE document, different lifecycle); this contract refuses rather than guess.",
+      "reason": "layout_invalid"
+    },
+    {
+      "note": "The loop declares an unknown kind or session state, is empty, carries a stage whose repeat is not `once` or `counted`, has a counted stage naming no parameter or a once stage carrying one -- or states a repeat count under a host-owned loop, whose iteration is data-dependent and therefore not the recipe's to state.",
+      "reason": "loop_invalid"
+    },
+    {
+      "note": "A loop parameter's bounds are not integers satisfying 1 <= minimum <= maximum, or parameters are unsorted or duplicated.",
+      "reason": "parameter_invalid"
+    },
+    {
+      "note": "A counted stage reads a parameter the recipe does not declare.",
+      "reason": "parameter_unknown"
+    },
+    {
+      "note": "A declared parameter is read by no counted stage.",
+      "reason": "parameter_unused"
+    },
+    {
+      "note": "A document, runner, variant, loop step, parameter, scheduler, or reference object carries a field this version does not define, or omits one it does.",
+      "reason": "recipe_fields_invalid"
+    },
+    {
+      "note": "`v` is not 1. A reader has exactly one version and says so loudly; it never reads a newer document on a best-effort basis.",
+      "reason": "recipe_version_unsupported"
+    },
+    {
+      "note": "A digest-pinned reference does not name this exact document. This is the build-time break that a re-mint is supposed to cause.",
+      "reason": "reference_mismatch"
+    },
+    {
+      "note": "Runners are unsorted or duplicated, a runner declares no variant, or its axes are unsorted or duplicated.",
+      "reason": "runner_invalid"
+    },
+    {
+      "note": "A loop stage names a runner the recipe does not declare, or a caller resolves a runner handle that does not exist.",
+      "reason": "runner_unknown"
+    },
+    {
+      "note": "A declared runner is run by no loop stage. The loop is the composition; a class no stage runs belongs to a different family.",
+      "reason": "runner_unused"
+    },
+    {
+      "note": "The scheduler block is not an object of finite JSON scalars sorted by unique name. torchcg validates its shape and never interprets its meaning.",
+      "reason": "scheduler_invalid"
+    },
+    {
+      "note": "Two variants of one runner disagree about parameters, flat arity, excluded inputs, leaf identity, dtype, or rank. Variants may differ only in concrete dimensions and symbol bounds, because one runner generates one binding.",
+      "reason": "signature_disagreement"
+    }
+  ],
+  "reserved_identifiers": [
+    "abstract",
+    "and",
+    "as",
+    "assert",
+    "async",
+    "await",
+    "become",
+    "box",
+    "break",
+    "case",
+    "class",
+    "const",
+    "continue",
+    "crate",
+    "def",
+    "del",
+    "do",
+    "dyn",
+    "elif",
+    "else",
+    "enum",
+    "except",
+    "extern",
+    "false",
+    "final",
+    "finally",
+    "fn",
+    "for",
+    "from",
+    "global",
+    "if",
+    "impl",
+    "import",
+    "in",
+    "is",
+    "lambda",
+    "let",
+    "loop",
+    "macro",
+    "macro_rules",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "none",
+    "nonlocal",
+    "not",
+    "or",
+    "override",
+    "pass",
+    "priv",
+    "pub",
+    "raise",
+    "ref",
+    "return",
+    "self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "try",
+    "type",
+    "typeof",
+    "union",
+    "unsafe",
+    "unsized",
+    "use",
+    "virtual",
+    "where",
+    "while",
+    "with",
+    "yield"
+  ]
+}

--- a/src/gen_worker/_vendor/torchcg/engine.py
+++ b/src/gen_worker/_vendor/torchcg/engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tempfile
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, cast
 
@@ -37,7 +37,7 @@ class AdmissionError(StorageError):
     """Materialized bytes do not exactly satisfy their requested graph plan."""
 
 
-class EnsureOutcome(str, Enum):
+class EnsureOutcome(StrEnum):
     REUSED = "reused"
     MINTED = "minted"
 
@@ -143,7 +143,7 @@ def _admit_constant_table(plan: _GraphClassPlan, constants: tuple[DeclaredConsta
 
 
 class Engine:
-    """One local compiled-graph engine backed exclusively by HashRepo."""
+    """One local compiled-graph engine backed exclusively by one tensorfs store."""
 
     def __init__(self, cas: LocalCAS) -> None:
         self._store = _CompiledGraphStore(cas)
@@ -250,13 +250,13 @@ class Engine:
             )
 
     def import_artifact(self, key: str | CompiledGraphKey, artifact: str | Path) -> StoreResult:
-        """Fully verify and attach bytes fetched by HashRepo under one exact key."""
+        """Fully verify and attach bytes admitted to the store under one exact key."""
 
         self._admit_host_metadata(read_metadata(artifact))
         return self._store.store(key, artifact)
 
     def export_artifact(self, key: str | CompiledGraphKey, destination: str | Path) -> Path:
-        """Export a fully verified artifact without exposing HashRepo ref layout."""
+        """Export a fully verified artifact without exposing the store's ref layout."""
 
         return self._store.export_artifact(key, destination)
 
@@ -271,7 +271,7 @@ class Engine:
     def _mint(self, plan: _GraphClassPlan) -> StoreResult:
         """Compile, package, verify, and publish one plan into the local CAS."""
 
-        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-mint-") as raw:
+        with tempfile.TemporaryDirectory(prefix="torchcg-mint-") as raw:
             workspace = Path(raw)
             package = _compile_package(plan, workspace)
             constants = declared_constants(package, plan.declaration.graph_class)

--- a/src/gen_worker/_vendor/torchcg/host_isa.py
+++ b/src/gen_worker/_vendor/torchcg/host_isa.py
@@ -145,7 +145,7 @@ def _fresh_thread_value(function: Any) -> object:
     def read() -> None:
         value.append(function())
 
-    thread = threading.Thread(target=read, name="torch-compiled-graphs-isa-readback", daemon=True)
+    thread = threading.Thread(target=read, name="torchcg-isa-readback", daemon=True)
     thread.start()
     thread.join()
     if not value:

--- a/src/gen_worker/_vendor/torchcg/identity.py
+++ b/src/gen_worker/_vendor/torchcg/identity.py
@@ -15,6 +15,16 @@ _TOOLCHAIN_DIGEST_HEX = 16
 #: The v1 identity axes, in canonical order. Public because consumers otherwise
 #: re-declare it and fence the copy; a duplicate that drifts is how a correctly
 #: named module computes wrong keys with nothing raising.
+#:
+#: These three are the whole canonical fingerprint: the toolchain block's
+#: MEMBERS are the caller's to choose, not this package's. The measured
+#: rationale — a 2026-08-16 pod matrix, 10 conclusive rows, 3 hosts — lives in
+#: `benchmarks/host_fingerprint/README.md`. It found os_release/glibc/
+#: libstdc++/c++-compiler load-breaking in both directions, python_abi and
+#: triton inert on a CPU target, and torch_config_digest unstable across hosts
+#: for the same wheel. Every one of those is a caller-supplied member; the
+#: facts this package does own (`machine`, `host_isa_*`) went unmeasured and
+#: stay fail-closed.
 REQUIRED_AXES: tuple[str, ...] = ("graph", "sm", "toolchain")
 
 #: The artifact-metadata block carrying graph-class facts. Public for the same

--- a/src/gen_worker/_vendor/torchcg/storage.py
+++ b/src/gen_worker/_vendor/torchcg/storage.py
@@ -1,4 +1,15 @@
-"""Exact-key compiled-graph policy over HashRepo's generic local CAS."""
+"""Exact-key compiled-graph policy over one tensorfs content-addressed store.
+
+A compiled-graph artifact is a compressed tarball, so it enters the store as one
+whole unchunked blob named by the sha256 of its bytes. An exact-key ref points
+straight at that blob: there is no per-artifact manifest, because a manifest
+holding exactly one file entry is an indirection with nothing to describe.
+
+Lookup therefore returns the blob's own immutable path. Reading an artifact
+copies nothing -- ``resolve`` untars directly out of the store. Only
+``export_artifact``, whose entire purpose is to hand a caller an independent
+file on the caller's own device, writes the bytes a second time.
+"""
 
 from __future__ import annotations
 
@@ -11,16 +22,17 @@ import shutil
 import stat
 import tempfile
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
-from ..tensorfs import CASRef, DigestMismatch, FileEntry, LocalCAS, RefConflict, RepositoryManifest
+from ..tensorfs import CASRef, DigestMismatch, LocalCAS, RefConflict
 
 from .artifact import ArtifactError, _fsync_dir, unpack_artifact
 from .identity import CompiledGraphKey, is_compiled_graph_key
 
 _COMPILED_GRAPH_PATH = "compiled_graph.tar.gz"
-_REF_PREFIX = "torch-compiled-graphs/v1"
+_REF_PREFIX = "torchcg/v1"
+_READ_BUFFER = 1 << 20
 
 
 class StorageError(RuntimeError):
@@ -31,7 +43,7 @@ class QuarantinedArtifact(StorageError):
     """An exact-key record failed integrity or admission and cannot be reused."""
 
 
-class StoreOutcome(str, Enum):
+class StoreOutcome(StrEnum):
     STORED = "stored"
     PRESENT = "present"
     REPAIRED = "repaired"
@@ -42,17 +54,17 @@ class StoreOutcome(str, Enum):
 class StoreResult:
     outcome: StoreOutcome
     key: str
-    manifest: CASRef
+    artifact: CASRef
 
 
 @dataclass(frozen=True, slots=True)
 class StoredCompiledGraph:
-    """One verified compiled graph materialized for a caller."""
+    """One verified compiled graph unpacked for a caller."""
 
     key: str
     directory: Path
     metadata: dict[str, object]
-    manifest: CASRef
+    artifact: CASRef
 
     @property
     def package(self) -> Path:
@@ -75,8 +87,18 @@ def _graph_ref(key: str) -> str:
     return f"{_REF_PREFIX}/graphs/{key}"
 
 
-def _quarantine_ref(key: str, manifest: CASRef) -> str:
-    return f"{_REF_PREFIX}/quarantine/{key}/{manifest.digest}"
+def _quarantine_ref(key: str, artifact: CASRef) -> str:
+    return f"{_REF_PREFIX}/quarantine/{key}/{artifact.digest}"
+
+
+def _digest_file(path: Path) -> CASRef:
+    """Name a file by its bytes without writing them anywhere."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_READ_BUFFER):
+            digest.update(chunk)
+    return CASRef(digest.hexdigest())
 
 
 class _CompiledGraphStore:
@@ -85,19 +107,25 @@ class _CompiledGraphStore:
     def __init__(self, cas: LocalCAS) -> None:
         self.cas = cas
 
-    @staticmethod
-    def _file(manifest: RepositoryManifest) -> FileEntry:
-        if len(manifest.files) != 1 or manifest.files[0].path != _COMPILED_GRAPH_PATH:
-            raise StorageError("compiled-graph manifest must contain exactly its v1 artifact")
-        return manifest.files[0]
+    def _admit(self, artifact: Path) -> CASRef:
+        """Admit one whole-file blob, writing nothing when the store already holds it."""
 
-    def _is_quarantined(self, key: str, manifest: CASRef) -> bool:
-        return self.cas.read_ref(_quarantine_ref(key, manifest)) is not None
+        ref = _digest_file(artifact)
+        try:
+            if self.cas.contains(ref):
+                return ref
+        except DigestMismatch:
+            # The named blob is present but unusable; put_file replaces it atomically.
+            pass
+        return self.cas.put_file(artifact, expected=ref)
 
-    def _clear_quarantine(self, key: str, manifest: CASRef, expected: CASRef) -> bool:
+    def _is_quarantined(self, key: str, artifact: CASRef) -> bool:
+        return self.cas.read_ref(_quarantine_ref(key, artifact)) is not None
+
+    def _clear_quarantine(self, key: str, artifact: CASRef, expected: CASRef) -> bool:
         """Retire exactly one observed marker, never a newer quarantine."""
 
-        name = _quarantine_ref(key, manifest)
+        name = _quarantine_ref(key, artifact)
         try:
             self.cas.compare_and_swap_ref(name, None, expected=expected)
             return True
@@ -105,25 +133,25 @@ class _CompiledGraphStore:
             return self.cas.read_ref(name) is None
 
     def _retire_candidate_quarantine(
-        self, key: str, manifest: CASRef, observed: CASRef | None
+        self, key: str, artifact: CASRef, observed: CASRef | None
     ) -> None:
-        if observed is not None and self._clear_quarantine(key, manifest, observed):
+        if observed is not None and self._clear_quarantine(key, artifact, observed):
             return
-        if observed is None and not self._is_quarantined(key, manifest):
+        if observed is None and not self._is_quarantined(key, artifact):
             return
         raise QuarantinedArtifact(
             f"compiled graph {key} received a fresh quarantine during repair"
         )
 
-    def quarantine(self, key: str | CompiledGraphKey, manifest: CASRef) -> None:
+    def quarantine(self, key: str | CompiledGraphKey, artifact: CASRef) -> None:
         value = _key_value(key)
-        name = _quarantine_ref(value, manifest)
+        name = _quarantine_ref(value, artifact)
         marker = self.cas.put_bytes(
             json.dumps(
                 {
                     "format": 1,
                     "key": value,
-                    "manifest": str(manifest),
+                    "artifact": str(artifact),
                     "marker": secrets.token_hex(16),
                 },
                 sort_keys=True,
@@ -143,7 +171,7 @@ class _CompiledGraphStore:
 
         value = _key_value(key)
         source = Path(artifact)
-        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-import-") as raw:
+        with tempfile.TemporaryDirectory(prefix="torchcg-import-") as raw:
             owned = Path(raw) / _COMPILED_GRAPH_PATH
             shutil.copyfile(source, owned)
             with owned.open("rb") as handle:
@@ -154,8 +182,7 @@ class _CompiledGraphStore:
                     f"artifact states key {metadata.get('compiled_graph_key')!r}, "
                     f"expected {value!r}"
                 )
-            file = self.cas.ingest_file(owned, manifest_path=_COMPILED_GRAPH_PATH)
-        candidate = self.cas.store_manifest(RepositoryManifest((file,)))
+            candidate = self._admit(owned)
         candidate_quarantine = self.cas.read_ref(_quarantine_ref(value, candidate))
         ref_name = _graph_ref(value)
         current = self.cas.read_ref(ref_name)
@@ -205,7 +232,7 @@ class _CompiledGraphStore:
 
     @staticmethod
     def _verify_archive(artifact: Path, key: str) -> None:
-        with tempfile.TemporaryDirectory(prefix="torch-compiled-graphs-export-verify-") as raw:
+        with tempfile.TemporaryDirectory(prefix="torchcg-export-verify-") as raw:
             metadata = unpack_artifact(artifact, Path(raw) / "artifact")
         if metadata.get("compiled_graph_key") != key:
             raise ArtifactError(
@@ -213,8 +240,8 @@ class _CompiledGraphStore:
             )
 
     @staticmethod
-    def _require_exact_file(target: Path, expected: FileEntry) -> None:
-        """Accept an occupied destination only when it is the selected CAS file."""
+    def _require_exact_file(target: Path, expected: CASRef, size: int) -> None:
+        """Accept an occupied destination only when it is the selected CAS blob."""
 
         try:
             if target.is_symlink():
@@ -224,7 +251,7 @@ class _CompiledGraphStore:
                 before = os.fstat(source.fileno())
                 if not stat.S_ISREG(before.st_mode):
                     raise FileExistsError(f"destination {target} is not a regular file")
-                while chunk := source.read(1 << 20):
+                while chunk := source.read(_READ_BUFFER):
                     digest.update(chunk)
                 after = os.fstat(source.fileno())
         except FileNotFoundError:
@@ -237,11 +264,7 @@ class _CompiledGraphStore:
             and before.st_size == after.st_size
             and before.st_mtime_ns == after.st_mtime_ns
         )
-        if (
-            not stable
-            or after.st_size != expected.size_bytes
-            or digest.hexdigest() != expected.digest.digest
-        ):
+        if not stable or after.st_size != size or digest.hexdigest() != expected.digest:
             raise FileExistsError(
                 f"destination {target} is not the selected compiled-graph artifact"
             )
@@ -288,8 +311,8 @@ class _CompiledGraphStore:
                         ):
                             raise FileExistsError(message)
                         while True:
-                            target_chunk = os.read(target_member, 1 << 20)
-                            expected_chunk = os.read(expected_member, 1 << 20)
+                            target_chunk = os.read(target_member, _READ_BUFFER)
+                            expected_chunk = os.read(expected_member, _READ_BUFFER)
                             if target_chunk != expected_chunk:
                                 raise FileExistsError(message)
                             if not target_chunk:
@@ -331,24 +354,30 @@ class _CompiledGraphStore:
             if target_fd is not None:
                 os.close(target_fd)
 
-    def _require_selected(self, key: str, manifest: CASRef) -> None:
+    def _require_selected(self, key: str, artifact: CASRef) -> None:
         """Fail closed if publication or quarantine moved during resolution."""
 
-        if self.cas.read_ref(_graph_ref(key)) != manifest:
+        if self.cas.read_ref(_graph_ref(key)) != artifact:
             raise StorageError(f"compiled graph {key} changed during resolution")
-        if self._is_quarantined(key, manifest):
+        if self._is_quarantined(key, artifact):
             raise QuarantinedArtifact(
                 f"compiled graph {key} received a quarantine during resolution"
             )
 
     def export_artifact(self, key: str | CompiledGraphKey, destination: str | Path) -> Path:
-        """Export one exact CAS record as a fully verified artifact envelope."""
+        """Export one exact CAS blob as an independent, fully verified envelope.
+
+        This is the one path that still writes the artifact's bytes twice, and it
+        has to: the caller names a destination the store does not own, possibly on
+        another device. Hardlinking the store's own inode out would alias canonical
+        bytes into a tree that may outlive and rewrite them, so the export copies.
+        """
 
         value = _key_value(key)
-        manifest_ref = self.cas.read_ref(_graph_ref(value))
-        if manifest_ref is None:
+        artifact_ref = self.cas.read_ref(_graph_ref(value))
+        if artifact_ref is None:
             raise StorageError(f"compiled graph {value} is not present")
-        if self._is_quarantined(value, manifest_ref):
+        if self._is_quarantined(value, artifact_ref):
             raise QuarantinedArtifact(f"compiled graph {value} is quarantined")
 
         target = Path(destination)
@@ -358,25 +387,27 @@ class _CompiledGraphStore:
         temporary = Path(temporary_name)
         try:
             try:
-                manifest = self.cas.load_manifest(manifest_ref)
-                file = self._file(manifest)
-                self.cas.materialize(file, temporary)
+                blob = self.cas.verify_object(artifact_ref)
+                size = blob.stat().st_size
+            except (DigestMismatch, FileNotFoundError, ValueError) as exc:
+                self.quarantine(value, artifact_ref)
+                raise QuarantinedArtifact(
+                    f"compiled graph {value} failed export verification: {exc}"
+                ) from exc
+            # A destination write failing here is the caller's disk, not bad CAS
+            # bytes, so it propagates as OSError and quarantines nothing.
+            shutil.copyfile(blob, temporary)
+            try:
                 self._verify_archive(temporary, value)
-            except (
-                ArtifactError,
-                DigestMismatch,
-                FileNotFoundError,
-                StorageError,
-                ValueError,
-            ) as exc:
-                self.quarantine(value, manifest_ref)
+            except (ArtifactError, StorageError, ValueError) as exc:
+                self.quarantine(value, artifact_ref)
                 raise QuarantinedArtifact(
                     f"compiled graph {value} failed export verification: {exc}"
                 ) from exc
             try:
                 os.link(temporary, target)
             except FileExistsError:
-                self._require_exact_file(target, file)
+                self._require_exact_file(target, artifact_ref, size)
             _fsync_dir(target.parent)
             return target
         finally:
@@ -385,43 +416,41 @@ class _CompiledGraphStore:
     def resolve(
         self, key: str | CompiledGraphKey, destination: str | Path
     ) -> StoredCompiledGraph | None:
-        """Materialize and fully verify one exact key, or return a clean miss."""
+        """Unpack and fully verify one exact key, or return a clean miss.
+
+        The archive is untarred straight out of the store, so acquiring an artifact
+        copies nothing. The only bytes written are the unpacked directory the
+        caller asked for.
+        """
 
         value = _key_value(key)
-        manifest_ref = self.cas.read_ref(_graph_ref(value))
-        if manifest_ref is None:
+        artifact_ref = self.cas.read_ref(_graph_ref(value))
+        if artifact_ref is None:
             return None
-        if self._is_quarantined(value, manifest_ref):
+        if self._is_quarantined(value, artifact_ref):
             raise QuarantinedArtifact(f"compiled graph {value} is quarantined")
 
         target = Path(destination)
         target.parent.mkdir(parents=True, exist_ok=True)
-        descriptor, raw_archive = tempfile.mkstemp(
-            prefix="graph-", suffix=".tar.gz", dir=target.parent
-        )
-        os.close(descriptor)
-        archive = Path(raw_archive)
         candidate = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
         candidate.rmdir()
         try:
             try:
-                manifest = self.cas.load_manifest(manifest_ref)
-                file = self._file(manifest)
-                self.cas.materialize(file, archive)
+                blob = self.cas.verify_object(artifact_ref)
             except (DigestMismatch, FileNotFoundError, ValueError, StorageError) as exc:
-                self.quarantine(value, manifest_ref)
+                self.quarantine(value, artifact_ref)
                 raise QuarantinedArtifact(
                     f"compiled graph {value} failed CAS verification: {exc}"
                 ) from exc
             try:
-                metadata = unpack_artifact(archive, candidate)
+                metadata = unpack_artifact(blob, candidate)
             except ArtifactError as exc:
-                self.quarantine(value, manifest_ref)
+                self.quarantine(value, artifact_ref)
                 raise QuarantinedArtifact(
                     f"compiled graph {value} failed artifact verification: {exc}"
                 ) from exc
             if metadata.get("compiled_graph_key") != value:
-                self.quarantine(value, manifest_ref)
+                self.quarantine(value, artifact_ref)
                 raise QuarantinedArtifact(
                     f"stored artifact states key {metadata.get('compiled_graph_key')!r}, "
                     f"expected {value!r}"
@@ -432,18 +461,17 @@ class _CompiledGraphStore:
                 if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY) or not target.is_dir():
                     raise
                 self._require_exact_directory(target, candidate)
-                self._require_selected(value, manifest_ref)
-                return StoredCompiledGraph(value, target, metadata, manifest_ref)
+                self._require_selected(value, artifact_ref)
+                return StoredCompiledGraph(value, target, metadata, artifact_ref)
             _fsync_dir(target.parent)
-            self._require_selected(value, manifest_ref)
-            return StoredCompiledGraph(value, target, metadata, manifest_ref)
+            self._require_selected(value, artifact_ref)
+            return StoredCompiledGraph(value, target, metadata, artifact_ref)
         except QuarantinedArtifact:
             raise
         except (OSError, ArtifactError):
             raise
         except ValueError as exc:
-            self.quarantine(value, manifest_ref)
+            self.quarantine(value, artifact_ref)
             raise QuarantinedArtifact(f"compiled graph {value} failed verification: {exc}") from exc
         finally:
-            archive.unlink(missing_ok=True)
             shutil.rmtree(candidate, ignore_errors=True)

--- a/src/gen_worker/artifact_meta.py
+++ b/src/gen_worker/artifact_meta.py
@@ -133,33 +133,39 @@ def cell_metadata_fields() -> FrozenSet[str]:
     ever satisfy is refused for $0 instead of after a 25-minute paid compile
     (th#2098 / pgw#1340).
 
-    THE PRIVATE NAME IS THE POINT, and pgw#1345 is the receipt. The first
-    attempt exported ``ARTIFACT_METADATA_FIELDS`` from the vendored snapshot —
-    which pgw#1310's digest fence refuses by design (*"a vendored snapshot is
-    fixed upstream and re-vendored, never patched here"*), and refuses in the
-    de-required ``tests`` suite, so it merged and turned master red. A vendored
-    tree is READ, never edited; when the public name is wanted it is added
-    UPSTREAM and re-vendored.
+    THE PUBLIC NAME EXISTS NOW, and it is read here. pgw#1340 first exported
+    ``ARTIFACT_METADATA_FIELDS`` by editing the vendored snapshot, which
+    pgw#1310's digest fence refuses by design (*"a vendored snapshot is fixed
+    upstream and re-vendored, never patched here"*) and which turned master red;
+    pgw#1345 repaired that by reading the private ``_TOP_LEVEL_FIELDS`` and said
+    what the real fix was: *"when the public name is wanted it is added UPSTREAM
+    and re-vendored."* tcg#40 (torchcg#42, vendored here at pgw#1342) did exactly
+    that, so this reads the public name and the ``getattr`` shim is gone.
 
-    Reading ``_TOP_LEVEL_FIELDS`` is therefore the correct shape and the
-    precedent already exists — ``tests/tcg_artifacts.py`` reads
-    ``host_isa._host_requirement`` for the same reason, deliberately. It is
-    sited HERE, in the one first-party module that owns cell-metadata reads, so
-    the coupling has exactly one address to fix if upstream renames it.
+    That matters beyond tidiness. A private name is a name upstream owes nobody
+    anything about; a public one is fenced upstream against the behaviour it
+    claims — torchcg asserts ``ARTIFACT_METADATA_FIELDS`` against
+    ``validate_metadata``'s real refusals, so a drift between the set and the
+    validator goes red THERE, before it can reach a pod as a $1.00-a-burst
+    unstateable-axis bug.
+
+    Still sited HERE, in the one first-party module that owns cell-metadata
+    reads, so the coupling has exactly one address.
 
     Refuses loudly rather than answering an empty set: an empty vocabulary
     would make every axis look unstateable and silently disable every self-mint
     on the fleet.
     """
-    from gen_worker._vendor.torchcg import artifact as tcg_artifact
+    from gen_worker._vendor import torchcg as tcg
 
-    fields = getattr(tcg_artifact, "_TOP_LEVEL_FIELDS", None)
+    fields = getattr(tcg, "ARTIFACT_METADATA_FIELDS", None)
     if not fields:
         raise ArtifactMetadataError(
             "the vendored torchcg states no artifact-metadata vocabulary "
-            "(`_TOP_LEVEL_FIELDS`); nothing can decide which arm axes a cell "
-            "is able to state, and guessing would either refuse every mint or "
-            "admit a comparison that can never succeed")
+            "(`ARTIFACT_METADATA_FIELDS`, public since tcg#40); nothing can "
+            "decide which arm axes a cell is able to state, and guessing would "
+            "either refuse every mint or admit a comparison that can never "
+            "succeed")
     return frozenset(str(name) for name in fields)
 
 

--- a/tests/test_arm_axes_are_stateable_pgw1340.py
+++ b/tests/test_arm_axes_are_stateable_pgw1340.py
@@ -150,14 +150,18 @@ def test_a_REAL_divergence_is_still_refused_by_name(
 def test_the_vocabulary_IS_what_a_real_cell_carries() -> None:
     """pgw#1345 — the accessor is pinned to BEHAVIOUR, not to a restatement.
 
-    `artifact_meta.cell_metadata_fields()` reads a private name out of the
-    vendored torchcg (deliberately: a vendored snapshot is read, never patched
-    — pgw#1310's digest fence, which the first attempt at this violated and
-    turned master red). A private name can move under a re-vendor, so what is
-    asserted here is that the set it answers is EXACTLY the field set of a
-    metadata dict TCG itself built. If upstream renames or re-shapes it, this
-    goes red with the real cause instead of `unstateable_arm_axes()` quietly
-    answering "everything" and disabling every self-mint on the fleet.
+    `artifact_meta.cell_metadata_fields()` reads the vendored torchcg's
+    `ARTIFACT_METADATA_FIELDS`. That name is PUBLIC as of tcg#40, which is the
+    end pgw#1345 named for itself (*"when the public name is wanted it is added
+    UPSTREAM and re-vendored"*) after pgw#1340's hand-patch of the snapshot
+    turned master red on pgw#1310's digest fence.
+
+    A name can still move under a re-vendor, public or not, so what is asserted
+    here is unchanged and is the part that matters: the set it answers is
+    EXACTLY the field set of a metadata dict TCG itself built. If upstream
+    renames or re-shapes it, this goes red with the real cause instead of
+    `unstateable_arm_axes()` quietly answering "everything" and disabling every
+    self-mint on the fleet.
     """
     from gen_worker import artifact_meta
 

--- a/tests/test_retired_names_pgw1297.py
+++ b/tests/test_retired_names_pgw1297.py
@@ -23,22 +23,57 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 VENDORED = REPO / "src" / "gen_worker" / "_vendor" / "VENDORED.toml"
 
-#: The value `_tcg_version()` returned BEFORE the table key was renamed, read
-#: off `origin/master` at 12316afd. Hard-coded on purpose: reading it from
-#: VENDORED.toml would make this test agree with any rename of the thing it
-#: exists to hold still.
-TCG_REV_BEFORE_THE_RENAME = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368"
+#: The table key, which is the thing that must NEVER be what gets folded.
+TCG_TABLE_KEY = "torchcg"
+
+#: The rev this pin was written against, and the ONLY reason it is recorded:
+#: so the diff of a bump shows both endpoints. It is not asserted — see below.
+TCG_REV_BEFORE_THE_TCG39_BUMP = "ad5f4cb9f89bbe91d2a30ca218f70d5326630368"
 
 
-def test_the_vendored_table_rename_did_not_move_the_compile_memo_key() -> None:
-    # pgw#1327: the TCG component of `closure_digest` moved with the digest
-    # itself into `gen_worker.keyset`; the VALUE it returns must not have moved.
+def test_the_compile_memo_key_folds_the_REV_and_never_the_TABLE_NAME() -> None:
+    """pgw#1297's real invariant, stated so a legitimate bump cannot fake it.
+
+    This used to pin `tcg_version()` to a hard-coded rev, on the reasoning that
+    reading it from VENDORED.toml would make the test agree with any rename of
+    the thing it exists to hold still. That was right about renames and wrong
+    about bumps, and pgw#1342 is the bump: Paul's tcg#39 ruling moved the
+    vendored rev on purpose, so a literal that says "this rev, forever" now
+    asserts something the project has decided is false. A fence that a ruling
+    makes false gets deleted or edited into agreement, and neither teaches the
+    next reader anything.
+
+    So the property is stated structurally instead, and it is the property
+    pgw#1297 actually cared about: the derivation folds the REV — a 40-hex
+    commit — and never the table NAME. If it folded the name, a rename would
+    have re-minted the whole fleet while every rev stayed put; that is the
+    silent-money failure, and it is what this catches now.
+
+    WHAT MOVING THE REV COSTS, since this no longer stops you: `tcg_version()`
+    is a component of `closure_digest`, the compile memo's key. Bump the rev and
+    every boot memo on the fleet misses once and every family re-mints. That is
+    a fleet-wide GPU bill, not a lockfile edit — take a ruling first, the way
+    tcg#39 was taken, and say so in VENDORED.toml.
+    """
     from gen_worker.keyset import tcg_version
 
-    assert tcg_version() == TCG_REV_BEFORE_THE_RENAME, (
-        "the TCG component of `closure_digest` moved. The pgw#1297 rename was "
-        "supposed to change a lookup key and nothing else — a moved component "
-        "invalidates every boot memo on the fleet and re-mints every family."
+    recorded = tomllib.loads(VENDORED.read_text())["packages"][TCG_TABLE_KEY]["rev"]
+    folded = tcg_version()
+
+    assert folded != TCG_TABLE_KEY, (
+        "`closure_digest` is folding the VENDORED.toml TABLE KEY instead of the "
+        "rev. A rename of that key would then re-mint every family on the fleet "
+        "while nothing about the vendored code changed — pgw#1297."
+    )
+    assert len(folded) == 40 and set(folded) <= set("0123456789abcdef"), (
+        f"the TCG component of `closure_digest` is {folded!r}, which is not a "
+        f"commit. Whatever it is now, it is not the vendored rev."
+    )
+    assert folded == recorded, (
+        "the TCG component of `closure_digest` disagrees with VENDORED.toml, "
+        "which the file itself calls the single home of that fact. Two homes "
+        "for a key-derivation input is how the fleet re-mints for a reason "
+        "nobody can name."
     )
 
 

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -19,6 +19,7 @@ require either deleted project from an index (ie#738).
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import threading
 import tomllib
@@ -124,22 +125,43 @@ def test_the_storage_half_still_provides_what_the_ownership_ruling_keeps() -> No
     # pinned upstream snapshot, called by nothing here. The caller census is
     # `scripts/lint_materialization_hatch.py`, in the required `fast gates`.
     assert hasattr(LocalCAS, "materialize" + "_repository")
-def test_the_selection_contract_is_recorded_at_its_own_rev() -> None:
-    """pgw#1328: the torchcg snapshot is SPLIT at two revs, and it is declared.
+def test_the_torchcg_snapshot_is_one_rev() -> None:
+    """pgw#1342/tcg#39: the two-rev split is GONE, and nothing may re-grow it.
 
-    `selection.py` and its corpus come from tcg#37's merge; the storage half
-    deliberately does not, because the tip renames the compiled-graph ref
-    prefix and would orphan every stored artifact. A split that lives only in a
-    comment is a split nobody can audit, so the rev and the file list are
-    fields and the digest fence above covers them like any other vendored file.
+    pgw#1328 grafted `selection.py` over an older storage half because the tip
+    carried a storage re-key it was not entitled to take. Paul ruled the re-key
+    accepted (tcg#39) and this snapshot took it whole, so a second rev in this
+    table is now a fork of a storage identity with no ruling behind it. The
+    digest fence above cannot see that: a graft records perfectly well.
     """
 
     spec = MANIFEST["packages"]["torchcg"]
-    assert spec["selection_rev"] != spec["rev"]
-    assert set(spec["selection_files"]) == {
-        "selection.py", "contracts/ingress_selection_v1.json"}
-    for name in spec["selection_files"]:
-        assert name in spec["files"], f"{name} is not digest-fenced"
+    extra = sorted(k for k in spec if k.endswith("_rev") and k != "rev")
+    assert extra == [], (
+        f"the torchcg snapshot grew a second rev ({extra}). One rev, per "
+        f"tcg#39 — a graft forks the compiled-graph store's identity."
+    )
+    assert spec["rev"] == "41e38a2ad1c3e21ceda775490f102c9359b16499"
+    assert spec["subdir"] == "src/torchcg"
+
+
+def test_the_vendored_store_uses_the_frozen_ref_prefix() -> None:
+    """The re-key this bump paid for, asserted where the fleet can see it.
+
+    `torchcg/v1` is the address every compiled graph on every pod is filed
+    under. Moving it again is not a rename: it orphans every stored artifact at
+    once and costs another fleet-wide re-mint. Upstream froze it (torchcg
+    PR #41); this is the consumer-side half, so a rev bump that quietly moved
+    it could not reach a pod through this repo.
+    """
+
+    from gen_worker._vendor.torchcg import storage
+
+    key = "cg-key-v1-" + "0" * 56
+    assert storage._REF_PREFIX == "torchcg/v1"
+    assert storage._graph_ref(key) == f"torchcg/v1/graphs/{key}"
+    assert tuple(f.name for f in dataclasses.fields(storage.StoreResult)) == (
+        "outcome", "key", "artifact")
 
 
 def test_the_selection_contract_is_torch_free_and_registered() -> None:
@@ -148,9 +170,9 @@ def test_the_selection_contract_is_torch_free_and_registered() -> None:
     tcg#37's implementation reads four facts per feed (dtype, shape,
     contiguity, pointer alignment), so it needs no accelerator — which is why
     it can be a JSON corpus at all, and why an adopt-only pod can rank a call
-    before anything is loaded. It is also the reason the graft could not
-    disturb the rest of the snapshot: its only intra-package import is
-    `.ingress`, which is byte-identical across the two revs.
+    before anything is loaded. It arrived as a graft (pgw#1328) and is now part
+    of the ordinary one-rev snapshot (pgw#1342); the property that mattered
+    then still has to hold, because an adopt-only boot imports it eagerly.
     """
     import subprocess
     import sys
@@ -171,28 +193,16 @@ def test_the_selection_contract_is_torch_free_and_registered() -> None:
     assert proof.stdout.strip() == "ok"
 
 
-def test_the_recipe_vocabulary_is_recorded_at_its_own_rev() -> None:
-    """pgw#1332: torchcg is split at two revs too, and the split is declared.
-
-    `recipe.py` is tcg#38's `recipe_v1` and did not exist at `rev`. Bumping
-    `rev` instead would re-vendor a genesis-restart lineage whose `storage.py`,
-    `artifact.py`, `engine.py` and `identity.py` all moved, under a
-    compiled-graph adoption path that is live on the older ones — a storage
-    rewrite hidden inside an SDK change. A split that is only in a comment is a
-    split nobody can audit, so the rev is a field and the file list is a field,
-    and the digest fence above covers them like any other vendored file.
-    """
-
-    spec = MANIFEST["packages"]["torchcg"]
-    assert spec["recipe_rev"] != spec["rev"]
-    assert set(spec["recipe_files"]) == {"recipe.py"}
-    for name in spec["recipe_files"]:
-        assert name in spec["files"], f"{name} is not digest-fenced"
-
-
 def test_the_recipe_vocabulary_runs_against_the_VENDORED_identity_and_ingress() -> None:
-    """The reason the split is expressible at all: `recipe.py`'s only siblings
-    are `identity` and `ingress`, and both are compatible at the older rev.
+    """`recipe.py`'s only siblings are `identity` and `ingress`, and it folds
+    a real key through them.
+
+    pgw#1332 grafted this file at its own `recipe_rev` and this test guarded the
+    graft's compatibility claim. pgw#1342 took the whole package to one rev, so
+    the pairing is no longer a claim — but the EXECUTION still is, and it is the
+    half worth keeping: `recipe_v1` is the vocabulary the typed Family SDK
+    generates against, so a snapshot where the fold silently stopped producing a
+    key would be a codegen defect nothing else here notices.
 
     Proved by EXECUTING the pairing — fold a pinned class through
     `GraphClassVariant.key()` (which reaches `identity.from_axes` and

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -125,14 +125,17 @@ def test_the_storage_half_still_provides_what_the_ownership_ruling_keeps() -> No
     # pinned upstream snapshot, called by nothing here. The caller census is
     # `scripts/lint_materialization_hatch.py`, in the required `fast gates`.
     assert hasattr(LocalCAS, "materialize" + "_repository")
-def test_the_torchcg_snapshot_is_one_rev() -> None:
-    """pgw#1342/tcg#39: the two-rev split is GONE, and nothing may re-grow it.
 
-    pgw#1328 grafted `selection.py` over an older storage half because the tip
-    carried a storage re-key it was not entitled to take. Paul ruled the re-key
-    accepted (tcg#39) and this snapshot took it whole, so a second rev in this
-    table is now a fork of a storage identity with no ruling behind it. The
-    digest fence above cannot see that: a graft records perfectly well.
+
+def test_the_torchcg_snapshot_is_one_rev() -> None:
+    """pgw#1342/tcg#39: the graft fields are GONE, and nothing may re-grow one.
+
+    Two lanes grafted a newer file over an older storage half — pgw#1328's
+    `selection_rev`, pgw#1332's `recipe_rev` — each because the tip carried a
+    storage re-key its own lane was not entitled to take. Paul ruled the re-key
+    accepted (tcg#39) and this snapshot took the tip whole, so a second rev in
+    this table is now a fork of a storage identity with no ruling behind it.
+    The digest fence above cannot see that: a graft records perfectly well.
     """
 
     spec = MANIFEST["packages"]["torchcg"]
@@ -141,7 +144,10 @@ def test_the_torchcg_snapshot_is_one_rev() -> None:
         f"the torchcg snapshot grew a second rev ({extra}). One rev, per "
         f"tcg#39 — a graft forks the compiled-graph store's identity."
     )
-    assert spec["rev"] == "41e38a2ad1c3e21ceda775490f102c9359b16499"
+    # The rev itself is NOT restated here. VENDORED.toml says it is "the single
+    # home of the fact", and a copy of a rev in a test is a second home that
+    # drifts. What this asserts is the SHAPE the ruling fixed: one rev, and the
+    # post-rename layout it must have been taken from.
     assert spec["subdir"] == "src/torchcg"
 
 


### PR DESCRIPTION
Executes Paul's tcg#39 ruling (2026-08-17), verbatim: *"you can delete all of the existing compiled graphs from db / filesystem if you want; we're pre-launch. We can also recompile everything again."*

## What the grafts were, and why they end

Two lanes had grafted a newer file over an older storage half — pgw#1328's `selection_rev`, pgw#1332's `recipe_rev` — each because the tip carried a storage RE-KEY its own lane was not entitled to take as a line item:

| moved | from | to |
|---|---|---|
| `_REF_PREFIX` | `torch-compiled-graphs/v1` | `torchcg/v1` |
| `StoreResult` / `StoredCompiledGraph` field | `.manifest` | `.artifact` |
| custody shape | ref → one-entry `RepositoryManifest` → file | ref → the artifact blob |

The ruling accepts it: the store is a cache, an orphaned ref is a miss, a miss re-mints on demand, and minting is a side effect of serving (§4.28) — so the fleet repairs itself without anyone driving it. `rev = 94a7872` whole; both graft fields deleted.

`test_the_selection_contract_is_recorded_at_its_own_rev` and `test_the_recipe_vocabulary_is_recorded_at_its_own_rev` are replaced by **`test_the_torchcg_snapshot_is_one_rev`**, which refuses ANY `*_rev` key besides `rev`. That matters: a graft records perfectly well under a digest fence, so the digest fence can never be what notices one.

## The two things the re-vendor surfaced — neither was the ref prefix

**1. The real fleet cost is the CLOSURE DIGEST.** `tcg_version()` is `vendored_rev("torchcg")` and feeds `closure_digest`, the compile memo's key. Moving the rev misses every boot memo on the fleet and re-mints every family, whatever `_REF_PREFIX` does. `test_the_vendored_table_rename_did_not_move_the_compile_memo_key` pinned the old rev to make that loud, and it was **the only test in 4,901 that this bump turned red**.

It is rewritten rather than re-pinned. A literal saying *"this rev, forever"* asserts something a ruling has decided is false, and a fence a ruling falsifies gets edited into agreement instead of read. It now states pgw#1297's actual invariant structurally: the derivation folds a **40-hex REV**, never the VENDORED.toml **TABLE NAME**, and agrees with the file that calls itself the single home of that fact. The money sentence moved into the docstring, where the next lane considering a bump will read it.

**2. An UNDECLARED vendored rewrite.** Re-vendoring byte-for-byte deleted `ARTIFACT_METADATA_FIELDS`, which `fleet_cells` imports — because pgw#1340 added it to the vendored `artifact.py` and `__init__.py` **by hand** and listed it in no `rewrites` row. The digest fence passed because the digests were regenerated after the patch: an identity surface forked underneath the fence that exists to prevent exactly that.

It is declared now, **with its expiry**. [torchcg#42 (tcg#40)](https://github.com/cozy-creator/torchcg/pull/42) gives the closed metadata vocabulary its real home — public for the same reason `REQUIRED_AXES` is — and this row is deleted at the re-vendor that follows it.

I audited the vendored **tensorfs** the same way: no undeclared edit. Every file is byte-identical to its declared rev (`rev` for the storage half, `read_plane_rev` for the read plane), `__init__.py` excepted, which is declared.

## One call-site reduction

**`VENDORED_HATCH` is now EMPTY.** The new store untars straight out of the CAS, so the vendored half stopped reaching the single-file materialization hatch; the lint already refuses a declaration that outlives its last call. §9's `tcg-artifact-export` row has exactly one live caller, first-party in `aot_delivery.py` with an inline marker.

`StoreResult.manifest` had **no call site** in this repo — the only consumer reads `.outcome` — so that half of the rename cost nothing at the seam.

Rebased onto #896 (pgw#1303), whose `_lint_scope.is_unowned` already excludes `_vendor/` from the §1.33 point-5 layout fence; my earlier local fix for the same `recipe.layouts` collision was dropped in favour of it.

## Evidence

- Red proof: `_REF_PREFIX = "torchcg/v2"` in the vendored tree → `test_every_vendored_file_matches_its_recorded_digest` **and** `test_the_vendored_store_uses_the_frozen_ref_prefix` both red.
- Upstream red proofs (torchcg#41): prefix edit → 7 red; `StoreResult.artifact` → `.manifest` → 6 red.
- Full CI on the pre-rebase head: **4,900 passed, 1 failed** — the failure being exactly the rev pin above, now rewritten.
- All 37 fast-gate scripts green (both selftests each), `ruff` clean, `mypy` 846 files clean.