### PR TITLE
pgw#1346 K11: the eager tier gets a runtime binding, so inst.tuned exists

### DIFF
--- a/changelog.d/pgw1346.md
+++ b/changelog.d/pgw1346.md
@@ -355,3 +355,30 @@
   before any dispatch has named a checkpoint, skips unresolved models instead —
   un-warmed is honest, refusing would break the boot of every hub-resolved
   endpoint.
+
+## K11 — the EAGER tier gets a runtime binding, so `inst.tuned` exists
+
+- **An eager model could be declared but never CONSTRUCTED.** `render_eager`
+  emits a real `Model` subclass, but the serving path refused it: a model that
+  declares no runners has no eager module and no armed cell, which is exactly
+  the shape `residency.instance_for` rejected. So `inst.tuned` — the whole
+  replacement for `ctx.defaults` — was unreachable for every eager model, and
+  that one refusal gated anima (5 `ctx.defaults` reads), hidream (14), the
+  auxiliary-model class, and all 11 weight-bearing boundary endpoints at once.
+  A model declaring no runners is now complete with a ref and its tuned values;
+  the refusal is scoped to a model that DECLARES a graph and has nothing to run
+  it, which is still a pod-level failure.
+- **`NoGraphBacking`** gives that state its own name. `DualBacking(None, None)`
+  refuses, and an empty `EagerBacking` would say *"no eager module bound for
+  runner 'x'; it has []"* — sending the reader hunting for a registration that
+  was never supposed to happen. "Nothing to arm, by declaration" and "not armed
+  yet" are different answers and only one is a defect.
+- **`inst.path` and `inst.pipeline` are the eager tier's serving surface**, the
+  way a typed runner call is a graph model's. Measured across the boundary
+  batch: 8 of 11 weight-bearing endpoints hand a local path to an external
+  binary or a custom loader, and 3 use an object the worker constructed. Both
+  refuse by name rather than returning an empty path or `None` — a handler that
+  shells out with `""` fails somewhere far away, and the answer is only useful
+  at the point it stops being true. The executor materializes the path through
+  the same `store.ensure_local` call that already served slot-path injection,
+  so the two cannot disagree.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -10748,8 +10748,21 @@ class Executor:
             ref = wire_ref(binding)
             path = await self.store.ensure_local(ref, snapshots.get(ref), binding=binding)
             kwargs[name] = Path(path) if sig.get(name) is Path else str(path)
