### PR TITLE
pgw#1383: the mint terminalises on EVERY exit, including "I am not going to publish"

### DIFF
--- a/changelog.d/pgw1383.md
+++ b/changelog.d/pgw1383.md
@@ -1,0 +1,24 @@
+- **A self-mint now TERMINALISES on every exit, including *"I am not going to publish"*.** Measured
+  on `j56tate13oav13` (A40, $0.44/hr): a mint whose compile children ALL finished — `status=compiled
+  exit=0` ×2, pool ledger complete — and whose publish the hub then declined (`release_unserved`)
+  never reached a terminal phase. `self_mint_compile inductor_compile` stayed RUNNING, the pod read
+  as busy on its own background work, and it billed for 30 minutes until a human deleted it ($0.35).
+  The hub's stall detector fired four times and was RIGHT not to condemn a serving pod for
+  background work (pgw#1243's no-magic-timeouts doctrine stands); the worker never said it had
+  finished, so a correct policy had nothing to act on.
+
+  `_background_mint`'s three terminal emissions collapse into ONE `_report_mint_end` in its
+  `finally`, so "this mint ended, and here is why" is a property of every exit rather than of the
+  branches somebody remembered to write. Each end carries a DISTINCT typed `phase`:
+  `self_mint_skipped` for the hub's own refusal code (`release_unserved`, `http_409`, …),
+  `no_sink`, `incomplete`, `nothing_to_publish`, `keep_no_publisher` and `nothing_adopted`
+  (pgw#1379's arm-refused-all-classes shape); `self_mint_abort` for `abandoned_<code>` and `error`.
+  A mint that PUBLISHED gets no new row — `self_mint_publish phase=published` already is that end's
+  terminus, and a second one would double-count the only end that ships bytes.
+
+  Two mechanisms make the fold exact. `mark_terminus` records the typed REASON beside the
+  terminus — the same flat token that terminus already emits as its event `phase=`, so one string
+  rather than two derivations of one fact. And a `publishing` terminus is DOWNGRADED by what the
+  uploads actually did: it is set before the first byte moves, so a mint whose every upload the hub
+  refused would otherwise report itself published. No timeouts, no env gates — every reason is a
+  fact the worker already held.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -8147,7 +8147,10 @@ class Executor:
         ``j56tate13oav13``). The hub's policy is right; it needed a fact."""
         act = bg.act
         assert act is not None
-        end, reason, detail = "", "", ""
+        # NOT named `reason`/`detail`: `test_fn_unavailable_vocabulary_th1563`
+        # scans this module for `reason = "..."` bindings feeding the
+        # FnUnavailable slot, and a same-named local anywhere pollutes it.
+        end, end_reason, end_detail = "", "", ""
         try:
             with activity_mod.watchdog(act):
                 await self._supervise_mint(rec, bg, act)
@@ -8159,8 +8162,8 @@ class Executor:
                 "continues at its current tier",
                 bg.spec.name, bg.abandon_code, bg.abandon_reason)
             end = fleet_compiled_graphs_mod.MINT_END_ABANDONED
