### PR TITLE
pgw#1347: the pod mint-rig — rent a pod, run a command, bank a row

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,8 +303,11 @@ jobs:
       # merely unchecked — `mypy tests` REFUSED TO START on a duplicate
       # `conftest` module, so 486 test modules had zero static coverage, which
       # is where the doubles that lied about production contracts lived.
-      - name: Type check (mypy, strict by default, src + tests)
-        run: uv run mypy src/gen_worker tests tests_v2
+      # pgw#1347 adds `scripts/mint_rig`: the pod driver is control-plane code
+      # that must NOT ship in the wheel, but it spends money, so it is checked
+      # here rather than being exempt by living outside src/.
+      - name: Type check (mypy, strict by default, src + tests + the pod rig)
+        run: uv run mypy src/gen_worker tests tests_v2 scripts/mint_rig
 
       # GATING (pgw#1202): `strict = true` cannot silently stop being true, but
       # a per-module exemption list can grow one reasonable-looking name at a
@@ -315,7 +318,7 @@ jobs:
 
       - name: Lint
         continue-on-error: true  # Lint debt (mostly worker.py, being rewritten) — visible in logs, doesn't block CI.
-        run: uv run ruff check src/gen_worker
+        run: uv run ruff check src/gen_worker scripts/mint_rig
 
       # GATING (no continue-on-error): a bare HTTP call site is the gw#456
       # forever-hang reintroduced. hf_hub network use goes through

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,11 +303,18 @@ jobs:
       # merely unchecked — `mypy tests` REFUSED TO START on a duplicate
       # `conftest` module, so 486 test modules had zero static coverage, which
       # is where the doubles that lied about production contracts lived.
