### PR TITLE
pgw#1346 W1b-2: a declared model becomes a servable instance

### DIFF
--- a/changelog.d/pgw1346.md
+++ b/changelog.d/pgw1346.md
@@ -321,3 +321,37 @@
   `build` callable to construct a model library inside. That is a checked claim,
   not a convention — all fifteen new modules are named in
   `serve.role.MODEL_FREE_MODULES` (57 of 66 roots now), where the fence proves it.
+
+
+- **A declared model is now SERVABLE.** This is the half the typed SDK was
+  missing: pgw#1332 landed the declaration, the codegen and the backings, but
+  nothing on a pod ever CONSTRUCTED an instance —
+  `set_instance_resolver`/`bind_models`/`resolver_instances` had zero call sites
+  in `src/`, so `@endpoint` type-checked, published a manifest and handed the
+  handler nothing. The missing fact was that a declaration's `Runner.build`
+  makes a WEIGHTLESS module from config (that is what the mint traces), so
+  serving eagerly means reaching the weight-bearing module the loader already
+  produced — and nothing said which one that was. `Runner(..., component=...)`
+  names it as a dotted path in the loaded component tree
+  (`"transformer"`, `"vae.decoder"`), `gen_worker.model.residency` turns that
+  into an `EagerBacking`, and the executor folds it with any armed cells into
+  one `DualBacking` on a real instance passed as a handler keyword argument.
+  `component` is a SERVING fact and is deliberately **not** exported: every
+  committed `EXPORT_DIGEST` is unchanged.
+- **Instances are built per REQUEST, not per setup.** A `Model` value carries
+  this request's checkpoint ref and that checkpoint's catalog-stamped tuned
+  values, and two requests on one warm pod can name two checkpoints; an instance
+  cached across them would serve the first one's tuning forever. Only the cheap
+  half is per-call — the weights are whatever residency already holds.
+  `inst.tuned` decodes the SAME wire field `ctx.defaults` reads
+  (`ModelBinding.inference_defaults`), so the new surface and the retiring one
+  cannot disagree about what the hub said.
+- Refusals that replace a wrong render nobody can explain: a model with neither
+  an eager module nor an armed cell refuses at dispatch naming the model and the
+  ref; a parameter this request names no checkpoint for is refused rather than
+  defaulted (a model bound to "whatever was resident" is exactly the
+  cross-request bleed the axis split prevents); a malformed catalog stamp
+  refuses rather than silently serving neutral values. Warm-up, which runs
+  before any dispatch has named a checkpoint, skips unresolved models instead —
+  un-warmed is honest, refusing would break the boot of every hub-resolved
+  endpoint.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5063,7 +5063,8 @@ class Executor:
                 )
                 for obj in objects
             }
-            handler_kwargs = await self._handler_kwargs(wj.spec, snapshots or {})
+            handler_kwargs = await self._handler_kwargs(
+                wj.spec, snapshots or {}, warm=True)
             t0 = time.monotonic()
             with tempfile.TemporaryDirectory(prefix="gw-warmup-") as tmp:
                 try:
@@ -10272,7 +10273,8 @@ class Executor:
                 effective_config,
                 snapshot=invocation_snapshot,
             )
-            kwargs = await self._handler_kwargs(spec, snapshots)
+            kwargs = await self._handler_kwargs(
+                spec, snapshots, order.slots, order.adapters)
             adapters = await self._prepare_adapters(order.adapters, spec, snapshots)
             ctx.raise_if_cancelled("canceled")
         except (asyncio.CancelledError, CanceledError):
