### PR TITLE
pgw#1355: a cold boot states its own decomposition — boot_stages, spans that overlap honestly

### DIFF
--- a/changelog.d/pgw1355.md
+++ b/changelog.d/pgw1355.md
@@ -1,0 +1,54 @@
+- **pgw#1355: a cold boot reports its own decomposition, as one row.** e2e#1892
+  measured an 877 s cold serve and had to assemble the breakdown BY HAND out of
+  four different event kinds — request-row timestamps for the queue and the
+  compute, `worker_boot_phases` for the pull and the load, `boot_adopt`'s
+  `duration_ms` on `worker_activity_events` for the 805 s key-set derive. Every
+  number already existed; nowhere stated the SHAPE. `gen_worker.boot_stages`
+  emits a versioned `boot_stages` event series when a worker becomes ready: one
+  `phase=stage:<name>` row per span carrying `t0_ms`/`t1_ms` offsets from OS
+  process start, then one `phase=ready` roll-up whose `duration_ms` is
+  wall-to-ready and whose `detail` packs the whole table, so reading a pod's
+  cold start is a ONE-ROW query. `k=v` detail in the grammar the th#1839 route
+  already serves verbatim — **no hub schema change, no proto change, no
+  migration.**
+
+- **pgw#1355: overlap is first-class, and the total is a UNION.** Stages run
+  concurrently on a real pod — a snapshot pull overlapping a component load
+  overlapping a derive — so the report carries intervals rather than durations
+  and refuses to serialize what actually ran in parallel. `critical_path_ms` is
+  the union of the spans, `overlap_ms` the difference between the sum and the
+  union, and `unmeasured_ms` the wall no stage explained, NAMED rather than
+  smeared across the stages that were measured. A fixture with a pull inside a
+  load asserts the stages do not add up past wall; making the total a sum turns
+  five tests red. This is `boot_phases`' own lesson (its summing reconciliation
+  once "explained" 3,338 ms of a 909 ms fetch) applied at the reporting layer.
+
+- **pgw#1355: the stage vocabulary is CLOSED, and the reader says so when it
+  does not understand a fleet.** Ten stages — `process_boot`, `imports`,
+  `hub_handshake`, `snapshot_pull`, `model_load`, `keyset`, `adopt`, `arm`,
+  `warmup`, `ready` — as an enum, because a renderer in another repository binds
+  to these tokens and a stage invented at a call site is a column that appears
+  in production and in no reader. An unknown name raises at the emitter AND at
+  the parser; a boot phase added to `boot_phases` with no stage and no
+  documented exemption fails `unmapped_phases()`.
+
+- **pgw#1355: the derive that dominates every cold sdxl boot finally has a
+  span.** pgw#1353 measured `worker_boot_phases` going `first_request_servable`
+  and then **871 s of silence** to `eager_ready`, because the key-set derive runs
+  during a REQUEST — after the boot window closed, so `boot_phases.in_boot()` is
+  already False and no ladder row can cover it. `boot_adopt` now records it as
+  one `keyset` stage carrying `keys_from`, recorded once per derive rather than
+  once per class (36 identical spans would report a boot whose stages sum to 36x
+  its own wall). The report is emitted at `eager_ready` — the first instant the
+  worker could actually answer a request — and NOT at `first_request_servable`,
+  which on an eager-first boot fires before the model is loaded at all.
+
+- **pgw#1355: two windows no span could cover are now measured, not estimated.**
+  `boot_phases` records its own import instant, so process start splits into
+  `process_boot` (interpreter + `site` + the import chain up to the recorder,
+  which nothing can bracket because the recorder is part of what is being
+  imported) and `imports` (torch, discovery, executor construction, the
+  environment seal). A duration longer than the process has existed is clamped —
+  a negative offset is not representable — and the clamp CONFESSES as
+  `clamped_ms`, because a silently shortened span is a wrong measurement that
+  reads as a right one.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -243,6 +243,21 @@ KIND_PROCESS_ROLE = "process_role"
 # ActivityUpdate field holds them and the th#1839 route serves `detail`
 # verbatim, so this needs no hub change.
 KIND_SNAPSHOT_PULL = "snapshot_pull"
+# pgw#1355: the COLD BOOT's own decomposition — per-stage spans carrying
+# start/end offsets from OS process start, plus one terminal roll-up. Its own
+# KIND because it is the only row that answers "where did this pod's cold start
+# go" without a join: e2e#1892 assembled an 877 s cold serve out of FOUR event
+# kinds by hand (request-row timestamps, `worker_boot_phases` load spans,
+# `boot_adopt.duration_ms`, `compute_ms`/`finalize_ms`), and the largest stage
+# of all — pgw#1353's 805 s key-set derive — had no span on any channel.
+# `phase=stage:<name>` is one span, `phase=ready` the roll-up carrying the
+# packed table; `duration_ms` is that stage's wall, and the roll-up's is
+# wall-to-ready. The stage vocabulary is CLOSED (`boot_stages.Stage`) because a
+# renderer in another repo binds to these tokens. `detail` is the same `k=v`
+# grammar `snapshot_pull` uses, served verbatim by the th#1839 route, so this
+# needs no hub schema change. See `boot_stages.py` for why the total is a UNION
+# and never a sum.
+KIND_BOOT_STAGES = "boot_stages"
 # th#1322: the roll-up phase both mint routes report their TOTAL under. A
 # reader groups on (kind, phase) and must never sum a roll-up together with
 # its own children.

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -270,6 +270,49 @@ class BootAdoptOutcome:
         return self.adoption is not None
 
 
+def _record_keyset_stage(
+    outcome: "BootAdoptOutcome | DerivedKeySet",
+    *,
+    family: str,
+    function: str,
+) -> None:
+    """Record the key set as one :data:`gen_worker.boot_stages.Stage.KEYSET`
+    span (pgw#1355).
+
+    Takes either half of ``_key_set``'s return: a refusal still consumed real
+    wall, and a stage that only appears on the happy path cannot answer "why
+    was this boot slow" on the boot that was slow AND failed.
+
+    ``keys_from`` is carried because it is the axis that separates a 805 s boot
+    from a 5 ms one — pgw#1353's whole finding is that every production pod
+    reported ``traced``, the FALLBACK, and nothing made that visible while it
+    was happening.
+
+    Never raises: telemetry never fails a boot.
+    """
+    try:
+        from . import boot_stages
+
+        wall_ms = int(getattr(outcome, "derive_ms", 0)
+                      or getattr(outcome, "wall_ms", 0) or 0)
+        source = getattr(outcome, "key_source", None) or getattr(
+            outcome, "source", None)
+        entry_keys = getattr(outcome, "entry_keys", None)
+        boot_stages.record_ending_now(
+            boot_stages.Stage.KEYSET,
+            duration_ms=wall_ms,
+            label="boot_adopt.key_set",
+            family=family,
+            function=function,
+            keys_from=(source.value if source is not None else "-"),
+            classes=(len(entry_keys) if entry_keys is not None else ""),
+            workers=getattr(outcome, "workers", "") or "",
+            memo=getattr(getattr(outcome, "memo", None), "value", "") or "",
+        )
+    except Exception:  # pragma: no cover — telemetry never fails a boot
+        logger.debug("keyset stage span dropped", exc_info=True)
+
+
 def report(outcome: BootAdoptOutcome) -> BootAdoptOutcome:
     """Emit this decision as ONE typed event, and return it unchanged.
 
@@ -577,6 +620,19 @@ def attempt(
         function=fn, modules=modules, family=family, spec=spec, slots=slots,
         declared_hint=declared_hint, work_root=work_root, memo_dir=memo_dir,
         device=device, derive=derive, keyset_roots=keyset_roots)
+    # pgw#1355: the key set is a COLD-BOOT STAGE, recorded exactly once per
+    # derive — here, where `_key_set` has just returned, rather than in
+    # `report`, which runs once PER CLASS. On sdxl that is 36 calls carrying
+    # the same `derive_ms`, and 36 identical spans would report a boot whose
+    # stages sum to 36x its own wall. The union would still be right; the
+    # overlap figure would be nonsense, and a figure that is nonsense on the
+    # normal path is a figure nobody trusts on the abnormal one.
+    #
+    # This is the span pgw#1353 measured the absence of: the derive runs during
+    # a REQUEST, after `boot_phases.in_boot()` has already gone False, so no
+    # ladder row covers its 805 seconds and `worker_boot_phases` shows 871 s of
+    # silence where the dominant phase of the boot actually was.
+    _record_keyset_stage(outcome, family=family, function=fn)
     if isinstance(outcome, BootAdoptOutcome):
         return (report(outcome),)
     derived = outcome

--- a/src/gen_worker/boot_phases.py
+++ b/src/gen_worker/boot_phases.py
@@ -266,10 +266,29 @@ def _resolve_process_start() -> float:
 
 _process_start_unix = _resolve_process_start()
 
+#: Wall clock at THIS MODULE's import (pgw#1355). The earliest instant any
+#: gen_worker code can observe, so `process start -> here` is the interpreter +
+#: `site` + the import chain up to the recorder — the one window that is
+#: structurally unspannable, because nothing can open a span before the module
+#: that opens spans exists. `sdk_ready` already names the whole pre-SDK window
+#: as ONE lump; this splits it into "the interpreter came up" and "we imported
+#: torch and built an executor", which have completely different fixes.
+_module_import_unix: float = time.time()
+
 
 def process_start_unix() -> float:
     """Wall-clock OS process start for this worker."""
     return _process_start_unix
+
+
+def module_import_ms() -> int:
+    """ms from OS process start to this module's import.
+
+    Never negative and never past `sdk_ready`: `_resolve_process_start` falls
+    back to import time when psutil cannot read /proc, which would make the two
+    the same instant rather than an inverted interval.
+    """
+    return max(0, int(round((_module_import_unix - _process_start_unix) * 1000.0)))
 
 
 def process_uptime_ms() -> int:

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -113,6 +113,22 @@ PHASE_STAGE_PREFIX: Final[str] = "stage:"
 #: carry the full fidelity either way.
 MAX_PACKED_RUNS: Final[int] = 32
 
+#: How many per-stage rows one boot may put on the wire.
+#:
+#: NOT a stylistic cap. `boot_phases` buffers up to 2048 rows, and a
+#: pathological boot (a checkpoint with hundreds of components, a pod that
+#: reconnected repeatedly) would turn `emit` into a two-thousand-message burst
+#: on the worker->hub stream at exactly the moment the pod is trying to start
+#: serving. The report must never be able to cost more than the thing it
+#: reports on.
+#:
+#: The ROLL-UP is never dropped — it is emitted after the children and carries
+#: the packed table, so a truncated series still answers the question the whole
+#: event exists for. What is lost is per-span detail, and `rows_truncated=` says
+#: so rather than leaving a reader to wonder why a stage has fewer rows than
+#: spans.
+MAX_STAGE_ROWS: Final[int] = 64
+
 
 class Stage(StrEnum):
     """The closed cold-boot stage vocabulary.
