### PR TITLE
pgw#1385: the clone destination validator admits the hub's OWN scratch repo

### DIFF
--- a/changelog.d/pgw1385.md
+++ b/changelog.d/pgw1385.md
@@ -1,0 +1,17 @@
+- **The clone destination validator admits the hub's OWN scratch repo, so a `publishes=true` job
+  stops dying in its body at the one address the platform hands out.** A publishing job never
+  writes the destination the submitter named: the hub rewrites `payload.destination_repo` on the
+  wire to `<org>/_job-<job-id>` (th#2068) and carved that reserved prefix out of its own
+  normalizer. The SDK never got the twin, so `normalize_destination_ref` measured the
+  hub-authored name against the USER grammar `^[a-z0-9][a-z0-9.-]{0,127}$`, the leading `_`
+  missed the first character class, and `run_clone` raised
+  `ValueError: destination_repo must be '<owner>/<repo>'` on a real L4 — `clone-huggingface`,
+  `clone-civitai`, `mirror-expert-lora` and every other `run_clone` caller, i.e. the whole
+  BYOM/model-ingest surface, dead.
+
+  The carve-out is a strip-validate-reattach of ONE reserved prefix, now named once in
+  `gen_worker.scratchrepo` (the twin of the hub's `internal/scratchrepo`) so the next validator
+  inherits it rather than re-deriving it. Deliberately not a widened `^[a-z0-9_]`: `_job-` is
+  platform vocabulary, not a legal public name, so a user-authored `_anything` still refuses —
+  and, exactly as the hub splits it, the OWNER half stays strictly public, so a payload naming
+  `_job-…/repo` cannot squat the write authority the prefix anchors.

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -62,6 +62,7 @@ from .writer import (
 from .writer import (
     normalize_variant_filenames as _normalize_variant_filenames,
 )
+from ..scratchrepo import PREFIX as SCRATCH_PREFIX, is_scratch_name
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,16 @@ def _payload_destination_release(payload: Any) -> str:
     return str(getattr(payload, "destination_release", "") or "").strip()
 
 
+def _valid_repo_name(name: str) -> bool:
+    """The repo half of a destination ref: the public grammar, plus the hub's
+    ONE reserved scratch prefix. Twin of ``normalizeSchedulerRepoName`` — strip
+    the known prefix, validate the REST against the public charset, re-attach.
+    Never a widened charset: a user-authored ``_anything`` still refuses."""
+    if is_scratch_name(name):
+        return bool(_PUBLIC_NAME_RE.match(name[len(SCRATCH_PREFIX):]))
+    return bool(_PUBLIC_NAME_RE.match(name))
+
+
 def normalize_destination_ref(value: str) -> str:
     ref = str(value or "").strip().lower()
     if not ref:
@@ -136,7 +147,9 @@ def normalize_destination_ref(value: str) -> str:
         if ref.startswith(p):
             raise ValueError("destination_repo must be bare owner/repo (no provider prefix)")
     parts = ref.split("/", 1)
-    if len(parts) != 2 or not all(_PUBLIC_NAME_RE.match(p) for p in parts):
+    # The owner half stays strictly public — only the repo half may be scratch,
+    # exactly as the hub's own normalizer splits it.
+    if len(parts) != 2 or not _PUBLIC_NAME_RE.match(parts[0]) or not _valid_repo_name(parts[1]):
         raise ValueError("destination_repo must be '<owner>/<repo>'")
     return ref
 

--- a/src/gen_worker/scratchrepo.py
+++ b/src/gen_worker/scratchrepo.py
@@ -1,0 +1,22 @@
+"""Scratch-repo naming vocabulary — the SDK twin of the hub's
+``internal/scratchrepo`` (th#733, generalized to every repo-writing producer by
+th#1901/th#2068).
+
+A publishing run never writes the destination the submitter named: the hub
+rewrites it on the wire to the per-run scratch repo ``<org>/_job-<job-id>``.
+The leading underscore is deliberately OUTSIDE the public repo-name grammar, so
+a user-supplied ref can never name or squat a scratch repo. Every SDK validator
+that sees a hub-authored destination must admit this ONE prefix — and nothing
+else that starts with ``_``.
+"""
+
+#: The reserved repo-name prefix. Mirrors ``scratchrepo.Prefix``.
+PREFIX = "_job-"
+
+
+def is_scratch_name(name: str) -> bool:
+    """Whether a repo NAME (the half after the ``/``) is scratch-reserved."""
+    return str(name or "").strip().lower().startswith(PREFIX)
+
+
+__all__ = ["PREFIX", "is_scratch_name"]

--- a/tests/convert/test_clone_scratch_destination.py
+++ b/tests/convert/test_clone_scratch_destination.py
@@ -1,0 +1,47 @@
+"""pgw#1385: the SDK's clone destination validator admits the hub's OWN scratch
+repo, and nothing else that starts with an underscore.
+
+Measured on the production path, not inferred: a `publishes=true` job's
+destination is not the submitter's — the hub rewrites `payload.destination_repo`
+on the wire to `<org>/_job-<job-id>` (th#2068), and the hub carved that reserved
+prefix out of its own normalizer (`normalizeSchedulerRepoName`) precisely so the
+rewrite survives validation. The SDK never got the twin, so `run_clone` raised
+`ValueError: destination_repo must be '<owner>/<repo>'` in the job body on a real
+L4 — every BYOM/model-ingest job dead at the one address the platform hands out.
+
+The carve-out is a STRIP-VALIDATE-REATTACH of ONE reserved prefix, never a
+widened `^[a-z0-9_]` charset: `_job-` is platform vocabulary, not a legal public
+name, so a user-authored `_anything` must still refuse — otherwise a submitted
+payload could name a scratch-shaped repo and the write authority that the prefix
+anchors becomes squattable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.convert.clone import normalize_destination_ref
+from gen_worker.scratchrepo import PREFIX
+
+
+def test_hub_authored_scratch_destination_round_trips():
+    # The literal shape the hub minted for job 01a01390-… in the run that found
+    # this (transcribed, not derived from the code under test).
+    ref = "tensorhub/_job-01a01390-ea8a-70fc-8796-205f5dd2a012"
+    assert normalize_destination_ref(ref) == ref
+    # Case/whitespace normalization still applies through the prefix.
+    assert normalize_destination_ref("  TensorHub/_Job-01A01390-EA8A  ") == "tensorhub/_job-01a01390-ea8a"
+    assert PREFIX == "_job-"
+
+
+@pytest.mark.parametrize("ref", [
+    "tensorhub/_notjob-x",        # underscore, but not the reserved prefix
+    "tensorhub/_",                # bare underscore
+    "tensorhub/_job-",            # the prefix with nothing behind it
+    "tensorhub/_job-bad_name",    # prefix stripped, REST still fails the charset
+    "_job-01a01390/mymodel",      # scratch shape in the OWNER half: the hub
+                                  # carves out the repo half only
+])
+def test_user_authored_underscore_names_still_refuse(ref):
+    with pytest.raises(ValueError, match="destination_repo must be"):
+        normalize_destination_ref(ref)


### PR DESCRIPTION
**P0 — blocks e2e#1890 ch.3-publishing/4/5.** Measured on the production path: job `01a01390-ea8a-70fc-8796-205f5dd2a012` on a real L4 reached its body (`state=running`, `cold_boot_s=0`) and died 8 ms later with `ValueError: destination_repo must be '<owner>/<repo>'`.

## The defect

A `publishes=true` job never writes the destination the submitter named. The hub rewrites `payload.destination_repo` on the wire to `<org>/_job-<job-id>` (`job_dispatch_th2050.go:117-137`, th#2068) and carved that reserved prefix out of its OWN normalizer — `normalizeSchedulerRepoName` (`scheduler_dispatch.go:2996`), `internal/api/repo_normalize.go:14`, `catalog/service.go:716`, all keyed on the single `scratchrepo.Prefix`.

The SDK never got the twin. `normalize_destination_ref` (`convert/clone.py:139`) measured the hub-authored name against the USER grammar `^[a-z0-9][a-z0-9.-]{0,127}$`; the leading `_` misses the first character class, so `run_clone` — `clone-huggingface`, `clone-civitai`, `mirror-expert-lora`, the whole BYOM / model-ingest surface — is dead at the one address the platform hands out.

## The fix

`gen_worker/scratchrepo.py` names the reserved prefix ONCE (twin of the hub's `internal/scratchrepo`; the hub's reserved repo-prefix set is exactly `_job-`, verified at source — no second prefix to mirror). `normalize_destination_ref` strips the known prefix, validates the REST against the existing `_PUBLIC_NAME_RE`, re-attaches.

Deliberately NOT a widened `^[a-z0-9_]`: `_job-` is platform vocabulary, not a legal public name. A user-authored `_anything` still refuses, and — exactly as the hub splits it — the OWNER half stays strictly public, so a payload naming `_job-…/repo` cannot squat the write authority the prefix anchors.

## Enforcement census

Re-verified the filing lane's blast-radius claim: `clone.py` is the ONLY charset enforcement on a destination ref. `hubio/client.py:367` (`_repo_path`) and `request_context/_helpers.py:79` (`_parse_owner_repo`) are permissive `owner/repo` splits, and `procsplit/actions.py:85` `_REPO` already admits `_`. So publish/upload were never blocked and the fix is exactly the `run_clone` family.

## Tests

`tests/convert/test_clone_scratch_destination.py`, red-verified on this repo's tip: the measured `tensorhub/_job-01a01390-ea8a-70fc-8796-205f5dd2a012` ref failed at `clone.py:140` with that exact ValueError before the fix, passes after. Five refusal controls — `_notjob-x`, `_`, `_job-` (nothing behind the prefix), `_job-bad_name` (rest fails the charset), and `_job-…/mymodel` (scratch shape in the owner half) — stay typed refusals.

No wheel cut here: this rides the next wheel with pgw#1383's terminalise fix and the 0.126.0 chunker.