### PR TITLE
pgw#1331 owed row 3: the model-free claim covers the serve ROLE (14 -> 30 of 39 roots), and its residue is a ledger the fence checks

### DIFF
--- a/changelog.d/pgw1331.md
+++ b/changelog.d/pgw1331.md
@@ -27,10 +27,28 @@
   — that is how a binding reaches an optional `SPEC` — so `role.OPTIONAL_SERVE_IMPORTS` enumerates
   where it stops and goes red both on an unlisted guarded edge and on a listed row nobody reaches.
   `if TYPE_CHECKING:` bodies are skipped because they never execute. `serve.guard` blocks the same
-  libraries at run time with `ModelLibraryUnavailable`. **Scoped honestly:** the WHOLE serve role
-  is not statically model-free, because `gen_worker/__init__` reaches the eager worker's guts,
-  which import diffusers inside functions and are entitled to — `role.py` records that and names
-  the remaining cut.
+  libraries at run time with `ModelLibraryUnavailable`.
+- **The model-free claim covers the serve ROLE now, not just the family surface: 33 of its 42
+  roots, up from 14.** Two package roots were dragging the eager-capable worker's guts into every
+  closure that named them, so a module could not be model-free without also being outside the
+  package it lives in. `gen_worker/__init__` and `gen_worker/models/__init__` are PEP 562 lazy —
+  importing a package executes nothing and asking for a name costs exactly the one submodule that
+  defines it. The author surface is unchanged (`from gen_worker import endpoint` and
+  `gen_worker.endpoint` both still work), and the eager block survives verbatim under
+  `if TYPE_CHECKING` so mypy still checks it. New `gen_worker.compile_facts` holds the compile
+  facts a SERVING process reads — the arm-marker readers and the `runtime_key` toolchain probe —
+  so `serving_mode`, a per-request reporting module, no longer imports the 3,100-line arming
+  brain to read two of them; `compile_cache` re-exports them rather than re-implementing them, so
+  `compile_cache.runtime_key` is that one function and every existing caller and monkeypatch is
+  unaffected.
+- **The residue is a checked ledger instead of a comment.** `role.MODEL_BEARING_SERVE_MODULES`
+  names the nine serve-role roots that still reach a model library, and the fence asserts every
+  one of them still does: a row whose cut lands goes RED until it is moved into
+  `MODEL_FREE_MODULES`, so the list can only shrink and an owed cut cannot rot into an allowlist.
+  The role is the two tuples spliced, so every module is covered by exactly one claim. All nine
+  trace to two causes, both named at the declaration: `compile_cache` holds the compile-cache
+  IDENTITY functions the key set folds a cell key from, and `aot_serve` reaches
+  `models.memory`/`models.lora_lifted` directly.
 - **A family declaration mints its own graph classes.** `gen_worker.model.mint` /
   `gen-worker model mint` bridges a `GraphModelSpec` to packed AOTI artifacts through the mint lane's
   inner seam (`export_program` → `build_call_ingress` → `keying_block` → `Engine.compile`), with no

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -47,7 +47,7 @@
 # ---------------------------------------------------------------------------
 # VIOLATION — the burn-down list. Each names its blocker.
 # ---------------------------------------------------------------------------
