### PR TITLE
pgw#1352: the sm-clearance probe — pgw#1348 rows 1-6 on the bare-pod route

### DIFF
--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -33,7 +33,15 @@ from . import cards as cards_mod
 from .driver import Rig, uploads_for
 from .rail import Rail
 from .row import RigRow
-from .workload import POD_ROOT, Upload, Workload, install_sdist, install_wheel, mint_model
+from .workload import (
+    POD_ROOT,
+    Upload,
+    Workload,
+    install_sdist,
+    install_wheel,
+    mint_model,
+    sm_probe,
+)
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -111,6 +119,49 @@ def cmd_mint(args: argparse.Namespace) -> int:
         install=install + tuple(args.setup),
         uploads=uploads,
         fleet_line=fleet_line,
+        name=args.name,
+    )
+    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    return 0 if row.verdict == "green" else 1
+
+
+def build_repo_archive(out: Path) -> Path:
+    """`git archive` of the WORKING TREE'S COMMIT — src, tests, examples, scripts.
+
+    A tarball rather than a wheel because `micro_mint_rig` puts `<repo>/src` and
+    `<repo>/tests` ahead of site-packages: the code under test is the tree, and
+    the wheel installed beside it only satisfies dependencies. `git archive`
+    rather than `tar` of the checkout so what ships is a COMMIT — the row's
+    `repo_sha` then answers "which code cleared this sm" without anybody
+    trusting a working directory.
+    """
+    out.parent.mkdir(parents=True, exist_ok=True)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=REPO, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    with out.open("wb") as fh:
+        subprocess.run(["git", "archive", "--format=tar.gz", sha], cwd=REPO, stdout=fh, check=True)
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=REPO, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        raise SystemExit(
+            "pgw#1352: the worktree is dirty, so `git archive HEAD` would ship code that is not "
+            "what you are looking at. Commit first — a probe row's whole value is naming the "
+            f"commit that cleared the sm.\n{dirty[:500]}"
+        )
+    return out
+
+
+def cmd_probe(args: argparse.Namespace) -> int:
+    """pgw#1348 rows 1-6: does this sm compile, re-use and match eager at all."""
+    install, uploads = _delivery(args)
+    archive = build_repo_archive(REPO / "dist" / "repo.tar.gz")
+    workload = sm_probe(
+        archive,
+        vehicle=args.vehicle,
+        install=install + tuple(args.setup),
+        uploads=uploads,
         name=args.name,
     )
     row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
@@ -227,6 +278,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     mint.add_argument("--name", default="mint")
     mint.set_defaults(fn=cmd_mint)
+
+    probe = sub.add_parser(
+        "probe",
+        help="pgw#1348 rows 1-6: an sm-clearance probe — the micro vehicle's full "
+        "mint/publish/adopt/parity cycle on one rented card, no hub needed.",
+    )
+    _rent_flags(probe)
+    probe.add_argument("--vehicle", default="micro", help="micro | tiny | micro-lora | …")
+    probe.add_argument("--name", default="probe")
+    probe.set_defaults(fn=cmd_probe)
 
     run = sub.add_parser("run", help="Any named command on a rented pod.")
     _rent_flags(run)

--- a/scripts/mint_rig/__main__.py
+++ b/scripts/mint_rig/__main__.py
@@ -121,7 +121,9 @@ def cmd_mint(args: argparse.Namespace) -> int:
         fleet_line=fleet_line,
         name=args.name,
     )
-    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    row = _rig(args).run(
+        cards_mod.pick(args.gpu), workload, image=args.image, rerolls=int(args.rerolls)
+    )
     return 0 if row.verdict == "green" else 1
 
 
@@ -164,7 +166,9 @@ def cmd_probe(args: argparse.Namespace) -> int:
         uploads=uploads,
         name=args.name,
     )
-    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    row = _rig(args).run(
+        cards_mod.pick(args.gpu), workload, image=args.image, rerolls=int(args.rerolls)
+    )
     return 0 if row.verdict == "green" else 1
 
 
@@ -178,7 +182,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         artifacts=tuple(args.artifact) or (POD_ROOT,),
         progress_paths=tuple(args.progress) or (POD_ROOT,),
     )
-    row = _rig(args).run(cards_mod.pick(args.gpu), workload, image=args.image)
+    row = _rig(args).run(
+        cards_mod.pick(args.gpu), workload, image=args.image, rerolls=int(args.rerolls)
+    )
     return 0 if row.verdict == "green" else 1
 
 
