### PR TITLE
pgw#1380: ctx.load — the native store→VRAM serving loader (meta skeleton, file-order stream, zero disk writes)

### DIFF
--- a/src/gen_worker/models/materialized_view.py
+++ b/src/gen_worker/models/materialized_view.py
@@ -68,7 +68,35 @@ _SCRATCH = itertools.count()
 
 VIEWS_DIR = "materialized"
 
-__all__ = ["VIEWS_DIR", "third_party_dir", "view_root_for"]
+#: Set once the pgw#1380 streaming loader is bound in this process. From that
+#: moment a materialization is a DEFECT rather than a burn-down row: Paul's
+#: 2026-08-19 ruling narrowed tier 3 to external-binary runtimes and AOT `.so`
+#: delivery, and a serving pytorch endpoint reaches it for NO reason — its
+#: weights stream store->VRAM and its configs are real files in the projected
+#: tree. Nothing is blocked (a refusal here would turn a wrong-but-working pod
+#: into a dead one); the log simply stops reading as normal.
+_no_fill_serving = False
+
+__all__ = [
+    "VIEWS_DIR",
+    "no_fill_serving",
+    "serving_streams_weights",
+    "third_party_dir",
+    "view_root_for",
+]
+
+
+def no_fill_serving(active: bool = True) -> None:
+    """Declare that this process serves with the streaming loader bound."""
+
+    global _no_fill_serving
+    _no_fill_serving = bool(active)
+
+
+def serving_streams_weights() -> bool:
+    """True when a materialization here would be a pgw#1380 defect."""
+
+    return _no_fill_serving
 
 
 def view_root_for(snapshot_root: Path | str) -> Path:
@@ -174,9 +202,20 @@ def third_party_dir(path: Path | str, *, why: str) -> Path:
         finally:
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
-    _log.info(
-        "materialized_view snapshot=%s rel=%s bytes=%d files=%d why=%s "
-        "(pgw#1303 tier 3: the last resort of the access ladder)",
-        root.name, rel or "(whole tree)", written, len(wanted), why,
-    )
+    if _no_fill_serving:
+        _log.error(
+            "DEFECT materialized_view snapshot=%s rel=%s bytes=%d files=%d "
+            "why=%s — this process serves with the pgw#1380 streaming loader "
+            "bound, so a serving pytorch endpoint reached tier 3 for weights "
+            "it already has in the chunk store. The 2026-08-19 no-fill ruling "
+            "leaves tier 3 to external binaries and AOT .so delivery only; "
+            "this copy is a bug in the caller, not a burn-down row.",
+            root.name, rel or "(whole tree)", written, len(wanted), why,
+        )
+    else:
+        _log.info(
+            "materialized_view snapshot=%s rel=%s bytes=%d files=%d why=%s "
+            "(pgw#1303 tier 3: the last resort of the access ladder)",
+            root.name, rel or "(whole tree)", written, len(wanted), why,
+        )
     return out

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -167,10 +167,17 @@ class LoadContext(Generic[MT_co]):
             self.pipe = ctx.load(StableDiffusionXLPipeline)
 
         No ``torch_dtype=`` (the lane contract IS the dtype), no
-        ``.to("cuda")`` (weights land on device). Behind the call: the
-        pgw#1380 native tensorfs->VRAM engine when bound; until it lands,
-        an eager ``from_pretrained`` bridge over the projected checkpoint
-        tree keeps the eager path runnable."""
+        ``.to("cuda")`` (weights land on device). Behind the call is
+        pgw#1380's ``gen_worker.serving.streaming`` engine: the pipeline
+        built from configs on ``meta``, then its weights walked out of the
+        chunk store in FILE order through pinned staging onto the device,
+        with no tensor file written or read anywhere. The host binds it off
+        the projected checkpoint tree (which carries its own store), so
+        PLACEMENT stays a worker decision and this code names no device.
+
+        The eager ``from_pretrained`` bridge survives for a tree with no
+        chunk store behind it — a bare download, a local run, a fixture —
+        where there is nothing to stream from."""
         if self._engine is not None:
             built: P = self._engine.build(
                 pipeline_cls,

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -72,6 +72,8 @@ class EndpointHost:
         *,
         lane_contract: str = "",
         engine: Optional[LoaderEngine] = None,
+        device: str = "cuda",
+        io: str = "buffered",
         output_dir: Optional[Path] = None,
         context_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -82,9 +84,28 @@ class EndpointHost:
         }
         self.instances: Dict[type, ModelInstance] = {}
         self.adoption: Any = None
+        if engine is None:
+            # pgw#1380: the native store->VRAM engine, bound off the
+            # checkpoint tree the worker already resolved — a projected
+            # snapshot carries its own chunk store, so nothing extra is
+            # plumbed here. `None` back means this tree has no store behind
+            # it (a bare download, a fixture) and `ctx.load` keeps the eager
+            # bridge; PLACEMENT is decided here, by the worker, never by
+            # author code.
+            from .streaming import engine_for
+
+            engine = engine_for(binding.checkpoint_dir, device=device, io=io)
         self._engine = engine
         self._output_dir = output_dir
         self._context_kwargs = dict(context_kwargs or {})
+
+    def _stream_attributes(self) -> Dict[str, Any]:
+        """The streamed load's own numbers, or nothing when no engine ran."""
+        report = getattr(self._engine, "last_report", None)
+        if report is None:
+            return {}
+        attributes: Dict[str, Any] = report.attributes()
+        return attributes
 
     # -- contexts -----------------------------------------------------------
 
@@ -195,11 +216,17 @@ class EndpointHost:
             )
             model.load(load_context)
             self.instances[model_cls] = ModelInstance(model, load_context)
+            # pgw#1380: `model_load` IS the streaming span now. The fill's
+            # write-then-reread time did not move to a new stage — it left
+            # the boot, and what remains here is store->VRAM. The attributes
+            # say how fast and through what, so a regression is legible
+            # without a second measurement.
             boot_stages.record_ending_now(
                 boot_stages.Stage.MODEL_LOAD,
                 duration_ms=int((time.monotonic() - load_started) * 1000),
                 label=f"{self.loaded.module_name}:{model_cls.__name__}",
                 checkpoint=self.binding.checkpoint_ref,
+                **self._stream_attributes(),
             )
         if session is not None:
             # The mint-written requirements manifest is an AUDIT assertion

