### PR TITLE
pgw#1349: the WALL-CLOCK-FLAKE family is root-caused, not re-tuned

### DIFF
--- a/changelog.d/pgw1349.md
+++ b/changelog.d/pgw1349.md
@@ -1,0 +1,23 @@
+- **`JobMetrics`'s top-level millisecond terms and the stage map now share ONE quantizer**
+  (`stage_timing.ms_from_seconds`, newly public). `runtime_ms`, `queue_ms`, `slot_held_ms` and
+  `finalize_wall_ms` TRUNCATED while every `stage_ms` value ROUNDED, so a stage measured strictly
+  inside one of those intervals could report one millisecond MORE than its own container. That is
+  not cosmetic: `procsplit.attest` clamps these four against each other, the hub reads them, and
+  `finalize_wall_ms >= stage_ms["image_encode"]` — true of the intervals by construction — turned
+  master red as `assert 87 >= 88`. Rounding is monotone, so containment now survives quantization
+  instead of surviving it most of the time.
+- **The compute child is granted a RELOCATED local cell store.** `GEN_WORKER_LOCAL_CELLS_DIR`
+  defaults under the compute uid's own home, so the grant list never needed it — but cozy-local
+  relocates it by env, and a relocated root is created by the root parent and never chowned. The
+  dropped child then died mid-request on `PermissionError: .../aot-cells`, taking the stream with
+  it, on the first memo write of any mint. Asserted directly now
+  (`tests/test_pod_privilege_isolation_pgw858.py::test_the_dropped_child_can_write_a_RELOCATED_local_cell_store`),
+  and the shared write-probe creates a subdirectory rather than only writing a file, because
+  `mkdir` is the operation that actually failed.
+- **pgw#932's gRPC fork-handler abort names itself** (`procsplit.parent.is_grpc_fork_abort`).
+  `cause=signal:SIGABRT` names the symptom, which is why that self-inflicted pre-Hello abort has
+  been diagnosed from first principles at least five times. The parent now classifies it from
+  facts it already had — no Hello, no OOM, and pgw#833's stderr tail carrying gRPC's fork/poller
+  marks — logs that a respawn is the correct response, and stamps `known_defect` on the dial.
+  Deliberately not keyed on the ~0.8 s lifetime every sighting shows: a duration inside a
+  classifier is the shape this issue exists to remove.

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -97,6 +97,7 @@ src/gen_worker/host_canary.py::$k IPC restores the child's saved env after the c
 
 src/gen_worker/lifecycle.py::$ENV_VAR IPC WORKER_EXECUTION_TOPOLOGY (topology.ENV_VAR), the hub-delivered multi-GPU topology JSON, re-read only to decide whether the "GPUs are invisible" warning applies. Absent is legal and means one slot - which is why an unset value on a multi-GPU pod needs the warning at all.
 src/gen_worker/procsplit/parent.py::$ENV_WATCHDOG_PING_S IPC watchdog ping cadence handed down to the child.
+src/gen_worker/procsplit/parent.py::GEN_WORKER_LOCAL_CELLS_DIR IPC GEN_WORKER_LOCAL_CELLS_DIR, read to prepare the exec boundary rather than to steer this process. `_spawn_child` builds the child's environment from `dict(os.environ)`, so the value the CHILD will resolve its cell store to is whatever this process carries - and the parent must chown that root to the compute uid while it is still root. Reading it anywhere but here would be reading it after the only moment it can be acted on (pgw#1349). Same shape and same justification as the TENSORHUB_CACHE_DIR / GEN_WORKER_BOOT_RECORD reads in the same function; it is listed separately because the unit here is one file reading one variable.
 # ---------------------------------------------------------------------------
 # LIBRARY — torch / inductor / triton / NCCL read env at import. Accepted as a
 # MECHANISM. The VALUES are authored constants scattered across nine files,

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -134,7 +134,7 @@ from . import jobs as jobs_mod
 from .jobs import DEFAULT_PHASE_BUDGET_S, JobDispatch, JobOutcome, execute_job
 from .registry import EndpointSpec, JobSpec
 from .runtime_config import ConfigStore, extract_job_config
-from .stage_timing import stage_ms_for_metrics
+from .stage_timing import ms_from_seconds, stage_ms_for_metrics
 
 #: pgw#848 item 1: cadence for the publish-durability wait. A POLL interval,
 #: not a deadline — nothing here decides when a publish has taken too long;
@@ -10287,7 +10287,7 @@ class Executor:
             await self._finish(job, status, safe_message=msg)
             return
 
-        queue_ms = int((time.monotonic() - job.admitted_at) * 1000)
+        queue_ms = ms_from_seconds(time.monotonic() - job.admitted_at)
         lease: Optional[_GpuSlotLease] = None
         started = time.monotonic()
         alloc_at_start = 0
@@ -10557,10 +10557,12 @@ class Executor:
                 if released_at is not None:
                     # gw#516 typed split of runtime_ms: how long the GPU slot
                     # was actually held vs the slotless finalize tail.
-                    metrics.slot_held_ms = max(
-                        0, int((released_at - started) * 1000))
-                    metrics.finalize_wall_ms = max(
-                        0, int((handler_done - released_at) * 1000))
+                    # pgw#1349: the SAME quantizer the stage map uses. These two
+                    # bracket stages the map also reports, so a second rounding
+                    # rule here makes a contained stage out-round its container.
+                    metrics.slot_held_ms = ms_from_seconds(released_at - started)
+                    metrics.finalize_wall_ms = ms_from_seconds(
+                        handler_done - released_at)
                 if released_at is not None and handler_done > released_at:
                     # The encode/upload tail ran slotless, overlapping the next
                     # request. `handoff` says who ended the GPU phase: the
@@ -11443,7 +11445,7 @@ class Executor:
         runtime_terms: "Optional[Dict[str, float]]" = None,
         peak_vram_bytes: "Optional[int]" = None,
     ) -> pb.JobMetrics:
