### PR TITLE
pgw#1344: the HF→GGUF tensor plane reads and writes through tensorfs, and the GGUF composes through the store

### DIFF
--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -294,6 +294,27 @@ gen_worker.boot_phases.servable_ms()
 # reasoning around it reads like enforcement; the ratchet has to make it say so
 # out loud.
 #
+#   pgw#1344 (this lane) — the NATIVE HF->GGUF tensor plane. `gguf_native.py`
+#   reads a snapshot's tensors through tensorfs, maps and permutes them, and
+#   composes the GGUF through `TensorWriter` so an unchanged tensor keeps the
+#   CAS objects it already has (measured in
+#   `tests/test_gguf_native_pgw1344.py`: two tensors / two objects shared with
+#   the safetensors source at f32, zero at f16, and the permuted pair correctly
+#   sharing nothing). It has no production caller for ONE reason, and it is a
+#   reason rather than an omission: `_run_gguf_inline` cannot switch to it until
+#   something produces the GGUF METADATA block — a model's vocabulary, chat
+#   template and pre-tokenizer identity — and today only `convert_hf_to_gguf.py`
+#   does. Shipping a guessed vocabulary is precisely the silent change pgw#1344
+#   exists to prevent, so the tensor half lands proven and the switch waits.
+#
+#     OWNER:  pgw#1344's follow-up — a faithful native metadata/vocabulary
+#             producer (or a reference run scoped to the tokenizer sidecars,
+#             which is a few MB rather than the multi-GB weights). The switch
+#             in `convert/convert.py::_run_gguf_inline` is one call once that
+#             exists, and `convert/gguf_tools.py`'s subprocess dies with it.
+#     EXPIRY: that issue. If these two rows outlive it, the tensor plane was
+#             never wired and this guard was right the first time.
+#
 # Delisted by WIRING under pgw#1271:
 #   boot_key.assert_memo_honest — called from `mint_supervisor.rule_on_boot_memo`
 #     at the seal/publish seam, the one moment a pod holds a freshly TRACED
@@ -314,6 +335,8 @@ gen_worker.convert.base_model_families.reset_foreign_family_maps()
 gen_worker.convert.dataset.Dataset.as_dataloader()
 gen_worker.convert.dataset.Dataset.is_prompt_corpus()
 gen_worker.convert.dataset.Dataset.iter_rows()
+gen_worker.convert.gguf_native.convert_snapshot_to_gguf()
+gen_worker.convert.gguf_native.hyperparameter_metadata()
 gen_worker.convert.layout_converters.ConversionIO.set_metadata()
 gen_worker.convert.layout_converters.classify_layout()
 gen_worker.convert.layout_converters.conversion_provenance()

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -48,10 +48,11 @@ subdir = "python/src/tensorfs"
 # and it is byte-identical to `8bafdfbb` except for the `rewrites` below.
 #
 # pgw#1330: THE SNAPSHOT IS SPLIT AT TWO REVS, ON PURPOSE, PERMANENTLY (see
-# the ownership ruling below), AND THIS IS THE ONLY RECORD OF IT. `project.py`, `tensors.py` and `gguf.py` come from
-# `read_plane_rev` below, NOT from `rev`. They are the consumption plane the
-# whole mixed-CAS cutover rests on — TFSSTUB1 render/parse, tree projection,
-# and the direct tensor reader — and they DID NOT EXIST at `8bafdfbb`.
+# the ownership ruling below), AND THIS IS THE ONLY RECORD OF IT. Every file in
+# `read_plane_files` comes from `read_plane_rev` below, NOT from `rev`. They are
+# the consumption plane the whole mixed-CAS cutover rests on — TFSSTUB1
+# render/parse, tree projection, the direct tensor reader and (pgw#1344) the
+# tensor WRITER — and they DID NOT EXIST at `8bafdfbb`.
 #
 # Why not simply bump `rev`: the newer lineage DELETED `LocalCAS.ingest_file`,
 # `LocalCAS.ingest_repository`, `LocalCAS.collect_garbage`,
@@ -107,10 +108,36 @@ subdir = "python/src/tensorfs"
 # in force here, so nothing the read plane is handed can be a manifest the
 # storage half would have refused. `tests/test_projected_tree_pgw1330.py`
 # proves the pairing executes rather than asserting it from imports.
-read_plane_rev = "333bb10016c328c5e3a275de2a2a314dbd0abcaf"
-read_plane_files = ["gguf.py", "project.py", "tensors.py"]
+#
+# pgw#1344: THE CONSUMPTION PLANE IS NOW A READ **AND WRITE** PLANE, and its
+# rev advances from `333bb10` to `21cec66` (tensorfs#106) to get `writer.py`.
+# `TensorWriter` composes a snapshot one tensor at a time in safetensors OR
+# GGUF on the seal planner's own object grid, which is the only way a converted
+# GGUF can share tensor objects with its safetensors source instead of being a
+# second copy of every byte. `convert/gguf_native.py` is its first caller.
+# `__init__.py` comes from this rev too and is now upstream's VERBATIM — the
+# pgw#1308 rewrite that used to live here is gone, because upstream itself no
+# longer re-exports a Python transfer plane. `project.py` is byte-identical at
+# both revs, so nothing about the projection half moved.
+#
+# ONE REWRITE IS REAL, and it is in `tensors.py`. At `21cec66` upstream's
+# `TensorReader._map` maps through the compiled extension
+# (`from .native import MappedObject`) and its comment says there is NO
+# fallback. pgw#1310 rules a compiled extension out of a source-vendored wheel,
+# so a straight take of that file would have deleted native tensor reads from
+# this repo outright. The rewrite restores the mapping in pure Python —
+# `_MappedObject`, an `mmap` exported through PEP 688's `__buffer__` — and it
+# is a restoration rather than a downgrade: upstream needed exactly two things
+# from the extension at that call site, a WEAK-REFERENCEABLE handle (so
+# `_maps` can stay the `WeakValueDictionary` that keeps an 8 GiB shard from
+# ending up resident) and a buffer that keeps its mapping alive for as long as
+# some view of it exists. A bare `mmap.mmap` supplies neither; a py3.12 class
+# with `__buffer__` supplies both, and py3.12 is this package's floor. Nothing
+# else in the file is touched, so every other line is still upstream's.
+read_plane_rev = "21cec66a580cb232210facbfccfa580a16d7196e"
+read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "writer.py"]
 rewrites = [
-  "`__init__.py`: the `transfer`, `journal` and `daemon` re-exports are gone with the modules (pgw#1308), and the `project`/`tensors` re-exports are added with the read plane (pgw#1330). No other file is touched, so the remaining digests are still upstream's.",
+  "`tensors.py`: `TensorReader._map` maps through a pure-Python `_MappedObject` (an `mmap` exported via PEP 688) instead of the compiled `tensorfs.native.MappedObject`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. Upstream's weak-mapping ownership rule is preserved exactly; see the paragraph above. No other file is edited, so the remaining digests are upstream's verbatim.",
 ]
 
 [packages.torchcg]
@@ -175,15 +202,16 @@ rewrites = [
 ]
 
 [packages.tensorfs.files]
-"__init__.py" = "51e60fc07782af7ff738c889be2fb1d9fa81224abfc0dfe546dde9d2191cf21b"
+"__init__.py" = "a66ced3cd03e042989602b9e122e4b3988be6be6611aacdb05b852c8a968ec7b"
 "chunking.py" = "69333dc0836f35b05c420780b7eac205993ebde54c1b91b1afe03e55c313bd7a"
-"gguf.py" = "458927d1bd86c2c166ed0168e9369f76f85387ac09bbb1eb5ecb095cdec6e055"
+"gguf.py" = "ced89fc42009ab2e69406d2726c9b0caf43254c51ab16bdcf37c5ad239a2d7be"
 "local.py" = "92ec0d1249115f08eb02fccf554e946d36854a4ae861bde8190590d404695e0e"
 "manifest.py" = "a93ee850992c17dd90a57946441875d282367556703b9e9d1c8be057ea12bed4"
 "project.py" = "2471c26e013b287a7554cecda51ff9b42c09f71cd6d6d57dd33ed4ef242c40cd"
 "py.typed" = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 "refs.py" = "f3a144543f423a6b01043294b21104ababaafdbfb31798560de678b69f27ac2f"
-"tensors.py" = "b68adf8b95161defb89ed06bdea8a778b54e21a461768a43ae658955ccc6db9d"
+"tensors.py" = "12ce32fdecebb1fd61b898cab0c40d9b13835af0353e2af95b4fa160bd4a4ad6"
+"writer.py" = "f44e74d983d2f642e8479f85a3682bb737dd76ffbd62c3fe7d684ae5c0c71ca1"
 
 [packages.torchcg.files]
 "__init__.py" = "df715b9d245945db3edb6b65cc92c5dc195e89bbf5df1c53f47fe8471eb8e004"

--- a/src/gen_worker/_vendor/tensorfs/__init__.py
+++ b/src/gen_worker/_vendor/tensorfs/__init__.py
@@ -1,4 +1,4 @@
-"""Content-addressed local storage, chunk manifests, and direct tensor reads."""
+"""Content-addressed local storage and direct tensor reads and writes."""
 
 from .local import DigestMismatch, LocalCAS, RefConflict
 from .manifest import MAX_CHUNK_SIZE, Chunk, FileEntry, RepositoryManifest
