### PR TITLE
pgw#1372: the entrypoint dispatch loop — signature-derived envelope, residency leases around every invocation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,13 @@ on:
     # skips drafts. Without it listed here a lane that opens a draft, pushes, then
     # clicks "Ready for review" gets NO run for the head it actually merges —
     # the same invisible-green this issue exists to remove.
-    types: [opened, synchronize, reopened, ready_for_review]
+    #
+    # `edited` is here for the same reason, measured on pgw#957: a stacked PR
+    # RETARGETED from its predecessor's branch onto master fires `edited` and
+    # nothing else. Its head never changes, so `synchronize` never comes, and
+    # the PR sat at `statusCheckRollup: []` against a base it had never been
+    # tested on — the exact invisible-green state above.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/changelog.d/pgw1372-serve-loop.md
+++ b/changelog.d/pgw1372-serve-loop.md
@@ -1,0 +1,13 @@
+- **The entrypoint dispatch loop lands (`gen_worker.serving.serve_loop` +
+  `envelope`).** The wire-facing serving path over the pgw#1382 split:
+  the SIGNATURE-DERIVED request envelope (`{"model"/"models", "adapters":
+  {"turbo", "loras"}, "input"}` — model picks keyed by slot name, adapter
+  rows decoded into typed `Adapter`/`DistillationAdapter` values with the
+  worker-side takeover guard re-asserted) decodes per entrypoint; every
+  invocation runs under `ResidencyManager` leases taken in STABLE SLOT-NAME
+  order (admission before allocation, LRU eviction between requests,
+  serialized loads, single-flight per instance); the call is ctx-first and
+  `ctx.warn` rows ride the `InvokeOutcome`. Instances are keyed
+  (model class x checkpoint x lane) and reused across requests; deploy state
+  arrives through the `BindingResolver` seam. `python -m gen_worker.serving
+  --envelope` serves the full production wire shape locally with zero hub.

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -30,6 +30,12 @@ from .context import (
     LoaderEngine,
     RequestContext,
 )
