### PR TITLE
pgw#1345: master is red on the vendored-snapshot fence — pgw#1340 patched a vendored tree, which is exactly what that fence exists to refuse

### DIFF
--- a/changelog.d/pgw1345.md
+++ b/changelog.d/pgw1345.md
@@ -1,0 +1,15 @@
+- **Master went red on the vendored-snapshot digest fence, and this is the repair.** pgw#1340
+  exported `ARTIFACT_METADATA_FIELDS` by editing `_vendor/torchcg` in place. pgw#1310's fence
+  refuses exactly that — *"a vendored snapshot is fixed upstream and re-vendored, never patched
+  here"* — but it lives in the de-required `tests` suite, so `fast gates` was green, the PR merged,
+  and the post-merge `ci.yaml` run on master was the first thing to say so. The vendored files are
+  restored byte-for-byte and the fence is green again.
+- The vocabulary now has ONE first-party address: `artifact_meta.cell_metadata_fields()`, which
+  reads `torchcg.artifact._TOP_LEVEL_FIELDS` and refuses loudly if it is gone. A vendored tree is
+  READ, never edited; the precedent is `tests/tcg_artifacts.py`, which reads
+  `host_isa._host_requirement` for the same reason and says so. Pinned to BEHAVIOUR rather than
+  restated: the accessor must equal the field set of a metadata dict TCG itself built, so an
+  upstream rename goes red with its real cause instead of `unstateable_arm_axes()` quietly
+  answering "everything" and disabling every self-mint on the fleet.
+- Nothing about th#2098's fix changes: the arm seam still compares only the three axes a cell can
+  state, and the $0 preflight still refuses a doomed mint at obligation-open.

--- a/src/gen_worker/_vendor/torchcg/__init__.py
+++ b/src/gen_worker/_vendor/torchcg/__init__.py
@@ -1,10 +1,6 @@
 """Mint and reuse verified PyTorch AOTInductor graphs through HashRepo."""
 
