### PR TITLE
pgw#1353 option (b): the key set outlives the ENDPOINT, not just the pod — `keys_from=hub`

### DIFF
--- a/changelog.d/pgw1361.md
+++ b/changelog.d/pgw1361.md
@@ -31,3 +31,26 @@
   closure"*. Refused BY NAME without `--hub`/`$COZY_HUB_URL` and `$COZY_WORKER_TOKEN`, and a
   publish that did not land is a non-zero exit — a `--publish` that quietly did nothing is
   exactly the failure this issue is about.
+
+- **TWO SEAM DEFECTS FOUND ON THE WAY, and either alone would have made the tier DEAD ON EVERY
+  FLEET POD — silently.** Under the process split the compute child holds no credential and
+  never names a free-form path: the parent refuses any request not matching
+  `procsplit/actions.py` by method AND full-path regex.
+
+  1. **`keysets.fetch` / `keysets.publish` were not in the action table.** Every unit test that
+     patches `broker.request` stays green with the tier completely unreachable — the parent's
+     refusal arrives as a `BrokerError`, `keyset.hub` correctly reads it as a miss, and the pod
+     derives for 805 s exactly as before. That is pgw#1309's shape precisely, so it is now
+     asserted against the TABLE rather than against the client. The path regex pins the address
+     grammar to the 32 lowercase hex `parse_closure_digest` admits; a looser `[^/]+` would let a
+     process running tenant code put anything it liked in a path segment the parent attaches the
+     pod's credential to. `keysets.publish` is deliberately NOT in `PUBLISH_ACTIONS`: pgw#980
+     disarms those on a live-edit probe because a probe writing a CELL poisons every later
+     adopter, and a key set carries no artifact and lands at a closure only that probe resolves.
+
+  2. **`parent._http_call` attached the body only when `method == "POST"`** — true while POST was
+     the only verb in the table, and silently fatal the moment a PUT joined it. A key-set publish
+     would have gone out with NO BODY, the hub would have answered a typed `keyset_invalid`, and
+     the child would have read a well-formed "no" to a request it believed it sent. Now every
+     body-bearing verb (POST/PUT/PATCH) sends what the action table already authorized; GET and
+     DELETE still send none, which is what they declare.

--- a/changelog.d/pgw1361.md
+++ b/changelog.d/pgw1361.md
@@ -1,0 +1,33 @@
+- **`keyset.store` gains a HUB tier, so a pod with no volume and no baked document stops paying
+  the 805 s.** Search order is now **shipped → durable → this pod's cache → the HUB → derive**,
+  and a hub hit reports `keys_from=hub` — its own `KeySource` member, so "which fix is reaching
+  the fleet" stays a query rather than a story.
+
+  pgw#1327 shipped the `cg-keyset-v1` document as a file; pgw#1353 row (a) put it on th#1813's
+  platform-placed durable root. Neither reaches an **ephemeral private deployment** — no network
+  volume, no baked document, a fresh container per pod — which measured **778-833 s of
+  `torch.export` per cold boot on four independent sdxl pods**, 94 % of `worker_queue_ms`, once
+  per pod forever. th#2123's `GET`/`PUT /v1/worker/keysets/<closure_digest>` is the one store
+  every pod shape can reach.
+
+  **On a successful derive the document is offered to the hub, best effort**, so a fleet
+  converges instead of paying per pod. The publish runs strictly AFTER the keys this boot needs
+  already exist, and **nothing it can do reaches the boot**: a hub that is down, a 409 from
+  another pod's document, a volume that vanished mid-read — every one is a logged sentence and
+  a boot that serves. There is deliberately no "publish only TRACED" guard: this runs on the
+  derive branch, where every read tier including the hub has already missed, so a `boot_key`
+  memo hit is exactly as worth publishing as a fresh trace.
+
+  **The hub degrades where a local document refuses, and the asymmetry is the design.** A
+  malformed document in the image or on the endpoint's volume is still `keyset_invalid` and
+  still propagates — it is a mint-lane defect that must be visible. A hub answer that does not
+  parse, or that names a DIFFERENT closure than the address it was asked at, is a MISS with a
+  recorded reason and the pod derives: the hub is a network peer on the boot path, and a pod
+  that refuses to boot because a cache was unreachable is strictly worse than the cost it was
+  avoiding.
+
+- **`scripts/emit_cg_keyset.py --publish`** sends every emitted closure to the hub's store, which
+  is what makes *"a serving pod never derives"* true rather than *"a serving pod derives once per
+  closure"*. Refused BY NAME without `--hub`/`$COZY_HUB_URL` and `$COZY_WORKER_TOKEN`, and a
+  publish that did not land is a non-zero exit — a `--publish` that quietly did nothing is
+  exactly the failure this issue is about.

--- a/scripts/emit_cg_keyset.py
+++ b/scripts/emit_cg_keyset.py
@@ -52,17 +52,39 @@ Where the output goes on a pod: ``/app/.tensorhub/cg-keyset-v1.json``, beside
 ``endpoint.lock`` (``gen_worker.keyset.store.IMAGE_KEYSET_DIR``), or anywhere
 ``GEN_WORKER_CG_KEYSET`` points.
 
+``--publish`` — THE MINT LANE FILLS THE HUB (pgw#1353 option (b) / th#2123)
+--------------------------------------------------------------------------
+The staged file only helps a pod that can read the filesystem it is staged on.
+``--publish`` sends every closure this run produced to the hub's key-set store,
+``PUT /v1/worker/keysets/<closure_digest>``, which is the one tier an EPHEMERAL
+private deployment can reach — no network volume, no baked document, a fresh
+container every time. **This is what makes "a serving pod never derives" true**:
+the mint lane pays the traces once, at mint time, and every serving pod of that
+closure reads them.
+
+Best effort per closure and reported per closure. A 409 means the store already
+holds a DIFFERENT document at that address — write-once, first one stands — and
+that is worth reading rather than retrying: two runs of the same code against
+the same subjects should produce the same class hashes.
+
+Needs a hub and a credential: ``--hub URL`` (or ``$COZY_HUB_URL``) and
+``$COZY_WORKER_TOKEN``. Refused by name when either is missing, never silently
+skipped — a publish flag that quietly did nothing is how a fleet keeps paying
+805 s while a green log line says the document was emitted.
+
 Usage::
 
     python scripts/emit_cg_keyset.py --from-cache ~/.cache/cozy --out build/
+    python scripts/emit_cg_keyset.py --from-cache ~/.cache/cozy --out build/ --publish
     python scripts/emit_cg_keyset.py --derive --module my_endpoint.main \\
         --function generate --slot pipeline=/cas/checkpoint \\
-        --slot-ref pipeline=tensorhub/wai-illustrious@prod --out build/
+        --slot-ref pipeline=tensorhub/wai-illustrious@prod --out build/ --publish
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -89,6 +111,58 @@ def _merge(out_path: Path, closures: Dict[str, object]) -> int:
         schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
         closures=merged)))  # type: ignore[arg-type]
     return len(merged)
+
+
+#: Where the credential comes from. Env, because it is a SECRET and secrets are
+#: config — never a flag, which lands in shell history and in CI logs.
+ENV_HUB_URL = "COZY_HUB_URL"
+ENV_HUB_TOKEN = "COZY_WORKER_TOKEN"
+
+
+def hub_tier(url: str) -> "object":
+    """The hub to publish to, or a SystemExit naming what is missing.
+
+    Refuses by name rather than degrading to "did not publish". A `--publish`
+    that silently does nothing is the failure this whole issue is about: a
+    fleet paying 805 s per pod while a green line says the document was
+    emitted.
+    """
+    from gen_worker.keyset.hub import HubTier
+
+    base = (url or os.environ.get(ENV_HUB_URL, "")).strip()
+    token = os.environ.get(ENV_HUB_TOKEN, "").strip()
+    missing = [name for name, value in (
+        (f"--hub or ${ENV_HUB_URL}", base), (f"${ENV_HUB_TOKEN}", token)) if not value]
+    if missing:
+        raise SystemExit(
+            f"--publish needs a hub and a credential; missing: {missing}")
+    return HubTier(base_url=base, bearer=token)
+
+
+def publish(out: Path, tier: "object") -> int:
+    """Offer every closure in the staged document to the hub. Returns failures.
+
+    Reads back from the STAGED FILE rather than from whatever the caller has in
+    hand, so `--publish` publishes exactly what `--out` says was produced — one
+    artifact, one claim, and no way for the two to disagree.
+    """
+    from gen_worker import keyset
+    from gen_worker.keyset import store as keyset_store
+    from gen_worker.keyset.hub import publish_closure
+
+    document = keyset_store.read_document(out)
+    failed = 0
+    for digest_text in sorted(document.closures):
+        digest = keyset.parse_closure_digest(digest_text)
+        reason = publish_closure(digest, document.closures[digest_text], tier)  # type: ignore[arg-type]
+        if reason:
+            failed += 1
+            print(f"  publish {digest}: REFUSED — {reason}")
+        else:
+            print(f"  publish {digest}: ok")
+    if failed:
+        print(f"{failed} closure(s) did not reach the hub")
+    return failed
 
 
 def from_cache(cache: Path, out: Path) -> int:
@@ -252,6 +326,15 @@ def main(argv: Optional[List[str]] = None) -> int:
              "closure digest, so a document derived without it is unaddressable")
     ap.add_argument("--out", default="")
     ap.add_argument("--work", default="")
+    ap.add_argument(
+        "--publish", action="store_true",
+        help="also PUT every emitted closure to the hub's key-set store "
+             f"(th#2123), so a pod with no volume and no baked document reads "
+             f"it instead of tracing. Needs --hub/${ENV_HUB_URL} and "
+             f"${ENV_HUB_TOKEN}.")
+    ap.add_argument(
+        "--hub", default="",
+        help=f"the hub base URL for --publish; defaults to ${ENV_HUB_URL}")
     args = ap.parse_args(argv)
 
     from gen_worker import keyset
@@ -279,11 +362,21 @@ def main(argv: Optional[List[str]] = None) -> int:
                 ap.error(f"--slot-ref must be NAME=REF, got {item!r}")
             refs[name] = ref
         work = Path(args.work or (out.parent / ".cg-keyset-work"))
-        return derive(tuple(args.module), args.function, slots, refs, out, work)
+        # The tier is built BEFORE the traces, so a missing credential costs a
+        # refusal in the first second rather than after a full derive.
+        tier = hub_tier(args.hub) if args.publish else None
+        status = derive(tuple(args.module), args.function, slots, refs, out, work)
+        if status or tier is None:
+            return status
+        return 1 if publish(out, tier) else 0
 
     if not args.from_cache:
         ap.error("pass --from-cache DIR or --derive")
-    return from_cache(Path(args.from_cache), out)
+    tier = hub_tier(args.hub) if args.publish else None
+    status = from_cache(Path(args.from_cache), out)
+    if status or tier is None:
+        return status
+    return 1 if publish(out, tier) else 0
 
 
 if __name__ == "__main__":

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -82,6 +82,8 @@ from . import activity, aot_identity, cell_resolve, keyset, local_cell_store
 from .child_contract import CompileSpec, MintSlot
 from .keyset import DerivedKeySet, KeySetError
 from .keyset import boot as keyset_boot
+from .keyset import hub as keyset_hub
+from .keyset import store as keyset_store
 
 logger = logging.getLogger(__name__)
 