@@ -698,13 +714,22 @@ def emit(table: Optional[BootStageTable] = None, *, family: str = "") -> bool:
 
         if table is None:
             table = collect()
-        for span in table.spans:
+        # Longest spans first, so a truncated series keeps the rows an operator
+        # would actually have read. Dropping the tail of an arbitrary order
+        # would be as likely to discard the 805 s derive as a 2 ms fold.
+        ordered = sorted(
+            table.spans, key=lambda s: s.duration_ms, reverse=True)
+        dropped = max(0, len(ordered) - MAX_STAGE_ROWS)
+        for span in ordered[:MAX_STAGE_ROWS]:
             activity_mod.emit_event(
                 KIND, stage_detail(span),
                 phase=PHASE_STAGE_PREFIX + span.stage.value,
                 duration_ms=span.duration_ms, family=family)
+        detail = rollup_detail(table)
+        if dropped:
+            detail = f"{detail} rows_truncated={dropped}"
         activity_mod.emit_event(
-            KIND, rollup_detail(table), phase=PHASE_READY,
+            KIND, detail, phase=PHASE_READY,
             duration_ms=table.wall_ms, family=family)
         logger.info("[boot] stages:\n%s", render(table))
         return True

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -646,9 +646,48 @@ def parse_runs(packed: str) -> Tuple[Tuple[Stage, int, int], ...]:
     return tuple(out)
 
 
+def _packed_or_refused(table: BootStageTable) -> Tuple[str, bool, bool]:
+    """Pack the table and PROVE the packed form parses back.
+
+    The renderer that consumes ``runs=`` lives in another repository, on a
+    release cadence this worker knows nothing about. If a packing bug ever
+    ships, the symptom over there is a parse error on a pod that is otherwise
+    healthy — days later, in somebody else's lane, with no way to tell a broken
+    emitter from a broken reader.
+
+    So the emitter checks its own output against its own parser before shipping
+    it. A token that does not round-trip is DROPPED and confessed as
+    ``runs_unpackable=1``, never shipped in the hope that the reader copes:
+    pgw#1339's rule, that a degradation is loud and the surviving report still
+    serves. Every scalar total is stated independently of ``runs=``, so a
+    reader that loses the packed table still gets the wall, the critical path
+    and the overlap.
+
+    Returns ``(packed, truncated, unpackable)``.
+    """
+    packed, truncated = pack_runs(table)
+    try:
+        parsed = parse_runs(packed)
+    except Exception:
+        logger.warning(
+            "[boot] the packed stage table does not parse back and was DROPPED "
+            "— the totals still ship; this is an emitter bug (pgw#1355)",
+            exc_info=True)
+        return "-", truncated, True
+    expected = table.runs()
+    if not truncated and list(parsed) != [
+            (stage, start, end) for stage, start, end in expected]:
+        logger.warning(
+            "[boot] the packed stage table round-tripped to a DIFFERENT table "
+            "and was dropped: %d run(s) in, %d out (pgw#1355)",
+            len(expected), len(parsed))
+        return "-", truncated, True
+    return packed, truncated, False
+
+
 def rollup_detail(table: BootStageTable) -> str:
     """The terminal roll-up's ``detail`` line."""
