### PR TITLE
pgw#1391: a lane stamp resolves against a real contract library, or it refuses

### DIFF
--- a/scripts/probe_lane_contracts.py
+++ b/scripts/probe_lane_contracts.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""pgw#1391 probe: does a lane whose contract document does not exist REFUSE?
+
+Three parts, run against whatever tree it is invoked from:
+
+  A. THE FENCE STILL BITES — a ``Model`` subclass whose lane names a document
+     that genuinely does not exist must refuse, at DECLARATION (which is what
+     carries the discovery guarantee: discovery imports the author module).
+  B. IT BITES ONLY WHAT DESERVES IT — ``sd15`` was the se#757 example and its
+     document now EXISTS (tensorfs#121), so it must RESOLVE. Same for the
+     sdxl and minimax-h3 controls, both live deployed lanes.
+  C. THE CORPUS — every golden vector in tensorfs's shared conformance corpus
+     must digest identically here, and every refusal vector must refuse.
+
+Discovery no longer enumerates lanes at all (pgw#1394 deleted ``_lane_stamps``
+because lane stamps were being written into the hub's ARTIFACT-layout fields).
+The refusal therefore rides on ``Model.__init_subclass__``, which is strictly
+better: it cannot be bypassed by a consumer that does not happen to enumerate
+lanes, and it fires on the author's machine at import.
+
+Run: ``python scripts/probe_lane_contracts.py``
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+
+def rule(title: str) -> None:
+    print(f"\n{'=' * 72}\n{title}\n{'=' * 72}")
+
+
+def show(label: str, thunk, *, brief: bool = False) -> None:
+    try:
+        print(f"  {label} -> {thunk()!r}")
+    except Exception as exc:  # noqa: BLE001 -- the probe reports, never raises
+        message = str(exc)
+        if brief and len(message) > 96:
+            message = message[:96] + " ...[refusal text elided]"
+        print(f"  {label} -> {type(exc).__name__}: {message}")
+
+
+# ── A. the silent lie ────────────────────────────────────────────────────────
+
+rule("A. THE FENCE BITES — a lane naming a document that does not exist")
+
+from gen_worker.models import SD15, SDXL  # noqa: E402
+from gen_worker.models.model_types import MissingContract  # noqa: E402
+from gen_worker.release import derive as _derive  # noqa: E402
+from gen_worker.serving import Model, lane_handle, model_lanes  # noqa: E402
+
+#: An invented stamp: tensorfs ships no such document and never will.
+NOPE = MissingContract("nope.not-a-document", 1)
+
+print("  -- declaration time (the seam discovery rides on) --")
+
+
+def _declare_explicit():
+    class NopeExplicit(Model[SDXL], lanes=(NOPE,)):
+        def load(self, ctx) -> None:  # noqa: ANN001
+            pass
+
+    return NopeExplicit
+
+
+show("class NopeExplicit(Model[SDXL], lanes=(NOPE,))", _declare_explicit)
+
+
+def _declare_requires():
+    class NopeRequires(Model[SDXL], requires={"nope.not-a-document@1": "vram12g"}):
+        def load(self, ctx) -> None:  # noqa: ANN001
+            pass
+
+    return NopeRequires
+
+
+show("class NopeRequires(..., requires={bogus stamp})", _declare_requires, brief=True)
+
+print("\n  -- the publish path (release/derive.py) --")
+warnings: list[str] = []
+show("_contract_document('NopeModel', NOPE, warnings)",
+     lambda: _derive._contract_document("NopeModel", NOPE, warnings), brief=True)
+print(f"  warnings collected -> {warnings!r}")
+show("_contract_digest(NOPE)", lambda: _derive._contract_digest(NOPE), brief=True)
+show("_resolve_lane(torchcg, NopeModel, NOPE)", lambda: _derive._resolve_lane(
+    __import__("gen_worker._vendor.torchcg", fromlist=["x"]), SDXL, NOPE
+), brief=True)
+
+print("\n  -- discovery imports the author module, so the class never builds --")
+show("model_lanes over a class that could not be declared",
+     lambda: "unreachable: __init_subclass__ already refused")
+
+print("\n  -- the SAME fence on a REAL type: Flux1 (tensorfs#124 owes its doc) --")
+from gen_worker.models import Flux1, Flux2Klein  # noqa: E402
+
+
+def _declare_flux1():
+    class Flux1Model(Model[Flux1]):
+        def load(self, ctx) -> None:  # noqa: ANN001
+            pass
+
+    return Flux1Model
+
+
+show("Flux1.canonical_contract", lambda: Flux1.canonical_contract)
+show("class Flux1Model(Model[Flux1])  # lanes= omitted", _declare_flux1, brief=True)
+print("  (it used to point at dit.blocks-fused-qkv@1, which matches 0 of 169")
+print("   real Flux tensors — a guaranteed refusal dressed as a resolved lane)")
+
+
+def _declare_klein():
+    class KleinModel(Model[Flux2Klein]):
+        def load(self, ctx) -> None:  # noqa: ANN001
+            pass
+
+    return KleinModel
+
+
+show("Flux2Klein.canonical_contract.stamp", lambda: Flux2Klein.canonical_contract.stamp)
+show("Flux2Klein.canonical_contract.dtype", lambda: Flux2Klein.canonical_contract.dtype)
+show("class KleinModel(Model[Flux2Klein])  # lanes= omitted",
+     lambda: _declare_klein().__name__)
+
+
+# ── A2. sd15 now RESOLVES — the fence bites only what deserves it ────────────
+
+rule("A2. sd15 — se#757's example, whose document tensorfs#121 authored")
+
+
+class Sd15Model(Model[SD15]):
+    """Exactly what a wave-2 migration lane writes: no ``lanes=`` at all."""
+
+    def load(self, ctx) -> None:  # noqa: ANN001
+        pass
+
+
+print("  class Sd15Model(Model[SD15]) declared with NO lanes= ... imported OK")
+show("model_lanes(Sd15Model)", lambda: [lane_handle(x) for x in model_lanes(Sd15Model)])
+for attribute in ("stamp", "dtype", "digest"):
+    show(f"canonical_contract.{attribute}", lambda a=attribute: getattr(SD15.canonical_contract, a))
+warnings = []
+show("_contract_document('Sd15Model', lane, warnings) keys",
+     lambda: sorted(_derive._contract_document("Sd15Model", SD15.canonical_contract, warnings)))
+print(f"  warnings collected -> {warnings!r}")
+show("_resolve_lane(torchcg, Sd15Model, lane)", lambda: _derive._resolve_lane(
+    __import__("gen_worker._vendor.torchcg", fromlist=["x"]), Sd15Model, SD15.canonical_contract
+))
+
+
+# ── B. the sdxl control ──────────────────────────────────────────────────────
+
+rule("B. sdxl control — the live deployed lane must keep working")
+
+
+class SdxlModel(Model[SDXL]):
+    def load(self, ctx) -> None:  # noqa: ANN001
+        pass
+
+
+show("model_lanes(SdxlModel)", lambda: [lane_handle(x) for x in model_lanes(SdxlModel)])
+for attribute in ("stamp", "dtype", "digest"):
+    show(f"canonical_contract.{attribute}", lambda a=attribute: getattr(SDXL.canonical_contract, a))
+show(
+    "canonical_contract.document is a real dict/str",
+    lambda: type(getattr(SDXL.canonical_contract, "document")).__name__,
+)
+warnings = []
+document = None
+try:
+    document = _derive._contract_document("SdxlModel", SDXL.canonical_contract, warnings)
+except Exception as exc:  # noqa: BLE001
+    print(f"  _contract_document -> {type(exc).__name__}: {exc}")
+print(f"  _contract_document keys -> {sorted(document) if document else document!r}")
+print(f"  warnings -> {warnings!r}")
+show("_contract_digest(lane)", lambda: _derive._contract_digest(SDXL.canonical_contract))
+
+#: tensorfs#121 re-declared this document COMPLETE over the shipped
+#: checkpoint header, so it re-digested from f1455f56... at tensorfs c3a831d.
+PINNED_SDXL_DIGEST = "ef01dd65f57bd95ae05d70f5a9893e9abab6b4f0831b05c4edf68ae9ebb148e8"
+show(
+    "digest == tensorfs pinned ef01dd65...",
+    lambda: _derive._contract_digest(SDXL.canonical_contract) == f"sha256:{PINNED_SDXL_DIGEST}",
+)
+
+
+# ── B2. the minimax-h3 control (the dtype-ordering waiver) ───────────────────
+
+rule("B2. minimax-h3 control — LIVE, dtype gained in tensorfs#121")
+
+from gen_worker.models import MiniMaxH3  # noqa: E402
+
+
+class H3Model(Model[MiniMaxH3]):
+    def load(self, ctx) -> None:  # noqa: ANN001
+        pass
+
+
+show("model_lanes(H3Model)", lambda: [lane_handle(x) for x in model_lanes(H3Model)])
+show("canonical_contract.digest", lambda: MiniMaxH3.canonical_contract.digest)
+show("canonical_contract.dtype", lambda: MiniMaxH3.canonical_contract.dtype)
+warnings = []
+show(
+    "_contract_document('H3Model', lane, warnings) keys",
+    lambda: sorted(_derive._contract_document("H3Model", MiniMaxH3.canonical_contract, warnings)),
+)
+show("_contract_digest(lane)", lambda: _derive._contract_digest(MiniMaxH3.canonical_contract))
+show("_resolve_lane", lambda: _derive._resolve_lane(
+    __import__("gen_worker._vendor.torchcg", fromlist=["x"]), H3Model,
+    MiniMaxH3.canonical_contract
+), brief=True)
+
+
+# ── C. the shared conformance corpus ─────────────────────────────────────────
+
+rule("C. tensorfs shared conformance corpus (spec/v1/contract-vectors)")
+
+try:
+    from gen_worker._vendor.tensorfs.contract import Contract, ContractError
+except Exception as exc:  # noqa: BLE001
+    print(f"  no vendored contract reader on this tree -> {type(exc).__name__}: {exc}")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parent.parent
+CORPUS = ROOT / "tests/testdata/contract-vectors"
+DOCUMENTS = ROOT / "src/gen_worker/_vendor/tensorfs/_contracts"
+vectors = json.loads((CORPUS / "contract-vectors.json").read_text())
+
+ok = bad = 0
+for case in vectors["golden"]:
+    # A library vector resolves against the documents THIS REPO VENDORS, so
+    # the corpus proves the bytes gen-worker actually publishes.
+    document = (
+        (DOCUMENTS / Path(case["file"]).name).read_text()
+        if "file" in case
+        else case["document"]
+    )
+    try:
+        contract = Contract.from_document(document)
+        agrees = contract.digest == case["digest"] and contract.stamp == case["stamp"]
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+        agrees = False
+    print(f"  golden {case['name']:<32} {'OK' if agrees else 'MISMATCH'}")
+    ok, bad = (ok + 1, bad) if agrees else (ok, bad + 1)
+
+for case in vectors["refusals"]:
+    try:
+        Contract.from_document(case["document"])
+        agrees, detail = False, "ACCEPTED (should have refused)"
+    except ContractError as exc:
+        agrees = exc.reason == case["reason"]
+        detail = f"reason={exc.reason!r}"
+    except Exception as exc:  # noqa: BLE001
+        agrees, detail = False, f"{type(exc).__name__}: {exc}"
+    print(f"  refusal {case['name']:<31} {'OK' if agrees else 'WRONG'} {detail}")
+    ok, bad = (ok + 1, bad) if agrees else (ok, bad + 1)
+
+print(f"\n  corpus: {ok} agree, {bad} disagree")
+sys.exit(1 if bad else 0)

--- a/src/gen_worker/_vendor/VENDORED.toml
+++ b/src/gen_worker/_vendor/VENDORED.toml
@@ -180,7 +180,66 @@ subdir = "python/src/tensorfs"
 # this snapshot emits can violate it.
 read_plane_rev = "21cec66a580cb232210facbfccfa580a16d7196e"
 read_plane_files = ["__init__.py", "gguf.py", "project.py", "tensors.py", "writer.py"]
+# pgw#1391: A THIRD REV, AND THE SAME REASON AS THE SECOND — the CONTRACT plane
+# did not exist at either of the two above. `rev` predates tensorfs's genesis
+# restart entirely and `read_plane_rev` predates tensorfs#111/#113/#114, so
+# neither carries `contract.py`, `contracts.py` or `_contracts/`. This is the
+# plane that makes a lane stamp FALSIFIABLE: without it a `Model` header could
+# claim `sd15.diffusers-bf16@1`, a document that exists nowhere, and every
+# surface in this repo accepted it (pgw#1391's measured reproduction).
+#
+# `contracts.py` and the six `_contracts/*.v1.json` documents are upstream's
+# VERBATIM. The documents are the wheel spelling of `spec/v1/contracts` (a
+# source checkout symlinks them, so they are copied dereferenced) and are the
+# same files the Rust core embeds.
+#
+# `contract.py` is a REWRITE, listed below, for exactly the `planner.py`
+# reason: upstream's version delegates to the compiled extension
+# (`from .native import contract_info`) and pgw#1310 rules a compiled extension
+# out of a source-vendored wheel. Taking it straight would have imported a
+# module that cannot exist here.
+#
+# ELEVEN documents, not six: `contract_plane_rev` advanced from `c3a831d` to
+# `107b8ac` (tensorfs#121) and then `2abc1b76` (tensorfs#124) inside pgw#1391
+# itself, and those bumps are the whole point rather than a chore. #121
+# authored the four se#757 blocker-A lane documents (`sd15`, `sd2`,
+# `hidream-o1`, `wan22` — sd15 and sd2 are SEPARATE documents with separate
+# digests) and gave `minimax.h3-dit-diffusers@1` the top-level `dtype` it owed;
+# #124 added `flux2-klein.diffusers-bf16@1`. Clearing the four
+# `MissingContract` sentinels in `models/model_types.py` took NO code change,
+# which is the property the sentinel shape exists to have.
+#
+# Two documents RE-DIGESTED across that bump and it is deliberate upstream:
+# `minimax.h3-dit-diffusers@1` gained its dtype, and `sdxl.diffusers-bf16@1`
+# was re-declared COMPLETE over the shipped checkpoint header (detection
+# specificity is the count of a file's keys a contract explains, so a sampled
+# document loses to a complete document for a neighbouring architecture).
+# Both kept version `@1`, so any release published before this bump recorded a
+# digest that no longer matches the document behind the same stamp.
+#
+# Three vendored documents declare NO top-level dtype on purpose —
+# `dit.blocks-fused-qkv`, `sdxl.clip-g-fused-qkv`, `sdxl.clip-g-split-qkv`.
+# They are FRAGMENTS (a family-shared block spelling and two CLIP component
+# spellings) that a `lanes=` header never names on its own. Do not "fix" them,
+# and do not let a declaration-time dtype read treat them as lanes.
+contract_plane_rev = "2abc1b76e8ee4c857abbb00e3c259b3a6bc2f595"
+contract_plane_files = [
+  "contract.py",
+  "contracts.py",
+  "_contracts/dit.blocks-fused-qkv.v1.json",
+  "_contracts/flux2-klein.diffusers-bf16.v1.json",
+  "_contracts/hidream-o1.diffusers-bf16.v1.json",
+  "_contracts/minimax.h3-dit-diffusers.v1.json",
+  "_contracts/minimax.h3-dit-native.v1.json",
+  "_contracts/sd15.diffusers-bf16.v1.json",
+  "_contracts/sd2.diffusers-bf16.v1.json",
+  "_contracts/sdxl.clip-g-fused-qkv.v1.json",
+  "_contracts/sdxl.clip-g-split-qkv.v1.json",
+  "_contracts/sdxl.diffusers-bf16.v1.json",
+  "_contracts/wan22.diffusers-bf16.v1.json",
+]
 rewrites = [
+  "`contract.py` (pgw#1391): the parse/validate/canonical/digest half is restored in pure Python instead of `from .native import contract_info`, because pgw#1310 rules a compiled extension out of a source-vendored wheel — the `planner.py` precedent exactly. The PUBLIC SURFACE is upstream's attribute for attribute (`Contract.from_document`, `.name/.version/.digest/.stamp/.label/.document/.description/.tensors/.sets`, the RAISING `.dtype`, `MissingDtype`, `TensorDecl`/`Fusion`/`Permute`), so a future pure-Python upstream re-vendor is a deletion rather than a migration. It adds one name upstream does not export, `ContractError`, carrying the kebab-case `reason` label the Rust and Go validators already share — the refusal corpus is keyed on it. Conformance is NOT asserted: `tests/test_lane_contracts.py` runs upstream's released `spec/v1/contract-vectors` corpus (tensorfs#114, the same one the Rust and Go implementations satisfy), vendored at `tests/testdata/contract-vectors/`, over the ELEVEN VENDORED DOCUMENTS plus the two anonymous customs — 13 golden digests and 19 typed refusals. A SHA-256 over a hand-built line rendering cannot agree by luck. It has already caught a real divergence rather than merely certifying agreement: tensorfs#121 relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment (`hidream-o1`, `flux-2`, `wan-2`; a LEADING hyphen still refuses) and the port refused `hidream-o1.diffusers-bf16` until it followed. NO KNOWN DIVERGENCE TODAY.",
   "`tensors.py`: `TensorReader._map` maps through a pure-Python `_MappedObject` (an `mmap` exported via PEP 688) instead of the compiled `tensorfs.native.MappedObject`, because pgw#1310 rules a compiled extension out of a source-vendored wheel. Upstream's weak-mapping ownership rule is preserved exactly; see the paragraph above. No other file is edited, so the remaining digests are upstream's verbatim.",
   "`planner.py` REPLACES `chunking.py` (pgw#1365): a pure-Python port of `crates/tensorfs-core/src/planner/{mod,safetensors,gguf}.rs` at `read_plane_rev`, because upstream deleted the Python chunker at `00c57c1` in favour of the Rust planner and pgw#1310 rules a compiled extension out of a source-vendored wheel. Conformance is asserted against upstream's released `spec/v1/planner-vectors` corpus, vendored at `tests/testdata/planner-vectors/`. Two knowing divergences, both tested by name: `plan_chunks` cuts a >64 MiB blob on the fixed grid (tensorhub's single-PUT promotion cap — pgw#1366), and a duplicate GGUF metadata key is planned as `gguf-v1` here and `blob-v1` upstream, because `gguf.read_header` does not record metadata keys.",
   "`local.py`: one line — `from .chunking import plan_chunks` becomes `from .planner import plan_chunks`. Every other line is `8bafdfbb`'s verbatim.",
@@ -262,6 +321,19 @@ rewrites = [
 
 [packages.tensorfs.files]
 "__init__.py" = "a66ced3cd03e042989602b9e122e4b3988be6be6611aacdb05b852c8a968ec7b"
+"_contracts/dit.blocks-fused-qkv.v1.json" = "95681781643548fc3bb696b84fee3d4c421f42e5fa5633c82fa6aae31f8e51e0"
+"_contracts/flux2-klein.diffusers-bf16.v1.json" = "7f792d62c7e7bd7bb8fa2cca84204f4911b8022c95417f004c2eb733b043974f"
+"_contracts/hidream-o1.diffusers-bf16.v1.json" = "c74f3489b21b8acdbf1acce919d1dade4128c59829ced2f36e89dc937836e347"
+"_contracts/minimax.h3-dit-diffusers.v1.json" = "40fedde5e31dbed2bb5c34b350f76d2961c3e40ef61a03c102c1ae9aab99e1e1"
+"_contracts/minimax.h3-dit-native.v1.json" = "d8c738a10c688bfbcb7b3135a5de1b903c3eea1cba55d50ba2cde220607b154f"
+"_contracts/sd15.diffusers-bf16.v1.json" = "01f3cdfca73430bf2f53546b8fbdfc9c946bb6c45ed8882e67abcf66e3b778ff"
+"_contracts/sd2.diffusers-bf16.v1.json" = "3ef484feb44e38adc278d75f002bbdf2375600fd5026ecf27d47cc0a2e406d83"
+"_contracts/sdxl.clip-g-fused-qkv.v1.json" = "2fe796a2c14d615e972655144b4cc6c2a01bd74d400c9dbe0eb2b3887d78ca98"
+"_contracts/sdxl.clip-g-split-qkv.v1.json" = "5d82d4dcad7ca97cc5291a4fc60e4916e24e6bc8baa14e0429be428b99d9d09a"
+"_contracts/sdxl.diffusers-bf16.v1.json" = "6612c3d61e495f62d9f06096c11a2182a8a440d969e4faa0f23258eec35abe60"
+"_contracts/wan22.diffusers-bf16.v1.json" = "bca462c22c83e43e28516fa21a7d7798d73f3a46c242f61a37d532701903e13b"
+"contract.py" = "b007d534da4f0a131bc7fe79001472cf08a94be0feedf229c0bba32fbb8c1d38"
+"contracts.py" = "7435a6e9569ce5da748c50aece447b74e427d841f5d757740b5fb4958b25dee9"
 "gguf.py" = "ced89fc42009ab2e69406d2726c9b0caf43254c51ab16bdcf37c5ad239a2d7be"
 "local.py" = "186401e38a14f74e70d20991fa47fdda4e10dc3f1c82b44c540eee73220b1f86"
 "manifest.py" = "a93ee850992c17dd90a57946441875d282367556703b9e9d1c8be057ea12bed4"

--- a/src/gen_worker/_vendor/tensorfs/_contracts/dit.blocks-fused-qkv.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/dit.blocks-fused-qkv.v1.json
@@ -1,0 +1,57 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "dit.blocks-fused-qkv",
+  "version": 1,
+  "description": "The DiT/ViT block spelling shared by Flux-family and timm-derived transformers: one fused qkv per block along the outermost axis, equal thirds, plus the removable AdaLN modulation set.",
+  "tensors": [
+    {
+      "role": "blocks.{i}.attn.qkv.weight",
+      "pattern": "blocks.{i}.attn.qkv.weight",
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          { "role": "q", "share": 1 },
+          { "role": "k", "share": 1 },
+          { "role": "v", "share": 1 }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv.bias",
+      "pattern": "blocks.{i}.attn.qkv.bias",
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          { "role": "q", "share": 1 },
+          { "role": "k", "share": 1 },
+          { "role": "v", "share": 1 }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.proj.weight",
+      "pattern": "blocks.{i}.attn.proj.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.{i}.weight",
+      "pattern": "blocks.{i}.adaLN_modulation.{i}.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.{i}.bias",
+      "pattern": "blocks.{i}.adaLN_modulation.{i}.bias",
+      "required": false
+    }
+  ],
+  "sets": {
+    "adaln_projections": [
+      "blocks.{i}.adaLN_modulation.{i}.weight",
+      "blocks.{i}.adaLN_modulation.{i}.bias"
+    ]
+  }
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/flux2-klein.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/flux2-klein.diffusers-bf16.v1.json
@@ -1,0 +1,291 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "flux2-klein.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical FLUX.2 Klein serve layout: the diffusers Flux2Transformer2DModel (Flux2KleinPipeline), all-bf16, every family derived from the real safetensors header of black-forest-labs/FLUX.2-klein-4B. This is NOT the timm block spelling dit.blocks-fused-qkv@1 declares - that fragment matches ZERO tensors in a flux tree (measured, tensorfs#124), because flux serves the diffusers spelling: 5 double-stream transformer_blocks and 20 single_transformer_blocks, no blocks.{i}.attn.qkv anywhere. THE SINGLE-STREAM FUSION IS NOT EQUAL THIRDS. single_transformer_blocks.{i}.attn.to_qkv_mlp_proj.weight is [27648, 3072] and fuses the attention projections AND the gated MLP input: q|k|v are 3072 each and the MLP input is 18432, because the MLP is gated and emits 2 x (mlp_ratio 3.0 x inner_dim 3072) = 2 x 9216. Shares are 1:1:1:6 in units of 3072, confirmed by attn.to_out.weight [3072, 12288] = 3072 attn + 9216 post-gate mlp and by the double-stream ff.linear_in [18432, 3072] / ff.linear_out [3072, 9216] pair. Thirds would mis-cut 3.4 GB of the 4B transformer. The role vocabulary is aligned with BFL's NATIVE packaging, which the same repo ships beside the diffusers tree (flux-2-klein-4b.safetensors, 149 tensors to the diffusers 169 - exactly 5 blocks x 2 streams x 2, the double-stream qkv this packaging splits and that one fuses in equal thirds). So to_q/to_k/to_v and add_q_proj/add_k_proj/add_v_proj carry #q/#k/#v role suffixes over one qkv role, which is what makes a native <-> diffusers conversion a run-preserving derive rather than a refusal, exactly as the sdxl.clip-g-* pair does. TRANSFORMER ONLY, deliberately, on the tensorfs#121 rule: AutoencoderKLFlux2 is the same key spelling as SD2's and SDXL's AutoencoderKL (251 keys vs 248, the extra three being the bn.* buffers, every shared key agreeing on rank), so declaring it would tie sdxl.diffusers-bf16@1 on any SDXL vae file and win it on name order; and the text encoder is a stock Qwen3ForCausalLM spelling that any future Qwen3 lane would collide with. The transformer is the compile subject and the only component that identifies the family. Derived from the 4B checkpoint. FLUX.2-klein-9B is gated (gated: auto - the sibling listing is public but every raw file read is 401 unauthenticated), so its layout is UNVERIFIED; if 9B spells a family differently this document refuses it loudly rather than half-matching. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "txt_in.weight",
+      "pattern": "context_embedder.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double_stream_modulation_img.weight",
+      "pattern": "double_stream_modulation_img.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double_stream_modulation_txt.weight",
+      "pattern": "double_stream_modulation_txt.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.adaln.weight",
+      "pattern": "norm_out.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "final_layer.linear.weight",
+      "pattern": "proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single_stream_modulation.weight",
+      "pattern": "single_stream_modulation.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.key_norm.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.query_norm.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear2.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.to_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "single.{i}.linear1.weight",
+      "pattern": "single_transformer_blocks.{i}.attn.to_qkv_mlp_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          },
+          {
+            "role": "mlp",
+            "share": 6
+          }
+        ]
+      }
+    },
+    {
+      "role": "time_in.fc1.weight",
+      "pattern": "time_guidance_embed.timestep_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "time_in.fc2.weight",
+      "pattern": "time_guidance_embed.timestep_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#k",
+      "pattern": "transformer_blocks.{i}.attn.add_k_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#q",
+      "pattern": "transformer_blocks.{i}.attn.add_q_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.qkv.weight#v",
+      "pattern": "transformer_blocks.{i}.attn.add_v_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.key_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_added_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.query_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_added_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.key_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.query_norm.weight",
+      "pattern": "transformer_blocks.{i}.attn.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_attn.proj.weight",
+      "pattern": "transformer_blocks.{i}.attn.to_add_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.proj.{i}.weight",
+      "pattern": "transformer_blocks.{i}.attn.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_attn.qkv.weight#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc1.weight",
+      "pattern": "transformer_blocks.{i}.ff.linear_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.img_mlp.fc2.weight",
+      "pattern": "transformer_blocks.{i}.ff.linear_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc1.weight",
+      "pattern": "transformer_blocks.{i}.ff_context.linear_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "double.{i}.txt_mlp.fc2.weight",
+      "pattern": "transformer_blocks.{i}.ff_context.linear_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "img_in.weight",
+      "pattern": "x_embedder.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/hidream-o1.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/hidream-o1.diffusers-bf16.v1.json
@@ -1,0 +1,475 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "hidream-o1.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "HiDream-O1-Image serve layout, all-bf16, as HiDream-ai/HiDream-O1-Image-Dev actually ships it. NOTE THE NAME: this checkpoint is NOT a diffusers multifolder tree. It is one sharded-transformers ROOT (model-0000N-of-00008.safetensors + model.safetensors.index.json, config.json architecture Qwen3VLForConditionalGeneration) that the serverless hidream-o1-image endpoint loads with DiffSynth's HiDreamO1ImageModel and aliases as pipe.transformer. The stamp keeps the family's .diffusers-bf16 spelling because that is what gen_worker's HiDreamO1.canonical_contract names; the layout below is the real root key space, derived from the real shard headers. The denoiser IS the Qwen3-VL backbone (36 lm layers) plus the diffusion adapter (x_embedder, t_embedder1, final_layer2); the 27-block vision tower carries the edit lane's reference conditioning and fuses qkv along the outermost axis in equal thirds, which is the one seam here. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "lm.head.weight",
+      "pattern": "lm_head.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.final_layer.linear.bias",
+      "pattern": "model.final_layer2.linear.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.final_layer.linear.weight",
+      "pattern": "model.final_layer2.linear.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.embed_tokens.weight",
+      "pattern": "model.language_model.embed_tokens.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.norm1.weight",
+      "pattern": "model.language_model.layers.{i}.input_layernorm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.mlp.down.weight",
+      "pattern": "model.language_model.layers.{i}.mlp.down_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.mlp.gate.weight",
+      "pattern": "model.language_model.layers.{i}.mlp.gate_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.mlp.up.weight",
+      "pattern": "model.language_model.layers.{i}.mlp.up_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.norm2.weight",
+      "pattern": "model.language_model.layers.{i}.post_attention_layernorm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.k_norm.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.k_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.k.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.k_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.out.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.o_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.q_norm.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.q_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.q.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.q_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.layers.{i}.attn.v.weight",
+      "pattern": "model.language_model.layers.{i}.self_attn.v_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "lm.norm.weight",
+      "pattern": "model.language_model.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.t_embedder.mlp.{i}.bias",
+      "pattern": "model.t_embedder1.mlp.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.t_embedder.mlp.{i}.weight",
+      "pattern": "model.t_embedder1.mlp.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.attn.proj.bias",
+      "pattern": "model.visual.blocks.{i}.attn.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.attn.proj.weight",
+      "pattern": "model.visual.blocks.{i}.attn.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.attn.qkv.bias",
+      "pattern": "model.visual.blocks.{i}.attn.qkv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vision.blocks.{i}.attn.qkv.weight",
+      "pattern": "model.visual.blocks.{i}.attn.qkv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vision.blocks.{i}.mlp.fc1.bias",
+      "pattern": "model.visual.blocks.{i}.mlp.linear_fc1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.mlp.fc1.weight",
+      "pattern": "model.visual.blocks.{i}.mlp.linear_fc1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.mlp.fc2.bias",
+      "pattern": "model.visual.blocks.{i}.mlp.linear_fc2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.mlp.fc2.weight",
+      "pattern": "model.visual.blocks.{i}.mlp.linear_fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.norm1.bias",
+      "pattern": "model.visual.blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.norm1.weight",
+      "pattern": "model.visual.blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.norm2.bias",
+      "pattern": "model.visual.blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.blocks.{i}.norm2.weight",
+      "pattern": "model.visual.blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.fc1.bias",
+      "pattern": "model.visual.deepstack_merger_list.{i}.linear_fc1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.fc1.weight",
+      "pattern": "model.visual.deepstack_merger_list.{i}.linear_fc1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.fc2.bias",
+      "pattern": "model.visual.deepstack_merger_list.{i}.linear_fc2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.fc2.weight",
+      "pattern": "model.visual.deepstack_merger_list.{i}.linear_fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.norm.bias",
+      "pattern": "model.visual.deepstack_merger_list.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.deepstack.{i}.norm.weight",
+      "pattern": "model.visual.deepstack_merger_list.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.merger.fc1.bias",
+      "pattern": "model.visual.merger.linear_fc1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.merger.fc1.weight",
+      "pattern": "model.visual.merger.linear_fc1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.merger.fc2.bias",
+      "pattern": "model.visual.merger.linear_fc2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.merger.fc2.weight",
+      "pattern": "model.visual.merger.linear_fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vision.merger.norm.bias",
+      "pattern": "model.visual.merger.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.merger.norm.weight",
+      "pattern": "model.visual.merger.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.patch_embed.bias",
+      "pattern": "model.visual.patch_embed.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vision.patch_embed.weight",
+      "pattern": "model.visual.patch_embed.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vision.pos_embed.weight",
+      "pattern": "model.visual.pos_embed.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.x_embedder.proj1.weight",
+      "pattern": "model.x_embedder.proj1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.x_embedder.proj2.bias",
+      "pattern": "model.x_embedder.proj2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.x_embedder.proj2.weight",
+      "pattern": "model.x_embedder.proj2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-diffusers.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-diffusers.v1.json
@@ -1,0 +1,90 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "minimax.h3-dit-diffusers",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "MiniMax-H3 DiT, diffusers repackaging (638 keys, 66.28 GB) -- what the hub actually ships. Attention is split to_q/to_k/to_v. Each is declared as 56 head slices so its runs are exactly the native contract's interleaved seam runs: the two packagings share every attention byte despite reading them in different orders. Exactly one key is spelled the same in both layouts.",
+  "tensors": [
+    {
+      "role": "blocks.{i}.attn.qkv#q",
+      "pattern": "transformer_blocks.{i}.attn.to_q.weight",
+      "dtypes": ["BF16"],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [{ "role": "", "share": 1 }]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv#k",
+      "pattern": "transformer_blocks.{i}.attn.to_k.weight",
+      "dtypes": ["BF16"],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [{ "role": "", "share": 1 }]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.qkv#v",
+      "pattern": "transformer_blocks.{i}.attn.to_v.weight",
+      "dtypes": ["BF16"],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [{ "role": "", "share": 1 }]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.out",
+      "pattern": "transformer_blocks.{i}.attn.to_out.0.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.q_norm",
+      "pattern": "transformer_blocks.{i}.attn.norm_q.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.k_norm",
+      "pattern": "transformer_blocks.{i}.attn.norm_k.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1",
+      "pattern": "transformer_blocks.{i}.ff.net.0.proj.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2",
+      "pattern": "transformer_blocks.{i}.ff.net.2.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.weight",
+      "pattern": "transformer_blocks.{i}.adaln_proj.linear.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.bias",
+      "pattern": "transformer_blocks.{i}.adaln_proj.linear.bias",
+      "rank": 1,
+      "required": false
+    }
+  ],
+  "sets": {
+    "adaln_projections": [
+      "transformer_blocks.{i}.adaln_proj.linear.weight",
+      "transformer_blocks.{i}.adaln_proj.linear.bias",
+      "norm_out.linear.weight",
+      "norm_out.linear.bias"
+    ]
+  }
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-native.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/minimax.h3-dit-native.v1.json
@@ -1,0 +1,72 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "minimax.h3-dit-native",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "MiniMax-H3 DiT, native/DiffSynth spelling (535 keys, 66.28 GB). Attention is one fused qkv_proj per block, HEAD-INTERLEAVED: 56 head-major triples (q,k,v adjacent within each head), not three stacked blocks. 11.56 GB of the DiT -- 17.4% -- sits behind those seams.",
+  "tensors": [
+    {
+      "role": "blocks.{i}.attn.qkv",
+      "pattern": "blocks.{i}.attn.qkv_proj.weight",
+      "dtypes": ["BF16"],
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "groups": 56,
+        "parts": [
+          { "role": "q", "share": 1 },
+          { "role": "k", "share": 1 },
+          { "role": "v", "share": 1 }
+        ]
+      }
+    },
+    {
+      "role": "blocks.{i}.attn.out",
+      "pattern": "blocks.{i}.attn.out_proj.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.q_norm",
+      "pattern": "blocks.{i}.attn.q_norm.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.attn.k_norm",
+      "pattern": "blocks.{i}.attn.k_norm.weight",
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc1",
+      "pattern": "blocks.{i}.mlp.fc1.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.mlp.fc2",
+      "pattern": "blocks.{i}.mlp.fc2.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.weight",
+      "pattern": "blocks.{i}.adaln_proj.linear.weight",
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "blocks.{i}.adaln.bias",
+      "pattern": "blocks.{i}.adaln_proj.linear.bias",
+      "rank": 1,
+      "required": false
+    }
+  ],
+  "sets": {
+    "adaln_projections": [
+      "blocks.{i}.adaln_proj.linear.weight",
+      "blocks.{i}.adaln_proj.linear.bias",
+      "final_layer.adaln_proj.linear.weight",
+      "final_layer.adaln_proj.linear.bias"
+    ]
+  }
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sd15.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sd15.diffusers-bf16.v1.json
@@ -1,0 +1,1008 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sd15.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical Stable Diffusion 1.x serve layout: the diffusers UNet2DConditionModel, all-bf16, every family derived from the real safetensors header of stable-diffusion-v1-5/stable-diffusion-v1-5. What separates this document from sd2.diffusers-bf16 is RANK, and it is a refusal rather than a shrug: SD1.x omits use_linear_projection, so all 32 *.attentions.{i}.proj_{in,out}.weight are 1x1 Conv2d (rank 4) where SD2.x has a Linear (rank 2). The key SET is identical - 686 keys, zero either side only - and cross_attention_dim 768-vs-1024 is invisible to a contract, so rank is the whole discriminator. The document declares the UNET ONLY, and that is deliberate: the diffusers VAE and text-encoder component files of an SD1.x/SD2.x tree are the SAME files SDXL ships (the SDXL repo's vae is the same 248-key AutoencoderKL spelling as SD2's, and the CLIP text encoders share every key name), so sdxl.diffusers-bf16 - which declares them completely - would tie with this document on any such file and identification would turn on which name sorts first. The UNet is the compile subject and the only component that identifies the family. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "unet.conv_in.bias",
+      "pattern": "conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.weight",
+      "pattern": "conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.bias",
+      "pattern": "conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.weight",
+      "pattern": "conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.bias",
+      "pattern": "conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.weight",
+      "pattern": "conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.bias",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.weight",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.bias",
+      "pattern": "mid_block.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.weight",
+      "pattern": "mid_block.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.bias",
+      "pattern": "mid_block.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.weight",
+      "pattern": "mid_block.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.bias",
+      "pattern": "mid_block.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.weight",
+      "pattern": "mid_block.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.bias",
+      "pattern": "mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.weight",
+      "pattern": "mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.bias",
+      "pattern": "mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.weight",
+      "pattern": "mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.bias",
+      "pattern": "mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.weight",
+      "pattern": "mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.bias",
+      "pattern": "mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.weight",
+      "pattern": "mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.bias",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.weight",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.bias",
+      "pattern": "time_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.weight",
+      "pattern": "time_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.bias",
+      "pattern": "time_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.weight",
+      "pattern": "time_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.bias",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.weight",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sd2.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sd2.diffusers-bf16.v1.json
@@ -1,0 +1,1008 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sd2.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical Stable Diffusion 2.x / SD-Turbo serve layout: the diffusers UNet2DConditionModel, all-bf16, every family derived from the real safetensors header of stabilityai/sd-turbo, which is what the sd15 endpoint's generate_turbo actually serves. SD2.x is its OWN document, not a spelling of sd15.diffusers-bf16: the key SET is identical (686 keys, zero either side only) and cross_attention_dim 1024-vs-768 is invisible to a contract, but use_linear_projection=true makes all 32 *.attentions.{i}.proj_{in,out}.weight a Linear (rank 2) where SD1.x has a 1x1 Conv2d (rank 4), and a claimed tensor whose rank disagrees is a refusal. The text encoder could never have been the discriminator either way: sd-turbo ships OpenCLIP ViT-H/14 exported in the CLIPTextModel spelling, so its keys are byte-identical to SD1.x's, 23 layers rather than 12. The document declares the UNET ONLY, and that is deliberate: the diffusers VAE and text-encoder component files of an SD1.x/SD2.x tree are the SAME files SDXL ships (the SDXL repo's vae is the same 248-key AutoencoderKL spelling as SD2's, and the CLIP text encoders share every key name), so sdxl.diffusers-bf16 - which declares them completely - would tie with this document on any such file and identification would turn on which name sorts first. The UNet is the compile subject and the only component that identifies the family. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "unet.conv_in.bias",
+      "pattern": "conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.weight",
+      "pattern": "conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.bias",
+      "pattern": "conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.weight",
+      "pattern": "conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.bias",
+      "pattern": "conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.weight",
+      "pattern": "conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.bias",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.weight",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.bias",
+      "pattern": "mid_block.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.weight",
+      "pattern": "mid_block.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.bias",
+      "pattern": "mid_block.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.weight",
+      "pattern": "mid_block.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.bias",
+      "pattern": "mid_block.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.weight",
+      "pattern": "mid_block.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.bias",
+      "pattern": "mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.weight",
+      "pattern": "mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.bias",
+      "pattern": "mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.weight",
+      "pattern": "mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.bias",
+      "pattern": "mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.weight",
+      "pattern": "mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.bias",
+      "pattern": "mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.weight",
+      "pattern": "mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.bias",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.weight",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.bias",
+      "pattern": "time_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.weight",
+      "pattern": "time_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.bias",
+      "pattern": "time_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.weight",
+      "pattern": "time_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.k.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.q.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.v.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.bias",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.weight",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.clip-g-fused-qkv.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.clip-g-fused-qkv.v1.json
@@ -1,0 +1,35 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sdxl.clip-g-fused-qkv",
+  "version": 1,
+  "description": "SDXL single-file packaging of OpenCLIP ViT-bigG: attention projections are one fused in_proj along the outermost axis, q|k|v in equal thirds. Measured at 0.315 GB per SDXL pair in the variant-corpus audit (F5).",
+  "tensors": [
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight",
+      "pattern": "conditioner.embedders.1.model.transformer.resblocks.{i}.attn.in_proj_weight",
+      "rank": 2,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          { "role": "q", "share": 1 },
+          { "role": "k", "share": 1 },
+          { "role": "v", "share": 1 }
+        ]
+      }
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias",
+      "pattern": "conditioner.embedders.1.model.transformer.resblocks.{i}.attn.in_proj_bias",
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          { "role": "q", "share": 1 },
+          { "role": "k", "share": 1 },
+          { "role": "v", "share": 1 }
+        ]
+      }
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.clip-g-split-qkv.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.clip-g-split-qkv.v1.json
@@ -1,0 +1,41 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sdxl.clip-g-split-qkv",
+  "version": 1,
+  "description": "The diffusers spelling of the same OpenCLIP ViT-bigG: one tensor per projection. Its roles are exactly the fused contract's seam-part roles, which is what makes the two packagings share every data object.",
+  "tensors": [
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.weight",
+      "rank": 2
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.weight",
+      "rank": 2
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.weight",
+      "rank": 2
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.bias",
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.bias",
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.bias",
+      "rank": 1,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/sdxl.diffusers-bf16.v1.json
@@ -1,0 +1,1998 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "sdxl.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical SDXL serve layout: the diffusers multifolder packaging (unet / vae / text_encoder / text_encoder_2), all-bf16. Matching is per component file, so every family is optional and each file matches the families it carries. The text-encoder patterns are the shared diffusers CLIP spelling \u2014 the CLIP-L file matches them too, distinguished by shape \u2014 and keep the sdxl.clip-g-* role vocabulary, which is what makes single-file <-> diffusers conversion of the CLIP-G tensors a run-preserving derive rather than a refusal. The declaration is COMPLETE over the shipped checkpoint's header (tensorfs#121): detection specificity is the count of a file's tensors a contract explains, so a sampled document loses to a complete document for a neighbouring architecture - sd2.diffusers-bf16 explains 1676 of the 1680 SDXL unet keys with no rank disagreement, because SDXL is SD2's spelling plus add_embedding. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.weight#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#q",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.q_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#k",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.k_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.qkv.bias#v",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.v_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.out.weight",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.out_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.attn.out.bias",
+      "pattern": "text_model.encoder.layers.{i}.self_attn.out_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc1.weight",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc2.weight",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.text_projection",
+      "pattern": "text_projection.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc1",
+      "pattern": "add_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc2",
+      "pattern": "add_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1",
+      "pattern": "time_embedding.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2",
+      "pattern": "time_embedding.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff1",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff2",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff1",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff2",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.q",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.k",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.v",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff1",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.0.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff2",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv",
+      "pattern": "quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv",
+      "pattern": "post_quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in",
+      "pattern": "encoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in",
+      "pattern": "decoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.q",
+      "pattern": "decoder.mid_block.attentions.{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc1.bias",
+      "pattern": "add_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.add_embedding.fc2.bias",
+      "pattern": "add_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.bias",
+      "pattern": "conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_in.weight",
+      "pattern": "conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.bias",
+      "pattern": "conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_norm_out.weight",
+      "pattern": "conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.bias",
+      "pattern": "conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.conv_out.weight",
+      "pattern": "conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in.bias",
+      "pattern": "decoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_norm_out.bias",
+      "pattern": "decoder.conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_norm_out.weight",
+      "pattern": "decoder.conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.bias",
+      "pattern": "decoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.weight",
+      "pattern": "decoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.group_norm.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.group_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.group_norm.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.group_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.k.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.k.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.out.{i}.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.out.{i}.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.q.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.v.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.v.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm1.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm1.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm2.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm2.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm1.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm1.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm2.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm2.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.conv.bias",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.conv.weight",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.norm.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_in.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.proj_out.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "down_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.bias",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.ds.{i}.conv.weight",
+      "pattern": "down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm1.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.norm2.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.bias",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.down.{i}.res.{i}.temb.weight",
+      "pattern": "down_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in.bias",
+      "pattern": "encoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_norm_out.bias",
+      "pattern": "encoder.conv_norm_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_norm_out.weight",
+      "pattern": "encoder.conv_norm_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.bias",
+      "pattern": "encoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.weight",
+      "pattern": "encoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.{i}.conv.bias",
+      "pattern": "encoder.down_blocks.{i}.downsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.{i}.conv.weight",
+      "pattern": "encoder.down_blocks.{i}.downsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm1.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm1.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm2.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm2.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.group_norm.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.group_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.group_norm.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.group_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.k.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.k.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.out.{i}.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.out.{i}.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.q.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.q.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.v.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.v.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm1.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm1.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm2.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm2.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.bias",
+      "pattern": "mid_block.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.norm.weight",
+      "pattern": "mid_block.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.bias",
+      "pattern": "mid_block.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_in.weight",
+      "pattern": "mid_block.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.bias",
+      "pattern": "mid_block.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.proj_out.weight",
+      "pattern": "mid_block.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "mid_block.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.bias",
+      "pattern": "mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv1.weight",
+      "pattern": "mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.bias",
+      "pattern": "mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.conv2.weight",
+      "pattern": "mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.bias",
+      "pattern": "mid_block.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm1.weight",
+      "pattern": "mid_block.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.bias",
+      "pattern": "mid_block.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.norm2.weight",
+      "pattern": "mid_block.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.bias",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.mid.res.{i}.temb.weight",
+      "pattern": "mid_block.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv.bias",
+      "pattern": "post_quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv.bias",
+      "pattern": "quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.embeddings.position_embedding.weight",
+      "pattern": "text_model.embeddings.position_embedding.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.embeddings.token_embedding.weight",
+      "pattern": "text_model.embeddings.token_embedding.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm1.bias",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm1.weight",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm2.bias",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.layer_norm2.weight",
+      "pattern": "text_model.encoder.layers.{i}.layer_norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc1.bias",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.layers.{i}.mlp.fc2.bias",
+      "pattern": "text_model.encoder.layers.{i}.mlp.fc2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.final_layer_norm.bias",
+      "pattern": "text_model.final_layer_norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "clip_g.final_layer_norm.weight",
+      "pattern": "text_model.final_layer_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc1.bias",
+      "pattern": "time_embedding.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.time_embedding.fc2.bias",
+      "pattern": "time_embedding.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.norm.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_in.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.proj_out.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.a{i}.out.{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.proj.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.ff{i}.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.ff.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.bias",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.attn.{i}.tb.{i}.norm3.weight",
+      "pattern": "up_blocks.{i}.attentions.{i}.transformer_blocks.{i}.norm3.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm1.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.norm2.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.bias",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.res.{i}.temb.weight",
+      "pattern": "up_blocks.{i}.resnets.{i}.time_emb_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.bias",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "unet.up.{i}.us.{i}.conv.weight",
+      "pattern": "up_blocks.{i}.upsamplers.{i}.conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/_contracts/wan22.diffusers-bf16.v1.json
+++ b/src/gen_worker/_vendor/tensorfs/_contracts/wan22.diffusers-bf16.v1.json
@@ -1,0 +1,1148 @@
+{
+  "format": "tensorfs-contract-v1",
+  "name": "wan22.diffusers-bf16",
+  "version": 1,
+  "dtype": "bfloat16",
+  "description": "The canonical Wan 2.2 serve layout: the diffusers multifolder packaging (transformer [+ transformer_2 for the A14B MoE pair] / vae / text_encoder), all-bf16. ONE document covers all three shipped repos - Wan-AI/Wan2.2-T2V-A14B-Diffusers, Wan2.2-I2V-A14B-Diffusers and Wan2.2-TI2V-5B-Diffusers - because their WanTransformer3DModel key set and ranks are IDENTICAL (only the block count differs, 40 vs 30, and {i} holes do not care). Both MoE halves are the same spelling, so transformer and transformer_2 match the same declarations. Matching is per component file, so every family is optional and each file matches the families it carries; that is also how the two VAEs coexist here - the A14B Wan2.1 VAE spells its encoder resnets flat (encoder.down_blocks.{i}.conv1) and its upsamplers indexed, the TI2V-5B Wan2.2 VAE nests them (encoder.down_blocks.{i}.resnets.{i}.conv1) with a single downsampler/upsampler, and no shared key disagrees on rank. The VAE mid-block attention fuses qkv along the outermost axis in equal thirds, which is the one seam here. The text encoder is UMT5 in the T5 spelling. Top-level dtype is the serve-side load dtype (ctx.lane.dtype); the per-tensor dtypes are the matcher's constraint that this really is the bf16 packaging.",
+  "tensors": [
+    {
+      "role": "dit.blocks.{i}.a{i}.norm_k.weight",
+      "pattern": "blocks.{i}.attn{i}.norm_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.norm_q.weight",
+      "pattern": "blocks.{i}.attn{i}.norm_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.k.bias",
+      "pattern": "blocks.{i}.attn{i}.to_k.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.k.weight",
+      "pattern": "blocks.{i}.attn{i}.to_k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.out.{i}.bias",
+      "pattern": "blocks.{i}.attn{i}.to_out.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.out.{i}.weight",
+      "pattern": "blocks.{i}.attn{i}.to_out.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.q.bias",
+      "pattern": "blocks.{i}.attn{i}.to_q.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.q.weight",
+      "pattern": "blocks.{i}.attn{i}.to_q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.v.bias",
+      "pattern": "blocks.{i}.attn{i}.to_v.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.a{i}.v.weight",
+      "pattern": "blocks.{i}.attn{i}.to_v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff{i}.bias",
+      "pattern": "blocks.{i}.ffn.net.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff{i}.proj.bias",
+      "pattern": "blocks.{i}.ffn.net.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff{i}.proj.weight",
+      "pattern": "blocks.{i}.ffn.net.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.ff{i}.weight",
+      "pattern": "blocks.{i}.ffn.net.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.norm2.bias",
+      "pattern": "blocks.{i}.norm2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.norm2.weight",
+      "pattern": "blocks.{i}.norm2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.blocks.{i}.scale_shift_table",
+      "pattern": "blocks.{i}.scale_shift_table",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "dit.cond.text_embedder.fc1.bias",
+      "pattern": "condition_embedder.text_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.cond.text_embedder.fc1.weight",
+      "pattern": "condition_embedder.text_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.cond.text_embedder.fc2.bias",
+      "pattern": "condition_embedder.text_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.cond.text_embedder.fc2.weight",
+      "pattern": "condition_embedder.text_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_embedder.fc1.bias",
+      "pattern": "condition_embedder.time_embedder.linear_1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_embedder.fc1.weight",
+      "pattern": "condition_embedder.time_embedder.linear_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_embedder.fc2.bias",
+      "pattern": "condition_embedder.time_embedder.linear_2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_embedder.fc2.weight",
+      "pattern": "condition_embedder.time_embedder.linear_2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_proj.bias",
+      "pattern": "condition_embedder.time_proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.cond.time_proj.weight",
+      "pattern": "condition_embedder.time_proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in.bias",
+      "pattern": "decoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_in.weight",
+      "pattern": "decoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.bias",
+      "pattern": "decoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.conv_out.weight",
+      "pattern": "decoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.norm.gamma",
+      "pattern": "decoder.mid_block.attentions.{i}.norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.proj.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.proj.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.qkv.bias",
+      "pattern": "decoder.mid_block.attentions.{i}.to_qkv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vae.decoder.mid.attn.{i}.qkv.weight",
+      "pattern": "decoder.mid_block.attentions.{i}.to_qkv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv1.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.bias",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.conv2.weight",
+      "pattern": "decoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm1.gamma",
+      "pattern": "decoder.mid_block.resnets.{i}.norm1.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.mid.res.{i}.norm2.gamma",
+      "pattern": "decoder.mid_block.resnets.{i}.norm2.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.norm_out.gamma",
+      "pattern": "decoder.norm_out.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv1.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv2.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm1.gamma",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm1.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.res.{i}.norm2.gamma",
+      "pattern": "decoder.up_blocks.{i}.resnets.{i}.norm2.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.resample.{i}.bias",
+      "pattern": "decoder.up_blocks.{i}.upsampler.resample.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.resample.{i}.weight",
+      "pattern": "decoder.up_blocks.{i}.upsampler.resample.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.time_conv.bias",
+      "pattern": "decoder.up_blocks.{i}.upsampler.time_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.time_conv.weight",
+      "pattern": "decoder.up_blocks.{i}.upsampler.time_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.resample.{i}.bias",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.resample.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.resample.{i}.weight",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.resample.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.time_conv.bias",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.time_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.decoder.up.{i}.us.{i}.time_conv.weight",
+      "pattern": "decoder.up_blocks.{i}.upsamplers.{i}.time_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.ffn.wi_0.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.DenseReluDense.wi_0.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.ffn.wi_1.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.DenseReluDense.wi_1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.ffn.wo.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.DenseReluDense.wo.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.attn.k.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.SelfAttention.k.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.attn.o.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.SelfAttention.o.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.attn.q.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.SelfAttention.q.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.attn.rel_bias.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.SelfAttention.relative_attention_bias.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.attn.v.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.SelfAttention.v.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "umt5.layers.{i}.l{i}.norm.weight",
+      "pattern": "encoder.block.{i}.layer.{i}.layer_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in.bias",
+      "pattern": "encoder.conv_in.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_in.weight",
+      "pattern": "encoder.conv_in.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.bias",
+      "pattern": "encoder.conv_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.conv_out.weight",
+      "pattern": "encoder.conv_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv1.bias",
+      "pattern": "encoder.down_blocks.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv1.weight",
+      "pattern": "encoder.down_blocks.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv2.bias",
+      "pattern": "encoder.down_blocks.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv2.weight",
+      "pattern": "encoder.down_blocks.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv_shortcut.bias",
+      "pattern": "encoder.down_blocks.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.conv_shortcut.weight",
+      "pattern": "encoder.down_blocks.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.resample.{i}.bias",
+      "pattern": "encoder.down_blocks.{i}.downsampler.resample.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.resample.{i}.weight",
+      "pattern": "encoder.down_blocks.{i}.downsampler.resample.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.time_conv.bias",
+      "pattern": "encoder.down_blocks.{i}.downsampler.time_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.ds.time_conv.weight",
+      "pattern": "encoder.down_blocks.{i}.downsampler.time_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.norm1.gamma",
+      "pattern": "encoder.down_blocks.{i}.norm1.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.norm2.gamma",
+      "pattern": "encoder.down_blocks.{i}.norm2.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.resample.{i}.bias",
+      "pattern": "encoder.down_blocks.{i}.resample.{i}.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.resample.{i}.weight",
+      "pattern": "encoder.down_blocks.{i}.resample.{i}.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv1.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv2.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.bias",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.conv_shortcut.weight",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.conv_shortcut.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm1.gamma",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm1.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.res.{i}.norm2.gamma",
+      "pattern": "encoder.down_blocks.{i}.resnets.{i}.norm2.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.time_conv.bias",
+      "pattern": "encoder.down_blocks.{i}.time_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.down.{i}.time_conv.weight",
+      "pattern": "encoder.down_blocks.{i}.time_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "umt5.final_layer_norm.weight",
+      "pattern": "encoder.final_layer_norm.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.norm.gamma",
+      "pattern": "encoder.mid_block.attentions.{i}.norm.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.proj.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.proj.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.proj.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.proj.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.qkv.bias",
+      "pattern": "encoder.mid_block.attentions.{i}.to_qkv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vae.encoder.mid.attn.{i}.qkv.weight",
+      "pattern": "encoder.mid_block.attentions.{i}.to_qkv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false,
+      "fusion": {
+        "axis": 0,
+        "parts": [
+          {
+            "role": "q",
+            "share": 1
+          },
+          {
+            "role": "k",
+            "share": 1
+          },
+          {
+            "role": "v",
+            "share": 1
+          }
+        ]
+      }
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv1.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv1.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.bias",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.conv2.weight",
+      "pattern": "encoder.mid_block.resnets.{i}.conv2.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm1.gamma",
+      "pattern": "encoder.mid_block.resnets.{i}.norm1.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.mid.res.{i}.norm2.gamma",
+      "pattern": "encoder.mid_block.resnets.{i}.norm2.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "vae.encoder.norm_out.gamma",
+      "pattern": "encoder.norm_out.gamma",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 4,
+      "required": false
+    },
+    {
+      "role": "dit.patch_embedding.bias",
+      "pattern": "patch_embedding.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.patch_embedding.weight",
+      "pattern": "patch_embedding.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv.bias",
+      "pattern": "post_quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.post_quant_conv.weight",
+      "pattern": "post_quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "dit.proj_out.bias",
+      "pattern": "proj_out.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "dit.proj_out.weight",
+      "pattern": "proj_out.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv.bias",
+      "pattern": "quant_conv.bias",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 1,
+      "required": false
+    },
+    {
+      "role": "vae.quant_conv.weight",
+      "pattern": "quant_conv.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 5,
+      "required": false
+    },
+    {
+      "role": "dit.scale_shift_table",
+      "pattern": "scale_shift_table",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 3,
+      "required": false
+    },
+    {
+      "role": "umt5.embed_tokens.weight",
+      "pattern": "shared.weight",
+      "dtypes": [
+        "BF16"
+      ],
+      "rank": 2,
+      "required": false
+    }
+  ]
+}

--- a/src/gen_worker/_vendor/tensorfs/contract.py
+++ b/src/gen_worker/_vendor/tensorfs/contract.py
@@ -1,0 +1,746 @@
+"""Layout contracts as objects: the actual layout, imported and passed around.
+
+A lane declaration is not a name or an enum pointing at a layout — it IS the
+layout: ``lanes=(tensorfs.contracts.SDXL_DIFFUSERS_BF16, ...)``. The
+predefined constants (:mod:`tensorfs.contracts`) are typed helpers over the
+curated library; an author who needs a layout the library does not ship
+constructs one inline::
+
+    my_layout = Contract(
+        dtype="bfloat16",
+        tensors=[
+            TensorDecl(
+                role="blocks.{i}.attn.qkv",
+                pattern="blocks.{i}.attn.qkv_proj.weight",
+                rank=2,
+                fusion=Fusion(parts=[("q", 1), ("k", 1), ("v", 1)]),
+            ),
+        ],
+    )
+
+Custom contracts are ANONYMOUS: there is deliberately no ``name=`` — identity
+is the content digest (``sha256:<hex>``), because a free-text name on an
+inline object validates nothing and can lie or collide. The author's variable
+name is their label; platform surfaces spell the digest. ``name@version``
+survives only for the curated library, where CI digest-pinning makes the name
+a real promise.
+
+Construction serializes to a v1 document and runs the validator, so a
+malformed contract refuses at author-module import time, never at deploy.
+
+pgw#1391 REWRITE — WHY THIS FILE IS NOT UPSTREAM'S VERBATIM
+-----------------------------------------------------------
+Upstream's ``contract.py`` delegates parse/validate/digest to the compiled
+Rust extension (``from .native import contract_info``), and pgw#1310 rules a
+compiled extension out of a source-vendored wheel. So the validator and the
+canonical rendering are restored here in pure Python, exactly as pgw#1365 did
+for ``planner.py``, and for the same reason.
+
+This is a PORT, not a reimplementation, and it is not asserted — it is proven.
+The digest input is a line-oriented canonical rendering fully specified by
+``crates/tensorfs-core/src/contract.rs`` (``Contract::canonical``) and
+independently re-expressed by tensorfs#114's Go implementation
+(``contract.go``). All three are pinned to ONE language-neutral corpus,
+``spec/v1/contract-vectors``, vendored at ``tests/testdata/contract-vectors/``
+and run by ``tests/test_lane_contracts.py``: every golden digest
+and every typed refusal. That corpus, not discipline, is the sync mechanism.
+
+The public surface is upstream's, attribute for attribute, so re-vendoring a
+future pure-Python upstream is a deletion rather than a migration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "CONTRACT_FORMAT",
+    "Contract",
+    "ContractError",
+    "Fusion",
+    "MissingDtype",
+    "Permute",
+    "TensorDecl",
+]
+
+#: The one document format tag.
+CONTRACT_FORMAT = "tensorfs-contract-v1"
+
+MAX_CONTRACT_NAME_BYTES = 64
+MAX_PATTERN_BYTES = 512
+MAX_DTYPE_BYTES = 32
+
+
+class MissingDtype(ValueError):
+    """A lane read asked for a load dtype the contract does not declare."""
+
+
+class ContractError(ValueError):
+    """A typed refusal, carrying the kebab-case ``reason`` label shared with
+    the Rust validator's ``ContractError::reason`` and the Go one's."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(f"contract: {reason}: {message}")
+        self.reason = reason
+        self.message = message
+
+
+def _refuse(reason: str, message: str) -> ContractError:
+    return ContractError(reason, message)
+
+
+# ── the author-facing declaration types ──────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Fusion:
+    """A fusion along the outermost axis: ``groups`` repetitions of the
+    ordered ``parts`` cycle, each part ``(role_suffix, share)``."""
+
+    parts: Sequence[tuple[str, int]]
+    groups: int = 1
+
+    def _raw(self) -> dict[str, Any]:
+        return {
+            "axis": 0,
+            **({"groups": self.groups} if self.groups != 1 else {}),
+            "parts": [{"role": role, "share": share} for role, share in self.parts],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Permute:
+    """A generalized permute: reshape to ``view``, permute those axes,
+    reshape back. ``view`` entries are literals, ``"shape[k]"`` /
+    ``"shape[k]/n"``, or ``"auto"``."""
+
+    view: Sequence[int | str]
+    axes: Sequence[int]
+
+    def _raw(self) -> dict[str, Any]:
+        return {"view": list(self.view), "axes": list(self.axes)}
+
+
+@dataclass(frozen=True, slots=True)
+class TensorDecl:
+    """One declared tensor family: its spelling-independent role, its spelling
+    in the file, and the constraints that make the contract falsifiable."""
+
+    role: str
+    pattern: str
+    dtypes: Sequence[str] = ()
+    rank: int | None = None
+    required: bool = True
+    fusion: Fusion | None = None
+    permute: Permute | None = None
+
+    def _raw(self) -> dict[str, Any]:
+        raw: dict[str, Any] = {"role": self.role, "pattern": self.pattern}
+        if self.dtypes:
+            raw["dtypes"] = list(self.dtypes)
+        if self.rank is not None:
+            raw["rank"] = self.rank
+        if not self.required:
+            raw["required"] = False
+        if self.fusion is not None:
+            raw["fusion"] = self.fusion._raw()
+        if self.permute is not None:
+            raw["permute"] = self.permute._raw()
+        return raw
+
+
+def _decl_of(raw: Mapping[str, Any]) -> TensorDecl:
+    fusion = None
+    if "fusion" in raw:
+        fusion = Fusion(
+            parts=tuple((part["role"], part["share"]) for part in raw["fusion"]["parts"]),
+            groups=raw["fusion"].get("groups", 1),
+        )
+    permute = None
+    if "permute" in raw:
+        permute = Permute(
+            view=tuple(raw["permute"]["view"]),
+            axes=tuple(raw["permute"]["axes"]),
+        )
+    return TensorDecl(
+        role=raw["role"],
+        pattern=raw["pattern"],
+        dtypes=tuple(raw.get("dtypes", ())),
+        rank=raw.get("rank"),
+        required=raw.get("required", True),
+        fusion=fusion,
+        permute=permute,
+    )
+
+
+# ── the validator (the port) ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class _Pattern:
+    """Literal text with ``{i}`` integer holes. Adjacent holes, a digit
+    directly after a hole, and stray braces all refuse."""
+
+    text: str
+    holes: int
+
+
+def _parse_pattern(text: object) -> _Pattern:
+    if not isinstance(text, str) or not text or len(text.encode()) > MAX_PATTERN_BYTES:
+        raise _refuse("pattern", json.dumps(text))
+    holes = 0
+    last_was_hole = False
+    rest = text
+    while rest:
+        at = rest.find("{i}")
+        if at < 0:
+            if "{" in rest or "}" in rest:
+                raise _refuse("pattern", json.dumps(text))
+            break
+        if at > 0:
+            if "{" in rest[:at] or "}" in rest[:at]:
+                raise _refuse("pattern", json.dumps(text))
+        elif last_was_hole:
+            # Adjacent holes cannot be separated by any input.
+            raise _refuse("pattern", json.dumps(text))
+        holes += 1
+        last_was_hole = True
+        rest = rest[at + 3 :]
+        if rest and rest[0].isdigit() and rest[0].isascii():
+            # A digit after a hole makes the split ambiguous.
+            raise _refuse("pattern", json.dumps(text))
+    return _Pattern(text=text, holes=holes)
+
+
+def _is_lower(character: str) -> bool:
+    return character.isascii() and (character.islower() or character.isdigit())
+
+
+def _is_contract_name(name: object) -> bool:
+    """``<producer>.<format>``, split on the FIRST dot.
+
+    The producer segment carries a hyphen because gen-worker's model-type
+    vocabulary does (``hidream-o1``, ``flux-2``, ``wan-2``) — tensorfs#121
+    relaxed it for exactly that reason. A LEADING hyphen still refuses. The
+    format segment is lowercase alphanumerics plus ``.``, ``-`` and ``_``,
+    also not leading.
+    """
+
+    if not isinstance(name, str) or not name or len(name.encode()) > MAX_CONTRACT_NAME_BYTES:
+        return False
+    producer, separator, layout = name.partition(".")
+    if not separator or not producer or not layout:
+        return False
+    if not _is_lower(producer[0]):
+        return False
+    if not all(_is_lower(character) or character == "-" for character in producer):
+        return False
+    if not _is_lower(layout[0]):
+        return False
+    return all(_is_lower(character) or character in ".-_" for character in layout)
+
+
+def _is_dtype(dtype: object) -> bool:
+    """Torch-style, lowercase, bounded — a shape, not an enum."""
+
+    if not isinstance(dtype, str) or not dtype or len(dtype.encode()) > MAX_DTYPE_BYTES:
+        return False
+    return all(
+        character.isascii() and (character.islower() or character.isdigit() or character == "_")
+        for character in dtype
+    )
+
+
+def _uint(value: object) -> int | None:
+    """A JSON non-negative integer, or ``None`` when the value is not one.
+    ``bool`` is not an integer here, matching the typed deserializers."""
+
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+_CONTRACT_FIELDS = frozenset(
+    {"format", "name", "version", "description", "dtype", "tensors", "sets"}
+)
+_TENSOR_FIELDS = frozenset({"role", "pattern", "dtypes", "rank", "required", "fusion", "permute"})
+_FUSION_FIELDS = frozenset({"axis", "groups", "parts"})
+_PART_FIELDS = frozenset({"role", "share"})
+_PERMUTE_FIELDS = frozenset({"view", "axes"})
+
+
+def _known_fields_only(raw: object, allowed: frozenset[str], what: str) -> Mapping[str, Any]:
+    """The typed deserializers on both other sides refuse an unknown field as
+    a JSON SHAPE error rather than a semantic one; so does this."""
+
+    if not isinstance(raw, Mapping):
+        raise _refuse("json", f"{what} is not an object")
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise _refuse("json", f"unknown field {unknown[0]!r} in {what}")
+    return raw
+
+
+@dataclass(frozen=True, slots=True)
+class _FusionPart:
+    role: str
+    share: int
+
+
+@dataclass(frozen=True, slots=True)
+class _Fusion:
+    groups: int
+    parts: tuple[_FusionPart, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _Dim:
+    kind: str  # "literal" | "axis" | "auto"
+    literal: int = 0
+    axis: int = 0
+    divisor: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class _Permute:
+    view: tuple[_Dim, ...]
+    axes: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _Tensor:
+    role: _Pattern
+    pattern: _Pattern
+    dtypes: tuple[str, ...]
+    rank: int | None
+    required: bool
+    fusion: _Fusion | None
+    permute: _Permute | None
+
+
+def _validate_fusion(pattern: str, raw: object) -> _Fusion:
+    raw = _known_fields_only(raw, _FUSION_FIELDS, "a fusion")
+    refusal = _refuse("fusion", json.dumps(pattern))
+    if "axis" not in raw or "parts" not in raw:
+        raise _refuse("json", "a fusion declares axis and parts")
+    axis = _uint(raw["axis"])
+    groups = _uint(raw.get("groups", 1))
+    if axis is None or groups is None or not isinstance(raw["parts"], list):
+        raise _refuse("json", "a fusion declares axis and parts")
+    # Only the outer axis concatenates; a single part in a single group is the
+    # whole tensor, which is not a fusion.
+    if axis != 0 or groups == 0 or not raw["parts"] or (groups == 1 and len(raw["parts"]) < 2):
+        raise refusal
+    seen: set[str] = set()
+    parts: list[_FusionPart] = []
+    for entry in raw["parts"]:
+        entry = _known_fields_only(entry, _PART_FIELDS, "a fusion part")
+        if "role" not in entry or "share" not in entry:
+            raise _refuse("json", "a fusion part declares role and share")
+        role, share = entry["role"], _uint(entry["share"])
+        if not isinstance(role, str) or share is None:
+            raise _refuse("json", "a fusion part declares role and share")
+        if share == 0 or role in seen:
+            raise refusal
+        seen.add(role)
+        # An unnamed part is only meaningful as the sole part of an
+        # interleaved slice: it IS the declared role.
+        if role == "" and len(seen) > 1:
+            raise refusal
+        parts.append(_FusionPart(role=role, share=share))
+    if len(parts) > 1 and any(part.role == "" for part in parts):
+        raise refusal
+    return _Fusion(groups=groups, parts=tuple(parts))
+
+
+def _parse_dim(value: object) -> _Dim | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return _Dim("literal", literal=value) if value > 0 else None
+    if not isinstance(value, str):
+        return None
+    if value == "auto":
+        return _Dim("auto")
+    if value.isdigit() and value.isascii():
+        literal = int(value)
+        return _Dim("literal", literal=literal) if literal > 0 else None
+    head, divided, divisor_text = value.partition("/")
+    divisor = 1
+    if divided:
+        if not (divisor_text.isdigit() and divisor_text.isascii()) or int(divisor_text) == 0:
+            return None
+        divisor = int(divisor_text)
+    if not head.startswith("shape[") or not head.endswith("]"):
+        return None
+    digits = head[len("shape[") : -1]
+    if not (digits.isdigit() and digits.isascii()):
+        return None
+    return _Dim("axis", axis=int(digits), divisor=divisor)
+
+
+def _validate_permute(pattern: str, fused: bool, raw: object) -> _Permute:
+    raw = _known_fields_only(raw, _PERMUTE_FIELDS, "a permute")
+    refusal = _refuse("permute", json.dumps(pattern))
+    if "view" not in raw or "axes" not in raw:
+        raise _refuse("json", "a permute declares view and axes")
+    view_raw, axes_raw = raw["view"], raw["axes"]
+    if not isinstance(view_raw, list) or not isinstance(axes_raw, list):
+        raise _refuse("json", "a permute declares view and axes")
+    axes: list[int] = []
+    for value in axes_raw:
+        axis = _uint(value)
+        if axis is None:
+            raise _refuse("json", "a permute axis is a non-negative integer")
+        axes.append(axis)
+    # A permute inside a fused tensor would mean its seam runs are NOT the
+    # split packaging's bytes, which is the one thing a seam promises.
+    if fused:
+        raise refusal
+    if len(view_raw) < 2 or len(axes) != len(view_raw):
+        raise refusal
+    seen = [False] * len(axes)
+    identity = True
+    for at, axis in enumerate(axes):
+        if axis >= len(seen) or seen[axis]:
+            raise refusal
+        seen[axis] = True
+        if at != axis:
+            identity = False
+    if identity:
+        # The identity permute is the absence of one.
+        raise refusal
+    view: list[_Dim] = []
+    for value in view_raw:
+        dim = _parse_dim(value)
+        if dim is None:
+            raise refusal
+        view.append(dim)
+    return _Permute(view=tuple(view), axes=tuple(axes))
+
+
+def _parse(raw: object) -> tuple[str | None, int | None, str | None, list[_Tensor], dict[str, list[_Pattern]]]:
+    """Validate one decoded v1 document. Refusals mirror the Rust and Go
+    validators reason for reason; the shared corpus proves it."""
+
+    raw = _known_fields_only(raw, _CONTRACT_FIELDS, "a contract")
+    if "format" not in raw or "tensors" not in raw:
+        raise _refuse("json", "missing format or tensors")
+    if raw["format"] != CONTRACT_FORMAT:
+        raise _refuse("format", str(raw["format"]))
+
+    name: str | None = None
+    version: int | None = None
+    has_name, has_version = "name" in raw, "version" in raw
+    if has_name and has_version:
+        if not _is_contract_name(raw["name"]):
+            raise _refuse("name", json.dumps(raw["name"]))
+        parsed = _uint(raw["version"])
+        if parsed is None:
+            raise _refuse("json", "version is a non-negative integer")
+        if parsed == 0:
+            raise _refuse("version", "must be at least 1")
+        name, version = raw["name"], parsed
+    elif has_name or has_version:
+        raise _refuse("identity", "name and version travel together or not at all")
+
+    dtype: str | None = None
+    if "dtype" in raw:
+        if not _is_dtype(raw["dtype"]):
+            raise _refuse("dtype", json.dumps(raw["dtype"]))
+        dtype = raw["dtype"]
+
+    if not isinstance(raw["tensors"], list):
+        raise _refuse("json", "tensors is a list")
+    if not raw["tensors"]:
+        raise _refuse("no-tensors", "a contract declares at least one tensor")
+
+    patterns: set[str] = set()
+    roles: set[str] = set()
+    tensors: list[_Tensor] = []
+    for entry in raw["tensors"]:
+        entry = _known_fields_only(entry, _TENSOR_FIELDS, "a tensor")
+        if "role" not in entry or "pattern" not in entry:
+            raise _refuse("json", "a tensor declares role and pattern")
+        pattern = _parse_pattern(entry["pattern"])
+        role = _parse_pattern(entry["role"])
+        if role.holes != pattern.holes:
+            raise _refuse("role-holes", json.dumps(role.text))
+        if pattern.text in patterns:
+            raise _refuse("duplicate", json.dumps(pattern.text))
+        patterns.add(pattern.text)
+        if role.text in roles:
+            raise _refuse("duplicate", json.dumps(role.text))
+        roles.add(role.text)
+
+        dtypes = entry.get("dtypes", [])
+        if not isinstance(dtypes, list) or not all(isinstance(item, str) for item in dtypes):
+            raise _refuse("json", "dtypes is a list of strings")
+        rank = None
+        if entry.get("rank") is not None:
+            rank = _uint(entry["rank"])
+            if rank is None:
+                raise _refuse("json", "rank is a non-negative integer")
+        required = entry.get("required", True)
+        if not isinstance(required, bool):
+            raise _refuse("json", "required is a boolean")
+
+        fusion = _validate_fusion(pattern.text, entry["fusion"]) if "fusion" in entry else None
+        permute = (
+            _validate_permute(pattern.text, fusion is not None, entry["permute"])
+            if "permute" in entry
+            else None
+        )
+        tensors.append(
+            _Tensor(
+                role=role,
+                pattern=pattern,
+                dtypes=tuple(dtypes),
+                rank=rank,
+                required=required,
+                fusion=fusion,
+                permute=permute,
+            )
+        )
+
+    sets: dict[str, list[_Pattern]] = {}
+    raw_sets = raw.get("sets", {})
+    if not isinstance(raw_sets, Mapping):
+        raise _refuse("json", "sets is an object")
+    for set_name, members in raw_sets.items():
+        if not isinstance(members, list):
+            raise _refuse("json", "a set is a list of patterns")
+        if not members:
+            raise _refuse("set", json.dumps(set_name))
+        sets[set_name] = [_parse_pattern(member) for member in members]
+    return name, version, dtype, tensors, sets
+
+
+def _canonical(
+    name: str | None,
+    version: int | None,
+    dtype: str | None,
+    tensors: Sequence[_Tensor],
+    sets: Mapping[str, Sequence[_Pattern]],
+) -> str:
+    """The canonical rendering, BYTE FOR BYTE what Rust and Go emit.
+
+    OMISSION-PRESERVING: an absent field emits no line at all, so the digests
+    of the pre-existing named library are byte-identical to what they were
+    when ``name``/``version`` were mandatory.
+    """
+
+    out = [f"{CONTRACT_FORMAT}\n"]
+    if name is not None:
+        out.append(f"name={name}\nversion={version}\n")
+    if dtype is not None:
+        out.append(f"dtype={dtype}\n")
+    for tensor in tensors:
+        rank = "any" if tensor.rank is None else str(tensor.rank)
+        out.append(
+            f"tensor role={tensor.role.text} pattern={tensor.pattern.text} "
+            f"rank={rank} required={'true' if tensor.required else 'false'} "
+            f"dtypes={','.join(tensor.dtypes)}"
+        )
+        if tensor.permute is not None:
+            out.append(" permute=")
+            for dim in tensor.permute.view:
+                if dim.kind == "literal":
+                    out.append(str(dim.literal))
+                elif dim.kind == "auto":
+                    out.append("auto")
+                else:
+                    out.append(f"shape[{dim.axis}]/{dim.divisor}")
+                out.append(",")
+            # The Rust side renders the axes list with Debug formatting.
+            out.append(":[" + ", ".join(str(axis) for axis in tensor.permute.axes) + "]")
+        if tensor.fusion is not None:
+            out.append(f" fusion=groups:{tensor.fusion.groups},")
+            for part in tensor.fusion.parts:
+                out.append(f"{part.role}:{part.share},")
+        out.append("\n")
+    for set_name in sorted(sets):
+        out.append(f"set {set_name}=")
+        for pattern in sets[set_name]:
+            out.append(f"{pattern.text},")
+        out.append("\n")
+    return "".join(out)
+
+
+# ── the object ───────────────────────────────────────────────────────────────
+
+
+class Contract:
+    """One frozen, validated layout contract.
+
+    The predefined :mod:`tensorfs.contracts` constants are instances of this
+    class; ``Contract(...)`` constructs an ANONYMOUS custom (no ``name=`` — a
+    custom's identity is its digest). Equality and hashing are by digest.
+    """
+
+    _digest: str
+    _document: str
+    _dtype: str | None
+    _name: str | None
+    _raw: dict[str, Any]
+    _stamp: str
+    _version: int | None
+
+    __slots__ = ("_digest", "_document", "_dtype", "_name", "_raw", "_stamp", "_version")
+
+    def __init__(
+        self,
+        *,
+        tensors: Sequence[TensorDecl],
+        dtype: str | None = None,
+        sets: Mapping[str, Sequence[str]] | None = None,
+        description: str = "",
+    ) -> None:
+        raw: dict[str, Any] = {"format": CONTRACT_FORMAT}
+        if description:
+            raw["description"] = description
+        if dtype is not None:
+            raw["dtype"] = dtype
+        raw["tensors"] = [decl._raw() for decl in tensors]
+        if sets:
+            raw["sets"] = {name: list(patterns) for name, patterns in sets.items()}
+        self._seal(raw)
+
+    def _seal(self, raw: dict[str, Any]) -> None:
+        """Canonicalize, validate, and freeze."""
+
+        document = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+        name, version, dtype, tensors, sets = _parse(raw)
+        digest = hashlib.sha256(
+            _canonical(name, version, dtype, tensors, sets).encode()
+        ).hexdigest()
+        object.__setattr__(self, "_raw", raw)
+        object.__setattr__(self, "_document", document)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_version", version)
+        object.__setattr__(self, "_dtype", dtype)
+        object.__setattr__(self, "_digest", digest)
+        object.__setattr__(
+            self, "_stamp", f"{name}@{version}" if name is not None else f"sha256:{digest}"
+        )
+
+    def __setattr__(self, attribute: str, value: object) -> None:
+        raise AttributeError("a Contract is frozen")
+
+    @classmethod
+    def from_document(cls, document: str) -> Contract:
+        """A contract from a raw v1 JSON document (library or custom)."""
+
+        contract = cls.__new__(cls)
+        try:
+            raw = json.loads(document)
+        except ValueError as exc:
+            raise _refuse("json", str(exc)) from None
+        contract._seal(raw)
+        return contract
+
+    @classmethod
+    def from_file(cls, path: str) -> Contract:
+        with open(path, encoding="utf-8") as handle:
+            return cls.from_document(handle.read())
+
+    # -- identity ---------------------------------------------------------
+
+    @property
+    def name(self) -> str | None:
+        """The library name; ``None`` on customs, which have none."""
+
+        return self._name
+
+    @property
+    def version(self) -> int | None:
+        return self._version
+
+    @property
+    def digest(self) -> str:
+        """Bare hex SHA-256 of the canonical rendering — identical to the
+        Rust ``Contract::digest``, and a custom's entire identity."""
+
+        return self._digest
+
+    @property
+    def stamp(self) -> str:
+        """``name@version`` for library documents, ``sha256:<hex>`` for
+        customs: what a snapshot records."""
+
+        return self._stamp
+
+    @property
+    def label(self) -> str:
+        """The human spelling: the name for library entries, a digest prefix
+        like ``sha256:ab12cd34…`` for customs."""
+
+        if self._name is not None:
+            return self._name
+        return f"sha256:{self._digest[:8]}…"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Contract):
+            return NotImplemented
+        return self._digest == other._digest
+
+    def __hash__(self) -> int:
+        return hash(self._digest)
+
+    def __repr__(self) -> str:
+        return f"Contract({self.label!r})"
+
+    # -- the document -----------------------------------------------------
+
+    @property
+    def document(self) -> str:
+        """The canonical JSON serialization: what travels in a release
+        derive document, and what every ``_tensorfs`` entrypoint accepts."""
+
+        return self._document
+
+    @property
+    def description(self) -> str:
+        return str(self._raw.get("description", ""))
+
+    @property
+    def tensors(self) -> tuple[TensorDecl, ...]:
+        return tuple(_decl_of(raw) for raw in self._raw["tensors"])
+
+    @property
+    def sets(self) -> dict[str, tuple[str, ...]]:
+        return {
+            name: tuple(patterns) for name, patterns in self._raw.get("sets", {}).items()
+        }
+
+    # -- the serve-side read ----------------------------------------------
+
+    @property
+    def dtype(self) -> str:
+        """The declared load dtype (``ctx.lane.dtype`` reads this). Reading
+        it on a contract that declares none is an author error, refused
+        loudly rather than answered with a guess."""
+
+        if self._dtype is None:
+            raise MissingDtype(
+                f"contract {self.label} declares no top-level dtype; "
+                "declare one on the lane contract to read it"
+            )
+        return self._dtype
+
+    @property
+    def torch_dtype(self) -> Any:
+        """``self.dtype`` resolved against torch, imported lazily."""
+
+        import importlib
+
+        torch = importlib.import_module("torch")
+        name = self.dtype
+        resolved = getattr(torch, name, None)
+        if resolved is None:
+            raise MissingDtype(f"torch has no dtype named {name!r}")
+        return resolved

--- a/src/gen_worker/_vendor/tensorfs/contracts.py
+++ b/src/gen_worker/_vendor/tensorfs/contracts.py
@@ -1,0 +1,76 @@
+"""The predefined contract library, one constant per document.
+
+``from tensorfs import contracts`` then
+``lanes=(contracts.SDXL_DIFFUSERS_BF16, ...)``: the constant IS the layout —
+a :class:`tensorfs.Contract` built at import from the packaged
+``spec/v1/contracts`` documents, the same files the Rust core embeds (the
+wheel carries them under ``tensorfs/_contracts``; in a source checkout they
+are symlinks into ``spec/v1/contracts``, so there is no generated copy to
+drift).
+
+Constant names derive mechanically from contract names (``.``/``-`` → ``_``,
+uppercase): ``sdxl.diffusers-bf16`` → ``SDXL_DIFFUSERS_BF16``. The
+unversioned constant is the library's newest version; :func:`get` pins a
+``name@version``; :func:`all` enumerates.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+
+from .contract import Contract
+
+__all__ = ["all", "get"]
+
+_builtin = tuple(  # noqa: RUF100 -- built once, at import, Rust-validated
+    sorted(
+        (
+            Contract.from_document(entry.read_text(encoding="utf-8"))
+            for entry in (files(__package__) / "_contracts").iterdir()
+            if entry.name.endswith(".json")
+        ),
+        key=lambda contract: (contract.name or "", contract.version or 0),
+    )
+)
+
+#: name -> newest contract; "name@version" -> that exact version.
+_by_ref: dict[str, Contract] = {}
+for _contract in _builtin:
+    _by_ref[f"{_contract.name}@{_contract.version}"] = _contract
+    _by_ref[str(_contract.name)] = _contract  # ascending sort: newest wins
+
+_by_constant: dict[str, Contract] = {
+    str(contract.name).replace(".", "_").replace("-", "_").upper(): contract
+    for contract in _builtin
+    if contract.version == _by_ref[str(contract.name)].version
+}
+
+
+def get(ref: str) -> Contract:
+    """The library contract ``ref`` names: ``name`` (newest) or
+    ``name@version`` (pinned)."""
+
+    try:
+        return _by_ref[ref]
+    except KeyError:
+        known = ", ".join(sorted(name for name in _by_ref if "@" in name))
+        raise KeyError(f"no library contract named {ref!r}; the library holds: {known}") from None
+
+
+def all() -> tuple[Contract, ...]:  # noqa: A001 -- the enumeration IS the point
+    """Every packaged library contract, every version."""
+
+    return _builtin
+
+
+def __getattr__(name: str) -> Contract:
+    """``contracts.SDXL_DIFFUSERS_BF16``-style constants, resolved against
+    the packaged library. Unknown names refuse with the known set."""
+
+    try:
+        return _by_constant[name]
+    except KeyError:
+        known = ", ".join(sorted(_by_constant))
+        raise AttributeError(
+            f"module {__name__!r} has no contract constant {name!r}; it has: {known}"
+        ) from None

--- a/src/gen_worker/models/model_types.py
+++ b/src/gen_worker/models/model_types.py
@@ -101,48 +101,142 @@ class Knob(msgspec.Struct, Generic[Number], frozen=True):
 
 # ── tensorfs contract seam ───────────────────────────────────────────────────
 #
-# tensorfs#111 seam: a canonical contract is an IMPORTED OBJECT, never a
-# pointer-string (Paul's contract-objects ruling 2026-08-18). Until the
-# vendored tensorfs ships ``contracts`` (tensorfs#111/#113), these are
-# placeholder objects carrying the eventual identity shape (``name`` +
-# ``version``; stamp ``<name>@<version>``, the identity
-# ``ContractRegistry.stamps()`` speaks). The swap is one edit: replace the
-# ``PendingContract`` assignments below with
-# ``from gen_worker._vendor.tensorfs.contracts import ...`` and delete
-# ``PendingContract``.
+# A canonical contract is an IMPORTED OBJECT, never a pointer-string (Paul's
+# contract-objects ruling 2026-08-18), and pgw#1391 makes the object REAL: the
+# constants below resolve against the vendored tensorfs contract library, so a
+# lane stamp is now falsifiable rather than free text.
+#
+# What that replaced (pgw#1391, measured): ``PendingContract(name, version)``
+# was a placeholder that answered ``stamp``/``contract`` for ANY name. Four of
+# the six constants named documents tensorfs does not ship, so a ``Model``
+# subclass that omitted ``lanes=`` fell through ``model_lanes()`` to one of
+# them and claimed, all the way into the published manifest, a lane the hub
+# cannot intern (se#757 blocker A). The live sdxl lane was no better off: a
+# placeholder has no ``document`` and no ``digest``, so every release shipped
+# ``"document": null`` for a contract tensorfs really does publish.
+#
+# A name the library does not carry becomes a ``MissingContract`` sentinel.
+# Import stays clean — the module must remain importable or every consumer
+# breaks — and CLAIMING one as a lane is what refuses. All ten current names
+# resolve, so no sentinel is live today; the MACHINERY STAYS, because se#757
+# blocker B is 21 more endpoints that will each want a ``ModelType`` before
+# their document exists, and this is the shape that lets them declare one
+# without shipping a lie. Clearing the original four took zero code change,
+# which is the property worth keeping.
+
+from .._vendor.tensorfs import contracts as _tensorfs_contracts
 
 
 class TensorLayoutContract(Protocol):
-    """What ``canonical_contract`` is typed against until tensorfs#111."""
+    """What ``canonical_contract`` is typed against: the tensorfs ``Contract``
+    surface a lane header, discovery and derive all read."""
 
     @property
-    def name(self) -> str: ...
+    def stamp(self) -> str: ...
     @property
-    def version(self) -> int: ...
+    def document(self) -> str: ...
+    @property
+    def digest(self) -> str: ...
+    @property
+    def dtype(self) -> str: ...
 
 
-class PendingContract(msgspec.Struct, frozen=True):
-    """Placeholder tensorfs Contract object (tensorfs#111 seam, see above).
+class MissingContractError(LookupError):
+    """A lane names a layout contract tensorfs ships no document for.
 
-    Satisfies the SDK's ``LaneContract`` protocol (pgw#1382): ``contract`` is
-    the string handle and ``dtype`` the load dtype, so a canonical contract
-    object may be written straight into a ``Model[...]`` ``lanes=`` header.
+    Raised on ANY lane-ish read of a :class:`MissingContract`, which is what
+    turns the se#757 silent lie loud: the stamp cannot be spelled, so it cannot
+    reach a manifest, a release document or a load.
     """
 
-    name: str
-    version: int
 
+class MissingContract:
+    """A named contract the vendored tensorfs library does not carry.
+
+    INERT AT IMPORT, LOUD ON USE. A hard refusal at module import would make
+    ``gen_worker.models`` unimportable and break everything downstream, so the
+    constant exists — but every attribute a lane header, discovery, derive or a
+    load would read (``stamp``, ``contract``, ``dtype``, ``document``,
+    ``digest``, ``label``, ``tensors``, ``sets``) refuses instead of answering.
+    It is deliberately NOT a ``LaneContract``-shaped liar: there is no path by
+    which it produces a string somebody could publish.
+    """
+
+    _name: str
+    _version: int
+
+    __slots__ = ("_name", "_version")
+
+    def __init__(self, name: str, version: int) -> None:
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_version", version)
+
+    def __setattr__(self, attribute: str, value: object) -> None:
+        raise AttributeError("a MissingContract is frozen")
+
+    def _refuse(self) -> MissingContractError:
+        carried = ", ".join(sorted(contract.stamp for contract in _tensorfs_contracts.all()))
+        return MissingContractError(
+            f"lane {self._name}@{self._version} names a tensorfs layout "
+            f"contract that DOES NOT EXIST. The vendored library carries: "
+            f"{carried}. A lane stamp is a promise the hub interns and the "
+            f"loader reads — it cannot be claimed by naming it. Author "
+            f"'{self._name}.v{self._version}.json' in tensorfs "
+            f"spec/v1/contracts (see its README), then re-vendor per "
+            f"gen_worker/_vendor/VENDORED.toml; this constant becomes a real "
+            f"contract with no code change. Until then declare a lane the "
+            f"library carries, or lanes=() for eager-permanent."
+        )
+
+    # Every read a lane header, discovery, derive or a load performs.
     @property
     def stamp(self) -> str:
-        return f"{self.name}@{self.version}"
+        raise self._refuse()
 
     @property
     def contract(self) -> str:
-        return self.stamp
+        raise self._refuse()
 
     @property
-    def dtype(self) -> object:
-        return CONTRACT_DTYPES.get(self.stamp)
+    def dtype(self) -> str:
+        raise self._refuse()
+
+    @property
+    def document(self) -> str:
+        raise self._refuse()
+
+    @property
+    def digest(self) -> str:
+        raise self._refuse()
+
+    @property
+    def label(self) -> str:
+        raise self._refuse()
+
+    @property
+    def tensors(self) -> tuple[object, ...]:
+        raise self._refuse()
+
+    @property
+    def sets(self) -> dict[str, tuple[str, ...]]:
+        raise self._refuse()
+
+    def __repr__(self) -> str:
+        return f"MissingContract({self._name!r}, {self._version!r}, NO DOCUMENT)"
+
+
+def _library(name: str, version: int) -> TensorLayoutContract:
+    """The library contract ``name@version``, or the sentinel that refuses.
+
+    The lookup happens at import so a name the library DOES carry is a real
+    ``Contract`` from that moment on — document, digest and dtype included —
+    while a name it does not carry costs nothing until somebody claims it.
+    """
+
+    try:
+        return _tensorfs_contracts.get(f"{name}@{version}")
+    except KeyError:
+        return MissingContract(name, version)
 
 
 #: stabilityai/stable-diffusion-xl-base-1.0 scheduler_config.json — SDXL's
@@ -210,25 +304,51 @@ FLUX2_KLEIN_SCHEDULER_CONFIG: Final[Mapping[str, object]] = {
     "use_karras_sigmas": False,
 }
 
-SDXL_DIFFUSERS_BF16: Final = PendingContract("sdxl.diffusers-bf16", 1)
-SD15_DIFFUSERS_BF16: Final = PendingContract("sd15.diffusers-bf16", 1)
-SD2_DIFFUSERS_BF16: Final = PendingContract("sd2.diffusers-bf16", 1)
-HIDREAM_O1_DIFFUSERS_BF16: Final = PendingContract("hidream-o1.diffusers-bf16", 1)
-WAN22_DIFFUSERS_BF16: Final = PendingContract("wan22.diffusers-bf16", 1)
-#: The one name here that is ALREADY a real tensorfs library contract
-#: (``contracts.MINIMAX_H3_DIT_DIFFUSERS``, beside ``minimax.h3-dit-native``) —
-#: the H3 contract file names it in ``lanes=``. Still a PendingContract only
-#: because the vendored tensorfs snapshot predates the ``contracts`` module.
-MINIMAX_H3_DIT_DIFFUSERS: Final = PendingContract("minimax.h3-dit-diffusers", 1)
-#: Also already a real tensorfs library contract — and the ONLY shipped one
-#: whose own ``description`` names the Flux family (pgw#1393). It is a
-#: family-PLURAL block-spelling FRAGMENT, not a lane document: no top-level
-#: ``dtype`` (so ``ctx.lane.dtype`` reads None on it, pgw#970) and its
-#: patterns are the timm/native ``blocks.{i}.attn.qkv`` spelling. Flux's own
-#: ``flux1.*``/``flux2-klein.*`` lane documents are OWED (tracked pgw#1393);
-#: until then this is the honest placeholder, and every migrating flux
-#: endpoint spells ``lanes=`` explicitly anyway.
-DIT_BLOCKS_FUSED_QKV: Final = PendingContract("dit.blocks-fused-qkv", 1)
+#: REAL — a tensorfs library document. Live on deploy lane
+#: ``a55e45a571cdb6188``.
+SDXL_DIFFUSERS_BF16: Final = _library("sdxl.diffusers-bf16", 1)
+#: REAL — beside ``minimax.h3-dit-native``; the H3 contract file names it in
+#: ``lanes=``. Live on deploy lane ``ab56185761f1597f1``.
+MINIMAX_H3_DIT_DIFFUSERS: Final = _library("minimax.h3-dit-diffusers", 1)
+
+#: REAL as of tensorfs#121, which authored these four for se#757 blocker A.
+#: They were ``MissingContract`` sentinels between pgw#1391's first commit and
+#: its re-vendor, and clearing them took NO code change here — the property the
+#: sentinel shape exists to have. ``sd15`` and ``sd2`` are SEPARATE documents
+#: with separate digests, not one shared one.
+SD15_DIFFUSERS_BF16: Final = _library("sd15.diffusers-bf16", 1)
+SD2_DIFFUSERS_BF16: Final = _library("sd2.diffusers-bf16", 1)
+HIDREAM_O1_DIFFUSERS_BF16: Final = _library("hidream-o1.diffusers-bf16", 1)
+WAN22_DIFFUSERS_BF16: Final = _library("wan22.diffusers-bf16", 1)
+
+#: REAL as of tensorfs#124 — FLUX.2 Klein's own transformer-only lane document
+#: (29 declarations). This is what makes ``flux.2-klein-4b``/``-9b``
+#: migratable, and it is what ``Flux2Klein.canonical_contract`` points at.
+FLUX2_KLEIN_DIFFUSERS_BF16: Final = _library("flux2-klein.diffusers-bf16", 1)
+
+#: NO DOCUMENT YET — tensorfs#124 owes it (blocked on HF access to the BFL
+#: repos), so this is a ``MissingContract`` sentinel and ``Model[Flux1]``
+#: refuses loudly, naming the document it wants.
+#:
+#: THAT IS DELIBERATE, AND IT IS SAFER THAN WHAT IT REPLACED. ``Flux1``
+#: pointed at ``dit.blocks-fused-qkv@1``, which is a family-PLURAL
+#: block-spelling FRAGMENT in the timm/native ``blocks.{i}.attn.qkv``
+#: spelling — it declares that pattern ``required: true`` and matches ZERO of
+#: the 169 tensors in a real Flux transformer header, whose tree is
+#: ``transformer_blocks.*``/``single_transformer_blocks.*``. So it was not a
+#: lane that MIGHT fail; it was a guaranteed refusal dressed as a resolved
+#: lane, which is exactly the silent lie pgw#1391 exists to kill. Pointing at
+#: nothing beats pointing at something that cannot match, and spelling the
+#: fragment in ``lanes=`` explicitly does not rescue it either.
+FLUX1_DIFFUSERS_BF16: Final = _library("flux1.diffusers-bf16", 1)
+
+#: REAL, and the only shipped document whose own ``description`` names the Flux
+#: family — but it is a FRAGMENT, not a lane document, and nothing here points
+#: a ``canonical_contract`` at it any more (see ``FLUX1_DIFFUSERS_BF16``). It
+#: declares no top-level ``dtype`` on purpose, as the two ``sdxl.clip-g-*``
+#: component fragments do, so claiming it as a serve lane refuses at
+#: declaration instead of reading ``None`` at load.
+DIT_BLOCKS_FUSED_QKV: Final = _library("dit.blocks-fused-qkv", 1)
 
 
 # ── bases ────────────────────────────────────────────────────────────────────
@@ -691,7 +811,7 @@ class Flux1(ModelType[Flux1Defaults]):
 
     name = "flux1"
     contracts = ("flux1.*",)
-    canonical_contract = DIT_BLOCKS_FUSED_QKV
+    canonical_contract = FLUX1_DIFFUSERS_BF16
     Defaults = Flux1Defaults
 
 
@@ -703,7 +823,7 @@ class Flux2Klein(ModelType[Flux2KleinDefaults]):
 
     name = "flux2-klein"
     contracts = ("flux2-klein.*",)
-    canonical_contract = DIT_BLOCKS_FUSED_QKV
+    canonical_contract = FLUX2_KLEIN_DIFFUSERS_BF16
     canonical_scheduler_config = FLUX2_KLEIN_SCHEDULER_CONFIG
     Defaults = Flux2KleinDefaults
 
@@ -761,44 +881,29 @@ def defaults_vocabularies() -> dict[str, type[msgspec.Struct]]:
 
 
 
-# ── interim lane-dtype seam (pgw#1370's derive consumes this) ────────────────
+# ── the lane-dtype side-channel is DELETED (pgw#1391) ───────────────────────
 #
-# INTERIM dtype resolution for lanes spelled as bare contract HANDLES. A lane
-# is a tensorfs layout contract; when the author imports the contract OBJECT
-# (tensorfs#111), dtype rides on it and this table is not consulted. Bare
-# handles resolve here until the canonical per-model-type entries land in
-# tensorfs ``spec/v1/contracts``.
-
-CONTRACT_DTYPES: dict[str, object] = {}
-
-
-def register_contract_dtype(handle: str, dtype: object) -> None:
-    known = CONTRACT_DTYPES.get(handle)
-    if known is not None and known != dtype:
-        raise ValueError(
-            f"contract {handle!r} already resolves to {known!r}; refusing to "
-            f"re-register it as {dtype!r}"
-        )
-    CONTRACT_DTYPES[handle] = dtype
-
-
-def _seed_sdxl_contracts() -> None:
-    try:
-        import torch
-    except ImportError:  # pragma: no cover - torch-less installs never derive
-        return
-    register_contract_dtype("sdxl.diffusers-bf16@1", torch.bfloat16)
-    # The fp8-rowwise lane LOADS bf16 (the quantized artifact path is the fp8
-    # pipeline's; the serve host's from_pretrained dtype stays bf16).
-    register_contract_dtype("cozy.sdxl-fp8-rowwise@1", torch.bfloat16)
-
-
-_seed_sdxl_contracts()
+# `CONTRACT_DTYPES` was a module-level MUTABLE dict and `register_contract_dtype()`
+# wrote to it, so the serve dtype was whatever code happened to register —
+# structurally disconnected from what the tensorfs document declares. Measured
+# at master `a9bec13e`: `sdxl.diffusers-bf16@1` answered `torch.bfloat16` only
+# because a seed function seeded it, while `minimax.h3-dit-diffusers@1` answered
+# `None` even though its document had declared `bfloat16` since tensorfs#121.
+# Had the registration and the document ever disagreed, the registration would
+# have won and no gate would have noticed.
+#
+# That is the same defect as the `PendingContract` lie one layer down: a fact
+# asserted BESIDE the real source instead of read FROM it. A lane's dtype now
+# comes from `Contract.dtype`, which reads the document, and from nowhere else.
+# There is deliberately no replacement hook: a caller wanting to register a
+# dtype for a document that declares none is treating a FRAGMENT as a serve
+# lane, which is the bug rather than a reason to keep the dict.
 
 
 __all__ = [
-    "CONTRACT_DTYPES",
     "DIT_BLOCKS_FUSED_QKV",
+    "FLUX1_DIFFUSERS_BF16",
+    "FLUX2_KLEIN_DIFFUSERS_BF16",
     "FLUX2_KLEIN_SCHEDULER_CONFIG",
     "Flux1",
     "Flux1Defaults",
@@ -817,7 +922,8 @@ __all__ = [
     "RifeDefaults",
     "MODEL_TYPES",
     "ModelType",
-    "PendingContract",
+    "MissingContract",
+    "MissingContractError",
     "SD15",
     "SchedulerName",
     "SD15_DIFFUSERS_BF16",
@@ -840,5 +946,4 @@ __all__ = [
     "defaults_vocabularies",
     "model_type_by_name",
     "model_type_for_contract",
-    "register_contract_dtype",
 ]

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -238,6 +238,15 @@ def _lane_model_class(module: ModuleType) -> Optional[type]:
             continue
         try:
             lanes = model_lanes(value)
+            # pgw#1391: `model_lanes` hands back the lane OBJECTS without
+            # reading them, so a class that omitted `lanes=` and fell through
+            # to a canonical contract with no tensorfs document got this far
+            # silently. Reading each lane's handle and dtype here is what makes
+            # the publish path refuse it, through the SAME conversion.
+            from ..serving.model import lane_dtype
+
+            for lane in lanes:
+                lane_dtype(lane, where=f"class {value.__qualname__!r}")
         except ModelDeclarationError as exc:
             # Omitted lanes with no canonical contract (tensorfs#111 not
             # shipped): the class cannot state its lanes — refuse loudly,
@@ -949,12 +958,21 @@ def _contract_document(
             f"a stamp with an unreadable layout behind it is worse than no "
             f"row."
         )
-    warnings.append(
-        f"{owner}: lane {lane_handle(lane)} carries NO layout document, so "
-        f"the release ships its stamp alone and the platform must already "
-        f"know the layout. Import a tensorfs Contract object."
+    # pgw#1391: this was a WARNING, and it fired on EVERY lane — including the
+    # live `sdxl.diffusers-bf16@1`, whose document tensorfs really does
+    # publish. Every release therefore carried `"document": null` and an empty
+    # digest, which is se#756's "the release proves NO lane". A stamp with no
+    # layout behind it is the bug, so it refuses. Under the contract library
+    # every real lane HAS a document.
+    raise DeriveError(
+        f"{owner}: lane {lane_handle(lane)} carries NO layout document. The "
+        f"whole point of contract OBJECTS is that the layout TRAVELS in the "
+        f"release metadata, so the platform needs no prior knowledge of it — "
+        f"a stamp alone is a claim the hub cannot intern. Declare the lane as "
+        f"an imported tensorfs Contract "
+        f"(`gen_worker.models.SDXL_DIFFUSERS_BF16`-style), never a handle "
+        f"string or a stand-in."
     )
-    return None
 
 
 def _contract_digest(lane: Any) -> str:

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -69,22 +69,100 @@ def lane_handle(lane: Any) -> str:
     ``digest`` is only ever used PREFIXED.
     """
 
-    for attribute in ("stamp", "contract"):
-        value = getattr(lane, attribute, None)
-        if isinstance(value, str) and value:
-            return value
-    name = getattr(lane, "name", None)
-    version = getattr(lane, "version", None)
-    if isinstance(name, str) and name and isinstance(version, int):
-        return f"{name}@{version}"
-    digest = getattr(lane, "digest", None)
-    if isinstance(digest, str) and digest:
-        return digest if digest.startswith("sha256:") else f"sha256:{digest}"
+    # pgw#1391: a lane that names a contract tensorfs ships no document for
+    # refuses HERE, at the one chokepoint every stamp-reading surface goes
+    # through (declaration, discovery's `_lane_stamps`, derive's
+    # `_lane_model_class`) — restated as a ModelDeclarationError so derive's
+    # existing conversion to a loud DeriveError needs no second pattern.
+    from ..models.model_types import MissingContractError
+
+    try:
+        for attribute in ("stamp", "contract"):
+            value = getattr(lane, attribute, None)
+            if isinstance(value, str) and value:
+                return value
+        name = getattr(lane, "name", None)
+        version = getattr(lane, "version", None)
+        if isinstance(name, str) and name and isinstance(version, int):
+            return f"{name}@{version}"
+        digest = getattr(lane, "digest", None)
+        if isinstance(digest, str) and digest:
+            return digest if digest.startswith("sha256:") else f"sha256:{digest}"
+    except MissingContractError as exc:
+        raise ModelDeclarationError(str(exc)) from exc
     raise ModelDeclarationError(
         f"lane {lane!r} carries no string handle (`stamp`, `contract`, "
         "`name`+`version` or `digest`); a lane is a tensorfs layout contract "
         "object"
     )
+
+
+#: Lane stamps whose contract document declares no top-level dtype UPSTREAM,
+#: waived at declaration time so a live model class is not refused for a gap
+#: only tensorfs can close.
+#:
+#: EMPTY, AND IT SHOULD STAY THAT WAY — the fence already did its job once. It
+#: briefly held ``minimax.h3-dit-diffusers@1`` while that document was
+#: dtype-less and its endpoint was live (deploy lane ``ab56185761f1597f1``);
+#: tensorfs#121 gave it ``bfloat16``, re-vendoring made
+#: ``test_the_h3_dtype_waiver_deletes_itself_when_upstream_lands_the_dtype``
+#: fail, and the entry was deleted. A waiver is a fact about the vendored
+#: document, never a preference, so it cannot outlive its reason.
+#:
+#: Three vendored documents are STILL dtype-less on purpose
+#: (``dit.blocks-fused-qkv``, ``sdxl.clip-g-fused-qkv``,
+#: ``sdxl.clip-g-split-qkv``) and need no waiver: they are FRAGMENTS a
+#: ``lanes=`` header never names on its own, so they never reach this check.
+#: Adding an entry here means knowingly accepting a lane whose serve-side
+#: ``ctx.lane.dtype`` will raise — do it only against a named upstream issue.
+DTYPELESS_UPSTREAM_LANES: frozenset[str] = frozenset()
+
+
+def lane_dtype(lane: Any, *, where: str) -> Any:
+    """The lane's declared load dtype, READ rather than looked for.
+
+    pgw#1391: ``isinstance(lane, LaneContract)`` is not this check. A
+    ``runtime_checkable`` Protocol with a property member resolves through
+    ``inspect.getattr_static`` on py3.12, so it never invokes the getter — a
+    ``@property`` that RAISES satisfies it. That is exactly how a contract
+    declaring no dtype used to clear declaration and die at load on a pod, and
+    how a documentless lane used to clear it at all.
+
+    So the dtype is read. ``MissingDtype`` (and the ``MissingContractError``
+    that a documentless lane raises first) become a declaration refusal naming
+    the author's own class header.
+    """
+
+    from ..models.model_types import MissingContractError
+
+    handle = lane_handle(lane)  # refuses first if there is no document at all
+    try:
+        dtype = lane.dtype
+    except MissingContractError as exc:  # pragma: no cover - lane_handle refuses first
+        raise ModelDeclarationError(str(exc)) from exc
+    except Exception as exc:
+        if handle in DTYPELESS_UPSTREAM_LANES:
+            return None
+        raise ModelDeclarationError(
+            f"{where}: lane {handle} declares no load dtype "
+            f"({type(exc).__name__}: {exc}). `ctx.lane.dtype` is on the serve "
+            f"path, so this refuses HERE rather than reading None at load on a "
+            f"rented pod. A tensorfs document with no top-level dtype is "
+            f"usually a FRAGMENT — a shared block or component spelling, not a "
+            f"serve layout — and the fix is then to author the real lane "
+            f"document in tensorfs spec/v1/contracts and re-vendor, NOT to add "
+            f"a dtype to the fragment. Declaring the fragment in `lanes=` "
+            f"explicitly does not make it a lane."
+        ) from exc
+    if dtype is None:
+        if handle in DTYPELESS_UPSTREAM_LANES:
+            return None
+        raise ModelDeclarationError(
+            f"{where}: lane {handle} answers None for its load dtype. A lane "
+            f"IS a tensorfs layout contract and its dtype is the contract's; "
+            f"None is not an answer."
+        )
+    return dtype
 
 
 def _parse_requires(
@@ -113,9 +191,9 @@ def _parse_requires(
             "UNDECLARED; an empty mapping is not a statement that this model "
             "runs anywhere."
         )
-    # `lanes=` omitted (None) means the canonical contract, resolved lazily —
-    # there is nothing to check the keys against yet. `lanes=()` IS a
-    # declaration, and every floor over it guards nothing.
+    # `lanes=()` IS a declaration, and every floor over it guards nothing.
+    # `None` reaches here only when the model type declares no canonical
+    # contract either, so there is genuinely nothing to check the keys against.
     declared = None if lanes is None else {lane_handle(lane) for lane in lanes}
     out: dict[str, Any] = {}
     for lane, value in requires.items():
@@ -203,6 +281,12 @@ class Model(Generic[MT]):
         declared = _declared_model_type(cls)
         if declared is not None:
             cls.__cozy_model_type__ = declared
+        # The lanes this class actually serves — declared, or the model type's
+        # canonical contract when `lanes=` is omitted. `requires=` is checked
+        # against THESE, not against the raw kwarg (pgw#1391): with `lanes=`
+        # omitted the old check had nothing to compare keys to and accepted a
+        # floor keyed to any stamp at all, including one naming no document.
+        effective_lanes: tuple[Any, ...] | None = lanes
         if lanes is not None:
             if not isinstance(lanes, tuple):
                 raise ModelDeclarationError(
@@ -216,10 +300,28 @@ class Model(Generic[MT]):
                         "contract (no `dtype`); a lane is an imported "
                         "tensorfs contract object, never a name string"
                     )
-                lane_handle(lane)
+                # The isinstance above only proves the ATTRIBUTE exists; this
+                # READS it, which is the pgw#1391 difference.
+                lane_dtype(lane, where=cls.__qualname__)
             cls.__cozy_lanes__ = tuple(lanes)
+        elif declared is not None:
+            # pgw#1391: OMITTING `lanes=` IS THE se#757 TRAP, so it is checked
+            # here too. `model_lanes()` falls through to the model type's
+            # `canonical_contract`, and the class that declares nothing is
+            # exactly the one that used to claim `sd15.diffusers-bf16@1` — a
+            # document that existed nowhere — all the way into a published
+            # manifest. Validating the fall-through target at declaration is
+            # what makes discovery refuse it, because discovery IMPORTS the
+            # author module: the guarantee rides on `__init_subclass__` rather
+            # than on any particular consumer remembering to enumerate lanes.
+            # (pgw#1394 deleted discovery's `_lane_stamps` for good reasons;
+            # this seam is why that deletion costs the fence nothing.)
+            canonical = getattr(declared, "canonical_contract", None)
+            if canonical is not None:
+                lane_dtype(canonical, where=f"{cls.__qualname__} (lanes= omitted)")
+                effective_lanes = (canonical,)
         if requires is not None:
-            cls.__cozy_requires__ = _parse_requires(cls, requires, lanes)
+            cls.__cozy_requires__ = _parse_requires(cls, requires, effective_lanes)
 
     # -- lifecycle hooks (the load/unload contract, pgw#1382) ---------------
 
@@ -284,6 +386,7 @@ def model_requires(cls: type) -> dict[str, Any]:
 
 
 __all__ = [
+    "DTYPELESS_UPSTREAM_LANES",
     "LANES_ATTR",
     "LaneContract",
     "MODEL_TYPE_ATTR",

--- a/tests/release_fixtures/lane_contracts.py
+++ b/tests/release_fixtures/lane_contracts.py
@@ -1,14 +1,57 @@
-"""tensorfs#111 contract-object stand-ins for the release fixtures.
+"""The release fixtures' lane contract — a REAL tensorfs contract document.
 
-A lane IS a tensorfs layout contract — an imported OBJECT carrying the
-handle and load dtype; never a bare string (Paul's contract-objects ruling;
-the Model class header refuses dtype-less lanes at declaration). Until the
-tensorfs surface ships, torchcg's resolved ``LaneRef`` is that shape.
+A lane IS a tensorfs layout contract: an imported OBJECT carrying the layout,
+its stamp and its load dtype; never a bare string, and never a handle-shaped
+stand-in (Paul's contract-objects ruling).
+
+pgw#1391 REPLACED THE STAND-IN THIS FILE USED TO BE. It was
+``LaneRef("tiny.diffusers-fp32@1", dtype=torch.float32)`` — a handle plus a
+dtype and NO LAYOUT, which is the exact shape the release path now refuses:
+the whole point of contract objects is that the layout TRAVELS in the release
+metadata, and a stamp with nothing behind it is a claim the hub cannot intern.
+The fixture asserted the release document's lane rows, so it was asserting the
+bug.
+
+It is a NAMED document rather than an anonymous custom because these tests pin
+the ``"contract": "tiny.diffusers-fp32@1"`` spelling in the derive document —
+the named-stamp path is what they exist to cover. The name is not in the
+curated library and makes no promise; the digest is real either way.
 """
 
 from __future__ import annotations
 
-import torch
-from torchcg import LaneRef
+import json
 
-TINY_DIFFUSERS_FP32 = LaneRef("tiny.diffusers-fp32@1", dtype=torch.float32)
+from gen_worker._vendor.tensorfs.contract import Contract
+
+#: A minimal but HONEST layout for the tiny fixture pipeline: real roles, real
+#: patterns, a real declared load dtype.
+TINY_DIFFUSERS_FP32 = Contract.from_document(
+    json.dumps(
+        {
+            "format": "tensorfs-contract-v1",
+            "name": "tiny.diffusers-fp32",
+            "version": 1,
+            "description": "release-fixture layout: the tiny diffusers pipeline in fp32",
+            "dtype": "float32",
+            "tensors": [
+                {
+                    "role": "unet.down_blocks.{i}.resnets.{i}.conv1",
+                    "pattern": "unet.down_blocks.{i}.resnets.{i}.conv1.weight",
+                    "rank": 4,
+                },
+                {
+                    "role": "unet.conv_out",
+                    "pattern": "unet.conv_out.weight",
+                    "rank": 4,
+                },
+                {
+                    "role": "vae.decoder.conv_out",
+                    "pattern": "vae.decoder.conv_out.weight",
+                    "rank": 4,
+                    "required": False,
+                },
+            ],
+        }
+    )
+)

--- a/tests/test_lane_contracts.py
+++ b/tests/test_lane_contracts.py
@@ -1,0 +1,302 @@
+"""pgw#1391: the vendored pure-Python contract reader agrees with tensorfs.
+
+`_vendor/tensorfs/contract.py` is a PORT of the Rust validator and canonical
+rendering (pgw#1310 rules the compiled extension out of a source-vendored
+wheel — the same reason `planner.py` is a port, pgw#1365). A port is worth
+nothing asserted, so it is pinned to the language-neutral corpus upstream
+released with tensorfs#114, `spec/v1/contract-vectors`, which Rust and Go both
+satisfy: every golden digest, every typed refusal.
+
+The golden LIBRARY vectors are resolved against the DOCUMENTS THIS REPO
+VENDORS, not against a copy shipped beside the corpus — so the test proves the
+bytes gen-worker actually publishes, and a bad re-vendor fails here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from gen_worker._vendor.tensorfs.contract import (
+    CONTRACT_FORMAT,
+    Contract,
+    ContractError,
+    MissingDtype,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+VECTORS = ROOT / "tests" / "testdata" / "contract-vectors"
+DOCUMENTS = ROOT / "src" / "gen_worker" / "_vendor" / "tensorfs" / "_contracts"
+UPSTREAM = ROOT.parent.parent.parent / "tensorfs"
+
+CORPUS = json.loads((VECTORS / "contract-vectors.json").read_text())
+
+
+def _document_of(case: dict) -> str:
+    """A golden vector's document: inline for the anonymous customs, and for a
+    library entry the VENDORED file of that name."""
+
+    if "document" in case:
+        return case["document"]
+    return (DOCUMENTS / Path(case["file"]).name).read_text(encoding="utf-8")
+
+
+def test_the_corpus_is_the_shape_this_test_assumes() -> None:
+    assert CORPUS["format"] == "tensorfs-contract-vectors-v1"
+    assert len(CORPUS["golden"]) >= 13
+    assert len(CORPUS["refusals"]) >= 19
+
+
+@pytest.mark.parametrize("case", CORPUS["golden"], ids=lambda case: case["name"])
+def test_every_golden_vector_digests_identically(case: dict) -> None:
+    """THE proof the canonical rendering is byte-identical to Rust's: a
+    SHA-256 over it cannot agree by luck."""
+
+    contract = Contract.from_document(_document_of(case))
+    assert contract.digest == case["digest"]
+    assert contract.stamp == case["stamp"]
+
+
+@pytest.mark.parametrize("case", CORPUS["refusals"], ids=lambda case: case["name"])
+def test_every_refusal_vector_refuses_with_the_shared_reason(case: dict) -> None:
+    with pytest.raises(ContractError) as caught:
+        Contract.from_document(case["document"])
+    assert caught.value.reason == case["reason"]
+
+
+def test_the_vendored_documents_are_exactly_the_corpus_library() -> None:
+    """No document may be added to the vendored library without a golden
+    vector pinning its digest — otherwise a hand-edited contract publishes."""
+
+    vendored = {path.name for path in DOCUMENTS.glob("*.json")}
+    pinned = {Path(case["file"]).name for case in CORPUS["golden"] if "file" in case}
+    assert vendored == pinned
+
+
+def test_the_library_loads_and_names_what_the_corpus_names() -> None:
+    from gen_worker._vendor.tensorfs import contracts
+
+    assert {contract.stamp for contract in contracts.all()} == {
+        case["stamp"] for case in CORPUS["golden"] if "file" in case
+    }
+    assert contracts.SDXL_DIFFUSERS_BF16.dtype == "bfloat16"
+    # tensorfs#121 authored the four se#757 blocker-A documents, so these now
+    # resolve where they used to be MissingContract sentinels.
+    for constant in (
+        "SD15_DIFFUSERS_BF16",
+        "SD2_DIFFUSERS_BF16",
+        "HIDREAM_O1_DIFFUSERS_BF16",
+        "WAN22_DIFFUSERS_BF16",
+        "FLUX2_KLEIN_DIFFUSERS_BF16",
+    ):
+        assert getattr(contracts, constant).dtype == "bfloat16"
+    assert contracts.SD15_DIFFUSERS_BF16.digest != contracts.SD2_DIFFUSERS_BF16.digest
+    with pytest.raises(AttributeError, match="no contract constant"):
+        contracts.NOPE_NOT_A_DOCUMENT  # noqa: B018 -- the refusal IS the assertion
+
+
+def test_a_document_declaring_no_dtype_raises_rather_than_answering_none() -> None:
+    """`release/derive.py` and `Model.__init_subclass__` both rely on this
+    being a RAISE: a `None` would be read as "no opinion" and travel.
+
+    `dit.blocks-fused-qkv@1` is a FRAGMENT — a family-shared block spelling no
+    `lanes=` header names on its own — so it is deliberately dtype-less
+    upstream and is the standing example.
+    """
+
+    from gen_worker._vendor.tensorfs import contracts
+
+    with pytest.raises(MissingDtype):
+        contracts.DIT_BLOCKS_FUSED_QKV.dtype
+
+
+def test_the_h3_dtype_waiver_deletes_itself_when_upstream_lands_the_dtype() -> None:
+    """pgw#1391 ordering waiver, SELF-DELETING BY CONSTRUCTION — AND IT DID.
+
+    The waiver briefly held `minimax.h3-dit-diffusers@1`, which was live on
+    deploy lane `ab56185761f1597f1` while its document declared no top-level
+    dtype. tensorfs#121 gave it `bfloat16`; re-vendoring made this test fail,
+    and the entry was deleted. That is the fence working, not a hypothetical.
+
+    It stays because the next such ordering hazard gets the same treatment: a
+    waiver is a fact about the vendored document, never a preference, so it
+    cannot outlive its reason.
+    """
+
+    from gen_worker.serving.model import DTYPELESS_UPSTREAM_LANES
+
+    still_dtypeless = set()
+    for path in DOCUMENTS.glob("*.json"):
+        contract = Contract.from_document(path.read_text(encoding="utf-8"))
+        try:
+            contract.dtype
+        except MissingDtype:
+            still_dtypeless.add(contract.stamp)
+
+    assert not DTYPELESS_UPSTREAM_LANES or DTYPELESS_UPSTREAM_LANES <= still_dtypeless, (
+        "a vendored contract GAINED its top-level dtype: delete it from "
+        "DTYPELESS_UPSTREAM_LANES — the waiver's whole reason is gone "
+        f"(now declared: {sorted(DTYPELESS_UPSTREAM_LANES - still_dtypeless)})"
+    )
+
+
+def test_the_document_property_is_the_canonical_json_string() -> None:
+    """`release/derive.py::_contract_document` parses this; a dict would have
+    shipped `"document": null` on every lane."""
+
+    from gen_worker._vendor.tensorfs import contracts
+
+    document = contracts.SDXL_DIFFUSERS_BF16.document
+    assert isinstance(document, str)
+    parsed = json.loads(document)
+    assert parsed["format"] == CONTRACT_FORMAT
+    assert parsed["name"] == "sdxl.diffusers-bf16"
+    assert document == json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+
+def test_the_corpus_matches_the_sibling_tensorfs_checkout() -> None:
+    """The vendored corpus is a SNAPSHOT; when the real repo is beside us,
+    prove the snapshot has not drifted from it."""
+
+    upstream = UPSTREAM / "spec" / "v1" / "contract-vectors" / "contract-vectors.json"
+    if not upstream.exists():
+        pytest.skip("no sibling tensorfs checkout")
+    ours = (VECTORS / "contract-vectors.json").read_bytes()
+    assert hashlib.sha256(upstream.read_bytes()).hexdigest() == hashlib.sha256(ours).hexdigest()
+
+
+def test_the_vendored_documents_match_the_sibling_tensorfs_checkout() -> None:
+    upstream = UPSTREAM / "spec" / "v1" / "contracts"
+    if not upstream.exists():
+        pytest.skip("no sibling tensorfs checkout")
+    for path in DOCUMENTS.glob("*.json"):
+        theirs = upstream / path.name
+        assert theirs.exists(), f"{path.name} is not an upstream document"
+        assert path.read_bytes() == theirs.read_bytes(), f"{path.name} drifted from upstream"
+
+
+def test_the_contract_plane_rev_is_recorded_in_vendored_toml() -> None:
+    manifest = tomllib.loads(
+        (ROOT / "src" / "gen_worker" / "_vendor" / "VENDORED.toml").read_text()
+    )
+    spec = manifest["packages"]["tensorfs"]
+    assert len(spec["contract_plane_rev"]) == 40
+    recorded = set(spec["contract_plane_files"])
+    assert "contracts.py" in recorded
+    assert {f"_contracts/{path.name}" for path in DOCUMENTS.glob("*.json")} <= recorded
+
+
+def test_a_dtypeless_FRAGMENT_is_importable_but_refuses_as_a_serve_lane() -> None:
+    """pgw#1393's `dit.blocks-fused-qkv@1` is the standing case, and both
+    halves matter.
+
+    It is a real library document and `Flux1.canonical_contract` points at it,
+    so `gen_worker.models` must import and that attribute must be readable —
+    refusing at import would break master. But it declares no top-level dtype
+    BECAUSE IT IS A FRAGMENT (a family-plural block spelling), and it matches
+    zero of the 169 tensors in the real Klein transformer header. So claiming
+    it as a serve lane must refuse, whether by omitting `lanes=` or by naming
+    it explicitly — the refusal is the point, not a gap to be waived.
+    """
+
+    from gen_worker.models import SDXL
+    from gen_worker.models.model_types import DIT_BLOCKS_FUSED_QKV
+    from gen_worker.serving import Model, ModelDeclarationError
+
+    assert DIT_BLOCKS_FUSED_QKV.stamp == "dit.blocks-fused-qkv@1"
+    with pytest.raises(MissingDtype):
+        DIT_BLOCKS_FUSED_QKV.dtype
+
+    with pytest.raises(ModelDeclarationError, match="declares no load dtype"):
+
+        class ExplicitFragment(Model[SDXL], lanes=(DIT_BLOCKS_FUSED_QKV,)):
+            def load(self, ctx: object) -> None: ...
+
+
+def test_flux1_points_at_no_document_rather_than_one_that_cannot_match() -> None:
+    """tensorfs#124's finding, and the reason the sentinel machinery stayed.
+
+    `Flux1.canonical_contract` used to be `dit.blocks-fused-qkv@1`, which
+    declares `blocks.{i}.attn.qkv.weight` REQUIRED and matches 0 of the 169
+    tensors in a real Flux transformer header (the tree is
+    `transformer_blocks.*` / `single_transformer_blocks.*`). That is a
+    GUARANTEED refusal wearing a resolved lane's clothes — the pgw#1391 bug
+    exactly. Pointing at a document that does not exist yet is strictly safer,
+    because it refuses by NAME and says what is owed.
+    """
+
+    from gen_worker.models import Flux1, Flux2Klein
+    from gen_worker.models.model_types import MissingContract, MissingContractError
+    from gen_worker.serving import Model, ModelDeclarationError
+
+    assert isinstance(Flux1.canonical_contract, MissingContract)
+    with pytest.raises(MissingContractError, match="flux1.diffusers-bf16@1"):
+        Flux1.canonical_contract.stamp
+
+    with pytest.raises(ModelDeclarationError, match="DOES NOT EXIST"):
+
+        class Flux1Model(Model[Flux1]):
+            def load(self, ctx: object) -> None: ...
+
+    # Klein DOES have its own document now, so it must resolve.
+    assert Flux2Klein.canonical_contract.stamp == "flux2-klein.diffusers-bf16@1"
+    assert Flux2Klein.canonical_contract.dtype == "bfloat16"
+
+    class KleinModel(Model[Flux2Klein]):
+        def load(self, ctx: object) -> None: ...
+
+    assert KleinModel.__cozy_model_type__ is Flux2Klein
+
+
+def test_a_lane_naming_no_document_refuses_at_declaration() -> None:
+    """The seam the DISCOVERY guarantee rides on now that pgw#1394 has removed
+    lane enumeration from `discovery/entrypoints_v2.py`: discovery imports the
+    author module, so `__init_subclass__` is what refuses."""
+
+    from gen_worker.models import SDXL
+    from gen_worker.models.model_types import MissingContract
+    from gen_worker.serving import Model, ModelDeclarationError
+
+    nope = MissingContract("nope.not-a-document", 1)
+    with pytest.raises(ModelDeclarationError, match="DOES NOT EXIST"):
+
+        class Claimed(Model[SDXL], lanes=(nope,)):
+            def load(self, ctx: object) -> None: ...
+
+    # ...and a `requires=` floor keyed to a stamp this model does not serve,
+    # which used to be accepted outright whenever `lanes=` was omitted.
+    with pytest.raises(ModelDeclarationError, match="does not declare"):
+
+        class Floored(Model[SDXL], requires={"nope.not-a-document@1": "vram12g"}):
+            def load(self, ctx: object) -> None: ...
+
+
+def test_no_vendored_stamp_ties_between_two_model_types() -> None:
+    """tensorfs#124 warned that eleven documents sharing component spellings
+    could make family detection TIE. It does not, and this pins it.
+
+    `model_type_for_contract` returns the FIRST matching type, so a tie would
+    be resolved by declaration order — a silent, order-dependent
+    classification. `dit.blocks-fused-qkv@1` matching nothing is the correct
+    answer for a family-plural fragment: unclassified is legal and visible.
+    """
+
+    from fnmatch import fnmatchcase
+
+    from gen_worker._vendor.tensorfs import contracts
+    from gen_worker.models.model_types import MODEL_TYPES
+
+    ties = {}
+    for contract in contracts.all():
+        hits = [
+            mt.name
+            for mt in MODEL_TYPES
+            if any(fnmatchcase(contract.stamp, pattern) for pattern in mt.contracts)
+        ]
+        if len(hits) > 1:
+            ties[contract.stamp] = hits
+    assert not ties, f"stamps claimed by more than one model type: {ties}"

--- a/tests/testdata/contract-vectors/contract-vectors.json
+++ b/tests/testdata/contract-vectors/contract-vectors.json
@@ -1,0 +1,180 @@
+{
+  "format": "tensorfs-contract-vectors-v1",
+  "golden": [
+    {
+      "name": "dit.blocks-fused-qkv.v1",
+      "file": "contracts/dit.blocks-fused-qkv.v1.json",
+      "digest": "57f09073ca1a631bb173293c84e11f462089d0fa8cf9ce45e142fc33881a17a1",
+      "stamp": "dit.blocks-fused-qkv@1"
+    },
+    {
+      "name": "flux2-klein.diffusers-bf16.v1",
+      "file": "contracts/flux2-klein.diffusers-bf16.v1.json",
+      "digest": "4d9fada187e6e086a1c4c496d81b785ce9419fc089e64d0141f6427b88e9d40d",
+      "stamp": "flux2-klein.diffusers-bf16@1"
+    },
+    {
+      "name": "hidream-o1.diffusers-bf16.v1",
+      "file": "contracts/hidream-o1.diffusers-bf16.v1.json",
+      "digest": "69003d11e2cb3b52628cb05e02c275916db74e318eabbce2f6e89be625c7e01f",
+      "stamp": "hidream-o1.diffusers-bf16@1"
+    },
+    {
+      "name": "minimax.h3-dit-diffusers.v1",
+      "file": "contracts/minimax.h3-dit-diffusers.v1.json",
+      "digest": "22bbb607d3e4351c18ac55e8d86c8a8a3d03296309b80e4419d4bc5153481f28",
+      "stamp": "minimax.h3-dit-diffusers@1"
+    },
+    {
+      "name": "minimax.h3-dit-native.v1",
+      "file": "contracts/minimax.h3-dit-native.v1.json",
+      "digest": "5f6b7b4a8cd070653607840b922c213a846838e35379737727111c4b0a8de56c",
+      "stamp": "minimax.h3-dit-native@1"
+    },
+    {
+      "name": "sd15.diffusers-bf16.v1",
+      "file": "contracts/sd15.diffusers-bf16.v1.json",
+      "digest": "0bc98e52edac1a4b3a8f063162d3785350413b60701ba49d9701e46d69f304d3",
+      "stamp": "sd15.diffusers-bf16@1"
+    },
+    {
+      "name": "sd2.diffusers-bf16.v1",
+      "file": "contracts/sd2.diffusers-bf16.v1.json",
+      "digest": "136b158fb5f96cd05f2a8b3accc0b3d36ea7b07b988a338ee4f7934d54a312e6",
+      "stamp": "sd2.diffusers-bf16@1"
+    },
+    {
+      "name": "sdxl.clip-g-fused-qkv.v1",
+      "file": "contracts/sdxl.clip-g-fused-qkv.v1.json",
+      "digest": "364c0c537e54013eab72994a3e6bf0b913cfb76ab1627dc0822b95cf17b1b262",
+      "stamp": "sdxl.clip-g-fused-qkv@1"
+    },
+    {
+      "name": "sdxl.clip-g-split-qkv.v1",
+      "file": "contracts/sdxl.clip-g-split-qkv.v1.json",
+      "digest": "c1bbfc65a89a736154504f68296b2b8be3dc43364d4dc04a192c08a184bf64fa",
+      "stamp": "sdxl.clip-g-split-qkv@1"
+    },
+    {
+      "name": "sdxl.diffusers-bf16.v1",
+      "file": "contracts/sdxl.diffusers-bf16.v1.json",
+      "digest": "ef01dd65f57bd95ae05d70f5a9893e9abab6b4f0831b05c4edf68ae9ebb148e8",
+      "stamp": "sdxl.diffusers-bf16@1"
+    },
+    {
+      "name": "wan22.diffusers-bf16.v1",
+      "file": "contracts/wan22.diffusers-bf16.v1.json",
+      "digest": "91036beea9878c462311d97a878a5dc94128283182fbf0948b30118852d97bd5",
+      "stamp": "wan22.diffusers-bf16@1"
+    },
+    {
+      "name": "custom-interleaved",
+      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"tensors\": [\n        {\"role\": \"b.{i}.qkv\", \"pattern\": \"b.{i}.qkv.weight\", \"rank\": 2,\n         \"fusion\": {\"axis\": 0, \"groups\": 56,\n                    \"parts\": [{\"role\": \"q\", \"share\": 1}, {\"role\": \"k\", \"share\": 1},\n                              {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"b.{i}.qkv#q\", \"pattern\": \"b.{i}.q.weight\", \"rank\": 2, \"required\": false,\n         \"fusion\": {\"axis\": 0, \"groups\": 56, \"parts\": [{\"role\": \"\", \"share\": 1}]}}\n    ]\n}",
+      "digest": "d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1",
+      "stamp": "sha256:d57b11915fe4e389472da10707d7307bf03636d522b12887f39c7efbf1abe9b1"
+    },
+    {
+      "name": "custom-rich",
+      "document": "{\n    \"format\": \"tensorfs-contract-v1\",\n    \"description\": \"vector fixture: every declaration branch\",\n    \"dtype\": \"bfloat16\",\n    \"tensors\": [\n        {\"role\": \"blocks.{i}.attn.qkv\", \"pattern\": \"blocks.{i}.attn.qkv_proj.weight\",\n         \"rank\": 2, \"dtypes\": [\"BF16\", \"F16\"],\n         \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 2}, {\"role\": \"k\", \"share\": 1},\n                                         {\"role\": \"v\", \"share\": 1}]}},\n        {\"role\": \"blocks.{i}.rope\", \"pattern\": \"blocks.{i}.rope.weight\", \"required\": false,\n         \"permute\": {\"view\": [4, \"shape[0]/2\", \"auto\", \"shape[1]\"], \"axes\": [0, 2, 1, 3]}}\n    ],\n    \"sets\": {\"adaln\": [\"blocks.{i}.adaln.weight\", \"norm_out.weight\"], \"rope\": [\"blocks.{i}.rope.weight\"]}\n}",
+      "digest": "840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f",
+      "stamp": "sha256:840107df52fe82b735067c3649b14cde234235ac28792be6f915c357fc786a0f"
+    }
+  ],
+  "refusals": [
+    {
+      "name": "not-json",
+      "document": "{",
+      "reason": "json"
+    },
+    {
+      "name": "unknown-field",
+      "document": "{\n        \"unknown\": 1, \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "json"
+    },
+    {
+      "name": "wrong-format",
+      "document": "{\n        \"format\": \"tensorfs-contract-v2\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "format"
+    },
+    {
+      "name": "uppercase-name",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"name\": \"Sdxl.Fused\", \"version\": 1, \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "name"
+    },
+    {
+      "name": "zero-version",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"name\": \"sdxl.fused\", \"version\": 0, \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "version"
+    },
+    {
+      "name": "name-without-version",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"name\": \"sdxl.fused\", \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "identity"
+    },
+    {
+      "name": "version-without-name",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"version\": 1, \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "identity"
+    },
+    {
+      "name": "uppercase-dtype",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"dtype\": \"BF16\", \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "dtype"
+    },
+    {
+      "name": "no-tensors",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": []\n    }",
+      "reason": "no-tensors"
+    },
+    {
+      "name": "adjacent-holes",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.{i}{i}\", \"pattern\": \"a.{i}{i}\"}]\n    }",
+      "reason": "pattern"
+    },
+    {
+      "name": "role-hole-mismatch",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.{i}\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "role-holes"
+    },
+    {
+      "name": "duplicate-pattern",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}, {\"role\": \"a.c\", \"pattern\": \"a.b\"}]\n    }",
+      "reason": "duplicate"
+    },
+    {
+      "name": "inner-axis-fusion",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"fusion\": {\"axis\": 1, \"parts\": [{\"role\": \"q\", \"share\": 1}, {\"role\": \"k\", \"share\": 1}]}}]\n    }",
+      "reason": "fusion"
+    },
+    {
+      "name": "one-part-fusion",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 1}]}}]\n    }",
+      "reason": "fusion"
+    },
+    {
+      "name": "zero-share",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 0}, {\"role\": \"k\", \"share\": 1}]}}]\n    }",
+      "reason": "fusion"
+    },
+    {
+      "name": "identity-permute",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"permute\": {\"view\": [2, \"auto\"], \"axes\": [0, 1]}}]\n    }",
+      "reason": "permute"
+    },
+    {
+      "name": "axes-not-a-permutation",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"permute\": {\"view\": [2, \"auto\"], \"axes\": [1, 1]}}]\n    }",
+      "reason": "permute"
+    },
+    {
+      "name": "permute-inside-fusion",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\", \"fusion\": {\"axis\": 0, \"parts\": [{\"role\": \"q\", \"share\": 1}, {\"role\": \"k\", \"share\": 1}]}, \"permute\": {\"view\": [2, \"auto\"], \"axes\": [1, 0]}}]\n    }",
+      "reason": "permute"
+    },
+    {
+      "name": "empty-set",
+      "document": "{\n        \"format\": \"tensorfs-contract-v1\",\n        \"tensors\": [{\"role\": \"a.b\", \"pattern\": \"a.b\"}], \"sets\": {\"adaln\": []}\n    }",
+      "reason": "set"
+    }
+  ]
+}


### PR DESCRIPTION
#1391: a lane stamp resolves against a real contract library, or it refuses

MEASURED ON MASTER FIRST. `PendingContract(name, version)` made a lane stamp
free text. A `Model` subclass that omits `lanes=` falls through `model_lanes()`
to its model type's `canonical_contract`, so `Sd15Model` claimed
`sd15.diffusers-bf16@1` — a document tensorfs did not ship — and imported,
type-checked and drove clean. Discovery put that stamp in the manifest with no
warning at all; publish travelled it stamp-only with one.

And the finding se#757 did not have: THE LIVE SDXL LANE WAS DOCUMENT-LESS TOO.
`_contract_document` returned None and `_contract_digest` returned "" for
`sdxl.diffusers-bf16@1`, a contract tensorfs really does publish. The layout
had never travelled.

THE FIX is to resolve the stamp against a real contract library, following the
`planner.py` precedent in `_vendor/VENDORED.toml`.

 * A THIRD vendored rev, `contract_plane_rev`. The contract plane existed at
   neither of the two already recorded: `rev` predates tensorfs's genesis
   restart, `read_plane_rev` predates tensorfs#111/#113/#114.
 * `contract.py` is a PURE-PYTHON PORT of the Rust validator and canonical
   rendering, because upstream delegates to `from .native import contract_info`
   and pgw#1310 rules a compiled extension out of a source-vendored wheel. The
   public surface is upstream's attribute for attribute, so pgw#1381's
   vendoring retirement becomes a deletion rather than a rewrite.
 * PROVEN, NOT ASSERTED. tensorfs#114's language-neutral corpus — the one the
   Rust and Go implementations both satisfy — is vendored at
   tests/testdata/contract-vectors/ and run over the ELEVEN vendored documents
   plus two anonymous customs: 13 golden digests and 19 typed refusals, 32
   agree / 0 disagree. A SHA-256 over a hand-built line rendering cannot agree
   by luck. It caught a real port bug that review would not have: tensorfs#121
   relaxed the contract-name grammar to admit a hyphen in the PRODUCER segment
   (hidream-o1, flux-2, wan-2), and the port refused `hidream-o1.diffusers-bf16`
   until it followed.
 * `PendingContract` IS DELETED. Every constant is a library lookup.
 * `lane_dtype()` READS the dtype instead of looking for it.
   `isinstance(lane, LaneContract)` was never that check: a `runtime_checkable`
   Protocol with a property member resolves through `inspect.getattr_static` on
   py3.12, so a `@property` that RAISES satisfies it. That is exactly how a
   dtype-less contract cleared declaration and died at load on a rented pod.
 * `_contract_document`'s document-less WARNING becomes a refusal.

TWO DECLARATION HOLES CLOSED, both of which the fence would otherwise miss:
omitting `lanes=` is the se#757 trap and was never validated at declaration
(only an explicit `lanes=` was), and `requires=` with `lanes=` omitted accepted
a floor keyed to ANY stamp because it had nothing to compare against.

WHERE THE REFUSAL LIVES. pgw#1394 rightly deleted discovery's `_lane_stamps`
(lane stamps were being written into the hub's ARTIFACT-layout fields, which
made every v2 endpoint unpublishable), so this lane's discovery hunk is dropped
and `entrypoints_v2.py` is byte-identical to master. The refusal rides on
`Model.__init_subclass__` instead, and discovery IMPORTS the author module.
That seam is strictly better than the deleted hook: it cannot be bypassed by a
consumer that does not happen to enumerate lanes, and it fires at import on the
author's machine rather than on a pod.

THE SENTINEL SHAPE, AND WHY IT STAYS. A name the library does not carry becomes
a `MissingContract` — inert at import (the module must stay importable or every
consumer breaks), refusing on any lane-ish read. It held sd15/sd2/hidream-o1/
wan22 until tensorfs#121 authored them, and clearing all four took NO code
change, which is the property it exists to have. It is immediately load-bearing
again: `Flux1.canonical_contract` now points at `flux1.diffusers-bf16@1`, which
tensorfs#124 still owes, INSTEAD OF `dit.blocks-fused-qkv@1`. That document
declares `blocks.{i}.attn.qkv.weight` required and matches ZERO of the 169
tensors in a real Flux transformer header (the tree is `transformer_blocks.*` /
`single_transformer_blocks.*`), so it was a guaranteed refusal wearing a
resolved lane's clothes — this bug exactly. Pointing at nothing beats pointing
at something that cannot match, and naming the fragment in `lanes=` explicitly
does not rescue it. se#757 blocker B is 21 more endpoints that will each want a
`ModelType` before their document exists.

CAUGHT ON THE WAY IN: `tests/release_fixtures/lane_contracts.py` was
`LaneRef("tiny.diffusers-fp32@1", dtype=torch.float32)` — a handle plus a dtype
and no layout. Four `test_release_derive.py` tests pinned the resulting lane
rows, i.e. asserted the bug. It is a real contract document now.

NOTE FOR CONSUMERS: `minimax.h3-dit-diffusers@1` and `sdxl.diffusers-bf16@1`
both RE-DIGESTED upstream while keeping version `@1`, so a release published
before this bump recorded a digest that no longer matches the document behind
the same stamp.

THE DTYPE SIDE-CHANNEL DIES WITH IT. `CONTRACT_DTYPES` was a module-level
MUTABLE dict and `register_contract_dtype()` wrote to it, so the serve dtype was
whatever code happened to register — structurally disconnected from the
document. Measured at master `a9bec13e`: `sdxl.diffusers-bf16@1` answered
`torch.bfloat16` only because a seed function seeded it, while
`minimax.h3-dit-diffusers@1` answered `None` even though its document had
declared `bfloat16` since tensorfs#121. Had the two ever disagreed the
registration would have won and no gate would have noticed — the same defect
one layer down. Zero callers outside the module; both names are deleted, with
no replacement hook.


---

Tracker: pgw#1391. Probe: `scripts/probe_lane_contracts.py` (exit 0).

**Pre-existing, not mine:** `tests/test_vendored_snapshot_pgw1310.py` fails on `torchcg/document.py` identically on `origin/master`.
