### PR TITLE
pgw#1370: the lane entry carries the producer's own document digest (th#2146 interlock)

### DIFF
--- a/changelog.d/pgw1370-contract-surface.md
+++ b/changelog.d/pgw1370-contract-surface.md
@@ -12,3 +12,8 @@
   parses the string; a lane that CLAIMS a document must produce a readable one (typed refusal —
   a stamp with an unreadable layout behind it is worse than no row), and a lane object exposing
   none at all travels stamp-only with a WARNING naming it, never silently.
+
+- **The lane entry carries the producer's OWN digest of that document** (`lane_contracts[…].digest`,
+  always `sha256:`-prefixed). The hub interns the layout and derives its own digest (th#2146);
+  carrying the producer's lets it ASSERT the two agree rather than trusting that a serialization
+  round-trip stayed canonical.

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -934,6 +934,21 @@ def _contract_document(
     return None
 
 
+def _contract_digest(lane: Any) -> str:
+    """The contract object's OWN digest of its layout document.
+
+    The hub interns the document and computes its own digest (th#2146); the
+    producer's digest travels beside it so a mismatch is an assertion rather
+    than a silent divergence in canonical serialization. Always the
+    ``sha256:``-prefixed spelling, whatever the object stores.
+    """
+
+    digest = getattr(lane, "digest", None)
+    if not isinstance(digest, str) or not digest:
+        return ""
+    return digest if digest.startswith("sha256:") else f"sha256:{digest}"
+
+
 def _resolve_lane(torchcg: ModuleType, cls: type, lane: Any) -> Any:
     """The resolved ``ctx.lane``: always a LaneRef with a REAL torch dtype.
 
@@ -1200,6 +1215,12 @@ def derive_release(
                 "document": _contract_document(
                     f"class {cls.__name__!r}", lane, warnings
                 ),
+                # The PRODUCER's own digest of that document. The hub interns
+                # the layout and derives its own digest (th#2146); carrying
+                # this lets it ASSERT the two agree instead of trusting a
+                # re-serialization round-trip. Empty when the lane object
+                # states none.
+                "digest": _contract_digest(lane),
             }
             # ie#740 placement floor for THIS lane, read off the class header
             # (`requires=`). Absent = undeclared, and the platform default is


### PR DESCRIPTION
Follow-on to #964, which made the lane's full tensorfs layout document actually travel
(it was emitting `"document": null`, and th#2146's hub cannot intern a null).

The hub interns that layout and derives its **own** digest. This carries the **producer's**
digest beside it — `lane_contracts[<stamp>].digest`, always `sha256:`-prefixed, read off the
`Contract` object — so a disagreement between the two is an **assertion**, not a silent
divergence in canonical serialization after a JSON round-trip.

Measured on the real sdxl contract file (PR #964's branch, before this commit):

```
stamp: sdxl.diffusers-bf16@1
document: 6 keys ['description','dtype','format','name','tensors','version'], 42 tensors
```

A lane object exposing no document at all (a `LaneRef` stand-in) still travels stamp-only with a
warning naming it, and `digest` is `""` — verified by running the tiny fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)