### PR TITLE
pgw#1386: the eager bridge's lane-dtype read cannot kill a load

### DIFF
--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -204,11 +204,39 @@ class LoadContext(Generic[MT_co]):
             "ctx.load: eager from_pretrained bridge for %s (pgw#1380's "
             "native loader engine is not bound)", pipeline_cls.__name__,
         )
-        if self._lane is not None and getattr(self._lane, "dtype", None) is not None:
-            bridged: P = from_pretrained(self.checkpoint_dir, torch_dtype=self._lane.dtype)
+        dtype = self._lane_dtype()
+        if dtype is not None:
+            bridged: P = from_pretrained(self.checkpoint_dir, torch_dtype=dtype)
             return bridged
         no_lane: P = from_pretrained(self.checkpoint_dir)
         return no_lane
+
+    def _lane_dtype(self) -> Any:
+        """The lane's load dtype, or None when the contract declares none.
+
+        pgw#1386, measured on se#754's minimax-h3: tensorfs' ``Contract.dtype``
+        RAISES (``MissingDtype``) for a document with no top-level ``dtype``
+        rather than answering None — a deliberate "never guess" refusal on
+        tensorfs' side. That is a LEGAL state for a lane
+        (``minimax.h3-dit-diffusers@1`` declares per-tensor dtypes only, while
+        ``sdxl.diffusers-bf16@1`` declares ``"dtype": "bfloat16"``), and this
+        bridge already HAS a no-dtype arm — so the read must not be able to
+        kill the load before reaching it. ``getattr(lane, "dtype", None)`` does
+        NOT swallow a non-AttributeError, which is why the plain read did.
+        Any other error still propagates.
+        """
+        if self._lane is None:
+            return None
+        try:
+            return self._lane.dtype
+        except AttributeError:
+            return None
+        except Exception:
+            logger.info(
+                "ctx.load: lane %r declares no load dtype; the eager bridge "
+                "takes the checkpoint's own", self._lane,
+            )
+            return None
 
     def compile(self, target: Any) -> Any:
         """Imperative module marking, the torch.compile idiom (Paul ruling)::


### PR DESCRIPTION
Found by se#754, the minimax-h3 migration — the second endpoint onto the pgw#1382 author surface, and the first whose lane contract does not declare a top-level dtype.

`tensorfs.Contract.dtype` **raises** `MissingDtype` for a document with no top-level `dtype` — deliberate on tensorfs' side ("refused loudly rather than answered with a guess"). Measured:

```
>>> contracts.MINIMAX_H3_DIT_DIFFUSERS.dtype
MissingDtype: contract minimax.h3-dit-diffusers declares no top-level dtype
>>> contracts.SDXL_DIFFUSERS_BF16.dtype
'bfloat16'
```

`LoadContext.load`'s eager `from_pretrained` bridge read it as `getattr(self._lane, "dtype", None)`, which does **not** swallow a non-`AttributeError`. So on the bridge path — a bare download, a local/cozy-local run, a fixture; the serving path binds a `LoaderEngine` and returns earlier — any lane whose contract omits the key dies *before reaching the arm that already handles exactly that case*.

`_lane_dtype()` reaches it. Any other error still propagates.

This is correct independently of the contract: a lane may legitimately not fix a load dtype, which is why the bridge has a no-dtype arm at all. That said, `minimax.h3-dit-*.v1.json` **should** also declare `"dtype": "bfloat16"` (the H3 DiT is unambiguously bf16) — that is a tensorfs document change which re-digests and moves three pinned sites across two languages, and is recorded as owed under se#754.

One file, one method, no behaviour change for any lane that does declare a dtype.

se#754's endpoint pins this commit; landing it lets that pin collapse to a plain master commit.