### PR TITLE
pgw#1370/#1371: the stored graph's digest is named `program` — the miner's contract, wired end to end

### DIFF
--- a/changelog.d/pgw1370-program-field.md
+++ b/changelog.d/pgw1370-program-field.md
@@ -1,0 +1,7 @@
+- **The stored graph's digest is named `program`, because that is what the miner reads.** pgw#962
+  landed the runtime mint reading `PROGRAM_DIGEST_FIELD = "program"` off each `GraphRecord` and
+  raising a typed `MissingProgramDigest` for any hole without one; the derive side had shipped the
+  same field spelled `artifact`. The two halves of the blob-in design could not meet — every hole
+  would have refused. The consumer is landed and the NAME is the contract, so the producer follows
+  it (torchcg tcg#50), and the vendored `GraphRecord` the serving side decodes gains the field
+  too. Pre-launch hardcut: no alias, no transitional acceptance of the old key.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -690,7 +690,7 @@ torchvision = [
   { index = "pytorch-cu130", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 # pgw#1370: dev-only (see the dev extra) — release envs pin their own torchcg.
-torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "6da868ae421ba2a8dc56644e1e87fecaa6ac997d" }
+torchcg = { git = "https://github.com/cozy-creator/torchcg", rev = "ad39909303554ffb1c3cbaf2a98d5c89f627219b" }
 # Saying which pins were deleted requires naming them.
 # retired-name: historical rationale, not a live reference.
 # pgw#1310 deleted the `hashrepo` / `torch-compiled-graphs` git pins that stood

--- a/src/gen_worker/_vendor/torchcg/document.py
+++ b/src/gen_worker/_vendor/torchcg/document.py
@@ -24,7 +24,7 @@ from .lane import LaneError, require_contract_ref, require_targets
 DOCUMENT_FORMAT = 1
 _DOCUMENT_FIELDS = frozenset(("v", "closure", "lanes"))
 _LANE_FIELDS = frozenset(("contract", "targets", "graphs", "unobserved_targets"))
-_GRAPH_FIELDS = frozenset(("graph", "target", "ingress"))
+_GRAPH_FIELDS = frozenset(("graph", "target", "ingress", "program"))
 
 
 class DocumentError(ValueError):
@@ -38,6 +38,13 @@ class GraphRecord:
     graph: str
     target: str
     ingress: CallIngress
+    #: CAS digest of this graph class's SERIALIZED ExportedProgram. The NAME
+    #: is the contract with the mint lane, which reads it as
+    #: ``PROGRAM_DIGEST_FIELD = "program"`` (pgw#962) and raises
+    #: ``MissingProgramDigest`` on an empty one. Produced by the publish
+    #: derive (pgw#1370); the miner downloads the blob and runs inductor on
+    #: it rather than re-tracing author code.
+    program: str = ""
 
     def __post_init__(self) -> None:
         if not is_graph_hash(self.graph):
@@ -46,12 +53,15 @@ class GraphRecord:
             raise DocumentError("graph record must name its target module path")
         if not isinstance(self.ingress, CallIngress):
             raise DocumentError("graph record must carry its CallIngress contract")
+        if not isinstance(self.program, str):
+            raise DocumentError("graph program digest must be a string")
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "graph": self.graph,
             "target": self.target,
             "ingress": self.ingress.as_dict(),
+            "program": self.program,
         }
 
 
@@ -214,6 +224,7 @@ class GraphSetDocument:
                         graph=raw_record["graph"],
                         target=raw_record["target"],
                         ingress=ingress,
+                        program=raw_record["program"],
                     )
                 )
             lanes.append(

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -144,7 +144,7 @@ def _hollow() -> ModuleType:
     return importlib.import_module("torchcg.hollow")
 
 
-def _graph_artifact_sink(cas_root: Optional[Path]) -> Optional[Any]:
+def _program_sink(cas_root: Optional[Path]) -> Optional[Any]:
     """Store each discovered graph's SERIALIZED ExportedProgram in the CAS.
 
     Paul's ruling (2026-08-20): the derive keeps THE WHOLE TRACED GRAPH, not
@@ -968,7 +968,7 @@ def _derive_lane(
     plans: list[tuple[_Entrypoint, tuple[Any, ...]]],
     checkpoint_dir: Path,
     warnings: list[str],
-    artifact_sink: Optional[Any] = None,
+    program_sink: Optional[Any] = None,
 ) -> Any:
     """One lane's instrumented runs, merged across defaults variants.
 
@@ -1097,7 +1097,7 @@ def _derive_lane(
 
             try:
                 lane_graphs = torchcg.discover_modules(
-                    handle, modules, drive, artifact_sink=artifact_sink
+                    handle, modules, drive, program_sink=program_sink
                 )
                 if set(lane_graphs.targets) - {
                     record.target for record in lane_graphs.graphs
@@ -1107,7 +1107,7 @@ def _derive_lane(
                     # before calling it unobserved.
                     request_ctx.step_budget = None
                     lane_graphs = torchcg.discover_modules(
-                        handle, modules, drive, artifact_sink=artifact_sink
+                        handle, modules, drive, program_sink=program_sink
                     )
             except DeriveError:
                 raise
@@ -1152,7 +1152,7 @@ def derive_release(
     """Derive the release metadata document for one endpoint module."""
 
     torchcg = _torchcg()
-    artifact_sink = _graph_artifact_sink(graph_cas)
+    program_sink = _program_sink(graph_cas)
 
     if lockfile is not None:
         closure = torchcg.closure_hash(_closure_entries_from_lockfile(lockfile))
@@ -1192,7 +1192,7 @@ def derive_release(
         for lane in model_lanes(cls):
             lane_graphs = _derive_lane(
                 torchcg, cls, lane, plans, checkpoint_dir, warnings,
-                artifact_sink=artifact_sink,
+                program_sink=program_sink,
             )
             lanes.append(lane_graphs)
             entry: dict[str, Any] = {

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ requires-dist = [
 provides-extras = ["torch", "vision", "images", "audio", "video", "signing", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=6da868ae421ba2a8dc56644e1e87fecaa6ac997d" }]
+dev = [{ name = "torchcg", git = "https://github.com/cozy-creator/torchcg?rev=ad39909303554ffb1c3cbaf2a98d5c89f627219b" }]
 
 [[package]]
 name = "gguf"
@@ -2235,7 +2235,7 @@ wheels = [
 [[package]]
 name = "torchcg"
 version = "0.1.0"
-source = { git = "https://github.com/cozy-creator/torchcg?rev=6da868ae421ba2a8dc56644e1e87fecaa6ac997d#6da868ae421ba2a8dc56644e1e87fecaa6ac997d" }
+source = { git = "https://github.com/cozy-creator/torchcg?rev=ad39909303554ffb1c3cbaf2a98d5c89f627219b#ad39909303554ffb1c3cbaf2a98d5c89f627219b" }
 dependencies = [
     { name = "safetensors" },
     { name = "tensorfs" },


### PR DESCRIPTION
pgw#962 landed the runtime mint reading `PROGRAM_DIGEST_FIELD = "program"` off each `GraphRecord`
and raising a typed `MissingProgramDigest` for any hole without one. The derive side had shipped
the same field spelled **`artifact`** — so the two halves of the blob-in design could not meet and
**every hole would have refused**.

The consumer is landed and the NAME is the contract, so the producer follows it:

- torchcg **tcg#50** (`e1b2a31`) renames `GraphRecord.artifact` → `.program`;
  **tcg#51** (`ad39909`) renames `artifact_sink` → `program_sink`. Repinned here.
- The **vendored** `GraphRecord` that the serving side decodes gains the field, so a real release
  document round-trips through the vendored decoder into the miner.
- Pre-launch hardcut: no alias, no transitional acceptance of the old key.

Proven by executing the whole seam, not by reading it:

```
emitted keys per graph: ['graph', 'ingress', 'program', 'target']
vendored decode ok; field: program
miner reads: sha256:9fdb340e917d5065941df6d7394572bf8bd18d513f2be07c48ef72b7ab5ef30a
```

With this and #964 (the lane's full tensorfs layout document, which the hub interns), both halves
the publish+mint chain was waiting on are delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)