-    packed, truncated = pack_runs(table)
+    packed, truncated, unpackable = _packed_or_refused(table)
     parts = [
         f"v={SCHEMA_VERSION}",
         f"wall_ms={table.wall_ms}",
@@ -667,6 +706,8 @@ def rollup_detail(table: BootStageTable) -> str:
             parts.append(f"{key}={value}")
     if truncated:
         parts.append("runs_truncated=1")
+    if unpackable:
+        parts.append("runs_unpackable=1")
     parts.append(f"runs={packed}")
     return " ".join(parts)
 

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -82,7 +82,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Dict, Final, List, Mapping, Optional, Sequence, Tuple

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -381,11 +381,19 @@ class BootStageTable:
         return int(round(100.0 * min(1.0, self.critical_path_ms / self.wall_ms)))
 
     def runs(self) -> List[Tuple[Stage, int, int]]:
-        """Disjoint runs per stage, in walk order then time order.
+        """Disjoint runs per stage, in CHRONOLOGICAL order.
 
-        Per stage rather than globally: a stage that ran twice with a gap is a
-        different fact from one that ran once for the span of both, and
+        Merged per stage rather than globally: a stage that ran twice with a
+        gap is a different fact from one that ran once across both, and
         collapsing them would hide it.
+
+        Sorted by start time rather than by the enum, because this table is
+        read as a timeline. Enum order looks right until a stage runs out of
+        position — on a real cold sdxl boot `model_load` happens THIRTEEN
+        MINUTES after `keyset` starts, and printing it above `keyset` because
+        it sits earlier in the vocabulary makes the reader distrust the
+        column they came for. The enum is the tiebreak for runs that begin
+        together, so the order is still total and still stable.
         """
         out: List[Tuple[Stage, int, int]] = []
         for stage in STAGES:
@@ -395,6 +403,7 @@ class BootStageTable:
                 continue
             for start, end in _union_runs(intervals):
                 out.append((stage, start, end))
+        out.sort(key=lambda row: (row[1], row[2], STAGES.index(row[0])))
         return out
 
     def busy_ms(self, stage: Stage) -> int:

--- a/src/gen_worker/boot_stages.py
+++ b/src/gen_worker/boot_stages.py
@@ -1,0 +1,776 @@
+"""pgw#1355: a cold boot states its OWN decomposition, as one readable fact.
+
+e2e#1892 measured an 877 s cold serve and had to assemble the breakdown BY
+HAND, from four different event kinds:
+
+    41 s   queue          the request row's own timestamps
+    ~18 s  boot/imports   `worker_boot_phases` (its own hub table, its own route)
+    1.1 s  snapshot pull  `load_phase` on that same table
+    2.5 s  model load     ditto
+    804 s  keyset derive  `boot_adopt.duration_ms` on `worker_activity_events`
+    6.2 s  compute        the request row again
+    2.4 s  finalize       the request row again
+
+Every one of those numbers already existed. What did not exist was a place
+where the SHAPE of a cold boot is stated once, so this module is a JOIN made
+durable at the source rather than a new clock. It reads the spans the worker
+already records — :mod:`gen_worker.boot_phases` (which already carries
+start/end offsets from OS process start), ``boot_adopt``'s derive wall, the
+``snapshot_pull`` roll-up — folds them into a CLOSED stage vocabulary, and
+emits one versioned ``boot_stages`` event series on the channel everything
+else is already read from.
+
+# Why a second reporter, when `boot_phases` is already good
+
+``boot_phases`` is a good instrument on a channel nobody joins against, with
+three holes:
+
+1. **It rides ``worker_boot_phases``** — a different hub table, a different
+   admin route (``admin_worker_boot_phases.go``) and a different reader from
+   ``worker_activity_events``, which is where ``boot_adopt``, ``snapshot_pull``,
+   ``compile_child`` and every other worker fact lands. Answering "where did
+   this pod's cold start go" therefore costs a cross-table join that no caller
+   had, so no caller did it.
+2. **Its window closes too early.** ``first_request_servable`` is marked when a
+   StateDelta advertises a function, which on an eager-first boot happens
+   before the model is loaded at all. pgw#1353 measured the consequence: the
+   ladder goes ``first_request_servable`` and then **871 s of silence** to
+   ``eager_ready``, and the 805 s keyset derive that fills the silence has no
+   span on any channel.
+3. **Its vocabulary is open.** 21 phase names, added as producers appeared.
+   That is right for a decomposition ladder and wrong for a report a renderer
+   in another repository has to bind to.
+
+So this module is deliberately NOT a replacement. ``boot_phases`` keeps every
+row at full fidelity; ``boot_stages`` is the reduction of it that fits on one
+line of an operator's screen, closed enough for a Go renderer to parse, and on
+the channel that renderer already reads.
+
+# Overlap is first-class, and the arithmetic is a UNION
+
+Stages run CONCURRENTLY on a real pod — a snapshot pull overlaps a component
+load overlaps a derive — and a report that serialized them would be inventing a
+boot that did not happen. Every span carries ``t0_ms``/``t1_ms`` as offsets from
+OS process start, so concurrency is visible rather than inferred.
+
+The consequence is the rule this module refuses to break: **the total is the
+UNION of the spans, never their sum.** ``boot_phases`` learned this the
+expensive way (its own header records a summing reconciliation that "explained"
+3,338 ms of a 909 ms fetch). A sum that exceeds wall is not a rounding problem,
+it is a report that has stopped describing time. So:
+
+    span_sum_ms  = the sum of every span's duration    (>= union whenever
+                                                        anything overlapped)
+    critical_path_ms = the UNION — wall in which SOMETHING was running
+    overlap_ms   = span_sum_ms - critical_path_ms      (>= 0, by construction)
+    unmeasured_ms = wall_ms - critical_path_ms         (the honest hole)
+
+``unmeasured_ms`` is NAMED, never smeared across the stages: "unmeasured" and
+"zero" are different answers, and the hole is the hint about where the next
+instrument belongs.
+
+# The vocabulary is CLOSED
+
+:class:`Stage` is an enum and :func:`record` REFUSES a name that is not in it.
+An open vocabulary is right for the ladder underneath and wrong here: a
+renderer in another repo binds to these tokens, and a stage invented at a call
+site is a column that appears in production and in no reader. A new stage is a
+deliberate edit to this file, which is the review this deserves.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Dict, Final, List, Mapping, Optional, Sequence, Tuple
+
+from . import boot_phases
+from .pb import worker_scheduler_pb2 as pb
+
+logger = logging.getLogger(__name__)
+
+#: Wire envelope version. A reader that does not recognise it must say so
+#: rather than parse the fields it happens to know: this event is read by a Go
+#: renderer in another repository, on a fleet that upgrades independently of it.
+SCHEMA_VERSION: Final[int] = 1
+
+#: The kind, on `worker_activity_events` via the th#1839 route. Mirrored in
+#: `activity.KIND_BOOT_STAGES`; defined there with the rest of the vocabulary.
+KIND: Final[str] = "boot_stages"
+
+#: The terminal roll-up's phase. Per-stage rows are `stage:<name>`; a reader
+#: after the whole table wants exactly one row and this is it.
+PHASE_READY: Final[str] = "ready"
+
+#: Prefix for the per-stage rows.
+PHASE_STAGE_PREFIX: Final[str] = "stage:"
+
+#: How many packed span runs the roll-up carries before it truncates loudly.
+#: `detail` is capped at 2000 chars hub-side; a run costs ~24. A boot with more
+#: disjoint runs than this has a finding of its own, and the per-stage rows
+#: carry the full fidelity either way.
+MAX_PACKED_RUNS: Final[int] = 32
+
+
+class Stage(StrEnum):
+    """The closed cold-boot stage vocabulary.
+
+    Ordered as a cold boot walks them. The order is a RENDERING convenience,
+    not a claim about sequence — several of these genuinely overlap, which is
+    the whole reason the spans carry offsets.
+    """
+
+    #: OS process creation -> the first gen_worker module that can observe a
+    #: clock. Interpreter startup, `site`, and the import chain up to the
+    #: recorder itself. No span can cover this: nothing can open a span before
+    #: the module that opens spans is imported, so it is measured as the
+    #: difference between two timestamps rather than bracketed.
+    PROCESS_BOOT = "process_boot"
+    #: The recorder exists -> the SDK is usable. `import torch`, endpoint-module
+    #: discovery, executor construction, and the environment seal that derives
+    #: the toolchain/sm key axes everything downstream needs. Process setup, as
+    #: distinct from any model work.
+    IMPORTS = "imports"
+    #: SDK ready -> the first local work this worker was told to do. The gRPC
+    #: dial, the Hello/HelloAck round trip and the wait for a residency order —
+    #: real boot seconds in which the worker deliberately does nothing, so no
+    #: span can cover them and leaving them unnamed reads as an instrument hole
+    #: rather than as the hub round trip it is.
+    HUB_HANDSHAKE = "hub_handshake"
+    #: Bytes onto local disk. Per component where the pull decomposes, because
+    #: four components inside one 200 s pull that each measure 180 s were
+    #: OVERLAPPED, and that is a different finding from four sequential 50 s
+    #: ones. pgw#1351's `snapshot_pull` roll-up says what those bytes cost the
+    #: wire; this says when they were moving.
+    SNAPSHOT_PULL = "snapshot_pull"
+    #: Weights on disk -> weights in VRAM. Per component where the load
+    #: decomposes.
+    MODEL_LOAD = "model_load"
+    #: The compiled-graph key set: DERIVED by tracing, or READ from shipped
+    #: data or this machine's memo. `keys_from` is the axis that tells them
+    #: apart and it is the single most load-bearing attribute in this table —
+    #: pgw#1353 measured `keys_from=traced` costing 805 s on every sdxl pod,
+    #: against milliseconds for a read.
+    KEYSET = "keyset"
+    #: Getting a compiled cell: the boot-adopt decision, the fetch it orders
+    #: and the staging/verification before the first dlopen.
+    ADOPT = "adopt"
+    #: Making a fetched cell the served path: entry admission, constant bind,
+    #: ingress arming, the parity sweep.
+    ARM = "arm"
+    #: The warm forwards. An ARMED warm pays the call; an unarmed one pays a
+    #: compile, and they are recorded as the same stage because they are the
+    #: same position in the boot — the attributes say which happened.
+    WARMUP = "warmup"
+    #: The terminal milestone: the first instant this worker could serve a
+    #: request at all. A zero-width span at `wall_ms`, so the vocabulary can
+    #: name the boundary without pretending it had a duration.
+    READY = "ready"
+
+
+#: Every stage, in walk order — the render order and the enum's declaration
+#: order are the same thing on purpose.
+STAGES: Final[Tuple[Stage, ...]] = tuple(Stage)
+
+#: Which stage each :mod:`gen_worker.boot_phases` phase folds into.
+#:
+#: A phase absent from this map contributes NOTHING to the table rather than
+#: being guessed into a bucket, and :func:`unmapped_phases` names the gap so a
+#: new boot phase with no home is a test failure here instead of a silent
+#: omission in production. That is the same rule `boot_phases.phase_class`
+#: applies to its own classification, for the same reason.
+_STAGE_BY_PHASE: Final[Mapping[str, Stage]] = {
+    boot_phases.PHASE_ENV_ESTABLISH: Stage.IMPORTS,
+    boot_phases.PHASE_LIB_MEMO: Stage.IMPORTS,
+    boot_phases.PHASE_WEIGHTS_FETCH: Stage.SNAPSHOT_PULL,
+    boot_phases.PHASE_COMPONENT_FETCH: Stage.SNAPSHOT_PULL,
+    boot_phases.PHASE_PIPELINE_LOAD: Stage.MODEL_LOAD,
+    boot_phases.PHASE_DECLARATION_COMPOSE: Stage.KEYSET,
+    boot_phases.PHASE_TRACE_FOR_KEY: Stage.KEYSET,
+    boot_phases.PHASE_KEY_FOLD: Stage.KEYSET,
+    boot_phases.PHASE_CELL_FETCH: Stage.ADOPT,
+    boot_phases.PHASE_CELL_VERIFY: Stage.ADOPT,
+    boot_phases.PHASE_CELL_HUB_RTT: Stage.ADOPT,
+    boot_phases.PHASE_CELL_ARM: Stage.ARM,
+    boot_phases.PHASE_ENTRY_ADMIT: Stage.ARM,
+    boot_phases.PHASE_WARMUP: Stage.WARMUP,
+}
+
+#: Boot phases that are deliberately NOT folded into a stage, with the reason.
+#: They are CUMULATIVE milestones — each measures from process start, so it
+#: covers wall clock the spans already account for, and adding one as a span
+#: would double-count the whole boot. Two of them are used as BOUNDARIES
+#: instead (see :func:`collect`).
+_MILESTONE_PHASES: Final[Mapping[str, str]] = {
+    boot_phases.PHASE_SDK_READY:
+        "boundary: splits process_boot from imports",
+    boot_phases.PHASE_HELLO:
+        "boundary: the hub handshake's close",
+    boot_phases.PHASE_EAGER_READY:
+        "the terminal — becomes Stage.READY and the roll-up's wall_ms",
+    boot_phases.PHASE_FIRST_REQUEST_SERVABLE:
+        "reported as the roll-up's servable_ms attribute, not as a span",
+    boot_phases.PHASE_COMPILED_SWAP:
+        "lands after the boot closes; the eager-serving window, not a stage",
+}
+
+
+def unmapped_phases() -> Tuple[str, ...]:
+    """Boot phases with neither a stage nor a documented exemption.
+
+    A boot phase that reaches production with no home here silently drops its
+    seconds out of this table. Asserted by the suite, so adding a phase to
+    ``boot_phases`` without deciding where it belongs is red rather than
+    invisible.
+    """
+    return tuple(sorted(
+        phase for phase in boot_phases.PHASES
+        if phase not in _STAGE_BY_PHASE and phase not in _MILESTONE_PHASES
+    ))
+
+
+class UnknownStageError(ValueError):
+    """A stage name that is not in the closed vocabulary.
+
+    Raised, never logged-and-dropped: the caller is inventing a column, and a
+    report that quietly accepts one is a report whose vocabulary is not closed
+    after all. Telemetry never breaks the work it measures, so every EMISSION
+    path catches broadly — but the refusal happens first, at the call site that
+    can actually be fixed.
+    """
+
+
+def _token(value: object) -> str:
+    """A ``k=v`` value with no whitespace in it, and never empty.
+
+    The same rule pgw#1351's ``snapshot_pull`` detail follows, and for the same
+    reason: an empty value ends the token at the ``=`` and silently merges the
+    next pair into it, while a value containing a space splits one pair into
+    two. Both produce a detail line that parses without error and means
+    something else.
+    """
+    cleaned = "".join(ch for ch in str(value if value is not None else "")
+                      if not ch.isspace())
+    return cleaned or "-"
+
+
+@dataclass(frozen=True, slots=True)
+class StageSpan:
+    """One interval of one stage, in ms from OS process start.
+
+    ``t0_ms``/``t1_ms`` rather than a duration, because a duration cannot say
+    whether two stages ran at the same time and that is the question this whole
+    module exists to answer.
+    """
+
+    stage: Stage
+    t0_ms: int
+    t1_ms: int
+    #: What produced this span — the originating boot phase, or the module that
+    #: recorded it directly. Carried so nothing is lost in the reduction: a
+    #: reader that wants the underlying ladder knows which row to go find.
+    label: str = ""
+    #: Stage-specific facts as ``k=v``-safe values (``keys_from``, ``classes``,
+    #: ``component``, ``bytes``, ``outcome``). Never load-bearing for the
+    #: arithmetic — the table reconciles on the intervals alone.
+    attrs: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.stage not in STAGES:
+            raise UnknownStageError(
+                f"{self.stage!r} is not a boot stage; the vocabulary is closed "
+                f"and is {[s.value for s in STAGES]}")
+        if self.t1_ms < self.t0_ms:
+            raise ValueError(
+                f"stage {self.stage.value} ends before it starts "
+                f"(t0_ms={self.t0_ms} t1_ms={self.t1_ms})")
+
+    @property
+    def duration_ms(self) -> int:
+        return self.t1_ms - self.t0_ms
+
+
+def _union_runs(intervals: Sequence[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    """Merge intervals into disjoint runs, in order.
+
+    The one arithmetic primitive this module has, and every total is computed
+    from it: overlapping time is counted ONCE. A sum is never a total here.
+    """
+    runs: List[Tuple[int, int]] = []
+    for start, end in sorted(intervals):
+        if runs and start <= runs[-1][1]:
+            if end > runs[-1][1]:
+                runs[-1] = (runs[-1][0], end)
+            continue
+        runs.append((start, end))
+    return runs
+
+
+def _union_ms(intervals: Sequence[Tuple[int, int]]) -> int:
+    return sum(end - start for start, end in _union_runs(intervals))
+
+
+@dataclass(frozen=True, slots=True)
+class BootStageTable:
+    """A cold boot's stages, and the totals that must reconcile.
+
+    ``wall_ms`` is the boot's own clock — process start to the terminal
+    milestone — and is NOT derived from the spans. That is deliberate: a total
+    computed from the parts can never fail to close, so it could never report
+    an instrument hole, and the hole is the finding.
+    """
+
+    spans: Tuple[StageSpan, ...]
+    wall_ms: int
+    #: Process start -> `first_request_servable`, when the boot reached it.
+    #: Reported beside the wall rather than as a stage: on an eager-first boot
+    #: it lands long before the pod can actually serve, and pgw#1353's 871 s of
+    #: silence is exactly the gap between the two.
+    servable_ms: int = 0
+    #: True when the packed roll-up dropped runs it could not fit.
+    truncated: bool = False
+
+    @property
+    def span_sum_ms(self) -> int:
+        """The sum of every span. Exceeds :attr:`critical_path_ms` whenever
+        anything overlapped, and is reported only so the difference can be."""
+        return sum(s.duration_ms for s in self.spans)
+
+    @property
+    def critical_path_ms(self) -> int:
+        """Wall in which SOMETHING was running — the union, never the sum.
+
+        This is the number a cold-start budget is spent against: shortening a
+        stage that ran entirely inside another stage's window buys nothing, and
+        only a union can say so.
+        """
+        return _union_ms([(s.t0_ms, s.t1_ms) for s in self.spans])
+
+    @property
+    def overlap_ms(self) -> int:
+        """How much of this boot was parallel. Non-negative by construction."""
+        return max(0, self.span_sum_ms - self.critical_path_ms)
+
+    @property
+    def unmeasured_ms(self) -> int:
+        """Wall no stage explained. NAMED, never smeared across the stages."""
+        return max(0, self.wall_ms - self.critical_path_ms)
+
+    @property
+    def accounted_pct(self) -> int:
+        if self.wall_ms <= 0:
+            return 0
+        return int(round(100.0 * min(1.0, self.critical_path_ms / self.wall_ms)))
+
+    def runs(self) -> List[Tuple[Stage, int, int]]:
+        """Disjoint runs per stage, in walk order then time order.
+
+        Per stage rather than globally: a stage that ran twice with a gap is a
+        different fact from one that ran once for the span of both, and
+        collapsing them would hide it.
+        """
+        out: List[Tuple[Stage, int, int]] = []
+        for stage in STAGES:
+            intervals = [
+                (s.t0_ms, s.t1_ms) for s in self.spans if s.stage is stage]
+            if not intervals:
+                continue
+            for start, end in _union_runs(intervals):
+                out.append((stage, start, end))
+        return out
+
+    def busy_ms(self, stage: Stage) -> int:
+        """One stage's own union — its wall, overlaps within it counted once."""
+        return _union_ms(
+            [(s.t0_ms, s.t1_ms) for s in self.spans if s.stage is stage])
+
+    def attr(self, key: str) -> str:
+        """The first value any span carries for ``key``, or ``""``.
+
+        How ``keys_from`` reaches the roll-up: it is a property of the boot,
+        recorded on the stage that learned it.
+        """
+        for span in self.spans:
+            value = span.attrs.get(key, "")
+            if value:
+                return value
+        return ""
+
+
+# --- the direct recorder ----------------------------------------------------
+# For stages with no `boot_phases` span of their own. pgw#1353's keyset derive
+# is the load-bearing case: it runs during a REQUEST, after the boot window
+# closed, so `boot_phases.in_boot()` is already False and no ladder row covers
+# its 805 seconds.
+
+_lock = threading.Lock()
+_recorded: List[StageSpan] = []
+
+
+def record(
+    stage: Stage,
+    *,
+    t0_ms: int,
+    t1_ms: int,
+    label: str = "",
+    **attrs: object,
+) -> None:
+    """Record one stage span directly, in ms from OS process start.
+
+    For a stage the ladder cannot see. Prefer instrumenting ``boot_phases`` when
+    the work IS inside the boot window — this is not a second way to say the
+    same thing, it is the way to say something the ladder structurally cannot.
+
+    A span recorded here and a ladder row covering the same wall do not
+    double-count: every total is a union.
+
+    Raises :class:`UnknownStageError` on a name outside the vocabulary. Never
+    raises for any other reason — a boot that succeeded is never failed by the
+    thing measuring it.
+    """
+    span = StageSpan(
+        stage=stage, t0_ms=max(0, int(t0_ms)), t1_ms=max(0, int(t1_ms)),
+        label=label,
+        attrs={k: _token(v) for k, v in attrs.items() if v not in (None, "")},
+    )
+    try:
+        with _lock:
+            _recorded.append(span)
+    except Exception:  # pragma: no cover — telemetry never breaks a boot
+        logger.debug("boot stage span dropped", exc_info=True)
+
+
+def record_ending_now(
+    stage: Stage, *, duration_ms: int, label: str = "", **attrs: object,
+) -> None:
+    """:func:`record` a span that just CLOSED, given only its duration.
+
+    The shape almost every existing internal measurement has: a caller times a
+    block with a monotonic clock and knows the wall it took, not the offsets it
+    occupied. Reading the process clock at the close recovers the interval, and
+    is the minimal instrument a stage needs to join this table.
+
+    A duration LONGER than the process has existed is a contradiction — the two
+    numbers came from different clocks, or the caller passed a wall it did not
+    measure here. The span is clamped to the process start, because a negative
+    offset is not representable, and the clamp CONFESSES as ``clamped_ms``: a
+    silently shortened span is a wrong measurement that reads as a right one,
+    which is the defect this whole vocabulary keeps closing.
+    """
+    end = boot_phases.process_uptime_ms()
+    wall = max(0, int(duration_ms))
+    lost = max(0, wall - end)
+    if lost:
+        attrs = {**attrs, "clamped_ms": lost}
+    record(stage, t0_ms=end - wall + lost, t1_ms=end, label=label, **attrs)
+
+
+def recorded() -> Tuple[StageSpan, ...]:
+    """Spans recorded directly (tests, diagnostics)."""
+    with _lock:
+        return tuple(_recorded)
+
+
+def reset_for_tests() -> None:
+    """Drop recorded spans and the once-only emission latch. Test-only."""
+    global _emitted
+    with _lock:
+        _recorded.clear()
+        _emitted = False
+
+
+# --- collection -------------------------------------------------------------
+
+
+def collect(
+    *,
+    rows: Optional[List["pb.BootPhase"]] = None,
+    extra: Sequence[StageSpan] = (),
+) -> BootStageTable:
+    """Fold this process's boot into the stage table.
+
+    ``rows`` overrides the ladder with one captured off the wire, so a test can
+    ask the SAME arithmetic about a modified boot — delete a stage's rows from a
+    real ladder and the verdict must move. ``extra`` adds spans without
+    recording them globally, which is how a fixture builds a boot that never
+    ran.
+    """
+    table = boot_phases.phase_table(rows)
+    milestones: Dict[str, int] = {
+        row.phase: row.duration_ms for row in table if row.cumulative}
+
+    spans: List[StageSpan] = []
+    for row in table:
+        if row.cumulative:
+            continue
+        stage = _STAGE_BY_PHASE.get(row.phase)
+        if stage is None:
+            continue
+        attrs: Dict[str, str] = {}
+        if row.function:
+            attrs["component"] = _token(row.function)
+        if row.bytes:
+            attrs["bytes"] = str(row.bytes)
+        if row.source:
+            attrs["source"] = _token(row.source)
+        if row.outcome and row.outcome != boot_phases.OUTCOME_OK:
+            attrs["outcome"] = _token(row.outcome)
+        if row.reason:
+            attrs["reason"] = _token(row.reason)
+        spans.append(StageSpan(
+            stage=stage, t0_ms=row.start_ms, t1_ms=row.end_ms,
+            label=row.phase, attrs=attrs))
+
+    # The two windows no span can cover, recovered from the milestones that
+    # bound them. `boot_phases` already names both in its own reconciliation;
+    # this states them as INTERVALS so they take their place in the table
+    # instead of living in a footer.
+    sdk_ready = milestones.get(boot_phases.PHASE_SDK_READY)
+    if sdk_ready is not None:
+        import_ms = min(boot_phases.module_import_ms(), sdk_ready)
+        spans.append(StageSpan(
+            stage=Stage.PROCESS_BOOT, t0_ms=0, t1_ms=import_ms,
+            label="interpreter+import"))
+        spans.append(StageSpan(
+            stage=Stage.IMPORTS, t0_ms=import_ms, t1_ms=sdk_ready,
+            label=boot_phases.PHASE_SDK_READY))
+        # SDK ready -> the first LOCAL work. A `hello` milestone bounds it
+        # exactly; without one, the first top-level span does, and with neither
+        # the stage is simply absent — which is the honest answer, not a zero.
+        handshake_end = milestones.get(boot_phases.PHASE_HELLO)
+        if handshake_end is None:
+            starts = [
+                row.start_ms for row in table
+                if not row.cumulative and not row.parent_ordinal
+                and row.start_ms >= sdk_ready]
+            handshake_end = min(starts) if starts else None
+        if handshake_end is not None and handshake_end >= sdk_ready:
+            spans.append(StageSpan(
+                stage=Stage.HUB_HANDSHAKE, t0_ms=sdk_ready,
+                t1_ms=handshake_end,
+                label=boot_phases.PHASE_HELLO if boot_phases.PHASE_HELLO
+                in milestones else "first_local_work"))
+
+    with _lock:
+        spans.extend(_recorded)
+    spans.extend(extra)
+
+    # The wall is the terminal milestone's own cumulative measurement, not a
+    # number derived from the spans: a total computed from the parts can never
+    # fail to close, so it could never report a hole.
+    wall_ms = milestones.get(boot_phases.PHASE_EAGER_READY, 0)
+    servable_ms = milestones.get(boot_phases.PHASE_FIRST_REQUEST_SERVABLE, 0)
+    if wall_ms <= 0:
+        # No terminal milestone: the boot has not reached ready. The table is
+        # still worth having (an operator looking at a stuck pod wants exactly
+        # this), and the wall falls back to the furthest span end so the
+        # reconciliation describes what HAS happened rather than dividing by
+        # zero.
+        wall_ms = max((s.t1_ms for s in spans), default=0)
+    if wall_ms > 0:
+        spans.append(StageSpan(
+            stage=Stage.READY, t0_ms=wall_ms, t1_ms=wall_ms, label="eager_ready"))
+
+    ordered = tuple(sorted(
+        spans, key=lambda s: (STAGES.index(s.stage), s.t0_ms, s.t1_ms)))
+    return BootStageTable(
+        spans=ordered, wall_ms=wall_ms, servable_ms=servable_ms)
+
+
+# --- the wire codec ---------------------------------------------------------
+# `detail` is free text the th#1839 route serves VERBATIM, so the grammar is
+# the contract: space-separated `k=v` whose values never contain spaces, which
+# `(\w+)=(\S+)` parses entirely. e2e's `detailKV` already implements exactly
+# that, so the renderer needs no new parser — only this packing.
+
+
+def pack_runs(table: BootStageTable) -> Tuple[str, bool]:
+    """The stage table as ONE ``k=v``-safe token: ``name:t0-t1,name:t0-t1``.
+
+    Packed into the roll-up so reading a boot's shape is a ONE-ROW query. The
+    per-stage rows carry the same intervals with their attributes; this is the
+    summary that makes the join unnecessary, not a replacement for them.
+
+    Returns the token and whether it was truncated. Truncation is reported, not
+    silent: a table that dropped runs is a table whose union no longer closes,
+    and a reader must be able to tell that from a boot that simply had fewer
+    stages.
+    """
+    runs = table.runs()
+    truncated = len(runs) > MAX_PACKED_RUNS
+    kept = runs[:MAX_PACKED_RUNS]
+    packed = ",".join(
+        f"{stage.value}:{start}-{end}" for stage, start, end in kept)
+    return (packed or "-"), truncated
+
+
+def parse_runs(packed: str) -> Tuple[Tuple[Stage, int, int], ...]:
+    """Inverse of :func:`pack_runs`. The round trip is what the suite asserts.
+
+    A run naming a stage outside the vocabulary raises: a reader that silently
+    skipped it would under-report a boot rather than say it does not understand
+    the fleet it is reading, and the second is the answer an operator can act
+    on.
+    """
+    if not packed or packed == "-":
+        return ()
+    out: List[Tuple[Stage, int, int]] = []
+    for entry in packed.split(","):
+        name, _, window = entry.partition(":")
+        start_s, _, end_s = window.partition("-")
+        try:
+            stage = Stage(name)
+        except ValueError as exc:
+            raise UnknownStageError(
+                f"{name!r} is not a boot stage; this reader does not understand "
+                f"the fleet that emitted it") from exc
+        out.append((stage, int(start_s), int(end_s)))
+    return tuple(out)
+
+
+def rollup_detail(table: BootStageTable) -> str:
+    """The terminal roll-up's ``detail`` line."""
+    packed, truncated = pack_runs(table)
+    parts = [
+        f"v={SCHEMA_VERSION}",
+        f"wall_ms={table.wall_ms}",
+        f"critical_path_ms={table.critical_path_ms}",
+        f"span_sum_ms={table.span_sum_ms}",
+        f"overlap_ms={table.overlap_ms}",
+        f"unmeasured_ms={table.unmeasured_ms}",
+        f"accounted_pct={table.accounted_pct}",
+        f"servable_ms={table.servable_ms}",
+        f"stages={len({s.stage for s in table.spans})}",
+        f"spans={len(table.spans)}",
+    ]
+    for key in ("keys_from", "classes", "family"):
+        value = table.attr(key)
+        if value:
+            parts.append(f"{key}={value}")
+    if truncated:
+        parts.append("runs_truncated=1")
+    parts.append(f"runs={packed}")
+    return " ".join(parts)
+
+
+def stage_detail(span: StageSpan) -> str:
+    """One per-stage row's ``detail`` line."""
+    parts = [
+        f"v={SCHEMA_VERSION}",
+        f"stage={span.stage.value}",
+        f"t0_ms={span.t0_ms}",
+        f"t1_ms={span.t1_ms}",
+    ]
+    if span.label:
+        parts.append(f"label={_token(span.label)}")
+    parts.extend(f"{k}={_token(v)}" for k, v in sorted(span.attrs.items()))
+    return " ".join(parts)
+
+
+# --- emission ---------------------------------------------------------------
+
+_emitted = False
+
+
+def emit(table: Optional[BootStageTable] = None, *, family: str = "") -> bool:
+    """Report this boot's stages: one row per span, then ONE terminal roll-up.
+
+    A series with a roll-up rather than a single event, for the reason
+    `aot_mint_phases` and `jit_compile` already use that shape: the roll-up is
+    what a reader groups on, and the children are what it drills into. The
+    roll-up is emitted LAST so a reader that sees it knows the series is
+    complete.
+
+    Once per process. Returns whether it emitted — False on a second call, so a
+    caller sitting on a `mark_once` boundary cannot double-report.
+
+    Never raises. A boot that reached ready is not failed by the report of it.
+    """
+    global _emitted
+    with _lock:
+        if _emitted:
+            return False
+        _emitted = True
+    try:
+        from . import activity as activity_mod
+
+        if table is None:
+            table = collect()
+        for span in table.spans:
+            activity_mod.emit_event(
+                KIND, stage_detail(span),
+                phase=PHASE_STAGE_PREFIX + span.stage.value,
+                duration_ms=span.duration_ms, family=family)
+        activity_mod.emit_event(
+            KIND, rollup_detail(table), phase=PHASE_READY,
+            duration_ms=table.wall_ms, family=family)
+        logger.info("[boot] stages:\n%s", render(table))
+        return True
+    except Exception:  # pragma: no cover — telemetry never breaks a boot
+        logger.debug("boot stages report failed", exc_info=True)
+        return False
+
+
+# --- rendering --------------------------------------------------------------
+
+
+def render(table: BootStageTable) -> str:
+    """The stage table as fixed-width text — what a runbook pastes.
+
+    The same table the e2e renderer prints from the wire, so an operator with a
+    pod shell and an operator reading the hub see the same shape.
+    """
+    lines = [
+        f"{'stage':<15} {'t0_ms':>9} {'t1_ms':>9} {'busy_ms':>9} "
+        f"{'bar':<32} what",
+    ]
+    scale = max(1, table.wall_ms)
+    for stage, start, end in table.runs():
+        attrs = " ".join(
+            sorted({
+                f"{k}={v}"
+                for span in table.spans if span.stage is stage
+                for k, v in span.attrs.items()
+            }))
+        head = int(round(32.0 * start / scale))
+        width = max(1, int(round(32.0 * (end - start) / scale))) if end > start else 0
+        bar = " " * head + "#" * min(width, max(0, 32 - head))
+        lines.append(
+            f"{stage.value:<15} {start:>9} {end:>9} {end - start:>9} "
+            f"{bar:<32} {attrs[:60]}")
+    lines.append("")
+    lines.append(
+        f"wall_ms={table.wall_ms} critical_path_ms={table.critical_path_ms} "
+        f"span_sum_ms={table.span_sum_ms} overlap_ms={table.overlap_ms} "
+        f"unmeasured_ms={table.unmeasured_ms} "
+        f"accounted_pct={table.accounted_pct}%")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "KIND",
+    "MAX_PACKED_RUNS",
+    "PHASE_READY",
+    "PHASE_STAGE_PREFIX",
+    "SCHEMA_VERSION",
+    "STAGES",
+    "BootStageTable",
+    "Stage",
+    "StageSpan",
+    "UnknownStageError",
+    "collect",
+    "emit",
+    "pack_runs",
+    "parse_runs",
+    "record",
+    "record_ending_now",
+    "recorded",
+    "render",
+    "reset_for_tests",
+    "rollup_detail",
+    "stage_detail",
+    "unmapped_phases",
+]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -4711,7 +4711,24 @@ class Executor:
             # trying to shrink and which nothing measured. Distinct from
             # `first_request_servable`, which additionally requires the hub to
             # have been told (a worker the hub cannot reach is not servable).
-            boot_mod.mark_once(boot_mod.PHASE_EAGER_READY, function=spec.name)
+            if boot_mod.mark_once(
+                    boot_mod.PHASE_EAGER_READY, function=spec.name):
+                # pgw#1355: THE cold-boot report, emitted at the one instant
+                # that is actually "ready". Deliberately NOT at
+                # `first_request_servable`, which lifecycle marks when a
+                # StateDelta advertises a function — on this eager-first boot
+                # that happens before the model is loaded at all, and pgw#1353
+                # measured the consequence: 871 s of silence between the two,
+                # filled entirely by a key-set derive that no channel reported.
+                # Ready means "could have answered a request", so the wall this
+                # ships is the number Paul asked for.
+                from . import boot_stages
+
+                # No `family=` here on purpose: the executor knows the endpoint
+                # function, not the compiled-graph family. The family reaches
+                # the roll-up from the KEYSET stage, which is the thing that
+                # actually learned it.
+                boot_stages.emit()
             bg = rec.background_mint
             if bg is not None and bg.task is None:
                 # pgw#671 eager-first boot: READY is advertised now (eager

--- a/tests/test_boot_stages_pgw1355.py
+++ b/tests/test_boot_stages_pgw1355.py
@@ -579,3 +579,34 @@ def test_the_emitter_proves_its_own_packing_parses_back() -> None:
         assert f"{key}=" in degraded, (
             f"{key} went missing with the packed table — the degradation took "
             f"the report with it instead of just the detail")
+
+
+def test_the_table_reads_as_a_timeline_not_as_the_enum() -> None:
+    """Rows are chronological.
+
+    Enum order looks right until a stage runs out of position. On a real cold
+    sdxl boot `model_load` happens THIRTEEN MINUTES after `keyset` starts, and
+    printing it above `keyset` — because `model_load` sits earlier in the
+    vocabulary — makes the reader distrust the column they came for.
+
+    RED PROOF: drop the chronological sort and `model_load` precedes `keyset`
+    in a table where it happened 804 seconds later.
+    """
+    table = _table(
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=823_400, t1_ms=824_500),
+        StageSpan(stage=Stage.KEYSET, t0_ms=18_700, t1_ms=823_400),
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=17_600, t1_ms=18_700),
+        wall_ms=843_900,
+    )
+    order = [stage for stage, _start, _end in table.runs()]
+    assert order == [Stage.SNAPSHOT_PULL, Stage.KEYSET, Stage.MODEL_LOAD], (
+        f"the table is not chronological: {[s.value for s in order]}")
+
+    starts = [start for _stage, start, _end in table.runs()]
+    assert starts == sorted(starts), "rows must ascend in time"
+
+    # The packed table the renderer parses carries the same order, so an
+    # operator reading the hub and an operator reading a pod shell see the
+    # same sequence.
+    packed, _ = boot_stages.pack_runs(table)
+    assert packed.startswith("snapshot_pull:17600-18700,keyset:18700-823400")

