### PR TITLE
pgw#1372: the adopt route was never callable — the procsplit action, the parent-mediated transport, and the real answer shape

### DIFF
--- a/src/gen_worker/procsplit/actions.py
+++ b/src/gen_worker/procsplit/actions.py
@@ -204,6 +204,31 @@ ACTIONS: Dict[str, HubAction] = {
             body=("family", "compiled_graph_key", "checkpoint_id", "ok", "error"),
             timeout_s=60.0,
         ),
+        # th#2133 / pgw#1372 — THE ADOPT ROUTE, the boot's one ask:
+        # `[release x lane x sm]` answered per graph, hit or miss. Without
+        # this entry the whole adopt-first boot is dead under the split (the
+        # only execution model since pgw#783) and dead SILENTLY, exactly as
+        # pgw#1353's keyset tier was: the parent refuses any unlisted path and
+        # the boot store treats the refusal as "no document", so every pod
+        # serves eager forever while nothing logs a defect.
+        #
+        # The path is the whole request except (lane, sm), so both are
+        # enumerated. `release_id` is the pod's OWN release either way — the
+        # hub refuses a credential adopting for a sibling release
+        # (`release_compiled_graphs_release_mismatch`) — but the grammar is
+        # pinned here too: identifiers, never a path.
+        #
+        # The ANSWER carries control only: per-graph digests, the mint's
+        # requirements manifest, and a PRESIGNED snapshot manifest. The .so
+        # bytes are fetched by the child directly off those URLs, so the seam
+        # stays inside its control-body ceiling on a 36-graph endpoint.
+        _a(
+            "release.compiled_graphs",
+            "GET",
+            r"^/v1/worker/releases/[A-Za-z0-9._+-]{1,128}/compiled-graphs$",
+            query=("lane", "sm"),
+            timeout_s=30.0,
+        ),
         # compiled graph discovery: list a system repo's checkpoints, resolve one
         # manifest. The manifest's artifact URL is PRESIGNED, so the bytes are
         # fetched by the child directly — the seam carries control, not data.

--- a/src/gen_worker/serving/__main__.py
+++ b/src/gen_worker/serving/__main__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -40,10 +41,19 @@ HTTP_TIMEOUT_S = 60.0
 
 
 class HttpReleaseGraphTransport:
-    """The thin th#2133 wire: one GET for the answer, one per presigned URL."""
+    """The thin th#2133 wire: one GET for the answer, one per presigned URL.
 
-    def __init__(self, base_url: str, timeout_s: float = HTTP_TIMEOUT_S) -> None:
+    The cozy-local / CI transport. In production the ask is parent-mediated
+    (``serving.hub_store.BrokerReleaseGraphTransport``) because the compute
+    child holds no credential — this one names a host and a bearer, which is
+    exactly what the split exists to take away from a serving process.
+    """
+
+    def __init__(
+        self, base_url: str, bearer: str = "", timeout_s: float = HTTP_TIMEOUT_S
+    ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.bearer = bearer
         self.timeout_s = timeout_s
 
     def release_compiled_graphs(
@@ -54,8 +64,24 @@ class HttpReleaseGraphTransport:
             f"{self.base_url}/v1/worker/releases/"
             f"{urllib.parse.quote(release_id, safe='')}/compiled-graphs?{query}"
         )
-        with urllib.request.urlopen(url, timeout=self.timeout_s) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+        request = urllib.request.Request(url)
+        if self.bearer:
+            request.add_header("Authorization", f"Bearer {self.bearer}")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                from .hub_store import ReleaseNotStamped
+
+                raise ReleaseNotStamped(
+                    f"release {release_id} carries no stamped compiled-graph "
+                    f"document; serving eager"
+                ) from exc
+            raise SystemExit(
+                f"adopt route answered {exc.code} from {url}: "
+                f"{exc.read().decode('utf-8', 'replace')[:400]}"
+            ) from exc
         if not isinstance(payload, dict):
             raise SystemExit(f"adopt route answered non-object JSON from {url}")
         return payload
@@ -103,6 +129,13 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--hub-base-url", default="",
                         help="hub base URL for the th#2133 adopt route")
     parser.add_argument("--release", default="", help="endpoint-release id (hub adopt)")