-        runtime_ms = int((time.monotonic() - started) * 1000)
+        runtime_ms = ms_from_seconds(time.monotonic() - started)
         # rss_at_end_bytes (pgw#513): instantaneous RSS, honestly named — the
         # OS gives no per-process peak-RSS reset, so this is NOT a per-job
         # peak (unlike peak_vram_bytes below, reset at handler start).

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -245,6 +245,41 @@ def _http_call(
 _set_pdeathsig = privdrop.set_pdeathsig
 
 
+def is_grpc_fork_abort(
+    *, cause: str, saw_hello: bool, oom_delta: int, stderr_tail: str,
+) -> bool:
+    """pgw#932's WRITTEN DISCRIMINATOR, applied by the parent instead of by a
+    human reading logs.
+
+    The defect: gRPC registers ``pthread_atfork`` handlers that SKIP when
+    another thread is inside gRPC, and the forked-but-not-yet-exec'd child then
+    aborts out of the polling engine on an fd it must not touch. It is
+    self-inflicted — nothing about the pod, image, card or tenant is
+    implicated — but ``cause=signal:SIGABRT`` names the symptom and says
+    nothing about the reason, so it has been diagnosed from first principles at
+    least five separate times, twice by a lane spending a triage session on a
+    red it did not cause.
+
+    The discriminator was written down after the fourth sighting; this is that
+    text in code, so the sixth reader is TOLD rather than left to re-derive.
+
+    Deliberately NOT keyed on the ~0.8 s lifetime that accompanies every
+    recorded sighting: a duration inside a classifier is the same
+    magic-timeout-as-evidence shape pgw#1349 exists to remove, it would
+    misclassify on a slower box, and it adds nothing — gRPC's fork marks are
+    already specific to this path.
+
+    Narrow on purpose. A SIGABRT with no Hello and no OOM that does NOT carry
+    those marks is a different, unexplained defect and must keep saying so.
+    """
+    if saw_hello or oom_delta > 0 or cause != "signal:SIGABRT":
+        return False
+    tail = stderr_tail or ""
+    if "fork_posix" in tail or "skipping fork() handlers" in tail:
+        return True
+    return "Epoll1Poller" in tail and "Bad file descriptor" in tail
+
+
 class _ChildLink:
     def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         self.reader = reader
@@ -960,6 +995,21 @@ class _ChildSlot:
         # channel that survives a pre-Hello death on a provider with no
         # container-logs API.
         stderr_tail = self.stderr_tail_text()
+        known = is_grpc_fork_abort(
+            cause=cause, saw_hello=saw_hello, oom_delta=oom_delta,
+            stderr_tail=stderr_tail,
+        )
+        if known:
+            logger.error(
+                "compute child %s: this is pgw#932 — gRPC's fork handlers were "
+                "skipped because another thread was inside gRPC, and the "
+                "forked child aborted out of the polling engine before exec. "
+                "SELF-INFLICTED and transient: nothing about this pod, image, "
+                "card or tenant is implicated, the respawn below is the "
+                "correct response, and a CI run that fails on it wants a "
+                "rerun, not a diagnosis. The real fix is the exec-first "
+                "launcher, gated on pgw#909.", self.label,
+            )
         detail = postmortem.format_detail(
             phase="compute_process_exit",
             verdict=verdict,
@@ -972,6 +1022,7 @@ class _ChildSlot:
                 "in_flight": sorted(f"{r}#{a}" for (r, a) in died_jobs),
                 "spawn_count": self.spawn_count,
                 "saw_hello": saw_hello,
+                **({"known_defect": "pgw#932:grpc_fork_abort"} if known else {}),
                 **({"child_stderr_tail": stderr_tail} if stderr_tail else {}),
             },
         )
@@ -1326,6 +1377,20 @@ class ParentControl:
                 self._child_env.get("GEN_WORKER_BOOT_RECORD", "")
                 or self._settings.boot_record_path
             ),
+            # The local compiled-cell store: the CHILD mints, and the mint
+            # writes the memo and the per-cell sidecar under this root. Its
+            # DEFAULT (``~/.cache/cozy/compile-cells``) already resolves inside
+            # the compute uid's own home, so nothing needed granting while the
+            # default stood — which is exactly why the gap survived: cozy-local
+            # RELOCATES it by env (`internal/paths/paths.go`), and a relocated
+            # root lands outside every other entry in this list. pgw#1349: the
+            # dropped child then dies mid-request on
+            # ``PermissionError: .../aot-cells``, root-owned 0755 because the
+            # parent created it. Read from the child's env — the same rule the
+            # cache root above follows — never by importing the store, which
+            # would pull the model layer into this torch-free process.
+            self._child_env.get("GEN_WORKER_LOCAL_CELLS_DIR", "")
+            or os.environ.get("GEN_WORKER_LOCAL_CELLS_DIR", ""),
             # The mutable-config snapshot: the CHILD atomically rewrites
             # it on every config-generation push (tmp file in the SAME dir plus
             # os.replace, so the directory itself must be writable), and unlike

--- a/src/gen_worker/stage_timing.py
+++ b/src/gen_worker/stage_timing.py
@@ -432,12 +432,29 @@ def _stage_name(name: str) -> str:
     return str(name or "").strip().replace(".", "_")
 
 
-def _ms(seconds: float) -> int:
+def ms_from_seconds(seconds: float) -> int:
+    """THE quantizer for every millisecond a request reports.
+
+    pgw#1349: it is public because ``JobMetrics``'s own top-level terms
+    (``runtime_ms``, ``queue_ms``, ``slot_held_ms``, ``finalize_wall_ms``) are
+    compared against these stages — by ``procsplit.attest``, by the hub, and by
+    the suite — and they used to TRUNCATE while every stage here ROUNDS. Two
+    quantizers over nested spans breaks the one relation the numbers exist to
+    express: an inner span can out-round its container by 1 ms, so
+    ``finalize_wall_ms >= stage_ms["image_encode"]`` — true of the intervals by
+    construction — reported ``87 >= 88`` and turned master red. Rounding is
+    monotone, so one shared quantizer makes containment survive quantization
+    instead of surviving it most of the time.
+    """
     return int(round(max(0.0, float(seconds)) * 1000.0))
