### PR TITLE
pgw#1341: the mint's provenance is durable beside the cell, so the FLEET can adopt what one pod compiled

### DIFF
--- a/changelog.d/pgw1341.md
+++ b/changelog.d/pgw1341.md
@@ -1,0 +1,33 @@
+- **A pod that armed its own compiled graph still could not hand it to the fleet — so every pod
+  re-minted what one pod had already compiled.** pgw#1340 opened the arm; the seam one step past
+  it was shut for the same reason. `fleet_cells._identity_axes` read `env_seal`,
+  `manifest_digest`, `family` and `weight_lane`/`lora_bucket` out of a cell's metadata, and
+  `intent_entry` read `sku` and `gen_worker` — six names TCG's CLOSED artifact vocabulary
+  (`torchcg.ARTIFACT_METADATA_FIELDS`, enforced by `validate_metadata` since pgw#1270) does not
+  contain. The first read FAILS CLOSED, so this was not a degraded row: it was
+  `CellPublishRefused("cell records no env_seal block")` on **every real artifact,
+  unconditionally**. Reproduced at $0 against a cell `torchcg.artifact.build_metadata` really
+  built. The hub's `compiled_graph_store` holds **zero rows**, which is the same fact from the
+  other end.
+- **The mint's provenance is now DURABLE beside the cell, and the publish reads it.**
+  `local_cell_store.MintProvenance` (env seal digest, execution lane, declaration manifest
+  digest, sku, gen_worker) is written into the store's sidecar in the same write that records
+  the upload obligation, by the mint, at the moment the bytes become durable. This is a design
+  change and not a line because `resume_owed_publishes` discharges an owed upload on a LATER
+  BOOT, in a different process, potentially on a different pod — re-deriving these from the live
+  runtime would attest one machine's card, wheel and env seal against another machine's bytes,
+  wrong in exactly the cases the retry exists for. `_identity_axes` and `intent_entry` take the
+  record as an argument; the three KEY axes are still recomputed from the artifact, because a
+  cell must corroborate its own identity. **The artifact vocabulary is untouched** — pgw#1270's
+  cut stands, and nothing reopens `metadata.json`.
+- **The refusal survives, narrowed.** A cell this machine can say nothing about is still refused
+  by name, before a byte moves — publishing it would invent the hub's `ArtifactIdentity` out of
+  whichever pod happened to be shipping it. What changed is that the refusal now fires on
+  genuine absence instead of on a metadata field no cell can carry.
+- **The fixtures are the fence, again.** `tests/harness/cell_meta.py` hand-wrote all six dead
+  field names, so the whole publish path was tested against a cell that cannot exist — pgw#1277's
+  finding verbatim (*"every fixture built the obsolete shape"*), one seam further along. It now
+  builds through `torchcg.artifact.build_metadata` and has no keyword for a field TCG does not
+  accept. `tests/test_publish_provenance_pgw1341.py` mints in a real subprocess and publishes
+  from a second process over the real publish wire, asserting the hub's recorded intent carries
+  the mint's facts and not the shipper's.

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -976,6 +976,7 @@ class CellPublisher:
             repo=repo, family=family, grants=tuple(grants))
 
     def publish(self, family: str, artifact: Path, meta: dict,
+                provenance: local_cell_store.MintProvenance,
                 mint_duration_ms: int = 0) -> str:
         """Publish ONE self-minted compiled graph. Returns the checkpoint id.
 
@@ -993,7 +994,8 @@ class CellPublisher:
         mint at once — :func:`aot_mint.publish` — asks for every token in one
         round trip.
         """
-        entry, sku, gen_worker = intent_entry(family, meta, mint_duration_ms)
+        entry, sku, gen_worker = intent_entry(
+            family, meta, provenance, mint_duration_ms)
         batch = self.publish_intent(
             family, [entry], sku=sku, gen_worker=gen_worker)
         return self.publish_granted(
@@ -1086,13 +1088,20 @@ class CellPublisher:
 
 
 def intent_entry(
-    family: str, meta: dict, mint_duration_ms: int = 0,
+    family: str, meta: dict, provenance: local_cell_store.MintProvenance,
+    mint_duration_ms: int = 0,
 ) -> Tuple[PublishEntry, str, str]:
-    """One artifact's metadata -> its entry plus the two pod axes it declares.
+    """One artifact + its mint provenance -> the entry and the two pod axes.
 
     The pod axes come back separately because they are BATCH-level on the wire:
     ``sku`` and ``gen_worker`` describe the pod, so a caller batching a whole
     mint reads them once and the hub attests them once.
+
+    pgw#1341: they come from ``provenance``, not from the metadata dict and not
+    from this process. They describe the POD THAT MINTED — and
+    :func:`resume_owed_publishes` ships from a later boot, so reading them live
+    would attest a different pod's card and a different wheel's version against
+    somebody else's bytes.
     """
     # pgw#712 (kept under the exact-identity ruling as defense-in-depth): a
     # cell whose metadata carries a foreign adoption provenance must never
@@ -1112,11 +1121,11 @@ def intent_entry(
     return (
         PublishEntry(
             compiled_graph_key=key,
-            identity_axes=_identity_axes(family, meta),
+            identity_axes=_identity_axes(family, meta, provenance),
             mint_duration_ms=max(0, int(mint_duration_ms or 0)),
         ),
-        str(meta.get("sku") or ""),
-        str(meta.get("gen_worker") or ""),
+        provenance.sku,
+        provenance.gen_worker,
     )
 
 
@@ -1190,9 +1199,11 @@ def _recomputed_key(meta: Mapping[str, Any]) -> tcg_identity.CompiledGraphKey:
             "(pgw#1046)") from exc
 
 
-def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
-    """The identity map the hub records for this cell, RECOMPUTED from the
-    artifact's own facts.
+def _identity_axes(
+    family: str, meta: dict, provenance: local_cell_store.MintProvenance,
+) -> Dict[str, str]:
+    """The identity map the hub records for this cell: the artifact's own key
+    axes, plus the MINT's recorded provenance for everything else.
 
     This is not inventory. th#1457's producer builds the worker's
     ``ExecutionSpec`` out of exactly this map: ``ArtifactFromCellRecord`` reads
@@ -1216,6 +1227,17 @@ def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
     ``graph_contract`` names the class SET this entry belongs to (coverage).
     Fusing them is what made adding one aspect ratio re-mint 35 unchanged
     classes.
+
+    pgw#1341 — WHERE EACH HALF COMES FROM, and why it is two sources and not
+    one. The three key axes are recomputed FROM THE ARTIFACT, because the
+    artifact is what the key is about and a cell must corroborate its own
+    identity. Everything else is read from :class:`~.local_cell_store.MintProvenance`,
+    because TCG's closed vocabulary has no field for any of it — this function
+    read ``env_seal``, ``manifest_digest``, ``family`` and ``weight_lane`` off
+    the metadata dict, and since pgw#1270 mints every artifact through TCG,
+    that made the seal check raise for EVERY real cell, unconditionally: a pod
+    that armed its own graph still could not hand it to the fleet, so every pod
+    re-minted what one pod had already compiled.
     """
     key = _recomputed_key(meta)
     stamped = str(meta.get("compiled_graph_key") or "").strip()
@@ -1224,25 +1246,27 @@ def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
             f"compiled_graph_key stamp {stamped} disagrees with the key its recorded "
             f"axes describe ({key.value}); refusing to publish an identity "
             "the artifact does not corroborate")
+    if not provenance.stated:
+        # NARROWED, not deleted (pgw#939: absence is a verdict). The refusal
+        # used to fire on a metadata field no cell can carry — i.e. always.
+        # It now fires on the genuine case it was written for: this machine
+        # holds bytes it cannot say anything about, which is what a publish
+        # under invented axes would hide. The hub's ArtifactFromCellRecord
+        # requires the seal digest and pgw#904's consumer refuses an identity
+        # without it, so a row published here is a cell the fleet can never arm.
+        raise CellPublishRefused(
+            f"this machine recorded no mint provenance for {key.value}; the "
+            "hub's ArtifactIdentity requires the env-seal digest "
+            "(pgw#903/pgw#1046) and a TCG artifact carries none, so the "
+            "publish has nothing to state it from (pgw#1341)")
     axes = {k: str(v) for k, v in key.as_dict().items()}
     # The manifest label — telemetry/coverage, never identity. Empty is
     # HONEST for an entry minted by a pod that has not folded its whole
     # declaration, so it is not a publish refusal.
-    axes[GRAPH_CONTRACT_AXIS] = str(meta.get("manifest_digest") or "").strip()
-    seal = meta.get(env_seal.SEAL_KEY)
-    if not isinstance(seal, dict) or not seal:
-        # The seal left the KEY (pgw#1059 amendment 4) but not the wire: the
-        # hub's ArtifactFromCellRecord requires the entry, and a row without
-        # it is a cell the fleet can never arm — same fail-closed rule as
-        # the axes above.
-        raise CellPublishRefused(
-            "cell records no env_seal block; the hub's ArtifactIdentity "
-            "requires its digest (pgw#903/pgw#1046)")
-    axes[ENV_SEAL_AXIS] = env_seal.seal_digest(seal)
-    axes["family"] = str(meta.get("family") or family or "")
-    axes["lane"] = cc.execution_lane_label(
-        str(meta.get("weight_lane") or ""),
-        int(meta.get("lora_bucket") or 0))
+    axes[GRAPH_CONTRACT_AXIS] = provenance.graph_contract
+    axes[ENV_SEAL_AXIS] = provenance.env_seal
+    axes["family"] = str(family or "")
+    axes["lane"] = provenance.lane
     return axes
 
 
@@ -1301,6 +1325,7 @@ def publishes_in_flight() -> Dict[str, Tuple[str, float]]:
 
 def _publish_async(
     publisher: CellPublisher, family: str, artifact: Path, meta: dict,
+    provenance: local_cell_store.MintProvenance,
     compiled_graph_key_digest: str = "", mint_duration_ms: int = 0,
     arm_token: str = "",
 ) -> threading.Thread:
@@ -1345,7 +1370,7 @@ def _publish_async(
         t0 = time.monotonic()
         try:
             checkpoint_id = publisher.publish(
-                family, artifact, meta, mint_duration_ms)
+                family, artifact, meta, provenance, mint_duration_ms)
         except CellPublishRefused as exc:
             logger.warning("fleet-cells: publish refused (hub decision): %s", exc)
             # pgw#1096/§4.28: the hub has just ASSERTED this hardware's trust
@@ -1451,9 +1476,16 @@ def resume_owed_publishes(
                 "a later boot re-attempts it", cell.key)
             continue
         meta = artifact_meta.try_read_metadata(artifact) or {}
