### PR TITLE
pgw#1339: a changelog fragment is dated by its issue's COMMITS, not by the fragment file

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -242,6 +242,24 @@ the bullet is appended to that existing section under the *attributed after the
 cut* note — one heading, in place, with every unrelated fragment left pending.
 Dry-run it first and read the pending list.
 
+### One issue, many lanes: `pgw1346-<suffix>.md` (pgw#1339)
+
+A fragment name is `<prefix><number>[-<suffix>].md`. **The suffix exists because
+`changelog.d/pgw1346.md` became a shared path again** — around ten batch lanes
+appended to the one file, which re-serialised the merge queue and ejected PRs as
+`CONFLICTING` (pgw#916 twice), the precise failure `changelog.d/` was built to
+remove. A lane of a batched issue writes its own file:
+
+```
+changelog.d/pgw1346-b3-math.md      changelog.d/pgw1346-b4-video.md
+```
+
+Disjoint paths, so they cannot conflict; the same issue number, so they are dated
+by the same commits and land **adjacent in one section**, unsuffixed file first
+then suffixes in order. **The `<prefix><number>` core is never optional** — it is
+what dates and orders the fragment — so `pgw-b3-math.md` or `b3-math.md` is
+refused by `--check` at the lane's own PR, not at the cut.
+
 `--cut-ref` (default `HEAD`) names the commit being released. Cutting from an
 older commit — which `docs/releasing.md` tells you to do when a lane's red is not
 yours — means work merged after it is not in your wheel, so pass the same ref you

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -203,7 +203,49 @@ now prints each fragment as `pending` or `consumed -> <version>`.
 
 **`--version` with nothing pending for it is not an error** — it is how a
 mis-attribution is repaired without cutting: the older sections are corrected, no
-new section is written, and the tool says so.
+new section is written, and the tool says so. **Nothing assembled AT ALL is a
+refusal** (exit 1, nothing written): naming a version no pending fragment belongs
+to is a mistyped invocation, not a repair.
+
+### The version is derived from the WORK, not from the fragment file (pgw#1339)
+
+**What this replaces, and it bit two cutters in two days:** attribution used to
+read the commit that added the fragment FILE. A fragment that does not exist yet —
+the case a repair is *for* — has no such commit, so it took the
+"in no tag → the version being cut" fallback, and so did every other pending
+fragment. `--version 0.121.0`, run to date one late fragment into an
+already-released section, therefore swept **every** pending fragment into
+`## 0.121.0`: 5 on the first attempt, **16** on the second, including work that
+had shipped in no wheel at all. The recipe was safe only when nothing else was
+pending, which on this repo is never.
+
+A fragment is now dated by its issue's **authored commits** — the ones whose
+SUBJECT says `pgw#1323:`, not the ones whose body mentions it — falling back to
+the fragment file's own commit only when no subject names the issue. It is
+assembled into the earliest release tag whose tree contains **all** of them; a
+note is true only once everything it describes has shipped. Work in no tag rides
+the version being cut, **and only if that version is not already released** — the
+guard that tells a repair from a cut. Anything else stays pending and is printed:
+
+```
+$ scripts/assemble_changelog.py --version 0.121.0 --dry-run
+pgw1323.md -> 0.121.0 (late; its code shipped in v0.121.0)
+1 fragment(s) pending, not in 0.121.0:
+  pgw1356.md: its work (commit subjects: e95000c7, 5c574917) is in no release tag,
+  and 0.121.0 is already released -- unshipped work cannot be dated into it
+```
+
+**Repairing a silent release note is now the documented one-liner it always
+claimed to be:** write `changelog.d/<issue>.md`, run
+`assemble_changelog.py --version <the version whose tag contains the work>`, and
+the bullet is appended to that existing section under the *attributed after the
+cut* note — one heading, in place, with every unrelated fragment left pending.
+Dry-run it first and read the pending list.
+
+`--cut-ref` (default `HEAD`) names the commit being released. Cutting from an
+older commit — which `docs/releasing.md` tells you to do when a lane's red is not
+yours — means work merged after it is not in your wheel, so pass the same ref you
+are tagging and the tool will hold those fragments for the next cut.
 
 ### SWEEP THE FRAGMENTS AGAINST `origin/master`, NOT YOUR CHECKOUT
 

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -23,6 +23,11 @@ change; the change is the thing a release note dates. So
     that version is not itself already released and the work is in the cut ref.
     Otherwise the fragment stays PENDING and is listed, never swept.
 
+A fragment name may carry a per-lane suffix -- `pgw1346-b3-math.md` -- so the
+lanes of one batched issue write DISJOINT paths instead of queueing behind a
+shared `pgw1346.md`. The `<prefix><number>` core is what dates and orders it, so
+it stays mandatory; the suffix is only a filename.
+
 Two failures this kills, both observed:
 
   * 0.114.3 shipped pgw#1244's code with changelog.d/pgw1244.md unconsumed, and
@@ -52,8 +57,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-# <prefix><number>.md -- prefix names the id space (pgw, th, te, ...).
-NAME = re.compile(r"^(?P<prefix>[a-z]+)(?P<number>\d+)$")
+# <prefix><number>[-<suffix>].md -- prefix names the id space (pgw, th, te, ...).
+#
+# The optional suffix is pgw#1346's lesson: ~10 lanes of one batched issue were
+# all appending to a single `pgw1346.md`, which re-serialised the merge queue on
+# a shared path and cost repeated CONFLICTING ejections -- the exact failure
+# `changelog.d/` exists to remove. `pgw1346-b3-math.md` and `pgw1346-b4-video.md`
+# are disjoint files that still resolve to issue pgw#1346 for dating, and land
+# adjacent in the section. The <prefix><number> core stays mandatory: it is what
+# attribution keys on, so a suffix can never smuggle in an undatable fragment.
+NAME = re.compile(
+    # A 2+ letter prefix, so a suffixed name cannot be read as one: `b3-math`
+    # would otherwise parse as issue b#3 and be dated by nothing.
+    r"^(?P<prefix>[a-z]{2,})(?P<number>\d+)(?:-(?P<suffix>[a-z0-9][a-z0-9-]*))?$"
+)
 UNRELEASED = re.compile(r"^## Unreleased\b.*?(?=^## )", re.M | re.S)
 VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 RELEASE_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
@@ -111,7 +128,10 @@ def read_ledger(root: Path) -> list[tuple[str, str]]:
         if not VERSION.match(version):
             sys.exit(f"{path}:{lineno}: {version!r} is not an X.Y.Z version")
         if not NAME.match(stem):
-            sys.exit(f"{path}:{lineno}: {stem!r} is not a <prefix><number> fragment")
+            sys.exit(
+                f"{path}:{lineno}: {stem!r} is not a "
+                "<prefix><number>[-<suffix>] fragment"
+            )
         if stem in seen:
             sys.exit(f"{path}:{lineno}: {stem} is recorded twice")
         seen.add(stem)
@@ -124,10 +144,16 @@ def write_ledger(root: Path, rows: list[tuple[str, str]]) -> None:
     ledger_path(root).write_text(LEDGER_HEADER + body)
 
 
-def collect(root: Path) -> tuple[list[tuple[int, str, Path]], list[tuple[str, Path]]]:
-    """(pending, consumed) fragments -- pending ordered by issue NUMBER."""
+def collect(
+    root: Path,
+) -> tuple[list[tuple[int, str, str, Path]], list[tuple[str, Path]]]:
+    """(pending, consumed) fragments.
+
+    Pending is ordered by issue NUMBER, then by suffix -- so one issue's
+    per-lane fragments land adjacent in the section, unsuffixed one first.
+    """
     consumed_at = {stem: version for version, stem in read_ledger(root)}
-    pending: list[tuple[int, str, Path]] = []
+    pending: list[tuple[int, str, str, Path]] = []
     consumed: list[tuple[str, Path]] = []
     for path in fragments_dir(root).glob("*.md"):
         if path.name == "README.md":
@@ -135,15 +161,17 @@ def collect(root: Path) -> tuple[list[tuple[int, str, Path]], list[tuple[str, Pa
         m = NAME.match(path.stem)
         if not m:
             sys.exit(
-                f"{path}: name must be <prefix><number>.md (e.g. pgw968.md); "
-                "the number is what orders the release section."
+                f"{path}: name must be <prefix><number>[-<suffix>].md "
+                "(e.g. pgw968.md, or pgw1346-b3-math.md for one lane of a "
+                "batched issue); the number is what orders the release section "
+                "and what dates the fragment, so it is never optional."
             )
         if not path.read_text().strip():
             sys.exit(f"{path}: empty fragment")
         if path.stem in consumed_at:
             consumed.append((consumed_at[path.stem], path))
             continue
-        pending.append((int(m["number"]), m["prefix"], path))
+        pending.append((int(m["number"]), m["prefix"], m["suffix"] or "", path))
     return sorted(pending), sorted(consumed)
 
 
@@ -215,6 +243,7 @@ class Work:
     """What a fragment's issue actually shipped in, derived from git."""
 
     stem: str
+    issue: str  # `pgw#1346` -- the suffix does not date anything
     commits: tuple[str, ...]
     from_subject: bool
     released_in: str | None  # earliest release tag containing ALL of `commits`
@@ -226,6 +255,7 @@ def resolve(
     m = NAME.match(path.stem)
     assert m is not None, path  # collect() already refused anything else
     key = f"{m['prefix']}{int(m['number'])}"
+    issue = f"{m['prefix']}#{int(m['number'])}"
     commits = list(dict.fromkeys(index.get(key, [])))
     from_subject = bool(commits)
     if not commits and (added := added_commit(root, path)):
@@ -236,7 +266,7 @@ def resolve(
             cache[commit] = containing_versions(root, commit)
         contained = cache[commit] if contained is None else contained & cache[commit]
     released_in = min(contained, key=version_key) if contained else None
-    return Work(path.stem, tuple(commits), from_subject, released_in)
+    return Work(path.stem, issue, tuple(commits), from_subject, released_in)
 
 
 def render(body: list[Path]) -> str:
@@ -273,7 +303,7 @@ def held_reason(work: Work, cutting: str, cutting_released: bool, ref: str) -> s
     """Why a fragment is not being assembled -- printed, never silent."""
     if not work.commits:
         return (
-            f"no commit subject names {work.stem}, and the fragment file is not "
+            f"no commit subject names {work.issue}, and the fragment file is not "
             f"committed: nothing proves it shipped in {cutting}"
         )
     where = "commit subjects" if work.from_subject else "the fragment's add commit"
@@ -288,7 +318,7 @@ def held_reason(work: Work, cutting: str, cutting_released: bool, ref: str) -> s
 
 def plan_versions(
     root: Path,
-    pending: list[tuple[int, str, Path]],
+    pending: list[tuple[int, str, str, Path]],
     cutting: str,
     cutting_released: bool,
     cut_ref: str,
@@ -298,7 +328,7 @@ def plan_versions(
     by_version: dict[str, list[Path]] = {}
     held: list[tuple[Path, str]] = []
     cache: dict[str, set[str]] = {}
-    for _, _, path in pending:
+    for *_, path in pending:
         work = resolve(root, path, index, cache)
         if work.released_in is not None:
             by_version.setdefault(work.released_in, []).append(path)
@@ -333,7 +363,7 @@ def main() -> int:
     pending, consumed = collect(root)
 
     if args.check:
-        for _, _, path in pending:
+        for *_, path in pending:
             print(f"pending  {path.relative_to(root)}")
         for version, path in consumed:
             print(f"consumed {path.relative_to(root)} -> {version}")

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -60,6 +60,14 @@ RELEASE_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
 # `pgw#1323: ...`, `th#2082 follow-up: ...` -- an issue reference in a commit
 # SUBJECT. Bodies are excluded on purpose: a body cites related issues, a
 # subject claims authorship of the change.
+#
+# Every ref in the subject counts, not just the leading one: 8 of the last 451
+# subjects here trail it (`ci: fence the launch boundary (pgw#1239)`), and
+# dropping those would date those fragments by the wrong signal. The cost is
+# that a subject cross-referencing a second issue (67 of 451) lends it a commit
+# it did not author -- which the all-commits rule below fails SAFE on: a stray
+# commit outside a tag only ever moves a fragment LATER or into the printed
+# pending list, never into a wheel that lacks the change.
 SUBJECT_REF = re.compile(r"(?<![0-9a-z])(?P<prefix>[a-z]+)#0*(?P<number>\d+)(?![0-9])")
 
 LEDGER = "consumed.tsv"

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -8,20 +8,36 @@ them here.
 
 pgw#1226: a cut MARKS the fragments it consumed in changelog.d/consumed.tsv; it
 no longer deletes them, and it does not decide which version a fragment belongs
-to. That is DERIVED: a fragment is attributed to the earliest release tag whose
-tree contains it, and to the version being cut if no tag contains it. So
+to. That is DERIVED from git.
 
-  * a fragment that lands after the tag is in no tag, and rides the NEXT cut;
-  * a fragment that was in a TAGGED tree and never got assembled is attributed
-    BACK to that version instead of being silently re-dated to this one.
+pgw#1339: what is derived is the version containing the fragment's SUBJECT WORK,
+not the version containing the fragment FILE. A fragment is a document about a
+change; the change is the thing a release note dates. So
 
-The second case is the failure this replaces. 0.114.3 shipped pgw#1244's code
-with changelog.d/pgw1244.md still unconsumed, and under the old tooling the next
-cut would have written that bullet under its own version -- a release note
-pointing at the wrong wheel, with nothing in the tree able to notice.
+  * the issue's authored commits are resolved from commit SUBJECTS
+    (`pgw#1323: ...`), falling back to the commit that added the fragment file
+    when no subject names the issue;
+  * the fragment is attributed to the earliest release tag whose tree contains
+    ALL of them -- a note is only true once everything it describes has shipped;
+  * if no tag contains them it belongs to the version being cut, and only if
+    that version is not itself already released and the work is in the cut ref.
+    Otherwise the fragment stays PENDING and is listed, never swept.
+
+Two failures this kills, both observed:
+
+  * 0.114.3 shipped pgw#1244's code with changelog.d/pgw1244.md unconsumed, and
+    the old tooling would have written that bullet under the NEXT version -- a
+    release note pointing at a wheel that did not contain the change.
+  * `--version 0.121.0`, run to date ONE late fragment into an already-released
+    section, dated every other pending fragment to 0.121.0 as well: 16 of them
+    on the 0.123.0 cutter's tree, including work that had shipped in no wheel at
+    all. The old rule's "in no tag -> the version being cut" fallback cannot
+    tell a repair from a cut. This one can: those 16 are in no tag AND 0.121.0
+    is already released, so they stay pending.
 
     scripts/assemble_changelog.py --check
     scripts/assemble_changelog.py --version 0.92.0 --headline "**what changed**"
+    scripts/assemble_changelog.py --version 0.121.0   # repair: append-only
 """
 
 from __future__ import annotations
@@ -31,6 +47,7 @@ import datetime as dt
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -40,6 +57,10 @@ NAME = re.compile(r"^(?P<prefix>[a-z]+)(?P<number>\d+)$")
 UNRELEASED = re.compile(r"^## Unreleased\b.*?(?=^## )", re.M | re.S)
 VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 RELEASE_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+# `pgw#1323: ...`, `th#2082 follow-up: ...` -- an issue reference in a commit
+# SUBJECT. Bodies are excluded on purpose: a body cites related issues, a
+# subject claims authorship of the change.
+SUBJECT_REF = re.compile(r"(?<![0-9a-z])(?P<prefix>[a-z]+)#0*(?P<number>\d+)(?![0-9])")
 
 LEDGER = "consumed.tsv"
 LEDGER_HEADER = (
@@ -47,9 +68,10 @@ LEDGER_HEADER = (
     "# contains them. Written by scripts/assemble_changelog.py; lanes never edit it.\n"
     "# <version>\\t<fragment stem>\n"
 )
+LATE_NOTE_MARK = "*Attributed after the cut (pgw#1226)"
 LATE_NOTE = (
-    "*Attributed after the cut (pgw#1226): this fragment was in the tagged tree "
-    "and was not assembled into the section at cut time.*"
+    f"{LATE_NOTE_MARK}: the change below shipped in this version's tag and was "
+    "not assembled into the section at cut time.*"
 )
 # Consumed fragments stay on disk for this many PRIOR releases, so that a
 # fragment a recently-merged branch could still be carrying is never removed
@@ -126,27 +148,87 @@ def git(root: Path, *args: str) -> str:
     return done.stdout.strip()
 
 
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
 def release_versions(root: Path) -> list[str]:
     """Released versions, oldest first."""
     tags = git(root, "tag", "--list", "v*", "--sort=v:refname").splitlines()
     return [m["version"] for t in tags if (m := RELEASE_TAG.match(t.strip()))]
 
 
-def attribution(root: Path, path: Path, cutting: str) -> str:
-    """The earliest released version whose tree holds this fragment, else `cutting`.
+def subject_index(root: Path, refs: list[str]) -> dict[str, list[str]]:
+    """`pgw1323` -> the commits whose SUBJECT claims that issue.
 
-    Derived rather than declared: the cutter cannot mis-remember which sweep
-    they ran, and a fragment that shipped inside a tag cannot be re-dated.
+    One `git log` pass over the whole search space, because doing it per
+    fragment is the same history walked N times. Merges are excluded: a merge
+    subject names the PR number, not the issue, and its parents are here anyway.
+
+    The space is the cut ref, HEAD and the release tags -- deliberately NOT
+    `--all`: every open lane worktree carries commits whose subjects claim an
+    issue, and letting unmerged work count would hold that issue's fragment out
+    of a cut it genuinely belongs in.
     """
+    index: dict[str, list[str]] = {}
+    out = git(root, "log", "--no-merges", "--format=%H%x1f%s", *refs)
+    for line in out.splitlines():
+        commit, _, subject = line.partition("\x1f")
+        for m in SUBJECT_REF.finditer(subject):
+            key = f"{m['prefix']}{int(m['number'])}"
+            index.setdefault(key, []).append(commit)
+    return index
+
+
+def added_commit(root: Path, path: Path) -> str:
+    """The commit that added this fragment FILE, or '' if it is uncommitted."""
     rel = path.relative_to(root).as_posix()
-    added = git(root, "log", "--diff-filter=A", "--format=%H", "-1", "--", rel)
-    if not added:
-        return cutting  # not committed yet -- it is this cut's own
-    contains = git(root, "tag", "--contains", added, "--sort=v:refname").splitlines()
-    for tag in contains:
-        if m := RELEASE_TAG.match(tag.strip()):
-            return m["version"]
-    return cutting
+    return git(root, "log", "--diff-filter=A", "--format=%H", "-1", "--", rel)
+
+
+def containing_versions(root: Path, commit: str) -> set[str]:
+    tags = git(root, "tag", "--contains", commit).splitlines()
+    return {m["version"] for t in tags if (m := RELEASE_TAG.match(t.strip()))}
+
+
+def is_ancestor(root: Path, commit: str, ref: str) -> bool:
+    done = subprocess.run(
+        ("git", "merge-base", "--is-ancestor", commit, ref),
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return done.returncode == 0
+
+
+@dataclass(frozen=True)
+class Work:
+    """What a fragment's issue actually shipped in, derived from git."""
+
+    stem: str
+    commits: tuple[str, ...]
+    from_subject: bool
+    released_in: str | None  # earliest release tag containing ALL of `commits`
+
+
+def resolve(
+    root: Path, path: Path, index: dict[str, list[str]], cache: dict[str, set[str]]
+) -> Work:
+    m = NAME.match(path.stem)
+    assert m is not None, path  # collect() already refused anything else
+    key = f"{m['prefix']}{int(m['number'])}"
+    commits = list(dict.fromkeys(index.get(key, [])))
+    from_subject = bool(commits)
+    if not commits and (added := added_commit(root, path)):
+        commits = [added]
+    contained: set[str] | None = None
+    for commit in commits:
+        if commit not in cache:
+            cache[commit] = containing_versions(root, commit)
+        contained = cache[commit] if contained is None else contained & cache[commit]
+    released_in = min(contained, key=version_key) if contained else None
+    return Work(path.stem, tuple(commits), from_subject, released_in)
 
 
 def render(body: list[Path]) -> str:
@@ -175,14 +257,64 @@ def append_to_section(text: str, version: str, body: list[Path]) -> str:
             f"{', '.join(p.stem for p in body)} to. That version is released and "
             "its section should exist; do not invent one."
         )
-    note = "" if LATE_NOTE in m.group(0) else f"{LATE_NOTE}\n\n"
+    note = "" if LATE_NOTE_MARK in m.group(0) else f"{LATE_NOTE}\n\n"
     return text[: m.end()] + f"{note}{render(body)}\n\n" + text[m.end() :]
+
+
+def held_reason(work: Work, cutting: str, cutting_released: bool, ref: str) -> str:
+    """Why a fragment is not being assembled -- printed, never silent."""
+    if not work.commits:
+        return (
+            f"no commit subject names {work.stem}, and the fragment file is not "
+            f"committed: nothing proves it shipped in {cutting}"
+        )
+    where = "commit subjects" if work.from_subject else "the fragment's add commit"
+    short = ", ".join(c[:8] for c in work.commits)
+    if cutting_released:
+        return (
+            f"its work ({where}: {short}) is in no release tag, and {cutting} is "
+            f"already released -- unshipped work cannot be dated into it"
+        )
+    return f"its work ({where}: {short}) is not in {ref}"
+
+
+def plan_versions(
+    root: Path,
+    pending: list[tuple[int, str, Path]],
+    cutting: str,
+    cutting_released: bool,
+    cut_ref: str,
+    index: dict[str, list[str]],
+) -> tuple[dict[str, list[Path]], list[tuple[Path, str]]]:
+    """Split the pending fragments into {version: fragments} and held-back."""
+    by_version: dict[str, list[Path]] = {}
+    held: list[tuple[Path, str]] = []
+    cache: dict[str, set[str]] = {}
+    for _, _, path in pending:
+        work = resolve(root, path, index, cache)
+        if work.released_in is not None:
+            by_version.setdefault(work.released_in, []).append(path)
+            continue
+        # In no release tag. It rides the version being cut only if that
+        # version is not itself already released -- otherwise this is a repair
+        # run, and dating unshipped work into a shipped wheel is the defect.
+        in_cut = all(is_ancestor(root, c, cut_ref) for c in work.commits)
+        if not cutting_released and in_cut:
+            by_version.setdefault(cutting, []).append(path)
+        else:
+            held.append((path, held_reason(work, cutting, cutting_released, cut_ref)))
+    return by_version, held
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", type=Path, default=ROOT)
     ap.add_argument("--version")
+    ap.add_argument(
+        "--cut-ref",
+        default="HEAD",
+        help="the commit being cut; unreleased work counts only if it is here",
+    )
     ap.add_argument("--date", default=dt.date.today().isoformat())
     ap.add_argument("--headline", default="")
     ap.add_argument("--check", action="store_true", help="validate only")
@@ -213,35 +345,47 @@ def main() -> int:
     if not released:
         sys.exit("refusing: no vX.Y.Z tags found -- attribution cannot be derived")
 
-    by_version: dict[str, list[Path]] = {}
-    for _, _, path in pending:
-        by_version.setdefault(attribution(root, path, args.version), []).append(path)
+    cutting: str = args.version
+    cutting_released = cutting in released
+    refs = list(dict.fromkeys([args.cut_ref, "HEAD", *(f"v{v}" for v in released)]))
+    index = subject_index(root, refs)
+    by_version, held = plan_versions(
+        root, pending, cutting, cutting_released, args.cut_ref, index
+    )
 
     changelog = root / "CHANGELOG.md"
     text = changelog.read_text()
     # Late attributions first: inserting the new section shifts every offset
     # below it, and the sections being appended to are all below it.
-    for version in sorted(v for v in by_version if v != args.version):
+    late = sorted(
+        (v for v in by_version if v != cutting or cutting_released), key=version_key
+    )
+    for version in late:
         text = append_to_section(text, version, by_version[version])
         for path in by_version[version]:
             print(f"{path.name} -> {version} (late; its code shipped in v{version})")
     section = ""
-    mine = by_version.get(args.version, [])
+    mine = [] if cutting_released else by_version.get(cutting, [])
     if mine:
-        section = new_section(args.version, args.date, args.headline, mine)
+        section = new_section(cutting, args.date, args.headline, mine)
         text = insert_new_section(text, section)
         for path in mine:
-            print(f"{path.name} -> {args.version}")
-    else:
-        # Not an error: naming the NEXT version with nothing pending for it is
-        # how a mis-attribution is repaired without cutting anything.
-        print(f"note: nothing pending belongs to {args.version} -- no new section")
+            print(f"{path.name} -> {cutting}")
+    elif not late:
+        # Not an error to name a version nothing belongs to -- but nothing is
+        # written for it either, and the held listing below says why.
+        print(f"note: nothing pending belongs to {cutting} -- no new section")
+    if held:
+        print(f"{len(held)} fragment(s) pending, not in {cutting}:")
+        for path, why in held:
+            print(f"  {path.name}: {why}")
+    if not by_version:
+        sys.exit(f"nothing assembled: no pending fragment's work is in {cutting}")
 
-    ledger = read_ledger(root) + [
-        (version, path.stem)
-        for version in sorted(by_version)
-        for path in by_version[version]
-    ]
+    ledger = read_ledger(root) + sorted(
+        ((version, path.stem) for version in by_version for path in by_version[version]),
+        key=lambda row: (version_key(row[0]), row[1]),
+    )
 
     if args.dry_run:
         print(section, end="")
@@ -251,14 +395,18 @@ def main() -> int:
     write_ledger(root, ledger)
 
     # Consumed fragments are marked, not deleted -- but they do not accumulate
-    # forever either. Prune what an older release already consumed.
-    keep = {args.version, *released[-RETAIN_PRIOR_RELEASES:]}
+    # forever either. Prune what an older release already consumed. The window
+    # is anchored on the NEWEST version known, so a repair run of an older
+    # version prunes exactly what a cut would, and no more.
+    known = sorted({*released, cutting}, key=version_key)
+    keep = {cutting, *known[-(RETAIN_PRIOR_RELEASES + 1) :]}
     for version, path in consumed:
         if version not in keep:
             path.unlink()
             print(f"pruned {path.name} (consumed by {version})")
 
-    print(f"{len(pending)} fragment(s) assembled; {len(ledger)} in {LEDGER}")
+    assembled = sum(len(paths) for paths in by_version.values())
+    print(f"{assembled} fragment(s) assembled; {len(ledger)} in {LEDGER}")
     print("now: git add CHANGELOG.md changelog.d  (with the version bump)")
     return 0
 

--- a/tests/test_changelog_attribution_pgw1339.py
+++ b/tests/test_changelog_attribution_pgw1339.py
@@ -269,6 +269,72 @@ def test_work_outside_the_cut_ref_rides_the_next_cut(repair_repo: Path) -> None:
     assert f"is not in {cut_ref}" in done.stdout
 
 
+# --------------------------------------------------------------------------
+# per-lane fragment names: one issue, many lanes, no shared path
+# --------------------------------------------------------------------------
+
+
+def test_per_lane_fragments_of_one_issue_fold_into_one_section(
+    repair_repo: Path,
+) -> None:
+    """pgw#1346's ~10 lanes shared `pgw1346.md` and re-serialised the queue.
+
+    Disjoint files, one issue: both are dated by `pgw#1346`'s commits, both land
+    in the same section, adjacent and ordered, each with its own ledger row.
+    """
+    work(repair_repo, "pgw1346", "the B3 math half")
+    fragment(repair_repo, "pgw1346-b4-video", "the video half")
+    fragment(repair_repo, "pgw1346-b3-math", "the math half")
+    fragment(repair_repo, "pgw1346", "the roll-up")
+
+    done = assemble(repair_repo, "--version", "0.122.0")
+    assert done.returncode == 0, done.stderr
+
+    body = section((repair_repo / "CHANGELOG.md").read_text(), "0.122.0")
+    for stem in ("pgw1346", "pgw1346-b3-math", "pgw1346-b4-video"):
+        assert stem in body
+    # unsuffixed first, then suffixes in order, and all three adjacent -- the
+    # section must not depend on filesystem order.
+    assert (
+        body.index("pgw1346:")
+        < body.index("pgw1346-b3-math:")
+        < body.index("pgw1346-b4-video:")
+    )
+    assert body.index("pgw1346-b4-video:") < body.index("pgw1350:")
+
+    rows = [
+        ln
+        for ln in (repair_repo / LEDGER).read_text().splitlines()
+        if not ln.startswith("#")
+    ]
+    assert "0.122.0\tpgw1346" in rows
+    assert "0.122.0\tpgw1346-b3-math" in rows
+    assert "0.122.0\tpgw1346-b4-video" in rows
+
+
+def test_a_suffixed_fragment_is_dated_by_its_ISSUE_not_its_suffix(
+    repair_repo: Path,
+) -> None:
+    """The suffix is a filename. `pgw#1323`'s tag is what dates the lane file."""
+    fragment(repair_repo, "pgw1323-fence", "the cross-repo consumer fence")
+
+    done = assemble(repair_repo, "--version", "0.121.0")
+    assert done.returncode == 0, done.stderr
+    assert "pgw1323-fence" in section(
+        (repair_repo / "CHANGELOG.md").read_text(), "0.121.0"
+    )
+
+
+@pytest.mark.parametrize("stem", ["pgw-b3-math", "b3-math", "pgw1346-B3", "pgw1346-"])
+def test_a_name_with_no_issue_number_is_refused(repair_repo: Path, stem: str) -> None:
+    """A suffix may not become an escape hatch: no number, nothing to date it."""
+    (repair_repo / "changelog.d" / f"{stem}.md").write_text("- **a lane half**\n")
+
+    done = assemble(repair_repo, "--check")
+    assert done.returncode != 0
+    assert "must be <prefix><number>[-<suffix>].md" in done.stdout + done.stderr
+
+
 def test_an_issue_with_no_subject_commit_falls_back_to_the_fragments_own_commit(
     repair_repo: Path,
 ) -> None:

--- a/tests/test_changelog_attribution_pgw1339.py
+++ b/tests/test_changelog_attribution_pgw1339.py
@@ -1,0 +1,299 @@
+"""pgw#1339: `--version X` assembles only fragments whose WORK is inside X.
+
+The defect this covers was reproduced twice, by two cutters who had not read
+each other's notes. `assemble_changelog.py --version 0.121.0`, run to date one
+late fragment into an already-released section, swept **every** pending
+fragment into `## 0.121.0` -- 16 of them on the second attempt, including work
+that had shipped in no wheel at all. The old rule dated a fragment by the
+commit that added the fragment FILE, and fell back to "the version being cut"
+when no tag contained it; an uncommitted or late-added fragment therefore
+always took the fallback, and the fallback cannot tell a repair from a cut.
+
+Driven against a REAL git repository in a tmpdir -- real commits, real `v*`
+tags, the real script as a subprocess -- because every claim here is a claim
+about what git answers. The fixture inherits NO git config
+(`GIT_CONFIG_GLOBAL`/`SYSTEM` are /dev/null), so it needs no signing bypass.
+
+The fixture is the 0.123.0 cutter's shape at small scale: `v0.121.0` contains
+pgw#1323's commit and nothing else pending does, so a `--version 0.121.0` run
+must assemble exactly one fragment and hold the rest.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "assemble_changelog.py"
+LEDGER = "changelog.d/consumed.tsv"
+LATE = "Attributed after the cut (pgw#1226)"
+
+# The pending fragments that landed AFTER v0.121.0 -- the sweep's victims.
+AFTER_TAG = ("pgw1330", "pgw1340", "pgw1350")
+
+CHANGELOG = """\
+# Changelog
+
+## Unreleased
+
+Unreleased entries live in `changelog.d/`, one file per issue.
+
+## 0.121.0 (2026-08-16) — a hub-dispatched `@job` reaches its body
+
+- **pgw#1338: the dispatch half.**
+
+## 0.120.0 (2026-08-15) — the boot half
+
+- **pgw#1300: the boot half.**
+"""
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_AUTHOR_NAME": "pgw1339 fixture",
+    "GIT_AUTHOR_EMAIL": "pgw1339@fixture.invalid",
+    "GIT_COMMITTER_NAME": "pgw1339 fixture",
+    "GIT_COMMITTER_EMAIL": "pgw1339@fixture.invalid",
+}
+
+
+def git(root: Path, *args: str) -> str:
+    done = subprocess.run(
+        ("git", *args), cwd=root, env=GIT_ENV, capture_output=True, text=True
+    )
+    assert done.returncode == 0, f"git {args}: {done.stderr}"
+    return done.stdout.strip()
+
+
+def fragment(root: Path, stem: str, text: str) -> None:
+    (root / "changelog.d" / f"{stem}.md").write_text(f"- **{stem}: {text}**\n")
+
+
+def work(root: Path, stem: str, subject: str) -> None:
+    """A commit whose SUBJECT claims the issue -- the thing being dated."""
+    number = stem.removeprefix("pgw")
+    src = root / f"{stem}_work.py"
+    src.write_text(f"{src.read_text() if src.exists() else ''}# {subject}\n")
+    git(root, "add", f"{stem}_work.py")
+    git(root, "commit", "-q", "-m", f"pgw#{number}: {subject}")
+
+
+def assemble(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        (sys.executable, str(SCRIPT), "--root", str(root), *args),
+        capture_output=True,
+        text=True,
+    )
+
+
+def section(text: str, version: str) -> str:
+    m = re.search(rf"^## {re.escape(version)}\b.*?(?=^## |\Z)", text, re.M | re.S)
+    assert m, f"no '## {version}' section in:\n{text}"
+    return m.group(0)
+
+
+@pytest.fixture
+def repair_repo(tmp_path: Path) -> Path:
+    """v0.121.0 holds pgw#1323's commit; three later issues are pending.
+
+    pgw#1323's own fragment does not exist yet -- that is the live shape: the
+    change shipped as a silent release note and the fragment is being written
+    now, months of commits later.
+    """
+    root = tmp_path / "pgw"
+    (root / "changelog.d").mkdir(parents=True)
+    (root / "CHANGELOG.md").write_text(CHANGELOG)
+    (root / "changelog.d" / "README.md").write_text("# changelog.d\n")
+    git(root, "init", "-q", "-b", "master")
+    git(root, "add", "CHANGELOG.md", "changelog.d")
+    git(root, "commit", "-q", "-m", "base")
+    git(root, "tag", "v0.120.0")
+
+    work(root, "pgw1323", "the cross-repo consumer fence stopped reading")
+    git(root, "tag", "v0.121.0")
+
+    for stem in AFTER_TAG:
+        work(root, stem, "landed after the 0.121.0 tag")
+        fragment(root, stem, "landed after the 0.121.0 tag")
+        git(root, "add", f"changelog.d/{stem}.md")
+        git(root, "commit", "-q", "-m", f"pgw#{stem.removeprefix('pgw')}: fragment")
+    return root
+
+
+# --------------------------------------------------------------------------
+# the defect: `--version <older>` swept every pending fragment into it
+# --------------------------------------------------------------------------
+
+
+def test_a_repair_run_does_not_sweep_unshipped_fragments_into_the_old_section(
+    repair_repo: Path,
+) -> None:
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+
+    done = assemble(repair_repo, "--version", "0.121.0")
+    assert done.returncode == 0, done.stderr
+
+    text = (repair_repo / "CHANGELOG.md").read_text()
+    assert "pgw1323" in section(text, "0.121.0")
+    # the whole defect: work that is in NO tag may not be dated into a shipped
+    # wheel, and 0.121.0 is shipped.
+    for stem in AFTER_TAG:
+        assert stem not in text, f"{stem} was swept into a released section"
+
+    # ...and they are not silently dropped either.
+    assert f"{len(AFTER_TAG)} fragment(s) pending, not in 0.121.0:" in done.stdout
+    for stem in AFTER_TAG:
+        assert f"{stem}.md:" in done.stdout
+    assert "is in no release tag" in done.stdout
+
+
+def test_the_ledger_records_only_what_was_assembled(repair_repo: Path) -> None:
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+    assert assemble(repair_repo, "--version", "0.121.0").returncode == 0
+
+    rows = [
+        ln
+        for ln in (repair_repo / LEDGER).read_text().splitlines()
+        if not ln.startswith("#")
+    ]
+    assert rows == ["0.121.0\tpgw1323"]
+    # held fragments stay pending, so the NEXT cut picks them up
+    for stem in AFTER_TAG:
+        assert (repair_repo / "changelog.d" / f"{stem}.md").exists()
+
+
+def test_the_repair_merges_into_the_existing_section_and_does_not_duplicate_it(
+    repair_repo: Path,
+) -> None:
+    """Bug 2: the repair used to PREPEND a second `## 0.121.0`, out of order."""
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+    assert assemble(repair_repo, "--version", "0.121.0").returncode == 0
+
+    text = (repair_repo / "CHANGELOG.md").read_text()
+    assert text.count("## 0.121.0") == 1
+    body = section(text, "0.121.0")
+    assert LATE in body
+    assert body.index("pgw#1338") < body.index("pgw1323")  # appended, not prepended
+    assert text.index("## 0.121.0") > text.index("## Unreleased")
+
+
+def test_a_fragment_committed_after_the_tag_is_still_dated_by_its_work(
+    repair_repo: Path,
+) -> None:
+    """The FILE is a document about the change; the COMMIT is the change."""
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+    git(repair_repo, "add", "changelog.d/pgw1323.md")
+    git(repair_repo, "commit", "-q", "-m", "pgw#1339: write the missing fragment")
+
+    done = assemble(repair_repo, "--version", "0.121.0")
+    assert done.returncode == 0, done.stderr
+    assert "pgw1323" in section(
+        (repair_repo / "CHANGELOG.md").read_text(), "0.121.0"
+    )
+
+
+def test_nothing_assembled_is_a_refusal_and_writes_nothing(
+    repair_repo: Path,
+) -> None:
+    before = (repair_repo / "CHANGELOG.md").read_text()
+    done = assemble(repair_repo, "--version", "0.121.0")
+    assert done.returncode != 0
+    assert "nothing assembled" in done.stdout + done.stderr
+    assert (repair_repo / "CHANGELOG.md").read_text() == before
+    assert not (repair_repo / LEDGER).exists()
+
+
+def test_partly_shipped_work_is_held_rather_than_dated_into_the_old_wheel(
+    repair_repo: Path,
+) -> None:
+    """A note is true only once EVERYTHING it describes has shipped."""
+    work(repair_repo, "pgw1323", "the follow-up that did NOT make 0.121.0")
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+
+    done = assemble(repair_repo, "--version", "0.121.0")
+    assert done.returncode != 0
+    assert "pgw1323.md:" in done.stdout
+    assert "pgw1323" not in (repair_repo / "CHANGELOG.md").read_text()
+
+
+# --------------------------------------------------------------------------
+# ...and a real cut still cuts
+# --------------------------------------------------------------------------
+
+
+def test_a_real_cut_takes_the_unshipped_work_and_late_attributes_the_rest(
+    repair_repo: Path,
+) -> None:
+    fragment(repair_repo, "pgw1323", "the cross-repo consumer fence")
+
+    done = assemble(repair_repo, "--version", "0.122.0", "--headline", "**the cut**")
+    assert done.returncode == 0, done.stderr
+
+    text = (repair_repo / "CHANGELOG.md").read_text()
+    assert "pgw1323" in section(text, "0.121.0")  # its work is in that tag
+    assert "pgw1323" not in section(text, "0.122.0")
+    for stem in AFTER_TAG:
+        assert stem in section(text, "0.122.0")
+    assert "**the cut**" in text
+    rows = [
+        ln
+        for ln in (repair_repo / LEDGER).read_text().splitlines()
+        if not ln.startswith("#")
+    ]
+    assert rows == [
+        "0.121.0\tpgw1323",
+        "0.122.0\tpgw1330",
+        "0.122.0\tpgw1340",
+        "0.122.0\tpgw1350",
+    ]
+
+
+def test_work_outside_the_cut_ref_rides_the_next_cut(repair_repo: Path) -> None:
+    """`--cut-ref` is the release commit: work not in it is not in the wheel."""
+    cut_ref = git(repair_repo, "rev-parse", "HEAD~1")  # before pgw1350's commit
+
+    done = assemble(repair_repo, "--version", "0.122.0", "--cut-ref", cut_ref)
+    assert done.returncode == 0, done.stderr
+
+    text = (repair_repo / "CHANGELOG.md").read_text()
+    assert "pgw1330" in section(text, "0.122.0")
+    assert "pgw1350" not in text
+    assert "1 fragment(s) pending, not in 0.122.0:" in done.stdout
+    assert f"is not in {cut_ref}" in done.stdout
+
+
+def test_an_issue_with_no_subject_commit_falls_back_to_the_fragments_own_commit(
+    repair_repo: Path,
+) -> None:
+    """pgw#1226's original signal, kept as the fallback it always was.
+
+    A 0.122.0 whose tree holds `pgw1360.md`, added under a subject that names
+    no issue: nothing else can date it, so the file's own commit does — and
+    dating it to the version being cut is the pgw#1226 defect all over again.
+    """
+    changelog = repair_repo / "CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text().replace(
+            "## 0.121.0",
+            "## 0.122.0 (2026-08-17) — the interim cut\n\n"
+            "- **pgw#1355: the interim half.**\n\n## 0.121.0",
+            1,
+        )
+    )
+    fragment(repair_repo, "pgw1360", "committed under a subject that names nothing")
+    git(repair_repo, "add", "CHANGELOG.md", "changelog.d/pgw1360.md")
+    git(repair_repo, "commit", "-q", "-m", "housekeeping")
+    git(repair_repo, "tag", "v0.122.0")
+
+    done = assemble(repair_repo, "--version", "0.123.0")
+    assert done.returncode == 0, done.stderr
+    text = (repair_repo / "CHANGELOG.md").read_text()
+    assert "pgw1360" in section(text, "0.122.0")
+    assert "## 0.123.0" not in text

--- a/tests/test_changelog_consumption_pgw1226.py
+++ b/tests/test_changelog_consumption_pgw1226.py
@@ -245,7 +245,10 @@ def test_check_needs_no_git_and_reports_both_states(tmp_path: Path) -> None:
     [
         ("0.114.3 pgw1244\n", "want '<version>"),
         ("0.114\tpgw1244\n", "is not an X.Y.Z version"),
-        ("0.114.3\tpgw868-a4\n", "is not a <prefix><number>"),
+        # pgw#1339: `pgw868-a4` is now a LEGAL per-lane name; an underscore
+        # is not, and neither is a stem with no issue number.
+        ("0.114.3\tpgw868_a4\n", "is not a <prefix><number>"),
+        ("0.114.3\tpgw-a4\n", "is not a <prefix><number>"),
         ("0.114.3\tpgw1244\n0.115.0\tpgw1244\n", "recorded twice"),
     ],
 )


### PR DESCRIPTION
## The defect

`scripts/assemble_changelog.py --version 0.121.0`, run to date ONE late fragment into an already-released section, swept **every** pending fragment into `## 0.121.0` — 5 on the 0.122.0 cutter's tree, **16** on the 0.123.0 cutter's, including work that had shipped in no wheel at all. Both cutters backed out; both filed it; neither had read the other first. The repair recipe in `docs/releasing.md` is safe only in a window that does not occur on a busy repo, so `pgw#1323`'s silent release note has stayed owed.

**Mechanism:** attribution read the commit that added the fragment FILE. A fragment that does not exist yet — the case a repair is *for* — has no such commit, so it took the `in no tag -> the version being cut` fallback, and so did every other pending fragment. The fallback cannot tell a repair from a cut.

## The rule, as implemented

pgw#1226's stated rule, made executable — the subject is the WORK, not the file:

1. the issue's authored commits come from commit **SUBJECTS** (`pgw#1323: …`), not bodies, in one `git log` pass over `--cut-ref`, `HEAD` and the release tags (deliberately **not** `--all`: an open lane worktree would otherwise hold its own issue out of a cut it belongs in);
2. the fragment is attributed to the **earliest release tag whose tree contains ALL of them** — a note is true only once everything it describes has shipped;
3. work in no tag rides the version being cut, **and only if that version is not itself already released** and the work is in `--cut-ref` (new flag, default `HEAD`);
4. anything else stays **pending**, printed with the reason (`N fragment(s) pending, not in X:`), never swept;
5. nothing assembled at all is a refusal that writes nothing.

The fragment file's own add-commit survives as the **fallback** for an issue whose commits never name it — pgw#1226's original signal, demoted to what it always was, and no longer a *constraint*. That demotion is what makes a repair work: a fragment written months late is dated by the work, not by the day it was typed.

**Bug 2 with it:** the repair used to PREPEND a duplicate `## 0.121.0` above `## 0.122.0` while the real section sat 170 lines below. Routing is now by whether the target version is RELEASED, not by whether it equals `--version`, so a repair appends into the existing section under the *attributed after the cut* note — what `docs/releasing.md` has always promised.

## Proof

`tests/test_changelog_attribution_pgw1339.py` — 9 tests, the real script as a subprocess against a real git repo with real `v*` tags, built as the 0.123.0 cutter's shape: `v0.121.0` holds pgw#1323's commit and nothing else pending does. **Five severances, each red 5/5, each reddening a DIFFERENT set** — no test carries another's weight:

| severance | red 5/5 | tests reddened |
|---|---|---|
| the released-version guard (`in no tag` -> cut anyway) | ✅ | 4 — the 16-sweep shape, the ledger, the partial-ship hold, the refusal |
| subject-work resolution (file commit only) | ✅ | 5 |
| the file-commit fallback | ✅ | 3 (2 of them pgw#1226's own) |
| the `--cut-ref` ancestry guard | ✅ | 1 |
| section routing (new section always) | ✅ | 1 — the duplicate heading |

pgw#1226's 11 existing tests stay green **unchanged**. `mypy --strict` clean on the script; `ruff check` clean.

Live dry-run on this tree, with `changelog.d/pgw1323.md` written and nothing committed:

```
$ scripts/assemble_changelog.py --version 0.121.0 --dry-run
pgw1323.md -> 0.121.0 (late; its code shipped in v0.121.0)
1 fragment(s) pending, not in 0.121.0:
  pgw1356.md: its work (commit subjects: e95000c7, 5c574917) is in no release tag,
  and 0.121.0 is already released -- unshipped work cannot be dated into it
```

pgw#1356 is correctly held: `v0.123.0` was cut from `0bb040b8`, so it does not contain those commits — verified with `git merge-base --is-ancestor`.

**Deliberately not touched:** `changelog.d/` contents and `CHANGELOG.md`, so this cannot collide with the release lane. This PR's own fragment is therefore owed and can be added late — which is now safe, and is the point.

Closes the assembler half of pgw#1339; unblocks the pgw#1323 repair.


---

## Scope addition: per-lane fragment names (the pgw#1346 queue serialization)

`changelog.d/pgw1346.md` had become a **shared path** for ~10 batch lanes of one issue - they all append to the one file, which re-serialises the merge queue and ejects PRs as `CONFLICTING` (#916 twice). That is precisely the failure `changelog.d/` exists to remove, arriving through the door pgw#968 did not close: a path is per-ISSUE, and a batched issue is many lanes.

A fragment is now `<prefix><number>[-<suffix>].md`:

- `pgw1346-b3-math.md` and `pgw1346-b4-video.md` are **disjoint files** that cannot conflict, and both resolve to issue `pgw#1346` for dating - the suffix is a filename, never an attribution axis;
- they fold into **one section**, ordered `(number, suffix)` so the unsuffixed file leads and the section never depends on filesystem order;
- each keeps its own `consumed.tsv` row;
- the `<prefix><number>` core stays **mandatory**: `pgw-b3-math.md` and `b3-math.md` are refused by `--check` at the lane's own PR, not at the cut. The prefix is 2+ letters for that reason - `b3-math` would otherwise parse as issue `b#3` and be datable by nothing.

`docs/releasing.md` carries the convention with the failure it prevents; the batch lanes are told to adopt it on pgw#1346's operational note in the tracker. The pgw#1226 ledger case for `pgw868-a4` is now a legal name and was replaced with `pgw868_a4` / `pgw-a4`, which are not.

Four more severances, each **red 5/5**: dropping the suffix from the grammar (2 tests), keying attribution on the stem instead of the issue (1), ordering by path instead of `(number, suffix)` (1), removing the name refusal (4). **27 tests green**; `mypy --strict` and `ruff check` clean.