+    parser.add_argument("--hub-token", default="",
+                        help="worker bearer for the adopt route (local/CI only; "
+                             "in production the parent holds the credential)")
+    parser.add_argument("--via-broker", action="store_true",
+                        help="make the adopt ask through procsplit's action "
+                             "broker — the PRODUCTION path, allowlisted as "
+                             "`release.compiled_graphs`")
     parser.add_argument("--sm", default="", help="this GPU's sm (e.g. sm_89)")
     parser.add_argument("--artifacts-dir", default=".compiled-graphs")
     return parser
@@ -117,15 +150,30 @@ def _adoption_source(
     if not args.sm:
         raise SystemExit("--sm is required to adopt (artifacts are per-sm)")
     if args.hub_base_url:
-        from .hub_store import HubGraphStore
+        from .hub_store import (
+            BrokerReleaseGraphTransport,
+            HubGraphStore,
+            ReleaseNotStamped,
+        )
 
         if not args.release:
             raise SystemExit("--release is required with --hub-base-url")
-        store: Any = HubGraphStore(
-            HttpReleaseGraphTransport(args.hub_base_url), args.release,
-            args.lane, args.sm,
+        transport: Any = (
+            BrokerReleaseGraphTransport(
+                base_url=args.hub_base_url, bearer=args.hub_token
+            )
+            if args.via_broker
+            else HttpReleaseGraphTransport(args.hub_base_url, args.hub_token)
         )
-        return store, store.get_graphs(args.release)
+        store: Any = HubGraphStore(transport, args.release, args.lane, args.sm)
+        try:
+            document = store.get_graphs(args.release)
+        except ReleaseNotStamped as exc:
+            # NOT a boot failure: an un-stamped release serves eager, which is
+            # the whole eager bridge. Say it, then take it.
+            print(f"adopt: {exc}", file=sys.stderr)
+            return None, None
+        return store, document
     from .._vendor.tensorfs import LocalCAS
     from .._vendor.torchcg.store import LocalGraphStore
 
@@ -213,16 +261,19 @@ def main(argv: list[str] | None = None) -> int:
         loader=_aoti_loader, artifacts_dir=Path(args.artifacts_dir),
     )
     if host.adoption is not None:
-        print(
-            json.dumps({
-                "adopted": [record.graph for record in host.adoption.adopted],
-                "holes": [
-                    {"graph": hole.record.graph, "reason": hole.reason}
-                    for hole in host.holes
-                ],
-            }),
-            file=sys.stderr,
-        )
+        report: dict[str, Any] = {
+            "adopted": [record.graph for record in host.adoption.adopted],
+            "holes": [
+                {"graph": hole.record.graph, "reason": hole.reason}
+                for hole in host.holes
+            ],
+        }
+        # The hub's own miss list, when the store is the hub: the ORDERED
+        # holes pgw#1371's background mint takes as `enable_compiled(holes=)`.
+        answered = getattr(store, "misses", None)
+        if answered is not None:
+            report["answered_misses"] = list(answered)
+        print(json.dumps(report), file=sys.stderr)
     for index, (function, raw) in enumerate(zip(args.invoke, args.payload)):
         result = host.dispatch(function, json.loads(raw), request_id=f"local-{index}")
         sys.stdout.buffer.write(msgspec.json.encode(result))

--- a/src/gen_worker/serving/hub_store.py
+++ b/src/gen_worker/serving/hub_store.py
@@ -3,26 +3,40 @@
 One ask per boot — ``GET /v1/worker/releases/<release>/compiled-graphs
 ?lane=<lane>&sm=<sm>`` — answers, for every graph in the release's lane, the
 artifact for THIS release's exact env + this sm (content digest, presigned
-transport URL, the mint's requirements manifest) or a per-graph MISS.
+transport manifest, the mint's requirements manifest) or a per-graph MISS.
 PARTIAL-HIT is the wire contract; exact-env is the ruling (no compat
 ranking on this route).
 
-The TRANSPORT is a seam (:class:`ReleaseGraphTransport`): the route lands in
-th#2133 and the worker's HTTP/procsplit wiring follows it — this store only
-states the answer shape and the verification. Publishing never happens here:
-the boot-side store is read-only, and mint publishes ride pgw#1371's
+The TRANSPORT is a seam (:class:`ReleaseGraphTransport`) with two
+implementations that live here because both are two-liners over machinery
+that already exists: :class:`BrokerReleaseGraphTransport` (production — the
+call is parent-mediated, since the compute child holds no credential) and
+``__main__``'s plain-HTTP one (cozy-local / CI). Publishing never happens
+here: the boot-side store is read-only, and mint publishes ride pgw#1371's
 publisher.
 
-Answer shape (built to th#2133's spec; the route is the authority once
-merged)::
+THE ANSWER SHAPE IS th#2133's, verbatim — this module was written against a
+SPECULATED ``{document, artifacts, misses}`` shape before the route landed,
+and the route answers something else::
 
-    {
-      "document":  {...GraphSetDocument...},
-      "artifacts": {"cg-graph-v1-...": {"digest": "<sha256 hex>",
-                                        "url": "<presigned>",
-                                        "manifest": {...RequirementsManifest...}}},
-      "misses":    ["cg-graph-v1-..."]
-    }
+    {"object": "release_compiled_graphs", "release_id": "...",
+     "binding_generation": 0, "env_lockfile_hash": "<64hex>",
+     "lane": "sdxl.diffusers-bf16@1", "lane_stamped": true,
+     "lane_contract": {"stamp": ..., "contract_digest": ..., "document": {...},
+                       "requires": ...},
+     "sm": "sm_89", "empty": false, "hits": 30, "misses": 6,
+     "graphs": [{"graph_hash": "cg-graph-v1:...", "graph_class": "...",
+                 "status": "hit"|"miss"|"transport_unavailable",
+                 "found": true, "program": "sha256:...",
+                 "module_path": "...", "ingress": {...},
+                 "content_digest": "...", "artifact_path": "...",
+                 "requirements_manifest": {...},
+                 "transport": {"snapshot_digest": ..., "files": [...]}}, ...],
+     "targets": [...], "unobserved_targets": [...]}
+
+The lane's graph document is REBUILT from that answer rather than shipped
+whole: the hub stores the derive's rows, not the derive's bytes, and the
+rebuild is the one place that knows it.
 """
 
 from __future__ import annotations
@@ -31,12 +45,32 @@ import hashlib
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Mapping, Optional, Protocol
+from typing import Any, Iterable, Mapping, Optional, Protocol
 
 from .._vendor.torchcg.document import DocumentError, GraphSetDocument
 from .._vendor.torchcg.graph_identity import EnvIdentity
 from .._vendor.torchcg.requirements import RequirementsError, RequirementsManifest
 from .._vendor.torchcg.store import PublishOutcome, StoreError
+
+#: One explicit budget per hub hop; a hung boot pull must fail visibly.
+HTTP_TIMEOUT_S = 60.0
+
+#: The route's own path, one spelling. ``procsplit.actions`` allowlists this
+#: shape and the parent refuses anything else, so the two must not drift.
+ADOPT_PATH = "/v1/worker/releases/{release_id}/compiled-graphs"
+
+#: A hit's per-graph row states these; a miss states only the fetch key.
+HIT = "hit"
+
+
+class ReleaseNotStamped(Exception):
+    """The release carries no stamped compiled-graph document.
+
+    NOT an error: an un-stamped release has no adopt-first story (th#2134
+    gates that), and the worker's answer is its eager path. The hub says it
+    with a typed 404 rather than an empty document, and this is that fact
+    crossing the transport seam.
+    """
 
 
 class ReleaseGraphTransport(Protocol):
@@ -45,12 +79,82 @@ class ReleaseGraphTransport(Protocol):
     def release_compiled_graphs(
         self, release_id: str, lane: str, sm: str
     ) -> Mapping[str, Any]:
-        """The one boot ask: the release's graph document + per-graph answer."""
+        """The one boot ask: the release's per-graph adopt answer.
+
+        Raises :class:`ReleaseNotStamped` when the hub answers its typed 404.
+        """
         ...
 
     def fetch_blob(self, url: str) -> bytes:
         """Follow one presigned artifact URL."""
         ...
+
+
+class BrokerReleaseGraphTransport:
+    """The PRODUCTION transport: the adopt ask, parent-mediated.
+
+    ``procsplit.broker.request`` is the one call shape for both execution
+    modes — it dials directly when the split is off and rides the seam when
+    it is on — so this class has no split-mode branch for a bug to hide in.
+    The ARTIFACT bytes do not ride the seam: presigned URLs are fetched by
+    this process directly, which is the same division the compiled-graph
+    resolve already uses ("the seam carries control, not data").
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "",
+        bearer: str = "",
+        timeout_s: float = HTTP_TIMEOUT_S,
+    ) -> None:
+        # Used ONLY in single-process mode; under the split the parent
+        # supplies both and ignores whatever this passed.
+        self.base_url = base_url.rstrip("/")
+        self.bearer = bearer
+        self.timeout_s = timeout_s
+
+    def release_compiled_graphs(
+        self, release_id: str, lane: str, sm: str
+    ) -> Mapping[str, Any]:
+        from ..procsplit import broker
+
+        response = broker.request(
+            "GET",
+            ADOPT_PATH.format(release_id=str(release_id)),
+            base_url=self.base_url,
+            bearer=self.bearer,
+            params={"lane": str(lane), "sm": str(sm)},
+            timeout=self.timeout_s,
+        )
+        if response.status_code == 404:
+            raise ReleaseNotStamped(
+                f"release {release_id} carries no stamped compiled-graph "
+                f"document; serving eager"
+            )
+        if response.status_code != 200:
+            raise StoreError(
+                f"adopt route answered {response.status_code} for release "
+                f"{release_id} lane={lane} sm={sm}: {response.text[:400]}"
+            )
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise StoreError("adopt route answered non-object JSON")
+        return payload
+
+    def fetch_blob(self, url: str) -> bytes:
+        import requests
+
+        got = requests.get(url, timeout=self.timeout_s)
+        got.raise_for_status()
+        return bytes(got.content)
+
+
+def _graph_rows(answer: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    rows = answer.get("graphs")
+    if not isinstance(rows, list):
+        return ()
+    return tuple(row for row in rows if isinstance(row, Mapping))
 
 
 class HubGraphStore:
@@ -65,6 +169,7 @@ class HubGraphStore:
         self._sm = str(sm)
         self._answer: Optional[Mapping[str, Any]] = None
         self._document: Optional[GraphSetDocument] = None
+        self._rows: Optional[dict[str, Mapping[str, Any]]] = None
 
     # -- the one ask --------------------------------------------------------
 
@@ -81,6 +186,30 @@ class HubGraphStore:
             self._answer = answer
         return self._answer
 
+    def _row(self, graph: str) -> Optional[Mapping[str, Any]]:
+        if self._rows is None:
+            self._rows = {
+                str(row.get("graph_hash") or ""): row
+                for row in _graph_rows(self._resolve())
+            }
+        return self._rows.get(str(graph))
+
+    @property
+    def misses(self) -> tuple[str, ...]:
+        """The graph hashes this env still needs, in answer order.
+
+        The hub already counted them; this is the ORDERED list behind the
+        count, which is what pgw#1371's background mint takes as ``holes``.
+        A ``transport_unavailable`` row is NOT a hole — the artifact exists
+        and the transport is retryable — so it is excluded deliberately.
+        """
+
+        return tuple(
+            str(row.get("graph_hash") or "")
+            for row in _graph_rows(self._resolve())
+            if str(row.get("status") or "") == "miss"
+        )
+
     def _env(self) -> EnvIdentity:
         document = self.get_graphs(self._release_id)
         if document is None:
@@ -92,25 +221,76 @@ class HubGraphStore:
             # This store holds exactly one env — the release's own. Any other
             # ask is a clean miss, never a compat answer (exact-env ruling).
             return None
-        artifacts = self._resolve().get("artifacts")
-        entry = artifacts.get(graph) if isinstance(artifacts, Mapping) else None
-        return entry if isinstance(entry, Mapping) else None
+        row = self._row(graph)
+        if row is None or str(row.get("status") or "") != HIT:
+            return None
+        return row
 
     # -- GraphStore ---------------------------------------------------------
 
     def get_graphs(self, name: str) -> Optional[GraphSetDocument]:
+        """Rebuild THIS lane's graph document out of the adopt answer.
+
+        The answer is per-(release, lane, sm), so the rebuilt document holds
+        exactly one lane — which is all the boot's AdoptSession reads. An
+        ``empty`` answer rebuilds the EXPLICIT eager-permanent document
+        (no lanes), never ``None``: absent and eager-permanent are different
+        facts and the route states which one it means.
+        """
+
         if name != self._release_id:
             return None
-        if self._document is None:
-            raw = self._resolve().get("document")
-            if raw is None:
-                return None
-            try:
-                self._document = GraphSetDocument.decode(raw)
-            except DocumentError as exc:
-                raise StoreError(
-                    f"release {self._release_id} graph document is unreadable: {exc}"
-                ) from exc
+        if self._document is not None:
+            return self._document
+        try:
+            answer = self._resolve()
+        except ReleaseNotStamped:
+            return None
+        closure = str(answer.get("env_lockfile_hash") or "")
+        lanes: list[dict[str, Any]] = []
+        if not answer.get("empty") and answer.get("lane_stamped"):
+            records: list[dict[str, Any]] = []
+            for row in _graph_rows(answer):
+                ingress = row.get("ingress")
+                if not isinstance(ingress, Mapping):
+                    raise StoreError(
+                        f"release {self._release_id} graph "
+                        f"{row.get('graph_hash')!r} carries no ingress contract; "
+                        f"the adopt answer cannot be dispatched against"
+                    )
+                records.append({
+                    "graph": str(row.get("graph_hash") or ""),
+                    "target": str(row.get("module_path") or ""),
+                    "ingress": ingress,
+                    "program": str(row.get("program") or ""),
+                })
+            observed = {record["target"] for record in records}
+            declared = [
+                str(target) for target in (answer.get("targets") or [])
+                if isinstance(target, str)
+            ]
+            unobserved = [
+                str(target) for target in (answer.get("unobserved_targets") or [])
+                if isinstance(target, str)
+            ]
+            # A lane that states no target list still has one: every target a
+            # graph names. Stating it beats refusing an otherwise-adoptable
+            # answer over a field the row set already implies.
+            targets = sorted(observed | set(declared) | set(unobserved))
+            lanes.append({
+                "contract": str(answer.get("lane") or self._lane),
+                "targets": targets,
+                "graphs": records,
+                "unobserved_targets": sorted(set(unobserved) - observed),
+            })
+        try:
+            self._document = GraphSetDocument.decode(
+                {"v": 1, "closure": closure, "lanes": lanes}
+            )
+        except DocumentError as exc:
+            raise StoreError(
+                f"release {self._release_id} graph document is unreadable: {exc}"
+            ) from exc
         return self._document
 
     def put_graphs(self, name: str, document: GraphSetDocument) -> None:
@@ -128,19 +308,19 @@ class HubGraphStore:
         entry = self._entry(graph, env)
         if entry is None:
             return None
-        url = str(entry.get("url") or "")
-        digest = str(entry.get("digest") or "")
-        if not url or not digest:
+        digest = str(entry.get("content_digest") or "")
+        artifact_path = str(entry.get("artifact_path") or "")
+        if not digest or not artifact_path:
             raise StoreError(
                 f"artifact ({graph}, {env.value}): the answer row is missing "
-                f"its url or digest"
+                f"its content digest or artifact path"
             )
-        payload = self._transport.fetch_blob(url)
+        payload = self._fetch_from_transport(graph, env, entry, artifact_path)
         observed = hashlib.sha256(payload).hexdigest()
-        if observed != digest:
+        if observed != digest.removeprefix("sha256:"):
             raise StoreError(
                 f"artifact ({graph}, {env.value}) failed digest verification: "
-                f"answer said {digest[:16]}..., bytes hash {observed[:16]}..."
+                f"answer said {digest[:23]}..., bytes hash {observed[:16]}..."
             )
         target = Path(destination)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -154,6 +334,50 @@ class HubGraphStore:
         finally:
             Path(temporary_name).unlink(missing_ok=True)
         return target
+
+    def _fetch_from_transport(
+        self,
+        graph: str,
+        env: EnvIdentity,
+        entry: Mapping[str, Any],
+        artifact_path: str,
+    ) -> bytes:
+        """Pull one artifact out of the hit's presigned snapshot manifest.
+
+        The transport is the same checkpoint file manifest the per-key
+        resolve builds — the artifact is ONE file inside it, addressed by
+        ``artifact_path``, and possibly chunked.
+        """
+
+        transport = entry.get("transport")
+        files = transport.get("files") if isinstance(transport, Mapping) else None
+        if not isinstance(files, list):
+            raise StoreError(
+                f"artifact ({graph}, {env.value}) answered a hit with no "
+                f"transport manifest"
+            )
+        for row in files:
+            if not isinstance(row, Mapping) or str(row.get("path") or "") != artifact_path:
+                continue
+            chunks = row.get("chunks")
+            if isinstance(chunks, list) and chunks:
+                blob = bytearray()
+                for chunk in chunks:
+                    if not isinstance(chunk, Mapping):
+                        continue
+                    blob += self._transport.fetch_blob(str(chunk.get("url") or ""))
+                return bytes(blob)
+            url = str(row.get("url") or "")
+            if not url:
+                raise StoreError(
+                    f"artifact ({graph}, {env.value}): transport row "
+                    f"{artifact_path!r} carries neither url nor chunks"
+                )
+            return self._transport.fetch_blob(url)
+        raise StoreError(
+            f"artifact ({graph}, {env.value}): the transport manifest names no "
+            f"file {artifact_path!r}"
+        )
 
     def publish_artifact(
         self,
@@ -173,7 +397,7 @@ class HubGraphStore:
         entry = self._entry(graph, env)
         if entry is None:
             return None
-        raw = entry.get("manifest")
+        raw = entry.get("requirements_manifest")
         if raw is None:
             return None
         try:
@@ -184,4 +408,10 @@ class HubGraphStore:
             ) from exc
 
 
-__all__ = ["HubGraphStore", "ReleaseGraphTransport"]
+__all__ = [
+    "ADOPT_PATH",
+    "BrokerReleaseGraphTransport",
+    "HubGraphStore",
+    "ReleaseGraphTransport",
+    "ReleaseNotStamped",
+]

--- a/tests/test_serving_adopt_first.py
+++ b/tests/test_serving_adopt_first.py
@@ -26,7 +26,7 @@ from gen_worker import boot_stages
 from gen_worker._vendor.tensorfs import LocalCAS
 from gen_worker._vendor.torchcg import EnvironmentMismatch
 from gen_worker._vendor.torchcg.discovery import discover_lane
-from gen_worker._vendor.torchcg.document import GraphSetDocument
+from gen_worker._vendor.torchcg.document import GraphRecord, GraphSetDocument
 from gen_worker._vendor.torchcg.graph_identity import EnvIdentity, closure_hash
 from gen_worker._vendor.torchcg.requirements import RequirementsManifest
 from gen_worker._vendor.torchcg.store import LocalGraphStore, StoreError
@@ -384,14 +384,19 @@ class StubTransport:
         return self.blobs[url]
 
 
-def _adopt_answer(document, hit, hole, payload: bytes) -> dict:
+def _adopt_answer(
+    document: GraphSetDocument,
+    hit: GraphRecord,
+    hole: GraphRecord,
+    payload: bytes,
+) -> dict[str, Any]:
     """One th#2133 answer: `hit` minted for this env, `hole` not."""
     import hashlib
 
     lane = document.lanes[0]
 
-    def row(record, status: str) -> dict:
-        base = {
+    def row(record: GraphRecord, status: str) -> dict[str, Any]:
+        base: dict[str, Any] = {
             "graph_hash": record.graph,
             "graph_class": "",
             "program": record.program,

--- a/tests/test_serving_adopt_first.py
+++ b/tests/test_serving_adopt_first.py
@@ -355,11 +355,19 @@ def test_a_store_less_boot_still_forms_the_full_mint_worklist(
     assert out.model == "ckpt:tiny@1"
 
 
-# --- the hub-backed store: th#2133's answer shape, transport stubbed --------
+# --- the hub-backed store: th#2133's REAL answer shape ----------------------
+#
+# This block used to can a `{document, artifacts, misses}` payload that the
+# route never emitted — it was written before th#2133 landed, and it made the
+# store look tested while `hub_store` could not have parsed one real answer.
+# What is canned below is the shape a live hub actually returned on
+# `GET /v1/worker/releases/<id>/compiled-graphs?lane=&sm=`: per-graph rows with
+# a `status`, the observed `ingress` CONTRACT (not just its digest — torchcg
+# dispatches on the rows), and a presigned snapshot manifest under `transport`.
 
 
 class StubTransport:
-    """The th#2133 route answer, canned; the wiring lands with the route."""
+    """The th#2133 route answer, canned in the shape the route emits."""
 
     def __init__(self, answer: Mapping[str, Any], blobs: Mapping[str, bytes]) -> None:
         self.answer = answer
@@ -376,32 +384,88 @@ class StubTransport:
         return self.blobs[url]
 
 
+def _adopt_answer(document, hit, hole, payload: bytes) -> dict:
+    """One th#2133 answer: `hit` minted for this env, `hole` not."""
+    import hashlib
+
+    lane = document.lanes[0]
+
+    def row(record, status: str) -> dict:
+        base = {
+            "graph_hash": record.graph,
+            "graph_class": "",
+            "program": record.program,
+            "module_path": record.target,
+            "ingress_digest": record.ingress.digest(),
+            # THE CONTRACT ITSELF. Without it the lane document cannot be
+            # rebuilt and no artifact can legally arm (th#2134's migration).
+            "ingress": record.ingress.as_dict(),
+            "status": status,
+            "found": status == "hit",
+        }
+        if status != "hit":
+            return base
+        base.update({
+            "content_digest": hashlib.sha256(payload).hexdigest(),
+            "artifact_path": "compiled/graph.so",
+            "size_bytes": len(payload),
+            "checkpoint_id": "sha256:deadbeef",
+            "artifact_kind": "aoti",
+            "requirements_manifest": manifest().as_dict(),
+            "transport": {
+                "snapshot_digest": "sha256:deadbeef",
+                "files": [{
+                    "path": "compiled/graph.so",
+                    "size_bytes": len(payload),
+                    "digest": hashlib.sha256(payload).hexdigest(),
+                    "url": "https://presigned.example/hit",
+                }],
+            },
+        })
+        return base
+
+    return {
+        "object": "release_compiled_graphs",
+        "release_id": "release-1",
+        "binding_generation": 0,
+        "env_lockfile_hash": document.closure,
+        "lane": lane.contract,
+        "lane_stamped": True,
+        "lane_contract": {"stamp": lane.contract, "contract_digest": "",
+                          "document": None, "requires": ""},
+        "sm": SM,
+        "empty": False,
+        "targets": list(lane.targets),
+        "unobserved_targets": list(lane.unobserved_targets),
+        "graphs": [row(hit, "hit"), row(hole, "miss")],
+        "hits": 1,
+        "misses": 1,
+    }
+
+
 def test_hub_store_partial_hit_verifies_digests_and_misses_clean(
     host: EndpointHost, binding: DeployBinding, tmp_path: Path
 ) -> None:
-    import hashlib
-
     document = publish_document(host)
     hit, hole = document.lanes[0].graphs
     payload = b"presigned-compiled-bytes"
-    answer = {
-        "document": document.as_dict(),
-        "artifacts": {
-            hit.graph: {
-                "digest": hashlib.sha256(payload).hexdigest(),
-                "url": "https://presigned.example/hit",
-                "manifest": manifest().as_dict(),
-            }
-        },
-        "misses": [hole.graph],
-    }
+    answer = _adopt_answer(document, hit, hole, payload)
     transport = StubTransport(answer, {"https://presigned.example/hit": payload})
     store = HubGraphStore(transport, "release-1", LANE, SM)
+
+    # The document is REBUILT from the answer — the hub stores the derive's
+    # rows, not the derive's bytes.
+    rebuilt = store.get_graphs("release-1")
+    assert rebuilt is not None and rebuilt.closure == document.closure
+    assert [r.graph for r in rebuilt.lanes[0].graphs] == sorted(
+        [hit.graph, hole.graph], key=lambda g: g)
+    # The ORDERED hole list pgw#1371's background mint consumes.
+    assert store.misses == (hole.graph,)
 
     calls: list = []
     adopted_host = fresh_host(binding, tmp_path)
     adopted_host.setup(
-        store=store, document=store.get_graphs("release-1"), sm=SM,
+        store=store, document=rebuilt, sm=SM,
         loader=counting_loader(calls),
         artifacts_dir=tmp_path / "adopted",
         installed=INSTALLED,
@@ -431,3 +495,38 @@ def test_hub_store_partial_hit_verifies_digests_and_misses_clean(
     # The boot-side store is read-only by construction.
     with pytest.raises(StoreError, match="read-only"):
         store.publish_artifact(hit.graph, ENV, tmp_path / "x.so", manifest())
+
+
+def test_the_adopt_route_is_allowlisted_in_procsplit_pgw1372() -> None:
+    """WITHOUT THIS ENTRY THE WHOLE ADOPT BOOT IS DEAD ON EVERY FLEET POD.
+
+    The split parent refuses any path not in the table, `hub_store` treats a
+    refusal as a miss (correctly — it must never block a boot), and every pod
+    serves eager forever while every test that patches `broker.request` stays
+    green. pgw#1353's keyset tier, exactly. So the assertion is on the TABLE.
+    """
+    from gen_worker.procsplit import actions
+
+    action, query, _ = actions.authorize({
+        "method": "GET",
+        "path": "/v1/worker/releases/rel-123/compiled-graphs",
+        "query": {"lane": LANE, "sm": SM},
+    })
+    assert action.name == "release.compiled_graphs"
+    assert query == {"lane": LANE, "sm": SM}
+
+    # An unlisted query key is a refusal, not an ignored field.
+    with pytest.raises(actions.ActionRefused, match="org_id"):
+        actions.authorize({
+            "method": "GET",
+            "path": "/v1/worker/releases/rel-123/compiled-graphs",
+            "query": {"lane": LANE, "sm": SM, "org_id": "someone-elses"},
+        })
+
+    # The path grammar is pinned: a release id is an identifier, never a path.
+    with pytest.raises(actions.ActionRefused, match="not an allowlisted"):
+        actions.authorize({
+            "method": "GET",
+            "path": "/v1/worker/releases/rel-123/extra/compiled-graphs",
+            "query": {"lane": LANE, "sm": SM},
+        })


### PR DESCRIPTION
Closes the last worker-side gap in pgw#1372: nothing in this repo could call th#2133's adopt route, and three separate things were wrong at once.

## 1. The action was missing from procsplit's table

`procsplit/actions.py` is the parent-side authorization surface — the compute child holds no credential, so it ASKS, and the parent refuses any method+path not enumerated there. The adopt route was not in it.

That failure is silent by design. `boot`'s store must never block a boot, so a refusal reads as "this release has no document" and the pod serves eager. Every unit test that patches `broker.request` stays green. This is pgw#1353's keyset tier verbatim — the tier was dead on every fleet pod, and the only thing that would have said so is a table assertion.

```
release.compiled_graphs  GET  ^/v1/worker/releases/[A-Za-z0-9._+-]{1,128}/compiled-graphs$  query=(lane, sm)
```

## 2. There was no production transport

`HttpReleaseGraphTransport` (in `serving/__main__.py`) names a host and carries a bearer. That is exactly the authority the split exists to take away from a process that imports tenant code. `BrokerReleaseGraphTransport` asks the parent instead, through `broker.request`, which has one call shape for both execution modes so there is no split-mode branch for a bug to hide in.

Artifact bytes do NOT ride the seam: the answer carries a presigned snapshot manifest and this process fetches from it directly. Same division the compiled-graph resolve already uses — the seam carries control, not data. A 36-graph sdxl answer stays inside the control-body ceiling.

## 3. `hub_store` could not parse a single real answer

It was written before the route landed, against a speculated shape:

```
{"document": {...GraphSetDocument...}, "artifacts": {key: {digest, url, manifest}}, "misses": [...]}
```

th#2133 answers something structurally different — a `graphs[]` array of per-graph rows with `status` in {hit, miss, transport_unavailable}, `content_digest`/`artifact_path` into a presigned `transport` manifest, `requirements_manifest`, and `misses` as an integer COUNT. Every accessor in the file read a key that is never present.

It now speaks the route verbatim, and REBUILDS the lane's `GraphSetDocument` from the answer rather than expecting one whole — the hub stores the derive's rows, not the derive's bytes, so the rebuild is the one place that knows how.

## Notes

- `ReleaseNotStamped` carries the route's typed 404 across the transport seam. Not stamped is not an error: the release serves eager, which is the whole eager bridge.
- `HubGraphStore.misses` is the ordered hole list `enable_compiled(holes=)` consumes. `transport_unavailable` is deliberately NOT a hole — the artifact exists and the transport is retryable, so minting it would be spend for nothing.
- An `empty` answer rebuilds the EXPLICIT eager-permanent document (no lanes), never `None`. Absent and eager-permanent are different facts and the route states which one it means.
- `--via-broker` on `python -m gen_worker.serving` drives the production ask locally.

## Depends on

The rebuild needs the observed ingress CONTRACT, and th#2133 stores only its 32-hex digest — torchcg dispatches per call on the ingress rows, so a digest-only answer can be fetched and never armed. tensorhub's th#2134 branch adds `ingress` to the adopt answer (migration 0106). Until that lands the store raises a named `StoreError` on a graph with no ingress instead of arming something it cannot verify.