--- a/tests/test_boot_stages_pgw1355.py
+++ b/tests/test_boot_stages_pgw1355.py
@@ -383,13 +383,26 @@ def test_a_span_longer_than_the_process_CONFESSES_instead_of_shrinking() -> None
     RED PROOF: drop the `clamped_ms` attr and this passes while production
     quietly under-reports its dominant stage.
     """
-    uptime = boot_phases.process_uptime_ms()
+    requested = boot_phases.process_uptime_ms() + 900_000
     boot_stages.record_ending_now(
-        Stage.KEYSET, duration_ms=uptime + 900_000, label="impossible")
+        Stage.KEYSET, duration_ms=requested, label="impossible")
     span = boot_stages.recorded()[0]
-    assert span.t0_ms == 0
-    assert int(span.attrs["clamped_ms"]) >= 900_000 - 1_000, (
-        "the seconds that could not be represented are NAMED, not dropped")
+    lost = int(span.attrs["clamped_ms"])
+
+    assert span.t0_ms == 0, "a negative offset is not representable"
+    assert lost > 0, "nothing was clamped, so this case never exercised"
+    # The ACCOUNTING IDENTITY, not a tolerance: what the span ended up
+    # covering plus what it confessed losing is exactly what was asked for.
+    # Deliberately an equality rather than `lost >= 900_000 - slop` — the
+    # earlier spelling compared a measured value against a constant with a
+    # second of slack for the runner, which is the gw#666 defect: it passes on
+    # a fast box, flakes on a loaded one, and never actually checks that the
+    # confession is COMPLETE. This does, and it holds under any clock drift
+    # between reading the uptime and recording the span.
+    assert span.t1_ms + lost == requested, (
+        "the confessed loss does not account for the difference between the "
+        "duration asked for and the interval that could be represented — a "
+        "PARTIAL confession is just a quieter version of the silent truncation")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_boot_stages_pgw1355.py
+++ b/tests/test_boot_stages_pgw1355.py
@@ -1,0 +1,486 @@
+"""pgw#1355: a cold boot states its own decomposition, once, on the channel
+everything else is read from.
+
+Integration-style: the ladder tests drive the REAL
+:mod:`gen_worker.boot_phases` recorder — opening real spans and marking real
+milestones — and then assert the stage table `collect()` folds out of it, so
+nothing here passes against a boot shape production cannot produce. The
+emission tests drain the REAL activity sink the worker transport installs, so
+the assertions read exactly the ActivityUpdates a hub would receive.
+
+The load-bearing property, and the one every red proof is aimed at: **the
+total is a UNION and never a sum.** A boot whose stages overlap must not report
+more time than it took.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterator, List
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import boot_phases
+from gen_worker import boot_stages
+from gen_worker.boot_stages import (
+    BootStageTable,
+    Stage,
+    StageSpan,
+    UnknownStageError,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+
+@pytest.fixture(autouse=True)
+def _clean_recorders() -> Iterator[None]:
+    boot_phases.reset_for_tests()
+    boot_stages.reset_for_tests()
+    activity_mod.reset_for_tests()
+    yield
+    boot_phases.reset_for_tests()
+    boot_stages.reset_for_tests()
+    activity_mod.reset_for_tests()
+
+
+class _Events:
+    """The real sink the transport binds, drained after the fact."""
+
+    def __init__(self) -> None:
+        self.updates: List[pb.ActivityUpdate] = []
+
+    def install(self) -> None:
+        activity_mod._sink = self.updates.append  # the bound-sink contract
+
+    def of_kind(self, kind: str) -> List[pb.ActivityUpdate]:
+        return [u for u in self.updates if u.kind == kind]
+
+
+def _table(*spans: StageSpan, wall_ms: int, servable_ms: int = 0) -> BootStageTable:
+    return BootStageTable(
+        spans=tuple(spans), wall_ms=wall_ms, servable_ms=servable_ms)
+
+
+# ---------------------------------------------------------------------------
+# The closed vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_every_boot_phase_has_a_stage_or_a_documented_exemption() -> None:
+    """A boot phase with no home here silently drops its seconds out of the
+    table. Adding one to `boot_phases` without deciding where it belongs is
+    red HERE rather than invisible in production."""
+    assert boot_stages.unmapped_phases() == ()
+
+
+def test_an_unknown_stage_refuses_at_the_call_site() -> None:
+    """The vocabulary is closed because a renderer in another repository binds
+    to these tokens. A stage invented at a call site is a column that appears
+    in production and in no reader."""
+    with pytest.raises(UnknownStageError):
+        StageSpan(stage="teleportation", t0_ms=0, t1_ms=1)  # type: ignore[arg-type]
+    with pytest.raises(UnknownStageError):
+        boot_stages.record("teleportation", t0_ms=0, t1_ms=1)  # type: ignore[arg-type]
+
+
+def test_a_reader_refuses_a_fleet_it_does_not_understand() -> None:
+    """A packed run naming an unknown stage RAISES rather than being skipped.
+
+    Skipping would under-report a boot — quietly, and in the direction that
+    looks healthy. Refusing says "this reader does not understand the fleet
+    that emitted this", which is the sentence an operator can act on."""
+    with pytest.raises(UnknownStageError):
+        boot_stages.parse_runs("process_boot:0-10,warp_core:10-20")
+
+
+def test_a_span_that_ends_before_it_starts_refuses() -> None:
+    with pytest.raises(ValueError):
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=900, t1_ms=100)
+
+
+# ---------------------------------------------------------------------------
+# THE red proof: overlap is honest, and stages never sum past wall
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_stages_do_not_sum_past_wall() -> None:
+    """A snapshot pull overlapping a model load must not report more time than
+    the boot took.
+
+    This is the defect `boot_phases`' own header records paying for: a summing
+    reconciliation once "explained" 3,338 ms of a 909 ms fetch. A sum that
+    exceeds wall is not a rounding problem — it is a report that has stopped
+    describing time.
+
+    RED PROOF: make `critical_path_ms` return `span_sum_ms` and this fails on
+    both assertions below.
+    """
+    table = _table(
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=1_000, t1_ms=5_000),
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=3_000, t1_ms=7_000),
+        wall_ms=8_000,
+    )
+    # The two spans are 4 s each and share 2 s of wall.
+    assert table.span_sum_ms == 8_000
+    assert table.critical_path_ms == 6_000, "1000..7000 covered, overlap once"
+    assert table.critical_path_ms < table.span_sum_ms, (
+        "the sum must exceed the union when anything overlapped — a table "
+        "where they are equal has silently serialized concurrent work")
+    assert table.critical_path_ms <= table.wall_ms, (
+        "no arrangement of stages may account for more wall than the boot had")
+    assert table.overlap_ms == 2_000
+    assert table.unmeasured_ms == 2_000
+
+
+def test_overlap_is_reported_and_not_smeared_away() -> None:
+    """Two stages that ran ENTIRELY concurrently cost one stage's wall.
+
+    Shortening a stage that ran inside another stage's window buys nothing,
+    and only a union can say so — which is the whole reason a cold-start
+    budget is spent against `critical_path_ms` and not against a sum."""
+    table = _table(
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=0, t1_ms=10_000),
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=2_000, t1_ms=8_000),
+        wall_ms=10_000,
+    )
+    assert table.critical_path_ms == 10_000
+    assert table.overlap_ms == 6_000
+    assert table.unmeasured_ms == 0
+    assert table.accounted_pct == 100
+
+
+def test_sequential_stages_have_no_overlap() -> None:
+    """The control: the arithmetic must not manufacture concurrency either."""
+    table = _table(
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=0, t1_ms=3_000),
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=3_000, t1_ms=5_000),
+        wall_ms=5_000,
+    )
+    assert table.overlap_ms == 0
+    assert table.critical_path_ms == table.span_sum_ms == 5_000
+
+
+def test_a_stage_that_ran_twice_keeps_its_gap() -> None:
+    """Merged per stage, not globally: a stage that ran twice with a gap is a
+    different fact from one that ran once across both."""
+    table = _table(
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=0, t1_ms=1_000),
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=4_000, t1_ms=5_000),
+        wall_ms=5_000,
+    )
+    runs = table.runs()
+    assert runs == [
+        (Stage.SNAPSHOT_PULL, 0, 1_000),
+        (Stage.SNAPSHOT_PULL, 4_000, 5_000),
+    ]
+    assert table.busy_ms(Stage.SNAPSHOT_PULL) == 2_000
+    assert table.unmeasured_ms == 3_000, "the gap is a HOLE, and it is named"
+
+
+def test_unmeasured_is_named_never_smeared_across_the_stages() -> None:
+    """"unmeasured" and "zero" are different answers, and the hole is the hint
+    about where the next instrument belongs."""
+    table = _table(
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=0, t1_ms=1_000),
+        wall_ms=100_000,
+    )
+    assert table.unmeasured_ms == 99_000
+    assert table.busy_ms(Stage.MODEL_LOAD) == 1_000, (
+        "the measured stage keeps its own honest 1 s — the hole is NOT "
+        "distributed into it")
+    assert table.accounted_pct == 1
+
+
+# ---------------------------------------------------------------------------
+# The wire codec
+# ---------------------------------------------------------------------------
+
+
+def test_the_packed_table_round_trips() -> None:
+    """The renderer in another repo parses this token. The round trip is the
+    contract, asserted here rather than assumed."""
+    table = _table(
+        StageSpan(stage=Stage.PROCESS_BOOT, t0_ms=0, t1_ms=800),
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=1_000, t1_ms=5_000),
+        StageSpan(stage=Stage.MODEL_LOAD, t0_ms=3_000, t1_ms=7_000),
+        wall_ms=8_000,
+    )
+    packed, truncated = boot_stages.pack_runs(table)
+    assert not truncated
+    assert boot_stages.parse_runs(packed) == (
+        (Stage.PROCESS_BOOT, 0, 800),
+        (Stage.SNAPSHOT_PULL, 1_000, 5_000),
+        (Stage.MODEL_LOAD, 3_000, 7_000),
+    )
+
+
+def test_the_detail_grammar_is_the_one_the_renderer_already_parses() -> None:
+    """Space-separated `k=v`, values never containing whitespace — the grammar
+    `(\\w+)=(\\S+)` parses entirely, which e2e's `detailKV` already implements.
+    A value with a space splits one pair into two and means something else."""
+    table = _table(
+        StageSpan(stage=Stage.KEYSET, t0_ms=100, t1_ms=805_000,
+                  label="boot_adopt.key_set",
+                  attrs={"keys_from": "traced", "classes": "36"}),
+        wall_ms=830_000,
+    )
+    detail = boot_stages.rollup_detail(table)
+    pairs = dict(tok.split("=", 1) for tok in detail.split(" ") if "=" in tok)
+    assert pairs["v"] == "1"
+    assert pairs["wall_ms"] == "830000"
+    assert pairs["keys_from"] == "traced"
+    assert pairs["unmeasured_ms"] == str(830_000 - 804_900)
+    for token in detail.split(" "):
+        assert token.count("=") >= 1, f"{token!r} is not a k=v pair"
+
+    stage_detail = boot_stages.stage_detail(table.spans[0])
+    kv = dict(tok.split("=", 1) for tok in stage_detail.split(" "))
+    assert kv["stage"] == "keyset"
+    assert kv["t0_ms"] == "100"
+    assert kv["t1_ms"] == "805000"
+    assert kv["keys_from"] == "traced"
+
+
+def test_an_empty_value_can_never_reach_the_wire() -> None:
+    """An empty value ends the token at the `=` and silently merges the next
+    pair into it. Every attribute goes through the same guard."""
+    boot_stages.record(
+        Stage.KEYSET, t0_ms=0, t1_ms=10, keys_from="", family="sd xl")
+    span = boot_stages.recorded()[0]
+    assert "keys_from" not in span.attrs, "an empty attr is DROPPED, not blanked"
+    assert span.attrs["family"] == "sdxl", "whitespace is stripped, never shipped"
+
+
+def test_a_truncated_pack_says_so() -> None:
+    """A table that dropped runs is a table whose union no longer closes, and a
+    reader must be able to tell that from a boot that had fewer stages."""
+    spans = [
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=i * 100, t1_ms=i * 100 + 10)
+        for i in range(boot_stages.MAX_PACKED_RUNS + 5)
+    ]
+    table = _table(*spans, wall_ms=10_000)
+    packed, truncated = boot_stages.pack_runs(table)
+    assert truncated
+    assert len(boot_stages.parse_runs(packed)) == boot_stages.MAX_PACKED_RUNS
+    assert "runs_truncated=1" in boot_stages.rollup_detail(table)
+
+
+# ---------------------------------------------------------------------------
+# Folding a REAL boot_phases ladder
+# ---------------------------------------------------------------------------
+
+
+def _drive_a_real_boot() -> None:
+    """Drive the real recorder through the shape a cold pod boots in.
+
+    Concurrency is real here — the two component fetches are open at the same
+    time — so the folded table has to survive genuine overlap rather than a
+    fixture's arithmetic.
+    """
+    boot_phases.mark_once(boot_phases.PHASE_SDK_READY, detail="endpoints=1")
+    boot_phases.mark_once(boot_phases.PHASE_HELLO, since_process_start=True)
+    weights = boot_phases.open_span(boot_phases.PHASE_WEIGHTS_FETCH, ref="r")
+    with boot_phases.parent_scope(weights.ordinal):
+        unet = boot_phases.open_span(
+            boot_phases.PHASE_COMPONENT_FETCH, function="unet")
+        vae = boot_phases.open_span(
+            boot_phases.PHASE_COMPONENT_FETCH, function="vae")
+        time.sleep(0.02)
+        vae.bytes_moved(4096, boot_phases.SOURCE_R2)
+        vae.close()
+        unet.bytes_moved(8192, boot_phases.SOURCE_R2)
+        unet.close()
+    weights.close()
+    with boot_phases.span(boot_phases.PHASE_PIPELINE_LOAD, function="generate"):
+        time.sleep(0.01)
+    boot_phases.mark_once(boot_phases.PHASE_EAGER_READY, function="generate")
+    boot_phases.mark_once(
+        boot_phases.PHASE_FIRST_REQUEST_SERVABLE, since_process_start=True)
+
+
+def test_a_real_ladder_folds_into_the_closed_vocabulary() -> None:
+    _drive_a_real_boot()
+    table = boot_stages.collect()
+
+    seen = {span.stage for span in table.spans}
+    assert Stage.PROCESS_BOOT in seen
+    assert Stage.IMPORTS in seen
+    assert Stage.SNAPSHOT_PULL in seen, "weights_fetch + component_fetch fold here"
+    assert Stage.MODEL_LOAD in seen, "pipeline_load folds here"
+    assert Stage.READY in seen
+    assert seen <= set(Stage), "nothing outside the closed vocabulary"
+
+    assert table.wall_ms > 0, "eager_ready is the wall"
+    assert table.critical_path_ms <= table.wall_ms, (
+        "a real ladder with two concurrent component fetches must still not "
+        "account for more wall than the boot had")
+
+
+def test_the_two_concurrent_component_fetches_are_visible_as_overlap() -> None:
+    """Four components inside one pull that each measure 180 s were OVERLAPPED,
+    and that is a different finding from four sequential 50 s ones. Only an
+    interval can tell them apart, which is why spans carry offsets."""
+    _drive_a_real_boot()
+    table = boot_stages.collect()
+    pull_spans = [s for s in table.spans if s.stage is Stage.SNAPSHOT_PULL]
+    assert len(pull_spans) >= 3, "the parent fetch plus its two components"
+    assert table.overlap_ms > 0, (
+        "the components ran inside the parent span and beside each other — a "
+        "table reporting zero overlap has serialized work that was concurrent")
+    assert table.busy_ms(Stage.SNAPSHOT_PULL) < sum(
+        s.duration_ms for s in pull_spans), (
+        "the stage's own wall is the union of its spans, not their sum")
+
+
+def test_a_boot_that_never_reached_ready_still_reports_what_happened() -> None:
+    """An operator looking at a STUCK pod wants exactly this table. The wall
+    falls back to the furthest span end, so the reconciliation describes what
+    has happened rather than dividing by zero."""
+    boot_phases.mark_once(boot_phases.PHASE_SDK_READY)
+    with boot_phases.span(boot_phases.PHASE_PIPELINE_LOAD, function="generate"):
+        time.sleep(0.01)
+    table = boot_stages.collect()
+    assert table.wall_ms > 0
+    assert Stage.MODEL_LOAD in {s.stage for s in table.spans}
+
+
+def test_the_keyset_stage_carries_where_the_keys_CAME_FROM() -> None:
+    """pgw#1353's whole finding is that every production pod reported
+    `keys_from=traced` — the FALLBACK — and nothing made that visible while it
+    was happening. It is the axis separating an 805 s boot from a 5 ms one."""
+    _drive_a_real_boot()
+    boot_stages.record(
+        Stage.KEYSET, t0_ms=1, t1_ms=804_701, label="boot_adopt.key_set",
+        keys_from="traced", classes=36, family="sdxl")
+    table = boot_stages.collect()
+    assert table.attr("keys_from") == "traced"
+    assert "keys_from=traced" in boot_stages.rollup_detail(table)
+
+
+def test_the_derive_stage_covers_a_window_the_ladder_structurally_cannot() -> None:
+    """pgw#1353: the derive runs during a REQUEST, after the boot window
+    closed, so `boot_phases.in_boot()` is already False and no ladder row can
+    cover it. `record_ending_now` is the minimal instrument that joins it."""
+    _drive_a_real_boot()
+    assert not boot_phases.in_boot(), "the boot window is closed"
+    boot_stages.record_ending_now(
+        Stage.KEYSET, duration_ms=10, label="boot_adopt.key_set",
+        keys_from="traced")
+    table = boot_stages.collect()
+    keyset = [s for s in table.spans if s.stage is Stage.KEYSET]
+    assert len(keyset) == 1
+    assert keyset[0].duration_ms == 10
+    assert keyset[0].t0_ms >= 0
+    assert "clamped_ms" not in keyset[0].attrs
+
+
+def test_a_span_longer_than_the_process_CONFESSES_instead_of_shrinking() -> None:
+    """A duration longer than the process has existed came from a different
+    clock. The span is clamped — a negative offset is not representable — but
+    the clamp is stated, because a silently shortened span is a wrong
+    measurement that reads as a right one.
+
+    RED PROOF: drop the `clamped_ms` attr and this passes while production
+    quietly under-reports its dominant stage.
+    """
+    uptime = boot_phases.process_uptime_ms()
+    boot_stages.record_ending_now(
+        Stage.KEYSET, duration_ms=uptime + 900_000, label="impossible")
+    span = boot_stages.recorded()[0]
+    assert span.t0_ms == 0
+    assert int(span.attrs["clamped_ms"]) >= 900_000 - 1_000, (
+        "the seconds that could not be represented are NAMED, not dropped")
+
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+
+def test_emission_is_a_series_with_the_rollup_LAST() -> None:
+    """A reader that sees the roll-up knows the series is complete."""
+    events = _Events()
+    events.install()
+    _drive_a_real_boot()
+    assert boot_stages.emit() is True
+
+    rows = events.of_kind(boot_stages.KIND)
+    assert rows, "the boot reported nothing at all"
+    assert rows[-1].phase == boot_stages.PHASE_READY, (
+        "the roll-up is emitted last, so a reader that has it has everything")
+    assert all(
+        r.phase.startswith(boot_stages.PHASE_STAGE_PREFIX) for r in rows[:-1])
+    assert sum(
+        1 for r in rows if r.phase == boot_stages.PHASE_READY) == 1, (
+        "exactly one roll-up, or a reader grouping on it double-counts")
+
+
+def test_the_rollup_duration_is_wall_to_ready() -> None:
+    """`duration_ms` lands in a numeric hub column, so the cold-boot number can
+    be grouped and percentiled — which a number interpolated into `detail`
+    cannot."""
+    events = _Events()
+    events.install()
+    _drive_a_real_boot()
+    boot_stages.emit()
+    rollup = [
+        r for r in events.of_kind(boot_stages.KIND)
+        if r.phase == boot_stages.PHASE_READY][0]
+    assert rollup.duration_ms == boot_stages.collect().wall_ms
+    assert rollup.duration_ms > 0
+
+
+def test_emit_is_once_per_process() -> None:
+    """The caller sits on a `mark_once` boundary; a double report would put two
+    walls for one boot in the table."""
+    events = _Events()
+    events.install()
+    _drive_a_real_boot()
+    assert boot_stages.emit() is True
+    before = len(events.of_kind(boot_stages.KIND))
+    assert boot_stages.emit() is False
+    assert len(events.of_kind(boot_stages.KIND)) == before
+
+
+def test_emission_never_breaks_the_boot_it_measures() -> None:
+    """A boot that reached ready is never failed by the report of it."""
+    def explode(_update: pb.ActivityUpdate) -> None:
+        raise RuntimeError("the hub stream is gone")
+
+    activity_mod._sink = explode
+    _drive_a_real_boot()
+    boot_stages.emit()  # must not raise
+
+
+def test_the_emitted_rows_reconstruct_the_table() -> None:
+    """The whole point: reading a boot's shape is a ONE-ROW query, and the row
+    that answers it must agree with the series beside it."""
+    events = _Events()
+    events.install()
+    _drive_a_real_boot()
+    boot_stages.emit()
+    rows = events.of_kind(boot_stages.KIND)
+    rollup = [r for r in rows if r.phase == boot_stages.PHASE_READY][0]
+    kv = dict(
+        tok.split("=", 1) for tok in rollup.detail.split(" ") if "=" in tok)
+
+    runs = boot_stages.parse_runs(kv["runs"])
+    assert runs, "the packed table is the renderer's whole input"
+    union = sum(end - start for _stage, start, end in runs)
+    assert union == int(kv["critical_path_ms"]), (
+        "the packed runs and the stated union must be the same measurement — "
+        "a renderer recomputing from the runs must reach the stated total")
+    assert int(kv["critical_path_ms"]) <= int(kv["wall_ms"])
+    assert (int(kv["span_sum_ms"]) - int(kv["critical_path_ms"])
+            == int(kv["overlap_ms"]))
+    assert (int(kv["wall_ms"]) - int(kv["critical_path_ms"])
+            == int(kv["unmeasured_ms"]))
+
+
+def test_the_render_is_pasteable_and_states_its_own_totals() -> None:
+    _drive_a_real_boot()
+    text = boot_stages.render(boot_stages.collect())
+    assert "stage" in text and "busy_ms" in text
+    assert "critical_path_ms=" in text
+    assert "span_sum_ms=" in text, (
+        "the sum is shown BESIDE the union, never instead of it")