@@ -240,6 +246,13 @@ def _rent_flags(parser: argparse.ArgumentParser) -> None:
         "Not a timeout: work that is moving is never stopped by this.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Write the kill-set and rent nothing.")
+    parser.add_argument(
+        "--rerolls",
+        default="0",
+        help="How many times to take ANOTHER HOST after a `reroll` verdict (a too-old "
+        "driver, or a pod that never answered). Not another budget: the rail carries "
+        "the dead pods' spend forward.",
+    )
     parser.add_argument("--deliver", default="sdist", choices=("sdist", "wheel", "image"))
     parser.add_argument("--spec", default="", help="pip requirement for --deliver wheel.")
     parser.add_argument("--dist", default="", help="Prebuilt dist for --deliver sdist.")

--- a/scripts/mint_rig/cards.py
+++ b/scripts/mint_rig/cards.py
@@ -129,6 +129,50 @@ CARDS: dict[str, Card] = {
         note="every sm_89 RunPod sells, cheapest-first. The FALLBACK when sm_86 "
         "is out of capacity — and on 2026-08-17 it was.",
     ),
+    "sm80": Card(
+        slug="sm80",
+        gpu_type_ids=("NVIDIA A100 80GB PCIe", "NVIDIA A100-SXM4-80GB", "NVIDIA A100-SXM4-40GB", "NVIDIA A30"),
+        sm_expected="8.0",
+        disk_gb=60,
+        usd_per_hour_hint=1.39,
+        data_center_part=True,
+        note="Ampere data-center. Forward-compat libcuda IS supported here, so a "
+        "570-driver host is a repair rather than a re-roll.",
+    ),
+    "sm90": Card(
+        slug="sm90",
+        gpu_type_ids=("NVIDIA H100 80GB HBM3", "NVIDIA H100 PCIe", "NVIDIA H100 NVL", "NVIDIA H200"),
+        sm_expected="9.0",
+        disk_gb=100,
+        usd_per_hour_hint=3.29,
+        data_center_part=True,
+    ),
+    "sm100": Card(
+        slug="sm100",
+        gpu_type_ids=("NVIDIA B200",),
+        sm_expected="10.0",
+        disk_gb=100,
+        usd_per_hour_hint=6.81,
+        data_center_part=True,
+        note="THE EXPENSIVE ONE. pgw#1084 §7.2's rule: nothing larger is bought on "
+        "an sm the micro probe has not cleared — which is what makes this a $1.84 "
+        "question rather than a $20 one.",
+    ),
+    "sm120": Card(
+        slug="sm120",
+        gpu_type_ids=(
+            "NVIDIA GeForce RTX 5090",
+            "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+            "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+        ),
+        sm_expected="12.0",
+        disk_gb=100,
+        usd_per_hour_hint=0.89,
+        data_center_part=False,
+        note="pgw#1084 §8.2 calls rtx-pro-6000 'the only mintable sm_120 SKU' and it "
+        "is NOT a registered gpu_sku_set, so sm_120 is bare-pod-only until th#2112 "
+        "lands — which is exactly the route this rig takes.",
+    ),
     "l40s": Card(
         slug="l40s",
         gpu_type_ids=("NVIDIA L40S", "NVIDIA L40"),

--- a/scripts/mint_rig/driver.py
+++ b/scripts/mint_rig/driver.py
@@ -184,7 +184,46 @@ class Rig:
 
     # ---- the one public verb -------------------------------------------------
 
-    def run(self, card: Card, workload: Workload, *, image: str = "", pod_name: str = "") -> RigRow:
+    def run(
+        self,
+        card: Card,
+        workload: Workload,
+        *,
+        image: str = "",
+        pod_name: str = "",
+        rerolls: int = 0,
+    ) -> RigRow:
+        """Rent, run, tear down — and take another host if this one was bad.
+
+        A `reroll` is the provider's fault, not the workload's: the host's driver
+        cannot reach the fleet CUDA line, or the pod never exposed a port inside
+        the bring-up budget. MEASURED 2026-08-17 across twelve rentals: roughly
+        half of them, on one evening, on the same public image. A matrix that
+        gives up on the first bad machine measures RunPod's weather rather than
+        the code.
+
+        The re-roll gets ANOTHER HOST, never another budget: `Rail.bank()`
+        carries the dead pod's spend forward, so `--rail 2.00` means $2.00
+        however many machines it takes. Every attempt banks its own row; this
+        returns the last one, whose `stage_trail` names the attempt.
+        """
+        row = self._run_once(card, workload, image=image, pod_name=pod_name)
+        attempt = 0
+        while row.verdict == "reroll" and attempt < rerolls:
+            attempt += 1
+            spent = self.rail.bank()
+            self.log(
+                f"[reroll] attempt {attempt}/{rerolls} — ${spent:.3f} of the "
+                f"${self.rail.max_usd:.2f} rail is gone to bad hosts; taking another"
+            )
+            if spent >= self.rail.max_usd * self.rail.start_headroom:
+                row.detail += f" | re-roll {attempt} REFUSED: no budget left"
+                break
+            row = self._run_once(card, workload, image=image, pod_name="")
+            row.stage("reroll", f"attempt {attempt} of {rerolls}")
+        return row
+
+    def _run_once(self, card: Card, workload: Workload, *, image: str = "", pod_name: str = "") -> RigRow:
         api, guard = self._api, self._guard
         name = pod_name or f"mintrig-{self.lane}-{int(time.time())}"
         image = image or FLEET_IMAGE

--- a/scripts/mint_rig/rail.py
+++ b/scripts/mint_rig/rail.py
@@ -38,6 +38,11 @@ class Rail:
     start_headroom: float = 0.85
     rate_per_hr: float = 0.0
     started_at: float = field(default_factory=time.time)
+    #: Spend from EARLIER pods of the same invocation. A re-roll takes another
+    #: host but does not get another budget: the rail is per-INVOCATION, and a
+    #: caller who declared $2 means $2 however many bad machines the provider
+    #: hands out.
+    banked_usd: float = 0.0
 
     def __post_init__(self) -> None:
         if not self.max_usd > 0:
@@ -64,7 +69,17 @@ class Rail:
 
     def spent_usd(self, now: float | None = None) -> float:
         now = time.time() if now is None else now
-        return self.rate_per_hr * max(0.0, now - self.started_at) / 3600.0
+        return self.banked_usd + self.rate_per_hr * max(0.0, now - self.started_at) / 3600.0
+
+    def bank(self, now: float | None = None) -> float:
+        """Close out the current pod's spend and stop its clock.
+
+        Called when a pod is torn down and another may be rented in its place.
+        Returns the total spent so far.
+        """
+        self.banked_usd = self.spent_usd(now)
+        self.rate_per_hr = 0.0
+        return self.banked_usd
 
     def remaining_usd(self, now: float | None = None) -> float:
         return self.max_usd - self.spent_usd(now)
@@ -79,7 +94,7 @@ class Rail:
         """
         if self.rate_per_hr <= 0:
             return float("inf")
-        return self.max_usd / self.rate_per_hr * 3600.0
+        return max(0.0, self.max_usd - self.banked_usd) / self.rate_per_hr * 3600.0
 
     def may_start(self, stage: str, now: float | None = None) -> None:
         """Refuse to begin `stage` when there is no headroom left to finish it."""

--- a/scripts/mint_rig/rail.py
+++ b/scripts/mint_rig/rail.py
@@ -68,8 +68,22 @@ class Rail:
         self.started_at = time.time() if at is None else at
 
     def spent_usd(self, now: float | None = None) -> float:
+        """Everything this INVOCATION has spent, dead pods included."""
+        return self.banked_usd + self.pod_spent_usd(now)
+
+    def pod_spent_usd(self, now: float | None = None) -> float:
+        """What the pod currently running has cost. Excludes banked spend.
+
+        The distinction is not bookkeeping. A per-POD allowance measured against
+        the cumulative total collapses the moment anything is banked: with a
+        $0.60 rail, a 10% bring-up sub-cap of $0.06 and $0.065 already gone to
+        one bad host, EVERY later bring-up is refused before its first
+        observation. Measured live on pgw#1348 row 2 — four re-rolls, each
+        `reroll` at $0.000 and 0.0 min, which reads as four dead hosts and was
+        really one arithmetic error.
+        """
         now = time.time() if now is None else now
-        return self.banked_usd + self.rate_per_hr * max(0.0, now - self.started_at) / 3600.0
+        return self.rate_per_hr * max(0.0, now - self.started_at) / 3600.0
 
     def bank(self, now: float | None = None) -> float:
         """Close out the current pod's spend and stop its clock.
@@ -133,8 +147,11 @@ class Rail:
         a cheap A4000), it is stated, and tripping it is a `railed` verdict with
         the stage named — not a silent retry. Once the pod answers, real progress
         markers exist and :class:`~mint_rig.progress.Gate` takes over.
