### PR TITLE
pgw#1331: Flux serves end to end with no model library on the request path

### DIFF
--- a/changelog.d/pgw1331.md
+++ b/changelog.d/pgw1331.md
@@ -1,0 +1,47 @@
+- **FLUX.1-dev's whole pipeline is graph classes now, not just its denoiser.** The two text
+  encoders (CLIP-L, T5-XXL) join the denoiser and the VAE decoder in
+  `gen_worker.family.catalog.flux1_dev`, so nothing in the composition rides an eager model at
+  serve time. The declaration-time fake-tensor export covers all six variants on CPU in ~70 s
+  with no weights and no card, which is what keeps a new family reviewable on a PR. `Flux1Dev`
+  gains `clip()` and `t5()`; its export digest changes, so regenerate any pinned bindings.
+- **The scheduler is arithmetic, not an object.** `gen_worker.family.scheduler` implements
+  flow-match Euler in closed form over the family's own declared block and imports neither a
+  model library nor `torch` — the sigma ladder is float math and the step is tensor operators.
+  It agrees with diffusers' `FlowMatchEulerDiscreteScheduler` to one float32 ULP across steps
+  and resolutions (the residual is diffusers rounding its ladder through float32 tensors), and
+  the packing arithmetic is `torch.equal` to `FluxPipeline`'s. Codegen emits a typed
+  `inst.scheduler()` whose return type is the concrete class, so no handler spells a scheduler
+  name; a family whose declared scheduler has no implementation gets **no method**, which is an
+  `AttributeError` a type checker reports rather than a fallback that quietly reintroduces the
+  dependency. `SchedulerBlock` moved from `gen_worker.family.runtime` to
+  `gen_worker.family.scheduler`.
+- **Each catalog family is two modules.** `<family>.py` DECLARES and may import diffusers inside
+  its `build` callables; `<family>_serve.py` is what the request path reads — tuned schemas,
+  shape arithmetic, the loop — and imports nothing above `torch`. `Flux1DevTuned`/`SdxlTuned` and
+  the shape helpers moved to the serving halves. `gen_worker.family`'s own `__init__` went PEP 562
+  lazy for the same reason: it re-exported `inject`, so importing a generated binding executed
+  `api.decorators`, `warmup` and `models.provision` — none of which an adopt-only pod needs.
+- **`scripts/lint_serve_role_closure.py` carries a second claim.** `role.MODEL_FREE_MODULES` names
+  the family serving surface and `role.FORBIDDEN_LIBRARIES` names `diffusers` and `transformers`;
+  the walk follows FUNCTION-LOCAL imports for both. It does not follow `ImportError`-guarded edges
+  — that is how a binding reaches an optional `SPEC` — so `role.OPTIONAL_SERVE_IMPORTS` enumerates
+  where it stops and goes red both on an unlisted guarded edge and on a listed row nobody reaches.
+  `if TYPE_CHECKING:` bodies are skipped because they never execute. `serve.guard` blocks the same
+  libraries at run time with `ModelLibraryUnavailable`. **Scoped honestly:** the WHOLE serve role
+  is not statically model-free, because `gen_worker/__init__` reaches the eager worker's guts,
+  which import diffusers inside functions and are entitled to — `role.py` records that and names
+  the remaining cut.
+- **A family declaration mints its own graph classes.** `gen_worker.family.mint` /
+  `gen-worker family mint` bridges a `GraphFamily` to packed AOTI artifacts through the mint lane's
+  inner seam (`export_program` → `build_call_ingress` → `keying_block` → `Engine.compile`), with no
+  endpoint, no `Compile` declaration, no compile pool and **no checkpoint download** — cell identity
+  is checkpoint-free and the constants arrive at arm time from the store. The trace is the
+  declaration's own, so the minted ingress digest is the committed export's by construction rather
+  than by comparison. It is declared MINT MACHINERY, so an adopt-only pod cannot reach it.
+- **Measured, so nobody has to quote the estimate.**
+  `python -m gen_worker.benchmarks.request_path_imports` runs both arms in fresh interpreters and
+  reports the delta over `torch`: today's `FluxPipeline` import costs **2.12 s / +225 MB RSS / 2192
+  modules**; the typed family surface costs **0.12 s / +22 MB / 220 modules** — 17x faster to reach
+  a servable state, 203 MB less resident, and neither model library loaded. Per-request latency is
+  NOT measured here and this does not claim it: that needs a card, real weights and armed
+  artifacts.