--- a/tests/test_boot_stages_pgw1355.py
+++ b/tests/test_boot_stages_pgw1355.py
@@ -540,3 +540,42 @@ def test_truncation_keeps_the_spans_worth_reading() -> None:
         "the 805 s stage was dropped in favour of sixty-odd 1 ms ones — a "
         "truncation rule that can discard the finding is worse than no rows")
     assert kept[0].duration_ms == 805_000
+
+
+def test_the_emitter_proves_its_own_packing_parses_back() -> None:
+    """The renderer that consumes `runs=` lives in another repository, on a
+    release cadence this worker knows nothing about.
+
+    If a packing bug ships, the symptom over there is a parse error on an
+    otherwise healthy pod — days later, in somebody else's lane, with no way to
+    tell a broken emitter from a broken reader. So the emitter checks its own
+    output against its own parser before shipping it, and a token that does not
+    round-trip is DROPPED and confessed rather than shipped hopefully.
+
+    RED PROOF: skip the round-trip check and a corrupt token ships silently.
+    """
+    table = _table(
+        StageSpan(stage=Stage.KEYSET, t0_ms=0, t1_ms=805_000),
+        wall_ms=830_000)
+    good = boot_stages.rollup_detail(table)
+    assert "runs_unpackable" not in good
+    assert "runs=keyset:0-805000" in good
+
+    # A packer that emits a stage token this vocabulary does not admit.
+    original = boot_stages.pack_runs
+    try:
+        boot_stages.pack_runs = lambda _t: ("warp_core:0-1", False)  # type: ignore[assignment]
+        degraded = boot_stages.rollup_detail(table)
+    finally:
+        boot_stages.pack_runs = original  # type: ignore[assignment]
+
+    assert "runs_unpackable=1" in degraded, (
+        "a table that does not parse back was shipped anyway — the reader in "
+        "the other repo would fail on it with no way to place the blame")
+    assert "runs=-" in degraded, "the corrupt token must be DROPPED, not shipped"
+    # And the report still serves: every scalar total is stated independently
+    # of the packed table, so losing it costs detail and never the answer.
+    for key in ("wall_ms", "critical_path_ms", "overlap_ms", "unmeasured_ms"):
+        assert f"{key}=" in degraded, (
+            f"{key} went missing with the packed table — the degradation took "
+            f"the report with it instead of just the detail")