+        # pgw#1341: the MINT's own facts, read back from the sidecar the mint
+        # wrote. This is the boundary the design exists for — a different boot,
+        # a different process, possibly a different pod — so nothing here is
+        # re-derived from the live runtime. A record that states none is
+        # refused by name inside the publish, not published under this
+        # machine's guesses.
         threads.append(_publish_async(
-            publisher, cell.family or str(meta.get("family") or ""),
-            artifact, dict(meta), compiled_graph_key_digest=cell.key,
+            publisher, cell.family,
+            artifact, dict(meta), cell.provenance,
+            compiled_graph_key_digest=cell.key,
             arm_token=cell.arm_token))
     if threads:
         logger.info(
@@ -2516,6 +2548,7 @@ def arm_from_local_store(
 
 def adopt_delegated_mint(
     pipe: Any, pending: "PendingSelfMint", artifacts: Sequence[Path],
+    manifest: str = "",
 ) -> Optional[SelfMint]:
     """pgw#784: adopt a cell a CHILD PROCESS just built, then publish it.
 
@@ -2534,10 +2567,22 @@ def adopt_delegated_mint(
 
     ``None`` = not adoptable. The caller treats that exactly like a disproven
     candidate (the mint failed, the worker keeps serving).
+
+    ``manifest`` is the mint's declaration-wide contract digest
+    (``aot_mint.MintResult.manifest``). It is a PARAMETER rather than something
+    read back off a cell because a TCG artifact has no field for it — pgw#1341
+    — and the caller is the only object that ever holds it.
     """
     state = pending._state
     if "minted" in state:
         return state["minted"]
+    # pgw#1341: ONE provenance for the whole mint, computed before the first
+    # byte is staged. Every row of one mint shares a family, a lane, a seal, a
+    # card and a wheel by construction, so a per-row derivation could only ever
+    # disagree with itself — and it is written with each row's sidecar so a
+    # crash between rows leaves no cell that cannot say what made it.
+    provenance = mint_provenance(pending, manifest=manifest)
+    state["provenance"] = provenance
 
     rows = [Path(a) for a in artifacts]
     if not rows:
@@ -2569,7 +2614,7 @@ def adopt_delegated_mint(
     # than the set, and a class that refuses is quarantined without touching a
     # sibling that armed.
     _durable_keys: Dict[Path, str] = {
-        row: _stage_durable(pending, row) for row in rows}
+        row: _stage_durable(pending, row, provenance) for row in rows}
     # pgw#1096: ONE gate for every self-produced cell — the child's, and the
     # local store's (§4.28). pgw#999's classification, pgw#1042's pre-arm axis
     # divergence and pgw#805's AOT-only arm all live in `_arm_exported_cell`;
@@ -2774,7 +2819,51 @@ def adopt_delegated_mint(
 # ---------------------------------------------------------------------------
 
 
-def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
+def mint_provenance(
+    pending: "PendingSelfMint", *, manifest: str = "",
+) -> local_cell_store.MintProvenance:
+    """The mint-time facts this cell's publish will need, stated ONCE (pgw#1341).
+
+    Every one of them is knowable HERE — in the parent of the mint, on the pod
+    that owns the card — and by NOBODY later: TCG's closed artifact vocabulary
+    has no field for any of them (:func:`artifact_meta.cell_metadata_fields`),
+    and ``resume_owed_publishes`` runs on a later boot in another process. So
+    this is the one derivation, and its output is written beside the bytes.
+
+    ``env_seal`` and ``lane`` are taken from the pending's OWN arm token rather
+    than recomputed, for the reason pgw#1042 gives about every axis at this
+    seam: two derivations of one fact is how an axis silently becomes two
+    facts. The token already states them, it is what split this obligation from
+    every other, and it was computed before the child was spawned.
+
+    ``manifest`` is the declaration-wide contract digest the mint just folded
+    (``aot_mint.MintResult.manifest``) — the class SET this entry belongs to.
+    Absent is HONEST (a pod that folded no manifest publishes an empty
+    ``graph_contract``, which is coverage telemetry, never identity) and is not
+    a refusal.
+    """
+    facts = pending.arm_key.facts_dict() if pending.arm_key is not None else {}
+    try:
+        sku = str(cc.runtime_key().get("sku") or "")
+    except Exception:  # noqa: BLE001 — a probe failure never fails a mint
+        sku = ""
+    try:
+        version = cc.gen_worker_version()
+    except Exception:  # noqa: BLE001
+        version = ""
+    return local_cell_store.MintProvenance(
+        env_seal=str(facts.get("env_seal") or ""),
+        lane=str(facts.get("lane") or ""),
+        graph_contract=str(manifest or ""),
+        sku=sku,
+        gen_worker=str(version or ""),
+    )
+
+
+def _stage_durable(
+    pending: "PendingSelfMint", artifact: Path,
+    provenance: local_cell_store.MintProvenance,
+) -> str:
     """Write a freshly minted artifact to the local CAS, UNVERIFIED.
 
     Returns the stamped ``ck1`` key the bytes were filed under, or ``""`` when
@@ -2785,7 +2874,9 @@ def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
     Unconditional, on every tier (§1.5). The publish state is decided here and
     only here: a machine with a live sink OWES an upload from this moment,
     which is what makes :func:`resume_owed_publishes` able to finish a
-    transfer the minting process never did.
+    transfer the minting process never did — and pgw#1341 is what makes it able
+    to STATE that transfer's axes: ``provenance`` lands in the same sidecar
+    write as the obligation, so the two can never be separated.
     """
     try:
         key = str((artifact_meta.try_read_metadata(artifact) or {}).get(
@@ -2801,6 +2892,7 @@ def _stage_durable(pending: "PendingSelfMint", artifact: Path) -> str:
         verdict=local_cell_store.VERDICT_UNVERIFIED,
         sink=(local_cell_store.SINK_NONE if sink_absent
               else local_cell_store.SINK_OWED),
+        provenance=provenance,
         cas_root=pending.cache_dir,
     )
     if stored is None:
@@ -2906,6 +2998,10 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             # upload a race against the cleanup.
             getattr(state.get("minted"), "artifact", pending.target),
             dict(state.get("meta") or {}),
+            # pgw#1341: THE SAME record the local store holds, so the immediate
+            # publish and a later boot's `resume_owed_publishes` state
+            # byte-identical axes for the same bytes.
+            state.get("provenance") or local_cell_store.MintProvenance(),
             compiled_graph_key_digest=str(
                 getattr(state.get("minted"), "compiled_graph_key", "")
                 or pending.arm_token),

--- a/src/gen_worker/local_cell_store.py
+++ b/src/gen_worker/local_cell_store.py
@@ -71,6 +71,11 @@ record and carry it:
   — the upload obligation, recorded beside the bytes rather than held in a
   thread, so it survives process death and pod retirement
   (:func:`cells_owed_to_sink` is what the next boot reads).
+* :class:`MintProvenance` (pgw#1341) — the mint-time facts a TCG artifact has
+  no field for (env seal, lane, manifest digest, sku, gen_worker). An owed
+  upload is discharged by a LATER boot, so the publish must read the facts of
+  the mint that produced the bytes, never the runtime that happens to be
+  shipping them.
 
 LAYOUT (one directory per cell, so a cell and the facts about it move as a
 unit)::
@@ -214,6 +219,80 @@ def _engine(cas_root: Optional[Path] = None) -> "Engine":
 
 
 @dataclass(frozen=True)
+class MintProvenance:
+    """What the MINT knew and the ARTIFACT cannot say (pgw#1341).
+
+    ``torchcg.artifact.validate_metadata`` refuses metadata outside its closed
+    vocabulary (``artifact_meta.cell_metadata_fields``), which holds the three
+    key axes and the host facts and NOTHING else. Every remaining fact the
+    fleet publish must state — the env seal the mint ran under, the execution
+    lane, the declaration-wide manifest digest, and the two pod axes the hub
+    attests — is therefore unstateable BY the cell, exactly as pgw#1340 found
+    for the arm seam. The answer is the same one: state it on the side of the
+    boundary that can, and make it durable there.
+
+    DURABLE is the load-bearing word. ``fleet_cells.resume_owed_publishes``
+    ships an owed cell on a LATER BOOT, in a different process, possibly on a
+    different pod, so re-deriving these from the live runtime would publish one
+    machine's facts about another machine's mint. They are written beside the
+    bytes at store time, read back by whoever ships them, and a cell that has
+    none is REFUSED rather than published under invented axes.
+
+    Empty strings are honest absences, not defaults: :func:`stated` is what
+    decides whether a publish may proceed, and it asks for the one fact whose
+    absence the hub's ``ArtifactIdentity`` cannot survive.
+    """
+
+    #: ``env_seal.seal_digest`` of the seal in force when the mint ran — the
+    #: DIGEST, not the block: the digest is what the wire carries, and it is
+    #: what the parent's own arm token already states.
+    env_seal: str = ""
+    #: ``compile_cache.execution_lane_label`` of the lane that was traced.
+    lane: str = ""
+    #: ``graph_facts.manifest_digest`` — which class SET this entry belongs to.
+    graph_contract: str = ""
+    #: The two POD axes the hub attests at publish-intent.
+    sku: str = ""
+    gen_worker: str = ""
+
+    @property
+    def stated(self) -> bool:
+        """True when this record can carry a publish at all.
+
+        The env seal is the criterion because it is the one the hub REQUIRES:
+        ``ArtifactFromCellRecord`` builds ``ArtifactIdentity.env_seal_digest``
+        from it and pgw#904's consumer refuses an identity without it. The
+        others degrade a row; this one makes it unarmable.
+        """
+        return bool(self.env_seal)
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "env_seal": self.env_seal, "lane": self.lane,
+            "graph_contract": self.graph_contract,
+            "sku": self.sku, "gen_worker": self.gen_worker,
+        }
+
+    @classmethod
+    def of(cls, raw: Any) -> "MintProvenance":
+        """The provenance a record file states; an empty one for anything else.
+
+        A record written before this field existed, or one whose block is not
+        an object, states NOTHING — which is a refusal at publish, never a
+        silently blank row.
+        """
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            env_seal=str(raw.get("env_seal") or ""),
+            lane=str(raw.get("lane") or ""),
+            graph_contract=str(raw.get("graph_contract") or ""),
+            sku=str(raw.get("sku") or ""),
+            gen_worker=str(raw.get("gen_worker") or ""),
+        )
+
+
+@dataclass(frozen=True)
 class CellRecord:
     """The POLICY facts this worker recorded about one cell. No bytes.
 
@@ -231,6 +310,9 @@ class CellRecord:
     verdict: str = VERDICT_ADMITTED
     #: One of the ``SINK_*`` constants.
     sink: str = SINK_NONE
+    #: pgw#1341: the mint facts the artifact cannot carry, durable here so a
+    #: later boot's publish states the MINT's facts and not its own.
+    provenance: MintProvenance = MintProvenance()
 
 
 @dataclass(frozen=True)
@@ -245,6 +327,7 @@ class LocalCell:
     stored_at: float
     verdict: str = VERDICT_ADMITTED
     sink: str = SINK_NONE
+    provenance: MintProvenance = MintProvenance()
 
 
 def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
@@ -323,6 +406,7 @@ def _record_of(key: str, raw: Dict[str, Any]) -> CellRecord:
         stored_at=float(raw.get("stored_at") or 0.0),
         verdict=str(raw.get("verdict") or VERDICT_ADMITTED),
         sink=str(raw.get("sink") or SINK_NONE),
+        provenance=MintProvenance.of(raw.get("provenance")),
     )
 
 
@@ -338,6 +422,9 @@ def _record_payload(record: CellRecord) -> Dict[str, Any]:
         "kind": ARTIFACT_KIND,
         "verdict": record.verdict,
         "sink": record.sink,
+        # pgw#1341: written with the bytes, on every tier, because the process
+        # that ships them may not be the process that minted them.
+        "provenance": record.provenance.as_dict(),
     }
 
 
@@ -395,6 +482,7 @@ def is_quarantined(key: str, root: Optional[Path] = None) -> bool:
 def store(
     artifact: Path, *, key: str, family: str, arm_token: str = "",
     verdict: str = VERDICT_ADMITTED, sink: str = SINK_NONE,
+    provenance: Optional[MintProvenance] = None,
     root: Optional[Path] = None, cas_root: Optional[Path] = None,
 ) -> Optional[CellRecord]:
     """Admit ``artifact`` to TCG under its STAMPED ``key`` and record the policy.
@@ -443,6 +531,7 @@ def store(
             key=key, family=str(family or ""), arm_token=str(arm_token or ""),
             bytes=Path(artifact).stat().st_size, stored_at=time.time(),
             verdict=str(verdict), sink=str(sink),
+            provenance=provenance or MintProvenance(),
         )
         _write_json_atomic(target_dir / RECORD_NAME, _record_payload(record))
     except Exception as exc:  # noqa: BLE001 — a cache miss must never be fatal
@@ -625,7 +714,8 @@ def lookup(
     return LocalCell(
         key=record.key, artifact=artifact, family=record.family,
         arm_token=record.arm_token, bytes=artifact.stat().st_size,
-        stored_at=record.stored_at, verdict=record.verdict, sink=record.sink)
+        stored_at=record.stored_at, verdict=record.verdict, sink=record.sink,
+        provenance=record.provenance)
 
 
 def note_memo(
@@ -906,6 +996,7 @@ __all__ = [
     "ENV_STORE_DIR",
     "LocalCell",
     "MEMO_DIRNAME",
+    "MintProvenance",
     "RECORD_NAME",
     "RecordUnreadable",
     "SINK_DELIVERED",

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -804,7 +804,12 @@ async def supervise(
             # stages each durable, verifies, arms and stores it in turn, and a
             # class that refuses costs itself.
             minted = fleet_cells.adopt_delegated_mint(
-                task.pipe, pending, [row.artifact for row in result.entries])
+                task.pipe, pending, [row.artifact for row in result.entries],
+                # pgw#1341: the declaration-wide contract digest this mint just
+                # folded. It is the `graph_contract` axis of every row's
+                # publish, no artifact can carry it, and this is the one object
+                # that holds it.
+                manifest=str(result.manifest or ""))
             if minted is not None:
                 return SupervisedResult(
                     status=ADOPTED, minted=minted, attempts=attempts,

--- a/tests/harness/cell_meta.py
+++ b/tests/harness/cell_meta.py
@@ -1,64 +1,82 @@
-"""pgw#1046: build a REAL exported-cell envelope for the publish-path tests.
+"""The publish path's fixture, built by TCG — never by hand (pgw#1046/pgw#1341).
 
 The publish path recomputes a cell's identity from its own recorded blocks and
-refuses anything that cannot state one — because the axis map it declares is
-what tensorhub's RunAttempt producer builds ``Arm.artifact`` /
+refuses anything that cannot state one, because the axis map it declares is what
+tensorhub's RunAttempt producer builds ``Arm.artifact`` /
 ``Arm.graph_contract_digest`` out of, and pgw#904's landed consumer refuses an
-``ArtifactIdentity`` missing any of them. A stub ``{"compiled_graph_key": …, "sku": …}``
-is therefore no longer a publishable cell in any tree, and a test that ships one
-proves only that an unarmable row still uploads.
+``ArtifactIdentity`` missing any of them.
 
-This is the minimal envelope that IS one: the same blocks ``aot_mint`` records
-(``aot_serve.entry_metadata`` + ``shared_identity_blocks``), at fixture
-scale. The ``compiled_graph_key`` is COMPUTED by TCG, never invented, so the stamp and the axes
-agree — which is itself one of the publish path's refusals.
+**THE FIXTURE FENCE, and why this module was rewritten.** Until pgw#1341 this
+built the envelope BY HAND — a dict with ``family``, ``sku``, ``gen_worker``,
+``weight_lane``, ``manifest_digest`` and ``env_seal`` in it. Since pgw#1270 TCG
+mints every artifact and ``torchcg.artifact.validate_metadata`` refuses metadata
+whose field set is not exactly ``artifact_meta.cell_metadata_fields()`` — which
+holds none of those six names. So the fixture described a cell that cannot
+exist, and the whole publish path was tested against it: ``_identity_axes``
+raised ``CellPublishRefused("cell records no env_seal block")`` for every real
+artifact on the fleet while this file kept CI green. That is pgw#1277's finding
+verbatim (*"CI stayed green because every fixture built the obsolete shape"*),
+one seam further along.
 
-pgw#1176: one artifact is ONE graph class, so this builds an ``entry`` block
-and no ``entries`` map. There is deliberately no way to ask this harness for a
-multi-entry artifact: production cannot pack one any more, and a fixture that
-could would be testing a shape nothing can produce.
+The metadata therefore comes from ``tcg_artifacts.metadata()``, i.e. from
+``torchcg.artifact.build_metadata`` — the same builder production uses — and
+there is deliberately no keyword here for a field TCG does not accept.
+
+Everything the publish needs and the artifact cannot say now lives in
+:func:`exported_cell_provenance`, which is the object production writes beside
+the bytes (``local_cell_store.MintProvenance``).
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Optional
 
-from gen_worker._vendor.torchcg import ARTIFACT_KIND, GRAPH_CLASS_BLOCK
-from gen_worker._vendor.torchcg import identity as tcg_identity
+from gen_worker import graph_facts
+from gen_worker.local_cell_store import MintProvenance
 
-from gen_worker import aot_serve, graph_facts
+import tcg_artifacts
 
-CLASS_HASH = "a" * 16
+#: The fixture's graph-class hash, derived by TCG from the declaration
+#: ``tcg_artifacts`` builds — read, never asserted, so a TCG fold change moves
+#: this with the key instead of leaving a stale literal behind.
+CLASS_HASH = str(tcg_artifacts.metadata()["graph_class"]["class_hash"])
 
 
 def exported_cell_meta(
     *,
-    family: str = "fam",
-    sku: str = "l4",
-    sm: str = "89",
-    gen_worker: str = "0.87.0",
-    weight_lane: str = "",
-    lora_bucket: int = 0,
-    **extra: Any,
+    sm: str = "sm_89",
+    graph_class: str = tcg_artifacts.GRAPH_CLASS,
+    witness: str = "fedcba9876543210",
+    toolchain: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, Any]:
-    """One exported (``aot-inductor``) cell's metadata, key stamped from it."""
-    meta: Dict[str, Any] = {
-        "family": family, "sku": sku, "sm": sm, "gen_worker": gen_worker,
-        "kind": ARTIFACT_KIND, "format": "pt2",
-        "weight_lane": weight_lane, "lora_bucket": int(lora_bucket),
-        "strict_export": True,
-        GRAPH_CLASS_BLOCK: {
-            "name": "unet/main",
-            "target": "unet", "fork": [], "class_dims": [],
-            "range_digest": "r1", "class_hash": CLASS_HASH, "graph": {"v": 2},
-        },
-        # The declaration-wide coverage LABEL. Telemetry, never identity —
-        # `_identity_axes` publishes it as `graph_contract`, and it may repeat
-        # across the entries of one declaration by construction.
-        "manifest_digest": graph_facts.manifest_digest([CLASS_HASH]),
-        "env_seal": {"v": 1, "torch": "2.9.0"},
-        "toolchain": {"torch": "2.9.0", "cuda": "12.8"},
-    }
-    meta.update(extra)
-    meta["compiled_graph_key"] = tcg_identity.from_artifact_metadata(meta).value
-    return meta
+    """One exported (``aot-inductor``) cell's metadata, as TCG builds it.
+
+    Every keyword is an axis a REAL artifact carries. There is no keyword for
+    ``family``/``sku``/``gen_worker``/``weight_lane``: a cell states none of
+    them, and a fixture that let a test pretend otherwise is what hid pgw#1341
+    for two wheels.
+    """
+    return tcg_artifacts.metadata(
+        graph_class=graph_class, witness=witness, sm=sm, toolchain=toolchain)
+
+
+def exported_cell_provenance(
+    *,
+    lane: str = "bf16-w16a16",
+    sku: str = "l4",
+    gen_worker: str = "0.87.0",
+    env_seal: str = "seal-" + "1" * 16,
+    graph_contract: str = "",
+) -> MintProvenance:
+    """The mint facts that ride BESIDE the artifact (pgw#1341).
+
+    Production writes this into the local store's sidecar at the moment the
+    bytes become durable, and both the immediate publish and a later boot's
+    ``resume_owed_publishes`` read it back. A test that publishes must supply
+    one for the same reason a pod must: the artifact cannot.
+    """
+    return MintProvenance(
+        env_seal=env_seal, lane=lane,
+        graph_contract=(graph_contract
+                        or graph_facts.manifest_digest([CLASS_HASH])),
+        sku=sku, gen_worker=gen_worker)

--- a/tests/test_aot_local_mint_pgw1096.py
+++ b/tests/test_aot_local_mint_pgw1096.py
@@ -57,6 +57,15 @@ assert KEY_A != KEY_B
 # pgw#1113: spelled in the CURRENT token scheme — a predecessor-scheme memo
 # is swept by `fleet_cells._sweep_superseded_memos_once`, which is the point.
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
+
+#: pgw#1341: the mint facts the local store holds beside the bytes. These rows
+#: are about the TRANSFER, not about the axes, so one honest record serves them
+#: all — but the publish takes it as an ARGUMENT now, because a TCG artifact
+#: cannot state any of it and a later boot must ship the MINT's facts.
+_PROVENANCE = local_cell_store.MintProvenance(
+    env_seal="seal-" + "9" * 16, lane="bf16-w16a16",
+    graph_contract="manifest-" + "8" * 8, sku="l4", gen_worker="0.123.0")
+
 ARM_B = fleet_cells.ARM_SCHEME + "-" + "2" * fleet_cells.ARM_DIGEST_HEX
 
 
@@ -585,7 +594,7 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
 
     class _Refusing:
         def publish(self, family: str, art: Path, meta: dict,
-                    mint_duration_ms: int = 0) -> str:
+                    provenance: Any = None, mint_duration_ms: int = 0) -> str:
             raise fleet_cells.CellPublishRefused(
                 "publish-intent refused (403): community_tier",
                 status=403, code=local_cell_store.UNTRUSTED_REFUSAL_CODE)
@@ -593,7 +602,8 @@ def test_an_untrusted_refusal_keeps_the_cell_instead_of_discarding_it(
     fleet_cells._publish_async(
         _Refusing(), "micro-diffusion",  # type: ignore[arg-type]
         local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
-        {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
+        {"compiled_graph_key": KEY_A}, _PROVENANCE,
+        compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
     assert local_cell_store.trust_class() == local_cell_store.TRUST_UNTRUSTED
@@ -614,12 +624,13 @@ def test_a_transport_failure_is_not_a_trust_verdict(
 
     class _Broken:
         def publish(self, family: str, art: Path, meta: dict,
-                    mint_duration_ms: int = 0) -> str:
+                    provenance: Any = None, mint_duration_ms: int = 0) -> str:
             raise RuntimeError("connection reset")
 
     fleet_cells._publish_async(
         _Broken(), "f", _artifact(tmp_path),  # type: ignore[arg-type]
-        {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
+        {"compiled_graph_key": KEY_A}, _PROVENANCE,
+        compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
     assert local_cell_store.trust_class() == ""

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -51,7 +51,7 @@ import pytest
 GUARD_MANIFEST_BLOCK = "guard_manifest"
 
 
-from harness.cell_meta import exported_cell_meta
+from harness.cell_meta import exported_cell_meta, exported_cell_provenance
 from gen_worker._vendor.tensorfs import MAX_CHUNK_SIZE
 
 from gen_worker import fleet_cells as fc
@@ -61,9 +61,13 @@ from gen_worker.hubio.client import HubPublishError
 FAMILY = "sdxl"
 # pgw#1046: computed from `_meta()`'s identity blocks, never invented — the
 # publish path refuses a stamp its recorded axes do not describe.
-COMPILED_GRAPH_KEY = exported_cell_meta(
-    family=FAMILY, sku="rtx-4090", gen_worker="0.91.0",
-    weight_lane="w8a8", lora_bucket=64)["compiled_graph_key"]
+COMPILED_GRAPH_KEY = exported_cell_meta()["compiled_graph_key"]
+
+# pgw#1341: the mint facts a TCG artifact cannot carry. They ride the local
+# store's sidecar in production and are an ARGUMENT to the publish here, which
+# is why they are not in `_meta()` below any more.
+PROVENANCE = exported_cell_provenance(
+    lane="w8a8-lora64", sku="rtx-4090", gen_worker="0.91.0")
 
 # The hub's group-wide default (internal/api/api.go: `maxRequestBodyMiddleware(32 << 20)`).
 HUB_BODY_CAP = 32 << 20
@@ -287,9 +291,7 @@ def _meta() -> dict:
     # pgw#1046: the identity blocks are REAL (the publish path recomputes the
     # key from them and refuses a cell that cannot state one); everything after
     # them is the measured bulk this test exists to size.
-    meta = exported_cell_meta(
-        family=FAMILY, sku="rtx-4090", gen_worker="0.91.0",
-        weight_lane="w8a8", lora_bucket=64)
+    meta = exported_cell_meta()
     meta |= {
         "torch": "2.9.0+cu128", "triton": "3.5.0", "cuda": "12.8",
         "cuda_driver": "570.86", "storage_dtype": "fp8", "source_ref": "root/sdxl",
@@ -396,7 +398,7 @@ def test_a_real_200mb_cell_publishes_through_the_real_cap(hub, artifact, monkeyp
     monkeypatch.setattr(fc.broker, "active", lambda: False)
     assert artifact.stat().st_size == ARTIFACT_BYTES
 
-    checkpoint = _publisher(hub).publish(FAMILY, artifact, _meta(), 354_450)
+    checkpoint = _publisher(hub).publish(FAMILY, artifact, _meta(), PROVENANCE, 354_450)
 
     assert checkpoint == "sha256:" + "c" * 64
     assert hub.httpd.refusals == [], (
@@ -476,7 +478,7 @@ def test_an_oversized_publish_stops_on_the_first_refusal(artifact, monkeypatch):
     hub = _Server(body_cap=2048)
     try:
         with pytest.raises(HubPublishError) as excinfo:
-            _publisher(hub).publish(FAMILY, artifact, _meta(), 0)
+            _publisher(hub).publish(FAMILY, artifact, _meta(), PROVENANCE, 0)
     finally:
         hub.close()
 

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -21,6 +21,7 @@ Run: pytest tests/test_cell_publish_v2_pgw807.py -q
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import http.server
 import json
@@ -40,6 +41,7 @@ from gen_worker import env_seal, graph_facts, receipts
 from gen_worker import fleet_cells as fc
 from gen_worker.hubio.client import HubPublishError
 from gen_worker.procsplit import actions
+from harness.cell_meta import exported_cell_meta, exported_cell_provenance
 
 FAMILY = "sdxl"
 
@@ -233,30 +235,26 @@ def artifact(tmp_path: Path) -> Path:
     return out
 
 
-# pgw#1046: a REAL exported-cell envelope, not the identity-less stub this
-# fixture used to carry. The publish path now recomputes the cell's key from
-# these blocks and refuses anything that cannot state one, so a stub here would
-# only prove that a cell the fleet can never arm still uploads.
-_CLASS_HASH = "a" * 16
+# pgw#1046 / pgw#1341: a REAL exported-cell envelope — built by TCG, never by
+# hand. This block used to be a literal dict carrying `family`, `sku`,
+# `gen_worker`, `weight_lane`, `manifest_digest` and `env_seal`; TCG's closed
+# vocabulary has none of those, so the fixture described a cell that cannot
+# exist and the publish path was green here while refusing every real artifact
+# on the fleet. What the artifact cannot say now rides `PROVENANCE`.
+META = exported_cell_meta()
+_CLASS_HASH = str(META[GRAPH_CLASS_BLOCK]["class_hash"])
 #: pgw#1176: the DECLARATION-wide coverage label, published as
 #: `graph_contract`. No longer a copy of the graph axis — `graph` is this
 #: entry's class hash (identity), this names the class set it belongs to.
 GRAPH_CONTRACT = graph_facts.manifest_digest([_CLASS_HASH])
-META = {
-    "family": FAMILY, "sku": "l4", "sm": "89",
-    "gen_worker": "0.87.0", "kind": "aot-inductor", "format": "pt2",
-    "weight_lane": "w8a8", "lora_bucket": 64, "strict_export": True,
-    GRAPH_CLASS_BLOCK: {
-        "name": "unet/main",
-        "target": "unet", "fork": [], "class_dims": [],
-        "range_digest": "r1", "class_hash": _CLASS_HASH, "graph": {"v": 2},
-    },
-    "manifest_digest": GRAPH_CONTRACT,
-    "env_seal": {"v": 1, "torch": "2.9.0"},
-    "toolchain": {"torch": "2.9.0", "cuda": "12.8"},
-}
 COMPILED_GRAPH_KEY = tcg_identity.from_artifact_metadata(META).value
-META["compiled_graph_key"] = COMPILED_GRAPH_KEY
+#: The env seal the mint ran under, as the mint recorded its DIGEST.
+SEAL_DIGEST = env_seal.seal_digest({"v": 1, "torch": "2.9.0"})
+#: pgw#1341: what the local store holds beside the bytes — the only source the
+#: publish has for the five facts a TCG artifact cannot carry.
+PROVENANCE = exported_cell_provenance(
+    lane="w8a8-lora64", sku="l4", gen_worker="0.87.0",
+    env_seal=SEAL_DIGEST, graph_contract=GRAPH_CONTRACT)
 
 #: The shape every cell in the corpus was published under before pgw#1046 —
 #: `_identity_axes`' six-axis FALLBACK, carrying neither identity digest. Kept
@@ -288,7 +286,7 @@ def test_publish_takes_the_v2_route_and_never_the_frozen_v1_one(
     the frozen v1 route is never touched. (RED: this same server answers
     /commits with the live 410, which is what the v1 publisher got.)"""
     seen = _events(monkeypatch)
-    ckpt = _publisher(hub).publish(FAMILY, artifact, dict(META),
+    ckpt = _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE,
                                    mint_duration_ms=347_940)
     assert ckpt == "sha256:" + "c" * 64
 
@@ -329,7 +327,8 @@ def test_publish_takes_the_v2_route_and_never_the_frozen_v1_one(
 
 
 def test_intent_carries_the_identity_axes_and_the_mint_cost(hub, artifact):
-    _publisher(hub).publish(FAMILY, artifact, dict(META), mint_duration_ms=347_940)
+    _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE,
+                            mint_duration_ms=347_940)
     intent = next(b for p, b in hub.httpd.calls if p.endswith("publish-intent"))
     # pgw#1224: the three ATTESTED axes are batch-level (all three are
     # properties of the POD); the key, the identity axes and the mint cost are
@@ -369,14 +368,14 @@ def test_publish_intent_states_the_full_arming_identity(hub, artifact):
     RED before the fix: `identity_axes` was
     ``{family, kind, format, sm, mode, lane}`` and this asserts on three keys
     that were not in it."""
-    _publisher(hub).publish(FAMILY, artifact, dict(META))
+    _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE)
     intent = next(b for p, b in hub.httpd.calls if p.endswith("publish-intent"))
     (entry,) = intent["entries"]
     axes = entry["identity_axes"]
 
     # Derived from the recorded blocks, never from a second stamp.
-    assert axes["toolchain"] == graph_facts.facts_digest(META["toolchain"])
-    assert axes["env_seal"] == env_seal.seal_digest(META["env_seal"])
+    assert axes["toolchain"] == graph_facts.facts_digest(dict(META["toolchain"]))
+    assert axes["env_seal"] == SEAL_DIGEST
     assert axes[fc.GRAPH_CONTRACT_AXIS] == GRAPH_CONTRACT
 
     # ...and the KEY axes hash to the key the cell is published under, so
@@ -409,14 +408,14 @@ def test_the_pre_fix_fallback_row_shape_can_no_longer_be_published(hub, artifact
     REFUSAL of a row shape that already exists in the store. This test guards
     the other end — that the worker can no longer create one."""
     with pytest.raises(fc.CellPublishRefused) as exc:
-        _publisher(hub).publish(FAMILY, artifact, dict(TODAYS_FALLBACK_META))
+        _publisher(hub).publish(FAMILY, artifact, dict(TODAYS_FALLBACK_META), PROVENANCE)
     assert "no computable identity" in str(exc.value)
     assert not hub.httpd.calls, "refused before the intent left the pod"
 
     # And the shape itself is unreachable: nothing in the publish path can
     # still emit an axis map without the two identity digests.
     with pytest.raises(fc.CellPublishRefused):
-        fc._identity_axes(FAMILY, dict(TODAYS_FALLBACK_META))
+        fc._identity_axes(FAMILY, dict(TODAYS_FALLBACK_META), PROVENANCE)
 
 
 @pytest.mark.parametrize("dropped", REQUIRED_AXES)
@@ -448,7 +447,7 @@ def test_a_stamp_that_disagrees_with_the_recorded_axes_is_refused(hub, artifact)
     forged = dict(META)
     forged["compiled_graph_key"] = "cg-key-v1-" + "9" * 56
     with pytest.raises(fc.CellPublishRefused, match="disagrees"):
-        _publisher(hub).publish(FAMILY, artifact, forged)
+        _publisher(hub).publish(FAMILY, artifact, forged, PROVENANCE)
     assert not hub.httpd.calls
 
 
@@ -467,9 +466,9 @@ def test_a_cell_with_no_manifest_digest_PUBLISHES(hub, artifact):
     What must still be refused is an entry with no IDENTITY, and the row below
     this one asserts exactly that.
     """
-    hollow = dict(META)
-    hollow["manifest_digest"] = ""
-    _publisher(hub).publish(FAMILY, artifact, hollow)
+    _publisher(hub).publish(
+        FAMILY, artifact, dict(META),
+        dataclasses.replace(PROVENANCE, graph_contract=""))
     assert hub.httpd.calls
 
 
@@ -481,7 +480,7 @@ def test_a_cell_with_no_class_hash_is_refused(hub, artifact):
     hollow[GRAPH_CLASS_BLOCK] = {
         **META[GRAPH_CLASS_BLOCK], "class_hash": ""}
     with pytest.raises(fc.CellPublishRefused):
-        _publisher(hub).publish(FAMILY, artifact, hollow)
+        _publisher(hub).publish(FAMILY, artifact, hollow, PROVENANCE)
     assert not hub.httpd.calls
 
 
@@ -489,7 +488,8 @@ def test_seam_authorizes_the_live_publish_payloads(hub, artifact):
     """The delta-1 allowlist REFUSES an unlisted body key, and the compute
     child is the process that publishes. So the table and the payloads are one
     contract: drive the publisher, then authorize exactly what it sent."""
-    _publisher(hub).publish(FAMILY, artifact, dict(META), mint_duration_ms=1)
+    _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE,
+                            mint_duration_ms=1)
     for path, body in hub.httpd.calls:
         if "/v1/worker/compiled-graphs/" not in path:
             continue
@@ -500,11 +500,11 @@ def test_republish_of_identical_bytes_uploads_nothing(hub, artifact):
     """Staged/dedup semantics: the second publish's need set is empty, so a
     pod re-run after a lost publish costs no transfer at all."""
     pub = _publisher(hub)
-    pub.publish(FAMILY, artifact, dict(META))
+    pub.publish(FAMILY, artifact, dict(META), PROVENANCE)
     first = list(hub.httpd.puts)
     assert first
     hub.httpd.puts.clear()
-    pub.publish(FAMILY, artifact, dict(META))
+    pub.publish(FAMILY, artifact, dict(META), PROVENANCE)
     assert hub.httpd.puts == [], "a re-publish of resident bytes re-uploaded"
 
 
@@ -519,7 +519,7 @@ def test_a_corrupted_chunk_is_refused_by_the_store_and_fails_the_publish(
 
     seen = _events(monkeypatch)
     with pytest.raises(HubPublishError) as exc:
-        _publisher(hub).publish(FAMILY, artifact, dict(META))
+        _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE)
     assert "failed to upload" in str(exc.value)
     # The poisoned object never landed; every honest one did.
     assert ("sha256:" + digest) not in hub.httpd.objects
@@ -536,7 +536,7 @@ def test_complete_over_missing_objects_is_a_typed_repudiation(hub, artifact,
     `code` + `retryable` bit and puts THAT on the wire as the failure phase."""
     monkeypatch.setattr(hub_client, "upload", lambda *a, **k: TransferReport())
     with pytest.raises(HubPublishError) as exc:
-        _publisher(hub).publish(FAMILY, artifact, dict(META))
+        _publisher(hub).publish(FAMILY, artifact, dict(META), PROVENANCE)
     assert exc.value.code == "objects_missing"
     assert exc.value.retryable is False
     assert fc._publish_failure_phase(exc.value) == "objects_missing"

--- a/tests/test_compiled_graph_key_pgw1059.py
+++ b/tests/test_compiled_graph_key_pgw1059.py
@@ -268,13 +268,20 @@ def _old_schema_digest(meta: dict) -> str:
         ).encode()
         return hashlib.sha256(encoded).hexdigest()[:16]
 
+    # pgw#1341: `format`, `family` and `env_seal` are spelled out rather than
+    # read off `meta`, for the same reason `combined_graph_hash` above is —
+    # TCG's closed vocabulary has no field for any of them, so a current
+    # artifact cannot supply them and reading `meta` would only find `None`.
+    # Their VALUES are irrelevant to the claim (the axis NAME SETS differ, so
+    # a collision needs a SHA-256 collision); what matters is that the payload
+    # is the dead one.
     axes = {
-        "format": str(meta["format"]),
+        "format": "pt2",
         "kind": "aot-inductor",
-        "family": meta["family"],
+        "family": "fam",
         "sm": meta["sm"],
         "contract": _digest16(contract_facts),
-        "env_seal": _digest16(dict(meta["env_seal"])),
+        "env_seal": _digest16({"v": 1, "torch": "2.9.0"}),
         "toolchain": _digest16(dict(meta["toolchain"])),
     }
     canonical = json.dumps(

--- a/tests/test_durability_inversion_pgw1183.py
+++ b/tests/test_durability_inversion_pgw1183.py
@@ -42,6 +42,15 @@ ARTIFACT_A = tcg_artifacts.build(_FIXTURE_DIR / "a.tar.gz", witness="a" * 16)
 KEY_A = tcg_artifacts.key_of(ARTIFACT_A)
 ARM_A = fleet_cells.ARM_SCHEME + "-" + "1" * fleet_cells.ARM_DIGEST_HEX
 
+#: pgw#1341: the mint facts the local store holds beside the bytes. These rows
+#: are about the TRANSFER, not about the axes, so one honest record serves them
+#: all — but the publish takes it as an ARGUMENT now, because a TCG artifact
+#: cannot state any of it and a later boot must ship the MINT's facts.
+_PROVENANCE = local_cell_store.MintProvenance(
+    env_seal="seal-" + "9" * 16, lane="bf16-w16a16",
+    graph_contract="manifest-" + "8" * 8, sku="l4", gen_worker="0.123.0")
+
+
 
 @pytest.fixture()
 def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -93,13 +102,17 @@ class _Sink:
     def __init__(self, on: bool = True) -> None:
         self._on = on
         self.published: List[Path] = []
+        self.provenances: List[Any] = []
 
     def enabled(self) -> bool:
         return self._on
 
     def publish(self, family: str, art: Path, meta: dict,
-                mint_duration_ms: int = 0) -> str:
+                provenance: Any = None, mint_duration_ms: int = 0) -> str:
         self.published.append(Path(art))
+        # pgw#1341: what a later boot ships is what the MINT recorded, so the
+        # sink records it and the retry row below can assert on it.
+        self.provenances.append(provenance)
         return "ckpt-1"
 
 
@@ -237,7 +250,8 @@ def test_a_failed_publish_does_not_destroy_the_bytes(
     fleet_cells._publish_async(
         _Broken(), "micro-diffusion",  # type: ignore[arg-type]
         local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
-        {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
+        {"compiled_graph_key": KEY_A}, _PROVENANCE,
+        compiled_graph_key_digest=KEY_A, arm_token=ARM_A,
     ).join(timeout=30)
 
     kept = local_cell_store.lookup(KEY_A, cas_root=cas)
@@ -259,7 +273,8 @@ def test_the_publish_thread_is_not_a_daemon(
     t = fleet_cells._publish_async(
         _Sink(), "f",  # type: ignore[arg-type]
         local_cell_store.lookup(KEY_A, cas_root=cas).artifact,  # type: ignore[union-attr]
-        {"compiled_graph_key": KEY_A}, compiled_graph_key_digest=KEY_A, arm_token=ARM_A)
+        {"compiled_graph_key": KEY_A}, _PROVENANCE,
+        compiled_graph_key_digest=KEY_A, arm_token=ARM_A)
     assert t.daemon is False
     t.join(timeout=30)
 
@@ -272,13 +287,17 @@ def test_a_pending_publish_is_retried_on_the_NEXT_boot(
     all — the bytes were gone and no record said an upload was owed."""
     local_cell_store.store(_artifact(tmp_path), key=KEY_A, family="f",
                            arm_token=ARM_A, sink=local_cell_store.SINK_OWED,
-                           cas_root=cas)
+                           provenance=_PROVENANCE, cas_root=cas)
     sink = _Sink()
 
     for t in fleet_cells.resume_owed_publishes(sink, cas):  # type: ignore[arg-type]
         t.join(timeout=30)
 
     assert [p.name for p in sink.published] == ["cell.tar.gz"]
+    # pgw#1341: the retry ships the MINT's facts, read back off the sidecar.
+    # Re-deriving them here would attest THIS boot's card and wheel against
+    # bytes another boot compiled.
+    assert sink.provenances == [_PROVENANCE]
     kept = local_cell_store.lookup(KEY_A, cas_root=cas)
     assert kept is not None
     assert kept.sink == local_cell_store.SINK_DELIVERED, (

--- a/tests/test_identity_is_tcg_pgw1277.py
+++ b/tests/test_identity_is_tcg_pgw1277.py
@@ -32,7 +32,7 @@ import pytest
 from gen_worker._vendor.torchcg import identity as tcg_identity
 from gen_worker._vendor.torchcg import is_compiled_graph_key
 
-from gen_worker import env_seal, fleet_cells, graph_facts
+from gen_worker import env_seal, fleet_cells, graph_facts, local_cell_store
 
 #: Exactly the metadata shape ``aot_mint`` records for a minted graph class:
 #: TCG's ``graph_class`` block, never an ``entry`` block.
@@ -45,11 +45,16 @@ TCG_METADATA: dict[str, Any] = {
     "sm": "sm_89",
     "graph_class": {"name": "unet", "target": "unet", "class_hash": "a" * 16},
     "toolchain": dict(TCG_TOOLCHAIN),
-    # A wire fact the hub's ArtifactIdentity requires by name, not a key axis
-    # (pgw#1059 amendment 4). The publish path fails closed without it, which
-    # is a separate refusal from the identity one this file is about.
-    env_seal.SEAL_KEY: {"v": 4, "matmul_precision": "high"},
 }
+
+#: pgw#1341: the env-seal digest the hub's ArtifactIdentity requires by name is
+#: NOT a key axis (pgw#1059 amendment 4) and NOT a metadata field — TCG's closed
+#: vocabulary has none. It rides the mint provenance the local store holds, and
+#: the publish path fails closed without it, which is a separate refusal from
+#: the identity one this file is about.
+PROVENANCE = local_cell_store.MintProvenance(
+    env_seal=env_seal.seal_digest({"v": 4, "matmul_precision": "high"}),
+    lane="bf16-w16a16", sku="l4", gen_worker="0.123.0")
 
 VECTORS = pathlib.Path(__file__).parent / "testdata" / "compiled_graph_key_vectors.json"
 
@@ -76,7 +81,7 @@ def test_the_worker_publish_path_keys_a_real_tcg_artifact() -> None:
     Mutate ``graph_class`` back to ``entry`` and this fails — which is the
     regression, stated as a test rather than as a comment.
     """
-    axes = fleet_cells._identity_axes("toy", dict(TCG_METADATA))
+    axes = fleet_cells._identity_axes("toy", dict(TCG_METADATA), PROVENANCE)
     expected = tcg_identity.from_artifact_metadata(TCG_METADATA)
     assert axes["graph"] == "a" * 16
     assert axes["sm"] == "sm_89"

--- a/tests/test_mint_credential_expiry_th1423.py
+++ b/tests/test_mint_credential_expiry_th1423.py
@@ -34,7 +34,7 @@ import pytest
 
 from gen_worker import fleet_cells as fc
 from gen_worker.hubio.client import HubPublishError
-from harness.cell_meta import exported_cell_meta
+from harness.cell_meta import exported_cell_meta, exported_cell_provenance
 
 LAPSE_S = 150  # how far past `exp` the presented credential is, in the JWT
 FAMILY = "sdxl"
@@ -42,8 +42,11 @@ FAMILY = "sdxl"
 # a real exported-cell envelope. The publish path recomputes the key
 # from the recorded blocks and refuses a cell that cannot state one, so the
 # credential-lapse legs below have to ride a cell that could genuinely publish.
-META = exported_cell_meta(family=FAMILY, gen_worker="0.76.6",
-                          weight_lane="w8a8", lora_bucket=64)
+META = exported_cell_meta()
+# pgw#1341: what the mint recorded beside the bytes. The credential legs below
+# have to ride a cell that could genuinely publish, and since pgw#1270 that
+# means an artifact TCG built PLUS the provenance the store holds.
+PROVENANCE = exported_cell_provenance(lane="w8a8-lora64", gen_worker="0.76.6")
 COMPILED_GRAPH_KEY = META["compiled_graph_key"]
 
 
@@ -146,7 +149,7 @@ def test_intent_401_carries_the_hubs_status_and_code(hub, artifact):
     `HubPublishError` never existed and `.status`/`.code` did not either."""
     live = _jwt(lifetime_s=900)
     with pytest.raises(HubPublishError) as caught:
-        _publisher(hub, live).publish(FAMILY, artifact, dict(META))
+        _publisher(hub, live).publish(FAMILY, artifact, dict(META), PROVENANCE)
 
     exc = caught.value
     assert exc.status == 401
@@ -165,7 +168,7 @@ def test_an_expired_credential_is_named_as_such_not_as_a_generic_401(
     RED before the fix: `_publish_failure_phase` returned `RuntimeError`."""
     dead = _jwt(lifetime_s=-LAPSE_S)
     with pytest.raises(HubPublishError) as caught:
-        _publisher(hub, dead).publish(FAMILY, artifact, dict(META))
+        _publisher(hub, dead).publish(FAMILY, artifact, dict(META), PROVENANCE)
 
     exc = caught.value
     assert exc.status == 401
@@ -186,7 +189,7 @@ def test_the_lapse_is_on_the_wire_before_the_intent_is_spent(
 
     with pytest.raises(HubPublishError):
         _publisher(hub, _jwt(lifetime_s=-LAPSE_S)).publish(
-            FAMILY, artifact, dict(META))
+            FAMILY, artifact, dict(META), PROVENANCE)
 
     legs = [(k, p, d) for k, p, d in seen if p == "credential_expired"]
     assert len(legs) == 1, seen
@@ -202,7 +205,7 @@ def test_a_live_credential_publishes_no_lapse_leg(hub, artifact, monkeypatch):
 
     with pytest.raises(HubPublishError):
         _publisher(hub, _jwt(lifetime_s=900)).publish(
-            FAMILY, artifact, dict(META))
+            FAMILY, artifact, dict(META), PROVENANCE)
 
     assert not [p for _, p in seen if p == "credential_expired"]
 
@@ -223,7 +226,8 @@ def test_the_background_publish_reports_the_grouped_phase(hub, artifact,
 
     thread = fc._publish_async(
         _publisher(hub, _jwt(lifetime_s=-LAPSE_S)),
-        FAMILY, artifact, dict(META), compiled_graph_key_digest=COMPILED_GRAPH_KEY)
+        FAMILY, artifact, dict(META), PROVENANCE,
+        compiled_graph_key_digest=COMPILED_GRAPH_KEY)
     thread.join()  # the publish thread itself is the bound — no clock
 
     assert ("self_mint_publish_failed", "worker_credential_expired") in seen

--- a/tests/test_publish_provenance_pgw1341.py
+++ b/tests/test_publish_provenance_pgw1341.py
@@ -1,0 +1,439 @@
+"""pgw#1341 — the PUBLISH path reads five facts a TCG artifact cannot carry.
+
+THE DEFECT, structural and provable for $0. Since pgw#1270 every artifact is
+minted by TCG, and ``torchcg.artifact.validate_metadata`` refuses metadata whose
+field set is not exactly ``artifact_meta.cell_metadata_fields()``::
+
+    compiled_graph_format  compiled_graph_key  constant_folding_fenced
+    graph_class  host_isa  kind  package_constants_in_so  sm  toolchain
+
+``fleet_cells._identity_axes`` read ``env_seal``, ``manifest_digest``, ``family``
+and ``weight_lane``/``lora_bucket`` out of that dict, and ``intent_entry`` read
+``sku`` and ``gen_worker``. None of the six is in the vocabulary. The first one
+FAILS CLOSED, so the outcome was not a degraded row — it was
+``CellPublishRefused("cell records no env_seal block")`` for **every real
+artifact, unconditionally**. pgw#1340 made a pod ARM its own compiled graph;
+this is the seam that decides whether the FLEET may adopt it, and it was shut.
+Consequence, in money: every pod re-mints a graph another pod already compiled.
+
+WHY IT IS A DESIGN CHANGE AND NOT A LINE. ``resume_owed_publishes`` discharges
+an owed upload on a LATER BOOT, in a different process, potentially on a
+different pod. Recomputing these from the live runtime would therefore attest
+one machine's card, wheel and env seal against another machine's bytes — a
+publish that is wrong in exactly the cases the retry exists for. The facts have
+to be DURABLE beside the cell, so they are: ``local_cell_store.MintProvenance``,
+written into the same sidecar as the upload obligation, by the mint, at the
+moment the bytes become durable.
+
+WHAT THIS FILE PROVES, in the order the design has to be believed:
+
+1. the RED, on a cell TCG really built: no provenance -> refused BY NAME;
+2. with the provenance the mint recorded, all five fields resolve;
+3. **BOOT 1 mints in one PROCESS, BOOT 2 publishes in another** — a real
+   subprocess writes the store, this process ships it over the real publish
+   wire, and the hub's recorded intent carries the mint's facts, not the
+   shipper's;
+4. the controls: a genuinely provenance-less cell still refuses, and the
+   ARM/serve path is untouched by any of it.
+
+THE FIXTURE FENCE (pgw#1340, applied here). Every cell below is built by
+``torchcg.artifact.build_metadata`` through ``tests/tcg_artifacts.py``. A
+hand-written envelope is exactly how this survived two wheels: pgw#1277 recorded
+the rule after finding the same class one block over — *"CI stayed green because
+every fixture built the obsolete shape."*
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+import tcg_artifacts
+from gen_worker import aot_serve, env_seal, fleet_cells, graph_facts
+from gen_worker import local_cell_store
+from gen_worker._vendor.torchcg import identity as tcg_identity
+from harness.cell_hub import local_cell_hub
+
+FAMILY = "sd15"
+LANE = "bf16-w16a16"
+SKU = "l4"
+GEN_WORKER = "0.123.0"
+ARM_TOKEN = "arm2-" + "1" * 64
+
+_FIXTURE_DIR = Path(tempfile.mkdtemp(prefix="pgw1341-"))
+atexit.register(shutil.rmtree, _FIXTURE_DIR, True)
+ARTIFACT = tcg_artifacts.build(_FIXTURE_DIR / "cell.tar.gz")
+KEY = tcg_artifacts.key_of(ARTIFACT)
+META: Dict[str, Any] = tcg_artifacts.metadata()
+MANIFEST = graph_facts.manifest_digest([str(META["graph_class"]["class_hash"])])
+SEAL_DIGEST = env_seal.seal_digest(env_seal.effective_seal())
+
+
+def _provenance(**kw: Any) -> local_cell_store.MintProvenance:
+    facts: Dict[str, Any] = dict(
+        env_seal=SEAL_DIGEST, lane=LANE, graph_contract=MANIFEST,
+        sku=SKU, gen_worker=GEN_WORKER)
+    facts.update(kw)
+    return local_cell_store.MintProvenance(**facts)
+
+
+# ---------------------------------------------------------------------------
+# 1. the RED — every real artifact, unconditionally
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_TCG_cell_states_none_of_the_five_publish_fields() -> None:
+    """THE $0 PROOF, on the vocabulary itself.
+
+    This is what makes the defect structural rather than a bad cell: the five
+    reads name fields the closed vocabulary does not contain, so no artifact
+    that exists can answer any of them.
+    """
+    from gen_worker import artifact_meta
+
+    vocabulary = artifact_meta.cell_metadata_fields()
+    for field in (env_seal.SEAL_KEY, "manifest_digest", "family",
+                  "weight_lane", "lora_bucket", "sku", "gen_worker"):
+        assert field not in vocabulary, field
+        assert field not in META, field
+
+
+def test_the_publish_refuses_a_cell_this_machine_can_say_nothing_about() -> None:
+    """THE RED, preserved and NARROWED (pgw#939: absence is a verdict).
+
+    Before this issue the same refusal fired on a metadata field no cell can
+    carry — i.e. always. It now fires on the case it was written for, and only
+    that one: bytes with no recorded mint provenance beside them.
+    """
+    with pytest.raises(fleet_cells.CellPublishRefused) as exc:
+        fleet_cells._identity_axes(
+            FAMILY, dict(META), local_cell_store.MintProvenance())
+    assert "no mint provenance" in str(exc.value)
+    assert "pgw#1341" in str(exc.value)
+
+
+def test_the_five_fields_all_resolve_from_the_recorded_provenance() -> None:
+    """The green half, field by field — each one named, so a silent blank in
+    any of them is a failure here rather than an unarmable row on the fleet."""
+    axes = fleet_cells._identity_axes(FAMILY, dict(META), _provenance())
+    key = tcg_identity.from_artifact_metadata(META)
+
+    # The three KEY axes still come from the artifact: a cell must corroborate
+    # its own identity, and provenance must never be able to restate it.
+    assert axes["graph"] == str(META["graph_class"]["class_hash"])
+    assert axes["sm"] == str(META["sm"])
+    assert axes["toolchain"] == tcg_identity.toolchain_axis_digest(
+        dict(META["toolchain"]))
+    assert key.value == META["compiled_graph_key"]
+
+    # The five that could not be stated before.
+    assert axes[fleet_cells.ENV_SEAL_AXIS] == SEAL_DIGEST
+    assert axes[fleet_cells.GRAPH_CONTRACT_AXIS] == MANIFEST
+    assert axes["family"] == FAMILY
+    assert axes["lane"] == LANE
+
+    entry, sku, gen_worker = fleet_cells.intent_entry(
+        FAMILY, dict(META), _provenance(), 347_940)
+    assert (sku, gen_worker) == (SKU, GEN_WORKER)
+    assert entry.compiled_graph_key == key.value
+    assert entry.mint_duration_ms == 347_940
+
+
+def test_no_publish_fact_is_read_from_the_cell_metadata() -> None:
+    """The rule, enforced rather than described.
+
+    A metadata dict that LIES — carrying the old field names with hostile
+    values — must not move a single published axis. Anything that still reads
+    them would show up here as an axis taking the forged value.
+    """
+    lying = dict(
+        META,
+        family="not-this-family",
+        weight_lane="w4a4",
+        lora_bucket=128,
+        manifest_digest="forged-manifest",
+        sku="h100",
+        gen_worker="0.0.1",
+        **{env_seal.SEAL_KEY: {"v": 99}},
+    )
+    entry, sku, gen_worker = fleet_cells.intent_entry(
+        FAMILY, lying, _provenance())
+    axes = dict(entry.identity_axes)
+    assert axes["family"] == FAMILY
+    assert axes["lane"] == LANE
+    assert axes[fleet_cells.GRAPH_CONTRACT_AXIS] == MANIFEST
+    assert axes[fleet_cells.ENV_SEAL_AXIS] == SEAL_DIGEST
+    assert (sku, gen_worker) == (SKU, GEN_WORKER)
+
+
+# ---------------------------------------------------------------------------
+# 2. the provenance is DURABLE — and survives the process that wrote it
+# ---------------------------------------------------------------------------
+
+
+#: BOOT 1. A real, separate interpreter: it mints (fixture bytes, no compile),
+#: stages the cell durable exactly as ``adopt_delegated_mint`` does, and dies.
+#: Everything the publish will need has to be on disk when it does.
+_BOOT_1 = textwrap.dedent(
+    """
+    import json, sys
+    from pathlib import Path
+
+    from gen_worker import compile_cache as cc
+    from gen_worker import fleet_cells, local_cell_store
+
+    artifact, cas, family, lane, seal, manifest, token, sku, gw = sys.argv[1:10]
+    # THE CARD THIS BOX DOES NOT HAVE. `mint_provenance`'s derivation runs for
+    # real — it calls these, and a cardless probe honestly answers "" — so the
+    # two POD axes are given a pod's answer here rather than a mint's worth of
+    # L4. Nothing else is faked: the store write, the sidecar, the artifact and
+    # the publish wire are all production's.
+    cc.runtime_key = lambda: {"sku": sku, "sm": "sm_89"}
+    cc.gen_worker_version = lambda: gw
+    pending = fleet_cells.PendingSelfMint(
+        family=family,
+        arm_token=token,
+        ref="root/family-%s#pending" % family,
+        cfg=None,
+        target=Path(artifact),
+        mint_root=Path(artifact).parent,
+        # A publisher this boot never gets to use: it is what makes the upload
+        # OWED, which is the obligation boot 2 discharges.
+        publisher=fleet_cells.CellPublisher(
+            base_url="http://boot-1.invalid", worker_jwt=lambda: "jwt",
+            image_digest="sha256:image"),
+        cache_dir=Path(cas),
+        arm_key=fleet_cells.ArmIdentity(facts=tuple(sorted({
+            "family": family, "lane": lane, "env_seal": seal,
+            "subject": "", "targets": "unet", "dynamic": "{}",
+            "regional": "0", "sm": "sm_89", "toolchain": "t",
+            "compiled_graph_format": "1",
+        }.items()))),
+    )
+    provenance = fleet_cells.mint_provenance(pending, manifest=manifest)
+    key = fleet_cells._stage_durable(pending, Path(artifact), provenance)
+    # The arm gate passing, which is what promotes the staged bytes: only an
+    # ADMITTED cell is ever owed to the sink.
+    fleet_cells._admit_durable(pending, key, key)
+    print(json.dumps({"key": key, "provenance": provenance.as_dict()}))
+    """
+)
+
+
+@pytest.fixture()
+def store_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "cozy-cells"
+    monkeypatch.setenv(local_cell_store.ENV_STORE_DIR, str(root))
+    return root
+
+
+def _boot_1(tmp_path: Path, store_root: Path) -> Dict[str, Any]:
+    """Run boot 1 in a REAL child process and return what it recorded."""
+    staged = tmp_path / "mint" / "cell.tar.gz"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ARTIFACT, staged)
+    env = dict(os.environ)
+    env[local_cell_store.ENV_STORE_DIR] = str(store_root)
+    proc = subprocess.run(
+        [sys.executable, "-c", _BOOT_1, str(staged), str(tmp_path / "cas"),
+         FAMILY, LANE, SEAL_DIGEST, MANIFEST, ARM_TOKEN, SKU, GEN_WORKER],
+        capture_output=True, text=True, env=env, timeout=300)
+    assert proc.returncode == 0, proc.stderr[-4000:]
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_boot_1_records_the_mint_facts_beside_the_bytes(
+    tmp_path: Path, store_root: Path,
+) -> None:
+    """The durable half, read back from disk by a process that did not mint.
+
+    The sidecar — not the artifact — is what carries them, which is the whole
+    design: TCG's vocabulary is closed and stays closed (pgw#1270).
+    """
+    recorded = _boot_1(tmp_path, store_root)
+    assert recorded["key"] == KEY
+
+    record = local_cell_store.read_record(KEY, store_root)
+    assert record is not None
+    assert record.sink == local_cell_store.SINK_OWED
+    assert record.family == FAMILY
+    assert record.provenance.env_seal == SEAL_DIGEST
+    assert record.provenance.lane == LANE
+    assert record.provenance.graph_contract == MANIFEST
+    # The two POD axes are read on the pod that minted, by the mint itself.
+    assert record.provenance.sku == SKU
+    assert record.provenance.gen_worker == GEN_WORKER
+    assert recorded["provenance"] == record.provenance.as_dict()
+
+    # And the artifact still says nothing about any of it.
+    from gen_worker import artifact_meta
+
+    bytes_on_disk = local_cell_store.materialize(
+        KEY, store_root, tmp_path / "cas")
+    assert bytes_on_disk is not None
+    packed = artifact_meta.read_metadata(bytes_on_disk)
+    assert env_seal.SEAL_KEY not in packed
+    assert "family" not in packed
+
+
+def test_boot_2_PUBLISHES_what_boot_1_minted(
+    tmp_path: Path, store_root: Path,
+) -> None:
+    """THE END-STATE PROOF. Two processes, one cell, one publish.
+
+    Boot 1 (a subprocess, now dead) minted and recorded. Boot 2 — this process,
+    holding nothing but the store — discharges the owed upload over the REAL
+    publish wire, and the hub receives the MINT's axes.
+
+    Before pgw#1341 this could not happen at all: ``resume_owed_publishes``
+    read the artifact's metadata, ``_identity_axes`` demanded an ``env_seal``
+    block no TCG artifact has, and the thread died on
+    ``CellPublishRefused`` without a byte moving.
+    """
+    _boot_1(tmp_path, store_root)
+
+    with local_cell_hub() as hub:
+        publisher = fleet_cells.CellPublisher(
+            base_url=hub.base, worker_jwt=lambda: "worker-jwt",
+            image_digest="sha256:" + "e" * 64)
+        threads = fleet_cells.resume_owed_publishes(
+            publisher, cas_root=tmp_path / "cas")
+        assert len(threads) == 1, "the owed cell must be shipped"
+        threads[0].join(timeout=120)
+        assert not threads[0].is_alive()
+
+        assert len(hub.intents) == 1, hub.routes()
+        intent = hub.intents[0]
+
+    # The two POD axes the hub ATTESTS — empty before this issue, on every row.
+    assert intent["axes"]["sku"] == SKU
+    assert intent["axes"]["gen_worker"] == GEN_WORKER
+    assert intent["axes"]["image_digest"] == "sha256:" + "e" * 64
+    assert intent["family"] == FAMILY
+
+    entry = intent["entries"][0]
+    assert entry["compiled_graph_key"] == KEY
+    axes = entry["identity_axes"]
+    # pgw#903's pre-dlopen fence compares this; it was published empty.
+    assert axes[fleet_cells.GRAPH_CONTRACT_AXIS] == MANIFEST
+    # The hub's ArtifactIdentity requires this; the publish never got here.
+    assert axes[fleet_cells.ENV_SEAL_AXIS] == SEAL_DIGEST
+    # The store-row self-description, blank before.
+    assert axes["family"] == FAMILY
+    assert axes["lane"] == LANE
+
+    # The obligation is discharged, durably, so a third boot ships nothing.
+    record = local_cell_store.read_record(KEY, store_root)
+    assert record is not None and record.sink == local_cell_store.SINK_DELIVERED
+
+
+# ---------------------------------------------------------------------------
+# 3. the controls
+# ---------------------------------------------------------------------------
+
+
+def test_a_cell_with_NO_recorded_provenance_still_refuses_by_name(
+    tmp_path: Path, store_root: Path,
+) -> None:
+    """The refusal survives, narrowed — the positive control.
+
+    A record written before this field existed (or by a route that recorded
+    nothing) states no provenance. Publishing it would invent the hub's
+    ``ArtifactIdentity`` out of the shipping pod's runtime, which is precisely
+    the unsound thing. It is refused, by name, before a byte moves.
+    """
+    staged = tmp_path / "mint" / "cell.tar.gz"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ARTIFACT, staged)
+    stored = local_cell_store.store(
+        staged, key=KEY, family=FAMILY, arm_token=ARM_TOKEN,
+        sink=local_cell_store.SINK_OWED, root=store_root,
+        cas_root=tmp_path / "cas")
+    assert stored is not None and not stored.provenance.stated
+
+    with local_cell_hub() as hub:
+        publisher = fleet_cells.CellPublisher(
+            base_url=hub.base, worker_jwt=lambda: "worker-jwt",
+            image_digest="sha256:" + "e" * 64)
+        threads = fleet_cells.resume_owed_publishes(
+            publisher, cas_root=tmp_path / "cas")
+        assert len(threads) == 1
+        threads[0].join(timeout=120)
+        assert hub.intents == [], "nothing may reach the hub"
+
+    record = local_cell_store.read_record(KEY, store_root)
+    assert record is not None
+    assert record.sink == local_cell_store.SINK_REFUSED
+
+
+def test_a_pre_pgw1341_sidecar_reads_back_without_inventing_facts(
+    tmp_path: Path, store_root: Path,
+) -> None:
+    """A record file with no ``provenance`` block at all.
+
+    It must read as an EMPTY provenance — never as defaults, and never as an
+    unreadable record: the bytes are fine and the cell still ARMS. Only the
+    publish is refused.
+    """
+    staged = tmp_path / "mint" / "cell.tar.gz"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ARTIFACT, staged)
+    assert local_cell_store.store(
+        staged, key=KEY, family=FAMILY, root=store_root,
+        cas_root=tmp_path / "cas") is not None
+    path = local_cell_store.cell_dir(KEY, store_root) / local_cell_store.RECORD_NAME
+    raw = json.loads(path.read_text())
+    raw.pop("provenance")
+    path.write_text(json.dumps(raw))
+
+    record = local_cell_store.read_record(KEY, store_root)
+    assert record is not None
+    assert record.provenance == local_cell_store.MintProvenance()
+    assert not record.provenance.stated
+
+
+def test_the_ARM_side_is_untouched(tmp_path: Path, store_root: Path) -> None:
+    """The negative control for the whole change.
+
+    pgw#1340 made the cell ARM. Nothing here may cost that: the serve-side
+    lookup still returns admitted bytes, the arm-token memo still resolves, and
+    the handback comparison still agrees with the runtime that minted it.
+    """
+    staged = tmp_path / "mint" / "cell.tar.gz"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(ARTIFACT, staged)
+    assert local_cell_store.store(
+        staged, key=KEY, family=FAMILY, arm_token=ARM_TOKEN,
+        provenance=_provenance(), root=store_root,
+        cas_root=tmp_path / "cas") is not None
+
+    cell = local_cell_store.lookup(KEY, store_root, tmp_path / "cas")
+    assert cell is not None
+    assert cell.verdict == local_cell_store.VERDICT_ADMITTED
+    assert cell.provenance.env_seal == SEAL_DIGEST
+    assert local_cell_store.lookup_for_arm(
+        ARM_TOKEN, store_root, tmp_path / "cas") is not None
+
+    # pgw#1340's seam, unchanged: the compared axes are the three a cell states.
+    assert fleet_cells.unstateable_arm_axes() == ()
+    arm = fleet_cells.ArmIdentity(facts=tuple(sorted({
+        "family": FAMILY, "lane": LANE, "env_seal": SEAL_DIGEST,
+        "subject": graph_facts.subject_digest(()), "targets": "unet",
+        "dynamic": "{}", "regional": "0",
+        "sm": str(META["sm"]),
+        aot_serve.COMPILED_GRAPH_FORMAT_KEY: str(
+            aot_serve.COMPILED_GRAPH_FORMAT),
+        "toolchain": tcg_identity.toolchain_axis_digest(
+            dict(META["toolchain"])),
+    }.items())))
+    assert fleet_cells.arm_axis_divergence(arm, dict(META)) == ""

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -37,7 +37,7 @@ from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure as gc
 from gen_worker.registry import CompileCell
-from harness.cell_meta import exported_cell_meta
+from harness.cell_meta import exported_cell_meta, exported_cell_provenance
 
 FAMILY = "toyfam"
 
@@ -206,7 +206,7 @@ def test_marked_cell_never_republishes(monkeypatch: pytest.MonkeyPatch,
         base_url="http://hub", worker_jwt=lambda: "jwt", image_digest="")
     meta = {"compiled_graph_key": "cg-key-v1-" + "a" * 56, fc.ADOPTION_MARK: ["foreign"]}
     with pytest.raises(fc.CellPublishRefused, match="pgw#712"):
-        pub.publish(FAMILY, artifact, meta)
+        pub.publish(FAMILY, artifact, meta, exported_cell_provenance())
 
 
 def test_publish_complete_carries_only_what_the_hub_decodes(
@@ -215,8 +215,10 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
     posts: list = []
     # pgw#1046: a real exported-cell envelope — publish recomputes the key from
     # the recorded blocks and refuses a cell that cannot state one.
-    meta = exported_cell_meta(family=FAMILY, sku="l4", gen_worker="1.0.0",
-                              **{GUARD_MANIFEST_BLOCK: _manifest()})
+    # pgw#1341: the ARTIFACT half is TCG's; the unbounded block is added HERE,
+    # visibly, because this test is about the declare bound stripping it —
+    # never hidden inside a fixture that could pretend a cell carries it.
+    meta = dict(exported_cell_meta(), **{GUARD_MANIFEST_BLOCK: _manifest()})
     key = meta["compiled_graph_key"]
 
     class _FakeResp:
@@ -265,7 +267,9 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
     artifact.write_bytes(b"cell-bytes")
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "jwt", image_digest="")
-    assert pub.publish(FAMILY, artifact, meta) == "cp-1"
+    assert pub.publish(
+        FAMILY, artifact, meta,
+        exported_cell_provenance(sku="l4", gen_worker="1.0.0")) == "cp-1"
 
     complete_url, body = posts[-1]
     assert complete_url.endswith("/publish-complete")


### PR DESCRIPTION
Closes the P1 COST seam one step past pgw#1340.

## The defect, reproduced at $0

`fleet_cells._identity_axes` read `env_seal`, `manifest_digest`, `family` and `weight_lane`/`lora_bucket` off a cell's metadata; `intent_entry` read `sku` and `gen_worker`. Six names TCG's **closed** artifact vocabulary has not contained since pgw#1270. The env-seal read fails closed, so it was not a degraded row — it was `CellPublishRefused("cell records no env_seal block")` on **every real artifact, unconditionally**. A pod could arm its own compiled graph and still not hand it to the fleet, so every pod re-minted what one pod had already compiled.

Reproduced on master `b7a9345a` against a cell `torchcg.artifact.build_metadata` really built:

```
RED: CellPublishRefused cell records no env_seal block; the hub's ArtifactIdentity requires its digest (pgw#903/pgw#1046)
RED(intent): CellPublishRefused cell records no env_seal block; ...
```

Same fact from the other end, measured on the standing `master` hub (2026-08-17): `compiled_graph_store` = **0 rows**, `compiled_graph_receipts` = **0 rows**. That answers the issue's fourth deliverable — no already-published row carries a blank `sku`/`gen_worker`/`graph_contract`, because there is no published row.

## The design

`resume_owed_publishes` discharges an owed upload on a **later boot, in a different process, potentially on a different pod**. Re-deriving these from the live runtime would attest one machine's card, wheel and env seal against another machine's bytes — wrong in exactly the cases the retry exists for. So they are stored where the bytes are.

- **`local_cell_store.MintProvenance`** (env-seal digest, execution lane, declaration manifest digest, sku, gen_worker) is written into the store's sidecar in the **same write** that records the upload obligation — pgw#1283's storage seam, not a parallel store.
- **`fleet_cells.mint_provenance`** is the one derivation, called once per mint in `adopt_delegated_mint` before the first byte is staged. `env_seal` and `lane` come from the pending's own arm token rather than being recomputed (pgw#1042: two derivations of one fact is how an axis becomes two).
- **`_identity_axes` / `intent_entry` take it as an argument.** No publish fact is read from cell metadata. The three key axes are still recomputed from the artifact, because a cell must corroborate its own identity.
- `graph_contract` is `MintResult.manifest`, threaded from `mint_supervisor` — the only object that holds it.

**The artifact vocabulary is untouched.** pgw#1270's cut stands; nothing reopens `metadata.json`.

The refusal survives, **narrowed**: a cell this machine can say nothing about is still refused by name before a byte moves. It now fires on genuine absence instead of on a field no cell can carry.

## Proof

`tests/test_publish_provenance_pgw1341.py`:

- **boot 1** mints and stages in a REAL subprocess, then dies;
- **boot 2** — the test process, holding nothing but the store — discharges the owed upload over the real publish wire to the `cell_hub` double, and the hub's recorded intent carries all five of the mint's facts (`sku`, `gen_worker`, `graph_contract`, `env_seal`, `family`/`lane`);
- controls: a cell with genuinely no provenance still refuses by name and reaches no hub; a pre-pgw#1341 sidecar reads back empty rather than as defaults; the arm/serve path is unchanged (`unstateable_arm_axes() == ()`, `arm_axis_divergence` still agrees).

**The fixture fence, applied** (pgw#1340's technique). `tests/harness/cell_meta.py` hand-wrote all six dead field names, so the whole publish path was green against a cell that cannot exist — pgw#1277's finding verbatim (*"every fixture built the obsolete shape"*), one seam further along. It now builds through `torchcg.artifact.build_metadata` and has **no keyword for a field TCG does not accept**.

Local: 863 passed / 14 skipped across every test file touching `fleet_cells` / `local_cell_store` / `CellPublisher`; mypy (src + tests + tests_v2) clean; ruff, and all eleven `fast gates` guard scripts including their selftests, green.

## Residue

`verify_numerics` and the post-arm path have still never executed on a real pod — unchanged, still owed to the first real mint (th#2098).

🤖 Generated with [Claude Code](https://claude.com/claude-code)