### PR TITLE
pgw#1346 K10: the sampler is a TUNED value, so the declaration carries a scheduler SET

### DIFF
--- a/changelog.d/pgw1346-k10-scheduler.md
+++ b/changelog.d/pgw1346-k10-scheduler.md
@@ -1,0 +1,42 @@
+- **pgw#1346 K10: the declaration carries a scheduler SET keyed by the tuned sampler, and
+  `euler_a` / `ddim` are implemented.** B2 closed with a structural blocker rather than a
+  budget one: the sampler is a CHECKPOINT value (`inst.tuned.scheduler`, six names on sdxl and
+  nine on sd15, over four diffusers classes) while `GraphModelSpec.scheduler` was ONE block,
+  so a second implemented kind would have been a class no declaration could attach to. The
+  live consequence it measured: **SDXL's DEFAULT sampler is `euler_a`**, so the family's single
+  declared `euler_discrete` block was its TRAINED schedule and not the one most requests ask
+  for. `GraphModelSpec.schedulers` is now `{sampler: Scheduler(kind, block)}`; the export
+  records a sorted `schedulers[]` array of `(sampler, name, parameters)`; codegen emits
+  `SCHEDULERS` + per-sampler `SCHEDULER_PARAMETERS` and a `scheduler()` that resolves
+  `inst.tuned.scheduler` to a concrete class over a closed union, with an optional `name=`
+  typed by a generated `…DeclaredSampler` Literal. A family with ONE sampler declares a set of
+  one and its accessor keeps the exact previous shape — no argument, one concrete return type —
+  so the single-scheduler migration (flux1_dev) is mechanical and B2's held endpoint migration
+  needs nothing from this change. **An undeclared stamp is `SCHEDULER_UNDECLARED`, never a
+  substitution**: serving the family's other schedule under the requested sampler's name is a
+  plausible wrong image and nothing else. New math, at B2's final instrument (relative 2e-4 vs
+  diffusers, timesteps EXACT, loops compared in the L2 norm with our ladder injected, and our
+  own ladder byte-identical under `ATEN_CPU_CAPABILITY=default`): `EulerAncestralDiscrete`
+  (same ladder as `euler`, stochastic step, **noise is a required parameter** — defaulting it
+  would be a silently different sampler) and `Ddim` (walks ALPHAS, not sigmas — `init_noise_sigma`
+  1.0 and `scale_model_input` the identity, so it is its own schedule type). Both loops measured
+  BIT-EXACT against diffusers with the table removed as a variable. Three sharp findings carved
+  into tests: `DDIMScheduler` does **not** clamp the terminal alpha under zero-terminal-SNR where
+  the euler family does; DDIM ROUNDS its linspace grid where the euler family interpolates at the
+  fractional position; and a block carrying a parameter its kind never reads is now REFUSED
+  (`EulerAncestralDiscrete` has no `final_sigmas_type`) rather than ignored. The per-step
+  ancestral noise is CPU-seeded and keyed by `(seed, step index)` through splitmix64's finalizer —
+  reproducible across pods AND across loop shapes, where an advancing generator is only the
+  former. **B3-math landed first and is ADDITIVE to the set**, so the staging shrank to one name:
+  `dpmsolver_multistep` and `unipc_multistep` slot in as two more members with no math change,
+  and **sd15's own default `dpmpp_2m_karras` is servable** — five samplers on sdxl and eight on
+  sd15/sd2, every one of them rendered end to end through the real `generate` in the suite. The
+  loop dispatches on the SCHEDULE TYPE and not on the name, because the differences are
+  load-bearing: a multistep solver carries history between steps and is NOT pre-scaled (its
+  `init_noise_sigma` is 1.0, so dividing its latents by `sqrt(sigma**2+1)` is a wrong image and
+  never an error), and `sde-dpmsolver++` consumes the same keyed noise `euler_a` does. The
+  declared blocks are asserted against `gen_worker.view.SAMPLERS`, which already defines each
+  sampler name completely for the `Slot`-served endpoints, rather than restated from memory.
+  **`lcm` is the one name still owed** — `LCMScheduler` has no module in `model/solvers/` — and a
+  checkpoint stamped with it refuses by name. B3's two solvers also gained the same
+  unread-parameter refusal.

--- a/changelog.d/pgw1346.md
+++ b/changelog.d/pgw1346.md
@@ -413,3 +413,4 @@
   clean master; adding a test file changed xdist's distribution and surfaced it.
   The test now establishes its own premise.
 
+

--- a/src/gen_worker/model/catalog/__init__.py
+++ b/src/gen_worker/model/catalog/__init__.py
@@ -70,9 +70,9 @@ if TYPE_CHECKING:  # pragma: no cover - the eager spelling, for type checkers on
     from ._generated.qwen36_27b_mtp import Qwen3627bMtp
     from ._generated.qwen36_35b_a3b import Qwen3635bA3b
     from ._generated.qwen_image import QwenImage, QwenImageLayout, QwenImageShape
-    from ._generated.sd2 import Sd2, Sd2Layout, Sd2Shape
-    from ._generated.sd15 import Sd15, Sd15Layout, Sd15Shape
-    from ._generated.sdxl import Sdxl, SdxlLayout, SdxlShape
+    from ._generated.sd2 import Sd2, Sd2DeclaredSampler, Sd2Layout, Sd2Shape
+    from ._generated.sd15 import Sd15, Sd15DeclaredSampler, Sd15Layout, Sd15Shape
+    from ._generated.sdxl import Sdxl, SdxlDeclaredSampler, SdxlLayout, SdxlShape
     from ._generated.stable_audio_open import StableAudioOpen
     from ._generated.trellis_3d import Trellis3d
     from ._generated.z_image import ZImage, ZImageBranches, ZImageLayout
