### PR TITLE
pgw#1389: a SUCCESSFUL v2 build no longer warns that it found nothing

### DIFF
--- a/changelog.d/pgw1389-v2-warning.md
+++ b/changelog.d/pgw1389-v2-warning.md
@@ -1,0 +1,15 @@
+### A successful v2 build warned that it had found nothing (pgw#1389)
+
+`validate_endpoint_lock` learned `entrypoints[]` (th#2146) and folds it into
+`functions` at its one site. `discover.py`'s second, standalone emptiness check
+did not, so every SUCCESSFUL v2 build printed
+
+    warning: no @endpoint or @job objects found
+
+over a manifest that declares its entrypoints perfectly well. The wording was
+wrong twice over: `@endpoint` is precisely the surface v2 replaced, so the line
+named the OLD decorator as missing while the NEW one was present and discovered.
+
+Measured on the standing builder: a v2 sdxl publish emitted it, and the same
+build admitted. A false alarm on the success path is not free — the pgw#1387
+investigation started from exactly these two warning lines.

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -1248,8 +1248,18 @@ def main() -> None:
     if not val.ok:
         _fail_build_input(*(f"error: {err}" for err in val.errors))
 
-    if not manifest.get("functions") and not manifest.get("jobs"):
-        print("warning: no @endpoint or @job objects found", file=sys.stderr)
+    # th#2146/pgw#1387: `entrypoints[]` counts. `validate_endpoint_lock` folds it
+    # into `functions` at its own one site, so it went quiet for a v2 release —
+    # this second, standalone check did not, and every SUCCESSFUL v2 build
+    # printed "no @endpoint or @job objects found" over a manifest that declares
+    # its entrypoints perfectly well. The wording is also now wrong: `@endpoint`
+    # is the surface v2 replaced, so the line named the OLD decorator as missing
+    # while the NEW one was present and discovered.
+    if not any(manifest.get(k) for k in ("functions", "entrypoints", "jobs")):
+        print(
+            "warning: no @entrypoint, @endpoint or @job objects found",
+            file=sys.stderr,
+        )
 
     sys.stdout.write(msgspec.toml.encode(_strip_none(manifest)).decode("utf-8"))
     if not sys.stdout.isatty():


### PR DESCRIPTION
Found while driving the se#751 sdxl endpoint through publish on the standing builder (e2e#1910, round 2).

## The bug

th#2146 taught `validate_endpoint_lock` that `entrypoints[]` is `functions[]`' successor spelling, and it folds the two at its one site — with a comment explaining that not folding *"scores every v2 release as empty."*

`discover.py` carried a **second, standalone** emptiness check that was not folded:

```python
if not manifest.get("functions") and not manifest.get("jobs"):
    print("warning: no @endpoint or @job objects found", file=sys.stderr)
```

So every **successful** v2 build prints it, over a manifest that declares its entrypoints perfectly well.

The wording is wrong twice over: `@endpoint` is precisely the surface v2 replaced, so the line names the **old** decorator as missing while the **new** one is present and discovered.

## Measured

A v2 sdxl publish on the standing builder:

```
#18 14.00 warning: no @endpoint or @job objects found
#18 DONE 14.8s
```

…and that release **admitted**. Note what is no longer there: `validate_endpoint_lock`'s `no functions discovered` warning, which correctly went quiet. One of the two checks learned the new key; the other did not.

## Why it is worth a commit

In round 1 of this journey these two warning lines were the *entire* visible symptom of pgw#1387 — a v2 endpoint discovering zero functions and the builder spending 9m20s before the hub refused. A false alarm on the success path is the same line lying in the other direction, and the next reader has no way to tell them apart.

The check now asks about all three keys and names the surface an author on this SDK actually writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)