### PR TITLE
pgw#1372: model residency — admission before allocation, two tiers, serialized loads

### DIFF
--- a/changelog.d/pgw1372-residency.md
+++ b/changelog.d/pgw1372-residency.md
@@ -1,0 +1,12 @@
+- **Model residency lands (`gen_worker.serving.residency`), Paul's
+  admission-before-allocation ruling encoded.** Placement is the worker's
+  decision: before an instance is even constructed, its exact weight bytes
+  (tensorfs manifest per lane) plus an activation-headroom estimate are
+  reserved against the VRAM budget; LRU residents demote until it fits; a
+  model that can never fit refuses typed at admission — never a CUDA OOM
+  mid-load. Loads are serialized per GPU; residency is two-tier
+  (VRAM -> host-staged -> chunk store, re-promotion is an H2D copy, never a
+  disk walk); tier moves happen only between requests (single-flight per
+  instance defines the window) and the author never observes them. The
+  `ModelBackend`/`InstanceSizer` protocols are the pgw#1382 seam — the
+  SDK-core Model wrapper implements the moves; this engine orders them.

--- a/scripts/lint_unreached_surface.py
+++ b/scripts/lint_unreached_surface.py
@@ -151,6 +151,19 @@ DEFINED_LABELS: Set[str] = set()
 # allowlists follow, and what stops this table becoming the place dead code
 # goes to be forgotten.
 EXEMPT_TARGETS: dict[str, str] = {
+    # pgw#1372: the residency engine (Paul's admission-before-allocation
+    # ruling). Its production caller is the entrypoint DISPATCH LOOP, which
+    # wraps every invocation in ResidencyManager.lease — that loop builds on
+    # the SDK-core Model/entrypoint primitives (pgw#1382) and is the
+    # pgw#1372 follow-up that wires it; these rows die with that wiring.
+    "gen_worker.serving.residency.ResidencyManager":
+        "dispatch-loop wiring owed by the pgw#1372 follow-up atop pgw#1382's "
+        "Model primitives",
+    "gen_worker.serving.residency.ResidencyManager.lease":
+        "dispatch-loop wiring owed by the pgw#1372 follow-up atop pgw#1382's "
+        "Model primitives",
+    "gen_worker.serving.residency.ResidencyManager.tier_of":
+        "operator/telemetry read; wired with the same dispatch-loop follow-up",
     # pgw#1372: the adopt-first boot's hub store. Its LIFECYCLE caller is the
     # vendored torchcg adopt path (`_vendor/torchcg/adopt.py` calls
     # `store.fetch_artifact` through the GraphStore protocol), which this

--- a/src/gen_worker/serving/residency.py
+++ b/src/gen_worker/serving/residency.py
@@ -1,0 +1,363 @@
+"""Model residency: admission BEFORE allocation, two tiers, serialized loads.
+
+Paul's pgw#1372 residency ruling (2026-08-18, verbatim framing: *"this should
+respect whatever the wishes of the worker are... we don't want random OOMs
+because 3 checkpoints were loaded at the same time"*):
+
+1. **Admission before allocation.** Placement is the WORKER's decision —
+   author code is device-neutral (no ``.to()``/``torch_dtype`` in the
+   contract file). Before constructing an instance, its EXACT weight byte
+   size (the tensorfs manifest per lane — known ahead of load) plus an
+   activation-headroom estimate (per model type / resolution class) is
+   reserved against the VRAM budget; LRU residents are evicted until it
+   fits. A model that can NEVER fit refuses typed at admission — a CUDA OOM
+   mid-load or at first request is a design bug, not bad luck.
+2. **Loads serialized per GPU.** Concurrent instance loads must not race the
+   VRAM budget or fragment pinned staging: one load gate.
+3. **Two-tier residency.** VRAM -> RAM-resident (host-staged weights;
+   re-promotion is an H2D copy, no disk walk) -> dropped to the chunk store.
+   Demotion/promotion happen only BETWEEN requests — single-flight per
+   instance guarantees the window — and the author never observes a tier
+   move.
+
+The SDK-core lane's ``Model`` wrapper (pgw#1382) sits ABOVE this engine: the
+worker resolves ``(checkpoint x lane)`` to a :class:`ModelBackend` factory
+and calls :meth:`ResidencyManager.lease` around every entrypoint invocation.
+The manager knows bytes, tiers and order — never author code.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Callable, Dict, Protocol, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: One resident identity: (checkpoint ref, lane contract handle).
+InstanceKey = Tuple[str, str]
+
+
+class ResidencyError(RuntimeError):
+    """A residency decision could not be made; the message names the bytes."""
+
+
+class NeverFits(ResidencyError):
+    """Typed admission refusal: this instance exceeds the whole budget —
+    no eviction schedule can ever make it fit."""
+
+
+class ModelBackend(Protocol):
+    """What one resident instance must provide (the pgw#1382 seam).
+
+    The SDK-core Model wrapper implements these over the author's own
+    ``load``/``unload`` hooks and the native tensor loader; the manager only
+    ORDERS the moves. Every method runs with the instance idle — the manager
+    guarantees the between-requests window — and under the worker's gates.
+    """
+
+    def load(self) -> None:
+        """Chunk store -> VRAM. First residency only; serialized per GPU."""
+        ...
+
+    def demote_to_host(self) -> None:
+        """VRAM -> host-staged weights (eviction to the warm tier)."""
+        ...
+
+    def promote_to_device(self) -> None:
+        """Host -> VRAM (an H2D copy; never a disk walk)."""
+        ...
+
+    def drop(self) -> None:
+        """Release both tiers; the chunk store is the only remaining copy.
+        The author's ``unload`` hook fires inside (best-effort tidiness,
+        never correctness)."""
+        ...
+
+
+class InstanceSizer(Protocol):
+    """Byte facts, known AHEAD of any allocation."""
+
+    def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        """Exact weight bytes for (checkpoint, lane) — the tensorfs manifest
+        for the lane's layout contract states this without loading."""
+        ...
+
+    def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        """The serving-time activation estimate (per model type / resolution
+        class) reserved alongside the weights."""
+        ...
+
+
+class Tier(StrEnum):
+    VRAM = "vram"
+    HOST = "host"
+    ABSENT = "absent"
+
+
+@dataclass
+class _Slot:
+    key: InstanceKey
+    backend: Any = None
+    weight_bytes: int = 0
+    headroom_bytes: int = 0
+    #: Where the BYTES are. `placing` below is the reservation that precedes
+    #: them — admission-before-allocation is exactly this distinction.
+    tier: Tier = Tier.ABSENT
+    #: True from the moment the VRAM reservation is claimed until the bytes
+    #: are on-device (or the placement failed). Counted like VRAM residency.
+    placing: bool = False
+    #: LRU clock value at last release; larger = more recently used.
+    last_used: int = 0
+    #: Requests currently holding or awaiting a lease on this instance.
+    #: A slot with inflight > 0 is never a tier-move candidate.
+    inflight: int = 0
+    #: Single-flight per model instance: one entrypoint at a time.
+    gate: threading.Lock = field(default_factory=threading.Lock)
+
+    @property
+    def vram_footprint(self) -> int:
+        return self.weight_bytes + self.headroom_bytes
+
+
+class Lease:
+    """One request's hold on a resident instance (single-flight).
+
+    Constructed only by :meth:`ResidencyManager.lease`; ``backend`` is the
+    live instance, on-device for the whole lease. Context-manager exit
+    releases the instance and stamps LRU recency.
+    """
+
+    def __init__(self, manager: "ResidencyManager", slot: _Slot) -> None:
+        self._manager = manager
+        self._slot = slot
+        self.backend = slot.backend
+        self._released = False
+
+    def __enter__(self) -> "Lease":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.release()
+
+    def release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._manager._release(self._slot)
+
+
+class ResidencyManager:
+    """The worker's placement authority for model instances on ONE device.
+
+    All byte accounting is RESERVATIONS (weights + headroom), never live
+    allocator readings: the point is deciding *before* allocating.
+    """
+
+    def __init__(
+        self,
+        vram_budget_bytes: int,
+        sizer: InstanceSizer,
+        *,
+        host_budget_bytes: int = 0,
+    ) -> None:
+        if vram_budget_bytes <= 0:
+            raise ResidencyError("vram_budget_bytes must be positive")
+        self.vram_budget_bytes = int(vram_budget_bytes)
+        self.host_budget_bytes = int(host_budget_bytes)
+        self._sizer = sizer
+        self._slots: Dict[InstanceKey, _Slot] = {}
+        self._state = threading.Condition(threading.Lock())
+        #: Loads and promotions serialized per GPU — ruling clause 2.
+        self._load_gate = threading.Lock()
+        self._clock = 0
+
+    # -- byte accounting (self._state held) ---------------------------------
+
+    def _vram_reserved(self) -> int:
+        return sum(
+            s.vram_footprint
+            for s in self._slots.values()
+            if s.tier is Tier.VRAM or s.placing
+        )
+
+    def _host_reserved(self) -> int:
+        return sum(s.weight_bytes for s in self._slots.values() if s.tier is Tier.HOST)
+
+    # -- the one public operation -------------------------------------------
+
+    def lease(
+        self,
+        checkpoint_ref: str,
+        lane: str,
+        factory: Callable[[], ModelBackend],
+    ) -> Lease:
+        """Admit, place and single-flight one request's model instance.
+
+        Blocks while the fit depends only on in-flight work draining
+        (progress, not a clock: every release re-evaluates). Raises
+        :class:`NeverFits` at ADMISSION when weights + headroom exceed the
+        whole budget — before ``factory`` runs, before any byte moves.
+        """
+        key: InstanceKey = (str(checkpoint_ref), str(lane))
+        weight = int(self._sizer.resident_bytes(*key))
+        headroom = int(self._sizer.activation_headroom_bytes(*key))
+        if weight <= 0:
+            raise ResidencyError(
+                f"{key}: the lane manifest states {weight} weight bytes; "
+                f"admission needs the real size"
+            )
+        if weight + headroom > self.vram_budget_bytes:
+            raise NeverFits(
+                f"{key}: needs {weight + headroom} bytes resident "
+                f"({weight} weights + {headroom} activation headroom) and the "
+                f"whole VRAM budget is {self.vram_budget_bytes}; no eviction "
+                f"schedule can fit it — refuse at admission, never OOM mid-load"
+            )
+
+        with self._state:
+            slot = self._slots.get(key)
+            if slot is None:
+                slot = _Slot(key=key, weight_bytes=weight, headroom_bytes=headroom)
+                self._slots[key] = slot
+            slot.inflight += 1  # from here on, no tier machinery touches it
+            try:
+                if slot.tier is not Tier.VRAM and not slot.placing:
+                    # Admission: evict LRU until the reservation fits, then
+                    # CLAIM it — atomically under the state lock, so
+                    # concurrent admissions serialize on the same arithmetic.
+                    self._make_room(slot)
+                    slot.placing = True
+            except BaseException:
+                slot.inflight -= 1
+                self._forget_if_dead(slot)
+                self._state.notify_all()
+                raise
+
+        # Materialize outside the state lock, under the serialized load gate.
+        try:
+            with self._load_gate:
+                with self._state:
+                    tier = slot.tier
+                if tier is not Tier.VRAM:
+                    if tier is Tier.HOST:
+                        slot.backend.promote_to_device()  # H2D, no disk walk
+                    else:
+                        slot.backend = factory()
+                        slot.backend.load()
+                    with self._state:
+                        slot.tier = Tier.VRAM
+                        slot.placing = False
+        except BaseException:
+            with self._state:
+                slot.placing = False
+                slot.inflight -= 1
+                self._forget_if_dead(slot)
+                self._state.notify_all()
+            raise
+
+        # Single-flight per instance: the request owns the slot until release.
+        slot.gate.acquire()
+        return Lease(self, slot)
+
+    def _release(self, slot: _Slot) -> None:
+        slot.gate.release()
+        with self._state:
+            slot.inflight -= 1
+            self._clock += 1
+            slot.last_used = self._clock
+            # A release is the progress event every blocked admission waits on.
+            self._state.notify_all()
+
+    # -- placement (self._state held) ---------------------------------------
+
+    def _make_room(self, incoming: _Slot) -> None:
+        """Evict LRU until the incoming reservation fits.
+
+        Tier moves touch IDLE slots only; when the only obstacle is
+        in-flight work, block until a release re-evaluates the fit —
+        single-flight defines drained, and drained instances are evictable.
+        """
+        need = incoming.vram_footprint
+        while True:
+            free = self.vram_budget_bytes - self._vram_reserved()
+            if free >= need:
+                return
+            idle = sorted(
+                (
+                    s
+                    for s in self._slots.values()
+                    if s.tier is Tier.VRAM and s.inflight == 0 and not s.placing
+                ),
+                key=lambda s: s.last_used,
+            )
+            if idle:
+                self._demote(idle[0])
+                continue
+            busy = sum(
+                s.vram_footprint
+                for s in self._slots.values()
+                if (s.tier is Tier.VRAM or s.placing)
+                and s.inflight > 0
+                and s is not incoming
+            )
+            if busy == 0:
+                raise ResidencyError(
+                    f"{incoming.key}: needs {need} bytes, {free} free, and "
+                    f"nothing resident is evictable or draining — the budget "
+                    f"arithmetic is inconsistent"
+                )
+            self._state.wait()
+
+    def _demote(self, slot: _Slot) -> None:
+        """VRAM -> HOST (or straight to the chunk store when the host tier
+        cannot take it). Idle slots only; host overflow drops host-LRU."""
+        if self.host_budget_bytes >= slot.weight_bytes:
+            while self._host_reserved() + slot.weight_bytes > self.host_budget_bytes:
+                host_lru = min(
+                    (s for s in self._slots.values() if s.tier is Tier.HOST),
+                    key=lambda s: s.last_used,
+                )
+                self._drop(host_lru)
+            slot.backend.demote_to_host()
+            slot.tier = Tier.HOST
+            logger.info(
+                "residency: %s demoted to host (%d bytes)", slot.key, slot.weight_bytes
+            )
+        else:
+            self._drop(slot)
+
+    def _drop(self, slot: _Slot) -> None:
+        slot.backend.drop()
+        slot.backend = None
+        slot.tier = Tier.ABSENT
+        logger.info("residency: %s dropped to the chunk store", slot.key)
+
+    def _forget_if_dead(self, slot: _Slot) -> None:
+        if slot.tier is Tier.ABSENT and slot.inflight == 0 and slot.backend is None:
+            self._slots.pop(slot.key, None)
+
+    # -- read side ----------------------------------------------------------
+
+    def tier_of(self, checkpoint_ref: str, lane: str) -> Tier:
+        with self._state:
+            slot = self._slots.get((str(checkpoint_ref), str(lane)))
+            return slot.tier if slot is not None else Tier.ABSENT
+
+    def reserved_bytes(self) -> Tuple[int, int]:
+        """(vram reservations, host reservations) — the worker's own view."""
+        with self._state:
+            return self._vram_reserved(), self._host_reserved()
+
+
+__all__ = [
+    "InstanceKey",
+    "InstanceSizer",
+    "Lease",
+    "ModelBackend",
+    "NeverFits",
+    "ResidencyError",
+    "ResidencyManager",
+    "Tier",
+]

--- a/tests/test_model_residency.py
+++ b/tests/test_model_residency.py
@@ -1,0 +1,262 @@
+"""Model residency: admission before allocation, LRU two-tier moves, gates.
+
+Integration-shaped: real ResidencyManager, real threads, recording backends —
+the byte arithmetic, ordering and blocking behavior under test are the real
+production objects; only the CUDA moves are recorders (this engine never
+touches tensors — the pgw#1382 Model wrapper does, behind ModelBackend).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Dict, List
+
+import pytest
+
+from gen_worker.serving.residency import (
+    NeverFits,
+    ResidencyManager,
+    Tier,
+)
+
+GB = 1024**3
+
+
+class Sizer:
+    def __init__(self, sizes: Dict[str, int], headroom: int = 1 * GB) -> None:
+        self.sizes = sizes
+        self.headroom = headroom
+
+    def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        return self.sizes[checkpoint_ref]
+
+    def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+        return self.headroom
+
+
+class Backend:
+    """Records every move; asserts loads never overlap (the load gate)."""
+
+    active_loads = 0
+    load_overlap = False
+
+    def __init__(self, name: str, journal: List[str]) -> None:
+        self.name = name
+        self.journal = journal
+
+    def load(self) -> None:
+        Backend.active_loads += 1
+        if Backend.active_loads > 1:
+            Backend.load_overlap = True
+        time.sleep(0.02)  # widen the window a racing load would need
+        self.journal.append(f"load:{self.name}")
+        Backend.active_loads -= 1
+
+    def demote_to_host(self) -> None:
+        self.journal.append(f"demote:{self.name}")
+
+    def promote_to_device(self) -> None:
+        self.journal.append(f"promote:{self.name}")
+
+    def drop(self) -> None:
+        self.journal.append(f"drop:{self.name}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend_class():
+    Backend.active_loads = 0
+    Backend.load_overlap = False
+    yield
+
+
+def manager(vram_gb: int, sizes: Dict[str, int], host_gb: int = 0) -> ResidencyManager:
+    return ResidencyManager(
+        vram_gb * GB, Sizer(sizes), host_budget_bytes=host_gb * GB
+    )
+
+
+def factory(name: str, journal: List[str]) -> "Callable[[], Backend]":
+    def make() -> Backend:
+        journal.append(f"construct:{name}")
+        return Backend(name, journal)
+
+    return make
+
+
+LANE = "sdxl.diffusers-bf16@1"
+
+
+def test_admission_refuses_a_never_fitting_model_before_any_allocation() -> None:
+    journal: List[str] = []
+    m = manager(10, {"huge": 12 * GB, "ok": 4 * GB})
+    with pytest.raises(NeverFits) as excinfo:
+        m.lease("huge", LANE, factory("huge", journal))
+    # The refusal is at ADMISSION: nothing was constructed, no byte moved.
+    assert journal == []
+    message = str(excinfo.value)
+    assert "13958643712" in message and "10737418240" in message
+    assert "refuse at admission" in message
+    # The card is untouched and still serves what fits.
+    with m.lease("ok", LANE, factory("ok", journal)):
+        pass
+    assert journal == ["construct:ok", "load:ok"]
+
+
+def test_lru_eviction_makes_room_and_demotes_to_host_in_order() -> None:
+    journal: List[str] = []
+    m = manager(10, {"a": 3 * GB, "b": 3 * GB, "c": 3 * GB}, host_gb=8)
+    with m.lease("a", LANE, factory("a", journal)):
+        pass
+    with m.lease("b", LANE, factory("b", journal)):
+        pass
+    # a(4) + b(4) reserved incl. headroom; c needs 4 -> evict LRU = a.
+    with m.lease("c", LANE, factory("c", journal)):
+        pass
+    assert journal == [
+        "construct:a", "load:a",
+        "construct:b", "load:b",
+        "demote:a",  # eviction happened BEFORE c's construction/load
+        "construct:c", "load:c",
+    ]
+    assert m.tier_of("a", LANE) is Tier.HOST
+    assert m.tier_of("b", LANE) is Tier.VRAM
+    assert m.tier_of("c", LANE) is Tier.VRAM
+
+
+def test_repromotion_is_an_h2d_copy_never_a_reload() -> None:
+    journal: List[str] = []
+    m = manager(10, {"a": 3 * GB, "b": 3 * GB, "c": 3 * GB}, host_gb=8)
+    for name in ("a", "b", "c"):  # c evicts a to host
+        with m.lease(name, LANE, factory(name, journal)):
+            pass
+    journal.clear()
+    with m.lease("a", LANE, factory("a", journal)):  # b is LRU now
+        pass
+    assert "promote:a" in journal
+    assert "construct:a" not in journal and "load:a" not in journal
+    assert journal.index("demote:b") < journal.index("promote:a")
+
+
+def test_host_tier_overflow_drops_the_oldest_host_resident() -> None:
+    journal: List[str] = []
+    # Host tier holds ONE 3 GB body only: the second demotion drops the first.
+    m = manager(10, {"a": 3 * GB, "b": 3 * GB, "c": 3 * GB, "d": 3 * GB}, host_gb=5)
+    for name in ("a", "b", "c", "d"):
+        with m.lease(name, LANE, factory(name, journal)):
+            pass
+    assert m.tier_of("a", LANE) is Tier.ABSENT  # dropped when b demoted
+    assert m.tier_of("b", LANE) is Tier.HOST
+    assert journal.index("demote:a") < journal.index("drop:a") < journal.index("demote:b")
+
+
+def test_a_zero_host_budget_drops_straight_to_the_chunk_store() -> None:
+    journal: List[str] = []
+    m = manager(10, {"a": 4 * GB, "b": 5 * GB})
+    with m.lease("a", LANE, factory("a", journal)):
+        pass
+    with m.lease("b", LANE, factory("b", journal)):
+        pass
+    assert "drop:a" in journal and "demote:a" not in journal
+    assert m.tier_of("a", LANE) is Tier.ABSENT
+
+
+def test_concurrent_loads_are_serialized_by_the_load_gate() -> None:
+    journal: List[str] = []
+    m = manager(64, {f"m{i}": 2 * GB for i in range(6)})
+    threads = [
+        threading.Thread(
+            target=lambda n=n: m.lease(n, LANE, factory(n, journal)).release()
+        )
+        for n in (f"m{i}" for i in range(6))
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not Backend.load_overlap, "two instance loads overlapped on one GPU"
+    assert sorted(j for j in journal if j.startswith("load:")) == sorted(
+        f"load:m{i}" for i in range(6)
+    )
+
+
+def test_single_flight_per_instance_and_no_tier_moves_in_flight() -> None:
+    journal: List[str] = []
+    m = manager(6, {"a": 4 * GB, "b": 4 * GB}, host_gb=8)
+    order: List[str] = []
+    first_in = threading.Event()
+    release_first = threading.Event()
+
+    def first() -> None:
+        with m.lease("a", LANE, factory("a", journal)):
+            order.append("first-in")
+            first_in.set()
+            release_first.wait(30)
+        order.append("first-out")
+
+    def second() -> None:
+        first_in.wait(30)
+        with m.lease("a", LANE, factory("a", journal)):
+            order.append("second-in")
+
+    def evictor() -> None:
+        first_in.wait(30)
+        # b needs the room a holds; a is IN FLIGHT, so this must BLOCK until
+        # a's requests drain — never move a mid-request.
+        with m.lease("b", LANE, factory("b", journal)):
+            order.append("evictor-in")
+
+    threads = [threading.Thread(target=f) for f in (first, second, evictor)]
+    for t in threads:
+        t.start()
+    time.sleep(0.15)
+    # Nobody got in while the first request held the instance, and a was not
+    # demoted underneath it.
+    assert order == ["first-in"]
+    assert "demote:a" not in journal and "drop:a" not in journal
+    release_first.set()
+    for t in threads:
+        t.join(timeout=30)
+    assert order[0] == "first-in" and set(order) == {
+        "first-in", "first-out", "second-in", "evictor-in",
+    }
+    # The eviction happened only once a was idle.
+    assert "demote:a" in journal
+
+
+def test_a_fits_after_drain_admission_blocks_instead_of_ooming() -> None:
+    journal: List[str] = []
+    m = manager(6, {"a": 4 * GB, "b": 4 * GB})
+    entered = threading.Event()
+    release = threading.Event()
+    landed: List[str] = []
+
+    def holder() -> None:
+        with m.lease("a", LANE, factory("a", journal)):
+            entered.set()
+            release.wait(30)
+
+    def contender() -> None:
+        entered.wait(30)
+        with m.lease("b", LANE, factory("b", journal)):
+            landed.append("b")
+
+    threads = [threading.Thread(target=holder), threading.Thread(target=contender)]
+    for t in threads:
+        t.start()
+    time.sleep(0.1)
+    assert landed == []  # blocked on the drain, not refused, not loaded
+    assert "construct:b" not in journal  # admission-before-allocation held
+    release.set()
+    for t in threads:
+        t.join(timeout=30)
+    assert landed == ["b"]
+
+
+def test_reservation_accounting_includes_headroom_and_reads_back() -> None:
+    journal: List[str] = []
+    m = manager(10, {"a": 3 * GB})
+    with m.lease("a", LANE, factory("a", journal)):
+        vram, host = m.reserved_bytes()
+        assert vram == 4 * GB  # 3 weights + 1 headroom
+        assert host == 0


### PR DESCRIPTION
Paul's residency ruling for the Model-instance serving loop, encoded and built (*"this should respect whatever the wishes of the worker are... we don't want random OOMs because 3 checkpoints were loaded at the same time"*).

- **Admission before allocation**: `ResidencyManager.lease(checkpoint, lane, factory)` reserves exact weight bytes (tensorfs manifest per lane — known ahead of load) + activation headroom against the VRAM budget BEFORE the instance factory runs; evicts LRU until it fits; `NeverFits` is a typed refusal at admission naming the bytes. A fit that only needs in-flight work to drain blocks on releases (progress, never a clock).
- **Loads serialized per GPU** — one load gate; concurrent instance loads cannot race the budget or fragment pinned staging.
- **Two-tier residency**: VRAM → host-staged (re-promotion = H2D copy, no disk walk) → chunk store; host overflow drops host-LRU; tier moves touch idle instances only (single-flight per instance defines the between-requests window); the author never observes a move.
- **The pgw#1382 seam**: `ModelBackend` (load/demote_to_host/promote_to_device/drop) + `InstanceSizer` protocols — the SDK-core Model wrapper implements the moves over the author's `load`/`unload` hooks and the native loader; this engine owns bytes, tiers and order. The dispatch loop that wraps every entrypoint invocation in a lease is the follow-up atop those primitives (unreached-surface rows name that owner).

Proofs: `tests/test_model_residency.py` — 9 scenarios with real threads (admission refusal before any construction, LRU demote ordering, H2D re-promotion with zero reload, host overflow drop, load-gate serialization with an overlap detector, single-flight + no-tier-moves-in-flight, drain-then-admit instead of OOM); 3 red-proof mutations each go red; 5x stable. Full mypy (937 files) + ruff + guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)