@@ -136,12 +136,15 @@ _FAMILIES: Final[dict[str, str]] = {
     "Ltx23Layout": "ltx23",
     "Ltx23VideoTokens": "ltx23",
     "Sd2": "sd2",
+    "Sd2DeclaredSampler": "sd2",
     "Sd2Layout": "sd2",
     "Sd2Shape": "sd2",
     "Sd15": "sd15",
+    "Sd15DeclaredSampler": "sd15",
     "Sd15Layout": "sd15",
     "Sd15Shape": "sd15",
     "Sdxl": "sdxl",
+    "SdxlDeclaredSampler": "sdxl",
     "SdxlLayout": "sdxl",
     "SdxlShape": "sdxl",
     "StableAudioOpen": "stable_audio_open",
@@ -212,12 +215,15 @@ __all__ = [
     "Ltx23Layout",
     "Ltx23VideoTokens",
     "Sd2",
+    "Sd2DeclaredSampler",
     "Sd2Layout",
     "Sd2Shape",
     "Sd15",
+    "Sd15DeclaredSampler",
     "Sd15Layout",
     "Sd15Shape",
     "Sdxl",
+    "SdxlDeclaredSampler",
     "SdxlLayout",
     "SdxlShape",
     "StableAudioOpen",

--- a/src/gen_worker/model/catalog/_generated/ernie.export.json
+++ b/src/gen_worker/model/catalog/_generated/ernie.export.json
@@ -1254,19 +1254,22 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 4096,
-      "max_shift": 1.15,
-      "num_train_timesteps": 1000,
-      "shift": 4.0,
-      "time_shift_type": "exponential",
-      "use_dynamic_shifting": false
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 4096,
+        "max_shift": 1.15,
+        "num_train_timesteps": 1000,
+        "shift": 4.0,
+        "time_shift_type": "exponential",
+        "use_dynamic_shifting": false
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.ernie_serve",
     "qualname": "ErnieTuned"

--- a/src/gen_worker/model/catalog/_generated/ernie.py
+++ b/src/gen_worker/model/catalog/_generated/ernie.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -77,7 +78,7 @@ class Ernie(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'ernie'
-    EXPORT_DIGEST: ClassVar[str] = 'd2a7a63d101d0a80c31af374340a8e8a'
+    EXPORT_DIGEST: ClassVar[str] = '6639463c402460c18a25a17a9bfe8f7d'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[ErnieTuned]] = ErnieTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -88,16 +89,22 @@ class Ernie(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 4096,
-        'max_shift': 1.15,
-        'num_train_timesteps': 1000,
-        'shift': 4.0,
-        'time_shift_type': 'exponential',
-        'use_dynamic_shifting': False,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 4096,
+            'max_shift': 1.15,
+            'num_train_timesteps': 1000,
+            'shift': 4.0,
+            'time_shift_type': 'exponential',
+            'use_dynamic_shifting': False,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -110,8 +117,13 @@ class Ernie(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/_generated/flux1_dev.export.json
+++ b/src/gen_worker/model/catalog/_generated/flux1_dev.export.json
@@ -488,18 +488,21 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 4096,
-      "max_shift": 1.15,
-      "num_train_timesteps": 1000,
-      "shift": 3.0,
-      "use_dynamic_shifting": true
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 4096,
+        "max_shift": 1.15,
+        "num_train_timesteps": 1000,
+        "shift": 3.0,
+        "use_dynamic_shifting": true
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.flux1_dev_serve",
     "qualname": "Flux1DevTuned"

--- a/src/gen_worker/model/catalog/_generated/flux1_dev.py
+++ b/src/gen_worker/model/catalog/_generated/flux1_dev.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class Flux1Dev(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'flux1_dev'
-    EXPORT_DIGEST: ClassVar[str] = '90b162d53cebd4da3afc06b003df7244'
+    EXPORT_DIGEST: ClassVar[str] = 'c4d6060360a8e6c786981e49d55544ef'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Flux1DevTuned]] = Flux1DevTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -88,15 +89,21 @@ class Flux1Dev(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 4096,
-        'max_shift': 1.15,
-        'num_train_timesteps': 1000,
-        'shift': 3.0,
-        'use_dynamic_shifting': True,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 4096,
+            'max_shift': 1.15,
+            'num_train_timesteps': 1000,
+            'shift': 3.0,
+            'use_dynamic_shifting': True,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -109,8 +116,13 @@ class Flux1Dev(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def clip(
         self,

--- a/src/gen_worker/model/catalog/_generated/flux1_schnell.export.json
+++ b/src/gen_worker/model/catalog/_generated/flux1_schnell.export.json
@@ -588,18 +588,21 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 4096,
-      "max_shift": 1.15,
-      "num_train_timesteps": 1000,
-      "shift": 1.0,
-      "use_dynamic_shifting": false
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 4096,
+        "max_shift": 1.15,
+        "num_train_timesteps": 1000,
+        "shift": 1.0,
+        "use_dynamic_shifting": false
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.flux1_schnell_serve",
     "qualname": "Flux1SchnellTuned"

--- a/src/gen_worker/model/catalog/_generated/flux1_schnell.py
+++ b/src/gen_worker/model/catalog/_generated/flux1_schnell.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class Flux1Schnell(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'flux1_schnell'
-    EXPORT_DIGEST: ClassVar[str] = 'b1fe93f25941811ea2295fce4b96f60a'
+    EXPORT_DIGEST: ClassVar[str] = 'b4aaa5782af8ef6646fa85c918167bfa'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Flux1SchnellTuned]] = Flux1SchnellTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -87,15 +88,21 @@ class Flux1Schnell(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 4096,
-        'max_shift': 1.15,
-        'num_train_timesteps': 1000,
-        'shift': 1.0,
-        'use_dynamic_shifting': False,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 4096,
+            'max_shift': 1.15,
+            'num_train_timesteps': 1000,
+            'shift': 1.0,
+            'use_dynamic_shifting': False,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -108,8 +115,13 @@ class Flux1Schnell(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def clip(
         self,

--- a/src/gen_worker/model/catalog/_generated/flux2_klein_4b.export.json
+++ b/src/gen_worker/model/catalog/_generated/flux2_klein_4b.export.json
@@ -948,18 +948,21 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 4096,
-      "max_shift": 1.15,
-      "num_train_timesteps": 1000,
-      "shift": 3.0,
-      "use_dynamic_shifting": true
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 4096,
+        "max_shift": 1.15,
+        "num_train_timesteps": 1000,
+        "shift": 3.0,
+        "use_dynamic_shifting": true
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.flux2_klein_4b_serve",
     "qualname": "Flux2Klein4bTuned"

--- a/src/gen_worker/model/catalog/_generated/flux2_klein_4b.py
+++ b/src/gen_worker/model/catalog/_generated/flux2_klein_4b.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class Flux2Klein4b(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'flux2_klein_4b'
-    EXPORT_DIGEST: ClassVar[str] = '147ffe2f97ee3a784bc88cbe2fd4542c'
+    EXPORT_DIGEST: ClassVar[str] = '8ed3fb7906ec1ba51cda3b3aa7922f55'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Flux2Klein4bTuned]] = Flux2Klein4bTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -85,15 +86,21 @@ class Flux2Klein4b(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 4096,
-        'max_shift': 1.15,
-        'num_train_timesteps': 1000,
-        'shift': 3.0,
-        'use_dynamic_shifting': True,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 4096,
+            'max_shift': 1.15,
+            'num_train_timesteps': 1000,
+            'shift': 3.0,
+            'use_dynamic_shifting': True,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -106,8 +113,13 @@ class Flux2Klein4b(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/_generated/flux2_klein_9b.export.json
+++ b/src/gen_worker/model/catalog/_generated/flux2_klein_9b.export.json
@@ -948,18 +948,21 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 4096,
-      "max_shift": 1.15,
-      "num_train_timesteps": 1000,
-      "shift": 3.0,
-      "use_dynamic_shifting": true
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 4096,
+        "max_shift": 1.15,
+        "num_train_timesteps": 1000,
+        "shift": 3.0,
+        "use_dynamic_shifting": true
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.flux2_klein_9b_serve",
     "qualname": "Flux2Klein9bTuned"

--- a/src/gen_worker/model/catalog/_generated/flux2_klein_9b.py
+++ b/src/gen_worker/model/catalog/_generated/flux2_klein_9b.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class Flux2Klein9b(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'flux2_klein_9b'
-    EXPORT_DIGEST: ClassVar[str] = '9d21338a5102a975495beb2696e1d974'
+    EXPORT_DIGEST: ClassVar[str] = '349ff9fd19c328f4abf710d3fca288b4'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Flux2Klein9bTuned]] = Flux2Klein9bTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -85,15 +86,21 @@ class Flux2Klein9b(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 4096,
-        'max_shift': 1.15,
-        'num_train_timesteps': 1000,
-        'shift': 3.0,
-        'use_dynamic_shifting': True,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 4096,
+            'max_shift': 1.15,
+            'num_train_timesteps': 1000,
+            'shift': 3.0,
+            'use_dynamic_shifting': True,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -106,8 +113,13 @@ class Flux2Klein9b(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/_generated/ltx23.export.json
+++ b/src/gen_worker/model/catalog/_generated/ltx23.export.json
@@ -895,12 +895,15 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "num_train_timesteps": 1000
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "num_train_timesteps": 1000
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.ltx23_serve",
     "qualname": "Ltx23Tuned"

--- a/src/gen_worker/model/catalog/_generated/ltx23.py
+++ b/src/gen_worker/model/catalog/_generated/ltx23.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -77,7 +78,7 @@ class Ltx23(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'ltx23'
-    EXPORT_DIGEST: ClassVar[str] = '85c89d59fbd4cccd5a51a873d2e1e737'
+    EXPORT_DIGEST: ClassVar[str] = 'ef0ed3beda290449b0443066c2e27eac'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Ltx23Tuned]] = Ltx23Tuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -89,9 +90,15 @@ class Ltx23(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'num_train_timesteps': 1000,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'num_train_timesteps': 1000,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -105,8 +112,13 @@ class Ltx23(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/_generated/qwen_image.export.json
+++ b/src/gen_worker/model/catalog/_generated/qwen_image.export.json
@@ -1239,20 +1239,23 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "base_image_seq_len": 256,
-      "base_shift": 0.5,
-      "max_image_seq_len": 8192,
-      "max_shift": 0.9,
-      "num_train_timesteps": 1000,
-      "shift": 1.0,
-      "shift_terminal": 0.02,
-      "time_shift_type": "exponential",
-      "use_dynamic_shifting": true
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "base_image_seq_len": 256,
+        "base_shift": 0.5,
+        "max_image_seq_len": 8192,
+        "max_shift": 0.9,
+        "num_train_timesteps": 1000,
+        "shift": 1.0,
+        "shift_terminal": 0.02,
+        "time_shift_type": "exponential",
+        "use_dynamic_shifting": true
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.qwen_image_serve",
     "qualname": "QwenImageTuned"

--- a/src/gen_worker/model/catalog/_generated/qwen_image.py
+++ b/src/gen_worker/model/catalog/_generated/qwen_image.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class QwenImage(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'qwen_image'
-    EXPORT_DIGEST: ClassVar[str] = '2737764f8a0c7d44bada4df584353fae'
+    EXPORT_DIGEST: ClassVar[str] = '09310b1a8c8bd43bd0f8ce9a7d7c238b'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[QwenImageTuned]] = QwenImageTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -85,17 +86,23 @@ class QwenImage(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'base_image_seq_len': 256,
-        'base_shift': 0.5,
-        'max_image_seq_len': 8192,
-        'max_shift': 0.9,
-        'num_train_timesteps': 1000,
-        'shift': 1.0,
-        'shift_terminal': 0.02,
-        'time_shift_type': 'exponential',
-        'use_dynamic_shifting': True,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'base_image_seq_len': 256,
+            'base_shift': 0.5,
+            'max_image_seq_len': 8192,
+            'max_shift': 0.9,
+            'num_train_timesteps': 1000,
+            'shift': 1.0,
+            'shift_terminal': 0.02,
+            'time_shift_type': 'exponential',
+            'use_dynamic_shifting': True,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -108,8 +115,13 @@ class QwenImage(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/_generated/sd15.export.json
+++ b/src/gen_worker/model/catalog/_generated/sd15.export.json
@@ -905,19 +905,126 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "euler_discrete",
-    "parameters": {
-      "beta_end": 0.012,
-      "beta_schedule": "scaled_linear",
-      "beta_start": 0.00085,
-      "final_sigmas_type": "zero",
-      "num_train_timesteps": 1000,
-      "prediction_type": "epsilon",
-      "steps_offset": 1,
-      "timestep_spacing": "leading"
+  "schedulers": [
+    {
+      "name": "ddim",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "clip_sample": false,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "set_alpha_to_one": false,
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "ddim"
+    },
+    {
+      "name": "ddim",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "clip_sample": false,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "set_alpha_to_one": false,
+        "steps_offset": 0,
+        "timestep_spacing": "trailing"
+      },
+      "sampler": "ddim_trailing"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "dpmpp_2m"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_karras"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "algorithm_type": "sde-dpmsolver++",
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_sde_karras"
+    },
+    {
+      "name": "euler_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "euler"
+    },
+    {
+      "name": "euler_ancestral_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "euler_a"
+    },
+    {
+      "name": "unipc_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "unipc"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.sd15_serve",
     "qualname": "Sd15Tuned"

--- a/src/gen_worker/model/catalog/_generated/sd15.py
+++ b/src/gen_worker/model/catalog/_generated/sd15.py
@@ -11,13 +11,15 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from gen_worker.model.catalog.sd15_serve import Sd15Tuned
+from gen_worker.model.errors import ModelError, ModelRefusal
 from gen_worker.model.runtime import Model
-from gen_worker.model.scheduler import EulerDiscrete, SchedulerBlock, SchedulerKind
+from gen_worker.model.scheduler import DPMSolverMultistep, Ddim, EulerAncestralDiscrete, EulerDiscrete, SchedulerBlock, SchedulerKind, UniPCMultistep
 from gen_worker.model.snapshot import ModelExport
 from gen_worker.model.spec import ModelSpec
 
@@ -51,6 +53,9 @@ def _declaration() -> ModelSpec | None:
 _SPEC = _declaration()
 
 
+#: Every sampler this family declares AND this SDK implements. Total: every value resolves.
+Sd15DeclaredSampler = Literal['ddim', 'ddim_trailing', 'dpmpp_2m', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler', 'euler_a', 'unipc']
+
 #: Every declared shape bucket. Exhaustive: every value resolves.
 Sd15Shape = Literal[4320768, 4800640, 5120512, 5120768, 6400480, 7680432, 7680512]
 
@@ -74,7 +79,7 @@ class Sd15(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'sd15'
-    EXPORT_DIGEST: ClassVar[str] = '6c925e43812d59b4f60333acaee25a6a'
+    EXPORT_DIGEST: ClassVar[str] = 'e4c5320ec22b1797ae8682cd159a451e'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Sd15Tuned]] = Sd15Tuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -87,30 +92,166 @@ class Sd15(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'beta_end': 0.012,
-        'beta_schedule': 'scaled_linear',
-        'beta_start': 0.00085,
-        'final_sigmas_type': 'zero',
-        'num_train_timesteps': 1000,
-        'prediction_type': 'epsilon',
-        'steps_offset': 1,
-        'timestep_spacing': 'leading',
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'ddim': SchedulerKind.DDIM,
+        'ddim_trailing': SchedulerKind.DDIM,
+        'dpmpp_2m': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'dpmpp_2m_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'dpmpp_2m_sde_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'euler': SchedulerKind.EULER_DISCRETE,
+        'euler_a': SchedulerKind.EULER_ANCESTRAL_DISCRETE,
+        'unipc': SchedulerKind.UNIPC_MULTISTEP,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'ddim': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'clip_sample': False,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'set_alpha_to_one': False,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'ddim_trailing': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'clip_sample': False,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'set_alpha_to_one': False,
+            'steps_offset': 0,
+            'timestep_spacing': 'trailing',
+        }),
+        'dpmpp_2m': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'dpmpp_2m_karras': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'dpmpp_2m_sde_karras': MappingProxyType({
+            'algorithm_type': 'sde-dpmsolver++',
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'euler': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'euler_a': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'unipc': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
         ('steps', 1, 100),
     )
 
-    def scheduler(self) -> EulerDiscrete:
-        """This family's declared scheduler, as bare typed math.
+    def scheduler(self, name: Sd15DeclaredSampler | None = None) -> DPMSolverMultistep | Ddim | EulerAncestralDiscrete | EulerDiscrete | UniPCMultistep:
+        """The scheduler this checkpoint's SAMPLER names, as bare typed math.
 
-        Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
-        digest — so a re-declared schedule changes this family's identity
-        instead of silently changing every request.
+        ``name`` defaults to ``self.tuned.scheduler`` — the value the
+        catalog stamped for THIS checkpoint — because the sampler is a
+        checkpoint fact and not a family constant. Pass it explicitly only
+        to override, and only with a sampler this family declares: the
+        parameter's type is the closed declared set, so anything else is a
+        type error before it is a runtime one.
+
+        A STAMPED sampler outside the declared set is refused, never
+        substituted. The tuned schema may admit more names than the SDK
+        implements schedulers for, and serving one of the others in its
+        place would render a different image than the recipe asked for,
+        silently and plausibly.
         """
-        return EulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        chosen = cast("Sd15Tuned", self.tuned).scheduler if name is None else name
+        if chosen == 'ddim':
+            return Ddim.from_block(
+                self.SCHEDULER_PARAMETERS['ddim']
+            )
+        if chosen == 'ddim_trailing':
+            return Ddim.from_block(
+                self.SCHEDULER_PARAMETERS['ddim_trailing']
+            )
+        if chosen == 'dpmpp_2m':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m']
+            )
+        if chosen == 'dpmpp_2m_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_karras']
+            )
+        if chosen == 'dpmpp_2m_sde_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_sde_karras']
+            )
+        if chosen == 'euler':
+            return EulerDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler']
+            )
+        if chosen == 'euler_a':
+            return EulerAncestralDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler_a']
+            )
+        if chosen == 'unipc':
+            return UniPCMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['unipc']
+            )
+        raise ModelError(
+            ModelRefusal.SCHEDULER_UNDECLARED,
+            f"sd15 is stamped with sampler {chosen!r}, which this SDK "
+            f"implements no scheduler for; it serves "
+            f"['ddim', 'ddim_trailing', 'dpmpp_2m', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler', 'euler_a', 'unipc']",
+        )
 
     def clip(
         self,
@@ -197,4 +338,4 @@ class Sd15(Model):
         )
 
 
-__all__ = ['Sd15', 'Sd15Layout', 'Sd15Shape']
+__all__ = ['Sd15', 'Sd15DeclaredSampler', 'Sd15Layout', 'Sd15Shape']

--- a/src/gen_worker/model/catalog/_generated/sd2.export.json
+++ b/src/gen_worker/model/catalog/_generated/sd2.export.json
@@ -905,19 +905,126 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "euler_discrete",
-    "parameters": {
-      "beta_end": 0.012,
-      "beta_schedule": "scaled_linear",
-      "beta_start": 0.00085,
-      "final_sigmas_type": "zero",
-      "num_train_timesteps": 1000,
-      "prediction_type": "epsilon",
-      "steps_offset": 1,
-      "timestep_spacing": "leading"
+  "schedulers": [
+    {
+      "name": "ddim",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "clip_sample": false,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "set_alpha_to_one": false,
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "ddim"
+    },
+    {
+      "name": "ddim",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "clip_sample": false,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "set_alpha_to_one": false,
+        "steps_offset": 0,
+        "timestep_spacing": "trailing"
+      },
+      "sampler": "ddim_trailing"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "dpmpp_2m"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_karras"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "algorithm_type": "sde-dpmsolver++",
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_sde_karras"
+    },
+    {
+      "name": "euler_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "euler"
+    },
+    {
+      "name": "euler_ancestral_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "euler_a"
+    },
+    {
+      "name": "unipc_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "unipc"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.sd15_serve",
     "qualname": "Sd2Tuned"

--- a/src/gen_worker/model/catalog/_generated/sd2.py
+++ b/src/gen_worker/model/catalog/_generated/sd2.py
@@ -11,13 +11,15 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from gen_worker.model.catalog.sd15_serve import Sd2Tuned
+from gen_worker.model.errors import ModelError, ModelRefusal
 from gen_worker.model.runtime import Model
-from gen_worker.model.scheduler import EulerDiscrete, SchedulerBlock, SchedulerKind
+from gen_worker.model.scheduler import DPMSolverMultistep, Ddim, EulerAncestralDiscrete, EulerDiscrete, SchedulerBlock, SchedulerKind, UniPCMultistep
 from gen_worker.model.snapshot import ModelExport
 from gen_worker.model.spec import ModelSpec
 
@@ -51,6 +53,9 @@ def _declaration() -> ModelSpec | None:
 _SPEC = _declaration()
 
 
+#: Every sampler this family declares AND this SDK implements. Total: every value resolves.
+Sd2DeclaredSampler = Literal['ddim', 'ddim_trailing', 'dpmpp_2m', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler', 'euler_a', 'unipc']
+
 #: Every declared shape bucket. Exhaustive: every value resolves.
 Sd2Shape = Literal[4320768, 4800640, 5120512, 5120768, 6400480, 7680432, 7680512]
 
@@ -74,7 +79,7 @@ class Sd2(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'sd2'
-    EXPORT_DIGEST: ClassVar[str] = '6ce2561bc0dd4aac3e59e6c8c460b7fa'
+    EXPORT_DIGEST: ClassVar[str] = 'c91eacb4b9dce903bf20e4c9e286122a'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[Sd2Tuned]] = Sd2Tuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -87,30 +92,166 @@ class Sd2(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'beta_end': 0.012,
-        'beta_schedule': 'scaled_linear',
-        'beta_start': 0.00085,
-        'final_sigmas_type': 'zero',
-        'num_train_timesteps': 1000,
-        'prediction_type': 'epsilon',
-        'steps_offset': 1,
-        'timestep_spacing': 'leading',
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'ddim': SchedulerKind.DDIM,
+        'ddim_trailing': SchedulerKind.DDIM,
+        'dpmpp_2m': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'dpmpp_2m_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'dpmpp_2m_sde_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'euler': SchedulerKind.EULER_DISCRETE,
+        'euler_a': SchedulerKind.EULER_ANCESTRAL_DISCRETE,
+        'unipc': SchedulerKind.UNIPC_MULTISTEP,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'ddim': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'clip_sample': False,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'set_alpha_to_one': False,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'ddim_trailing': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'clip_sample': False,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'set_alpha_to_one': False,
+            'steps_offset': 0,
+            'timestep_spacing': 'trailing',
+        }),
+        'dpmpp_2m': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'dpmpp_2m_karras': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'dpmpp_2m_sde_karras': MappingProxyType({
+            'algorithm_type': 'sde-dpmsolver++',
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'euler': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'euler_a': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'unipc': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
         ('steps', 1, 100),
     )
 
-    def scheduler(self) -> EulerDiscrete:
-        """This family's declared scheduler, as bare typed math.
+    def scheduler(self, name: Sd2DeclaredSampler | None = None) -> DPMSolverMultistep | Ddim | EulerAncestralDiscrete | EulerDiscrete | UniPCMultistep:
+        """The scheduler this checkpoint's SAMPLER names, as bare typed math.
 
-        Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
-        digest — so a re-declared schedule changes this family's identity
-        instead of silently changing every request.
+        ``name`` defaults to ``self.tuned.scheduler`` — the value the
+        catalog stamped for THIS checkpoint — because the sampler is a
+        checkpoint fact and not a family constant. Pass it explicitly only
+        to override, and only with a sampler this family declares: the
+        parameter's type is the closed declared set, so anything else is a
+        type error before it is a runtime one.
+
+        A STAMPED sampler outside the declared set is refused, never
+        substituted. The tuned schema may admit more names than the SDK
+        implements schedulers for, and serving one of the others in its
+        place would render a different image than the recipe asked for,
+        silently and plausibly.
         """
-        return EulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        chosen = cast("Sd2Tuned", self.tuned).scheduler if name is None else name
+        if chosen == 'ddim':
+            return Ddim.from_block(
+                self.SCHEDULER_PARAMETERS['ddim']
+            )
+        if chosen == 'ddim_trailing':
+            return Ddim.from_block(
+                self.SCHEDULER_PARAMETERS['ddim_trailing']
+            )
+        if chosen == 'dpmpp_2m':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m']
+            )
+        if chosen == 'dpmpp_2m_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_karras']
+            )
+        if chosen == 'dpmpp_2m_sde_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_sde_karras']
+            )
+        if chosen == 'euler':
+            return EulerDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler']
+            )
+        if chosen == 'euler_a':
+            return EulerAncestralDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler_a']
+            )
+        if chosen == 'unipc':
+            return UniPCMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['unipc']
+            )
+        raise ModelError(
+            ModelRefusal.SCHEDULER_UNDECLARED,
+            f"sd2 is stamped with sampler {chosen!r}, which this SDK "
+            f"implements no scheduler for; it serves "
+            f"['ddim', 'ddim_trailing', 'dpmpp_2m', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler', 'euler_a', 'unipc']",
+        )
 
     def clip(
         self,
@@ -197,4 +338,4 @@ class Sd2(Model):
         )
 
 
-__all__ = ['Sd2', 'Sd2Layout', 'Sd2Shape']
+__all__ = ['Sd2', 'Sd2DeclaredSampler', 'Sd2Layout', 'Sd2Shape']

--- a/src/gen_worker/model/catalog/_generated/sdxl.export.json
+++ b/src/gen_worker/model/catalog/_generated/sdxl.export.json
@@ -1470,19 +1470,83 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "euler_discrete",
-    "parameters": {
-      "beta_end": 0.012,
-      "beta_schedule": "scaled_linear",
-      "beta_start": 0.00085,
-      "final_sigmas_type": "zero",
-      "num_train_timesteps": 1000,
-      "prediction_type": "epsilon",
-      "steps_offset": 1,
-      "timestep_spacing": "leading"
+  "schedulers": [
+    {
+      "name": "ddim",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "clip_sample": false,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "set_alpha_to_one": false,
+        "steps_offset": 0,
+        "timestep_spacing": "trailing"
+      },
+      "sampler": "ddim_trailing"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_karras"
+    },
+    {
+      "name": "dpmsolver_multistep",
+      "parameters": {
+        "algorithm_type": "sde-dpmsolver++",
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "solver_order": 2,
+        "steps_offset": 1,
+        "timestep_spacing": "leading",
+        "use_karras_sigmas": true
+      },
+      "sampler": "dpmpp_2m_sde_karras"
+    },
+    {
+      "name": "euler_ancestral_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 1,
+        "timestep_spacing": "leading"
+      },
+      "sampler": "euler_a"
+    },
+    {
+      "name": "euler_discrete",
+      "parameters": {
+        "beta_end": 0.012,
+        "beta_schedule": "scaled_linear",
+        "beta_start": 0.00085,
+        "final_sigmas_type": "zero",
+        "num_train_timesteps": 1000,
+        "prediction_type": "epsilon",
+        "steps_offset": 0,
+        "timestep_spacing": "trailing"
+      },
+      "sampler": "euler_trailing"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.sdxl_serve",
     "qualname": "SdxlTuned"

--- a/src/gen_worker/model/catalog/_generated/sdxl.py
+++ b/src/gen_worker/model/catalog/_generated/sdxl.py
@@ -17,8 +17,9 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from gen_worker.model.catalog.sdxl_serve import SdxlTuned
+from gen_worker.model.errors import ModelError, ModelRefusal
 from gen_worker.model.runtime import Model
-from gen_worker.model.scheduler import EulerDiscrete, SchedulerBlock, SchedulerKind
+from gen_worker.model.scheduler import DPMSolverMultistep, Ddim, EulerAncestralDiscrete, EulerDiscrete, SchedulerBlock, SchedulerKind
 from gen_worker.model.snapshot import ModelExport
 from gen_worker.model.spec import ModelSpec
 
@@ -52,6 +53,9 @@ def _declaration() -> ModelSpec | None:
 _SPEC = _declaration()
 
 
+#: Every sampler this family declares AND this SDK implements. Total: every value resolves.
+SdxlDeclaredSampler = Literal['ddim_trailing', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler_a', 'euler_trailing']
+
 #: Every declared shape bucket. Exhaustive: every value resolves.
 SdxlShape = Literal[6401536, 7681344, 8321216, 8961152, 10241024, 11520896, 12160832, 13440768, 15360640]
 
@@ -75,7 +79,7 @@ class Sdxl(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'sdxl'
-    EXPORT_DIGEST: ClassVar[str] = '77b9062a5f143f6cd19b27e5911260a9'
+    EXPORT_DIGEST: ClassVar[str] = 'c449bb6dccf07d0fe2661855ba722edf'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[SdxlTuned]] = SdxlTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -89,30 +93,120 @@ class Sdxl(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'beta_end': 0.012,
-        'beta_schedule': 'scaled_linear',
-        'beta_start': 0.00085,
-        'final_sigmas_type': 'zero',
-        'num_train_timesteps': 1000,
-        'prediction_type': 'epsilon',
-        'steps_offset': 1,
-        'timestep_spacing': 'leading',
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'ddim_trailing': SchedulerKind.DDIM,
+        'dpmpp_2m_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'dpmpp_2m_sde_karras': SchedulerKind.DPMSOLVER_MULTISTEP,
+        'euler_a': SchedulerKind.EULER_ANCESTRAL_DISCRETE,
+        'euler_trailing': SchedulerKind.EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'ddim_trailing': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'clip_sample': False,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'set_alpha_to_one': False,
+            'steps_offset': 0,
+            'timestep_spacing': 'trailing',
+        }),
+        'dpmpp_2m_karras': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'dpmpp_2m_sde_karras': MappingProxyType({
+            'algorithm_type': 'sde-dpmsolver++',
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'solver_order': 2,
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+            'use_karras_sigmas': True,
+        }),
+        'euler_a': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 1,
+            'timestep_spacing': 'leading',
+        }),
+        'euler_trailing': MappingProxyType({
+            'beta_end': 0.012,
+            'beta_schedule': 'scaled_linear',
+            'beta_start': 0.00085,
+            'final_sigmas_type': 'zero',
+            'num_train_timesteps': 1000,
+            'prediction_type': 'epsilon',
+            'steps_offset': 0,
+            'timestep_spacing': 'trailing',
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
         ('steps', 1, 100),
     )
 
-    def scheduler(self) -> EulerDiscrete:
-        """This family's declared scheduler, as bare typed math.
+    def scheduler(self, name: SdxlDeclaredSampler | None = None) -> DPMSolverMultistep | Ddim | EulerAncestralDiscrete | EulerDiscrete:
+        """The scheduler this checkpoint's SAMPLER names, as bare typed math.
 
-        Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
-        digest — so a re-declared schedule changes this family's identity
-        instead of silently changing every request.
+        ``name`` defaults to ``self.tuned.scheduler`` — the value the
+        catalog stamped for THIS checkpoint — because the sampler is a
+        checkpoint fact and not a family constant. Pass it explicitly only
+        to override, and only with a sampler this family declares: the
+        parameter's type is the closed declared set, so anything else is a
+        type error before it is a runtime one.
+
+        A STAMPED sampler outside the declared set is refused, never
+        substituted. The tuned schema may admit more names than the SDK
+        implements schedulers for, and serving one of the others in its
+        place would render a different image than the recipe asked for,
+        silently and plausibly.
         """
-        return EulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        chosen = cast("SdxlTuned", self.tuned).scheduler if name is None else name
+        if chosen == 'ddim_trailing':
+            return Ddim.from_block(
+                self.SCHEDULER_PARAMETERS['ddim_trailing']
+            )
+        if chosen == 'dpmpp_2m_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_karras']
+            )
+        if chosen == 'dpmpp_2m_sde_karras':
+            return DPMSolverMultistep.from_block(
+                self.SCHEDULER_PARAMETERS['dpmpp_2m_sde_karras']
+            )
+        if chosen == 'euler_a':
+            return EulerAncestralDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler_a']
+            )
+        if chosen == 'euler_trailing':
+            return EulerDiscrete.from_block(
+                self.SCHEDULER_PARAMETERS['euler_trailing']
+            )
+        raise ModelError(
+            ModelRefusal.SCHEDULER_UNDECLARED,
+            f"sdxl is stamped with sampler {chosen!r}, which this SDK "
+            f"implements no scheduler for; it serves "
+            f"['ddim_trailing', 'dpmpp_2m_karras', 'dpmpp_2m_sde_karras', 'euler_a', 'euler_trailing']",
+        )
 
     def clip_g(
         self,
@@ -225,4 +319,4 @@ class Sdxl(Model):
         )
 
 
-__all__ = ['Sdxl', 'SdxlLayout', 'SdxlShape']
+__all__ = ['Sdxl', 'SdxlDeclaredSampler', 'SdxlLayout', 'SdxlShape']

--- a/src/gen_worker/model/catalog/_generated/z_image.export.json
+++ b/src/gen_worker/model/catalog/_generated/z_image.export.json
@@ -203,14 +203,17 @@
       ]
     }
   ],
-  "scheduler": {
-    "name": "flow_match_euler_discrete",
-    "parameters": {
-      "num_train_timesteps": 1000,
-      "shift": 6.0,
-      "use_dynamic_shifting": false
+  "schedulers": [
+    {
+      "name": "flow_match_euler_discrete",
+      "parameters": {
+        "num_train_timesteps": 1000,
+        "shift": 6.0,
+        "use_dynamic_shifting": false
+      },
+      "sampler": "flow_match_euler"
     }
-  },
+  ],
   "tuned": {
     "module": "gen_worker.model.catalog.z_image_serve",
     "qualname": "ZImageTuned"

--- a/src/gen_worker/model/catalog/_generated/z_image.py
+++ b/src/gen_worker/model/catalog/_generated/z_image.py
@@ -11,6 +11,7 @@ against that export; it does not produce it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import resources
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
@@ -74,7 +75,7 @@ class ZImage(Model):
     __slots__ = ()
 
     FAMILY: ClassVar[str] = 'z_image'
-    EXPORT_DIGEST: ClassVar[str] = '5e15b72bafb26382ebc1672825547f34'
+    EXPORT_DIGEST: ClassVar[str] = '78cf9ae31c526a35973c60b24f2c474f'
     EXPORT: ClassVar[ModelExport] = _EXPORT
     Tuned: ClassVar[type[ZImageTuned]] = ZImageTuned
     SPEC: ClassVar[ModelSpec | None] = _SPEC
@@ -85,11 +86,17 @@ class ZImage(Model):
     )
     LOOP_KIND: ClassVar[str] = 'staged'
     SESSION_STATE: ClassVar[str] = 'none'
-    SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({
-        'num_train_timesteps': 1000,
-        'shift': 6.0,
-        'use_dynamic_shifting': False,
+    #: Every SAMPLER this family declares a scheduler for, and the KIND
+    #: each one names. Keyed by the value a checkpoint is stamped with.
+    SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({
+        'flow_match_euler': SchedulerKind.FLOW_MATCH_EULER_DISCRETE,
+    })
+    SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = MappingProxyType({
+        'flow_match_euler': MappingProxyType({
+            'num_train_timesteps': 1000,
+            'shift': 6.0,
+            'use_dynamic_shifting': False,
+        }),
     })
     #: Declared loop counts: (name, minimum, maximum), inclusive bounds.
     PARAMETERS: ClassVar[tuple[tuple[str, int, int], ...]] = (
@@ -102,8 +109,13 @@ class ZImage(Model):
         Built from ``SCHEDULER_PARAMETERS`` above, which rides the export
         digest — so a re-declared schedule changes this family's identity
         instead of silently changing every request.
+
+        No argument: this family declares exactly one sampler
+        ('flow_match_euler'), so there is nothing for a checkpoint to choose.
         """
-        return FlowMatchEulerDiscrete.from_block(self.SCHEDULER_PARAMETERS)
+        return FlowMatchEulerDiscrete.from_block(
+            self.SCHEDULER_PARAMETERS['flow_match_euler']
+        )
 
     def denoiser(
         self,

--- a/src/gen_worker/model/catalog/ernie.py
+++ b/src/gen_worker/model/catalog/ernie.py
@@ -202,7 +202,10 @@ ERNIE: Final = GraphModelSpec(
     # takes 1..100 and the turbo function 1..16, and a family parameter bounds
     # the family rather than either lane.
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/flux1_dev.py
+++ b/src/gen_worker/model/catalog/flux1_dev.py
@@ -364,7 +364,10 @@ FLUX1_DEV: Final = GraphModelSpec(
         )
     ),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE: FLUX.1-dev's tuned schema names no sampler because the
+    # family serves exactly this schedule, so `inst.scheduler()` still takes no
+    # argument and still returns the concrete class (pgw#1346 K10).
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/flux1_schnell.py
+++ b/src/gen_worker/model/catalog/flux1_schnell.py
@@ -252,7 +252,10 @@ FLUX1_SCHNELL: Final = GraphModelSpec(
     ),
     # 1-4 steps is the distillation's published contract (ie#462).
     parameters=(Parameter("steps", minimum=1, maximum=4),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/flux2_klein_4b.py
+++ b/src/gen_worker/model/catalog/flux2_klein_4b.py
@@ -240,7 +240,10 @@ FLUX2_KLEIN_4B: Final = GraphModelSpec(
     ),
     loop=Loop(stages=(Stage("denoiser", repeat="steps"),)),
     parameters=(Parameter("steps", minimum=1, maximum=50),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/flux2_klein_9b.py
+++ b/src/gen_worker/model/catalog/flux2_klein_9b.py
@@ -239,7 +239,10 @@ FLUX2_KLEIN_9B: Final = GraphModelSpec(
     ),
     loop=Loop(stages=(Stage("denoiser", repeat="steps"),)),
     parameters=(Parameter("steps", minimum=1, maximum=50),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/ltx23.py
+++ b/src/gen_worker/model/catalog/ltx23.py
@@ -355,9 +355,14 @@ LTX23: Final = GraphModelSpec(
         Parameter("stage1_steps", minimum=1, maximum=50),
         Parameter("stage2_steps", minimum=1, maximum=50),
     ),
-    scheduler=Scheduler(
-        "flow_match_euler_discrete", {"num_train_timesteps": NUM_TRAIN_TIMESTEPS}
-    ),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={
+        "flow_match_euler": Scheduler(
+            "flow_match_euler_discrete", {"num_train_timesteps": NUM_TRAIN_TIMESTEPS}
+        )
+    },
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/qwen_image.py
+++ b/src/gen_worker/model/catalog/qwen_image.py
@@ -232,7 +232,10 @@ QWEN_IMAGE: Final = GraphModelSpec(
     # bottom to 1, because the turbo lane's fixed 8-step distill regime and the
     # boot warm-up's single step both run through the same family parameter.
     parameters=(Parameter("steps", minimum=1, maximum=80),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/catalog/qwen_image_serve.py
+++ b/src/gen_worker/model/catalog/qwen_image_serve.py
@@ -183,7 +183,12 @@ def schedule_for(instance: QwenImage, *, steps: int, shape: int) -> Schedule:
     step count.
     """
 
-    return FlowMatchLadder.from_block(instance.SCHEDULER_PARAMETERS).schedule(
+    # Indexed by SAMPLER (pgw#1346 K10): `SCHEDULER_PARAMETERS` is keyed by the
+    # name a checkpoint is stamped with. This family declares exactly one, so
+    # the key is a constant here rather than a checkpoint fact.
+    return FlowMatchLadder.from_block(
+        instance.SCHEDULER_PARAMETERS["flow_match_euler"]
+    ).schedule(
         steps, image_seq_len=packed_tokens(shape)
     )
 

--- a/src/gen_worker/model/catalog/sd15.py
+++ b/src/gen_worker/model/catalog/sd15.py
@@ -52,9 +52,9 @@ from ..spec import (
     Loop,
     Parameter,
     Runner,
-    Scheduler,
     Stage,
 )
+from .sd_samplers import sd_schedulers
 from .sd15_serve import (
     CFG_BATCH,
     LATENT_CHANNELS,
@@ -161,7 +161,7 @@ SD2_TEXT: Final[Mapping[str, Any]] = {
 #: identical to SDXL's — the three share a noise schedule and share nothing
 #: else. Stated in full for the reason ``sdxl.SCHEDULER`` is: EulerDiscrete
 #: defaults to diffusers' class defaults, which no Stable Diffusion uses.
-SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
+TRAINED: Final[Mapping[str, bool | int | float | str]] = {
     "num_train_timesteps": 1000,
     "beta_start": 0.00085,
     "beta_end": 0.012,
@@ -169,8 +169,36 @@ SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
     "prediction_type": "epsilon",
     "timestep_spacing": "leading",
     "steps_offset": 1,
+}
+
+#: The trained schedule under the ``euler`` sampler. Kept as its own name
+#: because it is the block the B2 measurements difference against.
+SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
+    **TRAINED,
     "final_sigmas_type": "zero",
 }
+
+#: The scheduler SET, keyed by the sampler a checkpoint is stamped with
+#: (pgw#1346 K10). Four of the nine names ``Sd15Sampler`` admits map onto a
+#: scheduler this SDK implements. The five absent ones (``dpmpp_2m``,
+#: ``dpmpp_2m_karras`` — which is `Sd15Tuned`'s DEFAULT — ``dpmpp_2m_sde_karras``,
+#: ``unipc``, ``lcm``) are MULTISTEP solvers owed to B3/B4, and a checkpoint
+#: stamped with one is refused BY NAME rather than served under a neighbouring
+#: schedule. Both SD1.5 and SD2 offer the same four: `Sd2Tuned` shares
+#: `Sd15Sampler` and defaults to ``euler_a``, which IS covered.
+SCHEDULERS: Final = sd_schedulers(
+    TRAINED,
+    (
+        "ddim",
+        "ddim_trailing",
+        "dpmpp_2m",
+        "dpmpp_2m_karras",
+        "dpmpp_2m_sde_karras",
+        "euler",
+        "euler_a",
+        "unipc",
+    ),
+)
 
 
 def _make_denoiser(config: Mapping[str, Any]) -> Any:
@@ -334,7 +362,7 @@ SD15: Final = GraphModelSpec(
         stages=(Stage("clip"), Stage("denoiser", repeat="steps"), Stage("decoder"))
     ),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("euler_discrete", SCHEDULER),
+    schedulers=SCHEDULERS,
 )
 
 #: Stable Diffusion 2.x, which is also SD-Turbo's architecture.
@@ -367,11 +395,12 @@ SD2: Final = GraphModelSpec(
         stages=(Stage("clip"), Stage("denoiser", repeat="steps"), Stage("decoder"))
     ),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("euler_discrete", SCHEDULER),
+    schedulers=SCHEDULERS,
 )
 
 __all__ = [
     "SCHEDULER",
+    "SCHEDULERS",
     "SD2",
     "SD2_TEXT",
     "SD2_UNET",

--- a/src/gen_worker/model/catalog/sd15_serve.py
+++ b/src/gen_worker/model/catalog/sd15_serve.py
@@ -15,9 +15,17 @@ one-way.
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, cast
 
-from ..scheduler import DiscreteSchedule, EulerDiscrete
+from ..scheduler import (
+    AncestralSchedule,
+    DdimSchedule,
+    DiscreteSchedule,
+    DpmSolverSchedule,
+    MultistepHistory,
+    UniPcHistory,
+    UniPcSchedule,
+)
 from ..spec import TunedValues
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -206,18 +214,25 @@ def token_ids(ids: Sequence[int], *, device: Any) -> Tensor:
     return torch.tensor([row], device=device, dtype=torch.long)
 
 
+#: Every schedule an SD1.5 / SD2 request can resolve to. See the sdxl entry
+#: for why this is a union rather than a base class.
+AnySchedule = (
+    DiscreteSchedule | AncestralSchedule | DdimSchedule | DpmSolverSchedule | UniPcSchedule
+)
+
+
 def schedule_for(
     instance: AnySd, *, steps: int, objective: str = "epsilon"
-) -> DiscreteSchedule:
-    """The sigma ladder for one request, from the family's OWN declared block.
+) -> AnySchedule:
+    """The schedule for one request, from the SAMPLER this checkpoint names.
 
     ``objective`` arrives per request: the SD2 768-v rows are v-prediction and
     the rest are epsilon, under ONE declaration — a checkpoint fact, so it
-    cannot live in the family's block.
+    cannot live in the family's block. The sampler is the same kind of fact and
+    arrives the same way, off ``inst.tuned.scheduler`` (pgw#1346 K10).
     """
 
-    scheduler: EulerDiscrete = instance.scheduler()
-    return scheduler.objective(objective).schedule(steps)
+    return instance.scheduler().objective(objective).schedule(steps)
 
 
 def encode_prompt(instance: AnySd, *, positive: Tensor, negative: Tensor) -> Tensor:
@@ -245,14 +260,60 @@ def initial_latents(
     return (noise * sigma).to(device=device, dtype=dtype)
 
 
+#: The keying that makes an ANCESTRAL sampler reproducible (pgw#1346 K10).
+#:
+#: ``euler_a`` consumes a fresh noise tensor at every step, so "same seed, same
+#: image" is a claim about that noise stream and not only about the initial
+#: latents. Two properties are wanted and they pull against each other:
+#: reproducibility across pods, and independence from the loop's shape.
+#:
+#: A running generator gives the first and not the second — step ``k``'s noise
+#: then depends on every draw before it, so a resumed loop, a preview pass or a
+#: reordered call site silently re-rolls the tail. So the stream is KEYED
+#: instead: step ``k`` draws from its own CPU generator seeded by mixing the
+#: request seed with ``k``. The mix is the 64-bit splitmix64 finalizer, chosen
+#: because adjacent seeds must not produce correlated streams and
+#: ``seed + k`` does exactly that — it makes step ``k`` of seed ``s`` identical
+#: to step ``k-1`` of seed ``s+1``.
+#:
+#: CPU-seeded for the reason ``initial_latents`` gives: a CUDA generator's
+#: stream is a property of the device, so a receipt replayed on another card
+#: would resolve different noise. On the CPU it cannot.
+_MIX: Final = 0x9E3779B97F4A7C15
+_MASK: Final = 0xFFFFFFFFFFFFFFFF
+
+
+def step_seed(seed: int, index: int) -> int:
+    """The seed step ``index`` of request ``seed`` draws its noise from."""
+
+    value = (seed + _MIX * (index + 1)) & _MASK
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK
+    return (value ^ (value >> 31)) & _MASK
+
+
+def step_noise(*, shape: int, seed: int, index: int, device: Any, dtype: Any) -> Tensor:
+    """The ancestral noise for ONE step. Keyed by ``(seed, index)`` — see above."""
+
+    import torch
+
+    rows, cols = latent_shape(shape)
+    generator = torch.Generator(device="cpu").manual_seed(step_seed(seed, index))
+    noise = torch.randn(
+        1, LATENT_CHANNELS, rows, cols, generator=generator, dtype=torch.float32
+    )
+    return noise.to(device=device, dtype=dtype)
+
+
 def denoise(
     instance: AnySd,
     *,
     shape: AnyShape,
     latents: Tensor,
     prompt_embeds: Tensor,
-    schedule: DiscreteSchedule,
+    schedule: AnySchedule,
     guidance: float,
+    seed: int = 0,
 ) -> Iterator[tuple[int, Tensor]]:
     """The denoising loop, yielding ``(step index, latents)`` after each step.
 
@@ -262,8 +323,28 @@ def denoise(
 
     import torch
 
+    def _noise(index: int, like: Tensor) -> Tensor:
+        return step_noise(
+            shape=int(shape), seed=seed, index=index, device=like.device, dtype=like.dtype
+        )
+
+    history: object = (
+        schedule.begin() if isinstance(schedule, DpmSolverSchedule | UniPcSchedule) else None
+    )
+
     for index, timestep in enumerate(schedule.timesteps):
-        batched = schedule.scale_model_input(index, torch.cat([latents] * CFG_BATCH))
+        stacked = torch.cat([latents] * CFG_BATCH)
+        # The pre-scale is the euler/ddim family's, NOT the multistep solvers'.
+        # DPM-Solver++ and UniPC integrate in the unscaled parameterisation —
+        # their `init_noise_sigma` is 1.0 — so dividing their latents by
+        # `sqrt(sigma**2+1)` would be a wrong image and never an error. The
+        # union type is what makes the omission a TYPE error rather than a
+        # discovery on a pod.
+        batched = (
+            schedule.scale_model_input(index, stacked)
+            if isinstance(schedule, DiscreteSchedule | AncestralSchedule | DdimSchedule)
+            else stacked
+        )
         prediction = instance.denoiser(
             shape=shape,
             sample=batched,
@@ -271,7 +352,32 @@ def denoise(
             encoder_hidden_states=prompt_embeds,
         )
         uncond, cond = prediction.chunk(2)
-        latents = schedule.step(index, uncond + guidance * (cond - uncond), latents)
+        guided = uncond + guidance * (cond - uncond)
+        if isinstance(schedule, AncestralSchedule):
+            # An ancestral step CONSUMES noise; the parameter is required, and
+            # the noise is CPU-seeded and keyed by (seed, index) — see above.
+            latents = schedule.step(index, guided, latents, _noise(index, latents))
+        elif isinstance(schedule, DpmSolverSchedule):
+            # A MULTISTEP solver carries history between steps, so the loop
+            # threads it rather than the schedule holding it: a schedule that
+            # kept `self._model_outputs` is one two concurrent requests share.
+            latents, history = schedule.step(
+                index,
+                guided,
+                latents,
+                cast("MultistepHistory", history),
+                noise=(
+                    _noise(index, latents)
+                    if schedule.algorithm_type == "sde-dpmsolver++"
+                    else None
+                ),
+            )
+        elif isinstance(schedule, UniPcSchedule):
+            latents, history = schedule.step(
+                index, guided, latents, cast("UniPcHistory", history)
+            )
+        else:
+            latents = schedule.step(index, guided, latents)
         yield index, latents
 
 
@@ -312,6 +418,7 @@ def generate(
         prompt_embeds=prompt_embeds,
         schedule=schedule,
         guidance=guidance,
+        seed=seed,
     ):
         if on_step is not None:
             on_step(index, len(schedule))
@@ -327,6 +434,9 @@ __all__ = [
     "generate",
     "initial_latents",
     "schedule_for",
+    "step_noise",
+    "step_seed",
+    "AnySchedule",
     "token_ids",
     "LATENT_CHANNELS",
     "SD15_SHAPES",

--- a/src/gen_worker/model/catalog/sd_samplers.py
+++ b/src/gen_worker/model/catalog/sd_samplers.py
@@ -1,0 +1,156 @@
+"""The Stable Diffusion lineage's SAMPLER vocabulary, in one place.
+
+pgw#1346 K10: ``GraphModelSpec.schedulers`` is a SET keyed by the sampler name
+a checkpoint is stamped with, because the sampler is a checkpoint fact and not
+a family constant. This module answers the one question that set-keying
+introduces and that no single family owns:
+
+    what does the name ``euler_a`` MEAN?
+
+It is not family truth — ``sdxl`` and ``sd15`` are two declarations offering
+overlapping subsets of ONE endpoint-visible vocabulary, and if each spelled
+``euler_a`` for itself the two could drift into meaning different schedules
+under one name. It is also not scheduler-math truth:
+:mod:`gen_worker.model.scheduler` deliberately knows no sampler names at all,
+only KINDS.
+
+So the mapping lives here, once, as a pair per name: the scheduler KIND, and
+the parameters that name overrides on the family's own trained schedule. The
+resolved blocks are what ride the export digest, so the DECLARATION still
+carries every value verbatim — this module only keeps two families from
+disagreeing about which values those are.
+
+**The names come from ``gen_worker.view.SAMPLERS``, which already DEFINES each
+one completely** — the diffusers class plus the config overrides — for the
+``Slot``-served endpoints. That table is the single source for "what does
+``dpmpp_2m_karras`` mean here", and the test suite asserts this module agrees
+with it rather than restating it from memory.
+
+**One name is still owed: ``lcm``.** ``LCMScheduler`` has no implementation in
+``model/solvers/`` yet. A checkpoint stamped with it is REFUSED by name
+(``SCHEDULER_UNDECLARED``), never served under a neighbouring schedule — which
+is the whole reason the set is exhaustive rather than defaulted. Every other
+name the two endpoints admit is declarable: the multistep pair arrived with
+pgw#1346 B3 (``dpmsolver_multistep``, ``unipc_multistep``), which landed ahead
+of this lane and is additive to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+from .. import scheduler
+from ..errors import ModelError, ModelRefusal
+from ..scheduler import IMPLEMENTED, SchedulerBlock, SchedulerValue, Trained, parse_kind
+from ..spec import Scheduler
+
+#: What each endpoint-visible sampler NAME means: the scheduler kind, and what
+#: that name overrides on the family's trained schedule.
+#:
+#: ``steps_offset`` is set to 0 by both trailing entries. It changes nothing —
+#: neither reference implementation reads it outside the ``leading`` branch —
+#: and it is stated anyway, because a declaration that carries a checkpoint's
+#: ``steps_offset=1`` beside ``timestep_spacing="trailing"`` reads as though
+#: the offset applies.
+SD_SAMPLERS: Final[Mapping[str, tuple[str, Mapping[str, SchedulerValue]]]] = {
+    #: The trained schedule walked deterministically. Every SD/SDXL
+    #: checkpoint's own `scheduler_config.json` spacing.
+    "euler": ("euler_discrete", {"final_sigmas_type": "zero"}),
+    #: SDXL-Lightning's published recipe, which the sdxl endpoint pins for both
+    #: its 4- and 8-step turbo arms. `trailing` ends a step above the bottom of
+    #: the ladder; a distilled 4-step recipe is destroyed by `leading`.
+    "euler_trailing": (
+        "euler_discrete",
+        {"timestep_spacing": "trailing", "steps_offset": 0, "final_sigmas_type": "zero"},
+    ),
+    #: SDXL's DEFAULT sampler, and sd2/SD-Turbo's. Same ladder as `euler`,
+    #: stochastic step — see `EulerAncestralDiscrete`. No `final_sigmas_type`:
+    #: the ancestral scheduler has none and declaring one is refused.
+    "euler_a": ("euler_ancestral_discrete", {}),
+    #: sd15's payload enum offers this one directly.
+    "ddim": ("ddim", {"set_alpha_to_one": False, "clip_sample": False}),
+    #: sd15's `generate_hyper` pins this UNCONDITIONALLY (a handler reaches
+    #: DDIM with no payload involved) and sdxl's enum offers it.
+    "ddim_trailing": (
+        "ddim",
+        {
+            "timestep_spacing": "trailing",
+            "steps_offset": 0,
+            "set_alpha_to_one": False,
+            "clip_sample": False,
+        },
+    ),
+    #: DPM-Solver++ (2M) on the trained beta ladder — sd15's plain `dpmpp_2m`.
+    "dpmpp_2m": (
+        "dpmsolver_multistep",
+        {"solver_order": 2, "final_sigmas_type": "zero"},
+    ),
+    #: The fleet's most-selected sampler and `Sd15Tuned`'s own DEFAULT: the same
+    #: solver on a KARRAS ladder, which is one declared boolean and nothing else.
+    "dpmpp_2m_karras": (
+        "dpmsolver_multistep",
+        {"solver_order": 2, "use_karras_sigmas": True, "final_sigmas_type": "zero"},
+    ),
+    #: STAMPED on two live sdxl catalog entries. The stochastic algorithm on the
+    #: same Karras ladder.
+    "dpmpp_2m_sde_karras": (
+        "dpmsolver_multistep",
+        {
+            "solver_order": 2,
+            "algorithm_type": "sde-dpmsolver++",
+            "use_karras_sigmas": True,
+            "final_sigmas_type": "zero",
+        },
+    ),
+    #: sd15's payload enum offers it. `view.SAMPLERS` overrides NOTHING, so this
+    #: is `UniPCMultistepScheduler`'s own defaults on the family's trained table.
+    "unipc": ("unipc_multistep", {}),
+}
+
+
+def sd_schedulers(
+    trained: SchedulerBlock, samplers: tuple[str, ...]
+) -> dict[str, Scheduler]:
+    """One family's declared scheduler set, from its trained noise schedule.
+
+    ``trained`` carries ONLY the trained-schedule parameters — the betas, the
+    objective, the spacing and offset the checkpoint's own config states. A
+    kind-specific parameter here would be a family declaring, say,
+    ``final_sigmas_type`` for a scheduler that has none, so it is refused
+    rather than dropped.
+
+    Every resolved block is CONSTRUCTED before it is returned. A block that
+    would refuse at serve time refuses at declaration import instead, on the
+    author's machine, with no pod behind it.
+    """
+
+    unknown = sorted(set(trained) - set(Trained.TRAINED_PARAMETERS))
+    if unknown:
+        raise ModelError(
+            ModelRefusal.SCHEDULER_INVALID,
+            f"the trained schedule may not carry {unknown[0]!r}: it is a parameter of ONE "
+            f"scheduler kind, so it belongs in this sampler's overrides. It reads "
+            f"{list(Trained.TRAINED_PARAMETERS)!r}",
+        )
+    resolved: dict[str, Scheduler] = {}
+    for sampler in samplers:
+        if sampler not in SD_SAMPLERS:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_UNDECLARED,
+                f"sampler {sampler!r} has no meaning in the SD vocabulary; it reads "
+                f"{sorted(SD_SAMPLERS)!r}",
+            )
+        kind, overrides = SD_SAMPLERS[sampler]
+        block: dict[str, SchedulerValue] = {**trained, **overrides}
+        # Construct it now: `from_block` is where an unread parameter, an
+        # unrecognised spacing or an unimplementable arm is refused. Resolved
+        # through `IMPLEMENTED`, the ONE table that pairs a kind with its
+        # class, rather than through a second mapping that can disagree.
+        implementation: Any = getattr(scheduler, IMPLEMENTED[parse_kind(kind)])
+        implementation.from_block(block)
+        resolved[sampler] = Scheduler(kind, block)
+    return resolved
+
+
+__all__ = ["SD_SAMPLERS", "sd_schedulers"]

--- a/src/gen_worker/model/catalog/sdxl.py
+++ b/src/gen_worker/model/catalog/sdxl.py
@@ -41,9 +41,9 @@ from ..spec import (
     Loop,
     Parameter,
     Runner,
-    Scheduler,
     Stage,
 )
+from .sd_samplers import sd_schedulers
 from .sdxl_serve import (
     CFG_BATCH,
     CLIP_G_WIDTH,
@@ -235,7 +235,7 @@ CLIP_G_TEXT: Final[Mapping[str, Any]] = {
 #: parameter would resolve to a schedule this family was never trained on.
 #: ``steps_offset=1`` and ``timestep_spacing="leading"`` are what every SDXL
 #: checkpoint's own ``scheduler/scheduler_config.json`` carries.
-SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
+TRAINED: Final[Mapping[str, bool | int | float | str]] = {
     "num_train_timesteps": 1000,
     "beta_start": 0.00085,
     "beta_end": 0.012,
@@ -243,8 +243,30 @@ SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
     "prediction_type": "epsilon",
     "timestep_spacing": "leading",
     "steps_offset": 1,
+}
+
+#: The trained schedule under the ``euler`` sampler — i.e. with the one
+#: parameter that is ``EulerDiscrete``'s and not the checkpoint's. Kept as its
+#: own name because it is the block every measurement in
+#: ``tests/test_sd_stage1_pgw1346.py`` differences against.
+SCHEDULER: Final[Mapping[str, bool | int | float | str]] = {
+    **TRAINED,
     "final_sigmas_type": "zero",
 }
+
+#: The scheduler SET, keyed by the sampler a checkpoint is stamped with
+#: (pgw#1346 K10). These are the three names in ``SdxlSampler`` that map onto
+#: a scheduler this SDK implements; the other three (``dpmpp_2m_karras``,
+#: ``dpmpp_2m_sde_karras``, ``lcm``) are MULTISTEP solvers owed to B3/B4 and
+#: are refused BY NAME rather than served under a neighbouring schedule.
+#:
+#: ``euler_a`` is the one that matters most: it is ``SdxlTuned.scheduler``'s
+#: DEFAULT, so before K10 the family's single declared ``euler_discrete``
+#: block was its trained schedule and not the one most requests asked for.
+SCHEDULERS: Final = sd_schedulers(
+    TRAINED,
+    ("ddim_trailing", "dpmpp_2m_karras", "dpmpp_2m_sde_karras", "euler_a", "euler_trailing"),
+)
 
 
 def _arm_hidden_state_capture(model: Any) -> Any:
@@ -382,13 +404,15 @@ SDXL: Final = GraphModelSpec(
         )
     ),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("euler_discrete", SCHEDULER),
+    schedulers=SCHEDULERS,
 )
 
 __all__ = [
     "CLIP_G_TEXT",
     "CLIP_L_TEXT",
     "SCHEDULER",
+    "SCHEDULERS",
+    "TRAINED",
     "SDXL",
     "UNET",
     "VAE",

--- a/src/gen_worker/model/catalog/sdxl_serve.py
+++ b/src/gen_worker/model/catalog/sdxl_serve.py
@@ -18,9 +18,17 @@ rather than two thirds of it.
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
-from ..scheduler import DiscreteSchedule, EulerDiscrete
+from ..scheduler import (
+    AncestralSchedule,
+    DdimSchedule,
+    DiscreteSchedule,
+    DpmSolverSchedule,
+    MultistepHistory,
+    UniPcHistory,
+    UniPcSchedule,
+)
 from ..spec import TunedValues
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -206,18 +214,30 @@ def token_ids(ids: Sequence[int], *, device: Any) -> Tensor:
     return torch.tensor([row], device=device, dtype=torch.long)
 
 
-def schedule_for(instance: Sdxl, *, steps: int, objective: str = "epsilon") -> DiscreteSchedule:
-    """The sigma ladder for one request, from the family's OWN declared block.
+#: Every schedule an SDXL request can resolve to. A UNION and not a base
+#: class: a DDIM trajectory has no sigmas and an ancestral step consumes noise,
+#: so the three genuinely differ where it matters and a common supertype would
+#: have to hide exactly those differences (pgw#1346 K10).
+AnySchedule = (
+    DiscreteSchedule | AncestralSchedule | DdimSchedule | DpmSolverSchedule | UniPcSchedule
+)
 
-    ``objective`` is a CHECKPOINT fact and arrives per request rather than from
-    the declaration: SDXL fine-tunes ship both epsilon and v-prediction under
-    one architecture, and ``gen_worker.view`` already resolves it from the
-    stamped objective for the diffusers path. No ``image_seq_len`` — this
-    ladder does not consult the resolution at all, unlike Flux's.
+
+def schedule_for(instance: Sdxl, *, steps: int, objective: str = "epsilon") -> AnySchedule:
+    """The schedule for one request, from the SAMPLER this checkpoint names.
+
+    Two checkpoint facts arrive here, both per request rather than from the
+    declaration. ``objective`` — SDXL fine-tunes ship both epsilon and
+    v-prediction under one architecture, and ``gen_worker.view`` already
+    resolves it from the stamped objective for the diffusers path. And the
+    SAMPLER, which ``instance.scheduler()`` reads off ``inst.tuned`` — the
+    default is ``euler_a``, so this is the common path and not the exotic one.
+
+    No ``image_seq_len``: none of these ladders consults the resolution at all,
+    unlike Flux's.
     """
 
-    scheduler: EulerDiscrete = instance.scheduler()
-    return scheduler.objective(objective).schedule(steps)
+    return instance.scheduler().objective(objective).schedule(steps)
 
 
 def encode_prompt(
@@ -281,6 +301,51 @@ def initial_latents(
     return (noise * sigma).to(device=device, dtype=dtype)
 
 
+#: The keying that makes an ANCESTRAL sampler reproducible (pgw#1346 K10).
+#:
+#: ``euler_a`` consumes a fresh noise tensor at every step, so "same seed, same
+#: image" is a claim about that noise stream and not only about the initial
+#: latents. Two properties are wanted and they pull against each other:
+#: reproducibility across pods, and independence from the loop's shape.
+#:
+#: A running generator gives the first and not the second — step ``k``'s noise
+#: then depends on every draw before it, so a resumed loop, a preview pass or a
+#: reordered call site silently re-rolls the tail. So the stream is KEYED
+#: instead: step ``k`` draws from its own CPU generator seeded by mixing the
+#: request seed with ``k``. The mix is the 64-bit splitmix64 finalizer, chosen
+#: because adjacent seeds must not produce correlated streams and
+#: ``seed + k`` does exactly that — it makes step ``k`` of seed ``s`` identical
+#: to step ``k-1`` of seed ``s+1``.
+#:
+#: CPU-seeded for the reason ``initial_latents`` gives: a CUDA generator's
+#: stream is a property of the device, so a receipt replayed on another card
+#: would resolve different noise. On the CPU it cannot.
+_MIX: Final = 0x9E3779B97F4A7C15
+_MASK: Final = 0xFFFFFFFFFFFFFFFF
+
+
+def step_seed(seed: int, index: int) -> int:
+    """The seed step ``index`` of request ``seed`` draws its noise from."""
+
+    value = (seed + _MIX * (index + 1)) & _MASK
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK
+    return (value ^ (value >> 31)) & _MASK
+
+
+def step_noise(*, shape: int, seed: int, index: int, device: Any, dtype: Any) -> Tensor:
+    """The ancestral noise for ONE step. Keyed by ``(seed, index)`` — see above."""
+
+    import torch
+
+    rows, cols = latent_shape(shape)
+    generator = torch.Generator(device="cpu").manual_seed(step_seed(seed, index))
+    noise = torch.randn(
+        1, LATENT_CHANNELS, rows, cols, generator=generator, dtype=torch.float32
+    )
+    return noise.to(device=device, dtype=dtype)
+
+
 def denoise(
     instance: Sdxl,
     *,
@@ -288,8 +353,9 @@ def denoise(
     latents: Tensor,
     prompt_embeds: Tensor,
     pooled: Tensor,
-    schedule: DiscreteSchedule,
+    schedule: AnySchedule,
     guidance: float,
+    seed: int = 0,
 ) -> Iterator[tuple[int, Tensor]]:
     """The denoising loop, yielding ``(step index, latents)`` after each step.
 
@@ -302,12 +368,32 @@ def denoise(
 
     import torch
 
+    def _noise(index: int, like: Tensor) -> Tensor:
+        return step_noise(
+            shape=int(shape), seed=seed, index=index, device=like.device, dtype=like.dtype
+        )
+
+    history: object = (
+        schedule.begin() if isinstance(schedule, DpmSolverSchedule | UniPcSchedule) else None
+    )
+
     added = {
         "text_embeds": pooled,
         "time_ids": time_ids(int(shape), device=latents.device, dtype=latents.dtype),
     }
     for index, timestep in enumerate(schedule.timesteps):
-        batched = schedule.scale_model_input(index, torch.cat([latents] * CFG_BATCH))
+        stacked = torch.cat([latents] * CFG_BATCH)
+        # The pre-scale is the euler/ddim family's, NOT the multistep solvers'.
+        # DPM-Solver++ and UniPC integrate in the unscaled parameterisation —
+        # their `init_noise_sigma` is 1.0 — so dividing their latents by
+        # `sqrt(sigma**2+1)` would be a wrong image and never an error. The
+        # union type is what makes the omission a TYPE error rather than a
+        # discovery on a pod.
+        batched = (
+            schedule.scale_model_input(index, stacked)
+            if isinstance(schedule, DiscreteSchedule | AncestralSchedule | DdimSchedule)
+            else stacked
+        )
         prediction = instance.denoiser(
             shape=shape,
             sample=batched,
@@ -316,7 +402,32 @@ def denoise(
             added_cond_kwargs=added,
         )
         uncond, cond = prediction.chunk(2)
-        latents = schedule.step(index, uncond + guidance * (cond - uncond), latents)
+        guided = uncond + guidance * (cond - uncond)
+        if isinstance(schedule, AncestralSchedule):
+            # An ancestral step CONSUMES noise; the parameter is required, and
+            # the noise is CPU-seeded and keyed by (seed, index) — see above.
+            latents = schedule.step(index, guided, latents, _noise(index, latents))
+        elif isinstance(schedule, DpmSolverSchedule):
+            # A MULTISTEP solver carries history between steps, so the loop
+            # threads it rather than the schedule holding it: a schedule that
+            # kept `self._model_outputs` is one two concurrent requests share.
+            latents, history = schedule.step(
+                index,
+                guided,
+                latents,
+                cast("MultistepHistory", history),
+                noise=(
+                    _noise(index, latents)
+                    if schedule.algorithm_type == "sde-dpmsolver++"
+                    else None
+                ),
+            )
+        elif isinstance(schedule, UniPcSchedule):
+            latents, history = schedule.step(
+                index, guided, latents, cast("UniPcHistory", history)
+            )
+        else:
+            latents = schedule.step(index, guided, latents)
         yield index, latents
 
 
@@ -365,6 +476,7 @@ def generate(
         pooled=pooled,
         schedule=schedule,
         guidance=guidance,
+        seed=seed,
     ):
         if on_step is not None:
             on_step(index, len(schedule))
@@ -380,6 +492,9 @@ __all__ = [
     "generate",
     "initial_latents",
     "schedule_for",
+    "step_noise",
+    "step_seed",
+    "AnySchedule",
     "time_ids",
     "token_ids",
     "CLIP_G_WIDTH",

--- a/src/gen_worker/model/catalog/z_image.py
+++ b/src/gen_worker/model/catalog/z_image.py
@@ -235,7 +235,10 @@ Z_IMAGE: Final = GraphModelSpec(
     # The base function's declared payload range. The two turbo functions cap
     # at 16, and a family parameter bounds the family rather than either lane.
     parameters=(Parameter("steps", minimum=1, maximum=80),),
-    scheduler=Scheduler("flow_match_euler_discrete", SCHEDULER),
+    # A set of ONE (pgw#1346 K10): this family's tuned schema names no sampler
+    # because it serves exactly this schedule, so `inst.scheduler()` still
+    # takes no argument and still returns the concrete class.
+    schedulers={"flow_match_euler": Scheduler("flow_match_euler_discrete", SCHEDULER)},
 )
 
 __all__ = [

--- a/src/gen_worker/model/codegen.py
+++ b/src/gen_worker/model/codegen.py
@@ -34,6 +34,7 @@ mutable state (G13).
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from typing import Final
 
 from .._vendor.torchcg.recipe import ParameterKind, SignatureParameter
@@ -176,16 +177,33 @@ def _method(export: ModelExport, runner: ExportedRunner) -> list[str]:
     return parts
 
 
-def _aliases(export: ModelExport) -> list[str]:
-    """The closed types: one per bucket axis, one for the layout set.
+def _aliases(export: ModelExport, implemented: Mapping[str, str]) -> list[str]:
+    """The closed types: one per bucket axis, one for the layout set, and —
+    when the family declares more than one — one for the SAMPLER set.
 
-    Both are exhaustive by construction — bucket coverage is total per layout
-    (G6) and a runner's layouts are a closed set (G15) — so a ``match`` over
-    either is complete and a value outside it cannot be spelled.
+    The first two are exhaustive by construction — bucket coverage is total per
+    layout (G6) and a runner's layouts are a closed set (G15) — so a ``match``
+    over either is complete and a value outside it cannot be spelled.
+
+    The sampler alias is deliberately NOT the family's tuned ``scheduler``
+    Literal and is deliberately not named like it. The tuned one says what a
+    checkpoint may be STAMPED with (a hub-visible contract tensorhub generates
+    a schema from); this one says what this SDK can SERVE. They are allowed to
+    differ — that difference is exactly the staged gap pgw#1346 K10 records —
+    and a handler passing ``name=`` is bounded by the servable one.
     """
 
     family = str(export.family)
     lines: list[str] = []
+    if len(implemented) > 1:
+        lines.append(
+            "#: Every sampler this family declares AND this SDK implements. Total: "
+            "every value resolves."
+        )
+        lines.append(
+            f"{_alias(family, 'declared_sampler')} = {_literal_strs(tuple(implemented))}"
+        )
+        lines.append("")
     for axis, values in export.buckets:
         lines.append(f"#: Every declared {str(axis)} bucket. Exhaustive: every value resolves.")
         lines.append(f"{_alias(family, str(axis))} = {_literal_ints(values)}")
@@ -210,7 +228,6 @@ def _class_facts(export: ModelExport) -> list[str]:
         + "),"
         for stage in loop.stages
     ]
-    scheduler = export.scheduler
     lines = [
         f'{_INDENT}FAMILY: ClassVar[str] = {family!r}',
         f'{_INDENT}EXPORT_DIGEST: ClassVar[str] = {export.digest()!r}',
@@ -225,17 +242,32 @@ def _class_facts(export: ModelExport) -> list[str]:
         f'{_INDENT}LOOP_KIND: ClassVar[str] = {loop.kind.value!r}',
         f'{_INDENT}SESSION_STATE: ClassVar[str] = {loop.session_state.value!r}',
     ]
-    if scheduler is not None:
-        kind = parse_kind(str(scheduler.name))
+    if export.schedulers:
         lines.append(
-            f"{_INDENT}SCHEDULER: ClassVar[SchedulerKind] = SchedulerKind.{kind.name}"
+            f"{_INDENT}#: Every SAMPLER this family declares a scheduler for, and the KIND"
         )
         lines.append(
-            f"{_INDENT}SCHEDULER_PARAMETERS: ClassVar[SchedulerBlock] = MappingProxyType({{"
+            f"{_INDENT}#: each one names. Keyed by the value a checkpoint is stamped with."
+        )
+        lines.append(
+            f"{_INDENT}SCHEDULERS: ClassVar[Mapping[str, SchedulerKind]] = MappingProxyType({{"
         )
         lines.extend(
-            f"{_INDENT * 2}{str(name)!r}: {value!r}," for name, value in scheduler.parameters
+            f"{_INDENT * 2}{str(row.sampler)!r}: "
+            f"SchedulerKind.{parse_kind(str(row.name)).name},"
+            for row in export.schedulers
         )
+        lines.append(f"{_INDENT}}})")
+        lines.append(
+            f"{_INDENT}SCHEDULER_PARAMETERS: ClassVar[Mapping[str, SchedulerBlock]] = "
+            "MappingProxyType({"
+        )
+        for row in export.schedulers:
+            lines.append(f"{_INDENT * 2}{str(row.sampler)!r}: MappingProxyType({{")
+            lines.extend(
+                f"{_INDENT * 3}{str(name)!r}: {value!r}," for name, value in row.parameters
+            )
+            lines.append(f"{_INDENT * 2}}}),")
         lines.append(f"{_INDENT}}})")
     lines.append(
         f"{_INDENT}#: Declared loop counts: (name, minimum, maximum), inclusive bounds."
@@ -249,27 +281,95 @@ def _class_facts(export: ModelExport) -> list[str]:
     return lines
 
 
-def _scheduler_method(implementation: str) -> list[str]:
-    """The typed accessor for a family whose scheduler the SDK implements.
+def _scheduler_method(export: ModelExport, implemented: dict[str, str]) -> list[str]:
+    """The typed accessor for the schedulers the SDK implements for a family.
 
-    The return type is the CONCRETE class, so a handler reaches flow-match
-    Euler's own API — ``schedule()``, ``step()`` — through the type checker
-    rather than through a name it typed. There is no registry lookup at request
-    time and no scheduler object: what comes back is a frozen dataclass of the
-    family's own declared constants (pgw#1331).
+    Two shapes, and which one is emitted is decided by the DECLARATION rather
+    than by taste (pgw#1346 K10):
+
+    * **one declared sampler** — no argument, and the return type is that ONE
+      concrete class. A handler reaches flow-match Euler's own API through the
+      type checker rather than through a name it typed, exactly as pgw#1331
+      shipped it. Nothing about a single-sampler family changes;
+    * **several** — the sampler is a CHECKPOINT fact, so it is read off
+      ``inst.tuned.scheduler`` and resolved against the declared set. The
+      return type is the closed UNION of the declared kinds' classes, an
+      undeclared stamp is a refusal naming both sides, and an explicit
+      ``name=`` argument is typed by the generated ``…DeclaredSampler``
+      literal — so a handler that spells a sampler this family does not
+      implement is a STATIC error on the author's machine.
+
+    There is no registry lookup at request time and no scheduler object: what
+    comes back is a frozen dataclass of the family's own declared constants.
     """
 
-    return [
-        "",
-        f"{_INDENT}def scheduler(self) -> {implementation}:",
-        f'{_INDENT * 2}"""This family\'s declared scheduler, as bare typed math.',
-        "",
-        f"{_INDENT * 2}Built from ``SCHEDULER_PARAMETERS`` above, which rides the export",
-        f"{_INDENT * 2}digest — so a re-declared schedule changes this family's identity",
-        f"{_INDENT * 2}instead of silently changing every request.",
-        f'{_INDENT * 2}"""',
-        f"{_INDENT * 2}return {implementation}.from_block(self.SCHEDULER_PARAMETERS)",
+    family = str(export.family)
+    tuned = export.tuned.qualname
+    rows = [
+        (str(row.sampler), implemented[str(row.sampler)])
+        for row in export.schedulers
+        if str(row.sampler) in implemented
     ]
+    if len(rows) == 1:
+        sampler, implementation = rows[0]
+        return [
+            "",
+            f"{_INDENT}def scheduler(self) -> {implementation}:",
+            f'{_INDENT * 2}"""This family\'s declared scheduler, as bare typed math.',
+            "",
+            f"{_INDENT * 2}Built from ``SCHEDULER_PARAMETERS`` above, which rides the export",
+            f"{_INDENT * 2}digest — so a re-declared schedule changes this family's identity",
+            f"{_INDENT * 2}instead of silently changing every request.",
+            "",
+            f"{_INDENT * 2}No argument: this family declares exactly one sampler",
+            f"{_INDENT * 2}({sampler!r}), so there is nothing for a checkpoint to choose.",
+            f'{_INDENT * 2}"""',
+            f"{_INDENT * 2}return {implementation}.from_block(",
+            f"{_INDENT * 3}self.SCHEDULER_PARAMETERS[{sampler!r}]",
+            f"{_INDENT * 2})",
+        ]
+    union = " | ".join(sorted({implementation for _, implementation in rows}))
+    alias = _alias(family, "declared_sampler")
+    lines = [
+        "",
+        f"{_INDENT}def scheduler(self, name: {alias} | None = None) -> {union}:",
+        f'{_INDENT * 2}"""The scheduler this checkpoint\'s SAMPLER names, as bare typed math.',
+        "",
+        f"{_INDENT * 2}``name`` defaults to ``self.tuned.scheduler`` — the value the",
+        f"{_INDENT * 2}catalog stamped for THIS checkpoint — because the sampler is a",
+        f"{_INDENT * 2}checkpoint fact and not a family constant. Pass it explicitly only",
+        f"{_INDENT * 2}to override, and only with a sampler this family declares: the",
+        f"{_INDENT * 2}parameter's type is the closed declared set, so anything else is a",
+        f"{_INDENT * 2}type error before it is a runtime one.",
+        "",
+        f"{_INDENT * 2}A STAMPED sampler outside the declared set is refused, never",
+        f"{_INDENT * 2}substituted. The tuned schema may admit more names than the SDK",
+        f"{_INDENT * 2}implements schedulers for, and serving one of the others in its",
+        f"{_INDENT * 2}place would render a different image than the recipe asked for,",
+        f"{_INDENT * 2}silently and plausibly.",
+        f'{_INDENT * 2}"""',
+        f'{_INDENT * 2}chosen = cast("{tuned}", self.tuned).scheduler if name is None else name',
+    ]
+    # One arm per sampler and a trailing refusal, rather than a table lookup
+    # with a default arm: a family may DECLARE a kind this SDK implements no
+    # math for, and a default arm would serve the last implemented kind in its
+    # place. There is nothing sensible to fall through to, so nothing does.
+    for sampler, implementation in rows:
+        lines.append(f"{_INDENT * 2}if chosen == {sampler!r}:")
+        lines.append(f"{_INDENT * 3}return {implementation}.from_block(")
+        lines.append(f"{_INDENT * 4}self.SCHEDULER_PARAMETERS[{sampler!r}]")
+        lines.append(f"{_INDENT * 3})")
+    lines.extend(
+        [
+            f"{_INDENT * 2}raise ModelError(",
+            f"{_INDENT * 3}ModelRefusal.SCHEDULER_UNDECLARED,",
+            f'{_INDENT * 3}f"{family} is stamped with sampler {{chosen!r}}, which this SDK "',
+            f'{_INDENT * 3}f"implements no scheduler for; it serves "',
+            f"{_INDENT * 3}f\"{sorted(sampler for sampler, _ in rows)!r}\",",
+            f"{_INDENT * 2})",
+        ]
+    )
+    return lines
 
 
 def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -> str:
@@ -299,21 +399,24 @@ def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -
             (ParameterKind.MAPPING, "Mapping"),
             (ParameterKind.SEQUENCE, "Sequence"),
         )
-        if kind in kinds
+        # `SCHEDULERS` and `SCHEDULER_PARAMETERS` are annotated `Mapping[...]`,
+        # so a family with a scheduler needs the alias whether or not any
+        # runner takes a mapping parameter.
+        if kind in kinds or (name == "Mapping" and export.schedulers)
     ]
-    scheduler = export.scheduler
-    #: The concrete bare-math class this family's declared scheduler resolves
-    #: to, or empty when the SDK implements no math for the declared name. The
-    #: miss is silent HERE and loud at the call site: the generated class simply
-    #: has no ``scheduler()``, so a handler that wants one gets an
+    #: Sampler -> the concrete bare-math class its declared KIND resolves to.
+    #: A sampler whose kind the SDK implements no math for is simply ABSENT
+    #: here, and the miss is silent in this table and loud at the call site:
+    #: a family whose every declared kind is unimplemented gets no
+    #: ``scheduler()`` method at all, so a handler that wants one gets an
     #: ``AttributeError`` from its own type checker rather than a fallback that
     #: quietly puts a model library back on the request path (pgw#1331).
-    scheduler_impl = (
-        IMPLEMENTED.get(parse_kind(str(scheduler.name))) if scheduler is not None else None
-    )
-    scheduler_names = sorted(
-        {"SchedulerBlock", "SchedulerKind", *([scheduler_impl] if scheduler_impl else [])}
-    )
+    implemented = {
+        str(row.sampler): implementation
+        for row in export.schedulers
+        if (implementation := IMPLEMENTED.get(parse_kind(str(row.name)))) is not None
+    }
+    scheduler_names = sorted({"SchedulerBlock", "SchedulerKind", *implemented.values()})
     imports = sorted(
         {
             "from gen_worker.model.runtime import Model",
@@ -323,7 +426,14 @@ def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -
         }
         | (
             {"from gen_worker.model.scheduler import " + ", ".join(scheduler_names)}
-            if scheduler is not None
+            if export.schedulers
+            else set()
+        )
+        # The refusal is reachable only from the several-samplers accessor:
+        # with one sampler there is nothing for a checkpoint to name wrongly.
+        | (
+            {"from gen_worker.model.errors import ModelError, ModelRefusal"}
+            if len(implemented) > 1
             else set()
         )
     )
@@ -334,7 +444,7 @@ def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -
     # a single-valued block would name the wrong one), and every generated
     # module before them happened to declare one.
     stdlib = ["from importlib import resources"]
-    if scheduler is not None:
+    if export.schedulers:
         stdlib.append("from types import MappingProxyType")
     if containers:
         # Imported at RUNTIME, not under TYPE_CHECKING: `collections.abc` is
@@ -377,7 +487,7 @@ def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -
     ]
     lines.extend(_lazy_declaration(spec_module, spec_attr))
     lines.append("")
-    lines.extend(_aliases(export))
+    lines.extend(_aliases(export, implemented))
     lines.extend(
         [
             "",
@@ -399,13 +509,15 @@ def render(export: ModelExport, *, spec_module: str = "", spec_attr: str = "") -
         ]
     )
     lines.extend(_class_facts(export))
-    if scheduler_impl:
-        lines.extend(_scheduler_method(scheduler_impl))
+    if implemented:
+        lines.extend(_scheduler_method(export, implemented))
     for runner in export.runners:
         lines.append("")
         lines.extend(_method(export, runner))
     aliases = [_alias(family, str(axis)) for axis, _ in export.buckets]
     aliases.append(_alias(family, "layout"))
+    if len(implemented) > 1:
+        aliases.append(_alias(family, "declared_sampler"))
     exported = ", ".join(repr(item) for item in [name, *sorted(aliases)])
     lines.extend(["", "", f"__all__ = [{exported}]", ""])
     return "\n".join(lines)

--- a/src/gen_worker/model/errors.py
+++ b/src/gen_worker/model/errors.py
@@ -47,6 +47,11 @@ class ModelRefusal(StrEnum):
     PARAMETER_INVALID = "parameter_invalid"
     #: The scheduler block is not a name plus finite JSON scalars.
     SCHEDULER_INVALID = "scheduler_invalid"
+    #: A checkpoint is stamped with a SAMPLER this family's declaration does
+    #: not carry a scheduler for (pgw#1346 K10). Never a fallback: serving the
+    #: family's other schedule would silently render a different image than the
+    #: recipe asked for, which is the whole reason the set is exhaustive.
+    SCHEDULER_UNDECLARED = "scheduler_undeclared"
     #: The declaration-time export could not produce a ``CallIngress``.
     EXPORT_FAILED = "export_failed"
     #: Two variants of one runner project onto different call signatures

--- a/src/gen_worker/model/export.py
+++ b/src/gen_worker/model/export.py
@@ -312,7 +312,6 @@ def export_model(family: GraphModelSpec) -> ModelExport:
             )
         )
     loop = family.staged_loop
-    scheduler = family.scheduler
     return ModelExport(
         family=FamilyName(family.name),
         buckets=tuple(
@@ -343,13 +342,17 @@ def export_model(family: GraphModelSpec) -> ModelExport:
             )
             for parameter in family.parameters
         ),
-        scheduler=None
-        if scheduler is None
-        else ExportedScheduler(
-            name=scheduler.name,
-            parameters=tuple(
-                (ParameterName(name), value) for name, value in scheduler.parameters.items()
-            ),
+        # `GraphModelSpec._validate_schedulers` already sorted the set by
+        # sampler, which is the order the export's own invariant wants.
+        schedulers=tuple(
+            ExportedScheduler(
+                sampler=sampler,
+                name=scheduler.name,
+                parameters=tuple(
+                    (ParameterName(name), value) for name, value in scheduler.parameters.items()
+                ),
+            )
+            for sampler, scheduler in family.schedulers.items()
         ),
         lora_tuned=None if family.lora_tuned is None else _tuned_ref(family.lora_tuned),
     )

--- a/src/gen_worker/model/scheduler.py
+++ b/src/gen_worker/model/scheduler.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar, Final, Protocol, Self
 
@@ -49,10 +49,13 @@ from .solvers.block import choice as _choice
 from .solvers.block import count as _count
 from .solvers.block import flag as _flag
 from .solvers.block import real as _real
+from .solvers.block import only as _only
 from .solvers.block import refuse as _refuse
+from .solvers.ladders import interpolate_table as _interpolate
 from .solvers.dpm_multistep import DPMSolverMultistep, DpmSolverSchedule, MultistepHistory
 from .solvers.precision import f32 as _f32
 from .solvers.precision import round_half_even as _round_half_even
+from .solvers.precision import alphas_cumprod as _alphas_cumprod
 from .solvers.precision import sigma_table as _sigma_table
 from .solvers.unipc_multistep import UniPCMultistep, UniPcHistory, UniPcSchedule
 
@@ -83,6 +86,14 @@ class SchedulerKind(StrEnum):
     #: measured -81% sharpness. Implemented by :class:`UniPCMultistep`
     #: (pgw#1346 B3).
     UNIPC_MULTISTEP = "unipc_multistep"
+    #: Euler with an ancestral (stochastic) step — SDXL's DEFAULT sampler,
+    #: reached as ``euler_a``. Implemented by :class:`EulerAncestralDiscrete`
+    #: (pgw#1346 K10). It CONSUMES NOISE per step; see that class.
+    EULER_ANCESTRAL_DISCRETE = "euler_ancestral_discrete"
+    #: Deterministic DDIM (eta=0), reached as ``ddim`` / ``ddim_trailing``.
+    #: Implemented by :class:`Ddim` (pgw#1346 K10). Alone among these it walks
+    #: ALPHAS rather than sigmas, which is why it has its own schedule type.
+    DDIM = "ddim"
 
 
 def parse_kind(value: object) -> SchedulerKind:
@@ -96,8 +107,6 @@ def parse_kind(value: object) -> SchedulerKind:
             f"scheduler {value!r} is not one of {[kind.value for kind in SchedulerKind]!r}; "
             "the host implements the named scheduler and this one has no name here",
         ) from None
-
-
 class Step(Protocol):
     """The one operation a denoising loop performs per step.
 
@@ -217,6 +226,26 @@ class FlowMatchEulerDiscrete:
     #: dataclass does not take it for a field with a mutable default.
     KIND: ClassVar[SchedulerKind] = SchedulerKind.FLOW_MATCH_EULER_DISCRETE
 
+    #: Every parameter the ``flow_match_euler_discrete`` KIND admits — which is
+    #: wider than what THIS class reads, and deliberately so. The kind has two
+    #: readers over one declared block: this class, and
+    #: :class:`~gen_worker.model.flow_ladders.FlowMatchLadder`, which projects
+    #: the same block plus ``shift_terminal`` / ``time_shift_type`` (pgw#1346
+    #: B3a). The admissible key set belongs to the KIND, not to whichever reader
+    #: a family happens to reach first — otherwise a legal declaration would
+    #: refuse depending on which class read it (pgw#1346 K10).
+    PARAMETERS: ClassVar[tuple[str, ...]] = (
+        "base_image_seq_len",
+        "base_shift",
+        "max_image_seq_len",
+        "max_shift",
+        "num_train_timesteps",
+        "shift",
+        "shift_terminal",
+        "time_shift_type",
+        "use_dynamic_shifting",
+    )
+
     def __post_init__(self) -> None:
         if self.num_train_timesteps < 1:
             raise ModelError(
@@ -238,6 +267,7 @@ class FlowMatchEulerDiscrete:
     def from_block(cls, block: SchedulerBlock) -> Self:
         """Build one from a declaration's scheduler parameter block."""
 
+        _only(block, cls.PARAMETERS)
         return cls(
             num_train_timesteps=_count(block, "num_train_timesteps", 1000),
             shift=_real(block, "shift", 1.0),
@@ -374,13 +404,22 @@ class FlowMatchEulerDiscrete:
 
 
 @dataclass(frozen=True, slots=True)
-class DiscreteSchedule:
-    """One request's resolved sigma ladder for a variance-exploding schedule.
+class VarianceExploding:
+    """One request's resolved sigma ladder, without the step that walks it.
 
     The flow-match :class:`Schedule` derives its timesteps from its sigmas;
     this one cannot, because the two are related through a trained table and
     not by a constant — so ``timesteps`` is carried rather than computed, and
     ``__post_init__`` is what keeps the pair from drifting apart.
+
+    **The ladder and the step are separate facts, and this class is the
+    evidence.** ``euler`` and ``euler_a`` resolve BIT-IDENTICAL sigmas from the
+    same trained table and the same spacing, and then walk them differently:
+    one deterministically, one by contracting to ``sigma_down`` and adding
+    ``sigma_up`` of fresh noise. Everything they share lives here so the two
+    cannot drift; ``step`` lives on the subclasses because its SIGNATURE
+    differs — an ancestral step consumes noise and a deterministic one must not
+    be able to accept it and ignore it.
 
     Immutable and request-scoped, for the same reason :class:`Schedule` is:
     there is no ``self._step_index`` here for two concurrent requests to share.
@@ -444,6 +483,34 @@ class DiscreteSchedule:
         sigma = self._sigma(index)
         return sample / _f32(math.sqrt(_f32(_f32(sigma * sigma) + 1.0)))
 
+    def predicted(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """The denoised sample this step predicts — ``x_0``.
+
+        Shared by both steps below because both reference implementations
+        compute it identically, and because the ``v_prediction`` arm is the one
+        piece of this arithmetic nobody rederives correctly from memory.
+        """
+
+        sigma = self._sigma(index)
+        if self.prediction_type == "epsilon":
+            return sample - sigma * model_output
+        variance = _f32(_f32(sigma * sigma) + 1.0)
+        return model_output * _f32(-sigma / _f32(math.sqrt(variance))) + (sample / variance)
+
+    def scale_noise(self, noise: Tensor, sample: Tensor, index: int = 0) -> Tensor:
+        """Add noise to a clean sample at one point on the ladder.
+
+        ``x + sigma * noise`` — the variance-EXPLODING forward, where the
+        flow-match schedule interpolates. img2img and inpaint need exactly it.
+        """
+
+        return sample + noise * self._sigma(index)
+
+
+@dataclass(frozen=True, slots=True)
+class DiscreteSchedule(VarianceExploding):
+    """The DETERMINISTIC Euler walk down a variance-exploding ladder."""
+
     def step(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
         """One Euler step down the ladder.
 
@@ -465,37 +532,185 @@ class DiscreteSchedule:
         """
 
         sigma = self._sigma(index)
-        if self.prediction_type == "epsilon":
-            predicted = sample - sigma * model_output
-        else:
-            variance = _f32(_f32(sigma * sigma) + 1.0)
-            predicted = model_output * _f32(-sigma / _f32(math.sqrt(variance))) + (
-                sample / variance
-            )
-        derivative = (sample - predicted) / sigma
+        derivative = (sample - self.predicted(index, model_output, sample)) / sigma
         return sample + derivative * _f32(self.sigmas[index + 1] - sigma)
-
-    def scale_noise(self, noise: Tensor, sample: Tensor, index: int = 0) -> Tensor:
-        """Add noise to a clean sample at one point on the ladder.
-
-        ``x + sigma * noise`` — the variance-EXPLODING forward, where the
-        flow-match schedule interpolates. img2img and inpaint need exactly it.
-        """
-
-        return sample + noise * self._sigma(index)
 
 
 @dataclass(frozen=True, slots=True)
-class EulerDiscrete:
-    """The U-Net families' Euler schedule, as bare typed math.
+class AncestralSchedule(VarianceExploding):
+    """The ANCESTRAL walk: contract to ``sigma_down``, then re-noise.
 
-    Every field is a DECLARED family fact read out of the recipe's scheduler
+    An ancestral sampler does not step along the ODE to the next sigma. It
+    steps to a SMALLER one (``sigma_down``) and adds back exactly the noise
+    (``sigma_up``) that restores the variance the ladder expects — so the
+    trajectory is stochastic and the sampler explores rather than descends.
+    That is why ``euler_a`` is the default an SDXL request gets and why its
+    output is not ``euler``'s output at the same seed.
+
+    **The noise is a PARAMETER, never a source this object owns**, and the
+    reason is the whole reproducibility argument this module is built on: a
+    scheduler holding an RNG is a scheduler whose two concurrent requests share
+    a stream, and this module imports no array library and could not seed one
+    honestly anyway. The caller supplies the noise, and the catalog's serving
+    half supplies it CPU-seeded and keyed by ``(request seed, step index)`` —
+    see ``sdxl_serve.step_noise``, which states the keying — so two pods
+    replaying one receipt draw the same tensor at step ``k`` regardless of what
+    the loop around it did.
+    """
+
+    def ancestral(self, index: int) -> tuple[float, float]:
+        """``(sigma_down, sigma_up)`` for one step.
+
+        ``sigma_up`` is the variance handed back to the noise and ``sigma_down``
+        is what is left for the deterministic move; ``sigma_up**2 +
+        sigma_down**2 == sigma_next**2`` up to float32. Both are resolved in the
+        reference's own float32 op order rather than folded, for the reason the
+        module header gives at length.
+        """
+
+        near = self._sigma(index)
+        far = self.sigmas[index + 1]
+        near2 = _f32(near * near)
+        far2 = _f32(far * far)
+        up = _f32(math.sqrt(_f32(_f32(far2 * _f32(near2 - far2)) / near2)))
+        down = _f32(math.sqrt(_f32(far2 - _f32(up * up))))
+        return down, up
+
+    def step(self, index: int, model_output: Tensor, sample: Tensor, noise: Tensor) -> Tensor:
+        """One ancestral Euler step. ``noise`` is REQUIRED, never defaulted.
+
+        Defaulting it to zeros would silently turn this into a worse
+        :class:`DiscreteSchedule` — same signature, plausible image, wrong
+        sampler — which is exactly the failure a required parameter costs
+        nothing to prevent.
+        """
+
+        sigma = self._sigma(index)
+        down, up = self.ancestral(index)
+        derivative = (sample - self.predicted(index, model_output, sample)) / sigma
+        return sample + derivative * _f32(down - sigma) + noise * up
+
+
+@dataclass(frozen=True, slots=True)
+class DdimSchedule:
+    """One request's resolved DDIM trajectory. It walks ALPHAS, not sigmas.
+
+    The odd one out on purpose, and the difference is not cosmetic:
+    ``DDIMScheduler`` never forms a sigma ladder at all. It reads
+    ``alphas_cumprod`` at the current and previous timestep and moves in the
+    variance-PRESERVING parameterisation, which is why its ``init_noise_sigma``
+    is 1.0 and its ``scale_model_input`` is the identity. Serving a DDIM
+    trajectory through :class:`DiscreteSchedule`'s API would pre-scale the
+    latents by ``1/sqrt(sigma**2+1)`` and start them at ~10x too much
+    variance — no error, just a ruined image — so the two are different types.
+
+    ``eta`` is fixed at 0: the deterministic sampler. Both endpoint names that
+    reach DDIM (``ddim``, ``ddim_trailing``) are the deterministic one, and an
+    ``eta > 0`` arm would be a noise-consuming step nothing declares.
+    """
+
+    #: The INTEGER train timesteps this trajectory visits, descending. Integer
+    #: and not float: DDIM indexes ``alphas_cumprod`` with them directly, where
+    #: the euler family interpolates a table at a fractional position.
+    timesteps: tuple[int, ...]
+    #: ``(alpha_prod_t, alpha_prod_t_prev)`` per step, resolved once.
+    alphas: tuple[tuple[float, float], ...]
+    num_train_timesteps: int
+    prediction_type: str
+    #: Always 1.0 — a variance-PRESERVING trajectory starts at unit variance.
+    #: Carried rather than assumed so a loop can read it off any schedule.
+    init_noise_sigma: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.timesteps:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, "a schedule needs at least one step"
+            )
+        if len(self.alphas) != len(self.timesteps):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"{len(self.alphas)} alpha pairs do not walk "
+                f"{len(self.timesteps)} timesteps",
+            )
+
+    def __len__(self) -> int:
+        return len(self.timesteps)
+
+    def _alphas(self, index: int) -> tuple[float, float]:
+        if not 0 <= index < len(self):
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"step {index} is outside this schedule's {len(self)} steps",
+            )
+        return self.alphas[index]
+
+    def scale_model_input(self, index: int, sample: Tensor) -> Tensor:
+        """The IDENTITY, and it is here so a loop does not have to know that.
+
+        ``DDIMScheduler.scale_model_input`` returns its argument: the
+        variance-preserving parameterisation keeps the sample at unit scale, so
+        there is nothing to divide out. Present rather than absent because the
+        alternative is a caller branching on which scheduler it got, which is
+        the branch that eventually forgets one.
+        """
+
+        self._alphas(index)
+        return sample
+
+    def predicted(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """The denoised sample this step predicts — ``x_0``."""
+
+        alpha, _ = self._alphas(index)
+        beta = _f32(1.0 - alpha)
+        if self.prediction_type == "epsilon":
+            return (sample - _f32(math.sqrt(beta)) * model_output) / _f32(math.sqrt(alpha))
+        return _f32(math.sqrt(alpha)) * sample - _f32(math.sqrt(beta)) * model_output
+
+    def step(self, index: int, model_output: Tensor, sample: Tensor) -> Tensor:
+        """One deterministic DDIM step — formula (12) of arXiv:2010.02502.
+
+        ``x_{t-1} = sqrt(a_prev) * x_0_hat + sqrt(1 - a_prev) * eps_hat``, with
+        ``eta = 0`` so the variance term vanishes. Written in the reference's
+        own moves rather than simplified, for the same reason the Euler step is.
+        """
+
+        alpha, previous = self._alphas(index)
+        original = self.predicted(index, model_output, sample)
+        if self.prediction_type == "epsilon":
+            residual = model_output
+        else:
+            beta = _f32(1.0 - alpha)
+            residual = _f32(math.sqrt(alpha)) * model_output + _f32(math.sqrt(beta)) * sample
+        direction = _f32(math.sqrt(_f32(1.0 - previous))) * residual
+        return _f32(math.sqrt(previous)) * original + direction
+
+    def scale_noise(self, noise: Tensor, sample: Tensor, index: int = 0) -> Tensor:
+        """The variance-PRESERVING forward: ``sqrt(a) * x + sqrt(1-a) * noise``.
+
+        Not ``x + sigma * noise``. Using the exploding form on an alpha
+        trajectory produces a plausible, wrong img2img strength.
+        """
+
+        alpha, _ = self._alphas(index)
+        return _f32(math.sqrt(alpha)) * sample + _f32(math.sqrt(_f32(1.0 - alpha))) * noise
+
+
+@dataclass(frozen=True, slots=True)
+class Trained:
+    """The trained noise schedule the three U-Net-family kinds descend from.
+
+    Every field is a DECLARED family fact read out of a recipe's scheduler
     block. The defaults are ``diffusers``' own class defaults and NOT
     Stable Diffusion's — a family that wants SD's trained noise schedule
     declares ``beta_start``/``beta_end``/``beta_schedule`` explicitly, exactly
     as FLUX declares its shift constants. Silently defaulting to SD's numbers
     would put a family fact in this module, which is the drift
     ``check_model_bindings.py`` exists to refuse one level up.
+
+    Shared by :class:`EulerDiscrete`, :class:`EulerAncestralDiscrete` and
+    :class:`Ddim` because they are three walks over ONE table, and a family
+    declaring several of them (pgw#1346 K10 — the sampler is a tuned value)
+    must not be able to state the same trained schedule three different ways.
     """
 
     num_train_timesteps: int = 1000
@@ -506,16 +721,24 @@ class EulerDiscrete:
     timestep_spacing: str = "linspace"
     steps_offset: int = 0
     rescale_betas_zero_snr: bool = False
-    final_sigmas_type: str = "zero"
-
-    KIND: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
 
     #: The closed sets. Every one of these is a value that changes the LADDER,
     #: so an unrecognised spelling refuses instead of falling through.
     BETA_SCHEDULES: ClassVar[tuple[str, ...]] = ("linear", "scaled_linear")
     PREDICTION_TYPES: ClassVar[tuple[str, ...]] = ("epsilon", "v_prediction")
     SPACINGS: ClassVar[tuple[str, ...]] = ("linspace", "leading", "trailing")
-    FINAL_SIGMAS: ClassVar[tuple[str, ...]] = ("zero", "sigma_min")
+
+    #: The parameters every kind below reads, before its own are added.
+    TRAINED_PARAMETERS: ClassVar[tuple[str, ...]] = (
+        "beta_end",
+        "beta_schedule",
+        "beta_start",
+        "num_train_timesteps",
+        "prediction_type",
+        "rescale_betas_zero_snr",
+        "steps_offset",
+        "timestep_spacing",
+    )
 
     def __post_init__(self) -> None:
         if self.num_train_timesteps < 1:
@@ -533,26 +756,26 @@ class EulerDiscrete:
             ("beta_schedule", self.beta_schedule, self.BETA_SCHEDULES),
             ("prediction_type", self.prediction_type, self.PREDICTION_TYPES),
             ("timestep_spacing", self.timestep_spacing, self.SPACINGS),
-            ("final_sigmas_type", self.final_sigmas_type, self.FINAL_SIGMAS),
         ):
             if value not in allowed:
                 raise _refuse(name, f"one of {list(allowed)!r}", value)
 
     @classmethod
-    def from_block(cls, block: SchedulerBlock) -> Self:
-        """Build one from a declaration's scheduler parameter block."""
+    def _trained_kwargs(cls, block: SchedulerBlock) -> dict[str, SchedulerValue]:
+        """The trained-schedule half of a block, parsed. Shared by every kind."""
 
-        return cls(
-            num_train_timesteps=_count(block, "num_train_timesteps", 1000),
-            beta_start=_real(block, "beta_start", 0.0001),
-            beta_end=_real(block, "beta_end", 0.02),
-            beta_schedule=_choice(block, "beta_schedule", "linear", cls.BETA_SCHEDULES),
-            prediction_type=_choice(block, "prediction_type", "epsilon", cls.PREDICTION_TYPES),
-            timestep_spacing=_choice(block, "timestep_spacing", "linspace", cls.SPACINGS),
-            steps_offset=_count(block, "steps_offset", 0),
-            rescale_betas_zero_snr=_flag(block, "rescale_betas_zero_snr", False),
-            final_sigmas_type=_choice(block, "final_sigmas_type", "zero", cls.FINAL_SIGMAS),
-        )
+        return {
+            "num_train_timesteps": _count(block, "num_train_timesteps", 1000),
+            "beta_start": _real(block, "beta_start", 0.0001),
+            "beta_end": _real(block, "beta_end", 0.02),
+            "beta_schedule": _choice(block, "beta_schedule", "linear", cls.BETA_SCHEDULES),
+            "prediction_type": _choice(
+                block, "prediction_type", "epsilon", cls.PREDICTION_TYPES
+            ),
+            "timestep_spacing": _choice(block, "timestep_spacing", "linspace", cls.SPACINGS),
+            "steps_offset": _count(block, "steps_offset", 0),
+            "rescale_betas_zero_snr": _flag(block, "rescale_betas_zero_snr", False),
+        }
 
     def objective(self, prediction_type: str) -> Self:
         """This scheduler with the checkpoint's stamped objective applied.
@@ -567,27 +790,22 @@ class EulerDiscrete:
         """
 
         if prediction_type not in self.PREDICTION_TYPES:
-            raise _refuse("prediction_type", f"one of {list(self.PREDICTION_TYPES)!r}",
-                          prediction_type)
+            raise _refuse(
+                "prediction_type", f"one of {list(self.PREDICTION_TYPES)!r}", prediction_type
+            )
         if prediction_type == self.prediction_type and not (
             prediction_type == "v_prediction" and not self.rescale_betas_zero_snr
         ):
             return self
-        return type(self)(
-            num_train_timesteps=self.num_train_timesteps,
-            beta_start=self.beta_start,
-            beta_end=self.beta_end,
-            beta_schedule=self.beta_schedule,
+        return replace(
+            self,
             prediction_type=prediction_type,
-            timestep_spacing=self.timestep_spacing,
-            steps_offset=self.steps_offset,
             rescale_betas_zero_snr=(
                 True if prediction_type == "v_prediction" else self.rescale_betas_zero_snr
             ),
-            final_sigmas_type=self.final_sigmas_type,
         )
 
-    def _timesteps(self, steps: int) -> tuple[float, ...]:
+    def _grid(self, steps: int) -> tuple[float, ...]:
         """The discrete timestep grid one spacing produces. Table 2 of
         arXiv:2305.08891, and the three spellings are not interchangeable:
         `leading` starts a step below the top of the ladder and `trailing`
@@ -616,17 +834,16 @@ class EulerDiscrete:
         span = total / steps
         count = math.ceil(total / span)
         return tuple(
-            _f32(_f32(_round_half_even(total - index * span)) - 1.0)
-            for index in range(count)
+            _f32(_f32(_round_half_even(total - index * span)) - 1.0) for index in range(count)
         )
 
-    def schedule(self, steps: int) -> DiscreteSchedule:
-        """The resolved sigma ladder for one request.
+    def _ladder(self, steps: int) -> tuple[tuple[float, ...], tuple[float, ...]]:
+        """``(timesteps, sigmas)`` for the two variance-EXPLODING kinds.
 
         No ``image_seq_len``: unlike the flow-match schedule, this ladder does
         not consult the resolution at all — the same 28 sigmas serve a
         1024x1024 render and a 1536x640 one. Stated because the opposite is
-        true one class up and the asymmetry is otherwise a trap.
+        true for FLUX and the asymmetry is otherwise a trap.
         """
 
         if steps < 1:
@@ -640,61 +857,275 @@ class EulerDiscrete:
             self.beta_schedule,
             self.rescale_betas_zero_snr,
         )
-        timesteps = self._timesteps(steps)
-        # FLOAT64 interpolation over the float32 table — numpy's `interp`
-        # promotes, and matching it is what makes the ladder bit-exact.
-        last = len(table) - 1
-        sigmas = []
-        for timestep in timesteps:
-            if timestep <= 0.0:
-                sigmas.append(table[0])
-            elif timestep >= last:
-                sigmas.append(table[last])
-            else:
-                low = int(timestep)
-                sigmas.append(table[low] + (table[low + 1] - table[low]) * (timestep - low))
-        terminal = 0.0 if self.final_sigmas_type == "zero" else table[0]
-        resolved = tuple(_f32(sigma) for sigma in sigmas)
-        maximum = max(resolved)
+        timesteps = self._grid(steps)
+        return timesteps, _interpolate(table, timesteps)
+
+    def _init_noise_sigma(self, sigmas: tuple[float, ...]) -> float:
+        """``sigma_max`` under trailing/linspace and ``sqrt(sigma_max**2 + 1)``
+        under leading — a fact of the SPACING, resolved once and carried."""
+
+        maximum = max(sigmas)
+        if self.timestep_spacing in ("linspace", "trailing"):
+            return maximum
+        return _f32(math.sqrt(_f32(_f32(maximum * maximum) + 1.0)))
+
+
+@dataclass(frozen=True, slots=True)
+class EulerDiscrete(Trained):
+    """The U-Net families' DETERMINISTIC Euler schedule, as bare typed math.
+
+    Reached as the ``euler`` and ``euler_trailing`` samplers. Everything about
+    the trained noise schedule is :class:`Trained`'s; this class adds one
+    parameter of its own, ``final_sigmas_type``, and the deterministic walk.
+    """
+
+    final_sigmas_type: str = "zero"
+
+    KIND: ClassVar[SchedulerKind] = SchedulerKind.EULER_DISCRETE
+    FINAL_SIGMAS: ClassVar[tuple[str, ...]] = ("zero", "sigma_min")
+    PARAMETERS: ClassVar[tuple[str, ...]] = (
+        *Trained.TRAINED_PARAMETERS,
+        "final_sigmas_type",
+    )
+
+    def __post_init__(self) -> None:
+        Trained.__post_init__(self)
+        if self.final_sigmas_type not in self.FINAL_SIGMAS:
+            raise _refuse(
+                "final_sigmas_type", f"one of {list(self.FINAL_SIGMAS)!r}", self.final_sigmas_type
+            )
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        _only(block, cls.PARAMETERS)
+        return cls(
+            **cls._trained_kwargs(block),  # type: ignore[arg-type]
+            final_sigmas_type=_choice(block, "final_sigmas_type", "zero", cls.FINAL_SIGMAS),
+        )
+
+    def schedule(self, steps: int) -> DiscreteSchedule:
+        """The resolved sigma ladder for one request."""
+
+        timesteps, sigmas = self._ladder(steps)
+        # `sigma_min` keeps the smallest TRAINED sigma as the terminal rather
+        # than landing on 0, which is a different final step and not a rounding
+        # choice — a distilled recipe that names it is destroyed by `zero`.
+        terminal = (
+            0.0
+            if self.final_sigmas_type == "zero"
+            else _sigma_table(
+                self.num_train_timesteps,
+                self.beta_start,
+                self.beta_end,
+                self.beta_schedule,
+                self.rescale_betas_zero_snr,
+            )[0]
+        )
         return DiscreteSchedule(
-            sigmas=(*resolved, _f32(terminal)),
+            sigmas=(*sigmas, _f32(terminal)),
             timesteps=timesteps,
             num_train_timesteps=self.num_train_timesteps,
             prediction_type=self.prediction_type,
-            init_noise_sigma=(
-                maximum if self.timestep_spacing in ("linspace", "trailing")
-                else _f32(math.sqrt(_f32(_f32(maximum * maximum) + 1.0)))
-            ),
+            init_noise_sigma=self._init_noise_sigma(sigmas),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EulerAncestralDiscrete(Trained):
+    """``euler_a`` — SDXL's DEFAULT sampler, and the one that consumes noise.
+
+    Its LADDER is :class:`EulerDiscrete`'s, value for value: same trained
+    table, same three spacings, same interpolation. Two things differ, and both
+    are load-bearing:
+
+    * there is **no** ``final_sigmas_type``. ``EulerAncestralDiscreteScheduler``
+      always terminates at 0.0 and offers no choice, so declaring one here
+      would be a parameter that changes nothing — refused by :func:`_only`
+      rather than accepted and ignored;
+    * the STEP contracts to ``sigma_down`` and adds ``sigma_up`` of fresh
+      noise, which makes the trajectory stochastic. See
+      :class:`AncestralSchedule` for where that noise comes from and how it is
+      keyed, because "reproducible" is a claim about the noise and not about
+      the ladder.
+
+    This is the class pgw#1346 K10 exists for: SDXL's declared block was its
+    TRAINED schedule under ``euler_discrete``, which is not the sampler most
+    requests get — ``SdxlTuned.scheduler`` defaults to ``euler_a``.
+    """
+
+    KIND: ClassVar[SchedulerKind] = SchedulerKind.EULER_ANCESTRAL_DISCRETE
+    PARAMETERS: ClassVar[tuple[str, ...]] = Trained.TRAINED_PARAMETERS
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        _only(block, cls.PARAMETERS)
+        return cls(**cls._trained_kwargs(block))  # type: ignore[arg-type]
+
+    def schedule(self, steps: int) -> AncestralSchedule:
+        """The resolved sigma ladder for one request. Terminates at 0.0."""
+
+        timesteps, sigmas = self._ladder(steps)
+        return AncestralSchedule(
+            sigmas=(*sigmas, 0.0),
+            timesteps=timesteps,
+            num_train_timesteps=self.num_train_timesteps,
+            prediction_type=self.prediction_type,
+            init_noise_sigma=self._init_noise_sigma(sigmas),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Ddim(Trained):
+    """``ddim`` / ``ddim_trailing`` — deterministic, and NOT a sigma walk.
+
+    Reached by three endpoint paths that pgw#1346 B2 enumerated: sd15's payload
+    enum offers ``ddim``, sd15's ``generate_hyper`` pins ``ddim_trailing``
+    unconditionally, and sdxl's enum offers ``ddim_trailing``. B2 recorded them
+    and could not implement any of them, because the declaration held ONE
+    scheduler; K10 is the change that lets a family declare this one BESIDE its
+    euler entries.
+
+    Two of its parameters are its own, and both are silent when wrong:
+
+    * ``set_alpha_to_one`` decides whether the trajectory's LAST step targets
+      ``alpha_bar = 1`` (a perfectly clean sample) or ``alphas_cumprod[0]``.
+      Stable Diffusion's shipped ``scheduler_config.json`` says ``false`` and
+      ``DDIMScheduler``'s class default says ``true``, so an omitted value
+      resolves to the opposite of what every SD checkpoint was configured with;
+    * ``clip_sample`` clamps the predicted ``x_0``. Every SD config sets it
+      false. It is DECLARABLE and only ``false`` is implementable here — see
+      :meth:`from_block` — because a true arm needs a tensor clamp with a
+      declared range, and no endpoint on this fleet asks for one.
+    """
+
+    set_alpha_to_one: bool = True
+    clip_sample: bool = False
+
+    KIND: ClassVar[SchedulerKind] = SchedulerKind.DDIM
+    PARAMETERS: ClassVar[tuple[str, ...]] = (
+        *Trained.TRAINED_PARAMETERS,
+        "clip_sample",
+        "set_alpha_to_one",
+    )
+
+    def __post_init__(self) -> None:
+        Trained.__post_init__(self)
+        if self.clip_sample:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                "clip_sample=True is declarable and not implemented: it needs a declared "
+                "clip range and no endpoint on this fleet configures one. Declare it false "
+                "or file the range, rather than getting an unclamped trajectory silently",
+            )
+
+    @classmethod
+    def from_block(cls, block: SchedulerBlock) -> Self:
+        """Build one from a declaration's scheduler parameter block."""
+
+        _only(block, cls.PARAMETERS)
+        return cls(
+            **cls._trained_kwargs(block),  # type: ignore[arg-type]
+            set_alpha_to_one=_flag(block, "set_alpha_to_one", True),
+            clip_sample=_flag(block, "clip_sample", False),
+        )
+
+    def _grid(self, steps: int) -> tuple[float, ...]:
+        """DDIM's INTEGER timestep grid, which is not euler's float one.
+
+        ``leading`` and ``trailing`` agree with the euler family. ``linspace``
+        does NOT: ``DDIMScheduler`` rounds it to integers and the euler
+        schedulers keep the fractional position and interpolate their table at
+        it. Sharing one grid would put a half-step error into every linspace
+        DDIM request — visible as a slightly wrong image and nothing else.
+        """
+
+        total = self.num_train_timesteps
+        if self.timestep_spacing == "linspace":
+            if steps == 1:
+                return (0.0,)
+            span = (total - 1) / (steps - 1)
+            return tuple(_round_half_even(index * span) for index in reversed(range(steps)))
+        return Trained._grid(self, steps)
+
+    def schedule(self, steps: int) -> DdimSchedule:
+        """The resolved alpha trajectory for one request."""
+
+        if steps < 1:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID, f"a schedule needs at least one step, got {steps}"
+            )
+        if steps > self.num_train_timesteps:
+            raise ModelError(
+                ModelRefusal.SCHEDULER_INVALID,
+                f"DDIM walks the trained grid, so {steps} steps cannot exceed its "
+                f"{self.num_train_timesteps} timesteps",
+            )
+        # `clamp_terminal` FALSE: `DDIMScheduler` does not overwrite the last
+        # alpha under zero-terminal-SNR rescaling, where the euler schedulers
+        # do. See `_alphas_cumprod`.
+        table = _alphas_cumprod(
+            self.num_train_timesteps,
+            self.beta_start,
+            self.beta_end,
+            self.beta_schedule,
+            self.rescale_betas_zero_snr,
+            False,
+        )
+        final = 1.0 if self.set_alpha_to_one else table[0]
+        stride = self.num_train_timesteps // steps
+        timesteps = tuple(int(value) for value in self._grid(steps))
+        alphas = tuple(
+            (table[timestep], table[timestep - stride] if timestep - stride >= 0 else final)
+            for timestep in timesteps
+        )
+        return DdimSchedule(
+            timesteps=timesteps,
+            alphas=alphas,
+            num_train_timesteps=self.num_train_timesteps,
+            prediction_type=self.prediction_type,
         )
 
 
 #: Which class implements which name. Read by the BINDING GENERATOR to pick a
 #: return annotation, and by nothing at request time — a handler reaches its
 #: scheduler through the generated ``inst.scheduler()``, whose return type is
-#: the concrete class, so no request-path code indexes this table.
+#: the concrete class (or the closed UNION of the ones the family declares), so
+#: no request-path code indexes this table.
 IMPLEMENTED: Final[Mapping[SchedulerKind, str]] = {
     SchedulerKind.FLOW_MATCH_EULER_DISCRETE: "FlowMatchEulerDiscrete",
     SchedulerKind.EULER_DISCRETE: "EulerDiscrete",
     SchedulerKind.DPMSOLVER_MULTISTEP: "DPMSolverMultistep",
     SchedulerKind.UNIPC_MULTISTEP: "UniPCMultistep",
+    SchedulerKind.EULER_ANCESTRAL_DISCRETE: "EulerAncestralDiscrete",
+    SchedulerKind.DDIM: "Ddim",
 }
 
 
 __all__ = [
-    "IMPLEMENTED",
+    "AncestralSchedule",
     "DPMSolverMultistep",
+    "Ddim",
+    "DdimSchedule",
     "DiscreteSchedule",
     "DpmSolverSchedule",
+    "EulerAncestralDiscrete",
     "EulerDiscrete",
     "FlowMatchEulerDiscrete",
+    "IMPLEMENTED",
     "MultistepHistory",
     "Schedule",
     "SchedulerBlock",
     "SchedulerKind",
     "SchedulerValue",
     "Step",
+    "Trained",
     "UniPCMultistep",
     "UniPcHistory",
     "UniPcSchedule",
+    "VarianceExploding",
     "parse_kind",
 ]

--- a/src/gen_worker/model/snapshot.py
+++ b/src/gen_worker/model/snapshot.py
@@ -534,26 +534,36 @@ class ExportedParameter:
 
 @dataclass(frozen=True, slots=True)
 class ExportedScheduler:
-    """The named scheduler and its parameter block, recorded and uninterpreted."""
+    """One SAMPLER, the scheduler kind it names, and that kind's block.
 
+    ``sampler`` is the key a checkpoint is stamped with (``inst.tuned.
+    scheduler``) and ``name`` is the scheduler KIND the host implements. They
+    are two different vocabularies and conflating them is the defect pgw#1346
+    K10 records: ``euler`` and ``euler_trailing`` are one kind under two
+    spacings, and ``euler_a`` is a different kind entirely.
+    """
+
+    sampler: str
     name: str
     parameters: tuple[tuple[ParameterName, SchedulerValue], ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         return {
+            "sampler": str(self.sampler),
             "name": str(self.name),
             "parameters": {str(name): value for name, value in self.parameters},
         }
 
     @classmethod
     def decode(cls, raw: object) -> ExportedScheduler:
-        row = _fields("scheduler", raw, frozenset(("name", "parameters")))
+        row = _fields("scheduler", raw, frozenset(("sampler", "name", "parameters")))
         parameters = row["parameters"]
         if not isinstance(parameters, Mapping):
             raise ModelError(
                 ModelRefusal.SNAPSHOT_INVALID, "scheduler parameters must be an object"
             )
         return cls(
+            sampler=_parse("sampler name", row["sampler"], parse_parameter_name),
             name=_parse("scheduler name", row["name"], parse_scheduler_name),
             parameters=tuple(
                 sorted(
@@ -615,7 +625,9 @@ class ModelExport:
     loop: ExportedLoop
     tuned: TunedRef
     parameters: tuple[ExportedParameter, ...] = ()
-    scheduler: ExportedScheduler | None = None
+    #: The scheduler SET, sorted by sampler name (pgw#1346 K10). Empty when the
+    #: family declares no scheduler.
+    schedulers: tuple[ExportedScheduler, ...] = ()
     lora_tuned: TunedRef | None = None
 
     def __post_init__(self) -> None:
@@ -674,6 +686,11 @@ class ModelExport:
                 ModelRefusal.SNAPSHOT_INVALID,
                 f"runner {str(unused[0])!r} is exported but no loop stage runs it",
             )
+        samplers = tuple(row.sampler for row in self.schedulers)
+        if samplers != tuple(sorted(set(samplers))):
+            raise ModelError(
+                ModelRefusal.SNAPSHOT_INVALID, "schedulers must be sorted by sampler and unique"
+            )
 
     # ---------------------------------------------------------------- reading
 
@@ -709,8 +726,8 @@ class ModelExport:
             "parameters": [parameter.as_dict() for parameter in self.parameters],
             "tuned": self.tuned.as_dict(),
         }
-        if self.scheduler is not None:
-            document["scheduler"] = self.scheduler.as_dict()
+        if self.schedulers:
+            document["schedulers"] = [row.as_dict() for row in self.schedulers]
         if self.lora_tuned is not None:
             document["lora_tuned"] = self.lora_tuned.as_dict()
         return document
@@ -736,7 +753,7 @@ class ModelExport:
             "family export",
             raw,
             frozenset(("v", "family", "buckets", "runners", "loop", "parameters", "tuned")),
-            frozenset(("scheduler", "lora_tuned")),
+            frozenset(("schedulers", "lora_tuned")),
         )
         version = row["v"]
         if type(version) is not int or version != EXPORT_VERSION:
@@ -764,7 +781,11 @@ class ModelExport:
                     tuple(int(value) for value in values),
                 )
             )
-        scheduler = row.get("scheduler")
+        schedulers = row.get("schedulers")
+        if schedulers is not None and not isinstance(schedulers, list):
+            raise ModelError(
+                ModelRefusal.SNAPSHOT_INVALID, "family export schedulers must be an array"
+            )
         lora = row.get("lora_tuned")
         return cls(
             family=FamilyName(str(row["family"])),
@@ -773,7 +794,9 @@ class ModelExport:
             loop=ExportedLoop.decode(row["loop"]),
             tuned=TunedRef.decode(row["tuned"]),
             parameters=tuple(ExportedParameter.decode(item) for item in row["parameters"]),
-            scheduler=None if scheduler is None else ExportedScheduler.decode(scheduler),
+            schedulers=()
+            if schedulers is None
+            else tuple(ExportedScheduler.decode(row) for row in schedulers),
             lora_tuned=None if lora is None else TunedRef.decode(lora),
         )
 

--- a/src/gen_worker/model/solvers/block.py
+++ b/src/gen_worker/model/solvers/block.py
@@ -76,12 +76,34 @@ def choice(block: SchedulerBlock, name: str, default: str, allowed: tuple[str, .
     return value
 
 
+def only(block: SchedulerBlock, known: tuple[str, ...]) -> SchedulerBlock:
+    """Refuse a block carrying a parameter this scheduler does not read.
+
+    The failure this prevents is silent and specific: ``EulerAncestralDiscrete``
+    has no ``final_sigmas_type`` and ``Ddim`` has no ``final_sigmas_type``
+    either, so a per-sampler block copied from the euler one keeps a key that
+    changes nothing — the declaration says one thing and the ladder does
+    another, with no error anywhere. Every reader below is total over its own
+    parameters, so an unknown key can only be a mistake (pgw#1346 K10).
+    """
+
+    unknown = sorted(set(block) - set(known))
+    if unknown:
+        raise ModelError(
+            ModelRefusal.SCHEDULER_INVALID,
+            f"scheduler parameter {unknown[0]!r} is not read by this scheduler; it reads "
+            f"{list(known)!r}",
+        )
+    return block
+
+
 __all__ = [
     "SchedulerBlock",
     "SchedulerValue",
     "choice",
     "count",
     "flag",
+    "only",
     "real",
     "refuse",
 ]

--- a/src/gen_worker/model/solvers/dpm_multistep.py
+++ b/src/gen_worker/model/solvers/dpm_multistep.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING, ClassVar, Self
 
 from ..errors import ModelError, ModelRefusal
 from . import ladders
-from .block import SchedulerBlock, choice, count, flag, real, refuse
+from .block import SchedulerBlock, choice, count, flag, only, real, refuse
 from .precision import f32, round_half_even, sigma_table, truncate_to_int
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -383,6 +383,29 @@ class DPMSolverMultistep:
     use_flow_sigmas: bool = False
     flow_shift: float = 1.0
 
+    #: Every parameter this kind reads. A block naming anything else is a
+    #: declaration that says one thing and schedules another (pgw#1346 K10).
+    PARAMETERS: ClassVar[tuple[str, ...]] = (
+        "algorithm_type",
+        "beta_end",
+        "beta_schedule",
+        "beta_start",
+        "euler_at_final",
+        "final_sigmas_type",
+        "flow_shift",
+        "lower_order_final",
+        "num_train_timesteps",
+        "prediction_type",
+        "rescale_betas_zero_snr",
+        "solver_order",
+        "solver_type",
+        "steps_offset",
+        "timestep_spacing",
+        "use_exponential_sigmas",
+        "use_flow_sigmas",
+        "use_karras_sigmas",
+    )
+
     BETA_SCHEDULES: ClassVar[tuple[str, ...]] = ("linear", "scaled_linear")
     PREDICTION_TYPES: ClassVar[tuple[str, ...]] = (
         "epsilon",
@@ -438,6 +461,7 @@ class DPMSolverMultistep:
     def from_block(cls, block: SchedulerBlock) -> Self:
         """Build one from a declaration's scheduler parameter block."""
 
+        only(block, cls.PARAMETERS)
         return cls(
             num_train_timesteps=count(block, "num_train_timesteps", 1000),
             beta_start=real(block, "beta_start", 0.0001),

--- a/src/gen_worker/model/solvers/precision.py
+++ b/src/gen_worker/model/solvers/precision.py
@@ -142,6 +142,41 @@ def sigma_table(
     asks for the same one.
     """
 
+    return tuple(
+        f32(math.sqrt(f32(f32(1.0 - alpha) / alpha)))
+        for alpha in alphas_cumprod(
+            num_train_timesteps,
+            beta_start,
+            beta_end,
+            beta_schedule,
+            rescale_betas_zero_snr,
+            True,
+        )
+    )
+
+
+@lru_cache(maxsize=32)
+def alphas_cumprod(
+    num_train_timesteps: int,
+    beta_start: float,
+    beta_end: float,
+    beta_schedule: str,
+    rescale_betas_zero_snr: bool,
+    clamp_terminal: bool,
+) -> tuple[float, ...]:
+    """The trained ``alphas_cumprod`` table — the root every kind descends from.
+
+    ``clamp_terminal`` is NOT a preference, and it is the one place the
+    diffusion-objective kinds genuinely disagree about the same table
+    (pgw#1346 K10). Under zero-terminal-SNR rescaling the euler schedulers and
+    the multistep solvers overwrite the LAST entry with the smallest positive
+    fp16 subnormal so the first SIGMA is finite; ``DDIMScheduler`` does not,
+    because it walks alphas rather than sigmas and has no infinity to avoid.
+    Reading one class's table into another is a silently different first step —
+    the one furthest from the data manifold, so the most visible one — which is
+    why the flag is a parameter here rather than a constant.
+    """
+
     if beta_schedule == "scaled_linear":
         roots = linspace_f32(math.sqrt(beta_start), math.sqrt(beta_end), num_train_timesteps)
         betas = [f32(root * root) for root in roots]
@@ -152,16 +187,15 @@ def sigma_table(
         betas = rescale_zero_terminal_snr(betas)
 
     cumulative = 1.0
-    alphas_cumprod: list[float] = []
+    table: list[float] = []
     for beta in betas:
         cumulative *= f32(1.0 - beta)
-        alphas_cumprod.append(f32(cumulative))
-    if rescale_betas_zero_snr:
+        table.append(f32(cumulative))
+    if rescale_betas_zero_snr and clamp_terminal:
         # Close to zero without being zero, so the first sigma is not inf.
         # Upstream's value verbatim: the smallest positive fp16 subnormal.
-        alphas_cumprod[-1] = 2.0**-24
-
-    return tuple(f32(math.sqrt(f32(f32(1.0 - alpha) / alpha))) for alpha in alphas_cumprod)
+        table[-1] = 2.0**-24
+    return tuple(table)
 
 
 def rescale_zero_terminal_snr(betas: list[float]) -> list[float]:
@@ -187,6 +221,7 @@ def rescale_zero_terminal_snr(betas: list[float]) -> list[float]:
 
 
 __all__ = [
+    "alphas_cumprod",
     "f32",
     "linspace_f32",
     "linspace_f64",

--- a/src/gen_worker/model/solvers/unipc_multistep.py
+++ b/src/gen_worker/model/solvers/unipc_multistep.py
@@ -48,7 +48,7 @@ from typing import TYPE_CHECKING, ClassVar, Self
 
 from ..errors import ModelError, ModelRefusal
 from . import ladders
-from .block import SchedulerBlock, choice, count, flag, real, refuse
+from .block import SchedulerBlock, choice, count, flag, only, real, refuse
 from .precision import f32, round_half_even, sigma_table, truncate_to_int
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -374,6 +374,28 @@ class UniPCMultistep:
     use_flow_sigmas: bool = False
     flow_shift: float = 1.0
 
+    #: Every parameter this kind reads. A block naming anything else is a
+    #: declaration that says one thing and schedules another (pgw#1346 K10).
+    PARAMETERS: ClassVar[tuple[str, ...]] = (
+        "beta_end",
+        "beta_schedule",
+        "beta_start",
+        "final_sigmas_type",
+        "flow_shift",
+        "lower_order_final",
+        "num_train_timesteps",
+        "predict_x0",
+        "prediction_type",
+        "rescale_betas_zero_snr",
+        "solver_order",
+        "solver_type",
+        "steps_offset",
+        "timestep_spacing",
+        "use_exponential_sigmas",
+        "use_flow_sigmas",
+        "use_karras_sigmas",
+    )
+
     BETA_SCHEDULES: ClassVar[tuple[str, ...]] = ("linear", "scaled_linear")
     PREDICTION_TYPES: ClassVar[tuple[str, ...]] = (
         "epsilon",
@@ -433,6 +455,7 @@ class UniPCMultistep:
     def from_block(cls, block: SchedulerBlock) -> Self:
         """Build one from a declaration's scheduler parameter block."""
 
+        only(block, cls.PARAMETERS)
         return cls(
             num_train_timesteps=count(block, "num_train_timesteps", 1000),
             beta_start=real(block, "beta_start", 0.0001),

--- a/src/gen_worker/model/spec.py
+++ b/src/gen_worker/model/spec.py
@@ -352,12 +352,21 @@ class Parameter:
 
 @dataclass(frozen=True, slots=True)
 class Scheduler:
-    """The named scheduler and its finite-scalar parameter block.
+    """One named scheduler KIND and its finite-scalar parameter block.
 
     Neither this package nor torchcg interprets it: the host implements the
     named scheduler. It rides in the declaration because two otherwise
     identical compositions under different schedulers are different pipelines,
     so it must be inside the digest a consumer pins.
+
+    **A family declares a SET of these, keyed by the sampler name its tuned
+    schema admits** — ``GraphModelSpec.schedulers`` (pgw#1346 K10). The sampler
+    is a CHECKPOINT fact, stamped per release slot into ``inst.tuned.scheduler``
+    and not a family constant, so a single-valued field could only ever be the
+    family's trained schedule while every request asked for something else:
+    SDXL's declared kind was ``euler_discrete`` while its default sampler is
+    ``euler_a``. A family with one sampler declares a set of one and nothing
+    about it changes.
     """
 
     name: str
@@ -607,10 +616,14 @@ class GraphModelSpec(ModelSpec):
     buckets: tuple[Bucket, ...] = ()
     loop: Loop | None = None
     parameters: tuple[Parameter, ...] = ()
-    scheduler: Scheduler | None = None
+    #: The scheduler SET, keyed by the SAMPLER NAME a checkpoint is stamped
+    #: with — i.e. by a value of this family's ``tuned.scheduler`` field
+    #: (pgw#1346 K10). Empty when the family declares no scheduler at all.
+    schedulers: Mapping[str, Scheduler] = field(default_factory=dict)
 
     def _validate(self) -> None:
         ModelSpec._validate(self)
+        self._validate_schedulers()
         if self.tuned is None:
             raise ModelError(
                 ModelRefusal.TUNED_INVALID,
@@ -687,6 +700,27 @@ class GraphModelSpec(ModelSpec):
                 ModelRefusal.PARAMETER_INVALID,
                 f"parameter {idle[0]!r} is declared but no counted stage reads it",
             )
+
+    def _validate_schedulers(self) -> None:
+        """The scheduler set: sampler-keyed, sorted, and never silently empty.
+
+        The KEY is a sampler name — a value the family's tuned schema admits —
+        and not a scheduler kind, which is why two keys may name the same kind
+        with different blocks (``euler`` and ``euler_trailing`` are one class
+        under two spacings) and why one key may not name two.
+        """
+
+        rows: dict[str, Scheduler] = {}
+        for raw_name, scheduler in self.schedulers.items():
+            sampler = _identifier("sampler", raw_name, parse_parameter_name)
+            if not isinstance(scheduler, Scheduler):
+                raise ModelError(
+                    ModelRefusal.SCHEDULER_INVALID,
+                    f"family {self.name!r} sampler {sampler!r} must name a Scheduler(...), "
+                    f"got {scheduler!r}",
+                )
+            rows[sampler] = scheduler
+        object.__setattr__(self, "schedulers", dict(sorted(rows.items())))
 
     @property
     def axis_values(self) -> dict[str, tuple[int, ...]]:

--- a/tests/harness/model_toys_pgw1332.py
+++ b/tests/harness/model_toys_pgw1332.py
@@ -36,6 +36,12 @@ class ToyTuned(TunedValues, frozen=True):
 
     steps: int = 4
     guidance: float = 3.5
+    #: The SAMPLER this checkpoint is stamped with. Present because pgw#1346
+    #: K10 keys the declared scheduler SET by exactly this field, and the toy
+    #: declares two — so this schema is what makes the generated `scheduler()`
+    #: resolvable at all. `hypothetical` is deliberately absent from the
+    #: declaration, so the refusal arm has something to refuse.
+    scheduler: str = "euler"
 
 
 def _torch() -> Any:
@@ -110,7 +116,13 @@ TOY_DIFFUSION = GraphModelSpec(
     ),
     loop=Loop(stages=(Stage("denoiser", repeat="steps"), Stage("decoder"))),
     parameters=(Parameter("steps", minimum=1, maximum=100),),
-    scheduler=Scheduler("euler_discrete", {"shift": 3.0}),
+    # A SET of two (pgw#1346 K10), so the toy exercises the several-samplers
+    # accessor rather than only the single-sampler one the catalog's Flux
+    # entry covers. Two names, two kinds, one trained table.
+    schedulers={
+        "euler": Scheduler("euler_discrete", {"timestep_spacing": "trailing"}),
+        "euler_a": Scheduler("euler_ancestral_discrete", {"timestep_spacing": "trailing"}),
+    },
 )
 
 

--- a/tests/test_ernie_pgw1346.py
+++ b/tests/test_ernie_pgw1346.py
@@ -313,8 +313,9 @@ def test_the_tuned_schema_carries_every_field_the_endpoint_stamps() -> None:
 def test_the_scheduler_block_is_the_checkpoints_own_static_shift() -> None:
     """Both checkpoints publish the identical block, so one declaration carries it."""
 
-    assert ERNIE.scheduler is not None
-    assert ERNIE.scheduler.name == "flow_match_euler_discrete"
+    # A set of ONE, keyed by sampler (pgw#1346 K10).
+    assert list(ERNIE.schedulers) == ["flow_match_euler"]
+    assert ERNIE.schedulers["flow_match_euler"].name == "flow_match_euler_discrete"
     assert SCHEDULER["shift"] == 4.0
     assert SCHEDULER["use_dynamic_shifting"] is False
     # `shift_terminal` is published as null and is therefore ABSENT: a block

--- a/tests/test_flux1_schnell_pgw1346.py
+++ b/tests/test_flux1_schnell_pgw1346.py
@@ -243,8 +243,9 @@ def test_the_scheduler_block_is_the_releases_own_and_is_static() -> None:
         assert SCHEDULER[field] == value, field
     assert SCHEDULER["use_dynamic_shifting"] is False
     assert SCHEDULER["shift"] == 1.0
-    assert FLUX1_SCHNELL.scheduler is not None
-    assert FLUX1_SCHNELL.scheduler.name == "flow_match_euler_discrete"
+    # A set of ONE, keyed by sampler (pgw#1346 K10).
+    assert list(FLUX1_SCHNELL.schedulers) == ["flow_match_euler"]
+    assert FLUX1_SCHNELL.schedulers["flow_match_euler"].name == "flow_match_euler_discrete"
 
 
 # ----------------------------------------------------------------- the buckets

--- a/tests/test_flux2_klein_4b_pgw1346.py
+++ b/tests/test_flux2_klein_4b_pgw1346.py
@@ -313,8 +313,11 @@ def test_klein_takes_no_guidance_embedding() -> None:
 def test_the_scheduler_block_is_the_checkpoints_own() -> None:
     """Declared, so it rides the export digest rather than the math."""
 
-    assert FLUX2_KLEIN_4B.scheduler is not None
-    assert FLUX2_KLEIN_4B.scheduler.name == "flow_match_euler_discrete"
+    # A set of ONE, keyed by sampler (pgw#1346 K10): this family serves exactly
+    # one schedule, so there is nothing for a checkpoint to choose.
+    assert {name: entry.name for name, entry in FLUX2_KLEIN_4B.schedulers.items()} == {
+        "flow_match_euler": "flow_match_euler_discrete"
+    }
     assert SCHEDULER["use_dynamic_shifting"] is True
     assert SCHEDULER["base_image_seq_len"] == 256
     assert SCHEDULER["max_image_seq_len"] == 4096

--- a/tests/test_flux2_klein_9b_pgw1346.py
+++ b/tests/test_flux2_klein_9b_pgw1346.py
@@ -173,8 +173,9 @@ def test_the_scheduler_block_is_the_checkpoints_own() -> None:
     """
 
     published = _fixture("scheduler.scheduler_config.json")
-    scheduler = FLUX2_KLEIN_9B.scheduler
-    assert scheduler is not None
+    # A set of ONE, keyed by sampler (pgw#1346 K10).
+    assert list(FLUX2_KLEIN_9B.schedulers) == ["flow_match_euler"]
+    scheduler = FLUX2_KLEIN_9B.schedulers["flow_match_euler"]
     assert scheduler.name == "flow_match_euler_discrete"
     for field, value in scheduler.parameters.items():
         assert value == published[field], field

--- a/tests/test_flux_stage1_pgw1331.py
+++ b/tests/test_flux_stage1_pgw1331.py
@@ -187,14 +187,31 @@ def test_every_declarable_scheduler_now_has_math_behind_it() -> None:
     unimplemented" impossible to reach rather than merely absent today. The
     absent-method MECHANISM is still fenced, at the generator, in
     ``tests/test_sd_stage1_pgw1346.py``.
+
+    pgw#1346 K10 added ``euler_ancestral_discrete`` and ``ddim`` to the closed
+    set WITH their math, so ``IMPLEMENTED`` is still total — which is the
+    property this test actually asserts, and it is now four names rather than
+    two. ``ddim`` is therefore no longer unparseable; the name that stands in
+    for "declarable but absent" is one nobody has implemented.
     """
 
-    assert Flux1Dev.SCHEDULER is SchedulerKind.FLOW_MATCH_EULER_DISCRETE
-    assert Sdxl.SCHEDULER is SchedulerKind.EULER_DISCRETE
+    # A SET of one, keyed by sampler (pgw#1346 K10). One entry is exactly what
+    # a family with a single schedule declares, and `scheduler()` keeps taking
+    # no argument because there is nothing for a checkpoint to choose.
+    assert dict(Flux1Dev.SCHEDULERS) == {
+        "flow_match_euler": SchedulerKind.FLOW_MATCH_EULER_DISCRETE
+    }
+    assert {name: kind.value for name, kind in Sdxl.SCHEDULERS.items()} == {
+        "ddim_trailing": "ddim",
+        "dpmpp_2m_karras": "dpmsolver_multistep",
+        "dpmpp_2m_sde_karras": "dpmsolver_multistep",
+        "euler_a": "euler_ancestral_discrete",
+        "euler_trailing": "euler_discrete",
+    }
     assert isinstance(Flux1Dev.fake().scheduler(), FlowMatchEulerDiscrete)
     assert set(IMPLEMENTED) == set(SchedulerKind)
     with pytest.raises(ModelError):
-        parse_kind("ddim")
+        parse_kind("lcm")
 
 
 def test_the_declared_block_is_the_scheduler_s_only_source_of_constants() -> None:
@@ -206,7 +223,7 @@ def test_the_declared_block_is_the_scheduler_s_only_source_of_constants() -> Non
     assert scheduler.max_image_seq_len == SCHEDULER["max_image_seq_len"]
     # …and the block rides the export digest, so re-declaring it re-identifies
     # the family rather than silently changing every request.
-    assert dict(Flux1Dev.SCHEDULER_PARAMETERS) == dict(SCHEDULER)
+    assert dict(Flux1Dev.SCHEDULER_PARAMETERS["flow_match_euler"]) == dict(SCHEDULER)
 
 
 # ------------------------------------------------------- the whole composition

--- a/tests/test_model_sdk.py
+++ b/tests/test_model_sdk.py
@@ -388,8 +388,16 @@ def test_the_generated_class_carries_the_class_level_facts_and_no_others(
     assert toy_binding.EXPORT_DIGEST == toy_export.digest()
     assert toy_binding.LOOP == (("denoiser", "counted", "steps"), ("decoder", "once", ""))
     assert toy_binding.LOOP_KIND == "staged"
-    assert toy_binding.SCHEDULER == "euler_discrete"
-    assert dict(toy_binding.SCHEDULER_PARAMETERS) == {"shift": 3.0}
+    # The scheduler SET, keyed by sampler (pgw#1346 K10). Two names, two
+    # kinds, and the blocks keyed the same way.
+    assert dict(toy_binding.SCHEDULERS) == {
+        "euler": "euler_discrete",
+        "euler_a": "euler_ancestral_discrete",
+    }
+    assert {name: dict(block) for name, block in toy_binding.SCHEDULER_PARAMETERS.items()} == {
+        "euler": {"timestep_spacing": "trailing"},
+        "euler_a": {"timestep_spacing": "trailing"},
+    }
     assert toy_binding.PARAMETERS == (("steps", 1, 100),)
     assert toy_binding.Tuned is ToyTuned
 
@@ -710,8 +718,6 @@ def _recipe_from(export: ModelExport, *, drift: bool = False) -> Any:
         Recipe,
         RecipeParameter,
         RecipeRunner,
-        SchedulerName,
-        Scheduler as RecipeScheduler,
     )
 
     runners = []
@@ -750,14 +756,11 @@ def _recipe_from(export: ModelExport, *, drift: bool = False) -> Any:
             RecipeParameter(name=row.name, minimum=row.minimum, maximum=row.maximum)
             for row in export.parameters
         ),
-        scheduler=(
-            None
-            if export.scheduler is None
-            else RecipeScheduler(
-                name=SchedulerName(export.scheduler.name),
-                parameters=export.scheduler.parameters,
-            )
-        ),
+        # `recipe_v1` records ONE scheduler and the declaration now carries a
+        # SET keyed by sampler (pgw#1346 K10), so there is no faithful
+        # projection — a mint emits no scheduler and `assert_recipe` compares
+        # none, which is why this is `None` rather than an arbitrary member.
+        scheduler=None,
     )
 
 
@@ -804,10 +807,14 @@ def test_payload_values_win_over_tuned_and_none_falls_through() -> None:
     assert resolve_tuned(_TunedIn(steps=8), tuned, tuned_fields(ToyTuned)) == {
         "steps": 8,
         "guidance": 6.0,
+        # The toy's sampler field (pgw#1346 K10) resolves the same way every
+        # other tuned value does — it is not special-cased anywhere.
+        "scheduler": "euler",
     }
     assert resolve_tuned(_TunedIn(), tuned, tuned_fields(ToyTuned)) == {
         "steps": 28,
         "guidance": 6.0,
+        "scheduler": "euler",
     }
 
 
@@ -842,7 +849,7 @@ def test_resolve_takes_a_payload_and_an_instance_and_needs_no_field_list(
 
 
 def test_tuned_fields_excludes_the_version_stamp() -> None:
-    assert tuned_fields(ToyTuned) == ("steps", "guidance")
+    assert tuned_fields(ToyTuned) == ("steps", "guidance", "scheduler")
 
 
 def test_catalog_values_decode_onto_the_instance_and_loras_overlay_them(
@@ -1291,7 +1298,17 @@ def test_every_catalog_family_is_callable_hubless(family: str) -> None:
 def test_the_catalog_index_and_its_exports_agree() -> None:
     from gen_worker.model import catalog
 
-    assert sorted(catalog.__all__) == sorted(catalog._FAMILIES)
+    # NO REPEATS, asserted rather than eyeballed (pgw#1346 B4's finding). This
+    # index is an ADDITIVE file that every family lane appends to, so union
+    # rebases accumulate duplicates — and only half of that class is
+    # gate-visible: ruff's F601 catches a repeated dict KEY, but a repeated
+    # string in a list or tuple changes no behaviour and passes every gate. A
+    # length comparison is what catches the half nothing else does.
+    assert len(catalog.__all__) == len(set(catalog.__all__)), sorted(
+        name for name in catalog.__all__ if catalog.__all__.count(name) > 1
+    )
+    assert len(catalog._FAMILIES) == len(catalog.__all__)
+    assert set(catalog.__all__) ^ set(catalog._FAMILIES) == set()
     for name in catalog.__all__:
         assert getattr(catalog, name) is not None
     with pytest.raises(AttributeError, match="the catalog has no"):

--- a/tests/test_qwen_image_pgw1346.py
+++ b/tests/test_qwen_image_pgw1346.py
@@ -188,8 +188,9 @@ def test_the_weight_lane_is_not_a_traced_graph_variant() -> None:
 def test_the_declared_block_is_the_checkpoints_own_including_the_stretch() -> None:
     """Two of these keys are read by nothing else in the SDK, and both matter."""
 
-    assert QWEN_IMAGE.scheduler is not None
-    assert QWEN_IMAGE.scheduler.name == "flow_match_euler_discrete"
+    # A set of ONE, keyed by sampler (pgw#1346 K10).
+    assert list(QWEN_IMAGE.schedulers) == ["flow_match_euler"]
+    assert QWEN_IMAGE.schedulers["flow_match_euler"].name == "flow_match_euler_discrete"
     assert SCHEDULER["use_dynamic_shifting"] is True
     assert SCHEDULER["shift_terminal"] == 0.02
     assert SCHEDULER["max_image_seq_len"] == 8192

--- a/tests/test_sd_stage1_pgw1346.py
+++ b/tests/test_sd_stage1_pgw1346.py
@@ -41,6 +41,7 @@ what the endpoints actually invoke rather than as prose.
 from __future__ import annotations
 
 import json
+import inspect
 import math
 import os
 import subprocess
@@ -56,14 +57,18 @@ from gen_worker.model.catalog import sdxl_serve as sx
 from gen_worker.model.catalog.sd15 import SCHEDULER as SD_SCHEDULER
 from gen_worker.model.catalog.sd15 import SD2, SD15
 from gen_worker.model.catalog.sdxl import SCHEDULER as SDXL_SCHEDULER
+from gen_worker.model.catalog.sdxl import TRAINED as SDXL_TRAINED
 from gen_worker.model.catalog.sdxl import SDXL
-from gen_worker.model.errors import ModelError
+from gen_worker.model.errors import ModelError, ModelRefusal
 from gen_worker.model.scheduler import (
     IMPLEMENTED,
+    AncestralSchedule,
+    Ddim,
+    DdimSchedule,
     DiscreteSchedule,
+    EulerAncestralDiscrete,
     EulerDiscrete,
     SchedulerKind,
-    parse_kind,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -408,12 +413,20 @@ def test_the_declared_block_is_the_scheduler_s_only_source_of_constants() -> Non
         0,
     )
     for spec, block in ((SDXL, SDXL_SCHEDULER), (SD15, SD_SCHEDULER), (SD2, SD_SCHEDULER)):
-        assert spec.scheduler is not None
+        assert spec.schedulers
         declared = EulerDiscrete.from_block(dict(block))
         assert declared.beta_schedule == "scaled_linear"
         assert declared.beta_start == 0.00085 and declared.beta_end == 0.012
         assert (declared.timestep_spacing, declared.steps_offset) == ("leading", 1)
-        assert dict(spec.scheduler.parameters) == dict(block)
+        # Every DECLARED sampler restates the same trained noise schedule; what
+        # differs between them is the kind and the spacing, never the betas.
+        # pgw#1346 K10's whole risk is a family declaring one trained table
+        # three slightly different ways, so this is the assertion that refuses
+        # it.
+        for entry in spec.schedulers.values():
+            resolved = dict(entry.parameters)
+            for shared in ("beta_start", "beta_end", "beta_schedule", "num_train_timesteps"):
+                assert resolved[shared] == block[shared]
 
 
 @pytest.mark.parametrize(
@@ -481,31 +494,72 @@ def test_every_declarable_scheduler_has_math_and_the_gap_is_still_fenced(
     """``IMPLEMENTED`` is TOTAL, and the absent-method mechanism still works.
 
     pgw#1331 proved the mechanism through SDXL, whose scheduler had no math.
-    Both names carry math now, so nothing in the catalog exercises the gap and
-    the mechanism has to be fenced at the GENERATOR instead — otherwise the
+    Every name carries math now, so nothing in the catalog exercises the gap
+    and the mechanism has to be fenced at the GENERATOR instead — otherwise the
     next declared-but-unimplemented scheduler discovers it by shipping.
+
+    K10 makes the fence sharper than it was, because the miss is now PER
+    SAMPLER: dropping ONE kind must remove only the arms that named it and
+    leave the rest of the accessor intact, and dropping every kind a family
+    declares must remove the method entirely.
     """
 
     from gen_worker.model import codegen
 
     assert set(IMPLEMENTED) == set(SchedulerKind)
-    assert Sdxl.SCHEDULER is SchedulerKind.EULER_DISCRETE
-    assert Sd15.SCHEDULER is SchedulerKind.EULER_DISCRETE
-    assert isinstance(Sdxl.fake().scheduler(), EulerDiscrete)
+    assert {name: kind.value for name, kind in Sdxl.SCHEDULERS.items()} == {
+        "ddim_trailing": "ddim",
+        "dpmpp_2m_karras": "dpmsolver_multistep",
+        "dpmpp_2m_sde_karras": "dpmsolver_multistep",
+        "euler_a": "euler_ancestral_discrete",
+        "euler_trailing": "euler_discrete",
+    }
+    assert {name: kind.value for name, kind in Sd15.SCHEDULERS.items()} == {
+        "ddim": "ddim",
+        "ddim_trailing": "ddim",
+        "dpmpp_2m": "dpmsolver_multistep",
+        "dpmpp_2m_karras": "dpmsolver_multistep",
+        "dpmpp_2m_sde_karras": "dpmsolver_multistep",
+        "euler": "euler_discrete",
+        "euler_a": "euler_ancestral_discrete",
+        "unipc": "unipc_multistep",
+    }
+    assert isinstance(Sdxl.fake().scheduler(), EulerAncestralDiscrete)
 
-    rendered = codegen.render_module(
-        Sdxl.EXPORT,
-        spec_module="gen_worker.model.catalog.sdxl",
-        spec_attr="SDXL",
-    )
-    assert "def scheduler(self)" in rendered
+    def render() -> str:
+        return codegen.render_module(
+            Sdxl.EXPORT,
+            spec_module="gen_worker.model.catalog.sdxl",
+            spec_attr="SDXL",
+        )
+
+    rendered = render()
+    assert "def scheduler(self" in rendered
+    assert (
+        "SdxlDeclaredSampler = Literal['ddim_trailing', 'dpmpp_2m_karras', "
+        "'dpmpp_2m_sde_karras', 'euler_a', 'euler_trailing']"
+    ) in rendered
+
+    # Drop ONE kind: the accessor survives, minus that sampler.
+    monkeypatch.delitem(IMPLEMENTED, SchedulerKind.DDIM)
+    partial = render()
+    assert "def scheduler(self" in partial
+    assert (
+        "SdxlDeclaredSampler = Literal['dpmpp_2m_karras', 'dpmpp_2m_sde_karras', "
+        "'euler_a', 'euler_trailing']"
+    ) in partial
+    # And the DECLARED-but-unimplemented sampler is still in the class facts,
+    # so the declaration is not quietly rewritten to match the implementation.
+    assert "'ddim_trailing': SchedulerKind.DDIM," in partial
+    assert "Ddim.from_block" not in partial
+
+    # Drop them all: no method at all, so a handler that wants one gets an
+    # AttributeError from its own type checker (pgw#1331's mechanism).
     monkeypatch.delitem(IMPLEMENTED, SchedulerKind.EULER_DISCRETE)
-    without = codegen.render_module(
-        Sdxl.EXPORT,
-        spec_module="gen_worker.model.catalog.sdxl",
-        spec_attr="SDXL",
-    )
-    assert "def scheduler(self)" not in without
+    monkeypatch.delitem(IMPLEMENTED, SchedulerKind.EULER_ANCESTRAL_DISCRETE)
+    monkeypatch.delitem(IMPLEMENTED, SchedulerKind.DPMSOLVER_MULTISTEP)
+    without = render()
+    assert "def scheduler(self" not in without
 
 
 def test_sdxl_declares_every_stage_of_the_pipeline() -> None:
@@ -659,7 +713,12 @@ def test_a_fake_backed_sd_generates_an_image_through_the_typed_callables(
     "close enough" in a shape assertion written loosely.
     """
 
-    instance = model.fake()
+    # SD1.5's stamped DEFAULT sampler is `dpmpp_2m_karras`, which pgw#1346 K10
+    # deliberately does NOT declare (a multistep solver, owed to B3/B4), so a
+    # default-tuned instance refuses rather than renders. Stamping `euler` here
+    # is the by-value equivalent of what a catalog slot does, and the refusal
+    # itself is asserted in its own test below.
+    instance = model.fake(tuned=model.Tuned(scheduler="euler"))
     shape = cast("sd.AnyShape", sd.pack_shape(width, height))
     image = sd.generate(
         instance,
@@ -780,44 +839,748 @@ def test_a_mint_can_be_narrowed_to_one_shape_so_a_gauntlet_row_is_affordable() -
         variants_of(SDXL, buckets={"shape": [5120512]})
 
 
-# ------------------------------------------------------------ the ddim decision
+# ---------------------------------------------- pgw#1346 K10: the scheduler SET
+#
+# B2 closed with a blocker rather than a deferral: the sampler is a TUNED value
+# and `GraphModelSpec.scheduler` was single-valued, so a second implemented
+# kind would have been a class no catalog declaration could attach to. The
+# consequence B2 measured is the reason this is not a nicety — SDXL's DEFAULT
+# sampler is `euler_a`, so the family's one declared block was its TRAINED
+# schedule and NOT the one most requests asked for.
+#
+# The instrument is B2's, unchanged and for its reasons: relative agreement at
+# 2e-4 against the reference (never ULP — the reference disagrees with itself
+# by up to 85 ULP across machines), exact timesteps, L2 for anything that
+# crosses zero, and our own ladder fenced byte-identical across CPU kernels,
+# which is the property the reference does not have.
 
 
-def test_ddim_is_reached_by_the_endpoints_and_is_deliberately_not_declared() -> None:
-    """pgw#1346 owed a ``ddim`` decision. It is: REACHED, and NOT DECLARABLE.
+def _ancestral_reference(block: dict[str, Any], **overrides: Any) -> Any:
+    diffusers = pytest.importorskip("diffusers")
+    merged = {**block, **overrides}
+    return diffusers.EulerAncestralDiscreteScheduler(
+        num_train_timesteps=int(merged["num_train_timesteps"]),
+        beta_start=float(merged["beta_start"]),
+        beta_end=float(merged["beta_end"]),
+        beta_schedule=str(merged["beta_schedule"]),
+        timestep_spacing=str(merged["timestep_spacing"]),
+        steps_offset=int(merged["steps_offset"]),
+        prediction_type=str(merged["prediction_type"]),
+        rescale_betas_zero_snr=bool(merged.get("rescale_betas_zero_snr", False)),
+    )
 
-    The enumeration, from the endpoints themselves rather than from intent:
 
-    * ``sd15``'s ``SD15Scheduler`` payload enum offers ``"ddim"``;
-    * ``sd15``'s ``generate_hyper`` handler pins ``"ddim_trailing"``
-      UNCONDITIONALLY — a function reaches DDIM with no payload involved;
-    * ``sdxl``'s ``SdxlScheduler`` offers ``"ddim_trailing"`` too.
+def _ddim_reference(block: dict[str, Any], **overrides: Any) -> Any:
+    diffusers = pytest.importorskip("diffusers")
+    merged = {**block, **overrides}
+    return diffusers.DDIMScheduler(
+        num_train_timesteps=int(merged["num_train_timesteps"]),
+        beta_start=float(merged["beta_start"]),
+        beta_end=float(merged["beta_end"]),
+        beta_schedule=str(merged["beta_schedule"]),
+        timestep_spacing=str(merged["timestep_spacing"]),
+        steps_offset=int(merged["steps_offset"]),
+        prediction_type=str(merged["prediction_type"]),
+        rescale_betas_zero_snr=bool(merged.get("rescale_betas_zero_snr", False)),
+        set_alpha_to_one=bool(merged.get("set_alpha_to_one", True)),
+        clip_sample=False,
+    )
 
-    So the honest answer to "does an endpoint function reach ddim" is YES. It
-    is still not implemented in this batch, and the reason is structural rather
-    than budgetary: ``GraphModelSpec.scheduler`` is ONE ``Scheduler`` block and
-    codegen emits ONE ``scheduler()`` method, so a second implemented kind
-    would be a class no declaration in the catalog could attach to. Declaring
-    classes nothing can select is the exact thing the catalog refused to do
-    with SDXL's text encoders one release ago.
 
-    **The blocker this exposes (pgw#1346 K10): the sampler is a TUNED value,
-    not a family constant.** ``SdxlTuned.scheduler`` and ``Sd15Tuned.scheduler``
-    already carry it per checkpoint, and the six/eight names they admit map
-    onto four different diffusers scheduler CLASSES. The declaration therefore
-    needs a scheduler SET keyed by tuned name — ``inst.scheduler()`` taking
-    ``inst.tuned.scheduler`` — before ddim, dpmpp or lcm can be implemented at
-    all. Until then the family's declared block is its TRAINED schedule, which
-    is the right single value if only one is allowed.
+def _trained(**overrides: Any) -> dict[str, Any]:
+    """The SDXL trained schedule, minus the parameters that are one KIND's."""
+
+    return {**dict(SDXL_TRAINED), **overrides}
+
+
+# ------------------------------------------------------------ the declaration
+
+
+def test_the_declaration_carries_a_scheduler_SET_keyed_by_the_tuned_sampler() -> None:
+    """K10's whole shape, in the two vocabularies it keeps apart.
+
+    The KEY is a sampler — a value ``inst.tuned.scheduler`` can hold. The
+    ``name`` is a scheduler KIND. They are not the same vocabulary and the
+    mapping between them is many-to-one in both directions: ``euler`` and
+    ``euler_trailing`` are ONE kind under two spacings, and ``ddim`` and
+    ``euler_a`` are two kinds under one trained table.
     """
 
-    assert "ddim" not in {kind.value for kind in SchedulerKind}
-    with pytest.raises(ModelError):
-        parse_kind("ddim")
-    with pytest.raises(ModelError):
-        parse_kind("ddim_trailing")
+    assert {name: entry.name for name, entry in SDXL.schedulers.items()} == {
+        "ddim_trailing": "ddim",
+        "dpmpp_2m_karras": "dpmsolver_multistep",
+        "dpmpp_2m_sde_karras": "dpmsolver_multistep",
+        "euler_a": "euler_ancestral_discrete",
+        "euler_trailing": "euler_discrete",
+    }
+    for spec in (SD15, SD2):
+        assert {name: entry.name for name, entry in spec.schedulers.items()} == {
+            "ddim": "ddim",
+            "ddim_trailing": "ddim",
+            "dpmpp_2m": "dpmsolver_multistep",
+            "dpmpp_2m_karras": "dpmsolver_multistep",
+            "dpmpp_2m_sde_karras": "dpmsolver_multistep",
+            "euler": "euler_discrete",
+            "euler_a": "euler_ancestral_discrete",
+            "unipc": "unipc_multistep",
+        }
+    # Sorted, so the export is canonical and the digest is stable under a
+    # re-ordered declaration.
+    for spec in (SDXL, SD15, SD2):
+        assert list(spec.schedulers) == sorted(spec.schedulers)
+        assert [row.sampler for row in export_model_of(spec).schedulers] == sorted(
+            spec.schedulers
+        )
 
-    # The names ARE in the tuned vocabularies, which is what makes this a
-    # deferral with a live consequence rather than a name nobody uses.
-    assert "ddim_trailing" in get_args(sx.SdxlSampler)
-    assert {"ddim", "ddim_trailing"} <= set(get_args(sd.Sd15Sampler))
+
+def export_model_of(spec: Any) -> Any:
+    """The committed export for a declaration, by family name."""
+
+    return {"sdxl": Sdxl, "sd15": Sd15, "sd2": Sd2}[spec.name].EXPORT
+
+
+def test_every_declared_sampler_is_a_name_the_tuned_schema_admits() -> None:
+    """The set is keyed by ``tuned.scheduler``, so it must be KEYABLE by it.
+
+    A declared sampler the tuned Literal cannot hold would be a scheduler no
+    checkpoint could ever select — the mirror image of the gap K10 closed, and
+    just as silent. Asserted as a SUBSET and not equality on purpose: the
+    reverse inclusion is the staged gap, and it has its own test below.
+    """
+
+    assert set(SDXL.schedulers) <= set(get_args(sx.SdxlSampler))
+    assert set(SD15.schedulers) <= set(get_args(sd.Sd15Sampler))
+    assert set(SD2.schedulers) <= set(get_args(sd.Sd15Sampler))
+
+
+def test_a_family_with_one_sampler_declares_a_set_of_one_and_nothing_changes() -> None:
+    """B2's held migration needs NOTHING from this change.
+
+    The single-scheduler families migrate mechanically to a set of one, and the
+    generated accessor keeps its exact previous shape: no argument, one
+    concrete return type. That is what makes the K10 declaration change safe to
+    land ahead of the endpoint migration rather than beside it.
+    """
+
+    from gen_worker.model.catalog import Flux1Dev
+
+    assert list(Flux1Dev.SCHEDULERS) == ["flow_match_euler"]
+    scheduler = Flux1Dev.fake().scheduler()
+    assert type(scheduler).__name__ == "FlowMatchEulerDiscrete"
+    # No `name=` parameter at all on the single-sampler accessor.
+    assert "name" not in inspect.signature(Flux1Dev.scheduler).parameters
+
+
+def test_a_stamped_sampler_the_sdk_cannot_serve_is_REFUSED_and_never_substituted() -> None:
+    """The staged gap, made loud.
+
+    ``Sd15Tuned``'s own DEFAULT is ``dpmpp_2m_karras``, which is a
+    ``DPMSolverMultistep`` — a MULTISTEP solver that reads the previous step's
+    model output and therefore does not fit the request-scoped, historyless
+    schedule this SDK serves. It is owed to B3/B4, which own that solver for
+    the DiT fleet anyway.
+
+    What must NOT happen is the thing a single-valued field made inevitable:
+    serving the family's other schedule under the requested sampler's name. The
+    image would be plausible and wrong, and nothing would say so. So the miss
+    is a refusal that names BOTH sides.
+    """
+
+    # `lcm` is the ONE name still owed: `LCMScheduler` has no module in
+    # `model/solvers/`. Everything else the two endpoints admit is declarable
+    # — the multistep pair arrived with B3-math, which landed ahead of this
+    # lane and is additive to the set mechanism.
+    with pytest.raises(ModelError) as exc:
+        Sd15.fake(tuned=Sd15.Tuned(scheduler="lcm")).scheduler()
+    assert exc.value.reason is ModelRefusal.SCHEDULER_UNDECLARED
+    assert "lcm" in str(exc.value)
+    assert "'euler_a'" in str(exc.value)
+
+    # sd15's own DEFAULT is `dpmpp_2m_karras`, and it is SERVABLE. That is the
+    # live half of K10 for this family: before the set, the declaration named
+    # `euler_discrete` while every default-tuned request asked for a solver
+    # nothing could attach.
+    assert Sd15.Tuned().scheduler == "dpmpp_2m_karras"
+    assert type(Sd15.fake().scheduler()).__name__ == "DPMSolverMultistep"
+
+    # Every name that is owed, enumerated here so the ledger is executable
+    # rather than prose. When B3/B4 land a solver, this set shrinks and this
+    # test is what says so.
+    owed_sdxl = set(get_args(sx.SdxlSampler)) - set(SDXL.schedulers)
+    owed_sd15 = set(get_args(sd.Sd15Sampler)) - set(SD15.schedulers)
+    assert owed_sdxl == {"lcm"}
+    assert owed_sd15 == {"lcm"}
+
+    # SDXL's and SD2's DEFAULTS are covered, which is the live half of K10:
+    # `euler_a` is what most SDXL requests actually ask for.
+    assert Sdxl.Tuned().scheduler == "euler_a" and "euler_a" in SDXL.schedulers
+    assert Sd2.Tuned().scheduler == "euler_a" and "euler_a" in SD2.schedulers
+
+
+def test_a_declared_block_may_not_carry_a_parameter_its_kind_never_reads() -> None:
+    """The silent failure a scheduler SET introduces, fenced.
+
+    With one scheduler a block was copied once. With several, the copy is per
+    sampler and the kinds do not read the same parameters:
+    ``EulerAncestralDiscrete`` has no ``final_sigmas_type`` and ``Ddim`` has no
+    ``final_sigmas_type`` either, while ``Ddim`` has two nobody else has. A
+    stale key would change NOTHING and say nothing, so every kind refuses one.
+    """
+
+    with pytest.raises(ModelError):
+        EulerAncestralDiscrete.from_block(_trained(final_sigmas_type="zero"))
+    with pytest.raises(ModelError):
+        Ddim.from_block(_trained(final_sigmas_type="zero"))
+    with pytest.raises(ModelError):
+        EulerDiscrete.from_block(_trained(set_alpha_to_one=True))
+    # …and the ones each kind DOES read still resolve.
+    assert EulerAncestralDiscrete.from_block(_trained()).timestep_spacing == "leading"
+    assert Ddim.from_block(_trained(set_alpha_to_one=False)).set_alpha_to_one is False
+
+    # `clip_sample=True` is declarable and NOT implementable: it needs a clip
+    # range no endpoint declares. Refused rather than ignored.
+    with pytest.raises(ModelError):
+        Ddim.from_block(_trained(clip_sample=True))
+
+
+def test_the_sampler_vocabulary_is_shared_so_two_families_cannot_disagree() -> None:
+    """``euler_a`` means one thing on this fleet, not one thing per family.
+
+    sdxl and sd15 are two declarations over ONE endpoint-visible sampler
+    vocabulary. If each spelled the mapping for itself they could drift into
+    scheduling different things under one name, which is a defect no test in
+    either family would catch.
+    """
+
+    from gen_worker.model.catalog.sd_samplers import SD_SAMPLERS, sd_schedulers  # noqa: F401
+
+    for sampler in set(SDXL.schedulers) & set(SD15.schedulers):
+        assert SDXL.schedulers[sampler].name == SD15.schedulers[sampler].name
+    assert set(SDXL.schedulers) | set(SD15.schedulers) <= set(SD_SAMPLERS)
+    # A trained block carrying a kind-specific parameter is refused where the
+    # SET is built, not at the first request that reaches that kind.
+    with pytest.raises(ModelError):
+        sd_schedulers({**dict(SDXL_TRAINED), "final_sigmas_type": "zero"}, ("euler_a",))
+    with pytest.raises(ModelError):
+        sd_schedulers(dict(SDXL_TRAINED), ("lcm",))
+
+    # And the vocabulary is not this module's invention: `gen_worker.view`
+    # already DEFINES each sampler name completely for the `Slot`-served
+    # endpoints — the diffusers class plus its config overrides. That table is
+    # the fleet's single source for "what does `dpmpp_2m_karras` mean", so the
+    # declared blocks are asserted against it rather than restated from memory.
+    from gen_worker.view import SAMPLERS
+
+    classes = {
+        "ddim": "DDIMScheduler",
+        "dpmsolver_multistep": "DPMSolverMultistepScheduler",
+        "euler_ancestral_discrete": "EulerAncestralDiscreteScheduler",
+        "euler_discrete": "EulerDiscreteScheduler",
+        "unipc_multistep": "UniPCMultistepScheduler",
+    }
+    for sampler, (kind, overrides) in SD_SAMPLERS.items():
+        reference, config = SAMPLERS[sampler]
+        assert classes[kind] == reference, sampler
+        for field, value in config.items():
+            assert overrides[field] == value, (sampler, field)
+
+
+# ------------------------------------------------------- euler_ancestral maths
+
+
+@pytest.mark.parametrize("steps", ENDPOINT_STEPS)
+@pytest.mark.parametrize("spacing", ["leading", "trailing", "linspace"])
+@pytest.mark.parametrize(
+    ("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)]
+)
+def test_the_euler_ancestral_ladder_matches_diffusers(
+    steps: int, spacing: str, objective: str, zero_snr: bool
+) -> None:
+    """``euler_a``'s LADDER is ``euler``'s, and its step is not.
+
+    Both halves are worth asserting. The ladder, because the two classes share
+    a trained table and a spacing and would be a real defect if they diverged;
+    and separately (below) the step, because that is where they differ.
+
+    Instrument per B2's carry-forward: relative at 2e-4, timesteps EXACT.
+    """
+
+    block = _trained(
+        timestep_spacing=spacing, prediction_type=objective, rescale_betas_zero_snr=zero_snr
+    )
+    theirs = _ancestral_reference(block)
+    theirs.set_timesteps(steps)
+    ours = EulerAncestralDiscrete.from_block(block).schedule(steps)
+
+    assert len(ours.sigmas) == len(theirs.sigmas)
+    assert _rel(ours.sigmas, theirs.sigmas.numpy()) <= RELATIVE
+    assert _ulp(ours.timesteps, theirs.timesteps.numpy()) == 0
+    assert _rel([ours.init_noise_sigma], [float(theirs.init_noise_sigma)]) <= RELATIVE
+
+    # The ladder IS euler's, value for value, under the same block. This is
+    # what lets `euler` and `euler_a` share one `_sigma_table`.
+    euler = EulerDiscrete.from_block({**block, "final_sigmas_type": "zero"}).schedule(steps)
+    assert ours.sigmas == euler.sigmas and ours.timesteps == euler.timesteps
+    assert ours.init_noise_sigma == euler.init_noise_sigma
+
+
+@pytest.mark.parametrize("spacing", ["leading", "trailing"])
+@pytest.mark.parametrize(
+    ("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)]
+)
+def test_a_whole_ancestral_loop_tracks_the_diffusers_loop(
+    spacing: str, objective: str, zero_snr: bool
+) -> None:
+    """28 stochastic steps, ours against theirs, with the table removed.
+
+    Our ladder is loaded into the reference first, exactly as B2's euler loop
+    test does, so this measures the STEP. The noise is the other variable and
+    it is removed the same way: the reference's generator is re-seeded to this
+    step's own key before each call, so both sides draw the SAME tensor and
+    what remains is the ancestral arithmetic — ``sigma_up``, ``sigma_down``,
+    and the contracted ``dt``.
+
+    Measured on this machine: BIT-EXACT, all four configurations. Asserted
+    relatively anyway, for B2's reason — ``pow`` is not correctly rounded and
+    varies by ISA, so a bitwise assertion against this reference is not a
+    portable claim about anything.
+    """
+
+    block = _trained(
+        timestep_spacing=spacing, prediction_type=objective, rescale_betas_zero_snr=zero_snr
+    )
+    theirs = _ancestral_reference(block)
+    theirs.set_timesteps(28)
+    schedule = EulerAncestralDiscrete.from_block(block).schedule(28)
+    assert _ulp(schedule.timesteps, theirs.timesteps.numpy()) == 0
+    theirs.sigmas = torch.tensor(schedule.sigmas, dtype=torch.float32)
+
+    torch.manual_seed(0)
+    ours_sample = torch.randn(2, 4, 32, 32) * float(schedule.init_noise_sigma)
+    their_sample = ours_sample.clone()
+    generator = torch.Generator(device="cpu")
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(2, 4, 32, 32)
+        assert _rel_norm(
+            schedule.scale_model_input(index, ours_sample).numpy(),
+            theirs.scale_model_input(their_sample, timestep).numpy(),
+        ) <= RELATIVE
+        seed = sx.step_seed(11, index)
+        noise = torch.randn(
+            prediction.shape,
+            generator=torch.Generator(device="cpu").manual_seed(seed),
+            dtype=torch.float32,
+        )
+        ours_sample = schedule.step(index, prediction, ours_sample, noise)
+        generator.manual_seed(seed)
+        their_sample = theirs.step(
+            prediction, timestep, their_sample, generator=generator
+        ).prev_sample
+        assert _rel_norm(ours_sample.numpy(), their_sample.numpy()) <= RELATIVE
+
+
+def test_the_ancestral_split_conserves_the_ladders_variance() -> None:
+    """``sigma_up**2 + sigma_down**2 == sigma_next**2``, which is WHY it works.
+
+    An ancestral step is not a worse Euler step; it is an Euler step to a
+    SMALLER sigma with the difference handed back as noise. If the split did
+    not conserve the variance the trajectory would drift off the ladder the
+    denoiser was trained on, and the failure would look like a slightly
+    over- or under-denoised image rather than an error.
+    """
+
+    schedule = EulerAncestralDiscrete.from_block(_trained()).schedule(28)
+    for index in range(len(schedule)):
+        down, up = schedule.ancestral(index)
+        target = schedule.sigmas[index + 1] ** 2
+        assert abs(down**2 + up**2 - target) <= max(target, 1e-12) * RELATIVE
+        # It steps DOWN past the next sigma, which is the whole point.
+        assert down <= schedule.sigmas[index + 1] + 1e-9
+    # The last step lands exactly on the clean sample: nothing is re-noised
+    # after the final one, or the image would come back with noise on it.
+    assert schedule.ancestral(len(schedule) - 1) == (0.0, 0.0)
+
+
+def test_an_ancestral_step_cannot_be_taken_without_noise() -> None:
+    """A defaulted noise argument would be a silently different sampler.
+
+    ``euler_a`` with zero noise is ``euler`` with a contracted step — a
+    plausible image, a wrong sampler, and no error anywhere. So the parameter
+    is required, and the two schedule types are different types rather than one
+    type with an optional argument.
+    """
+
+    ancestral = EulerAncestralDiscrete.from_block(_trained()).schedule(4)
+    deterministic = EulerDiscrete.from_block(dict(SDXL_SCHEDULER)).schedule(4)
+    sample = torch.randn(1, 4, 8, 8)
+    prediction = torch.randn(1, 4, 8, 8)
+    with pytest.raises(TypeError):
+        ancestral.step(0, prediction, sample)  # type: ignore[call-arg]
+    # And with noise it is genuinely a different trajectory from euler's.
+    noise = torch.randn(1, 4, 8, 8)
+    assert not torch.equal(
+        ancestral.step(0, prediction, sample, noise),
+        deterministic.step(0, prediction, sample),
+    )
+
+
+# -------------------------------------------------------------- the noise story
+
+
+def test_the_per_step_noise_is_keyed_so_two_pods_resolve_the_same_tensor() -> None:
+    """The reproducibility claim ``euler_a`` needs, and it is NOT the ladder's.
+
+    ``initial_latents`` already argues that a request's noise must mean the
+    same thing on two pods, and CPU-seeds for it. An ancestral sampler draws
+    again at EVERY step, so that argument has to cover the whole stream or it
+    covers almost none of it.
+
+    The stream is KEYED by ``(seed, index)`` rather than run from one advancing
+    generator. Both are reproducible across pods; only the keyed one is
+    reproducible across LOOP SHAPES, so a preview pass, a resumed loop or a
+    reordered call site cannot re-roll the tail. The mix is splitmix64's
+    finalizer because ``seed + index`` would make step ``k`` of seed ``s``
+    identical to step ``k-1`` of seed ``s+1`` — adjacent receipts sharing
+    noise, which is exactly the correlation a seed is supposed to prevent.
+    """
+
+    shape = sx.pack_shape(1024, 1024)
+    draw = lambda seed, index: sx.step_noise(  # noqa: E731
+        shape=shape, seed=seed, index=index, device="cpu", dtype=torch.float32
+    )
+    # Same key, same bytes — this is the whole claim, and it holds for a fresh
+    # call rather than for a position in a stream.
+    assert torch.equal(draw(7, 3), draw(7, 3))
+    assert tuple(draw(7, 3).shape) == (1, 4, 128, 128)
+    # Different step, different noise. Different seed, different noise.
+    assert not torch.equal(draw(7, 3), draw(7, 4))
+    assert not torch.equal(draw(7, 3), draw(8, 3))
+    # …and NOT merely different: the shift-by-one correlation `seed + index`
+    # would introduce is absent.
+    assert not torch.equal(draw(7, 4), draw(8, 3))
+    assert sx.step_seed(7, 4) != sx.step_seed(8, 3)
+    # The two families key identically — one story, not one per family.
+    assert sx.step_seed(7, 3) == sd.step_seed(7, 3)
+
+
+def test_the_whole_ancestral_loop_is_reproducible_from_one_seed() -> None:
+    """End to end, through the real serving path, on a fake backing.
+
+    The claim a receipt makes is about the LATENTS: this catalog's fake decoder
+    is deliberately input-insensitive, so asserting on the image would assert
+    nothing. Two runs at one seed must agree bit for bit; two seeds must not.
+    """
+
+    instance = Sdxl.fake()
+    assert isinstance(sx.schedule_for(instance, steps=3), AncestralSchedule)
+    shape = cast("SdxlShape", sx.pack_shape(1024, 1024))
+
+    def run(seed: int) -> Any:
+        schedule = sx.schedule_for(instance, steps=3)
+        latents = sx.initial_latents(
+            shape=int(shape), seed=seed, device="cpu", dtype=torch.float32,
+            sigma=schedule.init_noise_sigma,
+        )
+        for _, latents in sx.denoise(
+            instance,
+            shape=shape,
+            latents=latents,
+            prompt_embeds=torch.zeros(2, sx.TEXT_TOKENS, sx.CROSS_ATTENTION_WIDTH),
+            pooled=torch.zeros(2, sx.CLIP_G_WIDTH),
+            schedule=schedule,
+            guidance=6.0,
+            seed=seed,
+        ):
+            pass
+        return latents
+
+    assert torch.equal(run(5), run(5))
+    assert not torch.equal(run(5), run(6))
+
+
+# ---------------------------------------------------------------- the ddim maths
+
+
+@pytest.mark.parametrize("steps", ENDPOINT_STEPS)
+@pytest.mark.parametrize("spacing", ["leading", "trailing", "linspace"])
+@pytest.mark.parametrize("set_alpha_to_one", [True, False])
+@pytest.mark.parametrize(
+    ("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)]
+)
+def test_the_ddim_trajectory_matches_diffusers(
+    steps: int, spacing: str, set_alpha_to_one: bool, objective: str, zero_snr: bool
+) -> None:
+    """DDIM walks ALPHAS, so this compares alphas — and the timesteps are ints.
+
+    ``set_alpha_to_one`` is an axis rather than a fixed value because the class
+    default (True) is the OPPOSITE of what every Stable Diffusion
+    ``scheduler_config.json`` ships (False), and it changes only the LAST
+    step — the one that decides whether the trajectory lands on a clean sample.
+    A test that fixed it would measure the arm the fleet does not serve.
+
+    ``linspace`` is here for a specific reason: ``DDIMScheduler`` ROUNDS its
+    linspace grid to integers where the euler family keeps the fractional
+    position and interpolates a table at it. Sharing one grid function between
+    them would put a half-step error into every linspace DDIM request.
+    """
+
+    block = _trained(
+        timestep_spacing=spacing,
+        prediction_type=objective,
+        rescale_betas_zero_snr=zero_snr,
+        set_alpha_to_one=set_alpha_to_one,
+        clip_sample=False,
+    )
+    theirs = _ddim_reference(block)
+    theirs.set_timesteps(steps)
+    ours = Ddim.from_block(block).schedule(steps)
+
+    # EXACT: DDIM's grid is integer arithmetic on both sides.
+    assert ours.timesteps == tuple(int(value) for value in theirs.timesteps.tolist())
+    assert ours.init_noise_sigma == 1.0 == float(theirs.init_noise_sigma)
+
+    stride = 1000 // steps
+    reference = []
+    for timestep in ours.timesteps:
+        previous = timestep - stride
+        reference.append(
+            (
+                float(theirs.alphas_cumprod[timestep]),
+                float(theirs.alphas_cumprod[previous])
+                if previous >= 0
+                else float(theirs.final_alpha_cumprod),
+            )
+        )
+    assert _rel(
+        [value for pair in ours.alphas for value in pair],
+        [value for pair in reference for value in pair],
+    ) <= RELATIVE
+
+
+def test_ddim_does_not_clamp_the_terminal_alpha_where_the_euler_family_does() -> None:
+    """The one place three kinds genuinely disagree about ONE trained table.
+
+    Under zero-terminal-SNR rescaling ``EulerDiscreteScheduler`` and
+    ``EulerAncestralDiscreteScheduler`` overwrite ``alphas_cumprod[-1]`` with
+    the smallest positive fp16 subnormal so the first sigma is finite;
+    ``DDIMScheduler`` does not, because it never forms a sigma and has no
+    infinity to avoid. Sharing one cached table between them without the flag
+    would put a wrong FIRST step into every v-prediction DDIM request — the
+    step furthest from the data manifold, so the most visible one.
+    """
+
+    from gen_worker.model.solvers.precision import alphas_cumprod as _alphas_cumprod
+
+    clamped = _alphas_cumprod(1000, 0.00085, 0.012, "scaled_linear", True, True)
+    plain = _alphas_cumprod(1000, 0.00085, 0.012, "scaled_linear", True, False)
+    assert clamped[-1] == 2.0**-24
+    assert plain[-1] != clamped[-1]
+    assert clamped[:-1] == plain[:-1]
+    # Without the rescale the flag changes nothing, so it never fires by
+    # accident on the epsilon rows every SD checkpoint actually serves.
+    assert _alphas_cumprod(1000, 0.00085, 0.012, "scaled_linear", False, True) == (
+        _alphas_cumprod(1000, 0.00085, 0.012, "scaled_linear", False, False)
+    )
+
+    # And the reference agrees with our unclamped table where DDIM reads it.
+    theirs = _ddim_reference(_trained(prediction_type="v_prediction",
+                                      rescale_betas_zero_snr=True))
+    theirs.set_timesteps(28)
+    assert _rel(plain, theirs.alphas_cumprod.numpy()) <= RELATIVE
+
+
+@pytest.mark.parametrize("spacing", ["leading", "trailing"])
+@pytest.mark.parametrize(
+    ("objective", "zero_snr"), [("epsilon", False), ("v_prediction", True)]
+)
+def test_a_whole_ddim_loop_tracks_the_diffusers_loop(
+    spacing: str, objective: str, zero_snr: bool
+) -> None:
+    """28 deterministic steps, with OUR table injected so this is the step.
+
+    Same discipline as B2's euler loop and the ancestral one above: the table
+    is removed as a variable by loading ours into the reference, and what is
+    left is the arithmetic. ``scale_model_input`` is asserted too, because
+    DDIM's is the IDENTITY where the euler family divides by
+    ``sqrt(sigma**2+1)`` — feeding a DDIM trajectory through the euler
+    pre-scale is a wrong image and never an error.
+
+    Measured on this machine: BIT-EXACT across all four configurations.
+    """
+
+    from gen_worker.model.solvers.precision import alphas_cumprod as _alphas_cumprod
+
+    block = _trained(
+        timestep_spacing=spacing,
+        prediction_type=objective,
+        rescale_betas_zero_snr=zero_snr,
+        set_alpha_to_one=False,
+        clip_sample=False,
+    )
+    theirs = _ddim_reference(block)
+    theirs.set_timesteps(28)
+    table = _alphas_cumprod(1000, 0.00085, 0.012, "scaled_linear", zero_snr, False)
+    theirs.alphas_cumprod = torch.tensor(table, dtype=torch.float32)
+    theirs.final_alpha_cumprod = torch.tensor(table[0], dtype=torch.float32)
+    schedule = Ddim.from_block(block).schedule(28)
+
+    torch.manual_seed(0)
+    ours_sample = torch.randn(2, 4, 32, 32)
+    their_sample = ours_sample.clone()
+    for index, timestep in enumerate(theirs.timesteps):
+        prediction = torch.randn(2, 4, 32, 32)
+        # THE IDENTITY, asserted rather than skipped — and asserted about OUR
+        # function ALONE, which is what makes it exact. The two samples have
+        # already diverged by this point in the loop (parts per million, but
+        # not zero), so `torch.equal` ACROSS the two loops is the same
+        # unportable claim B2 spent three CI cycles retracting: it held on the
+        # development machine and failed on the runner. Both halves are here
+        # because they say different things — ours pre-scales by nothing, and
+        # theirs does the same to its own sample.
+        assert torch.equal(schedule.scale_model_input(index, ours_sample), ours_sample)
+        assert torch.equal(
+            theirs.scale_model_input(their_sample, timestep), their_sample
+        )
+        assert _rel_norm(
+            schedule.scale_model_input(index, ours_sample).numpy(),
+            theirs.scale_model_input(their_sample, timestep).numpy(),
+        ) <= RELATIVE
+        ours_sample = schedule.step(index, prediction, ours_sample)
+        their_sample = theirs.step(prediction, int(timestep), their_sample).prev_sample
+        assert _rel_norm(ours_sample.numpy(), their_sample.numpy()) <= RELATIVE
+
+
+def test_a_ddim_trajectory_is_not_a_sigma_ladder_and_says_so_in_its_type() -> None:
+    """Three schedules, three types, and the differences are load-bearing.
+
+    A common supertype would have to hide exactly what separates them: DDIM
+    has no sigmas and starts at unit variance, the ancestral step consumes
+    noise, and the euler step does not. Every one of those is a wrong IMAGE
+    rather than an error when it is got wrong, so the union is the honest
+    return type and ``isinstance`` is the honest dispatch.
+    """
+
+    instance = Sdxl.fake()
+    assert isinstance(instance.scheduler("ddim_trailing").schedule(4), DdimSchedule)
+    assert isinstance(instance.scheduler("euler_a").schedule(4), AncestralSchedule)
+    assert isinstance(instance.scheduler("euler_trailing").schedule(4), DiscreteSchedule)
+    # An `AncestralSchedule` is NOT a `DiscreteSchedule`, so a loop that only
+    # handles the deterministic step cannot silently accept it.
+    assert not isinstance(
+        instance.scheduler("euler_a").schedule(4), DiscreteSchedule
+    )
+
+    ddim = instance.scheduler("ddim_trailing").schedule(4)
+    assert ddim.init_noise_sigma == 1.0
+    assert not hasattr(ddim, "sigmas")
+    # DDIM cannot walk more steps than the trained grid has timesteps.
+    with pytest.raises(ModelError):
+        instance.scheduler("ddim_trailing").schedule(1001)
+
+
+# ------------------------------------------------------- cross-kernel stability
+
+
+@pytest.mark.parametrize("sampler", ["ddim_trailing", "euler_a"])
+def test_the_new_ladders_do_not_depend_on_which_cpu_kernel_torch_dispatched(
+    sampler: str,
+) -> None:
+    """B2's byte-stability fence, extended to the two new kinds.
+
+    This is the property the reference does NOT have and the reason this module
+    is an improvement rather than a transcription: ``torch``'s float32 CPU
+    ``linspace`` dispatches by ISA, so diffusers resolves a different ladder
+    depending on which CPU a pod rented. Ours cannot — every operation is IEEE
+    double arithmetic with one explicit narrowing — so the subprocess below,
+    forced onto the scalar kernels, must produce the SAME BYTES.
+
+    It matters more for an ancestral sampler than for a deterministic one:
+    ``sigma_up`` and ``sigma_down`` are derived from the ladder and then
+    MULTIPLIED INTO NOISE, so a ladder that moved by a ULP would move the
+    stochastic component of every step, not just the trajectory.
+    """
+
+    program = (
+        "import json;"
+        "from gen_worker.model.catalog import Sdxl;"
+        f"s=Sdxl.fake().scheduler({sampler!r}).schedule(28);"
+        "print(json.dumps("
+        "{'t': [float(x) for x in s.timesteps],"
+        " 'v': [float(x) for pair in s.alphas for x in pair]"
+        " if hasattr(s, 'alphas') else list(s.sigmas)}"
+        "))"
+    )
+    root = Path(__file__).resolve().parents[1] / "src"
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root), "ATEN_CPU_CAPABILITY": "default"},
+    )
+    assert result.returncode == 0, result.stderr
+    scalar = json.loads(result.stdout.strip().splitlines()[-1])
+
+    here = Sdxl.fake().scheduler(cast("Any", sampler)).schedule(28)
+    values = (
+        [value for pair in here.alphas for value in pair]
+        if isinstance(here, DdimSchedule)
+        else list(here.sigmas)
+    )
+    assert scalar["t"] == [float(value) for value in here.timesteps]
+    assert scalar["v"] == values
+
+
+@pytest.mark.parametrize("sampler", sorted(SDXL.schedulers))
+def test_every_declared_sdxl_sampler_renders_through_the_real_serving_path(
+    sampler: str,
+) -> None:
+    """The claim the SET makes, exercised once per member.
+
+    A declared scheduler that no loop can actually walk is the mirror image of
+    the gap K10 closed, and just as quiet — the declaration would look complete
+    and the first real request would fail. So every member is served end to
+    end, hubless and cardless, through the same ``generate`` an endpoint calls.
+
+    Five schedule types over five samplers, and the loop dispatches on the TYPE
+    rather than on the name: the multistep solvers carry history between steps
+    and are NOT pre-scaled (their ``init_noise_sigma`` is 1.0), the ancestral
+    one consumes keyed noise, and ``sde-dpmsolver++`` consumes it too. Getting
+    any of those wrong is a plausible wrong image, never an error.
+    """
+
+    instance = Sdxl.fake(tuned=Sdxl.Tuned(scheduler=cast("Any", sampler)))
+    shape = cast("SdxlShape", sx.pack_shape(1024, 1024))
+    seen: list[int] = []
+    image = sx.generate(
+        instance,
+        shape=shape,
+        positive=sx.token_ids([1, 2, 3], device="cpu"),
+        negative=sx.token_ids([], device="cpu"),
+        steps=4,
+        guidance=6.0,
+        seed=7,
+        on_step=lambda index, total: seen.append(index),
+    )
+    assert seen == [0, 1, 2, 3]
+    assert tuple(image.shape) == (1, 3, 1024, 1024)
+    assert float(image.min()) >= 0.0 and float(image.max()) <= 1.0
+
+
+@pytest.mark.parametrize("sampler", sorted(SD15.schedulers))
+def test_every_declared_sd15_sampler_renders_through_the_real_serving_path(
+    sampler: str,
+) -> None:
+    """The same claim for the family whose DEFAULT is a multistep solver."""
+
+    instance = Sd15.fake(tuned=Sd15.Tuned(scheduler=cast("Any", sampler)))
+    image = sd.generate(
+        instance,
+        shape=cast("sd.AnyShape", sd.pack_shape(512, 512)),
+        positive=sd.token_ids([1, 2, 3], device="cpu"),
+        negative=sd.token_ids([], device="cpu"),
+        steps=4,
+        guidance=7.0,
+        seed=3,
+    )
+    assert tuple(image.shape) == (1, 3, 512, 512)
+    assert float(image.min()) >= 0.0 and float(image.max()) <= 1.0

--- a/tests/test_video_dit_pgw1346.py
+++ b/tests/test_video_dit_pgw1346.py
@@ -296,34 +296,49 @@ def test_the_wan_models_decline_to_name_a_scheduler() -> None:
     """
 
     for model in (WAN22_T2V_A14B, WAN22_I2V_A14B, WAN22_TI2V_5B):
-        assert model.scheduler is None
+        assert model.schedulers == {}
     for binding in (Wan22T2vA14b, Wan22I2vA14b, Wan22Ti2v5b):
         assert not hasattr(binding, "scheduler")
 
-    # LTX, by contrast, has ONE honest answer and declares it.
-    assert LTX23.scheduler is not None
-    assert LTX23.scheduler.name == "flow_match_euler_discrete"
+    # LTX, by contrast, has ONE honest answer and declares it — as a set of
+    # one, keyed by sampler (pgw#1346 K10).
+    assert list(LTX23.schedulers) == ["flow_match_euler"]
+    assert LTX23.schedulers["flow_match_euler"].name == "flow_match_euler_discrete"
     assert hasattr(Ltx23, "scheduler")
 
 
 def test_k10_is_now_a_declaration_limit_and_not_a_missing_implementation() -> None:
-    """The sharpest form of K10: BOTH of Wan's solvers are implemented today.
+    """K10's sharpest form — and the LIMIT IS GONE. What remains is authoring.
 
     B3-math (pgw#923) landed `unipc_multistep` as bare typed math and verified
     the flow lane at all three served `flow_shift` values; B4 proves above that
     the distilled lane's ladder is `flow_match_euler_discrete` exactly. So the
-    obstacle was never a missing scheduler kind — it is that
-    `GraphModelSpec.scheduler` is ONE block and codegen emits ONE
-    `scheduler()`. A family whose CHECKPOINT chooses the solver has nowhere to
-    put the second one.
+    obstacle was never a missing scheduler kind — it was that
+    `GraphModelSpec.scheduler` was ONE block and codegen emitted ONE
+    `scheduler()`, leaving a family whose CHECKPOINT chooses the solver nowhere
+    to put the second one.
+
+    pgw#1346 K10 replaced that field with a SET keyed by the sampler a
+    checkpoint is stamped with, so this test inverts: both solvers are
+    implemented AND the declaration can now hold both. **What Wan still owes is
+    the KEY**, not the mechanism — `Wan22Tuned` declares no sampler field, so
+    there is no stamped value for `inst.scheduler()` to resolve. Adding it by
+    value from the endpoint (the same by-value migration `SdxlTuned` made) is
+    the whole of the remaining work, and it is B4's authoring call rather than
+    a declaration-surface one.
     """
 
     assert SchedulerKind.UNIPC_MULTISTEP in IMPLEMENTED
     assert SchedulerKind.FLOW_MATCH_EULER_DISCRETE in IMPLEMENTED
-    # ...and the field that would have to hold both is singular.
-    assert WAN22_T2V_A14B.scheduler is None
-    field = type(WAN22_T2V_A14B).__dataclass_fields__["scheduler"]
-    assert "Scheduler | None" in str(field.type)
+    # The field that has to hold both is now a SET, and it is empty rather than
+    # wrong: an empty set declares nothing, where a single-valued field would
+    # have had to name one of the two solvers and be wrong for every checkpoint
+    # served by the other.
+    assert WAN22_T2V_A14B.schedulers == {}
+    field = type(WAN22_T2V_A14B).__dataclass_fields__["schedulers"]
+    assert "Mapping[str, Scheduler]" in str(field.type)
+    # The key Wan owes: no sampler field to resolve against yet.
+    assert "scheduler" not in WAN22_T2V_A14B.tuned.__struct_fields__  # type: ignore[union-attr]
 
 
 def test_the_h3_eager_binding_is_a_type_with_no_runners() -> None:

--- a/tests/test_z_image_pgw1346.py
+++ b/tests/test_z_image_pgw1346.py
@@ -499,6 +499,7 @@ def test_the_declaration_exposes_one_runner_and_one_loop_stage() -> None:
     assert tuple(row.name for row in Z_IMAGE.runners) == ("denoiser",)
     assert Z_IMAGE.loop is not None
     assert tuple(stage.runner for stage in Z_IMAGE.loop.stages) == ("denoiser",)
-    assert Z_IMAGE.scheduler is not None
-    assert Z_IMAGE.scheduler.name == "flow_match_euler_discrete"
+    # A set of ONE, keyed by sampler (pgw#1346 K10).
+    assert list(Z_IMAGE.schedulers) == ["flow_match_euler"]
+    assert Z_IMAGE.schedulers["flow_match_euler"].name == "flow_match_euler_discrete"
     assert SCHEDULER["use_dynamic_shifting"] is False


### PR DESCRIPTION
## The blocker

B2 closed with a structural blocker rather than a budget one. The sampler is a **checkpoint** value — it already lives in `SdxlTuned.scheduler` / `Sd15Tuned.scheduler`, stamped per release slot — while `GraphModelSpec.scheduler` was ONE `Scheduler` block and codegen emitted ONE `scheduler()` method. A second implemented kind would have been a class no catalog declaration could attach to, which is exactly what the catalog refused to do with SDXL's text encoders one release ago.

The live consequence B2 measured: **SDXL's DEFAULT sampler is `euler_a`**, so the family's single declared `euler_discrete` block was its *trained* schedule and not the one most requests ask for.

## The mechanism

`GraphModelSpec.schedulers` is a `Mapping[sampler, Scheduler]`, keyed by a value the family's tuned schema admits. The export records a sorted `schedulers[]` array of `(sampler, name, parameters)`; codegen emits `SCHEDULERS` + per-sampler `SCHEDULER_PARAMETERS` and:

- **one declared sampler** → the accessor is unchanged: no argument, one concrete return type. `flux1_dev`, `flux1_schnell`, `flux2_klein_4b/9b` migrate mechanically to a set of one and nothing about them moves;
- **several** → `scheduler()` reads `inst.tuned.scheduler` and resolves it over a closed union, with an optional `name=` typed by a generated `…DeclaredSampler` `Literal` so a handler spelling an unservable sampler is a **static** error.

An undeclared stamp is `SCHEDULER_UNDECLARED` — **a refusal naming both sides, never a substitution**. Serving the family's other schedule under the requested sampler's name is a plausible wrong image and nothing else.

## The math

Two new kinds at B2's final instrument (relative 2e-4 vs diffusers, timesteps EXACT, loops in the L2 norm with our ladder injected, and our own ladder byte-identical under `ATEN_CPU_CAPABILITY=default`):

| kind | ladder vs diffusers | loop vs diffusers | cross-kernel |
|---|---|---|---|
| `euler_ancestral_discrete` | ≤2e-4 over 3 spacings × 2 objectives × 10 step counts; timesteps 0 ULP; ladder **identical** to `euler`'s | **bit-exact**, 4 configs, table + noise removed as variables | byte-identical |
| `ddim` | timesteps **exact ints**; alphas ≤2e-4 over 3 spacings × 2 objectives × 2 `set_alpha_to_one` × 10 step counts | **bit-exact**, 4 configs, our table injected | byte-identical |

Three findings carved into tests rather than prose:

- `DDIMScheduler` does **not** clamp the terminal alpha under zero-terminal-SNR where the euler family does — sharing one cached table without the flag puts a wrong *first* step (the one furthest from the manifold) into every v-pred DDIM request;
- DDIM **rounds** its `linspace` grid where the euler family keeps the fractional position and interpolates — one shared grid function would be a half-step error in every linspace DDIM request;
- a block carrying a parameter its kind never reads is now **refused** (`EulerAncestralDiscrete` has no `final_sigmas_type`), where before it changed nothing and said nothing.

## The noise story (`euler_a`)

An ancestral step consumes noise, so "same seed, same image" is a claim about the *stream*. The step's `noise` is a **required parameter** — a default would silently make it `euler` with a contracted step — and the catalog supplies it CPU-seeded and **keyed by `(request seed, step index)`** through splitmix64's finalizer. Keyed rather than drawn from one advancing generator: both are reproducible across pods, only the keyed one is reproducible across *loop shapes*, so a preview pass or a resumed loop cannot re-roll the tail. `seed + index` is refused explicitly because it makes step *k* of seed *s* identical to step *k-1* of seed *s+1*.

## Rebased onto B3-math, which is additive

B3-math (#923) landed first. Its solvers needed no math change to become declarable — they needed a declaration that can hold more than one scheduler. So the staged gap shrank from five names to **one**:

| family | declares | owed |
|---|---|---|
| `sdxl` | `ddim_trailing`, `dpmpp_2m_karras`, `dpmpp_2m_sde_karras`, `euler_a`, `euler_trailing` | `lcm` |
| `sd15` / `sd2` | the above minus `euler_trailing`, plus `ddim`, `dpmpp_2m`, `euler`, `unipc` | `lcm` |

**sd15's own default `dpmpp_2m_karras` is servable.** Every declared sampler renders end to end through the real `generate` in the suite. The loop dispatches on the schedule **type**: a multistep solver carries history and is **not** pre-scaled (its `init_noise_sigma` is 1.0), the ancestral step consumes keyed noise, and `sde-dpmsolver++` consumes it too — the union type is what makes omitting any of those a type error rather than a discovery on a pod.

Declared blocks are asserted against `gen_worker.view.SAMPLERS`, which already defines each sampler name completely for the `Slot`-served endpoints, rather than restated from memory. B3's two solvers gained the same unread-parameter refusal, and `precision.sigma_table` now derives from a `clamp_terminal`-aware `alphas_cumprod` so DDIM and the euler family share ONE trained table without sharing a clamp they disagree on.

## Red proofs (6/6)

Each mutation was applied to the implementation and the named tests confirmed red, then reverted:

| mutation | red |
|---|---|
| the refusal becomes a fallback to the first declared kind | 1 |
| `_only` accepts unknown keys | 1 |
| DDIM shares the euler *clamped* alpha table | 39 |
| DDIM reuses the euler (unrounded) linspace grid | 28 |
| the ancestral split drops `sigma_up` | 4 |
| the per-step noise key becomes `seed + index` | 1 |

## Gates

`mypy src/gen_worker tests tests_v2` **Success on 920 files**; `ruff check src/gen_worker` clean; `check_model_bindings.py` **7 graph + 11 eager pairs current**; all 19 fast-gate scripts green; `assemble_changelog --check` green. Targeted suites **797 passed** (`test_sd_stage1_pgw1346` 302, `test_dit_solvers_pgw1346` 224 — B3's, unchanged — plus flux stage-1, model SDK, declaration axes, SDK v2, objectives, both klein suites and flux1-schnell).

## What this unblocks

The scheduler axis of B2's held sdxl/sd15 endpoint migration, and B4's three Wan declarations. Single-scheduler families need nothing from this change — their accessor is byte-for-byte the shape it was.