### PR TITLE
#1392: model-less entrypoints are legal — zero model slots is a valid declaration

### DIFF
--- a/src/gen_worker/cli/release.py
+++ b/src/gen_worker/cli/release.py
@@ -105,10 +105,15 @@ def _run_derive(args: argparse.Namespace) -> int:
     for warning in result.warnings:
         print(f"warning: {warning}", file=sys.stderr)
     if result.eager_permanent:
-        print(
-            f"{result.endpoint}: no lanes -- explicit eager-permanent document",
-            file=sys.stderr,
+        # pgw#1392: two different reasons reach "no lanes" and the log must
+        # not conflate them — a model held eagerly (`lanes=()`), or NO MODEL
+        # AT ALL (a weightless endpoint: nothing to hold).
+        why = (
+            "no model class -- weightless endpoint, nothing to compile"
+            if result.weightless
+            else "no lanes -- explicit eager-permanent document"
         )
+        print(f"{result.endpoint}: {why}", file=sys.stderr)
     for lane_name, hashes in result.lane_graphs.items():
         print(f"lane {lane_name}: {len(hashes)} graph class(es)", file=sys.stderr)
         for graph in hashes:

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -111,6 +111,10 @@ class ReleaseDeriveResult:
     endpoint: str
     lane_graphs: dict[str, tuple[str, ...]]  # lane contract -> graph hashes
     warnings: tuple[str, ...] = ()
+    #: pgw#1392: NO model class anywhere, so there is nothing to hold at all.
+    #: Distinct from eager-permanent, which holds a model and compiles none —
+    #: both land on "no lanes", and a log that conflates them lies.
+    weightless: bool = False
 
     @property
     def eager_permanent(self) -> bool:
@@ -1293,6 +1297,10 @@ def derive_release(
             for lane in graphs_document.lanes
         },
         warnings=tuple(warnings),
+        # No lane class AND entrypoints still derived => every one of them
+        # declared zero model slots. An eager-permanent module also has no
+        # lane class, but its entrypoints carry slots and derive no plan.
+        weightless=cls is None and bool(plans),
     )
 
 

--- a/src/gen_worker/release/derive.py
+++ b/src/gen_worker/release/derive.py
@@ -268,7 +268,9 @@ class _Entrypoint:
     fn: Any
     payload_param: str
     payload_type: type
-    model_param: str
+    #: ``None`` for a WEIGHTLESS entrypoint (pgw#1392) — no model, no lane,
+    #: nothing traced; it is never a trace subject.
+    model_param: Optional[str]
     ctx_param: str
     #: (param name, annotation, base trace value) per platform-injected fact.
     injected: tuple[tuple[str, Any, Any], ...]
@@ -306,7 +308,18 @@ def _injected_trace_value(name: str, parameter_name: str, annotation: Any) -> An
 _SLOT_ORDER = ("ctx", "payload", "model", "adapter")
 
 
-def _entrypoints(module: ModuleType, model_cls: type) -> list[_Entrypoint]:
+def _entrypoints(
+    module: ModuleType, model_cls: Optional[type]
+) -> list[_Entrypoint]:
+    """The module's entrypoints bound to ``model_cls``.
+
+    ``model_cls`` is ``None`` for a module that declares no lane-bearing
+    Model class. Two disjoint cases live behind that: an eager-permanent
+    (``lanes=()``) module — whose entrypoints DO carry model slots and
+    derive no lane, exactly as before — and a WEIGHTLESS module (pgw#1392),
+    whose entrypoints carry ZERO model slots. Only the latter derive here,
+    so an eager-permanent release is byte-identical to what it was.
+    """
     import msgspec
 
     from ..request_context import RequestContext
@@ -342,7 +355,13 @@ def _entrypoints(module: ModuleType, model_cls: type) -> list[_Entrypoint]:
             else:
                 rest.append((parameter.name, hints.get(parameter.name)))
                 roles.append((parameter.name, "adapter"))
-        if model_param is None:
+        if model_cls is None:
+            # No lane-bearing class: only a WEIGHTLESS entrypoint (pgw#1392)
+            # derives. One that declares slots belongs to a lane this module
+            # does not have (eager-permanent) — unchanged, skipped.
+            if model_slots:
+                continue
+        elif model_param is None:
             continue
         if payload_param is None:
             raise DeriveError(
@@ -385,7 +404,7 @@ def _entrypoints(module: ModuleType, model_cls: type) -> list[_Entrypoint]:
                 model_slots=tuple(model_slots),
             )
         )