-src/gen_worker/compile_cache.py::WORKER_IMAGE_DIGEST VIOLATION WORKER_IMAGE_DIGEST is a Settings field AND a compile-cache KEY AXIS. runtime_key() has 21 callers and no settings; needs an install-once image identity. Latent not live: production pods receive this via env so the loader and the raw read agree - it diverges only on a deployment configuring it from yaml/.env/secrets, where the cell would silently key on "".
+src/gen_worker/compile_facts.py::WORKER_IMAGE_DIGEST VIOLATION WORKER_IMAGE_DIGEST is a Settings field AND a compile-cache KEY AXIS. runtime_key() has 21 callers and no settings; needs an install-once image identity. Latent not live: production pods receive this via env so the loader and the raw read agree - it diverges only on a deployment configuring it from yaml/.env/secrets, where the cell would silently key on "".
 src/gen_worker/models/store.py::RUNPOD_PROVIDER VIOLATION TENSORHUB_FILL_SOURCE_DIR has a Settings field; ModelStore.__init__ takes no Settings. Fix with the same pass that threads settings into the store (pgw#1206 C1 moved the read; it did not change it).
 src/gen_worker/postmortem.py::GEN_WORKER_BOOT_RECORD VIOLATION GEN_WORKER_BOOT_RECORD now HAS a field (boot_record_path). BOOT_RECORD_PATH is computed at IMPORT, before any process entry can have loaded config; needs an install-once path.
 src/gen_worker/postmortem.py::TENSORHUB_CACHE_DIR VIOLATION TENSORHUB_CACHE_DIR, same import-time constant, same fix.

--- a/scripts/lint_serve_role_closure.py
+++ b/scripts/lint_serve_role_closure.py
@@ -201,6 +201,14 @@ def _guarded(tree: ast.AST) -> Set[int]:
     return optional
 
 
+#: Parsed-import memo, keyed by (path, module). The model-bearing ledger walks
+#: one closure per declared row, and every walk re-parses the same ~150 files;
+#: memoizing takes the whole fence from 21s to under 3s, which is the
+#: difference between it fitting the required-gate budget and not. Results are
+#: read-only everywhere they are used.
+_IMPORT_MEMO: Dict[Tuple[str, str], Tuple[Set[str], Set[str], Set[str]]] = {}
+
+
 def _imports(path: Path, module: str) -> Tuple[Set[str], Set[str], Set[str]]:
     """What this file imports: (required gen_worker, guarded gen_worker, libraries).
 
@@ -209,6 +217,9 @@ def _imports(path: Path, module: str) -> Tuple[Set[str], Set[str], Set[str]]:
     this process would acquire whenever it is installed, which on an
     eager-capable pod is always.
     """
+    memo = _IMPORT_MEMO.get((str(path), module))
+    if memo is not None:
+        return memo
     package = _package_of(module)
     tree = ast.parse(path.read_text(), filename=str(path))
     optional_nodes = _guarded(tree)
@@ -240,6 +251,7 @@ def _imports(path: Path, module: str) -> Tuple[Set[str], Set[str], Set[str]]:
                 bucket.add(name)
             elif name:
                 libraries.add(name.split(".", 1)[0])
+    _IMPORT_MEMO[(str(path), module)] = (required, guarded, libraries)
     return required, guarded, libraries
 
 
@@ -387,6 +399,50 @@ def check_model_free(
     return problems
 
 
+def check_bearing_ledger(
+    bearing: Sequence[str],
+    free: Sequence[str],
+    libraries: Sequence[str],
+) -> List[str]:
+    """pgw#1331: every module EXCUSED from the model-free claim still needs it.
+
+    ``MODEL_BEARING_SERVE_MODULES`` is the residue of the model-free cut, and
+    an unchecked residue is the exact shape pgw#1176 measured rotting: prose
+    naming an owed cut, green forever, describing a tree that has moved. So the
+    list is asserted TRUE in both directions.
+
+    * A row that no longer reaches a forbidden library goes RED here. The only
+      way to make it green is to move it into ``MODEL_FREE_MODULES``, where the
+      real walk then holds it. **The list can only shrink.**
+    * A row that is also in ``MODEL_FREE_MODULES`` goes red: a module cannot
+      both be asserted model-free and be excused from the assertion.
+    """
+    problems: List[str] = []
+    overlap = sorted(set(bearing) & set(free))
+    if overlap:
+        problems.append(
+            f"pgw#1331: {overlap[0]} is in BOTH role.MODEL_FREE_MODULES and "
+            f"role.MODEL_BEARING_SERVE_MODULES. One module, one claim — the "
+            f"model-free walk would assert it while the ledger excuses it.")
+    forbidden = set(libraries)
+    for name in bearing:
+        if _module_path(name) is None:
+            problems.append(
+                f"`{name}` is declared in serve/role.py but is not a module "
+                f"under src/gen_worker. A fence naming a module that does not "
+                f"exist passes vacuously forever (pgw#1176).")
+            continue
+        seen, _, used, _ = closure((name,))
+        if not any(used.get(module, set()) & forbidden for module in seen):
+            problems.append(
+                f"pgw#1331: role.MODEL_BEARING_SERVE_MODULES names {name}, but "
+                f"its closure no longer reaches any of {sorted(forbidden)}. "
+                f"That cut has LANDED — move {name!r} into "
+                f"role.MODEL_FREE_MODULES so the real walk holds it. This "
+                f"ledger only ever shrinks; it is not an allowlist.")
+    return problems
+
+
 _SELFTEST_ROLE = '''
 SERVE_ROLE_MODULES = ("gen_worker.serve.role",)
 MINT_MACHINERY = ("gen_worker.aot_mint",)
@@ -459,11 +515,30 @@ def selftest() -> int:
             "accepted it. The hatch would then be open to any `try: import`.",
             file=sys.stderr)
         return 1
+    # …and the model-bearing LEDGER must go red in both of its directions, or
+    # the residue of the model-free cut is an allowlist that rots (pgw#1176).
+    # `serve.role` itself is model-FREE, so naming it as bearing must be
+    # refused — that is the arm which forces a landed cut to be recorded.
+    if not check_bearing_ledger(("gen_worker.serve.role",), (), libraries):
+        print(
+            "SELFTEST FAILED: a model-FREE module was accepted into "
+            "MODEL_BEARING_SERVE_MODULES. The ledger would then be an "
+            "allowlist that never shrinks, which is the prose it replaced.",
+            file=sys.stderr)
+        return 1
+    if not check_bearing_ledger((declaration,), (declaration,), libraries):
+        print(
+            "SELFTEST FAILED: a module claimed BOTH model-free and "
+            "model-bearing was accepted. One module, one claim.",
+            file=sys.stderr)
+        return 1
     print(
         f"pgw#1328/#1331 selftest: the fence goes red as designed "
         f"({len(problems)} violation(s) from a mint-reaching root, "
         f"{len(library_problems)} from a model-library root, an unlisted "
-        f"guarded edge is refused, and a computed declaration is refused)")
+        f"guarded edge is refused, a landed cut left in the bearing ledger is "
+        f"refused, a double-claimed module is refused, and a computed "
+        f"declaration is refused)")
     return 0
 
 
@@ -476,10 +551,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     roots = _declared_tuple("SERVE_ROLE_MODULES")
     banned = _declared_tuple("MINT_MACHINERY")
     model_free = _declared_tuple("MODEL_FREE_MODULES")
+    bearing = _declared_tuple("MODEL_BEARING_SERVE_MODULES")
     libraries = _declared_tuple("FORBIDDEN_LIBRARIES")
     optional = _declared_tuple("OPTIONAL_SERVE_IMPORTS")
     problems = check(roots, banned)
     problems.extend(check_model_free(model_free, libraries, optional, within=roots))
+    problems.extend(check_bearing_ledger(bearing, model_free, libraries))
     for line in problems:
         print(line, file=sys.stderr)
     if problems:
@@ -495,9 +572,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{len(banned)} mint modules absent)")
     print(
         f"pgw#1331: the model-free serve surface holds no model library "
-        f"({len(model_free)} declared root(s), {len(free)} gen_worker modules "
-        f"in the closure, {len(libraries)} libraries absent, {len(optional)} "
-        f"enumerated guarded edge(s))")
+        f"({len(model_free)} of {len(roots)} declared root(s), {len(free)} "
+        f"gen_worker modules in the closure, {len(libraries)} libraries "
+        f"absent, {len(optional)} enumerated guarded edge(s))")
+    print(
+        f"pgw#1331: the model-bearing ledger is exact ({len(bearing)} root(s) "
+        f"named as still reaching a model library, every one of them verified "
+        f"to still reach one — the list only shrinks)")
     return 0
 
 

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -12,112 +12,317 @@ resolution) via plain inheritance. It is the ONLY producer context: every
 ``@job`` body and every producer-shaped ``@endpoint`` handler receives one,
 and what a body may write comes from its declaration (``publishes`` /
 ``emits_media``), never from its kind.
+
+
+THE PACKAGE INDEX IS LAZY, AND THAT IS A SERVE-PATH GUARANTEE (pgw#1331)
+-------------------------------------------------------------------------
+Every ``import gen_worker.anything`` executes this file. With an eager block
+of re-exports that meant importing a graph binding — on an adopt-only pod that
+will never register an endpoint, never load a checkpoint and cannot compile —
+executed ``view``, ``models.provision``, ``models.loading``, ``api.streaming``
+and the rest of the EAGER-CAPABLE worker's guts, all of which name a model
+library inside a function. The serve role could not be asserted model-free
+while its own package root dragged them in.
+
+PEP 562 breaks that: importing this package costs nothing, and asking for a
+name costs exactly the one submodule that defines it. The author surface is
+byte-identical — ``from gen_worker import endpoint`` still works, and so does
+``gen_worker.endpoint`` — because ``__getattr__`` resolves through the same
+table the eager block used to spell out. ``if TYPE_CHECKING`` keeps the eager
+spelling for type checkers, which never execute it.
+
+``scripts/lint_serve_role_closure.py`` is what holds this: with the eager block
+back, the whole serve role reaches ``diffusers``/``transformers`` and the fence
+names the modules. ``gen_worker.model``'s own ``__init__`` is the same shape
+for the same reason, one layer down.
 """
 
-from . import io
-from .api.binding import Binding, Civitai, HF, Hub, ModelRef, ModelScope
-from .api.compile_axis import AxisClass, CompileAxis
-from .api.decorators import (
-    Compile,
-    ConfigParam,
-    DynamicDim,
-    NoWarmup,
-    Resources,
-    endpoint,
-    variant_of,
-    worker_function,
-    AcceptsReferences,
-)
-from .api.export_contract import (
-    Arg,
-    Dim,
-    Fork,
-    GraphClass,
-    Input,
-    MintBlocker,
-    import_export_declaration,
-    register_export_declaration,
-)
-from .api.derive import (
-    DeclarationMismatch,
-    assert_blockers,
-    assert_faithful,
-    cfg_image_classes,
-    class_set_delta,
-    contract_delta,
-    override_delta,
-)
-from .api.formula import RuntimeFormula
-from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot, resolve_slot
-from .families import GenerationDefaults
-from .models.tensor_layout_contract import (
-    LayoutDeclarationError, LayoutRequirements, RequirementTerms,
-)
-from .models.provision import (arm_compile, report_applied_attention,
-                               report_applied_lane, report_attention_backend)
-from .text_pin import TextLengthExceededError, pad_text_sequence
-from .geometry import (
-    FamilyGeometry,
-    FitMode,
-    FitPlan,
-    OutputSize,
-    RestoreResult,
-    fit_to_native,
-    nearest_bucket,
-    restore,
-    set_upscaler,
-)
-from .url_fetch import FetchedUrl, fetch_bytes
-from .view import for_request
-from .api.errors import (
-    AuthError,
-    CanceledError,
-    ChildCallError,
-    ChildCallRefusedError,
-    ChildCallTimeoutError,
-    ChildRequestCanceledError,
-    ChildRequestFailedError,
-    FatalError,
-    IllegalCombination,
-    OutputTooLargeError,
-    RefCompatibilitySurprise,
-    ResourceError,
-    RetryableError,
-    SnapshotBuildFailedError,
-    ValidationError,
-    WorkerError,
-)
-from .hub_error import HubApiError, HubError, parse_hub_error, raise_for_hub_error
-from .callout import ChildRequest
-from .api.progress import diffusers_step_callback
-from .api.streaming import (
-    BatchItemDelta,
-    Done,
-    Error,
-    IncrementalTokenDelta,
-    StreamItem,
-    StreamResult,
-    TokenUsage,
-    iter_transformers_text_deltas,
-)
-from .api.types import (
-    Asset,
-    AudioAsset,
-    ExpectedOutput,
-    ImageAsset,
-    MediaAsset,
-    PromptRole,
-    StringEnum,
-    Tensors,
-    VideoAsset,
-)
-from .request_context import (
-    JobContext,
-    RequestContext,
-    TrainingMetric,
-)
-from .api.jobs import job
-from .subproc import ProcessStalledError, run_process
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers only
+    from . import io
+    from .api.binding import (
+        Binding,
+        Civitai,
+        HF,
+        Hub,
+        ModelRef,
+        ModelScope,
+    )
+    from .api.compile_axis import (
+        AxisClass,
+        CompileAxis,
+    )
+    from .api.decorators import (
+        AcceptsReferences,
+        Compile,
+        ConfigParam,
+        DynamicDim,
+        NoWarmup,
+        Resources,
+        endpoint,
+        variant_of,
+        worker_function,
+    )
+    from .api.derive import (
+        DeclarationMismatch,
+        assert_blockers,
+        assert_faithful,
+        cfg_image_classes,
+        class_set_delta,
+        contract_delta,
+        override_delta,
+    )
+    from .api.errors import (
+        AuthError,
+        CanceledError,
+        ChildCallError,
+        ChildCallRefusedError,
+        ChildCallTimeoutError,
+        ChildRequestCanceledError,
+        ChildRequestFailedError,
+        FatalError,
+        IllegalCombination,
+        OutputTooLargeError,
+        RefCompatibilitySurprise,
+        ResourceError,
+        RetryableError,
+        SnapshotBuildFailedError,
+        ValidationError,
+        WorkerError,
+    )
+    from .api.export_contract import (
+        Arg,
+        Dim,
+        Fork,
+        GraphClass,
+        Input,
+        MintBlocker,
+        import_export_declaration,
+        register_export_declaration,
+    )
+    from .api.formula import (
+        RuntimeFormula,
+    )
+    from .api.jobs import (
+        job,
+    )
+    from .api.progress import (
+        diffusers_step_callback,
+    )
+    from .api.slot import (
+        OBJECTIVES,
+        ObjectiveMismatchError,
+        ResolvedSlot,
+        Slot,
+        resolve_slot,
+    )
+    from .api.streaming import (
+        BatchItemDelta,
+        Done,
+        Error,
+        IncrementalTokenDelta,
+        StreamItem,
+        StreamResult,
+        TokenUsage,
+        iter_transformers_text_deltas,
+    )
+    from .api.types import (
+        Asset,
+        AudioAsset,
+        ExpectedOutput,
+        ImageAsset,
+        MediaAsset,
+        PromptRole,
+        StringEnum,
+        Tensors,
+        VideoAsset,
+    )
+    from .callout import (
+        ChildRequest,
+    )
+    from .families import (
+        GenerationDefaults,
+    )
+    from .geometry import (
+        FamilyGeometry,
+        FitMode,
+        FitPlan,
+        OutputSize,
+        RestoreResult,
+        fit_to_native,
+        nearest_bucket,
+        restore,
+        set_upscaler,
+    )
+    from .hub_error import (
+        HubApiError,
+        HubError,
+        parse_hub_error,
+        raise_for_hub_error,
+    )
+    from .models.provision import (
+        arm_compile,
+        report_applied_attention,
+        report_applied_lane,
+        report_attention_backend,
+    )
+    from .models.tensor_layout_contract import (
+        LayoutDeclarationError,
+        LayoutRequirements,
+        RequirementTerms,
+    )
+    from .request_context import (
+        JobContext,
+        RequestContext,
+        TrainingMetric,
+    )
+    from .subproc import (
+        ProcessStalledError,
+        run_process,
+    )
+    from .text_pin import (
+        TextLengthExceededError,
+        pad_text_sequence,
+    )
+    from .url_fetch import (
+        FetchedUrl,
+        fetch_bytes,
+    )
+    from .view import (
+        for_request,
+    )
+
+#: Every submodule re-exported as a MODULE rather than as a name in one.
+_SUBMODULES: Final[tuple[str, ...]] = ("io",)
+
+#: Exported name -> the submodule that defines it. THE package index, and the
+#: reason it exists instead of a block of eager imports. The eager block is
+#: reproduced verbatim under ``if TYPE_CHECKING`` above, so the two cannot say
+#: different things without mypy noticing.
+_EXPORTS: Final[dict[str, str]] = {
+    "AcceptsReferences": "api.decorators",
+    "Arg": "api.export_contract",
+    "Asset": "api.types",
+    "AudioAsset": "api.types",
+    "AuthError": "api.errors",
+    "AxisClass": "api.compile_axis",
+    "BatchItemDelta": "api.streaming",
+    "Binding": "api.binding",
+    "CanceledError": "api.errors",
+    "ChildCallError": "api.errors",
+    "ChildCallRefusedError": "api.errors",
+    "ChildCallTimeoutError": "api.errors",
+    "ChildRequest": "callout",
+    "ChildRequestCanceledError": "api.errors",
+    "ChildRequestFailedError": "api.errors",
+    "Civitai": "api.binding",
+    "Compile": "api.decorators",
+    "CompileAxis": "api.compile_axis",
+    "ConfigParam": "api.decorators",
+    "DeclarationMismatch": "api.derive",
+    "Dim": "api.export_contract",
+    "Done": "api.streaming",
+    "DynamicDim": "api.decorators",
+    "Error": "api.streaming",
+    "ExpectedOutput": "api.types",
+    "FamilyGeometry": "geometry",
+    "FatalError": "api.errors",
+    "FetchedUrl": "url_fetch",
+    "FitMode": "geometry",
+    "FitPlan": "geometry",
+    "Fork": "api.export_contract",
+    "GenerationDefaults": "families",
+    "GraphClass": "api.export_contract",
+    "HF": "api.binding",
+    "Hub": "api.binding",
+    "HubApiError": "hub_error",
+    "HubError": "hub_error",
+    "IllegalCombination": "api.errors",
+    "ImageAsset": "api.types",
+    "IncrementalTokenDelta": "api.streaming",
+    "Input": "api.export_contract",
+    "JobContext": "request_context",
+    "LayoutDeclarationError": "models.tensor_layout_contract",
+    "LayoutRequirements": "models.tensor_layout_contract",
+    "MediaAsset": "api.types",
+    "MintBlocker": "api.export_contract",
+    "ModelRef": "api.binding",
+    "ModelScope": "api.binding",
+    "NoWarmup": "api.decorators",
+    "OBJECTIVES": "api.slot",
+    "ObjectiveMismatchError": "api.slot",
+    "OutputSize": "geometry",
+    "OutputTooLargeError": "api.errors",
+    "ProcessStalledError": "subproc",
+    "PromptRole": "api.types",
+    "RefCompatibilitySurprise": "api.errors",
+    "RequestContext": "request_context",
+    "RequirementTerms": "models.tensor_layout_contract",
+    "ResolvedSlot": "api.slot",
+    "ResourceError": "api.errors",
+    "Resources": "api.decorators",
+    "RestoreResult": "geometry",
+    "RetryableError": "api.errors",
+    "RuntimeFormula": "api.formula",
+    "Slot": "api.slot",
+    "SnapshotBuildFailedError": "api.errors",
+    "StreamItem": "api.streaming",
+    "StreamResult": "api.streaming",
+    "StringEnum": "api.types",
+    "Tensors": "api.types",
+    "TextLengthExceededError": "text_pin",
+    "TokenUsage": "api.streaming",
+    "TrainingMetric": "request_context",
+    "ValidationError": "api.errors",
+    "VideoAsset": "api.types",
+    "WorkerError": "api.errors",
+    "arm_compile": "models.provision",
+    "assert_blockers": "api.derive",
+    "assert_faithful": "api.derive",
+    "cfg_image_classes": "api.derive",
+    "class_set_delta": "api.derive",
+    "contract_delta": "api.derive",
+    "diffusers_step_callback": "api.progress",
+    "endpoint": "api.decorators",
+    "fetch_bytes": "url_fetch",
+    "fit_to_native": "geometry",
+    "for_request": "view",
+    "import_export_declaration": "api.export_contract",
+    "iter_transformers_text_deltas": "api.streaming",
+    "job": "api.jobs",
+    "nearest_bucket": "geometry",
+    "override_delta": "api.derive",
+    "pad_text_sequence": "text_pin",
+    "parse_hub_error": "hub_error",
+    "raise_for_hub_error": "hub_error",
+    "register_export_declaration": "api.export_contract",
+    "report_applied_attention": "models.provision",
+    "report_applied_lane": "models.provision",
+    "report_attention_backend": "models.provision",
+    "resolve_slot": "api.slot",
+    "restore": "geometry",
+    "run_process": "subproc",
+    "set_upscaler": "geometry",
+    "variant_of": "api.decorators",
+    "worker_function": "api.decorators",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SUBMODULES:
+        return import_module(f"{__name__}.{name}")
+    module = _EXPORTS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(import_module(f"{__name__}.{module}"), name)
+
+
+def __dir__() -> list[str]:
+    return sorted((*_EXPORTS, *_SUBMODULES))
 
 
 __all__ = [

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -90,6 +90,17 @@ from . import (
     serve_posture, settings_authority,
 )
 from .api.errors import FatalError, RetryableError
+# pgw#1331: the READ half of this module — the marker readers and the toolchain
+# probe — lives in `compile_facts`, which imports nothing above `hostfacts`.
+# Re-exported here (not re-implemented) so `compile_cache.runtime_key` is that
+# one function and every caller, and every test that monkeypatches it on this
+# module, is unaffected. Writing the marker is still this module's alone.
+from .compile_facts import (
+    MARKER_ATTR,
+    is_compile_armed,
+    runtime_key,
+    sku_slug,
+)
 from .models import w8a8_lora
 from .models.loading import pipeline_weight_lane
 from .models.memory import low_vram_mode
@@ -118,7 +129,10 @@ logger = logging.getLogger(__name__)
 # schema without gratuitously invalidating proven non-W8A8 cells. New W8A8
 # consumers require those fields; checkpoint bytes remain deliberately absent.
 SEMANTIC_TAG_FORMAT = 2
-_MARKER_ATTR = "_cozy_compile"
+#: The marker's one definition is `compile_facts.MARKER_ATTR`; this is the
+#: private spelling four existing readers already use. An alias assignment,
+#: not a second literal.
+_MARKER_ATTR = MARKER_ATTR
 _LOCK_TYPE = type(threading.Lock())
 
 # ---------------------------------------------------------------------------
@@ -643,56 +657,6 @@ def _record_guard_miss(
 # pgw#1034 had already ruled the two sets deliberately different. The cell key's
 # axes are `torchcg.REQUIRED_AXES`; this module's job is `runtime_key()`,
 # the ONE probe that states them.
-
-
-def sku_slug(gpu_name: str) -> str:
-    """Deterministic SKU slug: ``NVIDIA GeForce RTX 4090`` -> ``rtx-4090``,
-    ``NVIDIA H100 80GB HBM3`` -> ``h100-80gb-hbm3``."""
-    s = str(gpu_name or "").lower()
-    for noise in ("nvidia", "geforce"):
-        s = s.replace(noise, " ")
-    out = "".join(c if c.isalnum() else "-" for c in s).strip("-")
-    while "--" in out:
-        out = out.replace("--", "-")
-    return out
-
-
-def runtime_key() -> Dict[str, str]:
-    """The consumer-side half of the cache key, probed from this process.
-
-    pgw#1034: no ``cuda_driver``. gw#577 ruled it a host-lottery axis and took
-    it out of every key and every gate; what was left was a fact nothing read,
-    bought with a ``libcuda.so.1`` dlopen and a ``cuInit(0)`` on each call —
-    and this function is called per ``verify()``, not once.
-    """
-    key = {
-        "sku": "", "sm": "", "torch": "", "triton": "", "cuda": "",
-        "image_digest": os.environ.get("WORKER_IMAGE_DIGEST", "").strip(),
-    }
-    try:
-        import torch
-
-        key["torch"] = str(torch.__version__)
-        key["cuda"] = str(torch.version.cuda or "")
-        if cuda_ready():
-            key["sku"] = sku_slug(torch.cuda.get_device_name(0))
-            major, minor = torch.cuda.get_device_capability(0)
-            key["sm"] = f"sm_{major}{minor}"
-    except Exception:
-        # pgw#657: silently leaving these EMPTY manufactures a different cell
-        # key than every healthy pod computes — i.e. a guaranteed cache miss
-        # (and a mint) whose cause is invisible. Say it.
-        logger.warning(
-            "compile-cache: torch/CUDA runtime-key probe failed — cell identity "
-            "falls back to empty sku/sm/torch fields; expect a cache MISS",
-            exc_info=True)
-    try:
-        import triton
-
-        key["triton"] = str(triton.__version__)
-    except Exception:
-        logger.debug("compile-cache: triton version unavailable", exc_info=True)
-    return key
 
 
 def compile_target_block() -> str:
@@ -2791,68 +2755,6 @@ def cache_hit_count(pipeline: Any) -> int:
 def cache_miss_count(pipeline: Any) -> int:
     """FX-graph cache misses observed inside this exact pipeline's guard."""
     return _proof_count(pipeline, "cache_misses")
-
-
-def is_compile_armed(pipeline: Any) -> bool:
-    """True when this pipeline is serving COMPILED code right now.
-
-    pgw#1010: the JIT INTAKE arm names no artifact, so ``active_compile_ref``
-    is empty for a pipeline that is nonetheless serving compiled code. This is
-    the fact that separates it from true eager, and ``serving_mode`` reads it
-    per request — hence the cheap attribute probe rather than a target walk.
-
-    A guard that permanently degraded this target to eager (``_guarded``'s
-    fallback) clears the answer even though the wrapper is still installed:
-    reporting a degraded pipeline as compiled is the same lie as reporting an
-    unproven cell as adopted.
-    """
-    marker = getattr(pipeline, _MARKER_ATTR, None)
-    if marker is None:
-        return False
-    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
-    if isinstance(signal, dict) and signal.get("degraded"):
-        return False
-    return True
-
-
-def graph_break_reason(pipeline: Any) -> str:
-    """Torch's verbatim fullgraph refusal for this pipeline, or "".
-
-    Non-empty means the declared region did not trace whole and this process
-    permanently degraded it to eager. The executor turns it into the
-    ``graph_break`` eager posture, so every request the pod serves afterwards
-    names the real cause instead of an empty ``fallback_reason``."""
-    marker = getattr(pipeline, _MARKER_ATTR, None)
-    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
-    if isinstance(signal, dict):
-        return str(signal.get("graph_break") or "")
-    return ""
-
-
-def degrade_reason(pipeline: Any) -> str:
-    """pgw#1093: why this ARMED pipeline is permanently eager, or "".
-
-    Non-empty means `apply()` DID install the compiled callables and a served
-    call then failed permanently. That is a different fact from "no target
-    was ever installed", and before this the two were the same reading:
-    `is_compile_armed` False, `metrics.lane=…+eager`,
-    `fallback_reason=uncompiled`. The executor turns this into a
-    `compiled_degraded` eager posture so the distinction survives to the wire.
-    """
-    marker = getattr(pipeline, _MARKER_ATTR, None)
-    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
-    if isinstance(signal, dict):
-        return str(signal.get("degrade_reason") or "")
-    return ""
-
-
-def declared_range_refusal(pipeline: Any) -> str:
-    """The typed declared-range refusal for this pipeline, or ""."""
-    marker = getattr(pipeline, _MARKER_ATTR, None)
-    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
-    if isinstance(signal, dict):
-        return str(signal.get("declared_range_exceeded") or "")
-    return ""
 
 
 def unwrap(pipeline: Any) -> bool:

--- a/src/gen_worker/compile_facts.py
+++ b/src/gen_worker/compile_facts.py
@@ -1,0 +1,157 @@
+"""pgw#1331: the compile facts a SERVING process reads, with nothing behind them.
+
+``serving_mode`` answers "what actually served this request" and its own
+docstring promises it is *"deliberately duck-typed and free of executor
+internals so it can be unit-tested without a pipeline, a GPU, or a hub"*. It
+was not: it imported :mod:`gen_worker.compile_cache` — 3,100 lines of the
+EAGER-CAPABLE arming brain — to read two things, a marker attribute and a
+version probe. ``compile_cache`` imports ``models.loading`` / ``models.memory``
+/ ``models.w8a8_lora``, which construct diffusers and transformers objects
+inside their functions and are entitled to, so the whole adopt-only serve role
+inherited a model library through a per-request REPORTING module.
+
+So the facts live here and the machinery stays there. This module reads a
+marker somebody else wrote and probes the toolchain it is running on. It holds
+no state, arms nothing, and imports nothing above ``hostfacts`` — which is what
+lets ``gen_worker.serve.role.MODEL_FREE_MODULES`` name the whole role rather
+than a surface inside it.
+
+**There is one definition of each name, not two.** ``compile_cache`` imports
+``runtime_key`` / ``sku_slug`` / ``is_compile_armed`` from here and re-exports
+them, so ``compile_cache.runtime_key`` IS this function and every existing
+caller — and every test that monkeypatches it on ``compile_cache`` — is
+unaffected. The other three readers have no re-export at all: their one caller
+(``executor``) asks this module directly. Writing the marker is still
+``compile_cache``'s alone; this side only ever reads.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from .hostfacts import cuda_ready
+
+logger = logging.getLogger(__name__)
+
+#: The attribute ``compile_cache.apply()`` stamps onto an armed pipeline. The
+#: readers below are the whole of what a serving process needs from it.
+MARKER_ATTR = "_cozy_compile"
+
+
+def sku_slug(gpu_name: str) -> str:
+    """Deterministic SKU slug: ``NVIDIA GeForce RTX 4090`` -> ``rtx-4090``,
+    ``NVIDIA H100 80GB HBM3`` -> ``h100-80gb-hbm3``."""
+    s = str(gpu_name or "").lower()
+    for noise in ("nvidia", "geforce"):
+        s = s.replace(noise, " ")
+    out = "".join(c if c.isalnum() else "-" for c in s).strip("-")
+    while "--" in out:
+        out = out.replace("--", "-")
+    return out
+
+
+def runtime_key() -> Dict[str, str]:
+    """The consumer-side half of the cache key, probed from this process.
+
+    pgw#1034: no ``cuda_driver``. gw#577 ruled it a host-lottery axis and took
+    it out of every key and every gate; what was left was a fact nothing read,
+    bought with a ``libcuda.so.1`` dlopen and a ``cuInit(0)`` on each call —
+    and this function is called per ``verify()``, not once.
+    """
+    key = {
+        "sku": "", "sm": "", "torch": "", "triton": "", "cuda": "",
+        "image_digest": os.environ.get("WORKER_IMAGE_DIGEST", "").strip(),
+    }
+    try:
+        import torch
+
+        key["torch"] = str(torch.__version__)
+        key["cuda"] = str(torch.version.cuda or "")
+        if cuda_ready():
+            key["sku"] = sku_slug(torch.cuda.get_device_name(0))
+            major, minor = torch.cuda.get_device_capability(0)
+            key["sm"] = f"sm_{major}{minor}"
+    except Exception:
+        # pgw#657: silently leaving these EMPTY manufactures a different cell
+        # key than every healthy pod computes — i.e. a guaranteed cache miss
+        # (and a mint) whose cause is invisible. Say it.
+        logger.warning(
+            "compile-cache: torch/CUDA runtime-key probe failed — cell identity "
+            "falls back to empty sku/sm/torch fields; expect a cache MISS",
+            exc_info=True)
+    try:
+        import triton
+
+        key["triton"] = str(triton.__version__)
+    except Exception:
+        logger.debug("compile-cache: triton version unavailable", exc_info=True)
+    return key
+
+
+def _failure_signal(pipeline: Any) -> Dict[str, Any] | None:
+    marker = getattr(pipeline, MARKER_ATTR, None)
+    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
+    return signal if isinstance(signal, dict) else None
+
+
+def is_compile_armed(pipeline: Any) -> bool:
+    """True when this pipeline is serving COMPILED code right now.
+
+    pgw#1010: the JIT INTAKE arm names no artifact, so ``active_compile_ref``
+    is empty for a pipeline that is nonetheless serving compiled code. This is
+    the fact that separates it from true eager, and ``serving_mode`` reads it
+    per request — hence the cheap attribute probe rather than a target walk.
+
+    A guard that permanently degraded this target to eager (``_guarded``'s
+    fallback) clears the answer even though the wrapper is still installed:
+    reporting a degraded pipeline as compiled is the same lie as reporting an
+    unproven cell as adopted.
+    """
+    if getattr(pipeline, MARKER_ATTR, None) is None:
+        return False
+    signal = _failure_signal(pipeline)
+    return not (signal is not None and signal.get("degraded"))
+
+
+def graph_break_reason(pipeline: Any) -> str:
+    """Torch's verbatim fullgraph refusal for this pipeline, or "".
+
+    Non-empty means the declared region did not trace whole and this process
+    permanently degraded it to eager. The executor turns it into the
+    ``graph_break`` eager posture, so every request the pod serves afterwards
+    names the real cause instead of an empty ``fallback_reason``."""
+    signal = _failure_signal(pipeline)
+    return str(signal.get("graph_break") or "") if signal else ""
+
+
+def degrade_reason(pipeline: Any) -> str:
+    """pgw#1093: why this ARMED pipeline is permanently eager, or "".
+
+    Non-empty means `apply()` DID install the compiled callables and a served
+    call then failed permanently. That is a different fact from "no target
+    was ever installed", and before this the two were the same reading:
+    `is_compile_armed` False, `metrics.lane=…+eager`,
+    `fallback_reason=uncompiled`. The executor turns this into a
+    `compiled_degraded` eager posture so the distinction survives to the wire.
+    """
+    signal = _failure_signal(pipeline)
+    return str(signal.get("degrade_reason") or "") if signal else ""
+
+
+def declared_range_refusal(pipeline: Any) -> str:
+    """The typed declared-range refusal for this pipeline, or ""."""
+    signal = _failure_signal(pipeline)
+    return str(signal.get("declared_range_exceeded") or "") if signal else ""
+
+
+__all__ = [
+    "MARKER_ATTR",
+    "declared_range_refusal",
+    "degrade_reason",
+    "graph_break_reason",
+    "is_compile_armed",
+    "runtime_key",
+    "sku_slug",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -153,6 +153,10 @@ import inspect as _inspect
 import struct as _struct
 from .models.refs import parse_model_ref
 from . import compile_cache
+# pgw#1331: the marker READERS live beside the marker's definition in
+# `compile_facts`, which imports nothing above `hostfacts`. Read from there,
+# not through `compile_cache`'s re-export, so the fact and its home agree.
+from . import compile_facts
 from .models.loading import (
     is_modular_pipeline_class,
     plan_streamed_hydration,
@@ -2718,8 +2722,8 @@ class Executor:
         # arm names no artifact by construction (pgw#1010), so that gate
         # returns early for exactly the lane this defect lives on — and the
         # graph-broken pod would keep reporting an empty `fallback_reason`.
-        broke = compile_cache.graph_break_reason(target.pipeline)
-        out_of_range = compile_cache.declared_range_refusal(target.pipeline)
+        broke = compile_facts.graph_break_reason(target.pipeline)
+        out_of_range = compile_facts.declared_range_refusal(target.pipeline)
         if broke:
             self._note_eager_posture(
                 rec, cell_adopt.EagerPhase.GRAPH_BREAK.value,
@@ -3015,9 +3019,9 @@ class Executor:
         falls through to the generic `uncompiled`. This reads the reason
         straight off the pipeline's own failure signal instead.
         """
-        broke = compile_cache.graph_break_reason(pipeline)
-        out_of_range = compile_cache.declared_range_refusal(pipeline)
-        reason = compile_cache.degrade_reason(pipeline)
+        broke = compile_facts.graph_break_reason(pipeline)
+        out_of_range = compile_facts.declared_range_refusal(pipeline)
+        reason = compile_facts.degrade_reason(pipeline)
         if broke:
             self._note_eager_posture(
                 rec, cell_adopt.EagerPhase.GRAPH_BREAK.value,
@@ -3062,7 +3066,7 @@ class Executor:
             f"{type(p).__name__} armed={compile_cache.is_compile_armed(p)} "
             f"targets_resolve="
             f"{compile_cache.has_compile_target(p, spec.compile_cell())} "
-            f"degrade={compile_cache.degrade_reason(p) or '-'}"
+            f"degrade={compile_facts.degrade_reason(p) or '-'}"
             for p in orphans
         )
         logger.error(
@@ -4097,7 +4101,7 @@ class Executor:
         # identically to a never-installed one. Live, because a degrade can
         # land after boot on a target whose guard callback was never bound.
         for target in rec.compile_targets.values():
-            if compile_cache.degrade_reason(target.pipeline):
+            if compile_facts.degrade_reason(target.pipeline):
                 return cell_adopt.EagerPhase.COMPILED_DEGRADED.value
         if not any(
             s.compile is not None and s.compile.family for s in rec.specs

--- a/src/gen_worker/models/__init__.py
+++ b/src/gen_worker/models/__init__.py
@@ -1,34 +1,91 @@
-"""Models layer: refs, download (ensure_local), memory decisions, residency."""
+"""Models layer: refs, download (ensure_local), memory decisions, residency.
 
-from .cache_paths import (
-    tensorhub_cache_dir,
-    tensorhub_cas_dir,
-)
-from .download import (
-    build_provider_index_from_manifest,
-    ensure_local,
-    lookup_provider_for_ref,
-    set_provider_index,
-)
-from .refs import (
-    HuggingFaceRef,
-    ParsedModelRef,
-    TensorhubRef,
-    WireRef,
-    RefFragmentRemoved,
-    RetiredTagRef,
-    fold_ref,
-    format_model_ref,
-    normalize_model_ref,
-    parse_model_ref,
-    refuse_ref_fragment,
-)
-from .residency import (
-    LoadedComponentKey,
-    content_set_digest,
-    Residency,
-    Tier,
-)
+**The package index is LAZY, and that is a serve-path guarantee (pgw#1331).**
+This file used to eagerly re-export ``residency``, which imports ``loading``,
+which constructs diffusers and transformers objects. So *any* ``from .models
+import x`` — ``aot_serve`` asking for ``lora_lifted``, ``aot_constants``'
+tensor reader asking for a header parser — executed the whole eager weight
+loader, and the adopt-only serve role could not be asserted model-free through
+a package root it never wanted. PEP 562: importing this package costs nothing,
+and asking for a name costs exactly the one submodule that defines it. Same
+shape as ``gen_worker/__init__`` and ``gen_worker/model/__init__``, same
+reason.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers only
+    from .cache_paths import (
+        tensorhub_cache_dir,
+        tensorhub_cas_dir,
+    )
+    from .download import (
+        build_provider_index_from_manifest,
+        ensure_local,
+        lookup_provider_for_ref,
+        set_provider_index,
+    )
+    from .refs import (
+        HuggingFaceRef,
+        ParsedModelRef,
+        TensorhubRef,
+        WireRef,
+        RefFragmentRemoved,
+        RetiredTagRef,
+        fold_ref,
+        format_model_ref,
+        normalize_model_ref,
+        parse_model_ref,
+        refuse_ref_fragment,
+    )
+    from .residency import (
+        LoadedComponentKey,
+        content_set_digest,
+        Residency,
+        Tier,
+    )
+
+#: Exported name -> the submodule that defines it. The eager import block it
+#: replaces is reproduced verbatim under ``if TYPE_CHECKING`` above, so the two
+#: cannot say different things without mypy noticing.
+_EXPORTS: Final[dict[str, str]] = {
+    "HuggingFaceRef": "refs",
+    "LoadedComponentKey": "residency",
+    "ParsedModelRef": "refs",
+    "RefFragmentRemoved": "refs",
+    "Residency": "residency",
+    "RetiredTagRef": "refs",
+    "TensorhubRef": "refs",
+    "Tier": "residency",
+    "WireRef": "refs",
+    "build_provider_index_from_manifest": "download",
+    "content_set_digest": "residency",
+    "ensure_local": "download",
+    "fold_ref": "refs",
+    "format_model_ref": "refs",
+    "lookup_provider_for_ref": "download",
+    "normalize_model_ref": "refs",
+    "parse_model_ref": "refs",
+    "refuse_ref_fragment": "refs",
+    "set_provider_index": "download",
+    "tensorhub_cache_dir": "cache_paths",
+    "tensorhub_cas_dir": "cache_paths",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module = _EXPORTS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(import_module(f"{__name__}.{module}"), name)
+
+
+def __dir__() -> list[str]:
+    return sorted(_EXPORTS)
+
 
 __all__ = [
     "tensorhub_cache_dir",

--- a/src/gen_worker/serve/role.py
+++ b/src/gen_worker/serve/role.py
@@ -20,8 +20,9 @@ wire role this one refines — and it is declared ONCE, before anything imports.
 THE MODULE SETS, AND WHY THEY LIVE HERE
 ---------------------------------------
 :data:`SERVE_ROLE_MODULES`, :data:`MINT_MACHINERY`, :data:`MODEL_FREE_MODULES`,
-:data:`FORBIDDEN_LIBRARIES` and :data:`OPTIONAL_SERVE_IMPORTS` are read by THREE
-consumers: the runtime blocker (:mod:`gen_worker.serve.guard`), the CI fence
+:data:`MODEL_BEARING_SERVE_MODULES`, :data:`FORBIDDEN_LIBRARIES` and
+:data:`OPTIONAL_SERVE_IMPORTS` are read by THREE consumers: the runtime blocker
+(:mod:`gen_worker.serve.guard`), the CI fence
 (``scripts/lint_serve_role_closure.py``) and the tests. pgw#1176's measured
 lesson is that a fence naming symbols in its own string literals rots silently,
 and pgw#824's is that two lists of the same literals drift. So the role's own
@@ -29,9 +30,11 @@ module declares them and everything else — including the fence, which parses
 this file — reads them from here. There is one list.
 
 Two claims, two scopes, because they are not the same claim (pgw#1331). Every
-serve-role module is asserted MINT-FREE. The family surface named in
-``MODEL_FREE_MODULES`` is additionally asserted to reach no MODEL LIBRARY —
-that subset, and not the whole role, for the reason recorded on the tuple.
+serve-role module is asserted MINT-FREE. Each is ALSO either asserted to reach
+no MODEL LIBRARY (``MODEL_FREE_MODULES``, 33 roots) or named as still reaching
+one (``MODEL_BEARING_SERVE_MODULES``, 9) — and the second list is checked to be
+TRUE, so a module that gets cut free must be moved rather than left sitting in
+an exception list nobody re-reads. The role is the union, by splice.
 
 ``SERVE_ROLE_MODULES`` is a CLAIM, not a description: every name in it is a
 module the adopt-only path executes, asserted to be unable to reach anything in
@@ -72,22 +75,47 @@ class ServeRole(StrEnum):
     ADOPT_ONLY = "adopt_only"
 
 
-#: The subset of :data:`SERVE_ROLE_MODULES` that must reach NO model library —
-#: the typed family surface a request is actually served through (pgw#1331).
+#: Every serve-role module whose whole static closure reaches NO model library
+#: (pgw#1331). 33 of the role's 42 roots; the other nine are named, with their
+#: two causes, in :data:`MODEL_BEARING_SERVE_MODULES` directly below.
 #:
-#: **Why this is a subset and not the whole role, stated rather than hidden.**
-#: Every ``gen_worker`` import executes ``gen_worker/__init__.py``, and that
-#: package reaches ``models.loading`` / ``models.memory`` / ``view`` — the
-#: EAGER-CAPABLE worker's own guts, which import diffusers inside functions and
-#: legitimately need to, because an eager-capable pod serves eager on a miss
-#: (§4.28). Those imports never EXECUTE on an adopt-only pod, which is what
-#: :mod:`gen_worker.serve.guard` and pgw#1331's subprocess proof assert at run
-#: time. What a static walk can prove today is the property for the surface
-#: pgw#1331 built, and claiming more than that would be a fence describing a
-#: tree nobody has cut. **Owed, and named here so it is not rediscovered:**
-#: making the whole role statically model-free means making
-#: ``gen_worker/__init__`` lazy the way this package's own ``__init__`` now is.
+#: This used to be 14 — the typed family surface alone — because two PACKAGE
+#: ROOTS dragged the eager-capable worker's guts into every closure that named
+#: them. ``gen_worker/__init__`` eagerly re-exported ``view`` and
+#: ``models.provision``; ``gen_worker/models/__init__`` eagerly re-exported
+#: ``residency`` and through it ``loading``. Both are PEP 562 lazy now, so
+#: importing a package costs nothing and asking for a name costs exactly the
+#: submodule that defines it. ``serving_mode`` separately stopped importing
+#: ``compile_cache`` — 3,100 lines of arming brain — to read two facts, which
+#: now live in :mod:`gen_worker.compile_facts`.
 MODEL_FREE_MODULES: Tuple[str, ...] = (
+    # The role itself.
+    "gen_worker.serve",
+    "gen_worker.serve.guard",
+    "gen_worker.serve.mint_seam",
+    "gen_worker.serve.refusal",
+    "gen_worker.serve.role",
+    "gen_worker.serve.selection",
+    # §4.27 steps 1-3, the parts that state and materialize a key set.
+    "gen_worker.local_cell_store",
+    "gen_worker.keyset.document",
+    "gen_worker.keyset.identifiers",
+    # The arm's constants (pgw#1329) and the adopt outcome vocabulary.
+    "gen_worker.aot_constants",
+    "gen_worker.cell_adopt",
+    # The compile facts a serving process READS — the arm marker and the
+    # toolchain probe — with none of the machinery that writes them.
+    "gen_worker.compile_facts",
+    # The neutral dispatch order the wire head projects into, and the wire
+    # facts a refusal is reported as.
+    "gen_worker.activity",
+    "gen_worker.dispatch",
+    "gen_worker.process_role",
+    "gen_worker.serve_posture",
+    # pgw#1331: the typed family surface a request is actually SERVED through —
+    # the bindings, the backings behind them, the bare-math schedulers, and the
+    # catalog's serving halves. Roots, not incidental members: the claim this
+    # issue makes is that a Flux request runs end to end from here.
     "gen_worker.model",
     "gen_worker.model.backing",
     "gen_worker.model.errors",
@@ -108,50 +136,62 @@ MODEL_FREE_MODULES: Tuple[str, ...] = (
 )
 
 
+#: The serve-role modules that still reach a model library, and this is a
+#: LEDGER, not an allowlist: ``lint_serve_role_closure.py`` asserts every row
+#: really does reach one TODAY, so a row that gets fixed goes red until it is
+#: deleted. The list can only shrink. An owed cut written as prose rots
+#: (pgw#1176); written here it is checked on every PR.
+#:
+#: **Nine rows, TWO causes, and neither is a design question — both are moves
+#: too big to smuggle into the lane that measured them.**
+#:
+#: 1. **``compile_cache``, for seven of the nine.** It is the eager-capable
+#:    arming brain: it imports ``models.loading`` / ``models.memory`` /
+#:    ``models.w8a8_lora``, which construct diffusers and transformers objects
+#:    inside their functions and are entitled to, because an eager-capable pod
+#:    serves eager on a miss (§4.28). It is ALSO where the compile-cache
+#:    IDENTITY functions live — ``toolchain_digest``, ``content_keys``,
+#:    ``static_code_closure``, ``parse_cell_ref`` — and the key set folds a
+#:    cell key from those, so ``keyset.fold`` and ``keyset.closure`` import the
+#:    arming brain to do arithmetic and everything rooted at them inherits it
+#:    (``keyset``, ``keyset.boot``, ``keyset.store``, ``boot_adopt``;
+#:    ``cell_resolve`` reaches it through ``aot_delivery``). **The cut:** the
+#:    identity half of ``compile_cache`` moves out, the way its READ half
+#:    already did — :mod:`gen_worker.compile_facts` holds ``runtime_key`` and
+#:    the marker readers and imports nothing above ``hostfacts``.
+#: 2. **``aot_serve``'s three model-layer edges, for it and ``serving_mode``.**
+#:    ``models.memory`` (``is_cuda_oom``, a pure exception predicate that needs
+#:    no model library), ``compile_cache`` (four names, per cause 1) and
+#:    ``models.lora_lifted`` — which is the only one of the three that is a
+#:    real question rather than a move, because LoRA lifting genuinely belongs
+#:    to the eager model layer and the adopt-only arm's use of it has to be
+#:    read before it is relocated.
+MODEL_BEARING_SERVE_MODULES: Tuple[str, ...] = (
+    "gen_worker.boot_adopt",
+    "gen_worker.cell_resolve",
+    "gen_worker.keyset",
+    "gen_worker.keyset.boot",
+    "gen_worker.keyset.closure",
+    "gen_worker.keyset.fold",
+    "gen_worker.keyset.store",
+    "gen_worker.aot_serve",
+    "gen_worker.serving_mode",
+)
+
+
 #: Every module the ADOPT-ONLY serve path executes. The fence walks the
 #: transitive ``gen_worker`` import closure of these — function-local imports
 #: included, because a lazy ``from . import aot_mint`` inside a function is
 #: exactly the shape a re-coupling would take — and refuses any reach into
 #: :data:`MINT_MACHINERY`.
+#:
+#: Spliced from the two tuples above rather than retyped, so the model-free
+#: claim and the role are TOTAL by construction: every serve-role module is
+#: either asserted model-free or named as bearing one, and a module cannot fall
+#: out of both by being edited into a third list (pgw#824's drift rule).
 SERVE_ROLE_MODULES: Tuple[str, ...] = (
-    # The role itself.
-    "gen_worker.serve",
-    "gen_worker.serve.guard",
-    "gen_worker.serve.mint_seam",
-    "gen_worker.serve.refusal",
-    "gen_worker.serve.role",
-    "gen_worker.serve.selection",
-    # §4.27 steps 1-3: state the key set (as DATA since pgw#1327), ask this
-    # machine, ask the hub, materialize.
-    "gen_worker.boot_adopt",
-    "gen_worker.cell_resolve",
-    "gen_worker.local_cell_store",
-    "gen_worker.keyset",
-    "gen_worker.keyset.boot",
-    "gen_worker.keyset.closure",
-    "gen_worker.keyset.document",
-    "gen_worker.keyset.fold",
-    "gen_worker.keyset.identifiers",
-    "gen_worker.keyset.store",
-    # The arm (pgw#1329) and the dispatch it produces.
-    "gen_worker.aot_constants",
-    "gen_worker.aot_serve",
-    "gen_worker.cell_adopt",
-    # The neutral dispatch order the wire head projects into, and the wire
-    # facts a refusal is reported as.
-    "gen_worker.activity",
-    "gen_worker.dispatch",
-    "gen_worker.process_role",
-    "gen_worker.serve_posture",
-    "gen_worker.serving_mode",
-    # pgw#1331: the typed family surface a request is actually SERVED through —
-    # the bindings, the backings behind them, the bare-math schedulers, and the
-    # catalog's serving halves. Roots, not incidental members: the claim this
-    # issue makes is that a Flux request runs end to end from here, so it is
-    # also asserted mint-free, and a claim that is not a root is a claim
-    # nothing walks. They are ALSO the whole of MODEL_FREE_MODULES above,
-    # spliced rather than retyped so the two sets cannot drift (pgw#824).
     *MODEL_FREE_MODULES,
+    *MODEL_BEARING_SERVE_MODULES,
 )
 
 
@@ -260,6 +300,8 @@ def _reset_for_test(role: ServeRole = ServeRole.EAGER_CAPABLE) -> None:
 __all__ = [
     "FORBIDDEN_LIBRARIES",
     "MINT_MACHINERY",
+    "MODEL_BEARING_SERVE_MODULES",
+    "MODEL_FREE_MODULES",
     "OPTIONAL_SERVE_IMPORTS",
     "SERVE_ROLE_MODULES",
     "ServeRole",

--- a/src/gen_worker/serving_mode.py
+++ b/src/gen_worker/serving_mode.py
@@ -30,7 +30,12 @@ from functools import lru_cache
 from typing import Any, Optional, Tuple
 
 from . import aot_serve
-from . import compile_cache
+# pgw#1331: the two FACTS this module reads, not the 3,100-line arming brain
+# that also writes them. `compile_cache` imports `models.loading`/`memory`/
+# `w8a8_lora`, so importing it here put diffusers and transformers in the
+# adopt-only serve role's static closure — through a per-request REPORTING
+# module whose own docstring promises it needs no pipeline, GPU or hub.
+from . import compile_facts
 from . import serve_posture
 from .cell_adopt import EagerPhase
 
@@ -135,7 +140,7 @@ def classify_mode(active_compile_ref: str, pipeline: Any = None) -> str:
     """
     ref = str(active_compile_ref or "").strip()
     if not ref:
-        if pipeline is not None and compile_cache.is_compile_armed(pipeline):
+        if pipeline is not None and compile_facts.is_compile_armed(pipeline):
             return MODE_JIT_CELL
         return MODE_EAGER
     try:
@@ -165,7 +170,7 @@ def normalize_sm(raw: str) -> str:
 def detect_sm() -> str:
     """This device's compute capability, or "" when there is no CUDA device.
 
-    Reads ``compile_cache.runtime_key()`` — the same source the cell key is
+    Reads ``compile_facts.runtime_key()`` — the same source the cell key is
     built from, so a request's ``sm`` and the cell it ran is keyed by can never
     disagree.
 
@@ -176,7 +181,7 @@ def detect_sm() -> str:
     a cache with a staleness question. ``detect_sm.cache_clear()`` for tests.
     """
     try:
-        return normalize_sm(str(compile_cache.runtime_key().get("sm") or ""))
+        return normalize_sm(str(compile_facts.runtime_key().get("sm") or ""))
     except Exception:
         logger.debug("sm detection failed", exc_info=True)
         return ""

--- a/tests/test_armed_target_install_pgw1093.py
+++ b/tests/test_armed_target_install_pgw1093.py
@@ -52,6 +52,8 @@ from gen_worker import (
     worker_function,
 )
 from gen_worker import compile_cache as cc
+# pgw#1331: the marker READERS live beside the marker's definition.
+from gen_worker import compile_facts
 from gen_worker.executor import Executor
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
@@ -337,7 +339,7 @@ def test_a_boot_warmup_degrade_is_named_not_reported_as_uncompiled(
         )
         pipe = next(iter(rec.compile_targets.values())).pipeline
         assert cc.is_compile_armed(pipe) is False, "the guard degraded it"
-        assert "fa3 kernel refuses" in cc.degrade_reason(pipe)
+        assert "fa3 kernel refuses" in compile_facts.degrade_reason(pipe)
 
         assert rec.eager_posture == cell_adopt.EagerPhase.COMPILED_DEGRADED.value, (
             "0.98.0 leaves this EMPTY, so `_eager_posture` falls through to "

--- a/tests/test_flux_stage1_pgw1331.py
+++ b/tests/test_flux_stage1_pgw1331.py
@@ -745,3 +745,190 @@ def test_mint_family_packs_one_artifact_per_declared_variant(
         {"resolution": 1024},
     ]
     family_mint.assert_matches_export(minted, Flux1Dev.EXPORT)
+
+
+# ------------------------------------------------- the WHOLE role, not a surface
+#
+# pgw#1331's owed row 3, closed as far as it honestly goes and DECLARED for the
+# rest. The model-free claim covered 14 roots — the family surface — because two
+# package roots dragged the eager-capable worker's guts into any closure that
+# named them. Both are PEP 562 lazy now and the claim covers 30 of 39; the nine
+# that remain are a CHECKED ledger, not prose.
+
+
+def test_the_package_roots_execute_no_imports_at_all() -> None:
+    """``gen_worker`` and ``gen_worker.models`` import nothing when imported.
+
+    This is the property, stated where a reader can check it: the whole cut is
+    that executing a package root costs nothing. An eager re-export block would
+    show up here as a non-empty required set, one step before the fence reports
+    the ten modules it drags in.
+    """
+
+    fence = _fence()
+    for module in ("gen_worker", "gen_worker.models"):
+        path = fence._module_path(module)
+        assert path is not None
+        required, guarded, libraries = fence._imports(path, module)
+        assert required == set(), f"{module} imports {sorted(required)} at module scope"
+        assert guarded == set()
+        # `importlib` and `typing` only — nothing that costs anything.
+        assert libraries <= {"importlib", "typing", "__future__"}, sorted(libraries)
+
+
+@pytest.mark.parametrize("package", ["gen_worker", "gen_worker.models"])
+def test_the_lazy_package_index_resolves_every_name_it_promises(package: str) -> None:
+    """PEP 562 that cannot produce a name is a rename waiting to be found in prod.
+
+    ``__all__`` is the promise; ``__getattr__`` is what keeps it. A missing row
+    in the table raises AttributeError at the call site of a consumer we do not
+    own, which is the one failure mode this shape can introduce.
+    """
+
+    import importlib
+
+    module = importlib.import_module(package)
+    for name in module.__all__:
+        assert getattr(module, name) is not None, f"{package}.{name} does not resolve"
+    assert set(module.__all__) <= set(dir(module))
+    with pytest.raises(AttributeError):
+        module.a_name_this_package_never_exported  # type: ignore[attr-defined]
+
+
+def test_importing_the_serve_surface_loads_no_model_library() -> None:
+    """The static claim, observed in a FRESH interpreter rather than asserted.
+
+    The test process has already imported everything, so this can only be seen
+    from outside — same argument as pgw#1331's subprocess proof, one layer up:
+    the thing imported here is the serve ROLE's own modules, not the family
+    surface.
+    """
+
+    program = (
+        "import sys\n"
+        "import gen_worker\n"
+        "import gen_worker.models\n"
+        "import gen_worker.serve_posture\n"
+        "import gen_worker.compile_facts\n"
+        "import gen_worker.model.catalog.flux1_dev_serve\n"
+        "leaked = sorted(n for n in ('diffusers', 'transformers', "
+        "'gen_worker.view', 'gen_worker.models.loading', "
+        "'gen_worker.models.residency') if n in sys.modules)\n"
+        "print(','.join(leaked))\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True, check=True
+    )
+    assert out.stdout.strip() == "", f"the serve surface loaded {out.stdout.strip()}"
+
+
+def test_the_model_bearing_ledger_is_exact_and_total() -> None:
+    """Every serve-role module is either asserted model-free or named as not.
+
+    Total by splice, disjoint by check. A module cannot fall out of both claims
+    by being edited into a third list (pgw#824).
+    """
+
+    fence = _fence()
+    free = set(role.MODEL_FREE_MODULES)
+    bearing = set(role.MODEL_BEARING_SERVE_MODULES)
+    assert free | bearing == set(role.SERVE_ROLE_MODULES)
+    assert free & bearing == set()
+    assert tuple(fence._declared_tuple("MODEL_BEARING_SERVE_MODULES")) == \
+        role.MODEL_BEARING_SERVE_MODULES
+    assert fence.check_bearing_ledger(
+        role.MODEL_BEARING_SERVE_MODULES, role.MODEL_FREE_MODULES,
+        role.FORBIDDEN_LIBRARIES) == []
+
+
+def test_red_a_landed_cut_left_in_the_bearing_ledger_is_refused() -> None:
+    """The ledger only shrinks. A row that got fixed goes RED until it moves.
+
+    This is the arm that stops the residue becoming an allowlist — the failure
+    mode of every owed-cut comment this repo has ever shipped (pgw#1176).
+    """
+
+    fence = _fence()
+    problems = fence.check_bearing_ledger(
+        ("gen_worker.serve.role",), (), role.FORBIDDEN_LIBRARIES)
+    assert [line for line in problems if "That cut has LANDED" in line]
+
+
+def test_red_a_module_claimed_both_ways_is_refused() -> None:
+    """One module, one claim."""
+
+    fence = _fence()
+    problems = fence.check_bearing_ledger(
+        ("gen_worker.aot_serve",), ("gen_worker.aot_serve",), role.FORBIDDEN_LIBRARIES)
+    assert [line for line in problems if "BOTH" in line]
+
+
+def test_serving_mode_does_not_import_the_arming_brain() -> None:
+    """A per-request REPORTING module, importing 3,100 lines that load weights.
+
+    ``serving_mode`` is still in the bearing ledger — it reaches a model library
+    through ``aot_serve`` — so the fence's own walk cannot hold this separation
+    yet. It is asserted directly here so the cut cannot be undone silently
+    while that is true, and it is the first half of the bearing ledger's cause 1.
+    """
+
+    fence = _fence()
+    path = fence._module_path("gen_worker.serving_mode")
+    assert path is not None
+    required, guarded, _ = fence._imports(path, "gen_worker.serving_mode")
+    assert "gen_worker.compile_cache" not in (required | guarded)
+    assert "gen_worker.compile_facts" in required
+
+
+def test_the_compile_facts_are_one_definition_not_two() -> None:
+    """``compile_cache`` re-exports them; it does not re-implement them.
+
+    Two copies of ``runtime_key`` is two cell identities (pgw#824's drift rule
+    applied to a probe rather than to a list), and every test that monkeypatches
+    ``compile_cache.runtime_key`` would silently stop covering the real caller.
+    """
+
+    from gen_worker import compile_cache, compile_facts
+
+    for name in ("runtime_key", "sku_slug", "is_compile_armed"):
+        assert getattr(compile_cache, name) is getattr(compile_facts, name), name
+    assert compile_cache._MARKER_ATTR is compile_facts.MARKER_ATTR
+    # The three readers `compile_cache` does NOT re-export: the executor asks
+    # `compile_facts` for them directly, so there is no second address at all.
+    for name in ("graph_break_reason", "degrade_reason", "declared_range_refusal"):
+        assert not hasattr(compile_cache, name), name
+        assert getattr(compile_facts, name) is not None
+    # …and the executor reads them from that one address.
+    fence = _fence()
+    path = fence._module_path("gen_worker.executor")
+    assert path is not None
+    required, _, _ = fence._imports(path, "gen_worker.executor")
+    assert "gen_worker.compile_facts" in required
+
+
+def test_the_marker_readers_still_read_the_marker() -> None:
+    """Moved, not rewritten: the four readers against a hand-built marker."""
+
+    from gen_worker import compile_facts
+
+    class _Pipe:
+        pass
+
+    bare = _Pipe()
+    assert compile_facts.is_compile_armed(bare) is False
+    assert compile_facts.graph_break_reason(bare) == ""
+
+    armed = _Pipe()
+    setattr(armed, compile_facts.MARKER_ATTR, {"originals": ()})
+    assert compile_facts.is_compile_armed(armed) is True
+
+    degraded = _Pipe()
+    setattr(degraded, compile_facts.MARKER_ATTR, {"failure_signal": {
+        "degraded": True, "graph_break": "guard on x",
+        "degrade_reason": "cuda oom", "declared_range_exceeded": "steps=99",
+    }})
+    assert compile_facts.is_compile_armed(degraded) is False
+    assert compile_facts.graph_break_reason(degraded) == "guard on x"
+    assert compile_facts.degrade_reason(degraded) == "cuda oom"
+    assert compile_facts.declared_range_refusal(degraded) == "steps=99"
+    assert compile_facts.sku_slug("NVIDIA GeForce RTX 4090") == "rtx-4090"

--- a/tests/test_hub_worker_boundary_contracts_pgw1239.py
+++ b/tests/test_hub_worker_boundary_contracts_pgw1239.py
@@ -26,7 +26,10 @@ _SOURCE_PATHS = {
     "topology": _ROOT / "src" / "gen_worker" / "topology.py",
     "procsplit": _ROOT / "src" / "gen_worker" / "procsplit" / "__init__.py",
     "discovery": _ROOT / "src" / "gen_worker" / "discovery" / "discover.py",
-    "compile_cache": _ROOT / "src" / "gen_worker" / "compile_cache.py",
+    # pgw#1331: `runtime_key()` moved to `compile_facts`, the READ half of the
+    # compile cache — `compile_cache` re-exports it. The raw launch-value read
+    # is checked where it lives, not where it is re-exported from.
+    "compile_facts": _ROOT / "src" / "gen_worker" / "compile_facts.py",
     "model_store": _ROOT / "src" / "gen_worker" / "models" / "store.py",
     "provision": _ROOT / "src" / "gen_worker" / "models" / "provision.py",
 }
@@ -155,8 +158,8 @@ def _assert_contracts(document: dict[str, Any], sources: dict[str, str]) -> None
     for env_name, field_name in active.items():
         assert loader_map.get(env_name) == field_name, env_name
         assert field_name in settings_fields, field_name
-    assert "WORKER_IMAGE_DIGEST" in _raw_environ_gets(trees["compile_cache"]), (
-        "compile_cache must consume the raw WORKER_IMAGE_DIGEST launch value"
+    assert "WORKER_IMAGE_DIGEST" in _raw_environ_gets(trees["compile_facts"]), (
+        "compile_facts must consume the raw WORKER_IMAGE_DIGEST launch value"
     )
 
     external_secret_fields = {
@@ -341,7 +344,7 @@ def test_each_contract_class_has_semantic_red_pgw1239(tmp_path: Path, contract_c
             'BUILD_INPUT_FAILURE_MARKER = "BROKEN_BUILD_INPUT_FAILURE"',
         ),
         (
-            "compile_cache",
+            "compile_facts",
             'os.environ.get("WORKER_IMAGE_DIGEST", "")',
             'os.environ.get("BROKEN_WORKER_IMAGE_DIGEST", "")',
         ),

--- a/tests/test_regional_marks_pgw1082.py
+++ b/tests/test_regional_marks_pgw1082.py
@@ -32,6 +32,8 @@ import pytest
 import torch
 
 from gen_worker import compile_cache as cc
+# pgw#1331: the marker READERS live beside the marker's definition.
+from gen_worker import compile_facts
 
 
 class _Dim:
@@ -221,7 +223,7 @@ def test_a_declared_range_refusal_is_readable_off_the_pipeline():
     setattr(pipeline, cc._MARKER_ATTR, {"failure_signal": signal,
                                         "originals": (), "regional_mods": ()})
     assert guarded() == "eager"
-    assert "sequence" in cc.declared_range_refusal(pipeline)
+    assert "sequence" in compile_facts.declared_range_refusal(pipeline)
     assert cc.is_compile_armed(pipeline) is False
 
 


### PR DESCRIPTION
Closes pgw#1331's owed row 3. `role.py` recorded the cut in prose — *"making the whole role statically model-free means making `gen_worker/__init__` lazy"* — and this measures it, does it, and replaces the remaining prose with something CI can hold.

## Measured, per root, with the fence's own walk

| | model-free serve-role roots |
|---|---|
| before | **14 of 38** (the typed family surface) |
| after | **30 of 39**, and the 9 that are not are named with their two causes |

## Two package roots were the cause

Every `import gen_worker.anything` executes `gen_worker/__init__`, which eagerly re-exported `view` and `models.provision`. Every `from .models import x` executes `gen_worker/models/__init__`, which eagerly re-exported `residency` and through it `loading`. So a module could not be model-free without being outside the package it lives in.

Both are PEP 562 lazy now — the same shape `gen_worker/model/__init__` already had, for the same reason. The eager block survives **verbatim** under `if TYPE_CHECKING`, so mypy checks the two spellings against each other, and the author surface is unchanged (`from gen_worker import endpoint` and `gen_worker.endpoint` both still work; a test asserts every `__all__` name resolves through `__getattr__`).

## `gen_worker.compile_facts`

The compile facts a SERVING process READS — the four arm-marker readers plus the `runtime_key` / `sku_slug` toolchain probe — with none of the machinery that writes them. `serving_mode`'s own docstring promises it needs *"no pipeline, GPU, or hub"*, and it was importing 3,100 lines of eager-capable arming brain to read two of them.

**One definition of each name, not two.** `compile_cache` re-exports `runtime_key` / `sku_slug` / `is_compile_armed`, so every caller and every `monkeypatch.setattr(cc, "runtime_key", …)` in the suite is unaffected. The three readers with a single caller are read from `compile_facts` directly by `executor`, so they have no second address at all.

## The residue is a checked ledger, not a comment

`role.MODEL_BEARING_SERVE_MODULES` names the nine roots that still reach a model library, and `check_bearing_ledger` asserts each one **still does**. A row whose cut lands goes RED until it is moved into `MODEL_FREE_MODULES` — **the list can only shrink.** `SERVE_ROLE_MODULES` is the two tuples spliced, so the claim is total by construction and disjoint by check: no module can fall out of both.

That is the answer to pgw#1176's measured failure — an owed cut written as prose stays green while the tree moves under it.

**The two causes behind the nine**, named at the declaration so the next lane does not re-measure them:

1. **`compile_cache`, for seven.** It holds the compile-cache IDENTITY functions (`toolchain_digest`, `content_keys`, `static_code_closure`, `parse_cell_ref`) that `keyset.fold`/`keyset.closure` fold a cell key from — so the key set imports the arming brain to do arithmetic, and `keyset`, `keyset.boot`, `keyset.store`, `boot_adopt` and `cell_resolve` inherit it. The cut is the identity half moving out, the way the read half just did.
2. **`aot_serve`'s three model-layer edges, for it and `serving_mode`.** `models.memory` (`is_cuda_oom`, a pure exception predicate), `compile_cache` (four names, per cause 1), and `models.lora_lifted` — the only one of the three that is a design question rather than a move.

## Red-verified by distinguishable mutation

Each applied to a sandbox copy of the tree, run, and reverted:

| mutation | verdict |
|---|---|
| eager `gen_worker/__init__` | **9 violations**, naming `view`, `api.streaming`, `models.loading`, … |
| eager `gen_worker/models/__init__` | **7 violations**, naming `models.loading`, `models.residency`, … |
| a model-FREE module named in the bearing ledger | *"That cut has LANDED"* + the both-claims refusal |
| control, before and after each | green |

Two of those are new `--selftest` arms; two are new tests. The fence memoizes its parse — the ledger walks one closure per row, and without the memo the gate went 1s -> 21s, which does not fit the required-check budget. It is **2.9s**.

## Green

`mypy --strict` (861 files, `src` + `tests` + `tests_v2`), `ruff`, **all 40 fast-gate lints and selftests**, and: `test_flux_stage1_pgw1331` (54, was 44), `test_adopt_only_serve_role_pgw1328`, `test_cgkey_as_data_pgw1327`, `test_compile_cache`, `test_model_sdk_pgw1332`, `test_store_sourced_arm_pgw1329`, `test_benchmark_telemetry_pgw789`, `test_compile_proof_pgw637`, `test_mint_gate_pgw677`, `tests_v2`, plus the boot/executor/config suites a lazy-import regression would hit first. Rebased on `origin/master` `771a13c2` and re-run after.

## Not closed by this, and not claimed

- per-family before/after **LATENCY** — needs a card, real weights and armed artifacts (pgw#1331 owed row 2)
- the `--runner decoder` pod mint (~$0.03 on pgw#1347's rig)
- pgw#1341: a cell that ARMS still cannot be PUBLISHED. Unchanged here and untouched.