-from .artifact import (
-    ARTIFACT_METADATA_FIELDS,
-    COMPILED_GRAPH_FORMAT,
-    ArtifactError,
-)
+from .artifact import COMPILED_GRAPH_FORMAT, ArtifactError
 from .compiler import CompileError
 from .declaration import (
     DeclarationError,
@@ -44,7 +40,6 @@ from .storage import (
 
 __all__ = [
     "ARTIFACT_KIND",
-    "ARTIFACT_METADATA_FIELDS",
     "AdmissionError",
     "ArtifactError",
     "CompileError",

--- a/src/gen_worker/_vendor/torchcg/artifact.py
+++ b/src/gen_worker/_vendor/torchcg/artifact.py
@@ -71,20 +71,6 @@ _TOP_LEVEL_FIELDS = frozenset(
     )
 )
 
-#: The artifact metadata vocabulary, EXPORTED (pgw#1340). `validate_metadata`
-#: refuses any metadata whose field set is not exactly this, so the set is not
-#: a convention a consumer may extend — it is the closed answer to "what can a
-#: cell state about itself".
-#:
-#: pgw#1299 already ruled that a consumer imports TCG's vocabulary rather than
-#: spelling it, for keys. The FIELD SET needs the same treatment for a sharper
-#: reason: a consumer that assumes a field TCG does not write reads `None`, and
-#: `None` compares unequal to a real runtime fact forever. That is th#2098 —
-#: `fleet_cells.arm_axis_divergence` compared `family`, `weight_lane` and
-#: `env_seal` against a cell that structurally cannot carry them, so every
-#: self-mint refused after its compile: ~$1.00 of L4 per burst, for nothing.
-ARTIFACT_METADATA_FIELDS: frozenset[str] = _TOP_LEVEL_FIELDS
-
 _SAFETENSORS_DTYPES: dict[str, tuple[str, int]] = {
     "BOOL": ("bool", 1),
     "U8": ("uint8", 1),

--- a/src/gen_worker/artifact_meta.py
+++ b/src/gen_worker/artifact_meta.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import json
 import tarfile
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, FrozenSet, Optional, Union
 
 #: The packed envelope's member name, at the tar root, for every artifact kind.
 METADATA_NAME = "metadata.json"
@@ -122,10 +122,52 @@ def try_read_metadata(artifact: Union[str, Path]) -> Optional[Dict[str, Any]]:
         return None
 
 
+def cell_metadata_fields() -> FrozenSet[str]:
+    """TCG's CLOSED artifact-metadata vocabulary — what a cell can state.
+
+    ``torchcg.artifact.validate_metadata`` refuses any metadata whose field set
+    is not exactly this, so it is not a convention a consumer may extend. That
+    makes it the answer to a question worth $1.00 a burst: **can this axis be
+    compared across the handback boundary at all?** ``fleet_cells``
+    ``unstateable_arm_axes`` asks it at obligation-open, so a seam no cell could
+    ever satisfy is refused for $0 instead of after a 25-minute paid compile
+    (th#2098 / pgw#1340).
+
+    THE PRIVATE NAME IS THE POINT, and pgw#1345 is the receipt. The first
+    attempt exported ``ARTIFACT_METADATA_FIELDS`` from the vendored snapshot —
+    which pgw#1310's digest fence refuses by design (*"a vendored snapshot is
+    fixed upstream and re-vendored, never patched here"*), and refuses in the
+    de-required ``tests`` suite, so it merged and turned master red. A vendored
+    tree is READ, never edited; when the public name is wanted it is added
+    UPSTREAM and re-vendored.
+
+    Reading ``_TOP_LEVEL_FIELDS`` is therefore the correct shape and the
+    precedent already exists — ``tests/tcg_artifacts.py`` reads
+    ``host_isa._host_requirement`` for the same reason, deliberately. It is
+    sited HERE, in the one first-party module that owns cell-metadata reads, so
+    the coupling has exactly one address to fix if upstream renames it.
+
+    Refuses loudly rather than answering an empty set: an empty vocabulary
+    would make every axis look unstateable and silently disable every self-mint
+    on the fleet.
+    """
+    from gen_worker._vendor.torchcg import artifact as tcg_artifact
+
+    fields = getattr(tcg_artifact, "_TOP_LEVEL_FIELDS", None)
+    if not fields:
+        raise ArtifactMetadataError(
+            "the vendored torchcg states no artifact-metadata vocabulary "
+            "(`_TOP_LEVEL_FIELDS`); nothing can decide which arm axes a cell "
+            "is able to state, and guessing would either refuse every mint or "
+            "admit a comparison that can never succeed")
+    return frozenset(str(name) for name in fields)
+
+
 __all__ = [
     "MAX_METADATA_BYTES",
     "METADATA_NAME",
     "ArtifactMetadataError",
+    "cell_metadata_fields",
     "read_metadata",
     "try_read_metadata",
 ]

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -100,7 +100,7 @@ class EagerPhase(StrEnum):
     #: mint, nothing published, ~$1.00 of L4 per burst.
     #:
     #: A pod reporting this is reporting a CODE defect with a named owner
-    #: (an axis outside `torchcg.ARTIFACT_METADATA_FIELDS`), never a
+    #: (an axis outside `artifact_meta.cell_metadata_fields()`), never a
     #: capability, a card or a release — which is why it does not share a
     #: token with the mint-impossibility exits above.
     ARM_AXES_UNSTATEABLE = "arm_axes_unstateable"

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -64,12 +64,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
-from gen_worker._vendor.torchcg import (
-    ARTIFACT_KIND,
-    ARTIFACT_METADATA_FIELDS,
-    GRAPH_CLASS_BLOCK,
-    REQUIRED_AXES,
-)
+from gen_worker._vendor.torchcg import ARTIFACT_KIND, GRAPH_CLASS_BLOCK, REQUIRED_AXES
 from gen_worker._vendor.torchcg import is_compiled_graph_key
 from gen_worker._vendor.torchcg import identity as tcg_identity
 
@@ -227,7 +222,7 @@ class ArmIdentity:
 # the SAME reason `envelope` did one paragraph up, and the sweep that took
 # `envelope` should have taken them. Since pgw#1270 TCG mints every artifact
 # and `torchcg.artifact.validate_metadata` refuses metadata whose field set is
-# not exactly `ARTIFACT_METADATA_FIELDS` — which contains no `family`, no
+# not exactly `artifact_meta.cell_metadata_fields()` — which has no `family`, no
 # `weight_lane`/`lora_bucket` and no `env_seal`. So three of the six axes here
 # were read as `None` off every real cell and compared against a live runtime
 # fact: a seam that could only ever refuse.
@@ -300,10 +295,11 @@ def unstateable_arm_axes(
     the field of its own name — so a NEW axis added without a source entry is
     checked, never silently admitted.
     """
-    vocabulary = set(ARTIFACT_METADATA_FIELDS)
+    vocabulary = artifact_meta.cell_metadata_fields()
     return tuple(
         axis for axis in compared
         if not set(ARM_AXIS_CELL_SOURCES.get(axis, (axis,))) <= vocabulary)
+
 
 #: The pipeline attribute carrying the resolved :class:`graph_facts.SlotSubject`
 #: set the executor built this object from (pgw#1113). Stamped beside the
@@ -1989,7 +1985,7 @@ def _arming_policy(
             "artifact vocabulary is %s). Every mint under this seam would "
             "compile for 20-45 minutes and then refuse `key_axis_divergence`. "
             "Serving eager and spending nothing (pgw#1340)",
-            family, named, sorted(ARTIFACT_METADATA_FIELDS))
+            family, named, sorted(artifact_meta.cell_metadata_fields()))
         if bucket:
             cc.drop_lora_execution_lane(pipe)
         activity_mod.emit_event(

--- a/tests/test_arm_axes_are_stateable_pgw1340.py
+++ b/tests/test_arm_axes_are_stateable_pgw1340.py
@@ -147,6 +147,24 @@ def test_a_REAL_divergence_is_still_refused_by_name(
     assert got.startswith(f"{axis}: "), got
 
 
+def test_the_vocabulary_IS_what_a_real_cell_carries() -> None:
+    """pgw#1345 — the accessor is pinned to BEHAVIOUR, not to a restatement.
+
+    `artifact_meta.cell_metadata_fields()` reads a private name out of the
+    vendored torchcg (deliberately: a vendored snapshot is read, never patched
+    — pgw#1310's digest fence, which the first attempt at this violated and
+    turned master red). A private name can move under a re-vendor, so what is
+    asserted here is that the set it answers is EXACTLY the field set of a
+    metadata dict TCG itself built. If upstream renames or re-shapes it, this
+    goes red with the real cause instead of `unstateable_arm_axes()` quietly
+    answering "everything" and disabling every self-mint on the fleet.
+    """
+    from gen_worker import artifact_meta
+
+    assert artifact_meta.cell_metadata_fields() == frozenset(
+        _real_cell_metadata())
+
+
 def test_the_compared_set_is_not_empty() -> None:
     """A comparison narrowed to nothing would pass every cell and read green.
 


### PR DESCRIPTION
**`master` is RED and it is mine.** This is the repair, and it is small.

## The break

`ca41c527` (pgw#1340 / th#2098) turned the post-merge `ci.yaml` run on master red:

```
AssertionError: torchcg/__init__.py was edited in place. A vendored snapshot is
fixed upstream and re-vendored, never patched here — see VENDORED.toml.
```

pgw#1340 needed TCG's closed artifact-metadata vocabulary as a value it could ask a question of, and took the obvious route: add `ARTIFACT_METADATA_FIELDS = _TOP_LEVEL_FIELDS` to `_vendor/torchcg/artifact.py` and export it from `__init__`. **pgw#1310's digest fence refuses any in-place edit of a vendored snapshot, on purpose.** It was right and I was wrong.

## Why it merged anyway — worth reading, because the mechanism is working as designed

That fence lives in `tests`, which th#1965 dropped from the required set on Paul's pre-launch ruling. `fast gates` — the single required context — was green, the merge queue re-ran only the required contexts, and the **post-merge `ci.yaml` run on push-to-master was the first thing in the pipeline able to say no.**

That is exactly the documented trade: correctness latency moved from a pre-merge ceremony to a post-merge signal *that is watched and acted on*. It was watched. This PR is the acting.

## The repair

1. **`_vendor/torchcg/{artifact,__init__}.py` restored byte-for-byte** from `62944de9` (the pgw#1340 base). `test_vendored_snapshot_pgw1310.py` is green again.

2. **The vocabulary gets one first-party address instead**: `artifact_meta.cell_metadata_fields()`, reading `torchcg.artifact._TOP_LEVEL_FIELDS`.

   Reading a private name out of a vendored tree is the **correct** shape here, not a concession. A vendored snapshot is read, never edited; when the public name is genuinely wanted it is added *upstream* and re-vendored. The precedent is already in-tree and states the same reasoning — `tests/tcg_artifacts.py` reads `host_isa._host_requirement`, *"a private symbol, deliberately"*. Siting it in `artifact_meta` (the one first-party module that owns cell-metadata reads) gives the coupling exactly one address to fix if upstream renames it.

   It **refuses loudly** on an absent or empty vocabulary rather than answering an empty set — an empty set makes every axis look unstateable and would silently disable every self-mint on the fleet, which is a far worse failure than the one it guards.

3. **A behavioural pin, not a restatement.** `test_the_vocabulary_IS_what_a_real_cell_carries` asserts the accessor equals the field set of a metadata dict `torchcg.artifact.build_metadata` itself produced. A re-vendor that renames or re-shapes the private name goes red naming the real cause, instead of `unstateable_arm_axes()` quietly answering "everything".

**th#2098's fix is unchanged**: the arm seam still compares only the three axes a cell can state, and the $0 preflight still refuses a doomed mint at obligation-open before any child process is spawned.

## Verification

- `tests/test_vendored_snapshot_pgw1310.py` — **the red this fixes** — green.
- `tests/test_arm_axes_are_stateable_pgw1340.py` (now 10 rows), `test_handback_key_axes_pgw1042.py`, `test_identity_soundness_pgw1113.py` green.
- mypy strict (846 files), ruff, fast-gate lints clean.
- Zero deletions against `origin/master`.

## Side effect

The carry-forward note left on #897 (the vendored-torchcg re-sync) is now **obsolete** — there is nothing left in the vendored tree for that lane to carry. Corrected there.