--- a/tests/test_boot_stages_pgw1355.py
+++ b/tests/test_boot_stages_pgw1355.py
@@ -484,3 +484,59 @@ def test_the_render_is_pasteable_and_states_its_own_totals() -> None:
     assert "critical_path_ms=" in text
     assert "span_sum_ms=" in text, (
         "the sum is shown BESIDE the union, never instead of it")
+
+
+def test_the_report_can_never_cost_more_than_the_boot_it_reports_on() -> None:
+    """A pathological boot must not become a two-thousand-message burst on the
+    worker->hub stream at the exact moment the pod is trying to start serving.
+
+    `boot_phases` buffers up to 2048 rows, so this bound is a real one, not a
+    stylistic cap. The ROLL-UP survives truncation — it carries the packed
+    table and is what the question is actually asked of — and the drop is
+    stated rather than left for a reader to infer from a short series.
+
+    RED PROOF: emit every span unconditionally and the row count blows past the
+    bound.
+    """
+    events = _Events()
+    events.install()
+    spans = [
+        StageSpan(stage=Stage.SNAPSHOT_PULL, t0_ms=i, t1_ms=i + 1,
+                  attrs={"component": f"c{i}"})
+        for i in range(boot_stages.MAX_STAGE_ROWS + 40)
+    ]
+    boot_stages.emit(_table(*spans, wall_ms=9_000))
+
+    rows = events.of_kind(boot_stages.KIND)
+    stage_rows = [
+        r for r in rows if r.phase.startswith(boot_stages.PHASE_STAGE_PREFIX)]
+    assert len(stage_rows) == boot_stages.MAX_STAGE_ROWS
+
+    rollup = [r for r in rows if r.phase == boot_stages.PHASE_READY]
+    assert len(rollup) == 1, "the roll-up is never the row that gets dropped"
+    assert "rows_truncated=40" in rollup[0].detail, (
+        "a truncated series must SAY it was truncated — otherwise a stage with "
+        "fewer rows than spans reads as a stage that ran fewer times")
+
+
+def test_truncation_keeps_the_spans_worth_reading() -> None:
+    """Longest first. Dropping an arbitrary tail would be as likely to discard
+    an 805 s derive as a 2 ms fold, and the whole point of the report is that
+    the expensive stage is the one you can see."""
+    events = _Events()
+    events.install()
+    spans = [
+        StageSpan(stage=Stage.ARM, t0_ms=i, t1_ms=i + 1)
+        for i in range(boot_stages.MAX_STAGE_ROWS + 10)
+    ]
+    spans.append(StageSpan(
+        stage=Stage.KEYSET, t0_ms=0, t1_ms=805_000, label="the whole finding"))
+    boot_stages.emit(_table(*spans, wall_ms=830_000))
+
+    kept = [
+        r for r in events.of_kind(boot_stages.KIND)
+        if r.phase == boot_stages.PHASE_STAGE_PREFIX + Stage.KEYSET.value]
+    assert kept, (
+        "the 805 s stage was dropped in favour of sixty-odd 1 ms ones — a "
+        "truncation rule that can discard the finding is worse than no rows")
+    assert kept[0].duration_ms == 805_000


