### PR TITLE
pgw#1354: a jobs-only image boots, is CUDA-probed, and a boot that finds nothing says so on the wire

### DIFF
--- a/changelog.d/pgw1354.md
+++ b/changelog.d/pgw1354.md
@@ -1,0 +1,23 @@
+- **A JOBS-ONLY IMAGE BOOTS.** `entrypoint.get_modules_from_manifest` walked `manifest["functions"]`
+  and nothing else, so a package that declares its modules in `jobs[].module` — which is every
+  package te#218 re-authored, e.g. `conversion` 0.12.4 at 27 jobs / 0 functions — discovered ZERO
+  user modules and exited 1 before hello. Measured on rented hardware twice, on two card families
+  (e2e#1890): `deaths_before_hello=2`, `ready_at` NULL, no pod has ever reached hello off a
+  jobs-only image. pgw#1324's `worker.py` fix (`if not specs and not jobs`) is correct and sat one
+  frame too late — `collect_jobs([])` over an empty module list finds nothing either. The walk now
+  reads BOTH declaration blocks, from one derivation (`gen_worker.manifest_blocks`) rather than a
+  second walk beside the first.
+- **A jobs-only GPU image is CUDA-probed.** `cuda_probe.should_probe_cuda` read `functions[]` too,
+  so gw#529's bad-host guard silently did not apply to the jobs program: 10 of those 27 conversion
+  jobs ask for a card, on a device nothing had health-checked. It now reads the same both-block
+  derivation; the mixed CPU/GPU rule (defer to the installed torch build) is unchanged and applies
+  across blocks rather than per block.
+- **The no-modules exit dials a typed fatal.** It was the one fatal in `_run_main` that did not —
+  a bare `logger.error` + `return 1`. RunPod exposes no container-logs API, so the hub saw
+  `last_cause=exit:1` with no reason class and condemned the pod `[hardware-unsuitable]` with empty
+  driver/gpu: a boot bug wearing a hardware verdict, which is why this took a paid pod to find. It
+  now reports `no_user_modules` over the worker_fatal carrier with a detail that NAMES the gap —
+  how many functions and jobs the lock declared, how many modules that yielded, and which blocks
+  this build walks — and discriminates "declarations this wheel cannot read" from "no baked
+  manifest at all". The boot log's `manifest_loaded` phase gained `job_count` beside
+  `function_count` for the same reason.

--- a/src/gen_worker/cuda_probe.py
+++ b/src/gen_worker/cuda_probe.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 
 import msgspec
 from .hostfacts import cuda_ready
+from .manifest_blocks import declaration_rows
 
 CUDA_PROBE_FAILED_MARKER = "GEN_WORKER_CUDA_PROBE_FAILED"
 
@@ -97,15 +98,23 @@ def should_probe_cuda(
 ) -> bool:
     """Whether this concrete worker image must pass the CUDA health probe.
 
-    A manifest may contain both CPU and GPU functions because one endpoint
+    Read off EVERY declaration the image carries — ``@endpoint`` functions and
+    ``@job`` functions alike, via ``manifest_blocks.declaration_rows``. Both
+    row shapes carry the same ``resources.gpu``, so the question is one
+    question. pgw#1354: this walked ``functions[]`` alone, so a jobs-only GPU
+    image (10 of 27 conversion jobs declare ``gpu=True``) returned False and
+    was never probed — the gw#529 bad-host guard silently did not apply to the
+    whole jobs program.
+
+    A manifest may contain both CPU and GPU declarations because one endpoint
     release can publish separate ``accelerator=none`` and ``accelerator=cuda``
     images.  In that mixed case the installed torch build is the authoritative
     signal: probe CUDA images and let CPU-only images serve the CPU lane.  A
     GPU-only manifest is always probed so an accidentally CPU-built image
     fails before it can register.
     """
-    functions = (manifest or {}).get("functions", []) or []
-    gpu_requirements = [bool((fn.get("resources") or {}).get("gpu")) for fn in functions]
+    rows = declaration_rows(manifest)
+    gpu_requirements = [bool((row.get("resources") or {}).get("gpu")) for row in rows]
     if not any(gpu_requirements):
         return False
     if all(gpu_requirements):

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -63,7 +63,12 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
             ok=False,
             errors=("endpoint lock missing 'functions' list",),
         )
