### PR TITLE
pgw#1371: the mint streams per-class progress — a torn-down pool is legible as mid-flight work, never as zero

### DIFF
--- a/changelog.d/pgw1371-live-progress.md
+++ b/changelog.d/pgw1371-live-progress.md
@@ -1,0 +1,15 @@
+- **pgw#1371: the runtime mint streams per-class progress, so a torn-down pool
+  is legible as mid-flight work instead of `pool_busy_s 0 / n_entries 0`.** The
+  "pool never dispatches" fleet read (pods `rzz5p4e7b2kcpp` / `c7bx4yxbh3wx87`,
+  e2e#1892 runs 7/8) was a telemetry artifact: the pool dispatched and its
+  children compiled — `zco8e1bx0t1jgk` completed the identical 36-class sdxl
+  shape at 0.9989 pool efficiency in 3608 s — but a share of 36/K classes
+  reported once, at its end, so both pods (shut down at 2798 s / 471 s, before
+  the ~3600 s first-share horizon) rolled up zero everywhere and the hub read
+  the healthy mint as `self_stalled=t` for its whole life. The compile child now
+  writes one row per packed class and a position beat per phase boundary; the
+  pool harvests them every poll — `class_spans` fills live (the phase snapshot
+  and abandon table name what landed), the ledger carries `pool_classes_landed`
+  and `pool_child_cpu_s`, the silence window admits landed classes and position
+  beats as evidence, and the mint's progress counter beats per GRAPH CLASS
+  against the class goal instead of once per share against the worker count.

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -82,9 +82,11 @@ from gen_worker._vendor.torchcg.spans import (
 )
 
 from .aot_compile_pool import (
+    CLASS_ROW_DIRNAME,
     CODE_DIGEST,
     COMPILED,
     PACKAGE_ROOT,
+    POSITION_NAME,
     arm_parent_death_signal,
     EXIT_BAD_JOB,
     EXIT_COMPILED,
@@ -137,6 +139,48 @@ def _write(path: Path, report: EntryReport) -> None:
     tmp = path.with_suffix(".tmp")
     tmp.write_bytes(msgspec.json.encode(report))
     os.replace(tmp, path)
+
+
+def _mark_position(job: EntryJob, phase: str, *, detail: str = "") -> None:
+    """The child's position beat (pgw#1371), rewritten at phase boundaries.
+
+    A share is up to 36/K classes and its report lands once, at the very end
+    — so from the parent's side a 46-minute healthy share and a wedged one
+    read identically until the terminus (the 2026-08-18 fleet signature).
+    This file is the child SAYING where it is: the parent counts a CHANGED
+    position as silence-window evidence and quotes the last one when it
+    condemns. Best-effort by construction — telemetry never fails a mint.
+    """
+    try:
+        path = Path(job.report).parent / POSITION_NAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_bytes(json.dumps({
+            "phase": phase, "detail": detail[:200],
+            "epoch": round(time.time(), 3),
+        }).encode())
+        os.replace(tmp, path)
+    except OSError:
+        logger.debug("aot-compile: position beat failed", exc_info=True)
+
+
+def _stream_class_row(job: EntryJob, index: int, packed: PackedGraphClass) -> None:
+    """One packed class, streamed to the parent THE MOMENT it is on disk.
+
+    pgw#1371: the artifact itself already lands per class (pgw#1183's
+    durability atom); this row is the parent-visible half — it feeds the live
+    `class_spans`, the pool ledger's `classes_landed`, the per-class beat the
+    hub's stall rule reads, and the silence window. Written atomically and
+    named by index so the parent can harvest strictly in order.
+    """
+    try:
+        rows = Path(job.report).parent / CLASS_ROW_DIRNAME
+        rows.mkdir(parents=True, exist_ok=True)
+        tmp = rows / f".{index:03d}.tmp"
+        tmp.write_bytes(msgspec.json.encode(packed))
+        os.replace(tmp, rows / f"{index:03d}.json")
+    except OSError:
+        logger.debug("aot-compile: class row stream failed", exc_info=True)
 
 
 def _peak_rss() -> int:
@@ -507,6 +551,9 @@ def run(job: EntryJob) -> int:
     # serving pod must never be left burning CPU on a compiled graph nobody is waiting
     # for any more.
     _install_posture(job)
+    # The FIRST beat, before anything that can take minutes: a child whose
+    # position file never appears did not reach its own code.
+    _mark_position(job, "start")
     # The seal is the parent's — re-established, not re-derived, because this
     # process emits the very bytes the seal describes. A child that sealed
     # differently would produce an artifact the parent's verify() rejects on
@@ -517,6 +564,7 @@ def run(job: EntryJob) -> int:
     with ledger.span("child_seal_s"):
         env_seal.establish()
     seal_detail = dict(env_seal.LAST_ESTABLISH_SPANS)
+    _mark_position(job, "sealed")
     # Before ANY compile touches the card: every inductor GPU benchmark in
     # this process goes through the pool-wide lock, so K concurrent children
     # cannot time kernels against each other and bake contention-chosen
@@ -541,6 +589,7 @@ def run(job: EntryJob) -> int:
         # before anyone can argue about a persistent worker.
         with ledger.span("child_torch_import_s"):
             import torch
+        _mark_position(job, "torch_imported")
 
         # pgw#1215: this is what replaced `child_program_load_s`. The child
         # composes the weight-free target it is about to trace instead of
@@ -548,6 +597,7 @@ def run(job: EntryJob) -> int:
         with ledger.span("child_setup_s"):
             pipeline, spec, decl = build_pipeline(job)
             env_seal.assert_seal_unchanged("aot compile child setup")
+        _mark_position(job, "pipeline_composed")
     except PreflightRefused as exc:
         return _refuse(str(exc))
     except Exception as exc:  # noqa: BLE001
@@ -588,6 +638,9 @@ def run(job: EntryJob) -> int:
         for traced in _trace_share(aot_mint, pipeline, spec, decl, job):
             current_class = traced.name
             declared = int(traced.declared) or declared
+            _mark_position(
+                job, "compile", detail=f"{traced.name} "
+                f"({len(packed) + 1} of this share, {declared} declared)")
             timings = dict(traced.timings or {})
             row_trace = float(timings.get("export_s", 0.0))
             trace_s += row_trace
@@ -618,6 +671,13 @@ def run(job: EntryJob) -> int:
                 metadata=result.packed.metadata,
                 spans=spans,
             ))