+from .envelope import (
+    AdapterRow,
+    DecodedRequest,
+    EnvelopeError,
+    decode_envelope,
+)
 from .entrypoints import (
     ENTRYPOINT_ATTR,
     EntrypointDeclarationError,
@@ -44,6 +50,20 @@ from .loader import (
     load_endpoint,
     load_endpoint_module,
 )
+from .residency import (
+    InstanceSizer,
+    Lease,
+    ModelBackend,
+    NeverFits,
+    ResidencyError,
+    ResidencyManager,
+)
+from .serve_loop import (
+    BindingResolver,
+    InvokeOutcome,
+    ServeLoop,
+    manifest_sizer,
+)
 from .model import (
     LaneContract,
     Model,
@@ -54,6 +74,20 @@ from .model import (
 )
 
 __all__ = [
+    "manifest_sizer",
+    "decode_envelope",
+    "ServeLoop",
+    "ResidencyManager",
+    "ResidencyError",
+    "NeverFits",
+    "ModelBackend",
+    "Lease",
+    "InvokeOutcome",
+    "InstanceSizer",
+    "EnvelopeError",
+    "DecodedRequest",
+    "BindingResolver",
+    "AdapterRow",
     "ENTRYPOINT_ATTR",
     "Adapter",
     "DefaultsError",

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -85,6 +85,18 @@ def _parser() -> argparse.ArgumentParser:
                         help="entrypoint name to invoke (repeatable, pairs with --payload)")
     parser.add_argument("--payload", action="append", default=[],
                         help="JSON payload for the matching --invoke")
+    parser.add_argument("--envelope", action="append", default=[],
+                        help="full request envelope JSON for the matching --invoke "
+                             "(signature-derived: model/models, adapters, input); "
+                             "runs the ServeLoop with residency leases instead of "
+                             "the direct-args host dispatch")
+    parser.add_argument("--vram-budget-gb", type=float, default=0.0,
+                        help="envelope mode: the residency VRAM budget; 0 = size "
+                             "the budget to the checkpoint (fit exactly one)")
+    parser.add_argument("--weight-bytes", type=int, default=0,
+                        help="envelope mode: this checkpoint's manifest weight "
+                             "bytes (the tensorfs manifest states this in "
+                             "production; 0 = stat the local tree)")
     # Adoption sources, mutually exclusive; absent = the eager bridge.
     parser.add_argument("--graph-store", default="",
                         help="local compiled-graph CAS root (cozy-local shape)")
@@ -130,8 +142,58 @@ def _aoti_loader(path: Path, record: Any) -> Any:
     return torch._inductor.aoti_load_package(str(path))
 
 
+def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
+    """Envelope mode: the production dispatch loop, locally — the
+    signature-derived envelope through ServeLoop with residency leases
+    (admission before allocation) around every invocation."""
+    from .residency import ResidencyManager
+    from .serve_loop import ServeLoop, manifest_sizer
+
+    tree = Path(args.checkpoint)
+    weight = args.weight_bytes or sum(
+        f.stat().st_size for f in tree.rglob("*") if f.is_file()
+    ) or 1
+    headroom = max(weight // 4, 1)
+    budget = int(args.vram_budget_gb * (1024**3)) or (weight + headroom)
+
+    class _LocalResolver:
+        def resolve(self, model_cls: type, checkpoint_ref: str) -> DeployBinding:
+            return DeployBinding(
+                checkpoint_ref=checkpoint_ref,
+                checkpoint_dir=tree,
+                defaults=json.loads(args.defaults),
+            )
+
+        def default_pick(self, model_cls: type, slot_name: str) -> str:
+            return str(args.checkpoint_ref)
+
+    loop = ServeLoop(
+        loaded,
+        residency=ResidencyManager(
+            budget,
+            manifest_sizer({args.checkpoint_ref: weight}, headroom_bytes=headroom),
+        ),
+        resolver=_LocalResolver(),
+        lane_contract=args.lane,
+        output_dir=Path(args.output_dir),
+    )
+    for index, (function, raw) in enumerate(zip(args.invoke, args.envelope)):
+        outcome = loop.invoke(function, json.loads(raw), request_id=f"local-{index}")
+        for warning in outcome.warnings:
+            print(f"warn: {warning}", file=sys.stderr)
+        sys.stdout.buffer.write(msgspec.json.encode(outcome.result))
+        sys.stdout.buffer.write(b"\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    if args.envelope and args.payload:
+        raise SystemExit("--payload and --envelope are two modes; pick one")
+    if args.envelope:
+        if len(args.invoke) != len(args.envelope):
+            raise SystemExit("--invoke and --envelope must pair up")
+        return _serve_envelopes(args, load_endpoint(Path(args.endpoint_dir)))
     if len(args.invoke) != len(args.payload):
         raise SystemExit("--invoke and --payload must pair up")
     loaded = load_endpoint(Path(args.endpoint_dir))

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -161,6 +161,7 @@ def _serve_envelopes(args: argparse.Namespace, loaded: Any) -> int:
             return DeployBinding(
                 checkpoint_ref=checkpoint_ref,
                 checkpoint_dir=tree,
+                model=args.model or None,
                 defaults=json.loads(args.defaults),
             )
 

--- a/src/gen_worker/serving/envelope.py
+++ b/src/gen_worker/serving/envelope.py
@@ -1,0 +1,247 @@
+"""The request envelope: SIGNATURE-DERIVED, decoded per entrypoint (pgw#1372).
+
+Paul's envelope ruling: the checkpoint pick leaves the payload entirely —
+the platform wire shape is derived from the entrypoint's own signature,
+never declared twice::
+
+    {"model": "org/ckpt@3",                    # ONE model slot
+     "adapters": {"turbo": {...row...},        # per adapter-slot picks,
+                  "loras": [{...}, {...}]},    #   keyed by PARAMETER NAME
+     "input": {...the payload struct...}}
+
+    {"models": {"base": "...", "refiner": "..."},   # >1 model slots:
+     "input": {...}}                                #   keyed by slot name
+
+``input`` is the entrypoint's payload schema (typed 400s stay msgspec's).
+Adapter values are the HUB'S resolution output riding the request — fully
+pinned refs, local paths, decoded defaults, platform-clamped scale; the
+worker never resolves picks itself. A ``DistillationAdapter`` slot only
+accepts a distillation-marked row (the typed takeover guard, enforced here
+again even though the hub refuses first — a misdeploy must not seize the
+serving config).
+
+Everything unknown refuses loudly: an unknown top-level key, a pick for an
+undeclared slot, ``"model"`` against a multi-model signature (or
+``"models"`` against a single-model one), a list where the slot is single.
+Silence is never an outcome — a dropped pick would serve the wrong bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import msgspec
+
+from .context import Adapter, DistillationAdapter
+from .entrypoints import EntrypointSpec, SlotSpec
+
+
+class EnvelopeError(ValueError):
+    """The request envelope does not fit the entrypoint's signature."""
+
+
+class AdapterRow(msgspec.Struct, forbid_unknown_fields=True):
+    """One hub-resolved adapter as it rides the wire.
+
+    ``distillation`` is the hub's kind marker (release metadata records
+    which slots demand it); ``defaults`` is the decoded overlay row the
+    model type's schema gives meaning to."""
+
+    ref: str
+    path: str
+    name: str = ""
+    defaults: Optional[Dict[str, Any]] = None
+    scale: float = 1.0
+    distillation: bool = False
+
+    def materialize(self, defaults_schema: Optional[type]) -> Adapter:
+        """Build the typed slot value. ``defaults_schema`` is the model
+        type's adapter-defaults struct (``SDXL.Lora.Defaults`` — pgw#1377's
+        adapter-of-base scoping); the wire row's overlay decodes into it,
+        an absent overlay takes the schema's zero-arg servable values, and
+        an ill-typed one refuses naming the adapter."""
+        cls = DistillationAdapter if self.distillation else Adapter
+        defaults: Any = self.defaults
+        if defaults_schema is not None:
+            try:
+                defaults = (
+                    msgspec.convert(self.defaults, type=defaults_schema)
+                    if self.defaults is not None
+                    else defaults_schema()
+                )
+            except msgspec.ValidationError as exc:
+                raise EnvelopeError(
+                    f"adapter {self.ref!r} defaults do not fit "
+                    f"{defaults_schema.__name__}: {exc}"
+                ) from None
+        return cls(
+            name=self.name or self.ref,
+            path=Path(self.path),
+            defaults=defaults,
+            scale=self.scale,
+            ref=self.ref,
+        )
+
+
+class _Envelope(msgspec.Struct, forbid_unknown_fields=True):
+    """The raw wire shape; slot-level validity is per-entrypoint, below."""
+
+    input: msgspec.Raw
+    model: Optional[str] = None
+    models: Optional[Dict[str, str]] = None
+    adapters: Optional[Dict[str, msgspec.Raw]] = None
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedRequest:
+    """One envelope, decoded against one entrypoint's signature."""
+
+    payload: Any
+    #: Checkpoint pick per MODEL slot name (every declared slot present —
+    #: deploy defaults are the caller's to fill before decode refuses).
+    model_picks: Tuple[Tuple[str, str], ...]
+    #: Materialized value per ADAPTER slot name: Adapter | None for single
+    #: slots, list[Adapter] for plural ones.
+    adapter_values: Tuple[Tuple[str, Any], ...]
+
+
+def _decode_adapter_value(
+    slot: SlotSpec, raw: msgspec.Raw, defaults_schema: Optional[type]
+) -> Any:
+    if slot.kind == "adapters":
+        try:
+            rows = msgspec.json.decode(raw, type=List[AdapterRow])
+        except msgspec.ValidationError as exc:
+            raise EnvelopeError(
+                f"adapters[{slot.name!r}] must be a list of adapter rows: {exc}"
+            ) from None
+        return [row.materialize(defaults_schema) for row in rows]
+    try:
+        row = msgspec.json.decode(raw, type=Optional[AdapterRow])
+    except msgspec.ValidationError as exc:
+        raise EnvelopeError(
+            f"adapters[{slot.name!r}] must be one adapter row: {exc}"
+        ) from None
+    if row is None:
+        if slot.required:
+            raise EnvelopeError(
+                f"adapter slot {slot.name!r} is required and the envelope "
+                f"sends null"
+            )
+        return None
+    value = row.materialize(defaults_schema)
+    if slot.annotation is DistillationAdapter and not isinstance(
+        value, DistillationAdapter
+    ):
+        # The typed takeover guard, worker-side: a style LoRA cannot seize a
+        # distillation slot even when a misconfigured hub let it through.
+        raise EnvelopeError(
+            f"adapter slot {slot.name!r} takes a distillation adapter; "
+            f"{row.ref!r} is not distillation-marked (a misdeploy the hub "
+            f"should have refused)"
+        )
+    return value
+
+
+def decode_envelope(
+    spec: EntrypointSpec,
+    envelope: Any,
+    *,
+    default_picks: Optional[Mapping[str, str]] = None,
+    adapter_defaults_schema: Optional[type] = None,
+) -> DecodedRequest:
+    """Decode one wire envelope against one entrypoint's signature.
+
+    ``default_picks`` are the DEPLOYMENT's per-slot checkpoint defaults
+    (slot name -> ref); an envelope that names no pick for a slot falls back
+    there, and a slot with neither is a typed refusal — the worker never
+    guesses which bytes to serve.
+    """
+
+    if isinstance(envelope, (bytes, bytearray)):
+        raw_bytes = bytes(envelope)
+    else:
+        raw_bytes = msgspec.json.encode(envelope)
+    try:
+        parsed = msgspec.json.decode(raw_bytes, type=_Envelope)
+    except msgspec.ValidationError as exc:
+        raise EnvelopeError(f"malformed request envelope: {exc}") from None
+
+    model_slots = dict(spec.model_params)
+    defaults = dict(default_picks or {})
+
+    # -- model picks: "model" xor "models", derived from the signature ------
+    if parsed.model is not None and parsed.models is not None:
+        raise EnvelopeError('an envelope carries "model" or "models", never both')
+    picks: Dict[str, str] = {}
+    if len(model_slots) == 1:
+        (only_slot,) = model_slots
+        if parsed.models is not None:
+            raise EnvelopeError(
+                f'{spec.name!r} declares one model slot ({only_slot!r}); the '
+                f'envelope key is "model", not "models"'
+            )
+        if parsed.model is not None:
+            picks[only_slot] = parsed.model
+    else:
+        if parsed.model is not None:
+            raise EnvelopeError(
+                f'{spec.name!r} declares {len(model_slots)} model slots '
+                f'({sorted(model_slots)}); the envelope key is "models" '
+                f'keyed by slot name, not "model"'
+            )
+        for slot_name, ref in (parsed.models or {}).items():
+            if slot_name not in model_slots:
+                raise EnvelopeError(
+                    f'"models" names unknown slot {slot_name!r} '
+                    f"(declared: {sorted(model_slots)})"
+                )
+            picks[slot_name] = ref
+    for slot_name in model_slots:
+        if not picks.get(slot_name):
+            fallback = defaults.get(slot_name, "")
+            if not fallback:
+                raise EnvelopeError(
+                    f"model slot {slot_name!r} has no envelope pick and no "
+                    f"deployment default; the worker never guesses which "
+                    f"bytes to serve"
+                )
+            picks[slot_name] = fallback
+
+    # -- adapter picks: keyed by slot name, declared slots only -------------
+    adapter_slots = {slot.name: slot for slot in spec.slots if slot.kind != "model"}
+    sent = dict(parsed.adapters or {})
+    unknown = sorted(set(sent) - set(adapter_slots))
+    if unknown:
+        raise EnvelopeError(
+            f'"adapters" names undeclared slot(s) {unknown} '
+            f"(declared: {sorted(adapter_slots)})"
+        )
+    values: Dict[str, Any] = {}
+    for name, slot in adapter_slots.items():
+        if name in sent:
+            values[name] = _decode_adapter_value(
+                slot, sent[name], adapter_defaults_schema)
+        elif slot.kind == "adapters":
+            values[name] = []
+        elif slot.required:
+            raise EnvelopeError(
+                f"adapter slot {name!r} is required and the envelope sends "
+                f"no pick for it"
+            )
+        else:
+            values[name] = None
+
+    # -- the payload, last: its schema is the entrypoint's own --------------
+    payload = msgspec.json.decode(parsed.input, type=spec.payload_type)
+
+    return DecodedRequest(
+        payload=payload,
+        model_picks=tuple(sorted(picks.items())),
+        adapter_values=tuple(sorted(values.items())),
+    )
+
+
+__all__ = ["AdapterRow", "DecodedRequest", "EnvelopeError", "decode_envelope"]

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -1,0 +1,313 @@
+"""The entrypoint dispatch loop (pgw#1372): envelope in, leases around, result out.
+
+The wire-facing serving path over the pgw#1382 primitives:
+
+1. Route by function name (the route IS the entrypoint name).
+2. Decode the SIGNATURE-DERIVED envelope (:mod:`.envelope`): per-slot
+   checkpoint picks, hub-resolved adapter rows into typed slot values,
+   ``input`` against the entrypoint's own schema — every refusal typed,
+   before any author code runs.
+3. For every model slot in STABLE SLOT-NAME ORDER (the multi-model deadlock
+   rule), take a :class:`~gen_worker.serving.residency.ResidencyManager`
+   lease on ``(model class x checkpoint x lane)``: admission before
+   allocation, LRU two-tier eviction between requests, loads serialized,
+   single-flight per instance — Paul's residency ruling, wired around every
+   invocation.
+4. Invoke ctx-first: ``spec.fn(ctx, payload, *slot values in signature
+   order)``; release the leases; return the result with the request's
+   accumulated ``ctx.warn`` rows.
+
+Instances are keyed by (model class, checkpoint ref, lane): one resident
+author object per key, built inside the lease's admission window via
+``Model()`` + ``model.load(LoadContext)`` and dropped via the author's
+best-effort ``unload``. The deploy state comes through a
+:class:`BindingResolver` — the hub wiring implements it; tests and
+cozy-local implement it over local trees.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Tuple
+
+from .context import DeployBinding, LoadContext, LoaderEngine, RequestContext
+from .envelope import DecodedRequest, decode_envelope
+from .host import ServeDispatchError
+from .loader import LoadedEndpoint
+from .model import Model, lane_handle, model_type
+from .residency import InstanceSizer, ResidencyManager
+
+logger = logging.getLogger(__name__)
+
+
+class BindingResolver(Protocol):
+    """Deploy state per (model class, checkpoint pick) — the hub's half.
+
+    ``resolve`` returns the worker-resolved binding for a pick the hub
+    already validated against the slot's ``allowed_checkpoints`` (the
+    worker re-refuses nothing; it materializes). ``default_pick`` is the
+    deployment's per-slot default ref ('' = none bound).
+    """
+
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> DeployBinding: ...
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class InvokeOutcome:
+    """One served request: the entrypoint's result + the request facts the
+    envelope reply carries (``ctx.warn`` rows, adjustments)."""
+
+    result: Any
+    warnings: Tuple[str, ...]
+    adjustments: Tuple[Dict[str, str], ...]
+
+
+class _InstanceBackend:
+    """One resident (model class x checkpoint x lane) as residency sees it.
+
+    ``load`` runs the author's ``Model()`` + ``load(ctx)`` (inside the
+    manager's serialized load gate); ``drop`` runs the author's ``unload``
+    — best-effort tidiness, never correctness. The host tiers
+    (``demote_to_host``/``promote_to_device``) belong to the pgw#1380
+    native-loader wave: until it lands the loop runs the manager with a
+    zero host budget, so eviction is always a drop, and these arms refuse
+    loudly rather than pretend."""
+
+    def __init__(
+        self,
+        model_cls: type,
+        load_context: LoadContext[Any],
+    ) -> None:
+        self.model_cls = model_cls
+        self.load_context = load_context
+        self.model: Optional[Model[Any]] = None
+
+    def load(self) -> None:
+        model: Model[Any] = self.model_cls()  # cheap __init__ — no GPU, by contract
+        model.load(self.load_context)
+        self.model = model
+
+    def drop(self) -> None:
+        model, self.model = self.model, None
+        if model is None:
+            return
+        try:
+            model.unload(self.load_context)
+        except Exception:
+            logger.exception(
+                "unload(%s) raised; eviction proceeds (best-effort, never "
+                "correctness)", self.model_cls.__name__,
+            )
+
+    def demote_to_host(self) -> None:
+        raise NotImplementedError(
+            "host-tier staging rides the pgw#1380 native loader; run the "
+            "ResidencyManager with host_budget_bytes=0 until it lands"
+        )
+
+    def promote_to_device(self) -> None:
+        raise NotImplementedError(
+            "host-tier staging rides the pgw#1380 native loader; run the "
+            "ResidencyManager with host_budget_bytes=0 until it lands"
+        )
+
+
+class ServeLoop:
+    """The worker's wire-facing dispatcher for one loaded endpoint."""
+
+    def __init__(
+        self,
+        loaded: LoadedEndpoint,
+        *,
+        residency: ResidencyManager,
+        resolver: BindingResolver,
+        engine: Optional[LoaderEngine] = None,
+        lane_contract: str = "",
+        compile_sink_for: Optional[Callable[[type, Any], Any]] = None,
+        output_dir: Optional[Path] = None,
+        context_kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.loaded = loaded
+        self.residency = residency
+        self._resolver = resolver
+        self._engine = engine
+        #: The deploy's per-class lane pick (contract handle; '' = the single
+        #: declared lane / eager-permanent).
+        self.lanes: Dict[type, Any] = {
+            cls: loaded.lane(cls, lane_contract) for cls in loaded.models
+        }
+        self._compile_sink_for = compile_sink_for
+        self._output_dir = output_dir
+        self._context_kwargs = dict(context_kwargs or {})
+        #: Live backends by residency key, so a lease hit reuses the author
+        #: object instead of rebuilding it. Guarded: leases serialize per
+        #: key, but two DIFFERENT keys mutate this table concurrently.
+        self._backends: Dict[Tuple[type, str, str], _InstanceBackend] = {}
+        self._backends_lock = threading.Lock()
+
+    # -- placement ----------------------------------------------------------
+
+    def _lane_of(self, model_cls: type) -> Tuple[Any, str]:
+        lane = self.lanes[model_cls]
+        return lane, (lane_handle(lane) if lane is not None else "eager")
+
+    def _backend_factory(
+        self, model_cls: type, binding: DeployBinding, key: Tuple[type, str, str]
+    ) -> Callable[[], _InstanceBackend]:
+        def make() -> _InstanceBackend:
+            lane, _ = self._lane_of(model_cls)
+            sink = (
+                self._compile_sink_for(model_cls, lane)
+                if self._compile_sink_for is not None
+                else None
+            )
+            backend = _InstanceBackend(
+                model_cls,
+                LoadContext(
+                    binding=binding,
+                    model_type=model_type(model_cls),
+                    lane=lane,
+                    engine=self._engine,
+                    compile_sink=sink,
+                ),
+            )
+            with self._backends_lock:
+                self._backends[key] = backend
+            return backend
+
+        return make
+
+    # -- the one public operation -------------------------------------------
+
+    def invoke(
+        self, function: str, envelope: Any, *, request_id: str
+    ) -> InvokeOutcome:
+        """Serve one request end-to-end. See the module docstring for the
+        walk; every step before ``spec.fn`` refuses typed."""
+        spec = self.loaded.entrypoints.get(function)
+        if spec is None:
+            raise ServeDispatchError(
+                f"{self.loaded.module_name} serves no function {function!r} "
+                f"(functions: {sorted(self.loaded.entrypoints)})"
+            )
+        model_slots = dict(spec.model_params)
+        # Adapter overlays decode against the PRIMARY model type's adapter
+        # schema (pgw#1377 adapter-of-base scoping: SDXL.Lora.Defaults).
+        primary_type = model_type(spec.model_params[0][1])
+        lora_scope = getattr(primary_type, "Lora", None)
+        decoded: DecodedRequest = decode_envelope(
+            spec,
+            envelope,
+            default_picks={
+                name: self._resolver.default_pick(cls, name)
+                for name, cls in model_slots.items()
+            },
+            adapter_defaults_schema=getattr(lora_scope, "Defaults", None),
+        )
+        picks = dict(decoded.model_picks)
+        adapters = dict(decoded.adapter_values)
+
+        with ExitStack() as leases:
+            models: Dict[str, Model[Any]] = {}
+            primary_binding: Optional[DeployBinding] = None
+            # STABLE SLOT-NAME ORDER — the multi-model deadlock rule: every
+            # request over the same slot set acquires in one global order.
+            for slot_name in sorted(model_slots):
+                model_cls = model_slots[slot_name]
+                binding = self._resolver.resolve(model_cls, picks[slot_name])
+                _, lane_key = self._lane_of(model_cls)
+                key = (model_cls, binding.checkpoint_ref, lane_key)
+                with self._backends_lock:
+                    known = self._backends.get(key)
+                factory: Callable[[], Any]
+                if known is not None and known.model is not None:
+                    def factory(live: _InstanceBackend = known) -> _InstanceBackend:
+                        return live
+                else:
+                    # First residency, or dropped by eviction: fresh build.
+                    factory = self._backend_factory(model_cls, binding, key)
+                lease = self.residency.lease(
+                    binding.checkpoint_ref,
+                    f"{model_cls.__name__}/{lane_key}",
+                    factory,
+                )
+                leases.enter_context(lease)
+                backend = lease.backend
+                if backend.model is None:  # pragma: no cover — defensive
+                    raise ServeDispatchError(
+                        f"model slot {slot_name!r} has no live instance after "
+                        f"admission; the residency ledger is inconsistent"
+                    )
+                models[slot_name] = backend.model
+                if primary_binding is None:
+                    # The FIRST slot in signature order is the request's
+                    # primary routing fact (ctx.checkpoint_ref).
+                    first_slot = spec.model_params[0][0]
+                    primary_binding = self._resolver.resolve(
+                        model_slots[first_slot], picks[first_slot]
+                    )
+
+            ctx = self._make_context(request_id, primary_binding)
+            arguments = [
+                models[slot.name] if slot.kind == "model" else adapters[slot.name]
+                for slot in spec.slots
+            ]
+            result = spec.fn(ctx, decoded.payload, *arguments)
+        return InvokeOutcome(
+            result=result,
+            warnings=ctx.warnings,
+            adjustments=ctx.adjustments,
+        )
+
+    def _make_context(
+        self, request_id: str, binding: Optional[DeployBinding]
+    ) -> RequestContext[Any]:
+        kwargs: Dict[str, Any] = dict(self._context_kwargs)
+        if self._output_dir is not None:
+            kwargs.setdefault("local_output_dir", str(self._output_dir))
+        return RequestContext(
+            request_id,
+            binding=binding
+            or DeployBinding(checkpoint_ref="", checkpoint_dir=Path(".")),
+            **kwargs,
+        )
+
+
+def manifest_sizer(
+    weights: Mapping[str, int], *, headroom_bytes: int
+) -> InstanceSizer:
+    """An :class:`InstanceSizer` over a static ref->bytes table.
+
+    The production sizer reads the tensorfs manifest per (checkpoint, lane)
+    — exact bytes, known ahead of load; this helper is the local/cozy-local
+    shape (and the test double) until that wiring lands with the pgw#1380
+    loader engine.
+    """
+
+    class _Sizer:
+        def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            if checkpoint_ref not in weights:
+                raise KeyError(
+                    f"no manifest bytes for {checkpoint_ref!r}; admission "
+                    f"needs the real size"
+                )
+            return weights[checkpoint_ref]
+
+        def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            return headroom_bytes
+
+    return _Sizer()
+
+
+__all__ = [
+    "BindingResolver",
+    "InvokeOutcome",
+    "ServeLoop",
+    "manifest_sizer",
+]

--- a/tests/test_serve_loop_envelope.py
+++ b/tests/test_serve_loop_envelope.py
@@ -67,6 +67,7 @@ class LocalResolver:
         return DeployBinding(
             checkpoint_ref=checkpoint_ref,
             checkpoint_dir=self._tree(checkpoint_ref),
+            model="sdxl",
             defaults=self.defaults_by_ref.get(checkpoint_ref, {}),
         )
 

--- a/tests/test_serve_loop_envelope.py
+++ b/tests/test_serve_loop_envelope.py
@@ -1,0 +1,279 @@
+"""The entrypoint dispatch loop: envelope in, residency leases around, result out.
+
+Integration, no mocks beyond the seams the design names (LoaderEngine absent
+-> eager bridge; sizer = the static local table): the main_v2-contract-exact
+fixture endpoint serves REAL requests end-to-end on CPU with fake weights
+from config-only checkpoints, through the signature-derived envelope and
+`ResidencyManager.lease` around every invocation — the pgw#1372 dispatch
+loop the sdxl migration (se#751) lands on.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker.serving import DeployBinding, load_endpoint
+from gen_worker.serving.envelope import EnvelopeError
+from gen_worker.serving.host import ServeDispatchError
+from gen_worker.serving.residency import NeverFits, ResidencyManager, Tier
+from gen_worker.serving.serve_loop import ServeLoop, manifest_sizer
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "serving_v2_endpoint"
+RT_DIR = Path(__file__).parent / "fixtures" / "serving_rt_endpoint"
+
+GB = 1024**3
+
+DREAM = "org/dreamshaper@2"
+JUGGER = "org/juggernaut@7"
+HUGE = "org/videotitan@1"
+
+WEIGHTS = {DREAM: 3 * GB, JUGGER: 3 * GB, HUGE: 40 * GB,
+           "r/right@1": 1 * GB, "l/left@1": 1 * GB}
+
+TURBO_ROW = {
+    "ref": "cozy/lightning-4step@1", "path": "/adapters/lightning.safetensors",
+    "name": "lightning-4step", "distillation": True,
+    "defaults": {"scheduler": "euler_trailing"},
+}
+STYLE_ROW = {
+    "ref": "maker/ink-style@3", "path": "/adapters/ink.safetensors",
+    "name": "ink-style", "scale": 0.7,
+}
+
+
+class LocalResolver:
+    """Deploy state over local config-only trees — the BindingResolver seam."""
+
+    def __init__(self, root: Path, defaults_by_ref: Dict[str, Dict[str, Any]] | None = None) -> None:
+        self.root = root
+        self.defaults_by_ref = dict(defaults_by_ref or {})
+        self.default_picks: Dict[str, str] = {}
+        self.resolved: List[str] = []
+
+    def _tree(self, ref: str) -> Path:
+        tree = self.root / ref.replace("/", "_").replace("@", "_")
+        if not tree.exists():
+            tree.mkdir(parents=True)
+            (tree / "config.json").write_text(json.dumps({"seed": len(ref)}))
+        return tree
+
+    def resolve(self, model_cls: type, checkpoint_ref: str) -> DeployBinding:
+        self.resolved.append(checkpoint_ref)
+        return DeployBinding(
+            checkpoint_ref=checkpoint_ref,
+            checkpoint_dir=self._tree(checkpoint_ref),
+            defaults=self.defaults_by_ref.get(checkpoint_ref, {}),
+        )
+
+    def default_pick(self, model_cls: type, slot_name: str) -> str:
+        return self.default_picks.get(slot_name, "")
+
+
+def make_loop(
+    tmp_path: Path,
+    fixture: Path = FIXTURE_DIR,
+    *,
+    vram_gb: int = 64,
+    defaults_by_ref: Dict[str, Dict[str, Any]] | None = None,
+) -> tuple[ServeLoop, LocalResolver, ResidencyManager]:
+    loaded = load_endpoint(fixture)
+    resolver = LocalResolver(tmp_path / "trees", defaults_by_ref)
+    manager = ResidencyManager(
+        vram_gb * GB, manifest_sizer(WEIGHTS, headroom_bytes=1 * GB)
+    )
+    loop = ServeLoop(
+        loaded,
+        residency=manager,
+        resolver=resolver,
+        # The deploy's lane pick (multi-lane models refuse an unnamed lane).
+        lane_contract="sdxl.diffusers-bf16@1" if fixture is FIXTURE_DIR else "",
+        output_dir=tmp_path / "outputs",
+    )
+    return loop, resolver, manager
+
+
+def test_the_envelope_serves_end_to_end_with_fake_tensors(tmp_path: Path) -> None:
+    loop, _, manager = make_loop(tmp_path)
+    outcome = loop.invoke(
+        "generate",
+        {"model": DREAM, "input": {"prompt": "a lighthouse", "seed": 3}},
+        request_id="req-1",
+    )
+    result = outcome.result
+    # The fixture's structured evidence: the served checkpoint's pinned ref.
+    assert result.model == DREAM
+    assert result.loras == []
+    saved = tmp_path / "outputs" / result.image.ref
+    assert saved.is_file() and saved.stat().st_size > 0
+    assert outcome.warnings == ()
+    # The instance is resident under its reservation (weights + headroom).
+    assert manager.tier_of(DREAM, "SdxlModel/sdxl.diffusers-bf16@1") is Tier.VRAM
+
+
+def test_adapters_ride_the_envelope_and_the_scopes_restore(tmp_path: Path) -> None:
+    loop, _, _ = make_loop(tmp_path)
+    envelope = {
+        "model": DREAM,
+        "adapters": {"turbo": TURBO_ROW, "loras": [STYLE_ROW]},
+        "input": {"prompt": "ink harbor"},
+    }
+    outcome = loop.invoke("generate", envelope, request_id="req-2")
+    # Application order: the distillation adapter first, then style LoRAs;
+    # scale is the envelope-resolved value.
+    assert [(u.ref, u.scale) for u in outcome.result.loras] == [
+        ("cozy/lightning-4step@1", 1.0), ("maker/ink-style@3", 0.7),
+    ]
+    # The model-owned scopes restored the post-load baseline: no adapters
+    # remain applied on the persistent instance.
+    import serving_v2_fixture.main as v2
+
+    ((_, backend),) = loop._backends.items()
+    live = backend.model
+    assert isinstance(live, v2.SdxlModel)
+    assert live.pipe.active_adapters == []
+    assert live.pipe.loaded_loras == []
+
+    # A second, adapter-free request on the SAME instance serves clean.
+    second = loop.invoke(
+        "generate", {"model": DREAM, "input": {"prompt": "plain"}},
+        request_id="req-3",
+    )
+    assert second.result.loras == []
+
+
+def test_the_distillation_slot_guard_and_signature_derived_refusals(
+    tmp_path: Path,
+) -> None:
+    loop, resolver, _ = make_loop(tmp_path)
+    def refuse(envelope: Dict[str, Any]) -> str:
+        with pytest.raises(EnvelopeError) as excinfo:
+            loop.invoke("generate", envelope, request_id="r")
+        return str(excinfo.value)
+
+    # A style LoRA cannot seize the distillation slot (typed takeover guard).
+    message = refuse({"model": DREAM, "adapters": {"turbo": STYLE_ROW},
+                      "input": {"prompt": "x"}})
+    assert "not distillation-marked" in message
+    # "models" against a single-model signature.
+    assert '"model", not "models"' in refuse(
+        {"models": {"model": DREAM}, "input": {"prompt": "x"}})
+    # Picks for undeclared adapter slots.
+    assert "undeclared slot" in refuse(
+        {"model": DREAM, "adapters": {"stylegrid": STYLE_ROW},
+         "input": {"prompt": "x"}})
+    # No pick anywhere: the worker never guesses which bytes to serve.
+    assert "no envelope pick and no deployment default" in refuse(
+        {"input": {"prompt": "x"}})
+    # A deployment default fills the slot; the same envelope then serves.
+    resolver.default_picks["model"] = JUGGER
+    outcome = loop.invoke("generate", {"input": {"prompt": "x"}}, request_id="r2")
+    assert outcome.result.model == JUGGER
+    # Unknown functions stay a dispatch refusal, before envelope decode.
+    with pytest.raises(ServeDispatchError, match="no function 'enhance'"):
+        loop.invoke("enhance", {"input": {}}, request_id="r3")
+
+
+def test_step_distilled_checkpoint_ignores_turbo_and_warns(tmp_path: Path) -> None:
+    loop, _, _ = make_loop(
+        tmp_path, defaults_by_ref={DREAM: {"step_distilled": True, "cfg": False}}
+    )
+    outcome = loop.invoke(
+        "generate",
+        {"model": DREAM, "adapters": {"turbo": TURBO_ROW},
+         "input": {"prompt": "x"}},
+        request_id="r",
+    )
+    # ctx.warn rows ride the outcome (the reply envelope's warning channel).
+    assert any("already step-distilled" in w for w in outcome.warnings)
+    assert outcome.result.loras == []  # the adapter was ignored, not applied
+
+
+def test_residency_wraps_the_loop_lru_and_never_fits(tmp_path: Path) -> None:
+    loop, _, manager = make_loop(tmp_path, vram_gb=5)  # fits ONE 3G+1G instance
+    lane = "SdxlModel/sdxl.diffusers-bf16@1"
+    loop.invoke("generate", {"model": DREAM, "input": {"prompt": "a"}}, request_id="r1")
+    assert manager.tier_of(DREAM, lane) is Tier.VRAM
+    # The second checkpoint evicts the first BETWEEN requests (no host tier:
+    # straight back to the chunk store) — admission before allocation.
+    loop.invoke("generate", {"model": JUGGER, "input": {"prompt": "b"}}, request_id="r2")
+    assert manager.tier_of(JUGGER, lane) is Tier.VRAM
+    assert manager.tier_of(DREAM, lane) is Tier.ABSENT
+    # Re-serving the first re-admits it (a fresh load — nothing cached lies).
+    outcome = loop.invoke(
+        "generate", {"model": DREAM, "input": {"prompt": "c"}}, request_id="r3")
+    assert outcome.result.model == DREAM
+    # A model that can NEVER fit refuses typed at admission — before its
+    # instance is constructed, before any byte moves.
+    with pytest.raises(NeverFits, match="refuse at admission"):
+        loop.invoke("generate", {"model": HUGE, "input": {"prompt": "d"}},
+                    request_id="r4")
+
+
+def test_the_instance_is_reused_across_requests_not_rebuilt(tmp_path: Path) -> None:
+    loop, _, _ = make_loop(tmp_path)
+    loop.invoke("generate", {"model": DREAM, "input": {"prompt": "a"}}, request_id="r1")
+    ((key, backend),) = loop._backends.items()
+    first_model = backend.model
+    assert first_model is not None
+    loop.invoke("generate", {"model": DREAM, "input": {"prompt": "b"}}, request_id="r2")
+    assert loop._backends[key].model is first_model  # same author object
+
+
+def test_multi_model_slots_lease_in_stable_slot_name_order(tmp_path: Path) -> None:
+    loop, _, manager = make_loop(tmp_path, fixture=RT_DIR)
+    import serving_rt_fixture.main as rt
+
+    rt.reset()
+    lease_order: List[str] = []
+    true_lease = manager.lease
+
+    def spying_lease(checkpoint_ref: str, lane: str, factory: Any) -> Any:
+        lease_order.append(lane)
+        return true_lease(checkpoint_ref, lane, factory)
+
+    manager.lease = spying_lease  # type: ignore[method-assign]
+    outcome = loop.invoke(
+        "pair",
+        # Envelope key is "models" (two slots), keyed by SLOT NAME.
+        {"models": {"right": "r/right@1", "left": "l/left@1"},
+         "input": {"value": 5}},
+        request_id="r",
+    )
+    assert outcome.result.served_by == "SlowModel+OtherModel"
+    # STABLE slot-name order: "left" before "right", whatever the signature
+    # order — the multi-model deadlock rule.
+    assert lease_order == ["OtherModel/eager", "SlowModel/eager"]
+
+
+def test_single_flight_rides_the_lease_per_instance(tmp_path: Path) -> None:
+    loop, _, _ = make_loop(tmp_path, fixture=RT_DIR)
+    import serving_rt_fixture.main as rt
+
+    rt.reset()
+    done: List[str] = []
+
+    def held() -> None:
+        loop.invoke("run", {"model": "r/right@1", "input": {"value": 1, "hold": True}},
+                    request_id="h")
+        done.append("held")
+
+    def chaser() -> None:
+        rt.ENTERED.acquire()  # only once the first request is inside
+        loop.invoke("run", {"model": "r/right@1", "input": {"value": 2}},
+                    request_id="c")
+        done.append("chaser")
+
+    threads = [threading.Thread(target=held), threading.Thread(target=chaser)]
+    for t in threads:
+        t.start()
+    rt.RELEASE.set()
+    for t in threads:
+        t.join(timeout=30)
+    assert sorted(done) == ["chaser", "held"]
+    # The instrumented gauge proves one-at-a-time on the instance.
+    assert rt.HIGH_WATER == 1


### PR DESCRIPTION
Stacked on #954 (SDK-core — retargets to master when it lands). Paul's overnight mandate's dispatch-loop wave, with the final ruling set included: ctx-first invocation, signature-derived envelope (`{"model"/"models", "adapters": {"turbo","loras"}, "input"}`), `DistillationAdapter` slot kind re-guarded worker-side, `list[Adapter]` multi-slots, STABLE slot-name-order lease acquisition for multi-model entrypoints, `ctx.warn` riding the outcome, no `is_trace` anywhere.

- `serving/envelope.py`: the envelope IS the signature — model picks keyed by slot name (`model` xor `models`, derived from the model-slot count), adapter rows decoded into typed `Adapter`/`DistillationAdapter` (defaults against the model type's `Lora.Defaults`, pgw#1377 adapter-of-base scoping), every mismatch a typed refusal before author code runs.
- `serving/serve_loop.py`: `ServeLoop.invoke` = route → decode → residency leases in stable slot-name order (`(model class × checkpoint × lane)` instances, admission-before-allocation, LRU eviction BETWEEN requests, serialized loads, single-flight per instance rides the lease) → `spec.fn(ctx, payload, *slots)` → `InvokeOutcome` with warnings + adjustments. Deploy state via the `BindingResolver` seam; host tiers await pgw#1380 (zero host budget = drop; loud otherwise).
- `python -m gen_worker.serving --envelope`: the production wire shape locally, zero hub — the cozy-local acceptance surface, smoke-proven.

**Acceptance** (`tests/test_serve_loop_envelope.py`, CPU, fake weights, real diffusers schedulers through the main_v2-contract-exact fixture — the shape se#751's new `main.py` lands): envelope end-to-end render; turbo+loras application order with model-owned scopes restoring the post-load baseline; the takeover guard and the signature-derived refusal matrix; step-distilled turbo-ignore warning on the outcome; LRU + `NeverFits` through the loop; instance reuse; multi-model `models` envelope with lease order proven; single-flight proven by an instrumented gauge under real threads. 3 red-proof mutations red; 5× stable; scoped mypy/ruff/guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)