### PR TITLE
pgw#1387: pin the lane-handle wire agreement against the SHIPPED Contract shape

### DIFF
--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -138,6 +138,38 @@ def test_model_header_declarations_and_refusals() -> None:
     assert canonical is SDXL.canonical_contract
     assert lane_handle(canonical) == "sdxl.diffusers-bf16@1"
 
+    # The SHIPPED tensorfs Contract's attribute shape: `stamp` + `digest`,
+    # and NO `contract` (tensorfs#111). Every stand-in above spells `contract`,
+    # which short-circuits before `digest` is ever reached — so none of them
+    # can catch the defect that actually shipped: reading the bare 64-hex
+    # `digest` as the handle, which put `f1455f56…` where
+    # `sdxl.diffusers-bf16@1` belonged and made torchcg refuse the lane. This
+    # is the producer half of a cross-repo wire agreement, so the shape is
+    # pinned here rather than left to the one consumer that noticed.
+    class ShippedContract:
+        __slots__ = ("digest", "dtype", "name", "stamp", "version")
+
+        def __init__(self) -> None:
+            self.name = "sdxl.diffusers-bf16"
+            self.version = 1
+            self.stamp = "sdxl.diffusers-bf16@1"
+            self.digest = "f1455f56321d1f268772912c223170f015564ac0" + "0" * 24
+            self.dtype = None
+
+    assert lane_handle(ShippedContract()) == "sdxl.diffusers-bf16@1"
+
+    # A digest-only object still yields a STAMP, never a bare hex string:
+    # an anonymous custom contract's digest IS its stamp (tensorfs#112's third
+    # Stamp arm), and that spelling carries the `sha256:` prefix.
+    class AnonymousContract:
+        __slots__ = ("digest", "dtype")
+
+        def __init__(self) -> None:
+            self.digest = "a" * 64
+            self.dtype = None
+
+    assert lane_handle(AnonymousContract()) == "sha256:" + "a" * 64
+
     # A floor over a lane this model does not declare guards nothing.
     with pytest.raises(ModelDeclarationError, match="does not.*declare"):
         class StrayFloor(Model[SDXL], lanes=(), requires={"sdxl.other@1": "vram8g"}):


### PR DESCRIPTION
The `.stamp` ruling is **already satisfied at HEAD** — it landed in #964
(`9c365bc6`), and it is strictly stronger than requested: `stamp` leads,
`contract` is retained, `name`+`version` is a structural fallback, and `digest`
is only ever used **prefixed** (`sha256:<hex>`), which makes it a valid stamp
rather than a bare digest. Nothing to re-fix.

## Verified end-to-end, not by inspection

Against the **real** `tensorfs.contract.Contract` and the **merged** sdxl
endpoint (`se#751`, `main_v2.py` IS `main.py`):

```
type   : tensorfs.contract.Contract
stamp  : 'sdxl.diffusers-bf16@1'
digest : 'f1455f56321d1f268772912c223170f01556...'
has .contract attr: False
lane_handle -> 'sdxl.diffusers-bf16@1'      ← the stamp, not the digest

discovery on the merged sdxl endpoint:
  layouts             : {"pipeline": ["sdxl.diffusers-bf16@1"]}
  layout_requirements : {"sdxl.diffusers-bf16@1": {"min_vram_gb": 12.0}}
```

The release derive reads the same `lane_handle`, so `lane_contracts[].stamp`
carries the stamp too. `derive._contract_digest` is a *separate, deliberate*
field — the producer's digest travelling beside the document so a mismatch is
an assertion rather than silent divergence (th#2146) — and is always prefixed.

## What this PR actually adds: the missing guard

**Every lane stand-in in the suite spells `contract`**, which short-circuits
before `digest` is ever reached. The shipped `Contract` spells `stamp` +
`digest` and has **no** `contract`. So the pre-existing assertion
`lane_handle(canonical) == "sdxl.diffusers-bf16@1"` passes happily against the
*pre-fix* code — it could never have caught this. That is how the defect
shipped, and how it would regress.

**Red-proofed:** reverting `lane_handle` to the old `("contract", "digest")`
order leaves the old assertion GREEN and fails only the new one, with the exact
reported symptom:

```
E  AssertionError: assert 'f1455f56321d...0000000000000' == 'sdxl.diffusers-bf16@1'
```

Two cases pinned: the shipped shape resolves to its stamp, and a digest-only
anonymous contract still yields a **stamp** (`sha256:<hex>`, tensorfs#112's
third Stamp arm), never a bare hex string.

Suite 5x green; mypy strict clean; ruff and every fence lint green.