+
+        Measured against THIS POD's spend, not the invocation's total — see
+        :meth:`pod_spent_usd` for the four-dead-hosts incident that says why.
         """
-        spent = self.spent_usd(now)
+        spent = self.pod_spent_usd(now)
         cap = self.max_usd * fraction
         if spent >= cap:
             raise RailTripped(

--- a/scripts/mint_rig/workload.py
+++ b/scripts/mint_rig/workload.py
@@ -245,6 +245,62 @@ def install_wheel(spec: str, index_args: str = "") -> tuple[str, ...]:
     return (PIN_TORCH, _pip_install(spec, index_args))
 
 
+#: pgw#1352 / pgw#1348 rows 1-6. Where the shipped tree lands on the pod.
+POD_REPO = f"{POD_ROOT}/repo"
+
+
+def sm_probe(
+    archive: Path,
+    *,
+    vehicle: str = "micro",
+    install: tuple[str, ...] = (),
+    uploads: tuple[Upload, ...] = (),
+    name: str = "probe",
+) -> Workload:
+    """One sm-clearance probe — [[pgw#1348]] rows 1-6, on the bare-pod route.
+
+    WHY THIS VEHICLE NEEDS NO HUB, which is the whole reason these six rows are
+    buyable today while the other fifty are gated. `scripts/micro_mint_rig.py
+    --vehicle micro` runs the FULL production cycle against
+    `examples/micro-diffusion` — resolve, `MintSlot` handoff, a real child
+    interpreter, warmup, `torch.export` + AOTInductor, seal, publish, and a
+    SECOND OS process adopting the exact named cell and comparing every arm to
+    eager — and its publish leg goes to `harness.cell_hub.LocalCellHub`,
+    IN-PROCESS. So one pod proves compile AND re-use AND parity on that card,
+    with nothing external to be blocked on.
+
+    It ships the repository's own tree rather than a wheel, because the rig
+    inserts `<repo>/src` and `<repo>/tests` ahead of site-packages: the code
+    under test is the TREE, and the wheel is installed only to satisfy its
+    dependencies. Both digests land on the row.
+    """
+    root = f"{POD_ROOT}/micro-root"
+    report = f"{POD_ROOT}/{name}.json"
+    command = (
+        f"cd {POD_REPO} && nice -n 19 python3 scripts/micro_mint_rig.py "
+        f"--vehicle {vehicle} --device cuda --clean --root {root} --json {report} "
+        "&& echo RIG_DONE"
+    )
+    return Workload(
+        name=name,
+        command=command,
+        setup=install
+        + (
+            f"mkdir -p {POD_REPO} && tar -xzf {POD_ROOT}/{archive.name} -C {POD_REPO}",
+            # Proof the tree arrived whole, before a compile is paid for.
+            f"test -f {POD_REPO}/scripts/micro_mint_rig.py "
+            f"&& test -d {POD_REPO}/examples/micro-diffusion "
+            f"&& test -d {POD_REPO}/tests/harness",
+        ),
+        uploads=uploads + (Upload(local=archive),),
+        artifacts=(report, f"{POD_ROOT}/{name}.log", f"{POD_ROOT}/rigboot.json"),
+        # A cell that was never written is not a cleared sm, whatever the log says.
+        required_artifacts=(report,),
+        progress_paths=(root, "/root/.cache/torchinductor_root", "/root/.triton", POD_REPO),
+        env={"TORCHINDUCTOR_CACHE_DIR": "/root/.cache/torchinductor_root"},
+    )
+
+
 def mint_model(
     target: str,
     *,

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -402,6 +402,28 @@ def test_bring_up_is_bounded_by_MONEY_because_it_has_no_progress_signal() -> Non
         rail.check_sub("endpoint", 0.15, now=1500.0)
 
 
+def test_the_bringup_budget_is_PER_POD_or_every_reroll_dies_instantly() -> None:
+    """MEASURED LIVE on pgw#1348 row 2: four re-rolls, each `reroll` at $0.000
+    and 0.0 min. That reads as four dead hosts and was one arithmetic error —
+    the per-POD allowance was being measured against the CUMULATIVE total, so
+    once $0.065 was banked against a $0.06 sub-cap, every later bring-up was
+    refused before its first observation."""
+    rail = Rail(max_usd=0.60)
+    rail.observe_rate(0.74)
+    rail.clock_started(at=0.0)
+    rail.bank(now=316.0)  # ~$0.065 gone to a bad host
+    assert rail.banked_usd == pytest.approx(0.0650, abs=1e-3)
+
+    # A fresh pod. Its OWN bring-up allowance is untouched by the dead one.
+    rail.observe_rate(0.74)
+    rail.clock_started(at=1000.0)
+    rail.check_sub("endpoint", 0.10, now=1100.0)  # 100 s on THIS pod: fine
+    with pytest.raises(RailTripped):
+        rail.check_sub("endpoint", 0.10, now=1000.0 + 0.06 / 0.74 * 3600 + 1)
+    # …while the INVOCATION total still carries the dead pod forward.
+    assert rail.spent_usd(now=1100.0) > rail.pod_spent_usd(now=1100.0)
+
+
 def test_a_gate_with_no_staleness_rule_waits_as_long_as_the_rail_allows() -> None:
     calls = {"n": 0}
 

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -600,6 +600,36 @@ def test_a_pod_that_never_answers_is_a_REROLL_not_a_budget_overrun(tmp_path: Pat
     assert pods.deleted == ["pod1"]
 
 
+def test_a_reroll_takes_another_HOST_but_never_another_BUDGET(tmp_path: Path) -> None:
+    """MEASURED 2026-08-17: roughly half of twelve rentals on one evening came up
+    on a host that could not run the fleet CUDA line, or never exposed a port. A
+    matrix that gives up on the first bad machine measures the provider's weather
+    rather than the code — and one that re-rolls on a fresh budget each time has
+    no budget at all."""
+    pods = FakePods(rate=0.74)
+    rail = Rail(max_usd=1.0)
+    rig = _rig(tmp_path, pods, FakeTransport(rigboot_rc=91), rail=rail)
+    row = rig.run(cards_mod.pick("sm89"), Workload(name="w", command="x"), rerolls=2)
+
+    assert row.verdict == "reroll"
+    assert len(pods.created_bodies) == 3, "one attempt plus two re-rolls"
+    assert pods.deleted == ["pod1", "pod2", "pod3"], "every bad host is torn down"
+    # The rail carried each dead pod's spend forward rather than restarting.
+    assert rail.banked_usd > 0.0
+    assert any(s["stage"] == "reroll" for s in row.stage_trail)
+
+
+def test_rerolling_stops_when_the_budget_is_gone_not_when_the_count_runs_out(
+    tmp_path: Path,
+) -> None:
+    pods = FakePods(rate=3_600_000.0)  # $1000/s — the first pod eats the rail
+    rail = Rail(max_usd=0.05)
+    rig = _rig(tmp_path, pods, FakeTransport(rigboot_rc=91), rail=rail)
+    row = rig.run(cards_mod.pick("sm89"), Workload(name="w", command="x"), rerolls=5)
+    assert len(pods.created_bodies) < 6, "it stopped on money, not on the counter"
+    assert "no budget left" in row.detail
+
+
 def test_no_driver_at_all_is_also_a_reroll(tmp_path: Path) -> None:
     row = _rig(tmp_path, FakePods(), FakeTransport(rigboot_rc=92)).run(
         cards_mod.pick("a40"), Workload(name="w", command="x")

--- a/tests/test_pod_mint_rig_pgw1347.py
+++ b/tests/test_pod_mint_rig_pgw1347.py
@@ -37,7 +37,15 @@ from mint_rig.rail import Rail, RailTripped  # noqa: E402
 from mint_rig.row import Teardown  # noqa: E402
 from mint_rig.runpod import PodNotFound, RunpodRest  # noqa: E402
 from mint_rig.transport import Result, SshTransport  # noqa: E402
-from mint_rig.workload import POD_ROOT, Upload, Workload, install_sdist, mint_model  # noqa: E402
+from mint_rig.workload import (  # noqa: E402
+    POD_REPO,
+    POD_ROOT,
+    Upload,
+    Workload,
+    install_sdist,
+    mint_model,
+    sm_probe,
+)
 
 # --------------------------------------------------------------------------- #
 # fakes: the PROVIDER, not the rig
@@ -978,6 +986,51 @@ def test_a_missing_ssh_key_is_a_REFUSAL_with_a_row_not_a_traceback(
     assert row.verdict == "refused" and row.failed_stage == "create"
     assert "no RunPod ssh public key" in row.detail
     assert pods.created_bodies == [], "nothing was rented"
+
+
+# --------------------------------------------------------------------------- #
+# 8. pgw#1352 / pgw#1348 rows 1-6 — the sm-clearance probe
+# --------------------------------------------------------------------------- #
+
+
+def test_the_probe_ships_a_TREE_and_proves_it_arrived_before_paying_for_a_compile(
+    tmp_path: Path,
+) -> None:
+    """`micro_mint_rig` puts `<repo>/src` and `<repo>/tests` ahead of
+    site-packages, so the code under test is the TREE; the wheel beside it only
+    satisfies dependencies."""
+    archive = tmp_path / "repo.tar.gz"
+    archive.write_bytes(b"tarball")
+    workload = sm_probe(archive)
+    assert any(u.local == archive for u in workload.uploads)
+    untar = [line for line in workload.setup if "tar -xzf" in line]
+    assert untar and POD_REPO in untar[0]
+    guard = [line for line in workload.setup if line.startswith("test -f")]
+    assert guard and "micro_mint_rig.py" in guard[0] and "examples/micro-diffusion" in guard[0]
+    # A cell that was never written is not a cleared sm, whatever the log said.
+    assert workload.required_artifacts == (f"{POD_ROOT}/probe.json",)
+
+
+def test_the_probe_needs_no_hub_which_is_why_these_rows_are_buyable_today(tmp_path: Path) -> None:
+    """The micro vehicle publishes through an IN-PROCESS `LocalCellHub` and
+    adopts in a second OS process on the same pod, so one rental proves compile,
+    re-use and parity with nothing external to be blocked on. pgw#1348 gates
+    every other leg A on a hub wire proof; this row is exempt by construction."""
+    workload = sm_probe(tmp_path / "repo.tar.gz")
+    assert "--vehicle micro" in workload.command and "--device cuda" in workload.command
+    assert "--json" in workload.command, "the row IS the report; no report, no row"
+    assert "nice -n 19" in workload.command
+    for path in ("/root/.cache/torchinductor_root", POD_REPO):
+        assert path in workload.progress_paths
+
+
+def test_every_sm_class_the_gauntlet_names_has_a_card_set() -> None:
+    """pgw#1348 rows 1-6 are sm_86, sm_89, sm_80, sm_90, sm_100, sm_120."""
+    for slug, sm in (("sm86", "8.6"), ("sm89", "8.9"), ("sm80", "8.0"),
+                     ("sm90", "9.0"), ("sm100", "10.0"), ("sm120", "12.0")):
+        card = cards_mod.pick(slug)
+        assert card.sm_expected == sm
+        assert card.gpu_type_ids, "a pick names a SET; there is no capacity query to consult"
 
 
 def test_unknown_card_names_the_ones_that_exist() -> None:


### PR DESCRIPTION
pgw#1348 §5 asked for *"a thin wrapper over pgw#1347's rig… a caller, not a copy"*. This is that: a `probe` verb, an `sm_probe` **Workload value**, and the `sm_80/90/100/120` card sets the matrix names. The rig still owns rent, ship, run, capture, teardown and the row.

### Why these six rows are buyable while the other fifty are not

`scripts/micro_mint_rig.py --vehicle micro` runs the full production cycle against `examples/micro-diffusion` — resolve, `MintSlot` handoff, a real child interpreter, warmup, `torch.export` + AOTInductor, seal, publish, and a **second OS process** adopting the exact named cell and comparing every arm to eager — and its publish leg goes to `harness.cell_hub.LocalCellHub`, **in-process**. One pod therefore proves compile AND re-use AND parity on that card with nothing external to be blocked on, which is exactly why pgw#1348 §4 lists rows 1-6 as runnable today while gating every other leg A on the hub publish→adopt wire proof.

### It ships the TREE, not a wheel

`micro_mint_rig` inserts `<repo>/src` and `<repo>/tests` ahead of site-packages, so the code under test is the tree; the wheel installed beside it only satisfies dependencies. The archive is `git archive HEAD` and the CLI **refuses a dirty worktree** — a probe row's whole value is naming the commit that cleared the sm, and a tarball of a working directory names nothing. A setup line proves the tree arrived whole before a compile is paid for, and `probe.json` is a `required_artifact`, so a cell that was never written cannot read as a cleared sm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