@@ -459,13 +461,24 @@ def _key_set(
     device: int,
     derive: Optional["KeyDeriver"],
     keyset_roots: Sequence[Path],
+    hub: Optional[keyset_hub.HubTier] = None,
 ) -> "DerivedKeySet | BootAdoptOutcome":
     """This boot's key set — from DATA first, from a deriver only if injected.
 
-    The order is the whole leg. A shipped ``cg-keyset-v1`` answers in
-    milliseconds and runs no exporter; this machine's own cache answers next
-    (§4.28's compile-once-run-forever, unchanged); a mint-lane deriver is asked
-    last and only when the caller handed one over.
+    The order is the whole leg: **shipped -> durable -> this pod's cache -> the
+    HUB -> derive**. A shipped ``cg-keyset-v1`` answers in milliseconds and runs
+    no exporter; the endpoint's durable root answers next (pgw#1353 row (a));
+    this machine's own cache after that (§4.28's compile-once-run-forever,
+    unchanged); th#2123's hub store after THAT, because it is the only tier an
+    ephemeral private deployment can reach and a 10 s round trip is nothing
+    against the 805 s it replaces; and a mint-lane deriver is asked last and
+    only when the caller handed one over.
+
+    **On a successful derive the document is offered to the hub, best effort.**
+    That upload is the producer half of the tier and it is the reason a fleet
+    converges instead of paying per pod — and it runs strictly AFTER the keys
+    this boot needs already exist, so no failure of it can slow, block or
+    change this boot. See :func:`_publish_derived_key_set`.
 
     Returns a refusal OUTCOME rather than raising, because every failure here
     means "boot as this pod booted yesterday" and the reason is the countable
@@ -480,6 +493,7 @@ def _key_set(
             slots=slots,
             cache_dir=Path(memo_dir) if memo_dir else None,
             extra_roots=tuple(keyset_roots),
+            hub=hub,
         )
     except KeySetError as exc:
         if exc.reason != "keyset_absent":
@@ -509,7 +523,7 @@ def _key_set(
             family=family, function=function)
 
     try:
-        return derive(
+        derived = derive(
             function=function,
             modules=tuple(str(m) for m in modules),
             family=family,
@@ -534,6 +548,60 @@ def _key_set(
             reason, detail = "derive_failed", f"{type(exc).__name__}: {exc}"
         return BootAdoptOutcome(
             reason=reason, detail=detail, family=family, function=function)
+
+    # This pod just paid for the traces. Hand the answer to the hub so the NEXT
+    # pod of this endpoint does not — the whole producer half of th#2123, in one
+    # place, after the keys already exist.
+    _publish_derived_key_set(derived, memo_dir=memo_dir, hub=hub, family=family)
+    return derived
+
+
+def _publish_derived_key_set(
+    derived: "DerivedKeySet",
+    *,
+    memo_dir: Optional[Path],
+    hub: Optional[keyset_hub.HubTier],
+    family: str,
+) -> str:
+    """Offer this boot's freshly-derived closure to the hub. BEST EFFORT.
+
+    Returns the reason it did not happen, or ``""``. **It can never block, slow
+    or fail a boot**: it runs after the key set this boot needs already exists,
+    it is wrapped whole, and every one of its own failure modes is a logged
+    sentence.
+
+    The document is read back from the writable root the deriver just wrote
+    rather than rebuilt from ``derived``. Two reasons, and the second is the
+    important one: ``DerivedKeySet`` carries FOLDED keys — this pod's ``sm`` and
+    toolchain baked in — and a document built from those would be a
+    machine-DEPENDENT answer stored at a machine-independent address, wrong for
+    every pod on a different SKU. What must travel is the row the deriver
+    recorded, and ``store`` is the one place that row exists.
+    """
+    if hub is None:
+        return "no hub tier"
+    # NO SOURCE GUARD, and that is deliberate. This runs on the DERIVE branch
+    # only — every read tier already missed to get here, INCLUDING the hub — so
+    # whatever the deriver answered with is something the hub does not have.
+    # `boot_key.derive` can legitimately answer `MEMO` (its own cache hit), and
+    # that document is exactly as worth publishing as a freshly traced one: the
+    # pod holds it and the platform does not. A "publish only TRACED" guard
+    # reads plausible and would silently strand every cozy-local memo hit.
+    try:
+        row = keyset_store.closure_row(
+            Path(memo_dir) if memo_dir else None, derived.closure)
+        if row is None:
+            return "the derivation recorded no document to publish"
+        reason = keyset_hub.publish_closure(derived.closure, row, hub)
+    except Exception as exc:  # noqa: BLE001 — never fatal, see the docstring
+        logger.debug("boot-adopt: key set publish failed", exc_info=True)
+        reason = f"{type(exc).__name__}: {exc}"
+    if reason:
+        logger.warning(
+            "boot-adopt: %s traced its key set in %d ms and could NOT hand it to "
+            "the hub (%s) — the next pod of this endpoint pays it again",
+            family, derived.wall_ms, reason)
+    return reason
 
 
 class KeyDeriver(Protocol):
@@ -616,10 +684,16 @@ def attempt(
         text_lens=tuple(int(v) for v in (getattr(cfg, "text_lens", ()) or ())),
     )
 
+    # th#2123's hub tier is built from the SAME two values the resolve call
+    # uses, and from `hub_absent` — the caller's own sentence for why there is
+    # nobody to ask. One object, so "is there a hub" is answered once per boot
+    # instead of once per call site.
+    hub = keyset_hub.HubTier(
+        base_url=base_url, bearer=bearer, absent=str(hub_absent or ""))
     outcome = _key_set(
         function=fn, modules=modules, family=family, spec=spec, slots=slots,
         declared_hint=declared_hint, work_root=work_root, memo_dir=memo_dir,
-        device=device, derive=derive, keyset_roots=keyset_roots)
+        device=device, derive=derive, keyset_roots=keyset_roots, hub=hub)
     # pgw#1355: the key set is a COLD-BOOT STAGE, recorded exactly once per
     # derive — here, where `_key_set` has just returned, rather than in
     # `report`, which runs once PER CLASS. On sdxl that is 36 calls carrying
@@ -631,7 +705,10 @@ def attempt(
     # This is the span pgw#1353 measured the absence of: the derive runs during
     # a REQUEST, after `boot_phases.in_boot()` has already gone False, so no
     # ladder row covers its 805 seconds and `worker_boot_phases` shows 871 s of
-    # silence where the dominant phase of the boot actually was.
+    # silence where the dominant phase of the boot actually was. With th#2123's
+    # hub tier the same span now also covers the hub round trip, which is the
+    # right place for it: the stage answers "what did stating a key cost this
+    # boot", and 10 s of hub is one of the answers.
     _record_keyset_stage(outcome, family=family, function=fn)
     if isinstance(outcome, BootAdoptOutcome):
         return (report(outcome),)

--- a/src/gen_worker/keyset/__init__.py
+++ b/src/gen_worker/keyset/__init__.py
@@ -10,6 +10,7 @@ entry points, and it imports neither ``boot_key`` nor ``boot_trace_child``.
 Read in this order: :mod:`identifiers` (the grammar), :mod:`document` (the
 schema), :mod:`closure` (the address and why it is the whole safety story),
 :mod:`fold` (graph axis x runtime axes), :mod:`store` (where documents live),
+:mod:`hub` (the platform's own store, pgw#1353 option (b) / th#2123),
 :mod:`boot` (serve-side consumption), :mod:`emit` (mint-side production).
 
 ----------------------------------------------------------------------------
@@ -40,6 +41,7 @@ from .document import (
     KeySetDocument, ShippedClass, ShippedClosure, decode, empty, encode,
     parse_closure)
 from .fold import DerivedKeySet, KeySource, MemoVerdict, fold_entry_keys
+from .hub import HubTier, fetch_closure, publish_closure, single_closure_document
 from .identifiers import (
     ClassHash, ClosureDigest, CompiledGraphKey, FamilyName, GraphClassName,
     IngressDigest, KeySetError, parse_class_hash, parse_closure_digest,
@@ -57,6 +59,7 @@ __all__ = [
     "FamilyName",
     "GraphClassName",
     "GraphClassRow",
+    "HubTier",
     "IngressDigest",
     "KEYSET_FILENAME",
     "KEYSET_SCHEMA",
@@ -72,6 +75,7 @@ __all__ = [
     "decode",
     "empty",
     "encode",
+    "fetch_closure",
     "fold_entry_keys",
     "key_set_from_data",
     "parse_class_hash",
@@ -81,5 +85,7 @@ __all__ = [
     "parse_family_name",
     "parse_graph_class_name",
     "parse_ingress_digest",
+    "publish_closure",
+    "single_closure_document",
     "tcg_version",
 ]

--- a/src/gen_worker/keyset/boot.py
+++ b/src/gen_worker/keyset/boot.py
@@ -23,6 +23,7 @@ from ..child_contract import CompileSpec, MintSlot
 from . import store
 from .closure import closure_digest
 from .fold import DerivedKeySet, KeySource, MemoVerdict, fold_entry_keys
+from .hub import HubTier, fetch_closure
 from .identifiers import ClosureDigest, KeySetError
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ def key_set_from_data(
     slots: Mapping[str, MintSlot],
     cache_dir: Optional[Path] = None,
     extra_roots: Sequence[Path] = (),
+    hub: Optional[HubTier] = None,
 ) -> DerivedKeySet:
     """Derive this boot's ``cg-key-v1`` set from SHIPPED DATA.
 
@@ -61,38 +63,65 @@ def key_set_from_data(
     pod, §4.28) or, on an adopt-only role, refuses and serves as it booted
     before. It is never a boot that guesses a key.
 
-    ``reason='keyset_invalid'`` means a document was found and is malformed or
-    a version this worker does not read. That propagates rather than degrading
-    to "absent" on purpose: a broken shipped key set is a mint-lane defect that
-    must be visible, and reading past it is how every pod in a release silently
-    re-traces forever.
+    ``reason='keyset_invalid'`` means a LOCAL document was found and is
+    malformed or a version this worker does not read. That propagates rather
+    than degrading to "absent" on purpose: a broken shipped key set is a
+    mint-lane defect that must be visible, and reading past it is how every pod
+    in a release silently re-traces forever.
+
+    A HUB answer is held to the same admission and refused the same way, but a
+    refusal there is a MISS rather than a propagating error (see
+    :mod:`gen_worker.keyset.hub`): a local document is an artifact this image or
+    this endpoint's storage is responsible for, while the hub is a network peer
+    on the boot path, and a pod that refuses to boot because a cache was
+    unreachable is strictly worse than the 805 s it was avoiding.
     """
     started = time.monotonic()
     digest = closure_of(
         family=family, function=function, modules=modules, cfg=cfg, slots=slots)
     hit = store.lookup(digest, cache_dir=cache_dir, extra_roots=extra_roots)
-    if hit is None:
+    closure = hit.closure if hit is not None else None
+    source = hit.source if hit is not None else KeySource.HUB
+    where = str(hit.path) if hit is not None else ""
+    hub_reason = ""
+    if closure is None and hub is not None:
+        # ── THE HUB TIER (pgw#1353 option (b) / th#2123) ────────────────────
+        # Asked LAST among the readers and only when every local root missed: a
+        # local document is already on this machine, so asking the network
+        # first would put a round trip in front of an answer the pod is already
+        # holding. Asked BEFORE the deriver for the obvious reason — a 10 s
+        # timeout against 805 s of `torch.export`.
+        #
+        # `fetch_closure` never raises: a hub that is down, slow, or answering
+        # nonsense degrades to the derive this pod would have run anyway, and
+        # the reason rides the `keyset_absent` detail below so the degradation
+        # is readable instead of silent.
+        closure, hub_reason = fetch_closure(digest, hub)
+        where = f"hub {hub.base_url or 'via broker'}"
+    if closure is None:
         searched = [str(root) for root in store.shipped_roots(extra=extra_roots)]
         searched.extend(
             str(root) for root, _source in store.writable_roots(cache_dir))
+        searched.append(
+            f"hub ({hub_reason})" if hub is not None else "hub (no tier configured)")
         raise KeySetError(
             "keyset_absent",
             f"no cg-keyset-v1 document holds closure {digest} for family "
             f"{family!r}; roots searched: {searched}")
-    entry_keys = fold_entry_keys(hit.closure.class_hashes, family=family)
+    entry_keys = fold_entry_keys(closure.class_hashes, family=family)
     wall_ms = int((time.monotonic() - started) * 1000)
     logger.info(
         "keyset: %d key(s) for %s from %s data at %s in %d ms — no trace "
         "(closure %s, emitted by %s)",
-        len(entry_keys), family, hit.source.value, hit.path, wall_ms, digest,
-        hit.closure.emitted_by or "?")
+        len(entry_keys), family, source.value, where, wall_ms, digest,
+        closure.emitted_by or "?")
     return DerivedKeySet(
         entry_keys=entry_keys,
-        source=hit.source,
+        source=source,
         closure=digest,
         wall_ms=wall_ms,
         memo=(
-            MemoVerdict.HIT if hit.source is KeySource.MEMO
+            MemoVerdict.HIT if source is KeySource.MEMO
             else MemoVerdict.ABSENT),
-        width_reason=f"{hit.source.value} key set at {hit.path} — no trace child",
+        width_reason=f"{source.value} key set at {where} — no trace child",
     )

--- a/src/gen_worker/keyset/fold.py
+++ b/src/gen_worker/keyset/fold.py
@@ -45,10 +45,20 @@ class KeySource(enum.Enum):
     would be indistinguishable from the impossible case, and the ONE number this
     issue exists to move (how many pods pay the 805 s) would be unreadable off
     the boot events.
+
+    ``HUB`` is th#2123's store, and it is a DISTINCT value for the same reason
+    ``DURABLE`` is. The four tiers answer four different operational questions:
+    ``shipped`` says the mint lane baked it, ``durable`` says this endpoint has
+    storage that outlives a pod, ``hub`` says the platform holds it for an
+    endpoint shape that has neither, and ``traced`` says somebody paid 805 s.
+    Collapsing any pair would make "which fix is actually reaching the fleet"
+    unanswerable off the boot events — which is the exact blindness pgw#1353
+    was filed to end.
     """
 
     SHIPPED = "shipped"
     DURABLE = "durable"