-            reason = f"abandoned_{bg.abandon_code}"
-            detail = (
+            end_reason = f"abandoned_{bg.abandon_code}"
+            end_detail = (
                 f"background mint for {bg.spec.name} abandoned "
                 f"({bg.abandon_code}"
                 + (f": {bg.abandon_reason}" if bg.abandon_reason else "")
@@ -8176,8 +8179,9 @@ class Executor:
                 "for this process", bg.spec.name, type(exc).__name__, exc)
             # pgw#677 reopen: the abort cause rides the wire typed and
             # countable, in addition to the FAILED activity terminal.
-            end, reason = fleet_compiled_graphs_mod.MINT_END_ABORTED, "error"
-            detail = (
+            end = fleet_compiled_graphs_mod.MINT_END_ABORTED
+            end_reason = "error"
+            end_detail = (
                 f"background mint for {bg.spec.name} failed: "
                 f"{type(exc).__name__}: {exc}")
             act.failed(exc)
@@ -8191,7 +8195,7 @@ class Executor:
             self._assert_mint_termini(
                 bg.spec, list(bg.pendings.values()),
                 driver_owns_delegated=False)
-            self._report_mint_end(bg, end, reason, detail)
+            self._report_mint_end(bg, end, end_reason, end_detail)
             if rec.background_mint is bg:
                 rec.background_mint = None
             # pgw#789: WARM-COMPLETE. The eager-first boot (pgw#671) advertises
@@ -8208,7 +8212,7 @@ class Executor:
             self._on_state_change()
 
     def _report_mint_end(
-        self, bg: "_BackgroundMint", end: str, reason: str, detail: str,
+        self, bg: "_BackgroundMint", end: str, why: str, detail: str,
     ) -> None:
         """pgw#1383: ONE typed terminal event per mint, on EVERY exit path.
 
@@ -8222,7 +8226,7 @@ class Executor:
         """
         if not end:
             pendings = list({id(p): p for p in bg.pendings.values()}.values())
-            end, reason = fleet_compiled_graphs_mod.mint_end(pendings)
+            end, why = fleet_compiled_graphs_mod.mint_end(pendings)
         if end == fleet_compiled_graphs_mod.MINT_END_PUBLISHED:
             return
         kind = (
@@ -8234,10 +8238,10 @@ class Executor:
             kind,
             detail or (
                 f"the background mint for {bg.spec.name} ended {end} "
-                f"({reason}) and published nothing; serving continues at its "
+                f"({why}) and published nothing; serving continues at its "
                 f"current tier and this pod owes the fleet no further work "
                 f"for it"),
-            phase=reason or end,
+            phase=why or end,
         )
 
     async def _await_publish_durable(self, act: Any) -> None:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -8136,9 +8136,18 @@ class Executor:
         RUNNING on the wire for the whole background build (the hub's
         minting classification consumes exactly that) and terminates here —
         COMPLETED on arm or clean abandonment, FAILED on disproof/error
-        (serving stays eager either way; a mint failure never un-serves)."""
+        (serving stays eager either way; a mint failure never un-serves).
+
+        pgw#1383: and it TERMINALISES ON EVERY EXIT. The ``finally`` emits
+        exactly one typed ``self_mint_*`` event naming what this mint ended
+        as, including *"I am not going to publish"* — a mint whose compile
+        children all finished and whose publish was then declined used to end
+        with no terminus event at all, so the hub read the pod as busy on
+        background work and it billed until a human deleted it ($0.35 on
+        ``j56tate13oav13``). The hub's policy is right; it needed a fact."""
         act = bg.act
         assert act is not None
+        end, reason, detail = "", "", ""
         try:
             with activity_mod.watchdog(act):
                 await self._supervise_mint(rec, bg, act)
@@ -8149,14 +8158,13 @@ class Executor:
                 "background mint for %s abandoned cleanly (%s: %s); serving "
                 "continues at its current tier",
                 bg.spec.name, bg.abandon_code, bg.abandon_reason)
-            activity_mod.emit_event(
-                "self_mint_abort",
+            end = fleet_compiled_graphs_mod.MINT_END_ABANDONED
+            reason = f"abandoned_{bg.abandon_code}"
+            detail = (
                 f"background mint for {bg.spec.name} abandoned "
                 f"({bg.abandon_code}"
                 + (f": {bg.abandon_reason}" if bg.abandon_reason else "")
-                + "); serving continues at its current tier",
-                phase=f"abandoned_{bg.abandon_code}",
-            )
+                + "); serving continues at its current tier")
             act.completed()
         except Exception as exc:
             # pgw#737: free_targets — a failed mint that leaves its wrappers
@@ -8168,12 +8176,10 @@ class Executor:
                 "for this process", bg.spec.name, type(exc).__name__, exc)
             # pgw#677 reopen: the abort cause rides the wire typed and
             # countable, in addition to the FAILED activity terminal.