@@ -10692,10 +10694,25 @@ class Executor:
             await asyncio.to_thread(resolve, ref)
 
     async def _handler_kwargs(
-        self, spec: EndpointSpec, snapshots: Dict[WireRef, pb.Snapshot]
+        self,
+        spec: EndpointSpec,
+        snapshots: Dict[WireRef, pb.Snapshot],
+        slots: Optional[Mapping[str, dispatch.SlotOrder]] = None,
+        adapters: Optional[Mapping[str, Tuple[dispatch.AdapterOrder, ...]]] = None,
+        warm: bool = False,
     ) -> Dict[str, Any]:
         """Per-call model injection: handler parameters (after ctx, payload)
-        whose names match model slots receive the local snapshot path."""
+        whose names match model slots receive the local snapshot path, and
+        parameters bound to a declared MODEL receive a resolved instance.
+
+        pgw#1346: the second half is what makes the typed SDK servable. It is
+        built PER CALL rather than once at setup, because a `Model` value
+        carries this request's checkpoint ref and that checkpoint's tuned
+        values — two requests on one warm pod can name two checkpoints, and an
+        instance cached across them would serve the first one's tuning forever.
+        Only the cheap half is per-call: the weights are whatever residency
+        already holds, reached through `Runner.component`.
+        """
         try:
             sig = typing.get_type_hints(spec.method)
         except Exception:
@@ -10714,7 +10731,63 @@ class Executor:
             ref = wire_ref(binding)
             path = await self.store.ensure_local(ref, snapshots.get(ref), binding=binding)
             kwargs[name] = Path(path) if sig.get(name) is Path else str(path)
+        kwargs.update(
+            self._model_instance_kwargs(spec, slots or {}, adapters or {}, warm=warm))
         return kwargs
+
+    def _model_instance_kwargs(
+        self,
+        spec: EndpointSpec,
+        slots: Mapping[str, dispatch.SlotOrder],
+        adapters: Mapping[str, Tuple[dispatch.AdapterOrder, ...]],
+        warm: bool = False,
+    ) -> Dict[str, Any]:
+        """One resolved `Model` per declared model parameter (pgw#1346).
+
+        The three inputs each come from the ONE place that already owns them,
+        rather than being re-derived here:
+
+        * the ref and the catalog-stamped tuned values from this dispatch's
+          ``SlotOrder`` — the same wire fields `ctx.defaults` reads, so a model
+          instance and the retiring context surface cannot disagree about what
+          the hub said;
+        * the weight-bearing modules from ``_slot_pipeline``, which is already
+          the single answer to "what did this slot load", including the
+          th#980 component-override case where the residency handle is a
+          ModuleDict and the pipeline identity is held separately;
+        * the armed compiled runners from the adoption seam, when the pod has
+          any. Absent, the instance is eager-only and every typed call runs the
+          eager module — which is the honest state on a pod that has not armed,
+          not a degradation to report.
+        """
+
+        if not spec.families:
+            return {}
+        from .model.residency import instances_for
+
+        refs: Dict[str, str] = {}
+        stamped: Dict[str, str] = {}
+        lora_stamped: Dict[str, tuple[str, ...]] = {}
+        trees: Dict[str, Any] = {}
+        for name in spec.families:
+            order = slots.get(name)
+            if order is not None:
+                refs[name] = order.ref
+                stamped[name] = order.inference_defaults
+            elif name in spec.models:
+                # Hub-less (`gen-worker run`, hermetic tests): the declaration's
+                # own bootstrap ref is the only resolution source, exactly as it
+                # is for every other slot on that path.
+                refs[name] = str(wire_ref(spec.models[name]))
+            lora_stamped[name] = tuple(
+                a.inference_defaults for a in adapters.get(name, ())
+                if a.inference_defaults
+            )
+            trees[name] = self._slot_pipeline(spec, name)
+        return dict(instances_for(
+            spec.families, refs=refs, trees=trees,
+            stamped=stamped, lora_stamped=lora_stamped, skip_unresolved=warm,
+        ))
 
     async def _prepare_adapters(
         self,

--- a/src/gen_worker/model/__init__.py
+++ b/src/gen_worker/model/__init__.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers on
         fake_kwargs,
         resolver_instances,
     )
+    from .residency import eager_modules, instance_for, instances_for
     from .runtime import (
         DecodeSession,
         Model,
@@ -153,6 +154,9 @@ _EXPORTS: Final[dict[str, tuple[str, str]]] = {
     "fake_models": ("inject", "fake_models"),
     "fake_kwargs": ("inject", "fake_kwargs"),
     "instance_resolver": ("runtime", "instance_resolver"),
+    "eager_modules": ("residency", "eager_modules"),
+    "instance_for": ("residency", "instance_for"),
+    "instances_for": ("residency", "instances_for"),
     "resolve": ("runtime", "resolve"),
     "resolve_tuned": ("runtime", "resolve_tuned"),
     "resolver_instances": ("inject", "resolver_instances"),
@@ -227,9 +231,12 @@ __all__ = [
     "bind_models",
     "bound_models",
     "declared_model_specs",
+    "eager_modules",
     "fake_models",
     "fake_kwargs",
+    "instance_for",
     "instance_resolver",
+    "instances_for",
     "resolve",
     "resolve_tuned",
     "resolver_instances",

--- a/src/gen_worker/model/residency.py
+++ b/src/gen_worker/model/residency.py
@@ -1,0 +1,172 @@
+"""Turning what the worker already loaded into a `Model` instance (pgw#1346).
+
+This is the half the typed SDK was missing. pgw#1332 landed the declaration,
+the codegen, the backings and the injection helpers; what nothing did was
+CONSTRUCT an instance on a real pod, so `@endpoint(models={"flux": Flux1Dev})`
+type-checked, published a manifest and then handed the handler nothing.
+
+The gap was never the plumbing. It was one fact: a declaration's
+``Runner.build`` makes a WEIGHTLESS module from config — that is what the mint
+traces — so it cannot answer a request. Serving eagerly means reaching the
+weight-bearing module the loader already produced, and until ``Runner.component``
+existed nothing said which module that was. With it, the whole path is a lookup:
+
+    loaded pipeline ──Runner.component──▶ {runner: module} ──▶ EagerBacking
+    armed cells ─────────────────────────────────────────────▶ CompiledBacking
+                                    │
+                                    ▼
+                          Model.adopt(...) ──▶ handler kwarg
+
+Both backings are folded into one `DualBacking`, so a runner armed at this
+request's bucket runs compiled and every other call runs eager, with no branch
+in the handler and no second code path to keep honest.
+
+The instance is built PER REQUEST, deliberately. A `Model` value carries the
+checkpoint ref and that checkpoint's tuned values, and those are dispatch facts
+— two requests on one warm pod can name two checkpoints. The expensive half
+(the weights) is shared: this only wraps modules residency already holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeVar
+
+from .backing import Backing
+from .errors import ModelError, ModelRefusal
+from .runtime import Model
+from .spec import ModelSpec
+
+M = TypeVar("M", bound=Model)
+
+
+def _reach(tree: Any, path: str) -> Any:
+    """Walk a dotted attribute path, answering ``None`` at the first gap.
+
+    A missing component is not an error HERE: an optional lane, a pipeline that
+    genuinely lacks a refiner, or a runner with no eager equivalent all reach
+    this and all mean the same thing — no eager module for that runner. The
+    refusal, when it matters, comes from the backing at call time and names the
+    runner, which is the message an author can act on.
+    """
+
+    current = tree
+    for part in path.split("."):
+        current = getattr(current, part, None)
+        if current is None:
+            return None
+    return current
+
+
+def eager_modules(spec: ModelSpec | None, tree: Any) -> dict[str, Any]:
+    """The ``{runner: module}`` map an :class:`EagerBacking` is built from.
+
+    ``spec`` is ``None`` on an adopt-only serve pod, where importing the
+    declaration would acquire a model library the role forbids (pgw#1328). That
+    is not a failure: such a pod serves compiled cells, so an empty eager map is
+    the correct answer and the compiled backing carries the request.
+    """
+
+    if spec is None or tree is None:
+        return {}
+    out: dict[str, Any] = {}
+    for runner in spec.runners:
+        if not runner.component:
+            continue
+        module = _reach(tree, runner.component)
+        if module is not None:
+            out[runner.name] = module
+    return out
+
+
+def instance_for(
+    model: type[M],
+    *,
+    ref: str,
+    tree: Any = None,
+    compiled: Backing | None = None,
+    stamped: str = "",
+    lora_stamped: Sequence[str] = (),
+    label: str = "",
+) -> M:
+    """One resolved instance, from what this pod already has.
+
+    Refuses when NEITHER backing has anything, rather than handing back an
+    instance whose every call fails later with no context. A model bound to a
+    checkpoint the pod could not load is a dispatch-time fact and says so here,
+    naming the model and the ref.
+    """
+
+    from .tuned import tuned_from_catalog
+
+    eager = eager_modules(model.SPEC, tree)
+    if not eager and compiled is None:
+        raise ModelError(
+            ModelRefusal.BACKING_MISSING,
+            f"model {model.FAMILY!r} bound to {ref!r} has neither an eager module "
+            f"nor an armed cell on this pod. Either the checkpoint did not load, or "
+            f"the declaration's runners name components this tree does not have "
+            f"(declare `Runner(..., component=...)` for each runner that has an "
+            f"eager equivalent).",
+        )
+    return model.adopt(
+        ref=ref,
+        tuned=tuned_from_catalog(model, stamped, lora_stamped),
+        eager=eager or None,
+        compiled=compiled,
+        label=label or ref,
+    )
+
+
+def instances_for(
+    binds: Mapping[str, Any],
+    *,
+    refs: Mapping[str, str],
+    trees: Mapping[str, Any],
+    compiled: Mapping[str, Backing] | None = None,
+    stamped: Mapping[str, str] | None = None,
+    lora_stamped: Mapping[str, Sequence[str]] | None = None,
+    skip_unresolved: bool = False,
+) -> dict[str, Model]:
+    """One instance per declared handler parameter.
+
+    ``binds`` is the decorator's own record (parameter -> :class:`Bind`), so the
+    set of parameters filled here is exactly the set the decorator validated
+    against the handler's annotations. A parameter with no resolved ref is a
+    refusal and never a default: a model bound to "whatever was resident" is the
+    cross-request bleed the axis split exists to prevent.
+
+    ``skip_unresolved`` is for WARM-UP and nothing else. A warm pass runs before
+    any dispatch has named a checkpoint, so "no ref yet" is the expected state
+    there rather than a defect; skipping leaves the model un-warmed, which is
+    honest, where refusing would break the boot of every endpoint whose models
+    are hub-resolved. The serving path never passes it.
+    """
+
+    armed = compiled or {}
+    values = stamped or {}
+    overlays = lora_stamped or {}
+    out: dict[str, Model] = {}
+    for name, bind in binds.items():
+        ref = str(refs.get(name, "") or "").strip()
+        if not ref and skip_unresolved:
+            continue
+        if not ref:
+            raise ModelError(
+                ModelRefusal.BACKING_MISSING,
+                f"handler parameter {name!r} binds model "
+                f"{bind.model.FAMILY!r} and this request names no checkpoint for it",
+            )
+        out[name] = instance_for(
+            bind.model,
+            ref=ref,
+            tree=trees.get(name),
+            compiled=armed.get(name),
+            stamped=values.get(name, ""),
+            lora_stamped=overlays.get(name, ()),
+            label=name,
+        )
+    return out
+
+
+__all__ = ["eager_modules", "instance_for", "instances_for"]

--- a/src/gen_worker/model/spec.py
+++ b/src/gen_worker/model/spec.py
@@ -202,6 +202,22 @@ class Runner:
     example: ExampleFn
     axes: tuple[str, ...] = ()
     layouts: tuple[str, ...] = (DEFAULT_LAYOUT,)
+    #: Where this runner LIVES in a loaded component tree, as a dotted
+    #: attribute path (``"transformer"``, ``"vae.decode"``, ``"text_encoder_2"``).
+    #:
+    #: pgw#1346. ``build`` constructs a WEIGHTLESS module from config, which is
+    #: what the mint traces; it cannot serve a request because it has no
+    #: weights. Serving eagerly means reaching the weight-bearing module the
+    #: loader already produced, and this is the only thing that says which one
+    #: that is. Without it a declaration can be minted and type-checked but not
+    #: served eagerly, which is exactly the gap that blocked the `Slot`
+    #: deletion.
+    #:
+    #: Empty means "this runner has no eager equivalent" — a legitimate state
+    #: for a runner that only ever exists as a compiled graph class. Such a
+    #: runner simply does not appear in the eager backing, and a call to it
+    #: with no armed cell refuses by name rather than running the wrong thing.
+    component: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "name", _identifier("runner", self.name, parse_runner_name))
@@ -228,6 +244,17 @@ class Runner:
                 f"runner {self.name!r} layouts must be a non-empty sorted unique set",
             )
         object.__setattr__(self, "layouts", layouts)