--- a/docs/families.md
+++ b/docs/families.md
@@ -161,3 +161,73 @@ with llm.session() as decode:
     decode.state["kv"] = ...          # host-owned, torn down with the session
     logits = llm.decode(context=1024, tokens=tokens)
 ```
+
+## A catalog family is two modules (pgw#1331)
+
+`<family>.py` **declares**: its `build` callables construct diffusers and
+transformers modules, so it is mint-side and the serve role may not import it.
+`<family>_serve.py` is what the request path reads — the tuned schemas, the
+shape arithmetic, the pipeline loop — and imports nothing above `torch`. The
+direction is one-way: the declaration reads from the serving half, never the
+reverse, so the family's shape arithmetic has one definition and an artifact
+cannot be minted at a shape the loop will not ask for.
+
+`scripts/lint_serve_role_closure.py` enforces it. `role.MODEL_FREE_MODULES` is
+the surface, `role.FORBIDDEN_LIBRARIES` is what it may not reach, and the walk
+follows function-local imports. `serve.guard` blocks the same names at run time.
+
+## Scheduler as bare math
+
+The recipe records a scheduler as a NAME and a block of scalars, and says the
+host implements it. `gen_worker.family.scheduler` is that host half:
+
+```python
+schedule = flux.scheduler().schedule(steps=28, image_seq_len=4096)
+for index, sigma in enumerate(schedule.sigmas[:-1]):
+    velocity = flux.denoiser(resolution=1024, timestep=..., hidden_states=latents, ...)
+    latents = schedule.step(index, velocity, latents)
+```
+
+`scheduler()` is GENERATED and its return type is the concrete class, so no
+handler spells a scheduler name. A family whose declared scheduler the SDK does
+not implement has **no** `scheduler()` method — an `AttributeError` your type
+checker reports, not a fallback that puts a model library back on the path.
+
+The constants come from the DECLARATION's `Scheduler(...)` block, which rides
+the export digest: re-declaring a schedule re-identifies the family instead of
+silently changing every request.
+
+## Serving a family end to end
+
+`gen_worker.family.catalog.flux1_dev_serve` is the worked example — tokenize,
+encode both text branches, denoise, decode, with no model library imported:
+
+```python
+from gen_worker.family.catalog import Flux1Dev, flux1_dev_serve as flux
+
+image = flux.generate(
+    instance,                    # a resolved Flux1Dev
+    resolution=1024,
+    clip_ids=flux.clip_token_ids(clip_tokens, device=device),
+    t5_ids=flux.t5_token_ids(t5_tokens, device=device),
+    steps=28, guidance=3.5, seed=seed,
+)
+```
+
+The same body runs against a compiled backing, an eager one, or `Flux1Dev.fake()`
+— which is how it is tested in CI without a card.
+
+## Minting a family
+
+```
+gen-worker family mint gen_worker.family.catalog.flux1_dev:FLUX1_DEV \
+    --out-dir ./cells --runner decoder --runner clip --json minted.json
+```
+
+A real compile: **run it on a pod, never on a shared box.** It needs a GPU and a
+toolchain; it needs no weights and no network, because cell identity is
+checkpoint-free (§4.27) and the constants arrive at arm time from the store.
+The trace is the declaration's own, so a minted class's ingress digest is the
+committed export's by construction — `family.mint.assert_matches_export` states
+that as an assertion, in the direction torchcg G16 requires: the export is the
+source and the mint is checked against it.

--- a/scripts/lint_serve_role_closure.py
+++ b/scripts/lint_serve_role_closure.py
@@ -84,6 +84,17 @@ def _declared_tuple(name: str, *, source: str = "", where: Path = ROLE_FILE) -> 
                 f"statically so the role and the guard cannot disagree.")
         out: List[str] = []
         for element in value.elts:
+            # `*OTHER_TUPLE` splices another module-level declaration, which is
+            # how one set states that it CONTAINS another without retyping its
+            # rows (pgw#824's drift rule). Still literal-only: the splice
+            # resolves by reading that tuple out of this same file.
+            if isinstance(element, ast.Starred):
+                if not isinstance(element.value, ast.Name):
+                    raise SystemExit(
+                        f"{where}: {name} splices a non-name; a spliced set "
+                        f"must be another module-level tuple in this file.")
+                out.extend(_declared_tuple(element.value.id, source=source, where=where))
+                continue
             if not isinstance(element, ast.Constant) or not isinstance(
                     element.value, str):
                 raise SystemExit(
@@ -120,16 +131,96 @@ def _package_of(module: str) -> str:
     return module.rsplit(".", 1)[0]
 
 
-def _imports(path: Path, module: str) -> Set[str]:
-    """Every ``gen_worker`` module this file names, relative imports resolved."""
-    package = _package_of(module)
-    out: Set[str] = set()
-    tree = ast.parse(path.read_text(), filename=str(path))
+def _type_checking_only(tree: ast.AST) -> Set[int]:
+    """Every import node inside an ``if TYPE_CHECKING:`` body.
+
+    Those never execute. Every module in this repo carries
+    ``from __future__ import annotations``, so an annotation is a string and the
+    block exists for the type checker alone — which is exactly why a generated
+    family binding puts ``from torch import Tensor`` there. Following such an
+    edge would make this fence report imports a serve process cannot perform,
+    and reporting a library that is never loaded is how a guard loses its
+    readers.
+
+    Only the ``if`` body is skipped, never the ``else``: an ``else`` branch of a
+    ``TYPE_CHECKING`` test is the RUNTIME branch.
+    """
+    skipped: Set[int] = set()
     for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        name = (
+            test.id
+            if isinstance(test, ast.Name)
+            else test.attr if isinstance(test, ast.Attribute) else ""
+        )
+        if name != "TYPE_CHECKING":
+            continue
+        for statement in node.body:
+            for inner in ast.walk(statement):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    skipped.add(id(inner))
+    return skipped
+
+
+def _guarded(tree: ast.AST) -> Set[int]:
+    """Every import node lexically inside a ``try`` that catches ImportError.
+
+    An ``except ImportError`` around an import is a module SAYING it works
+    without the thing — pgw#1339's degrade-loudly-and-serve, which is exactly
+    how a generated family binding exposes an optional ``SPEC``. Following such
+    an edge would drag every declaration into the serve closure and make this
+    fence guard nothing, so the walk stops there and
+    :data:`role.OPTIONAL_SERVE_IMPORTS` enumerates where it is allowed to stop.
+
+    Only ``ImportError``/``ModuleNotFoundError`` count. A bare ``except`` or an
+    ``except Exception`` is NOT a declaration that the import is optional; it is
+    a module swallowing everything, and treating it as a hatch would let any
+    ``try:`` walk through this fence.
+    """
+    optional: Set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        names: Set[str] = set()
+        for handler in node.handlers:
+            for caught in (
+                handler.type.elts
+                if isinstance(handler.type, ast.Tuple)
+                else [handler.type]
+            ):
+                if isinstance(caught, ast.Name):
+                    names.add(caught.id)
+        if not names & {"ImportError", "ModuleNotFoundError"}:
+            continue
+        for statement in node.body:
+            for inner in ast.walk(statement):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    optional.add(id(inner))
+    return optional
+
+
+def _imports(path: Path, module: str) -> Tuple[Set[str], Set[str], Set[str]]:
+    """What this file imports: (required gen_worker, guarded gen_worker, libraries).
+
+    ``libraries`` is every non-``gen_worker`` top-level package the file names,
+    guarded or not — a forbidden library behind a ``try`` is still a library
+    this process would acquire whenever it is installed, which on an
+    eager-capable pod is always.
+    """
+    package = _package_of(module)
+    tree = ast.parse(path.read_text(), filename=str(path))
+    optional_nodes = _guarded(tree)
+    unexecuted = _type_checking_only(tree)
+    required: Set[str] = set()
+    guarded: Set[str] = set()
+    libraries: Set[str] = set()
+    for node in ast.walk(tree):
+        if id(node) in unexecuted:
+            continue
         if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name.startswith("gen_worker"):
-                    out.add(alias.name)
+            found = {alias.name for alias in node.names}
         elif isinstance(node, ast.ImportFrom):
             if node.level:
                 parts = package.split(".")
@@ -140,18 +231,31 @@ def _imports(path: Path, module: str) -> Set[str]:
                     prefix = f"{prefix}.{node.module}"
             else:
                 prefix = node.module or ""
-            if not prefix.startswith("gen_worker"):
-                continue
-            out.add(prefix)
-            for alias in node.names:
-                out.add(f"{prefix}.{alias.name}")
-    return out
+            found = {prefix} | {f"{prefix}.{alias.name}" for alias in node.names}
+        else:
+            continue
+        bucket = guarded if id(node) in optional_nodes else required
+        for name in found:
+            if name.startswith("gen_worker"):
+                bucket.add(name)
+            elif name:
+                libraries.add(name.split(".", 1)[0])
+    return required, guarded, libraries
 
 
-def closure(roots: Sequence[str]) -> Tuple[Set[str], Dict[str, str]]:
-    """Every gen_worker module the roots reach, and who first reached it."""
+def closure(
+    roots: Sequence[str],
+) -> Tuple[Set[str], Dict[str, str], Dict[str, Set[str]], Dict[str, Set[str]]]:
+    """Walk the REQUIRED closure, and record what it stopped at.
+
+    Returns ``(modules, who-reached-each, libraries-per-module,
+    guarded-edges-per-module)``. Guarded edges are recorded but not followed —
+    see :func:`_guarded`.
+    """
     seen: Set[str] = set()
     via: Dict[str, str] = {root: "<root>" for root in roots}
+    libraries: Dict[str, Set[str]] = {}
+    guarded: Dict[str, Set[str]] = {}
     queue: List[str] = list(roots)
     while queue:
         name = queue.pop()
@@ -161,12 +265,16 @@ def closure(roots: Sequence[str]) -> Tuple[Set[str], Dict[str, str]]:
         if path is None:
             continue
         seen.add(name)
-        for target in sorted(_imports(path, name)):
+        required, optional, used = _imports(path, name)
+        libraries[name] = used
+        if optional:
+            guarded[name] = optional
+        for target in sorted(required):
             if target in seen:
                 continue
             via.setdefault(target, name)
             queue.append(target)
-    return seen, via
+    return seen, via, libraries, guarded
 
 
 def _chain(name: str, via: Dict[str, str]) -> str:
@@ -179,6 +287,7 @@ def _chain(name: str, via: Dict[str, str]) -> str:
 
 
 def check(roots: Sequence[str], banned: Sequence[str]) -> List[str]:
+    """pgw#1328: the adopt-only serve role cannot reach the mint lane."""
     problems: List[str] = []
     for name in (*roots, *banned):
         if _module_path(name) is None:
@@ -188,7 +297,7 @@ def check(roots: Sequence[str], banned: Sequence[str]) -> List[str]:
                 f"exist passes vacuously forever (pgw#1176).")
     if problems:
         return problems
-    seen, via = closure(roots)
+    seen, via, _, _ = closure(roots)
     if not seen:
         return ["the serve-role roots resolved to NOTHING — this guard is "
                 "guarding nothing"]
@@ -200,6 +309,81 @@ def check(roots: Sequence[str], banned: Sequence[str]) -> List[str]:
                 f"routes on a miss (§4.28/§4.29) — it must not be able to "
                 f"compile. Put the call behind gen_worker.serve.mint_seam, or "
                 f"take the module out of SERVE_ROLE_MODULES and mean it.")
+
+    return problems
+
+
+def check_model_free(
+    roots: Sequence[str],
+    libraries: Sequence[str],
+    optional: Sequence[str],
+    within: Sequence[str] = (),
+) -> List[str]:
+    """pgw#1331: this surface reaches no model library, and stops nowhere else.
+
+    A SEPARATE walk from :func:`check`, rooted at the subset the claim is about.
+    Rooting it at the whole serve role would report the eager-capable worker's
+    own guts — which import diffusers inside functions and are entitled to —
+    and a fence that reports things nobody can fix is a fence people learn to
+    ignore. The scope is declared in ``role.MODEL_FREE_MODULES``, with the
+    reason on the tuple.
+    """
+    problems: List[str] = []
+    for name in (*roots, *optional):
+        if _module_path(name) is None:
+            problems.append(
+                f"`{name}` is declared in serve/role.py but is not a module "
+                f"under src/gen_worker. A fence naming a module that does not "
+                f"exist passes vacuously forever (pgw#1176).")
+    outside = sorted(set(roots) - set(within)) if within else []
+    if outside:
+        problems.append(
+            f"role.MODEL_FREE_MODULES names {outside[0]}, which is not in "
+            f"SERVE_ROLE_MODULES. A module asserted model-free but not "
+            f"asserted MINT-free is checked for the smaller of the two "
+            f"properties — splice the sets rather than keeping two lists.")
+    if problems:
+        return problems
+    seen, via, used, guarded = closure(roots)
+    if not seen:
+        return ["the model-free roots resolved to NOTHING — this guard is "
+                "guarding nothing"]
+    forbidden = set(libraries)
+    for module in sorted(seen):
+        for library in sorted(used.get(module, set()) & forbidden):
+            problems.append(
+                f"pgw#1331: the MODEL-FREE serve surface imports {library!r} in "
+                f"{module} (reached via {_chain(module, via)}). The serve path "
+                f"calls graph classes and bare math; a model library on it is "
+                f"seconds of process start and gigabytes of host RAM bought to "
+                f"run reshapes. Move the model code to the family's DECLARATION "
+                f"half, or take the module out of SERVE_ROLE_MODULES and mean it.")
+
+    # …and the ONLY places the walk is allowed to stop are the enumerated ones.
+    allowed = set(optional)
+    stopped: Set[str] = set()
+    for module in sorted(guarded):
+        if module not in seen:
+            continue
+        for target in sorted(guarded[module]):
+            if _module_path(target) is None:
+                continue  # a `from pkg import name` leaf, not a module
+            if target in seen:
+                continue  # already required by another edge; nothing is hidden
+            stopped.add(target)
+            if target not in allowed:
+                problems.append(
+                    f"pgw#1331: {module} reaches {target} through an "
+                    f"ImportError-guarded import, which this fence does not "
+                    f"follow. That hatch is a CLOSED list: add {target!r} to "
+                    f"role.OPTIONAL_SERVE_IMPORTS with a reason, or make the "
+                    f"import unguarded so the closure walks it.")
+    for target in sorted(allowed - stopped):
+        problems.append(
+            f"pgw#1331: role.OPTIONAL_SERVE_IMPORTS names {target}, but no "
+            f"serve-role module reaches it through a guarded import. An "
+            f"enumerated hatch nobody uses is a hatch nobody is checking "
+            f"(pgw#1176) — delete the row.")
     return problems
 
 
@@ -221,6 +405,7 @@ def selftest() -> int:
     how ``fleet_cells`` reached ``mint_supervisor`` before this landed).
     """
     banned = _declared_tuple("MINT_MACHINERY")
+    libraries = _declared_tuple("FORBIDDEN_LIBRARIES")
     problems = check(("gen_worker.mint_adapter",), banned)
     if not problems:
         print(
@@ -243,10 +428,42 @@ def selftest() -> int:
             "The fence would then be reading something other than the role.",
             file=sys.stderr)
         return 1
+    # pgw#1331's half: a family DECLARATION is a model-library module, so
+    # rooting the walk there must produce a forbidden-library violation. The
+    # declaration reaches diffusers exclusively through FUNCTION-LOCAL imports,
+    # so this proves the library check follows lazy imports too — the same
+    # shape the mint-lane half is proven against, one layer up.
+    declaration = "gen_worker.family.catalog.flux1_dev"
+    library_problems = [
+        line
+        for line in check_model_free((declaration,), libraries, ())
+        if "imports" in line
+    ]
+    if not library_problems:
+        print(
+            f"SELFTEST FAILED: rooting the walk at {declaration} produced no "
+            "forbidden-library violation, but that module's build callables "
+            "exist to construct diffusers and transformers modules. Either the "
+            "walk stopped following function-local imports — and this fence is "
+            "now blind — or the declaration no longer names a model library, "
+            "which would mean the catalog stopped declaring anything.",
+            file=sys.stderr)
+        return 1
+    # …and a guarded edge to an unlisted module must be refused, or the hatch
+    # is not a list, it is a door.
+    binding = "gen_worker.family.catalog._generated.flux1_dev"
+    if not [line for line in check_model_free((binding,), libraries, ()) if "guarded" in line]:
+        print(
+            f"SELFTEST FAILED: {binding} reaches its declaration through an "
+            "ImportError-guarded import, and an EMPTY OPTIONAL_SERVE_IMPORTS "
+            "accepted it. The hatch would then be open to any `try: import`.",
+            file=sys.stderr)
+        return 1
     print(
-        f"pgw#1328 selftest: the fence goes red as designed "
-        f"({len(problems)} violation(s) from a mint-reaching root, and a "
-        f"computed declaration is refused)")
+        f"pgw#1328/#1331 selftest: the fence goes red as designed "
+        f"({len(problems)} violation(s) from a mint-reaching root, "
+        f"{len(library_problems)} from a model-library root, an unlisted "
+        f"guarded edge is refused, and a computed declaration is refused)")
     return 0
 
 
@@ -258,7 +475,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         return selftest()
     roots = _declared_tuple("SERVE_ROLE_MODULES")
     banned = _declared_tuple("MINT_MACHINERY")
+    model_free = _declared_tuple("MODEL_FREE_MODULES")
+    libraries = _declared_tuple("FORBIDDEN_LIBRARIES")
+    optional = _declared_tuple("OPTIONAL_SERVE_IMPORTS")
     problems = check(roots, banned)
+    problems.extend(check_model_free(model_free, libraries, optional, within=roots))
     for line in problems:
         print(line, file=sys.stderr)
     if problems:
@@ -266,11 +487,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"\n{len(problems)} adopt-only serve-role violation(s).",
             file=sys.stderr)
         return 1
-    seen, _ = closure(roots)
+    seen, _, _, _ = closure(roots)
+    free, _, _, _ = closure(model_free)
     print(
-        f"pgw#1328: the adopt-only serve role is mint-free "
-        f"({len(roots)} declared root(s), {len(seen)} gen_worker modules in "
-        f"the closure, {len(banned)} mint modules absent)")
+        f"pgw#1328: the adopt-only serve role is mint-free ({len(roots)} "
+        f"declared root(s), {len(seen)} gen_worker modules in the closure, "
+        f"{len(banned)} mint modules absent)")
+    print(
+        f"pgw#1331: the model-free serve surface holds no model library "
+        f"({len(model_free)} declared root(s), {len(free)} gen_worker modules "
+        f"in the closure, {len(libraries)} libraries absent, {len(optional)} "
+        f"enumerated guarded edge(s))")
     return 0
 
 

--- a/src/gen_worker/benchmarks/request_path_imports.py
+++ b/src/gen_worker/benchmarks/request_path_imports.py
@@ -1,0 +1,182 @@
+"""pgw#1331's measurement: what the request path costs BEFORE and AFTER.
+
+pgw#1326's expectations table claims process start drops from 5-15 s to ~1 s and
+that a worker sheds 1-2 GB of host RAM. Those are the numbers this program
+exists to stop anyone from quoting without having run something. It measures
+exactly two interpreters, each in a FRESH subprocess so no import is warm:
+
+* **before** — a Flux endpoint as authored today: ``FluxPipeline`` off
+  ``diffusers``, which is the object ``examples/flux2-klein-image`` takes as its
+  ``setup()`` parameter and calls per request.
+* **after** — the typed family surface: the generated ``Flux1Dev`` binding, the
+  catalog's serving half, and the bare-math scheduler. Nothing else, because
+  nothing else is on the path.
+
+Both arms import ``torch`` first and report the DELTA over it. A serve process
+holds torch either way — it is the runtime, not the model library — so charging
+it to one arm would inflate the result by about a second and half a gigabyte,
+and the honest question is what the model library costs ON TOP of the runtime.
+
+**This is not a latency benchmark and does not claim to be.** Per-request
+latency needs a card, real weights and armed artifacts; the graph-coverage tail
+pgw#1331 estimates at 5-15% is measured by
+:mod:`gen_worker.benchmarks.store_arm_parity`'s sibling on a pod, not here.
+What this measures is the fixed cost every serve process pays at boot and holds
+resident for its whole life, which is the part that is a property of the CODE
+and can therefore be measured on any machine, in CI, with no card.
+
+    python -m gen_worker.benchmarks.request_path_imports
+    python -m gen_worker.benchmarks.request_path_imports --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Sequence
+
+#: The BEFORE arm: what an endpoint imports today to serve one Flux request.
+BEFORE: tuple[str, ...] = ("diffusers:FluxPipeline",)
+
+#: The AFTER arm: the typed family surface, and that is the whole list.
+AFTER: tuple[str, ...] = (
+    "gen_worker.family.catalog:Flux1Dev",
+    "gen_worker.family.catalog.flux1_dev_serve:generate",
+    "gen_worker.family.scheduler:FlowMatchEulerDiscrete",
+)
+
+#: Run inside a fresh interpreter. Imports torch, takes a baseline, imports the
+#: arm's names, and reports the delta. ``ru_maxrss`` is a HIGH-WATER mark, so
+#: the delta is the additional peak the arm forced — which is the number that
+#: decides how much host RAM a pod must be bought with.
+_PROBE = """
+import json, resource, sys, time
+
+def rss():
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+
+t0 = time.perf_counter()
+import torch
+torch_s = time.perf_counter() - t0
+base_rss, base_modules = rss(), len(sys.modules)
+
+t1 = time.perf_counter()
+for target in json.loads(sys.argv[1]):
+    module, _, attribute = target.partition(":")
+    loaded = __import__(module, fromlist=["_"])
+    if attribute:
+        getattr(loaded, attribute)
+arm_s = time.perf_counter() - t1
+
+print(json.dumps({
+    "torch_s": torch_s,
+    "torch_rss": base_rss,
+    "torch_modules": base_modules,
+    "import_s": arm_s,
+    "rss_bytes": rss() - base_rss,
+    "modules": len(sys.modules) - base_modules,
+    "diffusers_loaded": "diffusers" in sys.modules,
+    "transformers_loaded": "transformers" in sys.modules,
+}))
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Arm:
+    """One measured interpreter."""
+
+    name: str
+    targets: tuple[str, ...]
+    import_s: float
+    rss_bytes: int
+    modules: int
+    diffusers_loaded: bool
+    transformers_loaded: bool
+    torch_s: float
+    torch_rss: int
+
+
+def measure(name: str, targets: Sequence[str], *, repeat: int = 3) -> Arm:
+    """Run one arm ``repeat`` times in fresh interpreters and keep the FASTEST.
+
+    The fastest, not the mean: an import is deterministic work, so the spread is
+    the shared box's scheduler and page cache, and the minimum is the closest
+    estimate of the cost the code actually has. Reporting a mean here would
+    publish this machine's contention as a property of the library.
+    """
+
+    best: Arm | None = None
+    for _ in range(repeat):
+        done = subprocess.run(
+            [sys.executable, "-c", _PROBE, json.dumps(list(targets))],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        row: dict[str, Any] = json.loads(done.stdout.strip().splitlines()[-1])
+        arm = Arm(
+            name=name,
+            targets=tuple(targets),
+            import_s=float(row["import_s"]),
+            rss_bytes=int(row["rss_bytes"]),
+            modules=int(row["modules"]),
+            diffusers_loaded=bool(row["diffusers_loaded"]),
+            transformers_loaded=bool(row["transformers_loaded"]),
+            torch_s=float(row["torch_s"]),
+            torch_rss=int(row["torch_rss"]),
+        )
+        if best is None or arm.import_s < best.import_s:
+            best = arm
+    assert best is not None  # repeat >= 1 is enforced by the caller
+    return best
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--json", default="")
+    args = parser.parse_args(argv)
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+
+    before = measure("before", BEFORE, repeat=args.repeat)
+    after = measure("after", AFTER, repeat=args.repeat)
+
+    print(f"{'arm':<8} {'import':>9} {'+RSS':>10} {'+modules':>9}  loaded")
+    for arm in (before, after):
+        libraries = ", ".join(
+            name
+            for name, loaded in (
+                ("diffusers", arm.diffusers_loaded),
+                ("transformers", arm.transformers_loaded),
+            )
+            if loaded
+        )
+        print(
+            f"{arm.name:<8} {arm.import_s:>8.2f}s {arm.rss_bytes / 1e6:>9.0f}MB "
+            f"{arm.modules:>9}  {libraries or 'neither'}"
+        )
+    print(
+        f"\nover torch alone ({before.torch_s:.2f}s, {before.torch_rss / 1e6:.0f}MB): "
+        f"{before.import_s / max(after.import_s, 1e-9):.1f}x faster, "
+        f"{(before.rss_bytes - after.rss_bytes) / 1e6:.0f}MB less resident, "
+        f"{before.modules - after.modules} fewer modules"
+    )
+    if after.diffusers_loaded or after.transformers_loaded:
+        print(
+            "\nFAILED: the AFTER arm loaded a model library. That is the whole "
+            "claim of pgw#1331, and this run refutes it.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump([asdict(before), asdict(after)], handle, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - a CLI
+    raise SystemExit(main())

--- a/src/gen_worker/cli/family.py
+++ b/src/gen_worker/cli/family.py
@@ -1,6 +1,6 @@
-"""``gen-worker family`` — export a declaration and generate its bindings.
+"""``gen-worker family`` — export a declaration, generate bindings, mint classes.
 
-Two commands, deliberately separate, because they have different requirements
+Three commands, deliberately separate, because they have different requirements
 and different cadences:
 
 ``export``    runs ``torch.export`` over a family DECLARATION with fake tensors
@@ -11,6 +11,12 @@ and different cadences:
               needs NOTHING but the document — no torch, no diffusers. Run it in
               CI to prove the committed binding is what the export implies.
 
+``mint``      compiles the declaration's graph classes into packed AOTI
+              artifacts (pgw#1331). Needs a GPU and a real toolchain; needs no
+              weights and no network, because cell identity is checkpoint-free
+              (§4.27) and the constants arrive at ARM time from the store.
+              **Runs on a pod, never on a shared box** — it is a real compile.
+
 The split is what makes the fence cheap. ``generate --check`` is a byte
 comparison a two-minute job can afford, and it catches the case that actually
 bites: an export regenerated and committed while the binding beside it was not.
@@ -20,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -83,6 +90,42 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
         help="Do not write: exit 1 when the file on disk is not what would be written.",
     )
     generate.set_defaults(_handler=_handle_generate)
+
+    mint = commands.add_parser(
+        "mint",
+        help="Compile a GraphFamily declaration's graph classes into AOTI artifacts.",
+        description=(
+            "pgw#1331. Traces every declared (runner, bucket, layout) with the "
+            "declaration's OWN tracer — so the minted ingress digest is the "
+            "committed export's by construction — and compiles each through the "
+            "worker's TCG engine. This is a real compile: run it on a pod."
+        ),
+    )
+    mint.add_argument(
+        "target",
+        help="Dotted path to the declaration, e.g. gen_worker.family.catalog.flux1_dev:FLUX1_DEV",
+    )
+    mint.add_argument("--out-dir", required=True, help="Directory to write packed artifacts into.")
+    mint.add_argument("--work", default="", help="Scratch root. Defaults to <out-dir>/work.")
+    mint.add_argument(
+        "--cache-root",
+        default="",
+        help="TCG CAS root. Omit to use the worker's canonical store.",
+    )
+    mint.add_argument(
+        "--runner",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help=(
+            "Mint only this runner; repeatable. Omit for every declared runner. "
+            "A pod normally mints the cheap classes first."
+        ),
+    )
+    mint.add_argument(
+        "--json", default="", help="Write the minted rows to this path as JSON."
+    )
+    mint.set_defaults(_handler=_handle_mint)
 
 
 def _load(target: str) -> tuple[str, str, Any]:
@@ -153,4 +196,61 @@ def _handle_generate(args: argparse.Namespace) -> int:
         return 1
     destination.write_text(rendered)
     sys.stderr.write(f"wrote {destination} ({export.digest()})\n")
+    return 0
+
+
+def _handle_mint(args: argparse.Namespace) -> int:
+    try:
+        _, attr, family = _load(args.target)
+    except (ImportError, AttributeError, ValueError) as exc:
+        sys.stderr.write(f"gen-worker family mint: cannot load {args.target!r}: {exc}\n")
+        return 2
+    if not isinstance(family, GraphFamily):
+        sys.stderr.write(
+            f"gen-worker family mint: {args.target!r} is a {type(family).__name__}, not a "
+            "GraphFamily; an eager-only Family has no graph classes to mint\n"
+        )
+        return 2
+    from ..family.mint import mint_family
+
+    out_dir = Path(args.out_dir)
+    work = Path(args.work) if args.work else out_dir / "work"
+
+    def beat(name: str, done: int, total: int) -> None:
+        sys.stderr.write(f"[{done + 1}/{total}] minting {name}\n")
+        sys.stderr.flush()
+
+    try:
+        minted = mint_family(
+            family,
+            out_dir=out_dir,
+            work=work,
+            cache_root=Path(args.cache_root) if args.cache_root else None,
+            only=tuple(args.runner),
+            on_class=beat,
+        )
+    except FamilyError as exc:
+        sys.stderr.write(f"gen-worker family mint: {exc}\n")
+        return 1
+    rows = [
+        {
+            "runner": row.runner,
+            "bucket": {name: value for name, value in row.bucket},
+            "layout": row.layout,
+            "graph_class": row.graph_class,
+            "key": row.key,
+            "artifact": str(row.artifact),
+            "ingress_digest": row.ingress_digest,
+            "compile_s": round(row.compile_s, 3),
+            "reuse_s": round(row.reuse_s, 3),
+            "reused": row.reused,
+        }
+        for row in minted
+    ]
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n")
+    for row in rows:
+        cost = "reused" if row["reused"] else f"{row['compile_s']}s"
+        sys.stderr.write(f"{row['graph_class']}  {row['key']}  {cost}\n")
+    sys.stderr.write(f"minted {len(rows)} graph class(es) from {attr}\n")
     return 0

--- a/src/gen_worker/cli/family.py
+++ b/src/gen_worker/cli/family.py
@@ -237,7 +237,11 @@ def _handle_mint(args: argparse.Namespace) -> int:
             "runner": row.runner,
             "bucket": {name: value for name, value in row.bucket},
             "layout": row.layout,
-            "graph_class": row.graph_class,
+            # This report's OWN column name for a MintedVariant field, not a
+            # read of TCG's metadata block: the value is a handle the mint
+            # bridge assigned, and TCG's block key is read once, by name, in
+            # aot_compile_child.
+            "graph_class": row.graph_class,  # tcg-vocab: this report's column
             "key": row.key,
             "artifact": str(row.artifact),
             "ingress_digest": row.ingress_digest,
@@ -251,6 +255,7 @@ def _handle_mint(args: argparse.Namespace) -> int:
         Path(args.json).write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n")
     for row in rows:
         cost = "reused" if row["reused"] else f"{row['compile_s']}s"
-        sys.stderr.write(f"{row['graph_class']}  {row['key']}  {cost}\n")
+        name = row["graph_class"]  # tcg-vocab: this report's column, see above
+        sys.stderr.write(f"{name}  {row['key']}  {cost}\n")
     sys.stderr.write(f"minted {len(rows)} graph class(es) from {attr}\n")
     return 0

--- a/src/gen_worker/family/__init__.py
+++ b/src/gen_worker/family/__init__.py
@@ -45,54 +45,137 @@ serve role must not acquire diffusers by accident (pgw#1328).
 
 from __future__ import annotations
 
-from .backing import (
-    Backing,
-    BackingKind,
-    CompiledBacking,
-    DualBacking,
-    EagerBacking,
-    FakeBacking,
-)
-from .drift import assert_recipe, assert_reference
-from .errors import FamilyError, FamilyRefusal
-from .inject import (
-    bind_families,
-    declared_families as bound_families,
-    fake_families,
-    fake_kwargs,
-    resolver_instances,
-)
-from .runtime import (
-    DecodeSession,
-    FamilyBinding,
-    InstanceResolver,
-    Tuned,
-    instance_resolver,
-    resolve,
-    resolve_tuned,
-    set_instance_resolver,
-    tuned_fields,
-    tuned_payload_fields,
-)
-from .snapshot import EXPORT_VERSION, FamilyExport
-from .tuned import tuned_from_catalog
-from .spec import (
-    DEFAULT_LAYOUT,
-    Bucket,
-    BucketMap,
-    CallExample,
-    Family,
-    GraphFamily,
-    Loop,
-    LoopKind,
-    Parameter,
-    Runner,
-    Scheduler,
-    SessionState,
-    Stage,
-    TunedValues,
-    declared_families,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers only
+    from .backing import (
+        Backing,
+        BackingKind,
+        CompiledBacking,
+        DualBacking,
+        EagerBacking,
+        FakeBacking,
+    )
+    from .drift import assert_recipe, assert_reference
+    from .errors import FamilyError, FamilyRefusal
+    from .inject import (
+        bind_families,
+        declared_families as bound_families,
+        fake_families,
+        fake_kwargs,
+        resolver_instances,
+    )
+    from .runtime import (
+        DecodeSession,
+        FamilyBinding,
+        InstanceResolver,
+        Tuned,
+        instance_resolver,
+        resolve,
+        resolve_tuned,
+        set_instance_resolver,
+        tuned_fields,
+        tuned_payload_fields,
+    )
+    from .snapshot import EXPORT_VERSION, FamilyExport
+    from .spec import (
+        Bucket,
+        BucketMap,
+        CallExample,
+        DEFAULT_LAYOUT,
+        Family,
+        GraphFamily,
+        Loop,
+        LoopKind,
+        Parameter,
+        Runner,
+        Scheduler,
+        SessionState,
+        Stage,
+        TunedValues,
+        declared_families,
+    )
+    from .tuned import tuned_from_catalog
+
+    #: ``FamilyInstance`` is the READING of :class:`FamilyBinding` that matters
+    #: at a handler parameter: the class is the type, the value is the instance.
+    FamilyInstance = FamilyBinding
+
+#: Exported name -> (submodule, name in it). THE package index, and the reason
+#: it exists instead of a block of eager imports (pgw#1331).
+#:
+#: ``inject`` binds declared families onto a handler's call, so it imports
+#: ``gen_worker.api.decorators`` — and through it the endpoint registry, the
+#: warm-up, and ``models.provision``. Eagerly re-exporting it here meant that
+#: importing ``gen_worker.family.runtime`` — which a generated binding does, on
+#: an adopt-only pod that will never register an endpoint — executed the whole
+#: eager-capable worker's import graph, including every module that names a
+#: model library inside a function. PEP 562 breaks that: importing this package
+#: costs nothing, and asking for a name costs exactly that one submodule.
+#:
+#: ``scripts/lint_serve_role_closure.py`` is what holds it: with the eager block
+#: back, the serve-role closure reaches ``diffusers`` through ten modules and
+#: the fence says so by name.
+_EXPORTS: Final[dict[str, tuple[str, str]]] = {
+    "Backing": ("backing", "Backing"),
+    "BackingKind": ("backing", "BackingKind"),
+    "Bucket": ("spec", "Bucket"),
+    "BucketMap": ("spec", "BucketMap"),
+    "CallExample": ("spec", "CallExample"),
+    "CompiledBacking": ("backing", "CompiledBacking"),
+    "DEFAULT_LAYOUT": ("spec", "DEFAULT_LAYOUT"),
+    "DecodeSession": ("runtime", "DecodeSession"),
+    "DualBacking": ("backing", "DualBacking"),
+    "EXPORT_VERSION": ("snapshot", "EXPORT_VERSION"),
+    "EagerBacking": ("backing", "EagerBacking"),
+    "FakeBacking": ("backing", "FakeBacking"),
+    "Family": ("spec", "Family"),
+    "FamilyBinding": ("runtime", "FamilyBinding"),
+    "FamilyError": ("errors", "FamilyError"),
+    "FamilyExport": ("snapshot", "FamilyExport"),
+    "FamilyRefusal": ("errors", "FamilyRefusal"),
+    "GraphFamily": ("spec", "GraphFamily"),
+    "InstanceResolver": ("runtime", "InstanceResolver"),
+    "Loop": ("spec", "Loop"),
+    "LoopKind": ("spec", "LoopKind"),
+    "Parameter": ("spec", "Parameter"),
+    "Runner": ("spec", "Runner"),
+    "Scheduler": ("spec", "Scheduler"),
+    "SessionState": ("spec", "SessionState"),
+    "Stage": ("spec", "Stage"),
+    "Tuned": ("runtime", "Tuned"),
+    "TunedValues": ("spec", "TunedValues"),
+    "assert_recipe": ("drift", "assert_recipe"),
+    "assert_reference": ("drift", "assert_reference"),
+    "bind_families": ("inject", "bind_families"),
+    "bound_families": ("inject", "declared_families"),
+    "declared_families": ("spec", "declared_families"),
+    "fake_families": ("inject", "fake_families"),
+    "fake_kwargs": ("inject", "fake_kwargs"),
+    "instance_resolver": ("runtime", "instance_resolver"),
+    "resolve": ("runtime", "resolve"),
+    "resolve_tuned": ("runtime", "resolve_tuned"),
+    "resolver_instances": ("inject", "resolver_instances"),
+    "set_instance_resolver": ("runtime", "set_instance_resolver"),
+    "tuned_fields": ("runtime", "tuned_fields"),
+    "tuned_from_catalog": ("tuned", "tuned_from_catalog"),
+    "tuned_payload_fields": ("runtime", "tuned_payload_fields"),
+    "FamilyInstance": ("runtime", "FamilyBinding"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    row = _EXPORTS.get(name)
+    if row is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module, origin = row
+    return getattr(import_module(f"{__name__}.{module}"), origin)
+
+
+def __dir__() -> list[str]:
+    return sorted(_EXPORTS)
+
 
 #: **Two things are spelled ``Tuned``, and both spellings are deliberate.**
 #: ``Flux1Dev.Tuned`` is the family's tuned-value SCHEMA — a class, declared on
@@ -107,8 +190,6 @@ from .spec import (
 #: handler parameter: the class is the type, the value is the instance. One
 #: object, two names, because both readings are load-bearing in the design and
 #: a reader who arrives from either finds the thing they were told to look for.
-FamilyInstance = FamilyBinding
-
 __all__ = [
     "DEFAULT_LAYOUT",
     "EXPORT_VERSION",

--- a/src/gen_worker/family/catalog/_generated/flux1_dev.export.json
+++ b/src/gen_worker/family/catalog/_generated/flux1_dev.export.json
@@ -14,6 +14,14 @@
     "session_state": "none",
     "stages": [
       {
+        "repeat": "once",
+        "runner": "clip"
+      },
+      {
+        "repeat": "once",
+        "runner": "t5"
+      },
+      {
         "parameter": "steps",
         "repeat": "counted",
         "runner": "denoiser"
@@ -25,7 +33,7 @@
     ]
   },
   "lora_tuned": {
-    "module": "gen_worker.family.catalog.flux1_dev",
+    "module": "gen_worker.family.catalog.flux1_dev_serve",
     "qualname": "Flux1DevLoraTuned"
   },
   "parameters": [
@@ -36,6 +44,50 @@
     }
   ],
   "runners": [
+    {
+      "axes": [],
+      "name": "clip",
+      "variants": [
+        {
+          "bucket": {},
+          "ingress": {
+            "excluded_inputs": [],
+            "flat_arity": 1,
+            "inputs": [
+              {
+                "dtype": "int64",
+                "exported_name": "input_ids",
+                "name": "input_ids",
+                "param": "input_ids",
+                "param_position": 0,
+                "path": [],
+                "position": 0,
+                "shape": [
+                  1,
+                  77
+                ]
+              }
+            ],
+            "parameters": [
+              "input_ids"
+            ],
+            "symbols": {},
+            "v": 1
+          },
+          "ingress_digest": "d9ce232c770f450414c7fad78dcba745",
+          "layout": "bf16",
+          "outputs": [
+            {
+              "dtype": "bfloat16",
+              "shape": [
+                1,
+                768
+              ]
+            }
+          ]
+        }
+      ]
+    },
     {
       "axes": [
         "resolution"
@@ -389,16 +441,67 @@
           ]
         }
       ]
+    },
+    {
+      "axes": [],
+      "name": "t5",
+      "variants": [
+        {
+          "bucket": {},
+          "ingress": {
+            "excluded_inputs": [],
+            "flat_arity": 1,
+            "inputs": [
+              {
+                "dtype": "int64",
+                "exported_name": "input_ids",
+                "name": "input_ids",
+                "param": "input_ids",
+                "param_position": 0,
+                "path": [],
+                "position": 0,
+                "shape": [
+                  1,
+                  512
+                ]
+              }
+            ],
+            "parameters": [
+              "input_ids"
+            ],
+            "symbols": {},
+            "v": 1
+          },
+          "ingress_digest": "86e8b8b4fc273468ea91be5337358977",
+          "layout": "bf16",
+          "outputs": [
+            {
+              "dtype": "bfloat16",
+              "shape": [
+                1,
+                512,
+                4096
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "scheduler": {
     "name": "flow_match_euler_discrete",
     "parameters": {
-      "shift": 3.0
+      "base_image_seq_len": 256,
+      "base_shift": 0.5,
+      "max_image_seq_len": 4096,
+      "max_shift": 1.15,
+      "num_train_timesteps": 1000,
+      "shift": 3.0,
+      "use_dynamic_shifting": true
     }
   },
   "tuned": {
-    "module": "gen_worker.family.catalog.flux1_dev",
+    "module": "gen_worker.family.catalog.flux1_dev_serve",
     "qualname": "Flux1DevTuned"
   },
   "v": 1

--- a/src/gen_worker/family/catalog/_generated/flux1_dev.py
+++ b/src/gen_worker/family/catalog/_generated/flux1_dev.py
@@ -15,8 +15,9 @@ from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
-from gen_worker.family.catalog.flux1_dev import Flux1DevTuned
-from gen_worker.family.runtime import FamilyBinding, SchedulerBlock
+from gen_worker.family.catalog.flux1_dev_serve import Flux1DevTuned
+from gen_worker.family.runtime import FamilyBinding
+from gen_worker.family.scheduler import FlowMatchEulerDiscrete, SchedulerBlock, SchedulerKind
 from gen_worker.family.snapshot import FamilyExport
 from gen_worker.family.spec import Family
 
@@ -73,26 +74,67 @@ class Flux1Dev(FamilyBinding):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'flux1_dev'
-    EXPORT_DIGEST: ClassVar[str] = '0b12d90128648792a32da954b2c0aa6d'
+    EXPORT_DIGEST: ClassVar[str] = 'c8fbc4f9140e305739e45e8c87813842'
     EXPORT: ClassVar[FamilyExport] = _EXPORT
     Tuned: ClassVar[type[Flux1DevTuned]] = Flux1DevTuned
     SPEC: ClassVar[Family | None] = _SPEC
 
     #: Ordered stages of the declared loop: (runner, repeat, parameter).
     LOOP: ClassVar[tuple[tuple[str, str, str], ...]] = (
+        ('clip', 'once', ''),
+        ('t5', 'once', ''),
         ('denoiser', 'counted', 'steps'),
         ('decoder', 'once', ''),
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[str] = 'flow_match_euler_discrete'
+    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
     SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
+        'base_image_seq_len': 256,
+        'base_shift': 0.5,
+        'max_image_seq_len': 4096,
+        'max_shift': 1.15,
+        'num_train_timesteps': 1000,
         'shift': 3.0,
+        'use_dynamic_shifting': True,
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
         ('steps', 1, 100),
     )
+
+    def scheduler(self) -> FlowMatchEulerDiscrete:
+        """This family's declared scheduler, as bare typed math.
+
+        Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
+        digest — so a re-declared schedule changes this family's identity
+        instead of silently changing every request.
+        """
+        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+
+    def clip(
+        self,
+        *,
+        input_ids: Tensor,
+    ) -> Tensor:
+        """Call the 'clip' graph class of 'flux1_dev'.
+
+        Traced layouts: bf16. A compiled backing accepts exactly its
+        traced layout; an eager backing follows the fit ladder, which is
+        host policy and not this callable's business.
+        """
+        return cast(
+            "Tensor",
+            self._invoke(
+                'clip',
+                {},
+                'bf16',
+                (),
+                {
+                    'input_ids': input_ids,
+                },
+            ),
+        )
 
     def decoder(
         self,
@@ -158,6 +200,30 @@ class Flux1Dev(FamilyBinding):
                     'img_ids': img_ids,
                     'txt_ids': txt_ids,
                     'guidance': guidance,
+                },
+            ),
+        )
+
+    def t5(
+        self,
+        *,
+        input_ids: Tensor,
+    ) -> Tensor:
+        """Call the 't5' graph class of 'flux1_dev'.
+
+        Traced layouts: bf16. A compiled backing accepts exactly its
+        traced layout; an eager backing follows the fit ladder, which is
+        host policy and not this callable's business.
+        """
+        return cast(
+            "Tensor",
+            self._invoke(
+                't5',
+                {},
+                'bf16',
+                (),
+                {
+                    'input_ids': input_ids,
                 },
             ),
         )

--- a/src/gen_worker/family/catalog/_generated/sdxl.export.json
+++ b/src/gen_worker/family/catalog/_generated/sdxl.export.json
@@ -25,7 +25,7 @@
     ]
   },
   "lora_tuned": {
-    "module": "gen_worker.family.catalog.sdxl",
+    "module": "gen_worker.family.catalog.sdxl_serve",
     "qualname": "SdxlLoraTuned"
   },
   "parameters": [
@@ -350,7 +350,7 @@
     }
   },
   "tuned": {
-    "module": "gen_worker.family.catalog.sdxl",
+    "module": "gen_worker.family.catalog.sdxl_serve",
     "qualname": "SdxlTuned"
   },
   "v": 1

--- a/src/gen_worker/family/catalog/_generated/sdxl.py
+++ b/src/gen_worker/family/catalog/_generated/sdxl.py
@@ -16,8 +16,9 @@ from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
-from gen_worker.family.catalog.sdxl import SdxlTuned
-from gen_worker.family.runtime import FamilyBinding, SchedulerBlock
+from gen_worker.family.catalog.sdxl_serve import SdxlTuned
+from gen_worker.family.runtime import FamilyBinding
+from gen_worker.family.scheduler import SchedulerBlock, SchedulerKind
 from gen_worker.family.snapshot import FamilyExport
 from gen_worker.family.spec import Family
 
@@ -74,7 +75,7 @@ class Sdxl(FamilyBinding):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'sdxl'
-    EXPORT_DIGEST: ClassVar[str] = 'bd5b24bbdad7b9884cf03cd416a0b173'
+    EXPORT_DIGEST: ClassVar[str] = '8bb1091c8f87a59a2e799e6fc9643965'
     EXPORT: ClassVar[FamilyExport] = _EXPORT
     Tuned: ClassVar[type[SdxlTuned]] = SdxlTuned
     SPEC: ClassVar[Family | None] = _SPEC
@@ -86,7 +87,7 @@ class Sdxl(FamilyBinding):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[str] = 'euler_discrete'
+    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
     SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
         'timestep_spacing': 'leading',
     })

--- a/src/gen_worker/family/catalog/flux1_dev.py
+++ b/src/gen_worker/family/catalog/flux1_dev.py
@@ -3,12 +3,20 @@
 pgw#1326's catalog rule, literally: *"instead of importing diffusers, you
 import the catalog."* An endpoint imports :class:`~gen_worker.family.catalog.
 Flux1Dev` — the generated binding beside this file — and never touches
-diffusers. This module is where diffusers is allowed, and only inside the
-``build`` callables, which run at MINT time and on an eager-capable serving
-pod. Importing this module imports no model code at all, which is what lets an
-adopt-only serve role (pgw#1328) hold the bindings without acquiring diffusers.
+diffusers. This module is where diffusers and transformers are allowed, and
+only inside the ``build`` callables, which run at MINT time and on an
+eager-capable serving pod.
 
-**Checkpoint-free, and the architecture config is why.** The block below is
+**This module is MINT-SIDE and the serve role may not import it (pgw#1331).**
+Everything the request path needs — the tuned schemas, the packing arithmetic,
+the scheduler block's constants and the loop itself — lives in
+:mod:`gen_worker.family.catalog.flux1_dev_serve`, which imports ``torch`` and
+nothing above it. The import direction is one-way: this module reads from
+there, never the reverse, so the family's shape arithmetic has exactly one
+definition and an artifact cannot be minted at a shape the loop will not ask
+for. ``scripts/lint_serve_role_closure.py`` enforces the split.
+
+**Checkpoint-free, and the architecture config is why.** The blocks below are
 FLUX.1-dev's architecture, not any checkpoint's weights: every fine-tune that
 shares it shares the graph classes, which is what lets one compiled cell serve
 sixteen of them (DESIGN-RULINGS §4.27). A checkpoint whose config DIFFERS is a
@@ -18,15 +26,18 @@ it gets its own catalog entry rather than a fork arm here.
 
 **Why the modules are wrapped.** Each ``build`` returns a thin wrapper whose
 ``forward`` is exactly the call the binding exposes. Two reasons, both
-load-bearing: diffusers' own forwards take ``return_dict`` and other
-non-tensor arguments that ``CallIngress`` v1 cannot record a pinned value for
-(torchcg G4's known limit), so an unwrapped export would emit an unconstrained
-parameter a caller has to remember to pass correctly; and the wrapper is where
-the declaration states what the graph class RETURNS, instead of leaving it to
-whatever container version of diffusers is installed.
+load-bearing: the upstream forwards take ``return_dict`` and other non-tensor
+arguments that ``CallIngress`` v1 cannot record a pinned value for (torchcg
+G4's known limit), so an unwrapped export would emit an unconstrained parameter
+a caller has to remember to pass correctly; and the wrapper is where the
+declaration states what the graph class RETURNS, instead of leaving it to
+whatever container version of a model library is installed.
 
-Text encoders are deliberately absent: minting them is pgw#1331's lane, and a
-declaration that named a runner nothing exports would fail its own build.
+**Four runners, which is the whole pipeline** (pgw#1331 closed the gap): the
+two text encoders, the denoiser, and the VAE decoder. Nothing in FLUX.1-dev's
+composition is left riding an eager model at serve time, and the scheduler that
+threads them is bare typed math in :mod:`gen_worker.family.scheduler` rather
+than an object.
 """
 
 from __future__ import annotations
@@ -43,7 +54,16 @@ from ..spec import (
     Runner,
     Scheduler,
     Stage,
-    TunedValues,
+)
+from .flux1_dev_serve import (
+    CLIP_TOKENS,
+    LATENT_CHANNELS,
+    TEXT_TOKENS,
+    Flux1DevLoraTuned,
+    Flux1DevTuned,
+    compute_dtype,
+    latent_edge,
+    packed_tokens,
 )
 
 #: FLUX.1-dev's transformer architecture. Class-level truth: no weight, no
@@ -66,7 +86,7 @@ TRANSFORMER: Final[Mapping[str, Any]] = {
 VAE: Final[Mapping[str, Any]] = {
     "in_channels": 3,
     "out_channels": 3,
-    "latent_channels": 16,
+    "latent_channels": LATENT_CHANNELS,
     "block_out_channels": (128, 256, 512, 512),
     "layers_per_block": 2,
     "down_block_types": (
@@ -87,75 +107,55 @@ VAE: Final[Mapping[str, Any]] = {
     "shift_factor": 0.1159,
 }
 
-#: Prompt tokens the T5 branch is padded to. A pinned length, not an axis: a
-#: variable text dimension reaching a statically compiled denoiser mints a new
-#: graph per prompt length — unbounded and un-warmable.
-TEXT_TOKENS: Final = 512
+#: CLIP-L's text tower — FLUX.1-dev's ``text_encoder``. It contributes ONE
+#: pooled vector, which conditions the transformer's modulation; its per-token
+#: states are unused, which is why the wrapper returns only the pooled output.
+CLIP_TEXT: Final[Mapping[str, Any]] = {
+    "vocab_size": 49408,
+    "hidden_size": 768,
+    "intermediate_size": 3072,
+    "num_hidden_layers": 12,
+    "num_attention_heads": 12,
+    "max_position_embeddings": CLIP_TOKENS,
+    "hidden_act": "quick_gelu",
+    "layer_norm_eps": 1e-5,
+    "projection_dim": 768,
+    "eos_token_id": 2,
+}
 
-#: The VAE's spatial stride, and the transformer's packing factor. Together
-#: they turn a pixel edge into a token count, which is the ONLY arithmetic this
-#: declaration does.
-VAE_STRIDE: Final = 8
-PATCH: Final = 2
+#: T5-v1.1-XXL's encoder — FLUX.1-dev's ``text_encoder_2``, and the branch that
+#: actually carries the prompt. 4.7B parameters, which is why leaving it eager
+#: was the largest single hole in the compiled coverage.
+T5_TEXT: Final[Mapping[str, Any]] = {
+    "vocab_size": 32128,
+    "d_model": 4096,
+    "d_kv": 64,
+    "d_ff": 10240,
+    "num_layers": 24,
+    "num_heads": 64,
+    "relative_attention_num_buckets": 32,
+    "relative_attention_max_distance": 128,
+    "dropout_rate": 0.0,
+    "layer_norm_epsilon": 1e-6,
+    "feed_forward_proj": "gated-gelu",
+    "is_encoder_decoder": False,
+    "use_cache": False,
+    "tie_word_embeddings": False,
+}
 
-
-def latent_edge(resolution: int) -> int:
-    """Latent rows/cols for one pixel edge."""
-
-    return resolution // VAE_STRIDE
-
-
-def packed_tokens(resolution: int) -> int:
-    """Packed transformer tokens for one pixel edge."""
-
-    edge = latent_edge(resolution) // PATCH
-    return edge * edge
-
-
-class Flux1DevTuned(TunedValues, frozen=True):
-    """FLUX.1-dev's tuned-value SCHEMA. The values are catalog, per release slot.
-
-    Every field is a knob a checkpoint may legitimately have a different
-    opinion about. Nothing here is a graph fact: a value that changed the graph
-    would belong on a bucket axis, where the type system can keep the class set
-    exhaustive.
-    """
-
-    steps: int = 28
-    guidance: float = 3.5
-    shift: float = 3.0
-    #: A CLAMP, never a wire reshape: a request asking for more is served at
-    #: this value with an adjustment recorded, not refused.
-    max_guidance: float | None = None
-
-
-class Flux1DevLoraTuned(TunedValues, frozen=True):
-    """The LoRA-kind overlay for the same family: every field is "no opinion".
-
-    ``None`` means the overlay declines to override the checkpoint's own tuned
-    value. That is why every field is optional and none carries a real default:
-    an overlay with an opinion it did not mean to have would silently retune
-    every checkpoint it is applied to.
-    """
-
-    trigger_words: tuple[str, ...] = ()
-    recommended_weight: float | None = None
-    steps: int | None = None
-    guidance: float | None = None
-    shift: float | None = None
-
-
-def _compute_dtype(layout: str) -> Any:
-    """The compute dtype one layout token implies, for THIS family.
-
-    A layout token is opaque to the SDK — it records the token and never
-    interprets it (torchcg G15) — so the mapping to a torch dtype is the
-    declaration's, stated once here rather than inferred anywhere.
-    """
-
-    import torch
-
-    return torch.bfloat16 if layout == "bf16" else torch.float32
+#: FLUX.1-dev's scheduler block, as the checkpoint's own ``scheduler/
+#: scheduler_config.json`` states it. It is DECLARED here — not hardcoded in
+#: the math — so it rides the export digest: a re-declared schedule changes the
+#: family's identity instead of silently changing every request.
+SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
+    "num_train_timesteps": 1000,
+    "shift": 3.0,
+    "use_dynamic_shifting": True,
+    "base_shift": 0.5,
+    "max_shift": 1.15,
+    "base_image_seq_len": 256,
+    "max_image_seq_len": 4096,
+}
 
 
 def _denoiser(layout: str) -> Any:
@@ -168,7 +168,7 @@ def _denoiser(layout: str) -> Any:
     # `set_default_dtype` rather than `.to(dtype)`: a fake parameter cannot be
     # swapped in place, so the dtype has to be in force while the module is
     # BUILT. `fake_structure()` restores the process default afterwards.
-    torch.set_default_dtype(_compute_dtype(layout))
+    torch.set_default_dtype(compute_dtype(layout))
     # Bound as a value, not called through the imported name: diffusers ships
     # no complete stubs, and this keeps the untyped boundary at ONE line per
     # build instead of a `type: ignore` on every attribute of the result.
@@ -206,7 +206,7 @@ def _denoiser(layout: str) -> Any:
 def _denoiser_example(bucket: Mapping[str, int], layout: str) -> CallExample:
     import torch
 
-    dtype = _compute_dtype(layout)
+    dtype = compute_dtype(layout)
     tokens = packed_tokens(int(bucket["resolution"]))
     return CallExample(
         params=(
@@ -237,7 +237,7 @@ def _decoder(layout: str) -> Any:
     from diffusers import AutoencoderKL
     from torch import nn
 
-    torch.set_default_dtype(_compute_dtype(layout))
+    torch.set_default_dtype(compute_dtype(layout))
     autoencoder: Any = AutoencoderKL
 
     class _Decoder(nn.Module):
@@ -254,39 +254,124 @@ def _decoder(layout: str) -> Any:
 def _decoder_example(bucket: Mapping[str, int], layout: str) -> CallExample:
     import torch
 
-    dtype = _compute_dtype(layout)
+    dtype = compute_dtype(layout)
     edge = latent_edge(int(bucket["resolution"]))
     return CallExample(
         params=("latents",),
-        kwargs={"latents": torch.zeros(1, 16, edge, edge, dtype=dtype)},
+        kwargs={"latents": torch.zeros(1, LATENT_CHANNELS, edge, edge, dtype=dtype)},
     )
 
 
-#: FLUX.1-dev. Buckets are pixel edges; every runner has a class at each, so
-#: the generated ``Literal`` is exhaustive and every selection resolves.
+def _clip(layout: str) -> Any:
+    """CLIP-L's text tower, wrapped down to the ONE output Flux consumes.
+
+    The wrapper returns ``pooler_output`` alone. Returning the per-token states
+    beside it would put a 77x768 tensor in the graph class's egress that no
+    caller reads, and an artifact's outputs are part of its ingress digest — so
+    an unused output is a permanent contract, not dead weight that optimizes
+    away.
+    """
+
+    import torch
+    from torch import nn
+    from transformers import CLIPTextConfig, CLIPTextModel
+
+    torch.set_default_dtype(compute_dtype(layout))
+    config: Any = CLIPTextConfig
+    text_model: Any = CLIPTextModel
+
+    class _Clip(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.text_encoder = text_model(config(**dict(CLIP_TEXT)))
+
+        def forward(self, input_ids: Any) -> Any:
+            return self.text_encoder(input_ids=input_ids).pooler_output
+
+    return _Clip().eval()
+
+
+def _clip_example(bucket: Mapping[str, int], layout: str) -> CallExample:
+    import torch
+
+    del bucket, layout  # token IDs are integers; the layout decides no dtype here
+    return CallExample(
+        params=("input_ids",),
+        kwargs={"input_ids": torch.zeros(1, CLIP_TOKENS, dtype=torch.long)},
+    )
+
+
+def _t5(layout: str) -> Any:
+    """T5-XXL's encoder, wrapped down to its last hidden state.
+
+    This is the branch that carries the prompt: 512 tokens of 4096-dim states
+    that the joint attention reads at every one of the denoiser's steps. It is
+    also 4.7B parameters run once per request — the eager tail pgw#1331 exists
+    to close.
+    """
+
+    import torch
+    from torch import nn
+    from transformers import T5Config, T5EncoderModel
+
+    torch.set_default_dtype(compute_dtype(layout))
+    config: Any = T5Config
+    encoder: Any = T5EncoderModel
+
+    class _T5(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.text_encoder = encoder(config(**dict(T5_TEXT)))
+
+        def forward(self, input_ids: Any) -> Any:
+            return self.text_encoder(input_ids=input_ids).last_hidden_state
+
+    return _T5().eval()
+
+
+def _t5_example(bucket: Mapping[str, int], layout: str) -> CallExample:
+    import torch
+
+    del bucket, layout
+    return CallExample(
+        params=("input_ids",),
+        kwargs={"input_ids": torch.zeros(1, TEXT_TOKENS, dtype=torch.long)},
+    )
+
+
+#: FLUX.1-dev. Buckets are pixel edges; every runner that declares the axis has
+#: a class at each, so the generated ``Literal`` is exhaustive and every
+#: selection resolves. The text encoders declare NO axis: their token lengths
+#: are pinned by the architecture (CLIP-L's learned positions) and by the
+#: family (T5's 512), so bucketing them would generate classes nothing selects.
 FLUX1_DEV: Final = GraphFamily(
     name="flux1_dev",
     tuned=Flux1DevTuned,
     lora_tuned=Flux1DevLoraTuned,
     buckets=(Bucket("resolution", (768, 1024)),),
     runners=(
+        Runner("clip", build=_clip, example=_clip_example),
         Runner("decoder", build=_decoder, example=_decoder_example, axes=("resolution",)),
         Runner("denoiser", build=_denoiser, example=_denoiser_example, axes=("resolution",)),
+        Runner("t5", build=_t5, example=_t5_example),
     ),
-    loop=Loop(stages=(Stage("denoiser", repeat="steps"), Stage("decoder"))),
+    loop=Loop(
+        stages=(
+            Stage("clip"),
+            Stage("t5"),
+            Stage("denoiser", repeat="steps"),
+            Stage("decoder"),
+        )
+    ),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("flow_match_euler_discrete", {"shift": 3.0}),
+    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
 )
 
 __all__ = [
+    "CLIP_TEXT",
     "FLUX1_DEV",
-    "PATCH",
-    "TEXT_TOKENS",
+    "SCHEDULER",
+    "T5_TEXT",
     "TRANSFORMER",
     "VAE",
-    "VAE_STRIDE",
-    "Flux1DevLoraTuned",
-    "Flux1DevTuned",
-    "latent_edge",
-    "packed_tokens",
 ]

--- a/src/gen_worker/family/catalog/flux1_dev_serve.py
+++ b/src/gen_worker/family/catalog/flux1_dev_serve.py
@@ -1,0 +1,423 @@
+"""FLUX.1-dev's SERVING half: tuned schemas, packing math, and the loop.
+
+The catalog convention pgw#1331 introduces, and the reason the family's entry is
+two modules instead of one:
+
+* ``flux1_dev.py`` is the **declaration**. Its ``build`` callables construct
+  diffusers and transformers modules, so it is MINT-SIDE, and a serve process
+  that imported it would be one static edge away from acquiring a model library.
+* ``flux1_dev_serve.py`` — this module — is everything the REQUEST PATH needs
+  and nothing else. It imports ``torch`` (the runtime) and nothing above it: no
+  ``diffusers``, no ``transformers``, no pipeline object, no scheduler object.
+  ``scripts/lint_serve_role_closure.py`` asserts that, walking function-local
+  imports, and ``gen_worker.serve.role.FORBIDDEN_LIBRARIES`` is the list it
+  reads.
+
+The direction is one-way: the declaration imports from here, never the reverse.
+That is what keeps ONE definition of the family's shape arithmetic — the mint
+traces the graph classes at the token counts this module computes, so an
+artifact cannot be minted at a shape the loop will not ask for.
+
+**What "bare math" means here, concretely.** ``FluxPipeline.__call__`` is ~250
+lines that reach the same arithmetic through a pipeline registry, a scheduler
+object with mutable step state, a VAE image processor, and a component-loading
+layer. Every one of those is a serve-path dependency bought to run: two
+reshapes, a permute, an affine rescale, and one Euler step (which lives in
+:mod:`gen_worker.family.scheduler`). The functions below are that arithmetic,
+typed, with the family's own declared constants as their parameters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Final
+
+from ..scheduler import FlowMatchEulerDiscrete, Schedule
+from ..spec import TunedValues
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor
+
+    from ._generated.flux1_dev import Flux1Dev, Flux1DevResolution
+
+
+#: T5 prompt tokens the text branch is padded to. A PINNED length, not an axis:
+#: a variable text dimension reaching a statically compiled denoiser mints a new
+#: graph per prompt length — unbounded and un-warmable.
+TEXT_TOKENS: Final = 512
+
+#: CLIP-L's context window. Fixed by the encoder's learned position embeddings,
+#: so it is architecture and not a choice this catalog gets to make.
+CLIP_TOKENS: Final = 77
+
+#: The VAE's spatial stride, and the transformer's packing factor. Together they
+#: turn a pixel edge into a token count, which is the ONLY arithmetic the
+#: declaration does.
+VAE_STRIDE: Final = 8
+PATCH: Final = 2
+
+#: The latent channel count the transformer packs 2x2 blocks of into 64.
+LATENT_CHANNELS: Final = 16
+
+#: The affine the VAE's latent space is normalized by. Architecture, not tuning:
+#: these two are properties of the trained autoencoder.
+SCALING_FACTOR: Final = 0.3611
+SHIFT_FACTOR: Final = 0.1159
+
+
+def latent_edge(resolution: int) -> int:
+    """Latent rows/cols for one pixel edge.
+
+    Rounded to an even number, because the transformer packs 2x2 latent blocks
+    and an odd edge would leave a half-patch the packing cannot express.
+    """
+
+    return 2 * (resolution // (VAE_STRIDE * PATCH))
+
+
+def packed_tokens(resolution: int) -> int:
+    """Packed transformer tokens for one square pixel edge."""
+
+    edge = latent_edge(resolution) // PATCH
+    return edge * edge
+
+
+def compute_dtype(layout: str) -> Any:
+    """The compute dtype one tensor-layout token implies, for THIS family.
+
+    A layout token is opaque to the SDK — it records the token and never
+    interprets it (torchcg G15) — so the mapping to a torch dtype is the
+    family's, stated once here rather than inferred at each site that needs it.
+    """
+
+    import torch
+
+    return torch.bfloat16 if layout == "bf16" else torch.float32
+
+
+class Flux1DevTuned(TunedValues, frozen=True):
+    """FLUX.1-dev's tuned-value SCHEMA. The values are catalog, per release slot.
+
+    Every field is a knob a checkpoint may legitimately have a different opinion
+    about. Nothing here is a graph fact: a value that changed the graph would
+    belong on a bucket axis, where the type system can keep the class set
+    exhaustive.
+
+    It lives in the SERVING half because the request path resolves against it on
+    every call, and the declaration half is the one the serve role may not
+    import.
+    """
+
+    steps: int = 28
+    guidance: float = 3.5
+    shift: float = 3.0
+    #: A CLAMP, never a wire reshape: a request asking for more is served at
+    #: this value with an adjustment recorded, not refused.
+    max_guidance: float | None = None
+
+
+class Flux1DevLoraTuned(TunedValues, frozen=True):
+    """The LoRA-kind overlay for the same family: every field is "no opinion".
+
+    ``None`` means the overlay declines to override the checkpoint's own tuned
+    value. That is why every field is optional and none carries a real default:
+    an overlay with an opinion it did not mean to have would silently retune
+    every checkpoint it is applied to.
+    """
+
+    trigger_words: tuple[str, ...] = ()
+    recommended_weight: float | None = None
+    steps: int | None = None
+    guidance: float | None = None
+    shift: float | None = None
+
+
+# --------------------------------------------------------------- packing math
+
+
+def pack_latents(latents: Tensor) -> Tensor:
+    """``(B, C, H, W)`` latents -> ``(B, H/2 * W/2, C*4)`` transformer tokens.
+
+    One view, one permute, one reshape. This is the entirety of what the
+    pipeline's ``_pack_latents`` does, and it is here rather than imported
+    because importing it costs the package it lives in.
+    """
+
+    batch, channels, height, width = latents.shape
+    blocked = latents.view(batch, channels, height // PATCH, PATCH, width // PATCH, PATCH)
+    return blocked.permute(0, 2, 4, 1, 3, 5).reshape(
+        batch, (height // PATCH) * (width // PATCH), channels * PATCH * PATCH
+    )
+
+
+def unpack_latents(tokens: Tensor, *, edge: int) -> Tensor:
+    """The inverse of :func:`pack_latents`, back to ``(B, C, edge, edge)``."""
+
+    batch, _, channels = tokens.shape
+    grid = edge // PATCH
+    blocked = tokens.view(batch, grid, grid, channels // (PATCH * PATCH), PATCH, PATCH)
+    return blocked.permute(0, 3, 1, 4, 2, 5).reshape(
+        batch, channels // (PATCH * PATCH), edge, edge
+    )
+
+
+def latent_image_ids(edge: int, *, device: Any, dtype: Any) -> Tensor:
+    """The rope coordinate of every packed image token: ``(tokens, 3)``.
+
+    Channel 0 is the (unused, always-zero) temporal axis; channels 1 and 2 are
+    the token's row and column in the packed grid.
+    """
+
+    import torch
+
+    grid = edge // PATCH
+    ids = torch.zeros(grid, grid, 3, device=device, dtype=dtype)
+    ids[..., 1] = ids[..., 1] + torch.arange(grid, device=device, dtype=dtype)[:, None]
+    ids[..., 2] = ids[..., 2] + torch.arange(grid, device=device, dtype=dtype)[None, :]
+    return ids.reshape(grid * grid, 3)
+
+
+def text_ids(tokens: int, *, device: Any, dtype: Any) -> Tensor:
+    """The rope coordinate of every text token — all zero, by construction.
+
+    Flux gives the text branch no positional identity in the joint rope; the
+    tensor exists because the graph class's ingress declares it, not because it
+    carries information.
+    """
+
+    import torch
+
+    return torch.zeros(tokens, 3, device=device, dtype=dtype)
+
+
+def initial_latents(
+    *,
+    resolution: int,
+    batch: int,
+    seed: int,
+    device: Any,
+    dtype: Any,
+) -> Tensor:
+    """Pure noise, packed, for one request. Seeded on the CPU, deliberately.
+
+    A CPU generator makes a request's noise reproducible across GPU models and
+    driver versions, which is what lets a receipt's seed mean the same thing on
+    two different pods. The cost is one host-to-device copy of a few megabytes.
+    """
+
+    import torch
+
+    edge = latent_edge(resolution)
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    noise = torch.randn(
+        batch, LATENT_CHANNELS, edge, edge, generator=generator, dtype=torch.float32
+    )
+    return pack_latents(noise.to(device=device, dtype=dtype))
+
+
+def denormalize_latents(tokens: Tensor, *, resolution: int) -> Tensor:
+    """Undo the VAE's latent affine and unpack, ready for the decoder call."""
+
+    latents = unpack_latents(tokens, edge=latent_edge(resolution))
+    return (latents / SCALING_FACTOR) + SHIFT_FACTOR
+
+
+def to_image_range(decoded: Tensor) -> Tensor:
+    """The decoder's ``[-1, 1]`` output as ``[0, 1]``, clamped."""
+
+    return (decoded / 2 + 0.5).clamp(0, 1)
+
+
+# ---------------------------------------------------------------- the pipeline
+
+
+def schedule_for(instance: Flux1Dev, *, steps: int, resolution: int) -> Schedule:
+    """The sigma ladder for one request, from the family's OWN declared block.
+
+    The scheduler's constants ride the export digest, so a re-declared schedule
+    changes the family's identity rather than silently changing every request.
+    """
+
+    scheduler: FlowMatchEulerDiscrete = instance.scheduler()
+    return scheduler.schedule(steps, image_seq_len=packed_tokens(resolution))
+
+
+def encode_prompt(
+    instance: Flux1Dev,
+    *,
+    clip_ids: Tensor,
+    t5_ids: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Both text branches, through the family's typed callables.
+
+    Returns ``(prompt_embeds, pooled_projections)``: T5's per-token states drive
+    the joint attention, CLIP-L's pooled vector conditions the modulation. The
+    token IDs arrive already tokenized — tokenization is a pure-data step with
+    no model in it, and keeping it outside means this function needs no
+    tokenizer library either.
+    """
+
+    pooled = instance.clip(input_ids=clip_ids)
+    embeds = instance.t5(input_ids=t5_ids)
+    return embeds, pooled
+
+
+def denoise(
+    instance: Flux1Dev,
+    *,
+    resolution: Flux1DevResolution,
+    latents: Tensor,
+    prompt_embeds: Tensor,
+    pooled_projections: Tensor,
+    schedule: Schedule,
+    guidance: float,
+) -> Iterator[tuple[int, Tensor]]:
+    """The denoising loop, yielding ``(step index, latents)`` after each step.
+
+    A generator rather than a function returning the final tensor, so a caller
+    can report progress, honour cancellation and stream previews without this
+    module knowing what a request is. That is the same reason the scheduler is
+    passed in resolved: nothing in this loop reads request state.
+
+    ``guidance`` is FLUX.1-dev's EMBEDDED guidance — a conditioning input to the
+    transformer, not classifier-free guidance. There is no negative branch and
+    no second forward per step; a CFG family would declare a different loop.
+    """
+
+    import torch
+
+    device = latents.device
+    dtype = latents.dtype
+    image_ids = latent_image_ids(latent_edge(resolution), device=device, dtype=dtype)
+    txt_ids = text_ids(prompt_embeds.shape[1], device=device, dtype=dtype)
+    guidance_input = torch.full((latents.shape[0],), guidance, device=device, dtype=dtype)
+
+    for index, sigma in enumerate(schedule.sigmas[:-1]):
+        timestep = torch.full((latents.shape[0],), sigma, device=device, dtype=dtype)
+        velocity = instance.denoiser(
+            resolution=resolution,
+            hidden_states=latents,
+            encoder_hidden_states=prompt_embeds,
+            pooled_projections=pooled_projections,
+            timestep=timestep,
+            img_ids=image_ids,
+            txt_ids=txt_ids,
+            guidance=guidance_input,
+        )
+        latents = schedule.step(index, velocity, latents)
+        yield index, latents
+
+
+def decode(
+    instance: Flux1Dev,
+    *,
+    resolution: Flux1DevResolution,
+    latents: Tensor,
+) -> Tensor:
+    """Packed latents to an image tensor in ``[0, 1]``, ``(B, 3, H, W)``."""
+
+    return to_image_range(
+        instance.decoder(
+            resolution=resolution,
+            latents=denormalize_latents(latents, resolution=resolution),
+        )
+    )
+
+
+def generate(
+    instance: Flux1Dev,
+    *,
+    resolution: Flux1DevResolution,
+    clip_ids: Tensor,
+    t5_ids: Tensor,
+    steps: int,
+    guidance: float,
+    seed: int,
+    on_step: Callable[[int, int], None] | None = None,
+) -> Tensor:
+    """One FLUX.1-dev generation, end to end, with no model library imported.
+
+    Every heavy call goes through a typed family callable, so the whole of this
+    function runs unchanged against a compiled backing, an eager one, or a fake
+    one — which is what lets it be tested in CI without a card and served from
+    an artifact on a pod (pgw#1326's dual backing).
+
+    Placement is READ off the inputs, never chosen: the token tensors arrive on
+    the device the caller put them on, and the dtype comes from the layout the
+    family's own denoiser variant was traced against. A loop that picked its own
+    device is how a request lands on the wrong card.
+    """
+
+    device = clip_ids.device
+    dtype = compute_dtype(str(instance.variant("denoiser", {"resolution": resolution}).layout))
+    prompt_embeds, pooled = encode_prompt(instance, clip_ids=clip_ids, t5_ids=t5_ids)
+    latents = initial_latents(
+        resolution=resolution,
+        batch=int(prompt_embeds.shape[0]),
+        seed=seed,
+        device=device,
+        dtype=dtype,
+    )
+    schedule = schedule_for(instance, steps=steps, resolution=resolution)
+    for index, latents in denoise(
+        instance,
+        resolution=resolution,
+        latents=latents,
+        prompt_embeds=prompt_embeds,
+        pooled_projections=pooled,
+        schedule=schedule,
+        guidance=guidance,
+    ):
+        if on_step is not None:
+            on_step(index, len(schedule))
+    return decode(instance, resolution=resolution, latents=latents)
+
+
+def clip_token_ids(ids: Sequence[int], *, device: Any) -> Tensor:
+    """CLIP-L token IDs, padded/truncated to the encoder's fixed window."""
+
+    return _ids(ids, length=CLIP_TOKENS, device=device)
+
+
+def t5_token_ids(ids: Sequence[int], *, device: Any) -> Tensor:
+    """T5 token IDs, padded/truncated to the family's pinned text length."""
+
+    return _ids(ids, length=TEXT_TOKENS, device=device)
+
+
+def _ids(ids: Sequence[int], *, length: int, device: Any) -> Tensor:
+    import torch
+
+    row = list(ids)[:length]
+    row.extend([0] * (length - len(row)))
+    return torch.tensor([row], device=device, dtype=torch.long)
+
+
+__all__ = [
+    "CLIP_TOKENS",
+    "LATENT_CHANNELS",
+    "PATCH",
+    "SCALING_FACTOR",
+    "SHIFT_FACTOR",
+    "TEXT_TOKENS",
+    "VAE_STRIDE",
+    "Flux1DevLoraTuned",
+    "Flux1DevTuned",
+    "clip_token_ids",
+    "compute_dtype",
+    "decode",
+    "denoise",
+    "denormalize_latents",
+    "encode_prompt",
+    "generate",
+    "initial_latents",
+    "latent_edge",
+    "latent_image_ids",
+    "pack_latents",
+    "packed_tokens",
+    "schedule_for",
+    "t5_token_ids",
+    "text_ids",
+    "to_image_range",
+    "unpack_latents",
+]

--- a/src/gen_worker/family/catalog/sdxl.py
+++ b/src/gen_worker/family/catalog/sdxl.py
@@ -18,9 +18,15 @@ channels-last layout optimisation (measured at +7.2% on sdxl). Buckets keep
 each class statically specialised, and the closed ``Literal`` keeps the set
 exhaustive.
 
-Same rules as the Flux entry: diffusers is imported only inside ``build``, the
-config below is architecture (checkpoint-free), and the text encoders belong to
-pgw#1331.
+Same rules as the Flux entry: diffusers is imported only inside ``build`` and
+the config below is architecture (checkpoint-free). Its text encoders are still
+absent — pgw#1331 took ONE family end to end and Flux is that family; declaring
+SDXL's without a loop to serve them would be classes nothing selects.
+
+**This module is MINT-SIDE** (pgw#1331). The tuned schemas and the latent
+arithmetic the request path reads live in
+:mod:`gen_worker.family.catalog.sdxl_serve`, which imports nothing above
+``torch``; this half reads from there, never the reverse.
 """
 
 from __future__ import annotations
@@ -37,7 +43,16 @@ from ..spec import (
     Runner,
     Scheduler,
     Stage,
-    TunedValues,
+)
+from .sdxl_serve import (
+    CFG_BATCH,
+    LATENT_CHANNELS,
+    TEXT_TOKENS,
+    TIME_IDS,
+    SdxlLoraTuned,
+    SdxlTuned,
+    compute_dtype,
+    latent_edge,
 )
 
 #: SDXL's U-Net architecture. Every SDXL fine-tune shares it, which is exactly
@@ -87,67 +102,13 @@ VAE: Final[Mapping[str, Any]] = {
     "scaling_factor": 0.13025,
 }
 
-#: CLIP's pinned prompt length. Pinned, not an axis — same reason as Flux's.
-TEXT_TOKENS: Final = 77
-
-#: The VAE's spatial stride.
-VAE_STRIDE: Final = 8
-
-#: The two-batch classifier-free-guidance arity SDXL is traced at: cond and
-#: uncond ride ONE call. A CFG arity change is a different graph, so it is a
-#: fact of the declaration rather than a runtime flag.
-CFG_BATCH: Final = 2
-
-#: The micro-conditioning vector's width (original/crop/target sizes).
-TIME_IDS: Final = 6
-
-
-def latent_edge(resolution: int) -> int:
-    """Latent rows/cols for one pixel edge."""
-
-    return resolution // VAE_STRIDE
-
-
-class SdxlTuned(TunedValues, frozen=True):
-    """SDXL's tuned-value SCHEMA. Catalog stamps the values, per release slot."""
-
-    scheduler: Literal["euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras"] = "euler_a"
-    steps: int = 28
-    guidance: float = 6.0
-    negative: str = ""
-    #: A CLAMP, never a wire reshape.
-    max_guidance: float | None = None
-
-
-class SdxlLoraTuned(TunedValues, frozen=True):
-    """The LoRA-kind overlay: every field is "no opinion" unless stated."""
-
-    trigger_words: tuple[str, ...] = ()
-    recommended_weight: float | None = None
-    steps: int | None = None
-    guidance: float | None = None
-    scheduler: Literal["euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras"] | None = None
-
-
-def _compute_dtype(layout: str) -> Any:
-    """The compute dtype one layout token implies, for THIS family.
-
-    A layout token is opaque to the SDK — it records the token and never
-    interprets it (torchcg G15) — so the mapping to a torch dtype is the
-    declaration's, stated once here rather than inferred anywhere.
-    """
-
-    import torch
-
-    return torch.bfloat16 if layout == "bf16" else torch.float32
-
 
 def _denoiser(layout: str) -> Any:
     import torch
     from diffusers import UNet2DConditionModel
     from torch import nn
 
-    torch.set_default_dtype(_compute_dtype(layout))
+    torch.set_default_dtype(compute_dtype(layout))
     # Bound as a value, not called through the imported name: diffusers ships
     # no complete stubs, and this keeps the untyped boundary at ONE line per
     # build instead of a `type: ignore` on every attribute of the result.
@@ -179,12 +140,12 @@ def _denoiser(layout: str) -> Any:
 def _denoiser_example(bucket: Mapping[str, int], layout: str) -> CallExample:
     import torch
 
-    dtype = _compute_dtype(layout)
+    dtype = compute_dtype(layout)
     edge = latent_edge(int(bucket["resolution"]))
     return CallExample(
         params=("sample", "timestep", "encoder_hidden_states", "added_cond_kwargs"),
         kwargs={
-            "sample": torch.zeros(CFG_BATCH, 4, edge, edge, dtype=dtype),
+            "sample": torch.zeros(CFG_BATCH, LATENT_CHANNELS, edge, edge, dtype=dtype),
             # float32 deliberately: euler-family samplers present a float32
             # scalar timestep and ddim/dpmpp-family samplers present int64. The
             # integer -> float32 recast is `ingress_selection_v1`'s ONE
@@ -208,7 +169,7 @@ def _decoder(layout: str) -> Any:
     from diffusers import AutoencoderKL
     from torch import nn
 
-    torch.set_default_dtype(_compute_dtype(layout))
+    torch.set_default_dtype(compute_dtype(layout))
     autoencoder: Any = AutoencoderKL
 
     class _Decoder(nn.Module):
@@ -225,7 +186,7 @@ def _decoder(layout: str) -> Any:
 def _decoder_example(bucket: Mapping[str, int], layout: str) -> CallExample:
     import torch
 
-    dtype = _compute_dtype(layout)
+    dtype = compute_dtype(layout)
     edge = latent_edge(int(bucket["resolution"]))
     return CallExample(
         params=("latents",),
@@ -249,14 +210,7 @@ SDXL: Final = GraphFamily(
 )
 
 __all__ = [
-    "CFG_BATCH",
     "SDXL",
-    "TEXT_TOKENS",
-    "TIME_IDS",
     "UNET",
     "VAE",
-    "VAE_STRIDE",
-    "SdxlLoraTuned",
-    "SdxlTuned",
-    "latent_edge",
 ]

--- a/src/gen_worker/family/catalog/sdxl.py
+++ b/src/gen_worker/family/catalog/sdxl.py
@@ -32,7 +32,7 @@ arithmetic the request path reads live in
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Final, Literal
+from typing import Any, Final
 
 from ..spec import (
     Bucket,

--- a/src/gen_worker/family/catalog/sdxl_serve.py
+++ b/src/gen_worker/family/catalog/sdxl_serve.py
@@ -1,0 +1,98 @@
+"""Stable Diffusion XL's SERVING half: tuned schemas and shape arithmetic.
+
+The same two-module split ``flux1_dev_serve`` documents (pgw#1331), applied to
+the second catalog entry so the convention is the catalog's and not one
+family's exception: ``sdxl.py`` is the DECLARATION and imports diffusers inside
+its ``build`` callables; this module is what the request path reads, and it
+imports nothing above ``torch``.
+
+SDXL is deliberately NOT taken end to end here. pgw#1331 covers ONE family, and
+a hand-written SDXL loop with nothing measuring it is how a wrong schedule
+ships. What this module carries is the half the split makes structural — the
+tuned schemas a handler resolves against on every call, and the latent
+arithmetic both halves must agree on — so the serve-role fence covers the whole
+catalog rather than one entry of it, and the next family cannot regress the
+property by being written the old way.
+
+The consequence, stated rather than left to be discovered: ``Sdxl`` has no
+``scheduler()`` method, because ``euler_discrete``'s math is not implemented in
+:mod:`gen_worker.family.scheduler`. That is an ``AttributeError`` a type checker
+reports on the author's machine, which is the intended shape of the gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Literal
+
+from ..spec import TunedValues
+
+#: CLIP's pinned prompt length. Pinned, not an axis — a variable text dimension
+#: reaching a statically compiled denoiser mints a new graph per prompt length.
+TEXT_TOKENS: Final = 77
+
+#: The VAE's spatial stride.
+VAE_STRIDE: Final = 8
+
+#: The two-batch classifier-free-guidance arity SDXL is traced at: cond and
+#: uncond ride ONE call. A CFG arity change is a different graph, so it is a
+#: fact of the declaration rather than a runtime flag.
+CFG_BATCH: Final = 2
+
+#: The micro-conditioning vector's width (original/crop/target sizes).
+TIME_IDS: Final = 6
+
+#: SDXL's latent channel count.
+LATENT_CHANNELS: Final = 4
+
+
+def latent_edge(resolution: int) -> int:
+    """Latent rows/cols for one pixel edge."""
+
+    return resolution // VAE_STRIDE
+
+
+def compute_dtype(layout: str) -> Any:
+    """The compute dtype one tensor-layout token implies, for THIS family.
+
+    A layout token is opaque to the SDK — it records the token and never
+    interprets it (torchcg G15) — so the mapping to a torch dtype is the
+    family's, stated once here rather than inferred at each site that needs it.
+    """
+
+    import torch
+
+    return torch.bfloat16 if layout == "bf16" else torch.float32
+
+
+class SdxlTuned(TunedValues, frozen=True):
+    """SDXL's tuned-value SCHEMA. Catalog stamps the values, per release slot."""
+
+    scheduler: Literal["euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras"] = "euler_a"
+    steps: int = 28
+    guidance: float = 6.0
+    negative: str = ""
+    #: A CLAMP, never a wire reshape.
+    max_guidance: float | None = None
+
+
+class SdxlLoraTuned(TunedValues, frozen=True):
+    """The LoRA-kind overlay: every field is "no opinion" unless stated."""
+
+    trigger_words: tuple[str, ...] = ()
+    recommended_weight: float | None = None
+    steps: int | None = None
+    guidance: float | None = None
+    scheduler: Literal["euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras"] | None = None
+
+
+__all__ = [
+    "CFG_BATCH",
+    "LATENT_CHANNELS",
+    "TEXT_TOKENS",
+    "TIME_IDS",
+    "VAE_STRIDE",
+    "SdxlLoraTuned",
+    "SdxlTuned",
+    "compute_dtype",
+    "latent_edge",
+]

--- a/src/gen_worker/family/codegen.py
+++ b/src/gen_worker/family/codegen.py
@@ -38,6 +38,7 @@ from typing import Final
 
 from .._vendor.torchcg.recipe import ParameterKind, SignatureParameter
 from .errors import FamilyError, FamilyRefusal
+from .scheduler import IMPLEMENTED, parse_kind
 from .snapshot import ExportedRunner, FamilyExport
 
 #: Emitted verbatim at the top of every generated module. It names the command
@@ -225,7 +226,10 @@ def _class_facts(export: FamilyExport) -> list[str]:
         f'{_INDENT}SESSION_STATE: ClassVar[str] = {loop.session_state.value!r}',
     ]
     if scheduler is not None:
-        lines.append(f'{_INDENT}SCHEDULER: ClassVar[str] = {scheduler.name!r}')
+        kind = parse_kind(str(scheduler.name))
+        lines.append(
+            f"{_INDENT}SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.{kind.name}"
+        )
         lines.append(
             f"{_INDENT}SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({{"
         )
@@ -243,6 +247,29 @@ def _class_facts(export: FamilyExport) -> list[str]:
     )
     lines.append(f"{_INDENT})")
     return lines
+
+
+def _scheduler_method(implementation: str) -> list[str]:
+    """The typed accessor for a family whose scheduler the SDK implements.
+
+    The return type is the CONCRETE class, so a handler reaches flow-match
+    Euler's own API — ``schedule()``, ``step()`` — through the type checker
+    rather than through a name it typed. There is no registry lookup at request
+    time and no scheduler object: what comes back is a frozen dataclass of the
+    family's own declared constants (pgw#1331).
+    """
+
+    return [
+        "",
+        f"{_INDENT}def scheduler(self) -> {implementation}:",
+        f'{_INDENT * 2}"""This family\'s declared scheduler, as bare typed math.',
+        "",
+        f"{_INDENT * 2}Built from ``SCHEDULER_PARAMETERS`` above, which rides the export",
+        f"{_INDENT * 2}digest — so a re-declared schedule changes this family's identity",
+        f"{_INDENT * 2}instead of silently changing every request.",
+        f'{_INDENT * 2}"""',
+        f"{_INDENT * 2}return {implementation}.from_block(self.SCHEDULER_PARAMETERS)",
+    ]
 
 
 def render(export: FamilyExport, *, spec_module: str = "", spec_attr: str = "") -> str:
@@ -274,13 +301,31 @@ def render(export: FamilyExport, *, spec_module: str = "", spec_attr: str = "") 
         )
         if kind in kinds
     ]
+    scheduler = export.scheduler
+    #: The concrete bare-math class this family's declared scheduler resolves
+    #: to, or empty when the SDK implements no math for the declared name. The
+    #: miss is silent HERE and loud at the call site: the generated class simply
+    #: has no ``scheduler()``, so a handler that wants one gets an
+    #: ``AttributeError`` from its own type checker rather than a fallback that
+    #: quietly puts a model library back on the request path (pgw#1331).
+    scheduler_impl = (
+        IMPLEMENTED.get(parse_kind(str(scheduler.name))) if scheduler is not None else None
+    )
+    scheduler_names = sorted(
+        {"SchedulerBlock", "SchedulerKind", *([scheduler_impl] if scheduler_impl else [])}
+    )
     imports = sorted(
         {
-            "from gen_worker.family.runtime import FamilyBinding, SchedulerBlock",
+            "from gen_worker.family.runtime import FamilyBinding",
             "from gen_worker.family.snapshot import FamilyExport",
             "from gen_worker.family.spec import Family",
             f"from {tuned.module} import {tuned.qualname}",
         }
+        | (
+            {"from gen_worker.family.scheduler import " + ", ".join(scheduler_names)}
+            if scheduler is not None
+            else set()
+        )
     )
     stdlib = ["from importlib import resources", "from types import MappingProxyType"]
     if containers:
@@ -370,6 +415,8 @@ def render(export: FamilyExport, *, spec_module: str = "", spec_attr: str = "") 
         ]
     )
     lines.extend(_class_facts(export))
+    if scheduler_impl:
+        lines.extend(_scheduler_method(scheduler_impl))
     for runner in export.runners:
         lines.append("")
         lines.extend(_method(export, runner))

--- a/src/gen_worker/family/export.py
+++ b/src/gen_worker/family/export.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from .._vendor.torchcg.ingress import CallIngress, IngressError, build_call_ingress
@@ -97,18 +98,56 @@ def fake_structure() -> Iterator[Any]:
         torch.set_default_dtype(restore)
 
 
-def export_variant(
+@dataclass(frozen=True, slots=True)
+class TracedVariant:
+    """One traced (runner, bucket, layout), with the PROGRAM still attached.
+
+    :func:`export_variant` throws the program away — the snapshot only needs the
+    ingress and the output shapes. The mint needs the program itself, and it
+    must be the SAME program: an ingress digest derived from a second, subtly
+    different trace would make ``drift.assert_recipe`` compare two things that
+    were never one (torchcg G16). So there is one trace function and two
+    readings of its result, rather than two tracers that agree by inspection.
+    """
+
+    runner: str
+    bucket: dict[str, int]
+    layout: str
+    program: Any
+    ingress: CallIngress
+    outputs: tuple[ExportedOutput, ...]
+    example: CallExample
+
+    def snapshot(self) -> ExportedVariant:
+        """This trace as the document row it contributes."""
+
+        return ExportedVariant(
+            bucket=tuple(
+                sorted((BucketAxisName(str(k)), int(v)) for k, v in self.bucket.items())
+            ),
+            layout=LayoutContract(str(self.layout)),
+            ingress=self.ingress,
+            ingress_digest=IngressDigest(self.ingress.digest()),
+            outputs=self.outputs,
+        )
+
+
+def trace_variant(
     runner: Runner,
     bucket: Mapping[str, int],
     layout: str,
-) -> ExportedVariant:
-    """Export ONE (runner, bucket, layout) and read its call ingress.
+) -> TracedVariant:
+    """Trace ONE (runner, bucket, layout) and read its call ingress.
 
     The module and the example call are built inside one fake mode, so the
     program's placeholders carry fake metadata and nothing on the machine is
     allocated. Failures are named rather than propagated raw: an author reading
     ``export_failed: runner 'denoiser' at bucket ...`` knows which of a
     family's thirty-six rows refused.
+
+    The program is returned STILL ALIVE and the fake mode is closed around it,
+    which is the same order the mint lane uses (``aot_mint._export_entry``
+    exports inside ``structure_only.fake_mode_of`` and compiles outside it).
     """
 
     with fake_structure():
@@ -143,13 +182,25 @@ def export_variant(
                 f"produced no call ingress: {exc}",
             ) from exc
         outputs = _outputs(runner, program)
-    return ExportedVariant(
-        bucket=tuple(sorted((BucketAxisName(str(k)), int(v)) for k, v in bucket.items())),
-        layout=LayoutContract(str(layout)),
+    return TracedVariant(
+        runner=runner.name,
+        bucket={str(name): int(value) for name, value in bucket.items()},
+        layout=str(layout),
+        program=program,
         ingress=ingress,
-        ingress_digest=IngressDigest(ingress.digest()),
         outputs=outputs,
+        example=example,
     )
+
+
+def export_variant(
+    runner: Runner,
+    bucket: Mapping[str, int],
+    layout: str,
+) -> ExportedVariant:
+    """One traced variant, as the snapshot row it contributes."""
+
+    return trace_variant(runner, bucket, layout).snapshot()
 
 
 def _outputs(runner: Runner, program: Any) -> tuple[ExportedOutput, ...]:
@@ -299,8 +350,10 @@ def ingress_of(export: FamilyExport, runner: str, bucket: Mapping[str, int],
 
 
 __all__ = [
+    "TracedVariant",
     "export_family",
     "export_variant",
     "fake_structure",
     "ingress_of",
+    "trace_variant",
 ]

--- a/src/gen_worker/family/mint.py
+++ b/src/gen_worker/family/mint.py
@@ -1,0 +1,261 @@
+"""A family DECLARATION mints its own graph classes. No endpoint, no weights.
+
+pgw#1331's first two bullets ask for the VAE decoder and the text encoders to be
+minted as graph classes. Declaring them made them exportable; this module is
+what makes them MINTABLE — the bridge from a :class:`~gen_worker.family.spec.
+GraphFamily` to a packed AOTI artifact, through the mint lane's own inner seam.
+
+**Why a bridge and not a transpiler.** The production mint lane
+(``aot_mint.mint_graph_classes``) drives a compile POOL that re-composes a
+tenant's pipeline in fresh interpreters from ``modules`` + ``function`` +
+``MintSlot``s, and derives its example feeds from a registered
+``api.export_contract.Compile``. A family already carries everything that
+machinery reconstructs — ``Runner.build`` is the module, ``Runner.example`` is
+the call, ``Bucket``/``layouts`` are the coordinates — so making a family
+pretend to be an endpoint would be a second declaration of the same facts, and
+pgw#824's rule is that two lists of the same literals drift. This calls the
+seam BELOW the pool instead: ``export_program`` -> ``build_call_ingress`` ->
+``keying_block`` -> ``TracedClass`` -> ``Engine.compile``, which is the same
+sequence ``aot_compile_child`` runs and the same one ``measure_child`` already
+drives directly.
+
+**The trace is the declaration's own.** :func:`gen_worker.family.export.
+trace_variant` produces the program, and the snapshot in the catalog is
+produced from that same function — so the mint's ingress digest and the
+committed export's ingress digest are the same number by construction, not by
+comparison. That is torchcg G16's direction: the recipe ASSERTS against the
+declaration, it never becomes the source.
+
+**No checkpoint is downloaded, and that is the ruling, not a shortcut.**
+Cell identity is graph x sm x toolchain — checkpoint-free (DESIGN-RULINGS
+§4.27), which is exactly what lets one compiled cell serve sixteen fine-tunes.
+The declaration builds the ARCHITECTURE inside a fake-tensor mode, the program
+carries fake constants, and the real weights arrive at ARM time by manifest FQN
+out of the constant store (pgw#1329's ``arm_compiled_graph_from_store``). So
+minting a family costs a card and a compile, never a 24 GB download.
+
+**This module is MINT MACHINERY** and is declared as such in
+:data:`gen_worker.serve.role.MINT_MACHINERY`: an adopt-only pod that could
+reach it could compile, which is the one thing that role is defined by not
+being able to do (§4.28). The family SURFACE it mints for is on the serve path;
+this is not.
+
+Run it with ``gen-worker family mint`` — **on a pod, never on a shared box**.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..aot_inputs import ExportSpec
+from .errors import FamilyError, FamilyRefusal
+from .export import TracedVariant, trace_variant
+from .spec import GraphFamily, Runner
+
+
+def graph_class_name(runner: str, bucket: Mapping[str, int], layout: str) -> str:
+    """The handle one (runner, bucket, layout) is minted under.
+
+    A HANDLE, never an identity: what keys the artifact is the class hash the
+    trace produces (torchcg ``cg-key-v1``), and this name only has to be stable,
+    readable in a phase table, and unique within a family. Bucket axes are
+    sorted so the same variant spells the same name on any machine.
+    """
+
+    rows = "".join(f".{name}{int(value)}" for name, value in sorted(bucket.items()))
+    return f"{runner}{rows}.{layout}"
+
+
+def export_spec_for(
+    family: GraphFamily, runner: Runner, bucket: Mapping[str, int], layout: str
+) -> ExportSpec:
+    """The worker coordinates one declared variant is keyed under.
+
+    The mapping is one-for-one and there is nothing to invent: the family is the
+    family, the RUNNER is the target (one runner, one traced entry point), and
+    the BUCKET is ``class_dims`` — which is precisely the field whose values
+    separate two classes of the same target inside one artifact family.
+
+    ``layout`` rides ``specialization`` rather than being left implicit. The
+    dtype it implies is already inside the traced graph, so two layouts key
+    apart regardless; recording it makes the key's reason legible in the
+    envelope instead of only derivable from it.
+    """
+
+    return ExportSpec(
+        family=family.name,
+        target=runner.name,
+        class_dims=tuple(sorted((str(name), int(value)) for name, value in bucket.items())),
+        specialization={"layout": str(layout)},
+        strict=True,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MintedVariant:
+    """One packed artifact, and the declaration coordinate it answers."""
+
+    runner: str
+    bucket: tuple[tuple[str, int], ...]
+    layout: str
+    graph_class: str
+    key: str
+    artifact: Path
+    metadata: Mapping[str, Any]
+    ingress_digest: str
+    compile_s: float
+    reuse_s: float
+
+    @property
+    def reused(self) -> bool:
+        """Whether the CAS already held this class. Not a failure — the point."""
+
+        return self.compile_s == 0.0
+
+
+def variants_of(
+    family: GraphFamily, *, only: Sequence[str] = ()
+) -> tuple[tuple[Runner, dict[str, int], str], ...]:
+    """Every (runner, bucket, layout) to mint, in the declaration's own order.
+
+    ``only`` narrows to named runners — the shape a pod uses when it is minting
+    the cheap classes first and the 12-billion-parameter one last, or when a
+    previous attempt already banked half the set. A name the family does not
+    declare is REFUSED rather than silently minting nothing.
+    """
+
+    rows = family.variants()
+    if not only:
+        return rows
+    wanted = {str(name) for name in only}
+    unknown = sorted(wanted - {runner.name for runner in family.runners})
+    if unknown:
+        raise FamilyError(
+            FamilyRefusal.FAMILY_INVALID,
+            f"family {family.name!r} declares no runner {unknown[0]!r}; it has "
+            f"{sorted(runner.name for runner in family.runners)!r}",
+        )
+    return tuple(row for row in rows if row[0].name in wanted)
+
+
+def traced_classes(
+    family: GraphFamily, *, only: Sequence[str] = ()
+) -> Iterator[tuple[TracedVariant, ExportSpec, Any]]:
+    """Trace every selected variant, yielding one at a time.
+
+    A GENERATOR, and that is the memory bound: an exported program for a
+    12-billion-parameter denoiser is large even with fake constants, and the
+    caller compiles and releases each row before the next is traced. Building
+    the whole list first is how a mint pod runs out of host RAM on the family
+    it was bought for.
+    """
+
+    from .. import aot_mint
+
+    for runner, bucket, layout in variants_of(family, only=only):
+        traced = trace_variant(runner, bucket, layout)
+        spec = export_spec_for(family, runner, bucket, layout)
+        row = aot_mint.TracedClass(
+            name=graph_class_name(runner.name, bucket, layout),
+            block=aot_mint.keying_block(traced.program, traced.ingress, spec),
+            nodes=len(list(traced.program.graph_module.graph.nodes)),
+            program=traced.program,
+            declared=len(variants_of(family)),
+        )
+        yield traced, spec, row
+
+
+def mint_family(
+    family: GraphFamily,
+    *,
+    out_dir: Path,
+    work: Path,
+    cache_root: Path | None = None,
+    only: Sequence[str] = (),
+    on_class: Any = None,
+) -> tuple[MintedVariant, ...]:
+    """Compile and pack every declared graph class of ``family``.
+
+    This is the whole bridge. It opens the worker's own TCG engine — the same
+    one ``aot_compile_child`` opens, with the same sealed toolchain facts, so
+    the artifacts it produces are keyed identically to the ones the endpoint
+    mint lane produces and adopt by the same route.
+
+    Refuses on a plain :class:`~gen_worker.family.spec.Family`: an eager-only
+    family has no graph classes, and minting one would mean inventing them.
+    """
+
+    if not isinstance(family, GraphFamily):
+        raise FamilyError(
+            FamilyRefusal.FAMILY_INVALID,
+            f"family {getattr(family, 'name', family)!r} is eager-only and declares no "
+            "graph classes; declare a GraphFamily() before asking for a mint",
+        )
+    from .. import aot_compile_child
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    work.mkdir(parents=True, exist_ok=True)
+    engine, runtime = aot_compile_child._tcg_runtime(cache_root)
+    minted: list[MintedVariant] = []
+    for traced, spec, row in traced_classes(family, only=only):
+        if on_class is not None:
+            on_class(row.name, len(minted), row.declared)
+        result = aot_compile_child.compile_traced_class(
+            row, spec, engine, runtime, work=work, out_dir=out_dir
+        )
+        packed = result.packed
+        minted.append(
+            MintedVariant(
+                runner=traced.runner,
+                bucket=tuple(sorted(traced.bucket.items())),
+                layout=traced.layout,
+                graph_class=str(packed.name),
+                key=str(packed.key),
+                artifact=Path(str(packed.artifact)),
+                metadata=json.loads(str(packed.metadata)),
+                ingress_digest=str(traced.ingress.digest()),
+                compile_s=float(result.compile_s),
+                reuse_s=float(result.reuse_s),
+            )
+        )
+    return tuple(minted)
+
+
+def assert_matches_export(
+    minted: Sequence[MintedVariant], export: Any
+) -> None:
+    """Every minted class answers a variant the COMMITTED export declares.
+
+    The drift assertion torchcg G16 asks for, in the direction it asks for it:
+    the export is the source and the mint is checked against it. A mint whose
+    ingress digest differs from the committed one is an artifact that will arm
+    under a signature no handler was type-checked against, which is the failure
+    the whole binding scheme exists to make impossible.
+    """
+
+    for row in minted:
+        declared = export.runner(row.runner).variant(dict(row.bucket), row.layout)
+        if str(declared.ingress_digest) != row.ingress_digest:
+            raise FamilyError(
+                FamilyRefusal.EXPORT_FAILED,
+                f"minted class {row.graph_class!r} has ingress digest "
+                f"{row.ingress_digest!r}; the committed export declares "
+                f"{str(declared.ingress_digest)!r}. Regenerate the export and the "
+                "bindings from the declaration, then mint again — the mint never "
+                "becomes the source.",
+            )
+
+
+__all__ = [
+    "MintedVariant",
+    "assert_matches_export",
+    "export_spec_for",
+    "graph_class_name",
+    "mint_family",
+    "traced_classes",
+    "variants_of",
+]

--- a/src/gen_worker/family/runtime.py
+++ b/src/gen_worker/family/runtime.py
@@ -55,15 +55,6 @@ from .snapshot import ExportedVariant, FamilyExport
 from .spec import Family
 
 
-#: A scheduler block's value domain: the finite JSON scalars ``recipe_v1``
-#: permits. Defined HERE rather than inside a generated module's
-#: ``TYPE_CHECKING`` block so ``get_type_hints`` on a generated family class
-#: resolves — an annotation that only a type checker can read is a class
-#: nothing can introspect at runtime, which is a papercut waiting for the first
-#: caller that tries.
-SchedulerBlock = Mapping[str, bool | int | float | str]
-
-
 class InstanceResolver(Protocol):
     """How a dynamic ``Family.instance(ref)`` reaches real weights.
 
@@ -512,7 +503,6 @@ def resolve(payload: object, instance: FamilyBinding) -> dict[str, Any]:
 __all__ = [
     "TUNED",
     "DecodeSession",
-    "SchedulerBlock",
     "FamilyBinding",
     "InstanceResolver",
     "Tuned",

--- a/src/gen_worker/family/scheduler.py
+++ b/src/gen_worker/family/scheduler.py
@@ -1,0 +1,334 @@
+"""The declared schedulers, as bare typed math. No scheduler OBJECT, ever.
+
+``recipe_v1`` records a scheduler as a NAME and a block of finite scalars and
+says outright that torchcg never interprets it: *"the host implements the named
+scheduler and reads its parameters"* (torchcg G17). This module is the host's
+half for the names the catalog declares — and it is the whole of pgw#1331's
+third bullet, which asks for the step *"as bare typed tensor math in the SDK
+(flow-match/Euler ~20 lines) … either way, no diffusers scheduler object on the
+serve path"*.
+
+**Why this is a real cut and not a re-spelling.** ``FlowMatchEulerDiscrete``'s
+step is one line of arithmetic. Reaching it through diffusers costs the serve
+process the whole ``diffusers`` package — its pipeline registry, its dynamic
+module loader, its ``transformers`` and ``huggingface_hub`` transitive imports —
+to run ``sample + (sigma_next - sigma) * model_output``. The schedule itself is
+closed-form: a shifted linspace over sigmas. Nothing here needs a model
+library, and nothing here needs ``torch`` either — the sigma arithmetic is
+plain floats and the step is tensor OPERATORS, so this module imports neither
+and an adopt-only serve role (pgw#1328) holds it for free.
+
+**The parameters come from the DECLARATION, not from here.** A schedule is
+family truth: FLUX.1-dev's dynamic shift constants are in
+``gen_worker.family.catalog.flux1_dev``'s ``Scheduler(...)`` block, ride the
+export digest, and are read back through :meth:`FlowMatchEulerDiscrete.
+from_block`. A constant hardcoded in this module would be a second declaration
+of a family fact, which is the drift ``check_family_bindings.py`` exists to
+refuse one level up.
+
+**Closed set, parsed once.** :class:`SchedulerKind` is a ``StrEnum`` and the
+generated binding names a MEMBER of it, so no handler ever spells a scheduler
+name and no lookup is keyed by a string a caller typed. A declaration naming a
+scheduler this module does not implement is not a silent eager fallback: the
+generated class simply has no ``scheduler()`` method, so the miss is an
+``AttributeError`` a type checker reports on the author's machine (pgw#1332's
+"missing class = AttributeError at type-check", same mechanism).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, ClassVar, Final, Protocol, Self
+
+from .errors import FamilyError, FamilyRefusal
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor
+
+
+class SchedulerKind(StrEnum):
+    """Every scheduler name the catalog may declare. Closed, on purpose.
+
+    A name outside this set is refused by :func:`parse_kind` at declaration
+    import, not at serve time — the same discipline every other identifier in
+    the family vocabulary follows.
+    """
+
+    #: Rectified-flow Euler, the FLUX / SD3 family's schedule.
+    FLOW_MATCH_EULER_DISCRETE = "flow_match_euler_discrete"
+    #: The epsilon/v-prediction Euler schedule SDXL declares. DECLARED, not
+    #: implemented here: pgw#1331 covers one family end to end and inventing
+    #: SDXL's math with nothing measuring it is how a wrong schedule ships.
+    EULER_DISCRETE = "euler_discrete"
+
+
+def parse_kind(value: object) -> SchedulerKind:
+    """Parse one declared scheduler name into the closed set."""
+
+    try:
+        return SchedulerKind(str(value))
+    except ValueError:
+        raise FamilyError(
+            FamilyRefusal.SCHEDULER_INVALID,
+            f"scheduler {value!r} is not one of {[kind.value for kind in SchedulerKind]!r}; "
+            "the host implements the named scheduler and this one has no name here",
+        ) from None
+
+
+#: What a scheduler block's values may be — ``recipe_v1``'s finite JSON scalars.
+SchedulerValue = bool | int | float | str
+SchedulerBlock = Mapping[str, SchedulerValue]
+
+def _refuse(name: str, wanted: str, value: object) -> FamilyError:
+    return FamilyError(
+        FamilyRefusal.SCHEDULER_INVALID,
+        f"scheduler parameter {name!r} must be {wanted}, got {value!r}",
+    )
+
+
+def _flag(block: SchedulerBlock, name: str, default: bool) -> bool:
+    """Read one declared boolean.
+
+    Checked as ``bool`` and not as ``int`` even though ``bool`` IS an ``int`` in
+    Python: a block that said ``use_dynamic_shifting: 1`` means something the
+    author did not write, and accepting it is how a schedule silently changes.
+    """
+
+    value = block.get(name, default)
+    if not isinstance(value, bool):
+        raise _refuse(name, "a boolean", value)
+    return value
+
+
+def _count(block: SchedulerBlock, name: str, default: int) -> int:
+    """Read one declared integer. ``bool`` is refused, for the reason above."""
+
+    value = block.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _refuse(name, "an integer", value)
+    return value
+
+
+def _real(block: SchedulerBlock, name: str, default: float) -> float:
+    """Read one declared real. An integer literal is a legal spelling of one."""
+
+    value = block.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _refuse(name, "a real number", value)
+    return float(value)
+
+
+class Step(Protocol):
+    """The one operation a denoising loop performs per step.
+
+    Deliberately the narrowest shape that works: index in, tensors in, tensor
+    out. A scheduler that needed request state, a device, or a mutable step
+    counter would be an object with a lifecycle — which is exactly the thing
+    this module exists to not put back on the serve path.
+    """
+
+    def __call__(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Schedule:
+    """One request's resolved sigma ladder, and the step that walks it.
+
+    ``sigmas`` has ``len(timesteps) + 1`` entries and terminates at ``0.0``: the
+    last step lands exactly on the clean sample rather than near it, which is
+    the reason the terminal zero is part of the ladder instead of a special
+    case inside :meth:`step`.
+
+    Immutable and request-scoped. A scheduler that carried ``self._step_index``
+    across calls is the shape that makes two concurrent requests on one worker
+    silently share a counter; there is no counter here to share.
+    """
+
+    sigmas: tuple[float, ...]
+    num_train_timesteps: int
+
+    def __post_init__(self) -> None:
+        if len(self.sigmas) < 2:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                "a schedule needs at least one step, so at least two sigmas",
+            )
+        if self.sigmas[-1] != 0.0:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                f"a schedule must terminate at sigma 0.0, not {self.sigmas[-1]!r}",
+            )
+
+    def __len__(self) -> int:
+        return len(self.sigmas) - 1
+
+    @property
+    def timesteps(self) -> tuple[float, ...]:
+        """The timestep each step is evaluated at, in the model's own units.
+
+        Flow-matching models are conditioned on ``sigma * num_train_timesteps``,
+        which is why this is derived here rather than passed alongside: two
+        values that must agree are one value.
+        """
+
+        return tuple(sigma * self.num_train_timesteps for sigma in self.sigmas[:-1])
+
+    def step(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """One Euler step along the rectified flow. This is the whole method.
+
+        ``x_{t+1} = x_t + (sigma_{t+1} - sigma_t) * v(x_t, t)``. Written with
+        tensor OPERATORS only, so it holds for any tensor type and this module
+        imports no array library at all.
+        """
+
+        if not 0 <= index < len(self):
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                f"step {index} is outside this schedule's {len(self)} steps",
+            )
+        delta = self.sigmas[index + 1] - self.sigmas[index]
+        return sample + delta * model_output
+
+    def scale_noise(self, noise: Tensor, sample: Tensor, index: int = 0) -> Tensor:
+        """Interpolate a clean sample toward noise at one point on the ladder.
+
+        The forward half of the same flow: ``sigma * noise + (1 - sigma) * x``.
+        Present because img2img and inpaint need exactly it and would otherwise
+        each rediscover the interpolation — the hand-math this module replaces.
+        """
+
+        if not 0 <= index < len(self):
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                f"step {index} is outside this schedule's {len(self)} steps",
+            )
+        sigma = self.sigmas[index]
+        return sigma * noise + (1.0 - sigma) * sample
+
+
+@dataclass(frozen=True, slots=True)
+class FlowMatchEulerDiscrete:
+    """FLUX / SD3's rectified-flow Euler schedule, as closed-form arithmetic.
+
+    Every field is a DECLARED family fact read out of the recipe's scheduler
+    block; the defaults are the vocabulary's own, present so a block that omits
+    a parameter still resolves rather than refusing on a value nobody has an
+    opinion about.
+
+    **Dynamic shifting**, which FLUX.1-dev uses, moves the schedule's mass
+    toward high noise as the image gets bigger: a 1024x1024 generation has 16x
+    the tokens of a 256x256 one and needs proportionally more of its steps
+    spent far from the data manifold. ``mu`` interpolates linearly in sequence
+    length between ``base_shift`` and ``max_shift``, and the exponential shift
+    applies it. With ``use_dynamic_shifting`` false the static ``shift`` is used
+    instead and the sequence length is not consulted.
+    """
+
+    num_train_timesteps: int = 1000
+    shift: float = 1.0
+    use_dynamic_shifting: bool = False
+    base_shift: float = 0.5
+    max_shift: float = 1.15
+    base_image_seq_len: int = 256
+    max_image_seq_len: int = 4096
+
+    #: The kind this class implements, so the pairing is stated on the object
+    #: rather than only in the generator's table. ``ClassVar``, so the frozen
+    #: dataclass does not take it for a field with a mutable default.
+    KIND: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
+
+    def __post_init__(self) -> None:
+        if self.num_train_timesteps < 1:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                f"num_train_timesteps must be positive, got {self.num_train_timesteps}",
+            )
+        if self.use_dynamic_shifting and self.max_image_seq_len <= self.base_image_seq_len:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                "dynamic shifting interpolates between two DISTINCT sequence lengths; "
+                f"got base={self.base_image_seq_len} max={self.max_image_seq_len}",
+            )
+        if not self.use_dynamic_shifting and self.shift <= 0.0:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID, f"static shift must be positive, got {self.shift}"
+            )
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        return cls(
+            num_train_timesteps=_count(block, "num_train_timesteps", 1000),
+            shift=_real(block, "shift", 1.0),
+            use_dynamic_shifting=_flag(block, "use_dynamic_shifting", False),
+            base_shift=_real(block, "base_shift", 0.5),
+            max_shift=_real(block, "max_shift", 1.15),
+            base_image_seq_len=_count(block, "base_image_seq_len", 256),
+            max_image_seq_len=_count(block, "max_image_seq_len", 4096),
+        )
+
+    def mu(self, image_seq_len: int) -> float:
+        """The shift exponent for one sequence length. Linear interpolation."""
+
+        span = self.max_image_seq_len - self.base_image_seq_len
+        slope = (self.max_shift - self.base_shift) / span
+        return image_seq_len * slope + (self.base_shift - slope * self.base_image_seq_len)
+
+    def schedule(self, steps: int, *, image_seq_len: int = 0) -> Schedule:
+        """The resolved sigma ladder for one request.
+
+        ``image_seq_len`` is REQUIRED under dynamic shifting and refused when
+        absent: defaulting it would silently serve every resolution the
+        schedule of whichever one the default happened to name.
+        """
+
+        if steps < 1:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID, f"a schedule needs at least one step, got {steps}"
+            )
+        if self.use_dynamic_shifting and image_seq_len < 1:
+            raise FamilyError(
+                FamilyRefusal.SCHEDULER_INVALID,
+                "this scheduler shifts dynamically, so it needs the packed sequence length "
+                "of the latents it is scheduling; pass image_seq_len=",
+            )
+        # The unshifted ladder: `steps` points descending from 1.0, spaced so
+        # the final point is 1/steps rather than 0 — the terminal zero is
+        # appended below and is not one of the evaluated points.
+        raw = tuple(
+            1.0 - index * (1.0 - 1.0 / steps) / (steps - 1) if steps > 1 else 1.0
+            for index in range(steps)
+        )
+        if self.use_dynamic_shifting:
+            exponent = math.exp(self.mu(image_seq_len))
+            shifted = tuple(exponent / (exponent + (1.0 / sigma - 1.0)) for sigma in raw)
+        else:
+            shifted = tuple(
+                self.shift * sigma / (1.0 + (self.shift - 1.0) * sigma) for sigma in raw
+            )
+        return Schedule(sigmas=(*shifted, 0.0), num_train_timesteps=self.num_train_timesteps)
+
+
+#: Which class implements which name. Read by the BINDING GENERATOR to pick a
+#: return annotation, and by nothing at request time — a handler reaches its
+#: scheduler through the generated ``inst.scheduler()``, whose return type is
+#: the concrete class, so no request-path code indexes this table.
+IMPLEMENTED: Final[Mapping[SchedulerKind, str]] = {
+    SchedulerKind.FLOW_MATCH_EULER_DISCRETE: "FlowMatchEulerDiscrete",
+}
+
+
+__all__ = [
+    "IMPLEMENTED",
+    "FlowMatchEulerDiscrete",
+    "Schedule",
+    "SchedulerBlock",
+    "SchedulerKind",
+    "SchedulerValue",
+    "Step",
+    "parse_kind",
+]

--- a/src/gen_worker/serve/guard.py
+++ b/src/gen_worker/serve/guard.py
@@ -1,4 +1,12 @@
-"""pgw#1328: in the adopt-only role, IMPORTING mint machinery raises.
+"""pgw#1328/#1331: in the adopt-only role, importing what it forswore raises.
+
+Two promises, one mechanism. **pgw#1328:** a pod that adopts by key cannot
+compile, so importing :data:`~gen_worker.serve.role.MINT_MACHINERY` raises.
+**pgw#1331:** a pod that serves through compiled graph classes and bare typed
+math needs no model library, so importing
+:data:`~gen_worker.serve.role.FORBIDDEN_LIBRARIES` raises too — and that one is
+the promise with the measurable payoff, because ``import diffusers`` alone is
+seconds of process start and hundreds of megabytes of resident host memory.
 
 The CI fence (``scripts/lint_serve_role_closure.py``) proves no serve-role
 module *can* reach the mint lane. This is the other half, and the two are not
@@ -9,10 +17,13 @@ from the tenant's image. A pod that promises it cannot compile must keep that
 promise against code the fence never saw.
 
 So the adopt-only entry point installs a :mod:`sys.meta_path` finder ahead of
-every other, and any import of :data:`~gen_worker.serve.role.MINT_MACHINERY`
-(or a submodule of one) raises :class:`MintMachineryUnavailable` — an
-``ImportError``, so a caller that already handles an optional import degrades
-the way it does today rather than dying in a new place.
+every other, and any import of a declared name (or a submodule of one) raises
+an ``ImportError`` subclass, so a caller that already handles an optional
+import degrades the way it does today rather than dying in a new place. That
+degradation is not incidental: a generated family binding reaches its
+declaration through ``try: ... except ImportError``, and on this pod that is
+exactly the path it takes — pgw#1339's absent serving fact, degrading loudly
+and serving.
 
 **Why a finder and not a stub module.** A stub whose functions raise would let
 the import succeed and move the failure to the first CALL, which may be an
@@ -20,7 +31,8 @@ hour into a pod's life and inside somebody's ``except Exception``. The import
 is the earliest honest moment and the one a boot log can name.
 
 **It is deliberately NOT installed in the eager-capable role.** That role mints
-— §4.28 — and blocking it would break the only path that produces the
+— §4.28 — and it serves eager on a miss, which is exactly what a model library
+is for. Blocking either there would break the only path that produces the
 artifacts the adopt-only role adopts.
 """
 
@@ -55,16 +67,47 @@ class MintMachineryUnavailable(ImportError):
         self.blocked = blocked
 
 
-def _blocked_by(name: str) -> str:
-    """The MINT_MACHINERY entry ``name`` is, or is a submodule of; else ""."""
-    for entry in role_mod.MINT_MACHINERY:
+class ModelLibraryUnavailable(ImportError):
+    """A model library was imported in an adopt-only serve process (pgw#1331).
+
+    ``module`` is the name that was asked for; ``blocked`` is the declared
+    :data:`~gen_worker.serve.role.FORBIDDEN_LIBRARIES` entry it is (or is
+    under).
+    """
+
+    def __init__(self, module: str, blocked: str) -> None:
+        super().__init__(
+            f"{module} is a model library and this process holds the "
+            f"{role_mod.ServeRole.ADOPT_ONLY.value} serve role (pgw#1331): it "
+            f"serves through compiled graph classes and bare typed math, so it "
+            f"has no model to construct. Blocked by the declared entry "
+            f"{blocked!r}. If a family needs this, the need belongs in its "
+            f"DECLARATION half, which runs on the mint lane.")
+        self.module = module
+        self.blocked = blocked
+
+
+def _entry_for(name: str, declared: Sequence[str]) -> str:
+    """The declared entry ``name`` is, or is a submodule of; else ""."""
+    for entry in declared:
         if name == entry or name.startswith(f"{entry}."):
             return entry
     return ""
 
 
+def _blocked_by(name: str) -> str:
+    """The MINT_MACHINERY entry ``name`` is, or is a submodule of; else ""."""
+    return _entry_for(name, role_mod.MINT_MACHINERY)
+
+
 class _MintBlocker(importlib.abc.MetaPathFinder):
-    """Refuses at FIND time, before any loader is consulted."""
+    """Refuses at FIND time, before any loader is consulted.
+
+    ONE finder for both promises, rather than two: they are installed and
+    removed together, and a second entry on ``sys.meta_path`` would let one be
+    taken out while the other stayed, which is a half-kept promise nothing
+    reports.
+    """
 
     def find_spec(
         self,
@@ -75,6 +118,9 @@ class _MintBlocker(importlib.abc.MetaPathFinder):
         blocked = _blocked_by(fullname)
         if blocked:
             raise MintMachineryUnavailable(fullname, blocked)
+        library = _entry_for(fullname, role_mod.FORBIDDEN_LIBRARIES)
+        if library:
+            raise ModelLibraryUnavailable(fullname, library)
         return None
 
 
@@ -99,18 +145,19 @@ def install() -> None:
             f"the mint-import blocker is only for the "
             f"{role_mod.ServeRole.ADOPT_ONLY.value} role; this process holds "
             f"{role_mod.current().value}")
-    already = present()
+    already = (*present(), *libraries_present())
     if already:
         raise RuntimeError(
-            f"mint machinery is already imported in this process "
+            f"forsworn modules are already imported in this process "
             f"({', '.join(already)}) — installing the blocker now would "
             f"promise something that is already false")
     if _installed is None:
         _installed = _MintBlocker()
         sys.meta_path.insert(0, _installed)
         logger.info(
-            "pgw#1328: mint-import blocker installed (%d declared modules)",
-            len(role_mod.MINT_MACHINERY))
+            "pgw#1328/#1331: import blocker installed (%d mint modules, "
+            "%d model libraries)",
+            len(role_mod.MINT_MACHINERY), len(role_mod.FORBIDDEN_LIBRARIES))
 
 
 def installed() -> bool:
@@ -123,6 +170,12 @@ def present() -> Tuple[str, ...]:
         name for name in role_mod.MINT_MACHINERY if name in sys.modules)
 
 
+def libraries_present() -> Tuple[str, ...]:
+    """Declared model libraries already in ``sys.modules``, in declared order."""
+    return tuple(
+        name for name in role_mod.FORBIDDEN_LIBRARIES if name in sys.modules)
+
+
 def _uninstall_for_test() -> None:
     """Test-only: take the blocker back out. Never called by the worker."""
     global _installed
@@ -131,4 +184,11 @@ def _uninstall_for_test() -> None:
     _installed = None
 
 
-__all__ = ["MintMachineryUnavailable", "install", "installed", "present"]
+__all__ = [
+    "MintMachineryUnavailable",
+    "ModelLibraryUnavailable",
+    "install",
+    "installed",
+    "libraries_present",
+    "present",
+]

--- a/src/gen_worker/serve/role.py
+++ b/src/gen_worker/serve/role.py
@@ -204,6 +204,11 @@ MINT_MACHINERY: Tuple[str, ...] = (
     "gen_worker.aot_mint",
     "gen_worker.boot_key",
     "gen_worker.boot_trace_child",
+    # pgw#1331: a family declaration mints its OWN graph classes through this
+    # bridge. It is the family surface's mint half, and the family surface is
+    # on the serve path — which is exactly why it is named here: a serve-role
+    # module that could reach it would be a pod that can compile.
+    "gen_worker.family.mint",
     "gen_worker.keyset.emit",
     "gen_worker.mint_child",
     "gen_worker.mint_process",

--- a/src/gen_worker/serve/role.py
+++ b/src/gen_worker/serve/role.py
@@ -17,15 +17,21 @@ by passing no deriver"*. It is DECLARED by the process entry point that knows
 which process it is — the same shape as :mod:`gen_worker.process_role`, whose
 wire role this one refines — and it is declared ONCE, before anything imports.
 
-THE TWO MODULE SETS, AND WHY THEY LIVE HERE
--------------------------------------------
-:data:`SERVE_ROLE_MODULES` and :data:`MINT_MACHINERY` are read by THREE
+THE MODULE SETS, AND WHY THEY LIVE HERE
+---------------------------------------
+:data:`SERVE_ROLE_MODULES`, :data:`MINT_MACHINERY`, :data:`MODEL_FREE_MODULES`,
+:data:`FORBIDDEN_LIBRARIES` and :data:`OPTIONAL_SERVE_IMPORTS` are read by THREE
 consumers: the runtime blocker (:mod:`gen_worker.serve.guard`), the CI fence
 (``scripts/lint_serve_role_closure.py``) and the tests. pgw#1176's measured
 lesson is that a fence naming symbols in its own string literals rots silently,
 and pgw#824's is that two lists of the same literals drift. So the role's own
 module declares them and everything else — including the fence, which parses
 this file — reads them from here. There is one list.
+
+Two claims, two scopes, because they are not the same claim (pgw#1331). Every
+serve-role module is asserted MINT-FREE. The family surface named in
+``MODEL_FREE_MODULES`` is additionally asserted to reach no MODEL LIBRARY —
+that subset, and not the whole role, for the reason recorded on the tuple.
 
 ``SERVE_ROLE_MODULES`` is a CLAIM, not a description: every name in it is a
 module the adopt-only path executes, asserted to be unable to reach anything in
@@ -66,6 +72,39 @@ class ServeRole(StrEnum):
     ADOPT_ONLY = "adopt_only"
 
 
+#: The subset of :data:`SERVE_ROLE_MODULES` that must reach NO model library —
+#: the typed family surface a request is actually served through (pgw#1331).
+#:
+#: **Why this is a subset and not the whole role, stated rather than hidden.**
+#: Every ``gen_worker`` import executes ``gen_worker/__init__.py``, and that
+#: package reaches ``models.loading`` / ``models.memory`` / ``view`` — the
+#: EAGER-CAPABLE worker's own guts, which import diffusers inside functions and
+#: legitimately need to, because an eager-capable pod serves eager on a miss
+#: (§4.28). Those imports never EXECUTE on an adopt-only pod, which is what
+#: :mod:`gen_worker.serve.guard` and pgw#1331's subprocess proof assert at run
+#: time. What a static walk can prove today is the property for the surface
+#: pgw#1331 built, and claiming more than that would be a fence describing a
+#: tree nobody has cut. **Owed, and named here so it is not rediscovered:**
+#: making the whole role statically model-free means making
+#: ``gen_worker/__init__`` lazy the way this package's own ``__init__`` now is.
+MODEL_FREE_MODULES: Tuple[str, ...] = (
+    "gen_worker.family",
+    "gen_worker.family.backing",
+    "gen_worker.family.errors",
+    "gen_worker.family.runtime",
+    "gen_worker.family.scheduler",
+    "gen_worker.family.snapshot",
+    "gen_worker.family.spec",
+    "gen_worker.family.tuned",
+    "gen_worker.family.catalog",
+    "gen_worker.family.catalog._generated",
+    "gen_worker.family.catalog._generated.flux1_dev",
+    "gen_worker.family.catalog._generated.sdxl",
+    "gen_worker.family.catalog.flux1_dev_serve",
+    "gen_worker.family.catalog.sdxl_serve",
+)
+
+
 #: Every module the ADOPT-ONLY serve path executes. The fence walks the
 #: transitive ``gen_worker`` import closure of these — function-local imports
 #: included, because a lazy ``from . import aot_mint`` inside a function is
@@ -102,6 +141,55 @@ SERVE_ROLE_MODULES: Tuple[str, ...] = (
     "gen_worker.process_role",
     "gen_worker.serve_posture",
     "gen_worker.serving_mode",
+    # pgw#1331: the typed family surface a request is actually SERVED through —
+    # the bindings, the backings behind them, the bare-math schedulers, and the
+    # catalog's serving halves. Roots, not incidental members: the claim this
+    # issue makes is that a Flux request runs end to end from here, so it is
+    # also asserted mint-free, and a claim that is not a root is a claim
+    # nothing walks. They are ALSO the whole of MODEL_FREE_MODULES above,
+    # spliced rather than retyped so the two sets cannot drift (pgw#824).
+    *MODEL_FREE_MODULES,
+)
+
+
+#: Third-party packages :data:`MODEL_FREE_MODULES` may not import, at module
+#: scope or inside a function (pgw#1331).
+#:
+#: ``diffusers`` is the one the issue names, and the reason is not tidiness: it
+#: is 5-15 seconds of process start and 1-2 GB of host RAM (pgw#1326's measured
+#: table) bought to run a handful of reshapes and one Euler step, and it is what
+#: makes today's serve image un-shrinkable. ``transformers`` is here for the
+#: same reason and by the same argument — the text encoders are its models, and
+#: pgw#1331 makes them graph classes precisely so the serve path stops needing
+#: the library that defines them.
+#:
+#: **This is not a claim that the modules cannot be installed.** The mint lane
+#: needs both and has both; the fence is about what the SERVE closure REACHES.
+#: The runtime half is :mod:`gen_worker.serve.guard`, which blocks these names
+#: in an adopt-only process the same way it blocks the mint lane.
+FORBIDDEN_LIBRARIES: Tuple[str, ...] = (
+    "diffusers",
+    "transformers",
+)
+
+#: The gen_worker modules a serve-role module may reach ONLY through an
+#: ``ImportError``-guarded import, and the closed list of them.
+#:
+#: A generated family binding exposes ``SPEC`` by importing its own declaration
+#: inside ``try: ... except ImportError: return None``. The declaration builds
+#: diffusers modules, so on an adopt-only pod that import fails and the binding
+#: serves without it — pgw#1339's ruling exactly: the absence of a serving fact
+#: degrades loudly and serves, it does not refuse.
+#:
+#: The fence therefore does not FOLLOW a guarded edge, which would make every
+#: binding drag its declaration into the closure and the whole guard vacuous.
+#: What it does instead is require every guarded edge to name a module in this
+#: tuple, and require every module in this tuple to actually be reached — so
+#: the hatch is an enumerated list two people can read, never an open door that
+#: any ``try: import`` can walk through.
+OPTIONAL_SERVE_IMPORTS: Tuple[str, ...] = (
+    "gen_worker.family.catalog.flux1_dev",
+    "gen_worker.family.catalog.sdxl",
 )
 
 #: The mint lane. A serve-role module that reaches ANY of these is a pod that
@@ -158,7 +246,9 @@ def _reset_for_test(role: ServeRole = ServeRole.EAGER_CAPABLE) -> None:
 
 
 __all__ = [
+    "FORBIDDEN_LIBRARIES",
     "MINT_MACHINERY",
+    "OPTIONAL_SERVE_IMPORTS",
     "SERVE_ROLE_MODULES",
     "ServeRole",
     "adopt_only",

--- a/tests/test_adopt_only_serve_role_pgw1328.py
+++ b/tests/test_adopt_only_serve_role_pgw1328.py
@@ -69,7 +69,7 @@ def test_the_declared_serve_role_cannot_reach_the_mint_lane() -> None:
         "which is the drift channel reading it out of the source exists to "
         "close")
     assert tuple(banned) == role.MINT_MACHINERY
-    seen, via = fence.closure(roots)
+    seen, via, _, _ = fence.closure(roots)
     reached = sorted(name for name in banned if name in seen)
     assert not reached, f"reached {reached} via {[via.get(n) for n in reached]}"
     assert fence.main([]) == 0

--- a/tests/test_cgkey_as_data_pgw1327.py
+++ b/tests/test_cgkey_as_data_pgw1327.py
@@ -534,7 +534,7 @@ def test_the_serve_boot_key_path_cannot_reach_a_tracer() -> None:
         "gen_worker.keyset.emit",
     ):
         assert tracer in banned, f"{tracer} stopped being banned"
-    seen, via = fence.closure(roots)
+    seen, via, _, _ = fence.closure(roots)
     assert len(seen) > 20, "the roots resolved to nothing — the fence rotted"
     reached = sorted(name for name in banned if name in seen)
     assert not reached, (

--- a/tests/test_family_sdk_pgw1332.py
+++ b/tests/test_family_sdk_pgw1332.py
@@ -1292,7 +1292,10 @@ def test_a_family_owns_its_tuned_schema_registration() -> None:
         "the `@family(...)` class decorator is back; pgw#1332 resolved the name "
         "in favour of the family-owned schema"
     )
-    from gen_worker.family.catalog.sdxl import SDXL, SdxlLoraTuned, SdxlTuned
+    from gen_worker.family.catalog.sdxl import SDXL
+    # pgw#1331 moved the schemas to the family's SERVING half: they are read
+    # on every request and the serve role may not import the declaration.
+    from gen_worker.family.catalog.sdxl_serve import SdxlLoraTuned, SdxlTuned
 
     assert families.family_for("sdxl") is SdxlTuned
     assert families.family_for("sdxl", kind="lora") is SdxlLoraTuned

--- a/tests/test_flux_stage1_pgw1331.py
+++ b/tests/test_flux_stage1_pgw1331.py
@@ -27,8 +27,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import msgspec
 import pytest
 
+from gen_worker import RequestContext
+from gen_worker.family import Tuned, resolve
 from gen_worker.family import mint as family_mint
 from gen_worker.family.catalog import Flux1Dev, Sdxl
 from gen_worker.family.catalog import flux1_dev_serve as fx
@@ -572,3 +575,88 @@ def test_the_after_arm_of_the_measurement_loads_no_model_library() -> None:
     assert not after.transformers_loaded
     assert after.import_s < after.torch_s
     assert json.dumps([target for target in measurement.BEFORE])  # the arm is nameable
+
+
+# ------------------------------------------------------- request -> instance
+
+# The payload structs are MODULE-level, and that is load-bearing rather than
+# tidy: `tuned_payload_fields` resolves annotations through `get_type_hints`,
+# which cannot see a class defined inside a function body — so a locally
+# declared payload resolves NO tuned fields and every fallback silently stops
+# working. An endpoint author writes these at module scope for the same reason.
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    steps: Tuned[int] = None
+    guidance: Tuned[float] = None
+
+
+class _Out(msgspec.Struct):
+    shape: str = ""
+    steps: int = 0
+    guidance: float = 0.0
+
+
+def test_a_flux_endpoint_generates_through_the_declared_family_binding() -> None:
+    """The whole request path, as an endpoint author writes it.
+
+    ``@endpoint(families={...})`` is the ONE authoring contract, so this is not
+    a demonstration beside the real thing — it is the real thing, driven the way
+    placement drives it. The handler names no pipeline, no component, no graph
+    and no scheduler: it takes a resolved ``Flux1Dev``, resolves its tuned
+    values, and calls the composition. ``diffusers`` appears nowhere in it, and
+    the subprocess done-test above proves the process it runs in never loads one.
+    """
+
+    from gen_worker import endpoint
+    from gen_worker.family import fake_kwargs
+
+    @endpoint(families={"flux": Flux1Dev})
+    class Generate:
+        def generate(self, ctx: RequestContext, p: _In, flux: Flux1Dev) -> _Out:
+            values = resolve(p, flux)
+            image = fx.generate(
+                flux,
+                resolution=1024,
+                clip_ids=fx.clip_token_ids([1, 2, 3], device="cpu"),
+                t5_ids=fx.t5_token_ids([4, 5, 6], device="cpu"),
+                steps=int(values["steps"]),
+                guidance=float(values["guidance"]),
+                seed=1234,
+            )
+            return _Out(
+                shape=str(tuple(image.shape)),
+                steps=int(values["steps"]),
+                guidance=float(values["guidance"]),
+            )
+
+    kwargs = fake_kwargs(Generate)
+    assert set(kwargs) == {"flux"}
+    assert isinstance(kwargs["flux"], Flux1Dev)
+
+    # No opinion in the payload: the checkpoint's catalog-stamped tuned values
+    # win, and they arrive on the INSTANCE rather than on ctx.
+    defaulted = Generate().generate(None, _In(prompt="a cat"), **kwargs)  # type: ignore[arg-type]
+    assert defaulted.shape == "(1, 3, 1024, 1024)"
+    assert defaulted.steps == Flux1Dev.Tuned().steps
+    assert defaulted.guidance == Flux1Dev.Tuned().guidance
+
+    # An explicit payload value wins, resolved once in the SDK.
+    overridden = Generate().generate(  # type: ignore[arg-type]
+        None, _In(prompt="a cat", steps=3, guidance=1.5), **fake_kwargs(Generate)
+    )
+    assert (overridden.steps, overridden.guidance) == (3, 1.5)
+
+
+def test_the_handler_source_names_no_model_library() -> None:
+    """The catalog rule, literally: an endpoint imports a family, not diffusers."""
+
+    import inspect
+
+    source = inspect.getsource(test_a_flux_endpoint_generates_through_the_declared_family_binding)
+    body = source.split('"""', 2)[-1]
+    for library in role.FORBIDDEN_LIBRARIES:
+        assert library not in body
+    assert "FluxPipeline" not in body
+    assert "scheduler" not in body  # the loop asks the family for its own

--- a/tests/test_flux_stage1_pgw1331.py
+++ b/tests/test_flux_stage1_pgw1331.py
@@ -1,0 +1,574 @@
+"""pgw#1331 — Flux serves end to end with no model library on the request path.
+
+Four claims, and each is tested against the thing it is a claim ABOUT:
+
+1. **The bare math is the same math.** The scheduler and the packing arithmetic
+   are compared to diffusers' own, numerically, not by reading them. A
+   re-implementation nobody differenced is a rewrite with a bug in it.
+2. **The whole composition is graph classes.** All four runners export, and the
+   mint bridge turns each into a torchcg class declaration whose ingress digest
+   is the COMMITTED export's — which is what makes the typed binding and the
+   artifact one contract seen from two sides.
+3. **The request path holds no model library.** Statically, by the fence;
+   at run time, in a subprocess that installs the blocker, imports the surface
+   and generates an image — because an in-process check can never observe the
+   property (the test interpreter has already imported everything).
+4. **The gaps are shaped like refusals.** A family whose scheduler has no
+   implementation gets no ``scheduler()`` method; a mint whose digest drifts is
+   refused; an unlisted guarded import is refused.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.family import mint as family_mint
+from gen_worker.family.catalog import Flux1Dev, Sdxl
+from gen_worker.family.catalog import flux1_dev_serve as fx
+from gen_worker.family.catalog.flux1_dev import FLUX1_DEV, SCHEDULER
+from gen_worker.family.errors import FamilyError, FamilyRefusal
+from gen_worker.family.scheduler import (
+    IMPLEMENTED,
+    FlowMatchEulerDiscrete,
+    Schedule,
+    SchedulerKind,
+    parse_kind,
+)
+from gen_worker.serve import role
+
+torch = pytest.importorskip("torch")
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _fence() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "_pgw1331_fence", REPO / "scripts" / "lint_serve_role_closure.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------- the bare math
+
+
+@pytest.mark.parametrize("steps", [1, 4, 20, 28, 50])
+@pytest.mark.parametrize("resolution", [768, 1024])
+def test_the_flow_match_schedule_matches_diffusers_to_one_float32_ulp(steps: int, resolution: int) -> None:
+    """Our closed form and diffusers' object produce the SAME sigma ladder.
+
+    This is the evidence for "scheduler as bare typed math" being a MOVE rather
+    than a rewrite. If it ever stops holding, every image this family serves has
+    silently changed, and no other test in the repo would notice.
+    """
+
+    numpy = pytest.importorskip("numpy")
+    diffusers = pytest.importorskip("diffusers")
+    flux = pytest.importorskip("diffusers.pipelines.flux.pipeline_flux")
+
+    sequence = fx.packed_tokens(resolution)
+    theirs = diffusers.FlowMatchEulerDiscreteScheduler(**dict(SCHEDULER))
+    mu = flux.calculate_shift(
+        sequence,
+        theirs.config.base_image_seq_len,
+        theirs.config.max_image_seq_len,
+        theirs.config.base_shift,
+        theirs.config.max_shift,
+    )
+    theirs.set_timesteps(sigmas=numpy.linspace(1.0, 1 / steps, steps), mu=mu)
+
+    ours = FlowMatchEulerDiscrete.from_block(SCHEDULER).schedule(
+        steps, image_seq_len=sequence
+    )
+
+    assert FlowMatchEulerDiscrete.from_block(SCHEDULER).mu(sequence) == pytest.approx(mu)
+    assert len(ours) == steps
+    # The tolerance is ONE float32 ULP, and it is that because of a measured
+    # difference rather than a guessed one: diffusers rounds its shifted ladder
+    # through float32 tensors while this stays in float64 until a caller casts,
+    # so at most one entry per ladder lands a single ULP apart (measured worst
+    # case 6e-8 at sigma 0.513, which IS one ULP there). Every other entry is
+    # exact. A looser tolerance would hide a real formula difference; a tighter
+    # one would be asserting that two float widths agree, which they cannot.
+    assert list(ours.sigmas) == pytest.approx(
+        [float(value) for value in theirs.sigmas], rel=2e-7, abs=1e-9
+    )
+    assert list(ours.timesteps) == pytest.approx(
+        [float(value) for value in theirs.timesteps], rel=2e-7, abs=1e-6
+    )
+    assert numpy.float32(ours.sigmas[0]) == numpy.float32(1.0)
+    assert ours.sigmas[-1] == 0.0
+
+
+def test_the_euler_step_is_one_line_of_arithmetic() -> None:
+    """``x + (sigma_next - sigma) * v``, and the terminal sigma lands on zero."""
+
+    schedule = Schedule(sigmas=(1.0, 0.5, 0.0), num_train_timesteps=1000)
+    sample = torch.ones(2, 3)
+    velocity = torch.full((2, 3), 4.0)
+    assert torch.equal(schedule.step(0, velocity, sample), sample + (0.5 - 1.0) * velocity)
+    assert torch.equal(schedule.step(1, velocity, sample), sample + (0.0 - 0.5) * velocity)
+    with pytest.raises(FamilyError) as caught:
+        schedule.step(2, velocity, sample)
+    assert caught.value.reason is FamilyRefusal.SCHEDULER_INVALID
+
+
+@pytest.mark.parametrize("resolution", [768, 1024])
+def test_the_packing_arithmetic_is_bitwise_the_pipeline_s(resolution: int) -> None:
+    """Pack, unpack and the rope ids all equal ``FluxPipeline``'s, exactly."""
+
+    pipeline = pytest.importorskip("diffusers").FluxPipeline
+    edge = fx.latent_edge(resolution)
+    latents = torch.randn(2, fx.LATENT_CHANNELS, edge, edge)
+
+    packed = fx.pack_latents(latents)
+    assert torch.equal(packed, pipeline._pack_latents(latents, 2, fx.LATENT_CHANNELS, edge, edge))
+    assert packed.shape[1] == fx.packed_tokens(resolution)
+    assert torch.equal(fx.unpack_latents(packed, edge=edge), latents)
+    assert torch.equal(
+        fx.latent_image_ids(edge, device="cpu", dtype=torch.float32),
+        pipeline._prepare_latent_image_ids(None, edge // 2, edge // 2, "cpu", torch.float32),
+    )
+
+
+def test_a_schedule_terminating_anywhere_but_zero_is_refused() -> None:
+    """The terminal zero is part of the ladder, not a special case in ``step``."""
+
+    with pytest.raises(FamilyError) as caught:
+        Schedule(sigmas=(1.0, 0.5), num_train_timesteps=1000)
+    assert "terminate at sigma 0.0" in str(caught.value)
+
+
+def test_dynamic_shifting_refuses_to_guess_a_sequence_length() -> None:
+    """Defaulting it would serve every resolution one resolution's schedule."""
+
+    scheduler = FlowMatchEulerDiscrete.from_block(SCHEDULER)
+    assert scheduler.use_dynamic_shifting
+    with pytest.raises(FamilyError) as caught:
+        scheduler.schedule(4)
+    assert "image_seq_len" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "block, wanted",
+    [
+        ({"use_dynamic_shifting": 1}, "a boolean"),
+        ({"num_train_timesteps": 1.5}, "an integer"),
+        ({"base_shift": "0.5"}, "a real number"),
+    ],
+)
+def test_a_scheduler_block_is_parsed_not_coerced(block: dict[str, Any], wanted: str) -> None:
+    """``use_dynamic_shifting: 1`` means something the author did not write."""
+
+    with pytest.raises(FamilyError) as caught:
+        FlowMatchEulerDiscrete.from_block(block)
+    assert wanted in str(caught.value)
+
+
+def test_an_unimplemented_scheduler_is_an_absent_method_not_a_fallback() -> None:
+    """SDXL declares ``euler_discrete``; the SDK implements no math for it.
+
+    The gap's SHAPE is the point: ``Sdxl`` has no ``scheduler()``, so an author
+    who wants one is told by their own type checker. A base-class fallback that
+    returned "some scheduler" would put a model library back on the path at the
+    one moment nobody is looking.
+    """
+
+    assert Flux1Dev.SCHEDULER is SchedulerKind.FLOW_MATCH_EULER_DISCRETE
+    assert Sdxl.SCHEDULER is SchedulerKind.EULER_DISCRETE
+    assert isinstance(Flux1Dev.fake().scheduler(), FlowMatchEulerDiscrete)
+    assert not hasattr(Sdxl, "scheduler")
+    assert set(IMPLEMENTED) == {SchedulerKind.FLOW_MATCH_EULER_DISCRETE}
+    with pytest.raises(FamilyError):
+        parse_kind("ddim")
+
+
+def test_the_declared_block_is_the_scheduler_s_only_source_of_constants() -> None:
+    """A constant hardcoded in the math would be a second declaration of it."""
+
+    scheduler = Flux1Dev.fake().scheduler()
+    assert scheduler.base_shift == SCHEDULER["base_shift"]
+    assert scheduler.max_shift == SCHEDULER["max_shift"]
+    assert scheduler.max_image_seq_len == SCHEDULER["max_image_seq_len"]
+    # …and the block rides the export digest, so re-declaring it re-identifies
+    # the family rather than silently changing every request.
+    assert dict(Flux1Dev.SCHEDULER_PARAMETERS) == dict(SCHEDULER)
+
+
+# ------------------------------------------------------- the whole composition
+
+
+def test_the_family_declares_every_stage_of_the_pipeline() -> None:
+    """Two text encoders, the denoiser and the decoder — nothing left eager."""
+
+    assert [runner.name for runner in FLUX1_DEV.runners] == [
+        "clip",
+        "decoder",
+        "denoiser",
+        "t5",
+    ]
+    assert [row[0] for row in Flux1Dev.LOOP] == ["clip", "t5", "denoiser", "decoder"]
+    # The text encoders bucket on nothing: their token lengths are pinned by the
+    # architecture and by the family, so a bucket would generate classes nothing
+    # selects.
+    assert FLUX1_DEV.runner("clip").axes == ()
+    assert FLUX1_DEV.runner("t5").axes == ()
+    assert FLUX1_DEV.runner("denoiser").axes == ("resolution",)
+
+
+def test_every_declared_variant_carries_a_committed_ingress() -> None:
+    """The binding a handler compiles against covers all six classes."""
+
+    rows = family_mint.variants_of(FLUX1_DEV)
+    assert len(rows) == 6
+    for runner, bucket, layout in rows:
+        variant = Flux1Dev.EXPORT.runner(runner.name).variant(bucket, layout)
+        assert str(variant.ingress_digest)
+        assert variant.outputs
+
+
+def test_a_fake_backed_flux_generates_an_image_through_the_typed_callables() -> None:
+    """The whole loop, hubless and cardless, through the real code path.
+
+    Not a mock of the SDK — it IS the SDK, with the only part that needs a card
+    replaced (greenfield B8). So this exercises the packing, the schedule, four
+    typed callables and the ingress each of them resolves.
+    """
+
+    instance = Flux1Dev.fake()
+    seen: list[tuple[int, int]] = []
+    image = fx.generate(
+        instance,
+        resolution=1024,
+        clip_ids=fx.clip_token_ids([1, 2, 3], device="cpu"),
+        t5_ids=fx.t5_token_ids([4, 5, 6], device="cpu"),
+        steps=3,
+        guidance=3.5,
+        seed=7,
+        on_step=lambda index, total: seen.append((index, total)),
+    )
+    assert seen == [(0, 3), (1, 3), (2, 3)]
+    assert tuple(image.shape) == (1, 3, 1024, 1024)
+    assert float(image.min()) >= 0.0 and float(image.max()) <= 1.0
+    # Deterministic: a fake backing is a function of the declaration and the
+    # seed, so a receipt can assert on it.
+    again = fx.generate(
+        instance,
+        resolution=1024,
+        clip_ids=fx.clip_token_ids([1, 2, 3], device="cpu"),
+        t5_ids=fx.t5_token_ids([4, 5, 6], device="cpu"),
+        steps=3,
+        guidance=3.5,
+        seed=7,
+    )
+    assert torch.equal(image, again)
+
+
+def test_a_different_seed_is_a_different_starting_point() -> None:
+    """The seed reaches the latents; it is not decorative.
+
+    Asserted at the LATENTS and not at the image, and the reason is worth
+    stating: a fake backing's outputs are a function of the declaration, not of
+    the call, so the decoder returns the same tensor whatever it is handed. The
+    seed's effect is real and observable exactly where it is applied. A test
+    that asserted it at the image would be asserting a property the fake
+    backing does not have, and would go green only once a real backing arrived.
+    """
+
+    one = fx.initial_latents(
+        resolution=768, batch=1, seed=1, device="cpu", dtype=torch.float32
+    )
+    two = fx.initial_latents(
+        resolution=768, batch=1, seed=2, device="cpu", dtype=torch.float32
+    )
+    again = fx.initial_latents(
+        resolution=768, batch=1, seed=1, device="cpu", dtype=torch.float32
+    )
+    assert not torch.equal(one, two)
+    assert torch.equal(one, again)
+    assert tuple(one.shape) == (1, fx.packed_tokens(768), fx.LATENT_CHANNELS * 4)
+
+
+# ------------------------------------------------------------- the mint bridge
+
+
+def test_the_mint_bridge_declares_torchcg_classes_from_the_declaration_alone() -> None:
+    """Trace -> keying block -> class hash, with no endpoint and no weights.
+
+    Everything below ``Engine.compile`` runs on CPU under fake tensors, which is
+    the whole reason a family can be minted without downloading a checkpoint:
+    cell identity is checkpoint-free (§4.27) and the constants arrive at ARM
+    time from the store (pgw#1329).
+    """
+
+    from gen_worker import aot_mint
+
+    hashes: dict[str, str] = {}
+    for traced, spec, row in family_mint.traced_classes(FLUX1_DEV, only=("decoder",)):
+        declaration = aot_mint.tcg_graph_class_spec(row, spec).declare()
+        hashes[row.name] = str(declaration.class_hash)
+        assert spec.family == "flux1_dev"
+        assert spec.target == traced.runner
+        assert dict(spec.class_dims) == traced.bucket
+        assert spec.specialization == {"layout": traced.layout}
+        # THE drift property: the mint's ingress is the committed export's,
+        # because both come from the same tracer (torchcg G16).
+        committed = Flux1Dev.EXPORT.runner(traced.runner).variant(
+            traced.bucket, traced.layout
+        )
+        assert str(committed.ingress_digest) == traced.ingress.digest()
+        row.release()
+
+    assert sorted(hashes) == ["decoder.resolution1024.bf16", "decoder.resolution768.bf16"]
+    # Two buckets are two CLASSES: a runner armed at 1024 must not answer a 768
+    # call, and the identity is what makes that structural rather than checked.
+    assert len(set(hashes.values())) == 2
+
+
+def test_a_mint_whose_digest_drifted_from_the_export_is_refused() -> None:
+    """The export is the source; a mint that disagrees is the thing that is wrong."""
+
+    row = family_mint.MintedVariant(
+        runner="decoder",
+        bucket=(("resolution", 1024),),
+        layout="bf16",
+        graph_class="decoder.resolution1024.bf16",
+        key="cg-key-v1-" + "0" * 56,
+        artifact=Path("/nowhere.tar.gz"),
+        metadata={},
+        ingress_digest="not-the-committed-one",
+        compile_s=1.0,
+        reuse_s=0.0,
+    )
+    with pytest.raises(FamilyError) as caught:
+        family_mint.assert_matches_export([row], Flux1Dev.EXPORT)
+    assert "never becomes the source" in str(caught.value)
+    family_mint.assert_matches_export([], Flux1Dev.EXPORT)
+
+
+def test_minting_an_eager_only_family_is_refused_rather_than_invented() -> None:
+    from gen_worker.family.spec import Family, TunedValues
+
+    class _Tuned(TunedValues, frozen=True):
+        steps: int = 1
+
+    eager = Family(name="pgw1331_eager_only", tuned=_Tuned)
+    try:
+        with pytest.raises(FamilyError) as caught:
+            family_mint.mint_family(eager, out_dir=Path("/nowhere"), work=Path("/nowhere"))
+        assert "eager-only" in str(caught.value)
+    finally:
+        from gen_worker.families import base as families_base
+
+        families_base._REGISTRY.pop("pgw1331_eager_only", None)
+
+
+def test_a_runner_the_family_does_not_declare_is_refused() -> None:
+    with pytest.raises(FamilyError) as caught:
+        family_mint.variants_of(FLUX1_DEV, only=("unet",))
+    assert "declares no runner 'unet'" in str(caught.value)
+
+
+def test_the_mint_bridge_is_declared_mint_machinery() -> None:
+    """A serve-role module that could reach it would be a pod that can compile."""
+
+    assert "gen_worker.family.mint" in role.MINT_MACHINERY
+
+
+# ------------------------------------------------------------------- the fence
+
+
+def test_the_model_free_surface_reaches_no_model_library() -> None:
+    fence = _fence()
+    roots = fence._declared_tuple("MODEL_FREE_MODULES")
+    libraries = fence._declared_tuple("FORBIDDEN_LIBRARIES")
+    optional = fence._declared_tuple("OPTIONAL_SERVE_IMPORTS")
+    assert tuple(roots) == role.MODEL_FREE_MODULES
+    assert tuple(libraries) == role.FORBIDDEN_LIBRARIES
+    assert tuple(optional) == role.OPTIONAL_SERVE_IMPORTS
+    assert fence.check_model_free(roots, libraries, optional, within=role.SERVE_ROLE_MODULES) == []
+    assert fence.main([]) == 0
+
+
+def test_red_the_fence_fires_on_a_declaration_that_names_a_model_library() -> None:
+    """The declaration reaches diffusers only through FUNCTION-LOCAL imports.
+
+    So this one root proves both halves: that the library walk fires, and that
+    it still follows lazy imports — which is the shape the coupling takes.
+    """
+
+    fence = _fence()
+    problems = fence.check_model_free(
+        ("gen_worker.family.catalog.flux1_dev",), role.FORBIDDEN_LIBRARIES, ()
+    )
+    assert [line for line in problems if "diffusers" in line]
+    assert [line for line in problems if "transformers" in line]
+
+
+def test_red_an_unlisted_guarded_import_is_refused() -> None:
+    """The hatch is a closed list, not a door any ``try: import`` walks through."""
+
+    fence = _fence()
+    problems = fence.check_model_free(
+        ("gen_worker.family.catalog._generated.flux1_dev",), role.FORBIDDEN_LIBRARIES, ()
+    )
+    assert [line for line in problems if "guarded import" in line]
+
+
+def test_red_a_listed_hatch_nobody_uses_is_refused() -> None:
+    """An enumerated hatch nobody reaches is a hatch nobody is checking."""
+
+    fence = _fence()
+    problems = fence.check_model_free(
+        role.MODEL_FREE_MODULES,
+        role.FORBIDDEN_LIBRARIES,
+        (*role.OPTIONAL_SERVE_IMPORTS, "gen_worker.view"),
+    )
+    assert [line for line in problems if "no serve-role module reaches it" in line]
+
+
+def test_red_a_model_free_module_outside_the_serve_role_is_refused() -> None:
+    """Model-free but not mint-free is the smaller of the two properties."""
+
+    fence = _fence()
+    problems = fence.check_model_free(
+        ("gen_worker.view",), role.FORBIDDEN_LIBRARIES, (), within=role.SERVE_ROLE_MODULES
+    )
+    assert [line for line in problems if "not in SERVE_ROLE_MODULES" in line]
+
+
+def test_the_model_free_set_is_spliced_into_the_serve_role_set() -> None:
+    """One list. Retyping it is how pgw#824's drift starts."""
+
+    assert set(role.MODEL_FREE_MODULES) <= set(role.SERVE_ROLE_MODULES)
+    fence = _fence()
+    assert tuple(fence._declared_tuple("SERVE_ROLE_MODULES")) == role.SERVE_ROLE_MODULES
+
+
+def test_the_fence_selftest_passes() -> None:
+    assert _fence().selftest() == 0
+
+
+def test_type_checking_imports_are_not_followed() -> None:
+    """They never execute; reporting them would report a cost nobody pays."""
+
+    fence = _fence()
+    binding = REPO / "src/gen_worker/family/catalog/_generated/flux1_dev.py"
+    assert "from torch import Tensor" in binding.read_text()
+    _, _, libraries = fence._imports(binding, "gen_worker.family.catalog._generated.flux1_dev")
+    assert "torch" not in libraries
+
+
+# --------------------------------------------------------- the runtime blocker
+
+
+_DONE_TEST = r"""
+import sys
+
+from gen_worker.serve import guard, role
+
+role.declare(role.ServeRole.ADOPT_ONLY)
+guard.install()
+
+for name in role.FORBIDDEN_LIBRARIES:
+    try:
+        __import__(name)
+    except guard.ModelLibraryUnavailable as exc:
+        assert exc.blocked == name, (name, exc.blocked)
+    else:
+        raise SystemExit("IMPORTED " + name)
+
+# The whole serving surface, in a process that cannot acquire a model library.
+from gen_worker.family.catalog import Flux1Dev
+from gen_worker.family.catalog import flux1_dev_serve as fx
+from gen_worker.family.scheduler import FlowMatchEulerDiscrete
+
+instance = Flux1Dev.fake()
+assert isinstance(instance.scheduler(), FlowMatchEulerDiscrete)
+image = fx.generate(
+    instance,
+    resolution=768,
+    clip_ids=fx.clip_token_ids([1, 2, 3], device="cpu"),
+    t5_ids=fx.t5_token_ids([4, 5], device="cpu"),
+    steps=3,
+    guidance=3.5,
+    seed=11,
+)
+assert tuple(image.shape) == (1, 3, 768, 768), image.shape
+
+leaked = [name for name in role.FORBIDDEN_LIBRARIES if name in sys.modules]
+if leaked:
+    raise SystemExit("LEAKED " + ",".join(leaked))
+assert guard.libraries_present() == ()
+print("OK")
+"""
+
+
+def test_the_request_path_generates_in_a_process_that_cannot_import_diffusers() -> None:
+    """pgw#1331's done-test, and it must be a SUBPROCESS.
+
+    The test interpreter has already imported diffusers (the parity tests above
+    need it), so an in-process assertion could never observe the property. This
+    one boots a fresh adopt-only interpreter, installs the blocker, imports the
+    typed family surface, and generates a whole image — then checks that no
+    model library ever entered ``sys.modules``.
+    """
+
+    done = subprocess.run(
+        [sys.executable, "-c", _DONE_TEST],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert done.returncode == 0, done.stderr[-4000:]
+    assert done.stdout.strip().splitlines()[-1] == "OK"
+
+
+def test_the_blocker_refuses_to_promise_something_already_false() -> None:
+    """This interpreter HAS diffusers; installing now would be a lie."""
+
+    from gen_worker.serve import guard
+
+    previous = role.current()
+    try:
+        role._reset_for_test(role.ServeRole.ADOPT_ONLY)
+        assert "diffusers" in sys.modules or "transformers" in sys.modules
+        with pytest.raises(RuntimeError) as caught:
+            guard.install()
+        assert "already imported" in str(caught.value)
+    finally:
+        guard._uninstall_for_test()
+        role._reset_for_test(previous)
+
+
+def test_the_forbidden_libraries_are_the_ones_the_issue_names() -> None:
+    assert role.FORBIDDEN_LIBRARIES == ("diffusers", "transformers")
+
+
+# ------------------------------------------------------------- the measurement
+
+
+def test_the_after_arm_of_the_measurement_loads_no_model_library() -> None:
+    """The benchmark's own claim, asserted where CI can see it.
+
+    The numbers move with the machine; what must not move is which libraries
+    each arm ends up holding, because that is the property, and the arm lists
+    are what the measurement quotes.
+    """
+
+    from gen_worker.benchmarks import request_path_imports as measurement
+
+    after = measurement.measure("after", measurement.AFTER, repeat=1)
+    assert not after.diffusers_loaded
+    assert not after.transformers_loaded
+    assert after.import_s < after.torch_s
+    assert json.dumps([target for target in measurement.BEFORE])  # the arm is nameable

--- a/tests/test_flux_stage1_pgw1331.py
+++ b/tests/test_flux_stage1_pgw1331.py
@@ -364,7 +364,7 @@ def test_minting_an_eager_only_family_is_refused_rather_than_invented() -> None:
     class _Tuned(TunedValues, frozen=True):
         steps: int = 1
 
-    eager = Family(name="pgw1331_eager_only", tuned=_Tuned)
+    eager: Any = Family(name="pgw1331_eager_only", tuned=_Tuned)
     try:
         with pytest.raises(FamilyError) as caught:
             family_mint.mint_family(eager, out_dir=Path("/nowhere"), work=Path("/nowhere"))
@@ -372,7 +372,7 @@ def test_minting_an_eager_only_family_is_refused_rather_than_invented() -> None:
     finally:
         from gen_worker.families import base as families_base
 
-        families_base._REGISTRY.pop("pgw1331_eager_only", None)
+        families_base._REGISTRY.pop(("pgw1331_eager_only", "checkpoint"))
 
 
 def test_a_runner_the_family_does_not_declare_is_refused() -> None:
@@ -633,19 +633,21 @@ def test_a_flux_endpoint_generates_through_the_declared_family_binding() -> None
 
     kwargs = fake_kwargs(Generate)
     assert set(kwargs) == {"flux"}
-    assert isinstance(kwargs["flux"], Flux1Dev)
+    flux = kwargs["flux"]
+    assert isinstance(flux, Flux1Dev)
+    ctx: Any = None
 
     # No opinion in the payload: the checkpoint's catalog-stamped tuned values
     # win, and they arrive on the INSTANCE rather than on ctx.
-    defaulted = Generate().generate(None, _In(prompt="a cat"), **kwargs)  # type: ignore[arg-type]
+    defaulted = Generate().generate(ctx, _In(prompt="a cat"), flux)
     assert defaulted.shape == "(1, 3, 1024, 1024)"
     assert defaulted.steps == Flux1Dev.Tuned().steps
     assert defaulted.guidance == Flux1Dev.Tuned().guidance
 
     # An explicit payload value wins, resolved once in the SDK.
-    overridden = Generate().generate(  # type: ignore[arg-type]
-        None, _In(prompt="a cat", steps=3, guidance=1.5), **fake_kwargs(Generate)
-    )
+    second = fake_kwargs(Generate)["flux"]
+    assert isinstance(second, Flux1Dev)
+    overridden = Generate().generate(ctx, _In(prompt="a cat", steps=3, guidance=1.5), second)
     assert (overridden.steps, overridden.guidance) == (3, 1.5)
 
 
@@ -660,3 +662,84 @@ def test_the_handler_source_names_no_model_library() -> None:
         assert library not in body
     assert "FluxPipeline" not in body
     assert "scheduler" not in body  # the loop asks the family for its own
+
+
+# ------------------------------------------------- the bridge, through to pack
+
+
+class _StubEngine:
+    """The compile child's engine contract, without the compile.
+
+    The same shape ``tests/test_tcg_compile_child_pgw1270.py`` uses, and for the
+    same reason: a real AOTInductor compile needs a card and belongs on a pod
+    (``gen-worker family mint``), so the bar CI can hold is that everything on
+    either side of ``Engine.compile`` is real — a real declaration, a real
+    trace, a real ``GraphClassSpec``, a real packed row. That is exactly the bar
+    the production compile child is held to, and this bridge is not entitled to
+    a weaker one.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.specs: list[Any] = []
+
+    def compile(self, spec: Any, runtime: Any, destination: Path) -> Any:
+        from types import SimpleNamespace
+
+        del runtime, destination
+        self.specs.append(spec)
+        key = "cg-key-v1-" + f"{len(self.specs):056d}"
+        return SimpleNamespace(
+            outcome=SimpleNamespace(value="minted"),
+            compiled_graph=SimpleNamespace(
+                key=key,
+                metadata={
+                    "compiled_graph_key": key,
+                    "compiled_graph_format": 1,
+                    "graph_class": {"name": spec.graph_class},
+                },
+            ),
+        )
+
+    def export_artifact(self, key: str, destination: Path) -> Path:
+        del key
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"tcg-artifact")
+        return destination
+
+
+def test_mint_family_packs_one_artifact_per_declared_variant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole bridge: declaration in, packed rows out, digests agreeing."""
+
+    from gen_worker import aot_compile_child
+
+    engine = _StubEngine(tmp_path)
+    monkeypatch.setattr(
+        aot_compile_child, "_tcg_runtime", lambda cache_root=None: (engine, object())
+    )
+
+    minted = family_mint.mint_family(
+        FLUX1_DEV, out_dir=tmp_path / "cells", work=tmp_path / "work", only=("decoder",)
+    )
+
+    assert [row.graph_class for row in minted] == [
+        "decoder.resolution768.bf16",
+        "decoder.resolution1024.bf16",
+    ]
+    assert [dict(row.bucket) for row in minted] == [{"resolution": 768}, {"resolution": 1024}]
+    assert all(row.artifact.read_bytes() == b"tcg-artifact" for row in minted)
+    assert all(row.key.startswith("cg-key-v1-") for row in minted)
+    assert len({row.key for row in minted}) == 2
+    assert all(row.metadata["graph_class"]["name"] == row.graph_class for row in minted)
+    assert all(not row.reused for row in minted)
+    # The specs handed to the engine are REAL torchcg declarations built from
+    # the declaration's own trace, and every minted row's ingress digest is the
+    # committed export's.
+    assert [spec.target for spec in engine.specs] == ["decoder", "decoder"]
+    assert [dict(spec.class_dims) for spec in engine.specs] == [
+        {"resolution": 768},
+        {"resolution": 1024},
+    ]
+    family_mint.assert_matches_export(minted, Flux1Dev.EXPORT)


### PR DESCRIPTION
Stage 1 of the SPLIT program (pgw#1326), and the last item in it. Closes the graph-coverage gap: the whole FLUX.1-dev composition is graph classes, the scheduler is arithmetic, and the request path is fenced — statically and at run time — against every model library.

## What landed

**Four runners instead of two.** CLIP-L and T5-XXL join the denoiser and the VAE decoder in `gen_worker.family.catalog.flux1_dev`, so nothing in the composition rides an eager model at serve time. The declaration-time fake-tensor export covers all six variants on CPU in ~70 s, with no weights and no card.

**The scheduler is no longer an object.** `gen_worker.family.scheduler` implements flow-match Euler in closed form over the family's *own declared block*, and imports neither a model library nor `torch` — the sigma ladder is float math and the step is tensor operators. Codegen emits a typed `inst.scheduler()` whose return type is the concrete class, so no handler spells a scheduler name; a family whose declared scheduler has no implementation gets **no method** (SDXL's `euler_discrete`), which is an `AttributeError` a type checker reports rather than a fallback that quietly puts diffusers back.

**Each catalog family is two modules.** `<family>.py` declares (diffusers allowed, inside `build`); `<family>_serve.py` is what the request path reads — tuned schemas, packing arithmetic, the loop — and imports nothing above `torch`. `gen_worker.family`'s own `__init__` went PEP 562 lazy for the same reason: it re-exported `inject`, so importing a generated binding executed `api.decorators`, `warmup` and `models.provision`.

**A family declaration mints its own graph classes.** `gen_worker.family.mint` / `gen-worker family mint` bridges a `GraphFamily` to packed AOTI artifacts through the mint lane's *inner* seam (`export_program` → `build_call_ingress` → `keying_block` → `Engine.compile`) — no endpoint, no `Compile` declaration, no compile pool, and **no checkpoint download**, because cell identity is checkpoint-free (§4.27) and the constants arrive at arm time from the store (pgw#1329). The trace is the declaration's own, so a minted class's ingress digest is the committed export's by construction.

## The evidence

**The bare math is the same math, differenced rather than read.**

| claim | result |
|---|---|
| sigma ladder vs `FlowMatchEulerDiscreteScheduler` | equal to **one float32 ULP** over (1, 4, 20, 28, 50) steps x (768, 1024); worst case 6e-8 at sigma 0.513, which *is* one ULP there — diffusers rounds its ladder through float32 tensors, this stays float64 |
| `pack_latents` / `unpack_latents` / `latent_image_ids` vs `FluxPipeline` | `torch.equal`, both resolutions; unpack∘pack is the identity |

**Zero diffusers, two fences.** `role.MODEL_FREE_MODULES` names the surface and `role.FORBIDDEN_LIBRARIES` names `diffusers` and `transformers`; `lint_serve_role_closure.py` walks **function-local** imports for both claims (`14 declared roots, 26 modules in the closure, 2 libraries absent`). It does not follow `ImportError`-guarded edges — that is how a binding reaches an optional `SPEC`, pgw#1339's degrade-loudly-and-serve — so `OPTIONAL_SERVE_IMPORTS` enumerates the two places it stops and goes red on an unlisted edge *and* on a listed row nobody reaches. `serve.guard` blocks the same libraries at run time.

Red-proven: a declaration root fires the library walk (through function-local imports only); an unlisted guarded edge is refused; a listed hatch nobody uses is refused; a model-free module outside the serve role is refused. The **done-test is a subprocess** — an adopt-only interpreter installs the blocker, imports the family surface, generates a whole 768x768 image, and checks no model library ever entered `sys.modules`. In-process could never observe it: this interpreter imports diffusers to difference against.

**Measured before/after** (`python -m gen_worker.benchmarks.request_path_imports`), fresh interpreters, delta over `torch`:

| arm | import | +RSS | +modules | loaded |
|---|---|---|---|---|
| before — `diffusers:FluxPipeline` | 2.12 s | 225 MB | 2192 | diffusers, transformers |
| after — the typed family surface | 0.12 s | 22 MB | 220 | **neither** |

17x faster to a servable state, 203 MB less resident. **Per-request latency is not measured here and is not claimed** — that needs a card, real weights and armed artifacts.

## Scoped honestly

The **whole** serve role is not statically model-free, and `role.py` records why with the remaining cut named: `gen_worker/__init__` reaches `models.loading` / `models.memory` / `view`, which import diffusers inside functions and are *entitled* to, because an eager-capable pod serves eager on a miss (§4.28). Claiming more than the surface this issue built would be a fence describing a tree nobody has cut.

`Engine.compile` is the one step not exercised here — it needs a GPU, and the machine rules forbid local mints. Everything below it runs on CPU in the suite: six variants, real torchcg class hashes, ingress digests equal to the committed export, two resolution buckets keying apart.

## Green

`fast gates` inputs all green locally: `check_family_bindings` (2 pairs), `check_registry_contract`, `lint_serve_role_closure` + `--selftest`, `lint_mypy_ratchet`, `ruff`, `mypy --strict` (25 files, no new exemption). Tests: 43 new + `test_family_sdk_pgw1332` (68), `test_adopt_only_serve_role_pgw1328` (32), `test_cgkey_as_data_pgw1327` (27), `test_store_sourced_arm_pgw1329`, and 154 across the adjacent SDK/discovery suites.

**Breaking, pre-launch:** `Flux1Dev`/`Sdxl` export digests change (regenerate pinned bindings); `SchedulerBlock` moved from `gen_worker.family.runtime` to `gen_worker.family.scheduler`; the tuned schemas and shape helpers moved to the families' serving halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)