-            activity_mod.emit_event(
-                "self_mint_abort",
+            end, reason = fleet_compiled_graphs_mod.MINT_END_ABORTED, "error"
+            detail = (
                 f"background mint for {bg.spec.name} failed: "
-                f"{type(exc).__name__}: {exc}",
-                phase="error",
-            )
+                f"{type(exc).__name__}: {exc}")
             act.failed(exc)
         else:
             act.completed()
@@ -8185,6 +8191,7 @@ class Executor:
             self._assert_mint_termini(
                 bg.spec, list(bg.pendings.values()),
                 driver_owns_delegated=False)
+            self._report_mint_end(bg, end, reason, detail)
             if rec.background_mint is bg:
                 rec.background_mint = None
             # pgw#789: WARM-COMPLETE. The eager-first boot (pgw#671) advertises
@@ -8199,6 +8206,39 @@ class Executor:
             # `ensure_setup` — see `_mark_warm_complete`.
             self._mark_warm_complete(rec, bg.spec.name)
             self._on_state_change()
+
+    def _report_mint_end(
+        self, bg: "_BackgroundMint", end: str, reason: str, detail: str,
+    ) -> None:
+        """pgw#1383: ONE typed terminal event per mint, on EVERY exit path.
+
+        The driver's branches name the ends only THEY know (abandoned, error);
+        every other end is folded from the obligations' own recorded termini,
+        so a publish the hub refused, a withheld partial pack and an
+        arm-refused-all-classes mint each terminate under their own reason
+        rather than under a shared silence. ``published`` needs no event of its
+        own — ``self_mint_publish phase=published`` already is that terminus,
+        and a second row would double-count the only end that shipped.
+        """
+        if not end:
+            pendings = list({id(p): p for p in bg.pendings.values()}.values())
+            end, reason = fleet_compiled_graphs_mod.mint_end(pendings)
+        if end == fleet_compiled_graphs_mod.MINT_END_PUBLISHED:
+            return
+        kind = (
+            "self_mint_abort"
+            if end in (fleet_compiled_graphs_mod.MINT_END_ABORTED,
+                       fleet_compiled_graphs_mod.MINT_END_ABANDONED)
+            else "self_mint_skipped")
+        activity_mod.emit_event(
+            kind,
+            detail or (
+                f"the background mint for {bg.spec.name} ended {end} "
+                f"({reason}) and published nothing; serving continues at its "
+                f"current tier and this pod owes the fleet no further work "
+                f"for it"),
+            phase=reason or end,
+        )
 
     async def _await_publish_durable(self, act: Any) -> None:
         """Keep the mint's activity RUNNING until its compiled graph is DURABLE.

--- a/src/gen_worker/fleet_compiled_graphs.py
+++ b/src/gen_worker/fleet_compiled_graphs.py
@@ -1284,6 +1284,14 @@ _IN_FLIGHT: Dict[str, Tuple[str, float]] = {}
 _DURABLE_PROGRESS = 0
 _DURABLE_SEEN: set = set()
 
+#: pgw#1383: how each publish this process ATTEMPTED ended — the key's own
+#: terminal `phase` token (`published`, or the hub's classified refusal code).
+#: The mint driver folds it, because a terminus of `publishing` says only that
+#: an upload was started: a mint whose every upload was refused published
+#: nothing, and the pod must say so rather than hold its card on a mint that
+#: already decided it will not ship.
+_PUBLISH_OUTCOME: Dict[str, str] = {}
+
 
 def publish_durable_progress() -> int:
     """Monotonic count of durable publish transitions in this process."""
@@ -1307,6 +1315,22 @@ def publishes_in_flight() -> Dict[str, Tuple[str, float]]:
     thread has neither succeeded nor failed yet (pgw#815)."""
     with _IN_FLIGHT_LOCK:
         return dict(_IN_FLIGHT)
