### PR TITLE
pgw#1374: Paul's comment-purge mandate, third repo — 463 comment lines, and the measurement that says why it is not 8,828

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,96 +1,40 @@
 name: CI
 
-# pgw#952 — this workflow is split into two PARALLEL jobs, and runs the full
-# suite on every PR. pgw#977 (2026-08-05) narrowed the trigger back to `master`
-# alone, because `dev` was deleted when the three-tier flow retired — lanes now
-# PR straight to `master`, so `[master]` IS the every-lane trigger. Both jobs
-# are the master ruleset's required contexts (`fast gates`, `tests`).
-#
-# ─── THE GAP THIS CLOSES, AND WHY IT STAYS CLOSED ──────────────────────────────
-#
-# Until pgw#952 a lane PR in this repository could run NO CI AT ALL. Verified on
-# PR #466 (`950-legacy-hardcut`, 215+/178-): `statusCheckRollup` was `[]`. Not a
-# check that passed — no check ran. At the time the cause was `ci.yaml` naming
-# only `master` while lanes targeted `dev`; the branch names have since swapped
-# roles, and the invariant that matters is the one to preserve:
+# pgw#952 — this workflow is split into two PARALLEL jobs and runs the full
+# suite on every PR.
 #
 #   **THIS WORKFLOW MUST TRIGGER ON WHATEVER BRANCH LANES ACTUALLY PR INTO.**
 #
 # If that branch is ever renamed or a second one added, change the list here in
 # the same commit. A lane merging with an empty check rollup is the failure this
 # file exists to make impossible, and a reader cannot tell it apart from "CI is
-# broken". pgw#949 is the same failure already written down: the integration
-# branch sat RED on two gw#666 guard tests since PR #455 and nothing said so.
+# broken" — it has happened (pgw#952, `statusCheckRollup: []`; pgw#949, a branch
+# red on two guard tests with nothing saying so).
 #
 # ─── WHY THE FULL SUITE IS PRE-MERGE HERE, UNLIKE TENSORHUB ────────────────────
 #
-# An older header said "CI spend is metered (WORKSPACE-GIT-POLICY.md)". That is
-# true of tensorhub, which is PRIVATE — and it is why tensorhub's `verify` moved
-# to a post-merge `push: [master]` trigger (th#1621/th#1114, ~24 runner-hours/day
-# at lane volume). **This repository is PUBLIC**
-# (`gh repo view --json visibility` -> PUBLIC), and GitHub Actions on standard
-# runners is free and unmetered for public repositories. `ubuntu-latest` is a
-# standard runner. That constraint does not exist on this repo, so the suite
-# stays pre-merge where it can actually block a defect.
-#
-# What remains real is LATENCY, not spend. That is what the two jobs below are
-# for: a lane gets the cheap verdict in ~1m35s and does not wait 15m to learn
-# that mypy is unhappy.
+# Tensorhub's `verify` moved to a post-merge `push: [master]` trigger because it
+# is PRIVATE and metered (th#1621/th#1114, ~24 runner-hours/day at lane volume).
+# **This repository is PUBLIC**, and GitHub Actions on standard runners is free
+# and unmetered for public repositories — so the suite stays pre-merge where it
+# can actually block a defect. What remains real is LATENCY, not spend, which is
+# what the two jobs are for: the cheap verdict in ~1m40s instead of 15m.
 #
 # ─── MEASURED, ON THE RUNNER ───────────────────────────────────────────────────
 #
-# Not extrapolated from this 32-core box — a 4-core `ubuntu-latest` behaves
+# Never extrapolate from this 32-core box — a 4-core `ubuntu-latest` behaves
 # nothing like it, which is the trap th#1572's lane fell into by a factor of 40.
-# Left column: run 30847566437, the last green run of the old single-job shape,
-# re-attributed to the two jobs below. Right column: this workflow's OWN PR
-# (#467, head 91c73388) — the shape as it actually ships. Both cold; there is no
-# cache in either.
-#
-#                                    old shape   THIS workflow (PR #467)
-#   Set up job + checkout                   4s      4s   both jobs
-#   Install uv + Set up Python 3.12         3s      2s   both jobs
-#   uv sync --locked --extra dev           21s  21-28s   both jobs
-#   ------------------------------------------------------- gates
-#   Type check (mypy)                      60s     58s
-#   Lint (ruff)                             0s      1s
-#   HTTP timeout guard                      1s      1s
-#   unreached public surface guard          2s      2s
-#   config reads guard                      2s      2s
-#   Build package                           2s      1s
-#                                       -------  ------
-#   gates JOB WALL                      1m 35s  1m 42s   observed GREEN, twice
-#   ------------------------------------------------------- tests
-#   Install llama-server (pinned, CPU)      1s      1s
-#   Run tests (v1)                     10m 59s 11m 13s   3092 passed, 2 failed
-#   Run tests (v2)                      3m 47s   3m 54s   21 passed
-#                                       -------  ------
-#   tests JOB WALL                     15m 15s 15m 37s
-#
-# `tests/` runtime is the only noisy line — 10m 17s and 11m 13s on two runs of
-# the same tree. That is runner variance on a 4-core box, not a signal; size the
-# 40-minute timeout against the upper figure, not the lower.
-#
-# The two jobs run concurrently, so a full run is ~15m 40s of WALL time against
-# the old serial 16m 22s, while returning the cheap half TEN times sooner
-# (1m 42s). The split costs one extra ~25s install and buys that.
-#
-# NOTE ON THE `Run tests (v2)` LINE. Its first run on this PR reported `skipped`,
-# not a duration, because `tests/` was red and a failing step skips every later
-# step by default — so the two-step split had never once delivered the property
-# its own comment claimed for it since pgw#808 ("a collection error in either
-# must not erase the other's answer"). `if: !cancelled()` at the step is the fix,
-# and the 3m 54s / 21 passed above is the proof: same red `tests/`, v2 reported
-# anyway.
+# Cold, no cache: `gates` 1m 42s · `tests` 15m 37s, of which `uv sync --locked
+# --extra dev` is ~21s and mypy ~58s. `tests/` is the only noisy line (10m 17s
+# vs 11m 13s on the same tree) — runner variance, so size the 40-minute timeout
+# against the upper figure.
 #
 # NO CACHE STEP, deliberately, and this is the one place the tensorhub precedent
-# (th#1572) does NOT transfer. There, `setup-go`'s cache key was shared across
-# workflows, a cheap sibling won the save, and that job paid a 224s compile every
-# run — so two explicit `actions/cache` steps were load-bearing. The Python
-# equivalent does not bite: `uv sync --locked --extra dev` is 21 SECONDS cold, on
-# a runner with no warm cache at all. An `actions/cache` restore of a uv cache
-# large enough to matter would cost more than it saves, and would add a key that
-# can go stale against `uv.lock`. If this line ever stops being true, measure the
-# install step first — it is step 5 in every run.
+# (th#1572) does NOT transfer: there `setup-go`'s cache key was shared across
+# workflows and the job paid a 224s compile every run. `uv sync` is 21 SECONDS
+# cold, so an `actions/cache` restore large enough to matter would cost more
+# than it saves and would add a key that can go stale against `uv.lock`. If that
+# ever stops being true, measure the install step first.
 #
 # ─── NO `paths:` / `paths-ignore:` FILTER ──────────────────────────────────────
 #
@@ -138,22 +82,15 @@ name: CI
 # script guards would every one of them have passed it. That is why the full
 # suite is on the PR trigger and not just the cheap half.
 #
-# pgw#977 (2026-08-05): `dev` is retired and lanes PR straight to `master`, so
-# the trigger names `master` alone.
+# pgw#1264 (2026-08-14, Paul's ruling): `fast gates` is the master ruleset's
+# ONLY required context. `tests` gates nothing and no longer runs on
+# `merge_group` at all — measured over ~300 runs, `CI` on `merge_group` was p50
+# 911s of which `tests` was 868s, so the suite WAS the queue's wall clock while
+# proving nothing about the merge, and ten speculative entries would hold ten
+# concurrent 14-minute runners in front of the required job.
 #
-# pgw#1264 (2026-08-14, Paul's ruling — SUPERSEDES the paragraph above about both
-# jobs being required): `fast gates` is now the master ruleset's ONLY required
-# context. `tests` gates nothing, and it no longer runs on `merge_group` at all.
-# Measured over ~300 runs before this change: `CI` on `merge_group` p50 911s, of
-# which `fast gates` was 122s and `tests` 868s — so the suite WAS the queue's
-# wall clock while proving nothing about the merge. With the queue widened to ten
-# speculative entries it would also hold ten concurrent 14-minute runners, and
-# the required job would queue behind its own workflow.
-#
-# What replaces it, so nothing is actually lost: `tests` still runs on EVERY PR
-# push (a lane sees its own regression before merging), on `workflow_dispatch`,
-# and NIGHTLY on `master` via the `schedule:` below. Pre-launch, a regression
-# found by tonight's nightly is cheaper than fifteen minutes on every merge.
+# What replaces it, so nothing is lost: `tests` still runs on EVERY PR push, on
+# `workflow_dispatch`, and NIGHTLY on `master` via the `schedule:` below.
 # pgw#1209 (2026-08-13): `master` has a MERGE QUEUE. A queued PR is validated on
 # a `gh-readonly-queue/master/...` ref carrying master's tip plus every entry
 # ahead of it — which is the only place the "two PRs green alone, red together"
@@ -176,24 +113,19 @@ name: CI
 # The trigger is deliberately bare (no `branches:`/`paths:` filter). A filter
 # that excludes a merge group is indistinguishable from case 1.
 #
-# TWO THINGS MEASURED WHILE TURNING THIS ON, both of which cost a live queue
-# stall and neither of which is in the obvious write-ups:
+# TWO THINGS THAT COST A LIVE QUEUE STALL, neither in the obvious write-ups:
 #
-#   * **GitHub reads workflows from the MERGE-GROUP ref, not from `master`.**
-#     Verified: with the queue switched on before this trigger had landed, four
-#     entries were queued and exactly ONE run existed — the group for the entry
-#     that carried this file's own edit. The three ahead of it showed
-#     `statusCheckRollup: none` and would have sat until the 60-minute timeout
-#     evicted them. So **enable the queue only AFTER the `merge_group:` trigger
-#     is already on `master`**, or the first entries queued cannot pass.
-#     (Corollary, and the reason the ordering is easy to get wrong: a PR that
-#     ADDS the trigger can validate itself in the queue, because its own group
-#     contains its own edit. That works and still leaves everyone else stuck.)
+#   * **GitHub reads workflows from the MERGE-GROUP ref, not from `master`**, so
+#     **enable the queue only AFTER the `merge_group:` trigger is already on
+#     `master`** — entries queued before it produce no run at all and sit until
+#     the 60-minute timeout evicts them. The ordering is easy to get wrong
+#     because a PR that ADDS the trigger validates itself: its own group carries
+#     its own edit, while everyone else is stuck.
 #   * **The repo setting "Allow auto-merge" must be ON.** `gh pr merge <n>`
 #     routes a queue merge through `enablePullRequestAutoMerge`, so with it off
-#     the enqueue fails outright with
-#     `Auto merge is not allowed for this repository`. It is a repository
-#     setting, not part of the ruleset, so enabling the queue does not turn it on.
+#     the enqueue fails with `Auto merge is not allowed for this repository`. It
+#     is a repository setting, not part of the ruleset, so enabling the queue
+#     does not turn it on.
 on:
   workflow_dispatch: {}
   merge_group:
@@ -229,25 +161,20 @@ jobs:
     name: fast gates
     # pgw#1268: this job has NO `if:` and must never grow one. It is the repo's
     # only required context, and GitHub scores a SKIPPED required check as
-    # SATISFIED — so any condition here is a false-green generator. Measured on
-    # th#1223 (2026-08-14): a run triggered while the PR was a draft evaluated
+    # SATISFIED, so any condition here is a false-green generator. Measured on
+    # th#1223: a run triggered while the PR was a draft evaluated
     # `github.event.pull_request.draft == false` as false, the job skipped, and
-    # the PR read fully green having run nothing. Undrafting produced no new run
-    # (the sha already had one) and re-running replays the original draft=true
-    # payload, so the lane escaped only by force-pushing a no-op amend.
+    # the PR read fully green having run nothing — undrafting produced no new
+    # run and re-running replays the draft=true payload, so the lane escaped
+    # only by force-pushing a no-op amend.
     #
-    # It is NOT, contrary to the version of this comment that landed with the
-    # guard removal, also false on `merge_group`. `null == false` is TRUE:
-    # GitHub coerces both sides of `==` to a number, so it reads `0 == 0`
-    # (measured te#199 round 2 on training-endpoints queue ref run 31833225624,
-    # where a job guarded by exactly that clause RAN). The explicit
-    # `merge_group` / `schedule` / `workflow_dispatch` arms this line used to
-    # carry were therefore redundant — they defended a mechanism that does not
-    # exist, while the draft failure that does went unnoticed behind them. That
-    # is the second argument for no condition at all rather than a carefully
-    # armed one: a guard whose behaviour turns on an expression-coercion rule is
-    # a guard nobody reads correctly.
-    # At ~1m35s the draft guard saved a rounding error; unconditional is the fix.
+    # A draft guard is NOT also false on `merge_group`: `null == false` is TRUE,
+    # because GitHub coerces both sides of `==` to a number and reads `0 == 0`
+    # (measured te#199 round 2, queue-ref run 31833225624). So explicit
+    # `merge_group` / `schedule` / `workflow_dispatch` arms defend a mechanism
+    # that does not exist while the draft failure that does goes unnoticed
+    # behind them — which is the second argument for no condition at all. At
+    # ~1m40s the draft guard saves a rounding error.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -255,16 +182,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pgw#1264: `@v6` HERE ONLY, and the version bump is the point rather than
-      # hygiene. The dependency install is 19-21s of this job's ~128s and the
-      # rest is mypy, so the download cache is the only cheap win left — but
-      # `@v4` bundles `@actions/cache` v3, which speaks the cache API GitHub
-      # retired, and asking v4 to cache MEASURABLY fails:
-      #   ##[warning]Failed to restore: Cache service responded with 400
-      # with nothing saved and no step turning red. So `enable-cache: true` on
-      # `@v4` is dead config that reads as a working cache. The other three
-      # workflows stay on `@v4` deliberately: none of them is the required
-      # context, and an unused action bump is risk without a payoff.
+      # pgw#1264: `@v6` HERE ONLY, and the version is the point. `@v4` bundles
+      # `@actions/cache` v3, which speaks the cache API GitHub retired, so
+      # `enable-cache: true` on `@v4` is dead config that reads as a working
+      # cache — it warns `Failed to restore: Cache service responded with 400`,
+      # saves nothing, and turns no step red. The other three workflows stay on
+      # `@v4`: none is the required context, so an unused bump is risk with no
+      # payoff.
       #
       # Cache scope note: Actions caches are branch-scoped, and a merge-group ref
       # is nobody's child — so the entry that makes queue runs fast is the one
@@ -299,10 +223,8 @@ jobs:
       # module added tomorrow is born strict. 101 modules carry a named
       # single-flag exemption; the guard below is what stops that list growing.
       #
-      # pgw#1202 PR 2: the TEST tree is checked too. Before that it was not
-      # merely unchecked — `mypy tests` REFUSED TO START on a duplicate
-      # `conftest` module, so 486 test modules had zero static coverage, which
-      # is where the doubles that lied about production contracts lived.
+      # pgw#1202 PR 2: the TEST tree is checked too — that is where the doubles
+      # that lie about production contracts live.
       - name: Type check (mypy, strict by default, src + tests)
         run: uv run mypy src/gen_worker tests tests_v2
 
@@ -401,11 +323,10 @@ jobs:
 
       # GATING (pgw#1299): TCG owns the compiled-graph metadata vocabulary and
       # exports it. A respelled `"graph_class"` / `"aot-inductor"` does not fail
-      # at import when TCG renames the key — it returns None from a `.get()` on
-      # an artifact-metadata dict, the arm reads an un-armed compiled graph as a cache
-      # miss, and the fleet silently re-mints. Filed three times (pgw#1288,
-      # pgw#1299); remembering failed. AST-based, so prose is not a finding, and
-      # a genuinely different vocabulary is classified at the line.
+      # at import when TCG renames the key — it returns None from a `.get()`,
+      # the arm reads an un-armed compiled graph as a cache miss, and the fleet
+      # silently re-mints. AST-based, so prose is not a finding, and a genuinely
+      # different vocabulary is classified at the line.
       - name: pgw#1299 guard - nobody respells TCG's metadata vocabulary
         run: |
           uv run python scripts/lint_tcg_vocabulary.py --selftest
@@ -413,18 +334,13 @@ jobs:
 
       # GATING (pgw#1297): the CAS and compiled-graph libraries were renamed to
       # `tensorfs` and `torchcg`, and BOTH old PyPI projects are permanently
-      # deleted — so an old spelling never points at anything that exists. This
-      # rename half-landed twice (pgw#1310 repointed every import and left the
-      # vendored directory and a dozen docstrings behind), which is why it is a
-      # fence and not a sweep. Text-based on purpose, unlike the AST fence
-      # above: here the prose IS the defect, because a docstring naming a module
-      # nobody can import sends the reader nowhere. `_vendor/` is exempt
-      # structurally: a vendored file is fixed upstream and re-vendored, never
-      # respelled here, and the digest fence refuses a hand-patch. pgw#1342: the
-      # vendored ref namespace is `torchcg/v1` now — the re-key that renaming it
-      # would have caused was taken deliberately under tcg#39 and is frozen
-      # upstream, so this exemption no longer stands in for an old spelling.
-      # The script's own spellings are listed in `RETIRED`; see its docstring.
+      # deleted — so an old spelling never points at anything that exists. A
+      # fence and not a sweep, because this rename half-landed twice. Text-based
+      # on purpose, unlike the AST fence above: here the prose IS the defect,
+      # because a docstring naming a module nobody can import sends the reader
+      # nowhere. `_vendor/` is exempt structurally — a vendored file is fixed
+      # upstream and re-vendored, never respelled here, and the digest fence
+      # refuses a hand-patch.
       - name: pgw#1297 guard - no retired package name survives
         run: |
           uv run python scripts/lint_retired_package_names.py --selftest
@@ -451,16 +367,12 @@ jobs:
           uv run python scripts/lint_repo_ref_pins.py --selftest
           uv run python scripts/lint_repo_ref_pins.py
 
-      # GATING (A18 / §1.32(d), pgw#1307 -> pgw#1319): the flavor axis is
-      # deleted and the residue is now ZERO — `ProducedFlavor.flavor`, the
-      # `label` read and `classify_flavor_token` are gone, the class is
-      # DECLARED, and the former residue paths get no exemption.
-      # `tests/test_flavor_deletion_pgw1148.py` asserts the same deletion and is
-      # NOT skipped (its one skipping row died at pgw#1167), but it runs in
-      # `tests`, which pgw#1264 took off the merge path — so without this step
-      # the required context would have no opinion about the axis at all.
-      # Selftest first: the fence must prove it goes red before its green means
-      # anything, and its last arm regrows the residue in its own former files.
+      # GATING (A18 / §1.32(d), pgw#1319): the flavor axis is deleted and the
+      # residue is ZERO — the class is DECLARED and the former residue paths get
+      # no exemption. It runs HERE because the equivalent test lives in `tests`,
+      # which pgw#1264 took off the merge path, so without this step the
+      # required context would have no opinion about the axis at all. Selftest
+      # first: the fence must prove it goes red before its green means anything.
       - name: A18 guard - the flavor is deleted and its residue is zero
         run: |
           uv run python scripts/lint_flavor_deletion.py --selftest
@@ -588,13 +500,12 @@ jobs:
         run: uv run python scripts/lint_credential_identity.py
 
       # GATING (pgw#1152): the ADOPT-PATH half of the same class. Four gates in
-      # a row — pgw#1108, pgw#1122, pgw#1141, pgw#1141b — were one defect: a
-      # rule written against the SELF-MINT path that the boot-adopt path does
-      # not take. `aot_serve._KNOWN_AOT_KEYS` had two feeders, both
-      # self-produced routes, so a compiled graph that resolved, materialized and armed
-      # was scored on the dynamo ledger and thrown away on a real pod. The rule
-      # is structural now (registration happens inside `load_and_wrap`), and
-      # this fence keeps it: a production feeder off the seam is red, a stale
+      # a row were one defect — a rule written against the SELF-MINT path that
+      # the boot-adopt path does not take, so a compiled graph that resolved,
+      # materialized and armed was scored on the dynamo ledger and thrown away
+      # on a real pod. The rule is structural now (registration happens inside
+      # `load_and_wrap`), and this fence keeps it: a production feeder off the
+      # seam is red, a stale
       # row is red, a SECOND map into a fenced object is red, and a TEST that
       # hand-feeds one or stubs a lane accessor is red — it drives
       # tests/harness/adopt_rig.py instead. There is no CONVENTION class.
@@ -642,15 +553,14 @@ jobs:
       - name: Build package
         run: uv build
 
-      # pgw#1310 / ie#738. BUILDING the wheel is not INSTALLING it, and the
-      # difference is a whole class of defect this workflow could not see: for
-      # Naming what WAS required is the whole point of the sentence below.
-      # retired-name: historical rationale, not a live reference.
-      # two published releases `gen-worker`'s metadata required `hashrepo`, a
-      # PyPI project that had been DELETED, so every unlocked consumer install
-      # died at resolution while every check here stayed green. `uv sync
-      # --locked` cannot catch it — a lock resolves from sources (git pins
-      # included) that a published wheel does not carry.
+      # pgw#1310 / ie#738. BUILDING the wheel is not INSTALLING it, and that
+      # difference is a whole class of defect this workflow could not see.
+      # retired-name: historical rationale, not a live reference —
+      # `gen-worker`'s metadata once required `hashrepo`, a PyPI project that
+      # had been DELETED, so every unlocked consumer install died at resolution
+      # while every check here stayed green. `uv sync --locked` cannot catch it:
+      # a lock resolves from sources (git pins included) that a published wheel
+      # does not carry.
       #
       # Deliberately in `fast gates` and not in `tests`: `tests` is neither
       # required nor run on the queue ref, so a wheel gate living there proves
@@ -705,13 +615,12 @@ jobs:
   # merge path.
   tests:
     name: tests
-    # pgw#1264: `!= 'merge_group'` is the whole change. This job proved nothing
-    # about a merge (it is not required) while costing the queue ~868s of its
-    # ~911s p50, and ten speculative entries would have held ten 14-minute
-    # runners in front of the required `fast gates`. It still runs on every PR
-    # push, on `workflow_dispatch`, and nightly on `master` via `schedule:`.
-    # `schedule` is named explicitly for the same null-`pull_request` reason
-    # `merge_group` was: without it the nightly would skip this job silently.
+    # pgw#1264: `!= 'merge_group'` keeps this job off the queue — it proves
+    # nothing about a merge (it is not required) and cost ~868s of the queue's
+    # ~911s p50. It still runs on every PR push, on `workflow_dispatch`, and
+    # nightly on `master` via `schedule:`. `schedule` is named explicitly for
+    # the same null-`pull_request` reason `merge_group` was: without it the
+    # nightly would skip this job silently.
     if: github.event_name != 'merge_group' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -762,13 +671,11 @@ jobs:
       # `-v` is dropped: xdist's per-worker interleaving makes it unreadable,
       # and failures print in full either way.
       #
-      # pgw#966: `-rs` and `--skip-census-out=` are not decoration. Until this
-      # issue, a skipped row and a passing row were the same character of
-      # nothing in this log, and the pgw#858 container row had been skipping
-      # here since it landed — reading as coverage, executing only on developer
-      # boxes, which is how the pgw#956 flake reached `dev` behind a green CI.
-      # `-rs` puts the reasons in the log for a human; the JSON feeds the guard
-      # at the end of this job, which is what makes the NEXT one fail a build.
+      # pgw#966: `-rs` and `--skip-census-out=` are not decoration. A skipped
+      # row and a passing row are otherwise the same character of nothing in
+      # this log, which is how a row reads as coverage while executing only on
+      # developer boxes. `-rs` puts the reasons in the log for a human; the JSON
+      # feeds the guard at the end of this job, which fails the NEXT build.
       - name: Run tests (v1)
         run: uv run pytest tests/ -n 4 --dist loadfile -rs --skip-census-out=.skip-census-v1.json
 