-    if not out:
+    if not out and model_cls is not None:
         raise DeriveError(
             f"no @entrypoint function binds model class {model_cls.__name__!r} "
             f"(the model parameter's annotation is the binding)"
@@ -1181,10 +1200,17 @@ def derive_release(
     lane_contracts: dict[str, Any] = {}
     entrypoints: dict[str, Any] = {}
     warnings: list[str] = []
-    if cls is not None:
-        plans: list[tuple[_Entrypoint, tuple[Any, ...]]] = []
-        for plan in _entrypoints(module, cls):
-            owner = f"@entrypoint {plan.name}"
+    plans: list[tuple[_Entrypoint, tuple[Any, ...]]] = []
+    for plan in _entrypoints(module, cls):
+        owner = f"@entrypoint {plan.name}"
+        if cls is None:
+            # pgw#1392: a WEIGHTLESS entrypoint has no lane, so there is no
+            # trace subject and no pass is ever run. `traced_passes` says 0
+            # because 0 is the truth, not because the enumeration was
+            # skipped. It still publishes its envelope schema — the hub's
+            # auto-generated API docs are the point of this block.
+            payloads: tuple[Any, ...] = ()
+        else:
             payloads, capped = _auto_payloads(owner, plan.payload_type)
             if capped:
                 warnings.append(
@@ -1193,16 +1219,19 @@ def derive_release(
                     f"rest is first-encounter discovery (eager + background "
                     f"mint)"
                 )
-            plans.append((plan, payloads))
-            entrypoints[plan.name] = {
-                "envelope_schema": _envelope_schema(plan),
-                "model_slots": {
-                    slot_name: slot_cls.__name__
-                    for slot_name, slot_cls in plan.model_slots
-                },
-                "traced_passes": len(payloads),
-            }
+        plans.append((plan, payloads))
+        entrypoints[plan.name] = {
+            "envelope_schema": _envelope_schema(plan),
+            # Renders EMPTY for a weightless entrypoint — an honest {}, never
+            # a fabricated slot.
+            "model_slots": {
+                slot_name: slot_cls.__name__
+                for slot_name, slot_cls in plan.model_slots
+            },
+            "traced_passes": len(payloads),
+        }
 
+    if cls is not None:
         requires = model_requires(cls)
         for lane in model_lanes(cls):
             lane_graphs = _derive_lane(

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -15,14 +15,22 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
                  model: SdxlModel, turbo: Adapter | None,
                  loras: list[Adapter]) -> ImageOutput: ...
 
+    @entrypoint                       # WEIGHTLESS (pgw#1392): no slot at all
+    def transform(ctx: RequestContext, payload: TransformInput
+                  ) -> TransformOutput: ...
+
 * first: ``ctx`` annotated :class:`~gen_worker.serving.context.RequestContext`
 * second: the payload, a ``msgspec.Struct`` — the wire schema
-* remaining, in any order: model SLOTS (params annotated with a
-  :class:`~gen_worker.serving.model.Model` subclass — at least one) and
+* remaining, in any order and **possibly none**: model SLOTS (params
+  annotated with a :class:`~gen_worker.serving.model.Model` subclass) and
   adapter SLOTS (``Adapter`` / ``Adapter | None`` single, ``list[Adapter]``
   the request's picks; the hub resolves what rides per deployment/request
   into them). The PARAMETER NAME is the slot name the request envelope
   keys per-slot picks on (``{"model": ref, "loras": [{"ref":…, "scale":…}]}``).
+  **Zero slots is a valid declaration (pgw#1392)** — a CPU workflow helper
+  has no weights to type, so it declares none, its envelope carries no model
+  field, and nothing is ever made resident for it. Zero slots is legal;
+  junk slots are not — a declared parameter must still BE a valid slot.
 * return: a ``msgspec.Struct``
 
 The decorator validates at import (typed refusal names the exact defect) and
@@ -194,12 +202,13 @@ def entrypoint(fn: F) -> F:
                 f"parameter {parameter.name!r} is {parameter.kind.description}; "
                 "the signature is plain positional: (ctx, payload, *slots)",
             )
-    if len(parameters) < 3:
+    if len(parameters) < 2:
         raise _refuse(
             fn,
             f"takes {len(parameters)} parameters; the contract is "
-            "(ctx: RequestContext, payload: msgspec.Struct, "
-            "<slot>: <Model subclass or Adapter>, ...)",
+            "(ctx: RequestContext, payload: msgspec.Struct) followed by "
+            "ZERO OR MORE slots (<Model subclass or Adapter>) — pgw#1392: a "
+            "weightless entrypoint declares no slot at all",
         )
 
     ctx_parameter, payload_parameter, slot_parameters = (
@@ -228,12 +237,12 @@ def entrypoint(fn: F) -> F:
         _slot_of(fn, parameter.name, hints.get(parameter.name))
         for parameter in slot_parameters
     )
-    if not any(slot.kind == "model" for slot in slots):
-        raise _refuse(
-            fn,
-            "declares no model slot; at least one parameter must be "
-            "annotated with a gen_worker.Model subclass",
-        )
+    # pgw#1392: ZERO model slots is a valid declaration. A weightless
+    # entrypoint (a CPU workflow helper — dj-utils, music-analysis) has no
+    # weights to type, so it declares none; the envelope then has no model
+    # field at all and nothing is ever resident for it. Zero slots is legal,
+    # JUNK slots are not — `_slot_of` above still refuses every parameter
+    # that is neither a Model subclass nor an adapter form.
 
     return_type = _annotation_class(hints.get("return"))
     if return_type is None or not issubclass(return_type, msgspec.Struct):

--- a/src/gen_worker/serving/envelope.py
+++ b/src/gen_worker/serving/envelope.py
@@ -176,7 +176,17 @@ def decode_envelope(
     if parsed.model is not None and parsed.models is not None:
         raise EnvelopeError('an envelope carries "model" or "models", never both')
     picks: Dict[str, str] = {}
-    if len(model_slots) == 1:
+    if not model_slots:
+        # pgw#1392: a WEIGHTLESS entrypoint. Its envelope has NO model field
+        # — not a null one, not an empty one — so a pick is a typed refusal
+        # naming the real reason instead of advising the other spelling.
+        if parsed.model is not None or parsed.models is not None:
+            raise EnvelopeError(
+                f"{spec.name!r} declares no model slot; its envelope carries "
+                f'no "model"/"models" key at all (nothing is resident for a '
+                f"weightless entrypoint)"
+            )
+    elif len(model_slots) == 1:
         (only_slot,) = model_slots
         if parsed.models is not None:
             raise EnvelopeError(

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -89,7 +89,13 @@ class EndpointHost:
         #: it references no Model class, so it is never resident and has
         #: nothing to make resident.
         self._booted = False
-        if engine is None:
+        if engine is None and not loaded.models:
+            # pgw#1392: a WEIGHTLESS endpoint references no Model class, so
+            # nothing will ever be built through the loader engine. Probing
+            # the binding's tree for a chunk store would be work done to
+            # answer a question nobody asks.
+            engine = None
+        elif engine is None:
             # pgw#1380: the native store->VRAM engine, bound off the
             # checkpoint tree the worker already resolved — a projected
             # snapshot carries its own chunk store, so nothing extra is

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -84,6 +84,11 @@ class EndpointHost:
         }
         self.instances: Dict[type, ModelInstance] = {}
         self.adoption: Any = None
+        #: pgw#1392: "has boot run" is the real question. `instances` used to
+        #: stand in for it, which a WEIGHTLESS endpoint falsifies forever —
+        #: it references no Model class, so it is never resident and has
+        #: nothing to make resident.
+        self._booted = False
         if engine is None:
             # pgw#1380: the native store->VRAM engine, bound off the
             # checkpoint tree the worker already resolved — a projected
@@ -251,6 +256,7 @@ class EndpointHost:
                 unclaimed=len(session.unclaimed),
             )
         self.adoption = session
+        self._booted = True
 
     # -- eviction -----------------------------------------------------------
 
@@ -277,6 +283,7 @@ class EndpointHost:
         """Evict every resident instance (reverse residency order)."""
         for model_cls in list(reversed(list(self.instances))):
             self.evict(model_cls)
+        self._booted = False
 
     def rebind(self, binding: DeployBinding) -> None:
         """Swap the deploy binding (hub deploy state changed). Contexts made
@@ -308,14 +315,16 @@ class EndpointHost:
         it decodes against the entrypoint's own msgspec schema, so a payload
         that does not fit is a typed ``msgspec.ValidationError`` naming the
         field, before author code runs. The call runs under every slot
-        model's admission, acquired in slot-name order."""
+        model's admission, acquired in slot-name order — a WEIGHTLESS
+        entrypoint (pgw#1392) declares no slot, so it acquires nothing and
+        is called directly; there is no residency to admit it to."""
         spec = self.loaded.entrypoints.get(function)
         if spec is None:
             raise ServeDispatchError(
                 f"{self.loaded.module_name} serves no function {function!r} "
                 f"(functions: {sorted(self.loaded.entrypoints)})"
             )
-        if not self.instances:
+        if not self._booted:
             raise RuntimeError("dispatch(): boot the endpoint first (setup())")
         missing = [
             cls.__name__ for cls in spec.model_classes if cls not in self.instances

--- a/src/gen_worker/serving/loader.py
+++ b/src/gen_worker/serving/loader.py
@@ -89,7 +89,8 @@ def _surface_of(module: ModuleType) -> tuple[Dict[str, EntrypointSpec], Tuple[ty
         raise EndpointLoadError(
             f"{module.__name__} declares no entrypoints: an entrypoint is a "
             "module-level @entrypoint function "
-            "(ctx: RequestContext, payload: msgspec.Struct, <slot>: <Model>)"
+            "(ctx: RequestContext, payload: msgspec.Struct) plus zero or "
+            "more slots"
         )
     for cls in models:
         try:

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -199,8 +199,13 @@ class ServeLoop:
         model_slots = dict(spec.model_params)
         # Adapter overlays decode against the PRIMARY model type's adapter
         # schema (pgw#1377 adapter-of-base scoping: SDXL.Lora.Defaults).
-        primary_type = model_type(spec.model_params[0][1])
-        lora_scope = getattr(primary_type, "Lora", None)
+        # pgw#1392: a WEIGHTLESS entrypoint has no primary model and so no
+        # adapter vocabulary to overlay against — absent, never invented.
+        lora_scope = (
+            getattr(model_type(spec.model_params[0][1]), "Lora", None)
+            if spec.model_params
+            else None
+        )
         decoded: DecodedRequest = decode_envelope(
             spec,
             envelope,
@@ -218,6 +223,10 @@ class ServeLoop:
             primary_binding: Optional[DeployBinding] = None
             # STABLE SLOT-NAME ORDER — the multi-model deadlock rule: every
             # request over the same slot set acquires in one global order.
+            # pgw#1392: a WEIGHTLESS entrypoint's slot set is EMPTY, so this
+            # loop does not run — no lease, no admission, no load, and no
+            # compile subject. That is the whole of its serve path, and it
+            # is deliberate: there are no weights to make resident.
             for slot_name in sorted(model_slots):
                 model_cls = model_slots[slot_name]
                 binding = self._resolver.resolve(model_cls, picks[slot_name])

--- a/tests/release_fixtures/weightless_endpoint.py
+++ b/tests/release_fixtures/weightless_endpoint.py
@@ -1,0 +1,46 @@
+"""A WEIGHTLESS module (pgw#1392): entrypoints, no Model class anywhere.
+
+The shape se#757 blocker C measured as unmigratable — `dj-utils`'s shipped
+`def f(ctx, payload) -> Out` CPU workflow helpers, v2-spelled. No lanes, no
+weights, no compile subject, nothing resident.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import RequestContext, entrypoint
+
+
+class TransformInput(msgspec.Struct, forbid_unknown_fields=True):
+    text: str
+    upper: bool = False
+    repeat: int = 1
+
+
+class TransformOutput(msgspec.Struct):
+    text: str
+    length: int
+
+
+class ClosureGateInput(msgspec.Struct, forbid_unknown_fields=True):
+    values: list[float]
+    threshold: float = 0.5
+
+
+class ClosureGateOutput(msgspec.Struct):
+    passed: bool
+    above: int
+
+
+@entrypoint
+def transform(ctx: RequestContext, payload: TransformInput) -> TransformOutput:
+    text = (payload.text.upper() if payload.upper else payload.text) * payload.repeat
+    ctx.warn(f"transformed {len(payload.text)} chars")
+    return TransformOutput(text=text, length=len(text))
+
+
+@entrypoint
+def closure_gate(ctx: RequestContext, payload: ClosureGateInput) -> ClosureGateOutput:
+    above = sum(1 for value in payload.values if value >= payload.threshold)
+    return ClosureGateOutput(passed=above > 0, above=above)

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -226,7 +226,16 @@ def _bad_return(ctx: RequestContext, payload: _In, model: _M) -> int:
     return 0
 
 
-def _too_few(ctx: RequestContext, payload: _In) -> _Out:
+def _too_few(ctx: RequestContext) -> _Out:
+    return _Out()
+
+
+def _weightless(ctx: RequestContext, payload: _In) -> _Out:
+    """pgw#1392: the shipped `(ctx, payload) -> Out` workflow-helper shape."""
+    return _Out()
+
+
+def _junk_slot(ctx: RequestContext, payload: _In, junk: int) -> _Out:
     return _Out()
 
 
@@ -243,18 +252,37 @@ def test_malformed_entrypoint_signatures_refuse_typed() -> None:
     cases: list[tuple[Callable[..., Any], str]] = [
         (_payload_first, "ctx comes FIRST"),   # old payload-first order
         (_bad_payload, "payload"),
-        (_no_model, "declares no model slot"),
         (_bare_model, "bare Model base"),
         (_optional_model, r"`Adapter \| None`"),
         (_bad_list, r"`list\[Adapter\]`"),
         (_bad_return, "return type"),
-        (_too_few, "takes 2 parameters"),
+        (_too_few, "takes 1 parameters"),
         (_kw_only, "keyword"),
         (_Grouping.method, "MODULE-LEVEL"),
     ]
     for fn, pattern in cases:
         with pytest.raises(EntrypointDeclarationError, match=pattern):
             entrypoint(fn)
+
+
+def test_zero_model_slots_is_legal_pgw1392() -> None:
+    """pgw#1392: model-less entrypoints are LEGAL (se#757 blocker C).
+
+    `_no_model` used to be a refusal case here ("declares no model slot").
+    Ten shipped production functions have that signature, so the floor
+    dropped to zero. Junk slots did NOT become legal -- the loop above
+    still pins every other refusal, `_junk_slot` included."""
+
+    spec = getattr(entrypoint(_no_model), "__cozy_entrypoint__")
+    assert [slot.kind for slot in spec.slots] == ["adapter"]
+    assert spec.model_params == ()
+
+    spec = getattr(entrypoint(_weightless), "__cozy_entrypoint__")
+    assert spec.slots == ()
+    assert spec.model_classes == ()
+
+    with pytest.raises(EntrypointDeclarationError, match="must be a model slot"):
+        entrypoint(_junk_slot)
 
 
 # --- the ctx split ----------------------------------------------------------

--- a/tests/test_weightless_entrypoint_pgw1392.py
+++ b/tests/test_weightless_entrypoint_pgw1392.py
@@ -1,0 +1,240 @@
+"""pgw#1392: a WEIGHTLESS entrypoint declares, discovers, derives and SERVES.
+
+The se#757 blocker-C shape: ten shipped production functions whose signature
+is `def f(ctx, payload) -> Out` with no model anywhere. This drives one of
+them through the whole real path on CPU -- no weights, no GPU, no model
+download -- and pins the guarantees that were KEPT.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from gen_worker.serving.context import DeployBinding
+from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR, EntrypointDeclarationError
+from gen_worker.serving.envelope import EnvelopeError, decode_envelope
+from gen_worker.serving.host import EndpointHost
+from gen_worker.serving.loader import load_endpoint_module
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "weightless_endpoint"
+
+
+@pytest.fixture(scope="module")
+def weightless():
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+# -- declaration ------------------------------------------------------------
+
+
+def test_zero_model_slots_is_a_legal_declaration(weightless) -> None:
+    spec = getattr(weightless.transform, ENTRYPOINT_ATTR)
+    assert spec.name == "transform"
+    assert spec.slots == ()
+    assert spec.model_params == ()
+    assert spec.model_classes == ()
+    assert spec.payload_type is weightless.TransformInput
+    assert spec.return_type is weightless.TransformOutput
+
+
+def test_zero_slots_is_legal_but_junk_slots_are_not() -> None:
+    """Permitting ZERO slots is not permitting JUNK slots."""
+
+    source = (
+        "import msgspec\n"
+        "from gen_worker import Model, RequestContext, entrypoint\n"
+        "class In(msgspec.Struct): text: str\n"
+        "class Out(msgspec.Struct): text: str\n"
+    )
+
+    def declare(signature: str) -> None:
+        # A REAL module-level declaration: @entrypoint refuses nested
+        # functions first, so an in-function probe measures the wrong wall.
+        module = type(sys)("pgw1392_probe")
+        module.__dict__["__name__"] = "pgw1392_probe"
+        sys.modules["pgw1392_probe"] = module
+        try:
+            exec(source + signature, module.__dict__)  # noqa: S102
+        finally:
+            del sys.modules["pgw1392_probe"]
+
+    # The one that must now PASS.
+    declare("@entrypoint\ndef f(ctx: RequestContext, payload: In) -> Out: ...\n")
+
+    kept = {
+        "junk third parameter": (
+            "@entrypoint\n"
+            "def f(ctx: RequestContext, payload: In, junk: int) -> Out: ...\n"
+        ),
+        "bad ctx annotation": (
+            "@entrypoint\ndef f(ctx: str, payload: In) -> Out: ...\n"
+        ),
+        "non-Struct payload": (
+            "@entrypoint\ndef f(ctx: RequestContext, payload: dict) -> Out: ...\n"
+        ),
+        "non-Struct return": (
+            "@entrypoint\ndef f(ctx: RequestContext, payload: In) -> dict: ...\n"
+        ),
+        "keyword-only parameter": (
+            "@entrypoint\n"
+            "def f(ctx: RequestContext, payload: In, *, flag: bool = False)"
+            " -> Out: ...\n"
+        ),
+        "payload before ctx": (
+            "@entrypoint\ndef f(payload: In, ctx: RequestContext) -> Out: ...\n"
+        ),
+        "fewer than two parameters": (
+            "@entrypoint\ndef f(ctx: RequestContext) -> Out: ...\n"
+        ),
+        "bare Model base as a slot": (
+            "@entrypoint\n"
+            "def f(ctx: RequestContext, payload: In, model: Model) -> Out: ...\n"
+        ),
+    }
+    for label, signature in kept.items():
+        with pytest.raises(EntrypointDeclarationError, match=r".") as caught:
+            declare(signature)
+        assert caught.value, label
+
+
+# -- discovery --------------------------------------------------------------
+
+
+def test_discovery_publishes_a_row_with_no_slots(weightless) -> None:
+    from gen_worker.discovery.entrypoints_v2 import (
+        assert_manifest_advertises_something,
+        discover_entrypoints,
+        entrypoints_block,
+    )
+
+    rows = discover_entrypoints(MODULE)
+    by_name = {row["name"]: row for row in rows}
+    assert set(by_name) == {"transform", "closure_gate"}
+    for row in rows:
+        assert row["slots"] == []
+        assert row["input_schema"] and row["output_schema"]
+
+    # A weightless endpoint advertises something: the build does not stop.
+    assert_manifest_advertises_something({"entrypoints": entrypoints_block(rows)})
+
+
+# -- release derive ---------------------------------------------------------
+
+
+def test_derive_renders_an_envelope_with_no_model_field(
+    weightless, tmp_path: Path
+) -> None:
+    pytest.importorskip("torchcg")
+    from gen_worker.release.derive import derive_release
+
+    result = derive_release(weightless, checkpoint_dir=tmp_path)
+    document = json.loads(result.document)
+
+    # No model class -> no lane, no trace subject, no contract.
+    assert document["graphs"]["lanes"] == []
+    assert document["lane_contracts"] == {}
+    assert document["model_type"] is None
+    assert document["endpoint"] == MODULE  # no ':Model' half
+
+    # ...but the entrypoints ARE published: the hub's API docs are the point.
+    assert set(document["entrypoints"]) == {"transform", "closure_gate"}
+    entry = document["entrypoints"]["transform"]
+    assert entry["model_slots"] == {}, "an honest empty mapping, never a fake one"
+    assert entry["traced_passes"] == 0
+
+    # THE ENVELOPE HAS NO MODEL FIELD -- absent renders as ABSENT, not null,
+    # not empty.
+    schema = entry["envelope_schema"]
+    assert sorted(schema["properties"]) == ["input"]
+    assert schema["required"] == ["input"]
+    assert "model" not in json.dumps(schema)
+
+
+# -- serve ------------------------------------------------------------------
+
+
+def test_a_weightless_entrypoint_actually_serves(weightless) -> None:
+    loaded = load_endpoint_module(MODULE)
+    assert loaded.models == ()
+    assert sorted(loaded.entrypoints) == ["closure_gate", "transform"]
+
+    host = EndpointHost(
+        loaded, DeployBinding(checkpoint_ref="", checkpoint_dir=Path("."))
+    )
+    with pytest.raises(RuntimeError, match="boot the endpoint first"):
+        host.dispatch("transform", {"text": "x"}, request_id="early")
+
+    host.setup()  # nothing to load: the loop over loaded.models is empty
+    assert host.instances == {}
+
+    out = host.dispatch(
+        "transform",
+        {"text": "cozy", "upper": True, "repeat": 2},
+        request_id="pgw1392",
+    )
+    assert isinstance(out, weightless.TransformOutput)
+    assert out.text == "COZYCOZY" and out.length == 8
+
+    gate = host.dispatch(
+        "closure_gate",
+        {"values": [0.1, 0.9, 0.7], "threshold": 0.5},
+        request_id="pgw1392b",
+    )
+    assert gate.passed and gate.above == 2
+
+
+def test_the_wire_path_serves_and_takes_no_lease(weightless) -> None:
+    """The full envelope -> invoke -> outcome path. Nothing is made resident."""
+
+    from gen_worker.serving.residency import ResidencyManager
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    class NeverResolver:
+        def resolve(self, model_cls, checkpoint_ref):  # noqa: ANN001
+            raise AssertionError("a weightless request resolved a binding")
+
+        def default_pick(self, model_cls, slot_name):  # noqa: ANN001
+            raise AssertionError("a weightless request asked for a default pick")
+
+    class NeverSizer:
+        def resident_bytes(self, checkpoint_ref, lane):  # noqa: ANN001
+            raise AssertionError("a weightless request sized a residency slot")
+
+    loop = ServeLoop(
+        load_endpoint_module(MODULE),
+        residency=ResidencyManager(1 << 30, NeverSizer()),
+        resolver=NeverResolver(),
+    )
+    outcome = loop.invoke(
+        "transform",
+        {"input": {"text": "weightless"}},
+        request_id="pgw1392-wire",
+    )
+    assert outcome.result.text == "weightless"
+    assert outcome.warnings == ("transformed 10 chars",)
+
+
+def test_the_envelope_refuses_a_model_pick_by_name(weightless) -> None:
+    spec = load_endpoint_module(MODULE).entrypoints["transform"]
+    for envelope in (
+        {"input": {"text": "x"}, "model": "org/repo@rel"},
+        {"input": {"text": "x"}, "models": {"model": "org/repo@rel"}},
+    ):
+        with pytest.raises(EnvelopeError, match="declares no model slot"):
+            decode_envelope(spec, envelope)
+
+    # ...and the happy path decodes with no picks at all.
+    decoded = decode_envelope(spec, {"input": {"text": "x"}})
+    assert decoded.model_picks == ()
+    assert decoded.adapter_values == ()
+    assert decoded.payload.text == "x"

--- a/tests/test_weightless_entrypoints.py
+++ b/tests/test_weightless_entrypoints.py
@@ -164,6 +164,20 @@ def test_derive_renders_an_envelope_with_no_model_field(
     assert schema["required"] == ["input"]
     assert "model" not in json.dumps(schema)
 
+    # "No lanes" has two causes and the log may not conflate them: a model
+    # held eagerly (lanes=()) vs NO MODEL AT ALL.
+    assert result.eager_permanent and result.weightless
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        eager = derive_release(
+            importlib.import_module("eager_endpoint"), checkpoint_dir=tmp_path
+        )
+    finally:
+        sys.path.remove(str(FIXTURES))
+    assert eager.eager_permanent and not eager.weightless
+    assert json.loads(eager.document)["entrypoints"] == {}
+
 
 # -- serve ------------------------------------------------------------------
 

--- a/tests/test_weightless_entrypoints.py
+++ b/tests/test_weightless_entrypoints.py
@@ -1,9 +1,12 @@
-"""pgw#1392: a WEIGHTLESS entrypoint declares, discovers, derives and SERVES.
+"""A WEIGHTLESS entrypoint declares, discovers, derives and SERVES.
 
-The se#757 blocker-C shape: ten shipped production functions whose signature
-is `def f(ctx, payload) -> Out` with no model anywhere. This drives one of
-them through the whole real path on CPU -- no weights, no GPU, no model
-download -- and pins the guarantees that were KEPT.
+# pgw#1392: model-less entrypoints are legal -- zero model slots is a valid
+# declaration and the envelope has no model field (se#757 blocker C).
+
+Ten shipped production functions -- `dj-utils`, `music-analysis`,
+`quality-benchmark` -- have the signature `def f(ctx, payload) -> Out` with
+no model anywhere. This drives one of them through the whole real path on
+CPU (no weights, no GPU, no model download) and pins the guarantees KEPT.
 """
 
 from __future__ import annotations
@@ -12,6 +15,8 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
 
 import pytest
 
@@ -26,7 +31,7 @@ MODULE = "weightless_endpoint"
 
 
 @pytest.fixture(scope="module")
-def weightless():
+def weightless() -> Iterator[ModuleType]:
     sys.path.insert(0, str(FIXTURES))
     try:
         yield importlib.import_module(MODULE)
@@ -37,7 +42,7 @@ def weightless():
 # -- declaration ------------------------------------------------------------
 
 
-def test_zero_model_slots_is_a_legal_declaration(weightless) -> None:
+def test_zero_model_slots_is_a_legal_declaration(weightless: ModuleType) -> None:
     spec = getattr(weightless.transform, ENTRYPOINT_ATTR)
     assert spec.name == "transform"
     assert spec.slots == ()
@@ -110,7 +115,7 @@ def test_zero_slots_is_legal_but_junk_slots_are_not() -> None:
 # -- discovery --------------------------------------------------------------
 
 
-def test_discovery_publishes_a_row_with_no_slots(weightless) -> None:
+def test_discovery_publishes_a_row_with_no_slots(weightless: ModuleType) -> None:
     from gen_worker.discovery.entrypoints_v2 import (
         assert_manifest_advertises_something,
         discover_entrypoints,
@@ -132,7 +137,7 @@ def test_discovery_publishes_a_row_with_no_slots(weightless) -> None:
 
 
 def test_derive_renders_an_envelope_with_no_model_field(
-    weightless, tmp_path: Path
+    weightless: ModuleType, tmp_path: Path
 ) -> None:
     pytest.importorskip("torchcg")
     from gen_worker.release.derive import derive_release
@@ -163,7 +168,7 @@ def test_derive_renders_an_envelope_with_no_model_field(
 # -- serve ------------------------------------------------------------------
 
 
-def test_a_weightless_entrypoint_actually_serves(weightless) -> None:
+def test_a_weightless_entrypoint_actually_serves(weightless: ModuleType) -> None:
     loaded = load_endpoint_module(MODULE)
     assert loaded.models == ()
     assert sorted(loaded.entrypoints) == ["closure_gate", "transform"]
@@ -193,22 +198,25 @@ def test_a_weightless_entrypoint_actually_serves(weightless) -> None:
     assert gate.passed and gate.above == 2
 
 
-def test_the_wire_path_serves_and_takes_no_lease(weightless) -> None:
+def test_the_wire_path_serves_and_takes_no_lease(weightless: ModuleType) -> None:
     """The full envelope -> invoke -> outcome path. Nothing is made resident."""
 
     from gen_worker.serving.residency import ResidencyManager
     from gen_worker.serving.serve_loop import ServeLoop
 
     class NeverResolver:
-        def resolve(self, model_cls, checkpoint_ref):  # noqa: ANN001
+        def resolve(self, model_cls: type, checkpoint_ref: str) -> Any:
             raise AssertionError("a weightless request resolved a binding")
 
-        def default_pick(self, model_cls, slot_name):  # noqa: ANN001
+        def default_pick(self, model_cls: type, slot_name: str) -> str:
             raise AssertionError("a weightless request asked for a default pick")
 
     class NeverSizer:
-        def resident_bytes(self, checkpoint_ref, lane):  # noqa: ANN001
+        def resident_bytes(self, checkpoint_ref: str, lane: str) -> int:
             raise AssertionError("a weightless request sized a residency slot")
+
+        def activation_headroom_bytes(self, checkpoint_ref: str, lane: str) -> int:
+            raise AssertionError("a weightless request reserved activation bytes")
 
     loop = ServeLoop(
         load_endpoint_module(MODULE),
@@ -224,7 +232,7 @@ def test_the_wire_path_serves_and_takes_no_lease(weightless) -> None:
     assert outcome.warnings == ("transformed 10 chars",)
 
 
-def test_the_envelope_refuses_a_model_pick_by_name(weightless) -> None:
+def test_the_envelope_refuses_a_model_pick_by_name(weightless: ModuleType) -> None:
     spec = load_endpoint_module(MODULE).entrypoints["transform"]
     for envelope in (
         {"input": {"text": "x"}, "model": "org/repo@rel"},


### PR DESCRIPTION
Discharges [se#757] blocker C. Tracker: `python-gen-worker/progress.md` #1392.

## 🟡 The ruling is PENDING PAUL RATIFICATION — implemented anyway under velocity mode

> **Model-less entrypoints are legal. Zero model slots is a valid declaration. The envelope simply has no model field, and no `Model` class is required.**

Ratification ask filed in the tracker's `HUMAN_MUST_DO.md`; recorded as pgw#1382 open question 7.

## Why

Ten shipped, in-production functions are CPU workflow helpers with no model anywhere — `dj-utils` (4), `music-analysis` (3), `quality-benchmark` (3). Their v1 signature is `def f(ctx, payload) -> Out`. `@entrypoint` refused that twice over (arity floor of 3; "declares no model slot"). Both refusals were **deliberate** — statelessness is structural in pgw#1382 — but the design took "an entrypoint serves a model" as an axiom and one seventh of the shipped fleet has been the counterexample the whole time.

## What changed

- `serving/entrypoints.py`: arity floor 3 → 2; the "declares no model slot" refusal is deleted. **Everything else kept** — plain-positional, ctx-first + `RequestContext`-annotated, `msgspec.Struct` payload and return, and a third-or-later param must still BE a valid slot.
- `serving/host.py`: `dispatch()` gated on a non-empty `instances` map (permanently empty for a weightless endpoint); now an explicit booted flag.
- `serving/serve_loop.py`: `invoke()` read `model_params[0]` unconditionally. The residency-lease loop is naturally empty — no lease, no admission, no compile subject.
- `release/derive.py`: `derive_release` wrapped the WHOLE entrypoint enumeration in `if cls is not None`, so a weightless module derived `entrypoints: {}`. Only the LANE loop stays guarded; `lanes=()` eager-permanent modules derive byte-identically.
- `serving/envelope.py`: a zero-slot entrypoint sent a model pick now gets a refusal naming the real reason.

**The envelope has no model field** — `_envelope_schema` already omitted `models` when empty, so absent renders as absent. `model_slots` renders `{}`. Discovery needed no change (`slots: []`).

No new decorator, no `kind="workflow"`, no new manifest kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)