--- a/src/gen_worker/serving/streaming/__init__.py
+++ b/src/gen_worker/serving/streaming/__init__.py
@@ -1,0 +1,84 @@
+"""The native store->VRAM serving loader (pgw#1380).
+
+``ctx.load(StableDiffusionXLPipeline)`` — one spelling, no ``torch_dtype=``
+(the lane contract IS the dtype), no ``.to("cuda")`` (weights land on device),
+and no file: a serving pytorch endpoint never materializes tensor bytes.
+
+* :mod:`.skeleton` — the pipeline built from configs, parameters on meta.
+* :mod:`.source` — the tensorfs byte-source seam (the torch boundary).
+* :mod:`.staging` — the pinned ring and the copy stream.
+* :mod:`.engine` — the file-order walk that fills the skeleton.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from .engine import LoadError, LoadReport, NameMismatch, StreamingLoader
+from .skeleton import Skeleton, SkeletonError
+from .source import (
+    BridgeWeightStore,
+    NativeWeightStore,
+    StreamedTensor,
+    TensorStream,
+    WeightStore,
+    WeightStoreUnavailable,
+    native_available,
+    store_for,
+)
+from .staging import StagingPool
+
+logger = logging.getLogger(__name__)
+
+
+def engine_for(
+    checkpoint_dir: Path | str,
+    *,
+    device: Any = "cuda",
+    io: str = "buffered",
+) -> Optional[StreamingLoader]:
+    """The loader engine for a projected checkpoint tree, or ``None``.
+
+    ``None`` is the honest answer for a tree with no chunk store behind it
+    (a bare download, a fixture): there is nothing to stream from, so the
+    caller keeps whatever path it had rather than being handed an engine
+    that would refuse on first use.
+
+    Binding one ARMS the no-fill defect signal: from here on a
+    ``materialized_view`` call in this process is a bug, not a burn-down row
+    (Paul's 2026-08-19 ruling narrowed tier 3 away from serving pytorch).
+    """
+    store = store_for(checkpoint_dir)
+    if store is None:
+        logger.info(
+            "ctx.load: %s is not a projected snapshot tree — no chunk store "
+            "to stream from, so no streaming engine is bound",
+            checkpoint_dir,
+        )
+        return None
+    from ...models import materialized_view
+
+    materialized_view.no_fill_serving(True)
+    return StreamingLoader(store, device=device, io=io)
+
+
+__all__ = [
+    "engine_for",
+    "BridgeWeightStore",
+    "LoadError",
+    "LoadReport",
+    "NameMismatch",
+    "NativeWeightStore",
+    "Skeleton",
+    "SkeletonError",
+    "StagingPool",
+    "StreamedTensor",
+    "StreamingLoader",
+    "TensorStream",
+    "WeightStore",
+    "WeightStoreUnavailable",
+    "native_available",
+    "store_for",
+]

--- a/src/gen_worker/serving/streaming/engine.py
+++ b/src/gen_worker/serving/streaming/engine.py
@@ -1,0 +1,467 @@
+"""``ctx.load``'s engine: chunk store -> pinned staging -> device, no files.
+
+Paul's 2026-08-19 ruling: filling tensor bytes into a real safetensors file so
+``from_pretrained`` can mmap it is *"the completely wrong design"*. This is the
+replacement. A serving pytorch endpoint reads its weights out of the CAS
+objects it already holds and lands them on the device; nothing is written, and
+``materialized_view`` is not on this path at all.
+
+Four properties, each load-bearing:
+
+1. **File order, never module order.** ``load_state_dict`` iterates the
+   MODULE, which walks the checkpoint's bytes in whatever order the module
+   tree happens to have — the scrambled access pattern the load-order ruling
+   measured at ~10x worse. This engine walks the container's byte range
+   forward, once, and assigns by NAME as it goes. Canonical packaging is
+   load-order-optimal, so sequential streaming preserves that win by
+   construction rather than by luck.
+2. **Windows, not tensors.** A window is a staging buffer's worth of
+   consecutive file bytes; the tensors that overlap it are scattered out of
+   it. Small tensors coalesce into one read for free (SDXL has ~2.5k of
+   them), and a tensor larger than the window simply spans several.
+3. **dtype passthrough.** Bytes land verbatim in the container's own dtype —
+   bf16 stays bf16, fp8 stays fp8 with its scale tensors beside it. Any
+   conversion is the STORE's contract-negotiation job (the lane IS a tensorfs
+   layout contract), never load time. A container that disagrees with the
+   active lane is reported, not silently repaired.
+4. **Nothing survives on meta.** Every parameter and buffer is accounted for
+   by name. A missing name would serve uninitialized memory on the first
+   request, so it is a typed refusal naming the names.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from . import skeleton as _skeleton
+from .source import StreamedTensor, TensorStream, WeightStore, component_of
+from .staging import DEFAULT_BUFFER_BYTES, DEFAULT_BUFFERS, StagingPool
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+logger = logging.getLogger(__name__)
+
+#: safetensors' own dtype spellings -> torch dtypes. Passthrough only: this
+#: table exists to ALLOCATE the destination, never to convert anything.
+_TORCH_DTYPE: Mapping[str, str] = {
+    "F64": "float64",
+    "F32": "float32",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "I64": "int64",
+    "I32": "int32",
+    "I16": "int16",
+    "I8": "int8",
+    "U8": "uint8",
+    "BOOL": "bool",
+}
+
+
+class LoadError(RuntimeError):
+    """A streamed load could not be completed as specified."""
+
+
+class NameMismatch(LoadError):
+    """The checkpoint's tensor names and the skeleton's do not correspond."""
+
+
+@dataclass(slots=True)
+class LoadReport:
+    """What the load actually did — the ``model_load`` span's attributes."""
+
+    weights_streamed_bytes: int = 0
+    weights_stream_gbps: float = 0.0
+    staging: str = "pageable"
+    io: str = "buffered"
+    containers: int = 0
+    tensors: int = 0
+    windows: int = 0
+    seconds: float = 0.0
+    dtypes: Tuple[str, ...] = ()
+
+    def attributes(self) -> Dict[str, object]:
+        return {
+            "weights_streamed_bytes": self.weights_streamed_bytes,
+            "weights_stream_gbps": round(self.weights_stream_gbps, 3),
+            "staging": self.staging,
+            "io": self.io,
+            "containers": self.containers,
+            "tensors": self.tensors,
+        }
+
+
+@dataclass(slots=True)
+class _Placement:
+    """One tensor's byte span in the file and the memory it lands in."""
+
+    name: str
+    offset: int
+    nbytes: int
+    flat: "torch.Tensor"
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.nbytes
+
+
+@dataclass(slots=True)
+class _Slot:
+    """Where one name lives in the skeleton."""
+
+    owner: Any
+    leaf: str
+    parameter: bool
+
+
+def _torch_dtype(spelling: str, name: str) -> "torch.dtype":
+    import torch
+
+    attribute = _TORCH_DTYPE.get(spelling.upper())
+    if attribute is None:
+        raise LoadError(
+            f"{name}: container dtype {spelling!r} has no byte-addressable "
+            f"torch dtype. Sub-byte and block-quantized containers are the "
+            f"external-binary class (the #1303 ladder's tier 3), not the "
+            f"serving pytorch path"
+        )
+    dtype = getattr(torch, attribute, None)
+    if dtype is None:
+        raise LoadError(
+            f"{name}: this torch build has no {attribute}, so dtype "
+            f"{spelling!r} cannot be loaded verbatim (and converting it "
+            f"would be the store's job, not the loader's)"
+        )
+    return dtype  # type: ignore[no-any-return]
+
+
+def _slots(module: "torch.nn.Module") -> Dict[str, _Slot]:
+    """name -> where it lives. Built once per component, off the MODULE — so
+    assignment is a dict lookup during a forward byte walk, never a tree walk
+    per tensor."""
+    found: Dict[str, _Slot] = {}
+    for name, _ in module.named_parameters(remove_duplicate=False):
+        owner, leaf = _owner_of(module, name)
+        found[name] = _Slot(owner=owner, leaf=leaf, parameter=True)
+    for name, _ in module.named_buffers(remove_duplicate=False):
+        owner, leaf = _owner_of(module, name)
+        found[name] = _Slot(owner=owner, leaf=leaf, parameter=False)
+    return found
+
+
+def _owner_of(root: "torch.nn.Module", qualified: str) -> Tuple[Any, str]:
+    parent, _, leaf = qualified.rpartition(".")
+    owner = root.get_submodule(parent) if parent else root
+    return owner, leaf
+
+
+def _install(slot: _Slot, tensor: "torch.Tensor") -> None:
+    """Replace the meta placeholder with real memory.
+
+    Assignment rather than ``copy_``: the placeholder has no storage to copy
+    into, and this is the same move ``load_state_dict(assign=True)`` makes.
+    ``requires_grad`` stays False — a serving pipeline never backpropagates,
+    and an autograd-tracking parameter would silently hold a graph.
+    """
+    import torch
+
+    if slot.parameter:
+        held = slot.owner._parameters.get(slot.leaf)
+        kind = type(held) if held is not None else torch.nn.Parameter
+        slot.owner._parameters[slot.leaf] = kind(tensor, requires_grad=False)
+    else:
+        slot.owner._buffers[slot.leaf] = tensor
+
+
+def _flat_bytes(tensor: "torch.Tensor") -> "torch.Tensor":
+    """A flat uint8 view of a freshly allocated contiguous tensor."""
+    import torch
+
+    return tensor.view(-1).view(torch.uint8)
+
+
+class StreamingLoader:
+    """The engine behind ``ctx.load`` — the pgw#1382 ``LoaderEngine`` seam.
+
+    Constructed by the WORKER, which supplies the byte source and the device:
+    placement is a worker decision (pgw#1372's residency manager admits the
+    exact weight byte size before a single allocation), and author code names
+    no device anywhere. ``build`` is the whole surface.
+    """
+
+    def __init__(
+        self,
+        store: WeightStore,
+        *,
+        device: Any = "cuda",
+        io: str = "buffered",
+        buffer_bytes: int = DEFAULT_BUFFER_BYTES,
+        buffers: int = DEFAULT_BUFFERS,
+    ) -> None:
+        if io not in ("buffered", "direct"):
+            raise LoadError(f"io must be 'buffered' or 'direct', not {io!r}")
+        self._store = store
+        self._device = device
+        self._io = io
+        self._buffer_bytes = int(buffer_bytes)
+        self._buffers = int(buffers)
+        self._planned: List[Tuple[str, str]] = []
+        self.last_report: Optional[LoadReport] = None
+
+    # -- the LoaderEngine protocol -----------------------------------------
+
+    def build(self, pipeline_cls: type, *, checkpoint_dir: Path, lane: Any) -> Any:
+        """Meta skeleton, then weights streamed into it. Returns a genuine
+        ``pipeline_cls`` with everything resident on the worker's device."""
+        import torch
+
+        started = time.perf_counter()
+        device = torch.device(self._device)
+        built = _skeleton.build(pipeline_cls, Path(checkpoint_dir))
+        report = LoadReport(io=self._io)
+
+        with StagingPool(
+            device,
+            buffer_bytes=self._buffer_bytes,
+            buffers=self._buffers,
+        ) as pool:
+            report.staging = pool.staging
+            for component, container in self._plan(built.modules):
+                self._stream_container(
+                    built.modules[component],
+                    component,
+                    container,
+                    pool=pool,
+                    device=device,
+                    report=report,
+                )
+            report.containers = len(self._planned)
+
+        for component, module in built.modules.items():
+            survivors = _skeleton.meta_survivors(module)
+            if survivors:
+                raise NameMismatch(
+                    f"component {component!r}: {len(survivors)} tensor(s) are "
+                    f"still on meta after the checkpoint's containers were "
+                    f"streamed — the checkpoint does not carry "
+                    f"{', '.join(survivors[:8])}"
+                    + (" …" if len(survivors) > 8 else "")
+                )
+
+        report.seconds = time.perf_counter() - started
+        if report.seconds > 0:
+            report.weights_stream_gbps = (
+                report.weights_streamed_bytes / report.seconds / 1e9
+            )
+        self.last_report = report
+        self._warn_on_lane(lane, report)
+        logger.info(
+            "ctx.load: %s resident on %s — %.2f GiB streamed in %.2fs "
+            "(%.2f GB/s, staging=%s io=%s, %d tensors over %d windows)",
+            pipeline_cls.__name__,
+            device,
+            report.weights_streamed_bytes / (1 << 30),
+            report.seconds,
+            report.weights_stream_gbps,
+            report.staging,
+            report.io,
+            report.tensors,
+            report.windows,
+        )
+        return built.pipeline
+
+    # -- planning ----------------------------------------------------------
+
+    def _plan(self, modules: Mapping[str, Any]) -> List[Tuple[str, str]]:
+        """(component, container) in MANIFEST order.
+
+        Manifest order is the packaging order, which for a canonical snapshot
+        is contract memory order. Reading containers in it keeps the whole
+        load sequential across component boundaries too, not just inside one.
+        """
+        planned: List[Tuple[str, str]] = []
+        for container in self._store.containers():
+            component = component_of(container)
+            if component in modules:
+                planned.append((component, container))
+        missing = sorted(set(modules) - {component for component, _ in planned})
+        if missing:
+            raise NameMismatch(
+                f"no tensor container in the store belongs to component(s) "
+                f"{', '.join(missing)}; their parameters would stay on meta"
+            )
+        self._planned = planned
+        return planned
+
+    # -- the file-order walk -----------------------------------------------
+
+    def _stream_container(
+        self,
+        module: Any,
+        component: str,
+        container: str,
+        *,
+        pool: StagingPool,
+        device: Any,
+        report: LoadReport,
+    ) -> None:
+        import torch
+
+        stream: TensorStream = self._store.open(
+            container, direct=self._io == "direct"
+        )
+        entries: Sequence[StreamedTensor] = stream.tensors
+        if not entries:
+            return
+
+        slots = _slots(module)
+        placements: List[_Placement] = []
+        unexpected: List[str] = []
+        seen: set[str] = set()
+        dtypes: set[str] = set(report.dtypes)
+
+        for entry in entries:
+            slot = slots.get(entry.name)
+            if slot is None:
+                unexpected.append(entry.name)
+                continue
+            dtype = _torch_dtype(entry.dtype, f"{component}/{entry.name}")
+            dtypes.add(entry.dtype.upper())
+            destination = torch.empty(
+                tuple(int(dim) for dim in entry.shape), dtype=dtype, device=device
+            )
+            flat = _flat_bytes(destination)
+            if flat.numel() != entry.nbytes:
+                raise LoadError(
+                    f"{component}/{entry.name}: the container says "
+                    f"{entry.nbytes} bytes, a {dtype} tensor of "
+                    f"{tuple(entry.shape)} holds {flat.numel()}"
+                )
+            pool.track(destination)
+            _install(slot, destination)
+            seen.add(entry.name)
+            placements.append(
+                _Placement(
+                    name=entry.name,
+                    offset=int(entry.offset),
+                    nbytes=int(entry.nbytes),
+                    flat=flat,
+                )
+            )
+
+        if unexpected:
+            raise NameMismatch(
+                f"{container}: {len(unexpected)} tensor(s) name nothing in "
+                f"component {component!r} — {', '.join(sorted(unexpected)[:8])}"
+                + (" …" if len(unexpected) > 8 else "")
+                + ". A name the skeleton cannot place is a checkpoint the "
+                "code does not match; ctx.load never guesses."
+            )
+
+        report.dtypes = tuple(sorted(dtypes))
+        # `tensors` is ascending file offset BY CONTRACT (tensorfs#115). The
+        # sort is belt-and-braces against a source that forgets: without it a
+        # scrambled walk would still be CORRECT and merely slow, which is the
+        # regression that hides forever.
+        placements.sort(key=lambda placement: placement.offset)
+        report.tensors += len(placements)
+        report.windows += self._walk(stream, placements, pool=pool, report=report)
+
+    def _walk(
+        self,
+        stream: TensorStream,
+        placements: List[_Placement],
+        *,
+        pool: StagingPool,
+        report: LoadReport,
+    ) -> int:
+        """Read the container's data range forward once, scattering as we go.
+
+        Everything between the first tensor's offset and the last tensor's end
+        is read, including any alignment padding between tensors: a window is
+        a byte range, not a tensor list, and skipping a few padding bytes
+        would cost a seek to save a memcpy.
+        """
+        position = placements[0].offset
+        finish = placements[-1].end
+        window = pool.buffer_bytes
+        first = 0
+        windows = 0
+
+        while position < finish:
+            count = min(window, finish - position)
+            slot = pool.acquire()
+            stream.readinto(position, count, slot.view[:count])
+            windows += 1
+            report.weights_streamed_bytes += count
+
+            index = first
+            while index < len(placements) and placements[index].offset < position + count:
+                placement = placements[index]
+                if placement.end <= position:
+                    index += 1
+                    first = index
+                    continue
+                low = max(placement.offset, position)
+                high = min(placement.end, position + count)
+                pool.copy_out(
+                    slot,
+                    low - position,
+                    placement.flat,
+                    low - placement.offset,
+                    high - low,
+                )
+                if placement.end <= position + count:
+                    first = index + 1
+                index += 1
+
+            pool.release(slot)
+            position += count
+
+        return windows
+
+    # -- the lane contract -------------------------------------------------
+
+    @staticmethod
+    def _warn_on_lane(lane: Any, report: LoadReport) -> None:
+        """The lane IS the dtype (there is no ``torch_dtype=`` to pass).
+
+        A container whose floating dtype is not the lane's means the tree was
+        not converted through the active contract before it reached this pod.
+        That is a STORE defect — reported here, never repaired here, because
+        a load-time conversion is exactly the byte-rewriting this whole
+        design deleted.
+        """
+        declared = getattr(lane, "dtype", None)
+        if declared is None or not report.dtypes:
+            return
+        spelling = str(declared).rsplit(".", 1)[-1].upper()
+        floating = {
+            name for name in report.dtypes if name.startswith(("F", "BF"))
+        }
+        aliases = {spelling, {"BFLOAT16": "BF16", "FLOAT16": "F16",
+                              "FLOAT32": "F32"}.get(spelling, spelling)}
+        if floating and not (floating & aliases):
+            logger.warning(
+                "ctx.load: the active lane declares dtype %s but this "
+                "checkpoint's containers carry %s — the tree was not "
+                "converted through the lane's layout contract before it "
+                "reached this pod; loading verbatim (conversion is the "
+                "store's job, never the loader's)",
+                declared,
+                ", ".join(sorted(floating)),
+            )
+
+
+__all__ = [
+    "LoadError",
+    "LoadReport",
+    "NameMismatch",
+    "StreamingLoader",
+]

