### PR TITLE
pgw#1380: the production serve path actually SELECTS the native reader

### DIFF
--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -405,15 +405,8 @@ gen_worker.worker_goals.install()
 gen_worker.mint_process.build_request()
 gen_worker.mint_process.run_mint()
 
-# pgw#1380's native tensorfs weight source — the chunk-store->VRAM path lands
-# behind LoadContext's LoaderEngine seam, and until the vendored tensorfs
-# store ships on the pod the serve path still takes the eager bridge, so
-# nothing in src/ reaches these three yet.
-#     OWNER:  pgw#1380's follow-up — wire `native_available()` into the
-#             LoaderEngine selection on the serve host so the native store is
-#             the default source when the vendored tensorfs is present.
-#     EXPIRY: the first deploy that loads a checkpoint through the native
-#             store. All three lines come out together.
-gen_worker.serving.streaming.source.NativeWeightStore
-gen_worker.serving.streaming.source.containers_for()
-gen_worker.serving.streaming.source.native_available()
+# pgw#1380's native weight source came out of this file on 2026-08-18: the
+# follow-up the OWNER row named is done — `store_for` calls `native_available()`
+# and constructs `NativeWeightStore`, so both are reached from src/. The third
+# line, `containers_for()`, was reached by nothing anywhere and was deleted
+# rather than re-baselined. All three came out together, as the row said.