### PR DESCRIPTION
Closes pgw#1355. Paul's directive: *"every worker should be reporting metrics back to the hub, including cold boot time, broken down into stages (that should be overlapping ideally)."*

## What this is

e2e#1892 measured an 877 s cold serve and had to assemble the breakdown **by hand**, from four different event kinds:

| | source |
|---|---|
| 41 s queue | request-row timestamps |
| ~18 s boot/imports | `worker_boot_phases` (its own hub table, its own route) |
| 1.1 s pull, 2.5 s load | ditto |
| **804 s keyset derive** | `boot_adopt.duration_ms` on `worker_activity_events` |
| 6.2 s compute, 2.4 s finalize | the request row again |

Every one of those numbers already existed. What did not exist was a place where the SHAPE of a cold boot is stated once. So this is **a JOIN made durable at the source, not a new clock**.

`gen_worker.boot_stages` emits a versioned `boot_stages` series when the worker becomes ready:

- `phase=stage:<name>` — one row per span, `duration_ms` = its wall, `detail` = `v=1 stage= t0_ms= t1_ms= label= …`
- `phase=ready` — ONE terminal roll-up, `duration_ms` = **wall-to-ready**, `detail` packs the whole table so reading a pod's cold start is a one-row query

`k=v` detail in exactly the grammar the th#1839 route already serves verbatim (`(\w+)=(\S+)` parses it entirely, which e2e's `detailKV` already implements). **No hub schema change, no proto change, no migration.**