+            # pgw#1371: the parent learns of the class NOW, not at the
+            # share's report — the artifact is already on disk, which is the
+            # durability bound (pgw#1183) this row makes visible.
+            _stream_class_row(job, len(packed) - 1, packed[-1])
+            _mark_position(
+                job, "packed", detail=f"{traced.name} "
+                f"({len(packed)} of this share, {declared} declared)")
     except aot_mint.MintRefused as exc:
         # NOT a discard. Every class this child already packed is on disk and
         # is named in the report — a share is not all-or-nothing, which is the

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -63,7 +63,7 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import (
     Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple)
@@ -91,6 +91,20 @@ ENTRY_CHILD_MODULE = "gen_worker.aot_compile_child"
 
 #: Report file each entry child writes before exiting.
 ENTRY_REPORT_NAME = "report.json"
+
+#: pgw#1371: per-class progress the child STREAMS while it works. A share is
+#: up to 36/K classes at 156-509 s each, and the report above lands once, at
+#: the end — so on the two 2026-08-18 fleet pods a pool 46 minutes into real
+#: compile work rolled up as `pool_busy_s 0 / n_entries 0` and was read as
+#: "the pool never dispatches" (pgw#1371's blocking-defect header; disproved
+#: against pod zco8e1bx0t1jgk, which completed the identical 36-class shape at
+#: 0.9989 efficiency in 3608 s). The child therefore writes one row per packed
+#: class into ``<slot>/classes/NNN.json`` the moment the artifact is on disk,
+#: and a position file at every phase boundary; the parent harvests both every
+#: poll. Progress rows are TELEMETRY AND LIVENESS EVIDENCE, never identity:
+#: the report stays the share's terminus and the artifact stays the atom.
+CLASS_ROW_DIRNAME = "classes"
+POSITION_NAME = "position.json"
 
 #: pgw#840: the directory that must be on the child's path for
 #: ``-m gen_worker.aot_compile_child`` to mean THIS gen_worker.
@@ -808,6 +822,16 @@ class _Running:
     #: than the child exiting under its own power. The exit code is then the
     #: parent's signal and says nothing about the compile — read the report.
     reaped_at_terminus: bool = False
+    #: pgw#1371: what this share has STREAMED so far — one row per class the
+    #: child packed, harvested live off ``<slot>/classes/``. The report at the
+    #: share's terminus remains authoritative; these exist so a mint that dies
+    #: mid-share still names what landed, and so the silence window judges
+    #: progress toward the GOAL rather than only CPU heat.
+    classes_landed: List[PackedGraphClass] = dataclass_field(
+        default_factory=list)
+    #: The child's last position beat (verbatim file content) and when the
+    #: parent saw it change.
+    position: str = ""
 
 
 @dataclass
@@ -865,6 +889,18 @@ class PoolLedger:
     #: which is the pass every CHILD used to pay.
     seal_seed_s: float = 0.0
     entries: int = 0
+    #: pgw#1371: graph classes the children have streamed as PACKED, live.
+    #: ``busy_s`` above counts only REAPED shares — on the 2026-08-18 fleet
+    #: pods that read a 46-minute, ~full-utilization pool as `pool_busy_s 0 /
+    #: pool_efficiency 0.0` because no 18-class share had reached its report
+    #: yet. This counts the goal instead of the reap.
+    classes_landed: int = 0
+    #: pgw#1371: CPU seconds the live children's process trees were OBSERVED
+    #: to burn (high-water per share, summed at the terminus). It is the
+    #: number that distinguishes "the pool did nothing" from "the pool was
+    #: torn down mid-flight" on a roll-up whose busy_s is 0 — exactly the
+    #: mis-read pgw#1371's blocking-defect header was.
+    child_cpu_s: float = 0.0
     @property
     def idle_s(self) -> float:
         return round(
@@ -893,6 +929,8 @@ class PoolLedger:
             "pool_entries": int(self.entries),
             "pool_workers": int(self.workers),
             "pool_workers_initial": int(self.workers_initial),
+            "pool_classes_landed": int(self.classes_landed),
+            "pool_child_cpu_s": round(self.child_cpu_s, 1),
         }
 
 
@@ -1014,6 +1052,13 @@ def arm_parent_death_signal() -> bool:
 def _read_report(path: Path) -> Optional[EntryReport]:
     try:
         return msgspec.json.decode(path.read_bytes(), type=EntryReport)
+    except (OSError, msgspec.DecodeError, msgspec.ValidationError):
+        return None
+
+
+def _read_class_row(path: Path) -> Optional[PackedGraphClass]:
+    try:
+        return msgspec.json.decode(path.read_bytes(), type=PackedGraphClass)
     except (OSError, msgspec.DecodeError, msgspec.ValidationError):
         return None
 
@@ -1234,7 +1279,15 @@ class EntryCompilePool:
         #: and inductor phase split, as the child measured them. The pool's
         #: other tables are per SHARE, and a share is several classes — the
         #: only granularity anybody asks about a compile is the class.
+        #: pgw#1371: fed LIVE from the children's streamed per-class rows as
+        #: well as from reaped reports, so the phase snapshot a killed mint
+        #: leaves behind names what actually landed instead of `n_entries=0`.
         self.class_spans: Dict[str, Dict[str, float]] = {}
+        #: pgw#1371: per-class landing callback for the CURRENT `compile()`
+        #: run, and the last per-share tree-CPU sample — the ledger's
+        #: `child_cpu_s` at the terminus.
+        self._on_class: Optional[Callable[[str, int, int], None]] = None
+        self._share_cpu_s: Dict[str, float] = {}
         # pgw#830: parent-side per-share spans (writing the job + spawn) and
         # the pool-level idle split. Kept separate from `entry_phases` because
         # they are NOT inside `compile_s`: they happen in the parent while
