### PR TITLE
pgw#1363 fix-forward: pgw#858 docker leg follows the COMPILED_GRAPHS_DIRNAME rename

### DIFF
--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -417,9 +417,9 @@ def test_the_dropped_child_can_write_a_RELOCATED_local_compiled_graph_store(drop
         f"{local_compiled_graph_store.ENV_STORE_DIR} is unset, so this row would pass "
         "for the wrong reason — the suite's autouse fixture sets it"
     )
-    assert not os.path.exists(os.path.join(root, local_compiled_graph_store.CELLS_DIRNAME)), (
+    assert not os.path.exists(os.path.join(root, local_compiled_graph_store.COMPILED_GRAPHS_DIRNAME)), (
         "this row must measure the CHILD creating the compiled graphs root — a "
-        f"{local_compiled_graph_store.CELLS_DIRNAME} this root parent made would be "
+        f"{local_compiled_graph_store.COMPILED_GRAPHS_DIRNAME} this root parent made would be "
         "root-owned and the probe would report the wrong thing"
     )
     # `write-probe` mkdirs a nested subtree before it writes, which is the


### PR DESCRIPTION
The full `tests` suite on PR #940's branch went red on ONE row: `test_the_dropped_child_can_write_a_RELOCATED_local_compiled_graph_store` runs inside a real `docker run` root parent, and its module-attribute reference `local_compiled_graph_store.CELLS_DIRNAME` was invisible to the mypy gate at rename time. Renamed to `COMPILED_GRAPHS_DIRNAME`. Fix-forward per Paul's 2026-08-18 enqueue-on-targeted-green ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)