### PR TITLE
pgw#1306: the three producer context classes DIE — th#2052 sentenced them and could not reach them

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ Full reference: [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
 - Compile envelope (the declared serving region — resolutions, text lengths,
   guidance, batch): `Compile`, `CompileAxis`, `AxisClass`, `DynamicDim`,
   `pad_text_sequence`; per-request views: `ctx.for_request` / `gen_worker.view`
-- Contexts: `RequestContext` (≤15 members), `ConversionContext`,
-  `DatasetContext`, `TrainingContext`
+- Contexts: `RequestContext` (≤15 members) and `JobContext`, the one producer
+  context — every `@job` body and every producer-kind `@endpoint` handler gets
+  it, and what it may write comes from the declaration, not the kind
 - Errors: `ValidationError`, `RetryableError`, `CanceledError`, `FatalError`
 - Streaming: `BatchItemDelta`, `IncrementalTokenDelta`, `Done`, `Error`
 - Value types: `Asset`, `ImageAsset`, `AudioAsset`, `VideoAsset`

--- a/changelog.d/pgw1306.md
+++ b/changelog.d/pgw1306.md
@@ -1,0 +1,50 @@
+- **`ConversionContext` / `DatasetContext` / `TrainingContext` are DELETED. `JobContext` is
+  the one producer context.** pgw#1294 merged the three classes and left the names as thin
+  aliases carrying a sentence: *"they die at th#2052."* **th#2052 is a tensorhub commit and
+  cannot delete Python** — the eight-issue jobs series had no pgw leg after the cut, so the
+  sentence named an executioner structurally incapable of carrying it out. This is the
+  carried-out sentence. Every producer function — `@job` bodies and producer-kind
+  `@endpoint` handlers alike — receives `JobContext`, and what a body may write comes from
+  its own declaration (`publishes` / `emits_media`), never from its kind.
+
+  **The collapse fixed a live defect, which is the part worth reading.** The three names
+  were pure aliases in `request_context`, so deleting them there is bookkeeping — but
+  `cli/local_context.py` still had a Local subclass PER KIND, each sitting on whichever
+  producer class it had inherited, and the three disagreed about the same question.
+  Measured on `b7a9345a`, `gen-worker run --allow-publish`:
+
+  | kind | class | `materialize_blob` it reached | honors `--allow-publish` |
+  |---|---|---|---|
+  | `conversion`, `job` | `LocalConversionContext` | local-CAS stub | yes |
+  | `dataset` | `LocalDatasetContext` | a near-copy of that stub | **no** |
+  | `training` | `LocalTrainingContext` | **`_PublisherMixin.materialize_blob`** | **no** |
+
+  The training arm overrode nothing, so a local run of a training endpoint reached the REAL
+  hub-backed implementation — in the dev loop whose entire purpose is to not have a hub.
+  Nobody chose that; it fell out of which producer-kind class each local subclass happened
+  to sit on. There is now ONE `LocalJobContext` for every producer kind, and one class
+  cannot disagree with itself. `LocalConversionContext` / `LocalDatasetContext` /
+  `LocalTrainingContext` are gone with the names.
+
+  **Hard cut, no shim, and the reason is checkable.** Nothing retired here ever crossed a
+  wire: `kind` is an author declaration read from local source (`@endpoint(kind=...)` at
+  import time, validated against a closed set in `discovery.validation._KNOWN_KINDS`) and
+  `execution_hints["kind"]` is outbound-only, so a worker never learns a kind from a
+  request and no older-wheel request can arrive carrying one of these names. The boundary
+  that is real is the WHEEL: a consumer pinned to 0.122.0 keeps the aliases in its own
+  wheel and is untouched; one that repins gets an `ImportError` at import time — immediate,
+  loud, located. A module `__getattr__` softening that would also have defeated the fence
+  below, which is the other reason not to write one.
+
+  `tests/test_producer_context_cut_pgw1306.py` is deliverable 2's fence and reads SOURCE
+  TEXT, not symbols, because an alias comes back through a re-export that a `hasattr` check
+  would miss. It scans tracked AND uncommitted files (a new file cannot smuggle the name in
+  for one commit), proves its own corpus is non-empty and its pattern can match before
+  believing a zero, and permits the three names only at DECLARED tombstones with an exact
+  line count — so a tombstone that grows is a re-import hiding behind prose, and one that
+  shrinks to zero is an exemption for nothing. Both directions are red.
+
+  Also re-authored: `test_every_declared_kind_builds_its_own_context` asserted each kind
+  built "its own" context, which pgw#1294 had already made VACUOUS — three of the four
+  producer bases were one class under three names, so it passed while saying nothing. It
+  now asserts the true property, that every producer kind builds the SAME class.

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -750,11 +750,18 @@ payload key and its own hub readers.
 
 ## Kinds
 
-`@endpoint(kind="conversion" | "training" | "dataset")` selects the context
-subclass the handler receives: `ConversionContext` adds `save_checkpoint` /
-`mktemp` / `source` / `destination`; `DatasetContext` adds
-`publish_dataset_revision` / `resolve_dataset`; `TrainingContext` adds the
-typed training-metric emitter.
+`@endpoint(kind="conversion" | "training" | "dataset")` declares a producer,
+and every producer receives the SAME context — `JobContext`, the one a `@job`
+body gets. It carries `save_checkpoint` / `mktemp` / `source` / `destination`,
+`publish_dataset_revision` / `resolve_dataset`, and the typed training-metric
+emitter, all on one class.
+
+There were once three kind-specific subclasses (`ConversionContext`,
+`DatasetContext`, `TrainingContext`). They were merged by pgw#1294 and the
+names deleted by pgw#1306; **do not reintroduce a per-kind context.** The kind
+describes the WIRE shape. What a body may write is its own declaration —
+`publishes=True` (and `emits_media=True` for a job) — and the hub mints the
+write grant off that declaration, never off the kind.
 
 Producer endpoints publish **explicitly**: write files locally, call
 `gen_worker.convert.publish_flavors(ctx, flavors)` — one Tensorhub commit per
@@ -763,7 +770,7 @@ Producer endpoints publish **explicitly**: write files locally, call
 ```python
 @endpoint(kind="conversion")
 class Convert:
-    def run(self, ctx: ConversionContext, p: In) -> Out:
+    def run(self, ctx: JobContext, p: In) -> Out:
         out_dir = ctx.mktemp()
         ...  # write model files under out_dir
         commits = publish_flavors(

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -169,7 +169,7 @@ The `.gen-worker-run/` directory is throwaway. Add it to `.gitignore` /
 Checkpoint publishing goes through `gen_worker.convert.publish_flavors(ctx,
 flavors)`, which talks to tensorhub directly using the worker capability
 token — with no token configured (plain local runs) it fails loudly
-instead of pretending to publish. `ConversionContext.materialize_blob`
+instead of pretending to publish. `JobContext.materialize_blob`
 is stubbed against the local CAS by default; pass `--allow-publish` to
 call the real tensorhub API (useful for round-tripping against a dev
 tensorhub).

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -7,10 +7,11 @@ One decorator, four bindings, a slim request context::
     @endpoint
     def hello(ctx: RequestContext, data: In) -> Out: ...
 
-``JobContext`` (aliased for now as ``ConversionContext`` / ``DatasetContext``
-/ ``TrainingContext``) adds the producer-contract surface (publish, mktemp,
-dataset resolution) via plain inheritance; the worker constructs the right
-subclass from ``@endpoint(kind=...)`` before dispatch.
+``JobContext`` adds the producer-contract surface (publish, mktemp, dataset
+resolution) via plain inheritance. It is the ONLY producer context: every
+``@job`` body and every producer-shaped ``@endpoint`` handler receives one,
+and what a body may write comes from its declaration (``publishes`` /
+``emits_media``), never from its kind.
 """
 
 from . import io
@@ -111,11 +112,8 @@ from .api.types import (
     VideoAsset,
 )
 from .request_context import (
-    ConversionContext,
-    DatasetContext,
     JobContext,
     RequestContext,
-    TrainingContext,
     TrainingMetric,
 )
 from .api.jobs import job
@@ -200,9 +198,6 @@ __all__ = [
     # Context types.
     "RequestContext",
     "JobContext",
-    "ConversionContext",
-    "DatasetContext",
-    "TrainingContext",
     "TrainingMetric",
     # Per-step progress helper for diffusers pipelines.
     "diffusers_step_callback",

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -1,17 +1,20 @@
 """LocalRequestContext — RequestContext subclass for ``gen-worker run``.
 
-Build the right kind-specific context for the selected method (RequestContext
-for inference, ConversionContext for conversion, DatasetContext for dataset,
-TrainingContext for training). Override the orchestrator-backed bits with
-local-mode equivalents:
+Build the context for the selected method — ``LocalRequestContext`` for
+inference, ``LocalJobContext`` for every producer kind and for ``@job``.
+There are TWO classes here, not five, and that is pgw#1306's point: kind
+selects a WIRE shape, never a context class and never write authority. Override
+the orchestrator-backed bits with local-mode equivalents:
 
 - ``emitter`` writes JSON lines to stderr so ``ctx.emit / progress / log``
   events are visible without competing with the stdout result.
 - ``save_bytes`` / ``save_file`` materialize files under
   ``./.gen-worker-run/outputs/<ref>`` and return an Asset with ``local_path``
   set (no tensorhub upload).
-- ``materialize_blob`` on ConversionContext falls back to the local CAS
-  unless ``--allow-publish`` delegates to the real implementation.
+- ``materialize_blob`` on ``LocalJobContext`` falls back to the local CAS
+  unless ``--allow-publish`` delegates to the real implementation. ONE answer
+  for every producer kind — before pgw#1306 there were three, and two of them
+  were wrong (see that class's docstring).
   (Checkpoint publishing goes through ``gen_worker.convert.publish_flavors``,
   which talks to tensorhub directly and fails loudly without credentials.)
 - ``_canceled`` is toggled by the installed SIGINT handler in ``run.py``.
@@ -38,10 +41,8 @@ from ..api.types import Asset
 from ..models.cache_paths import open_worker_cas
 from ..request_context import (
     REF_ORIGIN_PAYLOAD,
-    ConversionContext,
-    DatasetContext,
+    JobContext,
     RequestContext,
-    TrainingContext,
 )
 
 _LOCAL_OUTPUT_DIR_NAME = ".gen-worker-run"
@@ -152,12 +153,25 @@ def _materialize_local_blob(digest: str, dest: str | os.PathLike[str]) -> Path:
     return output
 
 
-class LocalConversionContext(LocalRequestContextMixin, ConversionContext):
-    """Conversion-kind local context.
+class LocalJobContext(LocalRequestContextMixin, JobContext):
+    """The local context every producer body gets: ``@job`` runs and every
+    producer-kind ``@endpoint`` alike.
 
     ``materialize_blob`` is stubbed against the local CAS unless
     ``--allow-publish`` was passed (in which case we delegate to the real
     implementation — useful for round-tripping against a dev tensorhub).
+
+    **pgw#1306 collapsed three classes into this one, and the collapse fixed a
+    live defect rather than tidying names.** There used to be a
+    `LocalConversionContext` / `LocalDatasetContext` / `LocalTrainingContext`,
+    selected by kind, and the three disagreed about the same question. Measured
+    on `b7a9345a`: `conversion` honored `--allow-publish`; `dataset` had a
+    near-copy of this stub that IGNORED it; `training` overrode nothing at all,
+    so `gen-worker run --offline` on a training endpoint reached
+    `_PublisherMixin.materialize_blob` — the REAL hub-backed implementation —
+    in the loop whose entire purpose is to not have a hub. Nobody chose that;
+    it was inherited from whichever producer-kind class each local subclass
+    happened to sit on. One class cannot disagree with itself.
     """
 
     def materialize_blob(
@@ -182,42 +196,6 @@ class LocalConversionContext(LocalRequestContextMixin, ConversionContext):
             ) from None
 
 
-class LocalDatasetContext(LocalRequestContextMixin, DatasetContext):
-    """Dataset-kind local context."""
-
-    def materialize_blob(
-        self, digest: str, dest: "str | os.PathLike[str]",
-        *, origin: str = REF_ORIGIN_PAYLOAD,
-    ) -> Path:
-        # Same fallback as ConversionContext (origin is a provenance tag for
-        # breaker classification; the local CAS stub has no breaker, so it is
-        # accepted and unused here).
-        d = (digest or "").strip()
-        if not d:
-            raise ValueError("materialize_blob: empty digest")
-        try:
-            return _materialize_local_blob(d, dest)
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                f"materialize_blob: blob {digest!r} not found in local CAS "
-                f"({open_worker_cas().root})"
-            ) from None
-
-
-class LocalTrainingContext(LocalRequestContextMixin, TrainingContext):
-    """Training-kind local context."""
-
-
-class LocalJobContext(LocalConversionContext):
-    """The ``gen-worker job run`` context: a real
-    :class:`~gen_worker.request_context.JobContext` with the hub-backed bits
-    stubbed, so an author's dev loop exercises the same body the pod will.
-
-    It inherits the conversion arm's local-CAS ``materialize_blob`` because the
-    two answer the same question and a second copy would drift.
-    """
-
-
 def build_local_context(
     *,
     kind: str,
@@ -228,14 +206,16 @@ def build_local_context(
     publishes: bool = False,
     emits_media: Optional[bool] = None,
 ) -> RequestContext:
-    """Factory: build the right context subclass for ``kind``.
+    """Factory: build the context for ``kind``.
 
     ``kind`` is the endpoint's declared kind string from discover_manifest, or
-    ``job`` for a ``@job`` run. An unrecognized kind is a REFUSAL, never a base
-    ``RequestContext``: the base class silently lacks the surface the kind
-    implies (``materialize_blob``, ``save_checkpoint``, the dataset writers), so
-    the substitution surfaces as a missing attribute deep inside a tenant body —
-    a typo'd kind reading as "this endpoint has no publisher".
+    ``job`` for a ``@job`` run. It answers exactly one question — *is this body
+    a producer?* — and every producer answer is the same class. An unrecognized
+    kind is a REFUSAL, never a base ``RequestContext``: the base class silently
+    lacks the producer surface (``materialize_blob``, ``save_checkpoint``, the
+    dataset writers), so the substitution surfaces as a missing attribute deep
+    inside a tenant body — a typo'd kind reading as "this endpoint has no
+    publisher".
     """
     rid = request_id or _local_request_id()
     em = emitter if emitter is not None else _stderr_emitter
@@ -257,14 +237,11 @@ def build_local_context(
     }
 
     k = (kind or "").strip().lower()
-    if k == "job":
+    # Every producer kind — and @job — gets the SAME class. The list is spelled
+    # out rather than written as `!= "inference"` so an unknown kind still hits
+    # the refusal below instead of being silently promoted to a producer.
+    if k in ("job", "conversion", "eval", "dataset", "training"):
         return LocalJobContext(allow_publish=allow_publish, **common)
-    if k in ("conversion", "eval"):
-        return LocalConversionContext(allow_publish=allow_publish, **common)
-    if k == "dataset":
-        return LocalDatasetContext(allow_publish=allow_publish, **common)
-    if k == "training":
-        return LocalTrainingContext(allow_publish=allow_publish, **common)
     if k == "inference":
         return LocalRequestContext(allow_publish=allow_publish, **common)
     raise ValueError(
@@ -278,9 +255,6 @@ def build_local_context(
 __all__ = [
     "build_local_context",
     "LocalRequestContext",
-    "LocalConversionContext",
-    "LocalDatasetContext",
     "LocalJobContext",
-    "LocalTrainingContext",
     "_stderr_emitter",
 ]

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -120,7 +120,7 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
     p.add_argument(
         "--allow-publish", action="store_true",
         help=(
-            "Allow ConversionContext.materialize_blob to call the real "
+            "Allow JobContext.materialize_blob to call the real "
             "tensorhub APIs. Default: stubbed against the local CAS."
         ),
     )

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -118,7 +118,7 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
     )
     p.add_argument(
         "--allow-publish", action="store_true",
-        help="Allow ConversionContext producer RPCs to hit real tensorhub.",
+        help="Allow JobContext producer RPCs to hit real tensorhub.",
     )
     p.add_argument(
         "--no-stdin", action="store_true",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -204,11 +204,15 @@ if not serve_role.adopt_only():
     from . import mint_adapter  # noqa: F401  (registers the mint side)
 from .hostfacts import cuda_ready
 
-# pgw#1294: the three producer contexts MERGED into JobContext, so every
-# producer kind resolves to the same class under three names until th#2052
-# deletes the names. The map stays explicit rather than collapsing to one
-# entry — the KINDS are still distinct declarations and one of them (eval)
-# deliberately publishes nothing.
+# pgw#1294 MERGED the three producer contexts into JobContext; pgw#1306 deleted
+# the three names, so this map is now the whole truth: producer -> JobContext,
+# inference -> RequestContext, and nothing in between. It stays a map rather
+# than `kind != "inference"` because the KINDS are still distinct wire
+# declarations and an unknown one must not be promoted to a producer by a
+# negation. What it does NOT do any more is decide write authority: a body may
+# write because its @job/@endpoint declaration says `publishes=True`, and the
+# hub mints the grant off that declaration. `eval` is the illustration — same
+# class, same surface, and the hub refuses its repo writes.
 _CONTEXT_BY_KIND: Dict[str, type] = {
     "inference": RequestContext,
     "conversion": JobContext,

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1614,8 +1614,8 @@ class RequestContext(Generic[D]):
 
 
 class _PublisherMixin:
-    """Producer-contract helpers shared by ConversionContext, DatasetContext
-    and TrainingContext: blob fetch by digest and ``materialize_blob``.
+    """Producer-contract helpers for ``JobContext``: blob fetch by digest and
+    ``materialize_blob``.
     Always combined with ``RequestContext`` via multiple inheritance (so
     ``self`` has ``_file_api_base_url`` / ``_owner`` /
     ``_get_worker_capability_token``).
@@ -2159,9 +2159,12 @@ class JobContext(_PublisherMixin, RequestContext[GenerationDefaults]):
     ``@endpoint`` and priced, with zero body edits. It is enforced by a test
     that registers one body both ways and runs it under both harnesses.
 
-    This class is the MERGE of what used to be three sibling contexts —
-    ``ConversionContext`` + ``TrainingContext`` + ``DatasetContext``, which are
-    now thin aliases of it and die at th#2052. It carries:
+    This class is the MERGE of what used to be three sibling contexts, one per
+    producer KIND (pgw#1294 merged them, pgw#1306 deleted the names). It is now
+    the ONLY producer context: no kind selects a different class, because no
+    kind decides what a body may write — the ``@job``/``@endpoint`` declaration
+    does (``publishes`` / ``emits_media``), and the hub mints the write grant
+    off that declaration. It carries:
 
     * the publisher surface from ``_PublisherMixin`` — ``save_checkpoint`` /
       ``open_checkpoint_stream`` (and ``gen_worker.convert.publish_flavors``),
@@ -2307,11 +2310,13 @@ class JobContext(_PublisherMixin, RequestContext[GenerationDefaults]):
         self._emit_event("request.training_metric", payload)
 
 
-# The three producer contexts MERGED into JobContext (pgw#1294): they were
-# already the same class plus one helper each, and one surface is what makes a
-# body portable between @job and @endpoint. THIN ALIASES, deliberately and
-# temporarily — th#2052 re-authors the last producer endpoints as jobs and
-# deletes these three names whole. Nothing new should reference them.
-ConversionContext = JobContext
-DatasetContext = JobContext
-TrainingContext = JobContext
+# pgw#1306: `ConversionContext` / `DatasetContext` / `TrainingContext` are GONE.
+# pgw#1294 merged them into JobContext and left the three names as thin aliases
+# with a sentence naming th#2052 as executioner; th#2052 is a tensorhub commit
+# and cannot delete Python, so this is where the sentence is carried out. The
+# names never crossed a wire — `kind` is an author declaration read from local
+# source (`@endpoint(kind=...)`, validated against a closed set in
+# `discovery/validation.py`), and `execution_hints["kind"]` is outbound-only —
+# so there is no retired shape to refuse, only a name to stop exporting.
+# `tests/test_producer_context_cut_pgw1306.py` is the text fence that keeps it
+# out.

--- a/src/gen_worker/testing/__init__.py
+++ b/src/gen_worker/testing/__init__.py
@@ -291,8 +291,8 @@ _RECORDING_CLASSES: Dict[type, type] = {}
 
 
 def _recording_class(cls: type) -> type:
-    """``RecordingRequestContext`` / ``RecordingConversionContext`` / ... —
-    built once per context class so ``isinstance(ctx, cls)`` still holds."""
+    """``RecordingRequestContext`` / ``RecordingJobContext`` — built once per
+    context class so ``isinstance(ctx, cls)`` still holds."""
     built = _RECORDING_CLASSES.get(cls)
     if built is None:
         built = type(f"Recording{cls.__name__}", (_RecordingMixin, cls), {})
@@ -308,9 +308,9 @@ def fake_context(
     recorder: Optional[Recorder] = None,
     **kwargs: Any,
 ) -> C:
-    """Build a :class:`RequestContext` (or ``cls=``, a producer-kind
-    subclass: ``ConversionContext``/``DatasetContext``/``TrainingContext``)
-    for a handler unit test, with ``ctx.slots`` pre-populated.
+    """Build a :class:`RequestContext` (or ``cls=JobContext``, the producer
+    context every ``@job`` body and producer-kind handler receives) for a
+    handler unit test, with ``ctx.slots`` pre-populated.
 
     ``slots`` maps slot name -> ``(ref, defaults)`` — exactly what a
     ``Slot``-declared endpoint's handler reads via

--- a/tests/convert/test_release_axis_pgw1279.py
+++ b/tests/convert/test_release_axis_pgw1279.py
@@ -20,18 +20,18 @@ from typing import Any
 import pytest
 from fake_hub import _FakeHub
 
-from gen_worker.request_context import TrainingContext
+from gen_worker.request_context import JobContext
 
 RELEASE = "2026.08"
 
 
-def _ctx(port: int, *, release: str = RELEASE) -> TrainingContext:
+def _ctx(port: int, *, release: str = RELEASE) -> JobContext:
     """A REAL producer request context: the hints the executor builds from the
     invoke's reserved `destination` struct, and nothing stubbed."""
     hints: dict[str, Any] = {"kind": "training", "destination_repo": "acme/model"}
     if release:
         hints["destination_release"] = release
-    return TrainingContext(
+    return JobContext(
         request_id="req-1",
         job_id="job-1",
         owner="acme",

--- a/tests/test_blob_digest_qualified_pgw991.py
+++ b/tests/test_blob_digest_qualified_pgw991.py
@@ -33,7 +33,7 @@ from gen_worker.api.errors import (
 from gen_worker.executor import _map_exception
 from gen_worker.request_context import (
     REF_ORIGIN_PLATFORM,
-    ConversionContext,
+    JobContext,
 )
 
 BLOB_BYTES = b"real blob bytes"
@@ -107,8 +107,8 @@ def hub() -> Iterator[str]:
         srv.server_close()
 
 
-def _ctx(hub_url: str) -> ConversionContext:
-    ctx = ConversionContext(request_id="r-pgw991")
+def _ctx(hub_url: str) -> JobContext:
+    ctx = JobContext(request_id="r-pgw991")
     ctx._file_api_base_url = hub_url
     ctx._worker_capability_token = "test-token"
     return ctx

--- a/tests/test_eval_kind_th1255.py
+++ b/tests/test_eval_kind_th1255.py
@@ -6,7 +6,7 @@ import pytest
 from gen_worker.api.decorators import KINDS, endpoint
 from gen_worker.discovery.validation import _KNOWN_KINDS
 from gen_worker.executor import _CONTEXT_BY_KIND
-from gen_worker.request_context import ConversionContext, RequestContext
+from gen_worker.request_context import JobContext, RequestContext
 
 
 class In(msgspec.Struct, forbid_unknown_fields=True):
@@ -41,6 +41,6 @@ def test_eval_context_materializes_reserved_refs_and_is_not_the_base():
     # source_info/destination_info kwargs; a base RequestContext would raise
     # TypeError on them. Registering the kind is mandatory, not cosmetic.
     cls = _CONTEXT_BY_KIND["eval"]
-    assert cls is ConversionContext
+    assert cls is JobContext
     assert cls is not RequestContext
     assert hasattr(cls, "source") and hasattr(cls, "source_path")

--- a/tests/test_job_decorator_pgw1294.py
+++ b/tests/test_job_decorator_pgw1294.py
@@ -98,10 +98,8 @@ def test_one_body_carries_both_declarations() -> None:
 def test_job_context_is_a_superset_of_the_producer_endpoint_context() -> None:
     """Promotion must be a redeploy, not a rewrite: every name a producer
     endpoint handler may use has to exist on JobContext, under that name."""
-    from gen_worker.request_context import ConversionContext, JobContext as JC
+    from gen_worker.request_context import JobContext as JC
 
-    # The three producer contexts merged (they are aliases until th#2052).
-    assert ConversionContext is JC
     for name in (
         "mktemp", "checkpoint_dir", "resolve_dataset", "dataset_paths",
         "save_checkpoint", "open_checkpoint_stream", "cancelled",

--- a/tests/test_legacy_arms_pgw1307b.py
+++ b/tests/test_legacy_arms_pgw1307b.py
@@ -290,27 +290,53 @@ def test_a_keyed_record_still_lists(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_every_declared_kind_builds_its_own_context() -> None:
+def test_every_declared_kind_builds_the_right_context() -> None:
+    """RE-AUTHORED by pgw#1306. As written this asserted each kind built "its
+    own" context, which pgw#1294 had already made vacuous — three of the four
+    producer bases were the same class under three names, so the test passed
+    while saying nothing. The real property is the opposite one: EVERY producer
+    kind builds the SAME class."""
     from gen_worker.cli.local_context import (
-        LOCAL_CONTEXT_KINDS, build_local_context,
+        LOCAL_CONTEXT_KINDS, LocalJobContext, build_local_context,
     )
-    from gen_worker.request_context import (
-        ConversionContext, DatasetContext, JobContext, TrainingContext,
-    )
+    from gen_worker.request_context import JobContext, RequestContext
 
-    expected = {
-        "inference": None,
-        "conversion": ConversionContext,
-        "eval": ConversionContext,
-        "dataset": DatasetContext,
-        "training": TrainingContext,
-        "job": JobContext,
-    }
-    assert set(LOCAL_CONTEXT_KINDS) == set(expected)
-    for kind, base in expected.items():
-        ctx = build_local_context(kind=kind)
-        if base is not None:
-            assert isinstance(ctx, base), kind
+    producer_kinds = {"conversion", "eval", "dataset", "training", "job"}
+    assert set(LOCAL_CONTEXT_KINDS) == producer_kinds | {"inference"}
+
+    built = {k: build_local_context(kind=k) for k in producer_kinds}
+    # One class, not five. `set` of one is the whole assertion.
+    assert {type(c) for c in built.values()} == {LocalJobContext}
+    for kind, ctx in built.items():
+        assert isinstance(ctx, JobContext), kind
+
+    inference = build_local_context(kind="inference")
+    assert isinstance(inference, RequestContext)
+    assert not isinstance(inference, JobContext)
+
+
+def test_allow_publish_reaches_materialize_blob_for_every_producer_kind() -> None:
+    """pgw#1306's red arm, kept as a fence. Before the collapse the three
+    kind-specific local contexts disagreed about this exact question: measured
+    on `b7a9345a`, `conversion` honored `--allow-publish`, `dataset` had a
+    near-copy of the stub that ignored it, and `training` overrode nothing at
+    all — so `gen-worker run` on a training endpoint reached the REAL
+    hub-backed `_PublisherMixin.materialize_blob` in the loop whose purpose is
+    to not have a hub. Nobody chose that; it fell out of which producer-kind
+    class each local subclass happened to sit on."""
+    from gen_worker.cli.local_context import LocalJobContext, build_local_context
+
+    impls = {}
+    for kind in ("conversion", "eval", "dataset", "training", "job"):
+        ctx = build_local_context(kind=kind, allow_publish=True)
+        # `getattr`, not `type(ctx).materialize_blob`: the factory is declared
+        # to return `RequestContext`, which has no such attribute — and that
+        # the producer arms DO is exactly what is under test here.
+        impls[kind] = getattr(type(ctx), "materialize_blob")
+    # One implementation, and it is the local-CAS stub — not the mixin's.
+    assert set(impls.values()) == {LocalJobContext.materialize_blob}
+    for kind, fn in impls.items():
+        assert "_local_allow_publish" in fn.__code__.co_names, kind
 
 
 def test_an_unknown_kind_refuses_instead_of_getting_a_base_context() -> None:

--- a/tests/test_payload_ref_provenance_th1259.py
+++ b/tests/test_payload_ref_provenance_th1259.py
@@ -34,7 +34,7 @@ from gen_worker.executor import _map_exception
 from gen_worker.request_context import (
     REF_ORIGIN_PAYLOAD,
     REF_ORIGIN_PLATFORM,
-    ConversionContext,
+    JobContext,
 )
 
 BLOB_BYTES = b"real blob bytes"
@@ -87,8 +87,8 @@ def hub() -> Iterator[str]:
         srv.server_close()
 
 
-def _ctx(hub_url: str) -> ConversionContext:
-    ctx = ConversionContext(request_id="r-th1259")
+def _ctx(hub_url: str) -> JobContext:
+    ctx = JobContext(request_id="r-th1259")
     ctx._file_api_base_url = hub_url
     ctx._worker_capability_token = "test-token"
     return ctx

--- a/tests/test_producer_context_cut_pgw1306.py
+++ b/tests/test_producer_context_cut_pgw1306.py
@@ -1,0 +1,203 @@
+"""pgw#1306 — the three producer context classes are GONE, and stay gone.
+
+pgw#1294 merged `ConversionContext` / `DatasetContext` / `TrainingContext` into
+`JobContext` and left the three names as thin aliases with a sentence naming
+th#2052 as their executioner. **th#2052 is a tensorhub commit and cannot delete
+Python**, so the sentence had no repo that could carry it out. This module is
+the carried-out sentence plus the fence that keeps it carried out.
+
+WHY A TEXT FENCE AND NOT A SYMBOL CHECK (deliverable 2, as filed). An alias can
+come back through a re-export — `from .request_context import ConversionContext`
+in `__init__.py` — and an `assert not hasattr(gen_worker, ...)` written against
+the package would still pass if a submodule kept the name and something else
+imported it from there. So the fence reads SOURCE TEXT across the tree.
+
+WHY NO TYPED WIRE REFUSAL. Nothing retired here ever crossed a wire. `kind` is
+an AUTHOR declaration read from local source — `@endpoint(kind=...)` at import
+time, validated against a closed set in `discovery.validation._KNOWN_KINDS` —
+and `execution_hints["kind"]` is outbound-only. A worker never learns a kind
+from a request, so no request shaped by an older wheel can arrive carrying one
+of these names. The peer-side story is the wheel boundary, not the wire: a
+package pinned to 0.122.0 keeps the aliases in its OWN wheel and is unaffected;
+one that repins gets an ImportError at import time, which is immediate, loud
+and located. That is a hard cut, and it is recorded here rather than softened
+with a shim — a module `__getattr__` naming the three strings would defeat the
+fence above.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: The three names, whole-word.
+RETIRED = ("ConversionContext", "DatasetContext", "TrainingContext")
+_PATTERN = re.compile(r"\b(" + "|".join(RETIRED) + r")\b")
+
+#: Scanned roots. `CHANGELOG.md` and `changelog.d/` are deliberately absent:
+#: they are an append-only HISTORY of released versions, and rewriting what
+#: 0.4.x shipped to match today's tree would be a lie. Everything else that can
+#: carry an import IS here — `.github/` included, because a workflow smoke-import
+#: (`python -c "from gen_worker import ..."`) is exactly the shape that breaks a
+#: build without any source file naming the symbol. Verified zero there at the
+#: cut; it stays scanned so it stays zero.
+SCAN_ROOTS = (
+    "src", "tests", "tests_v2", "scripts", "docs", "examples", ".github",
+)
+SCAN_FILES = ("README.md", "pyproject.toml", "conftest.py")
+
+#: TOMBSTONES — the only places allowed to spell a retired name, each with the
+#: number of lines that may do so. Declared, not blanket, and the count is the
+#: point: a tombstone that grows is a re-import hiding behind prose, and a
+#: declaration whose count no longer matches is refused in `test_tombstones_...`
+#: below. (pgw#1302 step 6 paid for this rule the other way round — a
+#: declaration that no longer describes anything is as bad as an undeclared
+#: hit.) A tombstone earns its exemption by saying what replaced the name; do
+#: not add one to keep an ordinary reference alive.
+TOMBSTONES = {
+    # The fence itself must spell what it forbids.
+    "tests/test_producer_context_cut_pgw1306.py": 7,
+    # The deletion site, where the successor and the reason live.
+    "src/gen_worker/request_context/__init__.py": 1,
+    # Author-facing: "do not reintroduce a per-kind context" needs the names.
+    "docs/endpoint-authoring.md": 2,
+}
+
+#: Suffixes worth reading. A wheel-name grep over .png is noise.
+SUFFIXES = {".py", ".pyi", ".md", ".toml", ".txt", ".yaml", ".yml", ".cfg", ".json"}
+
+
+def _tracked_files() -> list[Path]:
+    """Ask git, not the filesystem: a stale `.venv`, `__pycache__` or a
+    sibling's scratch file under the tree is not this repo's source.
+
+    `--others --exclude-standard` includes files that are NOT YET COMMITTED, so
+    a new file reintroducing a retired name goes red in the author's own run
+    rather than one commit later."""
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z", "--cached", "--others",
+         "--exclude-standard", "--", *SCAN_ROOTS, *SCAN_FILES],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    paths = sorted({p for p in out.split("\0") if p})
+    assert paths, "git ls-files returned nothing — the fence would be vacuous"
+    return [REPO / p for p in paths]
+
+
+def test_the_scan_actually_reads_files() -> None:
+    """The fence's own red arm: prove the corpus is non-empty and that the
+    pattern can MATCH, so a green below means "absent" and not "never looked".
+    A fence that cannot spell the symbol it guards counts zero and means
+    nothing (the lesson pgw#1302 step 6 paid for)."""
+    files = _tracked_files()
+    py = [f for f in files if f.suffix == ".py"]
+    assert len(py) > 200, f"only {len(py)} python files scanned"
+    assert _PATTERN.search("a ConversionContext here")
+    assert _PATTERN.search("DatasetContext")
+    assert _PATTERN.search("TrainingContext,")
+    # Whole-word: the pattern must not fire on an unrelated longer identifier.
+    assert not _PATTERN.search("MyConversionContextFactory")
+
+
+def _scan() -> dict[str, list[str]]:
+    """rel path -> the lines in it that name a retired context."""
+    found: dict[str, list[str]] = {}
+    for path in _tracked_files():
+        if path.suffix not in SUFFIXES:
+            continue
+        rel = path.relative_to(REPO).as_posix()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if _PATTERN.search(line):
+                found.setdefault(rel, []).append(f"{rel}:{lineno}: {line.strip()}")
+    return found
+
+
+def test_no_source_file_names_a_retired_producer_context() -> None:
+    hits = [
+        line
+        for rel, lines in _scan().items()
+        if rel not in TOMBSTONES
+        for line in lines
+    ]
+    assert not hits, (
+        "pgw#1306 retired ConversionContext / DatasetContext / TrainingContext. "
+        "`JobContext` is the one producer context, and a body's write authority "
+        "comes from its @job/@endpoint declaration, never from its kind:\n  "
+        + "\n  ".join(hits)
+    )
+
+
+def test_tombstones_describe_exactly_what_they_claim() -> None:
+    """A declaration is a claim about the tree, so it can be WRONG in two
+    directions and both are red: a tombstone that grew is a reference hiding
+    behind an exemption, and one that shrank to zero is an exemption for
+    nothing. Neither is caught by the scan above, which only ever looks
+    outside them."""
+    found = _scan()
+    problems: list[str] = []
+    for rel, expected in sorted(TOMBSTONES.items()):
+        actual = len(found.get(rel, []))
+        if actual != expected:
+            problems.append(
+                f"{rel}: declared {expected} tombstone line(s), found {actual}"
+                + ("  (delete the declaration)" if actual == 0 else "")
+            )
+    assert not problems, "\n  ".join(["stale tombstone declarations:", *problems])
+
+
+def test_the_names_are_not_importable_from_anywhere_they_used_to_be() -> None:
+    import gen_worker
+    from gen_worker import request_context
+
+    for name in RETIRED:
+        assert not hasattr(gen_worker, name), name
+        assert not hasattr(request_context, name), name
+        assert name not in gen_worker.__all__, name
+        with pytest.raises(ImportError):
+            exec(f"from gen_worker import {name}", {})
+        with pytest.raises(ImportError):
+            exec(f"from gen_worker.request_context import {name}", {})
+
+
+def test_job_context_is_still_exported_under_its_own_name() -> None:
+    """The other half of the cut: deleting three names must not have taken the
+    successor with them."""
+    import gen_worker
+    from gen_worker.request_context import JobContext
+
+    assert gen_worker.JobContext is JobContext
+    assert "JobContext" in gen_worker.__all__
+
+
+def test_no_kind_selects_a_different_producer_context() -> None:
+    """The PROPERTY the three classes used to carry, asserted directly rather
+    than by their absence: the executor's kind map answers `producer?` and
+    nothing else, so every producer kind resolves to one class."""
+    from gen_worker.executor import _CONTEXT_BY_KIND
+    from gen_worker.request_context import JobContext, RequestContext
+
+    assert _CONTEXT_BY_KIND["inference"] is RequestContext
+    producer = {k: v for k, v in _CONTEXT_BY_KIND.items() if k != "inference"}
+    assert set(producer) == {"conversion", "dataset", "training", "eval"}
+    assert set(producer.values()) == {JobContext}
+
+
+def test_write_authority_comes_from_the_declaration_not_the_kind() -> None:
+    """`publishes` is what gates the publisher surface. Two contexts of the
+    SAME class and (implicitly) the same kind disagree about writing, because
+    the declaration is what differs — which is the whole point of the cut."""
+    from gen_worker.request_context import JobContext
+
+    declared = JobContext(request_id="r-1306-yes", publishes=True)
+    undeclared = JobContext(request_id="r-1306-no", publishes=False)
+    assert type(declared) is type(undeclared)
+    assert declared.publishes is True
+    assert undeclared.publishes is False

--- a/tests/test_reserved_candidate_pgw684.py
+++ b/tests/test_reserved_candidate_pgw684.py
@@ -229,9 +229,9 @@ def test_inference_kind_ignores_reserved_candidate(tmp_path) -> None:
 def test_producer_ctx_candidate_state_is_independent() -> None:
     """Context-level contract: `candidate`/`candidate_path` are their own
     slots, and setting one reserved path never moves another."""
-    from gen_worker.request_context import ConversionContext
+    from gen_worker.request_context import JobContext
 
-    ctx = ConversionContext(
+    ctx = JobContext(
         request_id="r1",
         source_info={"ref": "acme/dit-base"},
         candidate_info={"ref": "acme/mirrored-svdq"},

--- a/tests/test_reserved_resume_from_pgw1242.py
+++ b/tests/test_reserved_resume_from_pgw1242.py
@@ -255,9 +255,9 @@ def test_inference_kind_ignores_reserved_resume_from(tmp_path: Path) -> None:
 
 def test_producer_ctx_resume_from_state_is_independent() -> None:
     """Setting one reserved path never moves another."""
-    from gen_worker.request_context import ConversionContext
+    from gen_worker.request_context import JobContext
 
-    ctx = ConversionContext(
+    ctx = JobContext(
         request_id="r1",
         source_info={"ref": "acme/dit-base"},
         candidate_info={"ref": "acme/dit-candidate"},

--- a/tests/test_stream_bounds_pgw1013.py
+++ b/tests/test_stream_bounds_pgw1013.py
@@ -35,7 +35,7 @@ import requests
 from blake3 import blake3
 
 from gen_worker.bounded_stream import StreamTooLarge, copy_bounded, free_space_bound
-from gen_worker.request_context import ConversionContext
+from gen_worker.request_context import JobContext
 from gen_worker.request_context._datasets import _download_url_streamed
 
 # The rig always OFFERS this much body. A site that only checks after the loop
@@ -272,8 +272,8 @@ def _blob_path(digest: str) -> str:
     return f"/api/v1/blobs/{urllib.parse.quote(digest, safe=':')}/content"
 
 
-def _ctx(rig: _Rig) -> ConversionContext:
-    ctx = ConversionContext(request_id="r-pgw1013")
+def _ctx(rig: _Rig) -> JobContext:
+    ctx = JobContext(request_id="r-pgw1013")
     ctx._file_api_base_url = _url(rig, "")
     ctx._worker_capability_token = "test-token"
     return ctx

--- a/tests/test_testing_recorder_pgw942.py
+++ b/tests/test_testing_recorder_pgw942.py
@@ -20,7 +20,7 @@ from PIL import Image
 from gen_worker import HF, Slot, endpoint
 from gen_worker.api.decorators import Compile, Resources
 from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
-from gen_worker.request_context import ConversionContext, RequestContext
+from gen_worker.request_context import JobContext, RequestContext
 from gen_worker.testing import (
     Recorder,
     fake_context,
@@ -153,9 +153,9 @@ def test_recorder_covers_every_save_kind() -> None:
 
 def test_recorder_works_for_producer_context_subclasses() -> None:
     rec = Recorder()
-    ctx = fake_context(request_id="req", cls=ConversionContext, recorder=rec)
+    ctx = fake_context(request_id="req", cls=JobContext, recorder=rec)
 
-    assert isinstance(ctx, ConversionContext)
+    assert isinstance(ctx, JobContext)
     ctx.save_bytes("outputs/req/blob.bin", b"raw")
     assert rec.refs == ["outputs/req/blob.bin"]
 


### PR DESCRIPTION
Closes the missing cross-repo leg of the JOBS program.

pgw#1294 merged `ConversionContext` / `DatasetContext` / `TrainingContext` into `JobContext`
and left the three names as thin aliases with a sentence: *"they die at th#2052."*
**th#2052 is a tensorhub commit and cannot delete Python.** The eight-issue series had no
pgw leg after the cut, so the sentence named an executioner structurally incapable of
carrying it out. This is the carried-out sentence.

## Per-class verdict

Base: `b7a9345a`. Classification is by CALL SITE PROPERTY, not by grep — a name's presence
says nothing about whether anything still derives behavior from it.

| class | what it was at base | what still derived from it | verdict |
|---|---|---|---|
| `ConversionContext` | `= JobContext` (pure alias, `request_context/__init__.py:2315`) | re-export in `gen_worker.__all__`; `LocalConversionContext` base; 7 test imports; 4 doc sites | **CUT** |
| `DatasetContext` | `= JobContext` (`:2316`) | re-export; `LocalDatasetContext` base — **and that subclass carried a real behavioral divergence** | **CUT** |
| `TrainingContext` | `= JobContext` (`:2317`) | re-export; `LocalTrainingContext` base — **the worst arm, see below** | **CUT** |

Write authority was already off these classes before this PR: `executor._CONTEXT_BY_KIND`
maps every producer kind to `JobContext` directly, and `@endpoint`'s own docstring states
the rule — *"the hub mints the worker-capability write grant off the declaration, never off
the kind."* So the deletion in `request_context` is bookkeeping.

## The one place kind still decided behavior — and it was wrong

`cli/local_context.py` had a Local subclass PER KIND, each sitting on whichever producer
class it had inherited. Measured on `b7a9345a` under `gen-worker run --allow-publish`:

| kind | class built | `materialize_blob` reached | honors `--allow-publish` |
|---|---|---|---|
| `conversion`, `job` | `LocalConversionContext` | local-CAS stub | yes |
| `dataset` | `LocalDatasetContext` | a near-copy of that stub | **no** |
| `training` | `LocalTrainingContext` | **`_PublisherMixin.materialize_blob`** | **no** |

The training arm overrode nothing, so a local run of a training endpoint reached the REAL
hub-backed implementation — in the dev loop whose entire purpose is to not have a hub.
Nobody chose that; it fell out of which producer-kind class each local subclass happened to
sit on. Now ONE `LocalJobContext` for every producer kind: one class cannot disagree with
itself.

## Hard cut, no shim

Nothing retired here ever crossed a wire. `kind` is an AUTHOR declaration read from local
source — `@endpoint(kind=...)` at import time, validated against a closed set in
`discovery.validation._KNOWN_KINDS` — and `execution_hints["kind"]` is outbound-only. A
worker never learns a kind from a request, so no request shaped by an older wheel can arrive
carrying one of these names. **There is no retired wire shape to refuse, so no typed refusal
was invented for one.**

The boundary that IS real is the wheel: a consumer pinned to `0.122.0` keeps the aliases in
its own wheel and is untouched; one that repins gets an `ImportError` at import time —
immediate, loud, located. A module `__getattr__` softening that would also have defeated the
text fence, which is the second reason not to write one.

## Reds (each arm shown live before the successor answered)

Every mutation is distinguishable — a different arm goes red for each.

| # | mutation | expected red | observed |
|---|---|---|---|
| A | restore the three alias assignments + the `__init__` re-exports (exactly `origin/master`) | text fence, tombstone counts, import fence | **3 failed, 4 passed** |
| B | re-split `LocalTrainingContext` and route `kind="training"` to it | the two `local_context` arms | **2 failed** — error names `_PublisherMixin.materialize_blob`, i.e. the original defect |
| C | give `_CONTEXT_BY_KIND["dataset"]` its own `JobContext` subclass | `test_no_kind_selects_a_different_producer_context` | **1 failed** |
| D | force `publishes=True` in `JobContext.__init__` (authority from the class, not the declaration) | `test_write_authority_comes_from_the_declaration_not_the_kind` | **1 failed** |
| E | append a `python -c "from gen_worker import ConversionContext"` smoke-import to `.github/workflows/ci.yaml` | text fence | **1 failed** — proves the `.github` arm is live |

Restoration verified after each: `grep` for the mutation residue is clean and the full set
returns green.

The fence also guards itself. `test_the_scan_actually_reads_files` asserts the corpus is
non-empty (>200 py files) and that the pattern can MATCH before any green is believed —
a fence that cannot spell the symbol it guards counts zero and means nothing. Tombstone
exemptions are DECLARED with an exact line count and refused in both directions: one that
grows is a re-import hiding behind prose, one that shrinks to zero is an exemption for
nothing.

## Also: a vacuous test, re-authored

`test_every_declared_kind_builds_its_own_context` asserted each kind built *"its own"*
context. pgw#1294 had already made that vacuous — three of the four producer bases were one
class under three names — so it passed while saying nothing. It now asserts the true
property: every producer kind builds the SAME class.

## Peer leg — FILED, not absorbed

te#218 migrated most producers to `@job`, but the `jobs` repo still imports
`ConversionContext`. It pins `gen-worker==0.122.0`, so **nothing is broken today**; the leg
must land before it repins. Exact sites:

**Production source (3):** `vlm_judge/src/vlm_judge/clips/judge.py:41,175,231,414` ·
`vlm_judge/src/vlm_judge/judge.py:35,261,602` · `vlm_judge/src/vlm_judge/images.py:15,39`
**Dockerfile smoke-imports (3) — these break the IMAGE BUILD, not just a test:**
`conversion/Dockerfile.cuda:60` · `conversion/Dockerfile.none:60` · `vlm_judge/Dockerfile:173`
**Tests (2):** `h3_finetuner/tests/test_endpoint_surface.py:170,172` ·
`tests/test_parity_judge_te215.py:53,187,188`
**Prose only, no break:** `fleet-floors.toml:274` · `tools/gate_pod_smoke.py:28` ·
`tests/test_{external_quality_eval,sample_persistence,svdq_quality_gate,precision_class_declared_te225,sdxl_w8a8_quality_gate}.py`

Lower-priority, separate hazard: `e2e/scenarios/j19_training_firstlight_test.go:746,785`
embeds `from gen_worker import ConversionContext` in a fixture pinned to `gen-worker==0.56.0`
— 66 minor versions stale. Unaffected by this cut; named because it is the e2e#246 pin-rot
shape.

## Verification

- `mypy src/gen_worker tests tests_v2` — **857 files, no issues**
- `ruff check src/gen_worker scripts/mint_rig` — clean
- `lint_fence_symbols` (6 fences, every named symbol exists) · `lint_unreached_surface`
  (exit 0) · `lint_mypy_ratchet` · `check_registry_contract` · `lint_config_reads` — all pass
- touched packages green: the new fence, `test_legacy_arms_pgw1307b`, `test_eval_kind_th1255`,
  `test_job_decorator_pgw1294`, `test_testing_recorder_pgw942`, `test_reserved_candidate_pgw684`,
  `test_reserved_resume_from_pgw1242`, `test_local_serve_no_publisher_pgw1127`,
  `test_runjob_intent_pgw1336`, `test_release_axis_pgw1279`, `test_blob_digest_qualified_pgw991`,
  `test_payload_ref_provenance_th1259`, `test_stream_bounds_pgw1013` — 150 passed
- `git merge --no-commit origin/master` clean before push; rebased on `dc5bd13e`

## Wheel

**Rides the NEXT wheel — `0.122.0` is already cut.** No version bump in this PR (library
release versioning rule 1: the committed version stays at the last published version between
releases; the bump happens only in the publish commit). Consumers pinned to `0.122.0` are
unaffected until they repin, which is exactly the window the peer leg above has to land in.
