### PR TITLE
pgw#1346 B3: DPM-Solver++ and UniPC as bare typed math, and two defects in the reference

### DIFF
--- a/changelog.d/pgw1346.md
+++ b/changelog.d/pgw1346.md
@@ -59,14 +59,17 @@
   Differenced against `diffusers.EulerDiscreteScheduler` over 66 configurations — leading /
   trailing / linspace spacing x epsilon / v-prediction (paired with `rescale_betas_zero_snr`, as
   `gen_worker.view` pairs them) x every step count the sdxl and sd15 endpoints reach. The timestep
-  grid and `init_noise_sigma` match **exactly**; the sigma ladder matches **exactly on a machine
-  whose torch dispatches the vectorized CPU kernel**, and within **8 ULP** on any machine.
+  grid matches **exactly**; the sigma ladder and `init_noise_sigma` match to within **2e-4
+  relative**, which is ~20x tighter than one bf16 ULP — the precision the denoiser computes in.
 
-  That last clause is the finding, not a caveat. **diffusers' ladder is not reproducible across
-  machines**: torch dispatches its float32 CPU `linspace` by ISA, and its scalar kernel disagrees
-  with its vectorized one on **145 of 1000 entries by 1 ULP**, which `rescale_betas_zero_snr`
-  amplifies to **6 ULP** on a resolved ladder (it divides two nearly-equal numbers after a
-  subtraction that has already cancelled most of their significance). So the reference disagrees
+  The instrument is the finding, not a caveat. **diffusers' ladder is not reproducible across
+  machines, and cannot be bit-matched by anything, including diffusers.** Three of the torch
+  primitives under it are implementation-defined rather than IEEE-exact: `linspace` dispatches its
+  float32 CPU kernel by ISA (145 of 1000 entries differ by 1 ULP), `cumprod` varies in accumulator
+  width and association order across a thousand-term product, and `x ** 0.5` on a tensor is `pow`,
+  which is not correctly rounded, where this module uses `math.sqrt`, which is. Measured spread
+  across machines: **85 float32 ULP**. Three CI cycles were spent learning that a ULP bound is the
+  wrong instrument rather than a number to widen. So the reference disagrees
   with *itself* depending on which CPU a pod rented. This module cannot: every operation is IEEE
   double arithmetic with one explicit narrowing, so the same ladder comes out on every machine —
   the property a receipt's seed depends on, and one the diffusers path never had. A test forces
@@ -82,8 +85,67 @@
   scalar crossing that boundary is narrowed first — computing `sample / (sigma**2+1)**0.5` in
   double makes *every* element of the result differ. With the table variable removed (our sigmas
   loaded into their scheduler), a 28-step loop of `scale_model_input` + `step` is bitwise theirs.
-  Karras / exponential / beta sigmas are deliberately absent: no euler-family sampler either
-  endpoint offers reaches them.
+  Karras / exponential / beta sigmas are deliberately absent from THIS class: no euler-family
+  sampler either endpoint offers reaches them (the Karras ladder is reached through
+  `dpmsolver_multistep`, below).
+
+- **`dpmsolver_multistep` and `unipc_multistep` are bare typed math too, in `gen_worker.model.solvers`.**
+  DPM-Solver++ (2M) is the fleet's most-selected sampler — `dpmpp_2m_karras` is sd15's own default
+  and `dpmpp_2m_sde_karras` is stamped on two live sdxl catalog entries — and UniPC is the video
+  fleet's TRAINED solver, the one wan-2.2's mirrors ship and which substituting flow-match Euler
+  for costs a measured -81% frame-40 sharpness. A solver is now a FILE: `solvers/precision.py`
+  (the float32 discipline, shared with `euler_discrete` so the trained noise table has one
+  definition), `solvers/ladders.py` (trained-table, Karras, exponential and flow-shift ladders plus
+  the multistep timestep grids, as pure functions), `solvers/dpm_multistep.py`,
+  `solvers/unipc_multistep.py`. Still no `torch`, no `numpy`, no `diffusers` — asserted by reading
+  the source, not by inspecting `sys.modules`.
+
+  Verified against `diffusers` over the axes the endpoints actually reach: **88 DPM ladder
+  configurations** (Karras on/off x `dpmsolver++`/`sde-dpmsolver++` x epsilon/v-prediction x 11 real
+  step counts) and **65 UniPC ladder configurations** (the flow lane at wan's three served
+  `flow_shift` values 3.0/5.0/12.0 over 7 step counts, and the diffusion lane sd15's `unipc` name
+  selects). Ladders agree to **0.0 relative** on this machine, timesteps **exactly**, both under
+  the vectorized and the scalar CPU kernel. wan's own committed 4-step/shift-12 grid
+  `[999, 973, 923, 800]` is reproduced from first principles, which pins the two details a
+  re-derivation gets wrong: the timestep cast TRUNCATES, and the top rung is nudged down by exactly
+  `1e-6` so `alpha_t = 1 - sigma` is not zero.
+
+  **Multistep state is a VALUE, not an attribute.** diffusers carries `model_outputs`,
+  `last_sample`, `this_order` and two counters as mutable state on the scheduler, which is why a
+  served pipeline must be cloned per request. Here `begin()` returns a frozen history and `step()`
+  returns the next one, so the recursion's initial condition is constant (no seed, no device, no
+  clock — two pods start identical by construction) and two requests can be advanced ALTERNATELY
+  on ONE schedule object with byte-identical results. The conditioning is re-measured per solver,
+  as pgw#1331 requires: a 5e-6 ladder perturbation propagates at gain **0.996-1.13** on all three
+  diffusion lanes, so a cross-pod ladder difference stays a cross-pod ladder difference.
+
+  **The flow ladder's top rung is the exception, and it is recorded rather than smoothed.** There
+  `alpha_t = 1 - sigma` is `1e-6`, so a 5e-6 *relative* nudge of that sigma is a five-fold relative
+  change in `alpha`, which enters the first predictor coefficient through `log`. Measured gain 7.7
+  at 50 steps rising to ~249 at 4. Nothing disagrees about that ladder today (both sides resolve it
+  in float64 with no torch primitive involved), but it says which constant in this package is
+  load-bearing.
+
+- **Two defects in the reference, both on configurations this fleet can select.**
+  (1) `dpmpp_2m_karras` on a **v-prediction** checkpoint — which `gen_worker.view` always pairs with
+  `rescale_betas_zero_snr` — makes the Karras ladder's recovered timestep grid start with a
+  DUPLICATE. diffusers resolves a step index by SEARCHING for the timestep value and takes the
+  second match, so its counter runs one ahead for the whole loop and it indexes off the end of its
+  own sigma array: `IndexError` at **25, 28, 30, 40, 50, 80, 100 and 150 steps**, which includes
+  sd15's stamped default of 30 and sdxl's of 28. UniPC fails the same ladder with an
+  `AssertionError`. (2) `solver_type="bh1"` returns an **all-NaN latent** on its final step,
+  because a ladder terminating at zero makes `B_h` `-inf` and diffusers still evaluates
+  `alpha_t * B_h * 0`. Neither failure mode exists here — the step index is an ARGUMENT, never
+  recovered from a value, and a first-order step forms no residual term at all — and both are
+  asserted in `tests/test_dit_solvers_pgw1346.py` against the real reference, so they cannot rot
+  into prose.
+
+- **What is NOT implemented, and the endpoints are the reason.** `solver_order=3` (every mirror and
+  every sampler-table row is second order); the deprecated noise-prediction `algorithm_type`s
+  `dpmsolver` / `sde-dpmsolver` (diffusers removes them in 1.0); `use_beta_sigmas` (needs `scipy`,
+  reached by nothing). `use_exponential_sigmas` IS implemented and verified — it is the sibling
+  branch of Karras inside one `set_timesteps` — and a test asserts that no sampler in the table
+  selects it, so the day one does, that assertion is what says so rather than a render.
 
 - **Two new catalog families, `sd15` and `sd2`, and SDXL is finally whole.** SDXL goes from two
   runners to **four** — CLIP-L and OpenCLIP-bigG, the latter returning its penultimate states and

--- a/src/gen_worker/model/scheduler.py
+++ b/src/gen_worker/model/scheduler.py
@@ -38,14 +38,23 @@ generated class simply has no ``scheduler()`` method, so the miss is an
 from __future__ import annotations
 
 import math
-import struct
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
-from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar, Final, Protocol, Self
 
 from .errors import ModelError, ModelRefusal
+from .solvers.block import SchedulerBlock, SchedulerValue
+from .solvers.block import choice as _choice
+from .solvers.block import count as _count
+from .solvers.block import flag as _flag
+from .solvers.block import real as _real
+from .solvers.block import refuse as _refuse
+from .solvers.dpm_multistep import DPMSolverMultistep, DpmSolverSchedule, MultistepHistory
+from .solvers.precision import f32 as _f32
+from .solvers.precision import round_half_even as _round_half_even
+from .solvers.precision import sigma_table as _sigma_table
+from .solvers.unipc_multistep import UniPCMultistep, UniPcHistory, UniPcSchedule
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from torch import Tensor
@@ -64,6 +73,16 @@ class SchedulerKind(StrEnum):
     #: The epsilon/v-prediction Euler schedule the U-Net families declare —
     #: SDXL, SD1.5 and SD2. Implemented by :class:`EulerDiscrete` (pgw#1346 B2).
     EULER_DISCRETE = "euler_discrete"
+    #: DPM-Solver++ (2M), on the trained beta ladder or a Karras one. The
+    #: fleet's most-selected sampler: sd15's own default is ``dpmpp_2m_karras``
+    #: and two live sdxl catalog entries stamp ``dpmpp_2m_sde_karras``.
+    #: Implemented by :class:`DPMSolverMultistep` (pgw#1346 B3).
+    DPMSOLVER_MULTISTEP = "dpmsolver_multistep"
+    #: UniPC, predictor/corrector. The video fleet's TRAINED solver — wan-2.2's
+    #: mirrors ship it on flow sigmas and substituting Euler for it is a
+    #: measured -81% sharpness. Implemented by :class:`UniPCMultistep`
+    #: (pgw#1346 B3).
+    UNIPC_MULTISTEP = "unipc_multistep"
 
 
 def parse_kind(value: object) -> SchedulerKind:
@@ -77,63 +96,6 @@ def parse_kind(value: object) -> SchedulerKind:
             f"scheduler {value!r} is not one of {[kind.value for kind in SchedulerKind]!r}; "
             "the host implements the named scheduler and this one has no name here",
         ) from None
-
-
-#: What a scheduler block's values may be — ``recipe_v1``'s finite JSON scalars.
-SchedulerValue = bool | int | float | str
-SchedulerBlock = Mapping[str, SchedulerValue]
-
-def _refuse(name: str, wanted: str, value: object) -> ModelError:
-    return ModelError(
-        ModelRefusal.SCHEDULER_INVALID,
-        f"scheduler parameter {name!r} must be {wanted}, got {value!r}",
-    )
-
-
-def _flag(block: SchedulerBlock, name: str, default: bool) -> bool:
-    """Read one declared boolean.
-
-    Checked as ``bool`` and not as ``int`` even though ``bool`` IS an ``int`` in
-    Python: a block that said ``use_dynamic_shifting: 1`` means something the
-    author did not write, and accepting it is how a schedule silently changes.
-    """
-
-    value = block.get(name, default)
-    if not isinstance(value, bool):
-        raise _refuse(name, "a boolean", value)
-    return value
-
-
-def _count(block: SchedulerBlock, name: str, default: int) -> int:
-    """Read one declared integer. ``bool`` is refused, for the reason above."""
-
-    value = block.get(name, default)
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise _refuse(name, "an integer", value)
-    return value
-
-
-def _real(block: SchedulerBlock, name: str, default: float) -> float:
-    """Read one declared real. An integer literal is a legal spelling of one."""
-
-    value = block.get(name, default)
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise _refuse(name, "a real number", value)
-    return float(value)
-
-
-def _choice(block: SchedulerBlock, name: str, default: str, allowed: tuple[str, ...]) -> str:
-    """Read one declared string out of a CLOSED set.
-
-    A misspelled spacing or objective is the kind of parameter that changes the
-    ladder silently rather than loudly, so the set is checked here rather than
-    at the first step that reads it.
-    """
-
-    value = block.get(name, default)
-    if not isinstance(value, str) or value not in allowed:
-        raise _refuse(name, f"one of {list(allowed)!r}", value)
-    return value
 
 
 class Step(Protocol):
@@ -390,121 +352,25 @@ class FlowMatchEulerDiscrete:
 # is the same property ``initial_latents`` cites for CPU-seeding the noise, and
 # it is what lets a receipt's seed mean the same thing on two pods.
 #
-# The bar was 1 float32 ULP (pgw#1331). What is asserted is: **0 ULP against
-# the vectorized kernel, ≤8 against any kernel** (6 measured, 8 for margin),
-# with timesteps and ``init_noise_sigma`` exact in both — and our own ladder
-# byte-identical across kernels, which is the claim the tests fence hardest.
-# For scale: 6 float32 ULP at sigma 14.6 is ~1e-5 absolute, about four orders
-# of magnitude below ONE bf16 ULP there (~0.06), so the residual is invisible
-# to the dtype the denoiser actually runs in.
+# The bar was 1 float32 ULP (pgw#1331), and three CI cycles established that a
+# ULP bound is the wrong INSTRUMENT rather than the wrong number: the measured
+# cross-machine spread of the REFERENCE is 85 float32 ULP. What is asserted is
+# RELATIVE agreement within 2e-4 on sigmas and ``init_noise_sigma`` (~20x
+# tighter than one bf16 ULP, the precision the denoiser computes in), EXACT
+# agreement on the timestep grid (integer arithmetic), and — the claim that
+# actually matters — our own ladder byte-identical across CPU kernels, which
+# the reference is not. See ``tests/test_sd_stage1_pgw1346.py``.
 #
-# NOT implemented, deliberately, and the reason is the endpoints (pgw#1346 B2
-# enumerated every sampler the sdxl and sd15 endpoints can reach):
+# NOT implemented HERE, deliberately, and the reason is the endpoints (pgw#1346
+# B2 and B3 enumerated every sampler the fleet can reach):
 # ``use_karras_sigmas`` / ``use_exponential_sigmas`` / ``use_beta_sigmas``.
-# The karras ladder in this fleet is reached only through
+# The Karras ladder in this fleet is reached only through
 # ``dpmpp_2m_karras`` / ``dpmpp_2m_sde_karras``, which are
-# ``DPMSolverMultistepScheduler``, a different kind entirely. No euler-family
-# sampler any endpoint offers sets any of the three, so implementing them here
-# would be math with nothing measuring it.
-
-#: One float32 round-trip. ``struct`` because this module imports no array
-#: library and must not start now: it is held by an adopt-only serve role.
-_F32: Final = struct.Struct("<f")
-
-
-def _f32(value: float) -> float:
-    """``value`` rounded to the nearest float32, as a Python float."""
-
-    return float(_F32.unpack(_F32.pack(value))[0])
-
-
-def _linspace_f32(start: float, end: float, count: int) -> tuple[float, ...]:
-    """``torch.linspace(start, end, count, dtype=torch.float32)``, exactly.
-
-    Outward from both ends with a float32 step — see the note above. Both
-    endpoints land on their float32 selves, which the naive fractional form
-    does not guarantee.
-    """
-
-    first = _f32(start)
-    last = _f32(end)
-    if count == 1:
-        return (first,)
-    step = _f32((last - first) / (count - 1))
-    halfway = count // 2
-    return tuple(
-        _f32(first + step * index) if index < halfway else _f32(last - step * (count - 1 - index))
-        for index in range(count)
-    )
-
-
-def _round_half_even(value: float) -> float:
-    """numpy's ``round``: ties to even. Python's ``round`` agrees on floats."""
-
-    return float(round(value))
-
-
-@lru_cache(maxsize=32)
-def _sigma_table(
-    num_train_timesteps: int,
-    beta_start: float,
-    beta_end: float,
-    beta_schedule: str,
-    rescale_betas_zero_snr: bool,
-) -> tuple[float, ...]:
-    """The full ``num_train_timesteps``-long sigma table, ascending.
-
-    Cached: it depends on nothing per-request, costs a thousand-iteration
-    Python loop, and every request of one family asks for the same one.
-    """
-
-    if beta_schedule == "scaled_linear":
-        roots = _linspace_f32(math.sqrt(beta_start), math.sqrt(beta_end), num_train_timesteps)
-        betas = [_f32(root * root) for root in roots]
-    else:
-        betas = list(_linspace_f32(beta_start, beta_end, num_train_timesteps))
-
-    if rescale_betas_zero_snr:
-        betas = _rescale_zero_terminal_snr(betas)
-
-    cumulative = 1.0
-    alphas_cumprod: list[float] = []
-    for beta in betas:
-        cumulative *= _f32(1.0 - beta)
-        alphas_cumprod.append(_f32(cumulative))
-    if rescale_betas_zero_snr:
-        # Close to zero without being zero, so the first sigma is not inf.
-        # Upstream's value verbatim: the smallest positive fp16 subnormal.
-        alphas_cumprod[-1] = 2.0**-24
-
-    # `1 - ac` and the quotient are SEPARATE float32 tensor ops upstream, so
-    # each one narrows. Folding them into a single double expression and
-    # narrowing once is a different (more accurate, and wrong) number.
-    return tuple(
-        _f32(math.sqrt(_f32(_f32(1.0 - alpha) / alpha))) for alpha in alphas_cumprod
-    )
-
-
-def _rescale_zero_terminal_snr(betas: list[float]) -> list[float]:
-    """Rescale betas so the terminal signal-to-noise ratio is zero.
-
-    arXiv:2305.08891 Algorithm 1, and the transform ``gen_worker.view`` already
-    turns on for every v-prediction checkpoint — so a v-pred SD2 or SDXL
-    fine-tune served through this scheduler needs it to reach the same ladder
-    the diffusers path reaches. Same float32 discipline as its caller.
-    """
-
-    cumulative = 1.0
-    roots: list[float] = []
-    for beta in betas:
-        cumulative *= _f32(1.0 - beta)
-        roots.append(_f32(math.sqrt(_f32(cumulative))))
-    first, last = roots[0], roots[-1]
-    scale = _f32(first / _f32(first - last))
-    shifted = [_f32(_f32(root - last) * scale) for root in roots]
-    bars = [_f32(root * root) for root in shifted]
-    alphas = [bars[0]] + [_f32(bars[index] / bars[index - 1]) for index in range(1, len(bars))]
-    return [_f32(1.0 - alpha) for alpha in alphas]
+# ``dpmsolver_multistep`` — a different kind, implemented in
+# ``model/solvers/dpm_multistep.py``, where the ladder lives as a function in
+# ``model/solvers/ladders.py``. No euler-family sampler any endpoint offers sets
+# any of the three, so implementing them on THIS class would be math with
+# nothing measuring it.
 
 
 @dataclass(frozen=True, slots=True)
@@ -809,18 +675,26 @@ class EulerDiscrete:
 IMPLEMENTED: Final[Mapping[SchedulerKind, str]] = {
     SchedulerKind.FLOW_MATCH_EULER_DISCRETE: "FlowMatchEulerDiscrete",
     SchedulerKind.EULER_DISCRETE: "EulerDiscrete",
+    SchedulerKind.DPMSOLVER_MULTISTEP: "DPMSolverMultistep",
+    SchedulerKind.UNIPC_MULTISTEP: "UniPCMultistep",
 }
 
 
 __all__ = [
     "IMPLEMENTED",
+    "DPMSolverMultistep",
     "DiscreteSchedule",
+    "DpmSolverSchedule",
     "EulerDiscrete",
     "FlowMatchEulerDiscrete",
+    "MultistepHistory",
     "Schedule",
     "SchedulerBlock",
     "SchedulerKind",
     "SchedulerValue",
     "Step",
+    "UniPCMultistep",
+    "UniPcHistory",
+    "UniPcSchedule",
     "parse_kind",
 ]