@@ -17,6 +17,8 @@ from .project import (
 from .refs import CASRef
 from .tensors import (
     DTYPE_BITS,
+    GGUF_FORMAT,
+    SAFETENSORS_FORMAT,
     BlockLayout,
     FileTooLarge,
     TensorError,
@@ -26,26 +28,30 @@ from .tensors import (
     open_tensors,
     read_entry,
 )
+from .writer import TensorWriter
 
 __all__ = [
+    "DTYPE_BITS",
+    "GGUF_FORMAT",
+    "SAFETENSORS_FORMAT",
+    "STUB_MAGIC",
+    "TENSOR_SUFFIXES",
+    "BlockLayout",
+    "FileTooLarge",
     "CASRef",
     "Chunk",
-    "DTYPE_BITS",
     "DigestMismatch",
-    "BlockLayout",
     "FileEntry",
-    "FileTooLarge",
     "LocalCAS",
     "MAX_CHUNK_SIZE",
     "ProjectionError",
     "RefConflict",
     "RepositoryManifest",
-    "STUB_MAGIC",
     "Stub",
-    "TENSOR_SUFFIXES",
     "TensorError",
     "TensorReader",
     "TensorView",
+    "TensorWriter",
     "dtype_itemsize",
     "is_tensor_container",
     "open_tensors",

--- a/src/gen_worker/_vendor/tensorfs/gguf.py
+++ b/src/gen_worker/_vendor/tensorfs/gguf.py
@@ -79,10 +79,19 @@ GGML_NAME: dict[int, str] = {
     41: "Q1_0", 42: "Q2_0",
 }
 
+# The reverse of GGML_NAME, so a `TensorView`'s dtype round-trips back into the
+# type id a directory entry has to carry.
+GGML_ID: dict[str, int] = {name: identifier for identifier, name in GGML_NAME.items()}
+
 # GGUF metadata value type ids -> fixed width, for the ones that have one.
 _FIXED_WIDTH = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
 _TYPE_STRING = 8
 _TYPE_ARRAY = 9
+
+# The Rust planner refuses anything below this (crates/tensorfs-core/src/
+# planner/gguf.rs), so composing a file that violates it would produce a
+# snapshot our own ingest path would reject.
+MIN_ALIGNMENT = 8
 
 
 class GGUFError(ValueError):
@@ -184,11 +193,41 @@ def _tensor_nbytes(shape: tuple[int, ...], elements: int, block_bytes: int) -> i
     return total
 
 
-def parse(read: Callable[[int, int], bytes], size: int) -> Iterator[GGUFTensor]:
-    """Yield every tensor a GGUF file declares, in declaration order.
+@dataclass(frozen=True, slots=True)
+class GGUFHeader:
+    """Everything before the data section, plus where the data section starts.
 
-    ``read(offset, length)`` supplies bytes; no tensor body is ever requested.
+    ``metadata`` is the encoded key/value block **verbatim** — the bytes
+    between the 24-byte prefix and the tensor directory. Carrying it as bytes
+    rather than as decoded values is deliberate: a conversion rewrites tensors,
+    not model metadata, and re-encoding a value it never looked at is a chance
+    to change a file for no reason.
     """
+
+    version: int
+    alignment: int
+    metadata_count: int
+    metadata: bytes
+    directory_start: int
+    directory_end: int
+    data_start: int
+    tensors: tuple[GGUFTensor, ...]
+
+
+def tensor_nbytes(ggml_type: int, shape: tuple[int, ...]) -> int:
+    """Encoded size of a tensor with these GGUF dimensions."""
+
+    layout = GGML_LAYOUT.get(ggml_type)
+    if layout is None:
+        raise GGUFError(f"unsupported ggml type {ggml_type}")
+    elements, block_bytes = layout
+    if not shape:
+        raise GGUFError("a GGUF tensor needs at least one dimension")
+    return _tensor_nbytes(shape, elements, block_bytes)
+
+
+def read_header(read: Callable[[int, int], bytes], size: int) -> GGUFHeader:
+    """Parse the whole directory, reading no tensor body."""
 
     cursor = _Cursor(read, size)
     if size < 24 or cursor.take(4) != MAGIC:
@@ -211,6 +250,9 @@ def parse(read: Callable[[int, int], bytes], size: int) -> Iterator[GGUFTensor]:
                 raise GGUFError("general.alignment must be a power of two")
             continue
         _skip_value(cursor, value_type, 0)
+
+    directory_start = cursor.position
+    metadata = read(24, directory_start - 24) if directory_start > 24 else b""
 
     declared: list[GGUFTensor] = []
     for _ in range(tensor_count):
@@ -238,19 +280,93 @@ def parse(read: Callable[[int, int], bytes], size: int) -> Iterator[GGUFTensor]:
             )
         )
 
+    directory_end = cursor.position
     # Tensor offsets are relative to the aligned start of the data section.
-    data_start = (cursor.position + alignment - 1) & ~(alignment - 1)
+    data_start = align_up(directory_end, alignment)
+    absolute: list[GGUFTensor] = []
     for tensor in declared:
-        absolute = data_start + tensor.offset
-        if absolute + tensor.nbytes > size:
+        start = data_start + tensor.offset
+        if start + tensor.nbytes > size:
             raise GGUFError(f"GGUF tensor {tensor.name!r} runs past the end of the file")
-        yield GGUFTensor(
-            name=tensor.name,
-            ggml_type=tensor.ggml_type,
-            dtype=tensor.dtype,
-            shape=tensor.shape,
-            offset=absolute,
-            nbytes=tensor.nbytes,
-            block_elements=tensor.block_elements,
-            block_bytes=tensor.block_bytes,
+        absolute.append(
+            GGUFTensor(
+                name=tensor.name,
+                ggml_type=tensor.ggml_type,
+                dtype=tensor.dtype,
+                shape=tensor.shape,
+                offset=start,
+                nbytes=tensor.nbytes,
+                block_elements=tensor.block_elements,
+                block_bytes=tensor.block_bytes,
+            )
         )
+    return GGUFHeader(
+        version=version,
+        alignment=alignment,
+        metadata_count=metadata_count,
+        metadata=metadata,
+        directory_start=directory_start,
+        directory_end=directory_end,
+        data_start=data_start,
+        tensors=tuple(absolute),
+    )
+
+
+def parse(read: Callable[[int, int], bytes], size: int) -> Iterator[GGUFTensor]:
+    """Yield every tensor a GGUF file declares, in declaration order.
+
+    ``read(offset, length)`` supplies bytes; no tensor body is ever requested.
+    """
+
+    return iter(read_header(read, size).tensors)
+
+
+def align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) & ~(alignment - 1)
+
+
+def encode_symbol(value: bytes) -> bytes:
+    return struct.pack("<Q", len(value)) + value
+
+
+def encode_prefix(version: int, tensor_count: int, metadata_count: int) -> bytes:
+    """The 24 bytes every GGUF file opens with."""
+
+    return MAGIC + struct.pack("<IQQ", version, tensor_count, metadata_count)
+
+
+def encode_tensor_info(
+    name: str, shape: tuple[int, ...], ggml_type: int, offset: int
+) -> bytes:
+    """One tensor directory entry, spelled exactly as the readers expect.
+
+    ``shape`` is GGUF's own ``ne`` order — fastest-varying dimension first —
+    which is the order :class:`GGUFTensor` reports, so a tensor read out of one
+    file and written into another needs no transposition of its geometry.
+    """
+
+    encoded = name.encode("utf-8")
+    if not 0 < len(encoded) <= MAX_TENSOR_NAME_LEN:
+        raise GGUFError(f"GGUF tensor name {name!r} is not a usable name")
+    if not 1 <= len(shape) <= MAX_DIMENSIONS:
+        raise GGUFError(f"GGUF tensor {name!r} cannot have {len(shape)} dimensions")
+    return (
+        encode_symbol(encoded)
+        + struct.pack("<I", len(shape))
+        + b"".join(struct.pack("<Q", dimension) for dimension in shape)
+        + struct.pack("<IQ", ggml_type, offset)
+    )
+
+
+def type_id(dtype: str) -> int:
+    """The ggml type id a :class:`~tensorfs.tensors.TensorView` dtype names."""
+
+    identifier = GGML_ID.get(dtype)
+    if identifier is None and dtype.startswith("GGML_"):
+        try:
+            identifier = int(dtype.removeprefix("GGML_"))
+        except ValueError:
+            identifier = None
+    if identifier is None or identifier not in GGML_LAYOUT:
+        raise GGUFError(f"unknown ggml type {dtype!r}")
+    return identifier

--- a/src/gen_worker/_vendor/tensorfs/tensors.py
+++ b/src/gen_worker/_vendor/tensorfs/tensors.py
@@ -19,6 +19,7 @@ import math
 import mmap
 import os
 import tempfile
+import weakref
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DTYPE_BITS",
+    "GGUF_FORMAT",
+    "SAFETENSORS_FORMAT",
     "BlockLayout",
     "FileTooLarge",
     "TensorError",
@@ -46,8 +49,10 @@ __all__ = [
 
 _SAFETENSORS_SUFFIX = ".safetensors"
 _GGUF_SUFFIX = ".gguf"
-_SAFETENSORS_FORMAT = "safetensors-v1"
-_GGUF_FORMAT = "gguf-v1"
+# The planner ids, which are also what `TensorView.format` reports and what
+# `TensorWriter` composes. Public because the write half dispatches on them.
+SAFETENSORS_FORMAT = "safetensors-v1"
+GGUF_FORMAT = "gguf-v1"
 _PREFIX_SIZE = 8
 # safetensors 0.8.0's own reader refuses header lengths above this. Matching it
 # keeps a malformed prefix from provoking a huge allocation here.
@@ -185,6 +190,35 @@ class TensorView:
         return at
 
 
+class _MappedObject:
+    """A read-only mapping of one CAS object, exported through the buffer protocol.
+
+    DECLARED REWRITE (pgw#1310): the pure-Python stand-in for
+    ``tensorfs.native.MappedObject``. Two properties are load-bearing and
+    ``mmap.mmap`` supplies neither on its own:
+
+    * it is **weak-referenceable**, so ``TensorReader._maps`` can be the
+      ``WeakValueDictionary`` upstream made it -- a strong cache there means a
+      conversion that touches every tensor of an 8 GiB shard ends with the whole
+      shard resident;
+    * the buffer it exports keeps the underlying ``mmap`` alive for exactly as
+      long as some view of it exists, so ``close()`` never has to revoke a live
+      buffer.
+
+    PEP 688's ``__buffer__`` (py3.12+, which is this package's floor) is what
+    makes both true without a C extension.
+    """
+
+    __slots__ = ("_handle", "__weakref__")
+
+    def __init__(self, path: Path) -> None:
+        with path.open("rb") as source:
+            self._handle = mmap.mmap(source.fileno(), 0, prot=mmap.PROT_READ)
+
+    def __buffer__(self, flags: int) -> memoryview:
+        return memoryview(self._handle)
+
+
 class TensorReader(Mapping[str, TensorView]):
     """Every tensor in a manifest, addressable without materializing a file.
 
@@ -206,7 +240,19 @@ class TensorReader(Mapping[str, TensorView]):
         self._entries = {entry.path: entry for entry in manifest.files}
         # (file path) -> (object start offsets, (ref, length) pairs)
         self._grid: dict[str, tuple[list[int], tuple[tuple[CASRef, int], ...]]] = {}
-        self._maps: dict[str, mmap.mmap] = {}
+        # WEAK on purpose. A mapping lives exactly as long as someone is
+        # reading through it: the `Py_buffer` a view holds keeps the mapping
+        # alive, and when the last view goes so does the mapping. A strong
+        # cache here would mean a conversion that touches every tensor of an
+        # 8 GiB shard ends with the whole shard resident. Measured with
+        # `python/benchmarks/writer_peak_rss.py --gib 8`, transforming every
+        # tensor of an 8 GiB shard: 8036.7 MiB peak RSS while this was strong,
+        # 310.1 MiB now -- and now flat in the shard's size rather than equal
+        # to it. Re-mapping an object a later read wants again is one
+        # `mmap(2)`; its digest stays in `_verified`, so it is not re-hashed.
+        self._maps: weakref.WeakValueDictionary[str, MappedObject] = (
+            weakref.WeakValueDictionary()
+        )
         self._verified: set[str] = set()
         self._index: dict[str, TensorView] | None = None
         self._closed = False
@@ -225,21 +271,16 @@ class TensorReader(Mapping[str, TensorView]):
     # -- lifecycle -------------------------------------------------------
 
     def close(self) -> None:
-        """Drop this reader's mappings.
+        """Refuse further reads. Mappings are not this object's to revoke.
 
         A mapping the caller still holds a ``memoryview`` into is *not*
-        force-unmapped — that would invalidate live buffers. It is released
-        instead, so the mapping survives exactly as long as the last view of
-        it. This is the same ownership rule the Rust reader gets from holding
-        each object in an ``Arc<Mmap>``; here refcounting supplies it.
+        force-unmapped — that would invalidate live buffers. The reader only
+        ever held weak references anyway: the ``Py_buffer`` each view carries is
+        what keeps its mapping alive, for exactly as long as the view. There is
+        no ``BufferError`` to swallow here and nothing to release.
         """
 
         self._closed = True
-        for handle in self._maps.values():
-            try:
-                handle.close()
-            except BufferError:
-                pass
         self._maps.clear()
 
     def __enter__(self) -> TensorReader:
@@ -359,6 +400,27 @@ class TensorReader(Mapping[str, TensorView]):
             return None
         return tuple(span)
 
+    def gguf_header(self, path: str) -> gguf.GGUFHeader:
+        """The GGUF directory of one file, tensor bodies untouched.
+
+        This is what a conversion hands to :class:`~tensorfs.writer.TensorWriter`
+        so the output carries the source's metadata block verbatim. A
+        conversion rewrites tensors; re-encoding model metadata it never looked
+        at would change the file for no reason.
+        """
+
+        entry = self._entry(path)
+        if not path.endswith(_GGUF_SUFFIX):
+            raise TensorError(f"{path!r} is not a GGUF file")
+
+        def read(offset: int, length: int) -> bytes:
+            return self.read_range(path, offset, length)
+
+        try:
+            return gguf.read_header(read, entry.size_bytes)
+        except gguf.GGUFError as error:
+            raise TensorError(f"{path}: {error}") from None
+
     def rekeyed(self, names: Mapping[str, str]) -> Mapping[str, TensorView]:
         """Serve these tensors under other names, admitting nothing.
 
@@ -409,7 +471,17 @@ class TensorReader(Mapping[str, TensorView]):
         return built
 
     def _map(self, ref: CASRef, size: int) -> memoryview:
-        """An mmap of one CAS object, verified at most once per reader."""
+        """An mmap of one CAS object, verified at most once per reader.
+
+        DECLARED REWRITE (pgw#1310, recorded in VENDORED.toml): upstream maps
+        through the compiled extension's ``tensorfs.native.MappedObject`` and
+        says there is no fallback. A source-vendored wheel cannot carry a
+        compiled extension, so this snapshot supplies the same object in pure
+        Python: :class:`_MappedObject` below owns an ``mmap`` and exports it
+        through PEP 688, which is the property upstream needed from the
+        extension here -- a weak-referenceable handle whose pages stay alive
+        exactly as long as some view of them does.
+        """
 
         key = ref.digest
         handle = self._maps.get(key)
@@ -419,9 +491,7 @@ class TensorReader(Mapping[str, TensorView]):
             # mapping exists the bytes are pinned by the inode, so the lock is
             # not held for the lifetime of the view.
             with self._cas._store_lock():
-                path = self._cas.object_path(ref)
-                with path.open("rb") as source:
-                    handle = mmap.mmap(source.fileno(), 0, prot=mmap.PROT_READ)
+                handle = _MappedObject(self._cas.object_path(ref))
             self._maps[key] = handle
         view = memoryview(handle)
         if len(view) != size:
@@ -504,7 +574,7 @@ class TensorReader(Mapping[str, TensorView]):
             yield TensorView(
                 name=tensor.name,
                 file=path,
-                format=_GGUF_FORMAT,
+                format=GGUF_FORMAT,
                 dtype=tensor.dtype,
                 shape=tensor.shape,
                 nbytes=tensor.nbytes,
@@ -569,7 +639,7 @@ class TensorReader(Mapping[str, TensorView]):
             yield TensorView(
                 name=name,
                 file=path,
-                format=_SAFETENSORS_FORMAT,
+                format=SAFETENSORS_FORMAT,
                 dtype=dtype,
                 shape=tuple(shape),
                 nbytes=nbytes,

--- a/src/gen_worker/_vendor/tensorfs/writer.py
+++ b/src/gen_worker/_vendor/tensorfs/writer.py
@@ -1,0 +1,375 @@
+"""Compose a new snapshot one tensor at a time, in safetensors or in GGUF.
+
+A conversion reads one tensor, transforms it, and writes it back. Nothing here
+ever holds a shard: new tensors are admitted as CAS objects as they arrive, and
+tensors the conversion did not touch are carried over **by reference**, keeping
+their existing digests so their objects are not rewritten and the hub has
+nothing new to fetch for them.
+
+Be precise about what that does and does not avoid. Inheriting a tensor skips
+holding its bytes and skips admitting them as new objects. It does **not** skip
+hashing them: v1 identifies a file by the digest of its bytes, so
+:meth:`TensorWriter.finish` still reads every byte once. Removing that pass
+needs a format change, not an API change.
+
+The emitted grid is the seal planner's, in both formats — header objects, then
+one object per tensor split every 64 MiB from that tensor's own start, plus
+GGUF's per-tensor alignment padding as its own object
+(``crates/tensorfs-core/src/planner/{safetensors,gguf}.rs``). That is what
+makes the result inheritable by the *next* conversion in turn, and it is
+asserted against the real planner rather than against a hand-written list of
+lengths.
+
+**Emission order is the caller's, and it is load-bearing.** Tensors are laid
+out in the order they were added, which is what lets a conversion reproduce its
+source's layout exactly by iterating the source's own header. See
+``TensorWriter``'s class docstring for what a caller who invents a fresh order
+does and does not give up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from . import gguf
+from .manifest import MAX_CHUNK_SIZE, Chunk, FileEntry
+from .refs import CASRef
+from .tensors import (
+    DTYPE_BITS,
+    GGUF_FORMAT,
+    SAFETENSORS_FORMAT,
+    TensorError,
+    TensorView,
+)
+
+if TYPE_CHECKING:
+    from .local import LocalCAS
+
+__all__ = ["TensorWriter"]
+
+
+@dataclass(slots=True)
+class _Pending:
+    name: str
+    dtype: str
+    shape: tuple[int, ...]
+    nbytes: int
+    # Exactly one of these is set. `inherited` reuses existing objects
+    # verbatim; `source` is a view whose bytes must be admitted afresh.
+    inherited: tuple[tuple[CASRef, int], ...] | None
+    chunks: tuple[tuple[CASRef, int], ...] | None
+
+
+
+
+def _split(total: int) -> Iterator[int]:
+    """Object lengths for a region, split every 64 MiB from its own start."""
+
+    while total > MAX_CHUNK_SIZE:
+        yield MAX_CHUNK_SIZE
+        total -= MAX_CHUNK_SIZE
+    if total:
+        yield total
+
+
+class TensorWriter:
+    """Build one safetensors or GGUF file from new and inherited tensors.
+
+    Peak memory is one tensor for :meth:`add`, or one 64 MiB piece when the
+    caller streams. No file is created at any point; :meth:`finish` returns a
+    :class:`~tensorfs.manifest.FileEntry` describing objects already durable in
+    the CAS.
+
+    The format follows the path's suffix. A GGUF file additionally needs the
+    metadata block it is being written with, because a GGUF file without one is
+    not a model — pass the source's, read with
+    :meth:`~tensorfs.tensors.TensorReader.gguf_header`. A conversion rewrites
+    tensors, not model metadata.
+
+    **Order.** Tensors are emitted in the order they were added. That is what
+    lets the conversion loop reproduce its source exactly: it iterates the
+    source's header, so it adds in the order the source was written in, and the
+    result is byte-identical to the source for the tensors it did not touch.
+
+    A caller that invents a fresh order instead gets a perfectly valid file
+    that is **not** byte-identical to the one the reference library would have
+    written for the same weights. What that costs is precisely one thing: the
+    file digest, and therefore the snapshot id, differ from the canonical
+    copy's. It does **not** cost dedup — the object grid is per tensor and
+    objects are named by their own bytes, so every tensor object is shared with
+    the canonical copy regardless of order, and only the header object differs.
+    ``test_reordering_costs_the_header_object_and_nothing_else`` is that claim
+    as a test.
+    """
+
+    def __init__(
+        self,
+        cas: LocalCAS,
+        path: str,
+        *,
+        gguf_header: gguf.GGUFHeader | None = None,
+    ) -> None:
+        self._cas = cas
+        self._path = path
+        self._pending: list[_Pending] = []
+        self._names: set[str] = set()
+        self._format = GGUF_FORMAT if path.endswith(".gguf") else SAFETENSORS_FORMAT
+        if self._format == GGUF_FORMAT:
+            if gguf_header is None:
+                raise TensorError(
+                    f"{path}: a GGUF file needs its metadata block; pass the "
+                    "source's gguf_header"
+                )
+            alignment = gguf_header.alignment
+            if alignment < gguf.MIN_ALIGNMENT or alignment & (alignment - 1):
+                raise TensorError(
+                    f"{path}: general.alignment {alignment} is not a power of "
+                    f"two at least {gguf.MIN_ALIGNMENT}"
+                )
+        elif gguf_header is not None:
+            raise TensorError(f"{path}: gguf_header is meaningless for a {self._format} file")
+        self._gguf = gguf_header
+
+    @property
+    def format(self) -> str:
+        """The container being composed: ``safetensors-v1`` or ``gguf-v1``."""
+
+        return self._format
+
+    def _claim(self, name: str) -> None:
+        if name in self._names:
+            raise TensorError(f"tensor {name!r} was added twice")
+        self._names.add(name)
+
+    def add(
+        self,
+        name: str,
+        dtype: str,
+        shape: Iterable[int],
+        data: bytes | Iterable[bytes],
+    ) -> None:
+        """Admit a new or transformed tensor.
+
+        ``data`` may be one buffer or an iterable of buffers, so a tensor
+        larger than memory can be streamed in without ever being contiguous.
+
+        ``dtype`` is a safetensors dtype (``"F32"``) for a safetensors file and
+        a ggml type name (``"Q4_K"``) for a GGUF one; ``shape`` is logical
+        row-major for the first and GGUF's own ``ne`` order for the second,
+        which is exactly what :class:`~tensorfs.tensors.TensorView` reports in
+        each case. So "read a tensor, transform it, write it back" needs no
+        translation of either.
+        """
+
+        self._claim(name)
+        if self._format == SAFETENSORS_FORMAT and dtype not in DTYPE_BITS:
+            raise TensorError(f"unknown safetensors dtype {dtype!r}")
+        dimensions = tuple(shape)
+        blocks = data if not isinstance(data, (bytes, bytearray, memoryview)) else (data,)
+
+        chunks: list[tuple[CASRef, int]] = []
+        carry = bytearray()
+        total = 0
+
+        def flush(final: bool) -> None:
+            nonlocal total
+            while len(carry) >= MAX_CHUNK_SIZE or (final and carry):
+                cut = min(MAX_CHUNK_SIZE, len(carry))
+                # One copy, not two: slicing the bytearray would materialise a
+                # second 64 MiB buffer before `bytes()` copied it again, and
+                # this is the resident high-water mark of the whole writer.
+                with memoryview(carry) as window:
+                    piece = bytes(window[:cut])
+                del carry[:cut]
+                chunks.append((self._cas.put_bytes(piece), len(piece)))
+                total += len(piece)
+
+        for block in blocks:
+            carry += memoryview(block).cast("B")
+            flush(False)
+        flush(True)
+
+        expected = self._declared_bytes(dtype, dimensions)
+        if total != expected:
+            raise TensorError(
+                f"{name}: supplied {total} bytes but {dtype}{list(dimensions)} needs {expected}"
+            )
+        self._pending.append(
+            _Pending(name, dtype, dimensions, total, None, tuple(chunks))
+        )
+
+    def _declared_bytes(self, dtype: str, shape: tuple[int, ...]) -> int:
+        if self._format == GGUF_FORMAT:
+            try:
+                return gguf.tensor_nbytes(gguf.type_id(dtype), shape)
+            except gguf.GGUFError as error:
+                raise TensorError(str(error)) from None
+        return _declared_bytes(dtype, shape)
+
+    def inherit(self, view: TensorView) -> None:
+        """Carry an untouched tensor over without moving or re-admitting its bytes.
+
+        Raises when the tensor does not occupy whole objects, because then it
+        has no digest of its own. That happens when the source was committed
+        under a grid that packs small tensors together; use :meth:`add` with
+        the tensor's bytes instead.
+        """
+
+        self._claim(view.name)
+        if view.format != self._format:
+            raise TensorError(
+                f"{view.name}: cannot inherit a {view.format} tensor into a "
+                f"{self._format} file; re-add its bytes instead"
+            )
+        span = view._reader.object_span(view)
+        if span is None:
+            raise TensorError(
+                f"{view.name}: is not object-aligned in {view.file!r}, so it "
+                "cannot be inherited by reference; add its bytes instead"
+            )
+        self._pending.append(
+            _Pending(view.name, view.dtype, view.shape, view.nbytes, span, None)
+        )
+
+    # -- the header, per format ------------------------------------------
+
+    def _safetensors_domains(self) -> tuple[list[bytes], list[int]]:
+        header: dict[str, object] = {}
+        cursor = 0
+        for item in self._pending:
+            header[item.name] = {
+                "dtype": item.dtype,
+                "shape": list(item.shape),
+                "data_offsets": [cursor, cursor + item.nbytes],
+            }
+            cursor += item.nbytes
+        encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+        encoded += b" " * (-len(encoded) % 8)
+        prefix = len(encoded).to_bytes(8, "little") + encoded
+        return [prefix], [0] * len(self._pending)
+
+    def _gguf_domains(self) -> tuple[list[bytes], list[int]]:
+        """The three header domains the GGUF planner keeps apart, plus padding.
+
+        `crates/tensorfs-core/src/planner/gguf.rs::plan_layout` emits the
+        metadata block, the tensor directory and the pre-data padding as
+        SEPARATE regions, and every tensor's trailing alignment padding as a
+        region of its own rather than as part of the tensor. Isolating padding
+        is what lets a GGUF share tensor objects with a safetensors twin, so
+        the writer has to cut in the same places or seal re-admits everything.
+        """
+
+        if self._gguf is None:  # pragma: no cover - the constructor refuses this
+            raise TensorError(f"{self._path}: no GGUF header")
+        alignment = self._gguf.alignment
+        prefix = (
+            gguf.encode_prefix(
+                self._gguf.version, len(self._pending), self._gguf.metadata_count
+            )
+            + self._gguf.metadata
+        )
+        directory = bytearray()
+        padding: list[int] = []
+        offset = 0
+        for item in self._pending:
+            try:
+                identifier = gguf.type_id(item.dtype)
+                directory += gguf.encode_tensor_info(
+                    item.name, item.shape, identifier, offset
+                )
+            except gguf.GGUFError as error:
+                raise TensorError(f"{item.name}: {error}") from None
+            padded = gguf.align_up(item.nbytes, alignment)
+            padding.append(padded - item.nbytes)
+            offset += padded
+
+        directory_end = len(prefix) + len(directory)
+        # An empty GGUF has no data section to align to, which is the one case
+        # where the planner does not round the directory up.
+        data_start = gguf.align_up(directory_end, alignment) if self._pending else directory_end
+        return [prefix, bytes(directory), b"\0" * (data_start - directory_end)], padding
+
+    def finish(self) -> FileEntry:
+        """Seal the file and return its manifest entry.
+
+        The whole-file digest is unavoidable: v1 identifies a file by the hash
+        of its bytes, so every byte is hashed here even for inherited tensors.
+        Their *objects* are still never rewritten and never re-uploaded, which
+        is where the saving actually lives -- but the hash pass is real, and
+        removing it would take a format change, not an API change.
+        """
+
+        if self._format == GGUF_FORMAT:
+            domains, padding = self._gguf_domains()
+        else:
+            domains, padding = self._safetensors_domains()
+
+        whole = hashlib.sha256()
+        chunks: list[Chunk] = []
+        size = 0
+
+        def emit(data: bytes) -> None:
+            """Admit one header domain, split on the planner's own grid."""
+
+            nonlocal size
+            at = 0
+            for length in _split(len(data)):
+                piece = data[at : at + length]
+                chunks.append(Chunk(self._cas.put_bytes(piece), length))
+                whole.update(piece)
+                size += length
+                at += length
+
+        for domain in domains:
+            emit(domain)
+
+        for item, pad in zip(self._pending, padding, strict=True):
+            for ref, length in item.inherited or item.chunks or ():
+                self._absorb(ref, length, whole)
+                chunks.append(Chunk(ref, length))
+                size += length
+            emit(b"\0" * pad)
+
+        return FileEntry(self._path, size, CASRef(whole.hexdigest()), tuple(chunks))
+
+    def _absorb(self, ref: CASRef, length: int, whole: hashlib._Hash) -> None:
+        """Fold one object into the whole-file digest, verifying it on the way.
+
+        ONE pass, not two. Reading the object to hash the file and then calling
+        ``verify_object`` to check the object would hash the same bytes twice,
+        and SHA-256 is what bounds this method -- the same double-pass the CAS
+        writer's own docstring warns about. The verification is not weakened:
+        the per-object digest is computed from the identical bytes and compared
+        to the name the object is stored under.
+        """
+
+        object_digest = hashlib.sha256()
+        path = self._cas.object_path(ref)
+        # Resolving under the shared store lock keeps collection from unlinking
+        # the object between resolution and open; the open fd pins it after.
+        with self._cas._store_lock():
+            handle = path.open("rb")
+        with handle:
+            observed = 0
+            while block := handle.read(1 << 20):
+                whole.update(block)
+                object_digest.update(block)
+                observed += len(block)
+        if observed != length:
+            raise TensorError(f"{ref}: object is {observed} bytes, expected {length}")
+        if object_digest.hexdigest() != ref.digest:
+            raise TensorError(f"{ref}: object bytes do not match their digest")
+
+
+def _declared_bytes(dtype: str, shape: tuple[int, ...]) -> int:
+    elements = 1
+    for dimension in shape:
+        elements *= dimension
+    bits = elements * DTYPE_BITS[dtype]
+    if bits % 8:
+        raise TensorError(f"{dtype}{list(shape)} is not a whole number of bytes")
+    return bits // 8

--- a/src/gen_worker/convert/gguf_native.py
+++ b/src/gen_worker/convert/gguf_native.py
@@ -1,0 +1,543 @@
+"""HF safetensors -> GGUF, read and written through tensorfs (pgw#1344).
+
+The property this exists for is NOT that it is cheaper than handing a
+materialized model tree to ``convert_hf_to_gguf.py``. It is that **the GGUF
+composes through the store**: a tensor whose GGUF bytes equal its safetensors
+bytes is admitted under the digest it already has, so a GGUF flavor of a model
+the store already holds costs only the tensors that genuinely change.
+
+Two facts make that work, and both are load-bearing:
+
+* the CAS object grid is **per tensor** -- a tensor of at least
+  ``MAX_CHUNK_SIZE`` gets objects cut from its own start in both containers, so
+  its objects are named by its own bytes and nothing else;
+* GGUF's per-tensor alignment padding is a **separate** object
+  (``TensorWriter._gguf_domains``), so padding never contaminates a tensor's
+  digest.
+
+Cross-container inheritance-by-reference is refused by
+:meth:`TensorWriter.inherit` -- a safetensors ``TensorView`` cannot be handed
+into a GGUF file, because the two containers disagree about dimension order.
+Sharing is therefore obtained the other way, and it is not a weaker result:
+:meth:`TensorWriter.add` puts the bytes through the content-addressed store,
+which returns the *existing* object for bytes it already holds. The saving is
+the same one -- nothing is rewritten and the hub has nothing new to fetch --
+and it is measured here rather than assumed, by
+:class:`ChunkSharing`.
+
+**What this module does not do.** It does not invent a model's metadata block.
+GGUF metadata is a model's vocabulary, its chat template and its
+hyperparameters, and reproducing a tokenizer faithfully is
+``convert_hf_to_gguf.py``'s several thousand lines, not this file's. The
+hyperparameter half IS mechanical and is built here from the natively-read
+``config.json``; the vocabulary half must be supplied by a caller that has a
+faithful source for it. A converter that guessed a vocabulary would be exactly
+the silent change this lane exists to avoid.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from .._vendor.tensorfs import LocalCAS, RepositoryManifest, TensorWriter, open_tensors
+from .._vendor.tensorfs import gguf as tfs_gguf
+from .._vendor.tensorfs.manifest import FileEntry
+from .._vendor.tensorfs.tensors import TensorReader, TensorView
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    pass
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ChunkSharing",
+    "GGUFConversion",
+    "GGUFUnsupported",
+    "TensorDisposition",
+    "convert_snapshot_to_gguf",
+    "hyperparameter_metadata",
+    "plan_tensors",
+]
+
+
+class GGUFUnsupported(ValueError):
+    """This converter will not produce a GGUF for this input.
+
+    Raised rather than guessed. Every message names the exact thing that is
+    missing, because the failure mode this class prevents is a GGUF that loads
+    and is quietly wrong.
+    """
+
+
+# The GGUF encodings this converter emits directly. Everything below is a pure
+# container/dtype decision; the k-quants are `llama-quantize`'s, and they run
+# over a GGUF this converter produced rather than over a model tree.
+DIRECT_ENCODINGS: frozenset[str] = frozenset({"f32", "f16", "bf16"})
+
+# safetensors dtype -> ggml type name, for the dtypes that mean the same bytes
+# in both containers. Anything absent has to be cast rather than carried.
+_SHARED_DTYPES: dict[str, str] = {"F32": "F32", "F16": "F16", "BF16": "BF16"}
+
+_ENCODING_DTYPE: dict[str, str] = {"f32": "F32", "f16": "F16", "bf16": "BF16"}
+
+# `config.json` model_type -> the gguf-py architecture whose tensor name map
+# and metadata keys apply. Deliberately short: an architecture is on this list
+# when its HF->GGUF mapping is exactly the name map plus the rope permute
+# below, and NOT when it merely has a `MODEL_ARCH` entry. Gemma rewrites norm
+# weights, and the qwen MoE families restack experts; neither is a name map,
+# so neither is here -- see this module's docstring on guessing.
+_ARCHITECTURES: dict[str, str] = {
+    "llama": "LLAMA",
+    "mistral": "LLAMA",
+    "qwen2": "QWEN2",
+}
+
+# The tensors the llama-family rope permute applies to, by their GGUF names.
+# `convert_hf_to_gguf.py::LlamaModel.modify_tensors` permutes exactly these.
+_PERMUTED_SUFFIXES = ("attn_q.weight", "attn_k.weight")
+
+
+@dataclass(frozen=True, slots=True)
+class TensorDisposition:
+    """What happened to one tensor, and therefore what it cost the store."""
+
+    source_name: str
+    gguf_name: str
+    dtype: str
+    shape: tuple[int, ...]
+    # "passthrough" when the bytes are the source's, verbatim; otherwise the
+    # transform that changed them. Only "passthrough" can share objects.
+    transform: str
+    objects: tuple[str, ...]
+
+    @property
+    def passthrough(self) -> bool:
+        return self.transform == "passthrough"
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkSharing:
+    """The dedup measurement, per tensor rather than in aggregate.
+
+    An aggregate count cannot tell "shared because the bytes are identical"
+    from "new because the tensor was transformed", and the second is not a
+    defect. This keeps them apart by name, so a regression reads as a NAMED
+    tensor that stopped sharing.
+    """
+
+    shared: tuple[str, ...]
+    transformed: tuple[str, ...]
+    # A passthrough tensor whose objects are NOT in the source: the source
+    # packed it with its neighbours, so it has no digest of its own to share.
+    # Not a defect -- a fact about the source's grid -- but never silent.
+    unshareable: tuple[str, ...]
+    shared_digests: frozenset[str]
+    new_digests: frozenset[str]
+
+    def describe(self) -> str:
+        return (
+            f"shared={len(self.shared)} tensors / {len(self.shared_digests)} objects; "
+            f"transformed={len(self.transformed)}; "
+            f"unshareable={len(self.unshareable)}; "
+            f"new objects={len(self.new_digests)}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GGUFConversion:
+    entry: FileEntry
+    dispositions: tuple[TensorDisposition, ...]
+    sharing: ChunkSharing
+
+
+# ---------------------------------------------------------------------------
+# metadata (the hyperparameter half only -- see the module docstring)
+# ---------------------------------------------------------------------------
+
+
+def _architecture(config: Mapping[str, object]) -> tuple[str, str]:
+    """(model_type, gguf-py MODEL_ARCH name) for a natively-read config.json."""
+
+    model_type = str(config.get("model_type") or "").strip().lower()
+    if model_type in _ARCHITECTURES:
+        return model_type, _ARCHITECTURES[model_type]
+    architectures = config.get("architectures")
+    if isinstance(architectures, list):
+        for raw in architectures:
+            cleaned = str(raw or "").strip().lower()
+            for prefix, arch in _ARCHITECTURES.items():
+                if cleaned.startswith(prefix):
+                    return prefix, arch
+    raise GGUFUnsupported(
+        f"gguf_unsupported_architecture:{model_type or architectures!r}; this "
+        f"converter maps {sorted(_ARCHITECTURES)} by name map plus rope permute "
+        f"alone. An architecture that rewrites tensor VALUES needs its rule "
+        f"written down before it can be converted here."
+    )
+
+
+def hyperparameter_metadata(
+    config: Mapping[str, object],
+    *,
+    encoding: str,
+    vocabulary: bytes = b"",
+    vocabulary_count: int = 0,
+) -> tuple[bytes, int, str]:
+    """Encode the GGUF key/value block for one model, minus its vocabulary.
+
+    Returns ``(metadata bytes, key count, MODEL_ARCH name)``. The bytes are
+    produced by ``gguf-py``'s own packer -- the same encoder
+    ``convert_hf_to_gguf.py`` writes with -- so this is a re-drive of the
+    reference encoding rather than a second implementation of it.
+
+    ``vocabulary`` is an already-encoded key/value run appended verbatim, for a
+    caller holding a faithful tokenizer block. It is NOT synthesized here; a
+    GGUF whose vocabulary this converter guessed would load and be wrong.
+    """
+
+    import gguf as gguf_py
+
+    _model_type, arch_name = _architecture(config)
+    arch = getattr(gguf_py.MODEL_ARCH, arch_name)
+    writer = gguf_py.GGUFWriter(path=None, arch=gguf_py.MODEL_ARCH_NAMES[arch])
+
+    block_count = _positive_int(config, "num_hidden_layers")
+    writer.add_block_count(block_count)
+    writer.add_context_length(_positive_int(config, "max_position_embeddings"))
+    writer.add_embedding_length(_positive_int(config, "hidden_size"))
+    writer.add_feed_forward_length(_positive_int(config, "intermediate_size"))
+    writer.add_head_count(_positive_int(config, "num_attention_heads"))
+    writer.add_head_count_kv(_head_count_kv(config))
+    writer.add_layer_norm_rms_eps(_number(config, "rms_norm_eps", 1e-5))
+    if config.get("rope_theta") is not None:
+        writer.add_rope_freq_base(_number(config, "rope_theta", 10000.0))
+    writer.add_vocab_size(_positive_int(config, "vocab_size"))
+    writer.add_file_type(_file_type(encoding))
+
+    count = len(writer.kv_data[0])
+    encoded = bytearray()
+    for key, value in writer.kv_data[0].items():
+        # `_pack_val` IS gguf-py's key/value encoder; `write_kv_data_to_file`
+        # is the same two calls with a file on the end. Reaching for it keeps
+        # one encoder in play instead of a second one written here.
+        encoded += writer._pack_val(key, gguf_py.GGUFValueType.STRING, add_vtype=False)
+        encoded += writer._pack_val(
+            value.value, value.type, add_vtype=True, sub_type=value.sub_type
+        )
+    if vocabulary:
+        if vocabulary_count <= 0:
+            raise ValueError("a vocabulary block must declare its key count")
+        encoded += vocabulary
+        count += vocabulary_count
+    return bytes(encoded), count, arch_name
+
+
+def _head_count_kv(config: Mapping[str, object]) -> int:
+    """GQA's KV head count, defaulting to full multi-head when absent."""
+
+    raw = config.get("num_key_value_heads")
+    if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+        return raw
+    return _positive_int(config, "num_attention_heads")
+
+
+def _number(config: Mapping[str, object], key: str, default: float) -> float:
+    raw = config.get(key)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return default
+    return float(raw)
+
+
+def _positive_int(config: Mapping[str, object], key: str) -> int:
+    raw = config.get(key)
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        raise GGUFUnsupported(f"gguf_config_missing:{key}")
+    return raw
+
+
+def _file_type(encoding: str) -> int:
+    import gguf as gguf_py
+
+    match encoding:
+        case "f32":
+            return int(gguf_py.LlamaFileType.ALL_F32)
+        case "f16":
+            return int(gguf_py.LlamaFileType.MOSTLY_F16)
+        case "bf16":
+            return int(gguf_py.LlamaFileType.MOSTLY_BF16)
+    raise GGUFUnsupported(
+        f"gguf_unsupported_encoding:{encoding}; direct encodings are "
+        f"{sorted(DIRECT_ENCODINGS)} (k-quants run over this converter's "
+        f"output, not over a model tree)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the tensor plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _Planned:
+    view: TensorView
+    gguf_name: str
+    dtype: str
+    ne: tuple[int, ...]
+    transform: str
+    # Non-zero only for a rope-permuted tensor: the head count its permute is
+    # cut by (q takes the attention heads, k takes the KV heads).
+    permute_heads: int = 0
+
+
+def plan_tensors(
+    reader: TensorReader,
+    config: Mapping[str, object],
+    *,
+    encoding: str,
+) -> tuple[_Planned, ...]:
+    """Decide, per tensor, its GGUF name, dtype and whether its bytes change.
+
+    Nothing is read here. The plan is what makes the dedup measurement legible
+    afterwards: a tensor's ``transform`` says up front whether its objects are
+    allowed to be the source's.
+    """
+
+    import gguf as gguf_py
+
+    _model_type, arch_name = _architecture(config)
+    arch = getattr(gguf_py.MODEL_ARCH, arch_name)
+    block_count = _positive_int(config, "num_hidden_layers")
+    name_map = gguf_py.TensorNameMap(arch, block_count)
+    target = _ENCODING_DTYPE.get(encoding)
+    if target is None:
+        raise GGUFUnsupported(f"gguf_unsupported_encoding:{encoding}")
+
+    head_count = _positive_int(config, "num_attention_heads")
+    head_count_kv = _head_count_kv(config)
+
+    planned: list[_Planned] = []
+    for name in reader:
+        view = reader[name]
+        if name.endswith((".attn_bias", ".rotary_emb.inv_freq")):
+            continue
+        gguf_name = name_map.get_name(name, try_suffixes=(".weight", ".bias"))
+        if gguf_name is None:
+            raise GGUFUnsupported(
+                f"gguf_unmapped_tensor:{name}; gguf-py's name map for "
+                f"{arch_name} has no GGUF name for it"
+            )
+
+        dtype = _target_dtype(gguf_name, view, target)
+        permute = arch_name == "LLAMA" and gguf_name.endswith(_PERMUTED_SUFFIXES)
+        heads = 0
+        if permute:
+            transform = "permute"
+            heads = head_count_kv if gguf_name.endswith("attn_k.weight") else head_count
+        elif dtype != _SHARED_DTYPES.get(view.dtype, view.dtype):
+            transform = f"cast:{view.dtype}->{dtype}"
+        else:
+            transform = "passthrough"
+        planned.append(
+            _Planned(
+                view=view,
+                gguf_name=gguf_name,
+                dtype=dtype,
+                # GGUF's `ne` is the reverse of safetensors' row-major shape.
+                ne=tuple(reversed(view.shape)),
+                transform=transform,
+                permute_heads=heads,
+            )
+        )
+    if not planned:
+        raise GGUFUnsupported("gguf_no_tensors: the snapshot declares no tensors")
+    return tuple(planned)
+
+
+def _target_dtype(gguf_name: str, view: TensorView, target: str) -> str:
+    """`convert_hf_to_gguf.py::prepare_tensors`' dtype rule, verbatim.
+
+    One dimension, or a norm weight, stays F32 whatever was asked for -- these
+    are the tensors whose precision llama.cpp will not trade. Everything else
+    takes the requested encoding.
+    """
+
+    if len(view.shape) <= 1 or gguf_name.endswith("_norm.weight"):
+        return "F32"
+    return target
+
+
+# ---------------------------------------------------------------------------
+# the conversion
+# ---------------------------------------------------------------------------
+
+
+def convert_snapshot_to_gguf(
+    cas: LocalCAS,
+    manifest: RepositoryManifest,
+    *,
+    encoding: str,
+    metadata: bytes,
+    metadata_count: int,
+    path: str = "model.gguf",
+    alignment: int = 32,
+    config: Mapping[str, object] | None = None,
+) -> GGUFConversion:
+    """Compose a GGUF from a snapshot, admitting only what actually changed.
+
+    Reads tensors through :class:`TensorReader` and writes through
+    :class:`TensorWriter`. No directory is projected, no file is written, and
+    peak resident memory is one tensor -- the streaming property
+    ``convert/writer.py`` already has, preserved because
+    :meth:`TensorWriter.add` takes an iterable of buffers.
+    """
+
+    reader = open_tensors(cas, manifest)
+    try:
+        if config is None:
+            config = json.loads(reader.read_file("config.json").decode("utf-8"))
+        assert config is not None
+        planned = plan_tensors(reader, config, encoding=encoding)
+
+        header = tfs_gguf.GGUFHeader(
+            version=3,
+            alignment=alignment,
+            metadata_count=metadata_count,
+            metadata=metadata,
+            # The writer recomputes the directory from what it was handed; only
+            # version/alignment/metadata are read off this.
+            directory_start=0,
+            directory_end=0,
+            data_start=0,
+            tensors=(),
+        )
+        writer = TensorWriter(cas, path, gguf_header=header)
+
+        source_digests = {
+            str(chunk.digest) for entry in manifest.files for chunk in entry.chunks
+        }
+        dispositions: list[TensorDisposition] = []
+        for item in planned:
+            writer.add(item.gguf_name, item.dtype, item.ne, _bytes_for(item))
+            # The writer records each tensor's admitted objects as it goes, so
+            # the dedup measurement is read off the real admission rather than
+            # recomputed from the bytes a second time.
+            objects = tuple(str(ref) for ref, _length in writer._pending[-1].chunks or ())
+            dispositions.append(
+                TensorDisposition(
+                    source_name=item.view.name,
+                    gguf_name=item.gguf_name,
+                    dtype=item.dtype,
+                    shape=item.ne,
+                    transform=item.transform,
+                    objects=objects,
+                )
+            )
+        entry = writer.finish()
+    finally:
+        reader.close()
+
+    sharing = _measure(dispositions, source_digests)
+    logger.info(
+        "gguf.native path=%s encoding=%s tensors=%d %s",
+        path, encoding, len(dispositions), sharing.describe(),
+    )
+    return GGUFConversion(entry=entry, dispositions=tuple(dispositions), sharing=sharing)
+
+
+def _bytes_for(item: _Planned) -> Iterable[bytes]:
+    """The tensor's GGUF bytes, streamed when nothing has to change.
+
+    A passthrough tensor is handed to the writer as the source's own buffers,
+    so it is never contiguous in memory and the store recognises its objects by
+    their digests. A transformed one is materialized once -- the transform
+    needs the whole tensor -- and released as soon as it is admitted.
+    """
+
+    if item.transform == "passthrough":
+        # `pieces()` yields `memoryview`s -- buffers, which is what the writer
+        # documents it takes; the annotation is `bytes` because that is the
+        # common case, not because a copy is wanted here.
+        return cast("Iterable[bytes]", item.view.pieces())
+    return (_transformed(item),)
+
+
+def _transformed(item: _Planned) -> bytes:
+    """The tensor's bytes after its declared transform, and nothing else.
+
+    The permute is done on RAW ELEMENTS -- it is an axis swap, exact at any
+    width, so it needs no float semantics and works on bf16 without a library
+    that knows what bf16 is. The dtype cast is done by torch, because numpy has
+    no bfloat16 and hand-rolling round-to-nearest-even is exactly the silent
+    numerics change this lane exists to avoid.
+    """
+
+    import numpy as np
+
+    view = item.view
+    data = view.tobytes()
+    if item.permute_heads:
+        raw = np.frombuffer(data, dtype=_RAW_DTYPE[_ITEMSIZE[view.dtype]])
+        array = raw.reshape(view.shape)
+        heads = item.permute_heads
+        # `convert_hf_to_gguf.py::LlamaModel.permute`, verbatim.
+        array = (
+            array.reshape(heads, 2, array.shape[0] // heads // 2, *array.shape[1:])
+            .swapaxes(1, 2)
+            .reshape(array.shape)
+        )
+        data = np.ascontiguousarray(array).tobytes()
+    if item.dtype != _SHARED_DTYPES.get(view.dtype, view.dtype):
+        data = _cast(data, view.dtype, item.dtype)
+    return data
+
+
+_ITEMSIZE = {"F32": 4, "F16": 2, "BF16": 2}
+_RAW_DTYPE = {4: "<u4", 2: "<u2", 1: "u1"}
+
+
+def _cast(data: bytes, source: str, target: str) -> bytes:
+    """A float cast, done by torch so the rounding is the fleet's own."""
+
+    import torch
+
+    dtypes = {"F32": torch.float32, "F16": torch.float16, "BF16": torch.bfloat16}
+    # `frombuffer` wants a writable buffer; the copy is one tensor, which is
+    # this function's whole working set either way.
+    tensor = torch.frombuffer(bytearray(data), dtype=dtypes[source])
+    result = tensor.to(dtypes[target]).contiguous()
+    # bf16 has no numpy counterpart, so the bytes come out through an integer
+    # view of the same width rather than through a dtype numpy must understand.
+    integral = {4: torch.int32, 2: torch.int16}[_ITEMSIZE[target]]
+    return bytes(result.view(integral).numpy().tobytes())
+
+
+def _measure(
+    dispositions: Sequence[TensorDisposition], source_digests: set[str]
+) -> ChunkSharing:
+    shared: list[str] = []
+    transformed: list[str] = []
+    unshareable: list[str] = []
+    shared_digests: set[str] = set()
+    new_digests: set[str] = set()
+    for item in dispositions:
+        hit = {digest for digest in item.objects if digest in source_digests}
+        miss = {digest for digest in item.objects if digest not in source_digests}
+        shared_digests |= hit
+        new_digests |= miss
+        if not item.passthrough:
+            transformed.append(item.gguf_name)
+        elif miss:
+            unshareable.append(item.gguf_name)
+        else:
+            shared.append(item.gguf_name)
+    return ChunkSharing(
+        shared=tuple(shared),
+        transformed=tuple(transformed),
+        unshareable=tuple(unshareable),
+        shared_digests=frozenset(shared_digests),
+        new_digests=frozenset(new_digests),
+    )

--- a/src/gen_worker/convert/gguf_tools.py
+++ b/src/gen_worker/convert/gguf_tools.py
@@ -131,7 +131,20 @@ def run_hf_to_gguf_conversion(
     encoding: str,
 ) -> None:
     # `convert_hf_to_gguf.py` is a SUBPROCESS reading the tree itself, so it
-    # gets real files (pgw#1303's gate; pgw#1335 owns cutting this lane).
+    # gets real files (pgw#1303's gate).
+    #
+    # pgw#1344 SCOPED WHAT IS LEFT HERE, and it is no longer "the conversion".
+    # The TENSOR plane is native: `convert/gguf_native.py` reads a snapshot
+    # through tensorfs, permutes and casts per tensor, and composes the GGUF
+    # through the store so an unchanged tensor keeps the objects it already
+    # has. What this subprocess still owns is the METADATA block -- a model's
+    # vocabulary, its chat template and its pre-tokenizer identity. That is
+    # deliberate and it is not laziness: reproducing a tokenizer faithfully is
+    # thousands of lines of upstream script that changes weekly, and a GGUF
+    # whose vocabulary this repo GUESSED would load and be quietly wrong --
+    # exactly the silent change pgw#1344 exists to prevent. So the honest state
+    # is one named hatch, fenced by `tests/test_gguf_native_pgw1344.py`, rather
+    # than a second tokenizer nobody can verify.
     cmd = [sys.executable, str(script_path),
            str(third_party_dir(hf_model_dir, why="convert_hf_to_gguf.py subprocess")),
            "--outfile", str(output_path), "--outtype", normalize_gguf_encoding(encoding)]

--- a/tests/test_gguf_native_pgw1344.py
+++ b/tests/test_gguf_native_pgw1344.py
@@ -1,0 +1,409 @@
+"""pgw#1344: the HF->GGUF conversion reads and writes through tensorfs, and the
+GGUF it produces COMPOSES THROUGH THE STORE.
+
+The acceptance property is not "it converted". It is that a tensor whose GGUF
+bytes equal its safetensors bytes is admitted under the digest it already has,
+so a GGUF flavor of a resident model costs only the tensors that genuinely
+change. That is asserted here by comparing CAS object digests, per tensor, and
+it distinguishes shared-because-identical from new-because-transformed rather
+than claiming blanket sharing.
+
+**Why the fixture's tensors are 64 MiB and not four floats.** The store's own
+grid packs tensors below `MAX_CHUNK_SIZE` in with their neighbours, so a tensor
+under that size has no digest of its own to share and the property is
+structurally unobservable. 64 MiB is the boundary the property lives at; a
+smaller fixture would pass vacuously. The fixture is still synthetic and
+CPU-trivial -- zeros and constant fills, no model, no compile.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from gen_worker._vendor.tensorfs import LocalCAS, RepositoryManifest
+from gen_worker._vendor.tensorfs.manifest import MAX_CHUNK_SIZE
+from gen_worker.convert.gguf_native import (
+    GGUFUnsupported,
+    convert_snapshot_to_gguf,
+    hyperparameter_metadata,
+)
+
+HIDDEN = 4096
+KV_ROWS = 512
+VOCAB = 256
+
+CONFIG = {
+    "model_type": "llama",
+    "architectures": ["LlamaForCausalLM"],
+    "num_hidden_layers": 1,
+    "hidden_size": HIDDEN,
+    "intermediate_size": HIDDEN,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 4,
+    "max_position_embeddings": 2048,
+    "rms_norm_eps": 1e-5,
+    "rope_theta": 10000.0,
+    "vocab_size": VOCAB,
+}
+
+# name -> (safetensors dtype, shape, seed). Two tensors are exactly one CAS
+# object wide, one on each side of the permute: `q_proj` is rewritten and
+# `v_proj` is not, which is the whole comparison.
+#
+# The values VARY ALONG ROWS on purpose. A constant fill made the first draft
+# of this test lie: the rope permute is a row shuffle, so permuting a constant
+# tensor reproduces it byte for byte and the permuted tensor "shared" its
+# source objects. Content the shuffle can actually move is what makes
+# "transformed => new objects" a real assertion instead of a coincidence.
+FIXTURE: dict[str, tuple[str, tuple[int, ...], int]] = {
+    "model.embed_tokens.weight": ("F32", (VOCAB, HIDDEN), 0x11),
+    "model.layers.0.input_layernorm.weight": ("F32", (HIDDEN,), 0x22),
+    "model.layers.0.self_attn.q_proj.weight": ("F32", (HIDDEN, HIDDEN), 0x33),
+    "model.layers.0.self_attn.k_proj.weight": ("F32", (KV_ROWS, HIDDEN), 0x44),
+    "model.layers.0.self_attn.v_proj.weight": ("F32", (HIDDEN, HIDDEN), 0x55),
+    "model.layers.0.self_attn.o_proj.weight": ("F32", (HIDDEN, HIDDEN), 0x66),
+    "model.layers.0.post_attention_layernorm.weight": ("F32", (HIDDEN,), 0x77),
+    "model.norm.weight": ("F32", (HIDDEN,), 0x88),
+}
+
+_ITEMSIZE = {"F32": 4, "F16": 2, "BF16": 2}
+
+
+def _content(shape: tuple[int, ...], seed: int) -> bytes:
+    """Finite float32 that varies along the row axis, generated not stored."""
+
+    import numpy as np
+
+    elements = 1
+    for dimension in shape:
+        elements *= dimension
+    values = (np.arange(elements, dtype=np.float32) + seed) % 997.0
+    return values.tobytes()
+
+
+def _safetensors_bytes(tensors: dict[str, tuple[str, tuple[int, ...], int]]) -> bytes:
+    header: dict[str, object] = {}
+    blobs: list[bytes] = []
+    cursor = 0
+    for name, (dtype, shape, seed) in tensors.items():
+        length = _ITEMSIZE[dtype]
+        for dimension in shape:
+            length *= dimension
+        header[name] = {
+            "dtype": dtype,
+            "shape": list(shape),
+            "data_offsets": [cursor, cursor + length],
+        }
+        cursor += length
+        blobs.append(_content(shape, seed))
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * (-len(encoded) % 8)
+    return len(encoded).to_bytes(8, "little") + encoded + b"".join(blobs)
+
+
+@pytest.fixture(scope="module")
+def snapshot(tmp_path_factory: pytest.TempPathFactory) -> tuple[LocalCAS, RepositoryManifest]:
+    """A synthetic HF snapshot, resident in a real CAS. No directory is read."""
+
+    root = tmp_path_factory.mktemp("pgw1344")
+    cas = LocalCAS(root / "cas")
+    staged = root / "staged"
+    staged.mkdir()
+    (staged / "model.safetensors").write_bytes(_safetensors_bytes(FIXTURE))
+    (staged / "config.json").write_text(json.dumps(CONFIG))
+    manifest = cas.ingest_repository(staged)
+    # The staged tree exists only to be admitted; from here the conversion sees
+    # the store and nothing else.
+    for path in sorted(staged.rglob("*"), reverse=True):
+        path.unlink() if path.is_file() else path.rmdir()
+    staged.rmdir()
+    return cas, manifest
+
+
+def _metadata(encoding: str) -> tuple[bytes, int]:
+    blob, count, arch = hyperparameter_metadata(CONFIG, encoding=encoding)
+    assert arch == "LLAMA"
+    return blob, count
+
+
+def _source_digests(manifest: RepositoryManifest) -> set[str]:
+    return {str(chunk.digest) for entry in manifest.files for chunk in entry.chunks}
+
+
+def test_the_source_grid_gives_the_large_tensors_objects_of_their_own(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """The precondition the whole property rests on, asserted rather than hoped.
+
+    If the store ever packed a 64 MiB tensor in with its neighbours, every
+    sharing assertion below would go vacuously green on an unshareable source.
+    """
+
+    _cas, manifest = snapshot
+    entry = next(e for e in manifest.files if e.path == "model.safetensors")
+    lengths = [chunk.length for chunk in entry.chunks]
+    assert lengths.count(MAX_CHUNK_SIZE) >= 2, (
+        f"the fixture's 64 MiB tensors did not get objects of their own: {lengths}"
+    )
+
+
+def test_an_unpermuted_tensor_shares_its_objects_with_its_safetensors_source(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """THE acceptance property (pgw#1344), measured on real CAS digests."""
+
+    cas, manifest = snapshot
+    blob, count = _metadata("f32")
+    result = convert_snapshot_to_gguf(
+        cas, manifest, encoding="f32", metadata=blob, metadata_count=count
+    )
+    sharing = result.sharing
+
+    # v_proj and o_proj pass through untouched at f32; q_proj and k_proj are
+    # rope-permuted, so their bytes -- and therefore their objects -- differ.
+    assert set(sharing.shared) == {"blk.0.attn_v.weight", "blk.0.attn_output.weight"}
+    assert set(sharing.transformed) == {"blk.0.attn_q.weight", "blk.0.attn_k.weight"}
+    assert len(sharing.shared_digests) == 2, sharing.describe()
+
+    # Everything else is UNSHAREABLE, and that is a fact about the SOURCE's
+    # grid rather than about this converter: a tensor below `MAX_CHUNK_SIZE`
+    # was packed in with its neighbours when the snapshot was admitted, so it
+    # has no digest of its own for anything to share. Naming them keeps the
+    # measurement honest -- "everything shared" would be the false claim.
+    assert set(sharing.unshareable) == {
+        "token_embd.weight",
+        "blk.0.attn_norm.weight",
+        "blk.0.ffn_norm.weight",
+        "output_norm.weight",
+    }
+
+    # The comparison that makes it a measurement rather than a claim: the
+    # SHARED tensor's own objects are literally the source's objects.
+    source = _source_digests(manifest)
+    passthrough = [d for d in result.dispositions if d.passthrough and d.objects]
+    assert passthrough, "the plan transformed every tensor; nothing could share"
+    for item in passthrough:
+        if item.gguf_name in sharing.unshareable:
+            continue
+        assert set(item.objects) <= source, (
+            f"{item.gguf_name} passes through unchanged but was admitted as new "
+            f"objects -- the GGUF stopped composing through the store"
+        )
+
+    # And the converse, so a mutation that shares EVERYTHING is red too: a
+    # permuted tensor must NOT be carrying the source's digests.
+    for item in result.dispositions:
+        if item.transform == "permute":
+            assert not (set(item.objects) & source), (
+                f"{item.gguf_name} was permuted but kept its source objects"
+            )
+
+
+def test_a_dtype_cast_legitimately_shares_nothing(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """f16 from an f32 source rewrites every 2-D tensor, and says so.
+
+    This is the discriminating half of the acceptance bar: sharing is a
+    consequence of the bytes being equal, never a property the converter
+    asserts. A converter that "shared" here would be wrong.
+    """
+
+    cas, manifest = snapshot
+    blob, count = _metadata("f16")
+    result = convert_snapshot_to_gguf(
+        cas, manifest, encoding="f16", metadata=blob, metadata_count=count
+    )
+    two_dimensional = [d for d in result.dispositions if len(d.shape) > 1]
+    assert two_dimensional
+    assert all(not d.passthrough for d in two_dimensional), (
+        "a cast to f16 left a 2-D tensor claiming passthrough"
+    )
+    # The 1-D norms stay F32 by llama.cpp's own rule, so they still pass through.
+    assert any(d.passthrough for d in result.dispositions if len(d.shape) == 1)
+
+
+def test_the_norms_keep_f32_whatever_encoding_was_asked_for(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """`convert_hf_to_gguf.py::prepare_tensors`' rule, not this file's opinion."""
+
+    cas, manifest = snapshot
+    blob, count = _metadata("bf16")
+    result = convert_snapshot_to_gguf(
+        cas, manifest, encoding="bf16", metadata=blob, metadata_count=count
+    )
+    by_name = {d.gguf_name: d for d in result.dispositions}
+    assert by_name["blk.0.attn_norm.weight"].dtype == "F32"
+    assert by_name["output_norm.weight"].dtype == "F32"
+    assert by_name["blk.0.attn_v.weight"].dtype == "BF16"
+
+
+def test_the_conversion_reads_no_directory(
+    snapshot: tuple[LocalCAS, RepositoryManifest], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The seam is not merely unused -- it is unreachable from this path.
+
+    pgw#1303's ladder is enforced by `models.materialized_view.third_party_dir`
+    logging every projection. Making it raise turns "the converter no longer
+    projects" from an absence into an assertion.
+    """
+
+    import gen_worker.models.materialized_view as materialized_view
+
+    def forbidden(path: object, *, why: str) -> Path:
+        raise AssertionError(f"the native GGUF conversion projected a tree: {why}")
+
+    monkeypatch.setattr(materialized_view, "third_party_dir", forbidden)
+    cas, manifest = snapshot
+    blob, count = _metadata("f32")
+    result = convert_snapshot_to_gguf(
+        cas, manifest, encoding="f32", metadata=blob, metadata_count=count
+    )
+    assert result.entry.path == "model.gguf"
+    assert result.entry.size_bytes > 0
+
+
+def test_the_output_parses_as_a_gguf_the_store_can_read_back(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """A composed file is only real if the reader that plans GGUF can walk it."""
+
+    from gen_worker._vendor.tensorfs import open_tensors
+
+    cas, manifest = snapshot
+    blob, count = _metadata("f32")
+    result = convert_snapshot_to_gguf(
+        cas, manifest, encoding="f32", metadata=blob, metadata_count=count
+    )
+    reader = open_tensors(cas, RepositoryManifest((result.entry,)))
+    try:
+        header = reader.gguf_header("model.gguf")
+        assert header.metadata_count == count
+        names = {tensor.name for tensor in header.tensors}
+        assert "blk.0.attn_q.weight" in names
+        assert "output_norm.weight" in names
+        # GGUF `ne` is the reverse of safetensors' row-major shape.
+        v = next(t for t in header.tensors if t.name == "blk.0.attn_v.weight")
+        assert v.shape == (HIDDEN, HIDDEN)
+        assert reader["blk.0.attn_v.weight"].nbytes == MAX_CHUNK_SIZE
+    finally:
+        reader.close()
+
+
+def test_an_architecture_without_a_written_down_rule_is_refused(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """Gemma rewrites norm VALUES; a name map cannot express that.
+
+    The refusal is the point: a converter that mapped gemma by name alone would
+    emit a GGUF that loads and is quietly wrong.
+    """
+
+    cas, manifest = snapshot
+    gemma = dict(CONFIG, model_type="gemma", architectures=["GemmaForCausalLM"])
+    with pytest.raises(GGUFUnsupported, match="gguf_unsupported_architecture"):
+        hyperparameter_metadata(gemma, encoding="f32")
+    blob, count = _metadata("f32")
+    with pytest.raises(GGUFUnsupported, match="gguf_unsupported_architecture"):
+        convert_snapshot_to_gguf(
+            cas, manifest, encoding="f32", metadata=blob,
+            metadata_count=count, config=gemma,
+        )
+
+
+def test_a_k_quant_encoding_is_refused_by_name(
+    snapshot: tuple[LocalCAS, RepositoryManifest],
+) -> None:
+    """k-quants are `llama-quantize`'s, and it runs over this output."""
+
+    with pytest.raises(GGUFUnsupported, match="gguf_unsupported_encoding"):
+        hyperparameter_metadata(CONFIG, encoding="q4_k_m")
+
+
+def test_the_remaining_gguf_hatch_is_named_and_is_the_only_one() -> None:
+    """pgw#1344's residue, pinned so it can only shrink.
+
+    The tensor plane is native. What still runs `convert_hf_to_gguf.py` as a
+    subprocess is the METADATA block -- a model's vocabulary, its chat template
+    and its pre-tokenizer identity -- and that is deliberate: reproducing a
+    tokenizer faithfully is thousands of lines of upstream script that changes
+    weekly, and a GGUF whose vocabulary this repo guessed would load and be
+    quietly wrong. That is the exact failure this issue exists to prevent, so
+    the honest state is one NAMED hatch rather than a second tokenizer.
+
+    This fence does two things a comment cannot: it refuses a SECOND hatch
+    appearing anywhere in the conversion package, and it refuses the native
+    converter growing one.
+    """
+
+    convert = Path(__file__).resolve().parents[1] / "src" / "gen_worker" / "convert"
+
+    # Call-shaped, not word-shaped: this module's prose says "materialized"
+    # and "subprocess" repeatedly, and a fence that cannot tell the two apart
+    # is one somebody deletes. The tensorfs hatch itself is NOT spelled here --
+    # `scripts/lint_materialization_hatch.py` owns that census tree-wide, and
+    # naming it in a string literal is what trips that lint.
+    native = (convert / "gguf_native.py").read_text()
+    for forbidden in ("third_party_dir(", "run_process(", "import subprocess"):
+        assert forbidden not in native, (
+            f"gen_worker/convert/gguf_native.py reaches {forbidden!r}. The native "
+            f"path composes through the store; a hatch there is the whole defect."
+        )
+
+    # The conversion package's seam CENSUS, with the issue that owns each row.
+    # Written down rather than counted so it can only shrink: a file that
+    # appears here without a row is a new hatch, and a row whose file stopped
+    # calling is a cut somebody has to come back and delete.
+    census = {
+        # pgw#1344: the METADATA block only. The tensors are native above.
+        "gguf_tools.py": "pgw#1344",
+        # pgw#1335 owns these -- the conversion pipeline is still directory
+        # shaped end to end, and cutting them is that issue's pipeline cut.
+        "source.py": "pgw#1335",
+        # pgw#1344 states why NOT: this site is handed an ordinary civitai
+        # download whose home is `dest_dir`, not a snapshot, so the seam is a
+        # no-op there today and cutting it correctly needs the projection-aware
+        # read pgw#1335's pipeline supplies.
+        "ingest.py": "pgw#1335",
+    }
+    callers = {
+        path.name
+        for path in convert.glob("*.py")
+        if "third_party_dir(" in path.read_text()
+    }
+    assert callers == set(census), (
+        f"the conversion package's seam census moved: on disk {sorted(callers)}, "
+        f"declared {sorted(census)}. Every projection in this package is owned "
+        f"by an issue; an undeclared one is a new hatch, not a detail."
+    )
+    tools = (convert / "gguf_tools.py").read_text()
+    assert "pgw#1344" in tools, (
+        "the surviving hatch must name the issue that scopes it, so a reader "
+        "meets the reason rather than the call"
+    )
+
+
+def test_a_two_dimensional_norm_weight_is_pinned_to_f32_too() -> None:
+    """The half of llama.cpp's dtype rule a llama fixture cannot reach.
+
+    `_target_dtype` pins BOTH one-dimensional tensors and anything named
+    `*_norm.weight`. A llama's norms are one-dimensional, so a mutation that
+    deleted the name clause survived every test above -- the fixture could not
+    tell the two clauses apart. Architectures with a 2-D norm exist, and
+    llama.cpp keeps those at F32 as well, so the clause is asserted directly
+    rather than left to a fixture that happens not to exercise it.
+    """
+
+    from gen_worker.convert.gguf_native import _target_dtype
+
+    class _View:
+        shape = (16, 16)
+
+    view = cast("object", _View())
+    assert _target_dtype("blk.0.attn_norm.weight", view, "F16") == "F32"  # type: ignore[arg-type]
+    assert _target_dtype("blk.0.attn_v.weight", view, "F16") == "F16"  # type: ignore[arg-type]

--- a/tests/test_vendored_snapshot_pgw1310.py
+++ b/tests/test_vendored_snapshot_pgw1310.py
@@ -81,17 +81,25 @@ def test_the_vendored_tensorfs_carries_no_transfer_plane() -> None:
 def test_the_read_plane_is_recorded_at_its_own_rev() -> None:
     """pgw#1330: the snapshot is SPLIT at two revs, and the split is declared.
 
-    `project.py`, `tensors.py` and `gguf.py` come from a rev the storage half
-    is deliberately NOT at: the newer lineage deleted three `LocalCAS` methods
-    this repo still calls (ingest, GC, and the whole-tree copy the chokepoint
-    uses — VENDORED.toml names them). A split that is only in a comment is a
-    split nobody can audit, so the rev is a field and the file list is a
-    field, and the digest fence above covers them like any other vendored file.
+    The consumption plane comes from a rev the storage half is deliberately NOT
+    at: the newer lineage deleted three `LocalCAS` methods this repo still
+    calls (ingest, GC, and the whole-tree copy the chokepoint uses —
+    VENDORED.toml names them). A split that is only in a comment is a split
+    nobody can audit, so the rev is a field and the file list is a field, and
+    the digest fence above covers them like any other vendored file.
+
+    pgw#1344 widened the plane rather than the split: `writer.py` joins it (the
+    GGUF/safetensors composer a conversion writes through) and `__init__.py`
+    comes from the same rev, verbatim, now that upstream no longer re-exports a
+    Python transfer plane. The membership is spelled out so a file JOINING the
+    plane is a decision somebody makes on purpose.
     """
 
     spec = MANIFEST["packages"]["tensorfs"]
     assert spec["read_plane_rev"] != spec["rev"]
-    assert set(spec["read_plane_files"]) == {"gguf.py", "project.py", "tensors.py"}
+    assert set(spec["read_plane_files"]) == {
+        "__init__.py", "gguf.py", "project.py", "tensors.py", "writer.py",
+    }
     for name in spec["read_plane_files"]:
         assert name in spec["files"], f"{name} is not digest-fenced"
 


### PR DESCRIPTION
Closes the tensor half of pgw#1344.

**The property.** A tensor whose GGUF bytes equal its safetensors bytes is admitted under the digest it ALREADY HAS, so a GGUF flavor of a resident model costs only the tensors that genuinely change. Measured, not asserted.

### The write plane was missing and is now vendored

tensorfs's consumption plane advances `333bb10` → `21cec66` (tensorfs#106) for `writer.py`. `TensorWriter` composes a snapshot one tensor at a time, in safetensors or GGUF, on the seal planner's own object grid — the only way a converted GGUF can share tensor objects with its source. `__init__.py`, `gguf.py` and `project.py` come from the same rev verbatim, so the pgw#1308 `__init__.py` rewrite is **deleted** rather than carried.

One rewrite is real and declared: at `21cec66` `TensorReader._map` maps through the compiled extension and says there is no fallback. pgw#1310 rules a compiled extension out of a source-vendored wheel, so a straight take would have deleted native tensor reads from this repo. `_MappedObject` restores it in pure Python via PEP 688's `__buffer__`, preserving both properties upstream needed there — a weak-referenceable handle (an 8 GiB shard does not end up resident) and a buffer that outlives the reader for as long as a view of it does.

### `convert/gguf_native.py`

Reads through `TensorReader`; maps names with gguf-py's own `TensorNameMap`; applies llama's rope permute on raw elements (an axis swap is exact at any width); pins 1-D and `*_norm.weight` to F32 the way `prepare_tensors` does; casts with torch so the rounding is the fleet's; composes through `TensorWriter`. No directory projected, peak memory one tensor.

Cross-container `inherit()` is refused by the writer (the containers disagree about dimension order), so sharing comes through content addressing instead — identical bytes resolve to the existing object.

**Measured on a synthetic llama snapshot in a real CAS:**

| encoding | shared | transformed | unshareable |
|---|---|---|---|
| f32 | 2 tensors / **2 objects** (`attn_v`, `attn_output`) | 2 (`attn_q`, `attn_k` — rope permute) | 4 (sub-64 MiB, packed by the source's own grid) |
| f16 | 0 | 5 (every 2-D tensor is cast) | 3 |

### What is NOT cut, and why

The subprocess survives for the **metadata block** — vocabulary, chat template, pre-tokenizer identity. Reproducing a tokenizer faithfully is thousands of lines of upstream script that changes weekly, and a guessed vocabulary would load and be quietly wrong: exactly the silent change this issue exists to prevent. So the hatch is NAMED at its call site and a fence pins the conversion package's whole seam census with the owning issue per row. `gguf_native`'s entry points sit in the unreached-surface baseline's IN FLIGHT section with an owner and an expiry.

### Red

12/12 mutations distinguished — writer off-grid cuts, permute no-op, passthrough altered in flight, cast claiming passthrough, both clauses of the F32 norm pin, gemma mapped by name alone, fabricated metadata count, a projection in the native path, a second projection in the package, the hatch naming no issue, a hand-patched vendored file, a fixture below the grid floor.

Local: mypy clean (855 files), ruff clean, all six `fast gates` guard lints exit 0, 204 tests green across `tests/convert` + the vendoring/projection/seam fences + the new file.