### PR TITLE
pgw#1355 follow-up: master is RED — boot_stages joins gw#601's activity-kind allowlist

### DIFF
--- a/changelog.d/pgw1355-activity-allowlist.md
+++ b/changelog.d/pgw1355-activity-allowlist.md
@@ -8,3 +8,12 @@
   under its own kind, deliberately NOT part of the activity's phase envelope, whose real content is
   asserted below over `KIND_WARMUP` alone. **Red-verified both ways:** shrinking the list back
   reddens the test, restoring it greens it, so the allowlist is still load-bearing.
+- **A SECOND master red, from pgw#1363's `cell` → `compiled graph` rename:**
+  `test_pod_privilege_isolation_pgw858` still reached `local_compiled_graph_store.CELLS_DIRNAME`,
+  an attribute the rename replaced with `COMPILED_GRAPHS_DIRNAME` — an `AttributeError` on every CI
+  run. It skips on a developer box (it needs docker + root), so only CI saw it.
+- **Why mypy did not catch it, and the argument that makes:** that module sits on the
+  `ignore_errors` mypy burn-down, so it was wholly unchecked. The pgw#1362 consolidation took it
+  OFF the list on its way through, and mypy then flagged the stale attribute immediately. **A test
+  module exempt from type checking is a test module that can silently stop running** — which is the
+  whole case for the burn-down.

--- a/changelog.d/pgw1355-activity-allowlist.md
+++ b/changelog.d/pgw1355-activity-allowlist.md
@@ -1,0 +1,10 @@
+- **master was RED: pgw#1355's `boot_stages` roll-up broke gw#601's activity-kind allowlist.**
+  `test_executor_setup_emits_monotonic_activity_phases` asserts that the kinds emitted during
+  `ensure_setup` are a subset of the phase envelope's neighbours; `boot_stages` is a new kind that
+  rides the same bind, so the subset assertion failed on every run. Caught by a consolidation lane
+  whose own PR could not meet its full-suite bar while master was red.
+- The fix adds `KIND_BOOT_STAGES` to that list, which is maintenance of the guard rather than a
+  widening of it: `boot_stages` is the same shape as pgw#1309's boot row — a self-contained event
+  under its own kind, deliberately NOT part of the activity's phase envelope, whose real content is
+  asserted below over `KIND_WARMUP` alone. **Red-verified both ways:** shrinking the list back
+  reddens the test, restoring it greens it, so the allowlist is still load-bearing.

--- a/tests/test_activity_gw601.py
+++ b/tests/test_activity_gw601.py
@@ -87,9 +87,14 @@ def test_executor_setup_emits_monotonic_activity_phases():
     # read as "one activity" only because the two used to share a kind.
     # pgw#1309's boot row (this process's pid and role) rides the same bind
     # and is likewise not part of the phase envelope.
+    # pgw#1355's boot_stages roll-up is the same shape as pgw#1309's boot row:
+    # a self-contained event under its own kind, emitted on the same bind, and
+    # deliberately NOT part of this activity's phase envelope. It joins the
+    # list; it is not folded into the envelope. The envelope's real content is
+    # asserted below, over KIND_WARMUP alone.
     assert {u.kind for u in ups} <= {
         activity.KIND_WARMUP, activity.KIND_WARMUP_SUMMARY,
-        activity.KIND_PROCESS_ROLE}
+        activity.KIND_PROCESS_ROLE, activity.KIND_BOOT_STAGES}
     ups = [u for u in ups if u.kind == activity.KIND_WARMUP]
     seqs = [u.seq for u in ups]
     assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), seqs

--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -417,9 +417,9 @@ def test_the_dropped_child_can_write_a_RELOCATED_local_compiled_graph_store(drop
         f"{local_compiled_graph_store.ENV_STORE_DIR} is unset, so this row would pass "
         "for the wrong reason — the suite's autouse fixture sets it"
     )
-    assert not os.path.exists(os.path.join(root, local_compiled_graph_store.CELLS_DIRNAME)), (
+    assert not os.path.exists(os.path.join(root, local_compiled_graph_store.COMPILED_GRAPHS_DIRNAME)), (
         "this row must measure the CHILD creating the compiled graphs root — a "
-        f"{local_compiled_graph_store.CELLS_DIRNAME} this root parent made would be "
+        f"{local_compiled_graph_store.COMPILED_GRAPHS_DIRNAME} this root parent made would be "
         "root-owned and the probe would report the wrong thing"
     )
     # `write-probe` mkdirs a nested subtree before it writes, which is the


### PR DESCRIPTION
🔴 **`master` is red right now.** Verified on a clean checkout of `db20e80d` with zero local modifications:

```
FAILED tests/test_activity_gw601.py::test_executor_setup_emits_monotonic_activity_phases
1 failed, 8 passed
```

`test_executor_setup_emits_monotonic_activity_phases` asserts that the activity kinds emitted during `ensure_setup` are a subset of the phase envelope's neighbours. **pgw#1355's `boot_stages` roll-up rides the same bind under a new kind**, so the subset assertion has failed on every run since that landed. CI's full `tests` job has been red on master's tip; only `fast gates` gates the queue, which is why it got through.

## The fix is guard maintenance, not widening

`boot_stages` is the **same shape as pgw#1309's boot row** — a self-contained event under its own kind, deliberately *not* part of this activity's phase envelope. The comment directly above that list already describes exactly this category and names `PROCESS_ROLE` as its previous member. The envelope's real content is asserted below, over `KIND_WARMUP` alone, and is untouched.

## Red-verified both ways

An allowlist edit that only makes things green is how a guard quietly dies, so:

| state | result |
|---|---|
| allowlist shrunk back (boot_stages removed) | **1 failed** |
| allowlist restored | **9 passed** |

The list is still load-bearing.

## Provenance

Found by the pgw#1362 test-consolidation lane, whose own PR #942 could not meet its non-negotiable full-suite bar while master was red. **Filed separately rather than smuggled into that PR**, so the fix is attributable to pgw#1355 and reviewable on its own.