+        component = str(self.component or "").strip()
+        if component and not all(
+            part.isidentifier() for part in component.split(".")
+        ):
+            raise ModelError(
+                ModelRefusal.CLASS_INVALID,
+                f"runner {self.name!r} component={self.component!r} must be a dotted "
+                "attribute path in the loaded component tree, e.g. 'transformer' or "
+                "'vae.decode'",
+            )
+        object.__setattr__(self, "component", component)
 
     @property
     def handle(self) -> RunnerName:

--- a/tests/harness/model_toys_pgw1332.py
+++ b/tests/harness/model_toys_pgw1332.py
@@ -103,8 +103,10 @@ TOY_DIFFUSION = GraphModelSpec(
     tuned=ToyTuned,
     buckets=(Bucket("resolution", (64, 128)),),
     runners=(
-        Runner("decoder", build=_decoder, example=_decoder_example, axes=("resolution",)),
-        Runner("denoiser", build=_denoiser, example=_denoiser_example, axes=("resolution",)),
+        Runner("decoder", build=_decoder, example=_decoder_example, axes=("resolution",),
+               component="vae.decoder"),
+        Runner("denoiser", build=_denoiser, example=_denoiser_example, axes=("resolution",),
+               component="transformer"),
     ),
     loop=Loop(stages=(Stage("denoiser", repeat="steps"), Stage("decoder"))),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
@@ -160,3 +162,21 @@ TOY_AR = GraphModelSpec(
 )
 
 __all__ = ["TOY_AR", "TOY_DIFFUSION", "WIDTH", "ToyArTuned", "ToyTuned"]
+
+
+def toy_loaded_tree() -> Any:
+    """A stand-in for what the LOADER produces on a real pod.
+
+    Not a mock of the SDK: these are the declaration's own modules, built by the
+    declaration's own `build` callables, arranged the way a diffusers-style
+    pipeline arranges them — a `.transformer` and a `.vae.decoder`. That shape
+    is the whole point, because `Runner.component` is what maps a runner onto
+    it, and a test that hand-built the map would not be testing the map.
+    """
+
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        transformer=_denoiser("bf16"),
+        vae=SimpleNamespace(decoder=_decoder("bf16")),
+    )