--- a/src/gen_worker/serving/streaming/skeleton.py
+++ b/src/gen_worker/serving/streaming/skeleton.py
@@ -1,0 +1,201 @@
+"""Step 1 of ``ctx.load``: the pipeline, built from CONFIGS, holding no bytes.
+
+``model_index.json`` names every component and the class that builds it. Each
+nn.Module component is constructed ``from_config`` under
+:func:`gen_worker.models.meta_init.init_empty_weights`, so its parameters land
+on ``meta`` — no storage, no read, no allocation. Everything else (scheduler,
+tokenizer, feature extractor, image processor) keeps its stock
+``from_pretrained`` against the projected tree: those are small REAL files that
+stay symlinks, and reading a 2 KB tokenizer through a streaming engine would
+be ceremony without a payoff.
+
+The result is a genuine instance of the pipeline class the author named. It is
+not a proxy, not a subclass, not a patched object — handlers, ``ctx.compile``
+marking and ``load_lora_weights`` all meet exactly what they would have met
+after ``from_pretrained``, minus the weights, which arrive next.
+
+Symmetry with the publish moment (pgw#1370): the SAME construction on meta,
+with nothing streamed into it, is what the derive traces. One surface, two
+moments — the ``ctx.compile`` duality, for weights.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
+
+from ...models.meta_init import init_empty_weights
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+logger = logging.getLogger(__name__)
+
+MODEL_INDEX = "model_index.json"
+
+
+class SkeletonError(RuntimeError):
+    """The meta skeleton could not be built from configs alone."""
+
+
+@dataclass(slots=True)
+class Skeleton:
+    """A meta-built pipeline and the components weights must reach."""
+
+    pipeline: Any
+    #: component name -> the nn.Module built on meta. Component ``""`` is a
+    #: single-module checkpoint with no ``model_index.json``.
+    modules: Dict[str, Any]
+    #: Components that came from a stock ``from_pretrained`` (small real
+    #: files); no tensor container of theirs is streamed.
+    passthrough: Tuple[str, ...] = ()
+
+
+def _resolve(library: str, class_name: str) -> type:
+    try:
+        module = importlib.import_module(library)
+    except ImportError as exc:
+        raise SkeletonError(
+            f"{MODEL_INDEX} names component class {library}.{class_name}, "
+            f"but {library!r} is not importable in this image"
+        ) from exc
+    found = getattr(module, class_name, None)
+    if found is None or not isinstance(found, type):
+        raise SkeletonError(
+            f"{library}.{class_name} is not a class in this image's "
+            f"{library} version"
+        )
+    return found
+
+
+def _is_module(cls: type) -> bool:
+    import torch
+
+    return issubclass(cls, torch.nn.Module)
+
+
+def _build_on_meta(cls: type, directory: Path, component: str) -> Any:
+    """Construct one nn.Module component from its config, on meta."""
+    load_config = getattr(cls, "load_config", None)
+    from_config = getattr(cls, "from_config", None)
+    if callable(load_config) and callable(from_config):
+        # diffusers ConfigMixin: the config is a plain dict on disk.
+        config = load_config(str(directory))
+        if isinstance(config, tuple):
+            config = config[0]
+        with init_empty_weights():
+            return from_config(config)
+
+    config_class = getattr(cls, "config_class", None)
+    if config_class is not None and hasattr(config_class, "from_pretrained"):
+        # transformers PreTrainedModel: the config is a typed object.
+        config = config_class.from_pretrained(str(directory))
+        with init_empty_weights():
+            return cls(config)
+
+    raise SkeletonError(
+        f"component {component!r} ({cls.__module__}.{cls.__name__}) exposes "
+        f"neither a diffusers from_config nor a transformers config_class, so "
+        f"it cannot be built weight-free; ctx.load never reads a checkpoint "
+        f"file to find out what a class wants"
+    )
+
+
+def build(
+    pipeline_cls: type,
+    checkpoint_dir: Path,
+    *,
+    extra_kwargs: Optional[Mapping[str, Any]] = None,
+) -> Skeleton:
+    """Build ``pipeline_cls`` from configs only. Reads no tensor bytes."""
+    index_path = Path(checkpoint_dir) / MODEL_INDEX
+    if not index_path.is_file():
+        raise SkeletonError(
+            f"{checkpoint_dir} carries no {MODEL_INDEX}; ctx.load builds a "
+            f"pipeline from its component index, and a tree without one is "
+            f"not a pipeline checkpoint"
+        )
+    try:
+        index = json.loads(index_path.read_text())
+    except ValueError as exc:
+        raise SkeletonError(f"{index_path} is not readable JSON: {exc}") from exc
+
+    components: Dict[str, Any] = {}
+    modules: Dict[str, Any] = {}
+    passthrough: List[str] = []
+
+    for name, spec in sorted(index.items()):
+        if name.startswith("_"):
+            continue
+        if not isinstance(spec, (list, tuple)) or len(spec) != 2:
+            continue
+        library, class_name = spec
+        if library is None or class_name is None:
+            # A declared-but-absent optional component (safety checker and
+            # friends). The pipeline takes None and says so itself.
+            components[name] = None
+            continue
+        directory = Path(checkpoint_dir) / name
+        if not directory.is_dir():
+            raise SkeletonError(
+                f"{MODEL_INDEX} declares component {name!r} but "
+                f"{directory} is not in the projected tree"
+            )
+        cls = _resolve(str(library), str(class_name))
+        if _is_module(cls):
+            components[name] = _build_on_meta(cls, directory, name)
+            modules[name] = components[name]
+        else:
+            components[name] = cls.from_pretrained(str(directory))  # type: ignore[attr-defined]
+            passthrough.append(name)
+
+    if not modules:
+        raise SkeletonError(
+            f"{index_path} declares no nn.Module component; there would be "
+            f"no weights to stream"
+        )
+
+    kwargs = dict(components)
+    if extra_kwargs:
+        kwargs.update(extra_kwargs)
+    try:
+        pipeline = pipeline_cls(**kwargs)
+    except TypeError as exc:
+        raise SkeletonError(
+            f"{pipeline_cls.__name__} refused the components "
+            f"{sorted(kwargs)} named by {index_path}: {exc}"
+        ) from exc
+
+    logger.info(
+        "ctx.load: meta skeleton %s built from configs — %d module component(s), "
+        "%d passthrough, 0 tensor bytes read",
+        pipeline_cls.__name__,
+        len(modules),
+        len(passthrough),
+    )
+    return Skeleton(pipeline=pipeline, modules=modules, passthrough=tuple(passthrough))
+
+
+def meta_survivors(module: "torch.nn.Module") -> Tuple[str, ...]:
+    """Every parameter or buffer still on ``meta``.
+
+    A survivor is never acceptable: it is a name the checkpoint did not carry,
+    silently serving garbage on the first request. ``remove_duplicate=False``
+    so a tied weight is reported under every name it answers to rather than
+    hiding behind whichever alias happened to be assigned.
+    """
+    left: List[str] = []
+    for name, parameter in module.named_parameters(remove_duplicate=False):
+        if parameter.device.type == "meta":
+            left.append(name)
+    for name, buffer in module.named_buffers(remove_duplicate=False):
+        if buffer.device.type == "meta":
+            left.append(name)
+    return tuple(sorted(left))
+
+
+__all__ = ["MODEL_INDEX", "Skeleton", "SkeletonError", "build", "meta_survivors"]

--- a/src/gen_worker/serving/streaming/source.py
+++ b/src/gen_worker/serving/streaming/source.py
@@ -1,0 +1,344 @@
+"""The byte-source seam: what the loader engine needs from tensorfs.
+
+The torch boundary is a ruling (tensorfs#115 item 4): **tensorfs yields bytes
+and geometry; gen-worker owns torch, CUDA and the pinned pool.** These
+Protocols are that boundary written down on this side of it, and they are the
+shape tensorfs#115 landed — ``TensorStreamReader`` satisfies
+:class:`TensorStream` structurally, with no adapter code at all.
+
+Two stores implement :class:`WeightStore`:
+
+* :class:`NativeWeightStore` over the maturin wheel's
+  ``tensorfs.native.{ObjectStore, Snapshot, TensorStreamReader}``. This is the
+  production path: ordered iteration is an API contract, ``readinto`` copies
+  in Rust with the GIL released, and ``direct=True`` opens ``O_DIRECT``.
+* :class:`BridgeWeightStore` over the storage plane pgw actually carries today
+  (``_vendor.tensorfs``'s ``LocalCAS`` + ``TensorReader``). Same real store,
+  same real chunked CAS objects, same file-order contract — it just copies
+  under the GIL, which is precisely the ~10x tensorfs#115 measured away.
+
+**The bridge dies with tensorfs#57**, the wheel-publish lane, and nothing else
+in the engine moves when it does: the engine only ever speaks
+:class:`WeightStore`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import (
+    Any,
+    Iterator,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Container formats whose tensors this engine can stream. A snapshot entry
+#: planned any other way (``blob-v1``) is not a tensor container and is left
+#: to the projected tree, where it is a symlink costing nothing.
+TENSOR_PLANNERS = frozenset({"safetensors-v1", "gguf-v1"})
+
+
+class StreamedTensor(Protocol):
+    """One tensor's geometry: the container's own dtype spelling, its shape,
+    and its byte span **absolute within the container file**."""
+
+    @property
+    def name(self) -> str: ...
+    @property
+    def dtype(self) -> str: ...
+    @property
+    def shape(self) -> Sequence[int]: ...
+    @property
+    def offset(self) -> int: ...
+    @property
+    def nbytes(self) -> int: ...
+
+
+@runtime_checkable
+class TensorStream(Protocol):
+    """One tensor container, readable at arbitrary offsets into caller memory.
+
+    ``tensors`` is **ascending file offset by contract** — not by accident,
+    and not safetensors header order, which is a different order in general.
+    Walking ``tensors`` and reading each in turn is the sequential access
+    pattern the load-order ruling measured at ~10x, and it is the ONLY order
+    this engine ever reads in.
+    """
+
+    @property
+    def tensors(self) -> Sequence[StreamedTensor]: ...
+    @property
+    def length(self) -> int: ...
+
+    def readinto(self, offset: int, length: int, buffer: Any) -> int:
+        """Copy ``[offset, offset+length)`` into a writable C-contiguous
+        buffer — typically CUDA-pinned host memory, which the store neither
+        knows nor cares about. Holes zero-fill, never skip."""
+        ...
+
+
+class WeightStore(Protocol):
+    """The checkpoint's tensor containers, addressable without a file."""
+
+    def containers(self) -> Sequence[str]:
+        """Checkpoint-relative paths of every tensor container, in a stable
+        order. Non-tensor files are not listed: they stay symlinks in the
+        projected tree and are read from there."""
+        ...
+
+    def open(self, container: str, *, direct: bool = False) -> TensorStream: ...
+
+
+class WeightStoreUnavailable(RuntimeError):
+    """No streamed byte source could be built for this checkpoint."""
+
+
+# -- the native store (tensorfs#115, via the tensorfs#57 wheel) -------------
+
+
+def _native_stream_reader() -> Any:
+    """``tensorfs.native.TensorStreamReader``, resolved at call time.
+
+    Resolved through :mod:`importlib` rather than a module-level import
+    because ``tensorfs`` is not yet a declared dependency of this package
+    (tensorfs#57 is the wheel-publish lane). A static import would make every
+    torchless boot pay an ImportError for a class only the serving path uses.
+    """
+    import importlib
+
+    try:
+        module = importlib.import_module("tensorfs.native")
+    except ImportError as exc:
+        raise WeightStoreUnavailable(
+            "the tensorfs wheel (tensorfs#57) is not installed, so the "
+            "native store->VRAM stream surface is unavailable in this image"
+        ) from exc
+    return getattr(module, "TensorStreamReader")
+
+
+class NativeWeightStore:
+    """The production byte source: the Rust extension's stream reader.
+
+    Constructed by the WORKER from the store and snapshot it already resolved
+    — the engine never opens a store of its own, because which store and
+    which snapshot serve is a worker decision, exactly as placement is.
+    """
+
+    def __init__(self, store: Any, records: Mapping[str, Sequence[Any]]) -> None:
+        self._store = store
+        self._records = dict(records)
+
+    @classmethod
+    def from_snapshot(cls, store: Any, snapshot: Any) -> "NativeWeightStore":
+        """Every tensor container of a committed snapshot, in snapshot order.
+
+        A snapshot entry's ``planner`` is what says a file is a tensor
+        container: the contract that planned it. Nothing here sniffs a
+        suffix, because the planner is the fact and the suffix is a habit.
+        """
+        records: dict[str, Sequence[Any]] = {}
+        for entry in snapshot.entries:
+            if getattr(entry, "planner", None) not in TENSOR_PLANNERS:
+                continue
+            run = snapshot.file_records(entry.path)
+            if run is None:
+                raise WeightStoreUnavailable(
+                    f"{entry.path!r} is planned {entry.planner!r} but the "
+                    f"snapshot carries no record run for it"
+                )
+            records[entry.path] = run
+        return cls(store, records)
+
+    def containers(self) -> Sequence[str]:
+        return tuple(self._records)
+
+    def open(self, container: str, *, direct: bool = False) -> TensorStream:
+        run = self._records.get(container)
+        if run is None:
+            raise WeightStoreUnavailable(
+                f"{container!r} is not a tensor container of this snapshot"
+            )
+        reader: TensorStream = _native_stream_reader()(self._store, run, direct)
+        return reader
+
+
+# -- the bridge over the plane pgw carries today (dies with tensorfs#57) ----
+
+
+class _BridgeStream:
+    """One container of a :class:`BridgeWeightStore`.
+
+    Geometry comes from the vendored ``TensorReader``'s own header parse, so
+    the names, dtypes, shapes and offsets are the SAME facts the native
+    reader reports; only the copy is Python's. Ordering is imposed here for
+    the same reason the Rust reader imposes it: header key order is not
+    offset order.
+
+    ONE container per reader, deliberately. The vendored reader indexes a
+    whole manifest into a flat name->view map and refuses a name that appears
+    twice — and in a pipeline checkpoint ``text_encoder`` and
+    ``text_encoder_2`` share every name they have. Names are only unique
+    WITHIN a container, which is also the only scope this engine ever
+    resolves them in.
+    """
+
+    def __init__(self, reader: Any, container: str) -> None:
+        self._reader = reader
+        self._container = container
+        views = sorted(reader.values(), key=lambda view: view.offset)
+        self._tensors: list[StreamedTensor] = list(views)
+        self._length = max((v.offset + v.nbytes for v in views), default=0)
+
+    @property
+    def tensors(self) -> Sequence[StreamedTensor]:
+        return tuple(self._tensors)
+
+    @property
+    def length(self) -> int:
+        return self._length
+
+    def readinto(self, offset: int, length: int, buffer: Any) -> int:
+        target = memoryview(buffer).cast("B")
+        if len(target) < length:
+            raise ValueError(
+                f"{self._container}: buffer holds {len(target)} bytes, "
+                f"the read needs {length}"
+            )
+        at = 0
+        # `_pieces` rather than `read_range` on purpose: `read_range` returns
+        # `bytes`, so every window would allocate and copy a second time. The
+        # pieces are zero-copy slices of the mapped CAS objects, which is the
+        # closest this plane gets to what the Rust reader does natively.
+        for piece in self._reader._pieces(self._container, offset, length):
+            target[at : at + len(piece)] = piece
+            at += len(piece)
+        return at
+
+
+class BridgeWeightStore:
+    """The interim byte source over ``_vendor.tensorfs``'s reader.
+
+    NOT a stand-in for missing code and NOT a mock: it reads the same chunked
+    CAS objects the fleet stores today, through the same header parse. What
+    it cannot carry is the SPEED — the copy happens in Python under the GIL,
+    which is the path tensorfs#115 measured at 0.59 GiB/s against the native
+    reader's 6.4 GiB/s. Delete this class the day tensorfs#57 publishes a
+    wheel; :class:`NativeWeightStore` already does everything it does.
+    """
+
+    #: What the vendored reader knows how to parse a header out of.
+    SUFFIXES = (".safetensors", ".gguf")
+
+    def __init__(self, cas: Any, manifest: Any, *, verify: bool = False) -> None:
+        self._cas = cas
+        self._manifest = manifest
+        self._verify = verify
+        self._open: list[Any] = []
+        self._entries = {
+            entry.path: entry
+            for entry in manifest.files
+            if entry.path.endswith(self.SUFFIXES)
+        }
+
+    def containers(self) -> Sequence[str]:
+        # Manifest order, which `RepositoryManifest` sorts by path — the same
+        # stable packaging order the native snapshot reports.
+        return tuple(self._entries)
+
+    def open(self, container: str, *, direct: bool = False) -> TensorStream:
+        from gen_worker._vendor.tensorfs.manifest import RepositoryManifest
+        from gen_worker._vendor.tensorfs.tensors import TensorReader
+
+        if direct:
+            raise WeightStoreUnavailable(
+                "io=direct needs the native reader's O_DIRECT open "
+                "(tensorfs#115); the interim bridge is buffered only"
+            )
+        entry = self._entries.get(container)
+        if entry is None:
+            raise WeightStoreUnavailable(
+                f"{container!r} is not a tensor container of this manifest"
+            )
+        reader = TensorReader(
+            self._cas,
+            RepositoryManifest(files=(entry,)),
+            verify=self._verify,
+        )
+        self._open.append(reader)
+        return _BridgeStream(reader, container)
+
+    def close(self) -> None:
+        for reader in self._open:
+            reader.close()
+        self._open.clear()
+
+
+def store_for(checkpoint_dir: Path | str) -> Optional[WeightStore]:
+    """The byte source backing a projected checkpoint tree, or ``None``.
+
+    ``None`` means the tree is not a snapshot this worker projected — a bare
+    HF download, a materialized directory, a fixture. There is no chunk store
+    behind it to stream from, so ``ctx.load`` has nothing to do here and the
+    caller keeps whatever path it had.
+
+    The resolution is the same one :mod:`gen_worker.models.projection` already
+    performs for every other consumer, so the engine needs no store handle
+    plumbed to it: the DIRECTORY the worker resolved carries its own store.
+    """
+    from ...models import projection
+
+    projected = projection.resolve_projection(checkpoint_dir)
+    if projected is None:
+        return None
+    return BridgeWeightStore(projected.cas, projected.manifest)
+
+
+def native_available() -> bool:
+    """True when a tensorfs carrying the #115 stream surface is importable.
+
+    Presence of the PACKAGE is not the question — pgw already resolves one
+    transitively through torchcg, pinned below #115. The question is whether
+    THIS build carries ``TensorStreamReader``, so the check asks for the
+    class rather than for the import.
+    """
+    try:
+        _native_stream_reader()
+    except (WeightStoreUnavailable, AttributeError):
+        return False
+    return True
+
+
+def containers_for(store: WeightStore, prefix: str) -> Iterator[str]:
+    """Every container of ``store`` under a checkpoint-relative directory."""
+    root = prefix.strip("/")
+    for path in store.containers():
+        if not root or path == root or path.startswith(root + "/"):
+            yield path
+
+
+def component_of(container: str) -> str:
+    """The pipeline component a container belongs to: its parent directory,
+    or ``""`` for a container at the checkpoint root (single-file pipelines)."""
+    parent = Path(container).parent
+    return "" if str(parent) == "." else str(parent)
+
+
+__all__ = [
+    "TENSOR_PLANNERS",
+    "BridgeWeightStore",
+    "NativeWeightStore",
+    "StreamedTensor",
+    "TensorStream",
+    "WeightStore",
+    "WeightStoreUnavailable",
+    "component_of",
+    "containers_for",
+    "native_available",
+    "store_for",
+]

--- a/src/gen_worker/serving/streaming/staging.py
+++ b/src/gen_worker/serving/streaming/staging.py
@@ -1,0 +1,187 @@
+"""Double-buffered staging: store bytes -> pinned host memory -> device.
+
+The pool is a small ring of large buffers. One buffer is being FILLED by the
+store's ``readinto`` (a blocking read that releases the GIL in Rust) while the
+others are being DRAINED by ``cudaMemcpyAsync`` on a dedicated copy stream.
+A CUDA event per buffer gates reuse, so a buffer is never refilled while its
+H2D is still in flight — that, and nothing else, is what makes the read and
+the copy overlap.
+
+Sizes: the default is 4 x 64 MiB. 64 MiB is the CAS object grid
+(tensorfs#81's contract-directed chunking splits a tensor every 64 MiB), so a
+window lines up with whole objects instead of straddling them, and 4 buffers
+is enough to keep a read in flight while three copies drain without pinning
+a gigabyte of host memory per load.
+
+The CPU arm is not a simulation of this — it is the SAME driver loop with a
+pageable pool and synchronous copies. Every ordering decision the engine makes
+(file-order windows, scatter, event gating) is therefore exercised by the
+CPU-side integration test, and only the ``cudaMemcpyAsync`` half is left for
+the pod benchmark to prove.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+logger = logging.getLogger(__name__)
+
+#: One staging buffer. A multiple of the 64 MiB CAS object grid.
+DEFAULT_BUFFER_BYTES = 64 * 1024 * 1024
+#: How many buffers ride the ring. Three is the minimum that keeps a read in
+#: flight behind two draining copies; four is the default headroom.
+DEFAULT_BUFFERS = 4
+
+
+class StagingError(RuntimeError):
+    """The staging pool could not be built or used as declared."""
+
+
+def _writable_view(tensor: "torch.Tensor") -> memoryview:
+    """A writable buffer-protocol view over a contiguous CPU uint8 tensor.
+
+    ``torch.Tensor`` exports no buffer protocol, and ``.numpy()`` would put
+    numpy on the base serving path, where this package deliberately carries
+    none. The address is stable for a pinned allocation and the tensor is
+    held by the slot that owns this view, so the view cannot outlive it.
+    """
+    import ctypes
+
+    count = tensor.numel()
+    block = (ctypes.c_ubyte * count).from_address(tensor.data_ptr())
+    return memoryview(block).cast("B")
+
+
+@dataclass(slots=True)
+class _Slot:
+    """One buffer plus the event that says when its last copy finished."""
+
+    index: int
+    tensor: "torch.Tensor"
+    view: memoryview
+    event: Optional[Any] = None
+
+
+class StagingPool:
+    """A ring of host buffers and the stream the copies ride.
+
+    ``pinned`` is a FACT about the pool, not a request: pinned memory needs a
+    CUDA context, so a CPU-destination load reports ``staging=pageable`` and
+    says so in telemetry rather than claiming a property it does not have.
+    """
+
+    def __init__(
+        self,
+        device: "torch.device",
+        *,
+        buffer_bytes: int = DEFAULT_BUFFER_BYTES,
+        buffers: int = DEFAULT_BUFFERS,
+    ) -> None:
+        import torch
+
+        if buffers < 2:
+            raise StagingError(
+                f"a staging pool of {buffers} buffer(s) cannot double-buffer; "
+                "the read and the copy would serialize"
+            )
+        if buffer_bytes <= 0:
+            raise StagingError("staging buffers must hold bytes")
+
+        self.device = device
+        self.buffer_bytes = int(buffer_bytes)
+        self.pinned = device.type == "cuda"
+        self._torch = torch
+        self._stream: Optional[Any] = (
+            torch.cuda.Stream(device=device)  # type: ignore[no-untyped-call]
+            if self.pinned
+            else None
+        )
+        self._slots: List[_Slot] = []
+        for index in range(buffers):
+            host = torch.empty(
+                self.buffer_bytes, dtype=torch.uint8, pin_memory=self.pinned
+            )
+            self._slots.append(
+                _Slot(index=index, tensor=host, view=_writable_view(host))
+            )
+        self._next = 0
+
+    # -- the ring ----------------------------------------------------------
+
+    def acquire(self) -> _Slot:
+        """The next buffer, once its previous copy has actually landed.
+
+        This wait is the whole gate. Without it the store would overwrite
+        bytes the device is still reading, and the corruption would be
+        nondeterministic and load-order dependent — the worst possible shape.
+        """
+        slot = self._slots[self._next]
+        self._next = (self._next + 1) % len(self._slots)
+        if slot.event is not None:
+            slot.event.synchronize()
+            slot.event = None
+        return slot
+
+    def copy_out(
+        self, slot: _Slot, src_offset: int, dst: "torch.Tensor", dst_offset: int, count: int
+    ) -> None:
+        """Enqueue ``count`` bytes of ``slot`` into a flat uint8 destination."""
+        source = slot.tensor[src_offset : src_offset + count]
+        target = dst[dst_offset : dst_offset + count]
+        if self._stream is None:
+            target.copy_(source)
+            return
+        with self._torch.cuda.stream(self._stream):
+            target.copy_(source, non_blocking=True)
+
+    def release(self, slot: _Slot) -> None:
+        """Mark every copy enqueued out of this buffer, so reuse can wait."""
+        if self._stream is None:
+            return
+        event = self._torch.cuda.Event()  # type: ignore[no-untyped-call]
+        event.record(self._stream)
+        slot.event = event
+
+    def track(self, tensor: "torch.Tensor") -> None:
+        """Tell the caching allocator this tensor is written on the copy
+        stream, not the stream it was allocated on. Skipping this is a
+        use-after-free the allocator hands out as a silently wrong tensor."""
+        if self._stream is not None:
+            tensor.record_stream(self._stream)
+
+    def finish(self) -> None:
+        """Block until every enqueued copy has landed, then make the compute
+        stream see them. Both halves are needed: the sync makes the bytes
+        real, the ``wait_stream`` makes the ordering visible to later work."""
+        if self._stream is None:
+            return
+        self._stream.synchronize()
+        self._torch.cuda.current_stream(self.device).wait_stream(self._stream)
+
+    def close(self) -> None:
+        self._slots.clear()
+
+    @property
+    def staging(self) -> str:
+        """The telemetry token: ``pinned`` or ``pageable``."""
+        return "pinned" if self.pinned else "pageable"
+
+    def __enter__(self) -> "StagingPool":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.finish()
+        self.close()
+
+
+__all__ = [
+    "DEFAULT_BUFFERS",
+    "DEFAULT_BUFFER_BYTES",
+    "StagingError",
+    "StagingPool",
+]

--- a/tests/streaming_fixture.py
+++ b/tests/streaming_fixture.py
@@ -1,0 +1,238 @@
+"""A real bf16 diffusers pipeline on disk — the article both pgw#1380 suites load.
+
+Real classes, real ``save_pretrained``, real safetensors. Nothing here is
+shaped to be convenient for the loader: ``text_encoder`` and ``text_encoder_2``
+share every parameter name (which is what a pipeline checkpoint looks like and
+what a globally-indexed reader collides on), and the weights are randomly
+initialized rather than filled, so a byte-equality assertion can actually see a
+wrong offset.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+
+def tiny_pipeline_class() -> type:
+    from diffusers import DiffusionPipeline
+
+    class TinyPipeline(DiffusionPipeline):
+        """A real ``DiffusionPipeline``: real components, real model_index."""
+
+        def __init__(self, unet: Any, vae: Any, text_encoder: Any,
+                     text_encoder_2: Any, scheduler: Any) -> None:
+            super().__init__()
+            self.register_modules(
+                unet=unet, vae=vae, text_encoder=text_encoder,
+                text_encoder_2=text_encoder_2, scheduler=scheduler,
+            )
+
+    return TinyPipeline
+
+
+def build_source(target: Path) -> type:
+    """Save a real bf16 pipeline to ``target`` and return its class."""
+    from diffusers import AutoencoderKL, DDIMScheduler, UNet2DConditionModel
+    from transformers import CLIPTextConfig, CLIPTextModel
+
+    torch.manual_seed(1380)
+    unet = UNet2DConditionModel(
+        sample_size=16, in_channels=4, out_channels=4, layers_per_block=1,
+        block_out_channels=(32, 64), norm_num_groups=4, cross_attention_dim=32,
+        attention_head_dim=4,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+    )
+    vae = AutoencoderKL(
+        in_channels=3, out_channels=3, latent_channels=4, norm_num_groups=4,
+        block_out_channels=(32,), down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+    )
+    text_config = CLIPTextConfig(
+        hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+        num_attention_heads=4, vocab_size=256, max_position_embeddings=32,
+        projection_dim=32,
+    )
+    pipeline_cls = tiny_pipeline_class()
+    pipeline = pipeline_cls(
+        unet=unet, vae=vae,
+        text_encoder=CLIPTextModel(text_config),
+        text_encoder_2=CLIPTextModel(text_config),
+        scheduler=DDIMScheduler(),
+    )
+    # bf16 on disk, so "dtype passthrough" is a claim with something to pass
+    # through: nothing in the engine names a dtype, and bf16 must come back
+    # bf16 without a `torch_dtype=` anywhere.
+    pipeline.to(torch.bfloat16)
+    pipeline.save_pretrained(str(target), safe_serialization=True)
+    for container in sorted(target.rglob("*.safetensors")):
+        scramble_offsets(container)
+    return pipeline_cls
+
+
+def scramble_offsets(path: Path) -> None:
+    """Rewrite a container so its HEADER order is not its OFFSET order.
+
+    ``safetensors`` writes tensors in header-key order, so a checkpoint saved
+    by the library has name order == offset order — and against such a file a
+    loader that walked in NAME order would look perfectly sequential. That is
+    the exact trap tensorfs#115 named ("assert order against a fixture whose
+    header order differs from offset order"), and without this the file-order
+    claim is untestable: a mutation that scrambles the walk stays green.
+
+    The header keys keep their sorted order; the BODY is laid out in reverse.
+    Both orders are legal safetensors — the format addresses by
+    ``data_offsets``, not by position — so the library still reads it, which
+    is what keeps the byte-equality control arm honest.
+    """
+    import struct
+
+    raw = path.read_bytes()
+    (size,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + size])
+    body = raw[8 + size :]
+
+    names = [key for key in header if key != "__metadata__"]
+    if len(names) < 2:
+        return
+    payloads = {
+        name: body[header[name]["data_offsets"][0] : header[name]["data_offsets"][1]]
+        for name in names
+    }
+    rebuilt = bytearray()
+    for name in reversed(names):
+        start = len(rebuilt)
+        rebuilt += payloads[name]
+        header[name]["data_offsets"] = [start, len(rebuilt)]
+    blob = json.dumps(header, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + bytes(rebuilt))
+
+
+def header_order_differs_from_offset_order(path: Path) -> bool:
+    """True when this container can witness a name-ordered walk."""
+    import struct
+
+    raw = path.read_bytes()
+    (size,) = struct.unpack("<Q", raw[:8])
+    header = json.loads(raw[8 : 8 + size])
+    ordered = [key for key in header if key != "__metadata__"]
+    offsets = [header[name]["data_offsets"][0] for name in ordered]
+    return offsets != sorted(offsets)
+
+
+def source_tensors(source: Path) -> Dict[str, Dict[str, Any]]:
+    """component -> {name: tensor}, read from the ORIGINAL files."""
+    from safetensors.torch import load_file
+
+    index = json.loads((source / "model_index.json").read_text())
+    found: Dict[str, Dict[str, Any]] = {}
+    for component, spec in index.items():
+        if component.startswith("_") or not isinstance(spec, list):
+            continue
+        directory = source / component
+        shards = sorted(directory.glob("*.safetensors")) if directory.is_dir() else []
+        if not shards:
+            continue
+        merged: Dict[str, Any] = {}
+        for shard in shards:
+            merged.update(load_file(str(shard)))
+        found[component] = merged
+    return found
+
+
+def assert_byte_equal(pipeline: Any, source: Path) -> int:
+    """Every parameter byte-equal to its source file. Returns the tensor count."""
+    checked = 0
+    for component, tensors in source_tensors(source).items():
+        module = getattr(pipeline, component)
+        live = dict(module.named_parameters(remove_duplicate=False))
+        live.update(dict(module.named_buffers(remove_duplicate=False)))
+        for name, want in tensors.items():
+            got = live.get(name)
+            assert got is not None, f"{component}/{name} never landed"
+            assert got.dtype == want.dtype, (
+                f"{component}/{name}: {want.dtype} on disk came back "
+                f"{got.dtype} — the loader converted, which is the store's job"
+            )
+            assert got.shape == want.shape
+            assert torch.equal(
+                got.reshape(-1).view(torch.uint8),
+                want.reshape(-1).view(torch.uint8),
+            ), f"{component}/{name} is not byte-equal to the source"
+            checked += 1
+    return checked
+
+
+class Lane:
+    """The minimum of a lane contract the engine reads: its dtype."""
+
+    dtype = torch.bfloat16
+
+
+# -- read tracing -----------------------------------------------------------
+
+
+class TracedStream:
+    def __init__(self, inner: Any, container: str,
+                 log: List[Tuple[str, int, int]]) -> None:
+        self._inner = inner
+        self._container = container
+        self._log = log
+
+    @property
+    def tensors(self) -> Any:
+        return self._inner.tensors
+
+    @property
+    def length(self) -> int:
+        return self._inner.length
+
+    def readinto(self, offset: int, length: int, buffer: Any) -> int:
+        self._log.append((self._container, int(offset), int(length)))
+        return self._inner.readinto(offset, length, buffer)
+
+
+class TracedStore:
+    """Records every byte range the engine asks the store for."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.reads: List[Tuple[str, int, int]] = []
+
+    def containers(self) -> Any:
+        return self._inner.containers()
+
+    def open(self, container: str, *, direct: bool = False) -> Any:
+        return TracedStream(
+            self._inner.open(container, direct=direct), container, self.reads
+        )
+
+    def assert_file_order(self) -> int:
+        """One forward pass per container, never a seek backwards.
+
+        Returns how many windows were read, so a caller can insist the walk
+        was actually multi-window — a single-window read is trivially ordered
+        and proves nothing about the ordering.
+        """
+        assert self.reads, "the engine read nothing"
+        per_container: Dict[str, List[Tuple[int, int]]] = {}
+        for container, offset, length in self.reads:
+            per_container.setdefault(container, []).append((offset, length))
+        for container, reads in per_container.items():
+            for (offset, length), (nxt, _) in zip(reads, reads[1:]):
+                assert nxt >= offset + length, (
+                    f"{container}: a read at {nxt} follows one ending at "
+                    f"{offset + length} — the walk is not in file order"
+                )
+        return len(self.reads)
+
+
+def write_bytes_now() -> int:
+    for line in Path("/proc/self/io").read_text().splitlines():
+        if line.startswith("write_bytes:"):
+            return int(line.split()[1])
+    raise AssertionError("/proc/self/io has no write_bytes")

--- a/tests/test_ctx_load_native_tensorfs_pgw1380.py
+++ b/tests/test_ctx_load_native_tensorfs_pgw1380.py
@@ -1,0 +1,190 @@
+"""pgw#1380 x tensorfs#115: the engine over the REAL native stream surface.
+
+The other suite proves the engine against the storage plane pgw carries today.
+This one proves it against the one it is DESIGNED for: the maturin extension's
+``ObjectStore`` + ``TensorStreamReader`` — ordered iteration as an API
+contract, ``readinto`` copying in Rust with the GIL released, and ``O_DIRECT``
+plumbed. No adapter code stands between them: ``TensorStreamReader`` satisfies
+the engine's ``TensorStream`` protocol structurally.
+
+The proof that the load really comes from the chunk store and not from a file
+is blunt: **every safetensors file is deleted after ingest**, and the pipeline
+loads anyway. Only ``model_index.json`` and the component configs remain, which
+is exactly the projected tree's shape (non-tensor files stay symlinks).
+
+Skipped until the tensorfs#57 wheel is a declared dependency of this package.
+It is not a hypothetical: run it with the wheel on the path and it is green.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors")
+native = pytest.importorskip(
+    "tensorfs.native",
+    reason="the tensorfs#57 wheel is not installed; tensorfs#115's native "
+           "stream surface is what this suite exercises",
+)
+
+from gen_worker.serving.streaming import NativeWeightStore, StreamingLoader  # noqa: E402
+from gen_worker.serving.streaming.skeleton import meta_survivors  # noqa: E402
+from streaming_fixture import (  # noqa: E402
+    Lane,
+    TracedStore,
+    build_source,
+    source_tensors,
+    write_bytes_now,
+)
+
+WINDOW = 4096
+
+
+def _admit(store: Any, path: Path) -> List[Any]:
+    """One file into the CAS, as its ordered record run — the TFM1 shape."""
+    _plan, admitted = store.admit_file(path)
+    return [native.FileRecord.data(item.digest, item.length) for item in admitted]
+
+
+@pytest.fixture(scope="module")
+def article(tmp_path_factory: pytest.TempPathFactory) -> Dict[str, Any]:
+    base = tmp_path_factory.mktemp("pgw1380-native")
+    source = base / "source-model"
+    pipeline_cls = build_source(source)
+    expected = source_tensors(source)
+
+    store = native.ObjectStore(base / "objects")
+    records: Dict[str, List[Any]] = {}
+    for container in sorted(source.rglob("*.safetensors")):
+        relative = container.relative_to(source).as_posix()
+        records[relative] = _admit(store, container)
+    assert records, "the fixture produced no tensor containers"
+
+    # THE PROOF: the bytes are only in the chunk store now.
+    for container in sorted(source.rglob("*.safetensors")):
+        container.unlink()
+
+    return {
+        "source": source,
+        "store": store,
+        "records": records,
+        "expected": expected,
+        "pipeline_cls": pipeline_cls,
+    }
+
+
+def _weight_store(article: Dict[str, Any]) -> NativeWeightStore:
+    return NativeWeightStore(article["store"], article["records"])
+
+
+def test_the_native_reader_loads_a_pipeline_with_no_tensor_file_on_disk(
+    article: Dict[str, Any]
+) -> None:
+    source: Path = article["source"]
+    assert not list(source.rglob("*.safetensors")), (
+        "a tensor file survived the fixture; the load could be reading it"
+    )
+
+    store = TracedStore(_weight_store(article))
+    loader = StreamingLoader(store, device="cpu", buffer_bytes=WINDOW, buffers=3)
+
+    before = write_bytes_now()
+    pipeline = loader.build(
+        article["pipeline_cls"], checkpoint_dir=source, lane=Lane()
+    )
+    written = write_bytes_now() - before
+
+    report = loader.last_report
+    assert report is not None
+    assert report.containers == 4
+    assert report.weights_streamed_bytes > 0
+
+    checked = 0
+    for component, tensors in article["expected"].items():
+        module = getattr(pipeline, component)
+        live = dict(module.named_parameters(remove_duplicate=False))
+        live.update(dict(module.named_buffers(remove_duplicate=False)))
+        for name, want in tensors.items():
+            got = live[name]
+            assert got.dtype == want.dtype
+            assert torch.equal(
+                got.reshape(-1).view(torch.uint8),
+                want.reshape(-1).view(torch.uint8),
+            ), f"{component}/{name} is not byte-equal to the ingested source"
+            checked += 1
+    assert checked > 100
+
+    for component in article["expected"]:
+        assert meta_survivors(getattr(pipeline, component)) == ()
+
+    windows = store.assert_file_order()
+    assert windows > 20
+    assert written < 1 << 20
+
+
+def test_the_native_readers_order_is_the_order_the_engine_walks(
+    article: Dict[str, Any]
+) -> None:
+    """``TensorStreamReader.tensors`` is ascending file offset BY CONTRACT
+    (tensorfs#115), which is what makes the engine's forward walk sequential
+    rather than merely monotonic-by-our-own-sort."""
+    store = _weight_store(article)
+    for container in store.containers():
+        offsets = [tensor.offset for tensor in store.open(container).tensors]
+        assert offsets == sorted(offsets), (
+            f"{container}: the native reader handed back header order, not "
+            f"file-offset order"
+        )
+
+
+def test_o_direct_is_plumbed_and_byte_identical_to_buffered(
+    article: Dict[str, Any]
+) -> None:
+    """``direct=True`` is the flagged variant the benchmark decides on
+    (e2e#1906): the default stays buffered, but the arm must exist and must
+    not change a single byte."""
+    loader = StreamingLoader(
+        _weight_store(article), device="cpu", io="direct",
+        buffer_bytes=WINDOW, buffers=3,
+    )
+    try:
+        pipeline = loader.build(
+            article["pipeline_cls"], checkpoint_dir=article["source"], lane=Lane()
+        )
+    except OSError as exc:  # tmpfs and friends refuse O_DIRECT outright
+        pytest.skip(f"this filesystem refuses O_DIRECT: {exc}")
+
+    report = loader.last_report
+    assert report is not None
+    assert report.io == "direct"
+    for component, tensors in article["expected"].items():
+        module = getattr(pipeline, component)
+        live = dict(module.named_parameters(remove_duplicate=False))
+        live.update(dict(module.named_buffers(remove_duplicate=False)))
+        for name, want in tensors.items():
+            assert torch.equal(
+                live[name].reshape(-1).view(torch.uint8),
+                want.reshape(-1).view(torch.uint8),
+            ), f"{component}/{name} differs between the direct and buffered arms"
+
+
+def test_the_native_reader_satisfies_the_engines_protocol(
+    article: Dict[str, Any]
+) -> None:
+    """Structural, not nominal: nothing adapts the extension to the engine.
+    If tensorfs renames a member, this is where it is caught rather than in a
+    load that half-works."""
+    from gen_worker.serving.streaming import TensorStream
+
+    store = _weight_store(article)
+    stream = store.open(next(iter(store.containers())))
+    assert isinstance(stream, TensorStream)
+    first = stream.tensors[0]
+    for member in ("name", "dtype", "shape", "offset", "nbytes"):
+        assert hasattr(first, member), f"StreamTensor lost {member}"

--- a/tests/test_ctx_load_streams_pgw1380.py
+++ b/tests/test_ctx_load_streams_pgw1380.py
@@ -1,0 +1,325 @@
+"""pgw#1380: ``ctx.load`` streams a checkpoint store->memory, writing nothing.
+
+No mocks anywhere. A REAL diffusers pipeline is built and ``save_pretrained``
+to real safetensors files; those files are ingested into a REAL chunked
+``LocalCAS``; the tree is projected exactly as the chokepoint projects it (so
+every tensor file in it is a POINTER STUB, not bytes); and the engine loads
+from the chunk store. What is asserted is what the ruling asked for:
+
+* every parameter is byte-equal to the source file's bytes;
+* the store is read in ASCENDING FILE OFFSET order, per container, over MANY
+  windows — proven by a read trace, because a scrambled walk is still correct
+  and merely slow, which is the regression that would otherwise hide forever;
+* the load writes ~zero bytes to disk (``/proc/self/io``);
+* nothing survives on ``meta``.
+
+The CUDA half (pinned staging, ``cudaMemcpyAsync`` on a copy stream, per-buffer
+events) rides the SAME driver loop this exercises — only the copy primitive
+differs — and its measurement is e2e#1906's, on a pod.
+
+The same engine over the REAL tensorfs stream surface (the tensorfs#115
+extension) is ``test_ctx_load_native_tensorfs_pgw1380.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors")
+
+from gen_worker._vendor.tensorfs import LocalCAS, project_snapshot  # noqa: E402
+from gen_worker.models.projection import REF_PREFIX, SNAPSHOTS_DIR  # noqa: E402
+from gen_worker.serving.streaming import (  # noqa: E402
+    BridgeWeightStore,
+    NameMismatch,
+    StreamingLoader,
+    engine_for,
+)
+from gen_worker.serving.streaming.skeleton import meta_survivors  # noqa: E402
+from streaming_fixture import (  # noqa: E402
+    Lane,
+    TracedStore,
+    assert_byte_equal,
+    build_source,
+    header_order_differs_from_offset_order,
+    write_bytes_now,
+)
+
+#: Small on purpose: the walk must span MANY windows, because a load that
+#: fits in one window is trivially in file order and proves nothing.
+WINDOW = 4096
+
+
+def _project(base: Path, source: Path, key: str) -> Path:
+    """Ingest into a real CAS and project the tree, the chokepoint's way."""
+    cas = LocalCAS(base)
+    manifest = cas.ingest_repository(source)
+    cas.compare_and_swap_ref(
+        REF_PREFIX + key, cas.store_manifest(manifest), expected=None
+    )
+    tree = base / SNAPSHOTS_DIR / key
+    project_snapshot(cas, manifest, tree)
+    return tree
+
+
+@pytest.fixture(scope="module")
+def article(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    base = tmp_path_factory.mktemp("pgw1380")
+    source = base / "source-model"
+    pipeline_cls = build_source(source)
+    tree = _project(base, source, key="b" * 64)
+    return {"base": base, "source": source, "tree": tree,
+            "pipeline_cls": pipeline_cls}
+
+
+def _cas_manifest(tree: Path) -> Tuple[Any, Any]:
+    from gen_worker.models import projection
+
+    projected = projection.resolve_projection(tree)
+    assert projected is not None
+    return projected.cas, projected.manifest
+
+
+# -- the acceptance ---------------------------------------------------------
+
+
+def test_the_fixture_can_actually_witness_a_scrambled_walk(
+    article: dict[str, Any]
+) -> None:
+    """The guard on the guard.
+
+    ``safetensors`` writes tensors in header-key order, so a library-saved
+    checkpoint has name order == offset order — and against one of those, a
+    loader walking in NAME order looks perfectly sequential and every
+    file-order assertion below passes on a lie. This is the assertion that
+    keeps the rest honest, and it is separate so a fixture that silently
+    stopped scrambling fails HERE, by name, rather than nowhere.
+    """
+    containers = sorted(article["source"].rglob("*.safetensors"))
+    assert containers
+    for container in containers:
+        assert header_order_differs_from_offset_order(container), (
+            f"{container.name}: header order IS offset order, so this "
+            f"fixture cannot tell a file-order walk from a name-order one"
+        )
+
+
+def test_ctx_load_streams_store_to_memory_writing_nothing(
+    article: dict[str, Any]
+) -> None:
+    tree: Path = article["tree"]
+    source: Path = article["source"]
+    pipeline_cls: type = article["pipeline_cls"]
+
+    # The tree really is stub-only: reading a weight file at its path yields
+    # a pointer, not weights. If this stops holding the rest proves nothing.
+    from gen_worker.models.projection import stub_at
+
+    stubs = [p for p in sorted(tree.rglob("*.safetensors")) if stub_at(p) is not None]
+    assert stubs, f"{tree} projected no pointer stubs — nothing to stream"
+
+    store = TracedStore(BridgeWeightStore(*_cas_manifest(tree)))
+    loader = StreamingLoader(store, device="cpu", buffer_bytes=WINDOW, buffers=3)
+
+    before = write_bytes_now()
+    pipeline = loader.build(pipeline_cls, checkpoint_dir=tree, lane=Lane())
+    written = write_bytes_now() - before
+
+    assert isinstance(pipeline, pipeline_cls)
+    report = loader.last_report
+    assert report is not None
+    assert report.weights_streamed_bytes > 0
+    assert report.staging == "pageable"  # no CUDA here; the fact is reported
+    assert report.io == "buffered"
+    assert report.containers == 4
+
+    # 1. BYTE EQUALITY, per parameter, against the source files.
+    assert assert_byte_equal(pipeline, source) > 100
+
+    # 2. NOTHING ON META.
+    for component in ("unet", "vae", "text_encoder", "text_encoder_2"):
+        assert meta_survivors(getattr(pipeline, component)) == ()
+
+    # 3. FILE ORDER, over many windows.
+    windows = store.assert_file_order()
+    assert windows > 20, (
+        f"only {windows} window(s) were read; a walk that fits in one window "
+        f"is ordered by accident and cannot witness a scrambled one"
+    )
+    assert report.windows == windows
+
+    # 4. ZERO DISK WRITES. Not "few files created": no bytes. A little slack
+    #    for the process's own logging/journal noise, orders of magnitude
+    #    below the weights a fill would have written.
+    assert written < 1 << 20, (
+        f"the streamed load wrote {written} bytes; the whole point of the "
+        f"2026-08-19 ruling is that it writes none"
+    )
+
+
+def test_every_container_is_read_end_to_end_exactly_once(
+    article: dict[str, Any]
+) -> None:
+    """The windows tile each container's data range: no gap (a tensor read
+    from nowhere) and no overlap (a byte paid for twice)."""
+    store = TracedStore(BridgeWeightStore(*_cas_manifest(article["tree"])))
+    loader = StreamingLoader(store, device="cpu", buffer_bytes=WINDOW, buffers=3)
+    loader.build(article["pipeline_cls"], checkpoint_dir=article["tree"], lane=Lane())
+
+    per_container: dict[str, list[tuple[int, int]]] = {}
+    for container, offset, length in store.reads:
+        per_container.setdefault(container, []).append((offset, length))
+    for container, reads in per_container.items():
+        cursor = reads[0][0]
+        for offset, length in reads:
+            assert offset == cursor, (
+                f"{container}: window starts at {offset}, previous ended at "
+                f"{cursor} — the walk is not a contiguous forward pass"
+            )
+            cursor = offset + length
+
+
+def test_the_engine_binds_off_the_projected_tree_alone(article: dict[str, Any]) -> None:
+    """A worker holding only the checkpoint DIRECTORY can bind the engine —
+    the projected tree carries its own chunk store."""
+    engine = engine_for(article["tree"], device="cpu")
+    assert engine is not None
+    pipeline = engine.build(
+        article["pipeline_cls"], checkpoint_dir=article["tree"], lane=Lane()
+    )
+    assert meta_survivors(pipeline.unet) == ()
+
+    from gen_worker.models import materialized_view
+
+    assert materialized_view.serving_streams_weights(), (
+        "binding the streaming engine must arm the no-fill defect signal"
+    )
+
+
+def test_a_tree_with_no_store_behind_it_binds_no_engine(tmp_path: Path) -> None:
+    bare = tmp_path / "bare-download"
+    bare.mkdir()
+    assert engine_for(bare, device="cpu") is None
+
+
+def test_an_unplaceable_name_refuses_instead_of_guessing(
+    article: dict[str, Any], tmp_path: Path
+) -> None:
+    """A container carrying a name the skeleton has no slot for is a
+    checkpoint the code does not match — a typed refusal, never a shrug."""
+    source = tmp_path / "source-model"
+    _copy_tree(article["source"], source)
+    _append_tensor(source / "vae" / "diffusion_pytorch_model.safetensors",
+                   "not_a_real_parameter")
+    tree = _project(tmp_path, source, key="c" * 64)
+
+    engine = engine_for(tree, device="cpu")
+    assert engine is not None
+    with pytest.raises(NameMismatch) as caught:
+        engine.build(article["pipeline_cls"], checkpoint_dir=tree, lane=Lane())
+    assert "not_a_real_parameter" in str(caught.value)
+
+
+def test_a_missing_name_refuses_rather_than_serving_meta(
+    article: dict[str, Any], tmp_path: Path
+) -> None:
+    """A tensor the checkpoint does not carry would serve uninitialized
+    memory on the first request. It refuses, naming the names."""
+    source = tmp_path / "source-model"
+    _copy_tree(article["source"], source)
+    victim = _drop_tensor(source / "vae" / "diffusion_pytorch_model.safetensors")
+    tree = _project(tmp_path, source, key="d" * 64)
+
+    engine = engine_for(tree, device="cpu")
+    assert engine is not None
+    with pytest.raises(NameMismatch) as caught:
+        engine.build(article["pipeline_cls"], checkpoint_dir=tree, lane=Lane())
+    assert "still on meta" in str(caught.value)
+    assert victim in str(caught.value)
+
+
+def test_a_load_reads_no_tensor_bytes_to_build_the_skeleton(
+    article: dict[str, Any]
+) -> None:
+    """Step 1 is configs only: the skeleton exists before a byte is read."""
+    from gen_worker.serving.streaming import skeleton
+
+    built = skeleton.build(article["pipeline_cls"], article["tree"])
+    assert set(built.modules) == {"unet", "vae", "text_encoder", "text_encoder_2"}
+    assert built.passthrough == ("scheduler",)
+    for module in built.modules.values():
+        assert meta_survivors(module), "a config-only build must hold NO weights"
+        assert all(
+            parameter.device.type == "meta" for parameter in module.parameters()
+        )
+
+
+def test_two_components_sharing_every_name_do_not_collide(
+    article: dict[str, Any]
+) -> None:
+    """``text_encoder`` and ``text_encoder_2`` are the same architecture and
+    share every parameter name, with DIFFERENT weights. Names are unique only
+    within a container, which is the only scope this engine resolves them in."""
+    engine = engine_for(article["tree"], device="cpu")
+    assert engine is not None
+    pipeline = engine.build(
+        article["pipeline_cls"], checkpoint_dir=article["tree"], lane=Lane()
+    )
+    first = dict(pipeline.text_encoder.named_parameters())
+    second = dict(pipeline.text_encoder_2.named_parameters())
+    assert set(first) == set(second)
+    differing = [
+        name for name in first
+        if not torch.equal(first[name], second[name])
+    ]
+    assert differing, (
+        "the two text encoders came back identical — one container's bytes "
+        "were served for both"
+    )
+
+
+# -- fixture surgery --------------------------------------------------------
+
+
+def _copy_tree(source: Path, target: Path) -> None:
+    import shutil
+
+    shutil.copytree(source, target)
+
+
+def _read_header(path: Path) -> Tuple[dict[str, Any], bytes]:
+    import struct
+
+    raw = path.read_bytes()
+    (size,) = struct.unpack("<Q", raw[:8])
+    return json.loads(raw[8 : 8 + size]), raw[8 + size :]
+
+
+def _write_container(path: Path, header: dict[str, Any], body: bytes) -> None:
+    import struct
+
+    blob = json.dumps(header, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + body)
+
+
+def _append_tensor(path: Path, name: str) -> None:
+    header, body = _read_header(path)
+    start = len(body)
+    body = body + bytes(range(16))
+    header[name] = {"dtype": "U8", "shape": [16], "data_offsets": [start, start + 16]}
+    _write_container(path, header, body)
+
+
+def _drop_tensor(path: Path) -> str:
+    header, body = _read_header(path)
+    victim = sorted(key for key in header if key != "__metadata__")[0]
+    header.pop(victim)
+    _write_container(path, header, body)
+    return victim


### PR DESCRIPTION
Closes the loader-engine half of pgw#1380, behind pgw#1382's `LoaderEngine` seam. **Based on `1382-model-split` (PR #954)** — retarget to `master` once that lands.

`self.pipe = ctx.load(StableDiffusionXLPipeline)` now means what the contract file says: no `torch_dtype=` (the lane contract IS the dtype), no `.to("cuda")` (placement is the worker's), and **no tensor file written or read at any point**.

## What landed — `gen_worker/serving/streaming/`

| module | what it owns |
|---|---|
| `skeleton.py` | `model_index.json` + configs → a genuine pipeline with every parameter on `meta`. Zero tensor bytes read. |
| `source.py` | The byte-source seam = the torch boundary. tensorfs#115's `TensorStreamReader` satisfies `TensorStream` **structurally** — no adapter code. `NativeWeightStore` (wheel) + `BridgeWeightStore` (the plane pgw carries today; dies with tensorfs#57). |
| `staging.py` | The buffer ring: pinned + `cudaMemcpyAsync` copy stream + one event per buffer on CUDA; the **same driver loop**, pageable and synchronous, off it. |
| `engine.py` | The **file-order** walk: the container's data range read forward once in windows, tensors scattered out of each. Never `load_state_dict`'s module order. |

Integration: `EndpointHost` binds the engine off the checkpoint tree it already resolved (a projected snapshot carries its own chunk store), `model_load` becomes the streaming span (`weights_streamed_bytes`, `weights_stream_gbps`, `staging=`, `io=`), and a `materialized_view` on a streaming serve pod now logs **ERROR as a DEFECT** rather than INFO as a burn-down row.

## Execution (velocity-mode acceptance)

Real 463 MiB bf16 container → real native tensorfs `ObjectStore` → 613 CAS objects → **source file deleted** → streamed:

- **10/10 runs byte-equal**, **10/10 with `/proc/self/io` write_bytes delta of exactly 0**
- buffered 0.48–0.95 GB/s, O_DIRECT 0.19–0.38 GB/s end-to-end; store `readinto` alone 0.89–1.11 GB/s
- shared box at load ~20, pageable staging, synchronous CPU copies — contention numbers. tensorfs#115 measured `readinto` at 6.4 GiB/s idle; **the pod is the real number (e2e#1906)**.

## Suites (13 tests, no mocks)

A real bf16 diffusers pipeline → real safetensors → real chunked CAS → projected to pointer stubs → loaded. Byte-equality per parameter, nothing on `meta`, a contiguous forward read trace over 100+ windows, zero disk writes. A second suite runs the same engine over the **real tensorfs#115 extension** with every safetensors file deleted after ingest, buffered and O_DIRECT.

Red-verified 5x: file-order→name-order **RED 5/5**, window scatter arithmetic **RED 5/5**, meta-survivor gate **RED 5/5**, unexpected-name gate **RED 5/5**; baseline GREEN 5/5. `mypy --strict` clean.

> The file-order mutation initially stayed **GREEN**: `safetensors` writes tensors in header-key order, so against a library-saved checkpoint a name-ordered walk looks perfectly sequential. The fixture now scrambles header order away from offset order (tensorfs#115's own bar) and carries its own guard test, so a fixture that silently stopped scrambling fails by name.

## What the e2e#1906 pod benchmark flips on

Nothing in this PR — the CUDA halves are live code, not stubs. On a CUDA host `StagingPool` allocates pinned buffers, opens a copy stream, and gates reuse on per-buffer events automatically; `engine_for(tree, device="cuda")` is the whole switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)