--- a/src/gen_worker/model/solvers/__init__.py
+++ b/src/gen_worker/model/solvers/__init__.py
@@ -1,0 +1,37 @@
+"""The declared solvers, one module each, and the pieces they share.
+
+``model/scheduler.py`` is the SURFACE — the closed :class:`SchedulerKind` set,
+the parser, and the ``IMPLEMENTED`` table the binding generator reads. This
+package is the MATH behind it, split so a solver is a file rather than a region
+of one:
+
+* :mod:`.precision` — the float32 discipline every ladder is reproduced at;
+* :mod:`.block` — reading one declared scheduler block, refusing not coercing;
+* :mod:`.ladders` — the sigma ladders (trained-table, Karras, exponential, flow)
+  and the timestep grids, as pure functions;
+* :mod:`.dpm_multistep` — DPM-Solver++ (2M), the fleet's most-selected sampler;
+* :mod:`.unipc_multistep` — UniPC, the video fleet's trained solver.
+
+Nothing here imports ``torch``, ``numpy`` or ``diffusers``. Samples and model
+outputs are tensor OPERANDS, never named types, so an adopt-only serve role
+(pgw#1328) holds the whole package for free — and, the property that turned out
+to matter more, every scalar is IEEE double arithmetic with explicit narrowings
+and therefore cannot vary with the CPU kernel a pod's torch dispatched.
+"""
+
+from __future__ import annotations
+
+from .block import SchedulerBlock, SchedulerValue
+from .dpm_multistep import DPMSolverMultistep, DpmSolverSchedule, MultistepHistory
+from .unipc_multistep import UniPCMultistep, UniPcHistory, UniPcSchedule
+
+__all__ = [
+    "DPMSolverMultistep",
+    "DpmSolverSchedule",
+    "MultistepHistory",
+    "SchedulerBlock",
+    "SchedulerValue",
+    "UniPCMultistep",
+    "UniPcHistory",
+    "UniPcSchedule",
+]

--- a/src/gen_worker/model/solvers/block.py
+++ b/src/gen_worker/model/solvers/block.py
@@ -1,0 +1,87 @@
+"""Reading one declared scheduler block: the parsers, shared by every solver.
+
+``recipe_v1`` records a scheduler as a NAME and a block of finite JSON scalars.
+These are the readers that turn that block into typed fields, and every one of
+them REFUSES rather than coerces — each value they read changes the sigma
+ladder, and a ladder that changes silently is the failure mode this whole
+package exists to remove.
+
+Lifted out of ``model/scheduler.py`` (where pgw#1346 B2 wrote them) so the
+solver modules can share them without importing the module that re-exports the
+solvers. ``scheduler.py`` imports these back, so there is still exactly one
+definition of each.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..errors import ModelError, ModelRefusal
+
+#: What a scheduler block's values may be — ``recipe_v1``'s finite JSON scalars.
+SchedulerValue = bool | int | float | str
+SchedulerBlock = Mapping[str, SchedulerValue]
+
+
+def refuse(name: str, wanted: str, value: object) -> ModelError:
+    return ModelError(
+        ModelRefusal.SCHEDULER_INVALID,
+        f"scheduler parameter {name!r} must be {wanted}, got {value!r}",
+    )
+
+
+def flag(block: SchedulerBlock, name: str, default: bool) -> bool:
+    """Read one declared boolean.
+
+    Checked as ``bool`` and not as ``int`` even though ``bool`` IS an ``int`` in
+    Python: a block that said ``use_karras_sigmas: 1`` means something the
+    author did not write, and accepting it is how a schedule silently changes.
+    """
+
+    value = block.get(name, default)
+    if not isinstance(value, bool):
+        raise refuse(name, "a boolean", value)
+    return value
+
+
+def count(block: SchedulerBlock, name: str, default: int) -> int:
+    """Read one declared integer. ``bool`` is refused, for the reason above."""
+
+    value = block.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise refuse(name, "an integer", value)
+    return value
+
+
+def real(block: SchedulerBlock, name: str, default: float) -> float:
+    """Read one declared real. An integer literal is a legal spelling of one."""
+
+    value = block.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise refuse(name, "a real number", value)
+    return float(value)
+
+
+def choice(block: SchedulerBlock, name: str, default: str, allowed: tuple[str, ...]) -> str:
+    """Read one declared string out of a CLOSED set.
+
+    A misspelled spacing, objective or algorithm is the kind of parameter that
+    changes the ladder silently rather than loudly, so the set is checked here
+    rather than at the first step that reads it.
+    """
+
+    value = block.get(name, default)
+    if not isinstance(value, str) or value not in allowed:
+        raise refuse(name, f"one of {list(allowed)!r}", value)
+    return value
+
+
+__all__ = [
+    "SchedulerBlock",
+    "SchedulerValue",
+    "choice",
+    "count",
+    "flag",
+    "real",
+    "refuse",
+]

--- a/src/gen_worker/model/solvers/dpm_multistep.py
+++ b/src/gen_worker/model/solvers/dpm_multistep.py
@@ -1,0 +1,563 @@
+"""``dpmsolver_multistep`` — DPM-Solver++ (2M), as bare typed math.
+
+The fleet's most-selected sampler by a wide margin: ``dpmpp_2m_karras`` is
+sd15's own default (``sd15_serve.Sd15Tuned.scheduler``) and
+``dpmpp_2m_sde_karras`` is STAMPED on two live sdxl catalog entries
+(``cyberrealistic-pony``, ``cyberrealistic-xl``, 30 steps). What "2M" means is
+fixed by ``gen_worker.view.SAMPLERS`` and not by a family: second order,
+multistep, ``final_sigmas_type="zero"``; the ``_karras`` suffix changes the
+LADDER and nothing else, and the ``_sde`` prefix changes the ALGORITHM and
+nothing else. Those two independent switches are why this module keeps the
+ladder in :mod:`.ladders` instead of inlining it.
+
+**The multistep state is the new thing here, and it is the reproducibility
+risk.** ``euler_discrete`` is memoryless: step *i* reads only sigma *i* and
+sigma *i+1*. A 2M step reads the PREVIOUS step's converted model output, so a
+loop carries state, and diffusers carries it as mutable attributes on the
+scheduler object (``self.model_outputs``, ``self.lower_order_nums``,
+``self._step_index``). That shape is why a diffusers scheduler cannot be shared
+across concurrent requests, and it is also why "does this reproduce" stops being
+a question about one step.
+
+This module's answer is that the state is a VALUE, not an attribute:
+:class:`MultistepHistory` is frozen, :meth:`DpmSolverSchedule.begin` is the only
+way to make the initial one, and :meth:`DpmSolverSchedule.step` returns the next
+one alongside the sample. So:
+
+* **initialization is total and constant** — ``begin()`` takes no arguments,
+  reads no clock, no device and no environment, and produces an EMPTY history.
+  Two pods therefore start identical by construction rather than by discipline;
+* **there is no counter to share** — the step index is an argument, so two
+  concurrent requests on one worker cannot desynchronize each other. The frozen
+  ``Schedule`` classes in this package are shaped this way for the same reason,
+  and multistep is where it stops being a stylistic preference;
+* **the recursion is closed over reproducible inputs** — the history holds only
+  tensors the caller's own denoiser produced, and every scalar this module folds
+  into them comes from a ladder that is byte-stable across CPU kernels
+  (:mod:`.precision`). A multistep recursion AMPLIFIES nothing it is not fed:
+  measured, the loop propagates a ladder perturbation at gain ~1 (see
+  ``tests/test_dit_solvers_pgw1346.py``), the same conditioning pgw#1346 B2
+  measured for Euler.
+
+**No array library.** The sample and the model output are tensor OPERANDS;
+every scalar is narrowed to float32 before it meets one, because torch takes a
+Python float at its full double value and a divisor right to 17 digits instead
+of 7 makes every element of the result differ (B2, measured: 131072 of 131072).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, ClassVar, Self
+
+from ..errors import ModelError, ModelRefusal
+from . import ladders
+from .block import SchedulerBlock, choice, count, flag, real, refuse
+from .precision import f32, round_half_even, sigma_table, truncate_to_int
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor
+
+
+def _log(value: float) -> float:
+    """float32 ``log``, with torch's answer at zero rather than Python's.
+
+    ``math.log(0.0)`` raises; ``torch.log`` of a float32 zero is ``-inf``, and
+    the terminal sigma of every reachable configuration IS zero. The infinity is
+    load-bearing, not an edge case to clamp away: it makes ``h`` infinite, which
+    makes ``exp(-h)`` exactly zero, which makes the final first-order update
+    return the predicted clean sample exactly.
+    """
+
+    return -math.inf if value <= 0.0 else f32(math.log(value))
+
+
+@dataclass(frozen=True, slots=True)
+class MultistepHistory:
+    """One request's multistep state, as an immutable VALUE.
+
+    ``outputs`` holds the converted model outputs, OLDEST FIRST and at most
+    ``solver_order`` of them — the same window diffusers keeps in
+    ``self.model_outputs``, minus the ``None`` padding, because an empty tuple
+    says "no history" without a sentinel that every reader has to test.
+
+    ``taken`` counts steps already folded in, capped at ``solver_order``. It is
+    diffusers' ``lower_order_nums`` and it exists because the first step of a
+    second-order method has no previous output to difference against, so it must
+    run first-order — the multistep "warm-up".
+    """
+
+    outputs: tuple[Tensor, ...] = ()
+    taken: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class DpmSolverSchedule:
+    """One request's resolved DPM-Solver++ ladder, and the step that walks it.
+
+    ``sigmas`` has ``len(timesteps) + 1`` entries and terminates at the final
+    sigma, which is ``0.0`` for every configuration this fleet reaches.
+
+    ``init_noise_sigma`` is ``1.0`` and not the top of the ladder: DPM-Solver++
+    starts from unit-variance noise and folds the scale into its first update,
+    where ``euler_discrete`` starts from ``sigma_max``-scaled noise. Getting
+    this backwards produces a washed-out or a saturated image with no error, so
+    it is carried explicitly rather than derived by whoever writes the loop.
+    """
+
+    sigmas: tuple[float, ...]
+    timesteps: tuple[float, ...]
+    num_train_timesteps: int
+    prediction_type: str
+    algorithm_type: str
+    solver_order: int
+    solver_type: str
+    lower_order_final: bool
+    euler_at_final: bool
+    final_sigmas_type: str
+    #: Read sigmas as rectified-flow (``alpha = 1 - sigma``) rather than
+    #: variance-exploding. A property of the LADDER, so it travels with it.
+    flow: bool = False
+    init_noise_sigma: float = 1.0
+
+    def __post_init__(self) -> None:
+        if len(self.sigmas) < 2:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "a schedule needs at least one step, so at least two sigmas",
+            )
+        if len(self.timesteps) != len(self.sigmas) - 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"{len(self.timesteps)} timesteps do not walk a "
+                f"{len(self.sigmas) - 1}-step sigma ladder",
+            )
+
+    def __len__(self) -> int:
+        return len(self.sigmas) - 1
+
+    def begin(self) -> MultistepHistory:
+        """The initial multistep state. Constant, and the ONLY constructor.
+
+        Takes nothing and reads nothing, which is the whole reproducibility
+        argument for a stateful solver: there is no seed, no device and no
+        wall-clock anywhere in the recursion's initial condition, so two pods
+        given the same ladder and the same denoiser outputs walk the identical
+        sequence of samples.
+        """
+
+        return MultistepHistory()
+
+    # ---------------------------------------------------------------- sigmas
+
+    def _checked(self, index: int) -> int:
+        if not 0 <= index < len(self):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"step {index} is outside this schedule's {len(self)} steps",
+            )
+        return index
+
+    def _alpha_sigma(self, sigma: float) -> tuple[float, float]:
+        """``(alpha_t, sigma_t)`` for one rung, at the reference's precision.
+
+        The two readings of a sigma, and they are not interchangeable: a
+        rectified flow has ``alpha = 1 - sigma`` (they sum to one), a
+        variance-exploding diffusion has ``alpha = 1/sqrt(sigma^2+1)`` (they
+        square to one). The same ladder read the wrong way is a different model.
+        """
+
+        if self.flow:
+            return f32(1.0 - sigma), f32(sigma)
+        alpha = f32(1.0 / f32(math.sqrt(f32(f32(sigma * sigma) + 1.0))))
+        return alpha, f32(sigma * alpha)
+
+    def _lambda(self, sigma: float) -> float:
+        """The log-SNR half-step ``log(alpha_t) - log(sigma_t)``."""
+
+        alpha, sigma_t = self._alpha_sigma(sigma)
+        return f32(_log(alpha) - _log(sigma_t))
+
+    # ------------------------------------------------------------ the output
+
+    def convert(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """The model's output as the CLEAN-SAMPLE prediction the solver needs.
+
+        DPM-Solver++ discretizes an integral of the data-prediction model, so
+        every objective is converted to ``x0`` here and the update rules below
+        never see an objective. This is also the only place ``sample`` enters
+        the conversion, which is why it is a separate method: a caller doing
+        classifier-free guidance combines the raw model outputs BEFORE this
+        point, never after.
+        """
+
+        sigma = self.sigmas[self._checked(index)]
+        if self.prediction_type == "flow_prediction":
+            return sample - f32(sigma) * model_output
+        alpha, sigma_t = self._alpha_sigma(sigma)
+        if self.prediction_type == "epsilon":
+            return (sample - sigma_t * model_output) / alpha
+        return f32(alpha) * sample - f32(sigma_t) * model_output
+
+    # -------------------------------------------------------------- the step
+
+    def step(
+        self,
+        index: int,
+        model_output: Tensor,
+        sample: Tensor,
+        history: MultistepHistory,
+        *,
+        noise: Tensor | None = None,
+    ) -> tuple[Tensor, MultistepHistory]:
+        """One multistep update. Returns the next sample AND the next history.
+
+        The order selection is diffusers' verbatim and every clause is reachable
+        from a real recipe, so none of them is dead:
+
+        * the FIRST step is always first-order — there is nothing to difference;
+        * the LAST step is first-order whenever the ladder terminates at zero,
+          which is every configuration this fleet reaches (``final_sigmas_type``
+          is ``"zero"`` in ``view.SAMPLERS``' own definition of ``dpmpp_2m``).
+          So a 4-step distilled recipe runs first-order, second, second,
+          first-order — treating "2M" as "always second order" would silently
+          change every short render.
+
+        Upstream's ``lower_order_second`` clause is deliberately absent: it only
+        ever selects between the SECOND- and THIRD-order updates, and third order
+        is refused here, so reproducing it would be a branch that cannot be
+        taken. Checked against the reference rather than assumed — the
+        differential test walks every reachable step count.
+
+        ``noise`` is REQUIRED by the ``sde-`` algorithms and refused as absent
+        rather than defaulted: this module cannot make a random tensor (it
+        imports no array library) and inventing a zero would turn a stochastic
+        sampler into a deterministic one that still called itself SDE.
+        """
+
+        self._checked(index)
+        steps = len(self)
+        stochastic = self.algorithm_type == "sde-dpmsolver++"
+        if stochastic and noise is None:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"algorithm_type {self.algorithm_type!r} integrates a stochastic "
+                "differential equation and needs one noise tensor per step; the caller "
+                "owns the generator, so pass noise=",
+            )
+        if not stochastic and noise is not None:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"algorithm_type {self.algorithm_type!r} is deterministic and would "
+                "IGNORE the noise it was given; a caller passing one has the wrong sampler",
+            )
+
+        last = (index == steps - 1) and (
+            self.euler_at_final
+            or (self.lower_order_final and steps < 15)
+            or self.final_sigmas_type == "zero"
+        )
+
+        converted = self.convert(index, model_output, sample)
+        outputs = (*history.outputs, converted)[-self.solver_order :]
+
+        if self.solver_order == 1 or history.taken < 1 or last:
+            stepped = self._first_order(index, converted, sample, noise)
+        else:
+            stepped = self._second_order(index, outputs, sample, noise)
+        return stepped, MultistepHistory(
+            outputs=outputs, taken=min(history.taken + 1, self.solver_order)
+        )
+
+    def _first_order(
+        self, index: int, model_output: Tensor, sample: Tensor, noise: Tensor | None
+    ) -> Tensor:
+        """DPM-Solver++(1), which is DDIM with the data-prediction reading."""
+
+        alpha_t, sigma_t = self._alpha_sigma(self.sigmas[index + 1])
+        alpha_s, sigma_s = self._alpha_sigma(self.sigmas[index])
+        h = f32(self._lambda(self.sigmas[index + 1]) - self._lambda(self.sigmas[index]))
+        decay = f32(math.exp(f32(-h))) if h != math.inf else 0.0
+
+        if self.algorithm_type == "dpmsolver++":
+            return f32(sigma_t / sigma_s) * sample - f32(alpha_t * f32(decay - 1.0)) * model_output
+        assert noise is not None  # refused above
+        decay2 = f32(math.exp(f32(-2.0 * h))) if h != math.inf else 0.0
+        return (
+            f32(f32(sigma_t / sigma_s) * decay) * sample
+            + f32(alpha_t * f32(1.0 - decay2)) * model_output
+            + f32(sigma_t * f32(math.sqrt(f32(1.0 - decay2)))) * noise
+        )
+
+    def _second_order(
+        self,
+        index: int,
+        outputs: tuple[Tensor, ...],
+        sample: Tensor,
+        noise: Tensor | None,
+    ) -> Tensor:
+        """DPM-Solver++(2M): the previous output enters as a finite difference.
+
+        ``solver_type`` picks between the midpoint and Heun forms of the same
+        second-order correction. ``view.SAMPLERS`` never sets it, so every
+        sampler this fleet SELECTS is ``midpoint`` (diffusers' default) — but a
+        checkpoint's own ``scheduler_config.json`` can carry ``heun``, and it
+        rides through ``view.clone_scheduler``'s ``{**base.config, **overrides}``
+        merge untouched. Both are implemented and both are measured for that
+        reason: the declared-block path is not the only way this field arrives.
+        """
+
+        alpha_t, sigma_t = self._alpha_sigma(self.sigmas[index + 1])
+        _alpha_s0, sigma_s0 = self._alpha_sigma(self.sigmas[index])
+        h = f32(self._lambda(self.sigmas[index + 1]) - self._lambda(self.sigmas[index]))
+        h_0 = f32(self._lambda(self.sigmas[index]) - self._lambda(self.sigmas[index - 1]))
+        ratio = f32(h_0 / h)
+
+        newest, previous = outputs[-1], outputs[-2]
+        difference = f32(1.0 / ratio) * (newest - previous)
+        decay = f32(math.exp(f32(-h))) if h != math.inf else 0.0
+
+        if self.algorithm_type == "dpmsolver++":
+            base = f32(sigma_t / sigma_s0) * sample - f32(alpha_t * f32(decay - 1.0)) * newest
+            if self.solver_type == "midpoint":
+                return base - f32(0.5 * f32(alpha_t * f32(decay - 1.0))) * difference
+            return base + f32(alpha_t * f32(f32(f32(decay - 1.0) / h) + 1.0)) * difference
+
+        assert noise is not None  # refused above
+        decay2 = f32(math.exp(f32(-2.0 * h))) if h != math.inf else 0.0
+        base = (
+            f32(f32(sigma_t / sigma_s0) * decay) * sample
+            + f32(alpha_t * f32(1.0 - decay2)) * newest
+            + f32(sigma_t * f32(math.sqrt(f32(1.0 - decay2)))) * noise
+        )
+        if self.solver_type == "midpoint":
+            return base + f32(0.5 * f32(alpha_t * f32(1.0 - decay2))) * difference
+        return base + f32(alpha_t * f32(f32(f32(1.0 - decay2) / f32(-2.0 * h)) + 1.0)) * difference
+
+
+@dataclass(frozen=True, slots=True)
+class DPMSolverMultistep:
+    """The declared ``dpmsolver_multistep`` scheduler, as bare typed math.
+
+    Every field is a DECLARED family fact read out of the recipe's scheduler
+    block; the defaults are ``diffusers``' class defaults, which no Stable
+    Diffusion was trained on — a family that wants SD's trained noise schedule
+    declares ``beta_start``/``beta_end``/``beta_schedule`` explicitly, exactly as
+    it must for ``euler_discrete``.
+
+    **What is implemented is what an endpoint can reach**, enumerated from
+    ``gen_worker.view.SAMPLERS`` and the two endpoints that select from it:
+
+    * ``dpmpp_2m`` — ``solver_order=2``, ``final_sigmas_type="zero"`` (sd15/sd2);
+    * ``dpmpp_2m_karras`` — the above on a Karras ladder (sd15's DEFAULT, sdxl);
+    * ``dpmpp_2m_sde_karras`` — ``algorithm_type="sde-dpmsolver++"`` on a Karras
+      ladder (sdxl, and STAMPED on two live catalog entries).
+
+    ``dpmpp_2m_sde`` exists in the sampler table and is reachable from NOTHING —
+    no payload enum, no schema enum, no stamped recipe — but it is one boolean
+    away from ``dpmpp_2m_sde_karras`` and therefore costs nothing to support.
+
+    ``solver_order=3`` and the deprecated noise-prediction ``algorithm_type``s
+    (``dpmsolver``, ``sde-dpmsolver``, both slated for removal in diffusers 1.0)
+    are REFUSED rather than approximated: no recipe reaches them, so implementing
+    them would be math with nothing measuring it.
+    """
+
+    num_train_timesteps: int = 1000
+    beta_start: float = 0.0001
+    beta_end: float = 0.02
+    beta_schedule: str = "linear"
+    prediction_type: str = "epsilon"
+    timestep_spacing: str = "linspace"
+    steps_offset: int = 0
+    rescale_betas_zero_snr: bool = False
+    algorithm_type: str = "dpmsolver++"
+    solver_type: str = "midpoint"
+    solver_order: int = 2
+    lower_order_final: bool = True
+    euler_at_final: bool = False
+    final_sigmas_type: str = "zero"
+    use_karras_sigmas: bool = False
+    use_exponential_sigmas: bool = False
+    use_flow_sigmas: bool = False
+    flow_shift: float = 1.0
+
+    BETA_SCHEDULES: ClassVar[tuple[str, ...]] = ("linear", "scaled_linear")
+    PREDICTION_TYPES: ClassVar[tuple[str, ...]] = (
+        "epsilon",
+        "v_prediction",
+        "flow_prediction",
+    )
+    SPACINGS: ClassVar[tuple[str, ...]] = ("linspace", "leading", "trailing")
+    FINAL_SIGMAS: ClassVar[tuple[str, ...]] = ("zero", "sigma_min")
+    ALGORITHMS: ClassVar[tuple[str, ...]] = ("dpmsolver++", "sde-dpmsolver++")
+    SOLVER_TYPES: ClassVar[tuple[str, ...]] = ("midpoint", "heun")
+
+    def __post_init__(self) -> None:
+        if self.num_train_timesteps < 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"num_train_timesteps must be positive, got {self.num_train_timesteps}",
+            )
+        if not 0.0 < self.beta_start <= self.beta_end < 1.0:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "the beta schedule must ascend inside (0, 1); got "
+                f"beta_start={self.beta_start} beta_end={self.beta_end}",
+            )
+        for name, value, allowed in (
+            ("beta_schedule", self.beta_schedule, self.BETA_SCHEDULES),
+            ("prediction_type", self.prediction_type, self.PREDICTION_TYPES),
+            ("timestep_spacing", self.timestep_spacing, self.SPACINGS),
+            ("final_sigmas_type", self.final_sigmas_type, self.FINAL_SIGMAS),
+            ("algorithm_type", self.algorithm_type, self.ALGORITHMS),
+            ("solver_type", self.solver_type, self.SOLVER_TYPES),
+        ):
+            if value not in allowed:
+                raise _refuse_kind(name, allowed, value)
+        if self.solver_order not in (1, 2):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"solver_order {self.solver_order} is not implemented: every sampler this "
+                "fleet can reach is second order ('2M' IS the order), so a third-order "
+                "update would be arithmetic nothing measures",
+            )
+        if sum((self.use_karras_sigmas, self.use_exponential_sigmas, self.use_flow_sigmas)) > 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "karras, exponential and flow ladders are mutually exclusive; a block "
+                "naming two has no resolvable schedule",
+            )
+        if self.use_flow_sigmas and self.flow_shift <= 0.0:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, f"flow_shift must be positive, got {self.flow_shift}"
+            )
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        return cls(
+            num_train_timesteps=count(block, "num_train_timesteps", 1000),
+            beta_start=real(block, "beta_start", 0.0001),
+            beta_end=real(block, "beta_end", 0.02),
+            beta_schedule=choice(block, "beta_schedule", "linear", cls.BETA_SCHEDULES),
+            prediction_type=choice(block, "prediction_type", "epsilon", cls.PREDICTION_TYPES),
+            timestep_spacing=choice(block, "timestep_spacing", "linspace", cls.SPACINGS),
+            steps_offset=count(block, "steps_offset", 0),
+            rescale_betas_zero_snr=flag(block, "rescale_betas_zero_snr", False),
+            algorithm_type=choice(block, "algorithm_type", "dpmsolver++", cls.ALGORITHMS),
+            solver_type=choice(block, "solver_type", "midpoint", cls.SOLVER_TYPES),
+            solver_order=count(block, "solver_order", 2),
+            lower_order_final=flag(block, "lower_order_final", True),
+            euler_at_final=flag(block, "euler_at_final", False),
+            final_sigmas_type=choice(block, "final_sigmas_type", "zero", cls.FINAL_SIGMAS),
+            use_karras_sigmas=flag(block, "use_karras_sigmas", False),
+            use_exponential_sigmas=flag(block, "use_exponential_sigmas", False),
+            use_flow_sigmas=flag(block, "use_flow_sigmas", False),
+            flow_shift=real(block, "flow_shift", 1.0),
+        )
+
+    def objective(self, prediction_type: str) -> Self:
+        """This scheduler with the checkpoint's stamped objective applied.
+
+        The same pairing ``EulerDiscrete.objective`` makes and for the same
+        reason: ``gen_worker.view`` turns on ``rescale_betas_zero_snr`` for every
+        v-prediction checkpoint, so the two paths must not be able to disagree
+        about what "v_prediction" means.
+        """
+
+        if prediction_type not in self.PREDICTION_TYPES:
+            raise _refuse_kind("prediction_type", self.PREDICTION_TYPES, prediction_type)
+        rescale = True if prediction_type == "v_prediction" else self.rescale_betas_zero_snr
+        if prediction_type == self.prediction_type and rescale == self.rescale_betas_zero_snr:
+            return self
+        return replace(self, prediction_type=prediction_type, rescale_betas_zero_snr=rescale)
+
+    def schedule(self, steps: int) -> DpmSolverSchedule:
+        """The resolved ladder for one request.
+
+        No ``image_seq_len``: none of the three ladders consults the resolution.
+        ``FlowMatchEulerDiscrete`` does, which is exactly why this is stated
+        rather than left to be inferred from a missing parameter.
+        """
+
+        if steps < 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, f"a schedule needs at least one step, got {steps}"
+            )
+
+        if self.use_flow_sigmas:
+            if self.final_sigmas_type != "zero":
+                raise ModelError(
+                    ModelRefusal.SCHEDULER_INVALID,
+                    "a flow ladder with final_sigmas_type='sigma_min' has no coherent "
+                    "terminal sigma — upstream reads it off a BETA table that a flow "
+                    "config's betas do not describe. Nothing reaches this combination",
+                )
+            raw = ladders.flow_sigmas(steps, self.num_train_timesteps, self.flow_shift)
+            timesteps = ladders.flow_timesteps(raw, self.num_train_timesteps)
+            terminal = 0.0
+        else:
+            table = sigma_table(
+                self.num_train_timesteps,
+                self.beta_start,
+                self.beta_end,
+                self.beta_schedule,
+                self.rescale_betas_zero_snr,
+            )
+            # The terminal sigma is the table's SMALLEST entry under
+            # `sigma_min`, whichever ladder was walked — upstream resolves it
+            # once, after the branch, rather than off the ladder's own last rung.
+            terminal = 0.0 if self.final_sigmas_type == "zero" else table[0]
+            if self.use_karras_sigmas or self.use_exponential_sigmas:
+                logs = ladders.log_table(table)
+                if self.use_karras_sigmas:
+                    raw = ladders.karras_sigmas(table[0], table[-1], steps)
+                    # ROUNDED, half to even: the Karras ladder synthesizes
+                    # sigmas that are not table entries, so the timestep the
+                    # model is conditioned on is read back out by interpolation
+                    # and then snapped.
+                    timesteps = tuple(
+                        round_half_even(ladders.sigma_to_t(sigma, logs)) for sigma in raw
+                    )
+                else:
+                    raw = ladders.exponential_sigmas(table[0], table[-1], steps)
+                    # TRUNCATED, not rounded — upstream omits the `.round()` on
+                    # this branch alone and the int64 cast truncates. The
+                    # asymmetry is upstream's; reproducing it is the point.
+                    timesteps = tuple(
+                        truncate_to_int(ladders.sigma_to_t(sigma, logs)) for sigma in raw
+                    )
+            else:
+                timesteps = ladders.discrete_timesteps(
+                    self.timestep_spacing, steps, self.num_train_timesteps, self.steps_offset
+                )
+                raw = ladders.interpolate_table(table, timesteps)
+
+        resolved = tuple(f32(sigma) for sigma in raw)
+        return DpmSolverSchedule(
+            sigmas=(*resolved, f32(terminal)),
+            timesteps=timesteps,
+            num_train_timesteps=self.num_train_timesteps,
+            prediction_type=self.prediction_type,
+            algorithm_type=self.algorithm_type,
+            solver_order=self.solver_order,
+            solver_type=self.solver_type,
+            lower_order_final=self.lower_order_final,
+            euler_at_final=self.euler_at_final,
+            final_sigmas_type=self.final_sigmas_type,
+            flow=self.use_flow_sigmas or self.prediction_type == "flow_prediction",
+        )
+
+
+def _refuse_kind(name: str, allowed: tuple[str, ...], value: object) -> ModelError:
+    return refuse(name, f"one of {list(allowed)!r}", value)
+
+
+__all__ = [
+    "DPMSolverMultistep",
+    "DpmSolverSchedule",
+    "MultistepHistory",
+]