@@ -1323,6 +1376,7 @@ class EntryCompilePool:
     def compile(
         self, template: EntryJob,
         *, on_share: Optional[Callable[[str, int, int], None]] = None,
+        on_class: Optional[Callable[[str, int, int], None]] = None,
         should_abandon: Optional[Callable[[], bool]] = None,
     ) -> Dict[str, PackedGraphClass]:
         """Dispatch this mint's declared classes K-wide and collect what the
@@ -1345,6 +1399,13 @@ class EntryCompilePool:
         reporting is best-effort by construction: a raising callback must never
         cost the mint the classes it already has.
 
+        ``on_class(name, landed, goal)`` (pgw#1371) fires as each GRAPH CLASS
+        lands — harvested live from the child's streamed rows, ``goal`` being
+        ``width.entries`` (the classes this attempt set out to mint). A share
+        is up to 36/K classes and reports once, so per-share progress on the
+        fleet meant the first beat arrived ~an hour in; per-class beats are
+        what keep the hub's stall rule honest for the whole mint.
+
         ``should_abandon()`` (pgw#1215 step 4) is polled in the same drain loop
         and raises :class:`EntryCompileAbandoned`, so the ``finally`` below
         group-kills every live child. The supervisor drives this pool from a
@@ -1366,6 +1427,7 @@ class EntryCompilePool:
         # named line (`seal_seed_s`) and never inside the capacity identity.
         self._seed_seal_memo()
         self.ledger.entries = width
+        self._on_class = on_class
 
         def _cb(name: str) -> None:
             if on_share is not None:
@@ -1408,8 +1470,8 @@ class EntryCompilePool:
                     raise EntryCompileAbandoned(
                         f"the supervisor abandoned this mint with "
                         f"{len(running)} of {width} share(s) still compiling; "
-                        f"{len(done)} graph class(es) are already packed and "
-                        f"stay on disk")
+                        f"{max(len(done), self.ledger.classes_landed)} graph "
+                        f"class(es) are already packed and stay on disk")
                 finished = self._reap(running)
                 if finished is None:
                     time.sleep(_POLL_S)
@@ -1454,6 +1516,16 @@ class EntryCompilePool:
         finally:
             self.ledger.wall_s = round(time.monotonic() - pool_t0, 3)
             self.ledger.busy_s = round(sum(self.entry_seconds.values()), 3)
+            # pgw#1371: one last harvest, then close the observed-CPU line.
+            # Ordered BEFORE the group kills below, so classes packed in the
+            # children's final seconds are named rather than lost, and the
+            # ledger of a torn-down pool says what its children were doing.
+            for row in running:
+                try:
+                    self._harvest_progress(row)
+                except Exception:  # noqa: BLE001 — telemetry never fails a mint
+                    logger.debug("aot-pool: final harvest failed", exc_info=True)
+            self.ledger.child_cpu_s = sum(self._share_cpu_s.values())
             # Closed at the LIVE width for the final interval, then rounded —
             # `charge` has been accumulating it all along (see there).
             charge("idle_other_s", 0)
@@ -1651,6 +1723,11 @@ class EntryCompilePool:
             row.peak_rss_bytes = max(
                 row.peak_rss_bytes, _peak_rss_bytes(row.proc))
             self.peak_rss_bytes = max(self.peak_rss_bytes, row.peak_rss_bytes)
+            # pgw#1371: harvest the child's streamed per-class rows and its
+            # position beat BEFORE the exit/report/liveness checks — landed
+            # classes are the pool's progress toward its goal, and they are
+            # evidence for the silence window below.
+            progressed = self._harvest_progress(row)
             if row.proc.poll() is not None:
                 return row
             # pgw#1243: A CHILD'S TERMINUS IS ITS REPORT, NOT ITS EXIT.
@@ -1670,10 +1747,63 @@ class EntryCompilePool:
                 row.reaped_at_terminus = True
                 _terminate_group(row.proc)
                 return row
-            self._judge_entry_liveness(row)
+            self._judge_entry_liveness(row, progressed=progressed)
         return None
 
-    def _judge_entry_liveness(self, row: _Running) -> None:
+    def _harvest_progress(self, row: _Running) -> bool:
+        """Read what this share has STREAMED since the last poll (pgw#1371).
+
+        Two files, both written by the child and both best-effort: one row per
+        packed class under ``<slot>/classes/``, and a position beat rewritten
+        at every phase boundary. Harvesting them is what turns "a share
+        reports once, at the end" into live per-class truth: ``class_spans``
+        (and through it every phase snapshot and aborted table), the ledger's
+        ``classes_landed``, and the ``on_class`` beat all advance the moment
+        an artifact is on disk. Returns whether anything advanced, which the
+        silence window counts as progress — a class landing IS the goal.
+        """
+        advanced = False
+        slot = Path(row.job.report).parent
+        rows_dir = slot / CLASS_ROW_DIRNAME
+        try:
+            names = sorted(
+                p for p in rows_dir.iterdir() if p.suffix == ".json")
+        except OSError:
+            names = []
+        for path in names[len(row.classes_landed):]:
+            packed = _read_class_row(path)
+            if packed is None:
+                # A row mid-write; the next poll gets it. Stop rather than
+                # skip so the count stays aligned with the sorted order.
+                break
+            row.classes_landed.append(packed)
+            if packed.name not in self.class_spans:
+                self.ledger.classes_landed += 1
+            self.class_spans[packed.name] = dict(packed.spans or {})
+            advanced = True
+            logger.info(
+                "aot-pool: %s landed graph class %s live (%d landed pool-wide)",
+                row.entry, packed.name, self.ledger.classes_landed)
+            if self._on_class is not None:
+                try:
+                    self._on_class(
+                        packed.name, self.ledger.classes_landed,
+                        int(self.width.entries))
+                except Exception:  # noqa: BLE001 — telemetry never fails a mint
+                    logger.debug(
+                        "entry-pool class callback failed", exc_info=True)
+        try:
+            position = (slot / POSITION_NAME).read_text()
+        except OSError:
+            position = ""
+        if position and position != row.position:
+            row.position = position
+            advanced = True
+        return advanced
+
+    def _judge_entry_liveness(
+        self, row: _Running, *, progressed: bool = False,
+    ) -> None:
         """Condemn a share that has stopped making MEASURED progress.
 
         pgw#1243. Until this existed the drain loop had no give-up test at
@@ -1682,20 +1812,31 @@ class EntryCompilePool:
         supervisor watched this whole process tree — and pgw#1215 step 4
         deleted that tier without moving the watch down with it.
 
-        Progress is MEASURED (process-tree CPU plus bytes written), never a
-        clock and never a frame the child could print while wedged, and the two
-        signals keep separate high-water marks so a quiet one cannot cancel a
-        moving one (pgw#964). A child inside a forty-minute `aot_compile`
-        advances this every poll and is never touched.
+        Progress is MEASURED, never a clock, and the signals keep separate
+        high-water marks so a quiet one cannot cancel a moving one (pgw#964):
+        process-tree CPU, bytes written, and — pgw#1371 — the share's OWN
+        streamed evidence (``progressed``: a class landing on disk, or the
+        child's position beat moving). The last two are the goal-anchored
+        half: they are what let a torn-down mint be read as "mid-flight, N
+        classes landed" instead of the `pool_busy_s 0` that the 2026-08-18
+        fleet pods rolled up. A child inside a forty-minute `aot_compile`
+        advances the CPU axis every poll and is never touched.
         """
         if row.window is None:
             row.window = SilenceWindow(self.entry_silence_window_s)
         cpu = _tree_cpu_seconds(row.proc.pid)
         mib = _dir_mib(Path(row.job.work))
-        advanced = False
+        advanced = bool(progressed)
         if cpu is not None and (
                 row.cpu_s is None or cpu - row.cpu_s >= _ENTRY_EVIDENCE_EPS):
             row.cpu_s, advanced = cpu, True
+        if cpu is not None:
+            # The ledger's observed-CPU line (pgw#1371): a high-water sample
+            # per share, kept even for a share that is later condemned or
+            # torn down — it is the number that says what the pool was doing
+            # when busy_s reads 0.
+            self._share_cpu_s[row.entry] = max(
+                self._share_cpu_s.get(row.entry, 0.0), float(cpu))
         if mib is not None and (
                 row.work_mib is None
                 or mib - row.work_mib >= _ENTRY_EVIDENCE_EPS):
@@ -1715,7 +1856,11 @@ class EntryCompilePool:
             f"{'unreadable' if row.cpu_s is None else f'{row.cpu_s:.1f}s'} "
             f"and its work dir "
             f"{'unreadable' if row.work_mib is None else f'{row.work_mib:.1f}MiB'} "
-            f"are both flat. It is wedged, not compiling; this build FAILS and "
+            f"are both flat, no graph class landed and its position beat is "
+            f"silent ({len(row.classes_landed)} class(es) landed before the "
+            f"silence; last position "
+            f"{row.position.strip()[:120] or '<none>'}). It is wedged, not "
+            f"compiling; this build FAILS and "
             f"this worker keeps serving eager",
             peak_rss_bytes=row.peak_rss_bytes)
 
@@ -1781,6 +1926,11 @@ class EntryCompilePool:
         # here, per child, would refuse the legitimate case and give the
         # illegitimate one the wrong name.
         if code == EXIT_COMPILED and report is not None:
+            # pgw#1371: the ledger's landed count is reconciled against the
+            # report, so a child too old to stream rows (or a report carrying
+            # classes a poll never saw) still counts every class exactly once.
+            self.ledger.classes_landed += sum(
+                1 for c in report.classes if c.name not in self.class_spans)
             if report.peak_rss_bytes:
                 self.peak_rss_bytes = max(
                     self.peak_rss_bytes, int(report.peak_rss_bytes))
@@ -1817,10 +1967,18 @@ class EntryCompilePool:
         # names what exists so a caller is never told the share produced
         # nothing when it produced most of a compiled graph.
         if report is not None and report.classes:
+            self.ledger.classes_landed += sum(
+                1 for c in report.classes if c.name not in self.class_spans)
             for packed in report.classes:
                 self.class_spans[packed.name] = dict(packed.spans or {})
             self.refused_classes[row.entry] = list(report.classes)
             self.entry_declared[row.entry] = int(report.declared_classes or 0)
+        elif report is None and row.classes_landed:
+            # pgw#1371: a share that died without a report still STREAMED the
+            # classes it packed, and they are on disk — name them exactly as a
+            # refusing report's are named, so "this share produced nothing"
+            # and "this share died on class k of n" stop reading the same.
+            self.refused_classes[row.entry] = list(row.classes_landed)
         detail = report.detail if report is not None else ""
         if not detail:
             detail = _stderr_tail(row.stderr_path)
@@ -2005,8 +2163,10 @@ def _exit_note(code: Optional[int]) -> str:
 
 
 __all__ = [
+    "CLASS_ROW_DIRNAME",
     "CODE_DIGEST",
     "COMPILED",
+    "POSITION_NAME",
     "CPUS_PER_ENTRY_WORKER",
     "DEFAULT_ENTRY_PEAK_RSS_BYTES",
     "ENTRY_CHILD_MODULE",

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1614,19 +1614,35 @@ def mint_graph_classes(
     # serial driver that fed `MintProgress.minted`.
     progress.class_spans = pool.class_spans
     progress.share_overlays = pool.entry_overlays
+    # pgw#1371: the bounded axis is GRAPH CLASSES, not shares. A share is up
+    # to 36/K classes and reports once — with share-granular beats the first
+    # progress of a real fleet mint arrived ~an hour in, the on-disk snapshot
+    # stayed the t=0 beat, and the hub's stall rule read a healthy mint as
+    # `self_stalled=t` for its entire life (pods rzz5p4e7b2kcpp /
+    # c7bx4yxbh3wx87, 2026-08-18). Every class landing beats, so the counter,
+    # the snapshot and podguard all advance at the granularity the work
+    # actually completes at.
+    goal = max(1, int(width.entries))
     progress.beat(
-        PHASE_INDUCTOR_COMPILE, 0, width.workers,
-        f"{width.workers} compile child(ren), one share each — {width.reason}")
+        PHASE_INDUCTOR_COMPILE, 0, goal,
+        f"{width.workers} compile child(ren), {goal} graph class(es) — "
+        f"{width.reason}")
     try:
         packed = pool.compile(
             template,
-            on_share=lambda name, done, total: progress.beat(
-                PHASE_INDUCTOR_COMPILE, done, total, name),
+            on_class=lambda name, done, total: progress.beat(
+                PHASE_INDUCTOR_COMPILE, done, max(total, goal), name),
             should_abandon=should_abandon)
     except aot_compile_pool.EntryCompileAbandoned:
         # Not a failure and not this mint's fault: the ledger still has to
         # survive, because the next attempt sizes K off it (pgw#848).
         progress.pool_ledger = _pool_facts(pool)
+        # pgw#1371: one terminal beat so the on-disk snapshot carries the
+        # final ledger (classes landed, observed child CPU) instead of the
+        # last mid-flight one — the abandoned table is precisely the one a
+        # reader needs to distinguish "torn down mid-flight" from "did
+        # nothing".
+        _final_beat(progress, pool, goal, "abandoned: the ledger is final")
         raise
     except aot_compile_pool.EntryCompileFailed as exc:
         # pgw#848: the pool's ledger and its MEASURED peak have to survive the
@@ -1634,6 +1650,7 @@ def mint_graph_classes(
         # and re-sizes K from. Without this the OOM'd attempt teaches the
         # retry nothing and attempt 2 runs the identical width.
         progress.pool_ledger = _pool_facts(pool)
+        _final_beat(progress, pool, goal, "failed: the ledger is final")
         if exc.resource:
             raise MintResourceExhausted(
                 str(exc), entry=exc.entry, basis=exc.basis,
@@ -1828,6 +1845,22 @@ def _device_peak_provenance() -> Dict[str, str]:
         "gen_worker": str(version),
         "phase": DEVICE_PEAK_PHASE,
     }
+
+
+def _final_beat(
+    progress: MintProgress, pool: Any, goal: int, note: str,
+) -> None:
+    """pgw#1371: stamp the terminal position off the pool's own ledger.
+
+    A guarded read, because telemetry never fails a mint and test doubles of
+    the pool legitimately carry no ledger.
+    """
+    ledger = getattr(pool, "ledger", None)
+    if ledger is None:
+        return
+    progress.beat(
+        PHASE_INDUCTOR_COMPILE,
+        int(getattr(ledger, "classes_landed", 0) or 0), int(goal), note)
 
 
 def _pool_facts(pool: aot_compile_pool.EntryCompilePool) -> Dict[str, Any]:

--- a/tests/harness/fake_compile_child.py
+++ b/tests/harness/fake_compile_child.py
@@ -68,15 +68,60 @@ else:
 
 out = Path(job["out_dir"])
 out.mkdir(parents=True, exist_ok=True)
+
+
+def _position(phase, detail=""):
+    # pgw#1371: the real child's position beat, faked with the same file
+    # protocol so the parent's harvest is exercised for real.
+    path = report.parent / "position.json"
+    tmp = path.with_suffix(".tmp")
+    tmp.write_bytes(json.dumps(
+        {{"phase": phase, "detail": detail, "epoch": time.time()}}).encode())
+    os.replace(tmp, path)
+
+
+def _stream_row(idx, row):
+    rows = report.parent / "classes"
+    rows.mkdir(parents=True, exist_ok=True)
+    tmp = rows / f".{{idx:03d}}.tmp"
+    tmp.write_bytes(json.dumps(row).encode())
+    os.replace(tmp, rows / f"{{idx:03d}}.json")
+
+
+_position("start")
+if mode == "slow-positions":
+    # pgw#1371: flat on every pgw#1243 axis — ~no CPU, no bytes in the work
+    # dir — but honestly beating its position while it "works". The window
+    # must admit the beat as evidence or it condemns a live share.
+    for i in range(12):
+        time.sleep(0.75)
+        _position("working", str(i))
 classes = []
+stream_hang_after = int(os.environ.get("PGW_FAKE_STREAM_HANG_AFTER", "-1"))
+if mode == "stream-then-hang":
+    # Burn a parent-visible sliver of CPU first, like a real compile child
+    # does from its first second — it is what the pool's observed-CPU ledger
+    # line (pgw#1371) records for a share that never reaches its report.
+    acc, t_burn = 0, time.time()
+    while time.time() - t_burn < 0.6:
+        acc += 1
 for name in names:
+    if mode == "stream-then-hang" and len(classes) == max(0, stream_hang_after):
+        # pgw#1371: the mid-flight shape — some classes landed and streamed,
+        # the share never reaches its report. The parent must already know
+        # everything this child packed.
+        while True:
+            time.sleep(60)
     artifact = out / (name.replace("/", "__") + ".tar.gz")
     artifact.write_text("packed graph class " + name)
-    classes.append({{
+    row = {{
         "name": name, "key": "ek1-" + name.replace("/", "-"),
         "artifact": str(artifact), "metadata": json.dumps({{"name": name}}),
         "spans": {{"export_s": 1.0, "compile_s": 2.0}},
-    }})
+    }}
+    classes.append(row)
+    _stream_row(len(classes) - 1, row)
+    _position("packed", name)
 
 now = time.time()
 refused = mode == "refuse-midway"

--- a/tests/test_mint_live_class_progress.py
+++ b/tests/test_mint_live_class_progress.py
@@ -1,0 +1,284 @@
+"""pgw#1371: a mint's progress is visible per GRAPH CLASS, live.
+
+THE FLEET SIGNATURE THIS PINS. Two 0.124.0 pods (rzz5p4e7b2kcpp,
+c7bx4yxbh3wx87, e2e#1892 runs 7/8) ran the 36-class sdxl runtime mint and
+rolled up ``pool_wall_s 2798 / pool_busy_s 0 / pool_efficiency 0.0`` and
+``status=abandoned n_entries=0`` — which the tracker read as "the pool never
+dispatches". It dispatches fine: pod zco8e1bx0t1jgk completed the IDENTICAL
+shape the day before at 0.9989 pool efficiency in 3608 s (hub
+``worker_activity_events``, read 2026-08-18). The defect is that a share of
+36/K classes reported ONCE, at its end, so a pool torn down 46 minutes into
+real compile work was indistinguishable — on every wire fact — from a pool
+that did nothing, and the hub's stall rule read the healthy mint as
+``self_stalled=t`` for its whole life.
+
+So the child streams a row per packed class and a position beat per phase, the
+parent harvests them every poll, and every consumer of "how far along is this
+mint" — the beat counter, the on-disk snapshot, the abandon table, the pool
+ledger, the silence window — advances at the granularity the work completes
+at. These tapes drive the REAL pool against REAL child processes; only the
+compile interior is faked (the local-testing rule: no local inductor).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from gen_worker import aot_compile_pool as pool_mod
+from harness import fake_compile_child
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import aot_mint  # noqa: E402
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+_DECLARED = 6
+
+#: Tape guard only — generous against the fix, tiny against the defect. No
+#: production code keys on it.
+_TAPE_GUARD_S = 60.0
+
+
+@pytest.fixture(autouse=True)
+def _clean_fake_child_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PGW_FAKE_CHILD", raising=False)
+    monkeypatch.delenv("PGW_FAKE_DECLARED", raising=False)
+    monkeypatch.delenv("PGW_FAKE_STREAM_HANG_AFTER", raising=False)
+
+
+def _pool(
+    tmp_path: Path, *, mode: str, workers: int = 1,
+    window_s: float = 600.0,
+) -> pool_mod.EntryCompilePool:
+    os.environ["PGW_FAKE_CHILD"] = mode
+    os.environ["PGW_FAKE_DECLARED"] = str(_DECLARED)
+    width = pool_mod.entry_workers(
+        _DECLARED, limit=workers, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    return pool_mod.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=fake_compile_child.script(tmp_path),
+        entry_silence_window_s=window_s)
+
+
+def _template(tmp_path: Path) -> pool_mod.EntryJob:
+    return pool_mod.EntryJob(
+        function="generate", modules=("harness.toy_endpoints",),
+        out_dir=str(tmp_path / "artifacts"))
+
+
+def test_every_class_beats_as_it_lands_not_once_per_share(
+    tmp_path: Path,
+) -> None:
+    """RED before pgw#1371: the only pool callback was per SHARE.
+
+    One worker, six classes, so the old contract fired once — after
+    everything. The class contract fires six times with a monotonically
+    rising landed count against the class GOAL, which is what the hub's
+    stall-rule counter needs to stay honest through a share that takes an
+    hour on the fleet.
+    """
+    p = _pool(tmp_path, mode="ok")
+    landed: List[Tuple[str, int, int]] = []
+    packed = p.compile(
+        _template(tmp_path),
+        on_class=lambda name, done, total: landed.append((name, done, total)))
+
+    assert sorted(packed) == sorted(f"cls/dim={i}" for i in range(_DECLARED))
+    assert [done for _, done, _ in landed] == list(range(1, _DECLARED + 1)), (
+        "the landed count must rise by exactly one per streamed class — a "
+        "single end-of-share burst is the old share-granular blindness with "
+        "a new name")
+    assert all(total == _DECLARED for _, _, total in landed)
+    facts = p.ledger.facts()
+    assert facts["pool_classes_landed"] == _DECLARED
+    assert "pool_child_cpu_s" in facts
+
+
+def test_a_pool_torn_down_mid_share_reports_what_actually_landed(
+    tmp_path: Path,
+) -> None:
+    """THE fleet shape: abandoned before any share reached its report.
+
+    The child streams two classes and then never reports (the artifacts are
+    on disk — that is pgw#1183's per-class durability). The supervisor
+    abandons, exactly as the worker shutdown did on the two 0.124.0 pods.
+    Before pgw#1371 the pool's whole account of this was `busy_s 0` and an
+    empty class table; now the abandon sentence, the class spans and the
+    ledger all name the two landed classes, and the ledger carries the CPU
+    its children were observed burning.
+    """
+    os.environ["PGW_FAKE_STREAM_HANG_AFTER"] = "2"
+    p = _pool(tmp_path, mode="stream-then-hang")
+    seen: List[int] = []
+    t0 = time.monotonic()
+
+    def _abandon() -> bool:
+        # Abandon once the parent has SEEN two classes land; the deadline is
+        # the tape's own guard, and the assertions below catch it firing.
+        return len(seen) >= 2 or time.monotonic() - t0 > _TAPE_GUARD_S
+
+    with pytest.raises(pool_mod.EntryCompileAbandoned) as caught:
+        p.compile(
+            _template(tmp_path),
+            on_class=lambda name, done, total: seen.append(done),
+            should_abandon=_abandon)
+
+    assert len(seen) >= 2, (
+        "the parent never harvested the streamed classes — the abandon came "
+        "from the tape guard, which is exactly the fleet's blind mid-flight "
+        "teardown")
+    assert "2 graph class(es) are already packed" in str(caught.value)
+    assert p.ledger.classes_landed == 2
+    assert set(p.class_spans) == {"cls/dim=0", "cls/dim=1"}
+    # The observed-CPU line: the number that distinguishes "torn down
+    # mid-flight" from "did nothing" on a roll-up whose busy_s is 0.
+    assert p.ledger.facts()["pool_child_cpu_s"] > 0.0
+    # And the artifacts really are on disk for the next attempt's accretion.
+    for row in p.class_spans:
+        assert (tmp_path / "artifacts" /
+                (row.replace("/", "__") + ".tar.gz")).exists()
+
+
+def test_a_sleeping_share_that_streams_positions_is_not_condemned(
+    tmp_path: Path,
+) -> None:
+    """The silence window admits the child's OWN streamed evidence.
+
+    This child burns ~no CPU and writes nothing into its work dir — on the
+    pgw#1243 axes it is flat — but it beats its position file while it
+    works. RED with the harvest ignored by the window: the pool condemns a
+    share that is demonstrably advancing through its phases.
+    """
+    script = fake_compile_child.script(tmp_path)
+    os.environ["PGW_FAKE_CHILD"] = "slow-positions"
+    os.environ["PGW_FAKE_DECLARED"] = str(_DECLARED)
+    width = pool_mod.entry_workers(
+        _DECLARED, limit=1, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    p = pool_mod.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=script, entry_silence_window_s=3.0)
+
+    packed = p.compile(_template(tmp_path))
+    assert sorted(packed) == sorted(f"cls/dim={i}" for i in range(_DECLARED))
+
+
+def test_the_child_stream_protocol_roundtrips_into_the_harvest(
+    tmp_path: Path,
+) -> None:
+    """The REAL child-side writers against the REAL parent-side harvest.
+
+    The fake child above re-implements the file protocol; this drives the
+    production writer functions themselves, so the two sides cannot drift
+    apart silently.
+    """
+    from gen_worker import aot_compile_child as child_mod
+
+    slot = tmp_path / "share-000"
+    slot.mkdir(parents=True)
+    job = pool_mod.EntryJob(
+        function="generate", modules=("m",),
+        report=str(slot / pool_mod.ENTRY_REPORT_NAME),
+        work=str(slot / "work"), out_dir=str(tmp_path / "artifacts"))
+    artifact = tmp_path / "artifacts" / "a.tar.gz"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("x")
+
+    child_mod._mark_position(job, "compile", detail="cls/one (1 of 3)")
+    child_mod._stream_class_row(job, 0, pool_mod.PackedGraphClass(
+        name="cls/one", key="ek1-one", artifact=str(artifact),
+        metadata="{}", spans={"export_s": 1.5, "compile_s": 2.5}))
+
+    width = pool_mod.entry_workers(
+        3, limit=1, vcpus=16, available_bytes=64 * 1024**3, device_lock=True)
+    p = pool_mod.EntryCompilePool(tmp_path / "pool", width=width)
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        row = pool_mod._Running(
+            entry="share-000", proc=proc, job=job,
+            started=time.monotonic(), stderr_path=slot / "stderr.log")
+        beats: List[Tuple[str, int, int]] = []
+        p._on_class = lambda name, done, total: beats.append(
+            (name, done, total))
+
+        assert p._harvest_progress(row) is True
+        assert p.class_spans["cls/one"] == {"export_s": 1.5, "compile_s": 2.5}
+        assert p.ledger.classes_landed == 1
+        assert beats == [("cls/one", 1, 3)]
+        position = json.loads(row.position)
+        assert position["phase"] == "compile"
+        assert "cls/one" in position["detail"]
+        # Idempotent: nothing new means no advance and no double count.
+        assert p._harvest_progress(row) is False
+        assert p.ledger.classes_landed == 1
+    finally:
+        with contextlib.suppress(OSError):
+            proc.kill()
+        proc.wait()
+
+
+def test_a_killed_mints_snapshot_names_the_landed_classes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """END TO END through `mint_graph_classes`: the on-disk phase snapshot of
+    an abandoned mint carries n_entries > 0, real per-class spans and the
+    final pool ledger — everything runs 7/8 reported as zero.
+    """
+    monkeypatch.setenv("PGW_FAKE_CHILD", "stream-then-hang")
+    monkeypatch.setenv("PGW_FAKE_DECLARED", str(_DECLARED))
+    monkeypatch.setenv("PGW_FAKE_STREAM_HANG_AFTER", "2")
+    snapshot = tmp_path / "phases.json"
+    width = pool_mod.entry_workers(
+        _DECLARED, limit=1, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    seen: List[str] = []
+    t0 = time.monotonic()
+
+    def _progress(phase: str, step: int, total: int, note: str) -> None:
+        seen.append(f"{phase} {step}/{total} {note}")
+
+    def _abandon() -> bool:
+        return len([s for s in seen if "cls/" in s]) >= 2 \
+            or time.monotonic() - t0 > _TAPE_GUARD_S
+
+    with pytest.raises(pool_mod.EntryCompileAbandoned):
+        aot_mint.mint_graph_classes(
+            _template(tmp_path),
+            workdir=tmp_path / "pool",
+            width=width,
+            spec=aot_mint.ExportSpec(family="tiny1371", target="unet"),
+            python=fake_compile_child.script(tmp_path),
+            on_progress=_progress,
+            phase_snapshot=snapshot,
+            should_abandon=_abandon)
+
+    table = json.loads(snapshot.read_text())
+    assert table["n_entries"] == 2, (
+        "an abandoned mint must name the classes that landed — n_entries=0 "
+        "on 46 minutes of real work is the exact fleet mis-read this exists "
+        "to end")
+    assert set(table["entries"]) == {"cls/dim=0", "cls/dim=1"}
+    assert table["totals"]["export_s"] > 0
+    pool_block = table["pool"]
+    assert pool_block["pool_classes_landed"] == 2
+    assert pool_block["pool_child_cpu_s"] > 0.0
+    # The terminal beat stamped the final position.
+    assert table["at"]["note"].startswith("abandoned")
+    # The counter axis is CLASSES: the total the hub's stall rule sees is the
+    # class goal, never the worker count — and the class-named beats really
+    # reached the sink (the wire the hub's `self_stalled` verdict reads).
+    assert any(f"/{_DECLARED} " in s for s in seen)
+    assert any("cls/dim=0" in s for s in seen), (
+        "no per-class beat reached the progress sink — the hub would read "
+        "this healthy mint as self_stalled=t, which is the fleet signature")

--- a/tests/test_mint_rollup_terminus_pgw1356.py
+++ b/tests/test_mint_rollup_terminus_pgw1356.py
@@ -95,7 +95,7 @@ class _Pool:
         part-way has to leave the landed rows behind it — pinned by
         :func:`test_a_killed_mint_leaves_the_classes_that_landed_on_disk`.
         """
-        on_share = kwargs.get("on_share")
+        on_share = kwargs.get("on_class")  # pgw#1371: per-class beats
         packed: Dict[str, aot_compile_pool.PackedGraphClass] = {}
         for index, name in enumerate(_CLASSES):
             key = "cg-key-v1-" + f"{index}".rjust(56, "0")

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -334,12 +334,14 @@ def _drive_tcg_pool(
             pass
 
         def compile(self, *_args: Any, **kwargs: Any) -> dict[str, Any]:
-            on_share = kwargs["on_share"]
-            on_share("share-a", 1, 2)
+            # pgw#1371: the production driver beats per GRAPH CLASS now, off
+            # the child's streamed rows, and no longer passes `on_share`.
+            on_class = kwargs["on_class"]
+            on_class("cls/dim=0", 1, 2)
             if fail_after_first:
                 raise aot_compile_pool.EntryCompileFailed(
                     "share-b", "TCG refused share-b")
-            on_share("share-b", 2, 2)
+            on_class("cls/dim=1", 2, 2)
             return {}
 
     monkeypatch.setattr(aot_compile_pool, "EntryCompilePool", _Pool)
@@ -375,7 +377,11 @@ def test_the_tcg_pool_reports_every_share_as_it_lands(
     ]
     assert [beat[1] for beat in compile_beats] == [0, 1, 2]
     assert all(beat[2] == 2 for beat in compile_beats)
-    assert [beat[3] for beat in compile_beats[1:]] == ["share-a", "share-b"]
+    # pgw#1371: the beats name GRAPH CLASSES as they land, not shares — a
+    # share is up to 36/K classes and lands once, which on the fleet meant the
+    # first beat of a real mint arrived ~an hour in.
+    assert [beat[3] for beat in compile_beats[1:]] == [
+        "cls/dim=0", "cls/dim=1"]
 
 
 def test_a_tcg_pool_refusal_preserves_the_last_completed_share(
@@ -399,7 +405,7 @@ def test_a_tcg_pool_refusal_preserves_the_last_completed_share(
         "phase": aot_mint.PHASE_INDUCTOR_COMPILE,
         "step": 1,
         "total": 2,
-        "note": "share-a",
+        "note": "cls/dim=0",
     }
 
 


### PR DESCRIPTION
## Root cause (DB-proven, not inferred)

The pgw#1371 blocking-defect header — *"the pool never dispatches"* — is a misread of share-granular telemetry. From the standing hub's `worker_activity_events`:

- Pod **zco8e1bx0t1jgk** (0.122.0, 2026-08-17 19:57–20:58) ran the **identical** 36-class sdxl runtime-mint shape (`entry_workers 2, entries 36, vcpus 7`) to completion: both shares `child:finish status=compiled exit=0 classes=18`, `pool_wall_s 3608.19 / pool_busy_s 7208.36 / pool_efficiency 0.9989`. (It then died at adopt on pgw#1340/pgw#1356's `key_axis_divergence: family ''` — both fixed in 0.124.0.)
- Pods **rzz5p4e7b2kcpp** / **c7bx4yxbh3wx87** (0.124.0, e2e#1892 runs 7/8) ran the same shape and were **shut down by the harness at 2798 s and 471 s** — before the ~3600 s first-share horizon. A compile child reports ONCE, at the end of its 18-class share, and `pool_busy_s` / `n_entries` / the `compile:mint_progress` counter are fed only by reaped share reports — so 46 minutes of real, ~full-utilization compile work rolled up as `pool_busy_s 0 / n_entries 0`, and the hub's stall rule read the healthy mint as `self_stalled=t` from minute 10 to teardown (visible on the run-7 rows: `counter 0/2, self_stalled=t, occurrences 37`).

The pgw#1243 liveness guard measured the children's genuinely-advancing process-tree CPU and was **correct to stay quiet** — the pool was never idle; it only *reported* idle. Condemning it would have killed a working mint (the exact anti-pattern the no-magic-timeouts doctrine forbids).

## The fix

Per-class progress becomes a first-class wire:

- **`aot_compile_child`** streams one row per packed class into `<slot>/classes/NNN.json` the moment the artifact is on disk (the pgw#1183 durability atom, made parent-visible), plus a `position.json` beat at every phase boundary.
- **`aot_compile_pool`** harvests both every poll: `class_spans` fills live (so the phase snapshot and the abandon table name what landed — `n_entries` > 0 on a killed mint), the ledger gains `pool_classes_landed` and `pool_child_cpu_s` (observed child tree CPU — the number that distinguishes "torn down mid-flight" from "did nothing" when busy_s is 0), the silence window admits landed classes / position beats as evidence, a share that dies report-less still has its streamed classes named, and `compile()` grows an `on_class` callback.
- **`aot_mint.mint_graph_classes`** beats per GRAPH CLASS against the class goal (was: once per share against the worker count), so `compile:mint_progress` advances ~every class and `self_stalled` stays honest; a terminal beat stamps the final ledger onto the on-disk snapshot on abandon/failure.
- Guard condemnation polarity is unchanged: nothing newly condemned, nothing healthy killable.

## Tests

`tests/test_mint_live_class_progress.py` (real pool, real child processes, compile interior faked per the local-testing rule) covers: per-class beats, the exact fleet mid-flight-abandon shape (landed classes + observed CPU on the abandon path), the window admitting streamed evidence, the child↔pool file protocol with the production writer functions, and the killed-mint snapshot end-to-end through `mint_graph_classes`. Red-proofed with five mutations (window ignores progress / harvest disabled / driver drops on_class / child stops streaming / ledger stops counting) — each red; module 5x green; 429 tests green across the pool/mint suites; ruff + mypy clean.

## Deliberately NOT here (stated per the lane charter)

- **Per-graph mid-mint publish** — pgw#1371's own goal, blocked on th#2132/#1368.
- **CPU-budget / starvation fix** (run 7's invoke never returned in 65 min beside the mint): recommend nicing the fleet compile-child tree — `compile_posture`'s own doctrine says priority, not core reservation, is what protects a co-resident — but that reverses a tested pgw#1137 design statement and belongs to #1371's design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)