### PR TITLE
pgw#1356: a mint that finished says so, and names the classes it produced

### DIFF
--- a/changelog.d/pgw1356.md
+++ b/changelog.d/pgw1356.md
@@ -1,0 +1,32 @@
+- **A mint that FINISHED reported itself as still in flight, having produced nothing.** Measured
+  on a rented A40 (2026-08-17, pod `zco8e1bx0t1jgk`, $0.54): two compile children, 36 of 36 graph
+  classes `status=compiled exit=0`, pool efficiency 99.89 % — and the one roll-up the hub sees read
+  `aot_mint_phases in_flight status=in_flight n_entries=0 totals={'export_s': 0, 'compile_s': 0}
+  phases={} overlays={}`. An operator could not tell a finished mint from one the pod killed, which
+  is precisely the distinction pgw#848 built the on-disk snapshot to preserve. Two independent
+  defects, both required for the row to be readable: `mint_supervisor._mint_phase_table_of` read
+  the table from `entry.metadata["mint_phases"]` while the writer stamps `MintedArtifact
+  .mint_phases` — and `metadata` is TCG's CLOSED artifact vocabulary, which cannot legally carry
+  the field (`test_tcg_mint_parent_pgw1270` asserts its absence by name), so the reader could never
+  succeed and `phase_table` fell through to the snapshot on EVERY successful mint, inheriting the
+  snapshot's `in_flight` terminus. The reader now reads the typed field.
+- **The phase table's entry rows have had no writer since pgw#1215.** `_mint_phase_table` folded
+  `MintProgress.minted` — a list the SERIAL driver appended to as it exported in-process. pgw#1215
+  deleted that driver (`aot_mint.mint` no longer exists) and left the field with no writer, so
+  `n_entries` was `0`, and `entries`, `phases` and `overlays` were empty, for a mint of any size:
+  every per-class `entry:<name>` row the hub should have received was suppressed by an
+  `if not timings: continue`. The table is now folded out of `EntryCompilePool.class_spans`, per
+  GRAPH CLASS, straight off the children's reports, over the SURVIVOR set so an absorbed duplicate
+  is not double-counted. `phases` folds the flat `torchcg.spans` partition labels the child
+  actually writes; `overlays` come from the pool's per-SHARE ledger, which is the granularity they
+  are measured at — the child discards its per-class overlay split, and inventing a per-class
+  attribution would be worse than reporting none.
+- **A killed mint leaves the classes that landed behind it again.** `MintProgress` now BINDS the
+  pool's live `class_spans`/`entry_overlays` rather than copying them, so the snapshot rewritten on
+  every beat names what has landed so far. pgw#848's own worked example — attempt sixteen, killed
+  at class 30 of 36, reporting zero rows — has been the actual behaviour of every mint since the
+  serial driver was deleted.
+- This is NOT the `key_axis_divergence` refusal the same A40 mint also hit. That one is pgw#1340,
+  fixed on `master` and unreleased: `v0.122.0` was tagged at `3b10ede1` 3h28m BEFORE PR #895
+  merged, so the wheel the pod ran still compared `family` at the handback seam. The publish half
+  of that mint needs a CUT, not a code change.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1261,7 +1261,21 @@ class MintProgress:
     on_progress: Optional[Callable[[str, int, int, str], None]] = None
     t_mint: Optional[float] = None
     timings: Dict[str, float] = field(default_factory=dict)
-    minted: List[_MintedEntry] = field(default_factory=list)
+    #: pgw#1356: per GRAPH CLASS, and BOUND TO THE POOL'S OWN LIVE DICT
+    #: (:attr:`aot_compile_pool.EntryCompilePool.class_spans`) rather than
+    #: copied into. This replaces the ``minted: List[_MintedEntry]`` the
+    #: serial driver appended to — a driver pgw#1215 deleted, leaving the
+    #: field with no writer and every phase table reporting ``n_entries: 0``.
+    #: Sharing the dict is what makes pgw#848 true: the snapshot written on
+    #: every beat names the classes that have LANDED, so a mint the pod kills
+    #: at class 30 of 36 reports thirty rows instead of none.
+    class_spans: Mapping[str, Mapping[str, float]] = field(
+        default_factory=dict)
+    #: Per SHARE (:attr:`aot_compile_pool.EntryCompilePool.entry_overlays`),
+    #: bound live for the same reason. Share granularity is the granularity
+    #: the child measures overlays at.
+    share_overlays: Mapping[str, Mapping[str, float]] = field(
+        default_factory=dict)
     width: Optional[aot_compile_pool.PoolWidth] = None
     #: pgw#842: the pool's own ledger (pgw#830) once it has run, carried here
     #: so it reaches the phase table — and therefore the hub — instead of
