### PR TITLE
pgw#1346 W1b-1: the declaration surface the Slot deletion needs (K1-K5)

### DIFF
--- a/changelog.d/pgw1346.md
+++ b/changelog.d/pgw1346.md
@@ -24,6 +24,26 @@
   obligation to declare one; it is a first-class `ModelSpec` citizen on the same
   declaration surface. pgw#1326's "LLM/VLM models are graph citizens with
   sessions" binds only where a traceable graph exists, and `spec.py` says so.
+- **A model declaration now carries the axes that used to live on `Slot`,** so
+  the `Slot` deletion no longer loses them. `ModelSpec` takes `layouts=`,
+  `layouts_undeclarable=` and `layout_requirements=` — the SAME fields, parsed by
+  the SAME normalizers, so the ie#740 production floors (krea-2 `vram72g`,
+  flux.1-schnell `vram36g`, minimax-h3 `vram78g`, the `sm89+` fp8-rowwise guard)
+  migrate BY VALUE rather than by re-typing. The demand stays keyed by COMPONENT
+  PATH, not collapsed onto `Runner.layouts`: runners and components are not 1:1,
+  and a per-text-encoder demand has to remain expressible.
+- **`Bind` carries the three axes a model cannot know about itself** —
+  `selected_by` (a field of THIS endpoint's payload), `default_checkpoint` (this
+  deployment's bootstrap ref) and `root`. `@endpoint(models={"pipeline": Sdxl})`
+  stays the common case; `Bind(Krea2, selected_by="model")` is how an endpoint
+  adds one. Unlike a `Slot` declaration it needs no root marker: a handler names
+  every model it binds, by parameter, so there is nothing for a root to
+  disambiguate. Two roots is still a decoration-time error.
+- **`tuned=` is now optional on the eager tier.** An auxiliary model — a frame
+  interpolator, a latent upsampler, a tokenizer tree — has no inference
+  vocabulary, and publishing an empty schema under its name would put a name
+  into the hub's vocabulary that answers no question. A `GraphModelSpec` still
+  owes one.
 - Regenerating the catalog bindings under the new module path moved each
   model's `EXPORT_DIGEST` (a declaration's version IS its export digest, and the
   tuned schema's module path is part of the declaration): `sdxl` is

--- a/docs/models.md
+++ b/docs/models.md
@@ -236,3 +236,54 @@ The trace is the declaration's own, so a minted class's ingress digest is the
 committed export's by construction — `family.mint.assert_matches_export` states
 that as an assertion, in the direction torchcg G16 requires: the export is the
 source and the mint is checked against it.
+
+## Declaring what the model's code can execute
+
+Three axes ride the DECLARATION, because they describe the model's own code and
+two endpoints binding one model state one demand:
+
+```python
+SDXL = GraphModelSpec(
+    name="sdxl", tuned=SdxlTuned, runners=(...),
+    layouts={"*": ("plain.bf16@1",),
+             "text_encoder": ("cozy.fp8-rowwise@1", "plain.bf16@1")},
+    layout_requirements={"cozy.fp8-rowwise@1": "sm89+, vram24g"},
+)
+```
+
+* `layouts` — per COMPONENT PATH, the set of tensor-layout contract handles this
+  model's code can execute. `"*"` is the whole-tree default. The set is a
+  compatibility FILTER and its order carries no preference, so handles are
+  stored in canonical order.
+* `layouts_undeclarable` — the explicit third rung, a REASON string, mutually
+  exclusive with `layouts`. For bytes no registered handle names: a tokenizer
+  tree with no tensors, a GGUF quant axis, a compressed-tensors checkpoint.
+* `layout_requirements` — keyed by the HANDLE it guards, what EXECUTING that
+  contract needs of the machine. The compact term list IS the minimum;
+  `recommended` is additive and gates nothing. A key naming a handle `layouts`
+  does not accept is refused — a requirement guarding nothing is never checked.
+
+`Runner.layouts` is a different axis and keeps its own meaning: which layouts
+that GRAPH CLASS has traced variants for. A model may accept fp8 bytes for a
+component it has no fp8 graph class for.
+
+## Declaring what only the ENDPOINT knows
+
+Three axes cannot live on a shared model, because they name this endpoint's
+payload and this deployment. They ride `Bind`:
+
+```python
+@endpoint(models={"pipeline": Sdxl})                        # the common case
+@endpoint(models={"pipeline": Bind(Krea2, selected_by="model")})
+```
+
+* `selected_by` — the `str`-typed payload field that branches which checkpoint
+  serves this parameter.
+* `default_checkpoint` — the code-side bootstrap ref, and the only resolution
+  source in hub-less mode. A live hub mapping always wins.
+* `root` — which model answers the residual `ctx` questions that resolve against
+  one. Marking none is normal: a handler names every model it binds, so there is
+  nothing for a root to disambiguate. Marking two is a decoration-time error.
+
+`optional` is still DERIVED, never passed: a model is optional exactly when its
+handler parameter carries a default.

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -56,6 +56,7 @@ from .export_contract import (
 )
 from .formula import RuntimeFormula
 from ..model.runtime import Model
+from ..model.bind import Bind
 from ..model.spec import ModelSpec as FamilySpec
 from .slot import OBJECTIVES, TASKS, D, Slot
 from ..models import execution_lanes as lanespec
@@ -1148,7 +1149,7 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     # is what lets placement prefetch the weights and verify the VRAM fit before
     # a request lands; `ModelSpec.instance(ref)` inside a handler is the dynamic
     # escape hatch, and it is the one parse-don't-validate boundary.
-    families: Mapping[str, type["Model"]] = msgspec.field(default_factory=dict)
+    families: Mapping[str, "Bind[Any]"] = msgspec.field(default_factory=dict)
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -1603,8 +1604,12 @@ def _expand_formula_map(
 
 def _normalize_families(
     owner: str, families: Optional[Mapping[str, Any]]
-) -> Dict[str, type[Model]]:
-    """Parse ``families={...}`` into handler-parameter -> generated family type.
+) -> Dict[str, "Bind[Any]"]:
+    """Parse ``families={...}`` into handler-parameter -> :class:`Bind`.
+
+    A value is either a generated model class or a ``Bind`` wrapping one; both
+    normalize to a ``Bind`` HERE, once, so no downstream reader has to know the
+    mapping value has two shapes (pgw#1346 K3).
 
     The VALUE is the generated class, which is simultaneously the type a
     handler parameter is annotated with and the type of the instance it
@@ -1620,14 +1625,16 @@ def _normalize_families(
             f"@endpoint {owner}: families= must be a mapping of handler "
             f"parameter name -> family type, got {type(families).__name__}"
         )
-    out: Dict[str, type[Model]] = {}
-    for raw_name, value in families.items():
+    out: Dict[str, "Bind[Any]"] = {}
+    for raw_name, entry in families.items():
         name = str(raw_name or "").strip()
         if not name or not name.isidentifier():
             raise ValueError(
                 f"@endpoint {owner}: families= key {raw_name!r} must be a handler "
                 "parameter name"
             )
+        bind = entry if isinstance(entry, Bind) else None
+        value = bind.model if bind is not None else entry
         if not (isinstance(value, type) and issubclass(value, Model)):
             if isinstance(value, FamilySpec):
                 raise TypeError(
@@ -1646,14 +1653,29 @@ def _normalize_families(
                 f"@endpoint {owner}: families[{name!r}] = {value.__name__} carries no "
                 "family handle; it is not a generated binding"
             )
-        out[name] = value
+        out[name] = bind if bind is not None else Bind(model=value)
+    roots = sorted(n for n, b in out.items() if b.root)
+    if len(roots) > 1:
+        raise ValueError(
+            f"@endpoint {owner}: {len(roots)} models are marked root={roots}. Exactly "
+            "one model of a multi-model endpoint is THE root; an ambiguous root is a "
+            "decoration-time error, never a silent pick."
+        )
+    # No "you must mark one" rule, deliberately — and this is where the model
+    # surface is genuinely smaller than the `Slot` one it replaces. A root slot
+    # had to be picked because `ctx.defaults` and `ctx.for_request` resolve
+    # against ONE slot with nothing in the call naming it. A handler names every
+    # model it binds, by parameter, so there is no ambiguity for a root to
+    # settle: `root=` exists only to answer the residual `ctx` questions while
+    # they still exist, and an endpoint binding four models and marking none is
+    # a perfectly determined declaration.
     return dict(sorted(out.items()))
 
 
 def _validate_family_params(
     owner: str,
     fn: Callable[..., Any],
-    families: Mapping[str, type[Model]],
+    families: Mapping[str, "Bind[Any]"],
     *,
     is_method: bool,
 ) -> None:
@@ -1682,7 +1704,8 @@ def _validate_family_params(
     # The reverse direction runs even with NO declared families, which is the
     # case that actually bites: a bare `@endpoint` over a handler that took a
     # family instance would decorate cleanly and then have nothing prefetch it.
-    for name, declared in families.items():
+    for name, row in families.items():
+        declared = row.model
         annotation = hints.get(name)
         if annotation is None:
             raise ValueError(
@@ -1879,7 +1902,7 @@ def endpoint(
     config: Optional[Sequence[ConfigParam]] = ...,
     env: Optional[Sequence[str]] = ...,
     publishes: bool = ...,
-    families: Optional[Mapping[str, type[Model]]] = ...,
+    families: Optional[Mapping[str, "type[Model] | Bind[Any]"]] = ...,
 ) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
@@ -1901,7 +1924,7 @@ def endpoint(
     config: Optional[Sequence[ConfigParam]] = None,
     env: Optional[Sequence[str]] = None,
     publishes: bool = False,
-    families: Optional[Mapping[str, type[Model]]] = None,
+    families: Optional[Mapping[str, "type[Model] | Bind[Any]"]] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes.
 

--- a/src/gen_worker/api/jobs.py
+++ b/src/gen_worker/api/jobs.py
@@ -43,6 +43,7 @@ from typing import Any, Callable, Mapping, Optional, Sequence, TypeVar, overload
 
 import msgspec
 
+from ..model.bind import Bind
 from ..model.runtime import Model
 from .decorators import (
     Resources,
@@ -85,7 +86,7 @@ class JobDecl(msgspec.Struct, frozen=True, kw_only=True):
     #: between the two decorators unchanged — a job that could not take one
     #: would make the promotion a rewrite for precisely the endpoints most
     #: likely to want it.
-    families: Mapping[str, type["Model"]] = msgspec.field(default_factory=dict)
+    families: Mapping[str, "Bind[Any]"] = msgspec.field(default_factory=dict)
 
 
 def _qualname_owner(fn: Callable[..., Any]) -> str:
@@ -181,7 +182,7 @@ def job(
     publishes: bool = ...,
     emits_media: bool = ...,
     name: Optional[str] = ...,
-    families: Optional[Mapping[str, type[Model]]] = ...,
+    families: Optional[Mapping[str, "type[Model] | Bind[Any]"]] = ...,
 ) -> Callable[[T], T]: ...
 
 
@@ -195,7 +196,7 @@ def job(
     publishes: bool = False,
     emits_media: bool = False,
     name: Optional[str] = None,
-    families: Optional[Mapping[str, type[Model]]] = None,
+    families: Optional[Mapping[str, "type[Model] | Bind[Any]"]] = None,
 ) -> Any:
     """The one job decorator. See the module docstring for the shape."""
     if resources is not None and not isinstance(resources, Resources):

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -790,10 +790,15 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         families_block = [
             {
                 "parameter": parameter,
-                "family": str(getattr(family_type, "FAMILY", "")),
-                "export_digest": str(getattr(family_type, "EXPORT_DIGEST", "")),
+                "family": str(getattr(row.model, "FAMILY", "")),
+                "export_digest": str(getattr(row.model, "EXPORT_DIGEST", "")),
+                # pgw#1346 K3: the endpoint-coupled axis, emitted so PLACEMENT
+                # can see which payload field branches this parameter. Omitted
+                # when unset, so a model bound without one is byte-identical to
+                # what this key produced before `Bind` existed.
+                **({"selected_by": row.selected_by} if row.selected_by else {}),
             }
-            for parameter, family_type in sorted(es.families.items())
+            for parameter, row in sorted(es.families.items())
         ]
 
         fn: Dict[str, Any] = {
@@ -1023,10 +1028,11 @@ def _job_entry(spec: Any, root: Path) -> Dict[str, Any]:
                 "families": [
                     {
                         "parameter": parameter,
-                        "family": str(getattr(family_type, "FAMILY", "")),
-                        "export_digest": str(getattr(family_type, "EXPORT_DIGEST", "")),
+                        "family": str(getattr(row.model, "FAMILY", "")),
+                        "export_digest": str(getattr(row.model, "EXPORT_DIGEST", "")),
+                        **({"selected_by": row.selected_by} if row.selected_by else {}),
                     }
-                    for parameter, family_type in sorted(spec.families.items())
+                    for parameter, row in sorted(spec.families.items())
                 ]
             }
             if spec.families

--- a/src/gen_worker/model/__init__.py
+++ b/src/gen_worker/model/__init__.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers on
         EagerBacking,
         FakeBacking,
     )
+    from .bind import Bind, as_bind
     from .drift import assert_recipe, assert_reference
     from .errors import ModelError, ModelRefusal
     from .inject import (
@@ -142,6 +143,8 @@ _EXPORTS: Final[dict[str, tuple[str, str]]] = {
     "Stage": ("spec", "Stage"),
     "Tuned": ("runtime", "Tuned"),
     "TunedValues": ("spec", "TunedValues"),
+    "Bind": ("bind", "Bind"),
+    "as_bind": ("bind", "as_bind"),
     "assert_recipe": ("drift", "assert_recipe"),
     "assert_reference": ("drift", "assert_reference"),
     "bind_models": ("inject", "bind_models"),
@@ -193,6 +196,7 @@ __all__ = [
     "EXPORT_VERSION",
     "Backing",
     "BackingKind",
+    "Bind",
     "Bucket",
     "BucketMap",
     "CallExample",
@@ -217,6 +221,7 @@ __all__ = [
     "Stage",
     "Tuned",
     "TunedValues",
+    "as_bind",
     "assert_recipe",
     "assert_reference",
     "bind_models",

--- a/src/gen_worker/model/bind.py
+++ b/src/gen_worker/model/bind.py
@@ -1,0 +1,113 @@
+"""``Bind`` — the three axes that belong to the ENDPOINT, not to the model.
+
+pgw#1346 K3. When the retired ``Slot`` was split, most of its fields turned out
+to describe the model's own CODE — which tensor layouts it can execute, what
+executing them needs of the machine — and those went onto
+:class:`~gen_worker.model.spec.ModelSpec`, where two endpoints binding one model
+state one demand.
+
+Three did not, because they name something the model cannot know:
+
+* ``selected_by`` names a field of THIS endpoint's payload type. Two endpoints
+  binding ``Flux1`` may branch on differently-named fields, and a catalog model
+  has no payload to name.
+* ``default_checkpoint`` is a code-side bootstrap ref for hub-less runs. It is
+  a property of this deployment, not of the architecture.
+* ``root`` marks which of several bound models is THE one for an endpoint that
+  binds more than one. "Which of my models is primary" is a sentence only the
+  endpoint can say.
+
+So the mapping value stays a bare model class in the common case, and grows a
+wrapper exactly when one of those three is needed::
+
+    @endpoint(models={"pipeline": Flux1Dev})                      # the common case
+    @endpoint(models={"pipeline": Bind(Krea2, selected_by="model")})
+
+This is deliberately NOT ``Slot`` under a new name. It carries no
+``pipeline_cls`` (the declaration is the component tree), no ``layouts``
+(the model's), and no ``optional`` (still DERIVED from the handler parameter's
+own default, so the signature stays the single source of truth).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from .errors import ModelError, ModelRefusal
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..api.binding import ModelRef
+    from .runtime import Model
+
+M = TypeVar("M", bound="Model")
+
+
+@dataclass(frozen=True, slots=True)
+class Bind(Generic[M]):
+    """One entry of ``@endpoint(models={...})``, with its endpoint-coupled axes.
+
+    ``Bind(Flux1Dev)`` and a bare ``Flux1Dev`` mean exactly the same thing; the
+    wrapper exists to carry the three fields below and nothing else.
+    """
+
+    #: The generated model class. The handler parameter's annotation must be
+    #: this same class — the decorator checks it, so a `Bind` cannot quietly
+    #: bind a parameter to a different model than the one it is typed as.
+    model: type[M]
+
+    #: The ``str``-typed payload field that branches which checkpoint serves
+    #: this parameter. Validated at registration against the handler's payload
+    #: type: the field must exist and be plain ``str``. The enum of legal
+    #: values is overlaid live by the hub and is never baked into the SDK.
+    selected_by: str = ""
+
+    #: The code-side bootstrap ref, and the ONLY resolution source in hub-less
+    #: mode. A live hub mapping always wins when present.
+    default_checkpoint: "ModelRef | None" = None
+
+    #: THE root model, for the residual ``ctx`` questions that still resolve
+    #: against one — ``ctx.defaults``, ``ctx.for_request``. Marking none is
+    #: fine and is the normal case: a handler names every model it binds, by
+    #: parameter, so unlike a `Slot` declaration there is no ambiguity here for
+    #: a root to settle. Marking TWO is a decoration-time error.
+    root: bool = False
+
+    def __post_init__(self) -> None:
+        from .runtime import Model as _Model
+
+        if not (isinstance(self.model, type) and issubclass(self.model, _Model)):
+            raise ModelError(
+                ModelRefusal.FAMILY_INVALID,
+                f"Bind(model=...) must be a generated model class (a subclass of "
+                f"Model), got {self.model!r}. A declaration — ModelSpec / "
+                "GraphModelSpec — is what you EXPORT; what an endpoint binds is the "
+                "class generated from it.",
+            )
+        object.__setattr__(self, "selected_by", str(self.selected_by or "").strip())
+        object.__setattr__(self, "root", bool(self.root))
+        if self.default_checkpoint is not None:
+            from ..api.binding import ModelRef as _ModelRef
+
+            if not isinstance(self.default_checkpoint, _ModelRef):
+                raise ModelError(
+                    ModelRefusal.FAMILY_INVALID,
+                    f"Bind(default_checkpoint=...) must be a ModelRef (Hub/HF/"
+                    f"Civitai/ModelScope), got {type(self.default_checkpoint).__name__}",
+                )
+
+
+def as_bind(value: Any) -> Bind[Any]:
+    """Normalize one ``models={}`` value to a :class:`Bind`.
+
+    A bare model class is the common case and stays the common case; this is
+    the ONE place that reading is applied, so no downstream reader has to know
+    that a mapping value has two shapes.
+    """
+
+    if isinstance(value, Bind):
+        return value
+    return Bind(model=value)
+
+
+__all__ = ["Bind", "as_bind"]

--- a/src/gen_worker/model/export.py
+++ b/src/gen_worker/model/export.py
@@ -279,6 +279,15 @@ def _tuned_ref(schema: type) -> TunedRef:
     return TunedRef(module=schema.__module__, qualname=schema.__qualname__)
 
 
+def _require_tuned(family: GraphModelSpec) -> type:
+    if family.tuned is None:  # pragma: no cover - GraphModelSpec._validate refuses it
+        raise ModelError(
+            ModelRefusal.TUNED_INVALID,
+            f"graph model {family.name!r} carries no tuned schema to export",
+        )
+    return family.tuned
+
+
 def export_model(family: GraphModelSpec) -> ModelExport:
     """Export every declared variant of ``family`` into one snapshot.
 
@@ -321,7 +330,10 @@ def export_model(family: GraphModelSpec) -> ModelExport:
                 for stage in loop.stages
             ),
         ),
-        tuned=_tuned_ref(family.tuned),
+        # A GraphModelSpec always carries one — `GraphModelSpec._validate`
+        # refuses `tuned=None`, because the optional tier is the eager one and
+        # a graph model's parameters are exactly what a tuned schema names.
+        tuned=_tuned_ref(_require_tuned(family)),
         parameters=tuple(
             ExportedParameter(
                 name=ParameterName(parameter.name),

--- a/src/gen_worker/model/inject.py
+++ b/src/gen_worker/model/inject.py
@@ -41,7 +41,10 @@ def declared_models(target: object) -> dict[str, type[Model]]:
         decl = getattr(target, attribute, None)
         families = getattr(decl, "families", None) if decl is not None else None
         if families:
-            return dict(families)
+            # The decorator stores a `Bind` per parameter (pgw#1346 K3); what a
+            # caller binding kwargs wants is the CLASS, so the endpoint-coupled
+            # axes are dropped here rather than leaked into every consumer.
+            return {name: row.model for name, row in families.items()}
     return {}
 
 

--- a/src/gen_worker/model/spec.py
+++ b/src/gen_worker/model/spec.py
@@ -35,7 +35,7 @@ rather than a rewrite (pgw#1326 "One SDK shape").
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product
 from typing import TYPE_CHECKING, Any, Final
@@ -60,6 +60,12 @@ from .._vendor.torchcg.recipe import (
     parse_scheduler_name,
 )
 from ..families.base import KIND_CHECKPOINT, KIND_LORA, GenerationDefaults, register_family
+from ..models.tensor_layout_contract import (
+    LayoutDeclarationError,
+    normalize_layout_demand,
+    normalize_layout_requirements,
+    normalize_layout_undeclarable,
+)
 from .errors import ModelError, ModelRefusal
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -420,18 +426,36 @@ class ModelSpec:
     * AUXILIARY models an endpoint loads beside its checkpoint — a frame
       interpolator, a latent upsampler, a tokenizer tree. These are the K5
       class of pgw#1346's W2 plan, and they belong HERE rather than in a second
-      non-model spelling. They carry no inference vocabulary, so landing them
-      needs ``tuned`` to become optional — the one declaration change the
-      ``Slot`` deletion still owes, and it is NOT made here (see the pgw#1346
-      W1 report: the deletion is blocked on handler injection, not on this).
+      non-model spelling. They carry no inference vocabulary, which is why
+      ``tuned`` is optional.
+
+    **The layout axes are the model's, not the endpoint's** (pgw#1346 K1/K2/K4).
+    ``layouts`` / ``layouts_undeclarable`` / ``layout_requirements`` move here
+    from the retired ``Slot`` unchanged — same keys, same normalizers, same
+    refusals — because what bytes a model's CODE can execute, and what
+    executing them needs of the machine, are properties of the code. Two
+    endpoints binding one model state one demand. The three endpoint-COUPLED
+    axes (`selected_by`, `default_checkpoint`, `root`) went the other way, onto
+    :class:`~gen_worker.model.bind.Bind`, because they name a payload field and
+    a deploy rather than the model.
+
+    ``layouts`` stays keyed by COMPONENT PATH rather than by runner (K4). A
+    ``GraphModelSpec``'s runners and its component tree are not 1:1 — `SDXL`
+    declares two runners over a four-component tree — so collapsing the demand
+    onto ``Runner.layouts`` would make a per-text-encoder demand inexpressible.
+    ``Runner.layouts`` is a different axis and keeps its meaning: which layouts
+    that GRAPH CLASS has traced variants for.
     """
 
     name: str
-    tuned: type[GenerationDefaults]
+    tuned: type[GenerationDefaults] | None = None
     build: Callable[[], Any] | None = None
     lora_tuned: type[GenerationDefaults] | None = None
     on_load: Callable[[Model], None] | None = None
     runners: tuple[Runner, ...] = ()
+    layouts: Mapping[str, Sequence[str]] | None = None
+    layouts_undeclarable: str = ""
+    layout_requirements: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Validate EVERYTHING first, register last. Registration is a
@@ -445,7 +469,15 @@ class ModelSpec:
 
     def _validate(self) -> None:
         object.__setattr__(self, "name", _identifier("family", self.name, parse_family_name))
-        object.__setattr__(self, "tuned", _tuned_schema(self.name, self.tuned, "tuned"))
+        if self.tuned is not None:
+            object.__setattr__(self, "tuned", _tuned_schema(self.name, self.tuned, "tuned"))
+        elif self.lora_tuned is not None:
+            raise ModelError(
+                ModelRefusal.TUNED_INVALID,
+                f"model {self.name!r} declares lora_tuned= without tuned=. A LoRA "
+                "vocabulary refines a base one; there is none here to refine.",
+            )
+        self._validate_layouts()
         if self.lora_tuned is not None:
             object.__setattr__(
                 self, "lora_tuned", _tuned_schema(self.name, self.lora_tuned, "lora tuned")
@@ -461,6 +493,49 @@ class ModelSpec:
                 "GraphModelSpec() when the composition has graph classes",
             )
 
+    def _validate_layouts(self) -> None:
+        """The three layout axes, with ``Slot``'s own normalizers (pgw#1346).
+
+        Deliberately the SAME functions, not a re-implementation: the ie#740
+        production floors — sdxl's ``vram12g``, krea-2's ``vram72g``,
+        minimax-h3's th#1754 ``vram78g``, flux.1-schnell's ``vram36g`` — migrate
+        onto this declaration BY VALUE, and a second parser is how a floor
+        silently stops meaning what the incident made it mean.
+        """
+
+        where = f"{type(self).__name__}({self.name!r})"
+        if self.layouts is not None and str(self.layouts_undeclarable or "").strip():
+            raise LayoutDeclarationError(
+                f"{where}: layouts= and layouts_undeclarable= are mutually exclusive "
+                "— a model either names the contracts its code executes or says why "
+                "none is nameable, never both."
+            )
+        object.__setattr__(
+            self, "layouts",
+            None if self.layouts is None
+            else normalize_layout_demand(self.layouts, where=where),
+        )
+        object.__setattr__(
+            self, "layouts_undeclarable",
+            "" if self.layouts_undeclarable == ""
+            else normalize_layout_undeclarable(self.layouts_undeclarable, where=where),
+        )
+        if not self.layout_requirements:
+            object.__setattr__(self, "layout_requirements", {})
+        elif self.layouts is None:
+            raise LayoutDeclarationError(
+                f"{where}: layout_requirements= without layouts=. A requirement "
+                "guards a declared contract; there is none here to guard."
+            )
+        else:
+            object.__setattr__(
+                self, "layout_requirements",
+                normalize_layout_requirements(
+                    self.layout_requirements, where=where,
+                    accepted={h for hs in self.layouts.values() for h in hs},
+                ),
+            )
+
     def _register(self) -> None:
         """Publish this family's tuned schema(s) under its own name.
 
@@ -472,6 +547,13 @@ class ModelSpec:
         does not belong to one, which is the collision Paul ruled on.
         """
 
+        if self.tuned is None:
+            # An auxiliary or external-runtime model has no inference
+            # vocabulary, so there is no schema to publish and nothing for
+            # tensorhub to validate repo metadata against. Registering an empty
+            # one would put a name into the hub's vocabulary that answers no
+            # question — pgw#1346 K8: only a model with tuned values reaches it.
+            return
         try:
             register_family(self.name, self.tuned, kind=KIND_CHECKPOINT)
             if self.lora_tuned is not None:
@@ -502,6 +584,15 @@ class GraphModelSpec(ModelSpec):
 
     def _validate(self) -> None:
         ModelSpec._validate(self)
+        if self.tuned is None:
+            raise ModelError(
+                ModelRefusal.TUNED_INVALID,
+                f"graph model {self.name!r} declares no tuned= schema. `tuned` is "
+                "optional only on the EAGER tier, where an auxiliary or "
+                "external-runtime model genuinely has no inference vocabulary; a "
+                "declared graph serves generation requests and its parameters are "
+                "exactly what a tuned schema names.",
+            )
         axis_names = tuple(bucket.name for bucket in self.buckets)
         if axis_names != tuple(sorted(set(axis_names))):
             raise ModelError(

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -194,7 +194,7 @@ class EndpointSpec:
     # what the catalog says a resolved checkpoint IS, carried per REQUEST; a
     # family binding is what a handler PARAMETER is, declared once and read by
     # placement. Same struct, different axes.
-    families: Dict[str, type] = field(default_factory=dict)
+    families: Dict[str, Any] = field(default_factory=dict)
     # The handler's DERIVED config schema — the D in `ctx: RequestContext[D]`.
     # None when the handler annotates a bare context. Catalog recipe metadata
     # decodes against this type; code owns the schema, the catalog owns the
@@ -332,7 +332,7 @@ class JobSpec:
     # pgw#1332: the families this job binds, same shape and same meaning as
     # EndpointSpec's — portability between the decorators is a tested
     # requirement, so a body that takes a family instance promotes unchanged.
-    families: Dict[str, type] = field(default_factory=dict)
+    families: Dict[str, Any] = field(default_factory=dict)
     is_async: bool = False
     ctx_param: str = "ctx"
     payload_param: str = "payload"

--- a/tests/test_model_declaration_axes_pgw1346.py
+++ b/tests/test_model_declaration_axes_pgw1346.py
@@ -1,0 +1,266 @@
+"""pgw#1346 W1b — the declaration axes the `Slot` deletion needs (K1–K5).
+
+Every axis here is exercised through the REAL objects the fleet uses: the real
+`ModelSpec`/`GraphModelSpec` constructors with `Slot`'s own layout normalizers,
+the real `@endpoint` decorator, and the real discovery walk that writes
+`endpoint.lock`. Nothing is stubbed, because the property under test is that a
+production floor MEANS THE SAME THING after it moves.
+
+The floors asserted below are the live ie#740 values read out of
+`serverless-endpoints` on 2026-08-17 — krea-2's `vram72g`, flux.1-schnell's
+`vram36g`, the `sm89+` guard on the fp8-rowwise lane. They are production
+incidents preserved by value, which is exactly why this file compares NUMBERS
+and not spellings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.model.bind import Bind, as_bind
+from gen_worker.model.errors import ModelError
+from gen_worker.model.spec import GraphModelSpec, ModelSpec
+from gen_worker.models.tensor_layout_contract import LayoutDeclarationError
+
+from harness.model_toys_pgw1332 import ToyTuned
+
+BF16 = "plain.bf16@1"
+FP8 = "cozy.fp8-rowwise@1"
+
+
+# --------------------------------------------------------------------------
+# K1 — layout_requirements, the ie#740 execution floors, BY VALUE
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("endpoint_name", "compact", "vram", "sm"),
+    [
+        ("krea-2", "vram72g", 72.0, 0),
+        ("flux.1-schnell", "vram36g", 36.0, 0),
+        ("minimax-h3", "vram78g", 78.0, 0),
+        ("ernie", "vram32g", 32.0, 0),
+        ("musicgen", "vram12g", 12.0, 0),
+        ("qwen-image", "sm89+", 0.0, 89),
+    ],
+)
+def test_a_production_floor_survives_the_move_onto_the_model_by_value(
+    endpoint_name: str, compact: str, vram: float, sm: int
+) -> None:
+    """A floor that moves off `Slot` must still mean the same NUMBER.
+
+    These six are live declarations in `serverless-endpoints`. The reason this
+    asserts the parsed terms rather than the string is that the string is not
+    the contract — `min_vram_gb` is what a placement decision reads, and a
+    second parser that spelled it differently is how a floor silently stops
+    guarding the incident it was written for.
+    """
+
+    spec = ModelSpec(
+        name=f"floor_{endpoint_name.replace('-', '_').replace('.', '_')}",
+        layouts={"*": (BF16, FP8)},
+        layout_requirements={BF16 if vram else FP8: compact},
+    )
+    (requirement,) = spec.layout_requirements.values()
+    assert requirement.minimum.min_vram_gb == vram
+    assert requirement.minimum.min_sm == sm
+    # `recommended` is additive and gates nothing; the compact form IS the
+    # minimum, and inventing a recommendation from it would gate on a value
+    # nobody declared.
+    assert requirement.recommended is None
+
+
+def test_a_requirement_guarding_a_contract_the_model_does_not_accept_is_refused() -> None:
+    with pytest.raises(LayoutDeclarationError) as caught:
+        ModelSpec(name="floor_unaccepted", layouts={"*": (BF16,)},
+                  layout_requirements={FP8: "sm89+"})
+    assert FP8 in str(caught.value)
+
+
+def test_a_requirement_with_no_layouts_to_guard_is_refused() -> None:
+    with pytest.raises(LayoutDeclarationError) as caught:
+        ModelSpec(name="floor_no_layouts", layout_requirements={BF16: "vram72g"})
+    assert "without layouts=" in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# K2 — layouts_undeclarable, the explicit third rung
+# --------------------------------------------------------------------------
+
+
+def test_undeclarable_takes_a_reason_and_refuses_a_blank_one() -> None:
+    spec = ModelSpec(
+        name="gguf_probe",
+        layouts_undeclarable="GGUF: the quant axis has no registered handle",
+    )
+    assert spec.layouts_undeclarable.startswith("GGUF:")
+    assert spec.layouts is None
+    with pytest.raises(LayoutDeclarationError):
+        ModelSpec(name="gguf_blank_probe", layouts_undeclarable="   ")
+
+
+def test_declaring_both_layouts_and_undeclarable_is_refused() -> None:
+    """The tri-state may not be collapsed from both ends at once."""
+    with pytest.raises(LayoutDeclarationError) as caught:
+        ModelSpec(name="both_probe", layouts={"*": (BF16,)},
+                  layouts_undeclarable="also undeclarable")
+    assert "mutually exclusive" in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# K4 — the demand stays keyed by COMPONENT PATH, not by runner
+# --------------------------------------------------------------------------
+
+
+def test_a_per_component_demand_is_expressible_and_the_star_is_the_default() -> None:
+    """SDXL declares two runners over a four-component tree.
+
+    Collapsing this onto `Runner.layouts` would make a per-text-encoder demand
+    inexpressible, which is why the component-path keying survived the move.
+    """
+
+    spec = ModelSpec(
+        name="component_probe",
+        layouts={"*": (BF16,), "text_encoder": (FP8, BF16)},
+    )
+    assert spec.layouts is not None
+    assert spec.layouts["*"] == (BF16,)
+    # Canonical order, not written order: the set is a compatibility FILTER and
+    # a position in it must never read as a preference.
+    assert set(spec.layouts["text_encoder"]) == {FP8, BF16}
+    assert spec.layouts["text_encoder"] == tuple(sorted(spec.layouts["text_encoder"]))
+
+
+def test_runner_layouts_is_a_different_axis_and_keeps_its_meaning() -> None:
+    """`Runner.layouts` says which layouts a GRAPH CLASS has traced variants
+    for; `ModelSpec.layouts` says which layouts the model's code can execute.
+    A model may accept fp8 bytes for a component it has no fp8 graph class for.
+    """
+
+    from harness.model_toys_pgw1332 import TOY_DIFFUSION
+
+    assert TOY_DIFFUSION.runners[0].layouts == ("bf16",)
+    assert TOY_DIFFUSION.layouts is None
+
+
+# --------------------------------------------------------------------------
+# K5 — the eager tier is permanent, and an auxiliary model has no vocabulary
+# --------------------------------------------------------------------------
+
+
+def test_an_auxiliary_model_declares_no_tuned_schema_and_registers_nothing() -> None:
+    """A RIFE interpolator / latent upsampler / tokenizer tree has no
+    inference vocabulary. Publishing an empty schema under its name would put a
+    name into the hub's vocabulary that answers no question (K8).
+    """
+
+    from gen_worker.families.base import family_registry
+
+    before = dict(family_registry())
+    spec = ModelSpec(name="rife_interpolator_probe")
+    assert spec.tuned is None
+    assert dict(family_registry()) == before, (
+        "an auxiliary model published a tuned schema; K8 says only a model with "
+        "tuned values reaches the hub's vocabulary"
+    )
+
+
+def test_a_lora_vocabulary_with_no_base_vocabulary_to_refine_is_refused() -> None:
+    with pytest.raises(ModelError) as caught:
+        ModelSpec(name="lora_orphan_probe", lora_tuned=ToyTuned)
+    assert "without tuned=" in str(caught.value)
+
+
+def test_a_graph_model_still_owes_a_tuned_schema() -> None:
+    """`tuned` is optional only on the EAGER tier. A declared graph serves
+    generation requests and its parameters are what a tuned schema names.
+    """
+
+    with pytest.raises(ModelError) as caught:
+        GraphModelSpec(name="graph_no_tuned_probe")
+    assert "tuned" in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# K3 — Bind, the endpoint-coupled axes
+# --------------------------------------------------------------------------
+
+
+def test_a_bare_model_class_and_a_bare_bind_mean_the_same_thing() -> None:
+    from gen_worker.model.catalog import Sdxl
+
+    assert as_bind(Sdxl) == Bind(model=Sdxl)
+    assert as_bind(Bind(Sdxl, selected_by="model")).selected_by == "model"
+
+
+def test_bind_refuses_anything_that_is_not_a_generated_model_class() -> None:
+    with pytest.raises(ModelError) as caught:
+        Bind(object)  # type: ignore[type-var]
+    assert "generated model class" in str(caught.value)
+
+
+def test_bind_refuses_a_declaration_where_a_generated_class_belongs() -> None:
+    """The declaration is what you EXPORT; what an endpoint binds is the class
+    generated from it. A declaration has no typed callables on it, so binding
+    one would hand a handler something that looks resolved and is not.
+    """
+
+    from harness.model_toys_pgw1332 import TOY_DIFFUSION
+
+    with pytest.raises(ModelError):
+        Bind(TOY_DIFFUSION)  # type: ignore[arg-type]
+
+
+def test_binding_two_roots_is_a_decoration_time_error() -> None:
+    import msgspec
+
+    from gen_worker import RequestContext, endpoint
+    from gen_worker.model.catalog import Sdxl
+
+    class In(msgspec.Struct, frozen=True):
+        pass
+
+    class Out(msgspec.Struct, frozen=True):
+        pass
+
+    class TwoRoots:
+        def run(
+            self, ctx: RequestContext, p: In, left: Sdxl, right: Sdxl
+        ) -> Out:
+            return Out()
+
+    with pytest.raises(ValueError) as caught:
+        endpoint(families={
+            "left": Bind(Sdxl, root=True),
+            "right": Bind(Sdxl, root=True),
+        })(TwoRoots)
+    assert "root" in str(caught.value)
+
+
+def test_binding_several_models_and_marking_no_root_is_fine() -> None:
+    """The model surface is genuinely smaller than the `Slot` one it replaces:
+    a handler names every model it binds, by parameter, so there is no
+    ambiguity for a root to settle.
+    """
+
+    import msgspec
+
+    from gen_worker import RequestContext, endpoint
+    from gen_worker.model.catalog import Sdxl
+
+    class In(msgspec.Struct, frozen=True):
+        pass
+
+    class Out(msgspec.Struct, frozen=True):
+        pass
+
+    class NoRoot:
+        def run(
+            self, ctx: RequestContext, p: In, left: Sdxl, right: Sdxl
+        ) -> Out:
+            return Out()
+
+    decorated = endpoint(families={"left": Sdxl, "right": Sdxl})(NoRoot)
+    declared = getattr(decorated, "__gen_worker_endpoint__").families
+    assert sorted(declared) == ["left", "right"]
+    assert not any(row.root for row in declared.values())

--- a/tests/test_model_sdk_pgw1332.py
+++ b/tests/test_model_sdk_pgw1332.py
@@ -951,7 +951,11 @@ def test_a_handler_parameter_binds_a_resolved_instance(toy_binding: Any) -> None
         )
     )
     declared = getattr(Generate, ATTR).families
-    assert declared == {"toy": toy_binding}
+    # pgw#1346 K3: the decorator records a `Bind` per parameter — the model
+    # class plus this endpoint's own axes (selected_by / default_checkpoint /
+    # root). A bare class in the declaration normalizes to a bare `Bind`.
+    assert {name: row.model for name, row in declared.items()} == {"toy": toy_binding}
+    assert declared["toy"].selected_by == "" and not declared["toy"].root
     kwargs = fake_kwargs(Generate)
     assert set(kwargs) == {"toy"}
     result = Generate().generate(None, _In(), **kwargs)  # type: ignore[arg-type]
@@ -1066,7 +1070,8 @@ def test_a_job_binds_families_exactly_as_an_endpoint_does(toy_binding: Any) -> N
     )
     body = namespace["render"]
     declared = job(families={"toy": toy_binding})(body)
-    assert getattr(declared, JOB_ATTR).families == {"toy": toy_binding}
+    assert {n: r.model for n, r in getattr(declared, JOB_ATTR).families.items()} \
+        == {"toy": toy_binding}
     kwargs = fake_kwargs(declared)
     assert declared(None, _In(), **kwargs).shape.startswith("fake:")
 
@@ -1113,14 +1118,14 @@ def test_the_discovery_manifest_carries_the_families_a_function_binds(
         )
     )
     (spec,) = extract_specs(Generate, walked_module="tests.pgw1332")
-    assert spec.families == {"toy": toy_binding}
+    assert {n: r.model for n, r in spec.families.items()} == {"toy": toy_binding}
     block = [
         {
             "parameter": name,
-            "family": str(getattr(family, "FAMILY", "")),
-            "export_digest": str(getattr(family, "EXPORT_DIGEST", "")),
+            "family": str(getattr(row.model, "FAMILY", "")),
+            "export_digest": str(getattr(row.model, "EXPORT_DIGEST", "")),
         }
-        for name, family in sorted(spec.families.items())
+        for name, row in sorted(spec.families.items())
     ]
     assert block == [
         {

--- a/tests/test_sdk_v2_pgw647.py
+++ b/tests/test_sdk_v2_pgw647.py
@@ -384,7 +384,8 @@ def test_a_family_instance_param_is_the_one_permitted_extra(tmp_path):
         def generate(self, ctx: RequestContext, p: _In, sdxl: Sdxl) -> _Out:
             return _Out()
 
-    assert getattr(Gen, "__gen_worker_endpoint__").families == {"sdxl": Sdxl}
+    declared = getattr(Gen, "__gen_worker_endpoint__").families
+    assert {name: row.model for name, row in declared.items()} == {"sdxl": Sdxl}
 
 
 def test_class_models_require_setup():


### PR DESCRIPTION
Second PR of pgw#1346 W1. #901 landed the rename; this lands **the declaration surface the `Slot` deletion needs**, so the deletion becomes a code move instead of a silent data loss.

## Why this is a prerequisite, not a nice-to-have

Five of `Slot`'s axes had **no equivalent anywhere** on the model surface (the W2 plan's K1–K5). Deleting `Slot` without them drops every declared serving floor in the fleet, silently — 20 of 29 endpoint dirs carry one.

## K1 / K2 / K4 — the layout axes move onto `ModelSpec`

Same fields, same normalizers, on purpose. The ie#740 floors are production incidents preserved by value, and a second parser is exactly how a floor stops meaning what the incident made it mean.

```python
SDXL = GraphModelSpec(
    name="sdxl", tuned=SdxlTuned, runners=(...),
    layouts={"*": ("plain.bf16@1",),
             "text_encoder": ("cozy.fp8-rowwise@1", "plain.bf16@1")},
    layout_requirements={"cozy.fp8-rowwise@1": "sm89+, vram24g"},
)
```

`tests/test_model_declaration_axes_pgw1346.py` asserts the parsed **numbers** for six live `serverless-endpoints` declarations — krea-2 `vram72g`, flux.1-schnell `vram36g`, minimax-h3 `vram78g`, ernie `vram32g`, musicgen `vram12g`, qwen-image `sm89+` — not their spellings.

**K4 answered:** the demand stays keyed by COMPONENT PATH and is *not* collapsed onto `Runner.layouts`. Runners and components are not 1:1 (SDXL declares two runners over a four-component tree), so collapsing would make a per-text-encoder demand inexpressible. `Runner.layouts` keeps its own meaning: which layouts that GRAPH CLASS has traced variants for.

## K3 — `Bind`, the axes a model cannot know about itself

```python
@endpoint(models={"pipeline": Sdxl})                        # the common case
@endpoint(models={"pipeline": Bind(Krea2, selected_by="model")})
```

`selected_by` names a field of THIS endpoint's payload; `default_checkpoint` is this deployment's bootstrap ref; `root` answers the residual `ctx` questions. A bare class normalizes to a bare `Bind` in one place, so no downstream reader learns the mapping value has two shapes.

It is **not `Slot` renamed**: no `pipeline_cls` (the declaration is the component tree), no layouts (the model's), and `optional` is still derived from the handler parameter's own default.

It also needs **no "mark one root" rule** — and that is where this surface is genuinely smaller than the one it replaces. A root slot had to be picked because `ctx.defaults` resolves against one with nothing in the call naming it. A handler names every model it binds, by parameter, so an endpoint binding four models and marking none is fully determined. Two roots is still a decoration-time error.

## K5 / K8 — `tuned=` is optional on the eager tier

An auxiliary model (frame interpolator, latent upsampler, tokenizer tree) has no inference vocabulary. A test asserts it registers **nothing** — which is the K8 question the W2 plan asked W1 to settle: only a model with tuned values reaches the hub's vocabulary, so the five unregistered names need a tensorhub PR **only if** they declare a tuned schema. A `GraphModelSpec` still owes one.

## What is deliberately NOT here

The worker-side injection path and the `families=`→`models=` flip. Both are recorded in pgw#1346 with the exact seam so the next lane executes rather than re-derives:

- `Executor._handler_kwargs` (`executor.py:10686-10709`) is the **single** place handler kwargs are built, feeding `call_kwargs` at `:11179`. A `families=` parameter is silently skipped there today because it is not in `spec.models`.
- `Model.adopt(ref=, tuned=, eager={runner: module}, compiled=)` (`model/runtime.py:261-285`) is the constructor it must reach.
- `EagerBacking` wants `{runner_name: module}`; **no runner→component map exists anywhere yet** — that is the missing declaration field for the eager half.
- The tuned stamp is already on the wire in the same `pb.ModelBinding.inference_defaults`, keyed by `slot`. Because a model's `models={}` key doubles as the handler parameter name, **no tensorhub change is needed** — the hub keeps stamping `slot="pipeline"` exactly as today.
- `model/tuned.py:48` imports `api/slot._apply_lora_overrides`, so that function must be MOVED, not deleted, whenever `api/slot.py` goes.

## Verification

- `mypy src/gen_worker tests tests_v2` — **Success: no issues found in 857 source files**
- `ruff check src/gen_worker` — clean
- fast gates run locally: `lint_retired_sdk_spellings` (+selftest), `lint_retired_package_names`, `lint_serve_role_closure` (both roles — the new `tensor_layout_contract` import does NOT pull a model library into the adopt-only closure), `lint_serving_process_compiles`, `lint_unreached_surface`, `lint_fence_symbols`, `check_registry_contract`, `check_model_bindings`, `lint_layout_declarations`, `lint_mypy_ratchet`, `assemble_changelog --check` — all green
- 20 new tests in `tests/test_model_declaration_axes_pgw1346.py`; 150 green across the SDK/flux/v2/discovery suites
- full `tests/` suite: running locally before enqueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