--- a/src/gen_worker/serving/streaming/__init__.py
+++ b/src/gen_worker/serving/streaming/__init__.py
@@ -61,6 +61,11 @@ def engine_for(
     from ...models import materialized_view
 
     materialized_view.no_fill_serving(True)
+    logger.info(
+        "ctx.load: streaming %s through the %s byte source",
+        checkpoint_dir,
+        getattr(store, "KIND", type(store).__name__),
+    )
     return StreamingLoader(store, device=device, io=io)
 
 

--- a/src/gen_worker/serving/streaming/engine.py
+++ b/src/gen_worker/serving/streaming/engine.py
@@ -78,6 +78,9 @@ class LoadReport:
 
     weights_streamed_bytes: int = 0
     weights_stream_gbps: float = 0.0
+    #: Which byte source produced the number above — ``native`` or ``bridge``.
+    #: Unlabelled, the two differ by ~10x and read as the same measurement.
+    source: str = "bridge"
     staging: str = "pageable"
     io: str = "buffered"
     containers: int = 0
@@ -90,6 +93,7 @@ class LoadReport:
         return {
             "weights_streamed_bytes": self.weights_streamed_bytes,
             "weights_stream_gbps": round(self.weights_stream_gbps, 3),
+            "weights_stream_source": self.source,
             "staging": self.staging,
             "io": self.io,
             "containers": self.containers,
@@ -224,7 +228,10 @@ class StreamingLoader:
         started = time.perf_counter()
         device = torch.device(self._device)
         built = _skeleton.build(pipeline_cls, Path(checkpoint_dir))
-        report = LoadReport(io=self._io)
+        report = LoadReport(
+            io=self._io,
+            source=str(getattr(self._store, "KIND", type(self._store).__name__)),
+        )
 
         with StagingPool(
             device,

--- a/src/gen_worker/serving/streaming/source.py
+++ b/src/gen_worker/serving/streaming/source.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 #: to the projected tree, where it is a symlink costing nothing.
 TENSOR_PLANNERS = frozenset({"safetensors-v1", "gguf-v1"})
 
+#: The same fact spelled for a TFM1 manifest, which carries no planner: a
+#: vendored ``FileEntry`` says only where the bytes are, so the suffix is all
+#: there is to ask. Used on both sides so one store never sees a container
+#: the other would skip.
+TENSOR_SUFFIXES = (".safetensors", ".gguf")
+
 
 class StreamedTensor(Protocol):
     """One tensor's geometry: the container's own dtype spelling, its shape,
@@ -102,24 +108,28 @@ class WeightStoreUnavailable(RuntimeError):
 # -- the native store (tensorfs#115, via the tensorfs#57 wheel) -------------
 
 
-def _native_stream_reader() -> Any:
-    """``tensorfs.native.TensorStreamReader``, resolved at call time.
+def _native_module() -> Any:
+    """:mod:`tensorfs.native`, resolved at call time.
 
     Resolved through :mod:`importlib` rather than a module-level import
     because ``tensorfs`` is not yet a declared dependency of this package
     (tensorfs#57 is the wheel-publish lane). A static import would make every
-    torchless boot pay an ImportError for a class only the serving path uses.
+    torchless boot pay an ImportError for a module only the serving path uses.
     """
     import importlib
 
     try:
-        module = importlib.import_module("tensorfs.native")
+        return importlib.import_module("tensorfs.native")
     except ImportError as exc:
         raise WeightStoreUnavailable(
             "the tensorfs wheel (tensorfs#57) is not installed, so the "
             "native store->VRAM stream surface is unavailable in this image"
         ) from exc
-    return getattr(module, "TensorStreamReader")
+
+
+def _native_stream_reader() -> Any:
+    """``tensorfs.native.TensorStreamReader``, or a loud refusal."""
+    return getattr(_native_module(), "TensorStreamReader")
 
 
 class NativeWeightStore:
@@ -130,9 +140,38 @@ class NativeWeightStore:
     which snapshot serve is a worker decision, exactly as placement is.
     """
 
+    #: What a `LoadReport` calls this plane, so a GB/s number is never read
+    #: as the other one's.
+    KIND = "native"
+
     def __init__(self, store: Any, records: Mapping[str, Sequence[Any]]) -> None:
         self._store = store
         self._records = dict(records)
+
+    @classmethod
+    def from_manifest(cls, root: Path | str, manifest: Any) -> "NativeWeightStore":
+        """The native reader over the store the worker ALREADY wrote.
+
+        The two planes share their on-disk layout exactly —
+        ``objects/sha256/aa/bb/<hex>`` — so nothing is copied, converted or
+        re-ingested here: the same chunk objects are simply mapped by Rust
+        instead of by Python. Only the manifest spelling differs, and a
+        record run is the whole of what the reader wanted from it.
+
+        This is the path production actually takes. ``from_snapshot`` is for a
+        store whose refs are native snapshots; the worker's projection plane
+        still writes TFM1 manifests, and it is the manifest that resolves.
+        """
+        native = _native_module()
+        records: dict[str, Sequence[Any]] = {}
+        for entry in manifest.files:
+            if not entry.path.endswith(TENSOR_SUFFIXES):
+                continue
+            records[entry.path] = [
+                native.FileRecord.data(ref.digest, length)
+                for ref, length in entry.objects()
+            ]
+        return cls(native.ObjectStore(Path(root)), records)
 
     @classmethod
     def from_snapshot(cls, store: Any, snapshot: Any) -> "NativeWeightStore":
@@ -232,8 +271,10 @@ class BridgeWeightStore:
     wheel; :class:`NativeWeightStore` already does everything it does.
     """
 
+    KIND = "bridge"
+
     #: What the vendored reader knows how to parse a header out of.
-    SUFFIXES = (".safetensors", ".gguf")
+    SUFFIXES = TENSOR_SUFFIXES
 
     def __init__(self, cas: Any, manifest: Any, *, verify: bool = False) -> None:
         self._cas = cas
@@ -279,7 +320,9 @@ class BridgeWeightStore:
         self._open.clear()
 
 
-def store_for(checkpoint_dir: Path | str) -> Optional[WeightStore]:
+def store_for(
+    checkpoint_dir: Path | str, *, native: Optional[bool] = None
+) -> Optional[WeightStore]:
     """The byte source backing a projected checkpoint tree, or ``None``.
 
     ``None`` means the tree is not a snapshot this worker projected — a bare
@@ -290,12 +333,38 @@ def store_for(checkpoint_dir: Path | str) -> Optional[WeightStore]:
     The resolution is the same one :mod:`gen_worker.models.projection` already
     performs for every other consumer, so the engine needs no store handle
     plumbed to it: the DIRECTORY the worker resolved carries its own store.
+
+    **Which store is a CAPABILITY question, not a configuration one.** The
+    native reader is strictly better at the one job both stores have, so the
+    only thing worth asking is whether this image carries it — and se#756
+    ships a real ``tensorfs`` to the endpoint image, so in production it does.
+    ``native=`` forces the answer for a caller that wants to measure one plane
+    against the other; nothing reads an environment variable to decide.
     """
     from ...models import projection
 
     projected = projection.resolve_projection(checkpoint_dir)
     if projected is None:
         return None
+    if native is None:
+        native = native_available()
+    if native:
+        try:
+            return NativeWeightStore.from_manifest(
+                projected.cas.root, projected.manifest
+            )
+        except Exception:
+            # The bridge reads the SAME objects, so a native store that will
+            # not build costs speed and nothing else. Serving a request slowly
+            # beats refusing it — but say so loudly, because a silent fallback
+            # is how a ~10x regression hides.
+            logger.warning(
+                "ctx.load: the native tensorfs store would not open over %s "
+                "— falling back to the GIL-bound bridge, which is ~10x "
+                "slower (tensorfs#115)",
+                projected.cas.root,
+                exc_info=True,
+            )
     return BridgeWeightStore(projected.cas, projected.manifest)
 
 
@@ -331,6 +400,7 @@ def component_of(container: str) -> str:
 
 __all__ = [
     "TENSOR_PLANNERS",
+    "TENSOR_SUFFIXES",
     "BridgeWeightStore",
     "NativeWeightStore",
     "StreamedTensor",

--- a/src/gen_worker/serving/streaming/source.py
+++ b/src/gen_worker/serving/streaming/source.py
@@ -28,7 +28,6 @@ import logging
 from pathlib import Path
 from typing import (
     Any,
-    Iterator,
     Mapping,
     Optional,
     Protocol,
@@ -383,14 +382,6 @@ def native_available() -> bool:
     return True
 
 
-def containers_for(store: WeightStore, prefix: str) -> Iterator[str]:
-    """Every container of ``store`` under a checkpoint-relative directory."""
-    root = prefix.strip("/")
-    for path in store.containers():
-        if not root or path == root or path.startswith(root + "/"):
-            yield path
-
-
 def component_of(container: str) -> str:
     """The pipeline component a container belongs to: its parent directory,
     or ``""`` for a container at the checkpoint root (single-file pipelines)."""
@@ -408,7 +399,6 @@ __all__ = [
     "WeightStore",
     "WeightStoreUnavailable",
     "component_of",
-    "containers_for",
     "native_available",
     "store_for",
 ]

--- a/tests/test_weight_streaming.py
+++ b/tests/test_weight_streaming.py
@@ -318,8 +318,27 @@ def _append_tensor(path: Path, name: str) -> None:
 
 
 def _drop_tensor(path: Path) -> str:
+    """Rewrite the container WITHOUT one tensor — a real checkpoint that is
+    missing a name, not a malformed one.
+
+    The body is rebuilt and every surviving span reindexed, because popping a
+    header key alone leaves the victim's bytes in the body addressed by
+    nothing. The vendored reader shrugs at that gap; the native reader refuses
+    the file outright ("these records are not a tensor container"), and it is
+    right to — safetensors spans tile the body. Leaving the gap in would test
+    the store's tolerance for a corrupt file rather than the engine's refusal
+    to serve meta.
+    """
     header, body = _read_header(path)
     victim = sorted(key for key in header if key != "__metadata__")[0]
     header.pop(victim)
-    _write_container(path, header, body)
+    rebuilt = bytearray()
+    for name in sorted(
+        (key for key in header if key != "__metadata__"),
+        key=lambda key: header[key]["data_offsets"][0],
+    ):
+        start, end = header[name]["data_offsets"]
+        header[name]["data_offsets"] = [len(rebuilt), len(rebuilt) + (end - start)]
+        rebuilt += body[start:end]
+    _write_container(path, header, bytes(rebuilt))
     return victim

--- a/tests/test_weight_streaming_native_store.py
+++ b/tests/test_weight_streaming_native_store.py
@@ -32,6 +32,15 @@ native = pytest.importorskip(
     reason="the tensorfs#57 wheel is not installed; tensorfs#115's native "
            "stream surface is what this suite exercises",
 )
+if not hasattr(native, "TensorStreamReader"):
+    # Presence of the PACKAGE is not the question, and asking only that is why
+    # this suite was RED rather than skipped: pgw resolves a tensorfs
+    # transitively through torchcg, pinned BELOW #115. Ask for the surface.
+    pytest.skip(
+        "the installed tensorfs predates tensorfs#115 — it carries no "
+        "TensorStreamReader, which is the whole subject of this suite",
+        allow_module_level=True,
+    )
 
 from gen_worker.serving.streaming import NativeWeightStore, StreamingLoader  # noqa: E402
 from gen_worker.serving.streaming.skeleton import meta_survivors  # noqa: E402
@@ -188,3 +197,62 @@ def test_the_native_reader_satisfies_the_engines_protocol(
     first = stream.tensors[0]
     for member in ("name", "dtype", "shape", "offset", "nbytes"):
         assert hasattr(first, member), f"StreamTensor lost {member}"
+
+
+def test_store_for_selects_the_native_reader_over_a_projected_tree(
+    tmp_path: Path,
+) -> None:
+    """The wiring, not the reader: what a WORKER resolving a real projected
+    snapshot tree actually gets back.
+
+    ``NativeWeightStore`` was constructible long before it was constructed —
+    ``store_for`` returned the bridge unconditionally, so an image carrying a
+    real tensorfs (se#756) still served every request through the GIL-bound
+    copy. This asserts the selection itself, over a store written by the
+    vendored plane the worker really uses: the two planes share
+    ``objects/sha256/aa/bb/<hex>`` exactly, so the native reader maps the very
+    objects the projection wrote.
+    """
+    from gen_worker._vendor.tensorfs.local import LocalCAS
+    from gen_worker._vendor.tensorfs.project import project_snapshot
+    from gen_worker.serving.streaming import BridgeWeightStore, store_for
+    from gen_worker.serving.streaming.source import native_available
+
+    assert native_available()
+
+    source = tmp_path / "source-model"
+    pipeline_cls = build_source(source)
+    expected = source_tensors(source)
+
+    cas = LocalCAS(tmp_path / "store")
+    manifest = cas.ingest_repository(source)
+    cas.compare_and_swap_ref(
+        "snapshot:demo", cas.store_manifest(manifest), expected=None
+    )
+    tree = project_snapshot(cas, manifest, tmp_path / "store/snapshots/demo")
+
+    selected = store_for(tree)
+    assert isinstance(selected, NativeWeightStore), (
+        f"a projected tree with a real tensorfs installed resolved "
+        f"{type(selected).__name__} — the ~10x is being left on the floor"
+    )
+    assert sorted(selected.containers()) == sorted(
+        BridgeWeightStore(cas, manifest).containers()
+    ), "the two planes disagree about which files are tensor containers"
+
+    loader = StreamingLoader(selected, device="cpu", buffer_bytes=WINDOW, buffers=3)
+    pipeline = loader.build(pipeline_cls, checkpoint_dir=tree, lane=Lane())
+    report = loader.last_report
+    assert report is not None and report.source == "native"
+    for component, tensors in expected.items():
+        module = getattr(pipeline, component)
+        live = dict(module.named_parameters(remove_duplicate=False))
+        live.update(dict(module.named_buffers(remove_duplicate=False)))
+        for name, want in tensors.items():
+            assert torch.equal(
+                live[name].reshape(-1).view(torch.uint8),
+                want.reshape(-1).view(torch.uint8),
+            ), f"{component}/{name} is not byte-equal through the native store"
+
+    # The bridge stays reachable, because it is the fallback.
+    assert isinstance(store_for(tree, native=False), BridgeWeightStore)


### PR DESCRIPTION
Found by the e2e#1910 consumer-journey lane and recorded as an amendment on pgw#1380's lane note.

## The bug

`NativeWeightStore` is **constructed nowhere in `src/`**. `store_for` returns `BridgeWeightStore(projected.cas, projected.manifest)` unconditionally, `engine_for` hands that straight to `StreamingLoader`, and `native_available()` is only re-exported from `streaming/__init__.py` — never called to choose a store.

So the production serve path is the GIL-bound bridge no matter what tensorfs is installed. This module's own header calls that path *"precisely the ~10x tensorfs#115 measured away"* (0.59 GiB/s vs 6.4 GiB/s).

It is live, not hypothetical: se#751/se#756 ship a real `tensorfs` to the endpoint image as a PEP 508 git direct ref, so `native_available()` is **TRUE in a built sdxl image today and nothing asks it**.

## The fix

`store_for` selects native when the stream surface imports; the bridge stays the fallback.

Selection is a **capability** question, not a configuration one — the native reader is strictly better at the one job both stores have, so the only thing worth asking is whether the image carries it. Nothing reads an environment variable to decide (Paul's pgw#1312 ruling: envs are configs+secrets, never logic gates). `native=` forces the answer for a caller measuring one plane against the other.

`NativeWeightStore.from_manifest` is what makes this a two-line change rather than a migration: **the two planes share their on-disk layout exactly** — `objects/sha256/aa/bb/<hex>` on both sides — so the Rust reader maps the very objects the vendored projection already wrote. Nothing is copied, converted or re-ingested; only the manifest spelling differs, and a record run is all the reader ever wanted from it. `from_snapshot` stays for a store whose refs are native snapshots; the worker's projection plane still writes TFM1 manifests, and it is the manifest that resolves.

A `LoadReport` now carries `weights_stream_source`. Unlabelled, the two planes differ by ~10x and read as the same measurement — every `weights_stream_gbps` filed before this lands is a BRIDGE figure.

## Two pre-existing reds, both found by running it

- The native suite asked `importorskip("tensorfs.native")`. pgw resolves a tensorfs **transitively through torchcg, pinned below #115**, so the module imports and `TensorStreamReader` is absent: the suite was **RED on master**, not skipped (4 failures, reproducible at `origin/master`). It now asks for the surface, which is the same distinction `native_available()` already makes.
- `_drop_tensor` popped a header key and kept the body, leaving the victim's bytes addressed by nothing. The vendored reader shrugs at that gap; the native reader refuses the file outright ("these records are not a tensor container") and is right to — safetensors spans tile the body. The fixture now rebuilds the container, so the test proves the engine refuses to serve meta instead of probing a store's tolerance for a corrupt file.

## Run-proof (CPU path, real maturin extension, real projected tree)

Built a real bf16 diffusers pipeline, ingested it with the **vendored** `LocalCAS`, projected the snapshot tree the worker's own way, then resolved it:

```
source tree: 2.41 MB of real files
projected tree: 495 bytes of stubs/symlinks
native_available(): True
store_for(demo) -> NativeWeightStore (KIND=native)
  containers: ['text_encoder/model.safetensors', 'text_encoder_2/model.safetensors',
               'unet/diffusion_pytorch_model.safetensors', 'vae/diffusion_pytorch_model.safetensors']
[selected]      kind=native report={... 'weights_stream_source': 'native', 'containers': 4, 'tensors': 372}
[selected]      372 tensors byte-equal to the source
[forced-bridge] kind=bridge report={... 'weights_stream_source': 'bridge', 'containers': 4, 'tensors': 372}
[forced-bridge] 372 tensors byte-equal to the source
native and bridge agree on all 372 tensors
engine_for -> store kind native
```

The same script with the extension off the path prints `native_available(): False` -> `BridgeWeightStore` and loads byte-identically — the fallback, exercised, not asserted.

`io=direct` now actually reaches the native reader's `O_DIRECT` open (372 tensors byte-equal) where before it hit the bridge's unconditional refusal.

Suites, both ways: without the extension `9 passed, 1 skipped` (today's CI shape); with it `14 passed`.

## What remains GPU-validated

Everything CUDA: pinned-buffer allocation, `cudaMemcpyAsync` on the copy stream, and the real GB/s. The device axis is untouched by this change — the same `StreamingLoader` walk runs on both, and `device="cpu"` exercises every line of the selection and the byte path. Real numbers land through the endpoint lanes' route-2 deployments, and they will now be NATIVE and labelled so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)