--- a/src/gen_worker/model/solvers/ladders.py
+++ b/src/gen_worker/model/solvers/ladders.py
@@ -1,0 +1,229 @@
+"""The sigma LADDERS a multistep solver may walk, as bare functions.
+
+A solver is two separable things: the ladder it descends and the update rule it
+applies between rungs. Splitting them is not tidiness — the SAME
+``DPMSolverMultistep`` update runs on three different ladders depending on one
+declared boolean, and ``dpmpp_2m`` vs ``dpmpp_2m_karras`` differ in NOTHING else.
+Keeping the ladders as pure functions is what makes that statement checkable
+instead of a claim about a branch buried in ``set_timesteps``.
+
+Each function reproduces the precision of the reference stage by stage, per
+pgw#1346 B2's rule. The stages differ per ladder and the differences are
+load-bearing, so they are named at each function rather than summarized here.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .precision import f32, linspace_f64, round_half_even, truncate_to_int
+
+
+def interpolate_table(table: tuple[float, ...], timesteps: tuple[float, ...]) -> tuple[float, ...]:
+    """``numpy.interp(timesteps, arange(len(table)), table)``.
+
+    FLOAT64 interpolation over a float32 table — numpy's ``interp`` promotes,
+    and matching that promotion is what keeps the resolved ladder on the
+    reference's own value rather than a more-accurate neighbour of it.
+
+    The multistep solvers reach this with INTEGER timesteps (their spacings emit
+    ``int64``), so every interpolation lands exactly on a table entry; the
+    fractional branch is here because ``euler_discrete``'s ``linspace`` spacing
+    does not, and one interpolation shared beats two that may drift.
+    """
+
+    last = len(table) - 1
+    resolved: list[float] = []
+    for timestep in timesteps:
+        if timestep <= 0.0:
+            resolved.append(table[0])
+        elif timestep >= last:
+            resolved.append(table[last])
+        else:
+            low = int(timestep)
+            resolved.append(table[low] + (table[low + 1] - table[low]) * (timestep - low))
+    return tuple(resolved)
+
+
+def karras_sigmas(sigma_min: float, sigma_max: float, steps: int, rho: float = 7.0) -> tuple[float, ...]:
+    """The Karras ladder (arXiv:2206.00364 eq. 5), DESCENDING.
+
+    ``rho = 7`` is the paper's value and is not a declared parameter anywhere in
+    this fleet — ``diffusers`` hardcodes it too, so exposing it would invent an
+    axis no endpoint can reach.
+
+    Precision: the endpoints ``sigma_min``/``sigma_max`` arrive as float32 table
+    entries (upstream takes them through ``.item()`` off a float32 tensor) and
+    everything after is FLOAT64 — ``ramp`` is numpy's ``linspace``, not torch's,
+    and the two are different algorithms. The result is narrowed to float32 once,
+    at the end, by the caller that assembles the ladder.
+
+    At one step ``ramp`` is ``[0.0]``, so the ladder is the single value
+    ``sigma_max``: numpy's ``linspace(0, 1, 1)`` keeps the START. A one-step
+    distilled recipe is a real configuration here, so this is measured rather
+    than assumed.
+    """
+
+    if steps < 1:
+        raise ValueError(f"a karras ladder needs at least one step, got {steps}")
+    ramp = linspace_f64(0.0, 1.0, steps)
+    min_inv_rho = sigma_min ** (1.0 / rho)
+    max_inv_rho = sigma_max ** (1.0 / rho)
+    return tuple((max_inv_rho + point * (min_inv_rho - max_inv_rho)) ** rho for point in ramp)
+
+
+def exponential_sigmas(sigma_min: float, sigma_max: float, steps: int) -> tuple[float, ...]:
+    """A geometric ladder: ``exp(linspace(log(sigma_max), log(sigma_min), n))``.
+
+    **Not reachable from any endpoint in this fleet today**, and it is here for
+    one reason: it is the sibling branch of :func:`karras_sigmas` inside the same
+    ``set_timesteps``, and a solver that implements one branch of a two-branch
+    switch has an untested edge rather than a missing feature. It is verified
+    against ``diffusers`` exactly as the reachable ladders are, and
+    ``tests/test_dit_solvers_pgw1346.py`` asserts that NO payload enum in the
+    fleet selects it — so the day one does, the assertion is what tells us the
+    fact changed, rather than a render.
+    """
+
+    if steps < 1:
+        raise ValueError(f"an exponential ladder needs at least one step, got {steps}")
+    return tuple(
+        math.exp(point)
+        for point in linspace_f64(math.log(sigma_max), math.log(sigma_min), steps)
+    )
+
+
+def flow_sigmas(steps: int, num_train_timesteps: int, shift: float) -> tuple[float, ...]:
+    """The rectified-flow ladder a multistep solver walks, DESCENDING.
+
+    This is NOT ``FlowMatchEulerDiscrete``'s ladder, and the difference is the
+    thing that makes wan-2.2 and hidream reproducible rather than nearly so:
+    ``FlowMatchEulerDiscrete`` spaces ``steps`` points from 1.0 down to
+    ``1/steps``; the multistep solvers space ``steps + 1`` points from 1.0 down
+    to ``1/num_train_timesteps`` and DROP THE LAST. Same shift map, different
+    grid, and swapping them is a schedule change no assertion about "flow
+    matching" would catch.
+
+    The ``eps`` nudge at the top is upstream's and is required, not cosmetic: at
+    ``sigma == 1`` the flow reading gives ``alpha_t = 1 - sigma = 0`` and
+    ``log(alpha_t)`` is ``-inf``, so the first predictor step would produce NaN.
+    Upstream subtracts ``1e-6``; reproducing the exact constant is what keeps our
+    first timestep 999 rather than 1000.
+
+    Precision: numpy ``linspace`` in float64, the shift map in float64, narrowed
+    to float32 once by the caller.
+    """
+
+    if steps < 1:
+        raise ValueError(f"a flow ladder needs at least one step, got {steps}")
+    if num_train_timesteps < 1:
+        raise ValueError(f"num_train_timesteps must be positive, got {num_train_timesteps}")
+    raw = linspace_f64(1.0, 1.0 / num_train_timesteps, steps + 1)[:-1]
+    shifted = [shift * point / (1.0 + (shift - 1.0) * point) for point in raw]
+    if abs(shifted[0] - 1.0) < 1e-6:
+        shifted[0] -= 1e-6
+    return tuple(shifted)
+
+
+def flow_timesteps(sigmas: tuple[float, ...], num_train_timesteps: int) -> tuple[float, ...]:
+    """``(sigmas * num_train_timesteps)`` cast to int64 — TRUNCATED, not rounded.
+
+    Kept beside :func:`flow_sigmas` because the pair is one fact: 0.973013 is
+    timestep **973**, and rounding it to 973 by luck at four steps and to 974 at
+    forty is the shape of a bug that only shows up on the long lane.
+    """
+
+    return tuple(truncate_to_int(sigma * num_train_timesteps) for sigma in sigmas)
+
+
+def sigma_to_t(sigma: float, log_table: tuple[float, ...]) -> float:
+    """Invert the trained table: which (fractional) train timestep is ``sigma``?
+
+    Required by the Karras and exponential ladders and by nothing else: those
+    two SYNTHESIZE sigmas that are not table entries, so the timestep the model
+    is conditioned on has to be read back out of the table by interpolating in
+    LOG-sigma. The reachable ladders that interpolate the table in the other
+    direction already know their timesteps and never come here.
+
+    Upstream's ``_sigma_to_t``, including its two clamps: the index is clipped so
+    ``low_idx + 1`` is always in range, and the interpolation weight is clipped
+    to ``[0, 1]`` so a sigma outside the table's span saturates at an endpoint
+    instead of extrapolating off it.
+    """
+
+    log_sigma = math.log(max(sigma, 1e-10))
+    # `cumsum(dists >= 0).argmax()` over an ASCENDING table is the index of the
+    # last entry at or below `log_sigma` — and 0 when there is none, because
+    # argmax over an all-zero cumsum returns the first index.
+    below = sum(1 for entry in log_table if log_sigma - entry >= 0.0)
+    low_idx = min(max(below - 1, 0), len(log_table) - 2)
+    high_idx = low_idx + 1
+    low, high = log_table[low_idx], log_table[high_idx]
+    weight = (low - log_sigma) / (low - high)
+    weight = min(max(weight, 0.0), 1.0)
+    return (1.0 - weight) * low_idx + weight * high_idx
+
+
+def log_table(table: tuple[float, ...]) -> tuple[float, ...]:
+    """``numpy.log`` of the float32 sigma table, which is itself float32.
+
+    Narrowed, because upstream takes the log of a float32 array and gets a
+    float32 array back; the subsequent arithmetic in :func:`sigma_to_t` promotes
+    to float64 exactly as numpy does when it meets a float64 scalar.
+    """
+
+    return tuple(f32(math.log(entry)) for entry in table)
+
+
+def discrete_timesteps(
+    spacing: str,
+    steps: int,
+    num_train_timesteps: int,
+    steps_offset: int,
+) -> tuple[float, ...]:
+    """The multistep solvers' timestep grid — Table 2 of arXiv:2305.08891.
+
+    **Deliberately not shared with** ``EulerDiscrete._timesteps``, and the reason
+    is a real off-by-one rather than a preference: the multistep solvers space
+    over ``num_inference_steps + 1`` points and drop the last, where Euler spaces
+    over ``num_inference_steps``. At 28 steps under ``leading`` that is a stride
+    of 34 here and 35 there — a different schedule, from the same three
+    arguments. Folding the two into one helper is how the two families would
+    quietly become one.
+
+    All three branches are integer arithmetic on ``int64``, which is why the
+    resolved grid is EXACT on every machine and is asserted as such.
+    """
+
+    if spacing == "linspace":
+        # `linspace(...).round()[::-1][:-1]` — REVERSE first, THEN drop, which
+        # keeps the TOP of the ladder and discards timestep 0. Dropping before
+        # reversing keeps 0 and discards the top: the same three lines in the
+        # other order serve a schedule that never reaches the noisy end.
+        points = linspace_f64(0.0, num_train_timesteps - 1, steps + 1)
+        return tuple(round_half_even(point) for point in reversed(points[1:]))
+    if spacing == "leading":
+        # INTEGER division, and the stride divides `steps + 1` rather than
+        # `steps` — that is the whole difference from the Euler family's grid.
+        stride = num_train_timesteps // (steps + 1)
+        walk = [round_half_even(index * stride) for index in range(steps + 1)]
+        return tuple(point + steps_offset for point in reversed(walk[1:]))
+    if spacing == "trailing":
+        span = num_train_timesteps / steps
+        total = math.ceil(num_train_timesteps / span)
+        return tuple(
+            round_half_even(num_train_timesteps - index * span) - 1.0 for index in range(total)
+        )
+    raise ValueError(f"unknown timestep spacing {spacing!r}")
+
+
+__all__ = [
+    "discrete_timesteps",
+    "exponential_sigmas",
+    "flow_sigmas",
+    "flow_timesteps",
+    "interpolate_table",
+    "karras_sigmas",
+    "log_table",
+    "sigma_to_t",
+]

--- a/src/gen_worker/model/solvers/precision.py
+++ b/src/gen_worker/model/solvers/precision.py
@@ -1,0 +1,197 @@
+"""The float32 discipline every declared solver reproduces, in ONE place.
+
+pgw#1346 B2 established the rule and paid for it three times over: a scheduler
+ladder that agrees with ``diffusers`` *algebraically* does not agree with it
+*numerically*, because the reference is built at a precision — float32, stage by
+stage, with a double accumulator inside ``cumprod`` — that the obvious float64
+reading of the same formulae is 201 float32 ULP away from.
+
+B2 carried those primitives privately inside ``model/scheduler.py`` because
+``euler_discrete`` was the only consumer. It no longer is: ``dpmsolver_multistep``
+and ``unipc_multistep`` descend from the SAME trained beta table, and a second
+copy of ``_sigma_table`` would be a second declaration of the fleet's noise
+schedule — the drift ``check_model_bindings.py`` exists to refuse one level up,
+reappearing one level down. So the primitives live here and every solver imports
+them.
+
+**No array library, ever.** ``struct`` performs the one float32 round trip and
+``math`` performs the rest. The adopt-only serve role (pgw#1328) holds this
+module for free, and — the property that turned out to matter more — every value
+below is IEEE double arithmetic with explicit narrowings, so it cannot vary with
+which CPU kernel a pod's torch happened to dispatch. See
+``tests/test_dit_solvers_pgw1346.py`` for the subprocess fence that proves it.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+from functools import lru_cache
+from typing import Final
+
+#: One float32 round-trip.
+_F32: Final = struct.Struct("<f")
+
+
+def f32(value: float) -> float:
+    """``value`` rounded to the nearest float32, as a Python float."""
+
+    return float(_F32.unpack(_F32.pack(value))[0])
+
+
+def linspace_f32(start: float, end: float, count: int) -> tuple[float, ...]:
+    """``torch.linspace(start, end, count, dtype=torch.float32)``, exactly.
+
+    torch's float32 CPU kernel computes a float32 ``step`` and walks OUTWARD
+    FROM BOTH ENDS — ``start + step*i`` for the first half, ``end - step*(n-1-i)``
+    for the second — so both endpoints land on their float32 selves. The
+    straightforward ``start + (end-start)*i/(n-1)`` disagrees with it on 307 of
+    1000 entries (B2, measured).
+
+    This is the one place the module reproduces an IMPLEMENTATION rather than a
+    contract, and torch's own two CPU kernels disagree with each other here by
+    1 ULP on 145 of 1000 entries — which is why nothing downstream may assert
+    bit-equality against a torch-derived reference.
+    """
+
+    first = f32(start)
+    last = f32(end)
+    if count == 1:
+        return (first,)
+    step = f32((last - first) / (count - 1))
+    halfway = count // 2
+    return tuple(
+        f32(first + step * index) if index < halfway else f32(last - step * (count - 1 - index))
+        for index in range(count)
+    )
+
+
+def linspace_f64(start: float, stop: float, count: int) -> tuple[float, ...]:
+    """``numpy.linspace(start, stop, count)``, exactly — a DIFFERENT algorithm.
+
+    numpy computes ``arange(count) * step`` and then ``+= start``, and finally
+    OVERWRITES the last entry with ``stop`` verbatim. It does not walk in from
+    both ends the way torch does, and the two therefore resolve different
+    ladders from the same three arguments; the flow-sigma and Karras ladders
+    below are numpy's, the beta table is torch's, and mixing them up is a silent
+    schedule change rather than an error.
+
+    ``numpy.linspace(a, b, 1)`` is ``[a]`` — it keeps the START. B2 found the
+    same trap in the ``linspace`` timestep spacing at one step; it is restated
+    here because a one-step distilled recipe is a real endpoint configuration.
+    """
+
+    if count < 1:
+        raise ValueError(f"a linspace needs at least one point, got {count}")
+    if count == 1:
+        return (float(start),)
+    step = (stop - start) / (count - 1)
+    values = [index * step + start for index in range(count)]
+    values[-1] = float(stop)
+    return tuple(values)
+
+
+def round_half_even(value: float) -> float:
+    """numpy's ``round``: ties to even. Python's ``round`` agrees on floats."""
+
+    return float(round(value))
+
+
+def truncate_to_int(value: float) -> float:
+    """``torch.from_numpy(x).to(torch.int64)`` — truncation TOWARD ZERO.
+
+    Not rounding, and the difference is a whole timestep: the flow-sigma
+    ladder's ``sigma * num_train_timesteps`` lands on 973.013 and the model is
+    conditioned on **973**. Wan's own served grid (``[999, 973, 923, 800]`` at
+    4 steps / shift 12) is the fixture that pins it.
+    """
+
+    return float(int(value))
+
+
+@lru_cache(maxsize=32)
+def sigma_table(
+    num_train_timesteps: int,
+    beta_start: float,
+    beta_end: float,
+    beta_schedule: str,
+    rescale_betas_zero_snr: bool,
+) -> tuple[float, ...]:
+    """The full ``num_train_timesteps``-long sigma table, ASCENDING.
+
+    ``sqrt((1 - alphas_cumprod) / alphas_cumprod)`` — the variance-exploding
+    ladder every diffusion-objective solver in this package interpolates. The
+    three narrowings B2 measured are reproduced verbatim:
+
+      (a) ``betas`` through torch's float32 ``linspace`` kernel;
+      (b) ``alphas_cumprod`` accumulated in a DOUBLE running product and
+          narrowed to float32 only on store, which is what torch's ``cumprod``
+          does for float32 CPU tensors (a float32 accumulator is 15 ULP wrong);
+      (c) ``1-ac`` and the quotient as SEPARATE float32 operations, because they
+          are separate float32 tensor ops upstream — folding them into one
+          double expression is a different, more accurate, WRONG number.
+
+    One deliberate divergence, and it is the reason nothing here may be asserted
+    in ULP: upstream spells the square root ``** 0.5``, which on a tensor is
+    ``torch.pow`` and is NOT correctly rounded. This uses ``math.sqrt``, which
+    is. Where the two differ, ours is the more accurate and the more
+    deterministic of the pair, and no amount of care makes a correctly-rounded
+    root bit-match a ``pow`` that is not.
+
+    Cached: it depends on nothing per-request and every request of one family
+    asks for the same one.
+    """
+
+    if beta_schedule == "scaled_linear":
+        roots = linspace_f32(math.sqrt(beta_start), math.sqrt(beta_end), num_train_timesteps)
+        betas = [f32(root * root) for root in roots]
+    else:
+        betas = list(linspace_f32(beta_start, beta_end, num_train_timesteps))
+
+    if rescale_betas_zero_snr:
+        betas = rescale_zero_terminal_snr(betas)
+
+    cumulative = 1.0
+    alphas_cumprod: list[float] = []
+    for beta in betas:
+        cumulative *= f32(1.0 - beta)
+        alphas_cumprod.append(f32(cumulative))
+    if rescale_betas_zero_snr:
+        # Close to zero without being zero, so the first sigma is not inf.
+        # Upstream's value verbatim: the smallest positive fp16 subnormal.
+        alphas_cumprod[-1] = 2.0**-24
+
+    return tuple(f32(math.sqrt(f32(f32(1.0 - alpha) / alpha))) for alpha in alphas_cumprod)
+
+
+def rescale_zero_terminal_snr(betas: list[float]) -> list[float]:
+    """Rescale betas so the terminal signal-to-noise ratio is zero.
+
+    arXiv:2305.08891 Algorithm 1, and the transform ``gen_worker.view`` already
+    turns on for every v-prediction checkpoint — so a v-pred fine-tune served
+    through any solver here needs it to reach the same ladder the diffusers path
+    reaches. Same float32 discipline as its caller.
+    """
+
+    cumulative = 1.0
+    roots: list[float] = []
+    for beta in betas:
+        cumulative *= f32(1.0 - beta)
+        roots.append(f32(math.sqrt(f32(cumulative))))
+    first, last = roots[0], roots[-1]
+    scale = f32(first / f32(first - last))
+    shifted = [f32(f32(root - last) * scale) for root in roots]
+    bars = [f32(root * root) for root in shifted]
+    alphas = [bars[0]] + [f32(bars[index] / bars[index - 1]) for index in range(1, len(bars))]
+    return [f32(1.0 - alpha) for alpha in alphas]
+
+
+__all__ = [
+    "f32",
+    "linspace_f32",
+    "linspace_f64",
+    "rescale_zero_terminal_snr",
+    "round_half_even",
+    "sigma_table",
+    "truncate_to_int",
+]

--- a/src/gen_worker/model/solvers/unipc_multistep.py
+++ b/src/gen_worker/model/solvers/unipc_multistep.py
@@ -1,0 +1,549 @@
+"""``unipc_multistep`` — UniPC (predictor/corrector), as bare typed math.
+
+The solver the video fleet actually renders on. wan-2.2's own mirrors ship
+``UniPCMultistepScheduler`` with ``use_flow_sigmas=True`` and serve every
+undistilled lane on it, and substituting flow-match Euler for it is a MEASURED
+-81% frame-40 sharpness at 40 steps (wan-2.2 README) — this is not a stylistic
+sampler choice, it is the checkpoint's trained solver. sd15's and sd2's recipe
+vocabularies also admit a plain ``unipc`` on the diffusion ladder.
+
+**Two ladders, one update rule.** UniPC is the only solver in this package that
+is reached on BOTH a trained-beta ladder (sd15's ``unipc``) and a rectified-flow
+ladder (wan, hidream), and the difference is one declared boolean plus one
+reading of what a sigma means (:meth:`UniPcSchedule._alpha_sigma`). Sharing the
+update rule between them is the point: the alternative is two implementations of
+one paper that drift.
+
+**The state is bigger than DPM's, and that is the interesting part.** A
+predictor/corrector method carries the previous SAMPLE as well as the previous
+model outputs, because the corrector re-solves the step it just took using
+information that only arrived afterwards. diffusers keeps four mutable
+attributes for this (``model_outputs``, ``timestep_list``, ``last_sample``,
+``this_order``) plus two counters. Here they are one frozen value,
+:class:`UniPcHistory`, threaded through :meth:`UniPcSchedule.step`:
+
+* **initialization is total and constant** — ``begin()`` takes nothing, so the
+  recursion's initial condition cannot differ between two pods;
+* **the corrector is disabled at step 0 by the STATE, not by a counter** — an
+  empty ``last_sample`` is the whole condition, so a loop that restarts mid-way
+  cannot accidentally correct against a sample from a different request;
+* **the order warm-up is explicit** — ``order`` records what the predictor
+  actually used, because the corrector must re-solve at the SAME order and
+  reading it off the step index instead is how the two silently disagree on
+  short ladders.
+
+**No array library.** The 2x2 solve the second-order corrector needs is written
+in closed form rather than handed to a linear-algebra routine — partly because
+this module imports none, and partly because ``torch.linalg.solve`` on a 2x2
+float32 system is LAPACK, which is exactly the class of
+implementation-defined primitive pgw#1346 B2 established cannot be bit-matched.
+Two lines of algebra are more accurate AND deterministic.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, ClassVar, Self
+
+from ..errors import ModelError, ModelRefusal
+from . import ladders
+from .block import SchedulerBlock, choice, count, flag, real, refuse
+from .precision import f32, round_half_even, sigma_table, truncate_to_int
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor
+
+
+def _log(value: float) -> float:
+    """float32 ``log``, with torch's ``-inf`` at zero rather than Python's raise."""
+
+    return -math.inf if value <= 0.0 else f32(math.log(value))
+
+
+def _expm1(value: float) -> float:
+    """float32 ``expm1``. Upstream spells it ``torch.expm1``; it is not
+    ``exp(x) - 1``, and at the small ``h`` of a 50-step ladder the difference is
+    the entire significand."""
+
+    return f32(math.expm1(value))
+
+
+@dataclass(frozen=True, slots=True)
+class UniPcHistory:
+    """One request's predictor/corrector state, as an immutable VALUE.
+
+    ``outputs`` are the converted model outputs, OLDEST FIRST, at most
+    ``solver_order`` of them. ``last_sample`` is the sample the previous
+    predictor step started from — ``None`` before the first step, which is
+    exactly the condition that disables the corrector. ``order`` is the order the
+    previous predictor step actually ran at, and ``taken`` is the multistep
+    warm-up counter.
+    """
+
+    outputs: tuple[Tensor, ...] = ()
+    last_sample: Tensor | None = None
+    order: int = 0
+    taken: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class UniPcSchedule:
+    """One request's resolved UniPC ladder, and the step that walks it."""
+
+    sigmas: tuple[float, ...]
+    timesteps: tuple[float, ...]
+    num_train_timesteps: int
+    prediction_type: str
+    solver_order: int
+    solver_type: str
+    predict_x0: bool
+    lower_order_final: bool
+    #: Step indices whose CORRECTOR is skipped. Not declarable — a scheduler
+    #: block holds finite JSON scalars, not lists — and empty on every mirror in
+    #: the fleet. Carried so the field is not silently absent from the model.
+    disable_corrector: tuple[int, ...] = ()
+    flow: bool = False
+    init_noise_sigma: float = 1.0
+
+    def __post_init__(self) -> None:
+        if len(self.sigmas) < 2:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "a schedule needs at least one step, so at least two sigmas",
+            )
+        if len(self.timesteps) != len(self.sigmas) - 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"{len(self.timesteps)} timesteps do not walk a "
+                f"{len(self.sigmas) - 1}-step sigma ladder",
+            )
+
+    def __len__(self) -> int:
+        return len(self.sigmas) - 1
+
+    def begin(self) -> UniPcHistory:
+        """The initial predictor/corrector state. Constant, and the ONLY one."""
+
+        return UniPcHistory()
+
+    # ---------------------------------------------------------------- sigmas
+
+    def _checked(self, index: int) -> int:
+        if not 0 <= index < len(self):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"step {index} is outside this schedule's {len(self)} steps",
+            )
+        return index
+
+    def _alpha_sigma(self, sigma: float) -> tuple[float, float]:
+        """``(alpha_t, sigma_t)`` — flow sums to one, diffusion squares to one."""
+
+        if self.flow:
+            return f32(1.0 - sigma), f32(sigma)
+        alpha = f32(1.0 / f32(math.sqrt(f32(f32(sigma * sigma) + 1.0))))
+        return alpha, f32(sigma * alpha)
+
+    def _lambda(self, sigma: float) -> float:
+        alpha, sigma_t = self._alpha_sigma(sigma)
+        return f32(_log(alpha) - _log(sigma_t))
+
+    # ------------------------------------------------------------ the output
+
+    def convert(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """The model output in the form UniPC integrates.
+
+        ``predict_x0`` (true on every mirror in the fleet) integrates the
+        DATA-prediction model, so every objective converts to ``x0``; false
+        integrates the noise-prediction model and converts to epsilon. The two
+        are not a preference — the update rules below read the choice too, and
+        mixing them produces a plausible, wrong image.
+        """
+
+        sigma = self.sigmas[self._checked(index)]
+        alpha, sigma_t = self._alpha_sigma(sigma)
+        if self.predict_x0:
+            if self.prediction_type == "flow_prediction":
+                return sample - f32(sigma) * model_output
+            if self.prediction_type == "epsilon":
+                return (sample - sigma_t * model_output) / alpha
+            return f32(alpha) * sample - f32(sigma_t) * model_output
+        if self.prediction_type == "epsilon":
+            return model_output
+        if self.prediction_type == "v_prediction":
+            return f32(alpha) * model_output + f32(sigma_t) * sample
+        raise ModelError(
+            ModelRefusal.SCHEDULER_INVALID,
+            f"prediction_type {self.prediction_type!r} has no noise-prediction reading; "
+            "it is only defined under predict_x0",
+        )
+
+    # ------------------------------------------------------ the coefficients
+
+    def _phi(self, h: float) -> tuple[float, float, float]:
+        """``(hh, h_phi_1, B_h)`` — the exponential-integrator coefficients.
+
+        ``hh`` is ``-h`` under ``predict_x0`` and ``h`` otherwise; ``B_h`` is
+        ``hh`` for ``bh1`` and ``expm1(hh)`` for ``bh2``. Every mirror in the
+        fleet ships ``bh2``, which upstream recommends for step counts at or
+        above 10 — and wan's distilled lanes run FOUR, so ``bh1`` is the
+        documented better choice there and is implemented for the day a mirror
+        ships it.
+        """
+
+        hh = f32(-h) if self.predict_x0 else h
+        h_phi_1 = _expm1(hh)
+        b_h = hh if self.solver_type == "bh1" else _expm1(hh)
+        return hh, h_phi_1, b_h
+
+    def _weights(self, hh: float, h_phi_1: float, b_h: float, order: int) -> tuple[float, ...]:
+        """``b`` — the right-hand side of the order-conditions system."""
+
+        h_phi_k = f32(f32(h_phi_1 / hh) - 1.0)
+        factorial = 1
+        weights: list[float] = []
+        for index in range(1, order + 1):
+            weights.append(f32(f32(h_phi_k * factorial) / b_h))
+            factorial *= index + 1
+            h_phi_k = f32(f32(h_phi_k / hh) - f32(1.0 / factorial))
+        return tuple(weights)
+
+    @staticmethod
+    def _solve2(ratio: float, weights: tuple[float, ...]) -> tuple[float, float]:
+        """Solve ``[[1, 1], [ratio, 1]] @ rho = weights`` in closed form.
+
+        The 2x2 system upstream hands to ``torch.linalg.solve``. Written out
+        because a 2x2 LAPACK call is an implementation-defined primitive and this
+        is two lines of exact algebra — the same argument ``math.sqrt`` over
+        ``pow`` makes one module down.
+        """
+
+        first = (weights[1] - weights[0]) / (ratio - 1.0)
+        return f32(first), f32(weights[0] - first)
+
+    # -------------------------------------------------------------- the step
+
+    def step(
+        self,
+        index: int,
+        model_output: Tensor,
+        sample: Tensor,
+        history: UniPcHistory,
+    ) -> tuple[Tensor, UniPcHistory]:
+        """One predictor/corrector update. Returns the sample AND the history.
+
+        The order of operations is upstream's and it matters: the CORRECTOR runs
+        FIRST, re-solving the previous step with this step's model output, and
+        only then does the predictor take the new step from the corrected
+        sample. A loop that corrected afterwards would be a different method
+        with the same name.
+        """
+
+        self._checked(index)
+        converted = self.convert(index, model_output, sample)
+
+        corrected = sample
+        if index > 0 and index - 1 not in self.disable_corrector and history.last_sample is not None:
+            corrected = self._correct(index, converted, history)
+
+        outputs = (*history.outputs, converted)[-self.solver_order :]
+        if self.lower_order_final:
+            order = min(self.solver_order, len(self) - index)
+        else:
+            order = self.solver_order
+        order = min(order, history.taken + 1)
+
+        predicted = self._predict(index, outputs, corrected, order)
+        return predicted, UniPcHistory(
+            outputs=outputs,
+            last_sample=corrected,
+            order=order,
+            taken=min(history.taken + 1, self.solver_order),
+        )
+
+    def _predict(
+        self, index: int, outputs: tuple[Tensor, ...], sample: Tensor, order: int
+    ) -> Tensor:
+        """UniP: take the step, using ``order`` of the accumulated outputs."""
+
+        newest = outputs[-1]
+        alpha_t, sigma_t = self._alpha_sigma(self.sigmas[index + 1])
+        alpha_s0, sigma_s0 = self._alpha_sigma(self.sigmas[index])
+        h = f32(self._lambda(self.sigmas[index + 1]) - self._lambda(self.sigmas[index]))
+        hh, h_phi_1, b_h = self._phi(h)
+
+        residual: Tensor | None = None
+        if order > 1:
+            # Order 2 uses upstream's SIMPLIFIED weight of 1/2 rather than the
+            # solve — stated because the corrector at the same order does NOT,
+            # and assuming they match is a silent second-order error.
+            previous = outputs[-2]
+            rk = f32(
+                f32(self._lambda(self.sigmas[index - 1]) - self._lambda(self.sigmas[index])) / h
+            )
+            # Two SEPARATE float32 operations upstream — the difference is
+            # divided by `rk` and then weighted. Folding `0.5/rk` into one
+            # scalar happens to be exact here (0.5 only moves an exponent), and
+            # it is still written out, because the DPM sibling folds the
+            # reciprocal and this one does not: the asymmetry is upstream's.
+            residual = ((previous - newest) / f32(rk)) * 0.5
+
+        if self.predict_x0:
+            base = f32(sigma_t / sigma_s0) * sample - f32(alpha_t * h_phi_1) * newest
+            if residual is None:
+                return base
+            return base - f32(alpha_t * b_h) * residual
+        base = f32(alpha_t / alpha_s0) * sample - f32(sigma_t * h_phi_1) * newest
+        if residual is None:
+            return base
+        return base - f32(sigma_t * b_h) * residual
+
+    def _correct(self, index: int, this_output: Tensor, history: UniPcHistory) -> Tensor:
+        """UniC: re-solve the PREVIOUS step now that its endpoint is known."""
+
+        assert history.last_sample is not None  # guarded by the caller
+        order = history.order
+        newest = history.outputs[-1]
+        alpha_t, sigma_t = self._alpha_sigma(self.sigmas[index])
+        alpha_s0, sigma_s0 = self._alpha_sigma(self.sigmas[index - 1])
+        h = f32(self._lambda(self.sigmas[index]) - self._lambda(self.sigmas[index - 1]))
+        hh, h_phi_1, b_h = self._phi(h)
+
+        residual: Tensor | None = None
+        if order > 1:
+            previous = history.outputs[-2]
+            rk = f32(
+                f32(self._lambda(self.sigmas[index - 2]) - self._lambda(self.sigmas[index - 1])) / h
+            )
+            weights = self._weights(hh, h_phi_1, b_h, order)
+            leading, trailing = self._solve2(rk, weights)
+            residual = ((previous - newest) / f32(rk)) * leading
+            final = trailing
+        else:
+            # Order 1: upstream's simplified 1/2, not a solve.
+            final = 0.5
+
+        correction = f32(final) * (this_output - newest)
+        if residual is not None:
+            correction = residual + correction
+        if self.predict_x0:
+            base = f32(sigma_t / sigma_s0) * history.last_sample - f32(alpha_t * h_phi_1) * newest
+            return base - f32(alpha_t * b_h) * correction
+        base = f32(alpha_t / alpha_s0) * history.last_sample - f32(sigma_t * h_phi_1) * newest
+        return base - f32(sigma_t * b_h) * correction
+
+
+@dataclass(frozen=True, slots=True)
+class UniPCMultistep:
+    """The declared ``unipc_multistep`` scheduler, as bare typed math.
+
+    **What is implemented is what an endpoint can reach**, enumerated from the
+    endpoints rather than from the paper:
+
+    * **the flow lane** — ``use_flow_sigmas=True``,
+      ``prediction_type="flow_prediction"``, ``solver_order=2``,
+      ``solver_type="bh2"``, ``predict_x0=True``, ``lower_order_final=True``,
+      ``final_sigmas_type="zero"``, ``timestep_spacing="linspace"``. This is
+      wan-2.2's mirrors verbatim, at ``flow_shift`` 12.0 (the curated T2V value),
+      5.0 (the TI2V-5B mirror) and 3.0 (the A14B mirror / I2V), over 1, 4, 8, 40
+      and 50 steps;
+    * **the diffusion lane** — the same solver on the trained beta ladder, which
+      is what sd15's and sd2's ``unipc`` recipe name selects (SD betas,
+      ``leading`` spacing, ``steps_offset=1``).
+
+    ``solver_order=3`` is REFUSED: every mirror ships 2, and a third-order
+    predictor needs a 3x3 solve that nothing would measure.
+    """
+
+    num_train_timesteps: int = 1000
+    beta_start: float = 0.0001
+    beta_end: float = 0.02
+    beta_schedule: str = "linear"
+    prediction_type: str = "epsilon"
+    timestep_spacing: str = "linspace"
+    steps_offset: int = 0
+    rescale_betas_zero_snr: bool = False
+    solver_order: int = 2
+    solver_type: str = "bh2"
+    predict_x0: bool = True
+    lower_order_final: bool = True
+    final_sigmas_type: str = "zero"
+    use_karras_sigmas: bool = False
+    use_exponential_sigmas: bool = False
+    use_flow_sigmas: bool = False
+    flow_shift: float = 1.0
+
+    BETA_SCHEDULES: ClassVar[tuple[str, ...]] = ("linear", "scaled_linear")
+    PREDICTION_TYPES: ClassVar[tuple[str, ...]] = (
+        "epsilon",
+        "v_prediction",
+        "flow_prediction",
+    )
+    SPACINGS: ClassVar[tuple[str, ...]] = ("linspace", "leading", "trailing")
+    FINAL_SIGMAS: ClassVar[tuple[str, ...]] = ("zero", "sigma_min")
+    SOLVER_TYPES: ClassVar[tuple[str, ...]] = ("bh1", "bh2")
+
+    def __post_init__(self) -> None:
+        if self.num_train_timesteps < 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"num_train_timesteps must be positive, got {self.num_train_timesteps}",
+            )
+        if not 0.0 < self.beta_start <= self.beta_end < 1.0:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "the beta schedule must ascend inside (0, 1); got "
+                f"beta_start={self.beta_start} beta_end={self.beta_end}",
+            )
+        for name, value, allowed in (
+            ("beta_schedule", self.beta_schedule, self.BETA_SCHEDULES),
+            ("prediction_type", self.prediction_type, self.PREDICTION_TYPES),
+            ("timestep_spacing", self.timestep_spacing, self.SPACINGS),
+            ("final_sigmas_type", self.final_sigmas_type, self.FINAL_SIGMAS),
+            ("solver_type", self.solver_type, self.SOLVER_TYPES),
+        ):
+            if value not in allowed:
+                raise refuse(name, f"one of {list(allowed)!r}", value)
+        if self.solver_order not in (1, 2):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"solver_order {self.solver_order} is not implemented: every UniPC mirror "
+                "this fleet serves ships solver_order=2, and a third-order predictor "
+                "would be arithmetic nothing measures",
+            )
+        if sum((self.use_karras_sigmas, self.use_exponential_sigmas, self.use_flow_sigmas)) > 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "karras, exponential and flow ladders are mutually exclusive; a block "
+                "naming two has no resolvable schedule",
+            )
+        if self.use_flow_sigmas and self.flow_shift <= 0.0:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, f"flow_shift must be positive, got {self.flow_shift}"
+            )
+        if not self.predict_x0 and self.prediction_type == "flow_prediction":
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "a flow-prediction checkpoint has no noise-prediction reading; "
+                "predict_x0=False cannot integrate it",
+            )
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        return cls(
+            num_train_timesteps=count(block, "num_train_timesteps", 1000),
+            beta_start=real(block, "beta_start", 0.0001),
+            beta_end=real(block, "beta_end", 0.02),
+            beta_schedule=choice(block, "beta_schedule", "linear", cls.BETA_SCHEDULES),
+            prediction_type=choice(block, "prediction_type", "epsilon", cls.PREDICTION_TYPES),
+            timestep_spacing=choice(block, "timestep_spacing", "linspace", cls.SPACINGS),
+            steps_offset=count(block, "steps_offset", 0),
+            rescale_betas_zero_snr=flag(block, "rescale_betas_zero_snr", False),
+            solver_order=count(block, "solver_order", 2),
+            solver_type=choice(block, "solver_type", "bh2", cls.SOLVER_TYPES),
+            predict_x0=flag(block, "predict_x0", True),
+            lower_order_final=flag(block, "lower_order_final", True),
+            final_sigmas_type=choice(block, "final_sigmas_type", "zero", cls.FINAL_SIGMAS),
+            use_karras_sigmas=flag(block, "use_karras_sigmas", False),
+            use_exponential_sigmas=flag(block, "use_exponential_sigmas", False),
+            use_flow_sigmas=flag(block, "use_flow_sigmas", False),
+            flow_shift=real(block, "flow_shift", 1.0),
+        )
+
+    def objective(self, prediction_type: str) -> Self:
+        """This scheduler with the checkpoint's stamped objective applied."""
+
+        if prediction_type not in self.PREDICTION_TYPES:
+            raise refuse(
+                "prediction_type", f"one of {list(self.PREDICTION_TYPES)!r}", prediction_type
+            )
+        rescale = True if prediction_type == "v_prediction" else self.rescale_betas_zero_snr
+        if prediction_type == self.prediction_type and rescale == self.rescale_betas_zero_snr:
+            return self
+        return replace(self, prediction_type=prediction_type, rescale_betas_zero_snr=rescale)
+
+    def shifted(self, flow_shift: float) -> Self:
+        """This scheduler at another ``flow_shift``.
+
+        wan-2.2 re-shifts per REQUEST (``scheduling.reshift``) — the served value
+        is a curated 12.0 where the A14B mirror ships 3.0 — and it does so by
+        rebuilding the scheduler from its own config so ``use_flow_sigmas`` and
+        ``prediction_type`` survive. This is that operation with the survival
+        guaranteed by the type rather than by remembering.
+        """
+
+        if not self.use_flow_sigmas:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "flow_shift only moves a FLOW ladder; this scheduler walks the trained "
+                "beta table, where the field is ignored",
+            )
+        return replace(self, flow_shift=flow_shift)
+
+    def schedule(self, steps: int) -> UniPcSchedule:
+        """The resolved ladder for one request."""
+
+        if steps < 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, f"a schedule needs at least one step, got {steps}"
+            )
+
+        if self.use_flow_sigmas:
+            raw = ladders.flow_sigmas(steps, self.num_train_timesteps, self.flow_shift)
+            timesteps = ladders.flow_timesteps(raw, self.num_train_timesteps)
+            terminal = 0.0 if self.final_sigmas_type == "zero" else raw[-1]
+        else:
+            table = sigma_table(
+                self.num_train_timesteps,
+                self.beta_start,
+                self.beta_end,
+                self.beta_schedule,
+                self.rescale_betas_zero_snr,
+            )
+            if self.use_karras_sigmas or self.use_exponential_sigmas:
+                logs = ladders.log_table(table)
+                if self.use_karras_sigmas:
+                    raw = ladders.karras_sigmas(table[0], table[-1], steps)
+                    timesteps = tuple(
+                        round_half_even(ladders.sigma_to_t(sigma, logs)) for sigma in raw
+                    )
+                else:
+                    raw = ladders.exponential_sigmas(table[0], table[-1], steps)
+                    timesteps = tuple(
+                        truncate_to_int(ladders.sigma_to_t(sigma, logs)) for sigma in raw
+                    )
+                # UniPC reads the terminal sigma off the LADDER's own last rung
+                # here, where the plain branch below reads it off the TABLE.
+                # DPMSolverMultistep resolves it once for every branch. The
+                # asymmetry is upstream's; it is only observable under
+                # `final_sigmas_type="sigma_min"`, which nothing reaches.
+                terminal = 0.0 if self.final_sigmas_type == "zero" else raw[-1]
+            else:
+                timesteps = ladders.discrete_timesteps(
+                    self.timestep_spacing, steps, self.num_train_timesteps, self.steps_offset
+                )
+                raw = ladders.interpolate_table(table, timesteps)
+                terminal = 0.0 if self.final_sigmas_type == "zero" else table[0]
+
+        resolved = tuple(f32(sigma) for sigma in raw)
+        return UniPcSchedule(
+            sigmas=(*resolved, f32(terminal)),
+            timesteps=timesteps,
+            num_train_timesteps=self.num_train_timesteps,
+            prediction_type=self.prediction_type,
+            solver_order=self.solver_order,
+            solver_type=self.solver_type,
+            predict_x0=self.predict_x0,
+            lower_order_final=self.lower_order_final,
+            flow=self.use_flow_sigmas or self.prediction_type == "flow_prediction",
+        )
+
+
+__all__ = [
+    "UniPCMultistep",
+    "UniPcHistory",
+    "UniPcSchedule",
+]