+
+
+def publish_outcome(key: str) -> str:
+    """How this key's publish ENDED, "" while it is in flight (pgw#1383)."""
+    with _IN_FLIGHT_LOCK:
+        return str(_PUBLISH_OUTCOME.get(key, ""))
+
+
+def _note_publish_outcome(key: str, phase: str) -> None:
+    """Record one publish's terminal phase. LAST writer wins: the question is
+    how this key's most recent attempt ended, so a retry that lands must
+    outrank the refusal that preceded it."""
+    if not key:
+        return
+    with _IN_FLIGHT_LOCK:
+        _PUBLISH_OUTCOME[key] = phase or "unstated"
 
 
 def _publish_async(
@@ -1365,6 +1389,7 @@ def _publish_async(
             local_compiled_graph_store.note_refusal(
                 str(getattr(exc, "code", "") or ""), str(exc))
             _mark_publish(key, local_compiled_graph_store.SINK_REFUSED)
+            _note_publish_outcome(key, _publish_failure_phase(exc) or "refused")
             activity_mod.emit_event(
                 "self_mint_publish_failed",
                 f"family={family} key={key}: hub refused the publish: {exc}",
@@ -1382,6 +1407,7 @@ def _publish_async(
                 "fleet-compiled graphs: publish failed; the compiled graph stays durable in this "
                 "machine's local CAS and the upload is retried next boot",
                 exc_info=True)
+            _note_publish_outcome(key, _publish_failure_phase(exc))
             activity_mod.emit_event(
                 "self_mint_publish_failed",
                 f"family={family} key={key}: publish attempt failed: "
@@ -1393,6 +1419,7 @@ def _publish_async(
             )
         else:
             _note_durable(key, "published")
+            _note_publish_outcome(key, PUBLISH_OUTCOME_PUBLISHED)
             _mark_publish(key, local_compiled_graph_store.SINK_DELIVERED)
             activity_mod.emit_event(
                 "self_mint_publish",
@@ -2876,7 +2903,7 @@ def adopt_delegated_mint(
         # quarantines that class alone, further down, and never reaches this.
         for _row_key in _durable_keys.values():
             _quarantine_durable(_row_key)
-        mark_terminus(pending, TERMINUS_ABORTED)
+        mark_terminus(pending, TERMINUS_ABORTED, reason or "nothing_adopted")
         state["minted"] = None
         _unregister(pending)
         shutil.rmtree(pending.mint_root, ignore_errors=True)
@@ -3115,7 +3142,7 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             "packed, so nothing can ship",
             phase="nothing_to_publish",
         )
-        mark_terminus(pending, TERMINUS_WITHHELD)
+        mark_terminus(pending, TERMINUS_WITHHELD, "nothing_to_publish")
         return
     state["publish_resolved"] = True
     publisher = pending.publisher
@@ -3125,11 +3152,17 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
         # pgw#1371: this class shipped the moment it armed
         # (`adopt_minted_class`); the terminus only closes the books. One
         # upload per key, however the mint ends.
-        mark_terminus(pending, TERMINUS_PUBLISHING)
+        mark_terminus(pending, TERMINUS_PUBLISHING, "shipped_per_class")
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return
     if publisher is not None and publisher.enabled():
-        mark_terminus(pending, TERMINUS_PUBLISHING)
+        mark_terminus(pending, TERMINUS_PUBLISHING, "uploading")
+        # pgw#1383: the terminus ledger records the key it is shipping, the
+        # same way `adopt_minted_class` does — the driver reads that set to
+        # learn whether any upload of this mint actually landed.
+        state.setdefault("published_keys", set()).add(
+            str(getattr(state.get("minted"), "compiled_graph_key", "")
+                or pending.arm_token))
         _publish_async(
             publisher, pending.family,
             # §1.5: FROM THE DURABLE COPY. `adopt_delegated_mint` set this to
@@ -3176,7 +3209,7 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             "the fleet store still gains nothing",
             phase="no_sink",
         )
-        mark_terminus(pending, TERMINUS_WITHHELD)
+        mark_terminus(pending, TERMINUS_WITHHELD, "no_sink")
         shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
@@ -3210,7 +3243,7 @@ def keep_self_mint_local(pending: "PendingSelfMint") -> None:
             f"there is no compiled graph to keep either",
             phase="nothing_to_publish",
         )
-        mark_terminus(pending, TERMINUS_ABANDONED)
+        mark_terminus(pending, TERMINUS_ABANDONED, "nothing_to_publish")
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return
     logger.info(
@@ -3225,7 +3258,7 @@ def keep_self_mint_local(pending: "PendingSelfMint") -> None:
         f"because no sink exists to attempt one against",
         phase=KEEP_NO_PUBLISHER,
     )
-    mark_terminus(pending, TERMINUS_WITHHELD)
+    mark_terminus(pending, TERMINUS_WITHHELD, KEEP_NO_PUBLISHER)
     shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
@@ -3255,7 +3288,7 @@ def withhold_self_mint_publish(pending: "PendingSelfMint", reason: str) -> None:
             "withhold either",
             phase="nothing_to_publish",
         )
-        mark_terminus(pending, TERMINUS_ABANDONED)
+        mark_terminus(pending, TERMINUS_ABANDONED, "nothing_to_publish")
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return
     state["publish_resolved"] = True
@@ -3271,7 +3304,7 @@ def withhold_self_mint_publish(pending: "PendingSelfMint", reason: str) -> None:
         f"family={pending.family} key={pending.arm_token}: {reason}",
         phase="incomplete",
     )
-    mark_terminus(pending, TERMINUS_WITHHELD)
+    mark_terminus(pending, TERMINUS_WITHHELD, "incomplete")
     shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
@@ -3286,14 +3319,90 @@ TERMINUS_ABORTED = "aborted"
 TERMINUS_ABANDONED = "abandoned"
 
 
-def mark_terminus(pending: "PendingSelfMint", name: str) -> None:
-    """Record that this mint obligation reached ``name`` (pgw#815)."""
+def mark_terminus(
+    pending: "PendingSelfMint", name: str, reason: str = "",
+) -> None:
+    """Record that this mint obligation reached ``name``, and WHY (pgw#815).
+
+    pgw#1383: ``reason`` is the SAME flat token the terminus emits as its
+    event ``phase=``, so the driver's one terminal event and the obligation's
+    own event group under one string instead of two derivations of one fact.
+    """
     pending._state["terminus"] = name
+    if reason:
+        pending._state["terminus_reason"] = reason
 
 
 def terminus_of(pending: "PendingSelfMint") -> str:
     """The terminus this mint obligation reached, "" when it reached none."""
     return str(pending._state.get("terminus") or "")
+
+
+def terminus_reason(pending: "PendingSelfMint") -> str:
+    """Why this obligation ended, "" when it never said (pgw#1383)."""
+    return str(pending._state.get("terminus_reason") or "")
+
+
+#: pgw#1383: what a whole MINT ended as, folded from its obligations.
+#: ``published`` is the only end that leaves bytes with the fleet; every other
+#: end means the pod is holding a paid card for nothing and has to say so.
+MINT_END_PUBLISHED = "published"
+MINT_END_WITHHELD = "withheld"
+MINT_END_ABORTED = "aborted"
+MINT_END_ABANDONED = "abandoned"
+MINT_END_UNRESOLVED = "unresolved"
+
+#: The terminal phase a delivered upload reports.
+PUBLISH_OUTCOME_PUBLISHED = "published"
+
+#: Obligation terminus -> mint end, STRONGEST FIRST. One mint may hold several
+#: obligations and they can end differently; one that shipped means the mint
+#: produced something the fleet can adopt, so it outranks the rest.
+_MINT_END_ORDER: Tuple[Tuple[str, str], ...] = (
+    (TERMINUS_SEALED, MINT_END_PUBLISHED),
+    (TERMINUS_PUBLISHING, MINT_END_PUBLISHED),
+    (TERMINUS_WITHHELD, MINT_END_WITHHELD),
+    (TERMINUS_ABORTED, MINT_END_ABORTED),
+    (TERMINUS_ABANDONED, MINT_END_ABANDONED),
+)
+
+
+def _obligation_end(pending: "PendingSelfMint") -> Tuple[str, str]:
+    """One obligation's ``(end, reason)``.
+
+    A ``publishing`` terminus is DOWNGRADED by what the uploads actually did:
+    it is set before the first byte moves, so a mint whose every upload was
+    refused would otherwise report itself published. That downgrade is the
+    measured case — the hub declines, the bytes never ship, and the pod has to
+    know it is finished anyway.
+    """
+    terminus = terminus_of(pending)
+    end = dict(_MINT_END_ORDER).get(terminus, MINT_END_UNRESOLVED)
+    reason = terminus_reason(pending) or terminus or "no_terminus"
+    if end != MINT_END_PUBLISHED:
+        return end, reason
+    keys = [
+        k for k in (pending._state.get("published_keys") or ())
+        if publish_outcome(str(k))]
+    if not keys:
+        return end, reason
+    if any(publish_outcome(str(k)) == PUBLISH_OUTCOME_PUBLISHED for k in keys):
+        return MINT_END_PUBLISHED, PUBLISH_OUTCOME_PUBLISHED
+    return MINT_END_WITHHELD, publish_outcome(str(sorted(keys)[0]))
+
+
+def mint_end(pendings: Sequence["PendingSelfMint"]) -> Tuple[str, str]:
+    """One mint's END and its typed reason, folded over its obligations.
+
+    ``(unresolved, no_obligation)`` for a driver that opened nothing — which
+    is still an end, and still has to be said: the whole defect this closes is
+    a mint that finished and reported nothing at all.
+    """
+    ends: List[Tuple[str, str]] = [_obligation_end(p) for p in pendings]
+    if not ends:
+        return MINT_END_UNRESOLVED, "no_obligation"
+    rank = [e for _t, e in _MINT_END_ORDER] + [MINT_END_UNRESOLVED]
+    return min(ends, key=lambda row: rank.index(row[0]))
 
 
 def abandon_self_mint(pending: "PendingSelfMint") -> None:
@@ -3309,7 +3418,7 @@ def abandon_self_mint(pending: "PendingSelfMint") -> None:
     that never reached the CAS."""
     if pending._state.get("minted") is not None:
         return
-    mark_terminus(pending, TERMINUS_ABANDONED)
+    mark_terminus(pending, TERMINUS_ABANDONED, "capture_discarded")
     _unregister(pending)
     shutil.rmtree(pending.mint_root, ignore_errors=True)
 
@@ -3583,5 +3692,8 @@ __all__ = [
     "publish_self_mint",
     "publishes_in_flight",
     "terminus_of",
+    "mint_end",
+    "publish_outcome",
+    "terminus_reason",
     "withhold_self_mint_publish",
 ]

--- a/tests/test_mint_terminalises_on_every_exit.py
+++ b/tests/test_mint_terminalises_on_every_exit.py
@@ -1,0 +1,146 @@
+"""A mint must TERMINALISE on every exit — including "I am not going to publish".
+
+Measured on `j56tate13oav13` (A40, $0.44/hr, 2026-08-18): a self-mint whose
+compile children ALL finished (`status=compiled exit=0` x2, pool ledger
+complete) but whose publish the hub declined (`release_unserved`) never reached
+a terminal phase. `self_mint_compile inductor_compile` stayed RUNNING, the pod
+read as busy on background work, and it billed for 30 minutes until a human
+deleted it. The hub's stall detector fired four times and was RIGHT not to
+condemn a serving pod for its background work — the defect is that the worker
+never said it was finished, so a correct policy had nothing to act on.
+
+The two shapes that matter, and nothing between them:
+
+1. the mint runs to term and the publish is DECLINED -> one terminal
+   `self_mint_skipped` carrying the hub's own refusal code as `phase`;
+2. the mint runs to term and the publish LANDS -> untouched: `self_mint_publish
+   phase=published` is that end's terminus and no skip is invented beside it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from gen_worker import fleet_compiled_graphs
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from test_eager_first_boot_pgw671 import _Harness
+
+REFUSAL_CODE = "release_unserved"
+
+
+@pytest.fixture(autouse=True)
+def _clean_publish_ledger() -> Any:
+    """Both rows mint the SAME stub key, so the process-wide publish ledger
+    would carry one test's verdict into the other."""
+    fleet_compiled_graphs._PUBLISH_OUTCOME.clear()
+    yield
+    fleet_compiled_graphs._PUBLISH_OUTCOME.clear()
+
+
+class _Publisher:
+    """The fleet sink, minus the hub. ``refuse`` is the hub's classified code."""
+
+    def __init__(self, refuse: str = "") -> None:
+        self.refuse = refuse
+        self.calls = 0
+
+    def enabled(self) -> bool:
+        return True
+
+    def publish(
+        self, family: str, artifact: Path, meta: Any, provenance: Any,
+        mint_duration_ms: int = 0,
+    ) -> str:
+        self.calls += 1
+        if self.refuse:
+            raise fleet_compiled_graphs.CompiledGraphPublishRefused(
+                f"the release this compiled graph was built for is unserved "
+                f"({self.refuse})", status=409, code=self.refuse)
+        return "checkpoint-1"
+
+
+def _boot_with_publisher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, publisher: _Publisher,
+) -> _Harness:
+    """The pgw#671 rig, with a real publish sink hung off every obligation."""
+    h = _Harness(tmp_path, monkeypatch, compile_delay_s=0.05)
+    inner = h._fake_enable_compiled
+
+    def _armed(*args: Any, **kwargs: Any) -> Any:
+        outcome = inner(*args, **kwargs)
+        # PendingSelfMint is frozen; the sink is the one fact this rig injects.
+        object.__setattr__(outcome.self_mint, "publisher", publisher)
+        return outcome
+
+    monkeypatch.setattr(fleet_compiled_graphs, "enable_compiled", _armed)
+    return h
+
+
+def _events(h: _Harness, kind: str) -> List[Any]:
+    return [
+        m.activity_update for m in h.sent
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == kind
+    ]
+
+
+def _mint_activity_terminal(h: _Harness) -> Optional[int]:
+    states = h.activity_states("self_mint_compile")
+    return states[-1] if states else None
+
+
+def _run_mint(h: _Harness) -> None:
+    async def _go() -> None:
+        await h.boot()
+        await h.wait_mint(timeout=60.0)
+
+    asyncio.run(_go())
+
+
+def test_declined_publish_still_terminalises_with_the_hub_s_own_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The measured shape: children finish, the hub refuses, the mint ENDS."""
+    publisher = _Publisher(refuse=REFUSAL_CODE)
+    h = _boot_with_publisher(tmp_path, monkeypatch, publisher)
+
+    _run_mint(h)
+
+    assert publisher.calls == 1, "the rig never reached the publish leg"
+    skipped = _events(h, "self_mint_skipped")
+    assert len(skipped) == 1, (
+        "a mint that will not publish must terminalise exactly once — "
+        f"got {[(e.phase, e.detail) for e in skipped]}. Without it the pod "
+        "holds a paid card on an activity that never ends."
+    )
+    assert skipped[0].phase == REFUSAL_CODE, (
+        f"phase={skipped[0].phase!r} — the terminus must carry the hub's own "
+        "classified code, not prose and not a shared 'ended' token: a reason "
+        "that cannot be grouped cannot be acted on"
+    )
+    assert _mint_activity_terminal(h) == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+
+
+def test_a_mint_that_publishes_invents_no_terminus_beside_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The publishing end is untouched — one terminus, and it is the publish."""
+    publisher = _Publisher()
+    h = _boot_with_publisher(tmp_path, monkeypatch, publisher)
+
+    _run_mint(h)
+
+    assert publisher.calls == 1
+    published = [
+        e for e in _events(h, "self_mint_publish") if e.phase == "published"]
+    assert len(published) == 1, "the publish leg lost its own terminus"
+    assert _events(h, "self_mint_skipped") == [], (
+        "a mint that shipped is not skipped — a second terminal row here "
+        "would double-count the only end that leaves bytes with the fleet"
+    )
+    assert _mint_activity_terminal(h) == pb.ActivityState.ACTIVITY_STATE_COMPLETED


### PR DESCRIPTION
## The measurement

`j56tate13oav13` (A40, $0.44/hr, 2026-08-18). A self-mint whose compile children ALL finished —
`share-000 status=compiled exit=0 classes=7`, `share-001 status=compiled exit=0 classes=7`, pool
ledger `pool_efficiency 0.9925` — and whose publish the hub then declined (th#1326 mint hold
refused, `release_unserved`) **never reached a terminal phase**. `self_mint_compile
inductor_compile` stayed `running`, the worker kept its pod connected, and the pod billed for 30
minutes until a human deleted it. **$0.35 burned on a finished, unpublishable artifact.**

The hub SAW it and was right not to act:

```
[activity-stall] worker_background_activity_stalled … pod=j56tate13oav13: background activity
  self_mint_compile phase inductor_compile has not advanced for 25m39s … last position: step 2/2;
  NOT condemning a serving pod for its background work
```

pgw#1243's no-magic-timeouts doctrine is RIGHT and stays. **A stall detector that fires four times
and is right every time, on work that is already complete, is the shape of a missing terminal
event.** The missing piece is worker-side.

## The change

`_background_mint`'s three terminal emissions collapse into **one** `_report_mint_end` in its
`finally`, so "this mint ended, and here is why" is a property of EVERY exit rather than of the
branches somebody remembered to write. Every exit path, with a DISTINCT typed `phase`:

| exit | kind | `phase` |
|---|---|---|
| published | `self_mint_publish` (unchanged) | `published` |
| hub refused the upload | `self_mint_skipped` | the hub's own code — `release_unserved`, `http_409`, … |
| no publish sink | `self_mint_skipped` | `no_sink` |
| partial pack withheld (gw#612) | `self_mint_skipped` | `incomplete` |
| nothing packed | `self_mint_skipped` | `nothing_to_publish` |
| §4.28 machine, no sink by design | `self_mint_skipped` | `keep_no_publisher` |
| every class refused to arm (pgw#1379) | `self_mint_skipped` | `nothing_adopted` |
| abandoned | `self_mint_abort` | `abandoned_<code>` |
| driver error | `self_mint_abort` | `error` |

A mint that PUBLISHED gets no new row: `self_mint_publish phase=published` already IS that end's
terminus, and a second one would double-count the only end that ships bytes.

Two mechanisms make the fold exact:

* **`mark_terminus` records the typed REASON beside the terminus** — the same flat token that
  terminus already emits as its event `phase=`, so one string rather than two derivations of one
  fact. `terminus_reason` reads it back; `mint_end` folds a mint's obligations into one verdict.
* **a `publishing` terminus is DOWNGRADED by what the uploads actually did.** It is set before the
  first byte moves, so a mint whose every upload the hub refused would otherwise report itself
  published. `_publish_async` now records each key's terminal phase (`publish_outcome`), and
  `publish_self_mint` registers the key it ships the way `adopt_minted_class` already did.

No timeouts, no env gates: every reason is a fact the worker already held.

## Tests

`tests/test_mint_terminalises_on_every_exit.py`, two rows and no matrix:

1. **the measured shape** — children finish, the hub refuses `release_unserved`, and the mint ends
   with exactly one `self_mint_skipped phase=release_unserved` and a COMPLETED activity.
   **RED-VERIFIED against the pre-fix executor: `got []`.**
2. **a mint that WILL publish is untouched** — one `self_mint_publish phase=published`, no skip
   invented beside it. Green on both sides, so it is a regression guard, not a tautology.

Local: `mypy` (src + the new test) green, `ruff` green, every `fast gates` lint script green,
65-test adjacent mint sweep + 156-test publish/adopt sweep green.

## Scope

Mechanism-level and deliberately small. It survives Paul's 2026-08-18 mandate (pgw#1367/#1373)
demoting self-mint to fallback: publish-time mints on throwaway pods need terminalisation just as
much. No catalog/keyset coupling.

**Wheel-pending**: rides the next cut (0.126.0, with the chunker) — no release cut here.

Closes the first checklist item of pgw#1383.