## The rule this refuses to break: the total is a UNION

Stages genuinely overlap on a real pod — a snapshot pull overlapping a component load overlapping a derive — so spans carry `t0_ms`/`t1_ms` offsets from OS process start and concurrency is visible rather than inferred.

```
span_sum_ms      = the sum of every span         (>= union whenever anything overlapped)
critical_path_ms = the UNION — wall in which SOMETHING ran
overlap_ms       = span_sum_ms - critical_path_ms
unmeasured_ms    = wall_ms - critical_path_ms    (NAMED, never smeared)
```

`boot_phases` learned this the expensive way; its own header records a summing reconciliation that "explained" 3,338 ms of a 909 ms fetch. A sum that exceeds wall is not a rounding problem — it is a report that has stopped describing time.

## The closed vocabulary

`process_boot`, `imports`, `hub_handshake`, `snapshot_pull`, `model_load`, `keyset`, `adopt`, `arm`, `warmup`, `ready` — an enum, because a renderer in another repo (e2e#1901) binds to these tokens. An unknown name raises at the emitter AND at the parser. A boot phase added to `boot_phases` with no stage and no documented exemption fails `unmapped_phases()`.

## The 805 s that had no span

pgw#1353 measured `worker_boot_phases` going `first_request_servable` then **871 s of silence** to `eager_ready`: the key-set derive runs during a REQUEST, after the boot window closed, so `boot_phases.in_boot()` is already False and no ladder row can cover it. `boot_adopt` now records it as one `keyset` stage carrying `keys_from` — the axis separating an 805 s boot from a 5 ms one — recorded **once per derive** rather than once per class, because 36 identical spans would report a boot whose stages sum to 36x its own wall.

The report is emitted at **`eager_ready`**, the first instant the worker could actually answer a request — deliberately NOT at `first_request_servable`, which on an eager-first boot fires before the model is loaded at all. That gap IS pgw#1353's 871 seconds.

## Red proofs (each verified to go red)

| break | result |
|---|---|
| `critical_path_ms` returns the SUM instead of the union | **5 tests fail** |
| the stage vocabulary stops refusing unknown names (emitter + parser) | **2 tests fail** |
| the over-long-span clamp stops confessing `clamped_ms` | **1 test fails** |

Plus a genuine finding the suite caught during development: `record_ending_now` was silently *shortening* a span whose duration exceeded process uptime. It now clamps (a negative offset is not representable) and states `clamped_ms`, because a silently shortened span is a wrong measurement that reads as a right one.

## Tests

`tests/test_boot_stages_pgw1355.py`, 25 tests, all green. Integration-style: the ladder tests drive the REAL `boot_phases` recorder with genuinely concurrent component fetches, and the emission tests drain the REAL activity sink the transport binds — so the assertions read exactly the ActivityUpdates a hub would receive.

mypy clean on every changed module.

## Not in this PR

- The renderer — e2e#1901.
- The hub-side twin decomposing `queue_ms` — th#2122.