-    if len(functions) == 0:
+    if len(functions) == 0 and not (lock_dict.get("jobs") or ()):
+        # Jobs-aware (pgw#1354): a jobs-only release is legal (th#2049) and
+        # advertises 27 things, so the bare function count must not call it
+        # empty. Everything BELOW is function-shape by construction — slots,
+        # bindings, wire routes and compile cells are concepts a job does not
+        # declare (`_job_entry`) — so those walks stay functions-only.
         warnings.append("no functions discovered (endpoint will advertise nothing)")
 
     # Per-class accumulator for the "two methods slugify to the same route"

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -77,6 +77,12 @@ from . import config
 from . import worker_credential
 from .cuda_probe import CUDA_PROBE_FAILED_MARKER, probe_cuda, should_probe_cuda
 from .hardware_report import report_hardware_unsuitable
+from .manifest_blocks import (
+    DECLARATION_BLOCKS,
+    block_counts,
+    declaration_rows,
+    declared_row_count,
+)
 from .models.cache_paths import tensorhub_cas_dir
 try:
     from .worker import Worker
@@ -184,10 +190,17 @@ def load_manifest(path: Path = MANIFEST_PATH) -> Optional[Dict[str, Any]]:
 
 
 def get_modules_from_manifest(manifest: Dict[str, Any]) -> List[str]:
-    """Extract unique module names from the manifest."""
+    """Every user module this image must import, from BOTH declaration blocks.
+
+    pgw#1354: this walked ``functions[]`` alone, so a jobs-only package
+    (te#218 re-authored every conversion package that way — 27 jobs, 0
+    functions) yielded no modules and the boot below refused before hello.
+    Extended rather than paired with a second jobs walk: `manifest_blocks`
+    owns the one row derivation, and both this and the CUDA probe feed off it.
+    """
     modules = set()
-    for func in manifest.get("functions", []):
-        module = func.get("module")
+    for row in declaration_rows(manifest):
+        module = row.get("module")
         if module:
             modules.add(module)
     return sorted(modules)
@@ -424,11 +437,15 @@ def _run_main() -> int:
             logger.error(str(e))
             return 1
         user_modules = get_modules_from_manifest(manifest)
+        counts = block_counts(manifest)
         _log_startup_phase(
             "manifest_loaded",
             status="ok",
             manifest_path=str(manifest_path),
-            function_count=len(manifest.get("functions", [])),
+            function_count=counts["functions"],
+            # A boot log that counted only functions read "0 declarations" on
+            # the images the jobs program exists to run (pgw#1354).
+            job_count=counts["jobs"],
             module_count=len(user_modules),
         )
     else:
@@ -521,12 +538,43 @@ def _run_main() -> int:
         logger.info("  Local Model Cache Dir: %s", cache_cfg["local_model_cache_dir"])
 
     if not user_modules:
-        logger.error(
-            "No user function modules found. A baked manifest at %s is required.\n"
-            "Your Dockerfile should run discovery at build time:\n"
-            "  RUN mkdir -p /app/.tensorhub && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock\n"
-            "(non-container runs: set ENDPOINT_LOCK_PATH to the generated file)",
-            manifest_path,
+        # pgw#1354: this exit used to be a bare `logger.error` + `return 1`.
+        # RunPod exposes no container-logs API, so the hub saw `exit:1` with no
+        # reason class and condemned the pod `[hardware-unsuitable]` with empty
+        # driver/gpu — a boot bug wearing a hardware verdict, and it cost a paid
+        # pod to find. Every other fatal in this function dials typed; so does
+        # this one. The message DISCRIMINATES the two gaps, because they have
+        # different owners: no manifest at all is a Dockerfile that never ran
+        # discovery, while declarations-without-modules is a manifest this wheel
+        # cannot read (a block it does not walk, or rows with no `module`).
+        counts = block_counts(manifest)
+        declared = declared_row_count(manifest)
+        if manifest and declared:
+            reason = (
+                f"the manifest at {manifest_path} declares "
+                f"{counts['functions']} function(s) and {counts['jobs']} job(s) "
+                f"but no row carries a `module`, so this image has nothing to "
+                f"import. Declaration blocks this build walks: "
+                f"{', '.join(DECLARATION_BLOCKS)}."
+            )
+        elif manifest:
+            reason = (
+                f"the manifest at {manifest_path} declares no functions and no "
+                f"jobs — this image publishes nothing and cannot serve."
+            )
+        else:
+            reason = (
+                f"no baked manifest at {manifest_path}. Your Dockerfile should "
+                f"run discovery at build time:\n"
+                f"  RUN mkdir -p /app/.tensorhub && python -m gen_worker.discovery"
+                f" > /app/.tensorhub/endpoint.lock\n"
+                f"(non-container runs: set ENDPOINT_LOCK_PATH to the generated file)"
+            )
+        message = f"no user modules to import: {reason}"
+        logger.error("%s", message)
+        _log_worker_fatal(
+            "no_user_modules", RuntimeError(message), exit_code=1,
+            settings=settings,
         )
         return 1
 

--- a/src/gen_worker/manifest_blocks.py
+++ b/src/gen_worker/manifest_blocks.py
@@ -1,0 +1,66 @@
+"""The declaration rows of a baked ``endpoint.lock``.
+
+ONE walk over BOTH publishable shapes. A release may declare ``@endpoint``
+functions, ``@job`` functions, or both, and a release with jobs and ZERO
+functions is legal (th#2049) — so every reader that asks "what did this image
+declare" must ask it of both blocks, or it goes blind on the shape it was not
+written for.
+
+pgw#1354 is what blindness costs: ``entrypoint.get_modules_from_manifest`` and
+``cuda_probe.should_probe_cuda`` each walked ``functions[]`` alone, both
+written when everything was a function. The first pod ever booted off a
+jobs-only image (27 jobs, 0 functions) therefore found zero user modules and
+exited 1 before hello, twice, on two card families — and was never CUDA-probed
+on the way. The fix is this module: not a parallel jobs walk beside the
+function walk (two walks drift; the next block makes it three), but one
+derivation both feeders read.
+
+The two row shapes are deliberately identical where they overlap — ``name``,
+``module``, ``resources``, ``env``, ``publishes`` — because a job promoted to a
+serverless endpoint must not change identity on the way. That overlap is what
+makes one walk correct rather than merely convenient. A reader that needs a
+FUNCTION-ONLY concept (slots, bindings, compile cells, execution lanes — none
+of which a job declares) must still walk ``functions[]`` directly and say why.
+
+Stdlib only, and no ``gen_worker`` imports: the control parent reads this and
+must stay a bare interpreter with no path to torch (pgw#763).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+#: Every manifest block carrying declaration rows, in wire order.
+DECLARATION_BLOCKS = ("functions", "jobs")
+
+
+def declaration_rows(manifest: Optional[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    """Every declaration row in ``manifest``: functions then jobs.
+
+    Tolerant of a malformed or absent block — a lock this process cannot read
+    must not raise here, because the callers turn "nothing declared" into a
+    typed refusal that names the gap.
+    """
+    rows: List[Dict[str, Any]] = []
+    if not isinstance(manifest, Mapping):
+        return rows
+    for block in DECLARATION_BLOCKS:
+        for row in manifest.get(block) or ():
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def block_counts(manifest: Optional[Mapping[str, Any]]) -> Dict[str, int]:
+    """``{block: row count}`` for every declaration block — the shape a boot
+    log or a refusal quotes when it has to say what the image declared."""
+    counts: Dict[str, int] = {}
+    for block in DECLARATION_BLOCKS:
+        rows = (manifest or {}).get(block) if isinstance(manifest, Mapping) else None
+        counts[block] = len(rows) if isinstance(rows, list) else 0
+    return counts
+
+
+def declared_row_count(manifest: Optional[Mapping[str, Any]]) -> int:
+    """How many declarations this image carries, across both blocks."""
+    return sum(block_counts(manifest).values())

--- a/tests/test_jobs_only_boot_pgw1354.py
+++ b/tests/test_jobs_only_boot_pgw1354.py
@@ -1,0 +1,408 @@
+"""pgw#1354 (JOBS program, P0): a JOBS-ONLY IMAGE BOOTS, and a boot that finds
+nothing SAYS SO on the wire.
+
+Measured on rented hardware before this landed, twice, on two card families
+(e2e#1890 ch.3): the first pod ever booted off a jobs-only image — `conversion`
+0.12.4, **27 jobs / 0 functions**, gen-worker 0.122.0 — died at
+`entrypoint.py:523` with `deaths_before_hello=2`, `last_cause=exit:1`, no
+reason class, `ready_at` NULL. `get_modules_from_manifest` walked
+`manifest["functions"]` and nothing else, so a package that declares its
+modules in `jobs[].module` yielded ZERO user modules; pgw#1324's `worker.py`
+fix (`if not specs and not jobs`) is correct and sits one frame too late,
+because `collect_jobs([])` over an empty module list finds nothing either.
+
+Three properties, each with the one-line edit that turns it RED:
+
+1. **THE HEADLINE.** A REAL jobs-only `endpoint.lock` — baked by the REAL
+   `python -m gen_worker.discovery` out of a REAL package of `@job`s — yields
+   its modules and BOOTS through the REAL `_run_main`, with every job in the
+   executor's inventory. RED by restoring the `functions`-only loop in
+   `get_modules_from_manifest` (that is master exactly: 0 modules, exit 1).
+   Functions-only and mixed locks are the controls: extending the walk must
+   not change what a function-shaped release discovers.
+
+2. **THE CUDA PROBE IS NOT BLIND TO JOBS.** `should_probe_cuda` read
+   `functions[]` too, so a jobs-only GPU image was never health-probed and the
+   gw#529 bad-host guard silently did not apply to the whole jobs program.
+   RED by restoring `functions = (manifest or {}).get("functions", [])`.
+
+3. **THE SILENT DEATH DIES TOO.** The no-modules exit was a bare
+   `logger.error` + `return 1` — the ONE fatal in `_run_main` that did not
+   dial. RunPod exposes no container-logs API, so the hub saw `exit:1` and
+   condemned the pod `[hardware-unsuitable]` with empty driver/gpu: a boot bug
+   wearing a hardware verdict, and it cost a paid pod to find. It must now dial
+   `_log_worker_fatal("no_user_modules", ..., settings=settings)`, the report
+   must REACH the worker_fatal wire carrier (pre-Hello reporting is deliberately
+   preserved, th#2075), and the detail must NAME the gap — declarations found
+   vs modules found. RED by deleting the `_log_worker_fatal` call, or by
+   dropping `settings=` from it (which silently makes the dial a no-op).
+
+Nothing here is mocked that matters: the packages are real, the lock is baked
+by the real build command in a real subprocess, the registry walk is real, and
+`Worker.__init__` is the production constructor. Only the seams that need
+hardware or a hub are stood down — the CUDA device, the cache-dir mkdir, and
+`Worker.run`'s gRPC loop.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import entrypoint
+from gen_worker.cuda_probe import CudaProbeResult, should_probe_cuda
+
+pytest.importorskip("torch")
+
+
+# --------------------------------------------------------------------------
+# The packages, and the REAL bake
+# --------------------------------------------------------------------------
+
+#: The live shape this issue was measured on: `conversion` 0.12.4 declares 27
+#: jobs and zero functions, 10 of them on a card.
+JOB_COUNT = 27
+GPU_JOB_COUNT = 10
+#: Spread across two modules, so the walk is proved to UNION and de-duplicate
+#: rather than to return whatever the first row said.
+JOB_MODULES = ("main", "extra")
+
+_PREAMBLE = """
+import msgspec
+from gen_worker import JobContext, RequestContext, Resources, endpoint, job
+
+class In_(msgspec.Struct):
+    steps: int = 1
+
+class Out_(msgspec.Struct):
+    ok: bool = True
+"""
+
+
+def _job_source(index: int, *, gpu: bool) -> str:
+    resources = "Resources(gpu=True)" if gpu else "Resources(vcpus=2)"
+    return textwrap.dedent(f"""
+        @job(resources={resources})
+        def convert_{index:02d}(ctx: JobContext, spec: In_) -> Out_:
+            return Out_()
+    """)
+
+
+def _endpoint_source(name: str) -> str:
+    return textwrap.dedent(f"""
+        @endpoint
+        class {name}:
+            def generate(self, ctx: RequestContext, p: In_) -> Out_:
+                return Out_()
+    """)
+
+
+def _write_package(
+    root: Path, package: str, *, jobs: int, gpu_jobs: int, endpoints: bool,
+) -> None:
+    pkg = root / package
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    bodies: Dict[str, List[str]] = {name: [_PREAMBLE] for name in JOB_MODULES}
+    for index in range(jobs):
+        module = JOB_MODULES[index % len(JOB_MODULES)]
+        bodies[module].append(_job_source(index, gpu=index < gpu_jobs))
+    if endpoints:
+        bodies["main"].append(_endpoint_source("Gen"))
+    for module, parts in bodies.items():
+        (pkg / f"{module}.py").write_text("".join(parts))
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{package}"\nversion = "0.0.0"\n'
+        f'[tool.gen_worker]\nmain = "{package}.main"\n'
+    )
+
+
+def _bake(root: Path) -> Path:
+    """The REAL build step from the generated Dockerfile:
+    `python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock`."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(root), env.get("PYTHONPATH", "")]).strip(os.pathsep)
+    proc = subprocess.run(
+        [sys.executable, "-m", "gen_worker.discovery"],
+        cwd=str(root), env=env, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, (
+        f"the real bake refused:\n{proc.stderr}")
+    lock = root / ".tensorhub" / "endpoint.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text(proc.stdout)
+    return lock
+
+
+def _baked(
+    tmp_path_factory: pytest.TempPathFactory,
+    package: str,
+    *,
+    jobs: int,
+    gpu_jobs: int,
+    endpoints: bool,
+) -> Tuple[Path, Path]:
+    root = tmp_path_factory.mktemp(package)
+    _write_package(
+        root, package, jobs=jobs, gpu_jobs=gpu_jobs, endpoints=endpoints)
+    return root, _bake(root)
+
+
+@pytest.fixture(scope="module")
+def jobs_only(tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, Path]:
+    """te#218's shape: 27 jobs, 10 on a card, ZERO `@endpoint`s."""
+    return _baked(
+        tmp_path_factory, "conv_jobs",
+        jobs=JOB_COUNT, gpu_jobs=GPU_JOB_COUNT, endpoints=False)
+
+
+@pytest.fixture(scope="module")
+def functions_only(tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, Path]:
+    """The control: the shape every walk in this file was written for."""
+    return _baked(
+        tmp_path_factory, "fn_only", jobs=0, gpu_jobs=0, endpoints=True)
+
+
+@pytest.fixture(scope="module")
+def mixed(tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, Path]:
+    """The other control: one package carrying both, published once."""
+    return _baked(
+        tmp_path_factory, "both_kinds", jobs=4, gpu_jobs=2, endpoints=True)
+
+
+def _manifest(lock: Path) -> Dict[str, Any]:
+    manifest = entrypoint.load_manifest(lock)
+    assert manifest is not None, f"the baked lock at {lock} did not load"
+    return manifest
+
+
+# --------------------------------------------------------------------------
+# 1. the headline — discovery, then the whole boot
+# --------------------------------------------------------------------------
+
+def test_the_baked_jobs_only_lock_really_is_jobs_only(
+    jobs_only: Tuple[Path, Path],
+) -> None:
+    """The fixture is the defect's shape, stated by the artifact itself —
+    otherwise the arms below could pass against a lock that quietly grew a
+    function."""
+    manifest = _manifest(jobs_only[1])
+    assert manifest.get("functions") in (None, [])
+    assert len(manifest["jobs"]) == JOB_COUNT
+    assert sum(
+        1 for j in manifest["jobs"] if (j.get("resources") or {}).get("gpu")
+    ) == GPU_JOB_COUNT
+
+
+def test_a_jobs_only_manifest_yields_its_modules(
+    jobs_only: Tuple[Path, Path],
+) -> None:
+    """THE headline. RED on master: `[]`."""
+    modules = entrypoint.get_modules_from_manifest(_manifest(jobs_only[1]))
+    assert modules == [f"conv_jobs.{name}" for name in sorted(JOB_MODULES)], (
+        "a jobs-only package declares its modules in jobs[].module")
+
+
+def test_the_function_walk_is_unchanged_by_the_extension(
+    functions_only: Tuple[Path, Path], mixed: Tuple[Path, Path],
+) -> None:
+    """The controls: one walk over both blocks, not a different answer for the
+    shape that already worked."""
+    # A function row records the top-level package it is walked from; a job row
+    # records its own module. The union carries both spellings, and the registry
+    # walk each side runs is the one that reads its own.
+    assert entrypoint.get_modules_from_manifest(
+        _manifest(functions_only[1])) == ["fn_only"]
+    assert entrypoint.get_modules_from_manifest(_manifest(mixed[1])) == [
+        "both_kinds", "both_kinds.extra", "both_kinds.main"]
+
+
+def _boot(
+    monkeypatch: pytest.MonkeyPatch, root: Path, lock: Path,
+) -> Dict[str, Any]:
+    """Run the REAL `_run_main` against a REAL baked lock, standing down only
+    the seams that need hardware or a hub."""
+    observed: Dict[str, Any] = {"probed": False, "fatals": [], "dialed": []}
+
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.setenv("ENDPOINT_LOCK_PATH", str(lock))
+    monkeypatch.setenv("ORCHESTRATOR_PUBLIC_ADDR", "http://127.0.0.1:1")
+    monkeypatch.setattr(entrypoint, "_install_stack_dump_handler", lambda: None)
+    monkeypatch.setattr(entrypoint, "_establish_env_seal", lambda: {})
+    monkeypatch.setattr(
+        entrypoint, "_preflight_cache_dirs",
+        lambda: {"model_cache_dir": str(root / "cas"),
+                 "local_model_cache_dir": ""})
+
+    def _probe(device_index: int = 0) -> CudaProbeResult:
+        observed["probed"] = True
+        return CudaProbeResult(ok=True)
+
+    monkeypatch.setattr(entrypoint, "probe_cuda", _probe)
+
+    real_fatal = entrypoint._log_worker_fatal
+
+    def _fatal(phase: str, exc: BaseException, **kw: Any) -> None:
+        observed["fatals"].append((phase, str(exc), kw))
+        real_fatal(phase, exc, **kw)
+
+    monkeypatch.setattr(entrypoint, "_log_worker_fatal", _fatal)
+
+    # The wire carrier itself — `_log_worker_fatal` reaching it is the whole
+    # point of the typed dial (th#2075 preserved pre-Hello reporting).
+    from gen_worker import worker_fatal
+
+    def _report(settings: Any, phase: str, exc: Any, *, exit_code: int) -> bool:
+        observed["dialed"].append(
+            worker_fatal.build_fatal_detail(phase, exc, exit_code=exit_code))
+        return True
+
+    monkeypatch.setattr(worker_fatal, "report_worker_fatal", _report)
+
+    workers: List[Any] = []
+    real_init = entrypoint.Worker.__init__
+
+    def _init(self: Any, *a: Any, **kw: Any) -> None:
+        real_init(self, *a, **kw)
+        workers.append(self)
+
+    monkeypatch.setattr(entrypoint.Worker, "__init__", _init)
+    monkeypatch.setattr(entrypoint.Worker, "run", lambda self: 0)
+
+    observed["code"] = entrypoint._run_main()
+    observed["workers"] = workers
+    return observed
+
+
+def test_a_jobs_only_image_boots_with_every_job_in_its_inventory(
+    monkeypatch: pytest.MonkeyPatch, jobs_only: Tuple[Path, Path],
+) -> None:
+    """The production boot, end to end. RED on master at `code == 1` with no
+    Worker ever constructed — which is `deaths_before_hello=2` on a rented
+    Blackwell, for $0."""
+    root, lock = jobs_only
+    observed = _boot(monkeypatch, root, lock)
+
+    assert observed["code"] == 0, "a jobs-only image must reach the worker loop"
+    assert observed["fatals"] == [], "a healthy boot dials no fatal"
+    (worker,) = observed["workers"]
+    assert sorted(worker.executor.job_specs) == sorted(
+        f"convert-{i:02d}" for i in range(JOB_COUNT)), (
+        "pgw#1324's collect_jobs walk is reachable only once the entrypoint "
+        "hands it the jobs' modules")
+    assert not worker.executor.specs, "this package declares no @endpoint"
+
+
+def test_the_function_shaped_controls_still_boot(
+    monkeypatch: pytest.MonkeyPatch,
+    functions_only: Tuple[Path, Path],
+    mixed: Tuple[Path, Path],
+) -> None:
+    root, lock = functions_only
+    observed = _boot(monkeypatch, root, lock)
+    assert observed["code"] == 0 and observed["fatals"] == []
+    (worker,) = observed["workers"]
+    assert worker.executor.specs and not worker.executor.job_specs
+
+    monkeypatch.undo()
+    root, lock = mixed
+    observed = _boot(monkeypatch, root, lock)
+    assert observed["code"] == 0 and observed["fatals"] == []
+    (worker,) = observed["workers"]
+    assert worker.executor.specs and len(worker.executor.job_specs) == 4
+
+
+# --------------------------------------------------------------------------
+# 2. the CUDA probe
+# --------------------------------------------------------------------------
+
+def test_a_jobs_only_gpu_image_is_cuda_probed(
+    monkeypatch: pytest.MonkeyPatch, jobs_only: Tuple[Path, Path],
+) -> None:
+    """gw#529's bad-host guard applies to jobs. RED on master: never probed —
+    a GPU job boots on a card nothing health-checked."""
+    root, lock = jobs_only
+    assert should_probe_cuda(_manifest(lock), cuda_build=True) is True
+    assert _boot(monkeypatch, root, lock)["probed"] is True
+
+
+def test_the_probe_predicate_reads_both_blocks() -> None:
+    """The three states, at the predicate. A CPU-only jobs release is not
+    probed; an all-GPU one always is; the mixed case defers to the installed
+    torch build exactly as it does for functions."""
+    cpu_jobs = {"jobs": [{"module": "m", "resources": {"gpu": False}}]}
+    gpu_jobs = {"jobs": [{"module": "m", "resources": {"gpu": True}}]}
+    mixed_jobs = {"jobs": [
+        {"module": "m", "resources": {"gpu": True}},
+        {"module": "m", "resources": {"gpu": False}},
+    ]}
+    assert should_probe_cuda(cpu_jobs, cuda_build=True) is False
+    assert should_probe_cuda(gpu_jobs, cuda_build=False) is True
+    assert should_probe_cuda(mixed_jobs, cuda_build=True) is True
+    assert should_probe_cuda(mixed_jobs, cuda_build=False) is False
+    # And the union is across blocks: a GPU job beside a CPU function is the
+    # same mixed case, not two independent verdicts.
+    assert should_probe_cuda(
+        {"functions": [{"module": "m", "resources": {"gpu": False}}], **gpu_jobs},
+        cuda_build=False) is False
+    assert should_probe_cuda(None, cuda_build=True) is False
+
+
+# --------------------------------------------------------------------------
+# 3. the silent death
+# --------------------------------------------------------------------------
+
+def _empty_lock(tmp_path: Path, body: str) -> Tuple[Path, Path]:
+    lock = tmp_path / "endpoint.lock"
+    lock.write_text(body)
+    return tmp_path, lock
+
+
+def test_declarations_without_modules_dial_a_typed_fatal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The gap this class produces: rows the wheel can count but cannot import.
+    The exit stays 1 — and now it says WHY, on the wire, naming both counts."""
+    root, lock = _empty_lock(tmp_path, textwrap.dedent("""
+        [[jobs]]
+        name = "convert-00"
+        [[jobs]]
+        name = "convert-01"
+        [[functions]]
+        name = "generate"
+    """))
+    observed = _boot(monkeypatch, root, lock)
+
+    assert observed["code"] == 1
+    (phase, message, kw), = observed["fatals"]
+    assert phase == "no_user_modules"
+    assert kw.get("settings") is not None, (
+        "without settings the dial is a silent no-op — the exact defect")
+    assert "1 function(s) and 2 job(s)" in message, (
+        "the fatal must name the gap it found, not merely that it exited")
+    assert "functions, jobs" in message, "and which blocks this build walks"
+    (detail,) = observed["dialed"]
+    assert "no_user_modules" in detail and "exit_code=1" in detail
+
+
+def test_a_missing_manifest_dials_the_same_typed_fatal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The other gap, discriminated: no lock at all is a Dockerfile that never
+    ran discovery, and it too must be readable off the hub rather than off pod
+    stdout RunPod does not serve."""
+    observed = _boot(monkeypatch, tmp_path, tmp_path / "absent.lock")
+    assert observed["code"] == 1
+    (phase, message, kw), = observed["fatals"]
+    assert phase == "no_user_modules"
+    assert kw.get("settings") is not None
+    assert "no baked manifest" in message
+    assert "gen_worker.discovery" in message
+    assert observed["dialed"], "the hub must hear about this one too"

--- a/tests/test_jobs_only_boot_pgw1354.py
+++ b/tests/test_jobs_only_boot_pgw1354.py
@@ -57,6 +57,9 @@ import pytest
 
 from gen_worker import entrypoint
 from gen_worker.cuda_probe import CudaProbeResult, should_probe_cuda
+# The SAME class object `entrypoint` holds (`from .worker import Worker`), so
+# patching it here is patching what the boot constructs.
+from gen_worker.worker import Worker
 
 pytest.importorskip("torch")
 
@@ -267,14 +270,14 @@ def _boot(
     monkeypatch.setattr(worker_fatal, "report_worker_fatal", _report)
 
     workers: List[Any] = []
-    real_init = entrypoint.Worker.__init__
+    real_init = Worker.__init__
 
     def _init(self: Any, *a: Any, **kw: Any) -> None:
         real_init(self, *a, **kw)
         workers.append(self)
 
-    monkeypatch.setattr(entrypoint.Worker, "__init__", _init)
-    monkeypatch.setattr(entrypoint.Worker, "run", lambda self: 0)
+    monkeypatch.setattr(Worker, "__init__", _init)
+    monkeypatch.setattr(Worker, "run", lambda self: 0)
 
     observed["code"] = entrypoint._run_main()
     observed["workers"] = workers


### PR DESCRIPTION
Closes pgw#1354 (P0). Root-caused live by the e2e#1890 lane on two card families; fixed and red/green-verified here at $0 (no pods).

## What was broken

`entrypoint.get_modules_from_manifest` walked `manifest["functions"]` and nothing else. te#218 re-authored every conversion package as **jobs-only** (`conversion` 0.12.4 = 27 jobs / 0 functions), and those declare their modules in `jobs[].module` — which `discovery/discover.py` writes for every job and nobody read. So the first pod ever booted off a jobs-only image discovered ZERO user modules and hit `if not user_modules: return 1` **before hello**:

```
pod jfv904ztg8g7cm  RTX PRO 6000 Blackwell  created 20:37:10Z  dead 20:38:02Z
  worker_fatal: phase=compute_crash_loop deaths=2 deaths_before_hello=2 last_cause=exit:1
  [hardware-unsuitable] driver="" gpu=""     ready_at = NULL
```

pgw#1324's `worker.py` fix (`if not specs and not jobs`) is correct and sits **one frame too late** — `collect_jobs([])` over an empty module list finds nothing either. Its tests construct the executor directly and never traverse the entrypoint's module extraction, which is how a green suite shipped a wheel that cannot boot the one package shape the jobs program exists to run.

## Three changes

**1. One walk, both blocks.** New `gen_worker.manifest_blocks` owns the declaration-row derivation over `functions[]` + `jobs[]`; `get_modules_from_manifest` reads it. Deliberately not a second jobs walk beside the function walk — two walks drift, and the next block makes it three (the th#2105 precedent: one derivation, two feeders). Stdlib-only, no `gen_worker` imports, because the control parent reads it and must stay a bare interpreter (pgw#763).

**2. The CUDA probe stops being blind to jobs.** `should_probe_cuda` read `functions[]` too, so a jobs-only GPU image returned `False` and was **never health-probed** — gw#529's bad-host guard silently did not apply to the whole jobs program, and 10 of those 27 conversion jobs ask for a card. It now reads the same derivation. The mixed CPU/GPU rule (defer to the installed torch build) is unchanged and now applies *across* blocks rather than per block, which is the right answer: a release publishing separate `accelerator=none`/`accelerator=cuda` images is one release either way.

**3. The silent death dies too.** The no-modules exit was the **one** fatal in `_run_main` that did not dial — a bare `logger.error` + `return 1`. RunPod exposes no container-logs API, so the hub saw `exit:1` with no reason class and classified it `[hardware-unsuitable]` with empty driver/gpu: a boot bug wearing a hardware verdict, which is exactly why this took a paid pod to find. It now dials `_log_worker_fatal("no_user_modules", …, settings=settings)` over the worker_fatal carrier (pre-Hello reporting was deliberately preserved in th#2075), with a detail that NAMES the gap — how many functions and jobs the lock declared, how many modules that yielded, which blocks this build walks — and discriminates "declarations this wheel cannot read" from "no baked manifest at all", because those have different owners. `manifest_loaded` gained `job_count` beside `function_count` for the same reason.

## The class sweep (item 4)

This is the **fourth** instance of teach-the-next-layer (ingest th#2100 → lane derivation th#2105 → pick floor th#2120 → entrypoint here). Every `functions[]` walk in `src/`, classified:

| site | verdict |
|---|---|
| `entrypoint.get_modules_from_manifest` | **the defect** — now both blocks |
| `cuda_probe.should_probe_cuda` | **instance #5, found by this sweep** — now both blocks |
| `entrypoint` `manifest_loaded` `function_count` | **blind telemetry** — a boot log that read "0 declarations" on exactly the images the jobs program runs. `job_count` added |
| `discovery/validation.validate_endpoint_lock` — the `len(functions)==0` warning | **cosmetically wrong** — called a 27-job release "will advertise nothing". Now jobs-aware |
| `discovery/validation` — slot-layout, wire-route, aot-precondition walks | **correctly functions-only**: slots, bindings, compile cells and wire routes are concepts a job does not declare (`_job_entry`: "no execution lanes, no compile block, no slots/bindings") |
| `discovery/discover.main` refusal | **already jobs-aware** (`not functions and not jobs`) |
| `models/download.build_provider_index_from_manifest` | **correctly functions-only**: it indexes `functions[].bindings`, and a job that wants a hub-resolved model NAMES it in its payload rather than binding a slot |
| `cli/serve.py`, `cli/listing.py` | **not a manifest walk** — local-dev CLI over in-process registry candidates, no `endpoint.lock` read |

## Red/green, at $0

`tests/test_jobs_only_boot_pgw1354.py` — 9 arms, all driving production code. The packages are real `@job`/`@endpoint` sources; the `endpoint.lock` is baked by the **real** `python -m gen_worker.discovery` in a real subprocess (the generated Dockerfile's own build step); the boot is the real `_run_main` through the real `Worker.__init__`/registry walk. Only the CUDA device, the cache-dir mkdir and `Worker.run`'s gRPC loop are stood down. The jobs-only fixture is the measured shape: 27 jobs across 2 modules, 10 on a card, zero functions.

Four mutations, each re-run against the full file:

| mutation | red |
|---|---|
| restore the `functions`-only loop in `get_modules_from_manifest` (= master) | 3 failed — including the boot at `code == 1`, no Worker ever constructed, which is `deaths_before_hello=2` for $0 |
| restore `functions = manifest.get("functions")` in `should_probe_cuda` | 2 failed |
| delete the `_log_worker_fatal` call from the no-modules exit | 2 failed |
| keep the call but drop `settings=` (the dial silently becomes a no-op) | 2 failed |

Green: `9 passed`. Regression sweep over every file touching these modules — `313 passed`.

## Sequencing

Every jobs-only endpoint is dead-on-boot until a wheel ships this. jobs#230 must land before the jobs repo repins (its Dockerfile smoke-imports).
