### PR TITLE
pgw#1387: discovery reads the pgw#1382 author surface — entrypoints[] manifest block, empty manifest fails the build

### DIFF
--- a/changelog.d/pgw1382-requires.md
+++ b/changelog.d/pgw1382-requires.md
@@ -1,0 +1,5 @@
+### Added
+- `Model[MT]` class headers take `requires={contract: "vram12g"}` — the ie#740
+  machine floor, per lane, statically extractable at publish. The release
+  derive records it on each lane contract, so a deployment is sized without
+  running author code. Omitting it leaves placement undeclared.

--- a/changelog.d/pgw1387.md
+++ b/changelog.d/pgw1387.md
@@ -1,0 +1,10 @@
+### Fixed
+- Discovery reads the pgw#1382 author surface. `@entrypoint` stamps
+  `__cozy_entrypoint__` and the v1 walk looked for `__gen_worker_endpoint__`, so a
+  v2 endpoint discovered zero functions, the builder warned and exited 0, and hub
+  admission refused the empty manifest after the image bake. The manifest now
+  carries an `entrypoints[]` block — payload/return schemas, ordered slots with
+  their kinds, and each model's lanes as tensorfs contract stamps with their
+  ie#740 floors.
+- A manifest that advertises nothing fails the BUILD. It was a warning the bake
+  outlived.

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -3,9 +3,7 @@ package, extract every ``@endpoint`` object, and emit the endpoint.lock
 manifest as TOML on stdout. Run as ``python -m gen_worker.discovery``.
 """
 
-import hashlib
 import inspect
-import json
 import sys
 import traceback
 import typing
@@ -45,6 +43,12 @@ from gen_worker.discovery.execution_lanes import (
 from gen_worker.discovery.heavy_deps import stub_missing_heavy_deps
 from gen_worker.discovery.names import slugify_name
 from gen_worker.discovery.project import load_project_config
+from gen_worker.discovery.entrypoints_v2 import (
+    assert_manifest_advertises_something,
+    discover_entrypoints,
+    entrypoints_block,
+)
+from gen_worker.discovery.schema import type_schema_and_hash
 from gen_worker.discovery.walk import EndpointImportError, find_endpoints
 from gen_worker.registry import extract_specs
 from .validation import validate_endpoint_lock
@@ -475,9 +479,7 @@ def _slot_to_manifest(
 
 def _schema_and_hash(t: type) -> Tuple[Dict[str, Any], str]:
     """Generate JSON schema and SHA256 hash for a msgspec type."""
-    schema = msgspec.json.schema(t)
-    raw = json.dumps(schema, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    return schema, hashlib.sha256(raw).hexdigest()
+    return type_schema_and_hash(t)
 
 
 def _assert_unique_function_names(functions: List[Dict[str, Any]]) -> None:
@@ -1142,6 +1144,14 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
         "execution_lanes": manifest_block(derived),
         "decode_set": decode_set_manifest_block(decode_set),
     }
+    # The pgw#1382 half (pgw#1387). Same heavy-dep stubbing as the v1 walk, so
+    # a torch-less manifest build sees the same declarations an in-image build
+    # does. The block is emitted only when the package HAS a v2 surface: a v1
+    # endpoint's manifest is byte-identical to what it was.
+    with stub_missing_heavy_deps(cfg.discovery_heavy_deps):
+        v2_rows = discover_entrypoints(cfg.main)
+    if v2_rows:
+        manifest["entrypoints"] = entrypoints_block(v2_rows)
     # The jobs block sits BESIDE functions, never inside it: one package may
     # carry both, publish once, submit as needed. A release with jobs and zero
     # functions is legal (th#2049).
@@ -1152,6 +1162,9 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     if preconditions:
         manifest["aot_preconditions"] = [
             row.manifest_row() for row in preconditions]
+    # A manifest that advertises nothing is a BUILD failure, never a warning
+    # the bake outlives (pgw#1387).
+    assert_manifest_advertises_something(manifest)
     return manifest
 
 

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -1,0 +1,211 @@
+"""Publish-time extraction for the pgw#1382 author surface.
+
+The v1 walk looks for ``__gen_worker_endpoint__``; ``@entrypoint`` stamps
+``__cozy_entrypoint__`` and ``Model[MT]`` stamps its class header. Nothing
+read the new attributes, so a v2 endpoint discovered ZERO functions, the
+builder warned and exited 0, and hub admission refused a manifest that
+declared neither ``functions[]`` nor ``jobs[]`` nine minutes later (pgw#1387).
+
+This module is that missing half. It emits the NEW manifest shape — an
+``entrypoints[]`` block whose rows carry the payload/return schemas, the
+ordered slots with their kinds, and each referenced model's LANES as tensorfs
+contract stamps with their ie#740 placement floors. It deliberately does NOT
+map onto the retired ``(execution_lane, artifact_contract, decoder,
+key_topologies)`` quant vocabulary: that shape describes the pre-pgw#1382
+world, and translating into it would make the new surface lie in the old
+words. The hub reads the new rows (th#2140/th#2133 already read release
+metadata).
+
+WIRE FIELD NAMES ARE A CROSS-REPO CONTRACT. Everything below is what the hub
+side must key on; changing a name here is a two-repo change.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Any, Dict, List, Set
+
+from .schema import type_schema_and_hash
+
+#: One manifest block, one version. Bumped only when a row's MEANING changes;
+#: additive fields do not bump it (lenient decode, pgw#1376's evolution rule).
+ENTRYPOINTS_BLOCK_VERSION = 1
+
+
+class EntrypointDiscoveryError(ValueError):
+    """A v2 endpoint package does not yield an extractable surface."""
+
+
+def _entrypoint_specs(module: Any) -> List[Any]:
+    from ..serving.entrypoints import ENTRYPOINT_ATTR
+
+    out: List[Any] = []
+    for name, value in vars(module).items():
+        spec = getattr(value, ENTRYPOINT_ATTR, None)
+        if spec is None:
+            continue
+        # Re-exports: only the DECLARING module owns the row, exactly as the
+        # v1 walk skips re-exported @endpoint objects.
+        if getattr(value, "__module__", None) != module.__name__:
+            continue
+        out.append(spec)
+    return out
+
+
+def _lane_rows(model_cls: type) -> List[Dict[str, Any]]:
+    """One row per declared lane: the tensorfs contract stamp plus the
+    ie#740 floor the class header declared for it, when it declared one."""
+    from ..serving import lane_handle, model_lanes, model_requires
+
+    requires = model_requires(model_cls)
+    rows: List[Dict[str, Any]] = []
+    for lane in model_lanes(model_cls):
+        stamp = lane_handle(lane)
+        row: Dict[str, Any] = {"contract": stamp}
+        floor = requires.get(stamp)
+        if floor is not None:
+            row["requires"] = floor.render()
+        rows.append(row)
+    return rows
+
+
+def _model_row(model_cls: type) -> Dict[str, Any]:
+    from ..serving import model_type
+
+    declared = model_type(model_cls)
+    lanes = _lane_rows(model_cls)
+    return {
+        "class": model_cls.__name__,
+        "module": model_cls.__module__,
+        "model_type": getattr(declared, "name", None) or declared.__name__,
+        "lanes": lanes,
+        # `lanes=()` is the author STATING eager-permanent, and after Paul's
+        # F3 narrowing (2026-08-20) that tier means external-binary runtimes
+        # only. It is a declaration, never an inference about the model.
+        "eager_permanent": not lanes,
+    }
+
+
+def _slot_row(slot: Any) -> Dict[str, Any]:
+    from ..serving.context import DistillationAdapter
+
+    row: Dict[str, Any] = {
+        "name": slot.name,
+        "kind": slot.kind,
+        "required": bool(slot.required),
+    }
+    if slot.kind == "model":
+        row["model_class"] = slot.annotation.__name__
+    else:
+        # The typed takeover guard is a WIRE fact: the hub refuses an envelope
+        # pick whose adapter row is not distillation-marked for this slot.
+        row["distillation"] = slot.annotation is DistillationAdapter
+    return row
+
+
+def _entrypoint_row(spec: Any) -> Dict[str, Any]:
+    payload_schema, payload_hash = type_schema_and_hash(spec.payload_type)
+    return_schema, return_hash = type_schema_and_hash(spec.return_type)
+    return {
+        "name": spec.name,
+        "module": spec.fn.__module__,
+        "python_name": spec.fn.__name__,
+        "payload_schema": payload_schema,
+        "payload_schema_hash": payload_hash,
+        "return_schema": return_schema,
+        "return_schema_hash": return_hash,
+        "slots": [_slot_row(slot) for slot in spec.slots],
+        "models": [_model_row(cls) for cls in spec.model_classes],
+    }
+
+
+def discover_entrypoints(main_module: str) -> List[Dict[str, Any]]:
+    """Walk ``main_module``'s top-level package; return the manifest
+    ``entrypoints`` rows. Empty list = this package has no v2 surface, which
+    is a legal answer for a v1 endpoint and NOT an error here — the
+    empty-manifest refusal belongs to the caller that knows about jobs and v1
+    functions too (:func:`assert_manifest_advertises_something`)."""
+    top_level = main_module.split(".", 1)[0]
+    try:
+        top = importlib.import_module(top_level)
+    except Exception as exc:
+        raise EntrypointDiscoveryError(
+            f"could not import endpoint package {top_level!r}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    modules: List[Any] = [top]
+    if hasattr(top, "__path__"):
+        for sub in pkgutil.walk_packages(top.__path__, prefix=top.__name__ + "."):
+            try:
+                modules.append(importlib.import_module(sub.name))
+            except Exception as exc:
+                # Same rule as the v1 walk (pgw#689): a module that fails to
+                # import silently drops entrypoints from the release.
+                raise EntrypointDiscoveryError(
+                    f"could not import endpoint submodule {sub.name!r} "
+                    f"(walking {top_level!r}): {type(exc).__name__}: {exc}"
+                ) from exc
+
+    rows: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    for module in modules:
+        for spec in _entrypoint_specs(module):
+            row = _entrypoint_row(spec)
+            key = f"{row['module']}.{row['python_name']}"
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(row)
+
+    names: Dict[str, str] = {}
+    for row in rows:
+        prior = names.get(row["name"])
+        if prior is not None:
+            raise EntrypointDiscoveryError(
+                f"two entrypoints both named {row['name']!r}: {prior} and "
+                f"{row['module']}.{row['python_name']} — the request envelope "
+                "routes by this name, so one would silently shadow the other"
+            )
+        names[row["name"]] = f"{row['module']}.{row['python_name']}"
+    rows.sort(key=lambda r: r["name"])
+    return rows
+
+
+def entrypoints_block(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {"v": ENTRYPOINTS_BLOCK_VERSION, "entrypoints": rows}
+
+
+def assert_manifest_advertises_something(manifest: Dict[str, Any]) -> None:
+    """A release that advertises NOTHING is a build failure, not a warning.
+
+    pgw#1387, measured: the builder printed "no functions discovered", exited
+    0, spent 9m20s baking, pushed, and only then did hub admission refuse with
+    "manifest declares neither functions[] nor jobs[]". The refusal is
+    correct; discovering it after the build is the defect. An endpoint that
+    advertises nothing cannot serve anything, so there is no shape of release
+    for which shipping it is the right answer.
+    """
+    functions = manifest.get("functions") or []
+    jobs = manifest.get("jobs") or []
+    entrypoints = (manifest.get("entrypoints") or {}).get("entrypoints") or []
+    if functions or jobs or entrypoints:
+        return
+    raise EntrypointDiscoveryError(
+        "this endpoint advertises NOTHING: discovery found no @entrypoint "
+        "functions (pgw#1382), no @endpoint functions and no @job functions. "
+        "A release with an empty manifest is refused at hub admission, so the "
+        "build stops here rather than after the image bake. Check that the "
+        "module named by [tool.gen_worker] main is the one carrying the "
+        "declarations, and that its decorators are gen_worker's."
+    )
+
+
+__all__ = [
+    "ENTRYPOINTS_BLOCK_VERSION",
+    "EntrypointDiscoveryError",
+    "assert_manifest_advertises_something",
+    "discover_entrypoints",
+    "entrypoints_block",
+]

--- a/src/gen_worker/discovery/schema.py
+++ b/src/gen_worker/discovery/schema.py
@@ -1,0 +1,24 @@
+"""The ONE payload/return schema rendering, shared by both manifest halves.
+
+A schema hash that differs between the v1 ``functions[]`` block and the v2
+``entrypoints[]`` block for the same struct would be a wire lie, so there is
+exactly one canonicalization and both call it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Tuple
+
+import msgspec
+
+
+def type_schema_and_hash(t: type) -> Tuple[Dict[str, Any], str]:
+    """JSON schema + its SHA256 over the canonical (sorted, tight) encoding."""
+    schema = msgspec.json.schema(t)
+    raw = json.dumps(schema, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return schema, hashlib.sha256(raw).hexdigest()
+
+
+__all__ = ["type_schema_and_hash"]

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -63,13 +63,24 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
             ok=False,
             errors=("endpoint lock missing 'functions' list",),
         )
-    if len(functions) == 0 and not (lock_dict.get("jobs") or ()):
+    v2 = (lock_dict.get("entrypoints") or {}).get("entrypoints") or ()
+    if len(functions) == 0 and not (lock_dict.get("jobs") or ()) and not v2:
         # Jobs-aware (pgw#1354): a jobs-only release is legal (th#2049) and
         # advertises 27 things, so the bare function count must not call it
-        # empty. Everything BELOW is function-shape by construction — slots,
-        # bindings, wire routes and compiled graphs are concepts a job does not
-        # declare (`_job_entry`) — so those walks stay functions-only.
-        warnings.append("no functions discovered (endpoint will advertise nothing)")
+        # empty. pgw#1382-aware (pgw#1387): so is an entrypoints-only release,
+        # and THAT is the shape a v2 endpoint has. Everything BELOW is
+        # function-shape by construction — slots, bindings, wire routes and
+        # compiled graphs are concepts a job does not declare (`_job_entry`) —
+        # so those walks stay functions-only.
+        #
+        # An ERROR, not a warning (pgw#1387): a release advertising nothing is
+        # refused at hub admission, so a warning here just relocates the
+        # failure to nine minutes after the image bake.
+        errors.append(
+            "this endpoint advertises NOTHING: no @entrypoint, @endpoint or "
+            "@job declarations were discovered, and hub admission refuses a "
+            "manifest that declares neither functions[] nor jobs[]"
+        )
 
     # Per-class accumulator for the "two methods slugify to the same route"
     # check. Keyed by class_name → {function_slug: python_name}. A second

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -60,6 +60,7 @@ from ..serving.model import (
     ModelDeclarationError,
     lane_handle,
     model_lanes,
+    model_requires,
 )
 from ..serving.model import model_type as _strict_model_type
 from .trace_context import (
@@ -1154,16 +1155,25 @@ def derive_release(
                 "traced_passes": len(payloads),
             }
 
+        requires = model_requires(cls)
         for lane in model_lanes(cls):
             lane_graphs = _derive_lane(
                 torchcg, cls, lane, plans, checkpoint_dir, warnings,
                 artifact_sink=artifact_sink,
             )
             lanes.append(lane_graphs)
-            lane_contracts[lane_graphs.contract] = {
+            entry: dict[str, Any] = {
                 "stamp": lane_graphs.contract,
                 "document": _contract_document(lane),
             }
+            # ie#740 placement floor for THIS lane, read off the class header
+            # (`requires=`). Absent = undeclared, and the platform default is
+            # what the deployment gets — the honest state, never an invented
+            # floor.
+            floor = requires.get(lane_graphs.contract)
+            if floor is not None:
+                entry["requires"] = floor.render()
+            lane_contracts[lane_graphs.contract] = entry
 
     graphs_document = torchcg.GraphSetDocument(closure=closure, lanes=tuple(lanes))
     payload_dict: dict[str, Any] = {

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -70,6 +70,7 @@ from .model import (
     ModelDeclarationError,
     lane_handle,
     model_lanes,
+    model_requires,
     model_type,
 )
 
@@ -112,5 +113,6 @@ __all__ = [
     "load_endpoint",
     "load_endpoint_module",
     "model_lanes",
+    "model_requires",
     "model_type",
 ]

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -25,6 +25,7 @@ typed skeleton, not a toolbox; nothing else goes on it without a Paul ruling.
 from __future__ import annotations
 
 import typing
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:  # keep the base import-weightless
@@ -36,6 +37,7 @@ MT = TypeVar("MT")
 #: read surface.
 MODEL_TYPE_ATTR = "__cozy_model_type__"
 LANES_ATTR = "__cozy_lanes__"
+REQUIRES_ATTR = "__cozy_requires__"
 
 
 class ModelDeclarationError(TypeError):
@@ -68,6 +70,50 @@ def lane_handle(lane: Any) -> str:
     )
 
 
+def _parse_requires(
+    cls: type, requires: Mapping[Any, Any], lanes: tuple[Any, ...] | None
+) -> dict[str, Any]:
+    """``requires={contract: "vram12g, sm80+"}`` -> ``{handle: LayoutRequirements}``.
+
+    Keyed by LANE, because what a deployment needs of a machine is a property
+    of the weight format it runs: the bf16 lane's VRAM floor is not the fp8
+    lane's. Values speak the ie#740 requirement grammar (``"vram12g"``,
+    ``"sm90+, vram80g"``, ``{"minimum": ..., "recommended": ...}``), parsed
+    HERE so the refusal names the author's own class header, and statically
+    extractable at publish so placement never has to run author code.
+    """
+    from ..models.tensor_layout_contract import parse_layout_requirements
+
+    where = f"{cls.__qualname__} requires="
+    if not isinstance(requires, Mapping):
+        raise ModelDeclarationError(
+            f"{where} must be a mapping of lane contract -> requirement, "
+            f"got {type(requires).__name__}"
+        )
+    if not requires:
+        raise ModelDeclarationError(
+            f"{where}{{}} declares nothing. Omit it to leave placement "
+            "UNDECLARED; an empty mapping is not a statement that this model "
+            "runs anywhere."
+        )
+    # `lanes=` omitted (None) means the canonical contract, resolved lazily —
+    # there is nothing to check the keys against yet. `lanes=()` IS a
+    # declaration, and every floor over it guards nothing.
+    declared = None if lanes is None else {lane_handle(lane) for lane in lanes}
+    out: dict[str, Any] = {}
+    for lane, value in requires.items():
+        handle = lane if isinstance(lane, str) else lane_handle(lane)
+        if declared is not None and handle not in declared:
+            raise ModelDeclarationError(
+                f"{where}[{handle!r}] guards a lane this model does not "
+                f"declare. Its lanes are {sorted(declared)} — add the "
+                "contract to lanes= or drop the requirement; a requirement "
+                "over nothing is never checked."
+            )
+        out[handle] = parse_layout_requirements(value, where=f"{where}[{handle!r}]")
+    return out
+
+
 def _declared_model_type(cls: type) -> type | None:
     """The ``X`` in ``class C(Model[X])`` — from ``__orig_bases__``, no
     author code executed. ``None`` for a still-generic intermediate."""
@@ -98,16 +144,32 @@ class Model(Generic[MT]):
             def load(self, ctx: LoadContext[SDXL]) -> None: ...
 
     ``lanes=`` omitted means one lane — the model type's canonical contract;
-    ``lanes=()`` states eager-permanent explicitly. ``__init__`` stays FREE
+    ``lanes=()`` states eager-permanent explicitly. ``requires=`` states what
+    each lane needs of the machine in the ie#740 grammar, keyed by the same
+    contract objects::
+
+        class SdxlModel(
+            Model[SDXL],
+            lanes=(contracts.SDXL_DIFFUSERS_BF16,),
+            requires={contracts.SDXL_DIFFUSERS_BF16: "vram12g"},
+        ): ...
+
+    Omitting it leaves placement UNDECLARED, and the platform's default floor
+    is what a deployment then gets. ``__init__`` stays FREE
     (no GPU, no weights): construction and loading are separate moments, and
     derive/introspection instantiate without weights.
     """
 
     __cozy_model_type__: ClassVar[Any] = None
     __cozy_lanes__: ClassVar[tuple[Any, ...] | None] = None
+    __cozy_requires__: ClassVar[dict[str, Any]] = {}
 
     def __init_subclass__(
-        cls, *, lanes: tuple[Any, ...] | None = None, **kwargs: Any
+        cls,
+        *,
+        lanes: tuple[Any, ...] | None = None,
+        requires: Mapping[Any, Any] | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init_subclass__(**kwargs)
         if Model in cls.__bases__ and _declared_model_type(cls) is None and not any(
@@ -139,6 +201,8 @@ class Model(Generic[MT]):
                     )
                 lane_handle(lane)
             cls.__cozy_lanes__ = tuple(lanes)
+        if requires is not None:
+            cls.__cozy_requires__ = _parse_requires(cls, requires, lanes)
 
     # -- lifecycle hooks (the load/unload contract, pgw#1382) ---------------
 
@@ -193,11 +257,22 @@ def model_lanes(cls: type) -> tuple[Any, ...]:
     return (canonical,)
 
 
+def model_requires(cls: type) -> dict[str, Any]:
+    """The model class's per-lane machine requirements — publish-time
+    extraction, ``{}`` when the header declares none (placement then falls to
+    the platform default, which is what ie#740's floors exist to replace)."""
+
+    model_type(cls)  # validates cls
+    return dict(getattr(cls, REQUIRES_ATTR, None) or {})
+
+
 __all__ = [
     "LANES_ATTR",
     "LaneContract",
     "MODEL_TYPE_ATTR",
     "Model",
+    "REQUIRES_ATTR",
+    "model_requires",
     "ModelDeclarationError",
     "lane_handle",
     "model_lanes",

--- a/tests/fixtures/serving_v2_endpoint/src/serving_v2_fixture/main.py
+++ b/tests/fixtures/serving_v2_endpoint/src/serving_v2_fixture/main.py
@@ -233,6 +233,12 @@ class SdxlModel(
     # A lane IS a tensorfs layout contract — an imported object carrying the
     # actual layout. Omitting lanes= means one lane: SDXL's canonical contract.
     lanes=(contracts.SDXL_DIFFUSERS_BF16, contracts.COZY_SDXL_FP8_ROWWISE),
+    # What each lane needs of the machine (ie#740 grammar). Per-lane because
+    # the fp8 lane both fits smaller and needs the newer decoder.
+    requires={
+        contracts.SDXL_DIFFUSERS_BF16: "vram12g",
+        contracts.COZY_SDXL_FP8_ROWWISE: "sm89+, vram8g",
+    },
 ):
     """The stateful half: weights, compile-marked modules, defaults. One
     instance per (checkpoint x lane), LRU-resident, single-flight."""

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -37,6 +37,7 @@ from gen_worker.serving import (
     lane_handle,
     load_endpoint,
     model_lanes,
+    model_requires,
     model_type,
 )
 
@@ -102,6 +103,13 @@ def test_fixture_imports_clean_and_extracts_the_declared_surface() -> None:
     ]
     assert len(lanes) == 2
 
+    # ie#740 placement floors, per lane, from the same header — statically
+    # extractable, so a deployment is sized without running author code.
+    assert {h: r.render() for h, r in model_requires(SdxlModel).items()} == {
+        "sdxl.diffusers-bf16@1": "vram12g",
+        "cozy.sdxl-fp8-rowwise@1": "sm89+, vram8g",
+    }
+
 
 def test_model_header_declarations_and_refusals() -> None:
     with pytest.raises(ModelDeclarationError, match=r"Model\[SDXL\]"):
@@ -129,6 +137,11 @@ def test_model_header_declarations_and_refusals() -> None:
     (canonical,) = model_lanes(OmittedLanes)
     assert canonical is SDXL.canonical_contract
     assert lane_handle(canonical) == "sdxl.diffusers-bf16@1"
+
+    # A floor over a lane this model does not declare guards nothing.
+    with pytest.raises(ModelDeclarationError, match="does not.*declare"):
+        class StrayFloor(Model[SDXL], lanes=(), requires={"sdxl.other@1": "vram8g"}):
+            pass
 
     # Cheap __init__: constructing a model does not load anything.
     instance = EagerPermanent()


### PR DESCRIPTION
The publish-time half of the Model/entrypoint split did not exist. `@entrypoint`
stamps `__cozy_entrypoint__`; the v1 walk looks for `__gen_worker_endpoint__`.

**Measured on the standing builder:** a v2 sdxl endpoint discovered ZERO
functions, the builder printed `no functions discovered`, **exited 0**, spent
9m20s baking and pushing, and hub admission then refused with *"manifest
declares neither functions[] nor jobs[]"*.

## What lands

- **`discovery/entrypoints_v2.py`** — the missing extraction half. Emits the NEW
  manifest shape: an `entrypoints[]` block whose rows carry payload/return
  schemas, the ordered slots with their kinds (`model` / `adapter` / `adapters`,
  with the distillation marker the hub's pick guard keys on), and each referenced
  model's LANES as tensorfs contract stamps with the ie#740 floors.

  It deliberately does **not** map onto the retired `(execution_lane,
  artifact_contract, decoder, key_topologies)` quant vocabulary — that shape
  describes the pre-pgw#1382 world, and translating into it would make the new
  surface lie in the old words. **Wire field names here are a cross-repo
  contract**; the hub side accepts the new rows (th#2140/th#2133 already read
  release metadata).

- **An empty manifest fails the BUILD.** It was a warning the bake outlived. The
  lock validator agrees and is v2-aware, so an entrypoints-only release is legal
  exactly as a jobs-only one is (th#2049).

- **`requires=`** — written on the #954 branch and missed its merge. The
  class-header kwarg the lane rows above read: `requires={contract: "vram12g"}`,
  parallel to `lanes=`, valued in ie#740's own requirement grammar, parsed at
  class definition so the refusal names the author's header.

- One schema canonicalization (`discovery/schema.py`) shared by both manifest
  halves — a schema hash that differed between blocks for the same struct would
  be a wire lie.

## Verification

- The **frozen sdxl contract file** (serverless-endpoints `v2-contract-files`,
  ie#449) extracts publishably: one entrypoint `generate`, slots
  `[(model, model), (turbo, adapter), (loras, adapters)]`, lanes
  `sdxl.diffusers-bf16@1` + `cozy.sdxl-fp8-rowwise@1`.
- A package with no declarations is **refused before any bake**.
- The v1 manifest path is byte-identical — the block is emitted only when a v2
  surface exists. 90 discovery/manifest tests green; mypy strict clean; every
  fence lint green.

Closes pgw#1387. Follow-ups in pgw#1388.