@@ -787,15 +694,13 @@ jobs:
       # erase the other's answer. The flip (pgw#808: point CI at `tests_v2/`,
       # `git rm -r tests/`) deletes the step above and this comment with it.
       #
-      # pgw#952: `if: !cancelled()` is what makes the paragraph above TRUE. It
-      # never was — a failing step skips every later step by default, so a red
-      # `tests/` silently erased the `tests_v2/` answer, which is exactly the
-      # outcome the two-step split was written to prevent. Observed on this
-      # workflow's own PR: `tests/` failed on pgw#949's two guards and
-      # `tests_v2/` reported `skipped`, telling a reader nothing about the
-      # zero-based suite. `!cancelled()` rather than `always()` so a cancelled
-      # run (the concurrency group above cancels superseded pushes) does not
-      # spend four more minutes on a result nobody will read.
+      # pgw#952: `if: !cancelled()` is what makes the paragraph above TRUE. A
+      # failing step skips every later step by default, so without it a red
+      # `tests/` silently erases the `tests_v2/` answer — exactly the outcome
+      # the two-step split was written to prevent. `!cancelled()` rather than
+      # `always()` so a cancelled run (the concurrency group above cancels
+      # superseded pushes) does not spend four more minutes on a result nobody
+      # will read.
       - name: Run tests (v2, zero-based — pgw#808)
         if: ${{ !cancelled() }}
         run: uv run pytest tests_v2/ -n 4 --dist loadfile -rs --skip-census-out=.skip-census-v2.json

--- a/.github/workflows/master-health.yaml
+++ b/.github/workflows/master-health.yaml
@@ -4,13 +4,11 @@ name: master health
 #
 # THE FAILURE THIS EXISTS FOR, AND IT HAPPENED HERE. A REQUIRED context can sit
 # RED on `master` with no PR responsible, and every merge-queue entry behind it
-# pays. Live 2026-08-13 in THIS repository: the required `fast gates` context
-# was red on master from a dead `typing.Literal` import left by an unrelated
-# merge. Queue entries that had nothing to do with it were blocked until
-# another session happened to notice. Nobody owned the red, because no PR
-# caused it. The nightly at 09:17 would have re-run the gate within 24h — and
-# would have said nothing to anyone, because a red run in the Actions tab is
-# not loud. That gap is what this file closes.
+# pays — measured live in this repository, `fast gates` red on master from a
+# dead import left by an unrelated merge, blocking entries that had nothing to
+# do with it until another session happened to notice. The 09:17 nightly would
+# have re-run the gate within 24h and said nothing to anyone, because a red run
+# in the Actions tab is not loud. That gap is what this file closes.
 #
 # THIS IS NOT A MERGE GATE AND MUST NEVER BECOME ONE. The job is named
 # `master_health` so it can never be confused with this repository's one
@@ -19,22 +17,18 @@ name: master health
 # can never be the skipped-required-check hazard that GitHub scores as
 # satisfied.
 #
-# WHY A SCHEDULE AND NOT `push: [master]` (measured 2026-08-14).
-# A push-triggered run is attributable to the merge commit, which is why it was
-# the first choice. Two things sank it here:
+# WHY A SCHEDULE AND NOT `push: [master]`, measured — two things sink the push
+# trigger even though it is attributable to a merge commit:
 #
 #   * REDUNDANCY. The merge queue re-runs `fast gates` against the exact tree
 #     that becomes `master`, immediately before it becomes `master`. A push
-#     re-run can only disagree with the queue through drift that is TIME-based
-#     rather than merge-based — a released dependency, a runner-image bump, a
-#     peer repo at `@master`. Time-based drift is precisely what a schedule
-#     catches and a push structurally cannot.
-#   * VOLUME. `master` takes ~38 merges/day (266 first-parent merges over 7
-#     days). A full CI pass bills ~17 job-minutes (measured run 31832283855:
-#     `fast gates` 115s, `tests` 861s, each rounded UP to the minute). This
-#     repository is PUBLIC, so standard-runner minutes are free and unmetered
-#     — the cost is not billing, it is ~646 runner-minutes/day of concurrency
-#     competing with the repo's own PR CI, for a verdict the queue already gave.
+#     re-run can only disagree with the queue through TIME-based drift — a
+#     released dependency, a runner-image bump, a peer repo at `@master` —
+#     which is precisely what a schedule catches and a push structurally cannot.
+#   * VOLUME. `master` takes ~38 merges/day and a full CI pass is ~17
+#     job-minutes, so a push trigger is ~646 runner-minutes/day of concurrency
+#     competing with the repo's own PR CI for a verdict the queue already gave.
+#     (The repo is PUBLIC, so the cost is concurrency, never billing.)
 #
 # 4x/day bounds detection at 6h for four extra CI passes a day.
 #

--- a/scripts/_lint_scope.py
+++ b/scripts/_lint_scope.py
@@ -1,7 +1,7 @@
 """Which subtrees of `src/gen_worker` a repo guard may not judge, and why.
 
-ONE HOME for that fact. Each guard used to spell its own exclusion (or forget
-to), so a new such subtree meant finding every scanner by running them.
+ONE HOME for that fact: a guard that spells its own exclusion (or forgets to)
+makes a new such subtree a hunt through every scanner.
 
 A directory belongs here only when the code in it is NOT OURS TO CHANGE:
 

--- a/scripts/emit_cg_keyset.py
+++ b/scripts/emit_cg_keyset.py
@@ -283,10 +283,9 @@ def derive(
         # THE MINT LANE'S EMITTER DOES NOT NEED A CARD. The document is
         # machine-INDEPENDENT — TCG class hashes, nothing folded — while the
         # tail of `derive` folds this process's `sm` into keys THIS script never
-        # uses. On a cardless box that fold refuses `no_runtime_sm` and used to
-        # discard a complete, correct set of traces at the last step. The traces
-        # are recorded before the fold (pgw#1353), so the honest thing here is to
-        # look for what landed rather than to treat the exception as the answer.
+        # uses, and on a cardless box that fold refuses `no_runtime_sm`. The traces
+        # are recorded BEFORE the fold (pgw#1353), so look for what landed rather than
+        # treating the exception as the answer.
         folded = f"not folded ({type(exc).__name__}: {exc})"
     try:
         document = keyset_store.read_document(cache / keyset.KEYSET_FILENAME)

--- a/scripts/lint_flavor_deletion.py
+++ b/scripts/lint_flavor_deletion.py
@@ -7,15 +7,12 @@ merge path, so nothing in the REQUIRED context (`fast gates`) would have an
 opinion about the flavor axis. A rename that regrows a reader merges green and
 is found on a pod. This runs where the merge is decided.
 
-THE RESIDUE IS GONE (pgw#1319, 2026-08-17). `ProducedFlavor.flavor`,
-the `label = flavor.flavor or ...` read and `classify_flavor_token` are all
-DELETED. The cross-repo condition that held them alive is discharged: te#225
-and te#227 made `precision_class` a DECLARATION at every training-endpoints
-producer that publishes a non-base row (eight sites — the census was wrong
-twice before it was made from the tree), and `convert.publish` now REFUSES a
-publish of sub-16-bit bytes that declares no class instead of guessing one from
-a label. So this file no longer holds an allowance at a size; it asserts that
-the axis names nothing at all, and the former residue paths get NO exemption.
+THE RESIDUE IS ZERO (pgw#1319). `ProducedFlavor.flavor`, the
+`label = flavor.flavor or ...` read and `classify_flavor_token` are DELETED;
+`precision_class` is a DECLARATION at every producer that publishes a non-base
+row, and `convert.publish` REFUSES sub-16-bit bytes that declare no class
+rather than guessing one from a label. So this file holds no allowance at a
+size: it asserts the axis names nothing at all, with NO exemption.
 
 Three rules, all AST — a grep cannot tell `X.flavor` from `flavor_label(...)`
 from `cgroup_flavor`, and this axis is a four-way homonym (the compiled graph

--- a/scripts/lint_materialization_hatch.py
+++ b/scripts/lint_materialization_hatch.py
@@ -27,12 +27,11 @@ actually has. A new row is a decision someone makes on purpose, in the design
 doc, not a call site that appeared in a diff.
 
 **`extract()` is the RETIRED SPELLING and is refused.** The same ruling renamed
-it (tensorfs#107), so there is now ONE name for the operation upstream and
-here. A fence that quietly accepted both would let the old name drift back in
-the moment someone copies an old snippet — and the last time this fence had a
-spelling problem it read a census of ZERO while a live materialization ran
-unnoticed. It is refused rather than silently ignored so the failure is a
-message about the rename instead of a mystery.
+it (tensorfs#107), so there is ONE name upstream and here. A fence that quietly
+accepted both would let the old name drift back the moment someone copies an
+old snippet, and a spelling problem in this fence reads as a census of ZERO
+while a live materialization runs unnoticed. Refused, not ignored, so the
+failure is a message about the rename instead of a mystery.
 
 WHY A LINT AND NOT A TEST. The hatch's whole failure mode is a site nobody
 looked at: every individual call works perfectly and the suite stays green
@@ -108,14 +107,10 @@ RETIRED_DEFINED_IN = {
 
 #: The hatch itself, scanned only where tensorfs is imported.
 #:
-#: ONE SPELLING, as of the #1303 ruling. It used to be two: §9 and upstream
-#: called the single-file hatch `extract()` while the rev this repo PINS
-#: (`_vendor/VENDORED.toml`) called the same operation
-#: `LocalCAS.materialize(entry, destination)` -- and a fence that matched only
-#: upstream's name matched NOTHING in the code it guards, reading a census of
-#: zero while a live first-party materialization ran at `aot_delivery.py`.
-#: tensorfs#107 renamed upstream's to `materialize()`, so the two names
-#: converged and the guard spells the one symbol its own snapshot exports.
+#: ONE SPELLING, as of the #1303 ruling (tensorfs#107 renamed upstream's
+#: `extract()` to `materialize()`): the guard spells the one symbol its own
+#: vendored snapshot exports. Two names is how a fence matches NOTHING in the
+#: code it guards and reads a census of zero while a live materialization runs.
 HATCH = re.compile(r"\.materialize\s*\(")
 
 #: The RETIRED spelling. Refused, not ignored -- see the module docstring.

--- a/scripts/lint_repo_ref_pins.py
+++ b/scripts/lint_repo_ref_pins.py
@@ -11,12 +11,10 @@ quoted string, in Python, JSON, TOML, YAML and Markdown. The owner segment may
 not contain a `.`, which keeps a registry-qualified OCI ref (`docker.io/x:1`,
 `ghcr.io/y:v2`) out.
 
-An earlier version of this paragraph also claimed "image tags never match the
-shape at all". **That was wrong**, and pgw#1347 found it: a Docker Hub image in
-a user namespace — `pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime` — is
-`<owner>/<repo>:<tag>` exactly, with no dot in the owner. The shape genuinely
-cannot separate a hub model ref from a container image ref, so the separation
-has to be STATED.
+**Image tags DO match the shape**: a Docker Hub image in a user namespace —
+`pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime` — is `<owner>/<repo>:<tag>`
+exactly, with no dot in the owner (pgw#1347). The shape cannot separate a hub
+model ref from a container image ref, so the separation has to be STATED.
 
 THERE IS NO PATH ALLOWLIST, and the design point is that it needs none. The
 three places a `:tag` string legitimately survives are recognised by what they

--- a/scripts/lint_serving_process_compiles.py
+++ b/scripts/lint_serving_process_compiles.py
@@ -9,11 +9,10 @@
     middle mint-child tier and lets the serving parent supervise compile
     children directly.
 
-    What used to be bought with a whole extra pipeline load is bought here
-    instead: **``torch.export`` and the AOTI compile entry points may only be
-    NAMED by a module that runs inside a compile/trace child.** Every other
-    module in ``src/gen_worker`` is serving-process code by default and a call
-    there is red.
+    **``torch.export`` and the AOTI compile entry points may only be NAMED by a
+    module that runs inside a compile/trace child.** Every other module in
+    ``src/gen_worker`` is serving-process code by default and a call there is red —
+    bought structurally rather than with a whole extra pipeline load.
 
 Why the fence lands WITH the supervisor rewrite and not after it: a fence that
 arrives after the change it guards never had a chance to go red.

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -573,13 +573,10 @@ def reached(d: Definition, reach: Reach) -> bool:
 # ---------------------------------------------------------------------------
 
 # DIRECTORY names, and this list being CLOSED is the fence. A NAMED sibling that
-# is not on disk is a REFUSAL that prints the path, never a skip — the loop below
-# used to `continue` past it, which is how the 2026-08-16 rename made this scan
-# read 5 corpora while printing "across 6 siblings, 0 unlisted consumers"
-# (pgw#1323). Renaming the entry fixed that instance; refusing fixes the class.
-#
-# `inference-endpoints` became `serverless-endpoints` on 2026-08-16 and
-# `training-endpoints` became `jobs` on 2026-08-17; both directory moves are done.
+# is not on disk is a REFUSAL that prints the path, never a skip: a `continue`
+# there is how a repo rename made this scan read 5 corpora while printing
+# "across 6 siblings, 0 unlisted consumers" (pgw#1323). Renaming an entry fixes
+# one instance; refusing fixes the class.
 SIBLINGS = ("jobs", "serverless-endpoints",
             "private-inference-endpoints", "tensorhub", "e2e", "cozy-local")
 def _workspace() -> Path:
@@ -612,8 +609,8 @@ def _sibling_texts(
     ``corpus`` is ``(repo, where, text)`` over every sibling checkout, and
     optionally over the content of every REMOTE BRANCH — a call site can live on
     an unmerged branch and is a consumer just the same. ``scanned`` is the repos
-    actually READ, which is the number the report prints; ``len(SIBLINGS)`` is
-    the number it used to print, and the gap between them is the whole defect.
+    actually READ, and it — never ``len(SIBLINGS)`` — is the number the report
+    prints; the gap between them is the whole defect.
 
     **A named sibling that is not on disk is a REFUSAL, not a skip.** So is a
     ``git grep`` that fails for any reason other than "no match" (rc 1). This
@@ -725,9 +722,8 @@ def siblings_selftest() -> int:
             bad += 1
 
         # ARM 2 — one named sibling absent: a REFUSAL that names the path, and a
-        # `scanned` count that is smaller than the declared list. This is the
-        # exact shape the 2026-08-16/17 repo renames created, and before this
-        # change it was a `continue` under a printed "across 6 siblings".
+        # `scanned` count smaller than the declared list. This is the shape a repo
+        # rename creates.
         gone = ws / "jobs"
         corpus, scanned, refusals = _sibling_texts(False, (), (*present, "jobs"), ws)
         if not refusals:

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -601,12 +601,12 @@ def _first_artifact(outcome: Any) -> Path:
 def _publish(hub: Any, request: Any, artifact: Path, report: Any = None) -> str:
     """The real `CompiledGraphPublisher`, against the local hub.
 
-    pgw#1341 made PROVENANCE a required argument: the env seal, the lane, the
+    pgw#1341 makes PROVENANCE a required argument: the env seal, the lane, the
     manifest digest and the two pod axes are facts the ARTIFACT cannot state
     (torchcg's metadata vocabulary is closed), so the publisher takes them
-    alongside the bytes and REFUSES a compiled graph that has none. This rig had not been
-    updated and was calling the four-argument form; nothing noticed, because
-    `scripts/` is off mypy's shared path and the rig never runs in CI.
+    alongside the bytes and REFUSES a compiled graph that has none. Nothing
+    catches a stale call site here — `scripts/` is off mypy's shared path and
+    this rig never runs in CI.
 
     The record is built from what the MINT reported, not re-derived here: a
     stand-in would publish this process's facts about the child's mint.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -13,18 +13,14 @@ Kind/phase strings are wire-shared with tensorhub
 Without a bound transport sink (cozy-local, tests) reports land on the
 logger, which IS the local progress UI.
 
-ie#522 (2026-07-21): the watchdog's default liveness evidence was process
-CPU seconds ONLY. Two real activities are honestly alive while burning
-near-zero CPU on the reporting process: (1) an I/O-bound network model
-fill (large composite checkpoints, tens of GB, minutes over a real link —
-CPU-light by design); (2) inductor compile phases that fork subprocess
-compile workers (torch's async_compile) — their CPU burn never showed up
-in this process's own `time.process_time()`. Both read as "stalled" to the
-hub's th#965 layer-3 rule after 10 minutes of no heartbeat, even mid
-genuine progress. Reproduced live twice (ie#522 wan-2.2 animegen boot
-warmup, two different RunPod hosts, identical ~9.5min self_mint_compile
-CancelledError at phase=load). Fixed two ways below: `_process_cpu_evidence`
-now sums live (not just reaped) child-process CPU via psutil, and
+ie#522: process CPU seconds alone are NOT liveness evidence. Two real
+activities are honestly alive while burning near-zero CPU on the reporting
+process: (1) an I/O-bound network model fill (tens of GB over a real link —
+CPU-light by design); (2) inductor compile phases that fork subprocess compile
+workers (torch's async_compile), whose burn never reaches this process's own
+`time.process_time()`. Both read as "stalled" to the hub's th#965 layer-3 rule
+after 10 minutes, mid genuine progress. So `_process_cpu_evidence` sums live
+(not just reaped) child-process CPU via psutil, and
 `note_progress()` lets an I/O callback (model-download byte ticks) heartbeat
 the current activity directly — proof-of-life from genuine external
 progress, independent of the CPU-sampling watchdog thread entirely.
@@ -134,10 +130,9 @@ KIND_COMPONENT_MISS = "component_miss"
 # frame_std_min, so ie#634's "corr 0.29 was uploaded and billed" is countable
 # hub-side instead of invisible.
 KIND_OUTPUT_INTEGRITY = "output_integrity"
-# pgw#1117 / th#1777: the pre-stage envelope precondition refused a slot load.
-# th#1867 deleted KIND_ENVELOPE_REFUSAL with the precondition that emitted it
-# (pgw#1117/th#1777): it compared the bound artifact against the release's
-# declared `vram_gb` under `strict_vram`, and both declarations are gone. The
+# th#1867 deleted KIND_ENVELOPE_REFUSAL with the pre-stage envelope
+# precondition that emitted it (pgw#1117/th#1777): it compared the bound
+# artifact against a declared `vram_gb`, and that declaration is gone. The
 # question it was really asking — "is this slot bound to the wrong artifact?" —
 # is th#1913's, and it is answered against the CATALOG, not a card size.
 KIND_ROTATION_PRELOAD = "rotation_preload"
@@ -190,10 +185,10 @@ KIND_ADOPT_REFUSED = "adopt_refused"
 # `phase` is `memo_dishonest` / `memo_unrulable`; `detail` carries
 # `assert_memo_honest`'s own sentence, which names every disagreeing class.
 KIND_BOOT_MEMO = "boot_memo_honesty"
-# th#1322: JIT (dynamo/inductor) compile duration, as a typed numeric event.
-# It used to be `logger.info("compiled %s in %.0fs")` and nothing else, so on a
-# hub-spawned pod (no stdout, pgw#760) the one number an AOT-vs-JIT comparison
-# needs did not exist anywhere. Same shape as `aot_mint_phases` deliberately:
+# th#1322: JIT (dynamo/inductor) compile duration, as a typed numeric event —
+# never a log line, because a hub-spawned pod has no reachable stdout (pgw#760)
+# and this is the one number an AOT-vs-JIT comparison needs. Same shape as
+# `aot_mint_phases` deliberately:
 # `phase=minted` carries the mint's roll-up in `duration_ms`, `phase=shape:<WxH>`
 # / `phase=child:<phase>` carry the spans inside it, so comparing the two mint
 # routes is ONE grouped query over worker_activity_events rather than a regex
@@ -266,9 +261,7 @@ PHASE_MINTED = "minted"
 PHASE_LOAD = "load"
 PHASE_TRACE_GRAPH = "trace_graph"
 PHASE_INDUCTOR_COMPILE = "inductor_compile"
-# pgw#989: the dynamo mint used to report its router drain under
-# PHASE_INDUCTOR_COMPILE, next to a `warmup_forward` row holding every compile
-# it ever ran. Re-exported (defined in `warm_spans`, which the mint child can
+# pgw#989. Re-exported (defined in `warm_spans`, which the mint child can
 # import without protobuf) so the vocabulary is enumerable from one module.
 PHASE_ROUTER_DRAIN = warm_spans.PHASE_ROUTER_DRAIN
 PHASE_WARMUP_FORWARD = "warmup_forward"

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -99,12 +99,11 @@ AOTI_ALIGNMENT = tcg_selection.AOTI_ALIGNMENT
 #: resolve/publish route. A future artifact v2 does not make the key grammar
 #: v2.
 #:
-#: HARD CUT, not compatibility: formats 1/2/3 of the deleted compiled graph/bundle
-#: implementations have no reader here. There is no 3->1 mapping and no
-#: accepted set: TCG Engine validates the artifact format while importing and
-#: resolving it, so this worker cannot consume a retired package by accident.
-#: The window is real and was measured before this shipped: the old store held
-#: 0 rows and no `cg-key-v1` object existed anywhere durable.
+#: HARD CUT, not compatibility: formats 1/2/3 of the deleted compiled
+#: graph/bundle implementations have no reader here. There is no 3->1 mapping
+#: and no accepted set — TCG Engine validates the artifact format while
+#: importing and resolving it, so this worker cannot consume a retired package
+#: by accident.
 #:
 #: The name is QUALIFIED on purpose. §1.38b: *"use qualified names such as
 #: `compiled_graph_format`, never the generic `format` that let pgw#1230
@@ -811,12 +810,9 @@ def no_entry_detail(
 ) -> str:
     """The ``no_entry_admits`` sentence, CLOSEST ENTRY FIRST (pgw#1074).
 
-    The refusal this replaces said "36 tried" and then listed six in iteration
-    order — and the one entry whose dims matched the call was not among them,
-    so diagnosing a live refusal meant pulling the published compiled graph apart off-pod
-    to find out what the covering entry actually objected to. A refusal that
-    hides the one relevant miss is the pgw#1058 lesson repeating one layer up,
-    in the diagnostics.
+    A refusal that names N tried and then lists the first few in iteration
+    order hides the one entry whose dims matched the call — the pgw#1058 lesson
+    repeating one layer up, in the diagnostics.
 
     So: rank by :func:`miss_distance`, name the closest entry and its FULL
     reason first (it survives any downstream truncation), then account for
@@ -2055,11 +2051,9 @@ def enable(
     pgw#1176: a miss here is a miss for ONE graph class. Nothing about it
     un-arms a sibling, and the caller's retry/mint policy is per class too.
 
-    pgw#923: the outcome is RETURNED rather than narrated. The classified
-    refusal reason used to leave this function only as the ``phase`` of a
-    free-text ``aot_adopt`` event, which is why the adoption that actually
-    happens on every boot had no measured row anywhere — the caller could not
-    see what it had just been told.
+    pgw#923: the outcome is RETURNED rather than narrated. A classified refusal
+    that leaves this function only as the ``phase`` of a free-text
+    ``aot_adopt`` event is one the caller cannot act on.
     """
     if artifact is None:
         return AdoptOutcome.miss("no_artifact")
@@ -2095,13 +2089,11 @@ def enable(
 def _marker_states(subject: Any) -> List[Dict[str, Any]]:
     """Every wrapped target's state dict on a marker — PIPELINE or MODULE.
 
-    pgw#1176, CORRECTED. I first deleted the single-``state`` branch here as
-    "a legacy shape only tests build". That was half right and the wrong
-    half: a bare ``state`` on a PIPELINE is indeed a shape nothing produces
-    (and no fixture builds one any more), but this function is also called
-    with a MODULE, and a bare ``state`` is exactly what :func:`wrap_module`
-    writes there — on every arm, in production. Deleting it made
-    `execution_count(module)` answer 0 for a module that had served.
+    pgw#1176: the single-``state`` branch is NOT a legacy shape. A bare
+    ``state`` on a PIPELINE is indeed a shape nothing produces, but this
+    function is also called with a MODULE, and a bare ``state`` is exactly what
+    :func:`wrap_module` writes there — on every arm, in production. Deleting it
+    makes `execution_count(module)` answer 0 for a module that has served.
 
     So the branch is not legacy and stays; what it reads is named. The two
     markers are different objects and always were: :func:`wrap_module` writes
@@ -2246,12 +2238,8 @@ def armed_entries(pipeline: Any) -> Dict[str, str]:
 def is_armed(pipeline: Any) -> bool:
     """Whether this pipeline is serving ANY compiled graph class right now.
 
-    pgw#1176 DELETED the every-target rule ("one revoked target means the
-    compiled graph no longer serves the contract its key advertises"). That rule was
-    the arming half of the wrong atom: a key that advertised 36 classes made
-    partial service a lie, so the guard was locally correct — and it is what
-    forbade the incremental compile-and-adopt this design exists to deliver.
-    A key now advertises ONE class, an entry arms whole or not at all, and a
+    pgw#1176: there is NO every-target rule. A key advertises ONE class, an
+    entry arms whole or not at all, and a
     de-armed entry costs itself. Mixed compiled/eager service is not a
     degraded state; it is the design's normal one, and it is numerically as
     proven as full coverage because every armed entry passed the same mint

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -97,13 +97,10 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     planner / economics gate — all of which have measurements the endpoint
     author does not.
 
-    th#1867 (DESIGN-RULINGS §1.35) deleted the LAST THREE VRAM markers this
-    struct carried — ``vram_gb_hint``, ``min_vram_gb`` and ``strict_vram`` —
-    and they went as ONE change because §2.4 ruling 4 measured what a partial
-    cut does: the hub builder folds an absent ``min_vram_gb`` from ``vram_gb``,
-    so deleting one of them silently drops a floor. Paul's ruling in one line:
-    *"We should be able to run any model on any GPU. The challenge is not IF it
-    can run — it's: is it an EFFICIENT choice?"* A card that looks too small is
+    th#1867 (DESIGN-RULINGS §1.35): this struct carries NO VRAM marker. Paul's
+    ruling in one line: *"We should be able to run any model on any GPU. The
+    challenge is not IF it can run — it's: is it an EFFICIENT choice?"* A card
+    that looks too small is
     a card whose best (GPU, lane) pair sits further down the operator's ladder,
     and the RUNTIME picks that rung from what it MEASURES (``models/memory.py``
     ``select_auto_mode``), never from what the author guessed. §1.2 measured the
@@ -129,25 +126,18 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     Declaring ``min_sm`` or ``min_vram_gb`` implies ``gpu=True``;
     ``min_host_ram_gb`` does not, and is declarable at ``recommended`` only.
 
-    It SUBSUMES the two axes deleted with it. ``compute_capability`` (pgw#660)
-    was the hard GPU-architecture floor — a producer whose kernel is
+    It SUBSUMES the two axes deleted with it. ``min_sm`` is the hard
+    GPU-architecture floor (pgw#660) — a producer whose kernel is
     ``torch._scaled_mm`` cannot run below sm_89 at any precision, on any rung,
     ever, and with no carrier the scheduler placed the fp8 producer on sm_80
-    A100s (th#1155 six times; te#125 again). That floor survives verbatim as
-    ``min_sm``, in tensorhub's own BARE spelling (89, 100), which is the one
-    wire spelling for the axis on both sides; the dotted 8.9 is gone rather
-    than kept as a second form. ``ram_gb_hint`` (pgw#670, sized at 64 GB from
-    ie#484's 179-301 s host-starved encode tails) survives as
-    ``min_host_ram_gb``, at the recommended level: Paul 2026-07-11 ruled that
-    RunPod GPU pods cannot select or guarantee host RAM, so a host-RAM
-    MINIMUM is unenforceable theater. Unmet, it is a degrade warning, which is
-    what the offload rungs already do.
+    A100s. It is spelled BARE (89, 100), tensorhub's own spelling and the one
+    wire spelling on both sides. ``min_host_ram_gb`` (pgw#670) is declarable at
+    the RECOMMENDED level only: Paul 2026-07-11 ruled that RunPod GPU pods
+    cannot select or guarantee host RAM, so a host-RAM MINIMUM is unenforceable
+    theater. Unmet, it is a degrade warning, like the offload rungs.
 
-    There is no disk axis. ``min_disk_gb`` (pgw#732) existed for two releases
-    and no endpoint in any repo ever declared it — th#1233 sizes a pod's
-    container disk from the bytes the job will materialize, which covers every
-    live case — so HARDCUT C3 deleted the emitter rather than keep an unused
-    author-facing knob.
+    There is no disk axis: th#1233 sizes a pod's container disk from the bytes
+    the job will materialize, which covers every live case.
 
     ``vcpus`` declares the host-side vCPU ask (CPU-heavy encode);
     it does not imply ``gpu=True``. ``gpu_count`` declares how many devices
@@ -1227,10 +1217,10 @@ def _validate_handler_shape(
             "prefix non-handler methods with an underscore."
         )
     if is_method and len(params) > 2:
-        # pgw#1332 reopens this, for FAMILIES and nothing else. What SDK v2
-        # rejected was a per-handler MODEL argument: a slot injected per call
-        # made one live instance able to serve bindings it was not routed for,
-        # which is why `setup()` owns model state instead.
+        # pgw#1332 admits a per-handler parameter for FAMILIES and nothing
+        # else. What SDK v2 rejected was a per-handler MODEL argument: a slot
+        # injected per call makes one live instance able to serve bindings it
+        # was not routed for, which is why `setup()` owns model state.
         #
         # A family instance is the opposite shape and closes the same hole a
         # different way. It is not a slot, it is not a path, and it is not

--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -21,9 +21,8 @@ class Asset(msgspec.Struct):
         returns just ``ref`` + the immutable bytes-attestation fields
         (``sha256``, ``blake3``, ``size_bytes``, ``mime_type``,
         ``media_id``). gen-orchestrator re-presigns the download URL on
-        every client read via tensorhub's ``POST /api/v1/media/urls``.
-        gen-orchestrator issue #318 deleted the upload-time URL caching
-        and the asset-receipt JWT.
+        every client read via tensorhub's ``POST /api/v1/media/urls``; there is
+        no upload-time URL caching and no asset-receipt JWT.
       - Inline ``inline_bytes``: the worker SKIPPED the tensorhub upload
         and returned the raw bytes directly. Used when the client asked
         for ``Prefer: bytes=inline`` and the payload fits under the

--- a/src/gen_worker/artifact_meta.py
+++ b/src/gen_worker/artifact_meta.py
@@ -133,14 +133,10 @@ def compiled_graph_metadata_fields() -> FrozenSet[str]:
     ever satisfy is refused for $0 instead of after a 25-minute paid compile
     (th#2098 / pgw#1340).
 
-    THE PUBLIC NAME EXISTS NOW, and it is read here. pgw#1340 first exported
-    ``ARTIFACT_METADATA_FIELDS`` by editing the vendored snapshot, which
-    pgw#1310's digest fence refuses by design (*"a vendored snapshot is fixed
-    upstream and re-vendored, never patched here"*) and which turned master red;
-    pgw#1345 repaired that by reading the private ``_TOP_LEVEL_FIELDS`` and said
-    what the real fix was: *"when the public name is wanted it is added UPSTREAM
-    and re-vendored."* tcg#40 (torchcg#42, vendored here at pgw#1342) did exactly
-    that, so this reads the public name and the ``getattr`` shim is gone.
+    It reads torchcg's PUBLIC ``ARTIFACT_METADATA_FIELDS``, added upstream and
+    re-vendored (tcg#40 / torchcg#42, vendored at pgw#1342). A vendored snapshot
+    is fixed upstream and re-vendored, never patched here — pgw#1310's digest
+    fence refuses that by design.
 
     That matters beyond tidiness. A private name is a name upstream owes nobody
     anything about; a public one is fenced upstream against the behaviour it

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -88,7 +88,7 @@ from .keyset import store as keyset_store
 logger = logging.getLogger(__name__)
 
 #: Gates that refuse BEFORE :func:`attempt` is entered — the executor's own
-#: preconditions. These are the ones that used to be a bare ``return None``.
+#: preconditions. None of them may be a bare ``return None``.
 GATE_REASONS: Tuple[str, ...] = (
     # `aot_mint.export_declaration(family)` answered None: this family ships no
     # export declaration, so no key can name its class set.
@@ -130,9 +130,8 @@ LOCAL_REASONS: Tuple[str, ...] = (
     # capable as a property and as an accident of the arm-token memo.
     "local_hit",
     # Derived, asked this machine's own store, and it does not hold this key —
-    # and there is no hub to ask either. The honest successor to a `no_hub`
-    # that used to fire BEFORE the derivation and therefore before the local
-    # store had an address to be asked at.
+    # and there is no hub to ask either. Reported AFTER the derivation, because
+    # before it the local store has no address to be asked at.
     "local_miss_no_hub",
 )
 
@@ -180,12 +179,10 @@ DERIVE_REASONS: Tuple[str, ...] = (
 ASK_REASONS: Tuple[str, ...] = (
     "invalid_request", "resolve_unreachable",
     "miss", "materialize_failed", "hit",
-    # pgw#1122 — the LAST terminus, and the one the journey previously ran off
-    # the end of. `hit` was reported at resolve+materialize, and everything
-    # after it (the receipt gate, the publisher check, the arm itself) was
-    # somebody else's exception. So three pods emitted `boot_adopt=hit` and
-    # then failed their function, and the event that promised to name the gate
-    # named the gate BEFORE the one that refused.
+    # pgw#1122 — the LAST terminus. Reporting `hit` at resolve+materialize leaves
+    # the receipt gate, the publisher check and the arm itself as somebody else's
+    # exception, so a pod emits `boot_adopt=hit` and then fails its function —
+    # the event names a gate BEFORE the one that refused.
     "arm_refused",
 ) + tuple(compiled_graph_resolve.REFUSAL_CODES)
 

--- a/src/gen_worker/boot_key.py
+++ b/src/gen_worker/boot_key.py
@@ -1,13 +1,12 @@
 """MINT-LANE TOOLING (pgw#1327): derive a family's ``cg-key-v1`` entry key SET
 from CODE ALONE, by structure-only ``torch.export`` traces in child processes.
 
-**This module is no longer on the serve-boot path.** Until pgw#1327 every pod
-ran the traces below at boot — its own docstring said *"< 60 s, every time, ~99 %
-of it the traces"* — which made torch, diffusers and the endpoint's model code a
-hard dependency of a pod that will never compile anything. The traces compute a
-pure function of code the mint lane already ran, so their OUTPUT is now emitted
-as a ``cg-keyset-v1`` document (:mod:`gen_worker.keyset`) and a serve pod reads
-it as data. What remains here is the DERIVATION, which the mint lane owns:
+**This module is not on the serve-boot path** (pgw#1327). Running the traces
+below at boot makes torch, diffusers and the endpoint's model code a hard
+dependency of a pod that will never compile anything. They compute a pure
+function of code the mint lane already ran, so their OUTPUT is emitted as a
+``cg-keyset-v1`` document (:mod:`gen_worker.keyset`) and a serve pod reads it as
+data. What remains here is the DERIVATION, which the mint lane owns:
 
 * an ordinary Python serving pod that misses and mints (§4.28) runs this once and
   records the closure in its own cache;
@@ -70,14 +69,10 @@ and re-derives on the next boot. ``trust_memo=False`` is the explicit
 verification posture. A wrong key is never produced — at worst a cached row is
 thrown away, by the pod that proved it wrong.
 
-THE CALLER, named here because for the whole of pgw#1089's life there was none:
-``mint_supervisor.rule_on_boot_memo``, at the seal/publish seam of every
-supervised mint. Until pgw#1271 this paragraph described a check with **zero
-``src/`` callers** — ``trust_memo=False`` was passed only from tests, both
-production callers took the default, and so the sentence above was FALSE in the
-deployed configuration. It is a sentence that reads exactly like enforcement,
-which is why nothing caught it. If you move the mint's publish seam, move the
-call with it; a paragraph is not a caller.
+THE CALLER, named because this check once had none in ``src/`` while its
+description read exactly like enforcement: ``mint_supervisor.rule_on_boot_memo``,
+at the seal/publish seam of every supervised mint. If you move the mint's
+publish seam, move the call with it — a paragraph is not a caller.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/boot_trace_child.py
+++ b/src/gen_worker/boot_trace_child.py
@@ -209,13 +209,11 @@ def run(job: TraceJob) -> int:
 
     # The weight-free PREMISE, fenced (pgw#1173). Every declared target this
     # pipeline carries must hold zero real parameters — an ALL-of check, and
-    # one that does not care which device the weights are on. The two guards
-    # that stood here before could both read clean on a composition that traces
-    # real weights: `off_host_tensors` sees nothing because `place=False` puts
-    # them on the HOST, and `structure_only_components` is satisfied by ANY one
-    # virtual component, so a two-target family with one target stranded passed
-    # both. This is the seam every downstream VRAM conclusion rests on, so it
-    # fails closed and names the component, the class and the bytes.
+    # one that does not care which device the weights are on (`place=False`
+    # puts real weights on the HOST, where a device-scoped guard sees nothing;
+    # an ANY-of guard passes a two-target family with one target stranded).
+    # This is the seam every downstream VRAM conclusion rests on, so it fails
+    # closed and names the component, the class and the bytes.
     try:
         structure_only.assert_weight_free(
             pipeline, cfg.targets, what=f"the boot trace of {job.function!r}")

--- a/src/gen_worker/boot_trace_child.py
+++ b/src/gen_worker/boot_trace_child.py
@@ -41,16 +41,12 @@ The weight-free premise is FENCED, not assumed (pgw#1173)
 ---------------------------------------------------------
 Every VRAM conclusion in the compile loop follows from "compilation is
 weight-free", so this child proves it about the pipeline it is about to trace
-rather than inferring it from the absence of a complaint. Two guards used to
-stand here and neither could see the case they were named for: a
-``place=False`` load puts real weights on the HOST, where
-:func:`off_host_tensors` cannot see them, and
-``structure_only.structure_only_components`` is satisfied by ANY one virtual
-component, so a family declaring two targets passed with one of them stranded
-on real weights. :func:`gen_worker.models.structure_only.assert_weight_free`
-is the ALL-of check over the declared targets, device-blind, typed
-``StructureNotHonored`` — the type that already means exactly this and that
-this path is required to treat as fatal.
+rather than inferring it from the absence of a complaint.
+:func:`gen_worker.models.structure_only.assert_weight_free` is the ALL-of check
+over the declared targets, device-blind, typed ``StructureNotHonored``. A
+device-scoped guard cannot do it — a ``place=False`` load puts real weights on
+the HOST — and an ANY-of guard passes a family whose second target is stranded
+on real weights.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/child_contract.py
+++ b/src/gen_worker/child_contract.py
@@ -67,15 +67,11 @@ class CompileSpec(msgspec.Struct, frozen=True, kw_only=True):
 class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
     """One setup slot, as the parent resolved it. Present and complete, or absent.
 
-    pgw#974. This used to be parallel slot-keyed dicts on ``MintRequest`` —
-    ``snapshots`` (bytes) and ``slot_bindings`` (identity, pgw#969) — written
-    by separate statements, each independently allowed to be empty. Some of
-    the combinations that describes are incoherent, and one of them cost two
-    L40S pods: ``{"pipeline": "/tmp/x"}`` with no binding decoded, type-checked
-    and looked complete, and the child died 0.0 s into ``warmup_forward`` at
-    ``ctx.slots["pipeline"]``. ``ref`` and ``path`` therefore carry no
-    defaults: a slot with bytes and no identity cannot be constructed and
-    cannot be decoded.
+    pgw#974: ONE type, so bytes and identity cannot be written by separate
+    statements and independently left empty. ``ref`` and ``path`` carry no
+    defaults — a slot with bytes and no identity cannot be constructed and cannot
+    be decoded, which is the combination that used to type-check, look complete
+    and kill the child 0.0 s into ``warmup_forward``.
 
     A slot the parent did not resolve is ABSENT from the map — never a present
     one with a hole in it. ``child_preflight.assert_slots_resolvable`` still

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -13,8 +13,7 @@ the orchestrator-backed bits with local-mode equivalents:
   set (no tensorhub upload).
 - ``materialize_blob`` on ``LocalJobContext`` falls back to the local CAS
   unless ``--allow-publish`` delegates to the real implementation. ONE answer
-  for every producer kind — before pgw#1306 there were three, and two of them
-  were wrong (see that class's docstring).
+  for every producer kind (pgw#1306).
   (Checkpoint publishing goes through ``gen_worker.convert.publish_flavors``,
   which talks to tensorhub directly and fails loudly without credentials.)
 - ``_canceled`` is toggled by the installed SIGINT handler in ``run.py``.
@@ -161,17 +160,12 @@ class LocalJobContext(LocalRequestContextMixin, JobContext):
     ``--allow-publish`` was passed (in which case we delegate to the real
     implementation — useful for round-tripping against a dev tensorhub).
 
-    **pgw#1306 collapsed three classes into this one, and the collapse fixed a
-    live defect rather than tidying names.** There used to be a
-    `LocalConversionContext` / `LocalDatasetContext` / `LocalTrainingContext`,
-    selected by kind, and the three disagreed about the same question. Measured
-    on `b7a9345a`: `conversion` honored `--allow-publish`; `dataset` had a
-    near-copy of this stub that IGNORED it; `training` overrode nothing at all,
-    so `gen-worker run --offline` on a training endpoint reached
-    `_PublisherMixin.materialize_blob` — the REAL hub-backed implementation —
-    in the loop whose entire purpose is to not have a hub. Nobody chose that;
-    it was inherited from whichever producer-kind class each local subclass
-    happened to sit on. One class cannot disagree with itself.
+    **ONE class for every producer kind (pgw#1306), and that is the defect
+    fix.** Three kind-selected classes disagreed about whether
+    ``--allow-publish`` was honored, so ``gen-worker run --offline`` on a
+    training endpoint reached the REAL hub-backed ``materialize_blob`` in the
+    loop whose entire purpose is to not have a hub. One class cannot disagree
+    with itself.
     """
 
     def materialize_blob(

--- a/src/gen_worker/cli/model.py
+++ b/src/gen_worker/cli/model.py
@@ -191,8 +191,7 @@ def _handle_export(args: argparse.Namespace) -> int:
         return 2
     # An EAGER declaration takes the torch-free path: it has no graph classes,
     # so there is nothing to trace and `eager_model_v1` is what it can honestly
-    # state (pgw#1346 B5). The refusal this replaces was correct about the
-    # graph tier and wrong to leave the eager tier with no export at all.
+    # state (pgw#1346 B5).
     document: Any
     if isinstance(family, GraphModelSpec):
         from ..model.export import export_model

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -609,11 +609,9 @@ def run_setup(
         params = inspect.signature(setup_fn).parameters
     except (TypeError, ValueError):
         # Odd callables without an inspectable signature (decorated,
-        # C-implemented, wrapped). pgw#1307: this used to swallow the TypeError
-        # and re-call `setup_fn()` with NO models, silently dropping every
-        # resolved slot — the exact blanket arm this function's docstring
-        # forbids. A setup we cannot satisfy is an authoring error; let it
-        # raise, naming the models we resolved.
+        # C-implemented, wrapped). pgw#1307: never swallow the TypeError and
+        # re-call `setup_fn()` with NO models — a setup we cannot satisfy is an
+        # authoring error; let it raise, naming the models we resolved.
         setup_fn(**resolved_models)
         return {} if return_loaded else None
     if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -6,20 +6,13 @@ dirs, published as a repo flavor; workers that opt in via
 ``@endpoint(compile=Compile(...))`` seed those dirs before load and hit the
 cache with no compiler and no stall.
 
-**Who produces one, as of 2026-08-11 (th#1800).** The worker itself, and
-nobody else. The out-of-process producer this module was designed around —
-training-endpoints ``produce-inductor-cache`` — was DELETED by te#179 (it
-minted ``kind="torch-inductor-cache"``, and th#1788 made ``aot-inductor`` the
-only class the hub adopts, so its publishes were refused before entering the
-store), and DESIGN-RULINGS §4.28/§4.30 make that permanent: there is no
-central compile service, no mint request and no compile fleet, and compilation
-runs on the machine that will USE the compiled graph. A family too large to self-mint beside its own server is a
-PLACEMENT question — boot its serving pod on a card that fits, per §4.28's
-"pre-warming a release/SKU = boot an ordinary serving pod there". pgw#1175
-deleted the ``card_bytes`` figure that used to answer it: it was
-``resident + need`` where ``need`` already re-charged ``resident``, and the
-49-113 GiB card classes it produced are retracted (§4.33). A mint costs ~8 GiB;
-what a family needs is measured by attempting it.
+**Who produces one: the worker itself, and nobody else** (DESIGN-RULINGS
+§4.28/§4.30). There is no central compile service, no mint request and no
+compile fleet — compilation runs on the machine that will USE the compiled
+graph. A family too large to self-mint beside its own server is a PLACEMENT
+question: boot its serving pod on a card that fits, per §4.28's "pre-warming a
+release/SKU = boot an ordinary serving pod there". A mint costs ~8 GiB; what a
+family needs is measured by attempting it, never predicted (§4.33).
 
 Policy: cache miss / key mismatch / no artifact leaves ordinary lanes eager,
 never causing a boot stall or a runtime compile attempt in prod. A declared
@@ -116,13 +109,8 @@ logger = logging.getLogger(__name__)
 # ingredient of the semantic cache tag (`_semantic_cache_tag`) and is not the
 # compiled-graph metadata schema, which is `aot_serve.COMPILED_GRAPH_FORMAT`.
 #
-# pgw#1230 RENAMED it from `ARTIFACT_FORMAT`. Two different facts shared that
-# name across two modules; `fleet_compiled_graphs.arm_identity` read THIS one to compute
-# the `format` axis it compares against what the child stamped from
-# `aot_serve`'s. They were both 2, so the comparison passed by coincidence
-# until pgw#1176 moved the compiled graph schema to 3 — after which every freshly minted
-# compiled graph failed to arm with `key_axis_divergence`. The value is unchanged, so no
-# cache tag moves; only the name that made the confusion possible does.
+# pgw#1230 RENAMED it from the generic `ARTIFACT_FORMAT`, which two modules
+# shared for two different facts. The value is unchanged, so no cache tag moves.
 #
 # 2 (gw#391): key gained the producer gen-worker version. ie#496 extends its
 # metadata with the canonical module graph, shape/target table and weight-lane
@@ -143,10 +131,9 @@ _LOCK_TYPE = type(threading.Lock())
 # the class ``__code__`` dynamo already compiled — on torch 2.13 (inlined
 # nn-modules) the cached entry's guards match the new instance and the
 # warmup call runs COMPILED with zero FX/AOT counter movement
-# (calls>0, hits=0, misses=0). That signature against a compiled graph this process
-# already proved is service, not silence: disproving it bricked the
-# compiled lane fleet-wide on every multi-checkpoint session (2026-07-24
-# incident, 6/6 workers). The registry below records every compiled graph proven in
+# (calls>0, hits=0, misses=0). That signature is service, not silence:
+# disproving it bricked the compiled lane fleet-wide on every multi-checkpoint
+# session. The registry below records every compiled graph proven in
 # this process (a real FX/AOT hit, or a finalized self-mint); crediting the
 # in-memory surface additionally requires DIRECT evidence from dynamo that
 # compiled code for this object's targets is live
@@ -357,22 +344,21 @@ def reset_target_code(pipeline: Any) -> int:
 # ---------------------------------------------------------------------------
 # pgw#680: guard-miss doctrine — fail-on-recompile at serve time.
 #
-# The 187s incident class: a tenant request whose inputs miss every cached
-# guard set used to pay dynamo's INLINE recompile inside the request (and,
-# single-flight, stall every request queued behind it). Doctrine: tenant
+# A tenant request whose inputs miss every cached guard set used to pay dynamo's
+# INLINE recompile inside the request and, single-flight, stall every request
+# queued behind it — the 187s incident class. Doctrine: tenant
 # requests on compiled lanes run under a fail-on-recompile stance; the raise
 # is caught in the guard wrappers, THIS request serves eager immediately, the
 # guard-failure reason is recorded verbatim (Activity event + hub-countable),
 # and the exact input class is healed by the existing background warm driver
 # so the SECOND request of that shape is compiled.
 #
-# Stance choice (deliberate, torch 2.13): ``torch._dynamo.config
-# .error_on_recompile`` scoped via ``config.patch`` around the guarded
-# compiled call — NOT ``torch.compiler.set_stance("fail_on_recompile")``.
-# Two reasons, both verified against torch 2.13.0:
-#   1. Scope. ConfigModule user overrides are ContextVars, i.e. THREAD-LOCAL
-#      (the same mechanics gw#608 measured for ``enable_autograd_cache``).
-#      The stance therefore arms exactly the serving thread's guarded call;
+# Stance choice (deliberate, verified against torch 2.13.0):
+# ``torch._dynamo.config.error_on_recompile`` scoped via ``config.patch``
+# around the guarded compiled call — NOT
+# ``torch.compiler.set_stance("fail_on_recompile")``.
+#   1. Scope. ConfigModule user overrides are ContextVars, i.e. THREAD-LOCAL,
+#      so the stance arms exactly the serving thread's guarded call;
 #      the hot-swap shape-warm thread and the background mint driver — which
 #      run CONCURRENTLY with tenant requests by design (pgw#671) — keep
 #      compiling freely. ``set_stance`` mutates a module-global and swaps the
@@ -451,16 +437,13 @@ GRAPH_BREAK_TOKEN = "graph_break"
 #: pgw#1082: the declaration named a dynamic range its own inputs leave.
 DECLARED_RANGE_TOKEN = "declared_range_exceeded"
 
-#: pgw#1093: the CATCH-ALL permanent degrade. A regional/whole-graph target
-#: that raised anything OTHER than a graph break, a declared-range refusal or
-#: a recompile miss used to degrade to eager on a `logger.warning` alone —
-#: and a hub-spawned pod has no reachable stdout, so the degrade was invisible
-#: (pgw#824's own ruling). Worse, `is_compile_armed` then reads False, which
-#: makes an INSTALLED-THEN-DEGRADED target byte-identical on the wire to a
-#: NEVER-INSTALLED one: same `metrics.lane=…+eager`, same
-#: `fallback_reason=uncompiled`, same `boot_ended_uncompiled`, zero other
-#: rows. Two different defects, one indistinguishable reading — which is
-#: exactly how pgw#1093 spent a pod attributing the wrong cause.
+#: pgw#1093: the CATCH-ALL permanent degrade, for a regional/whole-graph
+#: target that raised anything OTHER than a graph break, a declared-range
+#: refusal or a recompile miss. It must reach the WIRE: `is_compile_armed`
+#: then reads False, which without this row makes an INSTALLED-THEN-DEGRADED
+#: target byte-identical to a NEVER-INSTALLED one — same
+#: `metrics.lane=…+eager`, same `fallback_reason=uncompiled`, same
+#: `boot_ended_uncompiled`. Two different defects, one reading.
 COMPILED_DEGRADE_TOKEN = "compiled_degraded"
 
 
@@ -750,13 +733,9 @@ def execution_lane_label(weight_lane: str, lora_bucket: int = 0) -> str:
     inside it (``("w8a8", 128)`` -> ``"w8a8-lora128"``). A bucket the lane
     string already carries wins — it is what was actually traced.
 
-    pgw#1040: this body existed twice, byte for byte, as
-    ``graph_facts``'s canonical execution lane and
-    ``aot_contract.ExportSpec.execution_lane_label``; both were folded here.
-    Since pgw#1059 the lane is store METADATA + discovery scoping, never a
-    key axis — but the one-derivation rule stands for the same reason: a
-    lane stamped under one spelling and scoped under another is a compiled graph
-    discovery can never find.
+    ONE derivation (pgw#1040), even though the lane is store METADATA +
+    discovery scoping and never a key axis: a lane stamped under one spelling
+    and scoped under another is a compiled graph discovery can never find.
     """
     base, observed = execution_lane_bucket(str(weight_lane or ""))
     bucket = observed or int(lora_bucket or 0)
@@ -1007,16 +986,16 @@ def toolchain_digest() -> Tuple[Tuple[str, str], ...]:
     CONFIGURE IT", per component — the ``toolchain`` key axis's whole input.
 
     THE COMPILER, and not the model libraries (pgw#1050): ``diffusers`` /
-    ``transformers`` / ``peft`` rode this axis until 2026-08-11 and were
-    evicted because their whole effect on a compiled graph arrives through the traced
-    graph, which the ``graph`` axis hashes node-for-node since pgw#1031 —
-    see ``torchcg.identity``'s membership rules for the channel-by-channel argument
-    and for the two fences (B1 code-only + the pgw#1097 folding fence;
-    ``env_seal.assert_seal_unchanged``) that close the routes around it.
-    Folded here, every model-library patch release re-keyed every compiled graph in
-    the fleet for a graph that had not moved. ``tcg.identity.toolchain_axis_digest``
-    is the READER of the same membership, and the pair is what keeps one
-    axis one derivation. Their versions stay RECORDED for forensics
+    ``transformers`` / ``peft`` are excluded because their whole effect on a
+    compiled graph arrives through the traced graph, which the ``graph`` axis
+    hashes node-for-node — see ``torchcg.identity``'s membership rules for the
+    channel-by-channel argument and for the two fences (B1 code-only + the
+    pgw#1097 folding fence; ``env_seal.assert_seal_unchanged``) that close the
+    routes around it. Folded here, every model-library patch release re-keyed
+    every compiled graph in the fleet for a graph that had not moved.
+    ``tcg.identity.toolchain_axis_digest`` is the READER of the same
+    membership, and the pair is what keeps one axis one derivation. Their
+    versions stay RECORDED for forensics
     (:func:`_lib_versions`, ``artifact_metadata``'s ``libs`` block) — an
     observability fact, exactly like ``sku``.
 
@@ -1432,19 +1411,10 @@ def fx_cache_failure_report() -> str:
     diagnosed.
 
     **pgw#1200 deleted the COMPILED GRAPH side, and with it the three-way
-    classification.** The report used to name B1 (*"the boot computed
-    different keys"*), B2 (*"the keys matched and the miss is in torch's
-    candidate-load path"*) or *"unreadable artifact"* — every one of them a
-    difference measured against FX entries read out of a
-    `torch-inductor-cache` tarball's `inductor/fxgraph/` tree. pgw#1178
-    deleted that format's last writer and pgw#1181 deleted the format, so the
-    tar walk could only ever yield nothing, and the arithmetic did not degrade
-    gracefully — it INVERTED. `fresh = live_keys - seeded` became EVERY live
-    key, so **B1 was named on every boot with any FX entry at all**, while B2
-    was structurally unreportable and `compiled_graph_keys=0` (*"unreadable"*) was the
-    normal case. Measured on the real function: handed an exported compiled graph — what
-    the caller passes today — the output was byte-identical to passing
-    ``None``, which is the shortest proof the argument carried no information.
+    classification.** It measured this boot's FX keys against entries read out
+    of a `torch-inductor-cache` tarball, a format pgw#1181 deleted — so the
+    walk could only yield nothing, and `fresh = live_keys - seeded` then
+    INVERTED into "every live key is fresh" on every boot.
 
     A diagnostic that always names one class is worse than none, because it is
     read as evidence. What survives is what the dynamo lane can actually
@@ -1612,12 +1582,10 @@ class CompileArmRefused(RuntimeError):
     """A NAMED, deterministic reason this process cannot arm this pipeline.
 
     pgw#985: what decides whether a second pod gets bought is the
-    CLASSIFICATION, not the message. ``arm_jit_intake`` used to raise a bare
-    ``RuntimeError`` for every decline — which the mint child let out as exit
-    1 (``CRASHED``, retryable) while the AOT recipe typed the identical
-    condition as a refusal (``EXIT_REFUSED``, terminal). Same fact, two
-    vocabularies, and the retryable one billed a second mint that could not
-    possibly succeed.
+    CLASSIFICATION, not the message. An untyped decline leaves the mint child
+    as exit 1 (``CRASHED``, retryable) while the AOT recipe types the identical
+    condition as a refusal (``EXIT_REFUSED``, terminal) — one fact, two
+    vocabularies, and the retryable one bills a mint that cannot succeed.
     """
 
 
@@ -1628,9 +1596,8 @@ def resolve_targets(
 
     ``(declared name, owner, attribute, eager callable)`` per resolvable
     target, in declaration order. :func:`has_compile_target`, :func:`apply`
-    and :func:`arm_jit_intake` all read THIS list (§1.29, one relation) —
-    it used to be scanned independently by the first two, which is how a
-    reader of the third could not tell which scan had spoken.
+    and :func:`arm_jit_intake` all read THIS list (§1.29, one relation), so a
+    reader can never be left wondering which independent scan had spoken.
 
     Whether the pipeline OWNS a declared target is the only question answered
     here. Whether this process can ARM the targets it owns is a different
@@ -1909,11 +1876,9 @@ def _mark_regional_blocks(owner: Any, dynamic_dims: tuple) -> int:
 class DeclaredRangeExceeded(RuntimeError):
     """A declared dynamic axis met an extent OUTSIDE its declared range.
 
-    pgw#1082: this used to be a ``ConstraintViolationError`` raised from
-    inside dynamo, caught by the guard as "some compiled target failed", and
-    swallowed into a permanent eager degrade that the wire still reported as
-    ``jit_cell``. It is an ENDPOINT DECLARATION defect — the declaration
-    named a range its own inputs leave — and it now says so by name.
+    pgw#1082: an ENDPOINT DECLARATION defect — the declaration named a range
+    its own inputs leave — typed so it cannot arrive as a dynamo-internal
+    ``ConstraintViolationError`` swallowed into a silent eager degrade.
     """
 
 
@@ -1945,22 +1910,12 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
     """Wrap a compiled callable so every call marks the DECLARED dynamic
     axes COHERENTLY across its whole argument tree before dynamo sees them.
 
-    pgw#1082 rewrote this. The old mapping marked one dim of one KIND of
-    tensor — dim 0 of every float for ``batch``, dim 1 of every rank-3 float
-    for ``sequence`` — and that is not what an axis is. Every sibling tensor
-    indexed by the same axis (integer index tensors, rotary tables inside a
-    tuple) stayed STATIC, so dynamo specialized the symbol on them and then
-    raised ``ConstraintViolationError`` against the mark on the float:
-
-        You marked L['hidden_states'].size()[1] as dynamic but your code
-        specialized it to be a constant
-
-    On minimax-h3 that fired on the FIRST call of every regional block, the
-    guard degraded the target to eager for the life of the pod, and (because
-    the regional guard forgot to raise the degraded flag) the wire still
-    reported ``serving_mode=jit_cell`` with an empty ``fallback_reason``. A
-    20.1B denoiser served 100% eager while every telemetry axis said
-    compiled — measured at 6.27 s/step against the rig's 4.31 (pgw#1078).
+    pgw#1082: marking one dim of one KIND of tensor is not what an axis is.
+    Every sibling tensor indexed by the same axis (integer index tensors,
+    rotary tables inside a tuple) stayed STATIC, so dynamo specialized the
+    symbol on them and raised ``ConstraintViolationError`` against the mark on
+    the float — degrading the target to eager for the life of the pod while the
+    wire still reported it compiled.
 
     So: find the axis EXTENT at its primary dim, then mark that extent
     wherever it appears in the argument tree, integer tensors included. An
@@ -1975,11 +1930,9 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
     ``ConstraintViolationError`` — a permanent eager degrade — even when the
     narrowing carries no correctness content. Inductor's index-dtype choice is
     exactly such a narrowing: ``can_use_32bit_indexing`` elects int32 from the
-    FIRST call's size hint and then installs ``check_leq(numel, INT32_MAX)``
-    (``_inductor/codegen/simd.py``), so on minimax-h3 the 5 s cold call
-    (38,015 rows x a 28,672 inner dim) pinned int32 and its guard,
-    ``sequence <= 74,898``, contradicted the declared max. Every width above
-    that took a hard refusal, which is why 11-15 s served 100% eager.
+    FIRST call's size hint and installs ``check_leq(numel, INT32_MAX)``
+    (``_inductor/codegen/simd.py``), whose guard then contradicts a wider
+    declared max and takes a hard refusal.
     Marking without bounds yields a ``RelaxedUnspecConstraint`` instead: the
     axis still may not specialize to a constant (the pgw#1082 failure this
     function exists to prevent), but the compiler may split the range, so the
@@ -2207,11 +2160,9 @@ def _guarded(
             # eager fallback: the tier flips to explicit eager on the wire.
             revoke(state["detail"])
             # pgw#672/pgw#673 posture: a broken optimization must never kill a
-            # serving worker. Mandatory lanes used to raise here (and the
-            # setup/dispatch paths then disabled every declared function —
-            # sm120 CantSplit retired the pod for $0.25 of nothing). They now
-            # degrade like every other lane, LOUDLY: the revocation above is
-            # the wire-visible tier flip, never silent eager (gw#586).
+            # serving worker. Mandatory lanes degrade like every other lane,
+            # LOUDLY: the revocation above is the wire-visible tier flip, never
+            # silent eager (gw#586).
             log = logger.error if fail_closed else logger.warning
             log(
                 "compile-cache: compiled %s failed (%s: %s); serving eager for "
@@ -2350,8 +2301,7 @@ def _guarded_regional(
                             str(exc), 600)
                     _emit_declared_range_event(label, exc)
                 else:
-                    # pgw#1093: the catch-all that used to reach the wire as
-                    # NOTHING. Without it an installed-then-degraded target
+                    # pgw#1093: without this row an installed-then-degraded target
                     # and a never-installed one are the same reading.
                     _emit_compiled_degrade_event(
                         label, exc, lane="regional", fail_closed=fail_closed)
@@ -2467,10 +2417,8 @@ def eager_tier_available(pipeline: Any) -> bool:
 
     This is the question a background/out-of-process mint actually asks, and
     it is NOT :func:`mandatory_serving`. Using the latter as a serveability
-    proxy is a category error, and it is the one that left AOT unmintable on
-    every lane: the plain lane declines by #730's measured hold, and the w8a8
-    lane — the lane the AOT program exists to serve — declined because
-    "executes quantized activations" was read as "cannot serve eager".
+    proxy is a category error that leaves AOT unmintable on every lane — it
+    reads "executes quantized activations" as "cannot serve eager".
 
     A quantized lane serves eager fine. ``_Fp8ScaledLinear.forward`` and
     ``_W4A4Linear.forward`` are complete eager forwards (``torch._scaled_mm``
@@ -2636,11 +2584,9 @@ def apply(
             owner.compile_repeated_blocks(dynamic=None, fullgraph=True)
             # pgw#1078: the declared marks are applied at the BLOCK ingress,
             # which is where this lane's graphs are traced. Without them
-            # `regional=True` + `dynamic=(...)` used to DECLINE and send the
-            # target to the whole-forward branch — silently serving a 20B
-            # denoiser by the one lane its author declared regional to avoid,
-            # then guard-missing to eager on every request whose sequence
-            # differed from the boot warmup's (minimax-h3, ie#632).
+            # `regional=True` + `dynamic=(...)` DECLINES and sends the target
+            # to the whole-forward branch — the one lane its author declared
+            # regional to avoid.
             if declared_dynamic:
                 _mark_regional_blocks(owner, declared_dynamic)
             # pgw#681: regional entry crosses the same canonical boundary as
@@ -2816,16 +2762,11 @@ def enable(pipeline: Any, cfg: Any) -> bool:
     """The one consumer entry point (executor + local CLI) for the JIT lane:
     arm compile under the safety policy.
 
-    It used to also SEED a delivered ``torch-inductor-cache`` artifact —
-    stage it, verify its recorded axes against this runtime, and merge its
-    inductor tree into the live cache — and pgw#1181 deleted that whole half
-    with the format. Nothing has produced such an artifact since pgw#1178
-    removed `mint_artifact`, its last writer, so every parameter of that
-    branch (`cache_dir`, `artifact`) named a file that could not exist.
-    Delivered compiled graphs arrive as AOT ``.pt2`` entries or TRT engines, and
-    `models.provision.arm_compiled` dispatches those on `metadata.json`'s
-    `kind` BEFORE this call; what reaches here is the no-artifact lane, which
-    is JIT intake (§4.34 keeps that) and cold compile.
+    NOTHING is seeded here: the ``torch-inductor-cache`` format is deleted
+    (pgw#1181). Delivered compiled graphs arrive as AOT ``.pt2`` entries or TRT
+    engines and `models.provision.arm_compiled` dispatches those on
+    `metadata.json`'s `kind` BEFORE this call; what reaches here is the
+    no-artifact lane, which is JIT intake (§4.34 keeps that) and cold compile.
 
     A W8A8 refusal names its exact cause (gw#577): the raise IS the
     wire-visible job error, and serve pods expose no logs, so a generic
@@ -2925,14 +2866,10 @@ def arm_jit_intake(pipe: Any, cfg: Any) -> None:
     class with no consumer (only ``aot-inductor`` compiled graphs are ever adopted), so
     every honest cold boot re-compiles and that is the contract, not a gap.
 
-    This used to be ``begin_fleet_mint``, which additionally re-pointed the
-    PROCESS-GLOBAL ``TORCHINDUCTOR_CACHE_DIR``/``TRITON_CACHE_DIR`` at a fresh
-    capture dir so the compile could be packed afterwards. With no artifact to
-    pack, that move has no purpose — and its removal deletes gw#608's whole
-    root-cause class (a capture dir stealing the process cache dir from a
-    sibling's seeded compiled graph), pgw#777's multi-execution-group refusal, and the
-    one-capture-per-process conflict, along with the env-restore transaction
-    they needed.
+    Nothing re-points the PROCESS-GLOBAL ``TORCHINDUCTOR_CACHE_DIR`` /
+    ``TRITON_CACHE_DIR``: with no artifact to pack there is nothing to capture,
+    which is what keeps a capture dir from stealing the process cache dir from
+    a sibling's seeded compiled graph (gw#608, pgw#777).
 
     Raises :class:`CompileArmRefused` — typed and deterministic. pgw#985: the
     two facts that can refuse here are DIFFERENT and are named as such. A

--- a/src/gen_worker/compiled_graph_adopt.py
+++ b/src/gen_worker/compiled_graph_adopt.py
@@ -8,14 +8,9 @@ partial indexes and a p50/p95/max admin surface. The other description was a
 free-text ``aot_adopt`` activity event that put ``family=… key=… sku=…`` in
 prose and no numbers anywhere.
 
-Only the free-text one was ever reachable from the path adoptions actually take
-(arming at boot, through ``fleet_compiled_graphs`` — historically called "boot attach",
-which names WHEN the compiled graph is armed, never a hub push); the typed one was
-reachable only from the
-hub-commanded ``ADOPT_COMPILE_CACHE`` operation, which no stack has ever
-dispatched. So the measured lane had zero rows on both live stacks while every
-real adoption landed at ``duration_ms=0``, and the percentile endpoint
-aggregated a population with no members.
+Adoptions take exactly one path — arming at boot, through
+``fleet_compiled_graphs``. The hub-commanded ``ADOPT_COMPILE_CACHE`` operation
+no stack has ever dispatched is not a second one.
 
 pgw#1032 finished the argument: ``ADOPT_COMPILE_CACHE`` is GONE on both sides.
 Its hub-side push was keyed off the COMPUTED (``kind="inductor"``) compiled graph key,
@@ -48,11 +43,10 @@ __all__ = ["AdoptOutcome", "CompiledGraphAdoption", "EagerPhase"]
 class EagerPhase(StrEnum):
     """Why a compile-declaring pipeline is serving EAGER — one token, shared.
 
-    pgw#824 gave the arming policy's declines a classified token instead of the
-    single ``mint_unavailable`` constant they used to share; the token rides
-    ``self_mint_skipped``/``self_mint_started`` as ``phase`` and rides out of
-    the decision as ``ArmOutcome.eager_reason``, so the hub's activity rows and
-    the request row's ``fallback_reason`` join on one string.
+    pgw#824: every arming-policy decline carries a classified token. It rides
+    ``self_mint_skipped``/``self_mint_started`` as ``phase`` and rides out of the
+    decision as ``ArmOutcome.eager_reason``, so the hub's activity rows and the
+    request row's ``fallback_reason`` join on one string.
 
     The tokens lived as bare literals at each ``return``, and the pgw#824 audit
     re-spelled the same nine strings in a second list to check they were all
@@ -69,13 +63,8 @@ class EagerPhase(StrEnum):
     """
 
     #: The mint-impossibility exits, each a distinct `_fail_closed` cause.
-    #: pgw#1010 retired three of the original nine with the in-process
-    #: capture that produced them — ``delivered_compiled_graph_seeded``,
-    #: ``capture_conflict`` and ``multi_group_in_process`` all named hazards
-    #: of moving the process-global inductor cache dir, and nothing moves it
-    #: any more; ``capture_arm_failed`` became ``jit_arm_failed``, which is
-    #: what it always measured (this process cannot arm its declared
-    #: targets), minus a capture that no longer exists.
+    #: Nothing moves the process-global inductor cache dir any more, so the
+    #: capture hazards that used to live here are gone (pgw#1010).
     NO_FAMILY = "no_family"
     NO_CUDA = "no_cuda"
     NO_TOOLCHAIN = "no_toolchain"
@@ -92,12 +81,10 @@ class EagerPhase(StrEnum):
     #: identity must not be re-minted) and was the one that only logged.
     COMPILED_GRAPH_QUARANTINED = "compiled_graph_quarantined"
 
-    #: pgw#1340 / th#2098: the handback seam compares an axis a packed compiled graph
-    #: structurally cannot state, so the arm can only ever refuse. The mint is
-    #: declined at obligation-open, for $0, instead of after 20-45 minutes of
-    #: paid GPU — which is what it cost on `sd15` for two wheels running:
-    #: `family: child compiled graph states '', this runtime computed 'sd15'`, every
-    #: mint, nothing published, ~$1.00 of L4 per burst.
+    #: pgw#1340 / th#2098: the handback seam compares an axis a packed compiled
+    #: graph structurally cannot state, so the arm can only ever refuse. The mint
+    #: is declined at obligation-open for $0, instead of after 20-45 minutes of
+    #: paid GPU (~$1.00 of L4 per burst, measured on `sd15`).
     #:
     #: A pod reporting this is reporting a CODE defect with a named owner
     #: (an axis outside `artifact_meta.compiled_graph_metadata_fields()`), never a
@@ -160,8 +147,7 @@ class EagerPhase(StrEnum):
 
     #: pgw#1093: an arm SUCCEEDED inside `setup()` and `_install_compile_targets`
     #: then resolved no declared target on the same object — the boot compiled
-    #: graphs it can never dispatch to. The pgw#1078 D2 class, one layer up,
-    #: and previously a bare `continue` with no note, no counter, no event.
+    #: graphs it can never dispatch to (the pgw#1078 D2 class, one layer up).
     ARMED_TARGET_UNRESOLVED = "armed_target_unresolved"
 
     #: pgw#1093: the record ended setup owning ZERO compile-capable candidate
@@ -198,10 +184,9 @@ class EagerPhase(StrEnum):
 class AdoptOutcome:
     """The result of arming ONE candidate artifact on ONE pipeline.
 
-    Truthy exactly when the compiled graph armed, so the many ``if enable_compiled(...)``
-    call sites read unchanged while the classified refusal — previously
-    reachable only as the ``phase`` of a free-text event — becomes a value the
-    caller can act on and put on the wire.
+    Truthy exactly when the compiled graph armed, so the many
+    ``if enable_compiled(...)`` call sites read unchanged while the classified
+    refusal is a value the caller can act on and put on the wire.
 
     ``reason`` is the short, stable, countable token (an ``AdoptError.reason``,
     a lane-gate refusal, ``no_compiled_graph``); ``detail`` is the human sentence.

--- a/src/gen_worker/contracts/__init__.py
+++ b/src/gen_worker/contracts/__init__.py
@@ -1,10 +1,9 @@
 """Versioned cross-repo contract corpora shipped with this package.
 
 th#1947 §4.2. These corpora are the AUTHORITY for values that two repositories
-must agree on. They used to live only under ``tests/testdata/``, which the wheel
-and sdist do not carry — so a consumer that pinned ``{authority, version,
-sha256}`` had nothing to consume, and the only way to read them was to vendor a
-byte copy and fence it with a drift script that fetched a moving branch tip.
+must agree on, and they ship IN THE PACKAGE: a consumer that pins
+``{authority, version, sha256}`` must be able to consume it without vendoring a
+byte copy fenced against a moving branch tip.
 
 Shipping them here makes the pin possible: a consumer installs a pinned version
 and reads the exact bytes it pinned. The accessor shape deliberately matches

--- a/src/gen_worker/convert/produced.py
+++ b/src/gen_worker/convert/produced.py
@@ -49,10 +49,8 @@ class ProducedFlavor(msgspec.Struct):
       - extra_files: rare escape hatch — sibling artifacts attached to the
         same flavor (e.g. a tokenizer.json next to a non-tree output).
 
-    **A18 / §1.32(d), pgw#1319: there is no ``flavor`` field.** It was the last
-    of the axis — a producer-local label that named no catalog row but still
-    decided the ``precision_class`` stamp through
-    ``classify_flavor_token``, which is deleted with it. What the bytes ARE is
+    **A18 / §1.32(d), pgw#1319: there is no ``flavor`` field**, and no
+    producer-local label decides a ``precision_class`` stamp. What the bytes ARE is
     stated by the ``dtype`` attribute and, when the producer knows it, an
     ``artifact_contract`` attribute (``ns.name@N``, PROVEN hub-side against the
     safetensors header — §1.33); what LANE they are on is stated by a
@@ -61,8 +59,8 @@ class ProducedFlavor(msgspec.Struct):
     sub-16-bit bytes that declares none is a refusal, not an unstamped publish.
 
     A job that emits several artifacts hands over several ``ProducedFlavor``
-    entries: N publishes joining ONE tag group. There is no flavor-label set
-    on a single publish (``flavors`` was deleted with the wire field).
+    entries: N publishes joining ONE tag group. A single publish carries no
+    flavor-label set.
     """
 
     path: _PathField

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -214,11 +214,9 @@ def destination_ref(ctx: Any, explicit: str = "") -> str:
     struct's key is ``ref``, and tag/flavor/checkpoint selectors are stripped
     so a caller that passed ``owner/repo:tag`` still addresses the repo.
 
-    pgw#1305: this used to read the retired ``destination.repo`` key and
-    nothing else, so an invoke carrying the ``destination={ref, release}``
-    that :func:`destination_release`'s own refusal asks for was told
-    ``destination_repo is required`` — the two halves of one reserved struct
-    disagreed about its key.
+    pgw#1305: it reads the SAME ``destination={ref, release}`` shape
+    :func:`destination_release`'s refusal asks for — the two halves of one
+    reserved struct may not disagree about its key.
     """
     ref = str(explicit or "").strip()
     if not ref:

--- a/src/gen_worker/convert/repack_spec.py
+++ b/src/gen_worker/convert/repack_spec.py
@@ -1,10 +1,8 @@
 """The repackage declaration schema — typed maps the SDK engine executes.
 
-``convert/`` used to be the one package with no
-registration hook, so every family's layout knowledge lived as a module-level
-private constant inside the SDK — ~430 lines of hand-ported per-family tensor
-surgery, four overlapping detection ladders, and two copies of the SDXL
-signature that disagreed with each other.
+``convert/`` carries a registration hook like every other package, so a
+family's layout knowledge is declared by the family rather than living as a
+module-level private constant inside the SDK.
 
 This module defines the *vocabulary*; :mod:`gen_worker.convert.repack_registry`
 holds the registrations; :mod:`gen_worker.convert.repack_engine` executes them.

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -538,12 +538,11 @@ def _run_main() -> int:
         logger.info("  Local Model Cache Dir: %s", cache_cfg["local_model_cache_dir"])
 
     if not user_modules:
-        # pgw#1354: this exit used to be a bare `logger.error` + `return 1`.
-        # RunPod exposes no container-logs API, so the hub saw `exit:1` with no
-        # reason class and condemned the pod `[hardware-unsuitable]` with empty
-        # driver/gpu — a boot bug wearing a hardware verdict, and it cost a paid
-        # pod to find. Every other fatal in this function dials typed; so does
-        # this one. The message DISCRIMINATES the two gaps, because they have
+        # pgw#1354: dial TYPED, like every other fatal in this function. RunPod
+        # exposes no container-logs API, so a bare `return 1` reaches the hub as
+        # `exit:1` with no reason class and is condemned `[hardware-unsuitable]` —
+        # a boot bug wearing a hardware verdict. The message DISCRIMINATES the two
+        # gaps, because they have
         # different owners: no manifest at all is a Dockerfile that never ran
         # discovery, while declarations-without-modules is a manifest this wheel
         # cannot read (a block it does not walk, or rows with no `module`).

--- a/src/gen_worker/families/__init__.py
+++ b/src/gen_worker/families/__init__.py
@@ -8,10 +8,8 @@ discovery walk runs. The old free-standing ``@family("...")`` class decorator
 is gone (pgw#1332): it held the word ``family`` for a defaults vocabulary while
 the typed ModelSpec SDK needed it for the family itself.
 
-``SdxlDefaults`` / ``WanDefaults`` used to ship here. No SDK code
-ever consumed them, and a vocabulary in the library is a vocabulary that needs a
-wheel release to change — they now live in inference-endpoints/sdxl and
-inference-endpoints/wan-2.2 respectively.
+A defaults vocabulary lives with the ENDPOINT that uses it, never here: a
+vocabulary in the library is one that needs a wheel release to change.
 """
 
 from __future__ import annotations

--- a/src/gen_worker/fleet_compiled_graphs.py
+++ b/src/gen_worker/fleet_compiled_graphs.py
@@ -40,8 +40,7 @@ PUBLISHER: user-controlled hardware is untrusted tier by definition, so its
 compiled graphs land in ``local_compiled_graph_store`` (``no_publish_sink_reason`` -> ``no_publish_sink``)
 and its obligation ends at :func:`keep_self_mint_local`. That absence is
 pinned structurally by ``tests/test_local_serve_no_publisher_pgw1127.py``,
-not by this paragraph: before pgw#1127 the local CLI armed JIT through
-``local_compiled_graphs`` and never reached the local store at all.
+not by this paragraph.
 
 Mint failures keep the pre-self-mint miss policy: plain lanes serve eager,
 quantized (w8a8/w4a4) lanes keep their typed fail-closed refusal.
@@ -130,11 +129,8 @@ class SelfMint:
     accounting treats the mint exactly like a hub-delivered compiled graph; the warmup
     proof, not the artifact source, gates serving.
 
-    pgw#1032: the hub fence this feeds is the one that verifies the ADVERTISED
-    active ref against the hub's own store. The old self-attested spelling
-    (``ActiveCompileRef == KeyRef(family, requested_cell_key)``) compared a
-    stamped key against a COMPUTED one — disjoint spaces since pgw#1010, so it
-    could never match — and is retired with the requested key itself.
+    pgw#1032: the hub fence this feeds verifies the ADVERTISED active ref
+    against the hub's own store — a STAMPED key, never a computed one.
     """
 
     family: str
@@ -213,26 +209,13 @@ class ArmIdentity:
 #: ``graph`` is deliberately absent: it exists only after the export, and
 #: comparing a declared-facts stand-in against the traced fact is the
 #: phantom divergence this type retires.
-# pgw#1176: ``envelope`` LEFT this comparison with the key. A per-entry
-# artifact records no DECLARED ENVELOPE — that is a manifest fact about the
-# whole declaration, not about one graph class — so comparing it here would
-# compare a value the child can no longer state against one the parent can,
-# and refuse every handback by construction.
-# pgw#1340 / th#2098: `family`, `lane` and `env_seal` LEFT this comparison for
-# the SAME reason `envelope` did one paragraph up, and the sweep that took
-# `envelope` should have taken them. Since pgw#1270 TCG mints every artifact
-# and `torchcg.artifact.validate_metadata` refuses metadata whose field set is
-# not exactly `artifact_meta.compiled_graph_metadata_fields()` — which has no `family`, no
-# `weight_lane`/`lora_bucket` and no `env_seal`. So three of the six axes here
-# were read as `None` off every real compiled graph and compared against a live runtime
-# fact: a seam that could only ever refuse.
-#
-# It was not theory. MEASURED on the standing `master` hub (2026-08-17):
-# `aot_entry_arm_failed key_axis_divergence — family: child compiled graph states '',
-# this runtime computed 'sd15'`, 224 rows on sd15 and 28 on ernie across wheels
-# 0.117.0 and 0.118.0. EVERY self-mint that reached the seam, none published,
-# each one paying ~25 minutes of L4 for the compile it then discarded — ~$1.00
-# per burst against 57.7 GPU-seconds of the inference it was meant to speed up.
+# `envelope` (pgw#1176) and `family`/`lane`/`env_seal` (pgw#1340 / th#2098) are
+# deliberately NOT here: `torchcg.artifact.validate_metadata` refuses metadata
+# whose field set is not exactly
+# `artifact_meta.compiled_graph_metadata_fields()`, which carries none of them,
+# so comparing one reads `None` off every real compiled graph against a live
+# runtime fact — a seam that could only ever refuse. MEASURED before the fix:
+# every self-mint that reached the seam refused, ~$1.00 of L4 per burst.
 #
 # What is left is exactly the three axes TCG keys the artifact ON, which is
 # what makes them the three that can genuinely refuse a foreign compiled graph.
@@ -606,12 +589,10 @@ def _credential_lapse_s(token: str, *, now: float) -> float:
 # reads them) — and the content is already bound by `snapshot_digest`, as
 # that file's own header says.
 #
-# THE MEASUREMENT that makes this a bound and not a preference: on a REAL
-# published sdxl compiled graph (checkpoint sha256:926bc9f5…, artifact 69,045,459 B),
-# `guard_manifest` alone is 13,092,487 bytes of the 13,377,167-byte metadata
-# — 98%. Everything else together is 285 KB. The declare body therefore grew
-# with the ARTIFACT, and at ~200 MB (a real compiled graph) it crossed the 32 MiB
-# route cap and the hub answered 413 thirty-two times.
+# THE MEASUREMENT that makes this a bound and not a preference (th#1645): on a
+# real published sdxl compiled graph `guard_manifest` alone is 98% of the
+# 13.4 MB metadata and everything else is 285 KB, so the declare body grew with
+# the ARTIFACT and crossed the route's 32 MiB cap.
 _UNBOUNDED_ENVELOPE_BLOCKS = frozenset({
     "guard_manifest",   # JIT lane: per-graph guard closures
     "entries",          # AOT lane: per-class contracts + constant manifests
@@ -619,10 +600,8 @@ _UNBOUNDED_ENVELOPE_BLOCKS = frozenset({
     "weight_contract",  # per-tensor weight rows
 })
 
-# pgw#904: the pgw#988 declare-contract assert died with `aot_compiled_graphs`. The
-# declare's worker-side CONSUMER (fetch-and-filter discovery) is deleted —
-# the hub now resolves the exact artifact and names it in `Arm.artifact`, so
-# the declare's reader is the hub, and its contract is enforced there.
+# The declare's only reader is the HUB — it resolves the exact artifact and
+# names it in `Arm.artifact` — so the declare's contract is enforced there.
 
 # The stated ceiling on a compiled graph's CONTROL-plane declare (§4.24). Measured
 # basis: the same real compiled graph's metadata minus the blocks above is 285 KB, and
@@ -1247,9 +1226,8 @@ def _identity_axes(
             f"axes describe ({key.value}); refusing to publish an identity "
             "the artifact does not corroborate")
     if not provenance.stated:
-        # NARROWED, not deleted (pgw#939: absence is a verdict). The refusal
-        # used to fire on a metadata field no compiled graph can carry — i.e. always.
-        # It now fires on the genuine case it was written for: this machine
+        # NARROWED, not deleted (pgw#939: absence is a verdict). It fires on the
+        # genuine case it was written for: this machine
         # holds bytes it cannot say anything about, which is what a publish
         # under invented axes would hide. The hub's ArtifactFromCompiledGraphRecord
         # requires the seal digest and pgw#904's consumer refuses an identity
@@ -1336,12 +1314,8 @@ def _publish_async(
     killed mid-upload when the pod retired" were the same observation —
     silence.
 
-    pgw#1183 changed what this function IS. It used to be the last thing that
-    ever touched the only copy of a mint — the bytes lived under the mint root
-    and a ``finally`` rmtree'd them on every exit path, so one
-    ``connection reset`` destroyed a 1 h 37 m mint, and the event text conceded
-    it in as many words (*"this pod must survive the upload or the compiled graph is
-    lost"*). It is now a transfer FROM the local CAS: ``artifact`` is the
+    pgw#1183: this is a transfer FROM the local CAS and never the last thing
+    touching the only copy of a mint. ``artifact`` is the
     store's own path, no path here is ever removed, the thread is not a daemon
     (the upload is bounded by the transport's own timeouts, so waiting for it
     at interpreter exit is finishing work, not hanging on it), and a failure
@@ -1507,17 +1481,13 @@ def delegation_refusal(pipe: Any, cfg: Any) -> str:
     child compiles: nothing is armed here, so a pipe with no eager tier has
     nothing to serve at all until the child finishes.
 
-    pgw#813 CORRECTION. This used to refuse ``mandatory_serving(pipe)`` — i.e.
-    it read "executes quantized activations" as "cannot serve eager". That is
-    a category error and it was the operative cause of AOT being unmintable on
-    every lane: the plain lane is held on dynamo by #730, and w8a8 — the lane
-    Paul ruled AOT-first — was refused a delegated minter here, so the miss
-    fell back to a dynamo compiled graph that AOT discovery can never adopt. A w8a8
-    pipeline serves eager perfectly well (``_Fp8ScaledLinear.forward`` is a
-    complete ``torch._scaled_mm`` forward; the fleet's own cold-boot ladder
-    measures it; pgw#672/#673 already made mandatory lanes DEGRADE to eager
-    loudly rather than raise). ``compile_cache.eager_tier_available`` is the
-    honest predicate and this is now its only caller-side use.
+    pgw#813: NEVER refuse on ``mandatory_serving(pipe)`` — reading "executes
+    quantized activations" as "cannot serve eager" is a category error, and it is
+    what left AOT unmintable on every lane. A w8a8 pipeline serves eager perfectly
+    well (``_Fp8ScaledLinear.forward`` is a complete ``torch._scaled_mm``
+    forward), and pgw#672/#673 make mandatory lanes DEGRADE to eager loudly rather
+    than raise. ``compile_cache.eager_tier_available`` is the honest predicate and
+    this is its only caller-side use.
 
     `Compile.regional` (the dynamo/JIT per-block knob, ie#381) is NOT a
     refusal here: since pgw#846 the AOT mint is always whole-graph and
@@ -1619,10 +1589,8 @@ def enable_compiled(
 
     pgw#923: the policy has a dozen exits and an adoption attempt can precede
     any of them, so the measured attempts are collected in ONE place rather
-    than threaded through each ``return``. That is the shape that lets a
-    refusal be reported: the old code could only announce an adoption from the
-    frame that made it, which is why the successful ones were narrated and the
-    measured ones never sent.
+    than threaded through each ``return`` — which is what lets a REFUSAL be
+    reported and not only a success.
     """
     if serve_posture.eager_only():
         # pgw#1142 / §4.32 item 4. `arming_block` would refuse every arm below
@@ -1999,13 +1967,6 @@ def _arming_policy(
     # the seam that admits it" is answered by two compile-time constants and
     # costs nothing to ask.
     #
-    # It is not hypothetical. pgw#1270 moved the artifact vocabulary to TCG and
-    # left three axes in the comparison that no compiled graph can state, and the fleet
-    # paid the full compile to rediscover it on every boot of every pod for two
-    # wheels: 224 `sd15` rows and 28 `ernie` rows of
-    # `aot_entry_arm_failed key_axis_divergence`, zero publishes, ~$1.00 of L4
-    # per burst against 57.7 GPU-seconds of the inference it was accelerating.
-    #
     # DEGRADE, never fail the worker (§4.33): the pod serves eager, which is
     # what it was doing anyway — the only thing this removes is the bill.
     unstateable = unstateable_arm_axes()
@@ -2140,10 +2101,9 @@ def _arming_policy(
     # Pipes whose obligation identity is the SAME token share one child mint:
     # same runtime, same declaration AND same subject — the same slot resolved
     # to the same checkpoint — so there is one computation to buy and one
-    # pending to open. pgw#1113 deleted the premise this comment used to
-    # state ("the qwen edit shape: two lanes, one family compiled graph"): two lanes are
-    # one compiled graph only when the graph says so, and the graph does not exist yet
-    # here. The obligation names its subject instead of assuming one.
+    # pending to open. Two lanes are one compiled graph only when the GRAPH says
+    # so, and the graph does not exist yet here — so the obligation names its
+    # subject instead of assuming one (pgw#1113).
     with _PENDING_LOCK:
         existing = _PENDING.get(key)
     if existing is not None:
@@ -2341,13 +2301,10 @@ def _arm_exported_compiled_graph(
     #
     # `try_read_metadata` answers None for both "this compiled graph has no envelope" and
     # "I refused to read the envelope it has", and every consumer here spent
-    # that distinction on `meta is not None`. Measured on row 7: a 16 MiB bound
-    # refused a 36-entry sdxl envelope, so check 1 below SILENTLY DID NOT RUN,
-    # `arm_aot` was handed None and skipped the lifted-binding install, and the
-    # refusal that reached the wire named a downstream contract gate
-    # (`lifted_inputs_unbindable`) with no root. 36/36 entries, 92 minutes and
-    # $1.584 discarded; the only trace of the cause was the word `unreadable`
-    # in one event's `compiled_graph_key=` field.
+    # that distinction on `meta is not None`. MEASURED: a size bound refusing a
+    # 36-entry sdxl envelope made check 1 below SILENTLY NOT RUN, `arm_aot` was
+    # handed None and skipped the lifted-binding install, and the wire named a
+    # downstream contract gate (`lifted_inputs_unbindable`) with no root.
     #
     # An envelope this runtime cannot READ is refused here, by name, before any
     # arm — the same class as a compiled graph that does not describe us. It belongs in
@@ -2618,9 +2575,7 @@ def adopt_delegated_mint(
     # pgw#1096: ONE gate for every self-produced compiled graph — the child's, and the
     # local store's (§4.28). pgw#999's classification, pgw#1042's pre-arm axis
     # divergence and pgw#805's AOT-only arm all live in `_arm_exported_compiled_graph`;
-    # the reasons this call site used to compute inline are unchanged, and the
-    # $2.72 lesson (attempt 26: a 36/36 mint refused by three events that all
-    # said "could not adopt") is kept there rather than repeated here.
+    # and the reasons live there rather than being recomputed at this call site.
     # §4.32 THE MINT-TIME GATE, and this is the only site that arms it: this
     # process compiled these bytes and is about to publish them to every pod
     # that will ever adopt this key. It runs the freshly compiled artifact and
@@ -3181,15 +3136,10 @@ def _unregister(pending: "PendingSelfMint") -> None:
 
 
 #: pgw#813: the typed `self_mint_skipped` phase each delegation refusal
-#: declines under. The old single `aot_requires_delegation` phase carried a
-#: hand-written either/or sentence ("GEN_WORKER_MINT_IN_PROCESS or eager-first
-#: off") that named two causes which were BOTH false on the measured pod while
-#: the true cause — the pipeline-side mandatory-lane misclassification — was
-#: not named at all. A refusal that cannot name its own cause is the defect.
-#: pgw#995 dropped `eager_first_disabled`: eager-first is unconditional, so
-#: that cause can no longer arise and a reason nobody can reach is dead prose.
-#: pgw#1010 dropped `mint_in_process_forced` with the env that produced it —
-#: there is no in-process mint shape to force.
+#: declines under. One phase per CAUSE — a refusal that cannot name its own
+#: cause is the defect, and a hand-written either/or sentence in the detail is
+#: how a refusal names two causes that are both false. A cause that can no
+#: longer arise is deleted rather than left as dead prose.
 _DELEGATION_DECLINE_PHASE = {
     "no_eager_tier": "aot_no_eager_tier",
     "caller_forced_in_process": "aot_mint_forced_in_process",
@@ -3262,12 +3212,10 @@ def mint_recipe(
                 "out-of-process minting is unavailable and an AOTI export "
                 "has no eager tier to serve from while it compiles"))
 
-    # pgw#853 put the refusal HERE rather than at import, because a refusal to
-    # MINT is not a refusal to IMPORT. pgw#1107 retired the thunk that carried
-    # it: the accessor is now a registry read that cannot raise, and the
-    # refusal arrives below as DATA (`open_blockers`) under its own phase. The
-    # `try/except` that used to wrap this call went with it — a gate that can
-    # no longer fire is a decorative one.
+    # pgw#853: a refusal to MINT is not a refusal to IMPORT. The accessor is a
+    # registry read that cannot raise, and the refusal arrives below as DATA
+    # (`open_blockers`) under its own phase — so there is no `try/except` here,
+    # because a gate that can no longer fire is a decorative one.
     decl = export_declaration(family)
 
     if decl is None:
@@ -3411,18 +3359,14 @@ def _fail_closed(
         if selection_bug is not None:
             raise refusal from selection_bug
         raise refusal
-    # pgw#805: this exit used to be a bare `logger.info` — and a serve pod
-    # exposes no logs (pgw#760), so "declared a compile target, minted
-    # nothing, refused nothing" was the whole observable behaviour of five
-    # real L4 pods. A plain lane DEGRADING to eager is a legitimate policy
+    # pgw#805: a serve pod exposes no logs (pgw#760), so this exit must reach
+    # the wire. A plain lane DEGRADING to eager is a legitimate policy
     # outcome; being unable to say so is not.
     #
-    # pgw#824: the phase is the CLASSIFIED cause, not the constant
-    # ``mint_unavailable`` every one of the nine exits used to share. The cause
-    # was only ever in the free-text detail, so counting "how much of this fleet
-    # is eager because there is no C toolchain" meant substring-matching a
-    # sentence. It is the same token the request row's ``fallback_reason``
-    # carries, so the two join.
+    # pgw#824: the phase is the CLASSIFIED cause, never one constant shared by
+    # every exit — counting "how much of this fleet is eager because there is no C
+    # toolchain" must not mean substring-matching a sentence. It is the same token
+    # the request row's ``fallback_reason`` carries, so the two join.
     logger.info("fleet-compiled graphs: serving eager (%s)", reason)
     activity_mod.emit_event(
         "self_mint_skipped",

--- a/src/gen_worker/hostfacts.py
+++ b/src/gen_worker/hostfacts.py
@@ -466,9 +466,8 @@ class HostFacts(msgspec.Struct, frozen=True, kw_only=True):
     gpu_sm: str = ""
     torch_version: str = ""
     #: The CUDA runtime torch was BUILT against. Measured by
-    #: `models.hub_policy.detect_worker_capabilities` and, until pgw#896,
-    #: dropped on the floor here while `gate_functions` read a dict key
-    #: nothing ever wrote — so the capability always went out as "".
+    #: `models.hub_policy.detect_worker_capabilities` and carried through to
+    #: `gate_functions` (pgw#896).
     cuda_version: str = ""
     #: The HOST driver, read from NVML: it must stay readable when the CUDA
     #: runtime is not.

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -427,12 +427,10 @@ class Router:
                     return EAGER, sig
                 return COMPILED, sig
             device = _first_cuda_device(args, kwargs)
-            # pgw#1215 step 4: the degrade-to-inline-compile fallback that
-            # stood here is DELETED with the ungated mode it belonged to. The
-            # warm thread owns the device while it compiles and ensures its
-            # own headroom inside the exclusive turn (`_ensure_headroom`), so
-            # tight headroom is no longer a reason to pay an inline compile on
-            # the serving thread.
+            # pgw#1215 step 4: there is no degrade-to-inline-compile fallback. The warm
+            # thread owns the device while it compiles and ensures its own headroom inside
+            # the exclusive turn (`_ensure_headroom`), so tight headroom is never a reason
+            # to pay an inline compile on the serving thread.
             turn = self.turn_gate
             if turn is None:
                 # Unreachable in production: `route` only gets here when the

--- a/src/gen_worker/keyset/document.py
+++ b/src/gen_worker/keyset/document.py
@@ -1,11 +1,10 @@
 """``cg-keyset-v1`` — the derived key set, as DATA.
 
-pgw#1327. A serve pod used to learn its own ``cg-key-v1`` set by running
-``torch.export`` in child processes at boot ("< 60 s, every time, ~99 % of it
-the traces"), which made torch, diffusers and the endpoint's model code a hard
-dependency of a pod that will never compile anything. Every input to those
-traces is code the mint lane already ran, so the OUTPUT — one TCG ``class_hash``
-per declared graph class — is shipped instead.
+pgw#1327. A serve pod must not learn its own ``cg-key-v1`` set by running
+``torch.export`` at boot — that makes torch, diffusers and the endpoint's model
+code a hard dependency of a pod that will never compile anything. Every input
+to those traces is code the mint lane already ran, so the OUTPUT — one TCG
+``class_hash`` per declared graph class — is shipped instead.
 
 What the document holds, and what it deliberately does not
 ---------------------------------------------------------

--- a/src/gen_worker/lifecycle_intents.py
+++ b/src/gen_worker/lifecycle_intents.py
@@ -675,11 +675,8 @@ class IntentRegistry:
         a request is what an intent gets BLOCKED on (``IntentState
         .blocker_request``), never an intent itself.
 
-        **A JOB is no longer one of them** (pgw#1336 / th#2052). The docstring
-        that stood here said these cover "a RunJob (the wire lacks a job intent
-        kind/owner field)"; the wire grew that field, so a job dispatch arrives
-        owning a hub-authored carrier and goes through
-        :meth:`adopt_dispatch_intent` instead.
+        **A JOB is NOT one of them** (pgw#1336 / th#2052): a job dispatch arrives
+        owning a hub-authored carrier and goes through :meth:`adopt_dispatch_intent`.
 
         Their IDs are deterministic for one operation identity, but they never
         impersonate a hub-authored DesiredIntent.

--- a/src/gen_worker/local_compiled_graph_store.py
+++ b/src/gen_worker/local_compiled_graph_store.py
@@ -7,13 +7,9 @@ elaboration: *"download model + code ONCE, compile ONCE, and every
 subsequent run of that code reuses the same compiled graph — same ck1 key
 derivation, same memo shortcut, fully offline-capable."*
 
-pgw#1283 — THE SPLIT. This module used to keep a SECOND copy of bytes TCG had
-already admitted to its CAS: ``aot_compile_child`` packs with
-``Engine.export_artifact``, and this module then hashed that file, copied it to
-``<root>/aot-cells/<key>/cell.tar.gz``, and re-hashed it on every lookup. Three
-digest passes over a multi-hundred-megabyte artifact, all of them re-deriving
-what the CAS derived when it ingested the bytes. That duplication is deleted.
-The two concerns that were tangled in it are now stated separately:
+pgw#1283 — THE SPLIT. This module keeps NO second copy of bytes TCG has
+already admitted to its CAS, and re-derives no digest the CAS derived when it
+ingested them. The two concerns are stated separately:
 
 **EXISTENCE is TCG's.** :func:`store` hands the artifact to
 ``Engine.import_artifact``, which unpacks it, checks that its metadata restates
@@ -333,14 +329,11 @@ class LocalCompiledGraph:
 def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
     """Replace ``path`` with ``payload``, atomically and collision-safely.
 
-    pgw#1283 criterion 6. The temp name used to be keyed on the pid alone,
-    which is not a distinct name for two THREADS of one process — and the memo
-    is written from the mint path and from the arm path, which do run
-    concurrently. Two writers then shared one temp file and could publish a
-    torn interleaving of both payloads under a name that says it is atomic.
-    The random suffix makes the name distinct per WRITE, not per process, and
-    the ``os.replace`` makes the publication atomic; the fsyncs make it
-    survive the crash the ordering is designed around.
+    pgw#1283 criterion 6. The random suffix makes the temp name distinct per
+    WRITE, not per process: the memo is written from the mint path and from the
+    arm path, which run concurrently, so a pid-keyed name lets two threads
+    interleave two payloads into one file. ``os.replace`` makes the publication
+    atomic; the fsyncs make it survive the crash the ordering is designed around.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}-{secrets.token_hex(8)}")
@@ -361,13 +354,11 @@ def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
 class RecordUnreadable(Exception):
     """A store file EXISTS but its bytes are not a usable record.
 
-    pgw#1283. Absence and corruption used to collapse into one ``None`` here,
-    and every caller then read that ``None`` as "nothing was ever stored". They
-    are not the same fact and they do not have the same cost: absence is the
-    normal empty-store case, while corruption means a file this store wrote is
-    no longer the file it wrote. Each caller now decides for itself, and every
-    one of them says so in the log — a store that silently re-mints is a store
-    that quietly bills a GPU pod for a defect nobody can see.
+    pgw#1283. Absence and corruption must not collapse into one ``None``: absence
+    is the normal empty-store case, while corruption means a file this store wrote
+    is no longer the file it wrote. Each caller decides for itself and says so in
+    the log — a store that silently re-mints quietly bills a GPU pod for a defect
+    nobody can see.
 
     Raising is safe precisely because every call site catches it: the module's
     rule that a cache miss must never be fatal is unchanged.
@@ -540,12 +531,11 @@ def store(
             "compiled anyway and the next one re-mints", key, exc)
         return None
     # pgw#1283 — EVERYTHING BELOW THIS LINE IS BEST-EFFORT. The bytes are in
-    # the CAS and the record is durable, which means the compiled graph IS stored and
-    # `lookup` will find it; anything that fails from here must not be able to
-    # turn that into a reported failure. The memo write used to sit inside the
-    # `try` above, so a failure to write a shortcut returned ``None`` while the
-    # compiled graph sat on disk — `fleet_compiled_graphs._stage_durable` then emitted
-    # `local_compiled_graph_store_failed` for a compiled graph that was, in fact, stored.
+    # the CAS and the record is durable, which means the compiled graph IS stored
+    # and `lookup` will find it; anything that fails from here must not be able to
+    # turn that into a reported failure. A memo write inside the `try` above would
+    # report `local_compiled_graph_store_failed` for a compiled graph that is, in
+    # fact, stored.
     if arm_token:
         note_memo(arm_token, key, root)
     logger.info(
@@ -576,8 +566,7 @@ def mark(
         raw = _read_json(target_dir / RECORD_NAME)
     except RecordUnreadable as exc:
         # pgw#1283: the transition is LOST, and that costs money in both
-        # directions — a dropped ADMITTED re-mints, a dropped DELIVERED
-        # re-uploads. It used to be indistinguishable from "no such compiled graph".
+        # directions — a dropped ADMITTED re-mints, a dropped DELIVERED re-uploads.
         logger.error(
             "local-compiled-graph-store: LOSING a state transition for %s — verdict=%r "
             "sink=%r were not applied because its record is unreadable (%s). "
@@ -830,10 +819,10 @@ def lookup_for_arm(
 def drop(key: str, root: Optional[Path] = None) -> None:
     """Forget this worker's POLICY for one compiled graph. The CAS keeps its bytes.
 
-    pgw#1283 — a deliberate narrowing. This used to delete the only copy of an
-    artifact; the bytes now live in the content-addressed store, where they may
-    be the same bytes another key or another route resolves, so a worker
-    decision about ONE arm identity must not delete them. What this removes is
+    pgw#1283 — a deliberate narrowing. The bytes live in the content-addressed
+    store, where they may be the same bytes another key or another route resolves,
+    so a worker decision about ONE arm identity must not delete them. What this
+    removes is
     the sidecar that grants permission to serve, and the materialized export
     beside it, which is exactly what "this compiled graph is stale for us" means. A later
     :func:`store` of the same artifact re-records it against bytes TCG will

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -87,9 +87,9 @@ from .mint_process import (
 
 logger = logging.getLogger(__name__)
 
-#: pgw#1010: the child builds ONE artifact kind. The dynamo recipe it used to
-#: also run produced a compiled graph with no consumer, and it is deleted rather than
-#: kept behind a request field nobody may set.
+#: pgw#1010: the child builds ONE artifact kind. A dynamo recipe would produce
+#: a compiled graph with no consumer, so it is deleted rather than kept behind a
+#: request field nobody may set.
 RECIPE_AOT = "aot"
 
 
@@ -337,12 +337,10 @@ def _mint_aot(
     compiled graph that filter rejects. Every pod missed, "re-minted" the wrong kind, and
     the next pod missed identically.
 
-    pgw#1215 (th#1834 Phase 3 keystone) changed WHERE the export happens. This
-    process used to trace every declared class itself and ship each
-    ``ExportedProgram`` to a compile child on disk — 36.04 s of
-    ``torch.export.load`` per class (pgw#1216). It now hands the compile
-    children the RECIPE and they trace their own share, so nothing is
-    serialized. What this process still owes the mint is everything only it can
+    pgw#1215 (th#1834 Phase 3 keystone): this process hands the compile children
+    the RECIPE and they trace their own share, so no ``ExportedProgram`` is ever
+    serialized (which cost 36.04 s of ``torch.export.load`` per class,
+    pgw#1216). What this process still owes the mint is everything only it can
     do: the kernel-lane A/B on a real card (pgw#947), the traceable-as-loaded
     refusal, the declared-blocker gate, the class ENUMERATION (the adapter fork
     depends on the composed pipeline), and moving the packed artifacts into the
@@ -356,14 +354,11 @@ def _mint_aot(
     out_dir = target.parent / "aot"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # pgw#824: `aot_mint.mint` used to be ONE opaque call spanning the family's
-    # whole declared class set (sdxl: 18), so this function framed `trace_graph`
-    # once and then said nothing at all until `seal_publish` below. A real
-    # export measured ~5 minutes of complete wire silence; the parent's only
-    # evidence that the child was working was that its CPU was warm, which
-    # proves alive, not progressing. Every entry now rides the frame protocol
-    # that already exists -- no new wire, and the parent's `_on_frame` lands it
-    # on the same self_mint_compile activity the hub already reads.
+    # pgw#824: EVERY ENTRY rides the frame protocol, never one opaque call
+    # spanning the family's whole declared class set. A warm CPU proves alive,
+    # not progressing, so a five-minute silence between `trace_graph` and
+    # `seal_publish` is not evidence. No new wire — the parent's `_on_frame`
+    # lands it on the same self_mint_compile activity the hub already reads.
     def _progress(phase: str, step: int, total: int, note: str) -> None:
         frame(phase=phase, step=step, total=total, note=note)
 
@@ -412,11 +407,9 @@ def _mint_aot(
     # pgw#1053, preserved across the keystone: from here on this process
     # neither exports nor serves — the children compose their own targets —
     # so its residents are dead weight on the card the children are about to
-    # compile on. It used to be `aot_mint.mint(release_residents=True)`, whose
-    # release fired when the parent's export producer was exhausted; there is
-    # no parent-side producer any more, so the same release is stated here at
-    # the same moment: after the last read of `pipe` (the class enumeration
-    # above) and before the first child spawns. It matters most on the
+    # compile on. The release is stated HERE: after the last read of `pipe`
+    # (the class enumeration above) and before the first child spawns. It
+    # matters most on the
     # REAL-WEIGHT FALLBACK path, where this process is holding a whole
     # checkpoint.
     released = _release_compile_recipe_residents(pipe)
@@ -537,13 +530,11 @@ def mint(request: MintRequest) -> MintReport:
     bind_slots(siblings, request.slots)
     assert_slots_resolvable(
         siblings, request.slots, what=mint_identity(request))
-    # pgw#1034: the wire struct IS the cfg. It used to be re-inflated into a
-    # `registry.CompileContract` to keep `contract_facts()` byte-identical for a
-    # key the child computed — the child has computed no key since pgw#758, so
-    # the rebuild only manufactured a CompileContract whose contract axes were
-    # whatever the wire happened to carry. Every consumer here reads the
-    # declared facts by name (family, targets, shapes, text_lens, guidance,
-    # lora_bucket) and the spec carries exactly those.
+    # pgw#1034: the wire struct IS the cfg — never re-inflated into a
+    # `registry.CompileContract`, whose contract axes would be whatever the wire
+    # happened to carry. Every consumer here reads the declared facts by name
+    # (family, targets, shapes, text_lens, guidance, lora_bucket) and the spec
+    # carries exactly those.
     cfg = request.cfg
 
     # pgw#1115: FAIL CLOSED on a declared mint blocker, here — after discovery

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -874,13 +874,11 @@ __all__ = [
 
 # --- the operator/one-shot request, built parent-side --------------------
 #
-# pgw#1215 step 4 moved these here from `mint_delegate`, which is DELETED.
-# That module existed to make the SERVING parent spawn a mint child; the
-# serving parent now supervises compile children directly
-# (`mint_supervisor`), so its driver — a retry loop that gave every attempt a
-# fresh `child-N` directory and therefore re-paid every finished graph class —
-# is gone rather than relocated. What survives is the request VOCABULARY, and
-# it belongs to the module that owns the child protocol: `scripts/
+# pgw#1215 step 4: the serving parent supervises compile children directly
+# (`mint_supervisor`), so there is no `mint_delegate` retry loop giving every
+# attempt a fresh `child-N` directory and re-paying every finished graph class.
+# What survives is the request VOCABULARY, and it belongs to the module that
+# owns the child protocol: `scripts/
 # micro_mint_rig.py` (the pre-publish proof harness) and any operator running
 # `python -m gen_worker.mint_child` by hand build a `MintRequest` through it.
 

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -4,18 +4,13 @@ compile children, per graph class.
     "...if miss then begin compiling and serve eager until the local compiled graph is
     available; then switch over to using that."
 
-**Two tiers, not three.** What stood here was a nested stack: the serving
-parent spawned ONE mint child (``mint_delegate.build_compiled_graph`` ->
-``mint_process.run_mint`` -> ``mint_child``), which loaded a second
-weight-free pipeline and then itself drove the K-wide compile pool. The
-middle tier existed to hold a pipeline the parent already holds a real copy
-of, and to buy th#1299's property — *"no inductor on the serving loop"* —
-with a whole extra process. th#1299's defect was inductor's GIL-holding
-orchestration starving the one asyncio task that carries the 10 s beat and
-eager serving; spawn / poll / collect / digest / CAS-write / publish are I/O
-and supervision and do not starve it. So the property is bought by a
-structural fence instead (``scripts/lint_serving_process_compiles.py``) and
-the middle tier is gone.
+**Two tiers, not three.** A middle tier holding a second weight-free pipeline
+the parent already has a real copy of buys nothing: th#1299's property — *"no
+inductor on the serving loop"* — is about inductor's GIL-holding orchestration
+starving the asyncio task that carries the 10 s beat, and spawn / poll /
+collect / digest / CAS-write / publish are I/O and supervision that do not
+starve it. The property is bought by a structural fence instead
+(``scripts/lint_serving_process_compiles.py``).
 
 What this module owns, and it is all supervision:
 
@@ -853,18 +848,12 @@ def _mint_phase_table_of(result: Any) -> Dict[str, Any]:
     (it is the RESULT's view, never the packed envelope's — the artifact
     deliberately carries no wall clocks), so any entry answers.
 
-    pgw#1356: READ OFF THE TYPED FIELD, which is where the writer has always
-    put it. This read ``entry.metadata["mint_phases"]`` — and ``metadata`` is
-    TCG's CLOSED artifact vocabulary, which has no such field and cannot be
-    extended (``test_tcg_mint_parent_pgw1270`` asserts ``"mint_phases" not in
-    survivor.metadata`` by name). So the reader could never find the table,
-    ``phase_table`` fell through to the on-disk snapshot on EVERY successful
-    mint, and the roll-up on the wire announced a completed mint as
-    ``status=in_flight`` — ``in_flight`` being the terminus
-    :func:`aot_mint.write_phase_snapshot` stamps on a beat. Measured on the
-    2026-08-17 A40 mint: 36 of 36 classes ``status=compiled exit=0``, roll-up
-    ``aot_mint_phases in_flight n_entries=0``, and the operator reading it
-    could not tell a finished mint from a killed one.
+    pgw#1356: READ OFF THE TYPED FIELD, which is where the writer puts it.
+    ``entry.metadata`` is TCG's CLOSED artifact vocabulary and can carry no
+    ``mint_phases`` (``test_tcg_mint_parent_pgw1270`` asserts its absence by
+    name), so reading it there falls through to the on-disk snapshot on every
+    successful mint and announces a completed mint as ``status=in_flight`` —
+    the terminus :func:`aot_mint.write_phase_snapshot` stamps on a beat.
     """
     for entry in getattr(result, "entries", ()):
         rows = getattr(entry, "mint_phases", None)

--- a/src/gen_worker/model/catalog/sdxl_serve.py
+++ b/src/gen_worker/model/catalog/sdxl_serve.py
@@ -6,13 +6,11 @@ family's exception: ``sdxl.py`` is the DECLARATION and imports diffusers inside
 its ``build`` callables; this module is what the request path reads, and it
 imports nothing above ``torch``.
 
-pgw#1346 B2 closed the gap this module's first draft recorded. SDXL used to
-stop at "tuned schemas and latent arithmetic" because ``euler_discrete`` was
-declared and unimplemented, so ``Sdxl`` had no ``scheduler()`` method at all.
-It has one now: :class:`~gen_worker.model.scheduler.EulerDiscrete` reproduces
+pgw#1346 B2: ``Sdxl.scheduler()`` is
+:class:`~gen_worker.model.scheduler.EulerDiscrete`, which reproduces
 ``diffusers``' ladder BIT-EXACTLY, and the declaration beside this module
-carries the four-runner tree (both text towers, the U-Net, the VAE decoder)
-rather than two thirds of it.
+carries the whole four-runner tree (both text towers, the U-Net, the VAE
+decoder).
 """
 
 from __future__ import annotations

--- a/src/gen_worker/model/scheduler.py
+++ b/src/gen_worker/model/scheduler.py
@@ -382,9 +382,9 @@ class FlowMatchEulerDiscrete:
 # is the same property ``initial_latents`` cites for CPU-seeding the noise, and
 # it is what lets a receipt's seed mean the same thing on two pods.
 #
-# The bar was 1 float32 ULP (pgw#1331), and three CI cycles established that a
-# ULP bound is the wrong INSTRUMENT rather than the wrong number: the measured
-# cross-machine spread of the REFERENCE is 85 float32 ULP. What is asserted is
+# A ULP bound is the wrong INSTRUMENT here, not the wrong number (pgw#1331):
+# the measured cross-machine spread of the REFERENCE is 85 float32 ULP. What is
+# asserted is
 # RELATIVE agreement within 2e-4 on sigmas and ``init_noise_sigma`` (~20x
 # tighter than one bf16 ULP, the precision the denoiser computes in), EXACT
 # agreement on the timestep grid (integer arithmetic), and — the claim that

--- a/src/gen_worker/model/solvers/precision.py
+++ b/src/gen_worker/model/solvers/precision.py
@@ -6,13 +6,11 @@ ladder that agrees with ``diffusers`` *algebraically* does not agree with it
 stage, with a double accumulator inside ``cumprod`` — that the obvious float64
 reading of the same formulae is 201 float32 ULP away from.
 
-B2 carried those primitives privately inside ``model/scheduler.py`` because
-``euler_discrete`` was the only consumer. It no longer is: ``dpmsolver_multistep``
-and ``unipc_multistep`` descend from the SAME trained beta table, and a second
-copy of ``_sigma_table`` would be a second declaration of the fleet's noise
-schedule — the drift ``check_model_bindings.py`` exists to refuse one level up,
-reappearing one level down. So the primitives live here and every solver imports
-them.
+``euler_discrete``, ``dpmsolver_multistep`` and ``unipc_multistep`` all descend
+from the SAME trained beta table, and a second copy of ``_sigma_table`` would be
+a second declaration of the fleet's noise schedule — the drift
+``check_model_bindings.py`` exists to refuse one level up, reappearing one level
+down. So the primitives live here and every solver imports them.
 
 **No array library, ever.** ``struct`` performs the one float32 round trip and
 ``math`` performs the rest. The adopt-only serve role (pgw#1328) holds this

--- a/src/gen_worker/model/spec.py
+++ b/src/gen_worker/model/spec.py
@@ -575,12 +575,11 @@ class ModelSpec:
     def _register(self) -> None:
         """Publish this family's tuned schema(s) under its own name.
 
-        The registration the retired ``@family("sdxl")`` decorator used to do,
-        moved onto the object that owns the schema. The registry itself is
-        unchanged — tensorhub still validates repo metadata against the
-        exported JSON Schema and ``gen-worker families export-schemas`` still
-        finds it — but a family can no longer be registered by a struct that
-        does not belong to one, which is the collision Paul ruled on.
+        Registration lives on the object that OWNS the schema, so a family cannot
+        be registered by a struct that does not belong to one — the collision Paul
+        ruled on. The registry is otherwise unchanged: tensorhub validates repo
+        metadata against the exported JSON Schema and
+        ``gen-worker families export-schemas`` finds it.
         """
 
         if self.tuned is None:

--- a/src/gen_worker/models/__init__.py
+++ b/src/gen_worker/models/__init__.py
@@ -1,12 +1,11 @@
 """Models layer: refs, download (ensure_local), memory decisions, residency.
 
 **The package index is LAZY, and that is a serve-path guarantee (pgw#1331).**
-This file used to eagerly re-export ``residency``, which imports ``loading``,
-which constructs diffusers and transformers objects. So *any* ``from .models
-import x`` — ``aot_serve`` asking for ``lora_lifted``, ``aot_constants``'
-tensor reader asking for a header parser — executed the whole eager weight
-loader, and the adopt-only serve role could not be asserted model-free through
-a package root it never wanted. PEP 562: importing this package costs nothing,
+An eager re-export of ``residency`` pulls in ``loading``, which constructs
+diffusers and transformers objects — so *any* ``from .models import x`` would
+execute the whole eager weight loader and the adopt-only serve role could not
+be asserted model-free through a package root it never wanted. PEP 562:
+importing this package costs nothing,
 and asking for a name costs exactly the one submodule that defines it. Same
 shape as ``gen_worker/__init__`` and ``gen_worker/model/__init__``, same
 reason.

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -13,9 +13,9 @@ and boot observability.
 **A snapshot this module publishes is a PROJECTED tree** (pgw#1308 step ⑥):
 symlinks into ``objects/`` for everything that is not a tensor container,
 ~128 B TFSSTUB1 pointer stubs for everything that is, and no tensor byte at
-any path in it. Whole-tree materialization -- the second complete copy this
-used to write -- has no caller left in this repo, and
-``scripts/lint_materialization_hatch.py`` refuses its return.
+any path in it. Whole-tree materialization -- a second complete copy -- has no
+caller in this repo, and ``scripts/lint_materialization_hatch.py`` refuses its
+return.
 """
 
 from __future__ import annotations
@@ -292,12 +292,12 @@ def _publish_snapshot(
 ) -> Path:
     """Project one snapshot tree under its process-shared lock.
 
-    **This is pgw#1308 step ⑥ — the chokepoint.** It used to ask the store for
-    a whole-tree materialization, writing a complete second copy of every byte
-    the store already held, so a resident model occupied disk twice
-    (pgw#1296(a)). It now projects: non-tensor files are relative symlinks
-    into ``objects/``, tensor containers are ~128 B TFSSTUB1 pointer stubs,
-    and the tensors are read out of the CAS through
+    **This is pgw#1308 step ⑥ — the chokepoint.** It PROJECTS rather than asking
+    the store for a whole-tree materialization, which writes a complete second copy
+    of every byte the store already holds (pgw#1296(a) measured the 2.000x):
+    non-tensor files are relative symlinks into ``objects/``, tensor containers are
+    ~128 B TFSSTUB1 pointer stubs, and the tensors are read out of the CAS
+    through
     :func:`gen_worker.models.tensor_source.open_tensor_source`.
 
     ``symlinks`` is the caller's ONE probe of the target filesystem, passed

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -93,13 +93,12 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
 FIT_FITS = "fits"
 FIT_INCOMPATIBLE = "incompatible"
 
-# th#1867 (§1.35) deleted the SIZE verdicts this module used to return —
-# `fp8`, `nvfp4`, `svdq_fp4`, `svdq_int4`, `emergency_fp8`, `gguf_quant`,
-# `offload`. Every one of them was derived from `Resources.vram_gb_hint`, an
-# author DECLARATION, compared against free VRAM: a prediction made before
-# anything is measured, which §4.33 forbids from acting as a floor and §1.35
-# forbids from acting at all. The rungs themselves did not go anywhere — they
-# are chosen at LOAD time by `models/memory.select_auto_mode` from the
+# th#1867 (§1.35): this module returns NO size verdicts. Every one of them was
+# derived from an author DECLARATION compared against free VRAM — a prediction
+# made before anything is measured, which §4.33 forbids from acting as a floor
+# and §1.35 forbids from acting at all. The rungs themselves did not go
+# anywhere — they are chosen at LOAD time by `models/memory.select_auto_mode`
+# from the
 # pipeline's real size against the card's real free VRAM, and reported as they
 # happen (`serve_fit.replan` -> FnDegraded). What is deleted is the guess, not
 # the ladder.

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -22,18 +22,12 @@ vocabulary those declarations are checked against: one home, and the publish
 gate refuses a value outside it rather than forwarding prose the hub cannot
 read.
 
-pgw#1300 / th#2055: the PLACEMENT half of this module is deleted. ``Placement``,
-``default_placement`` and ``placement_to_metadata`` stamped an SM allow-list, an
-SM floor and an engine list into that same block, and the hub read them to admit
-or refuse a card. **Pod purchase now depends only on the endpoint owner's
-(GPU, lane) ladder**, so the hub deleted every reader (`PlacementFromMetadata`,
-`defaultPlacement`, `admitted()`, `AdmitLiteral`'s sm/engine arms) and
-`StoredPrecisionOf` reads `precision_class` and nothing else. The stamp was not
-merely unread — it was WRONG and vetoing: `sm_allowed=(120, 121)` plus
-`engines=("nunchaku",)` for svdq-fp4 described a kernel window and a wheel the
-native engine has not needed since pgw#685, so a B200 (sm_100) could not bind a
-variant it serves. Correcting it was rejected: a correct allow-list still vetoes
-an owner's own rung. There is no local walk and no local AUTO fp8 fold; locally,
+pgw#1300 / th#2055: the PLACEMENT half of this module is deleted — no SM
+allow-list, no SM floor, no engine list. **Pod purchase depends only on the
+endpoint owner's (GPU, lane) ladder**, so the hub reads `precision_class` and
+nothing else. Correcting the stamp was REJECTED rather than attempted: a
+correct allow-list still vetoes an owner's own rung. There is no local walk and
+no local AUTO fp8 fold; locally,
 fit is the loading layer's job and selection within a tag group is §1.33
 contract compatibility.
 """

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -167,16 +167,12 @@ class LoadProgressReporter:
     def _progress(self) -> str:
         """This phase's byte line, in words that say what the numbers ARE.
 
-        pgw#1334: it used to read ``staged 0.55 GiB of 6.31 GiB``, and a pod's
-        blocker was filed as "the loader ran against a 9%-staged tree". Neither
-        number is a staging fraction. The left is this PROCESS's resident anon
-        memory (or its /proc read delta, whichever is smaller —
-        :meth:`_tick`); the right is ``os.walk`` over the tree that is ALREADY
-        on disk, measured after staging finished. Their ratio is a
-        memory-residency observation about a complete tree, and it cannot go
-        to 100% for a load that mmaps. Reading it as progress-toward-complete
-        is reading a number that does not exist, so the row no longer offers
-        the words for it.
+        pgw#1334: NEITHER number is a staging fraction, and the row deliberately
+        offers no words that suggest one. The left is this PROCESS's resident anon
+        memory (or its /proc read delta, whichever is smaller — :meth:`_tick`); the
+        right is ``os.walk`` over the tree ALREADY on disk. Their ratio is a
+        memory-residency observation about a complete tree and cannot reach 100%
+        for a load that mmaps.
         """
         return (f"resident {_gib(self._staged)} anon; tree on disk "
                 f"{_gib(self.total_bytes)}")

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -926,11 +926,8 @@ def pipeline_weight_lane(pipeline: Any) -> str:
 # runtime quants; if we're really memory-constrained then we should be
 # fetching the quant we need"). Armed on CUDA hosts (gw#420: fitting is the
 # runtime's job, not a flag).
-# th#1867 deleted FP8_STORAGE_FIT_FACTOR. It was a resident factor expressed
-# against the DECLARED card size (`resources.vram_gb`), consumed only by
-# `variant_fit`'s size arm to predict whether fp8 storage would fit. Both the
-# declaration and the prediction are gone; the fp8-storage rung is now entered
-# from a measured load, not from a factor times a guess.
+# th#1867: there is no fp8-storage fit FACTOR. The rung is entered from a
+# measured load, never from a factor times a declared card size.
 _EMERGENCY_MARGIN_GB = 2.0
 
 
@@ -2117,10 +2114,8 @@ def snapshot_component_weight_bytes(model_path: Path) -> Dict[str, int]:
     return {k: v for k, v in out.items() if v > 0}
 
 
-# th#1867 deleted `specialized_weight_layout`. Its own docstring named its only
-# consumer — "pgw#1117 asks exactly one question of it" — and pgw#1117's envelope
-# precondition is deleted with the two declarations it compared. The lane
-# detectors it wrapped are unchanged and still live in the loader itself.
+# th#1867 deleted `specialized_weight_layout` with pgw#1117's envelope
+# precondition. The lane detectors it wrapped live in the loader itself.
 
 def _adaptive_fit_rung(
     cls: Any, path: Path, *, fp8_planned: bool, compute_dtype: Any = None

--- a/src/gen_worker/models/materialized_view.py
+++ b/src/gen_worker/models/materialized_view.py
@@ -28,9 +28,9 @@ that hands a DIRECTORY to a third-party loader is handing it pointer stubs.
 Those loaders fail at their own parse site, correctly and loudly, and there
 is nothing this repo can change in them.
 
-Materialization used to be UNCONDITIONAL and WHOLE-TREE: every snapshot on
-every pod carried a complete second copy, whether or not anything ever handed
-a directory to a third party (pgw#1296(a) measured the 2.000x). Now:
+Materialization is neither unconditional nor whole-tree: a complete second copy
+on every pod costs 2.000x the disk (pgw#1296(a)) whether or not anything ever
+hands a directory to a third party. So:
 
 *   nothing is copied until a tier-3 site actually asks;
 *   only the SUBTREE it asks for is copied — a `from_pretrained` on one

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -82,12 +82,10 @@ def mark_shared_components(components: Optional[Dict[str, Any]]) -> int:
     `mat1 is on cuda:0, mat2 on cpu` in the middle of a generate — measured on
     krea-2, qwen-image, z-image and hidream-o1-image (ie#480 finding 12).
 
-    Until th#1867 this was enforced by `Resources.strict_vram`, an author
-    declaration that the endpoint could not tolerate CPU-touching rungs. The
-    declaration deserved to go (it was a card-size claim in softer words) but it
-    was ALSO the only enforcer of an invariant `provision`'s docstring still
-    states. This restores the invariant from a MEASURED fact — this object was
-    injected as a shared component — instead of from an author's word.
+    The invariant `provision`'s docstring states, enforced from a MEASURED fact
+    — this object was injected as a shared component — instead of from an
+    author's word. th#1867 deleted `Resources.strict_vram`, which was a
+    card-size claim in softer words but was also this invariant's only enforcer.
 
     Returns how many modules were marked, so a caller can assert on it.
     """
@@ -128,11 +126,9 @@ def shared_component_names(pipeline: Any) -> List[str]:
 GPU_VRAM_OVERHEAD_GB = 1.0
 
 
-# th#1867 deleted `effective_vram_requirement_gb`. It translated a DECLARED
-# `vram_gb` recommendation into a probed-VRAM floor, and its only caller was
-# `hub_policy.variant_fit`'s size arm — so with the declaration gone it had
-# nothing left to translate. `GPU_VRAM_OVERHEAD_GB` survives below because the
-# other use subtracts it from a MEASURED total, which is arithmetic on a fact.
+# th#1867 deleted `effective_vram_requirement_gb` with the declaration it
+# translated. `GPU_VRAM_OVERHEAD_GB` survives below because the other use
+# subtracts it from a MEASURED total, which is arithmetic on a fact.
 
 # The ladder itself lives in rung.py (pgw#1206 A2): one ordered Rung, one
 # walk, one price. This module keeps the probes and the appliers.
@@ -1334,12 +1330,10 @@ def place_pipeline(
     """
     log = logger or _LOG
     if not cuda_ready():
-        # pgw#1315: the CPU rung is APPLIED here, not merely described. The
-        # bare `{"mode": "cpu"}` this used to return left `low_vram_mode()`
-        # reading `""` — the ladder's own view of the pipeline was "never
-        # placed", so a later transition could not tell the bottom rung from an
-        # unprepped object. Plan time and the reactive descent now stamp ONE
-        # token.
+        # pgw#1315: the CPU rung is APPLIED here, not merely described — a bare
+        # `{"mode": "cpu"}` leaves `low_vram_mode()` reading `""`, so a later
+        # transition cannot tell the bottom rung from an unprepped object. Plan time
+        # and the reactive descent stamp ONE token.
         return apply_low_vram_config(pipeline, mode="cpu", logger=log)
     effective = select_auto_mode(pipeline=pipeline) if mode == "auto" else mode
     if mode == "auto":

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -467,12 +467,10 @@ def arm_aot(
                     "lifted artifact will refuse at assert_lifted_contract",
                     module_name, exc)
     # pgw#1168: THE ADOPT'S DEVICE COST, MEASURED AT THE ONE SEAM EVERY ARM
-    # ROUTE PASSES. pgw#1164 measured this in `fleet_compiled_graphs.adopt_delegated_mint`
-    # — the SELF-MINT adopt only — so the boot adopt, the local-store adopt and
-    # the re-arm ran the identical `aot_serve.enable` -> `load_and_wrap` and
-    # reported nothing. That is this program's most common defect shape (an
-    # emitter wired on one of N paths), and the fix is one emitter here rather
-    # than a second call site there.
+    # ROUTE PASSES — the boot adopt, the local-store adopt and the re-arm all run
+    # the identical `aot_serve.enable` -> `load_and_wrap`. An emitter wired on one
+    # of N paths is this program's most common defect shape; one emitter here
+    # beats a second call site there.
     #
     # The two terms are measured SEPARATELY because they answer different
     # questions, and the split is what decides whether the COMPILED GRAPH or the GATE is
@@ -494,11 +492,10 @@ def arm_aot(
     # route passes; its ATTRIBUTION was never wired at all. The two device
     # spans below (the load, and the §4.32 gate's forwards) are the adopt's
     # whole GPU surface, and until now neither held a compile in-flight marker
-    # — so a signal death in either was charged to whatever tenant request was
-    # running, `postmortem.compile_crash_rows()` stayed empty, and pgw#714's
-    # eager-only reboot never fired. Measured 2026-08-14: a z-image pod booked
-    # its adopt SIGSEGV against `generate`, restarted the same two arm_keys and
-    # crash-looped while th#1326 paid to hold it.
+    # — so without a marker a signal death in either is charged to whatever tenant
+    # request was running, `postmortem.compile_crash_rows()` stays empty, and
+    # pgw#714's eager-only reboot never fires (measured 2026-08-14: a z-image pod
+    # booked its adopt SIGSEGV against `generate` and crash-looped).
     _adopt_label = "adopt:" + (
         str((meta or {}).get("family") or getattr(cfg, "family", "") or "")
         or "unknown")
@@ -638,18 +635,15 @@ def arm_aot(
         # that it must not serve. Staying eager is the ordinary miss policy
         # every other adopt gate uses, so the tenant keeps being served.
         #
-        # pgw#923: and the ADOPT ledger agrees with it by CONSTRUCTION now.
-        # `enable` used to announce `aot_adopt phase=armed` before the gate
-        # ran, so a reader counting armed adoptions over-counted every numerics
-        # refusal and a second closing row existed only to correct the first.
-        # Nothing is announced until the arm is final, so the refusal is simply
-        # what this function returns; the numbers still ride `compiled_graph_numerics`.
+        # pgw#923: the ADOPT ledger agrees with it by CONSTRUCTION. Nothing is
+        # announced until the arm is FINAL — announcing `phase=armed` before the gate
+        # runs over-counts every numerics refusal — so the refusal is simply what this
+        # function returns; the numbers still ride `compiled_graph_numerics`.
         meta = aot_serve.armed_metadata(pipe)
-        # pgw#1176: THE PARITY REFUSAL IS PER ENTRY. This used to `unwrap` the
-        # whole pipeline, which was correct while the gate's subject was a
-        # 36-class compiled graph and is wrong now: the probe measures ONE graph class
-        # against the eager callable it was traced from, so a divergence
-        # condemns that class and says nothing about its siblings. The refused
+        # pgw#1176: THE PARITY REFUSAL IS PER ENTRY, never an `unwrap` of the whole
+        # pipeline: the probe measures ONE graph class against the eager callable it
+        # was traced from, so a divergence condemns that class and says nothing about
+        # its siblings. The refused
         # entry de-arms sticky, its siblings keep serving compiled, and it is
         # not published.
         graph_class = meta.get(GRAPH_CLASS_BLOCK) or {}
@@ -861,10 +855,9 @@ def enable_compiled(
                 return aot
             refused = aot
             artifact = None  # unusable artifact: fall through to eager policy
-    # pgw#1181: `compile_cache.enable` no longer takes an artifact — the
-    # `torch-inductor-cache` format it seeded has had no writer since pgw#1178
-    # and is deleted. Everything delivered is dispatched above by
-    # `metadata.json`'s `kind`; what reaches here is the JIT lane.
+    # pgw#1181: `compile_cache.enable` takes no artifact — the
+    # `torch-inductor-cache` format is deleted. Everything delivered is dispatched
+    # above by `metadata.json`'s `kind`; what reaches here is the JIT lane.
     armed = compile_cache.enable(pipe, cfg)
     if bucket and not armed:
         compile_cache.drop_lora_execution_lane(pipe)

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -535,14 +535,11 @@ def arm_aot(
             phase="measured",
         )
 
-    # §4.33 / pgw#1175: THE HEADROOM GATE IS GONE, and the ATTEMPT replaces it.
-    # `mint_budget.adopt_headroom` refused an arm here on `2 * activation`,
-    # where `activation` was a quarter of the RESIDENT SET whenever no forward
-    # had run — a fraction its own docstring called unmeasured — and its
-    # refusal was STICKY for the life of the process. Its own text conceded it
-    # "CANNOT refuse a card that merely cannot hold 36 runners", i.e. it could
-    # not refuse the failure it was written for (th#1825) and could refuse
-    # cards that were fine. The honest gate is the bind itself:
+    # §4.33 / pgw#1175: THERE IS NO HEADROOM GATE — the ATTEMPT is the gate.
+    # A predictive one (`2 * activation`, where `activation` was an unmeasured
+    # quarter of the resident set) refused stickily for the life of the process
+    # and could not refuse the failure it was written for (th#1825) while
+    # refusing cards that were fine. The honest gate is the bind itself:
     # `aot_serve.arm_compiled_graph` attempts THIS entry and returns a typed
     # `insufficient_adopt_vram` miss on a real device OOM, before any live
     # mutation, and this pod serves eager exactly as it did — on evidence.

--- a/src/gen_worker/models/refs.py
+++ b/src/gen_worker/models/refs.py
@@ -387,12 +387,10 @@ def parse_model_ref(raw: str, *, provider: str = "tensorhub") -> ParsedModelRef:
     accepted — callers must split prefix/payload upstream and pass them
     in explicitly.
 
-    Accepts either spelling of the huggingface provider — the short
-    internal form ``"hf"`` and the pgw#511 wire form ``"huggingface"``
-    (``ModelRef.source``, since pgw#523 deleted the ``.provider`` alias
-    that used to narrow it before callers got here) — and always returns
-    ``ParsedModelRef(provider="hf", ...)`` so every existing ``== "hf"``
-    comparison downstream keeps working unchanged.
+    Accepts either spelling of the huggingface provider — the short internal
+    form ``"hf"`` and the wire form ``"huggingface"`` (``ModelRef.source``) —
+    and always returns ``ParsedModelRef(provider="hf", ...)``, so every
+    ``== "hf"`` comparison downstream reads one spelling.
     """
     s = (raw or "").strip()
     if not s:

--- a/src/gen_worker/models/rung.py
+++ b/src/gen_worker/models/rung.py
@@ -1,10 +1,9 @@
 """THE degrade ladder (pgw#1206 A2) — one ordered ``Rung``, one walk, one price.
 
-Degrade-don't-OOM (Paul, 2026-07-10) used to span three vocabularies in five
-files, joined by f-strings: plan-time ``serve_fit.RUN_*`` (hub wire), placement
-modes in ``memory`` (``model_offload``/``group_offload``/``sequential``), and
-bare ``"fp8"`` load-rung strings through the executor's bookkeepers. This
-module is the single ordered ladder they all project from.
+Degrade-don't-OOM (Paul, 2026-07-10) as ONE ordered ladder. Plan-time
+``serve_fit.RUN_*`` (hub wire), ``memory``'s placement modes and the load-rung
+strings the executor's bookkeepers carry are all PROJECTIONS of it, never three
+vocabularies joined by f-strings.
 
 **No rung quantizes at runtime** (Paul, 2026-08-13, pgw#1206 D: *"We shouldn't
 be doing runtime quants; if we're really memory-constrained then we should be
@@ -86,11 +85,9 @@ PLACEMENT_LADDER: tuple[str, ...] = tuple(
 _BY_NAME = {r.name: r for r in LADDER}
 
 
-# pgw#1315 DELETED ``FLOOR_CPU_RUNG_UNEXECUTABLE``. It said the reactive walk
-# stopped one rung above ``cpu`` because this build could not execute that rung,
-# which made the always-runs guarantee true at plan time and FALSE on a descent
-# that reached the bottom. The refusal named our own code rather than the card,
-# which is what made it actionable: the fix is to execute the rung
+# pgw#1315: there is NO floor above ``cpu``. A reactive walk that stops one
+# rung short makes the always-runs guarantee true at plan time and false on a
+# descent that reaches the bottom; the fix is to execute the rung
 # (``memory.apply_low_vram_config`` mode ``cpu``), not to soften the wording.
 # A floor whose cause is gone must not be left pointing somewhere else.
 

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -276,11 +276,9 @@ def replan(
     hub switches on. A cast that could not apply passes ``wanted``/``ran``
     dtype tokens with no ``run_mode`` change.
 
-    th#1867: this is now the ONLY producer of the honest degradation warning.
-    It used to be written at plan time from the author's declared card size;
-    the transition it describes here is one that ACTUALLY HAPPENED, which is
-    the loud-and-quantified evidence §1.36's amendment asks for and the
-    declared number never was.
+    th#1867: the ONLY producer of the honest degradation warning, and the
+    transition it describes ACTUALLY HAPPENED — which is the loud-and-quantified
+    evidence §1.36's amendment asks for and a declared card size never was.
     """
     base = plan if plan is not None else ServePlan(
         serveable=True, run_mode=RUN_NATIVE, fit="", wanted="bf16", ran="bf16",

--- a/src/gen_worker/models/staging.py
+++ b/src/gen_worker/models/staging.py
@@ -199,13 +199,11 @@ _streams: dict = {}
 def copy_stream(device: Optional[Any] = None) -> Optional[Any]:
     """The dedicated H2D copy stream FOR ONE DEVICE; ``None`` off-CUDA.
 
-    this used to be a process-wide singleton created on the
-    first caller's device — device 0 in practice — so a promote onto
-    ``cuda:3`` queued its copies on card 0's stream context (falling through
-    to card 3's DEFAULT/compute stream) and then synchronized card 0: the
-    overlap-with-compute property was silently lost for every group but 0,
-    and the ``finally`` sync guarded the wrong card. One stream per device,
-    keyed by the target.
+    ONE STREAM PER DEVICE, keyed by the target. A process-wide singleton created
+    on the first caller's device queues a promote onto ``cuda:3`` in card 0's
+    stream context (falling through to card 3's DEFAULT/compute stream) and then
+    synchronizes card 0 — the overlap-with-compute property is silently lost for
+    every group but 0, and the ``finally`` sync guards the wrong card.
 
     ``device`` may be a ``torch.device``, an index, or ``None`` (= the
     thread-current device, which handler threads pin per group).

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -817,53 +817,27 @@ def under(mode: Optional[Any]) -> Iterator[None]:
 
 
 # ---------------------------------------------------------------------------
-# pgw#1111: the META round-trip is DELETED (pgw#1215)
+# TWO THINGS THAT MUST NOT COME BACK HERE
 # ---------------------------------------------------------------------------
 #
-# `to_meta_for_save` / `as_meta_for_save` / `has_meta_params` /
-# `revirtualize_from_meta` existed for exactly one reason: the entry-compile
-# pool handed each ExportedProgram to a child by `torch.export.save` in the
-# parent and `torch.export.load` in the child (pgw#809), and a structure-only
-# program's PARAMETERS are FAKE tensors, which have no storage to serialize.
-# Casting them to META let the metadata cross and re-virtualizing on the far
-# side restored `aot_compile`'s one-fake-mode precondition.
+# 1. A META round-trip (pgw#1111, deleted by pgw#1215). It existed because an
+#    ExportedProgram crossed a process boundary by `torch.export.save`/`.load`
+#    and a structure-only program's PARAMETERS are FAKE tensors with no storage
+#    to serialize. th#1834 Phase 3 deleted the crossing — the process that
+#    traces a graph class is the process that compiles it — so machinery that
+#    repairs a round trip nobody takes is a second, silent way to hold a
+#    program.
 #
-# th#1834 Phase 3's keystone deleted the crossing. The process that traces a
-# graph class is the process that compiles it (`aot_compile_child`), so the
-# fake tensors never leave the mode they were born in and there is nothing to
-# re-cast, serialize, or repair. Machinery that repairs a round trip nobody
-# takes is not "harmless if left" — it is a second, silent way to hold a
-# program, and the next reader has to disprove that it is live.
-
-
-# ---------------------------------------------------------------------------
-# pgw#1199: what USED to live here, and why it does not any more
-# ---------------------------------------------------------------------------
-#
-# `materialize_random` / `restore_virtual` / `stray_real_tensors` gave every
-# virtual parameter REAL random values so the mint child could run the pgw#984
-# does-it-run proof, then took them away again. That is one full checkpoint at
-# compute dtype, allocated in the process this module exists to keep empty,
-# concurrently with the parent's resident copy — 56.2 GB on wan-2.2 against
-# 15.5 GiB free, measured on pod `729431an6ugbvq`. It is also the number
-# §4.33's "a mint costs ~8 GiB" was really measuring: this walk, for an
-# sdxl-sized family.
-#
-# The proof did not need to be here. §4.33 steps 4-5 put verification on the
-# LIVE pipeline that already holds the weights, and `gen_worker.handler_proof`
-# is that: one warm forward through the endpoint's own handler, on the resident
-# pipeline, with REAL checkpoint values — strictly stronger than a random-value
-# re-run, and free on the fleet path where the executor's boot warm plan has
-# already run every declared handler before a mint is delegated.
-#
-# `stray_real_tensors` went with them, and this is the part worth stating
-# plainly rather than quietly: it hunted a REAL tensor cached on a plain
-# attribute by a lazily-built device-pinned table (ie#628's call-time class).
-# That residue existed *because* a real forward had just run here. With no real
-# values in this process the same lazy build fires inside the export's fake
-# mode and produces a FAKE constant, which the packer cannot pack — the
-# failure is still loud, it just arrives at pack time instead of at a stray
-# walk. Nothing silently ships.
+# 2. Real random values (pgw#1199): `materialize_random` / `restore_virtual` /
+#    `stray_real_tensors` allocated one full checkpoint at compute dtype IN
+#    THE PROCESS THIS MODULE EXISTS TO KEEP EMPTY — 56.2 GB on wan-2.2 against
+#    15.5 GiB free, and the number §4.33's "a mint costs ~8 GiB" was really
+#    measuring. §4.33 steps 4-5 put verification on the LIVE pipeline instead
+#    (`gen_worker.handler_proof`: one warm forward through the endpoint's own
+#    handler with REAL checkpoint values), which is strictly stronger. Without
+#    real values here a lazily-built device-pinned table (ie#628's call-time
+#    class) produces a FAKE constant the packer cannot pack — still loud, just
+#    at pack time rather than at a stray walk.
 
 
 __all__ = [

--- a/src/gen_worker/models/structure_only.py
+++ b/src/gen_worker/models/structure_only.py
@@ -296,11 +296,10 @@ def _refuse_artifact_lanes(root: Path, component: str, cls: Any) -> None:
 def _init_empty_weights(component: str = "") -> Any:
     """The meta-init seam, PROVEN on this process before it is used.
 
-    pgw#1123: this used to import ``accelerate`` — undeclared, absent from the
-    fleet's own probe image, and refusing under the same token a stranded
-    family refuses under. Both halves are fixed: the mechanism is owned
-    (:mod:`.meta_init`), and if it is ever unavailable anyway the refusal names
-    the missing CAPABILITY under its own token.
+    pgw#1123: the mechanism is OWNED (:mod:`.meta_init`) rather than an
+    undeclared ``accelerate`` import absent from the fleet's own probe image, and
+    if it is ever unavailable the refusal names the missing CAPABILITY under its
+    own token rather than the one a stranded family refuses under.
     """
     from . import meta_init
 

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -46,12 +46,9 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 SVDQ_METHOD = "svdquant"
-# pgw#1300: `SVDQ_FP4_SMS` / `SVDQ_INT4_SMS` are DELETED. They were nunchaku's
-# kernel windows, kept alive past pgw#1298 by two consumers that are now both
-# gone — `models/ladder.py`'s placement stamp (deleted here) and tensorhub's
-# `WORKER_PARSED_CONSTANTS` peer pin (deleted by th#2055 `65f0882f2`, whose
-# manifest no longer names this file). The only SM window this stack still
-# serves by is the native engine's own `svdq_native.SVDQ_NATIVE_FP4_SMS`.
+# pgw#1300: nunchaku's `SVDQ_FP4_SMS` / `SVDQ_INT4_SMS` kernel windows are
+# DELETED with both their consumers. The only SM window this stack serves by is
+# the native engine's own `svdq_native.SVDQ_NATIVE_FP4_SMS`.
 
 
 class SvdqError(RuntimeError):

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -641,11 +641,9 @@ def _axis_member(text: str, *, axis: str, where: str) -> str | None:
 
 # ── A19: the declaration is MANDATORY, and absence is not the tri-state ──────
 #
-# `layouts=None` used to mean UNDECLARED — a legitimate third rung that made
-# the hub's gate fall back to the image-wide decoder census. Measured
-# fleet-wide, that rung was not a considered choice anywhere: it was the
-# default, so "this slot has no opinion" and "nobody wrote the line" were one
-# state and no refusal could tell them apart.
+# `layouts=None` is NOT an UNDECLARED third rung. Measured fleet-wide, that
+# rung was never a considered choice: it was the default, so "this slot has no
+# opinion" and "nobody wrote the line" were one state no refusal could split.
 #
 # A19 (Paul, 2026-08-15) cuts the default away. A model slot states what it
 # consumes, or it states — with a reason — that no registered handle describes

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -247,10 +247,10 @@ def cpu_quota_cores() -> Optional[float]:
 def effective_cpu_count() -> int:
     """Honest usable-core count: host cores min'd with affinity and quota.
 
-    ``floor``, not ``int(x + 0.5)``: this used to round a 2.5-core quota UP to
-    3 while ``cpu_budget.cpu_allowance`` kept 2.5, so the fleet planned against
-    3 and torch ran 2.5 cores' worth of threads under a throttling kernel. The
-    integer derivation is stated once, in :class:`hostfacts.CpuAllowance`.
+    ``floor``, not ``int(x + 0.5)``: rounding a 2.5-core quota UP to 3 while
+    ``cpu_budget.cpu_allowance`` keeps 2.5 makes the fleet plan against 3 while
+    torch runs under a throttling kernel. The integer derivation is stated once,
+    in :class:`hostfacts.CpuAllowance`.
     """
     return hostfacts.cpu_allowance().whole_cores
 

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -795,12 +795,11 @@ def _typed_presigned_put(
     and the ``phase == "put"`` + ``status_code == 403`` pair is what
     :func:`presigned_upload_file` re-plans an expired presign on.
 
-    This helper exists because the conversion used to live only in the
-    MULTIPART leg. The direct-final PUT — the leg production always takes,
-    since ``_stream`` always sends ``sha256`` and the hub therefore always
-    mints ``put_url`` — raised ``TransportError`` raw: it never matched the
-    re-plan's ``except ArtifactTransferError``, so an expired presign lost a
-    whole completed render as an untyped ``RuntimeError``.
+    BOTH legs convert, not just the multipart one. The direct-final PUT is the
+    leg production always takes (``_stream`` always sends ``sha256``, so the
+    hub always mints ``put_url``), and a raw ``TransportError`` there never
+    matches the re-plan's ``except ArtifactTransferError`` — an expired presign
+    then loses a whole completed render as an untyped ``RuntimeError``.
     """
     try:
         with _presigned_put_slot():

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -625,14 +625,11 @@ def verify_delivered_artifact(artifact: Path, family: str) -> Receipt:
         # to know who we are — and asking anyway would make a seam hiccup
         # refuse the one class that never needed an identity.
         #
-        # pgw#1271: this branch used to call `refuse_untrusted_publisher(
-        # receipt, "", "")` here — INSIDE that callee's own early-return
-        # condition (`if not needs_viewer_identity(receipt): return`), so it
-        # executed exactly zero checks, immediately before the caller dlopens
-        # the artifact. A call that reads as the last gate before native-code
-        # execution and is structurally incapable of refusing is worse than no
-        # call: it answers the reader's question wrongly. What actually clears
-        # this tier is the SIGNATURE, and it ran above.
+        # pgw#1271: what clears this tier is the SIGNATURE, and it ran above. Do NOT
+        # add a `refuse_untrusted_publisher(receipt, "", "")` call here: it lands
+        # inside that callee's own early return and executes zero checks immediately
+        # before the caller dlopens the artifact. A call that reads as the last gate
+        # before native-code execution and cannot refuse is worse than no call.
         return receipt
     try:
         viewer = _self_viewer()

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1743,11 +1743,9 @@ class _PublisherMixin:
         self._candidate_path = str(path) if path else None
 
     # pgw#1242/te#185: the fifth reserved model input — a previously PUBLISHED
-    # checkpoint to CONTINUE from. `save_checkpoint` already publishes; before
-    # this there was no way to hand one back to a handler, so a training
-    # endpoint could not resume across pod loss at all and a multi-hour run
-    # restarted from zero. Absent on every existing payload struct — stays {}
-    # and is a no-op.
+    # checkpoint to CONTINUE from, which is what lets a training endpoint resume
+    # across pod loss instead of restarting a multi-hour run from zero. Absent on
+    # every existing payload struct — stays {} and is a no-op.
     @property
     def resume_from(self) -> dict[str, Any]:
         return dict(self._resume_from_info)
@@ -2159,10 +2157,9 @@ class JobContext(_PublisherMixin, RequestContext[GenerationDefaults]):
     ``@endpoint`` and priced, with zero body edits. It is enforced by a test
     that registers one body both ways and runs it under both harnesses.
 
-    This class is the MERGE of what used to be three sibling contexts, one per
-    producer KIND (pgw#1294 merged them, pgw#1306 deleted the names). It is now
-    the ONLY producer context: no kind selects a different class, because no
-    kind decides what a body may write — the ``@job``/``@endpoint`` declaration
+    The ONLY producer context (pgw#1294 / pgw#1306): no kind selects a
+    different class, because no kind decides what a body may write — the
+    ``@job``/``@endpoint`` declaration
     does (``publishes`` / ``emits_media``), and the hub mints the write grant
     off that declaration. It carries:
 

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -305,11 +305,10 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
     removes the shared object entirely; the rename stays atomic, and two
     winners simply publish the same verified bytes.
 
-    the size comparison used to sit after the loop, where the bytes
-    are already on disk and the only thing it can report is how far past the
-    declaration the shard went. The declared size is known before the first
-    byte, so it caps the stream; an entry that declares none falls back to the
-    destination filesystem, which is what an unbounded shard exhausts.
+    The declared size is known BEFORE the first byte, so it caps the stream
+    rather than reporting after the loop how far past the declaration the shard
+    already went. An entry that declares none falls back to the destination
+    filesystem, which is what an unbounded shard exhausts.
     """
 
     # ONE verified-download discipline (`hubio.fetch.fetch_once`)

--- a/src/gen_worker/rigcheck.py
+++ b/src/gen_worker/rigcheck.py
@@ -317,12 +317,9 @@ def _collect_authorities(
         found = _fleet_floors_authority(path)
         if found:
             authorities.append(found)
-    # ENDPOINT dists only. `gen-worker` used to be appended here as a
-    # last-resort authority, which made the SDK certify its own floor: the
-    # requirement it declares is the requirement the rig is installed against,
-    # so every rig passed, and `FleetLineUnknown` — the finding this function
-    # exists to produce — was unreachable on any machine with gen-worker
-    # installed, i.e. every machine that can run a rig.
+    # ENDPOINT dists only — never `gen-worker` itself. The SDK certifying its own
+    # floor means every rig passes and `FleetLineUnknown`, the finding this
+    # function exists to produce, is unreachable on any machine that can run one.
     for dist in endpoint_dists:
         found = _metadata_authority(dist)
         if found:

--- a/src/gen_worker/serve/role.py
+++ b/src/gen_worker/serve/role.py
@@ -79,15 +79,12 @@ class ServeRole(StrEnum):
 #: (pgw#1331). 67 of the role's 76 roots; the other nine are named, with their
 #: two causes, in :data:`MODEL_BEARING_SERVE_MODULES` directly below.
 #:
-#: This used to be 14 — the typed family surface alone — because two PACKAGE
-#: ROOTS dragged the eager-capable worker's guts into every closure that named
-#: them. ``gen_worker/__init__`` eagerly re-exported ``view`` and
-#: ``models.provision``; ``gen_worker/models/__init__`` eagerly re-exported
-#: ``residency`` and through it ``loading``. Both are PEP 562 lazy now, so
-#: importing a package costs nothing and asking for a name costs exactly the
-#: submodule that defines it. ``serving_mode`` separately stopped importing
-#: ``compile_cache`` — 3,100 lines of arming brain — to read two facts, which
-#: now live in :mod:`gen_worker.compile_facts`.
+#: What keeps the number high is PEP 562 laziness at the two package roots
+#: (``gen_worker/__init__``, ``gen_worker/models/__init__``): an eager
+#: re-export there drags the eager-capable worker's guts into every closure
+#: that names them. ``serving_mode`` likewise reads its two facts from
+#: :mod:`gen_worker.compile_facts` rather than importing ``compile_cache`` —
+#: 3,100 lines of arming brain.
 MODEL_FREE_MODULES: Tuple[str, ...] = (
     # The role itself.
     "gen_worker.serve",

--- a/src/gen_worker/serve/selection.py
+++ b/src/gen_worker/serve/selection.py
@@ -1,13 +1,11 @@
 """pgw#1328 x tcg#37: ingress selection is READ FROM THE CONTRACT, not re-derived.
 
 Ranking several armed graph classes against one live call — which admits, which
-is closest, which normalizations a feed needs — used to live only in
-``aot_serve``'s ``EntryDispatch.select`` / ``ingress_report`` /
-``miss_distance`` / ``recast_gap`` / ``alignment_gap``. tcg#37 published exactly
-that as ``ingress_selection_v1``: a schema, a rung table, two normalization
-domains and 20 vectors, with ``torchcg.selection`` as the torch-free reference
-implementation. This module is gen-worker ADOPTING it, which tcg#37 recorded as
-its own follow-on and pgw#1328 owns.
+is closest, which normalizations a feed needs — is tcg#37's
+``ingress_selection_v1``: a schema, a rung table, two normalization domains and
+20 vectors, with ``torchcg.selection`` as the torch-free reference
+implementation. This module is gen-worker ADOPTING it (pgw#1328), rather than a
+second ranking inside ``aot_serve``.
 
 WHAT MOVES AND WHAT STAYS
 -------------------------

--- a/src/gen_worker/serving_facts.py
+++ b/src/gen_worker/serving_facts.py
@@ -2,14 +2,11 @@
 statement that nobody said anything.
 
 pgw#1333. The three serving facts (``objective`` / ``distilled`` /
-``distilled_status``) used to travel as three loose scalars on
-``dispatch.SlotOrder``, every one of them defaulted, and every consumer read
-them with ``.get(name, "")``. That shape has exactly one failure mode and it
-cost a paid pod: a code path that never received the facts is
-INDISTINGUISHABLE from a checkpoint the catalog classified as nothing, so
-``api.slot._finish_resolved`` refused an ``epsilon`` checkpoint by saying
-"resolved checkpoint carries no training objective" — and the refusal was
-read, correctly given its text, as a catalog defect. It was a wire gap.
+``distilled_status``) travel as ONE struct, never as loose defaulted scalars
+read with ``.get(name, "")``. That shape has one failure mode and it cost a
+paid pod: a code path that never received the facts is INDISTINGUISHABLE from
+a checkpoint the catalog classified as nothing, so a wire gap is reported as a
+catalog defect.
 
 So the facts get a TYPE, and the gap gets a type of its own:
 

--- a/src/gen_worker/serving_mode.py
+++ b/src/gen_worker/serving_mode.py
@@ -54,10 +54,10 @@ FALLBACK_HEALING = "healing"
 FALLBACK_VOLATILE = "volatile"
 #: pgw#888: the hub PINNED an exact compiled graph and this target no longer
 #: serves it (de-armed for cause, revoked, superseded). The other four classes
-#: all describe a compiled graph that is armed and was skipped for one request; this one
-#: describes a compiled graph that is not here at all — and until the pgw#888 ruling it
-#: was not a fallback reason but a refusal, so the request had no serving mode
-#: to report. It rides here so an eager sample charged to a dispatch the hub
+#: all describe a compiled graph that is armed and was skipped for one request;
+#: this one describes a compiled graph that is not here at all, which pgw#888
+#: ruled is a FALLBACK REASON and not a refusal. It rides here so an eager
+#: sample charged to a dispatch the hub
 #: believed was compiled stays subtractable from the compiled measurement.
 FALLBACK_PINNED_CELL_UNAVAILABLE = "pinned_cell_unavailable"
 _PER_REQUEST_FALLBACKS = frozenset({
@@ -78,12 +78,10 @@ _PER_REQUEST_FALLBACKS = frozenset({
 # `self_mint_started` activity event carries in `phase`, so a request row and
 # the worker's own event stream join on one string instead of on a sentence.
 #
-# pgw#1035: these are ALIASES of :class:`compiled_graph_adopt.EagerPhase`, not a second
-# spelling of it. They used to be bare literals here while the arming lane's own
-# tokens lived in the enum — two lists of the same wire vocabulary, which is the
-# drift channel `EagerPhase` exists to close, and only `mint_in_progress` was
-# ever pinned across. Values are unchanged; the hub's grouped history is
-# untouched.
+# pgw#1035: these are ALIASES of :class:`compiled_graph_adopt.EagerPhase`, not
+# a second spelling of it. Bare literals here beside the arming lane's own enum
+# tokens are two lists of one wire vocabulary — the drift channel `EagerPhase`
+# exists to close.
 #: The arming brain has not answered yet (boot in flight, setup not finished).
 POSTURE_ARM_PENDING = EagerPhase.ARM_PENDING.value
 #: A mint is being built right now (delegated child, background driver); this

--- a/src/gen_worker/video_encode.py
+++ b/src/gen_worker/video_encode.py
@@ -114,12 +114,9 @@ def detect_encoder(*, refresh: bool = False) -> EncoderChoice:
     with _detect_lock:
         if _detected is not None and not refresh:
             return _detected
-        # th#1887: the GEN_WORKER_VIDEO_ENCODER switch is deleted. Its default
-        # was this probe, and neither other value could reach an encoder the
-        # probe would not: `x264` only SKIPPED the probe, and `nvenc` already
-        # fell back to x264 when the probe failed. So the probe was always the
-        # decision — the env could only make a pod encode on CPU while its
-        # NVENC ASIC sat idle, and never report the gap.
+        # th#1887: there is no encoder switch. The PROBE is always the decision — an
+        # env could only make a pod encode on CPU while its NVENC ASIC sat idle, and
+        # never report the gap.
         if _probe_nvenc():
             _detected = EncoderChoice("h264_nvenc", dict(NVENC_OPTIONS), hardware=True)
         else:


### PR DESCRIPTION
Third repo of Paul's comment-purge mandate, after serverless-endpoints
([[ie#747]], 8,828 lines / 31.4%) and tensorhub ([[th#2136]], 6,015 / 9.7% of the
addressable set). Same classifier, same green bar.

## What landed

**463 own-line comment + docstring lines removed** over 70 files:

| bucket | before | after | removed | ratio |
|---|---|---|---|---|
| `src/gen_worker` (.py) | 53,797 | 53,451 | 346 | 0.64% |
| `.github/workflows` (.yaml) | 806 | 705 | **101** | **12.5%** |
| `scripts/` (.py) | 4,212 | 4,196 | 16 | 0.38% |
| **addressable total** | **60,121** | **59,658** | **463** | **0.77%** |

The class deleted is the one both predecessors named and nothing else: campaign
play-by-play (`224 rows on sd15 and 28 on ernie across wheels 0.117.0 and
0.118.0`), backstories for code that no longer exists (`this used to be
begin_fleet_mint, which additionally re-pointed…`), CI archaeology (a benchmark
table comparing a superseded single-job workflow shape against its replacement),
and measurement narratives whose durable half is one CITATION. Every design
record, kill-predicate, owner, fence-asserted marker and single-sentence WHY
stays.

## The finding, and it is the point of this PR

**pgw is not serverless-endpoints and it is not even tensorhub. The 80% Paul
estimated is not available here, and the number is 0.8%, not 31%.**

th#2136 built, ran and did NOT ship a blanket "condense every multi-paragraph
comment to its first paragraph" rule after review showed it deleting the KEEP
class. The same rule was measured here:

| | lines | share |
|---|---|---|
| addressable Python prose (`src/`+`scripts/`+`examples/`, minus vendored/generated/worktree-locked) | 50,604 | — |
| what the blanket first-paragraph rule would delete | **28,407** | **56.1%** |

Twelve paragraphs were sampled at random from the 5,520 that rule would drop.
**Twelve of twelve are the KEEP class** — a load-bearing `-inf` in
`dpm_multistep._log` ("the infinity is load-bearing, not an edge case to clamp
away"), the w8a8 snapshot verifier's three-way tolerance contract, the SDK
`Asset` stored-vs-inline description, `flux1_dev_serve`'s structural argument for
why a serve module may not import its declaration, the llama fit ladder's
degraded-not-dead contract. Not one is historical narrative.

Three independent strata were sampled so that is not a regex artifact:

| stratum | sampled | were deletable |
|---|---|---|
| paragraphs the historical/campaign net flagged (3,022 lines / 467 paras / 178 files) | 480 lines read | ~15% |
| random non-first paragraphs >= 3 lines | 22 | 2 |
| random single-paragraph comment blocks of 2-6 lines (3,003 blocks / 9,767 lines) | 26 | **0** |

**pgw's Python comment corpus is design record and API reference, written
dense.** The historical residue is real, this PR removes it, and it is ~360
lines — not ~20k. Reaching Paul's 80% here means deleting what he said to keep.

**The one place the predecessors' ratio DOES transfer is the workflows** —
`ci.yaml` was 566 comment lines of 812 (70% of the file), the same shape
th#2136 found in `fast-gates.yaml` (489 -> 184). That is the 12.5% row above.

## A repair the sweep surfaced

`ci.yaml`'s `pgw#1310 gate` header had two lines spliced into the middle of a
sentence:

```
# difference is a whole class of defect this workflow could not see: for
# Naming what WAS required is the whole point of the sentence below.
# retired-name: historical rationale, not a live reference.
# two published releases `gen-worker`'s metadata required `hashrepo`, a
```

The splice was **load-bearing, not sloppiness**:
`lint_retired_package_names._classified` accepts its marker only on the finding's
own line or the one IMMEDIATELY above, and `hashrepo` is on the following line.
Reordered so the prose reads and the marker still classifies — the fence's
`--selftest` and its real scan are both green.

## Skipped, deliberately

* **`tests/` and `tests_v2/` ENTIRELY** (32,651 prose lines). [[#1362]]'s cluster
  table marks every remaining flat cluster TODO, its folds rewrite these comments
  anyway, and it has already MEASURED the tree-wide docstring collapse at 9,718
  lines as its own mechanical PR. Sweeping there collides with a live epic.
* `src/gen_worker/_vendor/` (digest-fenced) and `src/gen_worker/pb/` (generated).
* **`pyproject.toml`** — ie#747's finding #2: a comment in a pyproject costs a
  `[project].version` bump and therefore a relock. 142 comment lines left alone.
* `CHANGELOG.md` + `changelog.d/` — read as DATA by
  `test_changelog_attribution_pgw1339` and `test_changelog_consumption_pgw1226`.
* `docs/dockerfile.md` + `examples/micro-diffusion/Dockerfile` —
  `test_dockerfile_doc_contract_pgw1016` matches their RAW BYTES, comments
  included, because the hub's publish validator does.
* The seven `src/` files sibling worktrees are editing (`executor.py`,
  `aot_mint.py`, `aot_compile_pool.py`, `aot_compile_child.py`,
  `model/{backing,residency,runtime}.py`) plus
  `scripts/lint_{incident_test_names,mypy_ratchet}.py`.

## The presence-assertion inventory (th#2136's precondition, built FIRST)

125 `assert "…" in <text>` sites across `tests/`; 187 files read production
source. Nearly all assert CODE shape, which comment deletion cannot touch. The
comment-sensitive residue, all left untouched:

* `ValidationError.__doc__` must keep `"do not retry"` (`api/errors.py:8`,
  asserted at `test_declaration_refusal_pgw1075.py:212`) — verified present.
* The escape-hatch comment markers, counted before and after over
  `src/`+`scripts/`+`examples/`: `noqa` 303->303 · `type: ignore` 68->68 ·
  `pragma:` 123->123 · `tcg-vocab:` 15->15 · `fence-symbol-exempt:` 4->4 ·
  `refused:` 40->40 · `oci-image:` 3->3 · `mixed-cas-hatch:` 3->3 ·
  `pickle-ban:` 1->1. **All identical.**
* No fence in this repo asserts a comment's PRESENCE. Deleting comments can only
  ever *satisfy* a banned-vocabulary fence (`lint_tcg_vocabulary`,
  `lint_retired_*`), never break one — th#2136's finding, confirmed here.

## Green bar

* **AST identity per changed `.py`**, against the merge base, with docstrings
  normalised SEPARATELY (`ast.dump` of the tree with docstring `Expr` nodes
  stripped). 68/68 identical; the only reported differences are docstring text,
  reported by symbol name.
* **Both workflows `yaml.safe_load` to data byte-identical** to the merge base,
  and every replaced/inserted line is asserted to be a comment line by the
  applier.
* `mypy src/gen_worker tests tests_v2` -> **Success, 918 source files** (unchanged).
* `ruff check` clean; the full `fast gates` lint set green **including every
  `--selftest` arm** and `lint_unreached_surface --siblings-selftest`.
* The 20 presence-assertion test modules run locally: **224 passed**.
* Structural guards: **0 new orphaned `#:` sphinx-field blocks** (the three that
  exist are byte-identical to the base), and list/table lines 264 -> 266 —
  nothing dropped.
* `git diff --diff-filter=D --name-only origin/master HEAD` is empty.