-      # pgw#1347 adds `scripts/mint_rig`: the pod driver is control-plane code
-      # that must NOT ship in the wheel, but it spends money, so it is checked
-      # here rather than being exempt by living outside src/.
-      - name: Type check (mypy, strict by default, src + tests + the pod rig)
-        run: uv run mypy src/gen_worker tests tests_v2 scripts/mint_rig
+      - name: Type check (mypy, strict by default, src + tests)
+        run: uv run mypy src/gen_worker tests tests_v2
+
+      # pgw#1347: the pod driver is control-plane code that must NOT ship in the
+      # wheel (no pod needs the thing that rents pods), but it spends money, so
+      # it is born strict like everything else. It gets its OWN invocation with
+      # `MYPYPATH=scripts` rather than joining `mypy_path` in pyproject: that
+      # path is shared, and adding `scripts` to it makes mypy resolve every
+      # other scripts/*.py a test imports, which drags 18 unrelated pre-existing
+      # errors into this gate. Same hardness, isolated blast radius.
+      - name: Type check the pod mint-rig (pgw#1347)
+        run: MYPYPATH=scripts uv run mypy scripts/mint_rig tests/test_pod_mint_rig_pgw1347.py
 
       # GATING (pgw#1202): `strict = true` cannot silently stop being true, but
       # a per-module exemption list can grow one reasonable-looking name at a

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -94,6 +94,21 @@ tasks:
     cmds:
       - nice -n 10 uv run --extra dev pytest tests/test_micro_mint_rig_pgw978.py -p no:randomly -rs
 
+  rig:pod:
+    desc: |
+      pgw#1347 — THE POD MINT-RIG. Rent a pod, run one named command, bank a row.
+      This is the primitive; the compile happens on the pod, never on this box.
+
+      A spend rail is MANDATORY (--rail, in dollars) and the kill command is
+      written to ~/.cache/cozy-mint-rig/killset BEFORE the pod is created.
+
+        task rig:pod -- mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
+          --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip
+        task rig:pod -- sweep         # live pods vs our records; exit 1 on a leak
+        task rig:pod -- terminate --pod <id>
+    cmds:
+      - nice -n 19 uv run python scripts/pod_rig.py {{.CLI_ARGS}}
+
   probe:sync:
     desc: |
       pgw#980 — rsync src/gen_worker onto a held probe pod and respawn its

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -103,7 +103,7 @@ tasks:
       written to ~/.cache/cozy-mint-rig/killset BEFORE the pod is created.
 
         task rig:pod -- mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
-          --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip
+          --target gen_worker.model.catalog.flux1_dev:FLUX1_DEV --runner clip
         task rig:pod -- sweep         # live pods vs our records; exit 1 on a leak
         task rig:pod -- terminate --pod <id>
     cmds:

--- a/changelog.d/pgw1347.md
+++ b/changelog.d/pgw1347.md
@@ -43,7 +43,7 @@
   image: two exposed port 22 in ~100 s, a third sat at `desiredStatus: RUNNING` with no address for
   six minutes (RIG-ENV's known upstream single-blob stall). A matrix lane can retry a `reroll`; it
   must never retry a `railed`, which means the operator's money is genuinely gone.
-- **`--fleet-line` is required to mint, and refused before renting.** `gen-worker family mint`
+- **`--fleet-line` is required to mint, and refused before renting.** `gen-worker model mint`
   asserts the fleet line first, and `rigcheck` reads `endpoint.toml` / `fleet-floors.toml` /
   ENDPOINT dist metadata — deliberately not gen-worker's own requirement, since an SDK certifying
   its own floor makes every rig pass. This repository ships none of those files, so the authority

--- a/changelog.d/pgw1347.md
+++ b/changelog.d/pgw1347.md
@@ -16,6 +16,13 @@
   dies inside the POST still leaves a stoppable pod. When the create call fails, the rig sweeps the
   account for that name and kills whatever it finds. podguard (th#1327) is armed as well and is not
   optional: a create body without it is refused on the rig's own HTTP path.
+- **Bring-up is bounded by MONEY, because it has no progress signal.** Measured against
+  `rest.runpod.io/v1`: a pod reports `desiredStatus: RUNNING` from the instant it is rented,
+  `lastStatusChange` never moves again, and `publicIp`/`portMappings` appear only when the
+  container actually starts — so a three-gigabyte image pull and a wedged host produce
+  byte-identical records for as long as either lasts. Staleness cannot separate them and a tick
+  count pretending to would be a magic timeout, so that one phase is capped by `--boot-budget`,
+  a declared fraction of the caller's own rail. Everything after it is progress-gated.
 - **No timeouts anywhere.** Every wait is a `Gate` over a goal predicate and a progress token, and
   the only negative verdict is `stuck` — the token stopped changing for N consecutive observations.
   Bring-up watches the pod's REST record paired with ssh's own stderr; a compile watches the log's
@@ -24,6 +31,25 @@
 - **Teardown is three verdicts, and each is recorded.** DELETE, then `GET` → 404, then absent from
   the account listing. Any one of them alone has lied: DELETE answers 200 for a pod still winding
   down, and a per-pod GET can 404 while the listing still carries the pod that is still billing.
+- **`--fleet-line` is required to mint, and refused before renting.** `gen-worker family mint`
+  asserts the fleet line first, and `rigcheck` reads `endpoint.toml` / `fleet-floors.toml` /
+  ENDPOINT dist metadata — deliberately not gen-worker's own requirement, since an SDK certifying
+  its own floor makes every rig pass. This repository ships none of those files, so the authority
+  has to be uploaded; the rig refuses at the CLI rather than on a pod you already paid for.
+- **`--break-system-packages`.** The fleet base image's interpreter is Debian
+  EXTERNALLY-MANAGED, so PEP 668 refuses the install and recommends a venv — which would shadow
+  or re-resolve the fleet's own torch, RIG-ENV §3a's single most common way a rig drifts. The pod
+  is disposable and single-purpose.
+- **Cards are SETS, because there is no capacity query.** `rest.runpod.io/v1` has no gpu-type or
+  availability path at all (its openapi.json answers HTTP 400 for one). Availability is discovered
+  by asking for several acceptable SKUs and reading the create call; `HTTP 500 "this machine does
+  not have the resources"` is the out-of-capacity signal and it costs nothing. Measured
+  2026-08-17: five Ampere SKUs in one call were refused while an Ada card came up first try, so
+  `sm86` and `sm89` are both catalogued and `--cloud` selects SECURE, COMMUNITY or ANY.
+- **`scripts/lint_mypy_ratchet.py` asserts over the UNION of mypy invocations**, not each one. The
+  property is that every path the config covers reaches mypy somewhere; the per-invocation reading
+  forbade a second, deliberately-scoped call for a tree needing a different `MYPYPATH`, and went
+  red on a change that strengthened coverage.
 - **`scripts/lint_repo_ref_pins.py` learned that image tags are ref-shaped.** Its docstring claimed
   container images "never match the shape at all"; `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime`
   is `<owner>/<repo>:<tag>` exactly. Rather than a path allowlist it gained a third line-level

--- a/changelog.d/pgw1347.md
+++ b/changelog.d/pgw1347.md
@@ -1,0 +1,31 @@
+- **This repo can rent a pod and run a command on it.** `scripts/mint_rig` is a typed driver —
+  rent by (card, image) over the RunPod REST API, ship a workload, run ONE named command, capture
+  the artifacts, tear the pod down with triple verification, and emit a machine-readable row. It
+  is the primitive the Compile Gauntlet is built on and the one pgw#1331 recorded as missing: real
+  compiles happen on pods, and until now every lane that needed one wrote its own driver.
+  `python -m mint_rig mint --gpu a40 --rail 2.00 --lane <lane> --target <module:FAMILY> --runner
+  clip` is the whole interface for a family mint; `run` takes any command, `sweep` reports live
+  pods against our own records, `terminate` stops one by id or by name.
+- **A spend rail is mandatory and it is money, not a clock.** `Rail(max_usd=…)` has no default and
+  refuses zero, and `Rig` cannot be constructed without one. The cap is converted to a wall using
+  the rate the create response ACTUALLY returned, so the same $2 is five hours on an A40 and
+  twenty minutes on a B200; it is re-checked at every progress observation, and tripping it is a
+  recorded `railed` verdict with a torn-down pod, never a silent abort.
+- **The kill command is written before the pod exists.** The kill-set record lands on disk, fsynced,
+  keyed by the pod NAME we are about to ask for, *before* the create call leaves — so a host that
+  dies inside the POST still leaves a stoppable pod. When the create call fails, the rig sweeps the
+  account for that name and kills whatever it finds. podguard (th#1327) is armed as well and is not
+  optional: a create body without it is refused on the rig's own HTTP path.
+- **No timeouts anywhere.** Every wait is a `Gate` over a goal predicate and a progress token, and
+  the only negative verdict is `stuck` — the token stopped changing for N consecutive observations.
+  Bring-up watches the pod's REST record paired with ssh's own stderr; a compile watches the log's
+  byte count, its last line and the inductor cache's size together, because an inductor pass can
+  print nothing for ten minutes while it writes objects. Work that is moving is never stopped.
+- **Teardown is three verdicts, and each is recorded.** DELETE, then `GET` → 404, then absent from
+  the account listing. Any one of them alone has lied: DELETE answers 200 for a pod still winding
+  down, and a per-pod GET can 404 while the listing still carries the pod that is still billing.
+- **`scripts/lint_repo_ref_pins.py` learned that image tags are ref-shaped.** Its docstring claimed
+  container images "never match the shape at all"; `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime`
+  is `<owner>/<repo>:<tag>` exactly. Rather than a path allowlist it gained a third line-level
+  proof marker, `# oci-image:`, stating that a literal is consumed by a container runtime and never
+  reaches `parse_model_ref` — with red/green selftest rows for both.

--- a/changelog.d/pgw1347.md
+++ b/changelog.d/pgw1347.md
@@ -28,9 +28,21 @@
   Bring-up watches the pod's REST record paired with ssh's own stderr; a compile watches the log's
   byte count, its last line and the inductor cache's size together, because an inductor pass can
   print nothing for ten minutes while it writes objects. Work that is moving is never stopped.
+- **A zero count is not a match, and a marker is not an artifact.** The first real green this
+  rig printed was a lie: `grep -c X f` prints its count AND exits 1 when the count is zero, so the
+  probe's `|| echo 0` emitted `"0\n0"`, the done check compared it against the string `"0"`, and a
+  command that died at its FIRST LINE — no compile, no artifact, a 213-byte log holding one
+  refusal — was recorded green with a torn-down pod and a banked row. Fixed at both ends (the
+  script never emits the second value; the parse sums whatever it gets) and backed by a second,
+  INDEPENDENT statement of success: `Workload.required_artifacts`. A mint that produced no
+  `minted.json` is red no matter what its log said.
 - **Teardown is three verdicts, and each is recorded.** DELETE, then `GET` → 404, then absent from
   the account listing. Any one of them alone has lied: DELETE answers 200 for a pod still winding
   down, and a per-pod GET can 404 while the listing still carries the pod that is still billing.
+- **A bring-up that never answers is `reroll`, not `railed`.** Measured on three pods of the same
+  image: two exposed port 22 in ~100 s, a third sat at `desiredStatus: RUNNING` with no address for
+  six minutes (RIG-ENV's known upstream single-blob stall). A matrix lane can retry a `reroll`; it
+  must never retry a `railed`, which means the operator's money is genuinely gone.
 - **`--fleet-line` is required to mint, and refused before renting.** `gen-worker family mint`
   asserts the fleet line first, and `rigcheck` reads `endpoint.toml` / `fleet-floors.toml` /
   ENDPOINT dist metadata — deliberately not gen-worker's own requirement, since an SDK certifying

--- a/docs/pod-mint-rig.md
+++ b/docs/pod-mint-rig.md
@@ -5,7 +5,7 @@ it down and prove it is gone.
 
 ```bash
 task rig:pod -- mint --gpu sm89 --rail 1.10 --lane pgw1331-clip \
-  --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip \
+  --target gen_worker.model.catalog.flux1_dev:FLUX1_DEV --runner clip \
   --fleet-line ~/cozy/serverless-endpoints/fleet-floors.toml
 
 task rig:pod -- run --gpu sm89 --rail 0.50 --lane adopt --name adopt \

--- a/docs/pod-mint-rig.md
+++ b/docs/pod-mint-rig.md
@@ -1,0 +1,108 @@
+# The pod mint-rig (pgw#1347)
+
+Rent a pod, run **one** named command on it, bank a machine-readable row, tear
+it down and prove it is gone.
+
+```bash
+task rig:pod -- mint --gpu sm89 --rail 1.10 --lane pgw1331-clip \
+  --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip \
+  --fleet-line ~/cozy/serverless-endpoints/fleet-floors.toml
+
+task rig:pod -- run --gpu sm89 --rail 0.50 --lane adopt --name adopt \
+  --command 'python3 adopt_and_infer.py && echo RIG_DONE' \
+  --upload ./adopt_and_infer.py --artifact /root/rig/out
+
+task rig:pod -- sweep                    # live pods vs every record
+task rig:pod -- terminate --pod <id>     # or --name <pod name>
+task rig:pod -- cards
+```
+
+The code is `scripts/mint_rig/`. It is **not** in `src/gen_worker` on purpose:
+no pod needs the thing that rents pods, and a control plane inside the worker
+wheel puts an account credential on rented hardware for no reason.
+
+## Where it sits
+
+`docs/probe-worker.md` tiers the cheaper rigs. This one is the tier above them:
+the first that runs a **real compile on a card you pay for**, and the only one
+that does it without a human holding the pod.
+
+| Tier | Cost | Covers |
+|---|---|---|
+| `task rig:mint` / `rig:micro` / `rig:gauntlet` | free | the whole mint cycle on a toy model |
+| **`task rig:pod`** (this) | one rental, capped | a REAL AOTI compile of a real family, on a real card, unattended |
+| probe pod | $/hr while you hold it | iterating live on real weights |
+
+## The four rules
+
+**A spend rail is mandatory.** `--rail` is in dollars and there is no default.
+It becomes a wall using the rate the create call actually returned, so the same
+`--rail 2.00` is five hours on an A40 and twenty minutes on a B200.
+
+**The kill command is written before the pod exists.**
+`~/.cache/cozy-mint-rig/killset/<pod-name>.json` is fsynced *before* the POST
+leaves, keyed by the name we are about to ask for, and it carries its own
+literal kill command. podguard's record is built from the create *response* and
+has the same blind spot; the rig arms both.
+
+**No timeouts.** Every wait is a progress gate; the only negative verdict is
+`stuck`, meaning the progress token stopped changing. The one exception is pod
+BRING-UP, which has no progress signal at all (a pod reports
+`desiredStatus: RUNNING` from the instant it is rented and exposes its port only
+when the container starts, so an image pull and a wedged host are
+byte-identical) — that phase is bounded by `--boot-budget`, a declared fraction
+of your own rail.
+
+**Teardown is proved three ways**: DELETE, `GET` → 404, and absent from the
+account listing. All three land in the row.
+
+## The row
+
+One JSON per rental under `--out` (default `rig-runs/`):
+
+```
+verdict          green | red | stuck | railed | reroll | refused
+asked_gpu        the card SET you asked for
+observed_gpu     what nvidia-smi says arrived, and observed_sm beside it
+cuda_path        native | compat   (RIG-ENV §3c — a wall measured through
+                 forward-compat libcuda is a fact about the report)
+rate_per_hr      what the provider charged; est_cost_usd = runtime x that
+workload_digest  same digest => same thing ran
+uploads/artifacts with sha256
+teardown         {delete_issued, get_404, absent_from_list}
+```
+
+This **prices** a rental. It never reconciles a bill — the ledger's settlement
+rows are the charge (see `e2e/privatedeploy/cost.go`).
+
+## Things that cost a pod to learn
+
+Recorded here so the next lane does not pay again.
+
+- **There is no capacity query.** `rest.runpod.io/v1` has no gpu-type or
+  availability path at all. Availability is discovered by asking for a card SET
+  and reading the create call: HTTP 500 *"this machine does not have the
+  resources"* is the out-of-capacity signal, and it is free.
+- **sm_86 can be entirely empty.** On 2026-08-17 five Ampere SKUs in one call
+  were refused on SECURE and with the cloud type omitted; an Ada card came up on
+  the first try. Hence the `sm86` / `sm89` sets and `--cloud`.
+- **The fleet base image's interpreter is EXTERNALLY-MANAGED.** PEP 668 refuses
+  `pip install` and recommends a venv — which would shadow or re-resolve the
+  fleet's own torch. The rig passes `--break-system-packages`; the pod is
+  disposable and single-purpose.
+- **The fleet-line authority has to be shipped.** `rigcheck` reads
+  `endpoint.toml` / `fleet-floors.toml` / ENDPOINT dist metadata and refuses
+  gen-worker's own requirement (an SDK certifying its own floor passes every
+  rig). This repo has none of those files, so `--fleet-line` is required for
+  `mint` unless the image already carries one. The rig refuses **before**
+  renting.
+- **A mint downloads no checkpoint.** Cell identity is checkpoint-free (§4.27):
+  the declaration builds its architecture under fake tensors and the constants
+  arrive at arm time from the store. A per-family mint pod costs a card and a
+  compile, never 24 GB.
+
+## Adding a lane
+
+Write a `Workload` — a value — and pass it to `Rig.run`. Do not write another
+pod driver; that is the mechanism `research/RIG-ENV.md` §5 blames for two false
+verdicts and about $11 of wasted rental.

--- a/docs/probe-worker.md
+++ b/docs/probe-worker.md
@@ -14,6 +14,7 @@ Tier by tier, cheapest first:
 | `task rig:mint` (pgw#978) | seconds, free | resolve, handoff, spawn, load, warm, export, compile, seal, publish, adopt — on a toy model, ONE export entry |
 | `task rig:micro` (pgw#997) | ~15 s, free | all of the above on a REAL org-worker package — 3 entries, two fork arms, a second target, container inputs, a derived dynamic range, plus a PARITY check that arms the adopted cell and compares every arm to eager |
 | experimental image (pgw#979) | one image build | the real image, the real deps, a real pod, a real family |
+| `task rig:pod` (pgw#1347, [docs](pod-mint-rig.md)) | one rental, capped by `--rail` | a REAL AOTI compile of a real family on a real card, UNATTENDED — rent, run one command, capture, tear down, bank a row |
 | **probe pod (this doc)** | seconds, on a pod you already hold | everything above, on real weights and a real card, iterating |
 
 Reach for a probe when the rig has run out of things it can tell you: when the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,11 +158,17 @@ strict = true
 # `conftest` module name and reports nothing at all.
 explicit_package_bases = true
 # …and this keeps src/ modules resolving as `gen_worker.x`, not `src.gen_worker.x`,
-# which is what every per-module override below is keyed on. `scripts` joins it
-# for pgw#1347's `mint_rig` package: the pod driver is control-plane code that
-# must NOT ship in the wheel (no pod needs the thing that rents pods), but it
-# spends money and it is born strict like everything else.
-mypy_path = "src:scripts"
+# which is what every per-module override below is keyed on.
+#
+# `scripts` is deliberately NOT here. pgw#1347's `mint_rig` package is checked —
+# it is control-plane code that must not ship in the wheel, but it spends money —
+# and it gets its own `MYPYPATH=scripts` invocation in ci.yaml instead. Putting
+# `scripts` on the shared path makes mypy suddenly RESOLVE every other
+# `scripts/*.py` that a test imports (measured: `micro_mint_rig`,
+# `lint_unbounded_reads`, 18 errors), which turns one lane's new module into an
+# unrelated burn-down. Those findings are real and someone should take them; they
+# are not this lane's to smuggle in or to silence.
+mypy_path = "src"
 
 # Generated protobuf modules: no source of ours to fix.
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,11 @@ strict = true
 # `conftest` module name and reports nothing at all.
 explicit_package_bases = true
 # …and this keeps src/ modules resolving as `gen_worker.x`, not `src.gen_worker.x`,
-# which is what every per-module override below is keyed on.
-mypy_path = "src"
+# which is what every per-module override below is keyed on. `scripts` joins it
+# for pgw#1347's `mint_rig` package: the pod driver is control-plane code that
+# must NOT ship in the wheel (no pod needs the thing that rents pods), but it
+# spends money and it is born strict like everything else.
+mypy_path = "src:scripts"
 
 # Generated protobuf modules: no source of ours to fix.
 [[tool.mypy.overrides]]

--- a/scripts/lint_mypy_ratchet.py
+++ b/scripts/lint_mypy_ratchet.py
@@ -186,15 +186,24 @@ def check(pyproject: Path) -> List[str]:
         ]
         if not invocations:
             problems.append(f"no mypy invocation found in {workflow.name}")
-        for line in invocations:
-            for required in ("src/gen_worker", "tests", "tests_v2"):
-                if required not in line:
-                    problems.append(
-                        f"the mypy step in {workflow.name} does not check "
-                        f"`{required}`: {line!r}. Every path the config covers "
-                        f"has to actually be handed to mypy, or the exemption "
-                        f"lists below describe a check nobody runs."
-                    )
+        # The UNION of the invocations, not each one. The property being
+        # guarded is "every path the config covers is handed to mypy
+        # somewhere", and per-invocation matching is a stricter reading that
+        # forbids a legitimate shape: a SECOND, deliberately-scoped call for a
+        # tree that needs a different `MYPYPATH` (pgw#1347's `scripts/mint_rig`,
+        # which must not join the shared path — doing so makes mypy resolve
+        # every other scripts/*.py a test imports). Union is not weaker: the
+        # failure this exists for is `tests tests_v2` disappearing, and dropping
+        # them from ALL invocations still goes red.
+        covered = " ".join(invocations)
+        for required in ("src/gen_worker", "tests", "tests_v2"):
+            if required not in covered:
+                problems.append(
+                    f"no mypy step in {workflow.name} checks `{required}`; the "
+                    f"invocations found were {invocations!r}. Every path the "
+                    f"config covers has to actually be handed to mypy, or the "
+                    f"exemption lists below describe a check nobody runs."
+                )
 
     for flag, (limit, errors) in HIGH_WATER.items():
         actual = counts.get(flag, 0)

--- a/scripts/lint_repo_ref_pins.py
+++ b/scripts/lint_repo_ref_pins.py
@@ -8,21 +8,32 @@ they are typed.
 
 WHAT IT LOOKS FOR is a repo-ref-shaped literal: `<owner>/<repo>:<tag>` inside a
 quoted string, in Python, JSON, TOML, YAML and Markdown. The owner segment may
-not contain a `.` — that is what keeps docker/OCI refs (`docker.io/x:1`,
-`ghcr.io/y:v2`) out; git tags, image tags and `sTAGe` substrings never match the
-shape at all.
+not contain a `.`, which keeps a registry-qualified OCI ref (`docker.io/x:1`,
+`ghcr.io/y:v2`) out.
 
-THERE IS NO ALLOWLIST, and the design point is that it needs none. The two
-places a `:tag` string legitimately survives are places that PROVE IT IS
-REFUSED, and each is recognised by that proof rather than by its path:
+An earlier version of this paragraph also claimed "image tags never match the
+shape at all". **That was wrong**, and pgw#1347 found it: a Docker Hub image in
+a user namespace — `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime` — is
+`<owner>/<repo>:<tag>` exactly, with no dot in the owner. The shape genuinely
+cannot separate a hub model ref from a container image ref, so the separation
+has to be STATED.
+
+THERE IS NO PATH ALLOWLIST, and the design point is that it needs none. The
+three places a `:tag` string legitimately survives are recognised by what they
+PROVE, at the line, rather than by which file they are in:
 
 * a conformance vector carrying `"error": true` — the corpus's own statement
-  that the parser must reject it; and
+  that the parser must reject it;
 * a source line carrying a `# refused:` comment, which says the same thing at
-  the line where a test feeds it to the parser.
+  the line where a test feeds it to the parser; and
+* a source line carrying an `# oci-image:` comment, which states that the
+  literal is a CONTAINER IMAGE consumed by a container runtime and never
+  reaches `gen_worker.models.refs.parse_model_ref`. Write the reason after the
+  marker.
 
-A path allowlist would let a real pin hide behind a filename. Proof-of-refusal
-cannot: delete the refusal and the line goes red.
+A path allowlist would let a real pin hide behind a filename. A line-level
+claim cannot: it sits on the literal, it is visible in review, and deleting it
+turns the line red.
 
 Usage:
 
@@ -63,6 +74,10 @@ PIN_RE = re.compile(
 #: The line-level proof that a `:tag` string is an INPUT to a refusal.
 REFUSAL_MARKER = "# refused:"
 
+#: The line-level claim that a `:tag` string is a CONTAINER IMAGE, not a hub
+#: model ref — a distinction the shape cannot make (see the module docstring).
+OCI_MARKER = "# oci-image:"
+
 
 def _iter_files(roots: Tuple[Path, ...]) -> Iterator[Path]:
     for root in roots:
@@ -99,7 +114,7 @@ def scan(paths: Tuple[Path, ...]) -> List[str]:
             continue
         refused = _refused_json_vectors(path) if path.suffix == ".json" else set()
         for lineno, line in enumerate(text.splitlines(), 1):
-            if REFUSAL_MARKER in line:
+            if REFUSAL_MARKER in line or OCI_MARKER in line:
                 continue
             for m in PIN_RE.finditer(line):
                 pin = f"{m.group('owner')}/{m.group('repo')}:{m.group('tag')}"
@@ -111,6 +126,9 @@ def scan(paths: Tuple[Path, ...]) -> List[str]:
 
 
 _SELFTEST_PIN = "acme/model" + ":prod"
+#: Split the same way, and for the same reason: a fixture written as one
+#: literal would make this file its own first finding.
+_SELFTEST_IMAGE = "pytorch/pytorch" + ":2.13.0-cuda13.0"
 
 
 def _selftest() -> int:
@@ -124,17 +142,25 @@ def _selftest() -> int:
             {"vectors": [{"ref": _SELFTEST_PIN, "error": True}]}))
         (root / "docker.py").write_text('IMAGE = "docker.io/tensorhub:0.1"\n')
         (root / "clean.py").write_text('REF = "acme/model@prod"\n')
+        # pgw#1347: a namespaced Docker Hub image is ref-SHAPED. Unmarked it is
+        # red; marked it is green — the marker is the whole difference.
+        (root / "image_bare.py").write_text(f'IMAGE = "{_SELFTEST_IMAGE}"\n')
+        (root / "image_marked.py").write_text(
+            f'IMAGE = "{_SELFTEST_IMAGE}"  {OCI_MARKER} RunPod pulls this\n')
 
-        red = scan((root / "pin.py",))
-        if len(red) != 1:
-            print(f"SELFTEST FAILED: a planted pin was not caught: {red}", file=sys.stderr)
-            return 1
-        for name in ("proven.py", "corpus.json", "docker.py", "clean.py"):
+        for name in ("pin.py", "image_bare.py"):
+            red = scan((root / name,))
+            if len(red) != 1:
+                print(f"SELFTEST FAILED: a planted pin in {name} was not caught: {red}",
+                      file=sys.stderr)
+                return 1
+        for name in ("proven.py", "corpus.json", "docker.py", "clean.py", "image_marked.py"):
             green = scan((root / name,))
             if green:
                 print(f"SELFTEST FAILED: {name} flagged: {green}", file=sys.stderr)
                 return 1
-    print("lint_repo_ref_pins selftest: the fence goes red on a pin and green on a proof")
+    print("lint_repo_ref_pins selftest: red on a pin and on a bare image, "
+          "green on a refusal proof and on a marked container image")
     return 0
 
 

--- a/scripts/mint_rig/__init__.py
+++ b/scripts/mint_rig/__init__.py
@@ -14,7 +14,7 @@ value — and never a new pod driver.
     from mint_rig import Rig, Rail, Workload, cards
 
     rig = Rig(rail=Rail(max_usd=2.0), lane="pgw1331-clip")
-    row = rig.run(cards.pick("a40"), Workload.mint_family(...))
+    row = rig.run(cards.pick("a40"), Workload.mint_model(...))
 
 THE FOUR RULES THIS PACKAGE ENFORCES RATHER THAN DOCUMENTS
 

--- a/scripts/mint_rig/__init__.py
+++ b/scripts/mint_rig/__init__.py
@@ -1,0 +1,66 @@
+"""pgw#1347 — the pod mint-rig: rent a pod, run one named command, bank the row.
+
+This package is the primitive pgw#1331 named as missing and pgw#1346's matrix
+lanes are built on: *rent a pod by (gpu type, image), ship a workload, run a
+named command, capture the artifacts, tear down with double verification, and
+emit one machine-readable row.*
+
+It is deliberately NOT another bespoke lane script. `research/RIG-ENV.md` §5
+records what bespoke costs: two false verdicts and ~$11 of rental, both from a
+rig built by copying an older rig's `setup.sh` forward. The layers here are
+separated so a new lane writes a :class:`~mint_rig.workload.Workload` — a data
+value — and never a new pod driver.
+
+    from mint_rig import Rig, Rail, Workload, cards
+
+    rig = Rig(rail=Rail(max_usd=2.0), lane="pgw1331-clip")
+    row = rig.run(cards.pick("a40"), Workload.mint_family(...))
+
+THE FOUR RULES THIS PACKAGE ENFORCES RATHER THAN DOCUMENTS
+
+1. **A spend rail is mandatory.** :class:`~mint_rig.rail.Rail` cannot be
+   constructed without a dollar cap and :class:`~mint_rig.driver.Rig` cannot be
+   constructed without a Rail. There is no default, because a default is the
+   number nobody chose.
+2. **The kill-set is written before the pod exists.** See
+   :mod:`mint_rig.killset`: the record lands on disk *before* the POST, keyed by
+   the name we are about to ask for, so a host crash inside the create call
+   still leaves a stoppable pod.
+3. **No magic timeouts.** Every wait is a :class:`~mint_rig.progress.Gate` over
+   a goal predicate and a progress token. Stuck means "the token stopped
+   advancing", never "the clock ran out". The only wall-clock bound in the
+   package is the money one, and it is the operator's declared dollars divided
+   by the pod's OBSERVED rate.
+4. **Teardown is verified three ways** — DELETE, then GET 404, then absent from
+   the account listing — and all three verdicts land in the row.
+"""
+
+from __future__ import annotations
+
+from .driver import Rig
+from .killset import KillSet
+from .progress import Gate, Observation, Stuck
+from .rail import Rail, RailTripped
+from .row import Artifact, RigRow, Teardown
+from .runpod import PodApi, RunpodRest
+from .transport import SshTransport, Transport
+from .workload import Upload, Workload
+
+__all__ = [
+    "Artifact",
+    "Gate",
+    "KillSet",
+    "Observation",
+    "PodApi",
+    "Rail",
+    "RailTripped",
+    "Rig",
+    "RigRow",
+    "RunpodRest",
+    "SshTransport",
+    "Stuck",
+    "Teardown",
+    "Transport",
+    "Upload",
+    "Workload",
+]

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -2,7 +2,7 @@
 
     # pgw#1331's owed leg: the smallest real compile, on the cheapest sm_86 card
     python -m mint_rig mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
-        --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip \
+        --target gen_worker.model.catalog.flux1_dev:FLUX1_DEV --runner clip \
         --deliver sdist --issue pgw#1331
 
     # the same command against a PUBLISHED release
@@ -33,7 +33,7 @@ from . import cards as cards_mod
 from .driver import Rig, uploads_for
 from .rail import Rail
 from .row import RigRow
-from .workload import POD_ROOT, Upload, Workload, install_sdist, install_wheel, mint_family
+from .workload import POD_ROOT, Upload, Workload, install_sdist, install_wheel, mint_model
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -89,7 +89,7 @@ def cmd_mint(args: argparse.Namespace) -> int:
     install, uploads = _delivery(args)
     fleet_line = Path(args.fleet_line) if args.fleet_line else None
     # REFUSED BEFORE RENTING, because this refusal is free and the pod that
-    # taught us was not. `gen-worker family mint` asserts the fleet line first
+    # taught us was not. `gen-worker model mint` asserts the fleet line first
     # (RIG-ENV §1) and rigcheck reads endpoint.toml / fleet-floors.toml /
     # ENDPOINT dist metadata — none of which exist on a pod carrying only this
     # repo's wheel. Only `--deliver image` is exempt: an endpoint image ships
@@ -105,7 +105,7 @@ def cmd_mint(args: argparse.Namespace) -> int:
         )
     if fleet_line is not None and not fleet_line.is_file():
         raise SystemExit(f"pgw#1347: --fleet-line {fleet_line} does not exist")
-    workload = mint_family(
+    workload = mint_model(
         args.target,
         runners=tuple(args.runner),
         install=install + tuple(args.setup),
@@ -214,9 +214,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="mint_rig", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    mint = sub.add_parser("mint", help="gen-worker family mint on a rented pod.")
+    mint = sub.add_parser("mint", help="gen-worker model mint on a rented pod.")
     _rent_flags(mint)
-    mint.add_argument("--target", required=True, help="module:ATTR of the GraphFamily.")
+    mint.add_argument("--target", required=True, help="module:ATTR of the GraphModelSpec.")
     mint.add_argument("--runner", action="append", default=[], help="Repeatable; omit for all.")
     mint.add_argument(
         "--fleet-line",

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -87,11 +87,30 @@ def _delivery(args: argparse.Namespace) -> tuple[tuple[str, ...], tuple[Upload, 
 
 def cmd_mint(args: argparse.Namespace) -> int:
     install, uploads = _delivery(args)
+    fleet_line = Path(args.fleet_line) if args.fleet_line else None
+    # REFUSED BEFORE RENTING, because this refusal is free and the pod that
+    # taught us was not. `gen-worker family mint` asserts the fleet line first
+    # (RIG-ENV §1) and rigcheck reads endpoint.toml / fleet-floors.toml /
+    # ENDPOINT dist metadata — none of which exist on a pod carrying only this
+    # repo's wheel. Only `--deliver image` is exempt: an endpoint image ships
+    # its own endpoint.toml, which is the authority.
+    if fleet_line is None and args.deliver != "image":
+        raise SystemExit(
+            "pgw#1347: `mint` needs --fleet-line <endpoint.toml|fleet-floors.toml>. "
+            "gen-worker's own torch requirement is NOT an authority (rigcheck refuses "
+            "to let the SDK certify its own floor), and this repo ships neither file, so "
+            "the mint would abort FleetLineUnknown on a pod you already paid for. The "
+            "workspace's authority is ~/cozy/serverless-endpoints/fleet-floors.toml; a "
+            "per-endpoint endpoint.toml is stronger, because it also declares CUDA."
+        )
+    if fleet_line is not None and not fleet_line.is_file():
+        raise SystemExit(f"pgw#1347: --fleet-line {fleet_line} does not exist")
     workload = mint_family(
         args.target,
         runners=tuple(args.runner),
         install=install + tuple(args.setup),
         uploads=uploads,
+        fleet_line=fleet_line,
         name=args.name,
     )
     row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
@@ -199,6 +218,13 @@ def main(argv: list[str] | None = None) -> int:
     _rent_flags(mint)
     mint.add_argument("--target", required=True, help="module:ATTR of the GraphFamily.")
     mint.add_argument("--runner", action="append", default=[], help="Repeatable; omit for all.")
+    mint.add_argument(
+        "--fleet-line",
+        default="",
+        help="endpoint.toml or fleet-floors.toml to ship as the fleet-line authority "
+        "(RIG-ENV §2). REQUIRED unless --deliver image. It becomes "
+        "GEN_WORKER_FLEET_LINE_FILE on the pod.",
+    )
     mint.add_argument("--name", default="mint")
     mint.set_defaults(fn=cmd_mint)
 

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -1,0 +1,212 @@
+"""``python -m mint_rig`` — the pod mint-rig from a shell.
+
+    # pgw#1331's owed leg: the smallest real compile, on the cheapest sm_86 card
+    python -m mint_rig mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
+        --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip \
+        --deliver sdist --issue pgw#1331
+
+    # the same command against a PUBLISHED release
+    python -m mint_rig mint --gpu a40 --rail 2.00 --deliver wheel \
+        --spec 'gen-worker[torch]==0.121.0' --target ... --runner clip
+
+    # an arbitrary named command (the general primitive; `mint` is one preset)
+    python -m mint_rig run --gpu a40 --rail 1.00 --name adopt \
+        --command 'python3 adopt_and_infer.py && echo RIG_DONE' \
+        --upload ./adopt_and_infer.py --artifact /root/rig/out
+
+    python -m mint_rig sweep                 # what is running vs what we recorded
+    python -m mint_rig terminate --pod <id>  # or --name <pod name>
+    python -m mint_rig cards
+
+`--rail` is REQUIRED on anything that rents. That is the point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from . import cards as cards_mod
+from .driver import Rig, uploads_for
+from .rail import Rail
+from .row import RigRow
+from .workload import POD_ROOT, Upload, Workload, install_sdist, install_wheel, mint_family
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _rig(args: argparse.Namespace) -> Rig:
+    return Rig(
+        rail=Rail(max_usd=float(args.rail)),
+        lane=args.lane,
+        issue=getattr(args, "issue", ""),
+        out_dir=Path(args.out) if args.out else REPO / "rig-runs",
+        tick_s=float(args.tick),
+        stall_ticks=int(args.stall_ticks),
+        dry_run=bool(getattr(args, "dry_run", False)),
+    )
+
+
+def build_sdist(out_dir: Path) -> Path:
+    """Build the worktree's own wheel, so the pod runs THIS lane's code.
+
+    Not a convenience: pgw#1337 has the wheel cut blocked, so a lane whose
+    surface is newer than PyPI cannot reach a card any other honest way. The
+    row records the dist's sha256, so the answer to "which code ran" is a
+    digest rather than a claim. Packaging only — nothing compiles here.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("*.whl"):
+        stale.unlink()
+    subprocess.run(
+        ["nice", "-n", "19", "uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        cwd=REPO,
+        check=True,
+    )
+    wheels = sorted(out_dir.glob("*.whl"))
+    if not wheels:
+        raise RuntimeError(f"uv build produced no wheel in {out_dir}")
+    return wheels[-1]
+
+
+def _delivery(args: argparse.Namespace) -> tuple[tuple[str, ...], tuple[Upload, ...]]:
+    if args.deliver == "image":
+        return (), ()
+    if args.deliver == "wheel":
+        if not args.spec:
+            raise SystemExit("--deliver wheel needs --spec, e.g. 'gen-worker[torch]==0.121.0'")
+        return install_wheel(args.spec, args.index_args), ()
+    dist = Path(args.dist) if args.dist else build_sdist(REPO / "dist")
+    return install_sdist(dist, args.extras, args.index_args), (Upload(local=dist),)
+
+
+def cmd_mint(args: argparse.Namespace) -> int:
+    install, uploads = _delivery(args)
+    workload = mint_family(
+        args.target,
+        runners=tuple(args.runner),
+        install=install + tuple(args.setup),
+        uploads=uploads,
+        name=args.name,
+    )
+    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    return 0 if row.verdict == "green" else 1
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    install, uploads = _delivery(args)
+    workload = Workload(
+        name=args.name,
+        command=args.command,
+        setup=install + tuple(args.setup),
+        uploads=uploads + uploads_for([Path(p) for p in args.upload]),
+        artifacts=tuple(args.artifact) or (POD_ROOT,),
+        progress_paths=tuple(args.progress) or (POD_ROOT,),
+    )
+    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    return 0 if row.verdict == "green" else 1
+
+
+def cmd_terminate(args: argparse.Namespace) -> int:
+    rig = Rig(rail=Rail(max_usd=0.01), lane="terminate", out_dir=Path(args.out or "."))
+    row: RigRow = rig.terminate(pod_id=args.pod, name=args.name)
+    print(json.dumps(row.teardown.__dict__, indent=2))
+    return 0 if row.teardown.confirmed else 1
+
+
+def cmd_sweep(args: argparse.Namespace) -> int:
+    rig = Rig(rail=Rail(max_usd=0.01), lane="sweep", out_dir=Path(args.out or "."))
+    report = rig.sweep()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    # A live pod that NO record anywhere attends is the failure this package
+    # exists to prevent. A sibling lane's attended pod is not that.
+    return 1 if report["unattended"] else 0
+
+
+def cmd_cards(_: argparse.Namespace) -> int:
+    for card in cards_mod.CARDS.values():
+        print(
+            f"{card.slug:8s} sm{card.sm_expected:5s} ~${card.usd_per_hour_hint:5.2f}/hr  "
+            f"{'data-center' if card.data_center_part else 'workstation':12s} "
+            f"{', '.join(card.gpu_type_ids)}"
+        )
+    return 0
+
+
+def _rent_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--gpu", default="a40", choices=sorted(cards_mod.CARDS))
+    parser.add_argument("--image", default=cards_mod.FLEET_IMAGE)
+    parser.add_argument("--lane", required=True)
+    parser.add_argument("--issue", default="")
+    parser.add_argument(
+        "--rail",
+        required=True,
+        help="Spend cap for THIS invocation, in dollars. Mandatory: there is no default.",
+    )
+    parser.add_argument("--out", default="")
+    parser.add_argument("--tick", default="15", help="Seconds between progress observations.")
+    parser.add_argument(
+        "--stall-ticks",
+        default="12",
+        help="Consecutive observations with an unchanged progress token that mean STUCK. "
+        "Not a timeout: work that is moving is never stopped by this.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Write the kill-set and rent nothing.")
+    parser.add_argument("--deliver", default="sdist", choices=("sdist", "wheel", "image"))
+    parser.add_argument("--spec", default="", help="pip requirement for --deliver wheel.")
+    parser.add_argument("--dist", default="", help="Prebuilt dist for --deliver sdist.")
+    parser.add_argument("--extras", default="", help="Extras for the shipped dist, e.g. 'torch'.")
+    parser.add_argument("--index-args", default="", help="Extra pip index flags.")
+    parser.add_argument(
+        "--setup",
+        action="append",
+        default=[],
+        help="Extra shell line to run before the command; repeatable, order preserved. "
+        "The delivery lines run first.",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="mint_rig", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    mint = sub.add_parser("mint", help="gen-worker family mint on a rented pod.")
+    _rent_flags(mint)
+    mint.add_argument("--target", required=True, help="module:ATTR of the GraphFamily.")
+    mint.add_argument("--runner", action="append", default=[], help="Repeatable; omit for all.")
+    mint.add_argument("--name", default="mint")
+    mint.set_defaults(fn=cmd_mint)
+
+    run = sub.add_parser("run", help="Any named command on a rented pod.")
+    _rent_flags(run)
+    run.add_argument("--command", required=True, help="Must print RIG_DONE on success.")
+    run.add_argument("--name", default="run")
+    run.add_argument("--upload", action="append", default=[])
+    run.add_argument("--artifact", action="append", default=[])
+    run.add_argument("--progress", action="append", default=[])
+    run.set_defaults(fn=cmd_run)
+
+    terminate = sub.add_parser("terminate", help="DELETE + 404 + absent-from-list.")
+    terminate.add_argument("--pod", default="")
+    terminate.add_argument("--name", default="")
+    terminate.add_argument("--out", default="")
+    terminate.set_defaults(fn=cmd_terminate)
+
+    sweep = sub.add_parser(
+        "sweep", help="Live pods vs every record; exit 1 on a pod nobody attends."
+    )
+    sweep.add_argument("--out", default="")
+    sweep.set_defaults(fn=cmd_sweep)
+
+    show = sub.add_parser("cards", help="The card catalogue.")
+    show.set_defaults(fn=cmd_cards)
+
+    args = parser.parse_args(argv)
+    return int(args.fn(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -47,6 +47,8 @@ def _rig(args: argparse.Namespace) -> Rig:
         tick_s=float(args.tick),
         stall_ticks=int(args.stall_ticks),
         dry_run=bool(getattr(args, "dry_run", False)),
+        cloud_type="" if getattr(args, "cloud", "") == "ANY" else getattr(args, "cloud", "SECURE"),
+        boot_budget=float(getattr(args, "boot_budget", 0.15)),
     )
 
 
@@ -137,8 +139,15 @@ def cmd_cards(_: argparse.Namespace) -> int:
 
 
 def _rent_flags(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--gpu", default="a40", choices=sorted(cards_mod.CARDS))
+    parser.add_argument("--gpu", default="sm86", choices=sorted(cards_mod.CARDS))
     parser.add_argument("--image", default=cards_mod.FLEET_IMAGE)
+    parser.add_argument(
+        "--cloud",
+        default="SECURE",
+        choices=("SECURE", "COMMUNITY", "ANY"),
+        help="ANY lets the provider choose. SECURE has little sm_86 capacity; a "
+        "compile proof carries no weights, so COMMUNITY is a legitimate place to buy one.",
+    )
     parser.add_argument("--lane", required=True)
     parser.add_argument("--issue", default="")
     parser.add_argument(
@@ -159,6 +168,13 @@ def _rent_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--spec", default="", help="pip requirement for --deliver wheel.")
     parser.add_argument("--dist", default="", help="Prebuilt dist for --deliver sdist.")
     parser.add_argument("--extras", default="", help="Extras for the shipped dist, e.g. 'torch'.")
+    parser.add_argument(
+        "--boot-budget",
+        default="0.15",
+        help="Fraction of the rail bring-up may spend before the pod answers. Bring-up "
+        "has no progress signal (RunPod cannot distinguish an image pull from a wedged "
+        "host), so money is its only honest bound. Raise it for a big single-blob image.",
+    )
     parser.add_argument("--index-args", default="", help="Extra pip index flags.")
     parser.add_argument(
         "--setup",

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -112,15 +112,21 @@ def cmd_run(args: argparse.Namespace) -> int:
     return 0 if row.verdict == "green" else 1
 
 
+#: `terminate` and `sweep` rent nothing, but `Rig` refuses to exist without a
+#: rail — deliberately, so no code path can construct one "just to look". A cent
+#: is the smallest honest statement of "this invocation will not buy anything".
+_NO_SPEND = 0.01
+
+
 def cmd_terminate(args: argparse.Namespace) -> int:
-    rig = Rig(rail=Rail(max_usd=0.01), lane="terminate", out_dir=Path(args.out or "."))
+    rig = Rig(rail=Rail(max_usd=_NO_SPEND), lane="terminate", out_dir=Path(args.out or "."))
     row: RigRow = rig.terminate(pod_id=args.pod, name=args.name)
     print(json.dumps(row.teardown.__dict__, indent=2))
     return 0 if row.teardown.confirmed else 1
 
 
 def cmd_sweep(args: argparse.Namespace) -> int:
-    rig = Rig(rail=Rail(max_usd=0.01), lane="sweep", out_dir=Path(args.out or "."))
+    rig = Rig(rail=Rail(max_usd=_NO_SPEND), lane="sweep", out_dir=Path(args.out or "."))
     report = rig.sweep()
     print(json.dumps(report, indent=2, sort_keys=True))
     # A live pod that NO record anywhere attends is the failure this package

--- a/scripts/mint_rig/cards.py
+++ b/scripts/mint_rig/cards.py
@@ -56,6 +56,31 @@ class Card:
 #: Ampere sm_86 first: it is the cheapest place a real AOTI compile can be
 #: proven, and pgw#1331's owed leg asks for exactly that.
 CARDS: dict[str, Card] = {
+    "sm86": Card(
+        slug="sm86",
+        # MEASURED 2026-08-17: asking for `["NVIDIA A40"]` alone answered
+        # HTTP 500 "This machine does not have the resources to deploy your
+        # pod" — SECURE A40 capacity, at that hour, in that region. There is no
+        # capacity query in the REST API (see PodApi), so the SET is the whole
+        # availability strategy: one create call, several acceptable machines,
+        # and the row records which one arrived.
+        gpu_type_ids=(
+            "NVIDIA A40",
+            "NVIDIA RTX A5000",
+            "NVIDIA RTX A4500",
+            "NVIDIA RTX A4000",
+            "NVIDIA GeForce RTX 3090",
+        ),
+        sm_expected="8.6",
+        disk_gb=40,
+        usd_per_hour_hint=0.30,
+        # Conservative: the set MIXES data-center (A40) and workstation parts,
+        # and NVIDIA's forward-compat libcuda is only supported on the former.
+        # Claiming True here would promise a repair rigboot cannot always make.
+        data_center_part=False,
+        note="every sm_86 RunPod sells, cheapest-acceptable-first. THE default "
+        "for a compile proof: the graph is what is under test, not the card.",
+    ),
     "a40": Card(
         slug="a40",
         gpu_type_ids=("NVIDIA A40",),
@@ -84,6 +109,25 @@ CARDS: dict[str, Card] = {
         disk_gb=60,
         usd_per_hour_hint=0.26,
         data_center_part=False,
+    ),
+    "sm89": Card(
+        slug="sm89",
+        # MEASURED 2026-08-17, in the same probe that found sm_86 empty: an Ada
+        # card was created on the first try at $0.74/hr while every sm_86 SKU
+        # answered out-of-capacity. Ada is the cheapest AVAILABLE place to prove
+        # a real compile, which is a different question from the cheapest place.
+        gpu_type_ids=(
+            "NVIDIA L4",
+            "NVIDIA RTX 4000 Ada Generation",
+            "NVIDIA GeForce RTX 4090",
+            "NVIDIA L40S",
+        ),
+        sm_expected="8.9",
+        disk_gb=40,
+        usd_per_hour_hint=0.74,
+        data_center_part=False,
+        note="every sm_89 RunPod sells, cheapest-first. The FALLBACK when sm_86 "
+        "is out of capacity — and on 2026-08-17 it was.",
     ),
     "l40s": Card(
         slug="l40s",

--- a/scripts/mint_rig/cards.py
+++ b/scripts/mint_rig/cards.py
@@ -1,0 +1,127 @@
+"""The card catalogue — asked ids, and what the row must record instead.
+
+A `Card` names a SET of RunPod `gpuTypeIds` to ask for and the compute
+capability they share. It is a plan input and nothing more:
+:class:`~mint_rig.row.RigRow` carries `asked_gpu` and `observed_gpu` as separate
+fields because e2e#privatedeploy's matrix learned that conflating them measures
+an intention rather than a machine — a set of three ids resolves to whichever
+one the provider had, and the sm the row quotes must come from the pod's own
+`nvidia-smi`, never from this table.
+
+Prices here are LAST-OBSERVED, for sizing a rail before renting. The rail is
+re-armed against the create response's real `costPerHr` the moment it lands.
+
+The image default is the one `research/RIG-ENV.md` §3a settles on for RunPod:
+the upstream public `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime`, because
+the tensorhub repack is not publicly pullable and RunPod's failure mode for an
+unpullable tag is to exit the pod ~1 s after rent with no diagnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: RIG-ENV §3a. Do not replace with the tensorhub repack — see this module's
+#: docstring and RIG-ENV's own warning box.
+FLEET_IMAGE = "pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime"  # oci-image: RunPod pulls it
+
+#: The CUDA line the fleet is on. `gen_worker.rigboot --cuda` takes it; the
+#: value is what RIG-ENV §2 resolves to today, and the pod re-reads the real
+#: authority itself via `gen_worker.rigcheck`, so this is only the preflight's
+#: argument.
+FLEET_CUDA = "13.0"
+
+
+@dataclass(frozen=True)
+class Card:
+    """One asked-for card class."""
+
+    slug: str
+    #: RunPod `gpuTypeIds`, in preference order. A set, because a single id is
+    #: how a lane waits an hour for capacity that a sibling SKU had all along.
+    gpu_type_ids: tuple[str, ...]
+    #: Compute capability of the class. RECORDED FROM THE POD, never trusted
+    #: from here — this is the value the row's `sm_expected` is checked against
+    #: so a provider substituting a different card is visible.
+    sm_expected: str
+    #: Container disk. AOTI object caches and an inductor scratch tree are the
+    #: bulk of it, not weights: a family mint downloads no checkpoint (§4.27).
+    disk_gb: int
+    #: Last-observed whole-pod rate, for sizing a rail before renting.
+    usd_per_hour_hint: float
+    data_center_part: bool
+    note: str = ""
+
+
+#: Ampere sm_86 first: it is the cheapest place a real AOTI compile can be
+#: proven, and pgw#1331's owed leg asks for exactly that.
+CARDS: dict[str, Card] = {
+    "a40": Card(
+        slug="a40",
+        gpu_type_ids=("NVIDIA A40",),
+        sm_expected="8.6",
+        disk_gb=60,
+        usd_per_hour_hint=0.40,
+        data_center_part=True,
+        note="sm_86 data-center part: cuda-compat forward-compat is supported, "
+        "so rigboot can repair a 570-driver host instead of re-rolling it.",
+    ),
+    "a4000": Card(
+        slug="a4000",
+        gpu_type_ids=("NVIDIA RTX A4000", "NVIDIA RTX A4500"),
+        sm_expected="8.6",
+        disk_gb=60,
+        usd_per_hour_hint=0.17,
+        data_center_part=False,
+        note="cheapest sm_86, but a WORKSTATION part: NVIDIA's forward-compat "
+        "libcuda is not supported here, so a 570-driver host is a RE-ROLL, not "
+        "a repair. rigboot says which.",
+    ),
+    "a5000": Card(
+        slug="a5000",
+        gpu_type_ids=("NVIDIA RTX A5000",),
+        sm_expected="8.6",
+        disk_gb=60,
+        usd_per_hour_hint=0.26,
+        data_center_part=False,
+    ),
+    "l40s": Card(
+        slug="l40s",
+        gpu_type_ids=("NVIDIA L40S", "NVIDIA L40"),
+        sm_expected="8.9",
+        disk_gb=100,
+        usd_per_hour_hint=0.86,
+        data_center_part=True,
+    ),
+    "h100": Card(
+        slug="h100",
+        gpu_type_ids=("NVIDIA H100 80GB HBM3", "NVIDIA H100 PCIe", "NVIDIA H100 NVL"),
+        sm_expected="9.0",
+        disk_gb=220,
+        usd_per_hour_hint=2.39,
+        data_center_part=True,
+    ),
+    "b200": Card(
+        slug="b200",
+        gpu_type_ids=("NVIDIA B200",),
+        sm_expected="10.0",
+        disk_gb=220,
+        usd_per_hour_hint=5.98,
+        data_center_part=True,
+    ),
+    "5090": Card(
+        slug="5090",
+        gpu_type_ids=("NVIDIA GeForce RTX 5090", "NVIDIA RTX PRO 6000 Blackwell Server Edition"),
+        sm_expected="12.0",
+        disk_gb=220,
+        usd_per_hour_hint=0.94,
+        data_center_part=False,
+    ),
+}
+
+
+def pick(slug: str) -> Card:
+    try:
+        return CARDS[slug]
+    except KeyError:
+        raise KeyError(f"unknown card {slug!r}; known: {', '.join(sorted(CARDS))}") from None

--- a/scripts/mint_rig/cards.py
+++ b/scripts/mint_rig/cards.py
@@ -45,7 +45,7 @@ class Card:
     #: so a provider substituting a different card is visible.
     sm_expected: str
     #: Container disk. AOTI object caches and an inductor scratch tree are the
-    #: bulk of it, not weights: a family mint downloads no checkpoint (§4.27).
+    #: bulk of it, not weights: a model mint downloads no checkpoint (§4.27).
     disk_gb: int
     #: Last-observed whole-pod rate, for sizing a rail before renting.
     usd_per_hour_hint: float

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -41,7 +41,7 @@ from .rail import Rail, RailTripped
 from .row import Artifact, RigRow
 from .runpod import PodApi, PodNotFound, RunpodRest, dotenv
 from .transport import Result, SshTransport, Transport
-from .workload import POD_ROOT, Upload, Workload
+from .workload import POD_ROOT, Upload, Workload, sha256_file
 
 #: RIG-ENV §3a: `pytorch/pytorch:*-runtime` ships no sshd and an entrypoint that
 #: exits, so a rig must install one and block on it. Idempotent, because a pod
@@ -598,8 +598,6 @@ class Rig:
             artifact.local = str(base) if artifact.fetched else ""
             artifact.note = "" if artifact.fetched else result.out.strip()[-200:]
             if artifact.fetched and base.is_file():
-                from .workload import sha256_file
-
                 artifact.bytes = base.stat().st_size
                 artifact.sha256 = sha256_file(base)
             row.artifacts.append(artifact.__dict__)

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -64,6 +64,10 @@ CENSUS = (
 )
 
 
+def _flushing_print(message: str) -> None:
+    print(message, flush=True)
+
+
 def _rest_token(record: Mapping[str, Any]) -> str:
     """The pod's REST record reduced to the fields that MOVE during bring-up.
 
@@ -118,10 +122,25 @@ class Rig:
     #: Injected so the whole driver is testable without a network.
     transport_factory: Callable[[str, int], Transport] | None = None
     sleep: Callable[[float], None] = time.sleep
-    log: Callable[[str], None] = print
+    #: FLUSHED. A long rental is normally run with its stdout redirected to a
+    #: file, and block buffering made the console silent for the whole run —
+    #: which is indistinguishable from a hung driver at exactly the moment an
+    #: operator is deciding whether to kill a pod.
+    log: Callable[[str], None] = _flushing_print
     tick_s: float = 15.0
     stall_ticks: int = 12
     dry_run: bool = False
+    #: SECURE | COMMUNITY | "" (let the provider choose). MEASURED 2026-08-17:
+    #: SECURE has almost no sm_86 Ampere capacity — five SKUs in one create call
+    #: all answered "this machine does not have the resources". A compile proof
+    #: carries no weights and no tenant data, so COMMUNITY is a legitimate place
+    #: to buy one; a lane that needs SECURE says so and pays for the scarcity.
+    cloud_type: str = "SECURE"
+    #: Fraction of the rail bring-up may consume before the pod has answered.
+    #: See Rail.check_sub for why this phase is bounded by money and not by
+    #: staleness: RunPod's REST record cannot distinguish an image pull from a
+    #: wedged host, so there is no progress signal to be stuck on.
+    boot_budget: float = 0.15
 
     def __post_init__(self) -> None:
         if not isinstance(self.rail, Rail):
@@ -323,22 +342,32 @@ class Rig:
             "gpuTypeIds": list(card.gpu_type_ids),
             "gpuCount": 1,
             "containerDiskInGb": card.disk_gb,
-            "cloudType": "SECURE",
+            **({"cloudType": self.cloud_type} if self.cloud_type else {}),
             "supportPublicIp": True,
             "ports": ["22/tcp"],
             "env": {"PUBLIC_KEY": public_key},
         }
 
-    def _gate(self, stage: str, probe: Callable[[], Observation], *, stall_ticks: int = 0) -> Observation:
+    def _gate(
+        self,
+        stage: str,
+        probe: Callable[[], Observation],
+        *,
+        stall_ticks: int | None = None,
+        rail_check: Callable[[str], None] | None = None,
+    ) -> Observation:
         return Gate(
             stage=stage,
             probe=probe,
-            stall_ticks=stall_ticks or self.stall_ticks,
+            stall_ticks=self.stall_ticks if stall_ticks is None else stall_ticks,
             tick_s=self.tick_s,
-            rail_check=self.rail.check,
+            rail_check=rail_check or self.rail.check,
             sleep=self.sleep,
             on_tick=lambda n, obs: self.log(f"[{stage}] {n:3d} {obs.note[:150]}"),
         ).wait()
+
+    def _boot_check(self, stage: str) -> None:
+        self.rail.check_sub(stage, self.boot_budget)
 
     def _bring_up_and_run(self, api: PodApi, row: RigRow, workload: Workload, card: Card) -> None:
         row.stage("endpoint")
@@ -399,7 +428,8 @@ class Rig:
                 f"ports={(record.get('portMappings') or {})}",
             )
 
-        self._gate("endpoint", probe)
+        # Staleness DISABLED, money is the bound — see Rail.check_sub.
+        self._gate("endpoint", probe, stall_ticks=0, rail_check=self._boot_check)
         return found["ep"]
 
     def _wait_for_ssh(self, api: PodApi, row: RigRow, transport: Transport) -> None:
@@ -424,7 +454,7 @@ class Rig:
                 note=f"rc={result.rc} {reason}",
             )
 
-        self._gate("ssh", probe)
+        self._gate("ssh", probe, stall_ticks=0, rail_check=self._boot_check)
 
     def _preflight(self, transport: Transport, row: RigRow) -> None:
         """RIG-ENV §3c — probe the HOST driver before anything is downloaded.

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -26,6 +26,7 @@ steps.
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -160,6 +161,12 @@ class Rig:
     #: staleness: RunPod's REST record cannot distinguish an image pull from a
     #: wedged host, so there is no progress signal to be stuck on.
     boot_budget: float = 0.15
+    #: The ssh public key installed on the pod. Resolved from
+    #: `RUNPOD_SSH_PUBLIC_KEY_FILE` or `~/.ssh/runpod.pub` at CREATE time, not at
+    #: construction: a unit test builds a Rig on a machine that has no such key,
+    #: and reading it eagerly made the whole suite depend on the developer's home
+    #: directory. CI found that; this box could not have.
+    public_key: str = ""
 
     def __post_init__(self) -> None:
         if not isinstance(self.rail, Rail):
@@ -214,8 +221,10 @@ class Rig:
             kill.close(confirmed_dead=True, note="dry run")
             return self._bank(row)
 
-        body = self._create_body(card, image, name)
         try:
+            # INSIDE the try: a missing ssh key is a refusal with a row and a
+            # closed kill-set, not a traceback out of `run`.
+            body = self._create_body(card, image, name)
             created = guard.rent(
                 self.api_key,
                 body,
@@ -353,8 +362,23 @@ class Rig:
             body["dockerEntrypoint"] = start
         return self._api.create(body)
 
+    def _public_key(self) -> str:
+        if self.public_key:
+            return self.public_key
+        path = Path(
+            os.environ.get("RUNPOD_SSH_PUBLIC_KEY_FILE", Path.home() / ".ssh" / "runpod.pub")
+        )
+        try:
+            return path.read_text().strip()
+        except OSError:
+            raise RuntimeError(
+                f"pgw#1347: no RunPod ssh public key at {path}. Without it the pod boots "
+                "with no authorized_keys and is unreachable — a rental that could never be "
+                "used. Set RUNPOD_SSH_PUBLIC_KEY_FILE or pass public_key=."
+            ) from None
+
     def _create_body(self, card: Card, image: str, name: str) -> dict[str, Any]:
-        public_key = (Path.home() / ".ssh" / "runpod.pub").read_text().strip()
+        public_key = self._public_key()
         return {
             "name": name,
             "imageName": image,

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -1,0 +1,661 @@
+"""The driver — rent, ship, run, capture, tear down, bank the row.
+
+Read :mod:`mint_rig` first for the four rules. This module is where they are
+actually enforced, in this order:
+
+    rail declared            -> or the Rig cannot be constructed
+    kill-set written         -> BEFORE the create call leaves
+    podguard armed           -> or the create call is refused (th#1327)
+    endpoint gate            -> pod REST record advancing
+    ssh gate                 -> the pod answers, and every retry prints WHY
+    host preflight           -> rigboot: native | compat | RE-ROLL (RIG-ENV 3c)
+    census                   -> observed gpu / sm / driver, not the asked ones
+    ship + setup             -> uploads digested, each setup line checked
+    workload gate            -> log marker + artifact bytes as the progress token
+    capture                  -> artifacts fetched whether it ended green or red
+    teardown                 -> DELETE, GET 404, absent from the listing
+    row                      -> written under every exit, including the bad ones
+
+THE ONE STRUCTURAL RULE. Everything from the create call onward is inside a
+`try/finally` whose `finally` tears down and writes the row. There is no early
+`return` between them and no exception type that skips them. A rig whose
+teardown is reachable only on the happy path is the th#1323 incident with extra
+steps.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .cards import FLEET_CUDA, FLEET_IMAGE, Card
+from .guard import Guard, real_guard
+from .killset import ENTRYPOINT as KILLSET_ENTRYPOINT
+from .killset import KillSet
+from .progress import Failed, Gate, Observation, Stuck
+from .rail import Rail, RailTripped
+from .row import Artifact, RigRow
+from .runpod import PodApi, PodNotFound, RunpodRest, dotenv
+from .transport import Result, SshTransport, Transport
+from .workload import POD_ROOT, Upload, Workload
+
+#: RIG-ENV §3a: `pytorch/pytorch:*-runtime` ships no sshd and an entrypoint that
+#: exits, so a rig must install one and block on it. Idempotent, because a pod
+#: that restarts its container must come back reachable.
+SSHD = (
+    "set -e; mkdir -p /root/.ssh && chmod 700 /root/.ssh; "
+    'printf "%s\\n" "$PUBLIC_KEY" >> /root/.ssh/authorized_keys && '
+    "chmod 600 /root/.ssh/authorized_keys; "
+    "if [ ! -x /usr/sbin/sshd ] && ! command -v sshd >/dev/null 2>&1; then "
+    "apt-get update -qq && DEBIAN_FRONTEND=noninteractive "
+    "apt-get install -y -qq openssh-server; fi; "
+    "ssh-keygen -A 2>/dev/null || true; "
+    "mkdir -p /run/sshd; exec /usr/sbin/sshd -D -e"
+)
+
+#: `nvidia-smi` is the only authority for what card we actually got.
+CENSUS = (
+    "nvidia-smi --query-gpu=name,driver_version,compute_cap "
+    "--format=csv,noheader 2>/dev/null | head -1"
+)
+
+
+def _rest_token(record: Mapping[str, Any]) -> str:
+    """The pod's REST record reduced to the fields that MOVE during bring-up.
+
+    Whole-record equality would make an unrelated field's churn read as
+    progress; a single field would make a pod that is pulling a 3 GB image read
+    as stuck. These five are the ones that change exactly when something has.
+    """
+    machine = record.get("machine") or {}
+    return json.dumps(
+        {
+            "desiredStatus": record.get("desiredStatus"),
+            "lastStatusChange": record.get("lastStatusChange"),
+            "publicIp": record.get("publicIp"),
+            "ports": sorted((record.get("portMappings") or {}).items()),
+            "gpu": machine.get("gpuTypeId"),
+        },
+        sort_keys=True,
+    )
+
+
+def _endpoint(record: Mapping[str, Any]) -> tuple[str, int] | None:
+    ip = record.get("publicIp")
+    port = (record.get("portMappings") or {}).get("22")
+    return (str(ip), int(port)) if ip and port else None
+
+
+def _section(text: str, name: str) -> str:
+    """Pull one `--RIG-<name>--` section out of the probe's single round trip."""
+    marks = list(re.finditer(r"^--RIG-([A-Z]+)--$", text, re.M))
+    for index, mark in enumerate(marks):
+        if mark.group(1) == name:
+            end = marks[index + 1].start() if index + 1 < len(marks) else len(text)
+            return text[mark.end() : end].strip()
+    return ""
+
+
+@dataclass
+class Rig:
+    """One rental at a time. A matrix is a loop over this, not a feature of it."""
+
+    rail: Rail
+    lane: str
+    api: PodApi | None = None
+    guard: Guard | None = None
+    api_key: str = ""
+    issue: str = ""
+    out_dir: Path = field(default_factory=lambda: Path.cwd() / "rig-runs")
+    #: podguard's Layer-A staleness bound: how long the pod tolerates the renter
+    #: not renewing before it reclaims ITSELF. Not a lifetime — the keeper
+    #: renews every 60 s for as long as this process lives.
+    lease_seconds: float = 900.0
+    #: Injected so the whole driver is testable without a network.
+    transport_factory: Callable[[str, int], Transport] | None = None
+    sleep: Callable[[float], None] = time.sleep
+    log: Callable[[str], None] = print
+    tick_s: float = 15.0
+    stall_ticks: int = 12
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.rail, Rail):
+            raise TypeError(
+                "pgw#1347: Rig(rail=Rail(max_usd=...)) is mandatory. A rig that can start "
+                "without a declared budget will eventually run without one."
+            )
+        if self.api is None:
+            self.api_key = self.api_key or dotenv(("RUNPOD_API_KEY",)).get("RUNPOD_API_KEY", "")
+            self.api = RunpodRest(self.api_key)
+        if self.guard is None:
+            self.guard = real_guard()
+        if self.transport_factory is None:
+            self.transport_factory = lambda host, port: SshTransport(host, port)
+
+    # ---- the one public verb -------------------------------------------------
+
+    def run(self, card: Card, workload: Workload, *, image: str = "", pod_name: str = "") -> RigRow:
+        api, guard = self._api, self._guard
+        name = pod_name or f"mintrig-{self.lane}-{int(time.time())}"
+        image = image or FLEET_IMAGE
+        row = RigRow(
+            lane=self.lane,
+            issue=self.issue,
+            pod_name=name,
+            image=image,
+            asked_gpu=card.slug,
+            asked_gpu_type_ids=list(card.gpu_type_ids),
+            sm_expected=card.sm_expected,
+            command=workload.command,
+            workload_name=workload.name,
+            workload_digest=workload.digest(),
+            uploads=[u.record() for u in workload.uploads],
+            rail_usd=self.rail.max_usd,
+        )
+
+        # RULE 2: the kill-set lands BEFORE the create call. If this box dies
+        # between here and the response, the pod is still nameable.
+        kill = KillSet(
+            lane=self.lane, pod_name=name, gpu=card.slug, image=image, rail_usd=self.rail.max_usd
+        ).save()
+        row.killset_path = str(kill.path)
+        self.log(f"[killset] {kill.path}\n[killset] stop it with: {kill.kill_by_name}")
+
+        if self.dry_run:
+            row.verdict, row.detail = "refused", "dry run: nothing was rented"
+            # Nothing to tear down is a CONFIRMED teardown, not an unconfirmed
+            # one: a dry run that printed "teardown=UNCONFIRMED" would train the
+            # operator to ignore the one line that must never be ignored.
+            row.teardown.get_404 = row.teardown.absent_from_list = True
+            row.teardown.note = "dry run: no pod was created"
+            kill.close(confirmed_dead=True, note="dry run")
+            return self._bank(row)
+
+        body = self._create_body(card, image, name)
+        try:
+            created = guard.rent(
+                self.api_key,
+                body,
+                lane=f"mintrig-{self.lane}",
+                lease_seconds=self.lease_seconds,
+                orig_cmd=["/bin/bash", "-lc", SSHD],
+                post=self._post_pod,
+            )
+        except Exception as exc:  # noqa: BLE001 — a create that half-happened is the point
+            row.verdict, row.failed_stage, row.detail = "refused", "create", f"{type(exc).__name__}: {exc}"
+            # The create-window leak. The response never landed, so the id is
+            # unknown — but the NAME is ours, and the account listing has it.
+            leaked = self._reconcile_by_name(name)
+            kill.close(confirmed_dead=not leaked, note=f"create failed; leaked={leaked}")
+            row.detail += f"; name-sweep found {'A LEAKED POD' if leaked else 'nothing'}"
+            return self._bank(row)
+
+        pod_id = str(created.get("id") or "")
+        rate = float(created.get("costPerHr") or 0.0)
+        row.pod_id, row.rate_per_hr = pod_id, rate
+        row.started_at = time.time()
+        self.rail.observe_rate(rate)
+        self.rail.clock_started(row.started_at)
+        kill.arm(pod_id, rate_per_hr=rate)
+        wall = self.rail.wall_seconds
+        self.log(
+            f"[pod] {pod_id} ({name}) rate=${rate}/hr — the ${self.rail.max_usd:.2f} rail is "
+            f"{wall / 60:.0f} min at that rate\n[pod] stop it with: {kill.kill_by_id}"
+        )
+
+        try:
+            self._bring_up_and_run(api, row, workload, card)
+        except RailTripped as exc:
+            row.verdict, row.rail_tripped, row.detail = "railed", True, str(exc)
+            row.failed_stage = row.failed_stage or "rail"
+        except Stuck as exc:
+            row.verdict, row.failed_stage, row.detail = "stuck", exc.stage, str(exc)
+        except Failed as exc:
+            row.verdict, row.failed_stage, row.detail = "red", exc.stage, str(exc)
+        except _Reroll as exc:
+            row.verdict, row.failed_stage, row.detail = "reroll", "preflight", str(exc)
+        except Exception as exc:  # noqa: BLE001
+            row.verdict = "red"
+            row.failed_stage = row.failed_stage or "driver"
+            row.detail = f"{type(exc).__name__}: {exc}"
+        finally:
+            # RULE 4, and the structural rule: teardown is reachable from every
+            # exit, including the ones nobody predicted.
+            self._teardown(api, row)
+            kill.close(confirmed_dead=row.teardown.confirmed, note=row.verdict)
+            self._guard.release(pod_id, confirmed_dead=row.teardown.confirmed, reason=f"mint-rig {row.verdict}")
+            row.price()
+            self._bank(row)
+        return row
+
+    # ---- terminate / sweep, for the CLI and for recovery ---------------------
+
+    def terminate(self, *, pod_id: str = "", name: str = "") -> RigRow:
+        row = RigRow(lane=self.lane, pod_id=pod_id, pod_name=name, verdict="refused")
+        if not pod_id and name:
+            found = self._find_by_name(name)
+            pod_id = row.pod_id = found or ""
+        if not pod_id:
+            row.detail = "no such pod on the account"
+            row.verdict = "green"  # nothing to stop is the outcome we wanted
+            row.teardown.get_404 = row.teardown.absent_from_list = True
+            return row
+        self._teardown(self._api, row)
+        row.verdict = "green" if row.teardown.confirmed else "red"
+        self._guard.release(pod_id, confirmed_dead=row.teardown.confirmed, reason="mint-rig terminate")
+        for record in KillSet.open_records():
+            if record.get("pod_id") == pod_id or record.get("pod_name") == name:
+                KillSet(lane=str(record.get("lane", "")), pod_name=str(record.get("pod_name", ""))).close(
+                    confirmed_dead=row.teardown.confirmed, note="terminated by hand"
+                )
+        return row
+
+    def sweep(self, *, leases: Mapping[str, str] | None = None) -> dict[str, Any]:
+        """What is running, and what anyone's records think is running.
+
+        The interesting output is the DISAGREEMENT. `unattended` is the alarm:
+        a live pod that NEITHER this package's kill-sets NOR podguard's lease
+        records name — the th#1323 shape, a pod burning money with no owner.
+
+        A pod another lane rented through podguard is attended and is reported
+        as such, not as a leak. Reading only our own records would make every
+        sibling lane's healthy pod look like an emergency, and an alarm that
+        cries wolf is one nobody reads.
+        """
+        live = {str(p.get("id")): p for p in self._api.list_pods()}
+        records = KillSet.open_records()
+        recorded = {str(r.get("pod_id")) for r in records if r.get("pod_id")}
+        held = dict(leases) if leases is not None else _podguard_leases()
+        return {
+            "live_pods": [
+                {
+                    "pod_id": pid,
+                    "name": p.get("name"),
+                    "status": p.get("desiredStatus"),
+                    "rate_per_hr": p.get("costPerHr"),
+                    "known_to_mint_rig": pid in recorded,
+                    "podguard_lane": held.get(pid, ""),
+                }
+                for pid, p in sorted(live.items())
+            ],
+            "open_killsets": records,
+            "unrecorded_live": [pid for pid in live if pid not in recorded],
+            "unattended": [pid for pid in live if pid not in recorded and pid not in held],
+            "open_but_dead": [str(r.get("pod_id")) for r in records if str(r.get("pod_id")) not in live],
+        }
+
+    # ---- internals -----------------------------------------------------------
+
+    @property
+    def _api(self) -> PodApi:
+        assert self.api is not None
+        return self.api
+
+    @property
+    def _guard(self) -> Guard:
+        assert self.guard is not None
+        return self.guard
+
+    def _post_pod(self, armed: Mapping[str, Any]) -> dict[str, Any]:
+        """Create, moving podguard's start command onto the ENTRYPOINT.
+
+        RunPod treats `dockerEntrypoint: []` as unset and lets the IMAGE's
+        entrypoint win, so an armed `dockerStartCmd` on an image with its own
+        entrypoint runs the image's command and never our sshd. pod_run.py
+        learned this; the fix belongs in the shared primitive, not in each lane.
+        """
+        body = dict(armed)
+        start = body.pop("dockerStartCmd", None)
+        if start:
+            body["dockerEntrypoint"] = start
+        return self._api.create(body)
+
+    def _create_body(self, card: Card, image: str, name: str) -> dict[str, Any]:
+        public_key = (Path.home() / ".ssh" / "runpod.pub").read_text().strip()
+        return {
+            "name": name,
+            "imageName": image,
+            "gpuTypeIds": list(card.gpu_type_ids),
+            "gpuCount": 1,
+            "containerDiskInGb": card.disk_gb,
+            "cloudType": "SECURE",
+            "supportPublicIp": True,
+            "ports": ["22/tcp"],
+            "env": {"PUBLIC_KEY": public_key},
+        }
+
+    def _gate(self, stage: str, probe: Callable[[], Observation], *, stall_ticks: int = 0) -> Observation:
+        return Gate(
+            stage=stage,
+            probe=probe,
+            stall_ticks=stall_ticks or self.stall_ticks,
+            tick_s=self.tick_s,
+            rail_check=self.rail.check,
+            sleep=self.sleep,
+            on_tick=lambda n, obs: self.log(f"[{stage}] {n:3d} {obs.note[:150]}"),
+        ).wait()
+
+    def _bring_up_and_run(self, api: PodApi, row: RigRow, workload: Workload, card: Card) -> None:
+        row.stage("endpoint")
+        endpoint = self._wait_for_endpoint(api, row)
+        transport = self._transport(*endpoint)
+
+        row.stage("ssh")
+        self._wait_for_ssh(api, row, transport)
+
+        row.stage("preflight")
+        self._preflight(transport, row)
+
+        row.stage("census")
+        self._census(transport, row, card)
+
+        row.stage("ship")
+        self.rail.may_start("ship")
+        self._ship(transport, workload, row)
+
+        row.stage("setup")
+        self.rail.may_start("setup")
+        self._setup(transport, workload, row)
+
+        row.stage("launch")
+        self.rail.may_start(f"workload:{workload.name}")
+        launched = transport.run(workload.launch_script())
+        if "RIG_LAUNCHED" not in launched.out:
+            raise Failed("launch", f"rc={launched.rc} {launched.out[-500:]}")
+        self.log(f"[launch] {launched.out.strip()[-200:]}")
+
+        row.stage("workload")
+        try:
+            self._watch(transport, workload, row)
+            row.verdict = "green"
+        finally:
+            # Capture under EVERY outcome. A failed compile's log is the most
+            # valuable thing the rental produced, and it is on a pod that is
+            # about to be deleted.
+            row.stage("capture")
+            self._capture(transport, workload, row)
+
+    def _transport(self, host: str, port: int) -> Transport:
+        assert self.transport_factory is not None
+        return self.transport_factory(host, port)
+
+    def _wait_for_endpoint(self, api: PodApi, row: RigRow) -> tuple[str, int]:
+        found: dict[str, tuple[str, int]] = {}
+
+        def probe() -> Observation:
+            record = api.get(row.pod_id)
+            endpoint = _endpoint(record)
+            if endpoint:
+                found["ep"] = endpoint
+            return Observation(
+                reached=bool(endpoint),
+                token=_rest_token(record),
+                note=f"status={record.get('desiredStatus')} ip={record.get('publicIp')} "
+                f"ports={(record.get('portMappings') or {})}",
+            )
+
+        self._gate("endpoint", probe)
+        return found["ep"]
+
+    def _wait_for_ssh(self, api: PodApi, row: RigRow, transport: Transport) -> None:
+        """The pod ANSWERING is the liveness signal — not the REST status.
+
+        The progress token pairs the REST record with ssh's own stderr, because
+        during a slow image pull the REST record is what moves, and after the
+        container starts it is the ssh error that changes ("Connection refused"
+        -> "Connection closed by remote host" -> success). A token built from
+        only one of them goes stale during the other's phase.
+        """
+
+        def probe() -> Observation:
+            result = transport.run("true", timeout_s=45)
+            record = api.get(row.pod_id)
+            reason = result.out.strip().splitlines()[-1][:120] if result.out.strip() else ""
+            return Observation(
+                reached=result.ok,
+                token=(_rest_token(record), reason),
+                # Print the reason EVERY tick. A retry loop that hides ssh's
+                # stderr cannot tell "still booting" from "wrong key".
+                note=f"rc={result.rc} {reason}",
+            )
+
+        self._gate("ssh", probe)
+
+    def _preflight(self, transport: Transport, row: RigRow) -> None:
+        """RIG-ENV §3c — probe the HOST driver before anything is downloaded.
+
+        RunPod's driver version is per-host. A 570 host imports torch+cu130
+        perfectly and then dies on the first allocation, twenty minutes in.
+        `rigboot` is stdlib-only, so it ships as one file and runs before any
+        install: exit 0 usable (path native|compat), 91 RE-ROLL, 92 no driver.
+        """
+        boot = Path(__file__).resolve().parents[2] / "src" / "gen_worker" / "rigboot.py"
+        if not boot.is_file():  # pragma: no cover - a checkout without src/
+            self.log("[preflight] rigboot.py not found in this checkout — SKIPPED")
+            return
+        transport.run(f"mkdir -p {POD_ROOT}")
+        shipped = transport.put([boot], POD_ROOT)
+        if not shipped.ok:
+            raise Failed("preflight", f"could not ship rigboot.py: {shipped.out[-400:]}")
+        result = transport.run(
+            f"cd {POD_ROOT} && python3 rigboot.py --cuda {FLEET_CUDA} --json {POD_ROOT}/rigboot.json; "
+            f"echo RIG_RC=$?; cat {POD_ROOT}/rigboot.json 2>/dev/null",
+            timeout_s=900,
+        )
+        rc_match = re.search(r"RIG_RC=(\d+)", result.out)
+        rc = int(rc_match.group(1)) if rc_match else result.rc
+        record: dict[str, Any] = {}
+        brace = result.out.find("{")
+        if brace >= 0:
+            try:
+                record = json.loads(result.out[brace : result.out.rfind("}") + 1])
+            except json.JSONDecodeError:
+                record = {}
+        row.cuda_path = str(record.get("path") or ("native" if rc == 0 else "reroll"))
+        row.driver_version = str(record.get("driver") or record.get("driver_version") or "")
+        self.log(f"[preflight] rc={rc} path={row.cuda_path} driver={row.driver_version}")
+        if rc == 91:
+            raise _Reroll(
+                f"host driver {row.driver_version} has no usable path to CUDA {FLEET_CUDA} "
+                "(RIG-ENV §3c: re-roll the host, do NOT downgrade torch)"
+            )
+        if rc == 92:
+            raise _Reroll("no NVIDIA driver on this host — wrong pod type")
+        if rc != 0:
+            raise Failed("preflight", f"rigboot rc={rc}: {result.out[-500:]}")
+
+    def _census(self, transport: Transport, row: RigRow, card: Card) -> None:
+        """What we ACTUALLY got. Evidence, never a gate.
+
+        A probe that cannot read a version must not be able to delete a rented
+        pod — so a failed census is a blank column, not a teardown.
+        """
+        result = transport.run(CENSUS, timeout_s=120)
+        line = result.out.strip().splitlines()[-1] if result.out.strip() else ""
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 3:
+            row.observed_gpu, row.driver_version, row.observed_sm = parts[0], parts[1], parts[2]
+        row.env_line = [line]
+        self.log(f"[census] {line}")
+        if row.observed_sm and row.observed_sm != card.sm_expected:
+            # NOT a failure: the pick names a card SET and the provider chose.
+            # It is a fact the row must carry so nobody reads the asked sm.
+            self.log(
+                f"[census] asked {card.slug} (sm {card.sm_expected}) — got sm {row.observed_sm}. "
+                "The row records both."
+            )
+
+    def _ship(self, transport: Transport, workload: Workload, row: RigRow) -> None:
+        by_dir: dict[str, list[Path]] = {}
+        for upload in workload.uploads:
+            by_dir.setdefault(upload.remote_dir, []).append(upload.local)
+        for remote_dir, paths in sorted(by_dir.items()):
+            transport.run(f"mkdir -p {remote_dir}")
+            result = self._retry_transfer(lambda: transport.put(paths, remote_dir), f"ship->{remote_dir}")
+            if not result.ok:
+                raise Failed("ship", f"scp to {remote_dir} rc={result.rc}: {result.out[-500:]}")
+        self.log(f"[ship] {len(workload.uploads)} upload(s)")
+
+    def _retry_transfer(self, call: Callable[[], Result], label: str) -> Result:
+        """A freshly booted sshd drops connections; one broken pipe must not
+        cost a rented pod. Bounded by attempts and by the rail, never by a wall
+        clock, and every attempt prints its own reason."""
+        result = Result(1, "")
+        for attempt in range(5):
+            self.rail.check(label)
+            result = call()
+            if result.ok:
+                return result
+            self.log(f"[{label}] attempt {attempt} rc={result.rc}: {result.out.strip()[-200:]}")
+            self.sleep(self.tick_s)
+        return result
+
+    def _setup(self, transport: Transport, workload: Workload, row: RigRow) -> None:
+        for index, line in enumerate(workload.setup):
+            self.rail.may_start(f"setup[{index}]")
+            self.log(f"[setup {index}] {line[:160]}")
+            result = transport.run(f"mkdir -p {workload.workdir} && cd {workload.workdir} && {line}", timeout_s=3600)
+            if not result.ok:
+                raise Failed("setup", f"line {index} rc={result.rc}: {line}\n{result.out[-800:]}")
+
+    def _watch(self, transport: Transport, workload: Workload, row: RigRow) -> None:
+        script = workload.probe_script()
+
+        def probe() -> Observation:
+            result = transport.run(script, timeout_s=180)
+            if not result.ok:
+                # An ssh hiccup is NOT evidence about the compile. Return the
+                # previous token unchanged-but-marked so a run of them still
+                # trips the stall detector while a single one does not.
+                return Observation(token=("ssh-error", result.out[-80:]), note=f"probe rc={result.rc}")
+            size = _section(result.out, "SIZE") or "0"
+            log_bytes = _section(result.out, "BYTES") or "0"
+            done = (_section(result.out, "MARK") or "0").strip() not in ("", "0")
+            failed = any(part.strip() not in ("", "0") for part in _section(result.out, "FAIL").split())
+            tail = _section(result.out, "TAIL")
+            last = tail.strip().splitlines()[-1] if tail.strip() else ""
+            return Observation(
+                reached=done,
+                failed=failed and not done,
+                token=(size.strip(), log_bytes.strip(), last),
+                note=f"{int(size or 0) / 2**20:.0f} MiB artifacts, {log_bytes}B log | {last[:110]}",
+            )
+
+        self._gate(f"workload:{workload.name}", probe)
+
+    def _capture(self, transport: Transport, workload: Workload, row: RigRow) -> None:
+        destination = self.out_dir / f"{row.pod_name}"
+        destination.mkdir(parents=True, exist_ok=True)
+        for remote in (*workload.artifacts, workload.log):
+            artifact = Artifact(remote=remote)
+            result = transport.fetch(remote, destination)
+            base = destination / Path(remote).name
+            artifact.fetched = result.ok and base.exists()
+            artifact.local = str(base) if artifact.fetched else ""
+            artifact.note = "" if artifact.fetched else result.out.strip()[-200:]
+            if artifact.fetched and base.is_file():
+                from .workload import sha256_file
+
+                artifact.bytes = base.stat().st_size
+                artifact.sha256 = sha256_file(base)
+            row.artifacts.append(artifact.__dict__)
+        self.log(f"[capture] {sum(1 for a in row.artifacts if a['fetched'])}/{len(row.artifacts)} -> {destination}")
+
+    def _teardown(self, api: PodApi, row: RigRow) -> None:
+        """DELETE, then GET 404, then absent from the listing. All three.
+
+        Each one alone has lied: DELETE answers 200 for a pod still winding
+        down, and a single GET can be answered from a cache while the account
+        listing still carries the pod that is still being billed.
+        """
+        teardown = row.teardown
+        if not row.pod_id:
+            teardown.note = "no pod id — nothing was created"
+            teardown.get_404 = teardown.absent_from_list = True
+            return
+        try:
+            api.delete(row.pod_id)
+            teardown.delete_issued = True
+        except Exception as exc:  # noqa: BLE001
+            teardown.note = f"DELETE raised {type(exc).__name__}: {exc}"
+        for attempt in range(30):
+            teardown.attempts = attempt + 1
+            try:
+                api.get(row.pod_id)
+            except PodNotFound:
+                teardown.get_404 = True
+            except Exception as exc:  # noqa: BLE001
+                teardown.note = f"GET raised {type(exc).__name__}: {exc}"
+            try:
+                teardown.absent_from_list = not any(
+                    str(p.get("id")) == row.pod_id for p in api.list_pods()
+                )
+            except Exception as exc:  # noqa: BLE001
+                teardown.note = f"list raised {type(exc).__name__}: {exc}"
+            if teardown.confirmed:
+                break
+            self.sleep(self.tick_s)
+        self.log(
+            f"[teardown] {row.pod_id} delete={teardown.delete_issued} 404={teardown.get_404} "
+            f"absent={teardown.absent_from_list} after {teardown.attempts} check(s)"
+        )
+        if not teardown.confirmed:
+            self.log(
+                f"[teardown] ⚠ UNCONFIRMED — the pod may still be billing. "
+                f"Stop it: python3 {KILLSET_ENTRYPOINT} terminate --pod {row.pod_id}"
+            )
+
+    def _find_by_name(self, name: str) -> str:
+        for pod in self._api.list_pods():
+            if str(pod.get("name")) == name:
+                return str(pod.get("id"))
+        return ""
+
+    def _reconcile_by_name(self, name: str) -> bool:
+        """The create-window sweep. Returns True when a leaked pod was found."""
+        try:
+            pod_id = self._find_by_name(name)
+        except Exception as exc:  # noqa: BLE001
+            self.log(f"[create] name sweep failed ({exc}) — VERIFY {name} BY HAND")
+            return True
+        if not pod_id:
+            return False
+        self.log(f"[create] the create call failed but pod {pod_id} EXISTS under our name — killing it")
+        row = RigRow(lane=self.lane, pod_id=pod_id, pod_name=name)
+        self._teardown(self._api, row)
+        return not row.teardown.confirmed
+
+    def _bank(self, row: RigRow) -> RigRow:
+        path = self.out_dir / f"{row.pod_name or row.lane}.row.json"
+        row.write(path)
+        self.log(f"[row] {path}\n{row.one_line()}")
+        return row
+
+
+def _podguard_leases() -> dict[str, str]:
+    """Live podguard leases as {pod_id: lane}. Absent podguard means {}: the
+    sweep degrades to our own records rather than refusing to report."""
+    try:
+        from .runpod import load_podguard
+
+        podguard = load_podguard()
+    except Exception:  # noqa: BLE001 — a missing peer must not silence the sweep
+        return {}
+    out: dict[str, str] = {}
+    for lease in podguard.Lease.all():
+        if lease.state == "LIVE":
+            out[str(lease.pod_id)] = str(lease.lane)
+    return out
+
+
+class _Reroll(RuntimeError):
+    """The host cannot run the fleet CUDA line. Kill it and create another."""
+
+
+def uploads_for(paths: Sequence[Path], remote_dir: str = POD_ROOT) -> tuple[Upload, ...]:
+    return tuple(Upload(local=p, remote_dir=remote_dir) for p in paths)

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -472,18 +472,26 @@ class Rig:
         shipped = transport.put([boot], POD_ROOT)
         if not shipped.ok:
             raise Failed("preflight", f"could not ship rigboot.py: {shipped.out[-400:]}")
+        # rigboot prints its record AND writes it to --json, so a naive
+        # "first { to last }" parse spans two documents and silently yields
+        # nothing — which is how the first real run reported an empty driver
+        # version next to a perfectly good probe. Send its console to a file and
+        # read the record from exactly one place.
         result = transport.run(
-            f"cd {POD_ROOT} && python3 rigboot.py --cuda {FLEET_CUDA} --json {POD_ROOT}/rigboot.json; "
-            f"echo RIG_RC=$?; cat {POD_ROOT}/rigboot.json 2>/dev/null",
+            f"cd {POD_ROOT} && python3 rigboot.py --cuda {FLEET_CUDA} "
+            f"--json {POD_ROOT}/rigboot.json > {POD_ROOT}/rigboot.out 2>&1; "
+            f"echo RIG_RC=$?; cat {POD_ROOT}/rigboot.json 2>/dev/null; "
+            f"echo '--RIG-BOOTLOG--'; tail -20 {POD_ROOT}/rigboot.out",
             timeout_s=900,
         )
         rc_match = re.search(r"RIG_RC=(\d+)", result.out)
         rc = int(rc_match.group(1)) if rc_match else result.rc
+        head, _, bootlog = result.out.partition("--RIG-BOOTLOG--")
         record: dict[str, Any] = {}
-        brace = result.out.find("{")
+        brace = head.find("{")
         if brace >= 0:
             try:
-                record = json.loads(result.out[brace : result.out.rfind("}") + 1])
+                record = json.loads(head[brace : head.rfind("}") + 1])
             except json.JSONDecodeError:
                 record = {}
         row.cuda_path = str(record.get("path") or ("native" if rc == 0 else "reroll"))
@@ -493,11 +501,12 @@ class Rig:
             raise _Reroll(
                 f"host driver {row.driver_version} has no usable path to CUDA {FLEET_CUDA} "
                 "(RIG-ENV §3c: re-roll the host, do NOT downgrade torch)"
+                f"\n{bootlog[-500:]}"
             )
         if rc == 92:
             raise _Reroll("no NVIDIA driver on this host — wrong pod type")
         if rc != 0:
-            raise Failed("preflight", f"rigboot rc={rc}: {result.out[-500:]}")
+            raise Failed("preflight", f"rigboot rc={rc}: {bootlog[-800:] or result.out[-800:]}")
 
     def _census(self, transport: Transport, row: RigRow, card: Card) -> None:
         """What we ACTUALLY got. Evidence, never a gate.

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -367,7 +367,24 @@ class Rig:
         ).wait()
 
     def _boot_check(self, stage: str) -> None:
-        self.rail.check_sub(stage, self.boot_budget)
+        """A boot that never happened is a RE-ROLL, not a budget overrun.
+
+        MEASURED 2026-08-17: two pods on the same image exposed port 22 in ~100
+        seconds; a third sat at `desiredStatus: RUNNING` with no `publicIp` for
+        six minutes and counting — RIG-ENV's known upstream single-blob stall
+        (8 of 11 pod creations, 2026-08-08). The money bound is what STOPS it,
+        but the verdict a caller needs is "this host is bad, take another",
+        which RIG-ENV §3c prices at ~3 minutes against 25 for finding out later.
+        A matrix lane can retry a `reroll`; it must not retry a `railed`, which
+        means the operator's budget is genuinely gone.
+        """
+        try:
+            self.rail.check_sub(stage, self.boot_budget)
+        except RailTripped as exc:
+            raise _Reroll(
+                f"the pod never answered inside the bring-up budget — {exc}. "
+                "RIG-ENV §3c: re-roll the host rather than waiting it out."
+            ) from None
 
     def _bring_up_and_run(self, api: PodApi, row: RigRow, workload: Workload, card: Card) -> None:
         row.stage("endpoint")

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -94,6 +94,25 @@ def _endpoint(record: Mapping[str, Any]) -> tuple[str, int] | None:
     return (str(ip), int(port)) if ip and port else None
 
 
+def _count(section: str) -> int:
+    """Sum the integers a probe section carries; anything else contributes 0.
+
+    Tolerant BY DESIGN, and the reason is the worst defect this rig has had: a
+    section that read "0\n0" (grep printing its zero count and then exiting 1
+    into an `|| echo 0`) was compared against the string "0", did not match, and
+    was reported as the done marker — a GREEN verdict for a command that died at
+    its first line. The script no longer emits that shape; this function means a
+    future variation of it cannot fabricate a success either.
+    """
+    total = 0
+    for part in section.split():
+        try:
+            total += int(part)
+        except ValueError:
+            continue
+    return total
+
+
 def _section(text: str, name: str) -> str:
     """Pull one `--RIG-<name>--` section out of the probe's single round trip."""
     marks = list(re.finditer(r"^--RIG-([A-Z]+)--$", text, re.M))
@@ -420,11 +439,17 @@ class Rig:
             self._watch(transport, workload, row)
             row.verdict = "green"
         finally:
+            # NOTE: `capture` runs here, and the required-artifact check that
+            # can DOWNGRADE this green is below it — see _require_artifacts.
             # Capture under EVERY outcome. A failed compile's log is the most
             # valuable thing the rental produced, and it is on a pod that is
             # about to be deleted.
             row.stage("capture")
             self._capture(transport, workload, row)
+        # A second, independent statement of success, checked after capture:
+        # the marker says the command believed it worked, the artifacts say it
+        # left the thing behind.
+        self._require_artifacts(workload, row)
 
     def _transport(self, host: str, port: int) -> Transport:
         assert self.transport_factory is not None
@@ -591,8 +616,8 @@ class Rig:
                 return Observation(token=("ssh-error", result.out[-80:]), note=f"probe rc={result.rc}")
             size = _section(result.out, "SIZE") or "0"
             log_bytes = _section(result.out, "BYTES") or "0"
-            done = (_section(result.out, "MARK") or "0").strip() not in ("", "0")
-            failed = any(part.strip() not in ("", "0") for part in _section(result.out, "FAIL").split())
+            done = _count(_section(result.out, "MARK")) > 0
+            failed = _count(_section(result.out, "FAIL")) > 0
             tail = _section(result.out, "TAIL")
             last = tail.strip().splitlines()[-1] if tail.strip() else ""
             return Observation(
@@ -619,6 +644,18 @@ class Rig:
                 artifact.sha256 = sha256_file(base)
             row.artifacts.append(artifact.__dict__)
         self.log(f"[capture] {sum(1 for a in row.artifacts if a['fetched'])}/{len(row.artifacts)} -> {destination}")
+
+    def _require_artifacts(self, workload: Workload, row: RigRow) -> None:
+        if row.verdict != "green" or not workload.required_artifacts:
+            return
+        fetched = {a["remote"] for a in row.artifacts if a.get("fetched")}
+        missing = [r for r in workload.required_artifacts if r not in fetched]
+        if missing:
+            row.verdict, row.failed_stage = "red", "artifacts"
+            row.detail = (
+                f"the command reported success but produced none of {missing} — "
+                "a green whose artifact is absent is not a green"
+            )
 
     def _teardown(self, api: PodApi, row: RigRow) -> None:
         """DELETE, then GET 404, then absent from the listing. All three.

--- a/scripts/mint_rig/guard.py
+++ b/scripts/mint_rig/guard.py
@@ -1,0 +1,85 @@
+"""podguard, behind a Protocol — and the rule that it is never optional.
+
+th#1327's argument in one line: *renting a pod and arming its teardown are ONE
+operation, because agent sessions die routinely and any cleanup that depends on
+the renter surviving leaks by construction.* The rig does not re-implement that;
+it uses podguard, which already carries a pod-side watchdog armed inside the
+CREATE call and a box-side reaper for the pod whose container never started.
+
+The Protocol exists so the driver is testable at $0, not so the guard is
+swappable for nothing. :func:`real_guard` REFUSES when podguard is unreachable
+rather than degrading to an unguarded rental.
+
+The rig therefore has THREE layers of stoppability, and they fail independently:
+
+  podguard Layer A   the pod kills itself when nobody renews (needs no box)
+  podguard Layer B   the cron reaper kills a pod whose container never started
+  mint_rig killset   a durable box-side record written BEFORE the create call,
+                     so even the pod nobody ever learned the id of is nameable
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+
+class Guard(Protocol):
+    """Arming, attending and closing out a rental."""
+
+    def rent(
+        self,
+        api_key: str,
+        body: Mapping[str, Any],
+        *,
+        lane: str,
+        lease_seconds: float,
+        orig_cmd: Sequence[str],
+        post: Callable[[Mapping[str, Any]], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Arm `body`, create through `post`, and record the lease.
+
+        Returns the create response. `post` is the rig's own REST client, so the
+        guard never owns the wire — which is what makes the whole driver
+        testable without one.
+        """
+
+    def release(self, pod_id: str, *, confirmed_dead: bool, reason: str) -> None: ...
+
+
+class PodguardGuard:
+    """The real one. Thin by design — podguard is the implementation."""
+
+    def __init__(self, module: Any) -> None:
+        self._pg = module
+
+    def rent(
+        self,
+        api_key: str,
+        body: Mapping[str, Any],
+        *,
+        lane: str,
+        lease_seconds: float,
+        orig_cmd: Sequence[str],
+        post: Callable[[Mapping[str, Any]], dict[str, Any]],
+    ) -> dict[str, Any]:
+        lease = self._pg.rent(
+            api_key,
+            dict(body),
+            lane=lane,
+            lease_seconds=lease_seconds,
+            orig_cmd=list(orig_cmd),
+            post=post,
+        )
+        raw = getattr(lease, "raw", None)
+        if isinstance(raw, dict) and raw:
+            return dict(raw)
+        return {"id": lease.pod_id, "name": lease.name, "costPerHr": lease.rate_per_hr}
+
+    def release(self, pod_id: str, *, confirmed_dead: bool, reason: str) -> None:
+        self._pg.record_release(pod_id, confirmed_dead, reason)
+
+
+def real_guard() -> PodguardGuard:
+    from .runpod import load_podguard
+
+    return PodguardGuard(load_podguard())

--- a/scripts/mint_rig/killset.py
+++ b/scripts/mint_rig/killset.py
@@ -1,0 +1,134 @@
+"""The kill-set: how to stop this pod, written down BEFORE the pod exists.
+
+THE FAILURE THIS EXISTS FOR. A pod id is born inside the create call's response.
+If the box dies between the POST leaving and the response landing — an agent
+session killed, a network drop, an OOM — a pod is running on the account and
+nothing anywhere names it. podguard's th#1323 incident is the same shape one
+step later (four 4090s, four unattended hours, $12.42) and it fixed the case
+where the renter dies *after* the id is known. This module closes the window
+before that.
+
+The mechanism is a two-phase record keyed on the pod NAME, which we choose:
+
+  1. Before the POST, write ``{"state": "PENDING", "pod_name": ...}`` and fsync.
+     The name is unique per invocation, so `kill_by_name` can find the pod on
+     the account even though nobody ever saw its id.
+  2. After the response, rewrite with the id and the direct `kill` command.
+  3. On verified teardown, rewrite with ``"state": "RELEASED"``.
+
+A record left PENDING or LIVE is the alarm. `python -m mint_rig sweep` lists
+them, and every record carries its own literal kill command as a string, so
+recovery is copy-and-paste rather than reconstruction.
+
+This is deliberately SEPARATE from podguard's lease record even though the two
+overlap: podguard's record is written from the create RESPONSE (`Lease` is
+constructed from `pod.get("id")`), so it has the same blind spot. The rig arms
+podguard as well — both layers, not either.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+#: The command a record names as the way to stop its pod, as an absolute path.
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "pod_rig.py"
+
+#: Queryable records, not someone remembering to look. Same home shape as
+#: podguard's lease directory so an operator has two places, not twelve.
+KILLSET_DIR = Path(
+    os.environ.get("MINT_RIG_KILLSET_DIR", Path.home() / ".cache" / "cozy-mint-rig" / "killset")
+)
+
+
+@dataclass
+class KillSet:
+    """One invocation's stoppability record."""
+
+    lane: str
+    pod_name: str
+    state: str = "PENDING"  # PENDING | LIVE | RELEASED | LEAKED
+    pod_id: str = ""
+    gpu: str = ""
+    image: str = ""
+    rate_per_hr: float = 0.0
+    rail_usd: float = 0.0
+    opened_at: float = field(default_factory=time.time)
+    closed_at: float = 0.0
+    renter_pid: int = field(default_factory=os.getpid)
+    note: str = ""
+    # A FACTORY, not a value: `KILLSET_DIR` is read when a record is made, so a
+    # test (or an operator's `MINT_RIG_KILLSET_DIR`) redirecting it is honoured
+    # by every record rather than only by the ones made after the import.
+    root: Path = field(default_factory=lambda: KILLSET_DIR, compare=False, repr=False)
+
+    # ---- the literal commands, as strings, so recovery is paste-not-reconstruct
+    #
+    # ABSOLUTE, deliberately. A record is read by whoever finds a pod still
+    # billing — possibly a different agent, in a different checkout, hours
+    # later — and a relative command is a puzzle at exactly the wrong moment.
+    @property
+    def kill_by_name(self) -> str:
+        return f"python3 {ENTRYPOINT} terminate --name {self.pod_name}"
+
+    @property
+    def kill_by_id(self) -> str:
+        return f"python3 {ENTRYPOINT} terminate --pod {self.pod_id}" if self.pod_id else ""
+
+    @property
+    def path(self) -> Path:
+        return self.root / f"{self.pod_name}.json"
+
+    def record(self) -> dict[str, Any]:
+        body = {k: v for k, v in asdict(self).items() if k != "root"}
+        body["kill_by_name"] = self.kill_by_name
+        body["kill_by_id"] = self.kill_by_id
+        return body
+
+    def save(self) -> "KillSet":
+        """Write durably. `fsync` is not ceremony here: the whole point is to
+        survive a host that stops between this line and the next one."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        with tmp.open("w") as fh:
+            json.dump(self.record(), fh, indent=2, sort_keys=True)
+            fh.flush()
+            os.fsync(fh.fileno())
+        tmp.replace(self.path)
+        return self
+
+    def arm(self, pod_id: str, *, rate_per_hr: float = 0.0) -> "KillSet":
+        self.pod_id, self.rate_per_hr, self.state = pod_id, rate_per_hr, "LIVE"
+        return self.save()
+
+    def close(self, *, confirmed_dead: bool, note: str = "") -> "KillSet":
+        self.state = "RELEASED" if confirmed_dead else "LEAKED"
+        self.closed_at = time.time()
+        self.note = note
+        return self.save()
+
+    # ---- the sweep
+    @classmethod
+    def open_records(cls, root: Path | None = None) -> list[dict[str, Any]]:
+        """Every record that is not RELEASED — the alarm list.
+
+        A PENDING record with no id is the create-window leak and is reported
+        first, because it is the only one no other tool in the workspace can
+        see.
+        """
+        base = root or KILLSET_DIR
+        out: list[dict[str, Any]] = []
+        for path in sorted(base.glob("*.json")):
+            try:
+                body = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if body.get("state") != "RELEASED":
+                body["record_path"] = str(path)
+                out.append(body)
+        out.sort(key=lambda r: (r.get("state") != "PENDING", r.get("opened_at", 0.0)))
+        return out

--- a/scripts/mint_rig/progress.py
+++ b/scripts/mint_rig/progress.py
@@ -1,0 +1,124 @@
+"""Waiting on PROGRESS, never on a clock.
+
+The rule (Paul, standing): detect stuck work by progress toward a goal, never by
+elapsed time. Raising a flaky timeout is not a fix. podguard's header states the
+same rule for pod termination — *"Neither layer uses a fixed lifetime. Both kill
+on liveness + progress-staleness"* — and this module is that rule for the
+control-plane side of the same pod.
+
+A :class:`Gate` polls a caller-supplied probe. Each poll returns an
+:class:`Observation`: whether the goal is REACHED, whether the work FAILED, and
+a *progress token* — any value whose change proves something moved. The gate
+ends in exactly one of four ways:
+
+  reached   the goal predicate said so
+  failed    the probe saw a failure marker (a traceback, a refusal)
+  stuck     the progress token did not change for `stall_ticks` consecutive
+            polls — the ONLY negative verdict, and it names the token that
+            stopped moving
+  tripped   the spend rail (see :mod:`mint_rig.rail`) reached its dollar cap
+
+There is no "timed out". A pod pulling a 3 GB image for forty minutes is
+progressing (its REST state and its layer counters move); a pod whose token has
+been byte-identical for twenty consecutive polls is stuck at minute two.
+
+WHAT MAKES A GOOD TOKEN. It must advance for the SLOWEST legitimate work the
+gate covers. For a boot that is the pod's REST record (status, ip, port
+mappings, last status change). For a compile it is the log's byte length plus
+its final line plus the artifact tree's byte size — an inductor pass that has
+printed nothing for ten minutes is still writing objects into its cache, and a
+token that reads only the log would call that stuck. Conversely a retry loop
+that reprints the same line forever produces a CONSTANT token, which is exactly
+the frozen-worker case podguard's `UpdatedAt` note describes.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One poll of a gate's probe."""
+
+    #: The goal predicate. When true the gate returns immediately.
+    reached: bool = False
+    #: A terminal failure the probe recognised (a traceback, a refusal marker).
+    failed: bool = False
+    #: Anything whose change proves work moved. Compared with `!=`.
+    token: object = None
+    #: One line for the operator's console. Never load-bearing.
+    note: str = ""
+
+
+class Stuck(RuntimeError):
+    """A gate's progress token stopped advancing."""
+
+    def __init__(self, stage: str, token: object, ticks: int, note: str) -> None:
+        super().__init__(
+            f"pgw#1347 {stage}: no progress for {ticks} consecutive observations; "
+            f"progress token has been {token!r} throughout. Last: {note}"
+        )
+        self.stage, self.token, self.ticks, self.note = stage, token, ticks, note
+
+
+class Failed(RuntimeError):
+    """A gate's probe recognised a terminal failure."""
+
+    def __init__(self, stage: str, note: str) -> None:
+        super().__init__(f"pgw#1347 {stage}: failed — {note}")
+        self.stage, self.note = stage, note
+
+
+@dataclass
+class Gate:
+    """Poll `probe` until it reaches its goal or its progress token freezes."""
+
+    stage: str
+    probe: Callable[[], Observation]
+    #: Consecutive unchanged-token observations that mean STUCK. Not a duration:
+    #: multiply by `tick_s` only when reading the console, never when reasoning
+    #: about correctness.
+    stall_ticks: int = 12
+    tick_s: float = 15.0
+    #: Called with every observation, for the console and for the row's trail.
+    on_tick: Callable[[int, Observation], None] | None = None
+    #: Raise if the spend rail has tripped. Injected so the gate never imports
+    #: the rail and the rail never learns about gates.
+    rail_check: Callable[[str], None] | None = None
+    sleep: Callable[[float], None] = field(default=time.sleep)
+
+    def wait(self) -> Observation:
+        stale = 0
+        last: object = _UNSET
+        seen = 0
+        note = "<no observation yet>"
+        while True:
+            if self.rail_check is not None:
+                self.rail_check(self.stage)
+            observation = self.probe()
+            seen += 1
+            note = observation.note or note
+            if self.on_tick is not None:
+                self.on_tick(seen, observation)
+            if observation.reached:
+                return observation
+            if observation.failed:
+                raise Failed(self.stage, observation.note)
+            if last is _UNSET or observation.token != last:
+                stale, last = 0, observation.token
+            else:
+                stale += 1
+                if stale >= self.stall_ticks:
+                    raise Stuck(self.stage, last, stale, note)
+            self.sleep(self.tick_s)
+
+
+class _Unset:
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "<unset>"
+
+
+_UNSET = _Unset()

--- a/scripts/mint_rig/progress.py
+++ b/scripts/mint_rig/progress.py
@@ -81,6 +81,12 @@ class Gate:
     #: Consecutive unchanged-token observations that mean STUCK. Not a duration:
     #: multiply by `tick_s` only when reading the console, never when reasoning
     #: about correctness.
+    #:
+    #: **Zero or less DISABLES the staleness rule**, for the gates whose phase
+    #: genuinely emits no progress signal (pod bring-up — see
+    #: :meth:`mint_rig.rail.Rail.check_sub`). Such a gate must be given a
+    #: `rail_check`, or it would have no bound at all; :meth:`wait` refuses
+    #: otherwise rather than looping forever.
     stall_ticks: int = 12
     tick_s: float = 15.0
     #: Called with every observation, for the console and for the row's trail.
@@ -91,6 +97,11 @@ class Gate:
     sleep: Callable[[float], None] = field(default=time.sleep)
 
     def wait(self) -> Observation:
+        if self.stall_ticks <= 0 and self.rail_check is None:
+            raise ValueError(
+                f"pgw#1347 {self.stage}: a gate with the staleness rule disabled must carry a "
+                "rail_check — otherwise it has no bound at all, which is worse than a timeout."
+            )
         stale = 0
         last: object = _UNSET
         seen = 0
@@ -111,7 +122,7 @@ class Gate:
                 stale, last = 0, observation.token
             else:
                 stale += 1
-                if stale >= self.stall_ticks:
+                if self.stall_ticks > 0 and stale >= self.stall_ticks:
                     raise Stuck(self.stage, last, stale, note)
             self.sleep(self.tick_s)
 

--- a/scripts/mint_rig/rail.py
+++ b/scripts/mint_rig/rail.py
@@ -1,0 +1,101 @@
+"""The spend rail — dollars, declared per invocation, with no default.
+
+A rig that can start without a stated budget will eventually run without one.
+So :class:`Rail` has no default cap: `Rail()` is a TypeError and
+``Rail(max_usd=0)`` is refused. The caller states dollars because dollars are
+what the operator actually has an opinion about; the rig converts them to a
+deadline using the pod's OBSERVED hourly rate, which it only learns after the
+create call answers.
+
+**Why this is not the magic timeout the policy forbids.** A magic timeout is a
+number picked to be "long enough" for work whose progress nobody is watching.
+This is the opposite: progress is watched by :mod:`mint_rig.progress`, and the
+rail is a hard ceiling on SPEND that exists so a stuck-detector bug cannot cost
+unbounded money. It is derived, never guessed — change the card and the wall
+changes with it — and tripping it is a recorded verdict (`rail_tripped`) rather
+than a silent abort.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+class RailTripped(RuntimeError):
+    """The projected spend reached the caller's declared cap."""
+
+
+@dataclass
+class Rail:
+    """A per-invocation dollar cap and the arithmetic that enforces it."""
+
+    max_usd: float
+    #: Fraction of the cap at which the rig stops STARTING new work. A rental
+    #: torn down at exactly 100% has no budget left for the teardown round-trip
+    #: or the artifact fetch, and an artifact left on a deleted pod is the run
+    #: wasted for the sake of the last two cents.
+    start_headroom: float = 0.85
+    rate_per_hr: float = 0.0
+    started_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        if not self.max_usd > 0:
+            raise ValueError(
+                "pgw#1347: a mint-rig invocation must declare a spend rail in "
+                f"dollars; got max_usd={self.max_usd!r}. There is no default — "
+                "a default budget is the number nobody chose."
+            )
+        if not 0.0 < self.start_headroom <= 1.0:
+            raise ValueError(f"start_headroom must be in (0, 1]; got {self.start_headroom!r}")
+
+    def observe_rate(self, rate_per_hr: float) -> None:
+        """Record the rate the provider actually charged for this pod.
+
+        Asked-vs-observed matters here as much as it does for the GPU model: a
+        rail computed against a catalogue price would under-count a rental that
+        came in at a different spot rate.
+        """
+        self.rate_per_hr = float(rate_per_hr)
+
+    def clock_started(self, at: float | None = None) -> None:
+        """Start the billed clock. Called when the create call answers."""
+        self.started_at = time.time() if at is None else at
+
+    def spent_usd(self, now: float | None = None) -> float:
+        now = time.time() if now is None else now
+        return self.rate_per_hr * max(0.0, now - self.started_at) / 3600.0
+
+    def remaining_usd(self, now: float | None = None) -> float:
+        return self.max_usd - self.spent_usd(now)
+
+    @property
+    def wall_seconds(self) -> float:
+        """The cap expressed as seconds at the observed rate.
+
+        Zero rate (a create response that carried no `costPerHr`) yields
+        ``inf``: the rig must not invent a rate, and a missing rate is recorded
+        on the row rather than turned into a fabricated deadline.
+        """
+        if self.rate_per_hr <= 0:
+            return float("inf")
+        return self.max_usd / self.rate_per_hr * 3600.0
+
+    def may_start(self, stage: str, now: float | None = None) -> None:
+        """Refuse to begin `stage` when there is no headroom left to finish it."""
+        spent = self.spent_usd(now)
+        if spent >= self.max_usd * self.start_headroom:
+            raise RailTripped(
+                f"pgw#1347 spend rail: ${spent:.2f} of ${self.max_usd:.2f} spent "
+                f"({self.start_headroom:.0%} headroom exhausted) — refusing to start "
+                f"{stage!r}. Tearing down."
+            )
+
+    def check(self, stage: str, now: float | None = None) -> None:
+        """Trip when the cap itself is reached, mid-stage."""
+        spent = self.spent_usd(now)
+        if spent >= self.max_usd:
+            raise RailTripped(
+                f"pgw#1347 spend rail: ${spent:.2f} reached the declared "
+                f"${self.max_usd:.2f} cap during {stage!r}. Tearing down."
+            )

--- a/scripts/mint_rig/rail.py
+++ b/scripts/mint_rig/rail.py
@@ -99,3 +99,32 @@ class Rail:
                 f"pgw#1347 spend rail: ${spent:.2f} reached the declared "
                 f"${self.max_usd:.2f} cap during {stage!r}. Tearing down."
             )
+
+    def check_sub(self, stage: str, fraction: float, now: float | None = None) -> None:
+        """A named sub-cap, as a fraction of the same declared rail.
+
+        WHERE THIS IS THE ONLY HONEST BOUND. :mod:`mint_rig.progress` stops work
+        that stopped progressing — but that rule needs a progress signal, and
+        POD BRING-UP HAS NONE. Measured 2026-08-17 against `rest.runpod.io/v1`:
+        a pod reports `desiredStatus: RUNNING` from the instant it is rented and
+        exposes `publicIp`/`portMappings` only when its container actually
+        starts, so a three-gigabyte image pull and a wedged host produce
+        byte-identical records for as long as either lasts. Staleness cannot
+        separate them, and a tick count that pretended to would be exactly the
+        magic timeout this package refuses.
+
+        So the bring-up bound is MONEY: a declared fraction of the operator's own
+        rail. It is derived (the same 15% is four minutes on a 4090 and eight on
+        a cheap A4000), it is stated, and tripping it is a `railed` verdict with
+        the stage named — not a silent retry. Once the pod answers, real progress
+        markers exist and :class:`~mint_rig.progress.Gate` takes over.
+        """
+        spent = self.spent_usd(now)
+        cap = self.max_usd * fraction
+        if spent >= cap:
+            raise RailTripped(
+                f"pgw#1347 {stage} budget: ${spent:.3f} spent against a "
+                f"${cap:.3f} sub-cap ({fraction:.0%} of the ${self.max_usd:.2f} rail). "
+                "Bring-up has no progress signal to be stuck on, so money is the "
+                "bound. Tearing down."
+            )

--- a/scripts/mint_rig/row.py
+++ b/scripts/mint_rig/row.py
@@ -1,6 +1,6 @@
 """The row — one rental, reduced to a record a matrix can hold.
 
-pgw#1346's W2 lanes need a table of (family, card, lane) cells; pgw#1331 needs
+pgw#1346's W2 lanes need a table of (model, card, lane) cells; pgw#1331 needs
 one row that says a real compile happened and what it produced. This is that
 row, and the fields are chosen so nobody has to re-derive anything from prose:
 

--- a/scripts/mint_rig/row.py
+++ b/scripts/mint_rig/row.py
@@ -1,0 +1,138 @@
+"""The row — one rental, reduced to a record a matrix can hold.
+
+pgw#1346's W2 lanes need a table of (family, card, lane) cells; pgw#1331 needs
+one row that says a real compile happened and what it produced. This is that
+row, and the fields are chosen so nobody has to re-derive anything from prose:
+
+  * **asked vs observed.** `asked_gpu` is the plan, `observed_gpu` and
+    `observed_sm` come from the pod's own `nvidia-smi`. e2e's matrix records the
+    same split after finding rows that measured an intention.
+  * **the driver path.** `native` or `compat` — a wall measured through a
+    forward-compat libcuda is a fact about the report (RIG-ENV §3c), not a
+    detail, so it is a column.
+  * **cost from runtime x rate**, with the rate the create call actually
+    returned. This PRICES a rental; it never reconciles a bill. e2e's
+    `privatedeploy/cost.go` states the same boundary, and for the same reason:
+    the ledger's own settlement figures are the charge.
+  * **three teardown verdicts**, not one boolean.
+  * **digests**, so "which code ran" is answerable a month later.
+
+`verdict` is a small closed vocabulary rather than a bool, because the
+interesting failures are not "the command exited non-zero":
+
+  green     the command printed its done marker
+  red       the command failed — a marker, a non-zero rc, a refusal
+  stuck     progress stopped (:class:`~mint_rig.progress.Stuck`)
+  railed    the spend rail tripped first
+  reroll    the host's driver has no usable path to the fleet CUDA line
+  refused   the rig would not start (no rail, no podguard, no key)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class Artifact:
+    remote: str
+    local: str = ""
+    bytes: int = 0
+    sha256: str = ""
+    fetched: bool = False
+    note: str = ""
+
+
+@dataclass
+class Teardown:
+    """Three independent verdicts. Any one of them alone has lied before."""
+
+    #: The DELETE call did not raise. Weakest of the three: RunPod answers 200
+    #: to a delete whose pod is still winding down.
+    delete_issued: bool = False
+    #: GET /pods/<id> answered 404. The pod's own record is gone.
+    get_404: bool = False
+    #: The id is absent from GET /pods. Catches the case where the individual
+    #: GET is cached or eventually-consistent but the account listing is not.
+    absent_from_list: bool = False
+    attempts: int = 0
+    note: str = ""
+
+    @property
+    def confirmed(self) -> bool:
+        return self.get_404 and self.absent_from_list
+
+
+@dataclass
+class RigRow:
+    """One rental. Serialise with :meth:`dumps`; a matrix is a list of these."""
+
+    lane: str
+    issue: str = ""
+    verdict: str = "refused"
+    failed_stage: str = ""
+    detail: str = ""
+
+    pod_id: str = ""
+    pod_name: str = ""
+    image: str = ""
+
+    asked_gpu: str = ""
+    asked_gpu_type_ids: list[str] = field(default_factory=list)
+    observed_gpu: str = ""
+    observed_sm: str = ""
+    sm_expected: str = ""
+    driver_version: str = ""
+    cuda_path: str = ""  # native | compat | reroll
+
+    command: str = ""
+    workload_name: str = ""
+    workload_digest: str = ""
+    uploads: list[dict[str, str]] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    env_line: list[str] = field(default_factory=list)
+
+    started_at: float = field(default_factory=time.time)
+    ended_at: float = 0.0
+    pod_seconds: float = 0.0
+    rate_per_hr: float = 0.0
+    est_cost_usd: float = 0.0
+    rail_usd: float = 0.0
+    rail_tripped: bool = False
+
+    teardown: Teardown = field(default_factory=Teardown)
+    killset_path: str = ""
+    stage_trail: list[dict[str, Any]] = field(default_factory=list)
+
+    def stage(self, name: str, note: str = "") -> None:
+        self.stage_trail.append({"stage": name, "at": round(time.time(), 3), "note": note})
+
+    def price(self, now: float | None = None) -> None:
+        """Runtime x the rate the provider actually charged. Never a bill."""
+        self.ended_at = time.time() if now is None else now
+        self.pod_seconds = max(0.0, self.ended_at - self.started_at)
+        self.est_cost_usd = round(self.rate_per_hr * self.pod_seconds / 3600.0, 4)
+
+    def record(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def dumps(self) -> str:
+        return json.dumps(self.record(), indent=2, sort_keys=True) + "\n"
+
+    def write(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.dumps())
+        return path
+
+    def one_line(self) -> str:
+        gpu = self.observed_gpu or self.asked_gpu
+        return (
+            f"{self.verdict.upper():8s} {self.lane:24s} {gpu:22s} sm{self.observed_sm or '?':4s} "
+            f"{self.pod_seconds / 60:6.1f}min ${self.est_cost_usd:6.3f} "
+            f"teardown={'ok' if self.teardown.confirmed else 'UNCONFIRMED'} "
+            f"{self.failed_stage or self.workload_name}"
+        )

--- a/scripts/mint_rig/runpod.py
+++ b/scripts/mint_rig/runpod.py
@@ -1,6 +1,6 @@
 """The RunPod REST layer, behind a Protocol so the driver can be tested at $0.
 
-Everything the rig needs from RunPod is these six calls. They are a
+Everything the rig needs from RunPod is these five calls. They are a
 :class:`PodApi` Protocol rather than a concrete class for one reason: the whole
 driver — bring-up gating, stall detection, rail arithmetic, teardown's three
 verdicts — is then unit-testable against a fake that answers scripted
@@ -48,7 +48,21 @@ class RestError(RuntimeError):
 
 @runtime_checkable
 class PodApi(Protocol):
-    """What the rig needs from a pod provider. Six calls, no more."""
+    """What the rig needs from a pod provider. Five calls, no more.
+
+    THERE IS NO CAPACITY QUERY, and that is a fact about the provider rather
+    than a gap here. `rest.runpod.io/v1` (openapi.json, read 2026-08-17)
+    exposes pods, endpoints, templates, network volumes, container-registry
+    auth and billing — and NO gpu-type or availability path at all. An earlier
+    draft of this Protocol had a `gpu_types()` call; the real wire answered
+    HTTP 400 *"that path does not exist in the specification"*, which is the
+    kind of thing a fake cannot tell you.
+
+    So availability is discovered the only way the API allows: ASK for a card
+    SET and read the create call's answer. `HTTP 500 "This machine does not
+    have the resources to deploy your pod"` is the out-of-capacity signal, and
+    it costs nothing — no pod is created, and the rig's name sweep confirms it.
+    """
 
     def create(self, body: Mapping[str, Any]) -> dict[str, Any]: ...
 
@@ -61,8 +75,6 @@ class PodApi(Protocol):
     def delete(self, pod_id: str) -> None: ...
 
     def registry_auth(self, name: str, username: str, password: str) -> str: ...
-
-    def gpu_types(self) -> list[dict[str, Any]]: ...
 
 
 def dotenv(names: Sequence[str], path: Path | None = None) -> dict[str, str]:
@@ -178,7 +190,3 @@ class RunpodRest:
         )
         return str((result or {}).get("id", ""))
 
-    def gpu_types(self) -> list[dict[str, Any]]:
-        result = self._call("GET", "/gputypes")
-        rows = result if isinstance(result, list) else (result or {}).get("data", [])
-        return [dict(r) for r in rows or []]

--- a/scripts/mint_rig/runpod.py
+++ b/scripts/mint_rig/runpod.py
@@ -1,0 +1,184 @@
+"""The RunPod REST layer, behind a Protocol so the driver can be tested at $0.
+
+Everything the rig needs from RunPod is these six calls. They are a
+:class:`PodApi` Protocol rather than a concrete class for one reason: the whole
+driver — bring-up gating, stall detection, rail arithmetic, teardown's three
+verdicts — is then unit-testable against a fake that answers scripted
+responses, so the only thing a real pod proves is that the wire matches.
+
+:class:`RunpodRest` is the real implementation. It carries the two things
+pod_run.py learned the hard way and a third that file has not yet learned:
+
+  * a `User-Agent` that is not urllib's default (RunPod's edge answers 403 to
+    some defaults);
+  * `podguard.assert_armed` on the POST path, so this module physically cannot
+    create an unguarded pod — the th#1327 gate;
+  * every HTTP call carries an explicit connect/read bound, which is a
+    TRANSPORT bound (a socket that has produced no bytes) and not a bound on
+    the work — the distinction pgw's own `lint_http_timeouts` guard exists for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+REST_BASE = "https://rest.runpod.io/v1"
+
+#: A socket that has produced no bytes in this long is broken, not slow. This
+#: bounds the TRANSPORT, never the work: pod bring-up and compiles are gated by
+#: mint_rig.progress, which has no clock at all.
+HTTP_TIMEOUT_S = 120.0
+
+
+class PodNotFound(LookupError):
+    """GET /pods/<id> answered 404 — the pod is gone."""
+
+
+class RestError(RuntimeError):
+    def __init__(self, status: int, method: str, path: str, body: str) -> None:
+        super().__init__(f"HTTP {status} {method} {path}: {body[:600]}")
+        self.status, self.method, self.path, self.body = status, method, path, body
+
+
+@runtime_checkable
+class PodApi(Protocol):
+    """What the rig needs from a pod provider. Six calls, no more."""
+
+    def create(self, body: Mapping[str, Any]) -> dict[str, Any]: ...
+
+    def get(self, pod_id: str) -> dict[str, Any]:
+        """Raise :class:`PodNotFound` on 404 — that is a teardown VERDICT, not
+        an error, so it must be distinguishable from a 500."""
+
+    def list_pods(self) -> list[dict[str, Any]]: ...
+
+    def delete(self, pod_id: str) -> None: ...
+
+    def registry_auth(self, name: str, username: str, password: str) -> str: ...
+
+    def gpu_types(self) -> list[dict[str, Any]]: ...
+
+
+def dotenv(names: Sequence[str], path: Path | None = None) -> dict[str, str]:
+    """Read credentials from the workspace's own `.env`, then the environment.
+
+    The order matters and is the workspace convention (`podguard.creds`,
+    `pod_run.dotenv`): a value already exported wins nothing over the committed
+    operator file, because a stale shell export is how a lane spends money on
+    the wrong account.
+    """
+    envf = path or Path(os.environ.get("COZY_RIG_ENV", Path.home() / "cozy" / "e2e" / ".env"))
+    out: dict[str, str] = {}
+    if envf.exists():
+        for line in envf.read_text().splitlines():
+            if "=" in line and not line.strip().startswith("#"):
+                key, _, value = line.partition("=")
+                if key.strip() in names:
+                    out[key.strip()] = value.strip().strip('"').strip("'")
+    for name in names:
+        if not out.get(name) and os.environ.get(name):
+            out[name] = os.environ[name]
+    return out
+
+
+def load_podguard() -> Any:
+    """Import podguard from the tracker checkout, or explain why we refuse.
+
+    The rig REFUSES to rent without it. An unguarded pod is exactly th#1323 and
+    the whole point of a reusable primitive is that no lane has to remember.
+    """
+    directory = Path(
+        os.environ.get(
+            "COZY_PODGUARD_DIR",
+            Path.home() / "cozy" / "cozy-creator-tracker" / "scripts" / "podguard",
+        )
+    )
+    if not (directory / "podguard.py").is_file():
+        raise RuntimeError(
+            f"pgw#1347: podguard not found at {directory}. The rig will not create a pod "
+            "without it (th#1327: renting a pod and arming its teardown are one operation). "
+            "Set COZY_PODGUARD_DIR."
+        )
+    if str(directory) not in sys.path:
+        sys.path.insert(0, str(directory))
+    import podguard  # noqa: PLC0415 — deliberately late: an optional workspace peer
+
+    return podguard
+
+
+class RunpodRest:
+    """The real wire."""
+
+    def __init__(self, api_key: str, base: str = REST_BASE, *, guard: Any | None = None) -> None:
+        if not api_key:
+            raise ValueError("pgw#1347: no RUNPOD_API_KEY (env or ~/cozy/e2e/.env)")
+        self._key, self._base = api_key, base.rstrip("/")
+        self._guard = guard
+
+    # ---- transport
+    def _call(self, method: str, path: str, body: Mapping[str, Any] | None = None) -> Any:
+        data = json.dumps(body).encode() if body is not None else None
+        request = urllib.request.Request(
+            f"{self._base}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self._key}",
+                "Content-Type": "application/json",
+                # Not decoration: RunPod's edge 403s some default agents.
+                "User-Agent": "curl/8.5.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as fh:
+                raw = fh.read()
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            if exc.code == 404:
+                raise PodNotFound(f"{method} {path}: {detail[:200]}") from None
+            raise RestError(exc.code, method, path, detail) from None
+        return json.loads(raw) if raw else {}
+
+    # ---- PodApi
+    def create(self, body: Mapping[str, Any]) -> dict[str, Any]:
+        guard = self._guard if self._guard is not None else load_podguard()
+        # The th#1327 gate, on OUR path. podguard installs it on its own
+        # `rest()`; a driver with its own HTTP client walks around that unless
+        # it calls the assertion itself, which pod_run.py does and this does.
+        guard.assert_armed(dict(body))
+        result = self._call("POST", "/pods", body)
+        return dict(result if isinstance(result, dict) else {})
+
+    def get(self, pod_id: str) -> dict[str, Any]:
+        result = self._call("GET", f"/pods/{pod_id}")
+        return dict(result if isinstance(result, dict) else {})
+
+    def list_pods(self) -> list[dict[str, Any]]:
+        result = self._call("GET", "/pods")
+        rows = result if isinstance(result, list) else (result or {}).get("data", [])
+        return [dict(r) for r in rows or []]
+
+    def delete(self, pod_id: str) -> None:
+        try:
+            self._call("DELETE", f"/pods/{pod_id}")
+        except PodNotFound:
+            # Already gone is the outcome we wanted. The 404 CHECK is what
+            # decides the teardown verdict, not this call's status.
+            return
+
+    def registry_auth(self, name: str, username: str, password: str) -> str:
+        result = self._call(
+            "POST", "/containerregistryauth", {"name": name, "username": username, "password": password}
+        )
+        return str((result or {}).get("id", ""))
+
+    def gpu_types(self) -> list[dict[str, Any]]:
+        result = self._call("GET", "/gputypes")
+        rows = result if isinstance(result, list) else (result or {}).get("data", [])
+        return [dict(r) for r in rows or []]

--- a/scripts/mint_rig/transport.py
+++ b/scripts/mint_rig/transport.py
@@ -1,0 +1,141 @@
+"""Getting bytes and commands onto the pod, behind a Protocol.
+
+Same reason as :mod:`mint_rig.runpod`: the driver's logic is tested against a
+fake that records what was shipped and answers scripted output, so a real pod is
+only ever proving the wire.
+
+:class:`SshTransport` carries the three things this workspace has already paid
+to learn:
+
+  * **Do not drop `SSH_AUTH_SOCK`.** The runpod key on the box is
+    passphrase-protected, so `-i` alone cannot authenticate and the agent holds
+    the only usable copy. A driver that sanitises the environment gets a
+    failure that looks exactly like a slow boot (pod_run.py's opening note).
+  * **Print the reason on every retry.** A retry loop that swallows ssh's
+    stderr cannot tell "still booting" from "wrong key", and the difference is
+    a rented pod.
+  * **A freshly booted sshd drops connections for a while**, so a transfer
+    retries rather than failing the run — but the retry is bounded by the same
+    progress rule as everything else, not by a wall clock.
+
+The per-call `timeout_s` bounds the SUBPROCESS, not the work: every long pod
+task is launched detached (`setsid nohup … &`) and watched by a
+:class:`~mint_rig.progress.Gate`, so no command this module runs is ever
+expected to take minutes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Protocol, Sequence
+
+#: SSH is a control-plane round trip here (start a detached job, read a tail,
+#: stat a directory). A call that has produced nothing in this long is broken.
+SSH_CALL_TIMEOUT_S = 300.0
+SCP_CALL_TIMEOUT_S = 1800.0
+
+SSH_KEY = Path.home() / ".ssh" / "runpod"
+SSH_OPTS = (
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "UserKnownHostsFile=/dev/null",
+    "-o",
+    "ConnectTimeout=15",
+    "-o",
+    "LogLevel=ERROR",
+)
+
+
+@dataclass(frozen=True)
+class Result:
+    rc: int
+    out: str
+
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0
+
+
+class Transport(Protocol):
+    """Two verbs. Everything the rig does to a pod is one of them."""
+
+    def run(
+        self, script: str, *, timeout_s: float = SSH_CALL_TIMEOUT_S, env: Mapping[str, str] | None = None
+    ) -> Result: ...
+
+    def put(self, local: Sequence[Path], remote_dir: str, *, timeout_s: float = SCP_CALL_TIMEOUT_S) -> Result: ...
+
+    def fetch(self, remote: str, local_dir: Path, *, timeout_s: float = SCP_CALL_TIMEOUT_S) -> Result: ...
+
+
+@dataclass
+class SshTransport:
+    """The real one."""
+
+    host: str
+    port: int
+    user: str = "root"
+    key: Path = SSH_KEY
+    #: Injected so tests can drive the argv builder without a network.
+    runner: "_Runner" = field(default=None)  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.runner is None:
+            self.runner = _subprocess_runner
+
+    @property
+    def _opts(self) -> list[str]:
+        return ["-i", str(self.key), *SSH_OPTS]
+
+    def run(
+        self, script: str, *, timeout_s: float = SSH_CALL_TIMEOUT_S, env: Mapping[str, str] | None = None
+    ) -> Result:
+        # json.dumps, not shlex.quote: the value crosses a shell on THIS box and
+        # a shell on the pod, and a double-quoted JSON string survives both.
+        prelude = "".join(f"export {k}={json.dumps(v)}; " for k, v in (env or {}).items())
+        return self.runner(
+            ["ssh", *self._opts, "-p", str(self.port), f"{self.user}@{self.host}", prelude + script],
+            timeout_s,
+        )
+
+    def put(self, local: Sequence[Path], remote_dir: str, *, timeout_s: float = SCP_CALL_TIMEOUT_S) -> Result:
+        if not local:
+            return Result(0, "")
+        return self.runner(
+            [
+                "scp",
+                *self._opts,
+                "-P",
+                str(self.port),
+                *[str(p) for p in local],
+                f"{self.user}@{self.host}:{remote_dir}",
+            ],
+            timeout_s,
+        )
+
+    def fetch(self, remote: str, local_dir: Path, *, timeout_s: float = SCP_CALL_TIMEOUT_S) -> Result:
+        local_dir.mkdir(parents=True, exist_ok=True)
+        return self.runner(
+            ["scp", *self._opts, "-r", "-P", str(self.port), f"{self.user}@{self.host}:{remote}", str(local_dir)],
+            timeout_s,
+        )
+
+
+class _Runner(Protocol):
+    def __call__(self, argv: Sequence[str], timeout_s: float) -> Result: ...
+
+
+def _subprocess_runner(argv: Sequence[str], timeout_s: float) -> Result:
+    # NOTE: the environment is INHERITED, deliberately — SSH_AUTH_SOCK is the
+    # only usable copy of the passphrase-protected runpod key on this box.
+    try:
+        proc = subprocess.run(list(argv), capture_output=True, text=True, timeout=timeout_s)
+    except subprocess.TimeoutExpired as exc:
+        parts = [exc.stdout or b"", exc.stderr or b""]
+        text = "".join(p.decode(errors="replace") if isinstance(p, bytes) else p for p in parts)
+        return Result(124, f"{text}\n[transport] subprocess produced nothing for {timeout_s}s")
+    return Result(proc.returncode, (proc.stdout or "") + (proc.stderr or ""))

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -105,13 +105,20 @@ class Workload:
         for any length of time without costing the compile.
         """
         exports = "".join(f"export {k}={json.dumps(v)}; " for k, v in sorted(self.env.items()))
+        # A NON-ZERO EXIT MUST LEAVE A MARK. Measured 2026-08-17: the mint
+        # command's `rigcheck` leg aborted with a one-line refusal and no
+        # traceback, so the log simply stopped growing — and a gate that can only
+        # see "the token froze" then paid a full stall budget of rented pod to
+        # learn what the exit code had already said. The wrapper turns every
+        # non-zero exit into the FAIL marker the gate reads on its next tick.
+        wrapped = f"{{ {self.command}; }}; rc=$?; [ $rc -eq 0 ] || echo RIG_FAIL rc=$rc"
         return (
             f"mkdir -p {self.workdir} && cd {self.workdir} && "
             # The forward-compat libcuda binds only at process start and a
             # detached job inherits no login shell — RIG-ENV §3c.
             "{ [ -f /etc/profile.d/zz-cuda-compat.sh ] && . /etc/profile.d/zz-cuda-compat.sh; }; "
             f"{exports}"
-            f"setsid nohup bash -lc {json.dumps(self.command)} > {self.log} 2>&1 & "
+            f"setsid nohup bash -lc {json.dumps(wrapped)} > {self.log} 2>&1 & "
             "echo RIG_LAUNCHED $!"
         )
 
@@ -216,6 +223,7 @@ def mint_family(
     runners: tuple[str, ...] = (),
     install: tuple[str, ...] = (),
     uploads: tuple[Upload, ...] = (),
+    fleet_line: Path | None = None,
     name: str = "mint",
 ) -> Workload:
     """pgw#1331's owed leg as a workload value.
@@ -228,6 +236,18 @@ def mint_family(
     """
     only = " ".join(f"--runner {r}" for r in runners)
     out = f"{POD_ROOT}/cells"
+    # THE FLEET-LINE AUTHORITY HAS TO BE SHIPPED, and finding that out cost a
+    # pod. RIG-ENV §2: rigcheck reads endpoint.toml / fleet-floors.toml /
+    # ENDPOINT dist metadata, and deliberately does NOT accept `gen-worker`'s own
+    # requirement — an SDK certifying its own floor makes every rig pass. This
+    # repository contains none of those files, so a bare pod carrying only
+    # gen-worker aborts `FleetLineUnknown` before it compiles anything. The
+    # workspace's authority is ~/cozy/serverless-endpoints/fleet-floors.toml (and
+    # a per-endpoint endpoint.toml, which is the one that also declares CUDA).
+    env: dict[str, str] = {"TORCHINDUCTOR_CACHE_DIR": "/root/.cache/torchinductor_root"}
+    if fleet_line is not None:
+        uploads = uploads + (Upload(local=fleet_line),)
+        env["GEN_WORKER_FLEET_LINE_FILE"] = f"{POD_ROOT}/{fleet_line.name}"
     command = (
         # rigcheck FIRST: a mint measured off the fleet line is RIG-ENV §5's
         # two false verdicts, and its exit 90/91 is a cheaper answer than a
@@ -245,5 +265,5 @@ def mint_family(
         # The AOTI object cache and the packed cells both grow throughout the
         # compile; the log can be silent for minutes while they do.
         progress_paths=(out, f"{POD_ROOT}/work", "/root/.cache/torchinductor_root", "/root/.triton"),
-        env={"TORCHINDUCTOR_CACHE_DIR": "/root/.cache/torchinductor_root"},
+        env=env,
     )

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -169,7 +169,18 @@ PIN_TORCH = (
 def _pip_install(target: str, index_args: str = "") -> str:
     # `--no-input` so a prompt is a failure rather than a hang, and `-q` so the
     # log's byte growth means work rather than progress bars.
-    parts = ["pip install -q --no-input", f"-c {POD_ROOT}/constraints.txt"]
+    # `--break-system-packages`: MEASURED 2026-08-17 on
+    # pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime — its interpreter is a
+    # Debian EXTERNALLY-MANAGED one, so PEP 668 refuses the install outright and
+    # tells you to build a venv. A venv is the wrong answer here: the image's
+    # site-packages is where the fleet's own torch lives, and an isolated venv
+    # would either shadow it or re-resolve it from an index, which is RIG-ENV
+    # §3a's single most common way a rig drifts. The pod is disposable and
+    # single-purpose; breaking "the system" is the intended outcome.
+    parts = [
+        "pip install -q --no-input --break-system-packages",
+        f"-c {POD_ROOT}/constraints.txt",
+    ]
     if index_args:
         parts.append(index_args)
     # QUOTED: an extras suffix (`…whl[torch]`) is a glob pattern to bash, and an

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -78,6 +78,12 @@ class Workload:
     #: green or red. A failed compile's log is the most valuable thing the
     #: rental produced.
     artifacts: tuple[str, ...] = ()
+    #: Artifacts whose ABSENCE makes the run red no matter what the log said.
+    #: A second, independent statement of "it worked": the done marker says the
+    #: command believed it succeeded, this says it left the thing behind. They
+    #: fail independently, which is the whole point — the first real green this
+    #: rig ever printed was a command that died at line one.
+    required_artifacts: tuple[str, ...] = ()
     #: Remote paths whose byte size is polled as a progress token.
     progress_paths: tuple[str, ...] = ()
     #: Printed by the command when it has finished successfully.
@@ -127,14 +133,26 @@ class Workload:
 
         Deliberately ONE call: three separate ssh round-trips per tick is three
         chances to mistake a flaky connection for a stalled compile.
+
+        **`|| true`, never `|| echo 0`.** `grep -c` prints its count AND exits 1
+        when the count is zero, so `grep -c X f || echo 0` emits the two lines
+        "0\n0" for a log with no match. That is the bug that made this rig report
+        GREEN for a run whose command died at its first line: the done check read
+        the section as a single value, saw "0\n0" != "0", and called it a match.
+        A rig that can fabricate a success is worse than no rig, so the shape is
+        fixed at BOTH ends — the script never emits a second value, and
+        :func:`mint_rig.driver._count` sums whatever it gets.
         """
         paths = " ".join(f"'{p}'" for p in (self.progress_paths or (self.workdir,)))
         return (
             f"echo '--RIG-SIZE--'; du -sb {paths} 2>/dev/null | awk '{{s+=$1}} END {{print s+0}}'; "
-            f"echo '--RIG-BYTES--'; wc -c < '{self.log}' 2>/dev/null || echo 0; "
-            f"echo '--RIG-MARK--'; grep -c -F '{self.done_marker}' '{self.log}' 2>/dev/null || echo 0; "
+            f"echo '--RIG-BYTES--'; {{ wc -c < '{self.log}' 2>/dev/null || true; }}; "
+            f"echo '--RIG-MARK--'; {{ grep -c -F '{self.done_marker}' '{self.log}' 2>/dev/null || true; }}; "
             f"echo '--RIG-FAIL--'; "
-            + "; ".join(f"grep -c -F {json.dumps(m)} '{self.log}' 2>/dev/null || echo 0" for m in self.fail_markers)
+            + "; ".join(
+                f"{{ grep -c -F {json.dumps(m)} '{self.log}' 2>/dev/null || true; }}"
+                for m in self.fail_markers
+            )
             + f"; echo '--RIG-TAIL--'; tail -{tail_lines} '{self.log}' 2>/dev/null || true"
         )
 
@@ -262,6 +280,8 @@ def mint_family(
         setup=install,
         uploads=uploads,
         artifacts=(f"{POD_ROOT}/minted.json", f"{POD_ROOT}/{name}.log", f"{POD_ROOT}/rigboot.json"),
+        # A mint that produced no row produced nothing, whatever the log claims.
+        required_artifacts=(f"{POD_ROOT}/minted.json",),
         # The AOTI object cache and the packed cells both grow throughout the
         # compile; the log can be silent for minutes while they do.
         progress_paths=(out, f"{POD_ROOT}/work", "/root/.cache/torchinductor_root", "/root/.triton"),

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -1,0 +1,238 @@
+"""What to run on the pod — a VALUE, so a new lane writes data, not a driver.
+
+A :class:`Workload` says: what to put on the pod, how to make the code under
+test importable there, the one named command to run, which paths prove progress
+while it runs, which marker means done, and what to bring home. Nothing about
+renting, waiting or paying appears here.
+
+THE THREE DELIVERY MODES, and why all three exist.
+
+``image``   the code is already installed in the image. This is the route
+            pgw#1346's migrated endpoints take: the endpoint image IS the
+            subject, and installing anything over it would measure a different
+            artifact than the fleet runs.
+``wheel``   ``pip install gen-worker==X`` from PyPI. The route for proving a
+            RELEASE — what a pod built from a published wheel actually does.
+``sdist``   a dist file built from the worktree and shipped. The route for
+            proving a LANE, and it is not a convenience: pgw#1337 has the wheel
+            cut blocked, so a lane whose surface is newer than PyPI has no
+            other honest way to reach a card. The row records the dist's sha256,
+            so "which code ran" is a digest rather than a claim.
+
+WHAT A PROGRESS PATH IS FOR. :mod:`mint_rig.progress` needs a token that
+advances for the slowest legitimate work. For a compile the log alone is not
+enough — inductor can print nothing for ten minutes while it writes objects —
+so `progress_paths` names the trees whose byte size is polled alongside the
+log's tail. A path that does not exist yet contributes ``0`` and is not an
+error: an artifact directory appearing IS progress.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Mapping
+
+#: Where the rig works on the pod. One root, so `--artifacts` and the sweep's
+#: recovery instructions can name it without a per-lane convention.
+POD_ROOT = "/root/rig"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class Upload:
+    """One local path shipped to the pod, with the digest of what was shipped."""
+
+    local: Path
+    remote_dir: str = POD_ROOT
+
+    @property
+    def sha256(self) -> str:
+        return sha256_file(self.local) if self.local.is_file() else ""
+
+    def record(self) -> dict[str, str]:
+        return {"local": str(self.local), "remote_dir": self.remote_dir, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class Workload:
+    """One named command and everything it needs."""
+
+    name: str
+    #: The named command. Exactly one, run detached and watched.
+    command: str
+    #: Shell lines run before the command, in order. Each is checked; the first
+    #: non-zero rc fails the setup stage and names the line.
+    setup: tuple[str, ...] = ()
+    uploads: tuple[Upload, ...] = ()
+    #: Remote paths fetched back after the command ends — whether it ended
+    #: green or red. A failed compile's log is the most valuable thing the
+    #: rental produced.
+    artifacts: tuple[str, ...] = ()
+    #: Remote paths whose byte size is polled as a progress token.
+    progress_paths: tuple[str, ...] = ()
+    #: Printed by the command when it has finished successfully.
+    done_marker: str = "RIG_DONE"
+    #: Any of these in the log ends the gate as FAILED, immediately.
+    fail_markers: tuple[str, ...] = ("Traceback (most recent call last)", "RIG_FAIL")
+    env: Mapping[str, str] = field(default_factory=dict)
+    workdir: str = POD_ROOT
+
+    @property
+    def log(self) -> str:
+        return f"{self.workdir}/{self.name}.log"
+
+    def with_uploads(self, *uploads: Upload) -> "Workload":
+        return replace(self, uploads=self.uploads + uploads)
+
+    # ---- the launch line
+    def launch_script(self) -> str:
+        """Start the command DETACHED and return immediately.
+
+        `setsid nohup … &` is not incidental: a command run in the foreground of
+        an ssh session dies with the session, and an ssh session on a freshly
+        booted pod dies for reasons that have nothing to do with the work. The
+        gate then watches the log, so the control box may lose its connection
+        for any length of time without costing the compile.
+        """
+        exports = "".join(f"export {k}={json.dumps(v)}; " for k, v in sorted(self.env.items()))
+        return (
+            f"mkdir -p {self.workdir} && cd {self.workdir} && "
+            # The forward-compat libcuda binds only at process start and a
+            # detached job inherits no login shell — RIG-ENV §3c.
+            "{ [ -f /etc/profile.d/zz-cuda-compat.sh ] && . /etc/profile.d/zz-cuda-compat.sh; }; "
+            f"{exports}"
+            f"setsid nohup bash -lc {json.dumps(self.command)} > {self.log} 2>&1 & "
+            "echo RIG_LAUNCHED $!"
+        )
+
+    def probe_script(self, tail_lines: int = 3) -> str:
+        """One round trip that returns everything a gate observation needs.
+
+        Deliberately ONE call: three separate ssh round-trips per tick is three
+        chances to mistake a flaky connection for a stalled compile.
+        """
+        paths = " ".join(f"'{p}'" for p in (self.progress_paths or (self.workdir,)))
+        return (
+            f"echo '--RIG-SIZE--'; du -sb {paths} 2>/dev/null | awk '{{s+=$1}} END {{print s+0}}'; "
+            f"echo '--RIG-BYTES--'; wc -c < '{self.log}' 2>/dev/null || echo 0; "
+            f"echo '--RIG-MARK--'; grep -c -F '{self.done_marker}' '{self.log}' 2>/dev/null || echo 0; "
+            f"echo '--RIG-FAIL--'; "
+            + "; ".join(f"grep -c -F {json.dumps(m)} '{self.log}' 2>/dev/null || echo 0" for m in self.fail_markers)
+            + f"; echo '--RIG-TAIL--'; tail -{tail_lines} '{self.log}' 2>/dev/null || true"
+        )
+
+    def digest(self) -> str:
+        """A digest of the whole intent, uploads included.
+
+        Two rows with the same `workload_digest` ran the same thing. That is the
+        property a matrix needs and the one a prose 'command' column cannot give.
+        """
+        body: dict[str, Any] = {
+            "name": self.name,
+            "command": self.command,
+            "setup": list(self.setup),
+            "artifacts": list(self.artifacts),
+            "progress_paths": list(self.progress_paths),
+            "done_marker": self.done_marker,
+            "env": dict(sorted(self.env.items())),
+            "workdir": self.workdir,
+            "uploads": [u.record() for u in self.uploads],
+        }
+        return hashlib.sha256(json.dumps(body, sort_keys=True).encode()).hexdigest()
+
+
+# --- the delivery modes ------------------------------------------------------
+
+
+#: Generates a pip constraint file from the torch that is ALREADY INSTALLED.
+#: RIG-ENV §3a: "anything that lists torch as a dependency is installed
+#: --no-deps or from the SAME cu130 index. This is the single most common way a
+#: rig drifts." Deriving the constraint from the interpreter is stronger than
+#: either — the pin cannot be stale, because it is read from the thing it pins.
+PIN_TORCH = (
+    "python3 -c \"import torch,pathlib;"
+    f"pathlib.Path('{POD_ROOT}/constraints.txt')"
+    ".write_text('torch=='+torch.__version__+chr(10))\""
+)
+
+
+def _pip_install(target: str, index_args: str = "") -> str:
+    # `--no-input` so a prompt is a failure rather than a hang, and `-q` so the
+    # log's byte growth means work rather than progress bars.
+    parts = ["pip install -q --no-input", f"-c {POD_ROOT}/constraints.txt"]
+    if index_args:
+        parts.append(index_args)
+    # QUOTED: an extras suffix (`…whl[torch]`) is a glob pattern to bash, and an
+    # unmatched glob is passed through only by accident of the shell's settings.
+    parts.append(f"'{target}'")
+    return " ".join(parts)
+
+
+def install_sdist(dist: Path, extras: str = "", index_args: str = "") -> tuple[str, ...]:
+    """Install the code under test from a locally built dist file.
+
+    `--no-deps` is deliberately NOT used: a family DECLARATION builds its
+    architecture with the model library (diffusers is allowed inside `build`),
+    so an install that skipped dependencies could not trace anything.
+    """
+    target = f"{POD_ROOT}/{dist.name}" + (f"[{extras}]" if extras else "")
+    return (PIN_TORCH, _pip_install(target, index_args))
+
+
+def install_wheel(spec: str, index_args: str = "") -> tuple[str, ...]:
+    """Install a PUBLISHED distribution — the route that proves a RELEASE.
+
+    `spec` is a pip requirement verbatim, e.g. ``gen-worker[torch]==0.121.0``,
+    so the caller states extras and version in the one place pip already has a
+    grammar for.
+    """
+    return (PIN_TORCH, _pip_install(spec, index_args))
+
+
+def mint_family(
+    target: str,
+    *,
+    runners: tuple[str, ...] = (),
+    install: tuple[str, ...] = (),
+    uploads: tuple[Upload, ...] = (),
+    name: str = "mint",
+) -> Workload:
+    """pgw#1331's owed leg as a workload value.
+
+    `gen-worker family mint` needs a GPU and a real toolchain and needs NO
+    weights and NO network for the model — cell identity is checkpoint-free
+    (§4.27) and the constants arrive at arm time from the store. That is what
+    makes a per-family mint pod cheap enough to be routine, and it is why this
+    workload ships no checkpoint machinery at all.
+    """
+    only = " ".join(f"--runner {r}" for r in runners)
+    out = f"{POD_ROOT}/cells"
+    command = (
+        # rigcheck FIRST: a mint measured off the fleet line is RIG-ENV §5's
+        # two false verdicts, and its exit 90/91 is a cheaper answer than a
+        # compile that succeeds against the wrong torch.
+        "python3 -m gen_worker.rigcheck && "
+        f"gen-worker family mint {target} --out-dir {out} {only} "
+        f"--json {POD_ROOT}/minted.json && echo RIG_DONE"
+    )
+    return Workload(
+        name=name,
+        command=command,
+        setup=install,
+        uploads=uploads,
+        artifacts=(f"{POD_ROOT}/minted.json", f"{POD_ROOT}/{name}.log", f"{POD_ROOT}/rigboot.json"),
+        # The AOTI object cache and the packed cells both grow throughout the
+        # compile; the log can be silent for minutes while they do.
+        progress_paths=(out, f"{POD_ROOT}/work", "/root/.cache/torchinductor_root", "/root/.triton"),
+        env={"TORCHINDUCTOR_CACHE_DIR": "/root/.cache/torchinductor_root"},
+    )

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shlex
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Mapping
@@ -117,14 +118,23 @@ class Workload:
         # see "the token froze" then paid a full stall budget of rented pod to
         # learn what the exit code had already said. The wrapper turns every
         # non-zero exit into the FAIL marker the gate reads on its next tick.
-        wrapped = f"{{ {self.command}; }}; rc=$?; [ $rc -eq 0 ] || echo RIG_FAIL rc=$rc"
+        wrapped = f"{{ {self.command}; }}; rc=$?; [ \"$rc\" -eq 0 ] || echo RIG_FAIL rc=$rc"
         return (
             f"mkdir -p {self.workdir} && cd {self.workdir} && "
             # The forward-compat libcuda binds only at process start and a
             # detached job inherits no login shell — RIG-ENV §3c.
             "{ [ -f /etc/profile.d/zz-cuda-compat.sh ] && . /etc/profile.d/zz-cuda-compat.sh; }; "
             f"{exports}"
-            f"setsid nohup bash -lc {json.dumps(wrapped)} > {self.log} 2>&1 & "
+            # SINGLE-quoted, not json.dumps'd. This string crosses TWO shells —
+            # the one ssh starts on the pod, and the `bash -lc` it launches — and
+            # a double-quoted payload lets the FIRST one expand the SECOND one's
+            # variables. Measured: `rc=$?` arrived as `rc=` (the outer shell had
+            # already substituted an unset `$rc`), so the guard read
+            # `[ -eq 0 ]`, errored, and printed RIG_FAIL after every successful
+            # run. Single quotes suppress all expansion, so the payload reaches
+            # bash exactly as written. `$!` below is OUTSIDE the quotes and is
+            # meant for the outer shell.
+            f"setsid nohup bash -lc {shlex.quote(wrapped)} > {self.log} 2>&1 & "
             "echo RIG_LAUNCHED $!"
         )
 

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -227,7 +227,7 @@ def _pip_install(target: str, index_args: str = "") -> str:
 def install_sdist(dist: Path, extras: str = "", index_args: str = "") -> tuple[str, ...]:
     """Install the code under test from a locally built dist file.
 
-    `--no-deps` is deliberately NOT used: a family DECLARATION builds its
+    `--no-deps` is deliberately NOT used: a model DECLARATION builds its
     architecture with the model library (diffusers is allowed inside `build`),
     so an install that skipped dependencies could not trace anything.
     """
@@ -245,7 +245,7 @@ def install_wheel(spec: str, index_args: str = "") -> tuple[str, ...]:
     return (PIN_TORCH, _pip_install(spec, index_args))
 
 
-def mint_family(
+def mint_model(
     target: str,
     *,
     runners: tuple[str, ...] = (),
@@ -256,10 +256,10 @@ def mint_family(
 ) -> Workload:
     """pgw#1331's owed leg as a workload value.
 
-    `gen-worker family mint` needs a GPU and a real toolchain and needs NO
+    `gen-worker model mint` needs a GPU and a real toolchain and needs NO
     weights and NO network for the model — cell identity is checkpoint-free
     (§4.27) and the constants arrive at arm time from the store. That is what
-    makes a per-family mint pod cheap enough to be routine, and it is why this
+    makes a per-model mint pod cheap enough to be routine, and it is why this
     workload ships no checkpoint machinery at all.
     """
     only = " ".join(f"--runner {r}" for r in runners)
@@ -281,7 +281,7 @@ def mint_family(
         # two false verdicts, and its exit 90/91 is a cheaper answer than a
         # compile that succeeds against the wrong torch.
         "python3 -m gen_worker.rigcheck && "
-        f"gen-worker family mint {target} --out-dir {out} {only} "
+        f"gen-worker model mint {target} --out-dir {out} {only} "
         f"--json {POD_ROOT}/minted.json && echo RIG_DONE"
     )
     return Workload(

--- a/scripts/pod_rig.py
+++ b/scripts/pod_rig.py
@@ -2,7 +2,7 @@
 """pgw#1347 — the pod mint-rig, runnable from anywhere.
 
     scripts/pod_rig.py mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
-        --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip
+        --target gen_worker.model.catalog.flux1_dev:FLUX1_DEV --runner clip
     scripts/pod_rig.py sweep
     scripts/pod_rig.py terminate --pod <id>
 

--- a/scripts/pod_rig.py
+++ b/scripts/pod_rig.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""pgw#1347 — the pod mint-rig, runnable from anywhere.
+
+    scripts/pod_rig.py mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
+        --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip
+    scripts/pod_rig.py sweep
+    scripts/pod_rig.py terminate --pod <id>
+
+The package lives in `scripts/mint_rig/` and is deliberately NOT in
+`src/gen_worker`: no pod needs the thing that rents pods, and shipping a control
+plane inside the worker wheel is how a rented machine ends up holding an API key
+it has no use for. This file is the entry point that makes `scripts/` importable
+without a PYTHONPATH the operator has to remember — which matters because the
+kill-set records this exact command as the way to stop a pod.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mint_rig.__main__ import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -177,3 +177,13 @@ LOCAL-ONLY tests/test_micro_mint_rig_pgw978.py|the pgw#978 micro-mint rig is opt
 # divergence ledger parametrized over a list that has been empty since
 # 2026-08-02. None of them had ever run anywhere.
 STAGED tests/convert/test_p8_convert_publish_contract.py|pgw#566 open: normalize_adapter_state_dict only passes unet_config to converters with a named unet_config parameter (ins
+
+# pgw#1347 — the pod mint-rig's ONE row that reaches outside this repository.
+# It proves the gate the rig relies on is podguard's real `assert_armed` and not
+# a lookalike, so it needs the tracker checkout that owns podguard; a CI runner
+# has only this repo. The CONTRACT it guards (a create body without
+# PODGUARD_CONFIG_B64 is refused) is covered in CI by
+# `test_the_rest_layer_refuses_an_unarmed_create`, which fakes the guard — so
+# what is unverified on the runner is only "the real module agrees", and that is
+# verified on every developer box and before every real rental.
+CI-SKIPPED tests/test_pod_mint_rig_pgw1347.py|pgw#1347: podguard is a tracker-checkout peer, absent here

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -244,6 +244,10 @@ def _rig(tmp_path: Path, pods: FakePods, transport: FakeTransport, **kw: Any) ->
         api_key="k",
         out_dir=tmp_path / "runs",
         transport_factory=lambda host, port: transport,
+        # A FIXED key. Reading ~/.ssh/runpod.pub made every row in this file
+        # depend on the developer's home directory; CI has no such file and said
+        # so, 30 rows at a time.
+        public_key="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 pgw1347-test",
         sleep=lambda _s: None,
         log=lambda _m: None,
         tick_s=0.0,
@@ -959,6 +963,21 @@ def test_the_sm86_set_asks_for_every_ampere_sku_not_just_one(tmp_path: Path) -> 
     card = cards_mod.pick("sm86")
     assert len(card.gpu_type_ids) >= 4 and "NVIDIA A40" in card.gpu_type_ids
     assert card.sm_expected == "8.6"
+
+
+def test_a_missing_ssh_key_is_a_REFUSAL_with_a_row_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without an authorized key the pod boots unreachable — a rental that could
+    never be used — so it is refused before the create call, with a banked row."""
+    monkeypatch.setenv("RUNPOD_SSH_PUBLIC_KEY_FILE", str(tmp_path / "nope.pub"))
+    pods = FakePods()
+    rig = _rig(tmp_path, pods, FakeTransport())
+    rig.public_key = ""
+    row = rig.run(cards_mod.pick("sm89"), Workload(name="w", command="x"))
+    assert row.verdict == "refused" and row.failed_stage == "create"
+    assert "no RunPod ssh public key" in row.detail
+    assert pods.created_bodies == [], "nothing was rented"
 
 
 def test_unknown_card_names_the_ones_that_exist() -> None:

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -30,7 +30,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts"))
 
 from mint_rig import cards as cards_mod  # noqa: E402
-from mint_rig.driver import CENSUS, SSHD, Rig, _section  # noqa: E402
+from mint_rig.driver import CENSUS, SSHD, Rig, _count, _section  # noqa: E402
 from mint_rig.killset import KillSet  # noqa: E402
 from mint_rig.progress import Failed, Gate, Observation, Stuck  # noqa: E402
 from mint_rig.rail import Rail, RailTripped  # noqa: E402
@@ -196,10 +196,14 @@ class FakeTransport:
                 tail = "waiting for the hub to answer"
             else:
                 tail = f"[{self._probe_calls}/6] minting clip"
+            # `grep -c` prints its count and exits 1 when the count is zero.
+            # The fake reproduces that shape EXACTLY, because a fake that only
+            # ever emitted a clean "0" is what let the real false-green ship.
             return Result(
                 0,
                 f"--RIG-SIZE--\n{size}\n--RIG-BYTES--\n{100 if self.frozen else size}\n"
-                f"--RIG-MARK--\n{1 if done else 0}\n--RIG-FAIL--\n{1 if fail else 0}\n0\n"
+                f"--RIG-MARK--\n{1 if done else 0}\n"
+                f"--RIG-FAIL--\n{1 if fail else 0}\n0\n"
                 f"--RIG-TAIL--\n{tail}\n",
             )
         if "setsid nohup" in script:
@@ -688,6 +692,85 @@ def test_the_command_is_launched_detached_and_sources_the_compat_shim() -> None:
     # RIG-ENV §3c: a detached job inherits no login shell, so a forward-compat
     # libcuda repair is invisible to it unless it is sourced explicitly.
     assert "/etc/profile.d/zz-cuda-compat.sh" in script
+
+
+def test_a_ZERO_COUNT_IS_NOT_A_MATCH_however_the_shell_spells_it() -> None:
+    """THE WORST DEFECT THIS RIG HAS HAD, as a row.
+
+    `grep -c X f` prints its count AND exits 1 when the count is zero, so the
+    original `grep -c X f || echo 0` emitted "0\n0" for a log with no match. The
+    done check compared the section against the string "0", did not match, and
+    reported GREEN — for a real run whose command died at its first line and
+    produced no artifact at all. A rig that can fabricate a success is worse
+    than no rig.
+
+    Fixed at both ends: the script no longer emits the second value, and the
+    parse SUMS whatever it gets, so no future variation can resurrect it.
+    """
+    assert _count("0") == 0
+    assert _count("0\n0") == 0, "the exact shape that shipped a false green"
+    assert _count("") == 0
+    assert _count("0\n0\n0") == 0
+    assert _count("1") == 1
+    assert _count("0\n3") == 3
+    assert _count("grep: no such file") == 0
+
+
+def test_the_probe_script_never_emits_a_second_zero() -> None:
+    script = Workload(name="w", command="x").probe_script()
+    assert "|| echo 0" not in script, "grep already prints its own zero"
+    assert script.count("|| true") >= 3
+
+
+def test_a_command_that_dies_at_line_one_is_NOT_green(tmp_path: Path) -> None:
+    """The regression, end to end: no marker, no artifact, therefore not green."""
+
+    class DiesImmediately(FakeTransport):
+        def run(self, script: str, *, timeout_s: float = 300.0,
+                env: Mapping[str, str] | None = None) -> Result:
+            if "--RIG-SIZE--" in script:
+                # A tiny log holding a refusal, no marker, and — as the real
+                # shell does — a zero count that grep exits 1 on.
+                return Result(
+                    0,
+                    "--RIG-SIZE--\n0\n--RIG-BYTES--\n213\n--RIG-MARK--\n0\n"
+                    "--RIG-FAIL--\n0\n0\n--RIG-TAIL--\nno fleet-line authority is reachable\n",
+                )
+            return super().run(script, timeout_s=timeout_s, env=env)
+
+    workload = mint_family("m:F", runners=("clip",))
+    row = _rig(tmp_path, FakePods(), DiesImmediately(), stall_ticks=3).run(
+        cards_mod.pick("sm89"), workload
+    )
+    assert row.verdict != "green", "a log with no marker must never read as success"
+    assert row.verdict == "stuck"
+
+
+def test_a_marker_without_the_artifact_is_still_not_green(tmp_path: Path) -> None:
+    """The second, independent statement of success. The marker says the command
+    believed it worked; the artifact says it left the thing behind."""
+
+    class NoArtifact(FakeTransport):
+        def fetch(self, remote: str, local_dir: Path, *, timeout_s: float = 1800.0) -> Result:
+            self.fetched.append(remote)
+            if remote.endswith("minted.json"):
+                return Result(1, "scp: /root/rig/minted.json: No such file or directory")
+            local_dir.mkdir(parents=True, exist_ok=True)
+            (local_dir / Path(remote).name).write_text("x\n")
+            return Result(0, "")
+
+    row = _rig(tmp_path, FakePods(), NoArtifact()).run(
+        cards_mod.pick("sm89"), mint_family("m:F", runners=("clip",))
+    )
+    assert row.verdict == "red" and row.failed_stage == "artifacts"
+    assert "minted.json" in row.detail
+
+
+def test_a_mint_that_DID_produce_its_row_is_green(tmp_path: Path) -> None:
+    row = _rig(tmp_path, FakePods(), FakeTransport()).run(
+        cards_mod.pick("sm89"), mint_family("m:F", runners=("clip",))
+    )
+    assert row.verdict == "green", row.detail
 
 
 def test_the_probe_is_ONE_round_trip_and_parses_into_the_gate_observation() -> None:

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -177,8 +177,9 @@ class FakeTransport:
                 return Result(255, "ssh: connect to host 10.0.0.1 port 40022: Connection refused")
             return Result(0, "")
         if "rigboot.py" in script:
+            # Shaped like the real one: the record, then the bootlog section.
             body = json.dumps({"path": self.rigboot_path, "driver": "580.65.06"})
-            return Result(0, f"RIG_RC={self.rigboot_rc}\n{body}")
+            return Result(0, f"RIG_RC={self.rigboot_rc}\n{body}\n--RIG-BOOTLOG--\n{{not json}}\n")
         if "nvidia-smi" in script:
             return Result(0, "NVIDIA A40, 580.65.06, 8.6\n")
         if "--RIG-SIZE--" in script:
@@ -673,6 +674,25 @@ def test_the_mint_workload_asserts_the_fleet_line_before_it_compiles() -> None:
     # A compile's progress lives in the inductor cache long before the log moves.
     assert "/root/.cache/torchinductor_root" in workload.progress_paths
     assert workload.env["TORCHINDUCTOR_CACHE_DIR"] == "/root/.cache/torchinductor_root"
+
+
+def test_the_preflight_reads_the_record_and_not_the_bootlog_after_it(tmp_path: Path) -> None:
+    """The first real run reported an EMPTY driver beside a perfectly good
+    probe: rigboot prints its record AND writes it to --json, so a naive
+    first-brace-to-last-brace parse spanned two documents and yielded nothing."""
+    row = _rig(tmp_path, FakePods(), FakeTransport()).run(
+        cards_mod.pick("sm89"), Workload(name="w", command="x")
+    )
+    assert row.cuda_path == "native"
+
+
+def test_pip_breaks_the_system_because_the_pod_IS_the_system() -> None:
+    """MEASURED: the fleet base image's interpreter is Debian
+    EXTERNALLY-MANAGED, so PEP 668 refuses the install and recommends a venv —
+    which would shadow or re-resolve the fleet's own torch, RIG-ENV §3a's single
+    most common way a rig drifts."""
+    lines = install_sdist(Path("/tmp/gen_worker-9.whl"))
+    assert "--break-system-packages" in lines[1]
 
 
 def test_the_torch_pin_is_read_from_the_installed_interpreter_not_hardcoded() -> None:

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -37,7 +37,7 @@ from mint_rig.rail import Rail, RailTripped  # noqa: E402
 from mint_rig.row import Teardown  # noqa: E402
 from mint_rig.runpod import PodNotFound, RunpodRest  # noqa: E402
 from mint_rig.transport import Result, SshTransport  # noqa: E402
-from mint_rig.workload import POD_ROOT, Upload, Workload, install_sdist, mint_family  # noqa: E402
+from mint_rig.workload import POD_ROOT, Upload, Workload, install_sdist, mint_model  # noqa: E402
 
 # --------------------------------------------------------------------------- #
 # fakes: the PROVIDER, not the rig
@@ -485,8 +485,8 @@ def test_dry_run_writes_the_killset_and_rents_nothing(tmp_path: Path) -> None:
 def test_a_green_run_records_a_row_a_matrix_can_use(tmp_path: Path) -> None:
     pods, transport = FakePods(rate=0.40), FakeTransport(ssh_ready_after=2)
     guard = FakeGuard()
-    workload = mint_family(
-        "gen_worker.family.catalog.flux1_dev:FLUX1_DEV",
+    workload = mint_model(
+        "gen_worker.model.catalog.flux1_dev:FLUX1_DEV",
         runners=("clip",),
         install=("pip install -q x",),
         uploads=(Upload(local=tmp_path / "d.whl"),),
@@ -688,7 +688,7 @@ def test_the_workload_digest_covers_the_uploads_not_just_the_command(tmp_path: P
 
 
 def test_the_command_is_launched_detached_and_sources_the_compat_shim() -> None:
-    script = Workload(name="mint", command="gen-worker family mint X").launch_script()
+    script = Workload(name="mint", command="gen-worker model mint X").launch_script()
     assert "setsid nohup" in script and script.rstrip().endswith("echo RIG_LAUNCHED $!")
     # RIG-ENV §3c: a detached job inherits no login shell, so a forward-compat
     # libcuda repair is invisible to it unless it is sourced explicitly.
@@ -739,7 +739,7 @@ def test_a_command_that_dies_at_line_one_is_NOT_green(tmp_path: Path) -> None:
                 )
             return super().run(script, timeout_s=timeout_s, env=env)
 
-    workload = mint_family("m:F", runners=("clip",))
+    workload = mint_model("m:F", runners=("clip",))
     row = _rig(tmp_path, FakePods(), DiesImmediately(), stall_ticks=3).run(
         cards_mod.pick("sm89"), workload
     )
@@ -761,7 +761,7 @@ def test_a_marker_without_the_artifact_is_still_not_green(tmp_path: Path) -> Non
             return Result(0, "")
 
     row = _rig(tmp_path, FakePods(), NoArtifact()).run(
-        cards_mod.pick("sm89"), mint_family("m:F", runners=("clip",))
+        cards_mod.pick("sm89"), mint_model("m:F", runners=("clip",))
     )
     assert row.verdict == "red" and row.failed_stage == "artifacts"
     assert "minted.json" in row.detail
@@ -769,7 +769,7 @@ def test_a_marker_without_the_artifact_is_still_not_green(tmp_path: Path) -> Non
 
 def test_a_mint_that_DID_produce_its_row_is_green(tmp_path: Path) -> None:
     row = _rig(tmp_path, FakePods(), FakeTransport()).run(
-        cards_mod.pick("sm89"), mint_family("m:F", runners=("clip",))
+        cards_mod.pick("sm89"), mint_model("m:F", runners=("clip",))
     )
     assert row.verdict == "green", row.detail
 
@@ -819,13 +819,13 @@ def test_the_mint_ships_the_fleet_line_authority_because_the_sdk_is_not_one(tmp_
     files, so a pod carrying only its wheel aborts FleetLineUnknown."""
     authority = tmp_path / "fleet-floors.toml"
     authority.write_text("[floors]\ntorch = \"2.13.0\"\n")
-    workload = mint_family("m:F", runners=("clip",), fleet_line=authority)
+    workload = mint_model("m:F", runners=("clip",), fleet_line=authority)
     assert workload.env["GEN_WORKER_FLEET_LINE_FILE"] == f"{POD_ROOT}/fleet-floors.toml"
     assert any(u.local == authority for u in workload.uploads)
 
 
 def test_the_mint_workload_asserts_the_fleet_line_before_it_compiles() -> None:
-    workload = mint_family("m:F", runners=("clip",))
+    workload = mint_model("m:F", runners=("clip",))
     assert workload.command.startswith("python3 -m gen_worker.rigcheck && ")
     assert "--runner clip" in workload.command
     # A compile's progress lives in the inductor cache long before the log moves.

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -667,6 +667,28 @@ def test_the_probe_is_ONE_round_trip_and_parses_into_the_gate_observation() -> N
     assert _section(sample, "NOPE") == ""
 
 
+def test_a_quiet_non_zero_exit_leaves_a_MARK_and_does_not_cost_a_stall_budget() -> None:
+    """MEASURED: the mint's rigcheck leg aborted with a one-line refusal and no
+    traceback. The log simply stopped growing, so the only signal left was the
+    frozen token — and the gate paid a full stall budget of RENTED POD to learn
+    what the exit code had already said."""
+    script = Workload(name="w", command="do_thing").launch_script()
+    assert "RIG_FAIL rc=$rc" in script
+    assert "RIG_FAIL" in Workload(name="w", command="x").fail_markers[1]
+
+
+def test_the_mint_ships_the_fleet_line_authority_because_the_sdk_is_not_one(tmp_path: Path) -> None:
+    """RIG-ENV §2: rigcheck reads endpoint.toml / fleet-floors.toml / ENDPOINT
+    dist metadata and deliberately refuses gen-worker's own requirement — an SDK
+    certifying its own floor makes every rig pass. This repo ships none of those
+    files, so a pod carrying only its wheel aborts FleetLineUnknown."""
+    authority = tmp_path / "fleet-floors.toml"
+    authority.write_text("[floors]\ntorch = \"2.13.0\"\n")
+    workload = mint_family("m:F", runners=("clip",), fleet_line=authority)
+    assert workload.env["GEN_WORKER_FLEET_LINE_FILE"] == f"{POD_ROOT}/fleet-floors.toml"
+    assert any(u.local == authority for u in workload.uploads)
+
+
 def test_the_mint_workload_asserts_the_fleet_line_before_it_compiles() -> None:
     workload = mint_family("m:F", runners=("clip",))
     assert workload.command.startswith("python3 -m gen_worker.rigcheck && ")

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -564,6 +564,26 @@ def test_a_too_old_host_driver_is_a_REROLL_verdict_not_a_torch_problem(tmp_path:
     assert pods.deleted == ["pod1"], "a re-roll kills the host immediately — that is the saving"
 
 
+def test_a_pod_that_never_answers_is_a_REROLL_not_a_budget_overrun(tmp_path: Path) -> None:
+    """A matrix lane can retry a `reroll`; it must not retry a `railed`, which
+    means the operator's money is genuinely gone. MEASURED: two pods on the same
+    image answered in ~100s while a third sat silent for six minutes."""
+
+    class NeverAnswers(FakePods):
+        def _register(self, name: str) -> dict[str, Any]:
+            record = super()._register(name)
+            record["publicIp"], record["portMappings"] = "", None
+            return record
+
+    pods = NeverAnswers(rate=3_600_000.0)  # $1000/s: the sub-cap trips at once
+    row = _rig(tmp_path, pods, FakeTransport(), rail=Rail(max_usd=1.0)).run(
+        cards_mod.pick("sm89"), Workload(name="w", command="x")
+    )
+    assert row.verdict == "reroll" and row.failed_stage == "preflight"
+    assert "re-roll the host" in row.detail
+    assert pods.deleted == ["pod1"]
+
+
 def test_no_driver_at_all_is_also_a_reroll(tmp_path: Path) -> None:
     row = _rig(tmp_path, FakePods(), FakeTransport(rigboot_rc=92)).run(
         cards_mod.pick("a40"), Workload(name="w", command="x")
@@ -572,13 +592,28 @@ def test_no_driver_at_all_is_also_a_reroll(tmp_path: Path) -> None:
 
 
 def test_the_rail_tears_the_pod_down_and_says_so(tmp_path: Path) -> None:
-    # $1000/second: the arithmetic, not a plausible card. The point is that the
-    # rail is checked at every gate observation, so an exhausted budget stops
-    # the run wherever it is.
-    pods = FakePods(rate=3_600_000.0)
-    rail = Rail(max_usd=0.01)
-    row = _rig(tmp_path, pods, FakeTransport(), rail=rail).run(
-        cards_mod.pick("a40"), Workload(name="w", command="x")
+    """Money running out AFTER the pod came up is `railed`, not `reroll`: the
+    host was fine, the budget is gone, and a matrix lane must not retry it."""
+
+    class LateRail(Rail):
+        """Boot is affordable; the third check is not. Stated directly rather
+        than staged through a rate, because the property under test is WHICH
+        verdict a mid-run exhaustion produces, not the arithmetic (covered
+        above)."""
+
+        checks: int = 0
+
+        def check_sub(self, stage: str, fraction: float, now: float | None = None) -> None:
+            return None
+
+        def check(self, stage: str, now: float | None = None) -> None:
+            self.checks += 1
+            if self.checks > 2:
+                raise RailTripped(f"cap reached during {stage!r}")
+
+    pods = FakePods()
+    row = _rig(tmp_path, pods, FakeTransport(), rail=LateRail(max_usd=1.0)).run(
+        cards_mod.pick("sm89"), Workload(name="w", command="x")
     )
     assert row.verdict == "railed" and row.rail_tripped is True
     assert pods.deleted == ["pod1"]

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -761,8 +761,11 @@ def test_the_real_podguard_gate_is_the_one_we_call() -> None:
 
     try:
         podguard = load_podguard()
-    except RuntimeError as exc:  # the tracker checkout is not on a CI runner
-        pytest.skip(str(exc))
+    except RuntimeError:
+        # A STABLE reason string: the real exception names an absolute path,
+        # which would make this row's scripts/skip_census.txt key differ per
+        # machine and defeat the census that reads it.
+        pytest.skip("pgw#1347: podguard is a tracker-checkout peer, absent here")
     with pytest.raises(podguard.Unarmed):
         podguard.assert_armed({"env": {}})
     podguard.assert_armed({"env": {"PODGUARD_CONFIG_B64": "x"}})

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -112,8 +112,6 @@ class FakePods:
     def registry_auth(self, name: str, username: str, password: str) -> str:
         return "auth1"
 
-    def gpu_types(self) -> list[dict[str, Any]]:
-        return []
 
 
 class FakeGuard:
@@ -369,6 +367,40 @@ def test_gate_defers_to_the_rail() -> None:
             sleep=lambda _s: None,
             rail_check=lambda stage: rail.check(stage, now=1e9),
         ).wait()
+
+
+def test_bring_up_is_bounded_by_MONEY_because_it_has_no_progress_signal() -> None:
+    """MEASURED 2026-08-17: RunPod reports `desiredStatus: RUNNING` from the
+    instant of rent and exposes `publicIp`/`portMappings` only when the
+    container starts — so a 3 GB image pull and a wedged host produce identical
+    records. Staleness cannot separate them, and a tick count pretending to
+    would be the magic timeout this package refuses."""
+    rail = Rail(max_usd=2.0)
+    rail.observe_rate(0.74)
+    rail.clock_started(at=0.0)
+    # 15% of $2.00 is $0.30, which at $0.74/hr is ~24 minutes. DERIVED: the same
+    # fraction on a cheaper card buys proportionally longer.
+    rail.check_sub("endpoint", 0.15, now=1400.0)
+    with pytest.raises(RailTripped, match="no progress signal to be stuck on"):
+        rail.check_sub("endpoint", 0.15, now=1500.0)
+
+
+def test_a_gate_with_no_staleness_rule_waits_as_long_as_the_rail_allows() -> None:
+    calls = {"n": 0}
+
+    def probe() -> Observation:
+        calls["n"] += 1
+        return Observation(reached=calls["n"] >= 500, token="frozen solid")
+
+    Gate("endpoint", probe, stall_ticks=0, tick_s=0.0, sleep=lambda _s: None,
+         rail_check=lambda _stage: None).wait()
+    assert calls["n"] == 500, "a frozen token must not stop a gate that has no staleness rule"
+
+
+def test_a_gate_with_no_staleness_rule_and_no_rail_is_REFUSED() -> None:
+    """Unbounded is worse than a timeout, so it is not reachable."""
+    with pytest.raises(ValueError, match="must carry a rail_check"):
+        Gate("x", lambda: Observation(), stall_ticks=0, tick_s=0.0, sleep=lambda _s: None).wait()
 
 
 # --------------------------------------------------------------------------- #
@@ -678,6 +710,7 @@ def test_the_armed_start_command_is_moved_onto_the_entrypoint(tmp_path: Path) ->
     assert body["dockerEntrypoint"] == ["/bin/bash", "-lc", SSHD]
     assert "dockerStartCmd" not in body
     assert body["gpuTypeIds"] == ["NVIDIA A40"] and body["ports"] == ["22/tcp"]
+    assert body["cloudType"] == "SECURE"
     assert body["env"]["PODGUARD_CONFIG_B64"], "the guard must have armed it"
 
 
@@ -729,6 +762,23 @@ def test_ssh_argv_keeps_the_agent_socket_reachable() -> None:
     argv = seen["argv"]
     assert argv[0] == "ssh" and "root@1.2.3.4" in argv and "40022" in argv
     assert 'export HF_TOKEN="t"; echo hi' == argv[-1]
+
+
+def test_cloud_type_is_omitted_entirely_when_the_provider_should_choose(tmp_path: Path) -> None:
+    pods = FakePods()
+    _rig(tmp_path, pods, FakeTransport(), cloud_type="").run(
+        cards_mod.pick("sm86"), Workload(name="w", command="x")
+    )
+    # Omitted, not sent empty: RunPod reads "" as a cloud type it does not have.
+    assert "cloudType" not in pods.created_bodies[0]
+
+
+def test_the_sm86_set_asks_for_every_ampere_sku_not_just_one(tmp_path: Path) -> None:
+    """MEASURED: `["NVIDIA A40"]` alone answered HTTP 500 out-of-capacity, and
+    the REST API has no availability query, so the SET is the whole strategy."""
+    card = cards_mod.pick("sm86")
+    assert len(card.gpu_type_ids) >= 4 and "NVIDIA A40" in card.gpu_type_ids
+    assert card.sm_expected == "8.6"
 
 
 def test_unknown_card_names_the_ones_that_exist() -> None:

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -1,0 +1,736 @@
+"""pgw#1347 — the pod mint-rig, with the provider faked.
+
+WHY THE REST LAYER IS FAKED HERE AND NOWHERE ELSE. This workspace's standing
+rule is that mocks hide the bugs integration tests catch, and a pod driver is
+exactly the kind of code where that is true. The split this file takes is:
+
+  * everything the driver DECIDES — the mandatory rail, the kill-set written
+    before the create call, stall detection with no clock in it, the three
+    teardown verdicts, the create-window name sweep, the re-roll verdict — is
+    tested here against a fake provider, because those are decisions about
+    money and about leaks and they must be proven on the paths that are hard to
+    reach with a real pod (a create that half-happens; a listing that still
+    carries a deleted pod);
+  * everything the driver ASSERTS ABOUT THE WIRE is proven by the real run
+    recorded on pgw#1347/#1331, not by a mock.
+
+The fakes below therefore imitate the PROVIDER, never the rig.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+from mint_rig import cards as cards_mod  # noqa: E402
+from mint_rig.driver import CENSUS, SSHD, Rig, _section  # noqa: E402
+from mint_rig.killset import KillSet  # noqa: E402
+from mint_rig.progress import Failed, Gate, Observation, Stuck  # noqa: E402
+from mint_rig.rail import Rail, RailTripped  # noqa: E402
+from mint_rig.row import Teardown  # noqa: E402
+from mint_rig.runpod import PodNotFound, RunpodRest  # noqa: E402
+from mint_rig.transport import Result, SshTransport  # noqa: E402
+from mint_rig.workload import POD_ROOT, Upload, Workload, install_sdist, mint_family  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# fakes: the PROVIDER, not the rig
+# --------------------------------------------------------------------------- #
+
+
+class FakePods:
+    """A RunPod account with one pod in it, and every failure mode we care about."""
+
+    def __init__(
+        self,
+        *,
+        rate: float = 0.4,
+        create_raises: Exception | None = None,
+        creates_anyway: bool = False,
+        sticky_listing: bool = False,
+    ) -> None:
+        self.rate = rate
+        self.create_raises = create_raises
+        self.creates_anyway = creates_anyway
+        self.sticky_listing = sticky_listing
+        self.pods: dict[str, dict[str, Any]] = {}
+        self.created_bodies: list[dict[str, Any]] = []
+        self.deleted: list[str] = []
+        self.get_calls = 0
+        self._n = 0
+
+    def create(self, body: Mapping[str, Any]) -> dict[str, Any]:
+        self.created_bodies.append(dict(body))
+        if self.create_raises is not None:
+            if self.creates_anyway:
+                self._register(str(body.get("name", "")))
+            raise self.create_raises
+        return self._register(str(body.get("name", "")))
+
+    def _register(self, name: str) -> dict[str, Any]:
+        self._n += 1
+        pod_id = f"pod{self._n}"
+        record = {
+            "id": pod_id,
+            "name": name,
+            "costPerHr": self.rate,
+            "desiredStatus": "RUNNING",
+            "publicIp": "10.0.0.1",
+            "portMappings": {"22": 40022},
+            "lastStatusChange": "rented: 2026-08-17",
+            "machine": {"gpuTypeId": "NVIDIA A40"},
+        }
+        self.pods[pod_id] = record
+        return record
+
+    def get(self, pod_id: str) -> dict[str, Any]:
+        self.get_calls += 1
+        if pod_id not in self.pods:
+            raise PodNotFound(pod_id)
+        return dict(self.pods[pod_id])
+
+    def list_pods(self) -> list[dict[str, Any]]:
+        if self.sticky_listing:
+            # The failure the third verdict exists for: DELETE answered, the
+            # per-pod GET 404s, and the account listing still carries it.
+            return [dict(r) for r in ({**p} for p in self._all())]
+        return [dict(p) for p in self.pods.values()]
+
+    def _all(self) -> list[dict[str, Any]]:
+        return list(self.pods.values()) + [{"id": pid, "name": "ghost"} for pid in self.deleted]
+
+    def delete(self, pod_id: str) -> None:
+        self.deleted.append(pod_id)
+        self.pods.pop(pod_id, None)
+
+    def registry_auth(self, name: str, username: str, password: str) -> str:
+        return "auth1"
+
+    def gpu_types(self) -> list[dict[str, Any]]:
+        return []
+
+
+class FakeGuard:
+    """podguard, reduced to the two calls the driver makes of it."""
+
+    def __init__(self) -> None:
+        self.armed: list[dict[str, Any]] = []
+        self.released: list[tuple[str, bool, str]] = []
+
+    def rent(
+        self,
+        api_key: str,
+        body: Mapping[str, Any],
+        *,
+        lane: str,
+        lease_seconds: float,
+        orig_cmd: Sequence[str],
+        post: Callable[[Mapping[str, Any]], dict[str, Any]],
+    ) -> dict[str, Any]:
+        armed = dict(body)
+        env = dict(armed.get("env") or {})
+        env["PODGUARD_CONFIG_B64"] = "ZmFrZQ=="
+        armed["env"] = env
+        armed["dockerStartCmd"] = list(orig_cmd)
+        self.armed.append(armed)
+        return post(armed)
+
+    def release(self, pod_id: str, *, confirmed_dead: bool, reason: str) -> None:
+        self.released.append((pod_id, confirmed_dead, reason))
+
+
+class FakeTransport:
+    """A pod that answers. Scripted by substring, because the driver's scripts
+    are the thing under test and matching them exactly would just restate them."""
+
+    def __init__(
+        self,
+        *,
+        ssh_ready_after: int = 0,
+        rigboot_rc: int = 0,
+        rigboot_path: str = "native",
+        setup_fails_at: int | None = None,
+        ticks_to_done: int = 3,
+        workload_fails: bool = False,
+        frozen: bool = False,
+    ) -> None:
+        self.ssh_ready_after = ssh_ready_after
+        self.rigboot_rc, self.rigboot_path = rigboot_rc, rigboot_path
+        self.setup_fails_at = setup_fails_at
+        self.ticks_to_done, self.workload_fails, self.frozen = ticks_to_done, workload_fails, frozen
+        self.scripts: list[str] = []
+        self.puts: list[tuple[list[str], str]] = []
+        self.fetched: list[str] = []
+        self._ssh_calls = 0
+        self._probe_calls = 0
+        self._setup_calls = 0
+
+    def run(self, script: str, *, timeout_s: float = 300.0, env: Mapping[str, str] | None = None) -> Result:
+        self.scripts.append(script)
+        if script.strip() == "true":
+            self._ssh_calls += 1
+            if self._ssh_calls <= self.ssh_ready_after:
+                return Result(255, "ssh: connect to host 10.0.0.1 port 40022: Connection refused")
+            return Result(0, "")
+        if "rigboot.py" in script:
+            body = json.dumps({"path": self.rigboot_path, "driver": "580.65.06"})
+            return Result(0, f"RIG_RC={self.rigboot_rc}\n{body}")
+        if "nvidia-smi" in script:
+            return Result(0, "NVIDIA A40, 580.65.06, 8.6\n")
+        if "--RIG-SIZE--" in script:
+            self._probe_calls += 1
+            size = 0 if self.frozen else self._probe_calls * 1_048_576
+            done = not (self.workload_fails or self.frozen) and self._probe_calls >= self.ticks_to_done
+            fail = self.workload_fails and self._probe_calls >= self.ticks_to_done
+            if fail:
+                tail = "Traceback (most recent call last)"
+            elif self.frozen:
+                # A retry loop reprinting the same line forever: the log has
+                # BYTES but no progress. This is the shape a wall-clock gate
+                # cannot tell apart from a slow compile.
+                tail = "waiting for the hub to answer"
+            else:
+                tail = f"[{self._probe_calls}/6] minting clip"
+            return Result(
+                0,
+                f"--RIG-SIZE--\n{size}\n--RIG-BYTES--\n{100 if self.frozen else size}\n"
+                f"--RIG-MARK--\n{1 if done else 0}\n--RIG-FAIL--\n{1 if fail else 0}\n0\n"
+                f"--RIG-TAIL--\n{tail}\n",
+            )
+        if "setsid nohup" in script:
+            return Result(0, "RIG_LAUNCHED 1234")
+        if script.startswith("mkdir -p") and "&&" not in script:
+            return Result(0, "")
+        self._setup_calls += 1
+        if self.setup_fails_at is not None and self._setup_calls > self.setup_fails_at:
+            return Result(1, "ERROR: could not install")
+        return Result(0, "ok")
+
+    def put(self, local: Sequence[Path], remote_dir: str, *, timeout_s: float = 1800.0) -> Result:
+        self.puts.append(([str(p) for p in local], remote_dir))
+        return Result(0, "")
+
+    def fetch(self, remote: str, local_dir: Path, *, timeout_s: float = 1800.0) -> Result:
+        self.fetched.append(remote)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / Path(remote).name).write_text("artifact\n")
+        return Result(0, "")
+
+
+@pytest.fixture(autouse=True)
+def _killset_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "killset"
+    monkeypatch.setenv("MINT_RIG_KILLSET_DIR", str(root))
+    monkeypatch.setattr("mint_rig.killset.KILLSET_DIR", root)
+    return root
+
+
+def _rig(tmp_path: Path, pods: FakePods, transport: FakeTransport, **kw: Any) -> Rig:
+    guard = kw.pop("guard", None) or FakeGuard()
+    return Rig(
+        rail=kw.pop("rail", None) or Rail(max_usd=2.0),
+        lane=kw.pop("lane", "test"),
+        api=pods,
+        guard=guard,
+        api_key="k",
+        out_dir=tmp_path / "runs",
+        transport_factory=lambda host, port: transport,
+        sleep=lambda _s: None,
+        log=lambda _m: None,
+        tick_s=0.0,
+        **kw,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. the rail is mandatory, and it is money, not a clock
+# --------------------------------------------------------------------------- #
+
+
+def test_rail_refuses_to_exist_without_a_declared_cap() -> None:
+    with pytest.raises(TypeError):
+        Rail()  # type: ignore[call-arg]
+    for bad in (0.0, -1.0):
+        with pytest.raises(ValueError, match="declare a spend rail"):
+            Rail(max_usd=bad)
+
+
+def test_rig_refuses_to_exist_without_a_rail(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="mandatory"):
+        Rig(rail=None, lane="x", api=FakePods(), guard=FakeGuard())  # type: ignore[arg-type]
+
+
+def test_rail_wall_is_derived_from_the_observed_rate_not_a_constant() -> None:
+    rail = Rail(max_usd=2.0)
+    # No rate observed yet: the rig must not invent one.
+    assert rail.wall_seconds == float("inf")
+    rail.observe_rate(0.40)
+    assert rail.wall_seconds == pytest.approx(5.0 * 3600.0)
+    rail.observe_rate(5.98)  # a B200: the SAME cap is a much shorter wall
+    assert rail.wall_seconds == pytest.approx(2.0 / 5.98 * 3600.0)
+
+
+def test_rail_headroom_refuses_to_start_work_it_cannot_finish() -> None:
+    rail = Rail(max_usd=1.0, start_headroom=0.85)
+    rail.observe_rate(1.0)
+    rail.clock_started(at=0.0)
+    rail.may_start("ship", now=3000.0)  # $0.83 spent — still inside the headroom
+    with pytest.raises(RailTripped, match="headroom exhausted"):
+        rail.may_start("ship", now=3100.0)
+    rail.check("workload", now=3100.0)  # mid-stage the cap itself is the bound
+    with pytest.raises(RailTripped, match="reached the declared"):
+        rail.check("workload", now=3700.0)
+
+
+# --------------------------------------------------------------------------- #
+# 2. no magic timeouts: stuck is a frozen token, never an elapsed clock
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_returns_when_the_goal_is_reached() -> None:
+    seen: list[int] = []
+
+    def probe() -> Observation:
+        seen.append(len(seen))
+        return Observation(reached=len(seen) >= 3, token=len(seen))
+
+    result = Gate("s", probe, stall_ticks=2, tick_s=0.0, sleep=lambda _s: None).wait()
+    assert result.reached and len(seen) == 3
+
+
+def test_gate_never_stops_work_that_is_still_moving_however_long_it_takes() -> None:
+    """The whole rule, as a test: a thousand observations, all slow, none stuck.
+
+    A wall-clock gate would have fired long before tick 1000. This one cannot,
+    because the token advanced every time.
+    """
+    calls = {"n": 0}
+
+    def probe() -> Observation:
+        calls["n"] += 1
+        return Observation(reached=calls["n"] >= 1000, token=calls["n"])
+
+    Gate("compile", probe, stall_ticks=3, tick_s=0.0, sleep=lambda _s: None).wait()
+    assert calls["n"] == 1000
+
+
+def test_gate_is_stuck_when_the_token_freezes_and_names_the_token() -> None:
+    with pytest.raises(Stuck) as caught:
+        Gate(
+            "compile",
+            lambda: Observation(token="47 bytes", note="waiting for hub"),
+            stall_ticks=4,
+            tick_s=0.0,
+            sleep=lambda _s: None,
+        ).wait()
+    assert "47 bytes" in str(caught.value)
+    assert caught.value.ticks == 4
+
+
+def test_gate_stall_counter_resets_on_any_progress() -> None:
+    tokens = ["a", "a", "a", "b", "a", "a", "a", "c"]
+    steps = iter(tokens)
+
+    def probe() -> Observation:
+        return Observation(token=next(steps))
+
+    # stall_ticks=3 would fire on a naive counter; it must not, because the
+    # token changed at index 3 and again at 7.
+    with pytest.raises(StopIteration):
+        Gate("s", probe, stall_ticks=3, tick_s=0.0, sleep=lambda _s: None).wait()
+
+
+def test_gate_reports_a_failure_marker_immediately() -> None:
+    with pytest.raises(Failed, match="boom"):
+        Gate(
+            "s",
+            lambda: Observation(failed=True, note="boom"),
+            tick_s=0.0,
+            sleep=lambda _s: None,
+        ).wait()
+
+
+def test_gate_defers_to_the_rail() -> None:
+    rail = Rail(max_usd=0.5)
+    rail.observe_rate(10.0)
+    rail.clock_started(at=0.0)
+
+    with pytest.raises(RailTripped):
+        Gate(
+            "s",
+            lambda: Observation(token=object()),
+            tick_s=0.0,
+            sleep=lambda _s: None,
+            rail_check=lambda stage: rail.check(stage, now=1e9),
+        ).wait()
+
+
+# --------------------------------------------------------------------------- #
+# 3. the kill-set exists before the pod does
+# --------------------------------------------------------------------------- #
+
+
+def test_killset_is_written_before_the_create_call_leaves(tmp_path: Path, _killset_home: Path) -> None:
+    seen: dict[str, Any] = {}
+
+    class WatchingPods(FakePods):
+        def create(self, body: Mapping[str, Any]) -> dict[str, Any]:
+            # At the instant the POST is made, what is on disk?
+            seen["records"] = KillSet.open_records(_killset_home)
+            return super().create(body)
+
+    pods = WatchingPods()
+    rig = _rig(tmp_path, pods, FakeTransport())
+    rig.run(cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE"))
+
+    records = seen["records"]
+    assert len(records) == 1, "the kill-set must be on disk BEFORE the create call"
+    assert records[0]["state"] == "PENDING"
+    assert records[0]["pod_id"] == "", "the id cannot exist yet — that is the point"
+    # And it is stoppable by the one identifier that DOES exist: the name.
+    assert records[0]["pod_name"] in records[0]["kill_by_name"]
+    assert "terminate --name" in records[0]["kill_by_name"]
+    assert records[0]["kill_by_name"].split()[1].startswith("/"), (
+        "the kill command must be absolute — whoever reads it is not in our cwd"
+    )
+
+
+def test_killset_closes_on_a_verified_teardown(tmp_path: Path, _killset_home: Path) -> None:
+    rig = _rig(tmp_path, FakePods(), FakeTransport())
+    rig.run(cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE"))
+    assert KillSet.open_records(_killset_home) == [], "a released rental leaves no open record"
+
+
+def test_a_create_that_half_happened_is_swept_by_name(tmp_path: Path, _killset_home: Path) -> None:
+    """The create-window leak: the pod exists, the response never landed.
+
+    Nobody knows the id — but we chose the name, and the account listing has it.
+    """
+    pods = FakePods(create_raises=RuntimeError("connection reset"), creates_anyway=True)
+    rig = _rig(tmp_path, pods, FakeTransport())
+    row = rig.run(cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE"))
+
+    assert row.verdict == "refused" and row.failed_stage == "create"
+    assert pods.deleted == ["pod1"], "the orphan must be found by name and killed"
+    assert KillSet.open_records(_killset_home) == []
+
+
+def test_a_create_that_truly_failed_leaves_nothing_open(tmp_path: Path, _killset_home: Path) -> None:
+    pods = FakePods(create_raises=RuntimeError("no capacity"))
+    row = _rig(tmp_path, pods, FakeTransport()).run(
+        cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE")
+    )
+    assert row.verdict == "refused"
+    assert pods.deleted == []
+    assert KillSet.open_records(_killset_home) == []
+
+
+def test_dry_run_writes_the_killset_and_rents_nothing(tmp_path: Path) -> None:
+    pods = FakePods()
+    row = _rig(tmp_path, pods, FakeTransport(), dry_run=True).run(
+        cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE")
+    )
+    assert row.verdict == "refused" and pods.created_bodies == []
+    assert Path(row.killset_path).is_file()
+
+
+# --------------------------------------------------------------------------- #
+# 4. the whole cycle, and what the row must carry
+# --------------------------------------------------------------------------- #
+
+
+def test_a_green_run_records_a_row_a_matrix_can_use(tmp_path: Path) -> None:
+    pods, transport = FakePods(rate=0.40), FakeTransport(ssh_ready_after=2)
+    guard = FakeGuard()
+    workload = mint_family(
+        "gen_worker.family.catalog.flux1_dev:FLUX1_DEV",
+        runners=("clip",),
+        install=("pip install -q x",),
+        uploads=(Upload(local=tmp_path / "d.whl"),),
+    )
+    (tmp_path / "d.whl").write_text("wheel bytes")
+
+    row = _rig(tmp_path, pods, transport, guard=guard, lane="pgw1331-clip").run(
+        cards_mod.pick("a40"), workload
+    )
+
+    assert row.verdict == "green", row.detail
+    # asked vs observed are SEPARATE columns — a row that conflates them
+    # measures an intention, not a machine.
+    assert row.asked_gpu == "a40" and row.asked_gpu_type_ids == ["NVIDIA A40"]
+    assert row.observed_gpu == "NVIDIA A40" and row.observed_sm == "8.6"
+    assert row.sm_expected == "8.6" and row.driver_version == "580.65.06"
+    assert row.cuda_path == "native"
+    # cost is runtime x the rate the PROVIDER returned
+    assert row.rate_per_hr == 0.40
+    assert row.est_cost_usd == round(0.40 * row.pod_seconds / 3600.0, 4)
+    assert row.rail_usd == 2.0 and row.rail_tripped is False
+    # digests, so "which code ran" survives the month
+    assert len(row.workload_digest) == 64
+    assert row.uploads[0]["sha256"] == Upload(local=tmp_path / "d.whl").sha256
+    assert any(a["remote"].endswith("minted.json") and a["fetched"] for a in row.artifacts)
+    assert all(a["sha256"] for a in row.artifacts if a["fetched"])
+    # teardown, three ways
+    assert row.teardown.delete_issued and row.teardown.get_404 and row.teardown.absent_from_list
+    assert guard.released == [("pod1", True, "mint-rig green")]
+    # and the row is on disk under a stable name
+    banked = json.loads((tmp_path / "runs" / f"{row.pod_name}.row.json").read_text())
+    assert banked["verdict"] == "green"
+
+
+def test_the_ssh_gate_waits_for_the_pod_to_ANSWER_not_for_rest_to_say_running(tmp_path: Path) -> None:
+    transport = FakeTransport(ssh_ready_after=5)
+    row = _rig(tmp_path, FakePods(), transport).run(
+        cards_mod.pick("a40"), Workload(name="w", command="echo RIG_DONE")
+    )
+    assert row.verdict == "green"
+    assert sum(1 for s in transport.scripts if s.strip() == "true") == 6
+
+
+def test_artifacts_are_captured_even_when_the_workload_fails(tmp_path: Path) -> None:
+    transport = FakeTransport(workload_fails=True)
+    workload = Workload(name="mint", command="x", artifacts=(f"{POD_ROOT}/minted.json",))
+    row = _rig(tmp_path, FakePods(), transport).run(cards_mod.pick("a40"), workload)
+
+    assert row.verdict == "red" and row.failed_stage.startswith("workload")
+    assert f"{POD_ROOT}/minted.json" in transport.fetched
+    assert f"{POD_ROOT}/mint.log" in transport.fetched, "the failed run's log is the valuable part"
+    assert row.teardown.confirmed
+
+
+def test_a_frozen_workload_is_stuck_and_the_pod_still_dies(tmp_path: Path) -> None:
+    pods = FakePods()
+    row = _rig(tmp_path, pods, FakeTransport(frozen=True), stall_ticks=4).run(
+        cards_mod.pick("a40"), Workload(name="w", command="x")
+    )
+    assert row.verdict == "stuck"
+    assert pods.deleted == ["pod1"], "a stuck workload must not leave a pod billing"
+
+
+def test_a_setup_failure_is_red_and_names_the_line(tmp_path: Path) -> None:
+    workload = Workload(name="w", command="x", setup=("pip install a", "pip install b"))
+    row = _rig(tmp_path, FakePods(), FakeTransport(setup_fails_at=0)).run(cards_mod.pick("a40"), workload)
+    assert row.verdict == "red" and row.failed_stage == "setup"
+    assert "pip install a" in row.detail
+
+
+def test_a_too_old_host_driver_is_a_REROLL_verdict_not_a_torch_problem(tmp_path: Path) -> None:
+    """RIG-ENV §3c: 'driver too old' is a HOST fact. Do not downgrade torch."""
+    pods = FakePods()
+    row = _rig(tmp_path, pods, FakeTransport(rigboot_rc=91, rigboot_path="reroll")).run(
+        cards_mod.pick("a40"), Workload(name="w", command="x")
+    )
+    assert row.verdict == "reroll" and row.failed_stage == "preflight"
+    assert "re-roll" in row.detail
+    assert pods.deleted == ["pod1"], "a re-roll kills the host immediately — that is the saving"
+
+
+def test_no_driver_at_all_is_also_a_reroll(tmp_path: Path) -> None:
+    row = _rig(tmp_path, FakePods(), FakeTransport(rigboot_rc=92)).run(
+        cards_mod.pick("a40"), Workload(name="w", command="x")
+    )
+    assert row.verdict == "reroll" and "no NVIDIA driver" in row.detail
+
+
+def test_the_rail_tears_the_pod_down_and_says_so(tmp_path: Path) -> None:
+    # $1000/second: the arithmetic, not a plausible card. The point is that the
+    # rail is checked at every gate observation, so an exhausted budget stops
+    # the run wherever it is.
+    pods = FakePods(rate=3_600_000.0)
+    rail = Rail(max_usd=0.01)
+    row = _rig(tmp_path, pods, FakeTransport(), rail=rail).run(
+        cards_mod.pick("a40"), Workload(name="w", command="x")
+    )
+    assert row.verdict == "railed" and row.rail_tripped is True
+    assert pods.deleted == ["pod1"]
+
+
+# --------------------------------------------------------------------------- #
+# 5. teardown: three verdicts, because each one alone has lied
+# --------------------------------------------------------------------------- #
+
+
+def test_teardown_is_unconfirmed_while_the_account_listing_still_carries_the_pod(tmp_path: Path) -> None:
+    pods = FakePods(sticky_listing=True)
+    row = _rig(tmp_path, pods, FakeTransport()).run(cards_mod.pick("a40"), Workload(name="w", command="x"))
+
+    assert row.teardown.delete_issued and row.teardown.get_404
+    assert row.teardown.absent_from_list is False
+    assert row.teardown.confirmed is False, "404 alone is not proof the pod stopped billing"
+    assert row.teardown.attempts == 30, "an unconfirmed teardown is retried, not accepted"
+
+
+def test_teardown_confirmed_needs_both_the_404_and_the_listing() -> None:
+    assert Teardown(delete_issued=True, get_404=True, absent_from_list=True).confirmed
+    assert not Teardown(delete_issued=True, get_404=True).confirmed
+    assert not Teardown(delete_issued=True, absent_from_list=True).confirmed
+    assert not Teardown(delete_issued=True).confirmed
+
+
+def test_terminate_by_name_finds_the_pod_and_kills_it(tmp_path: Path) -> None:
+    pods = FakePods()
+    pods.create({"name": "mintrig-orphan-1"})
+    rig = _rig(tmp_path, pods, FakeTransport())
+    row = rig.terminate(name="mintrig-orphan-1")
+    assert row.teardown.confirmed and pods.deleted == ["pod1"]
+
+
+def test_sweep_flags_a_live_pod_NOBODY_attends(tmp_path: Path) -> None:
+    pods = FakePods()
+    pods.create({"name": "someone-elses-pod"})
+    report = _rig(tmp_path, pods, FakeTransport()).sweep(leases={})
+    assert report["unattended"] == ["pod1"]
+    assert report["live_pods"][0]["known_to_mint_rig"] is False
+
+
+def test_sweep_does_not_cry_wolf_over_a_sibling_lanes_attended_pod(tmp_path: Path) -> None:
+    """An alarm that fires on every healthy pod is one nobody reads."""
+    pods = FakePods()
+    pods.create({"name": "another-lanes-pod"})
+    report = _rig(tmp_path, pods, FakeTransport()).sweep(leases={"pod1": "svdq-bench-b200"})
+    assert report["unrecorded_live"] == ["pod1"], "it is still not OURS, and the row says so"
+    assert report["unattended"] == [], "but podguard attends it, so it is not a leak"
+    assert report["live_pods"][0]["podguard_lane"] == "svdq-bench-b200"
+
+
+# --------------------------------------------------------------------------- #
+# 6. the workload is a value, and the scripts it generates say what they mean
+# --------------------------------------------------------------------------- #
+
+
+def test_the_workload_digest_covers_the_uploads_not_just_the_command(tmp_path: Path) -> None:
+    dist = tmp_path / "gen_worker-0.1.whl"
+    dist.write_text("one")
+    a = Workload(name="w", command="c", uploads=(Upload(local=dist),))
+    first = a.digest()
+    dist.write_text("two")
+    assert a.digest() != first, "different bytes shipped is a different workload"
+    assert Workload(name="w", command="c").digest() != first
+
+
+def test_the_command_is_launched_detached_and_sources_the_compat_shim() -> None:
+    script = Workload(name="mint", command="gen-worker family mint X").launch_script()
+    assert "setsid nohup" in script and script.rstrip().endswith("echo RIG_LAUNCHED $!")
+    # RIG-ENV §3c: a detached job inherits no login shell, so a forward-compat
+    # libcuda repair is invisible to it unless it is sourced explicitly.
+    assert "/etc/profile.d/zz-cuda-compat.sh" in script
+
+
+def test_the_probe_is_ONE_round_trip_and_parses_into_the_gate_observation() -> None:
+    workload = Workload(name="mint", command="x", progress_paths=("/root/rig/cells",))
+    script = workload.probe_script()
+    for section in ("SIZE", "BYTES", "MARK", "FAIL", "TAIL"):
+        assert f"--RIG-{section}--" in script
+    assert "/root/rig/cells" in script
+    sample = "--RIG-SIZE--\n123\n--RIG-BYTES--\n45\n--RIG-MARK--\n0\n--RIG-FAIL--\n0\n--RIG-TAIL--\nminting clip\n"
+    assert _section(sample, "SIZE") == "123"
+    assert _section(sample, "TAIL") == "minting clip"
+    assert _section(sample, "NOPE") == ""
+
+
+def test_the_mint_workload_asserts_the_fleet_line_before_it_compiles() -> None:
+    workload = mint_family("m:F", runners=("clip",))
+    assert workload.command.startswith("python3 -m gen_worker.rigcheck && ")
+    assert "--runner clip" in workload.command
+    # A compile's progress lives in the inductor cache long before the log moves.
+    assert "/root/.cache/torchinductor_root" in workload.progress_paths
+    assert workload.env["TORCHINDUCTOR_CACHE_DIR"] == "/root/.cache/torchinductor_root"
+
+
+def test_the_torch_pin_is_read_from_the_installed_interpreter_not_hardcoded() -> None:
+    lines = install_sdist(Path("/tmp/gen_worker-9.whl"))
+    assert "torch.__version__" in lines[0], "RIG-ENV §2: the numbers are READ, never hardcoded"
+    assert "13.0" not in "".join(lines) and "2.13" not in "".join(lines)
+    assert f"-c {POD_ROOT}/constraints.txt" in lines[1]
+
+
+def test_the_start_command_installs_an_sshd_because_the_fleet_image_ships_none() -> None:
+    # RIG-ENV §3a. Also: the fleet image must be the PUBLIC upstream tag —
+    # RunPod exits a pod ~1s after rent, with no logs, for an unpullable one.
+    assert "openssh-server" in SSHD and "sshd -D" in SSHD
+    assert cards_mod.FLEET_IMAGE == (
+        "pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime"  # oci-image: the asserted tag
+    )
+    assert "tensorhub/endpoints" not in cards_mod.FLEET_IMAGE
+
+
+def test_the_census_reads_the_card_from_the_pod(tmp_path: Path) -> None:
+    assert "nvidia-smi" in CENSUS and "compute_cap" in CENSUS
+
+
+# --------------------------------------------------------------------------- #
+# 7. the create body, and the th#1327 gate
+# --------------------------------------------------------------------------- #
+
+
+def test_the_armed_start_command_is_moved_onto_the_entrypoint(tmp_path: Path) -> None:
+    """RunPod treats dockerEntrypoint=[] as unset and lets the IMAGE win, so an
+    armed dockerStartCmd on an image with its own entrypoint never runs."""
+    pods = FakePods()
+    _rig(tmp_path, pods, FakeTransport()).run(cards_mod.pick("a40"), Workload(name="w", command="x"))
+    body = pods.created_bodies[0]
+    assert body["dockerEntrypoint"] == ["/bin/bash", "-lc", SSHD]
+    assert "dockerStartCmd" not in body
+    assert body["gpuTypeIds"] == ["NVIDIA A40"] and body["ports"] == ["22/tcp"]
+    assert body["env"]["PODGUARD_CONFIG_B64"], "the guard must have armed it"
+
+
+def test_the_rest_layer_refuses_an_unarmed_create() -> None:
+    """th#1327's gate, on OUR http path — podguard installs it on its own."""
+
+    class Refuser:
+        class Unarmed(RuntimeError):
+            pass
+
+        def assert_armed(self, body: Mapping[str, Any]) -> None:
+            if not (body.get("env") or {}).get("PODGUARD_CONFIG_B64"):
+                raise self.Unarmed("unarmed")
+
+    rest = RunpodRest("key", guard=Refuser())
+    with pytest.raises(RuntimeError, match="unarmed"):
+        rest.create({"name": "x", "env": {}})
+
+
+def test_the_real_podguard_gate_is_the_one_we_call() -> None:
+    """Proves the assertion we rely on is podguard's, not a lookalike.
+
+    Skipped where the tracker checkout is absent (CI): the CONTRACT is that a
+    body without PODGUARD_CONFIG_B64 is refused, and the test above proves the
+    rig honours it. This one proves the real module agrees.
+    """
+    from mint_rig.runpod import load_podguard
+
+    try:
+        podguard = load_podguard()
+    except RuntimeError as exc:  # the tracker checkout is not on a CI runner
+        pytest.skip(str(exc))
+    with pytest.raises(podguard.Unarmed):
+        podguard.assert_armed({"env": {}})
+    podguard.assert_armed({"env": {"PODGUARD_CONFIG_B64": "x"}})
+
+
+def test_ssh_argv_keeps_the_agent_socket_reachable() -> None:
+    """The runpod key on the box is passphrase-protected: the agent holds the
+    only usable copy, so a transport that sanitised the environment would fail
+    in a way that looks exactly like a slow boot."""
+    seen: dict[str, Any] = {}
+
+    def runner(argv: Sequence[str], timeout_s: float) -> Result:
+        seen["argv"] = list(argv)
+        return Result(0, "")
+
+    SshTransport("1.2.3.4", 40022, runner=runner).run("echo hi", env={"HF_TOKEN": "t"})
+    argv = seen["argv"]
+    assert argv[0] == "ssh" and "root@1.2.3.4" in argv and "40022" in argv
+    assert 'export HF_TOKEN="t"; echo hi' == argv[-1]
+
+
+def test_unknown_card_names_the_ones_that_exist() -> None:
+    with pytest.raises(KeyError, match="a40"):
+        cards_mod.pick("nope")

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -595,28 +595,29 @@ def test_no_driver_at_all_is_also_a_reroll(tmp_path: Path) -> None:
     assert row.verdict == "reroll" and "no NVIDIA driver" in row.detail
 
 
-def test_the_rail_tears_the_pod_down_and_says_so(tmp_path: Path) -> None:
+def test_the_rail_tears_the_pod_down_and_says_so(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Money running out AFTER the pod came up is `railed`, not `reroll`: the
-    host was fine, the budget is gone, and a matrix lane must not retry it."""
+    host was fine, the budget is gone, and a matrix lane must not retry it.
 
-    class LateRail(Rail):
-        """Boot is affordable; the third check is not. Stated directly rather
-        than staged through a rate, because the property under test is WHICH
-        verdict a mid-run exhaustion produces, not the arithmetic (covered
-        above)."""
+    Boot is made affordable and the third check is not, stated directly rather
+    than staged through a rate — the property under test is WHICH verdict a
+    mid-run exhaustion produces, and the arithmetic that decides WHEN is covered
+    above.
+    """
+    calls = {"n": 0}
 
-        checks: int = 0
+    def late_check(self: Any, stage: str, now: float | None = None) -> None:
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise RailTripped(f"cap reached during {stage!r}")
 
-        def check_sub(self, stage: str, fraction: float, now: float | None = None) -> None:
-            return None
-
-        def check(self, stage: str, now: float | None = None) -> None:
-            self.checks += 1
-            if self.checks > 2:
-                raise RailTripped(f"cap reached during {stage!r}")
+    monkeypatch.setattr(Rail, "check", late_check)
+    monkeypatch.setattr(Rail, "check_sub", lambda *a, **k: None)
 
     pods = FakePods()
-    row = _rig(tmp_path, pods, FakeTransport(), rail=LateRail(max_usd=1.0)).run(
+    row = _rig(tmp_path, pods, FakeTransport(), rail=Rail(max_usd=1.0)).run(
         cards_mod.pick("sm89"), Workload(name="w", command="x")
     )
     assert row.verdict == "railed" and row.rail_tripped is True
@@ -793,6 +794,22 @@ def test_a_quiet_non_zero_exit_leaves_a_MARK_and_does_not_cost_a_stall_budget() 
     script = Workload(name="w", command="do_thing").launch_script()
     assert "RIG_FAIL rc=$rc" in script
     assert "RIG_FAIL" in Workload(name="w", command="x").fail_markers[1]
+
+
+def test_the_launch_payload_survives_BOTH_shells_it_crosses() -> None:
+    """It crosses the shell ssh starts on the pod AND the `bash -lc` that shell
+    launches. A double-quoted payload lets the FIRST expand the SECOND's
+    variables: measured, `rc=$?` arrived as `rc=` and the guard `[ -eq 0 ]`
+    errored, printing RIG_FAIL after every SUCCESSFUL run — a fail marker that
+    always fires is a fail marker that means nothing."""
+    script = Workload(name="mint", command="echo hi && echo RIG_DONE").launch_script()
+    payload = script.split("bash -lc ", 1)[1].split(" > ", 1)[0]
+    assert payload.startswith("'") and payload.endswith("'"), (
+        "the payload must be SINGLE-quoted; single quotes suppress every expansion"
+    )
+    assert "$rc" in payload and "$?" in payload, "which is why the variables survive verbatim"
+    # `$!` is deliberately OUTSIDE the quotes: it is for the outer shell.
+    assert script.endswith("echo RIG_LAUNCHED $!")
 
 
 def test_the_mint_ships_the_fleet_line_authority_because_the_sdk_is_not_one(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes the gap pgw#1331 recorded in its own owed row: *"no lightweight 'rent a pod and run a command' primitive exists in pgw"*. Paul's Compile Gauntlet needs the opposite — many pods, routinely, proving that every model we support compiles, re-uses and serves.

`scripts/mint_rig` is a typed, unit-tested driver whose interface is a `Workload` **value** plus a card, so a new lane writes data rather than another pod driver (the mechanism `research/RIG-ENV.md` §5 blames for two false verdicts and ~$11 of wasted rental).

```
task rig:pod -- mint --gpu a40 --rail 2.00 --lane pgw1331-clip \
  --target gen_worker.family.catalog.flux1_dev:FLUX1_DEV --runner clip
task rig:pod -- sweep                    # live pods vs every record
task rig:pod -- terminate --pod <id>
```

### Four rules, enforced rather than documented

1. **A spend rail is mandatory.** `Rail(max_usd=…)` has no default and refuses zero; `Rig` cannot be constructed without one. The cap becomes a wall using the rate the create response *actually returned*, so the same $2 is five hours on an A40 and twenty minutes on a B200.
2. **The kill command is written before the pod exists** — fsynced, keyed by the pod name we are about to ask for, before the POST leaves. podguard's own record is built from the create *response* and has the same blind spot. A failed create sweeps the account for that name and kills what it finds. podguard (th#1327) is armed as well and is not optional.
3. **No magic timeouts.** Every wait is a `Gate` over a goal predicate and a progress token; the only negative verdict is `stuck`. Bring-up pairs the pod's REST record with ssh's own stderr; a compile watches log bytes + last line + inductor cache size together, because inductor can print nothing for ten minutes while it writes objects.
4. **Teardown is verified three ways** — DELETE, GET 404, absent from the listing — and all three land in the row.

### The row

`asked_gpu` vs `observed_gpu`/`observed_sm` (the pick names a card *set*; `nvidia-smi` says what arrived), native-vs-compat driver path, runtime × the provider's rate, upload and artifact digests, and a closed verdict vocabulary: `green | red | stuck | railed | reroll | refused`.

Host preflight runs `gen_worker.rigboot` before anything is downloaded, so RIG-ENV §3c's twenty-minutes-in "driver too old" is a `reroll` and a dead pod at minute two. Artifacts are captured under every outcome.

### Tests

40 rows, faking the **provider** and never the rig: the mandatory rail, the create-window leak, a frozen workload, a sticky account listing, a too-old driver, and a thousand-tick compile a wall-clock gate would have killed. `scripts/mint_rig` joins the `mypy --strict` and `ruff` invocations — it is control-plane code that must not ship in the wheel, but it spends money.

### Drive-by

`scripts/lint_repo_ref_pins.py` claimed container image tags "never match the shape at all"; `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime` is `<owner>/<repo>:<tag>` exactly. It gained a third line-level proof marker, `# oci-image:`, with red and green selftest rows — a path allowlist would have let a real pin hide behind a filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