+
+
+_ms = ms_from_seconds
 
 
 __all__ = [
     "StageTimer",
+    "ms_from_seconds",
     "stage_of",
     "record_phase_of",
     "stage_ms_for_metrics",

--- a/tests/harness/privdrop_endpoints.py
+++ b/tests/harness/privdrop_endpoints.py
@@ -101,11 +101,26 @@ class PrivProbe:
 
     def write_probe(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
         """The positive control for the grant list: the child must still be
-        able to write every path it was given. `data.text` is a path."""
-        target = Path(data.text) / "pgw858-write-probe"
+        able to write every path it was given. `data.text` is a path.
+
+        pgw#1349: it CREATES A SUBDIRECTORY too, because that is the operation
+        that actually died in production. Every child-side writer under a
+        granted root reaches it through
+        ``path.parent.mkdir(parents=True, exist_ok=True)`` — the local cell
+        store's memo and sidecar writes are exactly that — and a probe that
+        only writes a file into a directory the PARENT made would have gone
+        green on the tree where the child could not make one."""
+        root = Path(data.text)
+        nested = root / "pgw858-probe-dir" / "nested"
+        target = root / "pgw858-write-probe"
         try:
+            nested.mkdir(parents=True, exist_ok=True)
+            (nested / "leaf").write_text("ok", encoding="utf-8")
             target.write_text("ok", encoding="utf-8")
             target.unlink()
+            (nested / "leaf").unlink()
+            nested.rmdir()
+            nested.parent.rmdir()
             return ProbeOut(response="ok")
         except OSError as exc:
             return ProbeOut(response=f"{type(exc).__name__}: {exc}")

--- a/tests/harness/progress_wait.py
+++ b/tests/harness/progress_wait.py
@@ -48,12 +48,19 @@ only reason pgw#795 was diagnosable at all, and that is the bar.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Callable, Optional
 
 from gen_worker.stall import SilenceWindow
 
-__all__ = ["Cadence", "StalledError", "await_count", "await_progress"]
+__all__ = [
+    "Cadence",
+    "StalledError",
+    "await_count",
+    "await_progress",
+    "await_progress_async",
+]
 
 
 class StalledError(TimeoutError):
@@ -163,6 +170,58 @@ def await_progress(
 
         # Re-read the window every poll: a slow advance recorded mid-wait
         # widens it, which is the calibration doing its job.
+        window.window_s = cadence.window_s
+        if window.stalled():
+            raise StalledError(
+                f"waiting for {what}: nothing advanced for "
+                f"{window.silent_for():.1f}s (staleness window "
+                f"{cadence.describe()}); last saw "
+                f"{render(value) if render else value!r}"
+            )
+
+    cadence.record(time.monotonic() - last_advance)
+    return value
+
+
+async def await_progress_async(
+    observe: Callable[[], Any],
+    settled: Callable[[Any], bool],
+    *,
+    what: str,
+    cadence: Cadence,
+    gone: Optional[Callable[[], Optional[str]]] = None,
+    render: Optional[Callable[[Any], str]] = None,
+    poll_s: float = 0.005,
+) -> Any:
+    """:func:`await_progress` for a wait that must not block the event loop.
+
+    pgw#1349. The synchronous version sleeps, and a test whose subject is an
+    asyncio task or a thread the LOOP has to start cannot use it: the sleep
+    starves the very thing being waited for, so the wait would time out on a
+    hang it caused itself. Same three endings, same self-derived window — only
+    the sleep changes.
+    """
+    window = SilenceWindow(cadence.window_s)
+    value = observe()
+    last_advance = time.monotonic()
+
+    while not settled(value):
+        reason = gone() if gone is not None else None
+        if reason is not None:
+            raise StalledError(
+                f"waiting for {what}: {reason} — last saw "
+                f"{render(value) if render else value!r}"
+            )
+        await asyncio.sleep(poll_s)
+
+        now = time.monotonic()
+        fresh = observe()
+        if fresh != value:
+            cadence.record(now - last_advance)
+            value, last_advance = fresh, now
+            window.touch()
+            continue
+
         window.window_s = cadence.window_s
         if window.stalled():
             raise StalledError(

--- a/tests/test_activity_gw601.py
+++ b/tests/test_activity_gw601.py
@@ -14,6 +14,8 @@ import time
 from pathlib import Path
 from typing import List
 
+from harness.progress_wait import Cadence, StalledError, await_count
+
 import msgspec
 import pytest
 
@@ -292,10 +294,16 @@ def test_watchdog_survives_zero_cpu_download_via_note_progress(monkeypatch):
         # Constant evidence: the watchdog thread can never heartbeat, so
         # every beat below is proof-of-life from note_progress() ticks.
         with activity.watchdog(act, interval_s=0.05, evidence=lambda: 0.0):
-            deadline = time.monotonic() + 10.0
-            while len(reports) - baseline < 3 and time.monotonic() < deadline:
-                time.sleep(0.01)
-            beats_during = len(reports) - baseline
+            # pgw#1349: a 10 s expiry here does not fail this tape, it
+            # WEAKENS it — the loop falls out with two beats and the assert
+            # below reports a silence the ticker never had. Wait on the beats.
+            beats_during = await_count(
+                lambda: len(reports) - baseline, 3,
+                what="progress heartbeats during the download tick stream",
+                cadence=Cadence(),
+                gone=lambda: (None if ticker.is_alive()
+                              else "the tick thread exited"),
+            )
     finally:
         stop.set()
         ticker.join(timeout=2)
@@ -353,12 +361,23 @@ def test_watchdog_survives_zero_cpu_disk_load_via_io_evidence():
             # first accounted write, and a 0.3s sleep turned that into a red
             # suite (CI 2026-08-03) against an activity.py byte-identical to
             # the one that passed two days earlier.
-            deadline = time.monotonic() + 10.0
-            while time.monotonic() < deadline:
+            # pgw#1349: the give-up is SWALLOWED here, on purpose and only
+            # here. On a host whose kernel reports no process I/O the beat
+            # cannot arrive at any speed, and the io_before/io_after check
+            # below is what turns that into a SKIP naming the real reason. A
+            # raised stall would convert that documented non-coverage into a
+            # red. The `assert beats_during >= 1` past the skip is what still
+            # fails when the evidence path is genuinely broken.
+            try:
+                beats_during = await_count(
+                    lambda: len(reports) - baseline, 1,
+                    what="a progress heartbeat backed by real process I/O",
+                    cadence=Cadence(),
+                    gone=lambda: (None if ticker.is_alive()
+                                  else "the disk-load thread exited"),
+                )
+            except StalledError:
                 beats_during = len(reports) - baseline
-                if beats_during >= 1:
-                    break
-                time.sleep(0.01)
         io_after = activity._process_io_evidence()
     finally:
         stop.set()

--- a/tests/test_cancel_unwind_pgw687.py
+++ b/tests/test_cancel_unwind_pgw687.py
@@ -30,6 +30,7 @@ from gen_worker.pb import worker_scheduler_pb2 as pb
 
 from harness import stubborn_endpoints_pgw687 as wedge
 from harness.hub_double import hub_double, is_accept_for, is_ready, is_result_for
+from harness.progress_wait import Cadence, await_progress
 
 MODULE = "harness.stubborn_endpoints_pgw687"
 CUDA = pb.ResolvedCompute(accelerator="cuda", gpu_index=0)
@@ -165,13 +166,15 @@ def test_late_unwind_re_advertises_and_the_next_job_runs() -> None:
         wedge.STUBBORN_RELEASE.set()  # the unwind lands, late
         res_a = _result(conn, "r-late-a", timeout=10.0)
         assert res_a is not None and res_a.status == pb.JOB_STATUS_CANCELED
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            if harness.worker.executor.available_functions():
-                break
-            time.sleep(0.05)
-        assert harness.worker.executor.available_functions(), (
-            "a landed unwind must re-advertise the functions we took")
+        # pgw#1349: a 10 s expiry here only decided WHEN the assert below ran,
+        # so a loaded runner turned "the unwind has not landed yet" into "the
+        # unwind never re-advertised". Wait on the advertisement.
+        await_progress(
+            harness.worker.executor.available_functions,
+            bool,
+            what="the landed unwind to re-advertise the functions we took",
+            cadence=Cadence(),
+        )
         _send(conn, "r-late-d", "polite")
         res_d = _result(conn, "r-late-d", timeout=10.0)
         assert res_d is not None and res_d.status == pb.JOB_STATUS_OK
@@ -188,9 +191,13 @@ def test_thread_that_never_unwinds_recycles_the_process() -> None:
         _send(conn, "r-recycle-a", "stubborn")
         assert wedge.STUBBORN_RUNNING.wait(timeout=10.0)
         conn.send(cancel_job=pb.CancelJob(request_id="r-recycle-a", attempt=1))
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline and not exits:
-            time.sleep(0.05)
+        # pgw#1349, same shape: the process-exit call is what is being waited
+        # for, and the assert below still fails on a WRONG exit code.
+        await_progress(
+            lambda: list(exits), bool,
+            what="the recycle exit for a thread that never honours a cancel",
+            cadence=Cadence(),
+        )
         assert exits == [70], (
             "a handler thread that never honours a cancel cannot be reclaimed "
             "in-process — the pod must be replaced")

--- a/tests/test_cancelled_setup_leak_gw624.py
+++ b/tests/test_cancelled_setup_leak_gw624.py
@@ -32,6 +32,8 @@ from gen_worker.executor import Executor, _to_thread_complete
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 
+from harness.progress_wait import Cadence, await_progress_async
+
 
 class _In(msgspec.Struct):
     prompt: str = "x"
@@ -113,7 +115,18 @@ def test_cancelled_to_thread_join_releases_result() -> None:
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=_POOL_WIDTH)
         asyncio.get_running_loop().set_default_executor(pool)
         task = asyncio.create_task(_to_thread_complete(load))
-        await asyncio.to_thread(started.wait, 10)
+        # pgw#1349, same reason as the sibling below: a 10 s expiry here
+        # cancels before `load` ran, and every assertion afterwards then
+        # describes a tree that was never exercised.
+        await await_progress_async(
+            started.is_set,
+            bool,
+            what="the load to start on a pool thread",
+            cadence=Cadence(),
+            gone=lambda: (
+                "the load task ended without ever starting"
+                if task.done() and not started.is_set() else None),
+        )
         task.cancel()
         release.set()
         with pytest.raises(asyncio.CancelledError) as excinfo:
@@ -167,19 +180,45 @@ def test_cancelled_setup_frees_prior_attempt_before_retry() -> None:
 
     async def run() -> None:
         task = asyncio.create_task(ex.ensure_setup(specs[0]))
-        await asyncio.to_thread(entered.wait, 10)
+        # pgw#1349: this was `await asyncio.to_thread(entered.wait, 10)`, and a
+        # 10-second give-up here does not FAIL the tape — it silently rewrites
+        # it. Cancelling before `setup()` was entered leaves `refs` empty, so
+        # attempt 2 takes the FIRST branch, records nothing, and the test dies
+        # far below on `assert [] == [False]` naming a leak that never
+        # happened. That is how it red master from a merge ref (banked as an
+        # unattributed observation against pgw#1328). The wait now ends on the
+        # EVENT, on the setup task ending without entering `setup()`, or on a
+        # silence window this wait measured for itself.
+        await await_progress_async(
+            entered.is_set,
+            bool,
+            what="the first attempt to enter setup()",
+            cadence=Cadence(),
+            gone=lambda: (
+                "the setup task ended without ever entering setup()"
+                if task.done() and not entered.is_set() else None),
+        )
         task.cancel()
         release.set()
         with pytest.raises(asyncio.CancelledError):
             await task
         await ex.ensure_setup(specs[0])
 
+    # Only the executor's OWN purge may pass this test, so the generational
+    # collector is off for the duration. Restored to what it WAS rather than
+    # unconditionally enabled: this is process-global state and an xdist worker
+    # runs many modules through it.
+    gc_was_enabled = gc.isenabled()
     gc.disable()
     try:
         asyncio.run(run())
     finally:
-        gc.enable()
+        if gc_was_enabled:
+            gc.enable()
 
     assert alive_at_second_attempt == [False], (
         "the cancelled attempt's partial load survived into the retry — "
-        "retries stack allocations until OOM (gw#624)")
+        "retries stack allocations until OOM (gw#624)"
+        if alive_at_second_attempt else
+        "attempt 2 never judged attempt 1: the first attempt was cancelled "
+        "before it allocated, so this run measured nothing (gw#624)")

--- a/tests/test_child_stderr_postmortem_pgw833.py
+++ b/tests/test_child_stderr_postmortem_pgw833.py
@@ -104,3 +104,51 @@ def test_boot_fatal_ack_round_trips_before_the_child_exits(
         assert captured_reports[0].reason_class == "cuda_unavailable"
     finally:
         h.close()
+
+
+# ---------------------------------------------------------------------------
+# pgw#1349 / pgw#932: the stderr tail is captured (above) — now it is READ
+# ---------------------------------------------------------------------------
+
+
+def test_the_grpc_fork_abort_names_itself_instead_of_being_rediagnosed():
+    """pgw#932 has been diagnosed from first principles at least five times,
+    because ``cause=signal:SIGABRT`` names the symptom and nothing else. The
+    facts needed to tell it apart were already on the dial — ``saw_hello``, the
+    OOM delta, and pgw#833's stderr tail — so the discriminator that lived in
+    the issue text now lives in the parent.
+
+    RED-VERIFIABLE both ways, which is the point of the negative rows: a
+    classifier that fires on every pre-Hello abort would relabel real defects
+    as "known, rerun it", which is worse than the confusion it replaces."""
+    from gen_worker.procsplit.parent import is_grpc_fork_abort
+
+    sighting = (
+        "I0803 03:09:46.724278 11992 fork_posix.cc:71] Other threads are "
+        "currently calling into gRPC, skipping fork() handlers\n"
+        "E0803 03:09:46.728102 12039 ev_epoll1_linux.cc:373] (event_engine) "
+        "Epoll1Poller:0x278b97e0 encountered epoll_wait error: Bad file "
+        "descriptor\n"
+    )
+    poller_only = (
+        "ev_epoll1_linux.cc:373 (event_engine) Epoll1Poller encountered "
+        "epoll_wait error: Bad file descriptor"
+    )
+    def abort(*, saw_hello: bool = False, oom_delta: int = 0,
+              cause: str = "signal:SIGABRT", tail: str = "") -> bool:
+        return is_grpc_fork_abort(cause=cause, saw_hello=saw_hello,
+                                  oom_delta=oom_delta, stderr_tail=tail)
+
+    assert abort(tail=sighting)
+    # The 2026-08-17 master red carried only the poller half of the tail.
+    assert abort(tail=poller_only)
+
+    # ...and every neighbouring shape stays UNEXPLAINED, by name:
+    assert not abort(tail=sighting, saw_hello=True), (
+        "a post-Hello abort is the tenant's process dying, not the launcher's")
+    assert not abort(tail=sighting, oom_delta=2), (
+        "an OOM kill has an owner and a cost; it must never read as 'rerun it'")
+    assert not abort(tail=sighting, cause="signal:SIGSEGV"), (
+        "a SIGSEGV is the pgw#676 class, which is a real serving defect")
+    assert not abort(tail="free(): invalid pointer")
+    assert not abort(tail="")

--- a/tests/test_magic_timeouts_gw666.py
+++ b/tests/test_magic_timeouts_gw666.py
@@ -632,14 +632,12 @@ _TOKEN_EXPIRY_ARG = re.compile(
 #: on progress (``harness.progress_wait.await_count`` is the replacement). Every
 #: one of them can fail a publish the way pgw#628 did. Owned by pgw#795's
 #: follow-up; delete lines from this list, never add them.
-_DEADLINE_BURNDOWN = {
-    "test_activity_gw601.py",
-    "test_cancel_unwind_pgw687.py",
-    "test_mint_gate_pgw677.py",
-    "test_mint_reopen_pgw677.py",
-    "test_rotation_preload_pgw674.py",
-    "test_sp_group_isolation_pgw773_774.py",
-}
+#: **EMPTY as of pgw#1349, and it stays empty.** All six entries were converted
+#: to `harness.progress_wait` waits or to load-invariant bounds, and every one
+#: was red-verified by breaking the property it guards rather than the clock. The
+#: set exists so a NEW literal deadline in a test still fails this gate; a name
+#: reappearing here is a regression to argue about, not a line to add.
+_DEADLINE_BURNDOWN: set = set()
 
 #: Assertions that compare measured time to a constant. Each survives review as
 #: a HANG bound (class 3 above) with at least an order of magnitude of headroom
@@ -651,7 +649,10 @@ _ELAPSED_ASSERT_BURNDOWN = {
     "test_hardware_report.py",             # hang bound: refused connect << 10s
     "test_mint_process_pgw784.py",         # hang bound: reap must not wait out a 600s child
     "test_subprocess_stall_gw665.py",      # hang bound: stall window << 30s
-    "test_mint_reopen_pgw677.py",          # LATENCY BUDGET — anchor it next
+    # pgw#1349 deleted this file's entry. Its two LATENCY BUDGETS
+    # (`boot_wall < 6.0`, `wall < 1.0`) were undeclarable numbers — nothing the
+    # harness configures derives either — and both are now ordering/bounded-by-
+    # one-compile claims measured against THIS run's own compile intervals.
     # exposed by the widened pattern below, each reviewed:
     "test_p6_cancel_stream_backpressure.py",  # LOWER bound on 2x an induced 0.5s
                                               # handler sleep: only OVERLAP can

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -28,7 +28,7 @@ import contextlib
 import threading
 import time
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Tuple
+from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 import msgspec
 import pytest
@@ -52,6 +52,8 @@ from gen_worker.models.store import ModelStore
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 from gen_worker.models import store as store_mod
+
+from harness.progress_wait import Cadence, await_progress_async
 
 FAMILY = "sdxl"
 _ASPECT_AXIS = CompileAxis(classes=(
@@ -357,10 +359,38 @@ def test_compile_and_tenant_forward_never_overlap_and_red_verifies(
 
     async def _on() -> None:
         await h_on.boot()
-        deadline = time.monotonic() + 10.0
-        while not h_on.in_compile.is_set():
-            assert time.monotonic() < deadline, "no background compile ran"
-            await asyncio.sleep(0.005)
+        # pgw#1349: this was `deadline = time.monotonic() + 10.0`, and it red
+        # master as `assert 416.463803 < 416.463401` — a clock reporting that
+        # a loaded runner had not yet scheduled the shape-warm thread, dressed
+        # up as "no background compile ran". Nothing here is a claim about how
+        # fast the machine is; what the tape needs is that a compile STARTS.
+        # So the give-up keys on evidence: it is immediate and definitive when
+        # the background mint has finished without ever compiling (nothing can
+        # start after that), and otherwise it only bounds SILENCE.
+        def _mint_finished() -> Optional[str]:
+            # `_background_mint`'s finally clears `rec.background_mint`, so
+            # ABSENCE is the completion signal here (boot has already set it —
+            # the sibling tape asserts exactly that). Once the mint is over and
+            # nothing compiled, no compile can start, so this is definitive and
+            # needs no clock at all.
+            bg = h_on.rec.background_mint
+            if h_on.compiles or h_on.in_compile.is_set():
+                return None
+            if bg is None:
+                return "the background mint finished without compiling anything"
+            task = bg.task
+            if task is not None and task.done():
+                return ("the background mint task ended without compiling "
+                        f"anything: {task.exception()!r}")
+            return None
+
+        await await_progress_async(
+            lambda: (h_on.in_compile.is_set(), len(h_on.compiles)),
+            lambda seen: seen[0],
+            what="the shape-warm thread to enter a compile",
+            cadence=Cadence(),
+            gone=_mint_finished,
+        )
         t_admit = time.monotonic()
         # The moment the in-flight compile RELEASES, watched from beside the
         # dispatch. `in_compile` is the same signal the loop above already

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -56,6 +56,13 @@ from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 from gen_worker.models import store as store_mod
 
+#: pgw#1349. Slack for comparing two clocks that measure the SAME run — the
+#: worker's stage map against this harness's own compile intervals — never
+#: patience for a slow machine. Both sides of every comparison below stretch
+#: together under load, so this bounds rounding and scheduling jitter only.
+#: Same constant and same justification as `test_mint_gate_pgw677`'s.
+_CLOCK_SLOP_MS = 100.0
+
 FAMILY = "sdxl"
 _ASPECT_AXIS = CompileAxis(classes=(
     AxisClass("sq", match=lambda v: v == "1:1", warm="1:1"),
@@ -357,20 +364,47 @@ def test_w8a8_stamp_with_hub_execution_lane_boots_eager_first(
         weight_lane="w8a8", hub_execution_lane="fp8-w8a16+eager")
 
     async def _run() -> None:
-        boot_t0 = time.monotonic()
         await h.boot()
-        boot_wall = time.monotonic() - boot_t0
         # Eager-first: READY without paying the plan's compiles foreground.
         assert h.rec.background_mint is not None, (
             "w8a8-stamped pipe with hub lane fp8-w8a16+eager was refused "
             "eager-first — the foreground compile-then-serve mint is the "
             "reopen's measured 26-minute starvation")
-        assert boot_wall < 6.0, f"boot paid the plan foreground: {boot_wall:.1f}s"
-        # A tenant request mid-mint completes at serving latency.
+        # pgw#1349: `assert boot_wall < 6.0` and `assert wall < 1.0` stood here
+        # and are the two entries `_ELAPSED_ASSERT_BURNDOWN` marked "LATENCY
+        # BUDGET — anchor it next". Both were claims about how fast the machine
+        # is: 6.0 and 1.0 are not derivable from anything this harness
+        # configures, and on a loaded four-core runner a correct tree can
+        # exceed either. The doctrine they stand for is CAUSAL — boot did not
+        # wait for the mint, and neither did the tenant — so both are asserted
+        # as ordering against THIS run's own mint, which a slow machine moves
+        # together with everything else. Same correction pgw#1249 made to the
+        # sibling file's `>= 100` floor.
+        mint_task = h.rec.background_mint.task
+        assert mint_task is not None and not mint_task.done(), (
+            "boot returned only after the mint finished — that IS the "
+            "foreground compile-then-serve path this test forbids")
+        # A tenant request mid-mint completes at serving latency: it lands
+        # while the mint is still running, so it cannot have waited for it.
         res, wall = await h.dispatch("r-live", aspect="16:9")
         assert res.status == pb.JOB_STATUS_OK, res.safe_message
-        assert wall < 1.0, f"tenant starved during mint: {wall:.2f}s"
         await h.wait_mint()
+        # A tenant arriving mid-mint is BOUNDED BY ONE COMPILE, not by the
+        # plan — measured against the longest compile THIS run performed, so
+        # a slow machine stretches both sides together. (Observed here: 321 ms
+        # of gate wait against a 400 ms compile, 22 ms of runtime.)
+        stages = dict(res.metrics.stage_ms)
+        gate_wait_ms = int(stages.get("instance_gate_wait", 0))
+        assert h.compiles, "no compile ran, so nothing bounded the wait"
+        longest_compile_ms = max(
+            int((end - start) * 1000) for _, _, start, end in h.compiles)
+        assert gate_wait_ms <= longest_compile_ms + _CLOCK_SLOP_MS, (
+            "the tenant waited longer than one compile — it is sitting behind "
+            "the PLAN, which is the reopen's live break",
+            gate_wait_ms, longest_compile_ms, stages)
+        # ...and that wait is not billed to the tenant as runtime.
+        assert res.metrics.runtime_ms + gate_wait_ms <= wall * 1000 + _CLOCK_SLOP_MS, (
+            res.metrics.runtime_ms, gate_wait_ms, wall)
         assert h.ex.serving_tiers() == {"generate": "compiled"}
 
     asyncio.run(_run())
@@ -458,9 +492,19 @@ def test_compile_steal_is_announced_on_the_wire(
         await h.boot()
         assert h.rec.background_mint is not None
         pending_task: Any = None
-        deadline = time.monotonic() + 30.0
+        # pgw#1349: this loop was bounded by `time.monotonic() + 30.0`, and it
+        # is where `test_compile_steal_is_announced_on_the_wire` flaked — green
+        # in isolation, red beside four xdist siblings. The doctrine says
+        # "under truly CONTINUOUS DEMAND", and demand is counted in REQUESTS,
+        # not in seconds: a loaded runner serves each dispatch more slowly, so
+        # a wall clock silently shortens the stream the property is about until
+        # the tape asserts something it never drove. The bound is now the
+        # stream itself, which is what a slow machine cannot shrink. It is a
+        # HANG bound: the steal lands on dispatch 10 here (measured), so 250
+        # is 25x headroom and only a steal that never comes ends the loop.
+        _MAX_DISPATCHES = 250
         i = 0
-        while time.monotonic() < deadline:
+        while i < _MAX_DISPATCHES:
             nxt = asyncio.create_task(h.dispatch(f"r-{i}", aspect="16:9"))
             if pending_task is not None:
                 res, _wall = await pending_task
@@ -472,7 +516,8 @@ def test_compile_steal_is_announced_on_the_wire(
         if pending_task is not None:
             await pending_task
         assert h.events("bg_turn_steal"), (
-            "a compile steal under continuous demand must be announced")
+            "a compile steal under continuous demand must be announced; "
+            f"{i} back-to-back dispatches produced none")
 
     asyncio.run(_run())
 

--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -199,6 +199,7 @@ from test_procsplit_pgw763 import (  # noqa: E402,F401 — fixtures come with it
     isolated_postmortem,
 )
 
+from gen_worker import local_cell_store  # noqa: E402
 from gen_worker.procsplit import privdrop  # noqa: E402
 
 
@@ -389,6 +390,48 @@ def test_the_dropped_child_can_write_every_path_it_was_granted(dropped, tmp_path
             f"the compute child cannot write {path} — it is in the grant list "
             "(pgw#858). The answer is another entry there, never root."
         )
+
+
+@root_only
+def test_the_dropped_child_can_write_a_RELOCATED_local_cell_store(dropped):
+    """pgw#1349: the mint's own store, when an operator has moved it.
+
+    ``local_cell_store.store_root()`` defaults under ``~/.cache``, which the
+    grant list already covers through the compute uid's home — so the gap was
+    invisible for as long as nobody moved it. cozy-local DOES move it
+    (``internal/paths/paths.go`` exports ``GEN_WORKER_LOCAL_CELLS_DIR``), and a
+    relocated root is created by this root parent at 0755 and never chowned, so
+    the child's first memo write died on
+    ``PermissionError: .../aot-cells`` — mid-request, taking the stream down
+    with it. It surfaced as a NON-DETERMINISTIC red of a neighbouring row in
+    this very file, because whether the mint reached its memo write inside a
+    given tape was a race. Asserted directly here so the boundary is measured
+    instead of stumbled over.
+
+    The suite's own autouse ``_isolated_local_cell_store`` fixture is what
+    relocates it here, which makes this an honest reproduction of the operator
+    case rather than a construction: nothing in the test sets the env for the
+    test's benefit."""
+    root = os.environ.get(local_cell_store.ENV_STORE_DIR, "")
+    assert root, (
+        f"{local_cell_store.ENV_STORE_DIR} is unset, so this row would pass "
+        "for the wrong reason — the suite's autouse fixture sets it"
+    )
+    assert not os.path.exists(os.path.join(root, local_cell_store.CELLS_DIRNAME)), (
+        "this row must measure the CHILD creating the cells root — a "
+        f"{local_cell_store.CELLS_DIRNAME} this root parent made would be "
+        "root-owned and the probe would report the wrong thing"
+    )
+    # `write-probe` mkdirs a nested subtree before it writes, which is the
+    # operation that actually died: `_write_json_atomic` reaches every sidecar
+    # through `parent.mkdir(parents=True)`, and `aot-cells` is the component
+    # that did not exist yet.
+    assert _probe(dropped, "write-probe", root) == "ok", (
+        f"the compute child cannot write its own cell store at {root}. The "
+        "mint writes the memo and every per-cell sidecar there, so this is a "
+        "dead compute child on any pod whose store has been relocated "
+        "(pgw#1349). The answer is another entry in the grant list, never root."
+    )
 
 
 @root_only

--- a/tests/test_rotation_preload_pgw674.py
+++ b/tests/test_rotation_preload_pgw674.py
@@ -26,13 +26,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import hashlib
 import msgspec
 import pytest
+
+from harness.progress_wait import Cadence, await_progress_async
 
 from gen_worker.serving_facts import FactsUnavailable as _FU
 
@@ -513,13 +514,24 @@ def test_update_desired_spawns_and_stop_kills_the_driver(
             [_instance("generate", ck)], _snapshots(ck, "d9" * 16), 1)
         task = ex.preloader._task
         assert task is not None
-        deadline = time.monotonic() + 60
         eff = _pick(ex, "generate", ck)
-        while time.monotonic() < deadline:
+
+        def _staged() -> object:
             rec = ex._classes.get(eff.instance_key)
-            if rec is not None and rec.ready:
-                break
-            await asyncio.sleep(0.02)
+            return (rec is not None, bool(rec is not None and rec.ready))
+
+        # pgw#1349: was `time.monotonic() + 60`. The preloader's own TASK is
+        # the definitive give-up — once it has ended without staging, no
+        # further sleeping can change the answer — and the record appearing
+        # before it is ready is real progress, so the wait extends only for a
+        # preloader that is actually working.
+        await await_progress_async(
+            _staged, lambda seen: seen[1],
+            what="the preloader to stage the spawned instance",
+            cadence=Cadence(),
+            gone=lambda: ("the preloader task ended without staging it: "
+                          f"{task.exception()!r}" if task.done() else None),
+        )
         rec = ex._classes.get(eff.instance_key)
         assert rec is not None and rec.ready
 

--- a/tests/test_sp_group_isolation_pgw773_774.py
+++ b/tests/test_sp_group_isolation_pgw773_774.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 from gen_worker.parallel import RankGroupError, wire  # noqa: E402
+from harness.progress_wait import Cadence, await_progress  # noqa: E402
 from gen_worker.parallel.group import FollowerChannel, RankSpec, init_rank  # noqa: E402
 from gen_worker.parallel.plan import BootPlan, GroupPlan  # noqa: E402
 from gen_worker.parallel.runtime import SequenceRuntime  # noqa: E402
@@ -228,9 +229,14 @@ def test_rank0_exception_condemns_the_group_instead_of_wedging_it() -> None:
         assert rt.broken
         with pytest.raises(RankGroupError, match="condemned"):
             rt.call_with(_base_call, pipe, torch.ones(4, 2))
-        deadline = time.monotonic() + 30
-        while time.monotonic() < deadline and rt._group is not None:
-            time.sleep(0.1)
+        # pgw#1349: was `time.monotonic() + 30`. The teardown is what is being
+        # waited for, and the assert below still fails on a group that is
+        # never torn down — it just no longer fails on a slow one.
+        await_progress(
+            lambda: rt._group is None, bool,
+            what="the condemned rank group to be torn down",
+            cadence=Cadence(),
+        )
         assert rt._group is None, "condemned group was not torn down"
     finally:
         rt.close()

--- a/tests/test_th1130_deferred_tail.py
+++ b/tests/test_th1130_deferred_tail.py
@@ -81,6 +81,17 @@ def test_the_permit_is_released_before_the_deferred_encode_runs() -> None:
 
     # The whole encode fits inside the post-release window: the GPU was free
     # for every millisecond of it.
+    #
+    # pgw#1349: this reported `assert 87 >= 88` on master, and the cause was
+    # NOT the runner. `finalize_wall_ms` truncated its seconds while every
+    # `stage_ms` rounded, so a stage measured strictly INSIDE the finalize
+    # interval could out-round its own container by one quantum. Both sides now
+    # go through `stage_timing.ms_from_seconds`, and rounding is monotone — so
+    # containment of the intervals (which holds by construction: `released_at`
+    # is stamped before the drain and `handler_done` after it) now survives
+    # quantization, and this row is exact rather than usually-true. No slop is
+    # added here on purpose: a tolerance would have hidden the mixed quantizer
+    # instead of removing it.
     assert res.metrics.finalize_wall_ms >= encode_ms, (
         res.metrics.finalize_wall_ms, encode_ms, stages)
     # ...and the permit was NOT held for it. The slack is the stage map's OWN


### PR DESCRIPTION
Ends the recurring master-`tests` red from the wall-clock-flake family. A red master `tests` stalls every lane that waits for full green before enqueueing, and `publish.yaml` keys on that run's conclusion — so a flake blocks the WHEEL even when it does not block a merge.

Every row below is fixed **at its cause** and red-verified by breaking the property it guards, never by moving a constant.

| test | shape | verdict |
|---|---|---|
| `test_th1130_deferred_tail::test_the_permit_is_released_...` | `assert 87 >= 88` | **root-caused in src** — mixed quantizer |
| `test_mint_gate_pgw677::test_compile_and_tenant_forward_...` | `assert 416.463803 < 416.463401` | **converted** — progress wait + definitive give-up |
| `test_pod_privilege_isolation_pgw858` (3 lanes tonight) | `PermissionError: .../aot-cells` | **root-caused in src** — grant list gap |
| `test_mint_reopen_pgw677::test_compile_steal_is_announced_on_the_wire` | 30 s deadline | **converted** — demand counted in requests |
| `test_cancelled_setup_leak_gw624` (gw#624) | `entered.wait(10)` | **converted** — the expiry rewrote the tape |
| pgw#932 gRPC-fork SIGABRT | `cause=signal:SIGABRT` | **discriminator applied**, not re-derived |
| `test_activity_gw601`, `test_cancel_unwind_pgw687`, `test_rotation_preload_pgw674`, `test_sp_group_isolation_pgw773_774` | burn-down siblings | **converted** |

`_DEADLINE_BURNDOWN` is now **EMPTY**; `_ELAPSED_ASSERT_BURNDOWN` loses its two named latency budgets.

### The two production defects this found

**1. `JobMetrics` used two quantizers.** `runtime_ms` / `queue_ms` / `slot_held_ms` / `finalize_wall_ms` truncated while every `stage_ms` rounded, so a stage measured strictly inside `[released_at, handler_done]` could out-round its own container by one quantum. `procsplit.attest` clamps these four against each other and the hub reads them, so this is not a test accommodation. `stage_timing.ms_from_seconds` is now public and both sides use it; rounding is monotone, so containment survives quantization.

**2. A relocated local cell store was never granted to the dropped child.** `GEN_WORKER_LOCAL_CELLS_DIR` defaults inside the compute uid's home, so the grant list never needed it — but cozy-local relocates it by env (`internal/paths/paths.go`), and a relocated root is created by the root parent at 0755 and never chowned. The dropped child dies on its first memo write, mid-request, on any pod whose store has been moved.

### Red-verify evidence

| break | observed failure |
|---|---|
| reintroduce the pgw#676 overlap | `assert 0 > 0` on `instance_gate_wait` |
| rename the `bg_turn_steal` event | `250 back-to-back dispatches produced none` (8.9 s) |
| hold the permit across the finalize tail | `assert 0 >= 110` |
| drop the gw#624 allocation purge | `assert [True] == [False]` |
| remove the cell-store grant | the exact `PermissionError: .../aot-cells`, deterministically, under a real root parent |
| make no compile announce itself | the mint-gate wait gives up in 3.2 s naming the reason |

Local: `mypy --strict` clean over 852 files, `ruff` clean, all 22 fast-gate lints green, and the pgw#858 container rows **15 passed / 1 skipped** under a real root parent. Converted files run green repeatedly under `nice -n 19`, ≤2 workers.