--- a/tests/test_dit_solvers_pgw1346.py
+++ b/tests/test_dit_solvers_pgw1346.py
@@ -1,0 +1,1100 @@
+"""pgw#1346 B3 — ``dpmsolver_multistep`` and ``unipc_multistep`` as bare math.
+
+pgw#1346 B2 built ``euler_discrete`` and, more usefully, built the INSTRUMENT.
+Its finding is this file's law and is not re-litigated here:
+
+* **a torch-derived reference cannot be bit-matched by anything, including
+  itself.** Three of its primitives are implementation-defined rather than
+  IEEE-exact — ``linspace`` dispatches its float32 CPU kernel by ISA,
+  ``cumprod`` varies in accumulator width and association order, and ``x ** 0.5``
+  on a tensor is ``pow``, which is not correctly rounded. Measured cross-machine
+  spread: 85 float32 ULP. So sigmas are compared RELATIVELY at 2e-4 (~20x tighter
+  than one bf16 ULP, the precision the denoiser computes in);
+* **timesteps are compared EXACTLY**, because they are integer arithmetic and
+  have never differed on any machine;
+* **loops are compared in the L2 NORM**, never element-wise: latents cross zero,
+  and an element-wise relative measure divides by the noise floor and reports 17%
+  for a parts-per-million difference;
+* **loops are compared with OUR ladder injected into the reference**, which
+  removes the table as a variable and makes the comparison a test of the STEP;
+* **our own ladder is fenced BYTEWISE across CPU kernels** in a subprocess, which
+  is the property the reference does not have and the reason to prefer this code
+  over the code it replaces.
+
+What B3 adds to that instrument, because multistep solvers are not memoryless:
+
+* **the conditioning is re-measured per solver.** B2 measured Euler at gain ~1.0
+  — a ladder perturbation propagates into the latents roughly 1:1, with no
+  chaotic amplification. That is what makes byte-stability a CORRECTNESS
+  property rather than a nicety, and it does not transfer for free to a
+  predictor/corrector recursion. Measured here, and one of the four lanes is NOT
+  gain-1 (see :func:`test_the_flow_ladders_first_rung_is_the_conditioning_risk`);
+* **the state's initial condition is asserted to be constant**, because "two pods
+  agree" is a claim about where the recursion starts as much as how it steps.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast, get_args
+
+import pytest
+
+from gen_worker.model.errors import ModelError
+from gen_worker.model.scheduler import IMPLEMENTED, SchedulerKind, parse_kind
+from gen_worker.model.solvers import ladders
+from gen_worker.model.solvers.dpm_multistep import (
+    DPMSolverMultistep,
+    DpmSolverSchedule,
+    MultistepHistory,
+)
+from gen_worker.model.solvers.unipc_multistep import (
+    UniPCMultistep,
+    UniPcHistory,
+    UniPcSchedule,
+)
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
+
+#: How far a value may sit from diffusers', RELATIVELY. B2's constant and B2's
+#: argument: ~40x the reference's own measured cross-machine spread (85 float32
+#: ULP ~ 5.1e-6) and ~20x TIGHTER than one bf16 ULP (3.9e-3).
+RELATIVE = 2e-4
+
+#: SD's trained noise schedule — the base config ``view.clone_scheduler`` merges
+#: a sampler's overrides onto for sd15, sd2 and sdxl. Declared in the catalog at
+#: ``model/catalog/sd15.py`` and ``model/catalog/sdxl.py``; restated here as the
+#: DIFFUSERS argument set so the reference and this module are built from one
+#: literal and cannot drift apart inside the test.
+SD_SCHEDULE: dict[str, Any] = {
+    "num_train_timesteps": 1000,
+    "beta_start": 0.00085,
+    "beta_end": 0.012,
+    "beta_schedule": "scaled_linear",
+    "timestep_spacing": "leading",
+    "steps_offset": 1,
+    "final_sigmas_type": "zero",
+    "solver_order": 2,
+}
+
+#: Every step count the sd15/sd2/sdxl recipes can reach a multistep solver at:
+#: sd15's stamped default (30), sdxl's (28), sd2/Turbo's (1), the distilled pins
+#: (4, 8), and the ends of the declared ranges (payload 1..80, sdxl's hub recipe
+#: max 150).
+DIFFUSION_STEPS = (1, 4, 8, 20, 25, 28, 30, 40, 50, 80, 150)
+
+#: wan-2.2's and hidream's reachable UniPC step counts: the boot warm-up (1),
+#: wan's distilled arms (4, 8), the 12-step natural-split arm, wan T2V/I2V's
+#: stamped 40, wan TI2V-5B's and hidream-full's 50, and the declared ceiling 80.
+FLOW_STEPS = (1, 4, 8, 12, 40, 50, 80)
+
+#: The three ``flow_shift`` values production reaches: wan's curated T2V 12.0,
+#: the TI2V-5B mirror's 5.0, and the A14B mirror / I2V 3.0 — which is also
+#: hidream-full's stamped shift.
+FLOW_SHIFTS = (3.0, 5.0, 12.0)
+
+
+# --------------------------------------------------------------- instruments
+
+
+def _rel(ours: Any, theirs: Any) -> float:
+    """Largest RELATIVE difference, scaled by the reference's own magnitude.
+
+    ``atol`` is deliberately absent: every value compared through this function
+    is a sigma or a timestep, all comfortably away from zero except a terminal
+    ``0.0`` both sides produce exactly.
+    """
+
+    a = np.asarray(ours, dtype=np.float64)
+    b = np.asarray(theirs, dtype=np.float64)
+    return float((np.abs(a - b) / np.maximum(np.abs(b), 1e-12)).max())
+
+
+def _rel_norm(ours: Any, theirs: Any) -> float:
+    """Relative difference of two TENSORS, in the L2 norm.
+
+    Separate from :func:`_rel` for B2's measured reason: latents cross zero, so
+    an element-wise relative measure divides by a value near the noise floor and
+    reports a meaningless 17% for a parts-per-million difference.
+    """
+
+    a = np.asarray(ours, dtype=np.float64).ravel()
+    b = np.asarray(theirs, dtype=np.float64).ravel()
+    return float(np.linalg.norm(a - b) / max(float(np.linalg.norm(b)), 1e-30))
+
+
+def _dpm_reference(**config: Any) -> Any:
+    diffusers = pytest.importorskip("diffusers")
+    return diffusers.DPMSolverMultistepScheduler(**config)
+
+
+def _unipc_reference(**config: Any) -> Any:
+    diffusers = pytest.importorskip("diffusers")
+    return diffusers.UniPCMultistepScheduler(**config)
+
+
+def _inject(theirs: Any, ours: DpmSolverSchedule | UniPcSchedule) -> Any:
+    """Load OUR ladder into the reference, so the loop tests the STEP.
+
+    B2's technique. The table has its own test and cannot be bit-exact, because
+    the reference is not bit-exact against itself across CPU kernels; feeding
+    both loops identical sigmas removes that variable, so what remains is the
+    update rule and the multistep state.
+    """
+
+    theirs.sigmas = torch.tensor(ours.sigmas, dtype=torch.float32)
+    theirs.timesteps = torch.tensor(ours.timesteps, dtype=torch.int64)
+    theirs.num_inference_steps = len(ours.timesteps)
+    return theirs
+
+
+# ------------------------------------------------- the reachable enumeration
+
+
+def test_the_implemented_variants_are_exactly_the_ones_an_endpoint_reaches() -> None:
+    """The enumeration, from the SDK's own sampler table and the endpoints.
+
+    ``gen_worker.view.SAMPLERS`` DEFINES each named sampler completely — the
+    endpoints select names, never configurations — so it is the only honest
+    source for "what does ``dpmpp_2m_karras`` mean here". Asserted rather than
+    described, because a row moving under this module is exactly the change that
+    would make a stamped recipe render differently without anything going red.
+    """
+
+    from gen_worker import view
+    from gen_worker.model.catalog import sd15_serve as sd
+    from gen_worker.model.catalog import sdxl_serve as sx
+
+    # DPM-Solver++: four rows, two switches, and the switches are independent.
+    assert view.SAMPLERS["dpmpp_2m"] == (
+        "DPMSolverMultistepScheduler",
+        {"solver_order": 2, "final_sigmas_type": "zero"},
+    )
+    assert view.SAMPLERS["dpmpp_2m_karras"][1]["use_karras_sigmas"] is True
+    assert view.SAMPLERS["dpmpp_2m_sde_karras"][1]["algorithm_type"] == "sde-dpmsolver++"
+    assert view.SAMPLERS["unipc"] == ("UniPCMultistepScheduler", {})
+
+    # Which of those names a recipe can actually carry.
+    sd15_names = set(get_args(sd.Sd15Sampler))
+    sdxl_names = set(get_args(sx.SdxlSampler))
+    assert {"dpmpp_2m", "dpmpp_2m_karras", "dpmpp_2m_sde_karras", "unipc"} <= sd15_names
+    assert {"dpmpp_2m_karras", "dpmpp_2m_sde_karras"} <= sdxl_names
+    # sdxl admits NO plain `dpmpp_2m` and NO `unipc` — the two families differ,
+    # and implementing to the union would be implementing to neither.
+    assert "dpmpp_2m" not in sdxl_names and "unipc" not in sdxl_names
+    # sd15's DEFAULT is a DPM-Solver++ variant, which is why this solver is the
+    # fleet's most-selected one and not an alternative.
+    assert sd.Sd15Tuned().scheduler == "dpmpp_2m_karras"
+
+    # `dpmpp_2m_sde` is DEFINED and reachable from nothing. Supported anyway —
+    # it is one boolean from `dpmpp_2m_sde_karras` — and recorded as unreachable
+    # so the day an enum admits it, this assertion is what says so.
+    assert "dpmpp_2m_sde" in view.SAMPLERS
+    assert "dpmpp_2m_sde" not in sd15_names | sdxl_names
+
+
+def test_no_endpoint_selects_an_exponential_or_beta_sigma_ladder() -> None:
+    """The two ladders that are IMPLEMENTED-but-unreachable, fenced.
+
+    ``exponential`` is implemented (it is the sibling branch of Karras inside one
+    ``set_timesteps``, and a solver with one branch of a two-branch switch has an
+    untested edge). ``beta`` is not implemented at all — it needs ``scipy``, and
+    nothing in this fleet has ever set it. Both facts are asserted here so a
+    future recipe that reaches for either goes red on this test rather than on a
+    render.
+    """
+
+    from gen_worker import view
+
+    for name, (_cls, extra) in view.SAMPLERS.items():
+        assert not extra.get("use_exponential_sigmas"), name
+        assert not extra.get("use_beta_sigmas"), name
+    # Karras, by contrast, IS reachable — and only through these two names.
+    karras = {n for n, (_c, e) in view.SAMPLERS.items() if e.get("use_karras_sigmas")}
+    assert karras == {"dpmpp_2m_karras", "dpmpp_2m_sde_karras"}
+
+
+def test_both_kinds_are_declarable_and_the_generator_can_import_the_class() -> None:
+    """``IMPLEMENTED`` stays TOTAL, and every name in it is importable.
+
+    The binding generator emits ``from gen_worker.model.scheduler import <name>``
+    from this table. A kind whose class lives in a submodule and is NOT
+    re-exported would generate a module that fails to import — at the tenant's
+    build, not here — so the re-export is the assertion.
+    """
+
+    from gen_worker.model import scheduler as surface
+
+    assert set(IMPLEMENTED) == set(SchedulerKind)
+    assert parse_kind("dpmsolver_multistep") is SchedulerKind.DPMSOLVER_MULTISTEP
+    assert parse_kind("unipc_multistep") is SchedulerKind.UNIPC_MULTISTEP
+    for kind, name in IMPLEMENTED.items():
+        implementation = getattr(surface, name, None)
+        assert implementation is not None, f"{kind} names {name}, which is not exported"
+        assert hasattr(implementation, "from_block")
+        assert hasattr(implementation, "schedule")
+
+
+# ------------------------------------------------------ dpmsolver_multistep
+
+
+@pytest.mark.parametrize("steps", DIFFUSION_STEPS)
+@pytest.mark.parametrize("karras", [False, True])
+@pytest.mark.parametrize("algorithm", ["dpmsolver++", "sde-dpmsolver++"])
+@pytest.mark.parametrize(("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)])
+def test_the_dpm_ladder_matches_diffusers_over_every_reachable_configuration(
+    steps: int, karras: bool, algorithm: str, objective: str, zero_snr: bool
+) -> None:
+    """88 configurations: the real axes, at the real step counts.
+
+    ``v_prediction`` is paired with ``rescale_betas_zero_snr`` because
+    ``gen_worker.view`` pairs them — a v-pred checkpoint on this fleet is ALWAYS
+    served with the rescale, so measuring the objective without it would measure
+    a configuration no request reaches.
+    """
+
+    config = dict(
+        SD_SCHEDULE,
+        use_karras_sigmas=karras,
+        algorithm_type=algorithm,
+        prediction_type=objective,
+        rescale_betas_zero_snr=zero_snr,
+    )
+    theirs = _dpm_reference(**config)
+    theirs.set_timesteps(steps)
+    ours = DPMSolverMultistep(**config).schedule(steps)
+
+    assert len(ours.sigmas) == len(theirs.sigmas)
+    assert _rel(ours.sigmas, theirs.sigmas.numpy()) <= RELATIVE
+    # EXACT: the grid is integer arithmetic on both sides.
+    assert list(ours.timesteps) == [float(t) for t in theirs.timesteps.tolist()]
+    # DPM-Solver++ starts from UNIT-variance noise, unlike euler_discrete.
+    assert ours.init_noise_sigma == float(theirs.init_noise_sigma) == 1.0
+
+
+@pytest.mark.parametrize("steps", [1, 4, 8, 28, 30])
+@pytest.mark.parametrize("algorithm", ["dpmsolver++", "sde-dpmsolver++"])
+@pytest.mark.parametrize("solver_type", ["midpoint", "heun"])
+def test_a_whole_dpm_loop_tracks_the_diffusers_loop(
+    steps: int, algorithm: str, solver_type: str
+) -> None:
+    """The multistep recursion, step for step, with the table removed.
+
+    ``solver_type`` is exercised on both settings even though ``view.SAMPLERS``
+    never sets it: a checkpoint's own ``scheduler_config.json`` rides through
+    ``view.clone_scheduler``'s ``{**base.config, **overrides}`` merge, so
+    ``heun`` can arrive without any recipe naming it.
+
+    Compared after EVERY step rather than once at the end: a divergence at step
+    3 and one at step 27 are different defects, and only the per-step assertion
+    tells them apart. It also pins the ORDER SCHEDULE — first-order first,
+    second-order in the middle, first-order last — because a wrong order shows up
+    as a jump at one index rather than as drift.
+    """
+
+    config = dict(
+        SD_SCHEDULE,
+        use_karras_sigmas=True,
+        algorithm_type=algorithm,
+        prediction_type="epsilon",
+        solver_type=solver_type,
+    )
+    ours = DPMSolverMultistep(**config).schedule(steps)
+    theirs = _inject(_dpm_reference(**config), ours)
+
+    torch.manual_seed(0)
+    our_sample = torch.randn(2, 4, 16, 16)
+    their_sample = our_sample.clone()
+    state = ours.begin()
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(2, 4, 16, 16)
+        noise = torch.randn(2, 4, 16, 16) if algorithm.startswith("sde") else None
+        our_sample, state = ours.step(index, prediction, our_sample, state, noise=noise)
+        their_sample = theirs.step(
+            prediction, timestep, their_sample, variance_noise=noise
+        ).prev_sample
+        assert _rel_norm(our_sample.numpy(), their_sample.numpy()) <= RELATIVE
+
+
+def test_the_dpm_step_residual_is_the_reference_s_own_float32_transcendentals() -> None:
+    """WHY the loop is not bit-exact even with the table removed, measured.
+
+    B2's Euler loop IS bit-exact under ladder injection, because its step is
+    arithmetic. A multistep coefficient is not: it passes through ``exp``,
+    ``log`` and ``expm1``, and torch evaluates those on a float32 tensor in
+    float32, where this module evaluates them in double and narrows once. Ours is
+    the more accurate and the more deterministic of the two — a correctly-rounded
+    double transcendental narrowed once cannot bit-match a float32-native one, by
+    construction, exactly as ``math.sqrt`` cannot bit-match ``pow``.
+
+    Asserted as a BOUND on the residual rather than as equality, and the bound is
+    three orders of magnitude tighter than the file's own tolerance, so this
+    would fail loudly on a real arithmetic error while never failing on the
+    library's rounding.
+    """
+
+    config = dict(SD_SCHEDULE, use_karras_sigmas=True, prediction_type="epsilon")
+    ours = DPMSolverMultistep(**config).schedule(30)
+    theirs = _inject(_dpm_reference(**config), ours)
+
+    torch.manual_seed(3)
+    our_sample = torch.randn(2, 4, 16, 16)
+    their_sample = our_sample.clone()
+    state = ours.begin()
+    worst = 0.0
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(2, 4, 16, 16)
+        our_sample, state = ours.step(index, prediction, our_sample, state)
+        their_sample = theirs.step(prediction, timestep, their_sample).prev_sample
+        worst = max(worst, _rel_norm(our_sample.numpy(), their_sample.numpy()))
+    assert 0.0 < worst <= 1e-5
+
+
+# ---------------------------------------------------------- unipc_multistep
+
+
+@pytest.mark.parametrize("steps", FLOW_STEPS)
+@pytest.mark.parametrize("shift", FLOW_SHIFTS)
+def test_the_unipc_flow_ladder_matches_diffusers_at_every_served_shift(
+    steps: int, shift: float
+) -> None:
+    """wan-2.2's own solver, at the shifts and step counts it actually serves.
+
+    The flow ladder is NOT ``FlowMatchEulerDiscrete``'s: it spaces ``steps + 1``
+    points from 1.0 down to ``1/num_train_timesteps`` and drops the last, where
+    the flow-match schedule spaces ``steps`` points down to ``1/steps``. Same
+    shift map, different grid.
+    """
+
+    config: dict[str, Any] = {
+        "num_train_timesteps": 1000,
+        "use_flow_sigmas": True,
+        "prediction_type": "flow_prediction",
+        "flow_shift": shift,
+        "solver_order": 2,
+        "solver_type": "bh2",
+        "predict_x0": True,
+        "lower_order_final": True,
+        "final_sigmas_type": "zero",
+        "timestep_spacing": "linspace",
+    }
+    theirs = _unipc_reference(**config)
+    theirs.set_timesteps(steps)
+    ours = UniPCMultistep(**config).schedule(steps)
+
+    assert len(ours.sigmas) == len(theirs.sigmas)
+    assert _rel(ours.sigmas, theirs.sigmas.numpy()) <= RELATIVE
+    assert list(ours.timesteps) == [float(t) for t in theirs.timesteps.tolist()]
+
+
+def test_the_unipc_flow_grid_is_the_wan_mirror_s_own_published_timesteps() -> None:
+    """``[999, 973, 923, 800]`` — wan-2.2's committed 4-step/shift-12 fixture.
+
+    A fixture from ANOTHER repository, reproduced from first principles here. It
+    pins the two details a re-derivation gets wrong: the timestep cast is a
+    TRUNCATION and not a rounding (0.973013 is 973), and the top rung is nudged
+    down by exactly ``1e-6`` so ``alpha_t = 1 - sigma`` is not zero — without
+    which the first predictor step is NaN rather than slightly different.
+    """
+
+    ours = UniPCMultistep(
+        use_flow_sigmas=True, prediction_type="flow_prediction", flow_shift=12.0
+    ).schedule(4)
+    assert list(ours.timesteps) == [999.0, 973.0, 923.0, 800.0]
+    # The nudge is applied in float64 and the ladder is narrowed to float32 once
+    # at the end, so the served value is the float32 neighbour of `1 - 1e-6` —
+    # about 1.5 float32 ULP away from it, and still 100x further from 1.0 than
+    # one ULP is, which is all the nudge has to achieve.
+    assert ours.sigmas[0] == pytest.approx(1.0 - 1e-6, abs=2e-7)
+    assert ours.sigmas[0] < 1.0
+    assert ours.sigmas[-1] == 0.0
+
+
+@pytest.mark.parametrize("steps", DIFFUSION_STEPS)
+@pytest.mark.parametrize("solver_type", ["bh1", "bh2"])
+@pytest.mark.parametrize(("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)])
+def test_the_unipc_diffusion_ladder_matches_diffusers(
+    steps: int, solver_type: str, objective: str, zero_snr: bool
+) -> None:
+    """The OTHER lane: sd15's and sd2's ``unipc``, on the trained beta table.
+
+    One solver, two ladders, one declared boolean between them — which is the
+    whole reason the ladders are functions in ``solvers/ladders.py`` rather than
+    branches inside a ``set_timesteps``.
+    """
+
+    config = dict(
+        SD_SCHEDULE,
+        solver_type=solver_type,
+        predict_x0=True,
+        lower_order_final=True,
+        prediction_type=objective,
+        rescale_betas_zero_snr=zero_snr,
+    )
+    theirs = _unipc_reference(**config)
+    theirs.set_timesteps(steps)
+    ours = UniPCMultistep(**config).schedule(steps)
+
+    assert _rel(ours.sigmas, theirs.sigmas.numpy()) <= RELATIVE
+    assert list(ours.timesteps) == [float(t) for t in theirs.timesteps.tolist()]
+
+
+@pytest.mark.parametrize(
+    ("steps", "flow", "shift"),
+    [(1, True, 12.0), (4, True, 12.0), (8, True, 5.0), (40, True, 12.0), (50, True, 3.0),
+     (4, False, 0.0), (28, False, 0.0), (30, False, 0.0)],
+)
+def test_a_whole_unipc_loop_tracks_the_diffusers_loop(
+    steps: int, flow: bool, shift: float, solver_type: str = "bh2"
+) -> None:
+    """Predictor AND corrector, step for step, on both ladders.
+
+    The corrector is what makes this more than a second DPM test: it re-solves
+    the PREVIOUS step using this step's model output, at the order the previous
+    predictor actually ran at. Reading that order off the step index instead of
+    off the state is the subtle way the two halves disagree on short ladders, so
+    the 1-, 4- and 8-step rows are load-bearing and not padding.
+
+    ``bh2`` only, because that is what every mirror in the fleet ships and
+    because the reference cannot complete a ``bh1`` loop at all — see
+    :func:`test_bh1_makes_the_reference_return_nan_on_its_final_step`.
+    """
+
+    if flow:
+        config: dict[str, Any] = {
+            "num_train_timesteps": 1000,
+            "use_flow_sigmas": True,
+            "prediction_type": "flow_prediction",
+            "flow_shift": shift,
+            "solver_order": 2,
+            "solver_type": solver_type,
+            "predict_x0": True,
+            "lower_order_final": True,
+            "final_sigmas_type": "zero",
+            "timestep_spacing": "linspace",
+        }
+    else:
+        config = dict(
+            SD_SCHEDULE,
+            solver_type=solver_type,
+            predict_x0=True,
+            lower_order_final=True,
+            prediction_type="epsilon",
+        )
+    ours = UniPCMultistep(**config).schedule(steps)
+    theirs = _inject(_unipc_reference(**config), ours)
+
+    torch.manual_seed(1)
+    our_sample = torch.randn(2, 4, 16, 16)
+    their_sample = our_sample.clone()
+    state = ours.begin()
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(2, 4, 16, 16)
+        our_sample, state = ours.step(index, prediction, our_sample, state)
+        their_sample = theirs.step(prediction, timestep, their_sample).prev_sample
+        assert _rel_norm(our_sample.numpy(), their_sample.numpy()) <= RELATIVE
+
+
+# ------------------------------------------------------------ the ladders
+
+
+@pytest.mark.parametrize("steps", [1, 4, 28, 30, 50])
+def test_the_karras_and_exponential_ladders_are_the_reference_s_own(steps: int) -> None:
+    """The two synthesized ladders, differenced against diffusers directly.
+
+    Tested as FUNCTIONS rather than only through a solver, because both are
+    shared by ``DPMSolverMultistep`` and ``UniPCMultistep`` and a shared function
+    that is only ever tested through one caller is tested once.
+    """
+
+    diffusers = pytest.importorskip("diffusers")
+    reference = diffusers.DPMSolverMultistepScheduler(**SD_SCHEDULE)
+    table = np.asarray(
+        ((1 - reference.alphas_cumprod) / reference.alphas_cumprod) ** 0.5, dtype=np.float32
+    )
+    flipped = np.flip(table).copy()
+
+    ours_table = tuple(
+        float(value)
+        for value in np.asarray(
+            _sigma_table_of(DPMSolverMultistep(**SD_SCHEDULE)), dtype=np.float32
+        )
+    )
+    assert _rel(ours_table, table) <= RELATIVE
+
+    for build, theirs_build in (
+        (ladders.karras_sigmas, reference._convert_to_karras),
+        (ladders.exponential_sigmas, reference._convert_to_exponential),
+    ):
+        ours = build(ours_table[0], ours_table[-1], steps)
+        theirs = theirs_build(in_sigmas=flipped, num_inference_steps=steps)
+        assert _rel(ours, np.asarray(theirs, dtype=np.float64)) <= RELATIVE
+
+    # And the inverse, which is what turns a synthesized sigma back into the
+    # timestep the model is conditioned on.
+    logs = ladders.log_table(ours_table)
+    synthesized = ladders.karras_sigmas(ours_table[0], ours_table[-1], steps)
+    log_sigmas = np.log(table)
+    for sigma in synthesized:
+        mine = ladders.sigma_to_t(sigma, logs)
+        theirs_t = float(reference._sigma_to_t(np.float64(sigma), log_sigmas))
+        assert abs(mine - theirs_t) <= 1e-6 * max(abs(theirs_t), 1.0)
+
+
+def _sigma_table_of(scheduler: DPMSolverMultistep) -> tuple[float, ...]:
+    from gen_worker.model.solvers.precision import sigma_table
+
+    return sigma_table(
+        scheduler.num_train_timesteps,
+        scheduler.beta_start,
+        scheduler.beta_end,
+        scheduler.beta_schedule,
+        scheduler.rescale_betas_zero_snr,
+    )
+
+
+def test_the_multistep_timestep_grid_is_not_the_euler_grid() -> None:
+    """The off-by-one that makes ``ladders.discrete_timesteps`` its own function.
+
+    The multistep solvers space over ``steps + 1`` points and drop one; the Euler
+    family spaces over ``steps``. At 28 steps under ``leading`` that is a stride
+    of 34 here and 35 there. Sharing one helper between the two families is how
+    they would quietly become one schedule.
+    """
+
+    from gen_worker.model.scheduler import EulerDiscrete
+
+    multistep = ladders.discrete_timesteps("leading", 28, 1000, 1)
+    euler = EulerDiscrete(
+        beta_start=0.00085,
+        beta_end=0.012,
+        beta_schedule="scaled_linear",
+        timestep_spacing="leading",
+        steps_offset=1,
+    ).schedule(28)
+    # 1000 // 29 = 34 here; 1000 // 28 = 35 there. Both grids start one stride
+    # BELOW the top of the ladder, and they start at different places.
+    assert multistep[0] == 953.0 and multistep[0] - multistep[1] == 34.0
+    assert euler.timesteps[0] == 946.0 and euler.timesteps[0] - euler.timesteps[1] == 35.0
+    assert multistep != euler.timesteps
+    # And the multistep grid is the reference's, exactly.
+    reference = _dpm_reference(**SD_SCHEDULE)
+    reference.set_timesteps(28)
+    assert list(multistep) == [float(t) for t in reference.timesteps.tolist()]
+
+
+# ---------------------------------------------------- the multistep STATE
+
+
+def test_the_multistep_state_initializes_from_nothing_and_is_immutable() -> None:
+    """"Two pods agree" is a claim about the recursion's INITIAL CONDITION too.
+
+    ``begin()`` takes no arguments, so there is no seed, no device and no clock
+    anywhere in it — two pods start identical by construction rather than by
+    discipline. And the value is frozen, so a step cannot mutate a history a
+    concurrent request is still holding.
+    """
+
+    dpm = DPMSolverMultistep(**SD_SCHEDULE).schedule(8)
+    unipc = UniPCMultistep(**SD_SCHEDULE, predict_x0=True).schedule(8)
+
+    assert dpm.begin() == MultistepHistory() == MultistepHistory(outputs=(), taken=0)
+    assert unipc.begin() == UniPcHistory()
+    assert unipc.begin().last_sample is None and unipc.begin().order == 0
+
+    with pytest.raises((AttributeError, TypeError)):
+        dpm.begin().taken = 3  # type: ignore[misc]
+    with pytest.raises((AttributeError, TypeError)):
+        unipc.begin().order = 2  # type: ignore[misc]
+
+
+def test_two_interleaved_requests_cannot_disturb_each_other() -> None:
+    """The property a mutable scheduler object cannot have, exercised.
+
+    diffusers keeps ``model_outputs``, ``last_sample`` and a step counter on the
+    scheduler, which is why a served pipeline must be cloned per request. Here
+    the state is a value the caller holds, so two loops can be advanced ALTERNATELY
+    on ONE schedule object and still produce exactly what each would alone.
+    """
+
+    schedule = UniPCMultistep(**SD_SCHEDULE, predict_x0=True).schedule(8)
+    torch.manual_seed(11)
+    starts = [torch.randn(1, 4, 8, 8), torch.randn(1, 4, 8, 8)]
+    predictions = [
+        [torch.randn(1, 4, 8, 8) for _ in range(8)],
+        [torch.randn(1, 4, 8, 8) for _ in range(8)],
+    ]
+
+    alone = []
+    for which in (0, 1):
+        sample, state = starts[which].clone(), schedule.begin()
+        for index in range(8):
+            sample, state = schedule.step(index, predictions[which][index], sample, state)
+        alone.append(sample)
+
+    samples = [starts[0].clone(), starts[1].clone()]
+    states = [schedule.begin(), schedule.begin()]
+    for index in range(8):
+        for which in (0, 1):  # interleaved, one step each, same schedule object
+            samples[which], states[which] = schedule.step(
+                index, predictions[which][index], samples[which], states[which]
+            )
+    assert torch.equal(samples[0], alone[0])
+    assert torch.equal(samples[1], alone[1])
+
+
+@pytest.mark.parametrize("steps", [4, 30])
+def test_the_dpm_order_schedule_is_the_reference_s_own(steps: int) -> None:
+    """WHICH steps run first-order, asserted rather than inferred from output.
+
+    A 4-step distilled recipe runs first, second, second, FIRST — the last step
+    drops to first order because the ladder terminates at zero. "2M means always
+    second order" is the misreading, and on a 4-step ladder it changes half the
+    render.
+    """
+
+    schedule = DPMSolverMultistep(**SD_SCHEDULE).schedule(steps)
+    state = schedule.begin()
+    orders = []
+    torch.manual_seed(2)
+    sample = torch.randn(1, 4, 8, 8)
+    for index in range(steps):
+        before = state
+        first_order = schedule.solver_order == 1 or before.taken < 1 or (
+            index == steps - 1 and schedule.final_sigmas_type == "zero"
+        )
+        orders.append(1 if first_order else 2)
+        sample, state = schedule.step(index, torch.randn(1, 4, 8, 8), sample, state)
+        assert len(state.outputs) == min(index + 1, schedule.solver_order)
+        assert state.taken == min(index + 1, schedule.solver_order)
+    assert orders[0] == 1 and orders[-1] == 1
+    assert orders[1] == 2
+
+
+# ------------------------------------------------------------ conditioning
+
+
+def _gain(
+    schedule: DpmSolverSchedule | UniPcSchedule,
+    steps: int,
+    *,
+    noise: bool = False,
+    skip_first: bool = False,
+    seed: int = 5,
+) -> float:
+    """Relative change in the LATENTS per unit relative change in the LADDER.
+
+    B2's conditioning measurement, re-run per solver: perturb the sigma ladder by
+    5e-6 relative — the scale of a genuine cross-machine disagreement — and see
+    what comes out. A gain near 1 means the loop propagates a ladder difference
+    without amplifying it, which is what makes ladder byte-stability a
+    CORRECTNESS property: two pods that resolve slightly different ladders render
+    slightly different images, not arbitrarily different ones.
+    """
+
+    scale = 5e-6
+    span = range(1 if skip_first else 0, len(schedule.sigmas) - 1)
+    bumped = list(schedule.sigmas)
+    for index in span:
+        bumped[index] = bumped[index] * (1.0 + scale)
+    nudged = replace(schedule, sigmas=tuple(bumped))
+
+    torch.manual_seed(seed)
+    start = torch.randn(2, 4, 16, 16)
+    predictions = [torch.randn(2, 4, 16, 16) for _ in range(steps)]
+    noises = [torch.randn(2, 4, 16, 16) for _ in range(steps)] if noise else [None] * steps
+
+    results = []
+    for variant in (schedule, nudged):
+        variant = cast("Any", variant)
+        sample, state = start.clone(), variant.begin()
+        for index in range(steps):
+            if noise:
+                sample, state = variant.step(
+                    index, predictions[index], sample, state, noise=noises[index]
+                )
+            else:
+                sample, state = variant.step(index, predictions[index], sample, state)
+        results.append(sample)
+    return _rel_norm(results[1].numpy(), results[0].numpy()) / scale
+
+
+def test_the_diffusion_lane_loops_are_conditioned_at_gain_one() -> None:
+    """B2 measured Euler at ~1.0. Three multistep lanes, re-measured.
+
+    Measured, not assumed: a predictor/corrector recursion could in principle
+    amplify, and this is the assertion that says these do not. The consequence is
+    B2's: a 5e-6 ladder disagreement between two pods is a 5e-6 latent
+    disagreement, four orders below one bf16 ULP — so our byte-stable ladder
+    turns a real cross-pod reproducibility hazard into no hazard at all.
+    """
+
+    karras = dict(SD_SCHEDULE, use_karras_sigmas=True, prediction_type="epsilon")
+    assert 0.5 <= _gain(DPMSolverMultistep(**karras).schedule(30), 30) <= 2.0
+    assert 0.5 <= _gain(DPMSolverMultistep(**karras).schedule(4), 4) <= 2.0
+    sde = dict(karras, algorithm_type="sde-dpmsolver++")
+    assert 0.5 <= _gain(DPMSolverMultistep(**sde).schedule(30), 30, noise=True) <= 2.0
+    unipc = dict(SD_SCHEDULE, predict_x0=True, prediction_type="epsilon")
+    assert 0.5 <= _gain(UniPCMultistep(**unipc).schedule(30), 30) <= 2.0
+
+
+@pytest.mark.parametrize("steps", [4, 8, 40, 50])
+def test_the_flow_ladders_first_rung_is_the_conditioning_risk(steps: int) -> None:
+    """The one lane that is NOT gain-1, and exactly where the sensitivity lives.
+
+    On wan's flow ladder ``alpha_t = 1 - sigma``, and the top rung sits at
+    ``1 - 1e-6`` — so ``alpha_t`` there is ``1e-6``, and a 5e-6 RELATIVE nudge of
+    that sigma is a **five-fold** relative change in ``alpha``, which enters the
+    first predictor coefficient through ``log``. Measured gain: 7.7 at 50 steps
+    rising to ~249 at 4, where that first step is a quarter of the render.
+    Exclude the top rung and the loop is conditioned like every other lane.
+
+    This is not a defect in either implementation — it is a property of the
+    schedule, and both sides resolve that ladder in pure float64 numpy with no
+    torch primitive involved, so nothing disagrees about it today. It is recorded
+    because it says which number in this package is load-bearing: the ``1e-6``
+    nudge in ``ladders.flow_sigmas`` is not a rounding detail, and anything that
+    changes it changes wan's render by orders of magnitude more than its own size.
+    """
+
+    schedule = UniPCMultistep(
+        use_flow_sigmas=True, prediction_type="flow_prediction", flow_shift=12.0
+    ).schedule(steps)
+    everywhere = _gain(schedule, steps)
+    below_the_top = _gain(schedule, steps, skip_first=True)
+    assert 0.5 <= below_the_top <= 2.0
+    assert everywhere > 5.0 * below_the_top
+
+
+# ----------------------------------------------- cross-kernel byte stability
+
+
+_FENCE = """
+import json
+from gen_worker.model.solvers.dpm_multistep import DPMSolverMultistep
+from gen_worker.model.solvers.unipc_multistep import UniPCMultistep
+sd = dict(num_train_timesteps=1000, beta_start=0.00085, beta_end=0.012,
+          beta_schedule="scaled_linear", timestep_spacing="leading", steps_offset=1,
+          final_sigmas_type="zero", solver_order=2)
+dpm = DPMSolverMultistep(**sd, use_karras_sigmas=True).schedule(30)
+unipc_flow = UniPCMultistep(use_flow_sigmas=True, prediction_type="flow_prediction",
+                            flow_shift=12.0).schedule(40)
+unipc_beta = UniPCMultistep(**sd, predict_x0=True).schedule(30)
+print(json.dumps({
+    "dpm": list(dpm.sigmas), "dpm_t": list(dpm.timesteps),
+    "unipc_flow": list(unipc_flow.sigmas), "unipc_flow_t": list(unipc_flow.timesteps),
+    "unipc_beta": list(unipc_beta.sigmas), "unipc_beta_t": list(unipc_beta.timesteps),
+}))
+"""
+
+
+def test_neither_solver_s_ladder_depends_on_which_cpu_kernel_torch_dispatched() -> None:
+    """The property the reference does NOT have, fenced — once per solver.
+
+    ``ATEN_CPU_CAPABILITY=default`` forces torch's scalar CPU kernels, whose
+    float32 ``linspace`` disagrees with the vectorized one on 145 of 1000
+    entries. Every sigma below is IEEE double arithmetic with explicit
+    narrowings, so the subprocess must produce the SAME BYTES — and, since the
+    loops above are conditioned at gain ~1, that is what makes a receipt's seed
+    mean the same thing on two pods.
+
+    The fence runs in a subprocess deliberately: the variable is read by torch at
+    IMPORT, so setting it in-process would prove nothing. It is also why this
+    module importing no array library is checkable rather than aspirational —
+    the subprocess never imports torch at all.
+    """
+
+    root = Path(__file__).resolve().parents[1] / "src"
+    result = subprocess.run(
+        [sys.executable, "-c", _FENCE],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root), "ATEN_CPU_CAPABILITY": "default"},
+    )
+    assert result.returncode == 0, result.stderr
+    scalar = json.loads(result.stdout.strip().splitlines()[-1])
+
+    here: dict[str, Any] = {
+        "dpm": DPMSolverMultistep(**SD_SCHEDULE, use_karras_sigmas=True).schedule(30),
+        "unipc_flow": UniPCMultistep(
+            use_flow_sigmas=True, prediction_type="flow_prediction", flow_shift=12.0
+        ).schedule(40),
+        "unipc_beta": UniPCMultistep(**SD_SCHEDULE, predict_x0=True).schedule(30),
+    }
+    for name, schedule in here.items():
+        assert tuple(scalar[name]) == schedule.sigmas, name
+        assert tuple(scalar[f"{name}_t"]) == schedule.timesteps, name
+
+
+# ------------------------------------------- what the reference cannot serve
+
+
+def test_a_v_prediction_karras_recipe_crashes_diffusers_and_serves_here() -> None:
+    """sd15's DEFAULT sampler on a v-prediction checkpoint. diffusers raises.
+
+    The enumeration, from the declared vocabulary rather than from intent:
+    ``Sd15Tuned.scheduler`` defaults to ``dpmpp_2m_karras``; the sd15 endpoint
+    declares ``objectives=("epsilon", "v_prediction")``; and ``gen_worker.view``
+    pairs v-prediction with ``rescale_betas_zero_snr``. That combination makes the
+    Karras ladder's recovered timestep grid start with a DUPLICATE — 999 twice —
+    and diffusers resolves a step index by SEARCHING for the timestep value,
+    taking the second match when there are two. Its counter is then one ahead for
+    the whole loop and it indexes off the end of its own sigma array.
+
+    Measured span: it raises at 25, 28, 30, 40, 50, 80, 100 and 150 steps, which
+    includes sd15's stamped default of 30 and sdxl's of 28. This module has no
+    such failure mode by construction — the step index is an ARGUMENT, never
+    recovered from a value — which is a correctness difference rather than a
+    performance one, and it is the reason this test asserts BOTH halves.
+    """
+
+    config = dict(
+        SD_SCHEDULE,
+        use_karras_sigmas=True,
+        prediction_type="v_prediction",
+        rescale_betas_zero_snr=True,
+    )
+    theirs = _dpm_reference(**config)
+    theirs.set_timesteps(30)
+    grid = theirs.timesteps.tolist()
+    assert grid[0] == grid[1], "the duplicate head is the mechanism"
+
+    sample = torch.randn(1, 4, 8, 8)
+    with pytest.raises(IndexError):
+        for timestep in theirs.timesteps:
+            sample = theirs.step(torch.randn(1, 4, 8, 8), timestep, sample).prev_sample
+
+    # And the same recipe, here.
+    ours = DPMSolverMultistep(**config).schedule(30)
+    sample, state = torch.randn(1, 4, 8, 8), ours.begin()
+    for index in range(len(ours)):
+        sample, state = ours.step(index, torch.randn(1, 4, 8, 8), sample, state)
+    assert torch.isfinite(sample).all()
+
+    # UniPC fails on the same ladder for the same reason, with a different
+    # exception, and is likewise served here.
+    unipc_config = dict(config, predict_x0=True, solver_type="bh2")
+    unipc_config.pop("algorithm_type", None)
+    reference = _unipc_reference(**unipc_config)
+    reference.set_timesteps(30)
+    sample = torch.randn(1, 4, 8, 8)
+    with pytest.raises((IndexError, AssertionError)):
+        for timestep in reference.timesteps:
+            sample = reference.step(torch.randn(1, 4, 8, 8), timestep, sample).prev_sample
+    mine = UniPCMultistep(**unipc_config).schedule(30)
+    sample, unipc_state = torch.randn(1, 4, 8, 8), mine.begin()
+    for index in range(len(mine)):
+        sample, unipc_state = mine.step(index, torch.randn(1, 4, 8, 8), sample, unipc_state)
+    assert torch.isfinite(sample).all()
+
+
+@pytest.mark.parametrize("steps", [4, 30])
+def test_bh1_makes_the_reference_return_nan_on_its_final_step(steps: int) -> None:
+    """The second thing this lane found in the reference, and it is a NaN.
+
+    ``bh1`` sets ``B_h = hh``. On the final step of a ladder that terminates at
+    zero — every configuration this fleet reaches — ``sigma_t`` is 0, so
+    ``lambda_t`` is ``+inf``, ``h`` is ``+inf`` and ``B_h`` is ``-inf``. That
+    step is first-order, so its residual is exactly zero, and diffusers still
+    evaluates ``alpha_t * B_h * 0``: **-inf times zero is NaN**, and the whole
+    latent comes back NaN.
+
+    This module never forms the product: a first-order step has no residual term
+    to add, so it returns the base update — which is the same value the reference
+    would produce in exact arithmetic. ``bh1`` is unreachable today (every mirror
+    in the fleet ships ``bh2``) and it is upstream's own recommendation for step
+    counts below 10, which wan's 4- and 8-step lanes are — so this is recorded
+    now rather than discovered by whoever first ships a ``bh1`` mirror.
+    """
+
+    config = dict(SD_SCHEDULE, solver_type="bh1", predict_x0=True, prediction_type="epsilon")
+    ours = UniPCMultistep(**config).schedule(steps)
+    theirs = _inject(_unipc_reference(**config), ours)
+
+    torch.manual_seed(4)
+    our_sample = torch.randn(1, 4, 8, 8)
+    their_sample = our_sample.clone()
+    state = ours.begin()
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(1, 4, 8, 8)
+        our_sample, state = ours.step(index, prediction, our_sample, state)
+        their_sample = theirs.step(prediction, timestep, their_sample).prev_sample
+        if index < steps - 1:
+            assert _rel_norm(our_sample.numpy(), their_sample.numpy()) <= RELATIVE
+
+    assert torch.isnan(their_sample).all(), "the reference's final bh1 step"
+    assert torch.isfinite(our_sample).all()
+    assert ours.sigmas[-1] == 0.0, "the terminal zero is what makes B_h infinite"
+
+
+# ---------------------------------------------------------------- refusals
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"solver_order": 3},
+        {"algorithm_type": "dpmsolver"},
+        {"algorithm_type": "deis"},
+        {"solver_type": "bh2"},
+        {"use_karras_sigmas": True, "use_flow_sigmas": True},
+        {"use_karras_sigmas": 1},
+        {"prediction_type": "sample"},
+        {"num_train_timesteps": 1.5},
+    ],
+)
+def test_a_dpm_block_is_parsed_not_coerced(block: dict[str, Any]) -> None:
+    """Every one of these changes the LADDER or the UPDATE, so none falls through."""
+
+    with pytest.raises(ModelError):
+        DPMSolverMultistep.from_block({**SD_SCHEDULE, **block})
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"solver_order": 3},
+        {"solver_type": "midpoint"},
+        {"predict_x0": False, "prediction_type": "flow_prediction"},
+        {"use_flow_sigmas": True, "flow_shift": 0.0},
+        {"use_exponential_sigmas": True, "use_karras_sigmas": True},
+    ],
+)
+def test_a_unipc_block_is_parsed_not_coerced(block: dict[str, Any]) -> None:
+    with pytest.raises(ModelError):
+        UniPCMultistep.from_block({**SD_SCHEDULE, **block})
+
+
+def test_a_stochastic_sampler_refuses_to_run_without_its_noise() -> None:
+    """``sde-dpmsolver++`` cannot invent a random tensor here, and must not.
+
+    This module imports no array library, so the caller owns the generator.
+    Defaulting the noise to zero would turn a stochastic sampler into a
+    deterministic one that still reported itself as SDE — the silent-failure
+    shape this package exists to remove. The mirror refusal matters as much: a
+    DETERMINISTIC sampler handed noise would ignore it, and a caller passing one
+    has selected the wrong sampler.
+    """
+
+    sde = DPMSolverMultistep(**SD_SCHEDULE, algorithm_type="sde-dpmsolver++").schedule(8)
+    sample = torch.randn(1, 4, 8, 8)
+    with pytest.raises(ModelError):
+        sde.step(0, torch.randn(1, 4, 8, 8), sample, sde.begin())
+
+    ode = DPMSolverMultistep(**SD_SCHEDULE).schedule(8)
+    with pytest.raises(ModelError):
+        ode.step(0, torch.randn(1, 4, 8, 8), sample, ode.begin(), noise=torch.zeros(1, 4, 8, 8))
+
+
+def test_a_step_outside_the_ladder_is_refused_by_both_solvers() -> None:
+    dpm = DPMSolverMultistep(**SD_SCHEDULE).schedule(4)
+    unipc = UniPCMultistep(**SD_SCHEDULE, predict_x0=True).schedule(4)
+    sample = torch.randn(1, 4, 8, 8)
+    for schedule, state in ((dpm, dpm.begin()), (unipc, unipc.begin())):
+        with pytest.raises(ModelError):
+            schedule.step(4, torch.randn(1, 4, 8, 8), sample, state)  # type: ignore[arg-type]
+        with pytest.raises(ModelError):
+            schedule.step(-1, torch.randn(1, 4, 8, 8), sample, state)  # type: ignore[arg-type]
+
+
+def test_the_declared_block_is_the_only_source_of_constants() -> None:
+    """A constant hardcoded in the math would be a second declaration of it.
+
+    The defaults are DIFFUSERS' class defaults — linear betas over [1e-4, 2e-2],
+    ``linspace`` spacing, ``flow_shift`` 1.0 — and no model in this fleet was
+    trained on any of them. A family that forgot to declare its schedule resolves
+    to a plausible, wrong one, which is the failure this asserts is still loud.
+    """
+
+    assert DPMSolverMultistep().beta_schedule == "linear"
+    assert DPMSolverMultistep().timestep_spacing == "linspace"
+    assert DPMSolverMultistep().algorithm_type == "dpmsolver++"
+    assert UniPCMultistep().solver_type == "bh2" and UniPCMultistep().predict_x0 is True
+    assert UniPCMultistep().flow_shift == 1.0
+
+    declared = UniPCMultistep.from_block(
+        {"use_flow_sigmas": True, "prediction_type": "flow_prediction", "flow_shift": 12.0}
+    )
+    assert declared.flow_shift == 12.0
+    # wan re-shifts per REQUEST and the rebuild must keep the flow reading.
+    reshifted = declared.shifted(3.0)
+    assert reshifted.flow_shift == 3.0
+    assert reshifted.use_flow_sigmas and reshifted.prediction_type == "flow_prediction"
+    with pytest.raises(ModelError):
+        UniPCMultistep(**SD_SCHEDULE, predict_x0=True).shifted(5.0)
+
+
+def test_a_v_prediction_checkpoint_carries_the_zero_snr_rescale_with_it() -> None:
+    """``objective()`` reproduces the pairing ``gen_worker.view`` already makes."""
+
+    for build in (DPMSolverMultistep, UniPCMultistep):
+        base = build(**SD_SCHEDULE)  # type: ignore[arg-type]
+        assert base.objective("epsilon") is base
+        v_pred = base.objective("v_prediction")
+        assert v_pred.prediction_type == "v_prediction" and v_pred.rescale_betas_zero_snr
+        assert v_pred.schedule(28).sigmas != base.schedule(28).sigmas
+        with pytest.raises(ModelError):
+            base.objective("sample")
+
+
+def test_neither_solver_scales_its_model_input() -> None:
+    """The trap ``euler_discrete`` sets for whoever writes the second loop.
+
+    ``EulerDiscrete`` REQUIRES ``scale_model_input`` — skipping it feeds a U-Net
+    latents whose variance grows with sigma. Both solvers here require the
+    opposite: diffusers' own ``scale_model_input`` is the identity for them, so a
+    loop that copies Euler's shape and scales anyway destroys the render with no
+    error. Asserted against the reference so the claim is theirs, not ours.
+    """
+
+    diffusers = pytest.importorskip("diffusers")
+    sample = torch.randn(1, 4, 8, 8)
+    for reference in (
+        diffusers.DPMSolverMultistepScheduler(**SD_SCHEDULE),
+        diffusers.UniPCMultistepScheduler(**SD_SCHEDULE),
+    ):
+        reference.set_timesteps(8)
+        assert torch.equal(reference.scale_model_input(sample, reference.timesteps[0]), sample)
+    assert not hasattr(DPMSolverMultistep(**SD_SCHEDULE).schedule(8), "scale_model_input")
+    assert not hasattr(
+        UniPCMultistep(**SD_SCHEDULE, predict_x0=True).schedule(8), "scale_model_input"
+    )
+
+
+def test_the_solver_modules_import_no_array_library() -> None:
+    """The adopt-only serve role holds this package for free, and it stays true.
+
+    Checked by reading the SOURCE rather than by inspecting ``sys.modules``: this
+    test file has already imported torch, so a runtime check would prove nothing.
+    """
+
+    import ast
+
+    package = Path(__file__).resolve().parents[1] / "src" / "gen_worker" / "model" / "solvers"
+    banned = {"torch", "numpy", "diffusers", "scipy"}
+    for source in sorted(package.glob("*.py")):
+        tree = ast.parse(source.read_text())
+        # `if TYPE_CHECKING: from torch import Tensor` is not an import — it is
+        # an annotation, erased at runtime by `from __future__ import
+        # annotations`. Stripped rather than allowlisted, so a REAL torch import
+        # anywhere else still trips this.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.If) and "TYPE_CHECKING" in ast.dump(node.test):
+                node.body = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = {alias.name.split(".")[0] for alias in node.names}
+            elif isinstance(node, ast.ImportFrom):
+                names = {(node.module or "").split(".")[0]}
+            else:
+                continue
+            assert not names & banned, f"{source.name} imports {names & banned}"
+    # `math` and `struct` are the whole numeric surface.
+    assert math.sqrt(4.0) == 2.0


### PR DESCRIPTION
The two multistep solvers the DiT fleet actually renders on, as pure modules under
`gen_worker/model/solvers/` — sigmas, multistep state and update rules, each in its own file,
importing no `torch`, no `numpy` and no `diffusers`. `SchedulerKind` gains `dpmsolver_multistep`
and `unipc_multistep`; `IMPLEMENTED` stays total, so a K10 scheduler-SET can wire them without
touching the math.

## The reachable enumeration, from the endpoints

`gen_worker.view.SAMPLERS` DEFINES each named sampler completely — endpoints select names, never
configurations — so it is the only honest source for "what does `dpmpp_2m_karras` mean here".

| solver | reachable spelling | configuration | who reaches it |
|---|---|---|---|
| DPM++ | `dpmpp_2m` | order 2, `final_sigmas_type=zero` | sd15, sd2 recipe enums |
| DPM++ | `dpmpp_2m_karras` | + `use_karras_sigmas` | **sd15's DEFAULT**, sdxl |
| DPM++ | `dpmpp_2m_sde_karras` | + `algorithm_type=sde-dpmsolver++` | sdxl — **STAMPED** on `cyberrealistic-pony` and `cyberrealistic-xl`, 30 steps |
| DPM++ | `dpmpp_2m_sde` | defined in `SAMPLERS`, in no enum and no recipe | **nobody** — supported anyway (one boolean from a reachable row), recorded as unreachable |
| UniPC | flow lane | `use_flow_sigmas`, `flow_prediction`, order 2, `bh2`, `predict_x0`, `lower_order_final`, `final_sigmas_type=zero`, `linspace` | wan-2.2's mirrors, at `flow_shift` 12.0 (curated T2V) / 5.0 (TI2V-5B mirror) / 3.0 (A14B mirror + I2V), over 1/4/8/12/40/50/80 steps |
| UniPC | diffusion lane | SD betas, `leading`, `steps_offset=1` | sd15's and sd2's `unipc` recipe name |

**Corrections to the batch plan, verified at the endpoints:**

- **hidream-o1-image does NOT reach `DPMSolverMultistep`.** Its only DPM references are
  "Copied from" comments inside `fm_solvers_unipc.py`. It reaches a UniPC only.
- **hidream's UniPC is not this UniPC, and declaring `unipc_multistep` for it would change its
  render.** Its vendored `FlowUniPCMultistepScheduler` applies the shift TWICE — once in
  `__init__` to the 1000-entry base array, once in `set_timesteps` to the resampled ladder.
  Measured against the diffusers flow ladder at shift 3.0: up to **2.7e-3 absolute** sigma
  difference, and timestep **974 vs 975** at 28 steps. Its `sigma_max` is a shifted value fed
  back into the shift map. That is an endpoint-owned deviation, not a bug this lane may absorb.
- **Nothing** in qwen-image, qwen-image-svdq-bench, z-image, anima, ernie, flux.2-klein-4b/9b,
  ltx-video-2.3 or minimax-h3 reaches either solver. anima's README says so outright; minimax-h3
  ships its own vendored `MiniMaxH3Scheduler`.
- `use_exponential_sigmas` and `use_beta_sigmas` are set true **nowhere** reachable.
  `use_karras_sigmas` arrives ONLY through the two `*_karras` sampler names — no checkpoint
  config supplies it.

## Verification — B2's instrument, per solver

Sigmas RELATIVE at 2e-4; timesteps EXACT; loops in the L2 NORM with our ladder injected into the
reference; a cross-kernel byte-stability subprocess fence per solver. Never element-wise relative
on a zero-crossing tensor, never a ULP bound against a torch-derived reference.

| claim | DPM-Solver++ | UniPC |
|---|---|---|
| ladder configs differenced | **88** (karras x algorithm x objective x 11 real step counts) | **65** (21 flow: 3 served shifts x 7 step counts; 44 diffusion: `bh1`/`bh2` x objective x 11) |
| sigma agreement | **0.0 relative** (bound 2e-4) | **0.0 relative** (bound 2e-4) |
| timestep agreement | **EXACT**, every config | **EXACT**, every config |
| `init_noise_sigma` | **1.0 on both sides** (not the top of the ladder — that is `euler_discrete`) | same |
| loop agreement, ladder injected | **1.5e-6 rel-L2** worst over 124 runnable configs | **2.4e-6 rel-L2** worst over 98 |
| cross-kernel byte stability | **identical bytes** under `ATEN_CPU_CAPABILITY=default` (sigmas AND timesteps) | same, both ladders |
| gain (5e-6 ladder perturbation) | **1.026** @30, **0.996** @4, **1.128** sde @30 | **1.036** diffusion @30; flow lane below |

**Why the loop is not bit-exact even with the table removed**, stated and bounded rather than
tolerated: a multistep coefficient passes through `exp`/`log`/`expm1`, which torch evaluates on a
float32 tensor in float32 where this module evaluates in double and narrows once. Ours is the more
accurate and the more deterministic of the two, by the same argument `math.sqrt` beats `pow` one
level down. The residual is asserted `0 < r <= 1e-5` — three orders inside the file's own
tolerance, so a real arithmetic error still goes red.

**wan's own committed fixture reproduced from first principles**: `[999, 973, 923, 800]` at 4
steps / shift 12. It pins the two details a re-derivation gets wrong — the timestep cast
TRUNCATES (0.973013 is 973), and the top rung is nudged down by exactly `1e-6` so
`alpha_t = 1 - sigma` is not zero.

## Multistep state, and the reproducibility story

diffusers carries `model_outputs`, `last_sample`, `this_order` and two counters as MUTABLE state
on the scheduler — which is why a served pipeline must be cloned per request. Here the state is a
frozen VALUE: `begin()` is the only constructor and takes nothing, `step()` returns the next
history alongside the sample.

- **Initialization is total and constant** — no seed, no device, no clock in the initial
  condition, so two pods start identical by construction rather than by discipline.
- **There is no counter to share** — a test advances two requests ALTERNATELY on ONE schedule
  object and asserts each is byte-identical to running it alone. diffusers structurally cannot.
- **The recursion is closed over reproducible inputs** — every scalar folded into it comes from a
  ladder proven byte-stable across CPU kernels, and the gain measurements above say a ladder
  difference propagates ~1:1 rather than chaotically. That is what makes byte-stability a
  correctness property and not a nicety.

**The one lane that is NOT gain-1, recorded rather than smoothed.** On wan's flow ladder
`alpha_t = 1 - sigma`, and the top rung sits at `1 - 1e-6` — so `alpha_t` there is `1e-6`, and a
5e-6 *relative* nudge of that sigma is a five-fold relative change in `alpha`, which enters the
first predictor coefficient through `log`. Measured gain **7.7 at 50 steps rising to ~249 at 4**;
exclude the top rung and it is 0.78-0.91, like every other lane. Neither implementation is wrong —
both resolve that ladder in float64 with no torch primitive involved, so nothing disagrees about
it today — but it says which constant in this package is load-bearing.

## Two defects in the reference, both on configurations this fleet can select

1. **`dpmpp_2m_karras` + v-prediction raises `IndexError` in diffusers.** `gen_worker.view` always
   pairs v-prediction with `rescale_betas_zero_snr`; that makes the Karras ladder's recovered
   timestep grid start with a DUPLICATE (999 twice). diffusers resolves a step index by SEARCHING
   for the timestep value and takes the second match when there are two, so its counter runs one
   ahead for the whole loop and it indexes off the end of its own sigma array. Measured span:
   **25, 28, 30, 40, 50, 80, 100 and 150 steps** — which includes sd15's stamped default of 30 and
   sdxl's of 28. UniPC fails the same ladder with an `AssertionError`.
2. **`solver_type="bh1"` returns an ALL-NaN latent on its final step.** A ladder terminating at
   zero makes `B_h` `-inf`, the final step is first-order so its residual is exactly zero, and
   diffusers still evaluates `alpha_t * B_h * 0`. `bh1` is unreachable today (every mirror ships
   `bh2`) but it is upstream's own recommendation below 10 steps, which wan's 4- and 8-step lanes
   are.

Neither failure mode exists here — the step index is an ARGUMENT, never recovered from a value,
and a first-order step forms no residual term at all — and both are asserted against the real
reference so they cannot rot into prose.

## What is deliberately NOT implemented

`solver_order=3` (every mirror and every sampler-table row is second order); the deprecated
noise-prediction `algorithm_type`s `dpmsolver`/`sde-dpmsolver` (diffusers removes them in 1.0);
`use_beta_sigmas` (needs `scipy`, reached by nothing); `solver_p`; a declarable `disable_corrector`
(a block holds finite JSON scalars, not lists, and it is `[]` on every mirror).
`use_exponential_sigmas` IS implemented and differenced against `_convert_to_exponential` — it is
the sibling branch of Karras inside one `set_timesteps`, and a solver with one branch of a
two-branch switch has an untested edge — with a test asserting no sampler selects it.

## Structure

`solvers/precision.py` now holds the float32 discipline `euler_discrete` carried privately, so the
trained noise table has ONE definition across three solvers rather than three copies of a family
fact. `solvers/block.py` holds the declared-block readers. `solvers/ladders.py` holds every ladder
and timestep grid as pure functions — including `discrete_timesteps`, which is deliberately NOT
shared with `EulerDiscrete._timesteps`: the multistep grid spaces over `steps + 1` points and
drops one where Euler spaces over `steps`, a stride of 34 vs 35 at 28 steps, and folding them
together is how two families quietly become one schedule.

## Gates

- `tests/test_dit_solvers_pgw1346.py` **224 passed** under auto-dispatch **AND** under
  `ATEN_CPU_CAPABILITY=default` (both kernels, deliberately).
- The affected surface — flux/sd15/sdxl stage-1, model SDK, declaration axes, SDK v2, objectives,
  model absence — **532 passed**.
- `mypy src/gen_worker tests tests_v2` **Success on 877 files**;
  `ruff check src/gen_worker scripts/mint_rig` clean;
  `check_model_bindings.py` **4 pairs byte-clean** (no declaration changed, so no export digest
  moved); `lint_serve_role_closure`, `lint_unreached_surface`, `lint_config_reads`,
  `lint_fence_symbols`, `lint_mypy_ratchet`, `lint_retired_sdk_spellings`,
  `lint_layout_declarations` all green.

## Integration with K10

No catalog declaration names either kind yet, and none can: `GraphModelSpec.scheduler` is ONE
`Scheduler` block and codegen emits ONE `scheduler()` method, which is exactly the blocker B2
raised as **K10** (the sampler is a TUNED value; the declaration needs a scheduler SET keyed by
tuned name). This PR is the math half and is complete without it — the classes are re-exported
from `gen_worker.model.scheduler` so the generator can import them by the name `IMPLEMENTED`
carries, and a test asserts that re-export holds for every kind. When K10 lands, wiring is a
declaration change with no math change.

**Not touched, per scope:** no endpoint, no catalog declaration, no pod.