-        kwargs.update(
-            self._model_instance_kwargs(spec, slots or {}, adapters or {}, warm=warm))
+        # pgw#1346 K11: the same materialization, for a parameter bound to a
+        # declared MODEL. An eager model's serving surface IS this path — 8 of
+        # the 11 measured boundary endpoints hand it to an external binary —
+        # so it is fetched here, beside the slot-path injection that already
+        # knew how, rather than through a second route that could disagree.
+        local: Dict[str, str] = {}
+        for name in spec.families:
+            binding = spec.models.get(name)
+            if binding is None:
+                continue
+            ref = wire_ref(binding)
+            local[name] = str(await self.store.ensure_local(
+                ref, snapshots.get(ref), binding=binding))
+        kwargs.update(self._model_instance_kwargs(
+            spec, slots or {}, adapters or {}, paths=local, warm=warm))
         return kwargs
 
     def _model_instance_kwargs(
@@ -10757,6 +10770,7 @@ class Executor:
         spec: EndpointSpec,
         slots: Mapping[str, dispatch.SlotOrder],
         adapters: Mapping[str, Tuple[dispatch.AdapterOrder, ...]],
+        paths: Optional[Mapping[str, str]] = None,
         warm: bool = False,
     ) -> Dict[str, Any]:
         """One resolved `Model` per declared model parameter (pgw#1346).
@@ -10803,7 +10817,8 @@ class Executor:
             trees[name] = self._slot_pipeline(spec, name)
         return dict(instances_for(
             spec.families, refs=refs, trees=trees,
-            stamped=stamped, lora_stamped=lora_stamped, skip_unresolved=warm,
+            stamped=stamped, lora_stamped=lora_stamped, paths=paths or {},
+            skip_unresolved=warm,
         ))
 
     async def _prepare_adapters(

--- a/src/gen_worker/model/backing.py
+++ b/src/gen_worker/model/backing.py
@@ -42,6 +42,10 @@ class BackingKind(StrEnum):
     EAGER = "eager"
     COMPILED = "compiled"
     FAKE = "fake"
+    #: pgw#1346 K11: the model declares no runners at all. Not a missing
+    #: backing — the ABSENCE of graph classes, which is a permanent and
+    #: legitimate state for an external-binary or non-PyTorch model.
+    NONE = "none"
 
 
 @runtime_checkable
@@ -272,6 +276,47 @@ class FakeBacking:
                 "does not determine; the fake backing refuses rather than invent one",
             )
         return bound
+
+
+class NoGraphBacking:
+    """The backing of a model that declares NO runners (pgw#1346 K11).
+
+    The eager tier's honest bottom. `musicgen`, `joycaption`, a GGUF LLM served
+    by llama-server: there is no graph to call, and the instance's value is its
+    ref, its catalog-stamped `tuned`, and the bytes it points at (`inst.path`)
+    or the object the worker built (`inst.pipeline`).
+
+    This exists instead of `DualBacking(None, None)` — which refuses — and
+    instead of an empty `EagerBacking`, whose refusal would say "no eager module
+    bound for runner 'x'; it has []" and send the reader hunting for a
+    registration that was never supposed to happen. The distinction is worth a
+    class: "not armed yet" and "there is nothing to arm, by declaration" are
+    different answers, and only one of them is a defect.
+    """
+
+    @property
+    def kind(self) -> BackingKind:
+        return BackingKind.NONE
+
+    def serves(self, runner: str, variant: ExportedVariant) -> bool:
+        del runner, variant
+        return False
+
+    def invoke(
+        self,
+        runner: str,
+        variant: ExportedVariant,
+        args: tuple[object, ...],
+        kwargs: Mapping[str, object],
+    ) -> Any:
+        del variant, args, kwargs
+        raise ModelError(
+            ModelRefusal.BACKING_MISSING,
+            f"runner {runner!r} was called on a model that declares NO runners. This is "
+            "an eager-tier model: it has no graph classes and owes none, so it serves "
+            "through `inst.path` / `inst.pipeline` and its tuned values, never a typed "
+            "runner call.",
+        )
 
 
 class DualBacking:

--- a/src/gen_worker/model/residency.py
+++ b/src/gen_worker/model/residency.py
@@ -88,6 +88,7 @@ def instance_for(
     stamped: str = "",
     lora_stamped: Sequence[str] = (),
     label: str = "",
+    path: str = "",
 ) -> M:
     """One resolved instance, from what this pod already has.
 
@@ -100,7 +101,8 @@ def instance_for(
     from .tuned import tuned_from_catalog
 
     eager = eager_modules(model.SPEC, tree)
-    if not eager and compiled is None:
+    declares_runners = bool(model.SPEC is not None and model.SPEC.runners)
+    if declares_runners and not eager and compiled is None:
         raise ModelError(
             ModelRefusal.BACKING_MISSING,
             f"model {model.FAMILY!r} bound to {ref!r} has neither an eager module "
@@ -109,12 +111,18 @@ def instance_for(
             f"(declare `Runner(..., component=...)` for each runner that has an "
             f"eager equivalent).",
         )
+    # pgw#1346 K11: a model that declares NO runners is complete without either
+    # backing. Refusing it here is what made `inst.tuned` unreachable for every
+    # eager model — and `inst.tuned` is the whole replacement for `ctx.defaults`,
+    # so the refusal blocked the ctx cut for all 11 boundary endpoints at once.
     return model.adopt(
         ref=ref,
         tuned=tuned_from_catalog(model, stamped, lora_stamped),
         eager=eager or None,
         compiled=compiled,
         label=label or ref,
+        path=path,
+        pipeline=tree if not declares_runners else None,
     )
 
 
@@ -126,6 +134,7 @@ def instances_for(
     compiled: Mapping[str, Backing] | None = None,
     stamped: Mapping[str, str] | None = None,
     lora_stamped: Mapping[str, Sequence[str]] | None = None,
+    paths: Mapping[str, str] | None = None,
     skip_unresolved: bool = False,
 ) -> dict[str, Model]:
     """One instance per declared handler parameter.
@@ -146,6 +155,7 @@ def instances_for(
     armed = compiled or {}
     values = stamped or {}
     overlays = lora_stamped or {}
+    local = paths or {}
     out: dict[str, Model] = {}
     for name, bind in binds.items():
         ref = str(refs.get(name, "") or "").strip()
@@ -165,6 +175,7 @@ def instances_for(
             stamped=values.get(name, ""),
             lora_stamped=overlays.get(name, ()),
             label=name,
+            path=local.get(name, ""),
         )
     return out
 

--- a/src/gen_worker/model/runtime.py
+++ b/src/gen_worker/model/runtime.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator, Mapping
+from pathlib import Path as _PathType
 from typing import (
     Annotated,
     Any,
@@ -49,7 +50,14 @@ from typing import (
 import msgspec
 
 from ..families.base import GenerationDefaults
-from .backing import Backing, BackingKind, DualBacking, EagerBacking, FakeBacking
+from .backing import (
+    Backing,
+    BackingKind,
+    DualBacking,
+    EagerBacking,
+    FakeBacking,
+    NoGraphBacking,
+)
 from .errors import ModelError, ModelRefusal
 from .snapshot import EagerExport, ExportedVariant, ModelExport
 from .spec import ModelSpec
@@ -152,6 +160,24 @@ class DecodeSession:
         self._state.clear()
 
 
+def _adopted_backing(
+    eager: Mapping[str, Any] | None, compiled: Backing | None
+) -> Backing:
+    """The backing for one adopted instance.
+
+    Both halves absent is NOT an error here, unlike inside `DualBacking`: a
+    model that declares no runners has nothing to arm and nothing to call, and
+    saying so with a `NoGraphBacking` is the difference between "this model is
+    eager-tier" and "this pod failed to load something" (pgw#1346 K11).
+    """
+
+    if eager is None and compiled is None:
+        return NoGraphBacking()
+    return DualBacking(
+        eager=None if eager is None else EagerBacking(eager), compiled=compiled
+    )
+
+
 class Model:
     """Base of every GENERATED model class: the type IS the class, the value
     IS the instance.
@@ -196,10 +222,14 @@ class Model:
     #: would import diffusers and the role forbids it (pgw#1328).
     SPEC: ClassVar[ModelSpec | None] = None
 
-    __slots__ = ("_backing", "_label", "_ref", "_tuned")
+    __slots__ = ("_backing", "_label", "_path", "_pipeline", "_ref", "_tuned")
 
     _backing: Backing
     _label: str
+    #: The local snapshot path, when the worker materialized one. pgw#1346 K11.
+    _path: str
+    #: The constructed object, when the worker loaded one.
+    _pipeline: Any
     _ref: str
     _tuned: GenerationDefaults
 
@@ -222,6 +252,8 @@ class Model:
         tuned: GenerationDefaults,
         backing: Backing,
         label: str = "",
+        path: str = "",
+        pipeline: Any = None,
     ) -> Self:
         """Build one instance. The ONLY way an instance comes into existence."""
 
@@ -236,6 +268,8 @@ class Model:
         object.__setattr__(self, "_tuned", tuned)
         object.__setattr__(self, "_backing", backing)
         object.__setattr__(self, "_label", str(label or ref))
+        object.__setattr__(self, "_path", str(path or ""))
+        object.__setattr__(self, "_pipeline", pipeline)
         spec = cls.SPEC
         if spec is not None and spec.on_load is not None:
             spec.on_load(self)
@@ -275,6 +309,8 @@ class Model:
         eager: Mapping[str, Any] | None = None,
         compiled: Backing | None = None,
         label: str = "",
+        path: str = "",
+        pipeline: Any = None,
     ) -> Self:
         """Build an instance from backings the caller already has.
 
@@ -286,10 +322,10 @@ class Model:
         return cls._materialize(
             ref=ref,
             tuned=tuned if tuned is not None else cls.Tuned(),
-            backing=DualBacking(
-                eager=None if eager is None else EagerBacking(eager), compiled=compiled
-            ),
+            backing=_adopted_backing(eager, compiled),
             label=label,
+            path=path,
+            pipeline=pipeline,
         )
 
     @classmethod
@@ -323,6 +359,50 @@ class Model:
         """A human-readable name for receipts and logs; the ref when unnamed."""
 
         return self._label
+
+    @property
+    def path(self) -> _PathType:
+        """The LOCAL SNAPSHOT PATH of this checkpoint's bytes (pgw#1346 K11).
+
+        The eager tier's serving surface, and the majority one: measured across
+        the boundary batch, 8 of 11 weight-bearing endpoints hand a path to an
+        external binary or a custom loader rather than calling a graph. Those
+        endpoints have no runner to invoke and never will — this is what they
+        are bound FOR.
+
+        Refuses rather than returning an empty path. A handler that shells out
+        to `llama-server` with `""` fails somewhere far away and confusingly;
+        the answer "this instance was not materialized with local bytes" is
+        only useful at the point it stops being true.
+        """
+
+        if not self._path:
+            raise ModelError(
+                ModelRefusal.BACKING_MISSING,
+                f"model {self.FAMILY!r} bound to {self._ref!r} has no local path on this "
+                "instance. A path is materialized by the worker when it resolves the "
+                "checkpoint; `.fake()` and a bare `.instance(ref)` do not produce one.",
+            )
+        return _PathType(self._path)
+
+    @property
+    def pipeline(self) -> Any:
+        """The CONSTRUCTED object the worker loaded for this checkpoint.
+
+        The other eager shape (3 of the 11 measured): a model whose serving is a
+        library object the worker built, not a graph this SDK traced and not a
+        path a binary reads. Kept deliberately untyped — the whole point of the
+        eager tier is that the SDK makes no claim about a shape it never saw.
+        """
+
+        if self._pipeline is None:
+            raise ModelError(
+                ModelRefusal.BACKING_MISSING,
+                f"model {self.FAMILY!r} bound to {self._ref!r} carries no constructed "
+                "object. Declare what to construct on the model, or read `.path` if this "
+                "model is bytes an external runtime loads itself.",
+            )
+        return self._pipeline
 
     @property
     def tuned(self) -> GenerationDefaults:

--- a/tests/test_eager_binding_pgw1346.py
+++ b/tests/test_eager_binding_pgw1346.py
@@ -1,0 +1,124 @@
+"""pgw#1346 K11 — the EAGER tier gets a runtime binding, so `inst.tuned` exists.
+
+B5 landed the declaration half: `eager_model_v1` and `render_eager` emit a real
+`Model` subclass for a model that declares no graph classes. What no code did
+was BUILD one on the serving path — `residency.instance_for` refused any model
+with neither an eager module nor an armed cell, and a runner-less model has
+neither by construction. So every eager model was unconstructible, `inst.tuned`
+was unreachable, and no `ctx.defaults` read on an eager endpoint could migrate.
+That single refusal gated anima (5 reads), hidream (14), the auxiliary-model
+class, and all 11 weight-bearing boundary endpoints at once.
+
+The tier also needed a SERVING SURFACE. Measured across the boundary batch, 8 of
+11 hand a local path to an external binary and 3 use an object the worker built
+— so `inst.path` and `inst.pipeline` are what an eager instance is FOR, the way
+a typed runner call is what a graph instance is for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.model.backing import BackingKind
+from gen_worker.model.catalog import Joycaption, Musicgen, Sdxl
+from gen_worker.model.errors import ModelError, ModelRefusal
+from gen_worker.model.residency import instance_for
+
+
+def test_an_eager_model_is_constructible_at_all() -> None:
+    """The K11 unblock, stated as the smallest possible claim.
+
+    Before this, `instance_for` refused every eager model — the model declares
+    no runners, so it has no eager module, so the "neither backing" refusal
+    fired unconditionally.
+    """
+
+    inst = instance_for(Musicgen, ref="hub:cozy/musicgen")
+    assert inst.ref == "hub:cozy/musicgen"
+
+
+def test_the_catalog_stamp_reaches_an_eager_instance() -> None:
+    """`inst.tuned` is the whole replacement for `ctx.defaults`, so an eager
+    model that cannot be constructed cannot migrate a single defaults read.
+    """
+
+    inst = instance_for(Musicgen, ref="hub:cozy/musicgen")
+    assert inst.tuned is not None
+    assert isinstance(inst.tuned, Musicgen.Tuned)
+
+
+def test_a_runner_less_model_reports_a_backing_of_NONE_not_a_missing_one() -> None:
+    """"Nothing to arm, by declaration" and "not armed yet" are different
+    answers, and only one of them is a defect. The backing kind says which.
+    """
+
+    inst = instance_for(Joycaption, ref="hub:cozy/joycaption")
+    assert inst.backing.kind is BackingKind.NONE
+
+
+# ---------------------------------------------------------------------------
+# The eager serving surface: path (8 of 11) and pipeline (3 of 11)
+# ---------------------------------------------------------------------------
+
+
+def test_the_local_path_is_what_an_external_binary_model_serves_through() -> None:
+    inst = instance_for(
+        Musicgen, ref="hub:cozy/musicgen", path="/cache/blobs/musicgen"
+    )
+    assert str(inst.path) == "/cache/blobs/musicgen"
+
+
+def test_asking_for_a_path_that_was_never_materialized_refuses_by_name() -> None:
+    """A handler that shells out with `""` fails somewhere far away and
+    confusingly. The answer is only useful at the point it stops being true.
+    """
+
+    inst = instance_for(Musicgen, ref="hub:cozy/musicgen")
+    with pytest.raises(ModelError) as caught:
+        inst.path
+    assert caught.value.reason is ModelRefusal.BACKING_MISSING
+    assert "no local path" in str(caught.value)
+
+
+def test_a_constructed_object_rides_the_instance_for_the_models_that_have_one() -> None:
+    built = object()
+    inst = instance_for(Musicgen, ref="hub:cozy/musicgen", tree=built)
+    assert inst.pipeline is built
+
+
+def test_asking_for_a_pipeline_that_was_never_built_refuses_by_name() -> None:
+    inst = instance_for(Musicgen, ref="hub:cozy/musicgen", path="/cache/x")
+    with pytest.raises(ModelError) as caught:
+        inst.pipeline
+    assert caught.value.reason is ModelRefusal.BACKING_MISSING
+    assert "carries no constructed object" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# The refusals the tier still owes
+# ---------------------------------------------------------------------------
+
+
+def test_calling_a_runner_on_a_model_that_declares_none_says_exactly_that() -> None:
+    """Not "no eager module bound for runner 'x'; it has []", which would send
+    the reader hunting for a registration that was never supposed to happen.
+    """
+
+    from gen_worker.model.backing import NoGraphBacking
+
+    with pytest.raises(ModelError) as caught:
+        NoGraphBacking().invoke("denoiser", None, (), {})  # type: ignore[arg-type]
+    assert "declares NO runners" in str(caught.value)
+    assert "inst.path" in str(caught.value)
+
+
+def test_a_GRAPH_model_with_no_backing_still_refuses_as_it_did_before() -> None:
+    """The K11 relaxation is scoped to models that declare no runners. A
+    declared graph with nothing to run it is still a pod-level failure, and
+    quietly handing back an instance would move the error somewhere useless.
+    """
+
+    with pytest.raises(ModelError) as caught:
+        instance_for(Sdxl, ref="hub:cozy/sdxl", tree=None)
+    assert caught.value.reason is ModelRefusal.BACKING_MISSING
+    assert "neither an eager module nor an armed cell" in str(caught.value)


### PR DESCRIPTION
Unblocks **K11** (B3b) and the `ctx.defaults` migration for every eager endpoint.

## The gap

B5 landed the declaration half — `render_eager` emits a real `Model` subclass for a model with no graph classes. What no code did was **build one on the serving path**: `residency.instance_for` refused any model with neither an eager module nor an armed cell, and a runner-less model has neither *by construction*.

So every eager model was unconstructible, `inst.tuned` was unreachable, and since `inst.tuned` is the entire replacement for `ctx.defaults`, that one refusal gated **anima (5 defaults reads), hidream (14), the auxiliary-model class, and all 11 weight-bearing boundary endpoints at once**.

## The fix

- A model that declares **no runners** is now complete with a ref and its tuned values.
- The refusal **stays** for a model that *declares* a graph and has nothing to run it — still a pod-level failure, and handing back an instance would move the error somewhere useless.
- **`NoGraphBacking`** names that state instead of reusing an empty `EagerBacking`, whose refusal would read *"no eager module bound for runner 'x'; it has []"* and send the reader hunting for a registration that was never supposed to happen. *"Nothing to arm, by declaration"* and *"not armed yet"* are different answers; only one is a defect.

## The eager tier's serving surface

`inst.path` and `inst.pipeline`, the way a typed runner call is a graph model's. B5's measurement: **8 of 11** weight-bearing boundary endpoints hand a local path to an external binary or a custom loader; **3** use an object the worker constructed.

Both refuse by name rather than returning an empty path or `None` — a handler that shells out to `llama-server` with `""` fails somewhere far away and confusingly. The executor materializes the path through the **same `store.ensure_local` call** that already served slot-path injection, so the two routes cannot disagree.

This is also the shape F0(b)'s path-kind would need, so it is deliberately expressed **on the instance** — it works whichever way Paul rules F0.

## Verification

- 9 new tests in `tests/test_eager_binding_pgw1346.py`
- 198 green across the eager/injection/axes/SDK/flux/v2 suites
- `mypy src/gen_worker tests tests_v2` — **Success: no issues found in 913 source files**; `ruff` clean
- `lint_serve_role_closure` (both roles), `lint_serving_process_compiles`, `lint_unreached_surface`, `lint_fence_symbols`, `check_registry_contract`, `check_model_bindings`, `lint_retired_sdk_spellings`, `assemble_changelog --check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