--- a/tests/test_model_injection_pgw1346.py
+++ b/tests/test_model_injection_pgw1346.py
@@ -1,0 +1,225 @@
+"""pgw#1346 W1b-2 — a declared model becomes a SERVABLE instance.
+
+This is the gap that blocked the `Slot` deletion: pgw#1332 landed the
+declaration, the codegen and the backings, but nothing on a real pod ever
+CONSTRUCTED an instance, so `@endpoint(models={...})` type-checked, published a
+manifest, and handed the handler nothing. `set_instance_resolver`,
+`bind_models` and `resolver_instances` had zero call sites in `src/`.
+
+Everything below runs the real path: the real declaration, the real
+declaration-time export, the real codegen, the real `Runner.component` lookup
+over a real module tree, the real `Model.adopt`, and real typed runner calls
+returning real tensors. The only thing not present is a GPU and a hub, and
+neither is on this path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+from gen_worker.model.bind import Bind
+from gen_worker.model.codegen import render_module
+from gen_worker.model.errors import ModelError, ModelRefusal
+from gen_worker.model.export import export_model
+from gen_worker.model.residency import eager_modules, instance_for, instances_for
+from gen_worker.model.snapshot import ModelExport
+
+from harness.model_toys_pgw1332 import TOY_DIFFUSION, WIDTH, toy_loaded_tree
+
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(scope="module")
+def toy_export() -> ModelExport:
+    return export_model(TOY_DIFFUSION)
+
+
+@pytest.fixture(scope="module")
+def toy_binding(toy_export: ModelExport, tmp_path_factory: pytest.TempPathFactory) -> Any:
+    root = tmp_path_factory.mktemp("pgw1346_bindings")
+    package = root / "pgw1346_generated"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "toy_diffusion.export.json").write_text(toy_export.dumps())
+    (package / "toy_diffusion.py").write_text(
+        render_module(
+            toy_export,
+            spec_module="harness.model_toys_pgw1332",
+            spec_attr="TOY_DIFFUSION",
+        )
+    )
+    sys.path.insert(0, str(root))
+    try:
+        module = importlib.import_module("pgw1346_generated.toy_diffusion")
+    finally:
+        sys.path.remove(str(root))
+    return module.ToyDiffusion
+
+
+# ---------------------------------------------------------------------------
+# Runner.component is the map, and it is the thing that was missing
+# ---------------------------------------------------------------------------
+
+
+def test_the_component_path_finds_every_declared_runner_in_a_loaded_tree() -> None:
+    """The declaration says `transformer` and `vae.decoder`; the tree has them.
+
+    A dotted path, because a component tree is a tree — the VAE's decoder is a
+    submodule, and a flat name could not reach it.
+    """
+
+    modules = eager_modules(TOY_DIFFUSION, toy_loaded_tree())
+    assert sorted(modules) == ["decoder", "denoiser"]
+
+
+def test_a_runner_with_no_component_declared_simply_has_no_eager_module() -> None:
+    """A legitimate state, not an error: a runner that only ever exists as a
+    compiled graph class. It is absent from the eager backing, and calling it
+    with no armed cell refuses BY NAME rather than running something else.
+    """
+
+    from dataclasses import replace
+
+    graphs_only = replace(
+        TOY_DIFFUSION,
+        runners=tuple(replace(r, component="") for r in TOY_DIFFUSION.runners),
+    )
+    assert eager_modules(graphs_only, toy_loaded_tree()) == {}
+
+
+def test_an_adopt_only_pod_has_no_declaration_and_that_is_not_a_failure() -> None:
+    """`SPEC` is None where importing the declaration would acquire a model
+    library the serve role forbids (pgw#1328). Such a pod serves compiled
+    cells, so an empty eager map is the correct answer.
+    """
+
+    assert eager_modules(None, toy_loaded_tree()) == {}
+
+
+# ---------------------------------------------------------------------------
+# The instance is real, and its typed calls reach the loaded weights
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_model_becomes_an_instance_whose_typed_call_runs_the_loaded_module(
+    toy_binding: Any,
+) -> None:
+    """The whole point of W1b-2, end to end.
+
+    `inst.denoiser(...)` is the GENERATED typed callable; it reaches the
+    `EagerBacking`, which reaches the module `Runner.component` found in the
+    loaded tree, which is a real `nn.Linear`. The assertion is on the tensor
+    that comes back, because a call that returned a shape-correct fake would
+    pass a weaker test and is exactly what this must not be.
+    """
+
+    tree = toy_loaded_tree()
+    inst = instance_for(toy_binding, ref="hub:toy/ckpt-a", tree=tree)
+
+    assert inst.ref == "hub:toy/ckpt-a"
+    tokens = 64 // 64
+    hidden = torch.ones(1, tokens, WIDTH, dtype=torch.float32)
+    out = inst.denoiser(
+        resolution=64, hidden_states=hidden, timestep=torch.zeros((), dtype=torch.float32)
+    )
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (1, tokens, WIDTH)
+    # The eager module is the one from the tree — same object, so the same
+    # weights. Proven by computing the expected value through it directly.
+    expected = tree.transformer(hidden, torch.zeros((), dtype=torch.float32))
+    assert torch.equal(out, expected)
+
+
+def test_two_parameters_of_one_model_bind_two_checkpoints_independently(
+    toy_binding: Any,
+) -> None:
+    """The axis split, on the real construction path: one model class, two
+    parameters, two refs, two instances that do not share identity.
+    """
+
+    binds = {"left": Bind(toy_binding), "right": Bind(toy_binding)}
+    tree = toy_loaded_tree()
+    out = instances_for(
+        binds,
+        refs={"left": "hub:toy/a", "right": "hub:toy/b"},
+        trees={"left": tree, "right": tree},
+    )
+    assert out["left"].ref == "hub:toy/a"
+    assert out["right"].ref == "hub:toy/b"
+    assert out["left"] is not out["right"]
+
+
+def test_the_catalog_stamp_lands_on_the_instance_not_on_ctx(toy_binding: Any) -> None:
+    """`inst.tuned` is the replacement for `ctx.defaults`, and it decodes the
+    SAME wire field the retiring context surface reads
+    (`ModelBinding.inference_defaults`), so the two cannot disagree.
+    """
+
+    inst = instance_for(
+        toy_binding, ref="hub:toy/ckpt", tree=toy_loaded_tree(),
+        stamped='{"steps": 7}',
+    )
+    assert inst.tuned.steps == 7
+
+
+def test_a_malformed_catalog_stamp_refuses_rather_than_serving_neutral_values(
+    toy_binding: Any,
+) -> None:
+    """tensorhub schema-validates at PUT time, so a decode failure here is real
+    version skew — and serving a checkpoint with values nobody could parse is
+    worse than refusing it.
+    """
+
+    with pytest.raises(ModelError) as caught:
+        instance_for(
+            toy_binding, ref="hub:toy/ckpt", tree=toy_loaded_tree(),
+            stamped='{"steps": "not-a-number"}',
+        )
+    assert caught.value.reason is ModelRefusal.TUNED_INVALID
+
+
+# ---------------------------------------------------------------------------
+# The refusals, which are what stop a wrong render nobody can explain
+# ---------------------------------------------------------------------------
+
+
+def test_a_model_with_neither_an_eager_module_nor_an_armed_cell_refuses_by_name(
+    toy_binding: Any,
+) -> None:
+    with pytest.raises(ModelError) as caught:
+        instance_for(toy_binding, ref="hub:toy/ckpt", tree=None)
+    assert caught.value.reason is ModelRefusal.BACKING_MISSING
+    assert "toy_diffusion" in str(caught.value)
+    assert "hub:toy/ckpt" in str(caught.value)
+
+
+def test_a_parameter_the_request_names_no_checkpoint_for_is_refused(
+    toy_binding: Any,
+) -> None:
+    """Never a default. A model bound to "whatever was resident" is the
+    cross-request bleed the axis split exists to prevent.
+    """
+
+    with pytest.raises(ModelError) as caught:
+        instances_for(
+            {"toy": Bind(toy_binding)}, refs={}, trees={"toy": toy_loaded_tree()},
+        )
+    assert caught.value.reason is ModelRefusal.BACKING_MISSING
+    assert "names no checkpoint" in str(caught.value)
+
+
+def test_warm_up_skips_a_model_no_dispatch_has_named_yet(toy_binding: Any) -> None:
+    """A warm pass runs before any dispatch names a checkpoint, so "no ref yet"
+    is the expected state there. Skipping leaves the model un-warmed, which is
+    honest; refusing would break the boot of every hub-resolved endpoint.
+    """
+
+    out = instances_for(
+        {"toy": Bind(toy_binding)}, refs={}, trees={"toy": toy_loaded_tree()},
+        skip_unresolved=True,
+    )
+    assert out == {}


### PR DESCRIPTION
Third PR of pgw#1346 W1. #901 renamed the types, #908 landed the declaration axes, and **this one makes a declared model actually serve a request.**

## The gap, precisely

pgw#1332 landed the declaration, the codegen, the backings and the injection helpers. What nothing did was CONSTRUCT an instance on a pod: `set_instance_resolver`, `bind_models`, `resolver_instances` and `fake_kwargs` had **zero call sites in `src/`**. So `@endpoint(families={"flux": Flux1Dev})` type-checked, published a manifest, and handed the handler nothing.

The blocker was never plumbing — it was one missing fact. A declaration's `Runner.build` makes a **weightless** module from config; that is exactly what the mint traces, and exactly why it cannot answer a request. Serving eagerly means reaching the weight-bearing module the **loader** produced, and nothing in the repo said which module that was.

## The fix

```python
Runner("denoiser", build=_denoiser, example=..., component="transformer")
Runner("decoder",  build=_decoder,  example=..., component="vae.decoder")
```

```
loaded pipeline ──Runner.component──▶ {runner: module} ──▶ EagerBacking
armed cells ─────────────────────────────────────────────▶ CompiledBacking
                                │
                                ▼
                      Model.adopt(...) ──▶ handler kwarg
```

A dotted path because a component tree is a tree — the VAE's decoder is a submodule. An empty `component` is a legitimate state (a runner that only ever exists as a compiled graph class): it is absent from the eager backing, and calling it with no armed cell refuses **by name** rather than running something else.

`component` is a SERVING fact, not part of the traced identity, so it is **not** in `family_export_v1`. Every committed `EXPORT_DIGEST` is unchanged and `check_model_bindings` is byte-clean.

## Injection semantics as landed

- **Per request, not per setup.** A `Model` value carries this request's checkpoint ref and that checkpoint's catalog-stamped tuned values. Two requests on one warm pod can name two checkpoints; an instance cached across them would serve the first one's tuning forever. Only the cheap half is per-call — the weights are whatever residency already holds.
- **Every input comes from the one place that already owns it.** Ref + catalog stamp from this dispatch's `SlotOrder` (the same `ModelBinding.inference_defaults` that `ctx.defaults` reads, so the new surface and the retiring one cannot disagree); LoRA overlays from `order.adapters`; modules from `_slot_pipeline`, already the single answer to "what did this slot load" — including the th#980 case where the residency handle is a `ModuleDict` and the pipeline identity is held separately.
- **Dual backing, no handler branch.** A runner armed at this request's bucket runs compiled; every other call runs eager.
- **Refusals replace a wrong render nobody can explain.** Neither eager module nor armed cell → refuses at dispatch naming model + ref. A parameter the request names no checkpoint for → refused, never defaulted (a model bound to "whatever was resident" is the cross-request bleed the axis split prevents). A malformed catalog stamp → refuses rather than serving neutral values.
- **Warm-up skips instead of refusing.** A warm pass runs before any dispatch has named a checkpoint, so "no ref yet" is expected there; un-warmed is honest, refusing would break the boot of every hub-resolved endpoint. The serving path never passes `skip_unresolved`.

## Verification

10 tests in `tests/test_model_injection_pgw1346.py` run the real path end to end — real declaration, real export, real codegen, real `Runner.component` lookup over a real module tree, real `Model.adopt`, real typed runner call. The keystone assertion compares the instance's output to calling the loaded module directly:

```python
out = inst.denoiser(resolution=64, hidden_states=hidden, timestep=t)
assert torch.equal(out, tree.transformer(hidden, t))
```

- `mypy src/gen_worker tests tests_v2` — **Success: no issues found in 869 source files**
- `ruff check src/gen_worker` — clean
- `lint_serve_role_closure` (both roles), `lint_serving_process_compiles`, `lint_unreached_surface`, `lint_fence_symbols`, `check_model_bindings`, `lint_retired_sdk_spellings`, `assemble_changelog --check` — green
- full `tests/` running locally before enqueue

## Still owed (W1b-3), unchanged from the tracker

The **flip and deletion**: `families=`→`models=` with the Slot-typed spelling deleted, `Slot` + `ctx.defaults` + the reachable decoder machinery removed, 57 in-repo declarations migrated. The one design point this PR settles for it: the flip must synthesize the internal slot record from the declaration, and the loader's "what class do I construct" needs `ModelSpec.build` to carry the pipeline class (catalog declarations set only `Runner.build` today).

Branched from `a8e94316`, which carries B2's known red in `tests/test_sd_stage1_pgw1346.py`; rebasing over #914 before enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
