### PR TITLE
pgw#1371: the runtime mint — holes-only scope, per-class adopt+publish, and a serving reserve that works

### DIFF
--- a/changelog.d/pgw1371-runtime-mint.md
+++ b/changelog.d/pgw1371-runtime-mint.md
@@ -1,0 +1,15 @@
+- **pgw#1371: the runtime mint is holes-only, per-class adopted and published,
+  and yields to the serving process.** The final-mandate shape: an obligation
+  can be SCOPED to named holes (`PendingSelfMint.holes` — the handoff pgw#1372
+  fills; the boot's per-class misses already ride `enable_compiled(holes=…)`
+  via `BootAdoptOutcome.graph_classes`), the compile children intersect their
+  shares with the hole list and prove coverage through their own
+  `targeted_classes` reports, and `adopt_minted_class` runs the durable →
+  §4.32 arm+parity → publish ladder for EACH class the moment its artifact
+  lands — so a pod killed mid-mint keeps (and the fleet store holds) every
+  completed graph, and the terminus folds the records instead of arming or
+  uploading twice. The FLEET entry-child tree now nices itself
+  (`FLEET_MINT_NICE=10`): e2e#1892 run 7 measured the core reserves failing
+  to protect serving (a 15m50s invocation never returned in 65 minutes beside
+  a 2-on-7 mint), and priority is the reserve mechanism that actually works;
+  the rig mint child and the serving process itself stay at full priority.

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -527,7 +527,7 @@ def _trace_share(
     declaration: Any,
     job: EntryJob,
 ) -> Any:
-    """Apply the retry filter before export and request no worker compile."""
+    """Apply the holes and retry filters before export; no worker compile."""
     return aot_mint.trace_for_key(
         pipeline,
         export_spec,
@@ -535,6 +535,7 @@ def _trace_share(
         share_index=int(job.share_index),
         share_count=int(job.share_count),
         have_classes=tuple(job.have_classes),
+        hole_classes=tuple(job.hole_classes),
     )
 
 
@@ -701,6 +702,22 @@ def run(job: EntryJob) -> int:
         except Exception:  # noqa: BLE001 — the pool refuses on 0, loudly
             logger.exception("aot-compile: could not enumerate declared rows")
 
+    # pgw#1371 holes-only: how many of THIS share's rows the hole list
+    # matched, before the have filter — the number the parent sums to prove
+    # hole coverage. -1 (no evidence) on a plain mint, and on a share that
+    # cannot enumerate — the pool refuses that loudly rather than treating
+    # it as zero.
+    targeted = -1
+    if job.hole_classes:
+        try:
+            targeted = aot_mint.share_targeted(
+                pipeline, spec, decl,
+                share_index=int(job.share_index),
+                share_count=int(job.share_count),
+                hole_classes=tuple(job.hole_classes))
+        except Exception:  # noqa: BLE001 — the pool refuses -1, loudly
+            logger.exception("aot-compile: could not count targeted rows")
+
     ledger.mark("child_trace_s", trace_s)
     ledger.mark("compile_wall_s", compile_s)
     ledger.mark("child_pack_s", pack_s)
@@ -709,6 +726,7 @@ def run(job: EntryJob) -> int:
         _write(report_path, EntryReport(
             entry=job.share, status=REFUSED, classes=packed,
             declared_classes=declared,
+            targeted_classes=targeted,
             phases=dict(partition),
             detail=(
                 f"{len(packed)} graph class(es) packed before the share "
@@ -723,6 +741,7 @@ def run(job: EntryJob) -> int:
     _write(report_path, EntryReport(
         entry=job.share, status=COMPILED, classes=packed,
         declared_classes=declared,
+        targeted_classes=targeted,
         phases=dict(partition),
         detail=f"{len(packed)} packed graph class(es), {declared} declared",
         elapsed_s=round(time.monotonic() - started, 2),

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -639,6 +639,17 @@ class EntryJob(msgspec.Struct, frozen=True, kw_only=True):
     share: str = ""
     share_index: int = 0
     share_count: int = 1
+    #: pgw#1371 holes-only: the ORDERED graph-class names this mint exists to
+    #: produce — the HOLES, i.e. the classes with no artifact for this pod's
+    #: (lane x sm) anywhere the caller could see (store, boot adopt, disk).
+    #: Empty means "the whole declaration" (the pre-holes behaviour, and the
+    #: full-miss case). A child intersects its share with this list BEFORE the
+    #: ``have_classes`` filter, and reports how many of its share's rows were
+    #: targeted so the parent can prove hole coverage without ever enumerating
+    #: the class names itself. Names that match nothing in the declaration are
+    #: reported loudly (a stale hole list) and never fail the mint — coverage
+    #: accretes, and a short holes mint is a smaller mint, not a short publish.
+    hole_classes: Tuple[str, ...] = ()
     #: pgw#1215 step 4: declared graph classes this pod ALREADY HAS as packed
     #: artifacts, from an earlier attempt of the same mint. A child skips them
     #: before it exports — not after, and not at pack time — so a retry pays
@@ -694,6 +705,12 @@ class EntryReport(msgspec.Struct, frozen=True, kw_only=True):
     #: without the parent ever enumerating it (``boot_key``'s rule, same
     #: sharding).
     declared_classes: int = 0
+    #: pgw#1371 holes-only: how many of THIS SHARE's rows matched the job's
+    #: ``hole_classes`` (counted before the ``have_classes`` filter). -1 when
+    #: the job named no holes — absent evidence, not zero. The parent sums
+    #: these across shares to prove the holes were covered, the same way
+    #: ``declared_classes`` proves the whole set.
+    targeted_classes: int = -1
     detail: str = ""
     elapsed_s: float = 0.0
     peak_rss_bytes: int = 0
@@ -1288,6 +1305,15 @@ class EntryCompilePool:
         #: `child_cpu_s` at the terminus.
         self._on_class: Optional[Callable[[str, int, int], None]] = None
         self._share_cpu_s: Dict[str, float] = {}
+        #: pgw#1371: the full-row landing callback (`on_row`), fired EXACTLY
+        #: ONCE per packed class — from the live harvest when the child
+        #: streams, from the report otherwise — so the supervisor's
+        #: per-class adopt/publish can never double-adopt one class.
+        self._on_row: Optional[Callable[[PackedGraphClass], None]] = None
+        self._rows_fired: set[str] = set()
+        #: share -> how many of its rows matched the job's hole list
+        #: (``EntryReport.targeted_classes``); -1 = the child reported none.
+        self.entry_targeted: Dict[str, int] = {}
         # pgw#830: parent-side per-share spans (writing the job + spawn) and
         # the pool-level idle split. Kept separate from `entry_phases` because
         # they are NOT inside `compile_s`: they happen in the parent while
@@ -1377,6 +1403,7 @@ class EntryCompilePool:
         self, template: EntryJob,
         *, on_share: Optional[Callable[[str, int, int], None]] = None,
         on_class: Optional[Callable[[str, int, int], None]] = None,
+        on_row: Optional[Callable[[PackedGraphClass], None]] = None,
         should_abandon: Optional[Callable[[], bool]] = None,
     ) -> Dict[str, PackedGraphClass]:
         """Dispatch this mint's declared classes K-wide and collect what the
@@ -1406,6 +1433,15 @@ class EntryCompilePool:
         fleet meant the first beat arrived ~an hour in; per-class beats are
         what keep the hub's stall rule honest for the whole mint.
 
+        ``on_row(packed)`` (pgw#1371) is the same landing with the FULL row —
+        name, key, artifact path, envelope — fired EXACTLY ONCE per class
+        whichever way it arrives (live stream, or the report of a child too
+        old to stream). It is the seam the supervisor's per-class
+        adopt-and-publish hangs off: the artifact is on disk when this fires,
+        so a mint killed later has still banked every class this reported.
+        Best-effort like every callback here — a raising sink is logged and
+        never costs the mint.
+
         ``should_abandon()`` (pgw#1215 step 4) is polled in the same drain loop
         and raises :class:`EntryCompileAbandoned`, so the ``finally`` below
         group-kills every live child. The supervisor drives this pool from a
@@ -1428,6 +1464,7 @@ class EntryCompilePool:
         self._seed_seal_memo()
         self.ledger.entries = width
         self._on_class = on_class
+        self._on_row = on_row
 
         def _cb(name: str) -> None:
             if on_share is not None:
@@ -1511,8 +1548,11 @@ class EntryCompilePool:
                 charge("idle_other_s", width - len(running))
             if failure is not None:
                 raise failure
-            self._assert_shares_whole(
-                declared, done, width, have=len(template.have_classes))
+            if template.hole_classes:
+                self._assert_holes_covered(template, done, width)
+            else:
+                self._assert_shares_whole(
+                    declared, done, width, have=len(template.have_classes))
         finally:
             self.ledger.wall_s = round(time.monotonic() - pool_t0, 3)
             self.ledger.busy_s = round(sum(self.entry_seconds.values()), 3)
@@ -1581,6 +1621,66 @@ class EntryCompilePool:
                 + f"but every child reported {want} declared — "
                 f"rows[i::{width}] did not partition the declaration and this "
                 f"compiled graph would be short")
+
+    def _assert_holes_covered(
+        self, template: EntryJob, done: Mapping[str, Any], width: int,
+    ) -> None:
+        """The holes-only twin of :meth:`_assert_shares_whole` (pgw#1371).
+
+        A holes mint packs ``(declaration ∩ holes) − have``, and the parent
+        can enumerate neither the declaration nor its intersection with the
+        holes — only the children can, and each reports how many of its
+        share's rows the hole list matched (``targeted_classes``, counted
+        before the ``have`` filter). Summing those across a partition of the
+        declaration IS the intersection's size, so the proof is::
+
+            len(done) == sum(targeted) − |have ∩ holes|
+
+        A hole name that matched NOTHING (the sum falls short of the hole
+        list) is a stale hole list — loud, wire-visible, and deliberately not
+        fatal: coverage accretes, and a smaller mint than asked for is a
+        smaller mint, not a short publish. A child that cannot report its
+        targeted count at all is refused — without it there is no evidence
+        the holes were covered rather than silently dropped.
+        """
+        missing = [
+            share for share, count in
+            ((s, self.entry_targeted.get(s, -1)) for s in self.entry_targeted)
+            if count < 0]
+        if len(self.entry_targeted) < width or missing:
+            raise EntryCompileFailed(
+                "pool",
+                f"this mint named {len(template.hole_classes)} hole(s) but "
+                f"{len(missing) or width - len(self.entry_targeted)} of "
+                f"{width} compile child(ren) reported no targeted count — "
+                f"there is no evidence the holes were covered rather than "
+                f"silently dropped")
+        targeted = sum(max(0, int(v)) for v in self.entry_targeted.values())
+        skipped = len(set(template.have_classes) & set(template.hole_classes))
+        if len(done) != targeted - skipped:
+            raise EntryCompileFailed(
+                "pool",
+                f"the {width} share(s) packed {len(done)} graph class(es) "
+                f"but their shares matched {targeted} of the "
+                f"{len(template.hole_classes)} named hole(s)"
+                + (f" ({skipped} already held)" if skipped else "")
+                + " — the hole shares do not reconcile and some named class "
+                  "is missing")
+        stale = len(set(template.hole_classes)) - targeted
+        if stale > 0:
+            detail = (
+                f"{stale} of {len(set(template.hole_classes))} named hole(s) "
+                f"matched NO declared graph class on any child's pipeline — "
+                f"the hole list is stale against this declaration; the "
+                f"{len(done)} matched class(es) minted normally")
+            logger.warning("aot-pool: %s", detail)
+            try:
+                from . import activity as activity_mod
+
+                activity_mod.emit_event(
+                    activity_mod.KIND_AOT_MINT, detail, phase="stale_holes")
+            except Exception:  # pragma: no cover — telemetry never fails a mint
+                logger.debug("aot-pool: stale-hole event failed", exc_info=True)
 
     def _seed_seal_memo(self) -> None:
         """pgw#832: write the parent's toolchain digests where every entry
@@ -1792,6 +1892,7 @@ class EntryCompilePool:
                 except Exception:  # noqa: BLE001 — telemetry never fails a mint
                     logger.debug(
                         "entry-pool class callback failed", exc_info=True)
+            self._fire_row(packed)
         try:
             position = (slot / POSITION_NAME).read_text()
         except OSError:
@@ -1800,6 +1901,25 @@ class EntryCompilePool:
             row.position = position
             advanced = True
         return advanced
+
+    def _fire_row(self, packed: PackedGraphClass) -> None:
+        """Deliver one packed class to ``on_row`` EXACTLY ONCE (pgw#1371).
+
+        Deduplicated by class name across both arrival routes — the live
+        stream and the share report — because the sink is the supervisor's
+        per-class adopt/publish, and adopting one class twice would arm and
+        upload the same bytes twice.
+        """
+        if self._on_row is None or packed.name in self._rows_fired:
+            return
+        self._rows_fired.add(packed.name)
+        try:
+            self._on_row(packed)
+        except Exception:  # noqa: BLE001 — a sink never fails a mint
+            logger.warning(
+                "aot-pool: on_row sink failed for %s; the class stays packed "
+                "on disk and the terminus adopt still sees it",
+                packed.name, exc_info=True)
 
     def _judge_entry_liveness(
         self, row: _Running, *, progressed: bool = False,
@@ -1946,6 +2066,9 @@ class EntryCompilePool:
                     f"out_dir {row.job.out_dir!r} is not visible to this "
                     f"process")
             self.entry_declared[row.entry] = int(report.declared_classes or 0)
+            self.entry_targeted[row.entry] = int(report.targeted_classes)
+            for packed in report.classes:
+                self._fire_row(packed)
             self.entry_phases[row.entry] = self._close_entry_partition(
                 row, report, elapsed=elapsed, reap_epoch=reap_epoch)
             self.entry_overlays[row.entry] = dict(report.overlays or {})
@@ -1971,6 +2094,9 @@ class EntryCompilePool:
                 1 for c in report.classes if c.name not in self.class_spans)
             for packed in report.classes:
                 self.class_spans[packed.name] = dict(packed.spans or {})
+                # A share that refused at class k still PACKED k-1 classes,
+                # and each is a durable artifact the per-class sink may adopt.
+                self._fire_row(packed)
             self.refused_classes[row.entry] = list(report.classes)
             self.entry_declared[row.entry] = int(report.declared_classes or 0)
         elif report is None and row.classes_landed:

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1562,6 +1562,8 @@ def mint_graph_classes(
     spec: ExportSpec,
     python: str = "",
     on_progress: Optional[Callable[[str, int, int, str], None]] = None,
+    on_landed: Optional[
+        Callable[[aot_compile_pool.PackedGraphClass], None]] = None,
     phase_snapshot: Optional[Path] = None,
     held: Sequence[MintedArtifact] = (),
     should_abandon: Optional[Callable[[], bool]] = None,
@@ -1632,6 +1634,11 @@ def mint_graph_classes(
             template,
             on_class=lambda name, done, total: progress.beat(
                 PHASE_INDUCTOR_COMPILE, done, max(total, goal), name),
+            # pgw#1371: the per-class adopt/publish seam — the caller receives
+            # each packed row the moment its artifact is on disk, so a mint
+            # killed later has already banked (and, on the supervisor's path,
+            # armed and published) every class this delivered.
+            on_row=on_landed,
             should_abandon=should_abandon)
     except aot_compile_pool.EntryCompileAbandoned:
         # Not a failure and not this mint's fault: the ledger still has to
@@ -2195,6 +2202,32 @@ def declared_class_rows(pipeline: Any, spec: ExportSpec, decl: Any) -> List[Any]
     return rows
 
 
+def share_targeted(
+    pipeline: Any, spec: ExportSpec, decl: Any,
+    *,
+    share_index: int = 0,
+    share_count: int = 1,
+    hole_classes: Sequence[str] = (),
+) -> int:
+    """How many of ONE share's rows a hole list matches (pgw#1371).
+
+    Counted over the SAME order and the SAME ``rows[i::K]`` slice
+    :func:`trace_for_key` mints from, and BEFORE any ``have`` filter, so the
+    parent can prove hole coverage by summing the children's reports —
+    ``sum(share_targeted) == |declaration ∩ holes|`` over a whole partition —
+    without ever enumerating class names itself. A second enumeration here is
+    cheap (declaration plans, no tracing) and cannot drift from the mint loop
+    because both read :func:`declared_class_rows`' one order.
+    """
+    ordered = declared_class_rows(pipeline, spec, decl)
+    count = max(1, int(share_count))
+    rows = ordered[max(0, int(share_index)) % count::count] if count > 1 \
+        else ordered
+    holes = {str(n) for n in hole_classes}
+    return sum(
+        1 for row in rows if _decl.plan_entry_name(row[0]) in holes)
+
+
 def trace_for_key(
     pipeline: Any,
     spec: ExportSpec,
@@ -2203,6 +2236,7 @@ def trace_for_key(
     share_index: int = 0,
     share_count: int = 1,
     have_classes: Sequence[str] = (),
+    hole_classes: Sequence[str] = (),
 ) -> Iterator[TracedClass]:
     """Export the named declared graph classes and yield each one's KEYING
     facts — §4.27 step 1's unit of work (pgw#1089).
@@ -2243,6 +2277,17 @@ def trace_for_key(
     count = max(1, int(share_count))
     rows = ordered[max(0, int(share_index)) % count::count] if count > 1 \
         else ordered
+    # pgw#1371 holes-only: when the caller names the HOLES — the classes with
+    # no artifact for this pod's (lane x sm) anywhere it could see — the
+    # share is intersected with them BEFORE the have filter, in the same
+    # post-shard position, so `rows[i::K]` stays the same partition of the
+    # same order and a filtered class never moves its siblings between
+    # children. `declared` is still the whole declaration's size; the pool's
+    # coverage proof for a holes mint reconciles against
+    # :func:`share_targeted` sums instead.
+    holes = {str(n) for n in hole_classes}
+    if holes:
+        rows = [row for row in rows if _decl.plan_entry_name(row[0]) in holes]
     # pgw#1215 step 4: a class this pod already holds as a packed artifact is
     # dropped from the share BEFORE the export, so a retry pays neither the
     # trace nor the compile for it. `declared` is unchanged — it is the size

--- a/src/gen_worker/boot_adopt.py
+++ b/src/gen_worker/boot_adopt.py
@@ -73,7 +73,7 @@ an answer this module is able to give.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dc_replace
 from pathlib import Path
 from typing import (
     Any, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple)
@@ -266,6 +266,12 @@ class BootAdoptOutcome:
     #: fleet still trace at boot" a query rather than an inference, and it is the
     #: fleet-side half of the zero-export acceptance.
     key_source: Optional[keyset.KeySource] = None
+    #: pgw#1371 holes-only: the declared graph-class NAME(S) behind
+    #: ``derived_key`` (several classes legitimately share one key after the
+    #: ingress merge). This is what turns a per-key MISS into a HOLE the mint
+    #: can be scoped to — the miss's key is an address, but the mint's unit is
+    #: the class name. Empty on outcomes that never derived a key set.
+    graph_classes: Tuple[str, ...] = ()
 
     @property
     def adopted(self) -> bool:
@@ -789,20 +795,31 @@ def attempt(
             logger.debug("boot-adopt: resolve call failed", exc_info=True)
             refused = ("resolve_unreachable", f"{type(exc).__name__}: {exc}")
 
+    # pgw#1371: the class NAMES behind each key, so a miss can be named as a
+    # HOLE. Inverted once — `entry_keys` is name -> key, and several names
+    # legitimately share one key after the ingress merge.
+    names_by_key: Dict[str, List[str]] = {}
+    for entry_name, entry_key in sorted(derived.entry_keys.items()):
+        names_by_key.setdefault(str(entry_key), []).append(str(entry_name))
+
+    def _named(outcome: BootAdoptOutcome) -> BootAdoptOutcome:
+        names = tuple(names_by_key.get(outcome.derived_key, ()))
+        return dc_replace(outcome, graph_classes=names) if names else outcome
+
     out: List[BootAdoptOutcome] = []
     for key in keys:
         done = settled.get(key)
         if done is not None:
-            out.append(done)
+            out.append(_named(done))
             continue
         if refused[0]:
-            out.append(report(BootAdoptOutcome(
+            out.append(_named(report(BootAdoptOutcome(
                 reason=refused[0], detail=refused[1], derived_key=key,
                 derive_ms=derived.wall_ms, family=family, function=fn,
-                key_source=derived.source)))
+                key_source=derived.source))))
             continue
-        out.append(_adopt_answer(
-            answers[key], derived, family=family, fn=fn, cache_dir=cache_dir))
+        out.append(_named(_adopt_answer(
+            answers[key], derived, family=family, fn=fn, cache_dir=cache_dir)))
     return tuple(out)
 
 

--- a/src/gen_worker/compile_posture.py
+++ b/src/gen_worker/compile_posture.py
@@ -67,6 +67,14 @@ import msgspec
 #: a niced compile still runs at full speed on an otherwise idle box.
 USER_MACHINE_NICE = 19
 
+#: pgw#1371: the FLEET mint tree's priority increment — the serving-reserve
+#: half that core arithmetic cannot buy (see :meth:`CompilePosture.nice_level`
+#: for the run-7 measurement that calibrated this away from 0). 10, not 19: a
+#: fleet mint is the pod's own owed work, and the only thing that outranks it
+#: is the serving process — it should win every contended slice without the
+#: mint being starved by, say, a co-tenant container at default priority.
+FLEET_MINT_NICE = 10
+
 #: The share of the pod's core budget a mint may take on a user's machine.
 #: See :meth:`CompilePosture.cpu_budget_cores` for the derivation.
 USER_MACHINE_CPU_SHARE = 2
@@ -106,11 +114,24 @@ class CompilePosture(msgspec.Struct, frozen=True, kw_only=True):
 
         Applied by the mint child TO ITSELF and inherited by every descendant
         — the entry-pool children, inductor's compile workers, and every
-        ``cc1plus`` under them. 0 on a pod: a mint there competes with a tenant
-        whose reserves are already held back explicitly, and de-prioritising it
-        on top of that would slow paid work for no gain.
+        ``cc1plus`` under them.
+
+        pgw#1371 (was 0 on a pod, *"de-prioritising it on top of the tenant's
+        reserves would slow paid work for no gain"* — FALSIFIED by e2e#1892
+        run 7): a 36-class sdxl runtime mint at K=2 on 7 vCPU left the SERVING
+        process so starved that an invocation which completes in 15m50s with
+        no mint never returned in 65 minutes. The reserves cannot protect the
+        tenant, because they bound the AVERAGE while each entry child's
+        inductor bursts ``compile_threads`` workers the K-formula deliberately
+        overcommits — and this module's own doctrine already states the
+        mechanism that does work: *"priority says who yields, at microsecond
+        granularity, in the kernel."* So the FLEET mint tree yields to the
+        serving process exactly as the user-machine tree yields to its owner —
+        a niced mint still runs flat out on an idle pod, and gets out of the
+        way the moment paid work arrives. The serving process itself is never
+        niced; only the mint tree is.
         """
-        return USER_MACHINE_NICE if self.user_machine else 0
+        return USER_MACHINE_NICE if self.user_machine else FLEET_MINT_NICE
 
     def cpu_budget_cores(self, vcpus: int, *, headroom: int) -> int:
         """Cores the pool may size itself against.
@@ -180,6 +201,7 @@ def current() -> CompilePosture:
 
 
 __all__ = [
+    "FLEET_MINT_NICE",
     "USER_MACHINE_MAX_ENTRY_WORKERS",
     "USER_MACHINE_NICE",
     "USER_MACHINE_RSS_RESERVE_BYTES",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5573,9 +5573,21 @@ class Executor:
         # addresses — one key, two routes, and `_arm_exported_compiled_graph` is the one
         # gate at the end of both.
         boot_local_key = ""
+        boot_holes: Tuple[str, ...] = ()
         if arm is None and spec.compile is not None and not eager_only:
             adopts = await asyncio.to_thread(
                 self._boot_adopt, spec, resolved_slots)
+            # pgw#1371 holes-only: every per-class MISS is a named HOLE, and
+            # the self-mint this boot may open is SCOPED to exactly those —
+            # a full miss names the whole declaration (the pre-holes mint),
+            # a partial hit names the remainder. Empty when the outcomes
+            # carry no names (a pre-derive refusal): the mint then covers
+            # the whole declaration, which is the only honest reading of
+            # "this boot could not say what is missing".
+            boot_holes = tuple(sorted({
+                str(name)
+                for outcome in adopts if outcome.adoption is None
+                for name in (outcome.graph_classes or ())}))
             # pgw#1176: the boot resolves ONE outcome per declared graph class.
             # Coverage accretes, so several hits are the expected shape and
             # each is armed on its own.
@@ -5696,7 +5708,8 @@ class Executor:
                     compile_selection=compile_selection,
                     snapshots=snapshots,
                     slot_identities=slot_identities,
-                    arm=arm, boot_local_key=boot_local_key)
+                    arm=arm, boot_local_key=boot_local_key,
+                    boot_holes=boot_holes)
                 rec.shared_keys.extend(inj.shared_keys)
                 # pgw#517: a self-loading (str/Path-slot) endpoint builds its
                 # own pipeline inside setup() and the executor never sees it
@@ -7467,6 +7480,7 @@ class Executor:
         slot_identities: Optional[Dict[str, _ResidencyIdentity]] = None,
         arm: Optional[_ArmOrder] = None,
         boot_local_key: str = "",
+        boot_holes: Tuple[str, ...] = (),
     ) -> "_InjectionResult":
         """Typed injection: each slot receives exactly what its ``setup``
         annotation says — a ``str``/``Path`` local path, or a constructed
@@ -7686,6 +7700,7 @@ class Executor:
                                 self._enable_compiled,
                                 pipe, spec.compile_contract(), compile_artifact,
                                 compile_selection, arm, boot_local_key,
+                                boot_holes,
                             )
                         except compile_cache.CompiledExecutionLaneUnavailableError as exc:
                             # Mandatory (w8a8/w4a4) lane: self-mint also hit a
@@ -8693,6 +8708,7 @@ class Executor:
         delivered: Optional["_CompileArtifactSelection"] = None,
         arm: Optional[_ArmOrder] = None,
         boot_local_key: str = "",
+        boot_holes: Tuple[str, ...] = (),
     ) -> "fleet_compiled_graphs.ArmOutcome":
         """Arm the best available compiled path for a freshly loaded pipeline.
 
@@ -8795,7 +8811,8 @@ class Executor:
                 # did before §4.27 existed. The refused compiled graph is not retried: it
                 # is not passed back in.
                 outcome = self._enable_compiled(
-                    pipe, cfg, None, boot_local_key=boot_local_key)
+                    pipe, cfg, None, boot_local_key=boot_local_key,
+                    boot_holes=boot_holes)
                 if outcome.armed or outcome.eager_reason:
                     return outcome
                 return dc_replace(
@@ -8810,6 +8827,9 @@ class Executor:
             # store answered on it. Empty on the fleet path, where the store is
             # empty and the lookup is one stat.
             boot_local_key=boot_local_key,
+            # pgw#1371: the boot's per-class misses, so a self-mint opened on
+            # this path is SCOPED to the holes instead of the declaration.
+            holes=boot_holes,
         )
 
     def _arming_enable(

--- a/src/gen_worker/fleet_compiled_graphs.py
+++ b/src/gen_worker/fleet_compiled_graphs.py
@@ -451,6 +451,14 @@ class PendingSelfMint:
     #: previously answerable only from an activity event that carried no compiled graph
     #: key. Monotonic: a wall-clock step must not turn a mint negative.
     armed_at: float = dataclasses.field(default_factory=time.monotonic)
+    #: pgw#1371 holes-only: the ORDERED graph-class names this obligation is
+    #: scoped to — the classes with no artifact for this pod's (lane x sm)
+    #: anywhere the opener could see. Empty = the whole declaration (a full
+    #: miss, and the pre-holes behaviour). This is the handoff shape the
+    #: adopt-first boot (pgw#1372) fills: a boot that adopts 30 of 36 classes
+    #: opens its background mint with the 6 misses here, and the supervisor
+    #: mints ONLY those.
+    holes: Tuple[str, ...] = ()
     _state: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
@@ -1614,8 +1622,14 @@ def enable_compiled(
     delivered_ref: str = "",
     delivered_digest: str = "",
     boot_local_key: str = "",
+    holes: Sequence[str] = (),
 ) -> ArmOutcome:
     """Fleet arming policy, plus the adoption ledger every exit shares.
+
+    ``holes`` (pgw#1371) scopes a MISS's self-mint obligation to the named
+    graph classes — the caller's list of classes with no artifact for this
+    (lane x sm). Empty means the whole declaration. It rides the returned
+    ``PendingSelfMint`` and changes nothing about arming itself.
 
     pgw#923: the policy has a dozen exits and an adoption attempt can precede
     any of them, so the measured attempts are collected in ONE place rather
@@ -1640,6 +1654,7 @@ def enable_compiled(
         publisher=publisher, delegate=delegate,
         delivered_ref=delivered_ref, delivered_digest=delivered_digest,
         adoptions=adoptions, boot_local_key=boot_local_key,
+        holes=holes,
     )
     if not adoptions:
         return outcome
@@ -1801,6 +1816,7 @@ def _arming_policy(
     delivered_digest: str,
     adoptions: List[CompiledGraphAdoption],
     boot_local_key: str = "",
+    holes: Sequence[str] = (),
 ) -> ArmOutcome:
     """Fleet arming policy (gw#587): delivered compiled graph first, self-mint on miss.
 
@@ -2166,6 +2182,7 @@ def _arming_policy(
         cfg=cfg, target=target,
         mint_root=mint_root, publisher=publisher, cache_dir=cache_dir,
         arm_key=arm_key,
+        holes=tuple(str(h) for h in holes),
     )
     with _PENDING_LOCK:
         _PENDING.setdefault(key, pending)
@@ -2546,6 +2563,110 @@ def arm_from_local_store(
     return minted
 
 
+def adopt_minted_class(
+    pipe: Any, pending: "PendingSelfMint", artifact: Path,
+) -> bool:
+    """pgw#1371: adopt ONE freshly minted graph class THE MOMENT it lands.
+
+    The per-class half of :func:`adopt_delegated_mint`, run while the mint's
+    other classes are still compiling — durable first, then the §4.32 arm +
+    strict parity gate, then the per-class publish. This is what turns the
+    36-at-once "seal at the end or lose everything" shape into pgw#1372's
+    contract (*"arm each as it lands"*): a pod killed mid-mint has already
+    ARMED and PUBLISHED every class this accepted, so its successor adopts
+    them from the store and mints only the remainder.
+
+    Ordering is §4.32-preserving by construction: nothing is published before
+    it has passed the same arm + numerics gate the batch adopt runs, because
+    an adopter runs no gate that could re-check what ships. A class that
+    refuses costs itself: its bytes are quarantined in the local CAS for
+    forensics and its siblings are untouched.
+
+    Returns True when the class ARMED (whether or not a publish sink exists).
+    Every outcome is recorded on the pending's state, and the terminus
+    :func:`adopt_delegated_mint` folds those records instead of re-arming or
+    re-publishing — one arm, one upload, per class, however the mint ends.
+    """
+    state = pending._state
+    incremental: Dict[str, Tuple[str, Path, Dict[str, Any]]] = \
+        state.setdefault("incremental", {})
+    inc_refused: Dict[str, Tuple[str, str]] = \
+        state.setdefault("incremental_refused", {})
+    # EXACTLY ONCE per class: the stream and the share report can both
+    # deliver the same landing, and a settled class must not be re-armed,
+    # re-staged or re-shipped.
+    try:
+        stamped = dict(artifact_meta.try_read_metadata(Path(artifact)) or {})
+        stamped_name = str(
+            (stamped.get(GRAPH_CLASS_BLOCK) or {}).get("name") or "")
+    except Exception:  # noqa: BLE001 — an unreadable stamp is refused below
+        stamped_name = ""
+    if stamped_name and stamped_name in incremental:
+        return True
+    if stamped_name and stamped_name in inc_refused:
+        return False
+    # Provenance with NO manifest: the declaration-wide contract digest folds
+    # only once every class is traced, and `mint_provenance` documents the
+    # absent manifest as honest coverage telemetry, never identity. The
+    # terminus recomputes the full record for its own bookkeeping.
+    provenance = state.get("incremental_provenance")
+    if provenance is None:
+        provenance = mint_provenance(pending, manifest="")
+        state["incremental_provenance"] = provenance
+    staged_key = _stage_durable(pending, artifact, provenance)
+    bucket = int(getattr(pending.cfg, "lora_bucket", 0) or 0)
+    row_armed, row_meta, row_refusal = _arm_exported_compiled_graph(
+        pipe, pending.cfg, pending.cache_dir, bucket,
+        Path(artifact), pending.arm_key, verify_numerics=True)
+    if row_meta is not None:
+        row_meta = dict(row_meta)
+    elif row_armed:
+        row_meta = _packed_metadata(Path(artifact))
+    else:
+        row_meta = {}
+    row_key = str(row_meta.get("compiled_graph_key") or "").strip()
+    entry_name = str(
+        (row_meta.get(GRAPH_CLASS_BLOCK) or {}).get("name") or "")
+    if not row_armed or not row_key:
+        if row_armed and not row_key:
+            row_refusal = (
+                "compiled_graph_key_missing",
+                "the child's entry carries no stamped compiled_graph_key")
+        inc_refused[entry_name or stamped_name or Path(artifact).name] = (
+            str(row_refusal[0]), str(row_refusal[1]))
+        _quarantine_durable(staged_key)
+        activity_mod.emit_event(
+            "aot_entry_arm_failed",
+            f"arm_key={pending.arm_token}: this class does not arm mid-mint "
+            f"({row_refusal[0]}"
+            f"{': ' + row_refusal[1] if row_refusal[1] else ''}); it serves "
+            f"EAGER, its bytes are quarantined, and its siblings — landed and "
+            f"still compiling — are unaffected.",
+            phase=str(row_refusal[0]),
+            family=pending.family,
+            compiled_graph_key=row_key,
+            graph_class=entry_name or Path(artifact).name,
+        )
+        return False
+    durable = _admit_durable(pending, row_key, staged_key)
+    durable_path = durable.artifact if durable is not None else Path(artifact)
+    incremental[entry_name or stamped_name or row_key] = (
+        row_key, durable_path, row_meta)
+    publisher = pending.publisher
+    if publisher is not None and publisher.enabled():
+        published: set = state.setdefault("published_keys", set())
+        if row_key not in published:
+            published.add(row_key)
+            _publish_async(
+                publisher, pending.family, durable_path, row_meta,
+                provenance,
+                compiled_graph_key_digest=row_key,
+                mint_duration_ms=max(
+                    0, int((time.monotonic() - pending.armed_at) * 1000)),
+                arm_token=pending.arm_token)
+    return True
+
+
 def adopt_delegated_mint(
     pipe: Any, pending: "PendingSelfMint", artifacts: Sequence[Path],
     manifest: str = "",
@@ -2585,21 +2706,46 @@ def adopt_delegated_mint(
     state["provenance"] = provenance
 
     rows = [Path(a) for a in artifacts]
-    if not rows:
+    # pgw#1371: classes already adopted (or refused) MID-MINT by
+    # `adopt_minted_class`. Their records fold straight into the outcome
+    # below — one arm, one durable write, one upload per class, however the
+    # mint ends — and the per-row machinery skips them entirely.
+    incremental: Dict[str, Tuple[str, Path, Dict[str, Any]]] = dict(
+        state.get("incremental") or {})
+    inc_refused: Dict[str, Tuple[str, str]] = dict(
+        state.get("incremental_refused") or {})
+
+    def _stamped_name(row: Path) -> str:
+        try:
+            meta = artifact_meta.try_read_metadata(row) or {}
+        except Exception:  # noqa: BLE001 — an unreadable row is not settled
+            return ""
+        return str((meta.get(GRAPH_CLASS_BLOCK) or {}).get("name") or "")
+
+    settled_names = set(incremental) | set(inc_refused)
+    row_names: Dict[Path, str] = (
+        {row: _stamped_name(row) for row in rows} if settled_names else {})
+    if not rows and not incremental:
         state["adopt_refusal"] = (
             "no_entry_artifact", "the child reported no entry artifact")
         return None
     # The FIRST entry keeps the pending's canonical target path (the resume
     # bank and the local-store write address it); the rest sit beside it under
     # their own keys. Nothing reads a compiled graph-shaped single path any more.
-    artifact = rows[0]
-    if artifact != pending.target:
-        try:
-            pending.target.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(artifact, pending.target)
-        except OSError:
-            shutil.copy2(artifact, pending.target)
-    rows[0] = pending.target
+    # pgw#1371: with every row settled mid-mint, `rows` can be empty and the
+    # canonical-path dance has nothing to do — the durable CAS copies are the
+    # addresses from here on.
+    if rows:
+        artifact = rows[0]
+        if artifact != pending.target:
+            try:
+                pending.target.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(artifact, pending.target)
+            except OSError:
+                shutil.copy2(artifact, pending.target)
+        if row_names.get(rows[0], ""):
+            row_names[pending.target] = row_names.pop(rows[0])
+        rows[0] = pending.target
     # §1.5 / §4.33 step 3 — DURABLE FIRST, and this is the whole ordering
     # change. The bytes go to the local CAS BEFORE anything verifies, arms,
     # publishes or cleans up, on EVERY tier, because the alternative is what
@@ -2614,7 +2760,11 @@ def adopt_delegated_mint(
     # than the set, and a class that refuses is quarantined without touching a
     # sibling that armed.
     _durable_keys: Dict[Path, str] = {
-        row: _stage_durable(pending, row, provenance) for row in rows}
+        row: _stage_durable(pending, row, provenance) for row in rows
+        # pgw#1371: a mid-mint-settled row is already durable (admitted or
+        # quarantined) under its own key; re-staging it would downgrade the
+        # verdict `adopt_minted_class` already earned.
+        if row_names.get(row, "") not in settled_names}
     # pgw#1096: ONE gate for every self-produced compiled graph — the child's, and the
     # local store's (§4.28). pgw#999's classification, pgw#1042's pre-arm axis
     # divergence and pgw#805's AOT-only arm all live in `_arm_exported_compiled_graph`;
@@ -2656,7 +2806,22 @@ def adopt_delegated_mint(
     # class costing a whole mint.
     adopted: List[Tuple[str, Path, Dict[str, Any]]] = []
     refusals: List[Tuple[str, str, str]] = []
+    folded: set = set()
     for row in rows:
+        settled = row_names.get(row, "")
+        if settled and settled in incremental:
+            # pgw#1371: armed, gated, made durable and published the moment it
+            # landed — fold the record, do not arm twice.
+            key_p, path_p, meta_p = incremental[settled]
+            adopted.append((
+                key_p, path_p if Path(path_p).exists() else row,
+                dict(meta_p)))
+            folded.add(settled)
+            continue
+        if settled and settled in inc_refused:
+            refusals.append((settled, *inc_refused[settled]))
+            folded.add(settled)
+            continue
         row_armed, row_meta, row_refusal = _arm_exported_compiled_graph(
             pipe, pending.cfg, pending.cache_dir,
             int(getattr(pending.cfg, "lora_bucket", 0) or 0),
@@ -2708,6 +2873,17 @@ def adopt_delegated_mint(
                 "the child's entry carries no stamped compiled_graph_key"))
             continue
         adopted.append((row_key, row, row_meta))
+
+    # pgw#1371: an incrementally settled class whose artifact never reached
+    # this call's `artifacts` list (the share died before its report; the
+    # streamed row was the only witness) still counts — its bytes are durable
+    # and, on the publish path, already uploaded.
+    for name, (key_p, path_p, meta_p) in incremental.items():
+        if name not in folded and all(k != key_p for k, _p, _m in adopted):
+            adopted.append((key_p, Path(path_p), dict(meta_p)))
+    for name, (reason_p, detail_p) in inc_refused.items():
+        if name not in folded and all(n != name for n, _r, _d in refusals):
+            refusals.append((name, reason_p, detail_p))
 
     armed = bool(adopted)
     meta = adopted[0][2] if adopted else None
@@ -2988,6 +3164,15 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
         return
     state["publish_resolved"] = True
     publisher = pending.publisher
+    minted_key = str(
+        getattr(state.get("minted"), "compiled_graph_key", "") or "")
+    if minted_key and minted_key in (state.get("published_keys") or set()):
+        # pgw#1371: this class shipped the moment it armed
+        # (`adopt_minted_class`); the terminus only closes the books. One
+        # upload per key, however the mint ends.
+        mark_terminus(pending, TERMINUS_PUBLISHING)
+        shutil.rmtree(pending.mint_root, ignore_errors=True)
+        return
     if publisher is not None and publisher.enabled():
         mark_terminus(pending, TERMINUS_PUBLISHING)
         _publish_async(

--- a/src/gen_worker/mint_supervisor.py
+++ b/src/gen_worker/mint_supervisor.py
@@ -588,6 +588,36 @@ def _emit_abort(
     )
 
 
+def _adopt_landed(task: "MintTask", pending: Any, row: Any) -> None:
+    """pgw#1371: the per-class adopt/publish sink, run as each class LANDS.
+
+    Called from the pool's supervision thread while sibling classes are still
+    compiling — the same concurrency the terminus adopt already has with live
+    serving. Never raises: a failed incremental adopt costs nothing but the
+    incremental property for that class, because the terminus
+    ``adopt_delegated_mint`` still sees the artifact on disk and runs the
+    ordinary batch path over it.
+    """
+    from . import fleet_compiled_graphs
+
+    try:
+        fleet_compiled_graphs.adopt_minted_class(
+            task.pipe, pending, Path(str(row.artifact)))
+    except Exception:  # noqa: BLE001 — the terminus adopt is the backstop
+        logger.warning(
+            "mint-supervisor: mid-mint adopt of %s failed; the class stays "
+            "packed on disk and the terminus adopt will retry it",
+            getattr(row, "name", "?"), exc_info=True)
+
+
+def _incremental_covered(pending: Any) -> int:
+    """How many classes `adopt_minted_class` has ARMED so far (pgw#1371)."""
+    try:
+        return len(pending._state.get("incremental") or {})
+    except Exception:  # noqa: BLE001 — a double without state answers 0
+        return 0
+
+
 def graph_dir(pending: Any) -> Path:
     """Where this obligation's packed graph classes accrete."""
     return Path(pending.mint_root) / GRAPH_DIRNAME
@@ -720,6 +750,16 @@ async def supervise(
                 detail="abandoned before attempt")
         held = held_graph_classes(out_dir)
         have = tuple(sorted(str(row.entry) for row in held))
+        # pgw#1371 holes-only: the obligation may be SCOPED — the opener named
+        # the classes with no artifact for this (lane x sm), and this mint
+        # produces those and nothing else. The class goal, the width and the
+        # completion test all shrink to the holes; the wider declaration is
+        # someone else's coverage (adopted at boot, or another pod's publish).
+        holes = tuple(
+            str(h) for h in (getattr(pending, "holes", ()) or ()))
+        todo = (
+            len(set(holes) - set(have)) if holes
+            else max(0, declared - len(have)))
         # §4.33 / pgw#1175: NOTHING IS BUDGETED. A `mint_budget.co_residency`
         # gate stood at the top of this loop and charged a weight-free child
         # for the PARENT's resident weights, already excluded from the free
@@ -728,7 +768,7 @@ async def supervise(
         # separate processes, crash-isolated, and a real shortfall comes back
         # classified from the card itself.
         width = aot_compile_pool.entry_workers(
-            max(1, declared - len(have)),
+            max(1, todo),
             # The one banked measurement that survives: what a previous
             # compile child on this pod really peaked at, in HOST RSS. K's
             # divisor and nothing else.
@@ -741,18 +781,25 @@ async def supervise(
         terminus = ""
         retryable = False
         try:
-            if len(have) >= declared:
-                # Every declared class is already on disk. The attempt is a
-                # no-op and saying so is cheaper than proving it with a pool.
+            if todo <= 0:
+                # Everything this obligation is scoped to is already on disk.
+                # The attempt is a no-op and saying so is cheaper than proving
+                # it with a pool.
                 result = aot_mint.fold_held_graph_classes(held, spec=spec)
             else:
                 result = await asyncio.to_thread(
                     aot_mint.mint_graph_classes,
-                    msgspec.structs.replace(template, have_classes=have),
+                    msgspec.structs.replace(
+                        template, have_classes=have, hole_classes=holes),
                     workdir=Path(pending.mint_root) / "compile-pool",
                     width=width,
                     spec=spec,
                     on_progress=_progress,
+                    # pgw#1371: adopt-and-publish EACH class the moment its
+                    # artifact lands — runs on the pool's supervision thread,
+                    # beside the still-compiling siblings, so a killed pod
+                    # keeps (and the fleet store holds) every completed graph.
+                    on_landed=lambda row: _adopt_landed(task, pending, row),
                     # pgw#848: rewritten on every beat, so a mint this pod is
                     # KILLED still leaves its measurements on disk.
                     phase_snapshot=snapshot,
@@ -790,7 +837,11 @@ async def supervise(
         if terminus == ABANDONED:
             return SupervisedResult(
                 status=ABANDONED, detail=last, attempts=attempts,
-                covered=len(have), declared=declared)
+                # pgw#1371: the classes `adopt_minted_class` armed before the
+                # abandon are REAL coverage — armed on this pipe, durable in
+                # the local CAS, and (with a sink) already uploaded.
+                covered=len(have) + _incremental_covered(pending),
+                declared=declared)
 
         if not last:
             act.phase(activity_mod.PHASE_SEAL_PUBLISH)

--- a/tests/harness/fake_compile_child.py
+++ b/tests/harness/fake_compile_child.py
@@ -55,6 +55,21 @@ if mode == "wedged-no-report":
 
 declared = int(os.environ.get("PGW_FAKE_DECLARED", "6"))
 mine = [f"cls/dim={{i}}" for i in range(index, declared, count)]
+# pgw#1371 holes-only: intersect the share with the job's hole list before
+# the have filter, exactly as `aot_mint.trace_for_key` does, and report how
+# many rows the holes matched (`targeted_classes`).
+holes = [str(h) for h in (job.get("hole_classes") or [])]
+targeted = -1
+if holes:
+    mine = [n for n in mine if n in holes]
+    targeted = len(mine)
+if os.environ.get("PGW_FAKE_OMIT_TARGETED"):
+    # A child that filtered to the holes but cannot PROVE it — the shape the
+    # pool must refuse rather than read as "covered".
+    targeted = -1
+have = [str(h) for h in (job.get("have_classes") or [])]
+if have:
+    mine = [n for n in mine if n not in have]
 if mode == "short" and index == 0:
     names = []
 elif mode == "collide":
@@ -129,6 +144,7 @@ report.write_bytes(json.dumps({{
     "entry": share, "status": "refused" if refused else "compiled",
     "classes": classes,
     "declared_classes": declared,
+    "targeted_classes": targeted,
     "detail": (
         f"{{len(classes)}} graph class(es) packed before the share refused: "
         f"graph class {{mine[1] if len(mine) > 1 else '?'}} refused"

--- a/tests/test_compile_politeness_pgw1137.py
+++ b/tests/test_compile_politeness_pgw1137.py
@@ -355,16 +355,28 @@ def test_a_user_machine_mint_child_NICES_ITSELF(
     assert compile_posture.current() == USER_MACHINE
 
 
-def test_a_FLEET_mint_child_never_nices_itself(
+def test_a_FLEET_RIG_mint_child_does_not_nice_itself(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The serving pod compiles exactly as fast as it did. A pod's mint already
-    competes with a tenant whose reserves are held back explicitly; de-
-    prioritising it on top of that would slow paid work for no gain."""
+    """The RIG mint child (a pod bought to mint, nothing co-resident) still
+    compiles at full priority — `mint_child._install_posture` is user-machine
+    only.
+
+    pgw#1371 narrowed what this pins: the RUNTIME mint's ENTRY children DO
+    nice themselves on FLEET now (`compile_posture.FLEET_MINT_NICE`, applied
+    in `aot_compile_child._install_posture` — see
+    `test_runtime_mint_holes_and_serving_reserve`), because e2e#1892 run 7
+    measured a serving process starved to a 65-minute non-return by a mint the
+    core reserves were supposed to protect it from. The rig path has no
+    co-resident to protect and keeps full priority."""
     nice, armed = _drive_child_posture(monkeypatch, FLEET)
     assert nice.levels == []
     assert armed == []
     assert compile_posture.current() == FLEET
+    assert compile_posture.FLEET.nice_level() == \
+        compile_posture.FLEET_MINT_NICE == 10, (
+        "the fleet ENTRY-child tree yields to the serving process (pgw#1371); "
+        "only the rig mint child stays at full priority")
 
 
 def test_a_kernel_that_refuses_the_nice_leaves_a_RUDE_mint_not_a_DEAD_one(
@@ -724,7 +736,11 @@ def test_the_posture_module_holds_POLICY_and_nothing_else() -> None:
     assert posture.cpu_budget_cores(4, headroom=2) == 2
 
     fleet = CompilePosture()
-    assert fleet.nice_level() == 0
+    # pgw#1371: the fleet MINT TREE yields to the serving process — run 7 of
+    # e2e#1892 measured the core reserves failing to protect it (65-minute
+    # non-return beside a 2-on-7 mint). Applied by the ENTRY children to
+    # themselves; the serving process is never niced.
+    assert fleet.nice_level() == compile_posture.FLEET_MINT_NICE == 10
     assert fleet.entry_ceiling(8) == 8
     assert fleet.rss_reserve_bytes(4 * 1024**3) == 4 * 1024**3
     assert fleet.cpu_budget_cores(32, headroom=2) == 30

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -236,7 +236,8 @@ def _seeded_enable(ex, artifact, ref=None, digest=None):
     warmup proof run unchanged."""
     from gen_worker import fleet_compiled_graphs
 
-    def _enable(pipe, cfg, art, delivered=None, arm=None, boot_local_key=""):
+    def _enable(pipe, cfg, art, delivered=None, arm=None, boot_local_key="",
+                boot_holes=()):
         return fleet_compiled_graphs.enable_compiled(
             pipe, cfg, ex.store._cache_dir, Path(artifact),
             delivered_ref=ref or CACHE_REF,

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -570,7 +570,8 @@ class _Rig:
             pass
         monkeypatch.setattr(
             self.ex, "_enable_compiled",
-            lambda p, cfg, artifact, delivered=None, arm=None, boot_local_key="":
+            lambda p, cfg, artifact, delivered=None, arm=None, boot_local_key="",
+                   boot_holes=():
                 fleet_compiled_graphs.enable_compiled(
                     p, cfg, self.ex.store._cache_dir, artifact,
                     publisher=None))

--- a/tests/test_runtime_mint_holes_and_serving_reserve.py
+++ b/tests/test_runtime_mint_holes_and_serving_reserve.py
@@ -1,0 +1,550 @@
+"""pgw#1371: the runtime mint — holes-only scope, per-class adopt/publish,
+and the serving reserve.
+
+The final-mandate shape (issue text, and pgw#1372's handoff contract): a
+serving worker that boots onto an unminted (lane x sm) serves EAGER, mints
+ONLY the holes — the graph classes with no artifact anywhere it could see —
+and ARMS AND PUBLISHES EACH ONE as it lands, so a killed pod keeps every
+completed graph and its successor mints only the remainder. Never
+all-or-nothing, at any step.
+
+Three seams, each driven for real with only the compile/arm interior faked
+(the local-testing rule — no local inductor, no local .so load):
+
+* the POOL takes an ordered hole list, children intersect their shares with
+  it before the ``have`` filter, and coverage is proven from the children's
+  own ``targeted_classes`` reports;
+* ``adopt_minted_class`` is the per-class half of ``adopt_delegated_mint`` —
+  durable, §4.32 arm+gate, publish, the moment a class lands — and the
+  terminus FOLDS those records instead of arming or uploading twice;
+* the FLEET entry-child tree nices itself (``FLEET_MINT_NICE``): e2e#1892
+  run 7 measured the core reserves failing to protect the serving process
+  (a 15m50s invocation never returned in 65 minutes beside a 2-on-7 mint),
+  and priority is the mechanism `compile_posture`'s own doctrine names as
+  the one that works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import aot_compile_pool as pool_mod
+from gen_worker import compile_posture
+from harness import fake_compile_child
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker import aot_mint, mint_supervisor  # noqa: E402
+from gen_worker import fleet_compiled_graphs as fleet  # noqa: E402
+from gen_worker.api.decorators import Compile  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+    reset_export_declarations,
+)
+import tcg_artifacts  # noqa: E402
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+_DECLARED = 6
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Any:
+    for name in ("PGW_FAKE_CHILD", "PGW_FAKE_DECLARED",
+                 "PGW_FAKE_STREAM_HANG_AFTER", "PGW_FAKE_OMIT_TARGETED"):
+        monkeypatch.delenv(name, raising=False)
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+# ======================================================================
+# 1. The pool mints only the named holes
+# ======================================================================
+
+def _pool(tmp_path: Path, *, workers: int = 2) -> pool_mod.EntryCompilePool:
+    os.environ["PGW_FAKE_CHILD"] = "ok"
+    os.environ["PGW_FAKE_DECLARED"] = str(_DECLARED)
+    width = pool_mod.entry_workers(
+        _DECLARED, limit=workers, vcpus=16, available_bytes=64 * 1024**3,
+        device_lock=True)
+    return pool_mod.EntryCompilePool(
+        tmp_path / "pool", width=width, cache_dir=str(tmp_path / "cache"),
+        python=fake_compile_child.script(tmp_path))
+
+
+def _job(tmp_path: Path, **fields: Any) -> pool_mod.EntryJob:
+    return pool_mod.EntryJob(
+        function="generate", modules=("harness.toy_endpoints",),
+        out_dir=str(tmp_path / "artifacts"), **fields)
+
+
+def test_the_pool_mints_exactly_the_named_holes(tmp_path: Path) -> None:
+    """Six declared, two holes named — two classes packed, coverage proven
+    from the children's own targeted counts, not from the declaration."""
+    packed = _pool(tmp_path).compile(_job(
+        tmp_path, hole_classes=("cls/dim=1", "cls/dim=3")))
+    assert sorted(packed) == ["cls/dim=1", "cls/dim=3"]
+
+
+def test_a_hole_this_pod_already_holds_is_not_re_minted(
+    tmp_path: Path,
+) -> None:
+    packed = _pool(tmp_path).compile(_job(
+        tmp_path,
+        hole_classes=("cls/dim=1", "cls/dim=3"),
+        have_classes=("cls/dim=1",)))
+    assert sorted(packed) == ["cls/dim=3"], (
+        "a hole already packed on disk must cost neither a trace nor a "
+        "compile — and the coverage proof must still close over the skip")
+
+
+def test_a_stale_hole_name_is_loud_and_never_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hole list can outlive a declaration (the release moved). The matched
+    classes mint; the unmatched name is a wire-visible confession, not a dead
+    mint — coverage accretes and a smaller mint is not a short publish."""
+    from gen_worker import activity as activity_mod
+
+    said: List[Tuple[str, str]] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: said.append(
+            (str(kw.get("phase", "")), detail)))
+    packed = _pool(tmp_path).compile(_job(
+        tmp_path, hole_classes=("cls/dim=2", "cls/dim=99")))
+    assert sorted(packed) == ["cls/dim=2"]
+    stale = [d for p, d in said if p == "stale_holes"]
+    assert stale and "1 of 2" in stale[0], (
+        "an unmatched hole name must be confessed on the wire — silently "
+        "minting fewer classes than asked is the subset-drop defect class")
+
+
+def test_a_child_that_cannot_prove_hole_coverage_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Without the targeted counts there is no evidence the holes were
+    covered rather than silently dropped — the exact claim the whole-set
+    proof exists to make unfalsifiable."""
+    os.environ["PGW_FAKE_OMIT_TARGETED"] = "1"
+    with pytest.raises(pool_mod.EntryCompileFailed) as caught:
+        _pool(tmp_path).compile(_job(
+            tmp_path, hole_classes=("cls/dim=1", "cls/dim=3")))
+    assert "no targeted count" in str(caught.value)
+
+
+# ======================================================================
+# 2. The REAL trace loop filters to the holes
+# ======================================================================
+
+FAMILY = "tiny1371"
+
+
+class _TinyUNet(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, sample: Any) -> Any:
+        return torch.tanh(self.lin(sample))
+
+
+def _declare() -> Any:
+    return register_export_declaration(Compile(
+        family=FAMILY,
+        targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(
+            GraphClass(dims={"B": 1}),
+            GraphClass(dims={"B": 2}),
+            GraphClass(dims={"B": 4}),
+        ),
+        inputs=(Input("sample", shape=("B", 4), dtype="model"),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    ))
+
+
+def test_trace_for_key_holes_filter_and_share_targeted_agree() -> None:
+    """The REAL export loop over the REAL declaration: the hole filter yields
+    exactly the named classes, `share_targeted` counts what the filter will
+    match (before any have filter), and both read the ONE row order — so the
+    parent's proof `sum(targeted) == |declaration ∩ holes|` is true by
+    construction, not by convention."""
+    decl = _declare()
+    pipe = SimpleNamespace(unet=_TinyUNet().eval())
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+
+    names = []
+    for row in aot_mint.trace_for_key(pipe, spec, decl):
+        names.append(row.name)
+        row.release()
+    assert len(names) == 3
+
+    holes = (names[1], "no/such/class")
+    minted = []
+    for row in aot_mint.trace_for_key(pipe, spec, decl, hole_classes=holes):
+        minted.append(row.name)
+        assert row.declared == 3, "declared stays the WHOLE declaration"
+        row.release()
+    assert minted == [names[1]]
+
+    assert aot_mint.share_targeted(
+        pipe, spec, decl, hole_classes=holes) == 1
+    # Over a 2-way partition the shard-local counts sum to the intersection.
+    assert sum(
+        aot_mint.share_targeted(
+            pipe, spec, decl, share_index=i, share_count=2,
+            hole_classes=tuple(names[:2]))
+        for i in range(2)) == 2
+    # And the have filter runs AFTER the targeted count, so a held hole is
+    # counted as targeted (the parent subtracts it knowingly).
+    held_minted = [
+        r.name for r in aot_mint.trace_for_key(
+            pipe, spec, decl, hole_classes=holes, have_classes=(names[1],))]
+    assert held_minted == []
+
+
+# ======================================================================
+# 3. Per-class adopt/publish, and the terminus fold
+# ======================================================================
+
+
+class _Publisher:
+    def __init__(self) -> None:
+        self.published: List[Tuple[str, str]] = []
+
+    def enabled(self) -> bool:
+        return True
+
+
+def _pending(tmp_path: Path, publisher: Any = None, **fields: Any) -> Any:
+    cfg = SimpleNamespace(
+        family="sdxl", lora_bucket=0, targets=("unet",), shapes=((4, 4),),
+        guidance_scales=(), text_lens=())
+    pending = fleet.PendingSelfMint(
+        family="sdxl", arm_token="arm2-tiny1371",
+        ref="root/family-sdxl#arm2-tiny1371", cfg=cfg,
+        target=tmp_path / "mint-root" / "cell.tar.gz",
+        mint_root=tmp_path / "mint-root", publisher=publisher,
+        cache_dir=tmp_path / "cas", **fields)
+    pending.mint_root.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "cas").mkdir(parents=True, exist_ok=True)
+    return pending
+
+
+def _patch_arm(
+    monkeypatch: pytest.MonkeyPatch, *, refuse: set | None = None,
+) -> List[Path]:
+    """Fake ONLY the arm/parity interior (a real .so load is a pod leg); the
+    metadata it answers with is the artifact's own stamped envelope."""
+    from gen_worker import artifact_meta
+
+    calls: List[Path] = []
+    refuse = refuse or set()
+
+    def _arm(pipe: Any, cfg: Any, cache_dir: Any, bucket: int,
+             artifact: Path, arm_key: Any, verify_numerics: bool = False,
+             ) -> Tuple[bool, Any, Tuple[str, str]]:
+        calls.append(Path(artifact))
+        meta = dict(artifact_meta.read_metadata(Path(artifact)))
+        name = str((meta.get("graph_class") or {}).get("name") or "")
+        if name in refuse:
+            return False, None, ("adopt_probe_failed", f"{name} refused")
+        return True, meta, ("", "")
+
+    monkeypatch.setattr(fleet, "_arm_exported_compiled_graph", _arm)
+    return calls
+
+
+def _patch_publish(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str]]:
+    """Intercept the upload seam — the transport itself cannot run locally.
+    Everything before it (durable staging, admit, dedupe) stays real."""
+    shipped: List[Tuple[str, str]] = []
+
+    def _pub(publisher: Any, family: str, artifact: Path, meta: dict,
+             provenance: Any, compiled_graph_key_digest: str = "",
+             mint_duration_ms: int = 0, arm_token: str = "") -> Any:
+        shipped.append((compiled_graph_key_digest, str(artifact)))
+        return SimpleNamespace(join=lambda *a, **k: None)
+
+    monkeypatch.setattr(fleet, "_publish_async", _pub)
+    return shipped
+
+
+def _two_artifacts(tmp_path: Path) -> Tuple[Path, Path]:
+    out = tmp_path / "mint-root" / "graphs"
+    out.mkdir(parents=True, exist_ok=True)
+    a = tcg_artifacts.build(out / "a.tar.gz", graph_class="denoiser/h=64,w=64")
+    b = tcg_artifacts.build(out / "b.tar.gz", graph_class="denoiser/h=96,w=96",
+                            witness="0123456789abcdef")
+    return a, b
+
+
+def test_a_class_is_armed_durable_and_published_the_moment_it_lands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publisher = _Publisher()
+    pending = _pending(tmp_path, publisher=publisher)
+    arms = _patch_arm(monkeypatch)
+    shipped = _patch_publish(monkeypatch)
+    a, b = _two_artifacts(tmp_path)
+
+    assert fleet.adopt_minted_class(object(), pending, a) is True
+    assert len(arms) == 1 and len(shipped) == 1
+    key_a = tcg_artifacts.key_of(a)
+    assert shipped[0][0] == key_a
+    # Durable BEFORE anything else could lose it: the shipped path is the
+    # local CAS copy, not the mint-root artifact the terminus cleans.
+    assert shipped[0][1] != str(a)
+    assert Path(shipped[0][1]).exists()
+    inc = pending._state["incremental"]
+    assert list(inc) == ["denoiser/h=64,w=64"]
+
+    # Landing the same class twice (stream + report race) uploads ONCE.
+    assert fleet.adopt_minted_class(object(), pending, a) is True
+    assert len(shipped) == 1
+
+    # THE TERMINUS FOLD: the batch adopt arms only the row the incremental
+    # path never saw, and the already-shipped key is not uploaded again.
+    minted = fleet.adopt_delegated_mint(object(), pending, [a, b])
+    assert minted is not None
+    # Counted, not name-matched: the terminus renames rows[0] onto the
+    # pending's canonical target, so a re-arm of `a` would wear a different
+    # basename. One incremental arm of a + one terminus arm of b — exactly.
+    assert len(arms) == 2, (
+        f"the terminus re-armed a class `adopt_minted_class` already armed — "
+        f"one arm per class, however the mint ends (arms: "
+        f"{[p.name for p in arms]})")
+    entries = pending._state["adopted_entries"]
+    assert {k for k, _p, _m in entries} == {key_a, tcg_artifacts.key_of(b)}
+
+    fleet.publish_self_mint(pending)
+    assert [k for k, _p in shipped].count(key_a) == 1, (
+        "the terminus publish re-uploaded a key that shipped when it landed")
+
+
+def test_a_mid_mint_refusal_costs_that_class_and_only_that_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    publisher = _Publisher()
+    pending = _pending(tmp_path, publisher=publisher)
+    arms = _patch_arm(monkeypatch, refuse={"denoiser/h=64,w=64"})
+    shipped = _patch_publish(monkeypatch)
+    a, b = _two_artifacts(tmp_path)
+
+    assert fleet.adopt_minted_class(object(), pending, a) is False
+    assert shipped == [], "a refused class must never ship"
+    assert "denoiser/h=64,w=64" in pending._state["incremental_refused"]
+
+    minted = fleet.adopt_delegated_mint(object(), pending, [a, b])
+    assert minted is not None, "the sibling still adopts"
+    assert minted.compiled_graph_key == tcg_artifacts.key_of(b)
+    # The refusal was folded, not re-armed: one incremental arm of a (the
+    # refusal itself) + one terminus arm of b — the terminus never re-tried a.
+    assert len(arms) == 2, [p.name for p in arms]
+
+
+def test_supervise_scopes_the_mint_to_the_pendings_holes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handoff contract (pgw#1372 fills it): `PendingSelfMint.holes` is
+    the mint's scope — the template the children get carries it, the width is
+    sized to it, and the per-class adopt sink rides along."""
+    monkeypatch.setattr(
+        mint_supervisor, "assert_family_mintable", lambda family: None)
+    monkeypatch.setattr(
+        fleet, "aot_export_spec",
+        lambda pipe, cfg: SimpleNamespace(
+            family="sdxl", strict=True, lora_bucket=0))
+    monkeypatch.setattr(
+        mint_supervisor, "export_declaration", lambda family: object())
+    monkeypatch.setattr(
+        aot_mint, "declared_class_rows",
+        lambda pipe, spec, decl: [object()] * _DECLARED)
+    monkeypatch.setattr(
+        fleet, "abandon_self_mint", lambda pending: None)
+
+    seen: Dict[str, Any] = {}
+
+    def _mint(template: Any, **kw: Any) -> Any:
+        seen["template"], seen["kwargs"] = template, kw
+        raise aot_mint.MintRefused("stop here — the wiring is the test")
+
+    monkeypatch.setattr(aot_mint, "mint_graph_classes", _mint)
+
+    pending = _pending(tmp_path, holes=("cls/a", "cls/b"))
+    task = mint_supervisor.MintTask(
+        pending=pending, pipe=object(), function="generate",
+        modules=("harness.toy_endpoints",))
+
+    class _Act:
+        def phase(self, *a: Any, **k: Any) -> None: ...
+        def note(self, *a: Any) -> None: ...
+        def heartbeat(self) -> None: ...
+
+    result = asyncio.run(mint_supervisor.supervise(
+        task, act=_Act(), max_attempts=1))
+    assert result.status == mint_supervisor.FAILED
+
+    template = seen["template"]
+    assert template.hole_classes == ("cls/a", "cls/b")
+    assert seen["kwargs"]["width"].entries == 2, (
+        "the pool is sized to the HOLES, not the declaration — a 2-hole mint "
+        "on a 36-class family must not open a 36-class-wide pool")
+    assert callable(seen["kwargs"]["on_landed"]), (
+        "the per-class adopt/publish sink is not wired — a killed pod would "
+        "lose every completed graph again")
+
+
+def test_supervise_with_every_hole_held_folds_and_never_pools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mint_supervisor, "assert_family_mintable", lambda family: None)
+    monkeypatch.setattr(
+        fleet, "aot_export_spec",
+        lambda pipe, cfg: SimpleNamespace(
+            family="sdxl", strict=True, lora_bucket=0))
+    monkeypatch.setattr(
+        mint_supervisor, "export_declaration", lambda family: object())
+    monkeypatch.setattr(
+        aot_mint, "declared_class_rows",
+        lambda pipe, spec, decl: [object()] * _DECLARED)
+    held_rows = [
+        SimpleNamespace(entry="cls/a", key="k1", artifact=Path("/x"),
+                        metadata={}),
+    ]
+    monkeypatch.setattr(
+        mint_supervisor, "held_graph_classes", lambda out_dir: held_rows)
+    folded: List[Any] = []
+
+    def _fold(held: Any, *, spec: Any) -> Any:
+        folded.append(held)
+        raise aot_mint.MintRefused("fold reached — that is the assertion")
+
+    monkeypatch.setattr(aot_mint, "fold_held_graph_classes", _fold)
+    monkeypatch.setattr(
+        aot_mint, "mint_graph_classes",
+        lambda *a, **k: pytest.fail(
+            "a fully-held holes mint opened a compile pool"))
+    monkeypatch.setattr(fleet, "abandon_self_mint", lambda pending: None)
+
+    pending = _pending(tmp_path, holes=("cls/a",))
+    task = mint_supervisor.MintTask(
+        pending=pending, pipe=object(), function="generate", modules=("m",))
+
+    class _Act:
+        def phase(self, *a: Any, **k: Any) -> None: ...
+        def note(self, *a: Any) -> None: ...
+        def heartbeat(self) -> None: ...
+
+    result = asyncio.run(mint_supervisor.supervise(
+        task, act=_Act(), max_attempts=1))
+    assert result.status == mint_supervisor.FAILED and folded
+
+
+def test_enable_compiled_scopes_the_pending_to_the_callers_holes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The executor half of the handoff: a MISS opened with named holes
+    produces a `PendingSelfMint` carrying them — the value `supervise` reads.
+    Real `enable_compiled`, the pgw#1033 miss fixture shape."""
+    from gen_worker import compile_cache as cc_mod  # noqa: F401
+    from gen_worker import config as gw_config
+    from gen_worker.api.decorators import Compile as _Compile
+    from gen_worker.compiled_graph_adopt import AdoptOutcome
+
+    gw_config.reload_for_test()
+    monkeypatch.setattr(
+        fleet.provision, "enable_compiled",
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss(
+            "no_compiled_graph"))
+    monkeypatch.setattr(fleet.cc, "has_compile_target", lambda p, c, **_kw: True)
+    monkeypatch.setattr(fleet.cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(fleet.cc, "mandatory_serving", lambda p: False)
+    monkeypatch.setattr(
+        fleet.cc, "apply_lora_execution_lane", lambda p, b, **_kw: None)
+    monkeypatch.setattr(fleet.cc, "drop_lora_execution_lane", lambda p: None)
+    monkeypatch.setattr(fleet, "_cuda_ready", lambda: True)
+    monkeypatch.setattr(fleet, "_PENDING", {})
+    arm_token = fleet.ARM_SCHEME + "-" + "a" * fleet.ARM_DIGEST_HEX
+    monkeypatch.setattr(
+        fleet, "arm_identity",
+        lambda *a, **k: fleet.ArmIdentity(
+            facts=(("family", "sdxl"), ("token_pin", arm_token))))
+    monkeypatch.setattr(
+        fleet.ArmIdentity, "token", property(lambda self: arm_token))
+    monkeypatch.setattr(
+        fleet.loading, "pipeline_weight_lane", lambda pipe: "plain")
+    register_export_declaration(_Compile(
+        family="sdxl", targets=("unet",), text_len=77,
+        shapes=((1024, 1024),),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}),),
+        inputs=(Input("sample", shape=("B", 4, 128, 128), dtype="bfloat16"),),
+        shape_strategy="static-rows", warm_changes_key=False))
+
+    cfg = SimpleNamespace(
+        family="sdxl", lora_bucket=0, shapes=((1024, 1024),),
+        targets=("unet",), text_lens=(77,), guidance_scales=(1.0,),
+        regional=False)
+    outcome = fleet.enable_compiled(
+        object(), cfg, tmp_path, None, publisher=None, delegate=True,
+        holes=("cls/a", "cls/b"))
+    pending = outcome.self_mint
+    assert isinstance(pending, fleet.PendingSelfMint)
+    assert pending.holes == ("cls/a", "cls/b"), (
+        "the holes died between the caller and the obligation — the mint "
+        "would cover the whole declaration again")
+    fleet.abandon_self_mint(pending)
+
+
+# ======================================================================
+# 4. The serving reserve: the FLEET entry-child tree yields
+# ======================================================================
+
+def test_fleet_entry_children_apply_the_serving_reserve_nice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """e2e#1892 run 7: 2 children on 7 vCPU starved the serving process into
+    a 65-minute non-return (15m50s baseline) — the core reserve bounds the
+    AVERAGE while inductor bursts `compile_threads` workers per child. The
+    kernel-level reserve is priority: the ENTRY child nices itself on FLEET,
+    and the serving process (never niced) wins every contended slice."""
+    from gen_worker import aot_compile_child
+
+    levels: List[int] = []
+
+    def _nice(inc: int) -> int:
+        levels.append(int(inc))
+        return int(inc)
+
+    monkeypatch.setattr(os, "nice", _nice)
+    # `_install_posture` publishes the posture process-wide; restore the
+    # module global so a sibling test's width arithmetic is not run under
+    # this tape's USER_MACHINE.
+    monkeypatch.setattr(compile_posture, "_INSTALLED", None)
+    monkeypatch.setattr(
+        aot_compile_child, "arm_parent_death_signal", lambda: True)
+
+    aot_compile_child._install_posture(pool_mod.EntryJob(
+        function="f", modules=("m",), posture=compile_posture.FLEET))
+    assert levels == [compile_posture.FLEET_MINT_NICE] == [10]
+
+    levels.clear()
+    aot_compile_child._install_posture(pool_mod.EntryJob(
+        function="f", modules=("m",), posture=compile_posture.USER_MACHINE))
+    assert levels == [compile_posture.USER_MACHINE_NICE] == [19]

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -279,7 +279,7 @@ class _Rig:
             monkeypatch.setattr(
                 self.ex, "_enable_compiled",
                 lambda p, cfg, artifact, delivered=None, arm=None,
-                       boot_local_key="":
+                       boot_local_key="", boot_holes=():
                     fleet_compiled_graphs.enable_compiled(
                         p, cfg, self.ex.store._cache_dir, artifact,
                         publisher=None))


### PR DESCRIPTION
The full pgw#1371 runtime-mint scope (Paul's cutover-acceleration mandate), riding PR #946's per-class streaming. Three halves:

## 1. Holes-only minting
- `PendingSelfMint.holes` — the handoff shape pgw#1372's adopt-first boot fills: adopt what the store answers, open the background mint scoped to the misses.
- `enable_compiled(holes=…)` stamps it at the miss; the executor names the holes from boot-adopt (`BootAdoptOutcome.graph_classes`, inverted off `DerivedKeySet.entry_keys`).
- `supervise()` sizes the pool to the holes; children intersect their `rows[i::K]` share with the hole list before the `have` filter (`trace_for_key(hole_classes=…)`); coverage is proven from the children's own `targeted_classes` reports: `len(done) == sum(targeted) − |have ∩ holes|`. A stale hole name is a loud `stale_holes` event, never a dead mint; a child that cannot prove its targeted count is refused.

## 2. Per-graph publish as entries finish — never all-or-nothing
- `adopt_minted_class` = the per-class half of `adopt_delegated_mint`, run off PR #946's `on_row` stream the moment each artifact lands: durable → §4.32 arm + strict parity gate → admit → per-class upload. **A pod killed mid-mint keeps, and the fleet store holds, every completed graph.**
- §4.32 preserved by construction: nothing ships before it passes the same gate the batch adopt ran, because adopters run no gate of their own.
- Exactly-once: the terminus folds the incremental records (no re-arm, no re-stage, no second upload — `publish_self_mint` skips an already-shipped key); a mid-mint refusal costs that class alone (quarantined; siblings and the still-compiling remainder untouched); abandoned supervisions report `covered = have + incrementally-armed`.

## 3. The serving reserve that actually works
`compile_posture.FLEET_MINT_NICE = 10`: the FLEET **entry-child tree** nices itself, so the serving process (never niced) wins every contended slice. Calibration is e2e#1892 run 7, filed in the issue: `entry_workers ≤ vcpus − serving_reserve` already held (2 ≤ 7−2) and the serving process STILL starved to a 65-minute non-return (15m50s baseline), because each child bursts `compile_threads` workers the K-formula deliberately overcommits. The module's own doctrine says priority, not core reservation, is the mechanism that preserves a co-resident; run 7 is the measurement that extends it to the fleet. The rig mint child (nothing co-resident) keeps full priority, pinned by the updated pgw#1137 test.

## Tests
`tests/test_runtime_mint_holes_and_serving_reserve.py` — real pool + real fake-child processes, the REAL `trace_for_key` export loop over a real declaration, real `tcg_artifacts` envelopes and the real local CAS; only the arm/parity interior and the upload transport are faked (the local-testing rule). Red-proofed with seven mutations, each red; 5x green randomized; 458-test adjacent sweep green; ruff + mypy clean.

Blocked-scope note: reading holes from the RELEASE metadata document (`th#2133`) and the `--graphs` operator subset stay with their own lanes; this PR establishes the mechanism and wires the boot-adopt source that exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)