### PR TITLE
pgw#1370 fix-forward: the derive imported api.model_base, which pgw#1382 deleted

### DIFF
--- a/changelog.d/pgw1370-fixforward.md
+++ b/changelog.d/pgw1370-fixforward.md
@@ -1,0 +1,5 @@
+- **`gen-worker release derive` imports a module that no longer exists.** `_entrypoints` still
+  reached for `gen_worker.api.model_base.Model` after pgw#1382 moved the base to
+  `gen_worker.serving.model` — a function-local import, so nothing caught it until the command
+  ran, and then EVERY derive died at `ModuleNotFoundError` before reading a single entrypoint.
+  The module-level `Model` was already the right one; the stale local shadow is deleted.

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -308,7 +308,6 @@ _SLOT_ORDER = ("ctx", "payload", "model", "adapter")
 def _entrypoints(module: ModuleType, model_cls: type) -> list[_Entrypoint]:
     import msgspec
 
-    from ..api.model_base import Model
     from ..request_context import RequestContext
 
     out: list[_Entrypoint] = []


### PR DESCRIPTION
`release/derive.py::_entrypoints` carried a **function-local**
`from ..api.model_base import Model` after pgw#1382 (#954) moved the base to
`gen_worker.serving.model`. Function-local, so it survived import, mypy and every gate — and
then killed `gen-worker release derive` on its first real call:

```
ModuleNotFoundError: No module named 'gen_worker.api.model_base'
```

before it read a single entrypoint. The module-level `Model` (already imported from
`..serving.model` at the top of the file) is the right one; the stale local shadow is deleted.

Caught by RUNNING the command, not by a gate — which is the whole argument for the velocity-mode
acceptance discipline. Proven fixed the same way: the tiny config-only endpoint derives 4 graph
classes, default-parameter class first (`[2, 4, 64, 64]`), 4 artifacts in the CAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)