@@ -1334,18 +1348,20 @@ def partial_phase_table(
     Empty dict when there is nothing yet — "no measurement" and "zero" must
     not read the same.
     """
-    minted = list(progress.minted)
+    class_spans = {
+        name: dict(spans) for name, spans in progress.class_spans.items()}
     timings = dict(progress.timings)
     started = progress.t_mint
     where = dict(progress.at)
-    if not minted and not timings and not where:
+    if not class_spans and not timings and not where:
         return {}
     if started is not None:
         # The mint's OWN wall clock, so an aborted total is comparable
         # with a completed one rather than being a sum of entry seconds.
         timings["total_s"] = round(time.monotonic() - float(started), 2)
     table = _mint_phase_table(
-        minted, timings, progress.width, progress.pool_ledger)
+        class_spans, timings, progress.width, progress.pool_ledger,
+        progress.share_overlays)
     table["terminus"] = terminus
     if where:
         # pgw#824 x pgw#825: the entries block names what FINISHED; this
@@ -1591,6 +1607,13 @@ def mint_graph_classes(
     progress.t_mint = t_mint
     pool = aot_compile_pool.EntryCompilePool(
         Path(workdir), width=width, python=python)
+    # pgw#1356: BOUND, not copied. The pool mutates these as each share's
+    # report lands, so every beat's on-disk snapshot names the graph classes
+    # that have landed so far — which is what pgw#848 promised a killed mint
+    # would leave behind and has not delivered since pgw#1215 deleted the
+    # serial driver that fed `MintProgress.minted`.
+    progress.class_spans = pool.class_spans
+    progress.share_overlays = pool.entry_overlays
     progress.beat(
         PHASE_INDUCTOR_COMPILE, 0, width.workers,
         f"{width.workers} compile child(ren), one share each — {width.reason}")
@@ -1712,11 +1735,19 @@ def mint_graph_classes(
         if keep != name:
             absorbed_by.setdefault(keep, []).append(name)
 
+    absorbed = {n for names in absorbed_by.values() for n in names}
+    # pgw#1356: the table is built from the classes this mint actually
+    # produced — SURVIVORS, so an absorbed duplicate is not double-counted the
+    # way it would be if this summed the pool's raw rows. A `held` class
+    # carried in from an earlier attempt has no spans in THIS pool, and stays
+    # absent rather than being invented as a zero: `n_entries` is what this
+    # attempt measured, and coverage is the manifest's question.
     phase_table = _mint_phase_table(
-        [], timings, width, progress.pool_ledger)
+        {name: spans for name, spans in pool.class_spans.items()
+         if name in metas and name not in absorbed},
+        timings, width, progress.pool_ledger, pool.entry_overlays)
     entries: List[MintedArtifact] = []
     blocks: Dict[str, Dict[str, Any]] = {}
-    absorbed = {n for names in absorbed_by.values() for n in names}
     for name in sorted(metas):
         if name in absorbed:
             continue
@@ -2292,10 +2323,11 @@ def tcg_graph_class_spec(traced: TracedClass, export_spec: ExportSpec) -> Any:
 
 
 def _mint_phase_table(
-    minted: Sequence[_MintedEntry],
+    class_spans: Mapping[str, Mapping[str, float]],
     timings: Mapping[str, float],
     width: Optional[aot_compile_pool.PoolWidth] = None,
     pool_ledger: Optional[Mapping[str, Any]] = None,
+    share_overlays: Optional[Mapping[str, Mapping[str, float]]] = None,
 ) -> Dict[str, Any]:
     """The per-mint phase table (#757's instrument-first deliverable): one
     readable record of where the mint's seconds went, per entry and in
@@ -2304,32 +2336,60 @@ def _mint_phase_table(
 
     pgw#809 adds the ``pool`` block: the K this mint ran at AND the budget
     that chose it. Without it a mint's wall clock is uninterpretable —
-    two mints of the same cell on two pods legitimately differ by 4x."""
-    entries = {
-        row.name: dict(row.timings) for row in minted}
+    two mints of the same cell on two pods legitimately differ by 4x.
+
+    pgw#1356 REBASES THE INPUT ONTO THE ONLY PROCESS THAT MEASURES IT. This
+    took ``Sequence[_MintedEntry]`` — rows the SERIAL driver appended to
+    ``MintProgress.minted`` as it exported in-process. pgw#1215 deleted that
+    driver (``aot_mint.mint`` no longer exists) and nothing has written
+    ``minted`` since, so every caller passed an empty sequence and this
+    answered ``n_entries: 0``, ``entries: {}``, ``phases: {}`` for mints of
+    any size. Measured on the A40 mint of 2026-08-17: 36 of 36 graph classes
+    compiled, ``exit=0``, and the roll-up on the wire read
+    ``n_entries=0 phases={} overlays={}``.
+
+    What replaces it is what the K-wide pool actually holds:
+    ``EntryCompilePool.class_spans``, per GRAPH CLASS, straight off each
+    child's report — and it is the same live dict the pool mutates, so the
+    on-disk snapshot a KILLED mint leaves behind names the classes that had
+    landed rather than reporting zero (pgw#848's own promise, unmet since
+    pgw#1215).
+
+    The spans are FLAT (``export_s``/``compile_s``/``reuse_s``/``nodes`` plus
+    ``torchcg.spans.PARTITION_KEYS`` labels), because that is the shape
+    ``aot_compile_child`` writes. So ``phases`` folds the partition labels out
+    of the flat rows rather than out of a nested ``phases`` block no child has
+    ever written.
+
+    ``share_overlays`` is per SHARE (``EntryCompilePool.entry_overlays``), not
+    per class, and is reported at the granularity it is measured at: the child
+    discards its per-class overlay split (``aot_compile_child`` names it
+    ``_overlays``), so claiming a per-class attribution here would be an
+    invention. Kept OUT of ``phases`` for pgw#830's reason — overlays nest
+    inside partition members, and summing them in was the original
+    attribution bug.
+    """
+    entries = {name: dict(spans) for name, spans in class_spans.items()}
     totals: Dict[str, float] = {
-        "export_s": round(sum(
-            float(row.timings.get("export_s") or 0) for row in minted), 2),
-        "compile_s": round(sum(
-            float(row.timings.get("compile_s") or 0) for row in minted), 2),
-        "warm_s": round(sum(
-            float(row.timings.get("warm_s") or 0) for row in minted), 2),
+        label: round(sum(
+            float(spans.get(label) or 0) for spans in entries.values()), 2)
+        for label in ("export_s", "compile_s", "warm_s")
     }
     phase_totals: Dict[str, float] = {}
+    for spans in entries.values():
+        for label in _PHASE_KEYS:
+            value = float(spans.get(label) or 0)
+            if value:
+                phase_totals[label] = round(
+                    phase_totals.get(label, 0.0) + value, 3)
     overlay_totals: Dict[str, float] = {}
-    for row in minted:
-        for label, value in (row.timings.get("phases") or {}).items():
-            phase_totals[label] = round(
-                phase_totals.get(label, 0.0) + float(value), 3)
-        # Kept OUT of `phases` on purpose (pgw#830): overlays nest inside
-        # partition members, and summing them in was the original
-        # attribution bug. Reported beside it, never inside it.
-        for label, value in (row.timings.get("overlays") or {}).items():
+    for overlays in (share_overlays or {}).values():
+        for label, value in overlays.items():
             overlay_totals[label] = round(
                 overlay_totals.get(label, 0.0) + float(value), 3)
     return {
         "v": 1,
-        "n_entries": len(minted),
+        "n_entries": len(entries),
         "compiler_owner": "torchcg",
         "totals": {**totals, **{k: v for k, v in timings.items()}},
         "phases": phase_totals,

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -852,10 +852,23 @@ def _mint_phase_table_of(result: Any) -> Dict[str, Any]:
     ``mint_graph_classes`` stamps the same table onto every entry it returns
     (it is the RESULT's view, never the packed envelope's — the artifact
     deliberately carries no wall clocks), so any entry answers.
+
+    pgw#1356: READ OFF THE TYPED FIELD, which is where the writer has always
+    put it. This read ``entry.metadata["mint_phases"]`` — and ``metadata`` is
+    TCG's CLOSED artifact vocabulary, which has no such field and cannot be
+    extended (``test_tcg_mint_parent_pgw1270`` asserts ``"mint_phases" not in
+    survivor.metadata`` by name). So the reader could never find the table,
+    ``phase_table`` fell through to the on-disk snapshot on EVERY successful
+    mint, and the roll-up on the wire announced a completed mint as
+    ``status=in_flight`` — ``in_flight`` being the terminus
+    :func:`aot_mint.write_phase_snapshot` stamps on a beat. Measured on the
+    2026-08-17 A40 mint: 36 of 36 classes ``status=compiled exit=0``, roll-up
+    ``aot_mint_phases in_flight n_entries=0``, and the operator reading it
+    could not tell a finished mint from a killed one.
     """
     for entry in getattr(result, "entries", ()):
-        rows = dict(entry.metadata or {}).get("mint_phases")
-        if isinstance(rows, dict):
+        rows = getattr(entry, "mint_phases", None)
+        if isinstance(rows, dict) and rows:
             return dict(rows)
     return {}
 

--- a/tests/test_child_traces_its_own_share_pgw1215.py
+++ b/tests/test_child_traces_its_own_share_pgw1215.py
@@ -265,6 +265,10 @@ def test_a_child_envelope_that_cannot_be_parsed_refuses(
     class _Pool:
         entry_seconds: Dict[str, float] = {}
         peak_rss_bytes = 0
+        #: pgw#1356: the phase table folds these, so a double without them is
+        #: a double of a pool that cannot say what it compiled.
+        class_spans: Dict[str, Dict[str, float]] = {}
+        entry_overlays: Dict[str, Dict[str, float]] = {}
 
         def __init__(self, *a: Any, **k: Any) -> None:
             pass

--- a/tests/test_mint_memory_fit_pgw848.py
+++ b/tests/test_mint_memory_fit_pgw848.py
@@ -252,7 +252,7 @@ def test_the_pools_own_measurement_reaches_the_bank_over_the_real_relay(
     width = pool.entry_workers(
         2, vcpus=16, available_bytes=64 * _GIB, device_lock=True, limit=2)
     table = aot_mint._mint_phase_table(
-        [], {"total_s": 1.0}, width,
+        {}, {"total_s": 1.0}, width,
         {"peak_child_rss_bytes": 6 * _GIB, "pool_workers": 2},
     )
     assert table["pool"]["peak_child_rss_bytes"] == 6 * _GIB, (

--- a/tests/test_mint_oom_classification_pgw848.py
+++ b/tests/test_mint_oom_classification_pgw848.py
@@ -212,7 +212,7 @@ def test_a_real_oom_killed_entry_child_is_a_retryable_shortfall_that_teaches_the
         assert facts["oom_basis"] == failure.basis
         assert facts["peak_child_rss_bytes"] == box.peak_rss_bytes > 0
         table = aot_mint._mint_phase_table(
-            [], {"total_s": 1.0}, width, facts,
+            {}, {"total_s": 1.0}, width, facts,
         )
         assert table["pool"]["oom_entry"] == "share-000"
 

--- a/tests/test_mint_rollup_terminus_pgw1356.py
+++ b/tests/test_mint_rollup_terminus_pgw1356.py
@@ -1,0 +1,282 @@
+"""pgw#1356 — a SUCCESSFUL mint's roll-up announced itself as still running.
+
+MEASURED on a rented A40 (pod ``zco8e1bx0t1jgk``, 2026-08-17, $0.54). Two
+compile children, 36 of 36 graph classes, ``status=compiled exit=0``, pool
+efficiency 99.89 % — and the one roll-up the hub sees said::
+
+    aot_mint_phases  in_flight  status=in_flight  n_entries=0  3608490ms
+
+Sixty minutes of measured work reported as *"still in flight, nothing
+produced"*. An operator reading that row cannot tell a finished mint from a
+mint the pod killed, which is the exact distinction pgw#848 built the on-disk
+snapshot to preserve.
+
+TWO INDEPENDENT DEFECTS, both of which have to be fixed for the row to be
+readable, and neither of which is the ``key_axis_divergence`` refusal the same
+pod also hit (that one is pgw#1340, fixed and unreleased):
+
+1. **The reader and the writer disagreed about an address.**
+   ``mint_graph_classes`` stamps the phase table onto ``MintedArtifact
+   .mint_phases``; ``mint_supervisor._mint_phase_table_of`` read
+   ``entry.metadata["mint_phases"]``. ``metadata`` is TCG's CLOSED artifact
+   vocabulary — ``test_tcg_mint_parent_pgw1270`` asserts ``"mint_phases" not
+   in survivor.metadata`` BY NAME — so the reader could never find it, and
+   ``phase_table`` fell through to the snapshot on every successful mint. The
+   snapshot's terminus is ``in_flight``, because a snapshot is a beat.
+
+2. **The table's entry rows had no writer.** ``_mint_phase_table`` folded
+   ``MintProgress.minted``, a list the SERIAL driver appended to as it
+   exported in-process. pgw#1215 deleted that driver (``aot_mint.mint`` does
+   not exist) and nothing has written the field since, so ``n_entries`` was
+   ``0`` and ``entries``/``phases`` were empty for a mint of any size. The
+   K-wide pool holds the real thing per GRAPH CLASS in
+   ``EntryCompilePool.class_spans``.
+
+Driven over the REAL relay — ``mint_graph_classes`` -> ``_mint_phase_table_of``
+-> ``phase_table`` -> ``_emit_aot_phases`` — because the defect was a seam
+between those four and any one of them tested alone reads green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker import aot_compile_pool, aot_mint, mint_supervisor
+
+_CLASSES = ("unet/a", "unet/b", "unet/c")
+
+
+def _metadata(name: str, key: str) -> Dict[str, Any]:
+    """TCG's closed envelope — the only shape a packed class can carry."""
+    return {
+        "compiled_graph_format": 1,
+        "kind": "aot-inductor",
+        "compiled_graph_key": key,
+        "graph_class": {"name": name, "class_hash": key[-16:], "graph": {}},
+        "sm": "cpu-test",
+        "toolchain": {"torch": "test"},
+    }
+
+
+def _spans(export_s: float, compile_s: float) -> Dict[str, float]:
+    """One class's spans, in the FLAT shape ``aot_compile_child`` writes."""
+    return {
+        "export_s": export_s, "compile_s": compile_s, "reuse_s": 0.0,
+        "nodes": 128.0, "lowering_s": 0.5, "codegen_s": 0.25,
+        "host_compile_s": 1.0, "graph_passes_s": 0.125,
+    }
+
+
+class _Pool:
+    """The K-wide pool, stubbed at the ONE boundary a laptop cannot cross.
+
+    Everything the defect lives in — the fold, the stamp, the parent-side
+    relay — is the real code. What is replaced is the spawn of compile
+    children, which is a real AOTI compile and therefore a pod leg.
+    """
+
+    peak_rss_bytes = 0
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.entry_seconds: Dict[str, float] = {
+            "share-000": 4.0, "share-001": 4.0}
+        self.class_spans: Dict[str, Dict[str, float]] = {}
+        self.entry_overlays: Dict[str, Dict[str, float]] = {}
+        self.landed: List[str] = []
+
+    def compile(self, *_args: Any, **kwargs: Any) -> Any:
+        """Land the classes one at a time, beating between each.
+
+        The pool populates ``class_spans`` as reports arrive, so a mint killed
+        part-way has to leave the landed rows behind it — pinned by
+        :func:`test_a_killed_mint_leaves_the_classes_that_landed_on_disk`.
+        """
+        on_share = kwargs.get("on_share")
+        packed: Dict[str, aot_compile_pool.PackedGraphClass] = {}
+        for index, name in enumerate(_CLASSES):
+            key = "cg-key-v1-" + f"{index}".rjust(56, "0")
+            self.class_spans[name] = _spans(1.0, 2.0)
+            self.entry_overlays[f"share-{index:03d}"] = {"autotune_s": 0.5}
+            self.landed.append(name)
+            packed[name] = aot_compile_pool.PackedGraphClass(
+                name=name, key=key, artifact=f"/tmp/{key}.tar.gz",
+                metadata=json.dumps(_metadata(name, key)))
+            if on_share is not None:
+                on_share(name, index + 1, len(_CLASSES))
+        return packed
+
+
+@pytest.fixture(autouse=True)
+def _pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(aot_compile_pool, "EntryCompilePool", _Pool)
+    monkeypatch.setattr(aot_mint, "_pool_facts", lambda _pool: {})
+    monkeypatch.setattr(
+        aot_mint, "canonicalize_packed_classes", lambda _blocks, _metas: {})
+
+
+def _mint(
+    tmp_path: Path, snapshot: Path | None = None,
+) -> aot_mint.MintResult:
+    width = aot_compile_pool.entry_workers(
+        len(_CLASSES), limit=2, vcpus=16,
+        available_bytes=64 * 1024 ** 3, device_lock=True)
+    return aot_mint.mint_graph_classes(
+        aot_compile_pool.EntryJob(
+            function="generate", modules=("m",), out_dir=str(tmp_path)),
+        workdir=tmp_path / "pool", width=width,
+        spec=aot_mint.ExportSpec(family="sdxl", target="unet"),
+        phase_snapshot=snapshot)
+
+
+def _wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> List[Dict[str, Any]]:
+    """The ROWS THE HUB SEES, through the parent-side relay verbatim.
+
+    The whole defect was a seam between the fold, the stamp, the supervisor's
+    two-source rule and the emitter, so the assertion has to be made on the
+    far side of all four — on the same ``aot_mint_phases`` row the A40 pod
+    put on the wire. The snapshot file is REAL and is read the way
+    :func:`mint_supervisor.SupervisedMint` reads it, because the fallback to
+    it is the defect's second half: without it the roll-up reads ``aborted``
+    instead of the production ``in_flight``, which is a different wrong answer
+    to the same question.
+    """
+    snapshot = tmp_path / "phases.json"
+    result = _mint(tmp_path, snapshot=snapshot)
+    rows: List[Dict[str, Any]] = []
+
+    def _emit(kind: str, detail: str, **kw: Any) -> None:
+        rows.append({"kind": kind, "detail": detail, **kw})
+
+    monkeypatch.setattr(aot_mint.activity_mod, "emit_event", _emit)
+    mint_supervisor._emit_aot_phases(
+        mint_supervisor.phase_table(
+            mint_supervisor._mint_phase_table_of(result),
+            mint_supervisor._read_snapshot(snapshot)),
+        family="sdxl", execution_lane="bf16-w16a16",
+        terminus="", elapsed_s=3608.49)
+    assert rows, "a mint that produced N classes emitted no roll-up at all"
+    return rows
+
+
+def _rollup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Dict[str, Any]:
+    return _wire(tmp_path, monkeypatch)[0]
+
+
+def test_a_finished_mint_does_not_announce_itself_as_in_flight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE PRODUCTION RED, on the exact wire row the A40 pod emitted.
+
+    Before pgw#1356 the supervisor could not read the table the mint wrote, so
+    ``phase_table`` fell through to the on-disk snapshot and the roll-up
+    carried the snapshot's ``in_flight`` terminus — on a mint that reached its
+    own terminus with every declared class packed.
+    """
+    row = _rollup(tmp_path, monkeypatch)
+
+    assert row["kind"] == aot_mint.MINT_PHASES_KIND
+    assert row["phase"] == aot_mint.activity_mod.PHASE_MINTED, (
+        "status=in_flight on a mint that finished — the operator cannot tell "
+        "it from a mint the pod killed")
+    assert "status=minted" in row["detail"]
+
+
+def test_the_rollup_counts_the_graph_classes_the_mint_produced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``n_entries=0`` on a 36-class mint, measured on the A40.
+
+    The count is the survivor set, so it is the number of artifacts that can
+    be published — not the number of shares, and not zero.
+    """
+    rows = _wire(tmp_path, monkeypatch)
+
+    assert f"n_entries={len(_CLASSES)}" in rows[0]["detail"]
+    assert {row["phase"] for row in rows if row["phase"].startswith("entry:")} \
+        == {f"entry:{name}" for name in _CLASSES}, (
+        "the per-class rows are how a slow mint says WHICH class it was slow "
+        "in; an empty entries block emits none of them")
+
+
+def test_the_rollup_carries_the_per_class_seconds_the_children_measured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paul's question — *"why is AOT mint so much slower than JIT?"* — is
+    answered by WHICH class the minutes are in. An empty ``entries`` block and
+    empty ``phases`` totals answer nothing, and that is what every mint since
+    pgw#1215 has reported.
+
+    ``phases`` folds the flat ``torchcg.spans`` partition labels the child
+    actually writes, rather than a nested block no child has ever written.
+    """
+    table = mint_supervisor._mint_phase_table_of(_mint(tmp_path))
+
+    assert table["totals"]["export_s"] == pytest.approx(1.0 * len(_CLASSES))
+    assert table["totals"]["compile_s"] == pytest.approx(2.0 * len(_CLASSES))
+    assert table["phases"]["host_compile_s"] == pytest.approx(
+        1.0 * len(_CLASSES))
+    assert table["phases"]["lowering_s"] == pytest.approx(0.5 * len(_CLASSES))
+    assert table["entries"]["unet/a"]["nodes"] == 128.0
+    assert set(table["entries"]) == set(_CLASSES)
+
+
+def test_overlays_are_reported_at_the_granularity_they_are_measured_at(
+    tmp_path: Path,
+) -> None:
+    """pgw#830: overlays nest INSIDE partition members, so they ride beside
+    ``phases`` and are never summed into it. The child discards its per-class
+    overlay split, so the honest source is the pool's per-SHARE ledger — an
+    invented per-class attribution would be worse than none.
+    """
+    table = mint_supervisor._mint_phase_table_of(_mint(tmp_path))
+
+    assert table["overlays"]["autotune_s"] == pytest.approx(
+        0.5 * len(_CLASSES))
+    assert "autotune_s" not in table["phases"]
+
+
+def test_a_killed_mint_leaves_the_classes_that_landed_on_disk(
+    tmp_path: Path,
+) -> None:
+    """pgw#848's promise, unmet since pgw#1215 deleted the field it read.
+
+    ``MintProgress`` binds the pool's LIVE ``class_spans`` rather than copying
+    a snapshot of it, so the table written on every beat names what has landed
+    so far. Attempt sixteen was killed at class 30 of 36 and reported zero
+    rows; this is the fence against that returning.
+    """
+    snapshot = tmp_path / "phases.json"
+    _mint(tmp_path, snapshot=snapshot)
+    table = json.loads(snapshot.read_text())
+
+    assert table["terminus"] == "in_flight", (
+        "a beat is a beat — only the mint's own terminus may claim otherwise")
+    assert table["n_entries"] > 0, (
+        "a killed mint that had already packed classes must not report zero")
+    assert set(table["entries"]) <= set(_CLASSES)
+
+
+def test_the_supervisor_reads_the_table_off_the_typed_field(
+    tmp_path: Path,
+) -> None:
+    """Stated so the address cannot drift back.
+
+    TCG's artifact vocabulary is CLOSED and refuses metadata carrying an extra
+    field, so ``metadata["mint_phases"]`` is not a place the writer is allowed
+    to put it — the previous reader was asking for something that could not
+    legally exist.
+    """
+    result = _mint(tmp_path)
+    survivor = result.entries[0]
+
+    assert survivor.mint_phases["n_entries"] == len(_CLASSES)
+    assert "mint_phases" not in survivor.metadata
+    assert mint_supervisor._mint_phase_table_of(result) == survivor.mint_phases

--- a/tests/test_pool_sizing_pgw842.py
+++ b/tests/test_pool_sizing_pgw842.py
@@ -278,7 +278,7 @@ def test_a_real_pools_width_and_ledger_land_hub_side(tmp_path: Path) -> None:
         "peak_child_rss_bytes": box.peak_rss_bytes,
     }
     table = aot_mint._mint_phase_table(
-        [], {"total_s": 12.5}, width, ledger,
+        {}, {"total_s": 12.5}, width, ledger,
     )
     updates = _relayed(table)
 
@@ -310,7 +310,7 @@ def test_a_narrow_pool_says_so_in_the_first_line() -> None:
         72, vcpus=21, available_bytes=13 * _GIB, device_lock=True)
     assert width.workers == 3 and width.underwidth == 5, width.reason
     table = aot_mint._mint_phase_table(
-        [], {"total_s": 554.78}, width, {"pool_wall_s": 453.0},
+        {}, {"total_s": 554.78}, width, {"pool_wall_s": 453.0},
     )
     updates = _relayed(table)
     detail = next(

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -325,6 +325,10 @@ def _drive_tcg_pool(
     class _Pool:
         entry_seconds: dict[str, float] = {}
         peak_rss_bytes = 0
+        #: pgw#1356: the phase table folds these, so a double without them is
+        #: a double of a pool that cannot say what it compiled.
+        class_spans: dict[str, dict[str, float]] = {}
+        entry_overlays: dict[str, dict[str, float]] = {}
 
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
             pass

--- a/tests/test_tcg_mint_parent_pgw1270.py
+++ b/tests/test_tcg_mint_parent_pgw1270.py
@@ -33,6 +33,16 @@ def _drive(
     class _Pool:
         entry_seconds: dict[str, float] = {}
         peak_rss_bytes = 0
+        #: pgw#1356: the phase table is folded out of the pool's per-CLASS
+        #: spans, so a double that omits them is a double of a pool that
+        #: cannot report what it compiled.
+        class_spans: dict[str, dict[str, float]] = {
+            name: {"export_s": 1.0, "compile_s": 2.0, "lowering_s": 0.5}
+            for name in packed
+        }
+        entry_overlays: dict[str, dict[str, float]] = {
+            "share-000": {"autotune_s": 0.25},
+        }
 
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
             pass


### PR DESCRIPTION
## The measurement

A rented A40 (2026-08-17, pod `zco8e1bx0t1jgk`, $0.54) ran a mint to completion for the first time: two compile children, **36 of 36 graph classes `status=compiled exit=0`**, pool efficiency 99.89 %. The one roll-up the hub sees read

```
aot_mint_phases in_flight status=in_flight n_entries=0
  totals={'export_s': 0, 'compile_s': 0, 'warm_s': 0} phases={} overlays={}
```

Sixty minutes of measured work, reported as *"still running, nothing produced"* — indistinguishable from a mint the pod killed, which is exactly the distinction pgw#848 built the on-disk snapshot to preserve.

## Two independent defects

**1. The reader and the writer disagreed about an address.** `mint_graph_classes` stamps the phase table onto `MintedArtifact.mint_phases`; `mint_supervisor._mint_phase_table_of` read `entry.metadata["mint_phases"]`. `metadata` is TCG's **closed** artifact vocabulary and cannot legally carry the field — `test_tcg_mint_parent_pgw1270` asserts `"mint_phases" not in survivor.metadata` by name. So the reader could never find it, `phase_table` fell through to the on-disk snapshot on *every successful mint*, and the roll-up inherited the terminus a snapshot stamps: `in_flight`, because a snapshot is a beat.

**2. The table's entry rows have had no writer since pgw#1215.** `_mint_phase_table` folded `MintProgress.minted`, a list the SERIAL driver appended to as it exported in-process. pgw#1215 deleted that driver (`aot_mint.mint` no longer exists) and left the field with no writer — so `n_entries` was `0`, `entries`/`phases`/`overlays` were empty for a mint of any size, and every per-class `entry:<name>` row was suppressed downstream by `if entry_s <= 0: continue`.

The table is now folded out of `EntryCompilePool.class_spans`, per GRAPH CLASS, over the **survivor** set so an absorbed duplicate is not double-counted. `phases` folds the flat `torchcg.spans` partition labels the child actually writes; `overlays` come from the pool's per-SHARE ledger, which is the granularity they are measured at — the child discards its per-class overlay split (`_overlays`), and inventing a per-class attribution would be worse than reporting none.

`MintProgress` **binds** the pool's live dicts rather than copying them, so the snapshot rewritten on every beat names the classes that have landed. pgw#848's own worked example — attempt sixteen, killed at class 30 of 36, reporting zero rows — has been the real behaviour of every mint since the serial driver died.

## Proof

`tests/test_mint_rollup_terminus_pgw1356.py` — **6/6 red on `origin/master`, 6/6 green here**, driven over the REAL relay (`mint_graph_classes` → `_mint_phase_table_of` → `phase_table` → `_emit_aot_phases`), because the defect is a seam between those four and any one of them tested alone reads green. Only the spawn of compile children is replaced (a real AOTI compile is a pod leg). The red run reproduces the production row character-for-character:

```
assert 'n_entries=3' in "family=sdxl lane=bf16-w16a16 status=in_flight n_entries=0
  totals={'export_s': 0, 'compile_s': 0, 'warm_s': 0, 'total_s': 0.0} phases={} overlays={}"
```

Blast radius **500 passed**; the 8 failures are the torch-missing baseline `origin/master` shows identically (same 8 names). mypy delta **zero** over 869 files. All 16 hard lint gates pass.

## What this is NOT

Not the `key_axis_divergence` refusal the same A40 mint also hit. **That one is already fixed on `master` by pgw#1340 (PR #895) and is UNRELEASED**: tag `v0.122.0` is `3b10ede1`, cut 3h28m *before* #895 merged, and `serverless-endpoints/sdxl` pins `gen-worker==0.122.0`. The wheel the pod ran still compared `family` at a seam no TCG artifact can state it across. **That half needs a release cut, not a code change.**

Closes the telemetry half of pgw#1356.