+    HUB = "hub"
     MEMO = "memo"
     TRACED = "traced"
 

--- a/src/gen_worker/keyset/hub.py
+++ b/src/gen_worker/keyset/hub.py
@@ -1,0 +1,254 @@
+"""The HUB tier of the key-set search: pull by closure digest, push after a derive.
+
+pgw#1353 option (b) / th#2123. `GET`/`PUT /v1/worker/keysets/<closure_digest>`.
+
+WHY A FOURTH TIER, WHEN THERE ARE ALREADY THREE
+-----------------------------------------------
+pgw#1327 gave a pod a document baked into its image; pgw#1353 gave it the
+platform-placed durable root; §4.28 already gave it its own cache. Each fixes a
+different pod and NONE of them fixes an **ephemeral private deployment**: no
+network volume (so the durable root is the pod's own disk, which dies with it),
+no baked document (the closure digest binds a deploy-time checkpoint ref the
+image build cannot state), and a fresh container every time. That pod pays the
+full derive — measured 778-833 s on four independent sdxl pods — once per pod,
+forever, and it is exactly the shape a private deployment takes.
+
+The hub is the one store every pod shape can reach. It is also the only one that
+can be filled by the MINT lane at mint time, which is the point: a serving pod
+should never derive, and `scripts/emit_cg_keyset.py --publish` is what makes
+that true without an image rebuild.
+
+DESIGN-RULINGS §4.29, AS AMENDED
+--------------------------------
+The ruling is *"the worker derives its key and asks the hub BY KEY: ONE artifact
+or MISS… admission verifies the answer against the derived key"*, and Paul's
+keys-shipped-as-data amendment is what puts a key SET inside it rather than only
+an artifact. This module is that shape one layer up: the address is the closure
+digest, the answer is one document or a miss, and admission is
+`document.parse_closure(document, digest)` — the answer must NAME the address it
+was asked at, or it is refused.
+
+AN OPTIMIZATION, NEVER A GATE — AND THE ASYMMETRY THAT MATTERS
+---------------------------------------------------------------
+A LOCAL document that does not parse is `keyset_invalid` and PROPAGATES, because
+a malformed document in the image or on the volume is a mint-lane defect that
+must be visible as itself. A HUB answer that does not parse is a MISS with a
+recorded reason, and the pod derives.
+
+That asymmetry is deliberate and is not laziness. The hub is a network peer on
+the boot path: it can be down, slow, rebuilding, or behind a middlebox that
+rewrote the body. Every one of those must degrade to the 805 s path the pod
+already had, because the alternative — a pod that refuses to boot because a
+cache was unreachable — is strictly worse than the problem this fixes. The
+`hub_reason` on the outcome is what keeps it from being silent.
+
+The PUBLISH half is best-effort by the same rule and one more: it runs AFTER the
+derive, so its failure cannot make this boot slower than it already was, and it
+never blocks. A pod that traced for 805 s and then could not upload has still
+booted; the next pod pays again and the reason is recorded.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .document import (KEYSET_SCHEMA, KEYSET_VERSION, ClosureRow, KeySetDocument,
+                       decode, encode, parse_closure)
+from .document import ShippedClosure
+from .identifiers import ClosureDigest, KeySetError
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "KEYSET_PATH_PREFIX",
+    "KEYSET_TIMEOUT_S",
+    "HubTier",
+    "fetch_closure",
+    "keyset_path",
+    "publish_closure",
+    "single_closure_document",
+]
+
+#: The route's address space. The path segment IS the closure digest — a
+#: validated :class:`ClosureDigest`, never an f-string of whatever was handy, so
+#: a caller cannot put a folded key or a class hash in the one place the hub
+#: reads as an address.
+KEYSET_PATH_PREFIX = "/v1/worker/keysets/"
+
+#: Mandatory (``scripts/lint_http_timeouts.py``). SHORT relative to the resolve
+#: route's 30 s, and the asymmetry is the design: a resolve answer saves a full
+#: cold mint and is worth waiting for, while this one saves a derive the pod can
+#: simply do. A hub that has not answered in 10 s cannot beat the fallback, so
+#: waiting longer only adds to the boot it is meant to shorten.
+KEYSET_TIMEOUT_S = 10.0
+
+
+@dataclass(frozen=True)
+class HubTier:
+    """WHO to ask, as a value.
+
+    A typed object rather than two loose strings threaded through five call
+    sites, and ``None`` rather than an empty ``HubTier`` for "there is nobody to
+    ask": the two states have different meanings and only one of them should be
+    able to reach :func:`fetch_closure`. ``absent`` carries the CALLER's own
+    sentence for why there is no hub (pgw#1127's shape), which is a detail and
+    never a decision.
+    """
+
+    base_url: str = ""
+    bearer: str = ""
+    absent: str = ""
+
+    @property
+    def reachable(self) -> bool:
+        """Whether asking is even meaningful.
+
+        Under the process split the child holds no credential and the parent
+        supplies both, so an empty ``bearer`` is NOT proof there is nobody to
+        ask — ``broker.request`` decides that. What makes a tier unreachable is
+        the caller SAYING so.
+        """
+        return not self.absent
+
+
+def keyset_path(digest: ClosureDigest) -> str:
+    """The route path for one address. Takes the validated type deliberately."""
+    return f"{KEYSET_PATH_PREFIX}{digest}"
+
+
+def single_closure_document(
+    digest: ClosureDigest, row: ClosureRow,
+) -> bytes:
+    """The exact bytes a PUT carries: ONE closure, keyed by its own address.
+
+    One closure and not the pod's whole document, because the address is
+    per-closure and the hub refuses a body naming more than one. Sending the
+    whole cache would also leak every other release this pod has ever booted
+    into a row addressed at one of them.
+    """
+    return encode(KeySetDocument(
+        schema=KEYSET_SCHEMA, version=KEYSET_VERSION,
+        closures={str(digest): row}))
+
+
+def fetch_closure(
+    digest: ClosureDigest, tier: HubTier,
+) -> Tuple[Optional[ShippedClosure], str]:
+    """Ask the hub for ONE closure. Returns ``(closure, reason)``.
+
+    ``(closure, "")`` is a hit; ``(None, reason)`` is everything else, and the
+    reason is never empty on a miss — a silent miss is indistinguishable from a
+    tier nobody wired, and this whole issue exists because a cost nobody could
+    see went unfixed for a release cycle.
+
+    NEVER RAISES. Every failure mode of a network peer on the boot path
+    degrades to "derive", which is what the pod did before this tier existed.
+    """
+    if not tier.reachable:
+        return None, f"no hub to ask: {tier.absent}"
+    from ..procsplit import broker
+
+    try:
+        resp = broker.request(
+            "GET", keyset_path(digest),
+            base_url=tier.base_url, bearer=tier.bearer,
+            timeout=KEYSET_TIMEOUT_S)
+    except Exception as exc:  # noqa: BLE001 — see the docstring
+        logger.debug("keyset: hub fetch failed", exc_info=True)
+        return None, f"hub unreachable ({type(exc).__name__}: {exc})"
+
+    if resp.status_code == 404:
+        # THE ORDINARY ANSWER, and a complete one. Nobody has derived this
+        # closure yet — which on the first pod of a release is the truth.
+        return None, "hub holds no document for this closure"
+    if resp.status_code != 200:
+        return None, f"hub answered {resp.status_code}: {resp.text[:200]}"
+
+    try:
+        document = decode(resp.text.encode("utf-8"))
+        closure = parse_closure(document, digest)
+    except KeySetError as exc:
+        # A hub answer that does not parse, or that carries a DIFFERENT closure
+        # than the address it was asked at, is refused and the pod derives.
+        # Refused rather than trusted: the address check is the whole admission
+        # (§4.29), and an answer that fails it is either a hub defect or
+        # something in between that rewrote the body — neither is a key set.
+        logger.warning(
+            "keyset: the hub's answer for closure %s did not admit (%s: %s)",
+            digest, exc.reason, exc.detail)
+        return None, f"hub answer refused ({exc.reason}: {exc.detail})"
+    except Exception as exc:  # noqa: BLE001 — see the docstring
+        logger.debug("keyset: hub answer unreadable", exc_info=True)
+        return None, f"hub answer unreadable ({type(exc).__name__}: {exc})"
+    return closure, ""
+
+
+def publish_closure(
+    digest: ClosureDigest, row: ClosureRow, tier: HubTier,
+) -> str:
+    """Offer one derived closure to the hub. Returns ``""`` on success.
+
+    BEST EFFORT AND NEVER FATAL, and the call site relies on that: it runs
+    after a derive that has already produced this boot's keys, so nothing here
+    can make this boot slower or less correct than it was. What it buys is the
+    NEXT pod's boot.
+
+    A 409 is not a failure worth escalating — it means another pod of this org
+    already stored a different document for this closure, the store is
+    write-once, and the incumbent stands. It is returned as a reason so it can
+    be recorded, because two pods running the same code against the same
+    subjects tracing different class hashes IS a finding; it is just not this
+    boot's problem, and the mint's own honesty gate is what adjudicates it.
+    """
+    if not tier.reachable:
+        return f"no hub to publish to: {tier.absent}"
+    from ..procsplit import broker
+
+    try:
+        body = single_closure_document(digest, row)
+    except KeySetError as exc:
+        # This pod's OWN document did not survive re-encoding. Not a hub
+        # problem, and worth a loud line: it means the deriver recorded a row
+        # this worker's own writer would refuse.
+        logger.warning(
+            "keyset: refusing to publish closure %s — %s: %s",
+            digest, exc.reason, exc.detail)
+        return f"document not encodable ({exc.reason}: {exc.detail})"
+
+    try:
+        resp = broker.request(
+            "PUT", keyset_path(digest),
+            base_url=tier.base_url, bearer=tier.bearer,
+            json=_json_of(body), timeout=KEYSET_TIMEOUT_S)
+    except Exception as exc:  # noqa: BLE001 — see the docstring
+        logger.debug("keyset: hub publish failed", exc_info=True)
+        return f"hub unreachable ({type(exc).__name__}: {exc})"
+
+    if resp.status_code in (200, 201):
+        logger.info(
+            "keyset: closure %s is now on the hub (%s) — the next pod of this "
+            "endpoint states its keys without tracing",
+            digest, "stored" if resp.status_code == 201 else "already stored")
+        return ""
+    if resp.status_code == 409:
+        return f"hub holds a different document for this closure: {resp.text[:200]}"
+    return f"hub refused the publish with {resp.status_code}: {resp.text[:200]}"
+
+
+def _json_of(body: bytes) -> Dict[str, Any]:
+    """The document, as the object ``broker.request`` serializes.
+
+    The broker's wire is ``json=``, so the bytes are re-serialized by
+    ``requests`` rather than sent verbatim. That is fine and is why the hub
+    computes its stored digest over WHAT IT RECEIVED rather than over anything
+    this side claims: the two are different byte strings for the same document,
+    and only one of them is the one anybody has to agree about.
+    """
+    import json as _json
+
+    parsed = _json.loads(body.decode("utf-8"))
+    if not isinstance(parsed, dict):  # pragma: no cover — encode() cannot do this
+        raise KeySetError("keyset_invalid", "a document must encode to an object")
+    return parsed

--- a/src/gen_worker/keyset/store.py
+++ b/src/gen_worker/keyset/store.py
@@ -13,7 +13,14 @@ Three kinds of location, and the difference is who derived the hashes:
   compile-once-run-forever promise for cozy-local reads the same document
   through the same closure digest).
 
-All three are the same document type. A key set is trusted because its closure
+A FOURTH location lives one module over, in :mod:`gen_worker.keyset.hub`: the
+platform's own store (pgw#1353 option (b) / th#2123), read after every root here
+misses and written after a derive. It is not in this module because it is not a
+FILESYSTEM location — it has no path, no ``mkdir``, and no atomic-rename story —
+but it is the same document read through the same closure address, and
+``closure_row`` below is how the row this module holds gets handed to it.
+
+All of them are the same document type. A key set is trusted because its closure
 digest matches what this pod's code would trace, never because of where it was
 found — so the locations need no separate grammar, no separate parser and no
 separate version ladder.
@@ -75,6 +82,7 @@ __all__ = [
     "KeySetHit",
     "assert_honest",
     "class_hashes",
+    "closure_row",
     "durable_root",
     "invalidate",
     "lookup",
@@ -261,6 +269,33 @@ def class_hashes(
                 break
             return closure.class_hashes
     return {}
+
+
+def closure_row(
+    cache_dir: Optional[Path], digest: ClosureDigest,
+) -> Optional[ClosureRow]:
+    """The RAW row a writable root holds for ``digest``, or ``None``.
+
+    The producer half of th#2123's hub tier reads through here. Deliberately the
+    raw :class:`ClosureRow` and not a :class:`ShippedClosure`: what travels to
+    the hub is the document a pod recorded, byte for byte, and re-deriving it
+    from a parsed view would mean this worker's writer and its reader could
+    disagree about a field neither of them reads.
+
+    Walks the SAME ``writable_roots`` ordering as everything else here, so the
+    row that gets published is the row a re-read would answer with — not one
+    from a root only this function knows about.
+    """
+    for root, _source in writable_roots(cache_dir):
+        for path in _candidate_files(root):
+            try:
+                document = read_document(path)
+            except KeySetError:
+                break
+            row = document.closures.get(str(digest))
+            if row is not None:
+                return row
+    return None
 
 
 def _publish(path: Path, document: KeySetDocument) -> None:

--- a/src/gen_worker/procsplit/actions.py
+++ b/src/gen_worker/procsplit/actions.py
@@ -163,6 +163,40 @@ ACTIONS: Dict[str, HubAction] = {
             body=("family", "keys"),
             timeout_s=30.0,
         ),
+        # th#2123 / pgw#1353 option (b): the compiled-graph KEY SET, pulled and
+        # pushed by its CLOSURE DIGEST. Two entries, and the path regex pins the
+        # address grammar — 32 lowercase hex, the same shape
+        # `keyset.identifiers.parse_closure_digest` admits and the same one the
+        # hub's own CHECK constraint enforces. A looser `[^/]+` would let a
+        # child put anything it liked in a path segment the parent signs for.
+        #
+        # WITHOUT THESE TWO ENTRIES THE TIER IS DEAD ON EVERY FLEET POD, and it
+        # is dead SILENTLY: the split's parent refuses any path not in this
+        # table, `keyset.hub` treats a refusal as a miss (correctly — it must
+        # never block a boot), and the pod derives for 805 s exactly as it did
+        # before while every unit test that patches `broker.request` stays
+        # green. That is pgw#1309's shape precisely, which is why
+        # `test_the_keyset_actions_are_allowlisted_pgw1353b` asserts the table
+        # rather than the client.
+        #
+        # GET carries no query and no body — the address is the whole request.
+        _a(
+            "keysets.fetch",
+            "GET",
+            r"^/v1/worker/keysets/[0-9a-f]{32}$",
+            timeout_s=10.0,
+        ),
+        # PUT carries the document, whose only top-level keys are the
+        # `cg-keyset-v1` envelope. Enumerated for the same reason the resolve
+        # body is: an action table that admitted one more key would let a child
+        # smuggle a field the hub's admission never agreed to read.
+        _a(
+            "keysets.publish",
+            "PUT",
+            r"^/v1/worker/keysets/[0-9a-f]{32}$",
+            body=("schema", "version", "closures"),
+            timeout_s=10.0,
+        ),
         _a(
             "compiled_graphs.publish_complete",
             "POST",

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -233,7 +233,16 @@ def _http_call(
         url,
         headers={"Authorization": f"Bearer {token}"},
         params=query or None,
-        json=body if method == "POST" else None,
+        # EVERY BODY-BEARING VERB, not just POST (pgw#1353b). This read
+        # `method == "POST"` while POST was the only verb in the table, so a
+        # PUT action went out with NO BODY AT ALL — and the failure is silent
+        # in the worst way: the hub receives an empty body, answers a typed
+        # refusal, and the child reads a well-formed "no" to a request it
+        # believes it sent. Which verbs may carry a body is `actions.py`'s
+        # decision (each entry enumerates its keys); this line only has to
+        # stop throwing away what that table already authorized. GET and
+        # DELETE keep sending none, which is what they declare.
+        json=body if method in ("POST", "PUT", "PATCH") else None,
         timeout=timeout,
     )
     return resp.status_code, resp.text

--- a/tests/test_boot_adopt_local_first_pgw1127.py
+++ b/tests/test_boot_adopt_local_first_pgw1127.py
@@ -299,20 +299,47 @@ def test_a_machine_holding_cells_DERIVES_even_with_no_hub_at_all(
 # ---------------------------------------------------------------------------
 
 
-def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
+def test_a_populated_store_and_an_unreachable_hub_never_ASKS_FOR_THE_CELL(
     store: Path, cas: Path, tmp_path: Path, declared: None, events: List[Any],
     no_wire: List[Any], monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """§4.28's *"never requested"*, enforced rather than described.
 
     A hub URL is CONFIGURED and points nowhere — the shape that matters, since
-    "no base_url" would make the old gate accidentally right. The boot derives,
-    its own store answers, and no connection is attempted by any layer.
+    "no base_url" would make the old gate accidentally right. The boot states
+    its key, its own store answers with the CELL, and **no cell is ever
+    requested over the wire.**
+
+    NARROWED 2026-08-17 (pgw#1353 option (b) / th#2123), deliberately, with the
+    argument written down rather than the assertion quietly relaxed.
+
+    This used to assert zero connections OF ANY KIND, at the socket. That was
+    the right fence for what §4.28 states — *"local cell, local repo-CAS… never
+    requested"* — and it stayed right until a second, different question
+    acquired a hub tier: **the KEY SET**. A pod cannot ask its own store
+    anything until it can state a key, and stating a key means either reading a
+    ``cg-keyset-v1`` document or running ~805 s of ``torch.export`` (measured on
+    four sdxl pods, pgw#1353). This test's pod holds NO such document — the
+    deriver is patched to a lambda, which hides that the real one would trace —
+    so the honest description of it is *"a pod about to spend 13 minutes"*, and
+    asking the hub once, with a 10 s bound and a fallthrough to the trace, is
+    strictly better for it.
+
+    §4.28 is about the ARTIFACT, and that property is unweakened and is now
+    asserted DIRECTLY rather than through a socket proxy: `resolve_batch` is
+    never called, and the only address dialled is the key-set route. A pod
+    genuinely told there is no hub (`base_url` unset) still dials nothing at
+    all — that is the test above, and it still fences at the socket.
     """
     local_cell_store.store(
         _cell(tmp_path), key=KEY_DERIVED, family="micro-diffusion",
         arm_token=ARM_A, cas_root=cas)
     monkeypatch.setattr(boot_key, "derive", lambda **kw: _derived())
+
+    asked: List[Any] = []
+    monkeypatch.setattr(
+        cell_resolve, "resolve_batch",
+        lambda family, keys, **kw: asked.append((family, list(keys))) or ())
 
     ex = _executor(tmp_path)
     ex.file_base_url = "http://127.0.0.1:9"   # discard port: nothing listens
@@ -320,9 +347,10 @@ def test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts(
 
     (out,) = ex._boot_adopt(_Spec(), {})
 
-    assert not no_wire, (
-        "the boot reached for the wire while holding the answer on disk: "
-        f"{no_wire}")
+    assert asked == [], (
+        f"the boot asked the hub for a CELL it was holding on disk: {asked}")
+    assert set(no_wire) <= {("127.0.0.1", 9)}, (
+        f"the boot dialled something other than the configured hub: {no_wire}")
     assert out.reason == boot_adopt.LOCAL_HIT
     assert out.local_key == KEY_DERIVED == out.derived_key
     row = _adopt_events(events)[-1]

--- a/tests/test_keyset_hub_tier_pgw1353b.py
+++ b/tests/test_keyset_hub_tier_pgw1353b.py
@@ -854,3 +854,147 @@ def test_the_emitter_reports_a_publish_that_did_not_land(
     status = emit.main(
         ["--from-cache", str(cache), "--out", str(tmp_path / "b"), "--publish"])
     assert status == 1, "a publish that did not land exited 0"
+
+
+# ---------------------------------------------------------------------------
+# THE SEAM — the layer every test above is structurally blind to.
+#
+# Under the process split (which is the real fleet configuration) the compute
+# child holds no credential and NEVER NAMES A FREE-FORM PATH: the parent
+# refuses any request that does not match `procsplit/actions.py` by method AND
+# full-path regex. Every test above patches `broker.request`, so all of them
+# stay green with the tier COMPLETELY DEAD on every fleet pod — the refusal
+# would arrive as a `BrokerError`, `keyset.hub` would correctly read it as a
+# miss, and the pod would derive for 805 s exactly as it does today.
+#
+# That is pgw#1309's shape precisely (its child-PID rows were merged and green
+# for a full cycle before a live pod emitted one), so it is asserted against the
+# TABLE rather than against this client.
+# ---------------------------------------------------------------------------
+
+
+def test_the_keyset_actions_are_allowlisted_pgw1353b() -> None:
+    from gen_worker.procsplit import actions
+
+    digest = _digest()
+    path = keyset_hub.keyset_path(digest)
+
+    fetch, query, body = actions.authorize({"method": "GET", "path": path})
+    assert fetch.name == "keysets.fetch"
+    assert query == {} and body is None
+
+    document = keyset_hub.single_closure_document(digest, _row(denoiser=HASH_A))
+    publish, _q, sent = actions.authorize({
+        "method": "PUT", "path": path, "json": json.loads(document.decode())})
+    assert publish.name == "keysets.publish"
+    assert sent is not None and set(sent) == {"schema", "version", "closures"}
+
+    # The timeouts the parent will hold its own control loop for must cover the
+    # client's own bound, or the seam gives up before the call it authorized.
+    assert fetch.timeout_s >= keyset_hub.KEYSET_TIMEOUT_S
+    assert publish.timeout_s >= keyset_hub.KEYSET_TIMEOUT_S
+
+
+def test_the_allowlisted_address_grammar_is_the_closure_digests_pgw1353b() -> None:
+    """The path regex pins the ADDRESS SHAPE, and it must be the same one
+    `parse_closure_digest` admits.
+
+    A looser `[^/]+` would let a process running tenant code put anything it
+    liked into a path segment the parent attaches the pod's credential to.
+    """
+    from gen_worker.procsplit import actions
+
+    for bad in (
+        "/v1/worker/keysets/" + "A" * 32,          # uppercase
+        "/v1/worker/keysets/" + "a" * 31,          # short
+        "/v1/worker/keysets/" + "a" * 33,          # long
+        "/v1/worker/keysets/../compiled-graphs",   # traversal
+        "/v1/worker/keysets/",                     # empty address
+        "/v1/worker/keysets/" + "a" * 32 + "/x",   # extra segment
+    ):
+        for method in ("GET", "PUT"):
+            with pytest.raises(actions.ActionRefused):
+                actions.authorize({"method": method, "path": bad, "json": {}})
+
+    # …and every address `parse_closure_digest` admits is one the seam allows,
+    # which is the direction that would strand the tier if it were wrong.
+    for good in ("0" * 32, "f" * 32, "a1b2c3d4e5f60718293a4b5c6d7e8f90"):
+        digest = keyset.parse_closure_digest(good)
+        action, _q, _b = actions.authorize(
+            {"method": "GET", "path": keyset_hub.keyset_path(digest)})
+        assert action.name == "keysets.fetch"
+
+
+def test_a_keyset_publish_is_not_a_PUBLISH_ACTION_pgw1353b() -> None:
+    """A key set is not a cell, and the probe disarm must not swallow it.
+
+    pgw#980 disarms `PUBLISH_ACTIONS` on a live-edit probe because a probe
+    writing a CELL into a shared family namespace poisons every pod that later
+    adopts from it. A key set carries no artifact and no signature — it is a
+    statement about a closure the writer can already compute — and its address
+    is a pure function of the code being run, so a probe's document lands at a
+    closure only that probe resolves. Including it here would disarm the tier on
+    exactly the pods a dev loop uses most.
+    """
+    from gen_worker.procsplit import actions
+
+    assert "keysets.publish" not in actions.PUBLISH_ACTIONS
+    assert "keysets.fetch" not in actions.PUBLISH_ACTIONS
+
+
+def test_the_parent_actually_SENDS_a_PUT_body_pgw1353b(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parent's half of the seam, at the one line that decides it.
+
+    `parent._http_call` is the ONLY place the worker JWT reaches the wire on a
+    child's behalf, and it used to attach the body ONLY on `method == "POST"` —
+    true while POST was the only verb in the action table, and silently fatal
+    the moment a PUT joined it. A key-set publish would have gone out with NO
+    BODY, the hub would have answered a typed `keyset_invalid`, and the child
+    would have read a well-formed "no" to a request it believed it sent. Nothing
+    above this test can see that: every other test in this file stops at
+    `broker.request`, which is the CHILD's side.
+
+    Asserted against the real function with `requests.request` captured, because
+    the defect is a keyword argument and only the call itself carries it.
+    """
+    from gen_worker.procsplit import parent as procsplit_parent
+
+    sent: List[Any] = []
+
+    class _Resp:
+        status_code = 201
+        text = '{"stored": true}'
+
+    import requests as _requests
+
+    def _capture(method: str, url: str, **kw: Any) -> Any:
+        sent.append((method, url, kw))
+        return _Resp()
+
+    monkeypatch.setattr(_requests, "request", _capture)
+
+    digest = _digest()
+    document = json.loads(
+        keyset_hub.single_closure_document(digest, _row(denoiser=HASH_A)).decode())
+    status, _text = procsplit_parent._http_call(
+        "PUT", "http://hub.local" + keyset_hub.keyset_path(digest),
+        "worker-jwt", {}, document, 10.0)
+
+    assert status == 201
+    assert len(sent) == 1
+    method, url, kwargs = sent[0]
+    assert method == "PUT" and url.endswith(str(digest))
+    assert kwargs["json"] == document, (
+        "the parent dropped the PUT body; the hub would receive an empty "
+        "document and the child would read a typed refusal to a request it "
+        "believes it sent")
+    assert kwargs["headers"]["Authorization"] == "Bearer worker-jwt"
+
+    # …and a GET still carries none, which is what its action declares.
+    sent.clear()
+    procsplit_parent._http_call(
+        "GET", "http://hub.local" + keyset_hub.keyset_path(digest),
+        "worker-jwt", {}, None, 10.0)
+    assert sent[0][2]["json"] is None

--- a/tests/test_keyset_hub_tier_pgw1353b.py
+++ b/tests/test_keyset_hub_tier_pgw1353b.py
@@ -1,0 +1,856 @@
+"""pgw#1353 option (b) / th#2123: the key set outlives the ENDPOINT, not just the pod.
+
+pgw#1353 row (a) put the document on th#1813's durable root and fixed every
+endpoint that HAS one. An **ephemeral private deployment** has none — no network
+volume, no baked document, a fresh container per pod — so it still paid the
+measured 778-833 s of ``torch.export`` once per pod, forever. This is the tier
+that fixes that one: the hub's own store, addressed by the same closure digest,
+``GET``/``PUT /v1/worker/keysets/<closure_digest>``.
+
+What is proved here:
+
+1. **THE HEADLINE — pod 1 traces and UPLOADS, pod 2 reads the hub and spawns
+   nothing.** Two ``boot_adopt.attempt`` calls with disjoint caches, NO durable
+   root at all (the ephemeral shape), one in-memory hub between them. Pod 2 runs
+   with an armed ``torch.export`` sentinel, an armed ``subprocess.Popen``
+   sentinel, and a deriver that fails the test if reached.
+2. **The evidence is queryable**: pod 2 reports ``keys_from=hub``, its own
+   ``KeySource`` member, so "which fix is reaching the fleet" stays a query.
+3. **What is uploaded is the MACHINE-INDEPENDENT document** — one closure, keyed
+   by its own address, with no folded ``cg-key-v1`` anywhere in the bytes.
+4. **Search order**: every local root beats the hub, and the hub is not even
+   asked when one answers.
+5. **RED — the tier is an optimization, never a gate.** A hub that 404s, 500s,
+   times out, or answers a DIFFERENT closure than the address it was asked at
+   all fall through to the deriver and BOOT.
+6. **RED — a failed upload never blocks a boot.** The pod that could not publish
+   still serves; only the next pod pays again.
+
+No tracer runs anywhere in this file. What is under test is the TIER, and a real
+``torch.export`` here would prove nothing this file claims.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple, cast
+
+import pytest
+
+from gen_worker import boot_adopt, cell_resolve, compile_cache as cc, keyset
+from gen_worker.child_contract import CompileSpec
+from gen_worker.keyset import document as doc_mod, hub as keyset_hub
+from gen_worker.keyset import store as keyset_store
+from gen_worker.procsplit import broker
+
+REPO = Path(__file__).resolve().parent.parent
+MICRO_SRC = REPO / "examples" / "micro-diffusion" / "src"
+
+FAMILY = "micro-diffusion"
+FUNCTION = "generate"
+MODULES: Tuple[str, ...] = ("micro_diffusion.main",)
+
+HASH_A = "a1b2c3d4e5f60718"
+HASH_B = "0f1e2d3c4b5a6978"
+HASH_C = "1234567890abcdef"
+INGRESS = "9" * 32
+
+
+@pytest.fixture(autouse=True)
+def _micro_on_path() -> Iterator[None]:
+    added = str(MICRO_SRC)
+    if added not in sys.path:
+        sys.path.insert(0, added)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _stable_sm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI has no card, and the fold needs an ``sm``."""
+    monkeypatch.setattr(
+        cc, "runtime_key", lambda: {"sm": "sm_89", "torch": "", "triton": ""})
+
+
+@pytest.fixture(autouse=True)
+def _ephemeral_pod(monkeypatch: pytest.MonkeyPatch) -> None:
+    """THE SHAPE UNDER TEST: no durable root, no shipped root.
+
+    This is not tidying — it is the fixture. An ephemeral private deployment
+    gets no ``GEN_WORKER_LOCAL_CELLS_DIR`` it can share and no baked document,
+    and a developer's own laptop may have both. Every test that let one leak in
+    would pass without the hub tier existing.
+    """
+    monkeypatch.delenv(keyset_store.ENV_LOCAL_CELLS_DIR, raising=False)
+    monkeypatch.delenv(keyset_store.ENV_KEYSET_PATH, raising=False)
+
+
+def _spec() -> CompileSpec:
+    return CompileSpec(
+        shapes=((64, 64),), targets=("transformer",), family=FAMILY,
+        lora_bucket=0, guidance_scales=(), text_lens=(8,))
+
+
+class _Cfg:
+    family = FAMILY
+    targets = ("transformer",)
+    shapes = ((64, 64),)
+    text_lens = (8,)
+    guidance_scales = ()
+    lora_bucket = 0
+
+
+def _digest() -> keyset.ClosureDigest:
+    return keyset.closure_of(
+        family=FAMILY, function=FUNCTION, modules=MODULES, cfg=_spec(), slots={})
+
+
+def _hashes(**classes: str) -> Dict[keyset.GraphClassName, keyset.ClassHash]:
+    return {
+        keyset.parse_graph_class_name(name): keyset.parse_class_hash(value)
+        for name, value in classes.items()
+    }
+
+
+def _row(**classes: str) -> doc_mod.ClosureRow:
+    return doc_mod.closure_row(
+        family=FAMILY,
+        function=FUNCTION,
+        tcg_version=keyset.tcg_version(),
+        classes={
+            name: doc_mod.GraphClassRow(
+                graph_class=name, class_hash=class_hash,
+                ingress_digest=INGRESS, target="transformer")
+            for name, class_hash in classes.items()
+        },
+        emitted_by="pgw#1353b fixture",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The hub, in memory: th#2123's two routes and its write-once rule, and nothing
+# else. Deliberately a REIMPLEMENTATION of the contract rather than a mock of
+# this client's calls — a mock that returned whatever the client asked for
+# would prove the client talks to itself.
+# ---------------------------------------------------------------------------
+
+
+class _Hub:
+    def __init__(self) -> None:
+        self.rows: Dict[str, bytes] = {}
+        self.gets: List[str] = []
+        self.puts: List[Tuple[str, bytes]] = []
+        self.get_status = 200
+        self.put_status = 0
+        self.raise_on: str = ""
+        self.answer_override: bytes = b""
+
+    def request(
+        self, method: str, path: str, *, base_url: str = "", bearer: str = "",
+        params: Any = None, json: Any = None, timeout: float = 30.0,
+    ) -> broker.HubResponse:
+        if self.raise_on and self.raise_on == method:
+            raise ConnectionError("hub is down")
+        assert path.startswith(keyset_hub.KEYSET_PATH_PREFIX), path
+        address = path[len(keyset_hub.KEYSET_PATH_PREFIX):]
+        if method == "GET":
+            self.gets.append(address)
+            if self.answer_override:
+                return broker.HubResponse(
+                    status_code=200, text=self.answer_override.decode())
+            if self.get_status != 200:
+                return broker.HubResponse(
+                    status_code=self.get_status, text='{"error":"forced"}')
+            stored = self.rows.get(address)
+            if stored is None:
+                return broker.HubResponse(
+                    status_code=404, text='{"found": false}')
+            return broker.HubResponse(status_code=200, text=stored.decode())
+        if method == "PUT":
+            body = _dumps(json)
+            self.puts.append((address, body))
+            if self.put_status:
+                return broker.HubResponse(
+                    status_code=self.put_status, text='{"error":"forced"}')
+            # th#2123's admission, in the two clauses that matter here: the
+            # document must NAME the address, and the store is write-once.
+            parsed = keyset.decode(body)
+            if list(parsed.closures) != [address]:
+                return broker.HubResponse(
+                    status_code=400,
+                    text='{"error":{"code":"keyset_address_mismatch"}}')
+            if address in self.rows:
+                return broker.HubResponse(
+                    status_code=200 if self.rows[address] == body else 409,
+                    text='{"stored": false}')
+            self.rows[address] = body
+            return broker.HubResponse(status_code=201, text='{"stored": true}')
+        raise AssertionError(f"the key-set tier used {method}, which th#2123 does not serve")
+
+
+def _dumps(payload: Any) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+@pytest.fixture
+def hub(monkeypatch: pytest.MonkeyPatch) -> _Hub:
+    fake = _Hub()
+    monkeypatch.setattr(broker, "request", fake.request)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Sentinels: the whole claim is "pod 2 does no work", so the absence of work is
+# what is armed, not the presence of an answer.
+# ---------------------------------------------------------------------------
+
+
+class _ExportSentinel:
+    def __init__(self) -> None:
+        self.touched = False
+
+    def __getattr__(self, name: str) -> Any:
+        self.touched = True
+        raise AssertionError(
+            f"pgw#1353b: the boot path reached torch.export.{name} — a hub key "
+            f"set costs one round trip, not a trace")
+
+
+class _RefusingDeriver:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **kwargs: Any) -> keyset.DerivedKeySet:
+        self.calls += 1
+        raise AssertionError(
+            "pgw#1353b: this pod re-derived even though the hub holds the "
+            "document — this is the 805 s the issue exists to delete")
+
+
+class _TracingDeriver:
+    """The mint-lane fallback, recording through the REAL store writer.
+
+    A spy, not a tracer. It does exactly what ``boot_key.derive`` does at the
+    step that matters here: write the machine-INDEPENDENT row into the writable
+    roots, which is where the publisher reads it back from.
+    """
+
+    def __init__(self, **classes: str) -> None:
+        self.calls = 0
+        self.classes = classes
+
+    def __call__(self, **kwargs: Any) -> keyset.DerivedKeySet:
+        self.calls += 1
+        digest = keyset.closure_of(
+            family=kwargs["family"], function=kwargs["function"],
+            modules=kwargs["modules"], cfg=kwargs["cfg"], slots=kwargs["slots"])
+        keyset_store.write_closure(
+            kwargs.get("memo_dir"), digest, _row(**self.classes))
+        return keyset.DerivedKeySet(
+            entry_keys=keyset.fold_entry_keys(
+                _hashes(**self.classes), family=kwargs["family"]),
+            source=keyset.KeySource.TRACED,
+            closure=digest,
+            wall_ms=804_700,
+        )
+
+
+class _Cell:
+    publisher_org = "org-a"
+    publisher_tier = "platform"
+    content_digest = "sha256:" + "ab" * 32
+
+    def __init__(self, key: str) -> None:
+        self.cell_ref = f"root/family-{FAMILY}#{key}"
+
+
+def _resolve_stub(family: str, keys: Any, **_kw: Any) -> Any:
+    return tuple(
+        cell_resolve.ResolveAnswer(
+            compiled_graph_key=str(key), status="hit",
+            cell=cast(Any, _Cell(str(key))))
+        for key in keys)
+
+
+def _boot(
+    tmp_path: Path, pod: str, deriver: Any, monkeypatch: pytest.MonkeyPatch,
+    *, hub_absent: str = "",
+) -> Tuple[boot_adopt.BootAdoptOutcome, ...]:
+    """One pod's boot-adopt, through the REAL ``boot_adopt.attempt``.
+
+    Each pod gets its OWN cache dir and no shared root of any kind — the honest
+    model of an ephemeral private deployment, where the hub is the only thing
+    two pods have in common.
+    """
+    cache = tmp_path / pod / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cell_resolve, "resolve_batch", _resolve_stub)
+    monkeypatch.setattr(
+        cell_resolve, "materialize", lambda cell, **_kw: tmp_path / "artifact.pt2")
+    return boot_adopt.attempt(
+        function=FUNCTION, modules=MODULES, cfg=_Cfg(), slots={},
+        declared_hint=2, work_root=tmp_path / pod / "work",
+        cache_dir=cache, memo_dir=cache,
+        base_url="http://hub.local", bearer="jwt", hub_absent=hub_absent,
+        derive=deriver)
+
+
+# ---------------------------------------------------------------------------
+# 1-3. THE HEADLINE, and what actually crosses the wire
+# ---------------------------------------------------------------------------
+
+
+def test_pod_two_reads_the_hub_and_traces_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """The acceptance row for an EPHEMERAL deployment: no volume, two pods.
+
+    Red-provable four ways: delete the hub read from ``key_set_from_data`` and
+    pod 2 hits ``_RefusingDeriver``; delete the publish from ``_key_set`` and
+    the hub holds nothing for pod 2 to read; report the hit as ``MEMO`` and the
+    ``keys_from`` assertion fails; publish the FOLDED keys and the
+    machine-independence assertion below fails.
+    """
+    assert keyset_store.durable_root() is None, (
+        "this fixture must be the ephemeral shape — with a durable root placed, "
+        "row (a) would carry the document and this test would prove nothing")
+
+    tracing = _TracingDeriver(denoiser=HASH_A, vae=HASH_B)
+    first = _boot(tmp_path, "pod1", tracing, monkeypatch)
+
+    assert tracing.calls == 1, "pod 1 is the pod that pays; it must have traced"
+    assert {o.key_source for o in first} == {keyset.KeySource.TRACED}
+    assert list(hub.rows) == [str(_digest())], (
+        "pod 1 traced for 805 s and did not hand the answer to the hub; every "
+        "pod of this endpoint will pay it again")
+
+    # ── the pod is destroyed. Nothing survives it but the hub ──────────────
+    sentinel = _ExportSentinel()
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        monkeypatch.setattr(torch, "export", sentinel, raising=False)
+    monkeypatch.setitem(sys.modules, "torch.export", sentinel)
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "Popen", _no_children)
+
+    refusing = _RefusingDeriver()
+    second = _boot(tmp_path, "pod2", refusing, monkeypatch)
+
+    assert refusing.calls == 0, "pod 2 re-derived; the hub tier did not answer"
+    assert not sentinel.touched
+    assert {o.key_source for o in second} == {keyset.KeySource.HUB}, (
+        "pod 2 must report keys_from=hub — a distinct KeySource is what makes "
+        "'how many pods still pay the 805 s' a query instead of a story")
+    assert hub.gets == [str(_digest())] * 2, (
+        f"the hub was asked at {hub.gets}; the address is the closure digest "
+        f"and nothing else")
+
+    # The two pods derived the SAME keys, which is the property the whole tier
+    # rests on: the document is machine-independent and the fold is local.
+    assert {o.derived_key for o in first} == {o.derived_key for o in second}
+
+
+def _no_children(*args: Any, **kwargs: Any) -> Any:
+    raise AssertionError(
+        f"pgw#1353b: the boot path spawned a process ({args[:1]!r}) — a pod "
+        f"reading the hub spawns none")
+
+
+def test_what_is_published_is_machine_independent_and_names_its_address(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """The bytes on the wire, inspected.
+
+    Three properties, and the middle one is the one that would be silently
+    wrong: ONE closure (the address is per-closure and the hub refuses more),
+    keyed by the address it is PUT at, and carrying NO folded ``cg-key-v1``
+    value — those fold this pod's ``sm`` and toolchain in, and a document
+    carrying them would be a wrong answer for every pod on another SKU.
+    """
+    tracing = _TracingDeriver(denoiser=HASH_A, vae=HASH_B)
+    outcomes = _boot(tmp_path, "pod1", tracing, monkeypatch)
+
+    assert len(hub.puts) == 1, f"expected exactly one PUT, got {hub.puts}"
+    address, body = hub.puts[0]
+    assert address == str(_digest())
+
+    document = keyset.decode(body)
+    assert list(document.closures) == [address], (
+        "the document must name exactly the address it was PUT at; that check "
+        "IS the hub's admission, and a body naming anything else is refused")
+    closure = keyset.parse_closure(document, _digest())
+    assert {str(c.graph_class) for c in closure.classes} == {"denoiser", "vae"}
+    assert {str(c.class_hash) for c in closure.classes} == {HASH_A, HASH_B}
+
+    folded = {str(key) for key in
+              (o.derived_key for o in outcomes) if key}
+    assert folded, "the fixture produced no folded keys, so this check is vacuous"
+    text = body.decode()
+    for key in folded:
+        assert key not in text, (
+            f"the published document carries the folded key {key}; the graph "
+            f"axis is machine-independent and the sm/toolchain axes must be "
+            f"restated by every reader")
+    assert "cg-key-v1" not in text
+
+
+# ---------------------------------------------------------------------------
+# 4. SEARCH ORDER — every local root beats the hub, and the hub is not asked
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_document_wins_and_the_hub_is_not_asked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """shipped -> durable -> cache -> hub, and the ordering is observable.
+
+    Not just "the right answer wins" — the hub must not even be ASKED, because
+    a round trip in front of an answer this machine is already holding is pure
+    added boot latency on the path this issue exists to shorten.
+    """
+    digest = _digest()
+    for name, place in (
+        ("shipped", lambda root: monkeypatch.setenv(
+            keyset_store.ENV_KEYSET_PATH, str(root))),
+        ("durable", lambda root: monkeypatch.setenv(
+            keyset_store.ENV_LOCAL_CELLS_DIR, str(root.parent))),
+    ):
+        monkeypatch.delenv(keyset_store.ENV_KEYSET_PATH, raising=False)
+        monkeypatch.delenv(keyset_store.ENV_LOCAL_CELLS_DIR, raising=False)
+        hub.gets.clear()
+        hub.rows[str(digest)] = keyset.encode(keyset.KeySetDocument(
+            schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
+            closures={str(digest): _row(denoiser=HASH_C)}))
+
+        root = tmp_path / name / keyset_store.DURABLE_KEYSET_DIRNAME
+        root.mkdir(parents=True, exist_ok=True)
+        (root / keyset.KEYSET_FILENAME).write_bytes(
+            keyset.encode(keyset.KeySetDocument(
+                schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
+                closures={str(digest): _row(denoiser=HASH_A, vae=HASH_B)})))
+        place(root)
+
+        outcomes = _boot(tmp_path, f"pod-{name}", _RefusingDeriver(), monkeypatch)
+        assert {o.key_source for o in outcomes} == {
+            keyset.KeySource.SHIPPED if name == "shipped" else keyset.KeySource.DURABLE
+        }, f"the {name} root did not win"
+        assert hub.gets == [], (
+            f"the {name} root answered and the hub was asked anyway ({hub.gets}); "
+            f"that is a network round trip in front of a local answer")
+        assert len(outcomes) == 2, (
+            "the local document declares two classes and the hub's declares "
+            "one, so an answer of length 1 means the hub won after all")
+
+
+# ---------------------------------------------------------------------------
+# 5. RED — the tier is an OPTIMIZATION and every failure falls through to boot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "arrange,why",
+    [
+        (lambda h: None,
+         "the hub simply holds nothing — the first pod of a release"),
+        (lambda h: setattr(h, "get_status", 503),
+         "the hub is down or rebuilding"),
+        (lambda h: setattr(h, "get_status", 401),
+         "this pod's credential was refused"),
+        (lambda h: setattr(h, "raise_on", "GET"),
+         "the connection failed outright"),
+        (lambda h: setattr(h, "answer_override", b"{not json"),
+         "something in between rewrote the body"),
+        (lambda h: setattr(h, "answer_override", json.dumps({
+            "schema": keyset.KEYSET_SCHEMA, "version": 99, "closures": {}}
+        ).encode()),
+         "the hub answered a version this worker does not read"),
+    ],
+    ids=["miss", "503", "401", "connection-error", "garbage", "unknown-version"],
+)
+def test_a_hub_that_cannot_answer_never_blocks_a_boot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+    arrange: Any, why: str,
+) -> None:
+    """Every failure mode of a network peer degrades to the derive.
+
+    The asymmetry against a LOCAL document is deliberate and is asserted
+    separately below: a malformed document in the image is a mint-lane defect
+    that must be visible, while a hub is a peer that can be down — and a pod
+    that refuses to boot because a cache was unreachable is strictly worse than
+    the 805 s it was avoiding.
+    """
+    arrange(hub)
+    tracing = _TracingDeriver(denoiser=HASH_A)
+    outcomes = _boot(tmp_path, "pod", tracing, monkeypatch)
+
+    assert tracing.calls == 1, f"the pod did not fall through to the deriver ({why})"
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.TRACED}
+    assert all(o.reason in ("local_miss_no_hub", "adopted", "local_hit", "miss")
+               or not o.reason.startswith("keyset_")
+               for o in outcomes), (
+        f"a hub fault surfaced as a KEY SET refusal ({why}); it must be a miss")
+
+
+def test_an_answer_at_the_wrong_address_is_refused_not_trusted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """ADMISSION (§4.29): the answer must NAME the address it was asked at.
+
+    A hub answering a document for some OTHER closure is either a hub defect or
+    something in between; either way the pod must derive rather than fold a
+    stranger's class hashes into its own keys. This is the check that makes it
+    safe for an untrusted pod to have written the row in the first place.
+    """
+    other = "f" * 32
+    hub.answer_override = keyset.encode(keyset.KeySetDocument(
+        schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
+        closures={other: _row(denoiser=HASH_C)}))
+
+    tracing = _TracingDeriver(denoiser=HASH_A)
+    outcomes = _boot(tmp_path, "pod", tracing, monkeypatch)
+
+    assert tracing.calls == 1, (
+        "the pod accepted a document addressed at a different closure")
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.TRACED}
+    assert {str(k) for k in _hashes(denoiser=HASH_C).values()} == {HASH_C}
+    for outcome in outcomes:
+        assert HASH_C not in str(outcome.derived_key or ""), (
+            "the stranger's class hash reached this pod's key")
+
+
+def test_a_local_document_that_is_corrupt_still_refuses_loudly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """THE OTHER HALF of the asymmetry, and the reason it is not laziness.
+
+    pgw#1327's rule is unchanged by this tier: a malformed document on a LOCAL
+    root is ``keyset_invalid`` and propagates, because it is a mint-lane or
+    image defect that must be visible as itself. Only the HUB degrades.
+    """
+    root = tmp_path / "shipped"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / keyset.KEYSET_FILENAME).write_bytes(b"{ not a document")
+    monkeypatch.setenv(keyset_store.ENV_KEYSET_PATH, str(root))
+
+    tracing = _TracingDeriver(denoiser=HASH_A)
+    outcomes = _boot(tmp_path, "pod", tracing, monkeypatch)
+
+    assert tracing.calls == 0, (
+        "a corrupt LOCAL document degraded to a derive; it must refuse, or "
+        "every pod in the release silently re-traces forever beside a broken "
+        "artifact")
+    assert [o.reason for o in outcomes] == ["keyset_invalid"]
+    assert hub.gets == [], "the hub was asked past a corrupt local document"
+
+
+# ---------------------------------------------------------------------------
+# 6. RED — the UPLOAD never blocks a boot either
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "arrange,why",
+    [
+        (lambda h: setattr(h, "put_status", 503), "the hub is down"),
+        (lambda h: setattr(h, "put_status", 409), "another pod stored a different document"),
+        (lambda h: setattr(h, "put_status", 403), "this pod may not write"),
+        (lambda h: setattr(h, "raise_on", "PUT"), "the connection failed outright"),
+    ],
+    ids=["503", "409", "403", "connection-error"],
+)
+def test_a_failed_upload_never_blocks_the_boot_that_paid_for_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+    arrange: Any, why: str,
+) -> None:
+    """The pod that traced still serves. Only the NEXT pod pays again.
+
+    The publish runs strictly after the keys this boot needs already exist, so
+    nothing it can do is allowed to reach the boot's outcome.
+    """
+    arrange(hub)
+    tracing = _TracingDeriver(denoiser=HASH_A, vae=HASH_B)
+    outcomes = _boot(tmp_path, "pod", tracing, monkeypatch)
+
+    assert tracing.calls == 1
+    assert len(outcomes) == 2, f"the boot lost its outcomes when the upload failed ({why})"
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.TRACED}
+    assert all(o.derived_key for o in outcomes), (
+        f"the boot produced no keys after a failed upload ({why})")
+
+
+def test_nothing_is_published_when_the_keys_came_from_a_document(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """A pod that READ its keys has learned nothing new to publish.
+
+    Re-uploading would be a write-once conflict at best and a wasted round trip
+    at worst — and it is exactly the shape that would make every pod of a busy
+    endpoint PUT on every boot.
+
+    TWO ARMS, and the second is the one with teeth. On a HUB hit the pod's own
+    writable roots hold nothing, so a missing source guard would be masked by
+    the read-back finding no row. On a DURABLE hit the row IS on a writable
+    root — every pod of a volume-backed endpoint would re-PUT what it just
+    read — so this arm is what makes the guard load-bearing rather than
+    decorative.
+    """
+    digest = _digest()
+    hub.rows[str(digest)] = keyset.encode(keyset.KeySetDocument(
+        schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
+        closures={str(digest): _row(denoiser=HASH_A)}))
+
+    outcomes = _boot(tmp_path, "pod", _RefusingDeriver(), monkeypatch)
+
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.HUB}
+    assert hub.puts == [], f"a hub-reading pod wrote back: {hub.puts}"
+
+    # ── the durable arm ──────────────────────────────────────────────────
+    volume = tmp_path / "volume"
+    monkeypatch.setenv(keyset_store.ENV_LOCAL_CELLS_DIR, str(volume))
+    subtree = volume / keyset_store.DURABLE_KEYSET_DIRNAME
+    subtree.mkdir(parents=True, exist_ok=True)
+    (subtree / keyset.KEYSET_FILENAME).write_bytes(
+        keyset.encode(keyset.KeySetDocument(
+            schema=keyset.KEYSET_SCHEMA, version=keyset.KEYSET_VERSION,
+            closures={str(digest): _row(denoiser=HASH_A)})))
+    hub.gets.clear()
+
+    durable = _boot(tmp_path, "pod-vol", _RefusingDeriver(), monkeypatch)
+    assert {o.key_source for o in durable} == {keyset.KeySource.DURABLE}
+    assert hub.puts == [], (
+        f"a pod that READ its key set off the endpoint volume PUT it back "
+        f"({hub.puts}); every pod of that endpoint would do this on every boot")
+
+
+def test_a_producer_read_back_that_explodes_never_blocks_the_boot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """The publisher's OUTER guard, made load-bearing rather than defensive.
+
+    ``closure_row`` reads a file off a volume this pod does not own. A mount
+    that has gone away mid-boot, a permissions change, a truncated read — none
+    of them are this boot's problem, because this boot already has its keys.
+    """
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("the volume went away mid-boot")
+
+    monkeypatch.setattr(keyset_store, "closure_row", _explode)
+    tracing = _TracingDeriver(denoiser=HASH_A, vae=HASH_B)
+    outcomes = _boot(tmp_path, "pod", tracing, monkeypatch)
+
+    assert tracing.calls == 1
+    assert len(outcomes) == 2 and all(o.derived_key for o in outcomes), (
+        "a read-back failure in the PRODUCER reached the boot's outcome")
+    assert hub.puts == []
+
+
+def test_a_derivers_own_memo_hit_is_published_too(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """The publish has NO source guard, and this is why.
+
+    ``boot_key.derive`` answers ``MEMO`` when its own cache already holds the
+    closure — a cozy-local machine on its second boot, a pod whose container
+    restarted. Every read tier has already missed to reach the deriver at all,
+    INCLUDING the hub, so a memo-sourced document is exactly as worth
+    publishing as a freshly traced one: this machine holds it and the platform
+    does not. A "publish only TRACED" guard reads plausible and would strand
+    every one of those.
+    """
+    class _MemoDeriver:
+        def __call__(self, **kwargs: Any) -> keyset.DerivedKeySet:
+            digest = keyset.closure_of(
+                family=kwargs["family"], function=kwargs["function"],
+                modules=kwargs["modules"], cfg=kwargs["cfg"], slots=kwargs["slots"])
+            keyset_store.write_closure(
+                kwargs.get("memo_dir"), digest, _row(denoiser=HASH_A))
+            return keyset.DerivedKeySet(
+                entry_keys=keyset.fold_entry_keys(
+                    _hashes(denoiser=HASH_A), family=kwargs["family"]),
+                source=keyset.KeySource.MEMO, closure=digest, wall_ms=3)
+
+    outcomes = _boot(tmp_path, "pod", _MemoDeriver(), monkeypatch)
+
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.MEMO}
+    assert [a for a, _ in hub.puts] == [str(_digest())], (
+        "a machine holding a document the hub does not have kept it to itself")
+
+
+def test_publish_closure_returns_a_reason_and_never_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The producer's OWN contract, asserted where it lives.
+
+    ``boot_adopt`` wraps this call too, so a raise here is survivable — which
+    is exactly why it must also be asserted HERE: a guard covered only by a
+    second guard is a guard nobody can prove works, and the day the outer one
+    is narrowed the boot path acquires a raise nobody added.
+    """
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise ConnectionError("hub is down")
+
+    monkeypatch.setattr(broker, "request", _explode)
+    tier = keyset_hub.HubTier(base_url="http://hub.local", bearer="jwt")
+    reason = keyset_hub.publish_closure(_digest(), _row(denoiser=HASH_A), tier)
+    assert reason and "ConnectionError" in reason
+
+    # …and the READ half has the same contract, for the same reason.
+    closure, why = keyset_hub.fetch_closure(_digest(), tier)
+    assert closure is None and "ConnectionError" in why
+
+
+def test_a_pod_with_no_hub_asks_none_and_still_boots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """``hub_absent`` is the CALLER's sentence for "there is nobody to ask".
+
+    cozy-local and an embedded worker are the real cases. The tier must make no
+    call at all — not a call that fails — and the boot must be exactly what it
+    was before this tier existed.
+    """
+    tracing = _TracingDeriver(denoiser=HASH_A)
+    outcomes = _boot(
+        tmp_path, "pod", tracing, monkeypatch,
+        hub_absent="cozy-local runs with no hub")
+
+    assert hub.gets == [] and hub.puts == [], (
+        "a pod told there is no hub dialled one anyway")
+    assert tracing.calls == 1
+    assert {o.key_source for o in outcomes} == {keyset.KeySource.TRACED}
+
+
+# ---------------------------------------------------------------------------
+# The tier's own units — the pieces the boot test exercises only indirectly
+# ---------------------------------------------------------------------------
+
+
+def test_the_address_is_a_validated_type_at_the_wire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``keyset_path`` takes a ``ClosureDigest``, and that is not decoration.
+
+    The path segment is the one place the hub reads as an address. A folded key
+    or a class hash landing there would be stored at an address no pod ever
+    looks up — a silent miss, forever, for the whole endpoint.
+    """
+    digest = keyset.parse_closure_digest("a" * 32)
+    assert keyset_hub.keyset_path(digest) == "/v1/worker/keysets/" + "a" * 32
+    for bad in ("", "A" * 32, "a" * 31, "cg-key-v1-" + "a" * 56):
+        with pytest.raises(keyset.KeySetError) as caught:
+            keyset.parse_closure_digest(bad)
+        assert caught.value.reason == "keyset_invalid"
+
+
+def test_the_published_body_is_one_closure_keyed_by_its_address() -> None:
+    digest = keyset.parse_closure_digest("b" * 32)
+    body = keyset_hub.single_closure_document(digest, _row(denoiser=HASH_A))
+    assert list(keyset.decode(body).closures) == [str(digest)]
+
+
+def test_closure_row_reads_back_what_the_deriver_wrote(tmp_path: Path) -> None:
+    """The producer's own read-back, which is where the published bytes come
+    from. Reading the RAW row rather than a parsed view is what keeps the
+    writer and the reader from disagreeing about a field neither of them
+    reads."""
+    digest = _digest()
+    assert keyset_store.closure_row(tmp_path, digest) is None
+    keyset_store.write_closure(tmp_path, digest, _row(denoiser=HASH_A))
+    row = keyset_store.closure_row(tmp_path, digest)
+    assert row is not None and set(row.classes) == {"denoiser"}
+    assert keyset_store.closure_row(tmp_path, keyset.parse_closure_digest("c" * 32)) is None
+
+
+# ---------------------------------------------------------------------------
+# THE MINT LANE'S EMITTER — the producer that makes "a serving pod never
+# derives" true, rather than "a serving pod derives once per closure".
+# ---------------------------------------------------------------------------
+
+
+def _emitter() -> Any:
+    """`scripts/emit_cg_keyset.py`, imported as a module.
+
+    Loaded by path rather than added to `sys.path` permanently: it is an
+    operator script, not an importable part of the package, and a test that
+    made it importable would be testing a shape the mint lane does not have.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "emit_cg_keyset_under_test", REPO / "scripts" / "emit_cg_keyset.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_emitter_publishes_every_staged_closure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """`--publish` sends the STAGED document, closure by closure.
+
+    This is the row that makes a serving pod never derive at all: the mint lane
+    pays the traces once and fills the store, instead of the first pod of every
+    release paying them.
+    """
+    emit = _emitter()
+    digest = _digest()
+    cache = tmp_path / "podcache"
+    keyset_store.write_closure(cache, digest, _row(denoiser=HASH_A, vae=HASH_B))
+    out = tmp_path / "build"
+
+    monkeypatch.setenv(emit.ENV_HUB_URL, "http://hub.local")
+    monkeypatch.setenv(emit.ENV_HUB_TOKEN, "jwt")
+    status = emit.main(
+        ["--from-cache", str(cache), "--out", str(out), "--publish"])
+
+    assert status == 0
+    assert [a for a, _ in hub.puts] == [str(digest)]
+    stored = keyset.decode(hub.rows[str(digest)])
+    assert list(stored.closures) == [str(digest)]
+    assert set(stored.closures[str(digest)].classes) == {"denoiser", "vae"}
+
+
+def test_the_emitter_refuses_a_publish_it_cannot_perform(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """A `--publish` with no credential REFUSES BY NAME.
+
+    Never a silent skip. A publish flag that quietly did nothing is the exact
+    failure this issue is about — a fleet paying 805 s per pod while a green
+    log line says the document was emitted — and it would be invisible in a
+    build log that scrolls.
+    """
+    emit = _emitter()
+    cache = tmp_path / "podcache"
+    keyset_store.write_closure(cache, _digest(), _row(denoiser=HASH_A))
+    monkeypatch.delenv(emit.ENV_HUB_URL, raising=False)
+    monkeypatch.delenv(emit.ENV_HUB_TOKEN, raising=False)
+
+    with pytest.raises(SystemExit) as caught:
+        emit.main(["--from-cache", str(cache), "--out",
+                   str(tmp_path / "build"), "--publish"])
+    assert emit.ENV_HUB_TOKEN in str(caught.value)
+    assert hub.puts == []
+
+
+def test_the_emitter_reports_a_publish_that_did_not_land(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub: _Hub,
+) -> None:
+    """A refused PUT is a NON-ZERO exit, so a build step can see it.
+
+    A write-once conflict is the interesting case: it means two runs of the
+    same code against the same subjects traced different class hashes, which is
+    a finding rather than a retry.
+    """
+    emit = _emitter()
+    hub.put_status = 409
+    cache = tmp_path / "podcache"
+    keyset_store.write_closure(cache, _digest(), _row(denoiser=HASH_A))
+    monkeypatch.setenv(emit.ENV_HUB_URL, "http://hub.local")
+    monkeypatch.setenv(emit.ENV_HUB_TOKEN, "jwt")
+
+    status = emit.main(
+        ["--from-cache", str(cache), "--out", str(tmp_path / "b"), "--publish"])
+    assert status == 1, "a publish that did not land exited 0"


### PR DESCRIPTION
The worker half of **pgw#1353 option (b)**. Hub half: tensorhub th#2123, PR cozy-creator/tensorhub#1406, **merged `e18940df`**.

## What was still broken after row (a)

Row (a) (PR #915) put the `cg-keyset-v1` document on th#1813's durable root and fixed every endpoint that **has** one. An **ephemeral private deployment** has none — no network volume, no baked document, a fresh container per pod — so it still paid the measured **778-833 s** of `torch.export` once per pod, forever. That is 94 % of `worker_queue_ms` on a cold sdxl serve, on four independent pods.

## The tier

```
shipped → durable → this pod's cache → THE HUB → derive
```

`src/gen_worker/keyset/hub.py` — `GET`/`PUT /v1/worker/keysets/<closure_digest>` through the existing parent-mediated broker, with `HubTier` carrying *who to ask* as one value instead of two strings threaded through five call sites. A hub hit reports `KeySource.HUB` → **`keys_from=hub`** on the `boot_adopt` event: its own member, for the same reason `DURABLE` is one. The four tiers answer four different operational questions — *baked* / *this endpoint has durable storage* / *the platform holds it for an endpoint that has neither* / *somebody paid 805 s* — and collapsing any pair makes "which fix is reaching the fleet" unanswerable off the boot events.

**Admission is the address check** (§4.29, as amended by Paul's keys-shipped-as-data ruling). The answer must NAME the closure it was asked at, or it is refused and the pod derives. That is what makes it safe for an untrusted pod to have written the row: a writer can only make a statement about a closure it could already derive itself, and a lie costs a resolve MISS plus a re-mint — never a wrong graph.

**Asked last among the readers, before the deriver.** A local document is already on this machine, so a round trip in front of it is pure added boot latency; and a 10 s bound against 805 s of tracing needs no argument.

## The producer

On a derive, the document is offered to the hub — **best effort, never blocking**. It runs strictly after the keys this boot needs already exist, so no failure of it can slow, block or change this boot. A pod that traced for 805 s and could not upload has still booted, and the reason is logged.

The row is **read back from the writable root the deriver just wrote**, not rebuilt from `DerivedKeySet`: that type carries *folded* keys with this pod's `sm` and toolchain baked in, and a document built from those would be a machine-dependent answer stored at a machine-independent address — wrong for every pod on another SKU.

There is deliberately **no "publish only TRACED" guard**. This runs on the derive branch, where every read tier *including the hub* has already missed, so a `boot_key.derive` memo hit is exactly as worth publishing as a fresh trace. That guard reads plausible and would strand every cozy-local memo hit; it is mutation-tested as an **added** guard for exactly that reason.

`scripts/emit_cg_keyset.py --publish` fills the store from the **mint lane**, which is what makes *"a serving pod never derives"* true rather than *"a serving pod derives once per closure"*. Refused BY NAME without `--hub`/`$COZY_HUB_URL` and `$COZY_WORKER_TOKEN`; a publish that did not land exits non-zero.

## The asymmetry, stated because it is a design choice

A malformed document on a **local** root is still `keyset_invalid` and still propagates — a mint-lane or image defect that must be visible as itself. A **hub** answer that does not parse, or names another closure, is a MISS with a recorded reason. The hub is a network peer on the boot path; a pod that refuses to boot because a cache was unreachable is strictly worse than the cost it was avoiding.

## ⚠️ One other lane's fence is narrowed

`test_a_populated_store_and_an_unreachable_hub_makes_zero_http_attempts` (pgw#1127) fenced §4.28's *"never requested"* **at the socket**. §4.28 is about the **artifact**, and that property is **unweakened** — it is now asserted DIRECTLY (`resolve_batch` is never called) instead of through a socket proxy, plus the only address dialled must be the key-set route.

The argument, written into the test rather than left in a commit message: that pod holds no key-set document (its deriver is a patched lambda, which hides that the real one would trace), so the honest description of it is *"a pod about to spend 13 minutes"*, and one 10 s bounded ask with a fallthrough is strictly better for it. **A pod genuinely told there is no hub still dials nothing at all** — that is the test above it, and it still fences at the socket.

## Proof

`tests/test_keyset_hub_tier_pgw1353b.py`: two `boot_adopt.attempt` calls with disjoint caches, **no durable root** (the ephemeral shape), one in-memory hub between them that **reimplements th#2123's contract** rather than mocking this client's calls — a mock that returned whatever the client asked for would prove the client talks to itself. Pod 2 boots with an armed `torch.export` sentinel, an armed `subprocess.Popen` sentinel, and a deriver that fails the test if reached.

**Mutation audit — 11 severed or added guards, `red 5/5` each:**

| mutation | verdict |
|---|---|
| the hub read deleted from `key_set_from_data` | **red 5/5** |
| the publish deleted from `_key_set` | **red 5/5** |
| a hub hit reports `keys_from=memo` | **red 5/5** |
| a plausible "publish only TRACED" guard *added* | **red 5/5** |
| the read tier not distinguished (hub-read pod publishes back) | **red 5/5** |
| admission accepts an answer at the wrong address | **red 5/5** |
| a hub fault propagates instead of degrading | **red 5/5** |
| a failed upload propagates instead of degrading | **red 5/5** |
| the producer read-back guard narrowed past `OSError` | **red 5/5** |
| the hub asked BEFORE the local roots | **red 5/5** |
| a corrupt LOCAL document degrades to a miss | **red 5/5** |

Blast radius **186 tests** green across the keyset, boot-adopt, cell-resolve and boot-key files. mypy clean over 937 files. All 24 hard lint gates and `assemble_changelog --check` pass.

## Wheel

`changelog.d/pgw1361.md` — **rides 0.125.0**, the next cut. `0.124.0` already carries row (a). The fleet needs to do nothing until the next repin: the hub tier is read by new wheels only, and a hub with the routes and a wheel without them is exactly today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)