### PR TITLE
#1393: FLUX.2 Klein's noise schedule is SOURCED — the 4B repo is not HF-gated

### DIFF
--- a/src/gen_worker/models/model_types.py
+++ b/src/gen_worker/models/model_types.py
@@ -181,6 +181,35 @@ SD15_SCHEDULER_CONFIG: Final[Mapping[str, object]] = {
     "clip_sample": False,
 }
 
+#: black-forest-labs/FLUX.2-klein-4B scheduler/scheduler_config.json, fetched
+#: VERBATIM from the family owner's own repo (pgw#1393). FLUX.2 Klein is
+#: FLOW-MATCHING, so there is no beta schedule here at all — the shape is a
+#: shift ladder, and ``use_dynamic_shifting`` is exactly why pgw#1393 refused
+#: to invent one: the effective shift is a function of image sequence length
+#: between ``base_image_seq_len`` and ``max_image_seq_len``, so no frozen
+#: triple could have stood in for it. 4B is the ONE BFL flux repo that is not
+#: HF-gated; 9B is the same architecture (its endpoint module differs by a
+#: single VRAM floor) and rides the same schedule. FLUX.1's own repos are
+#: gated, so ``Flux1.canonical_scheduler_config`` stays empty — do not invent
+#: it by analogy with these numbers.
+FLUX2_KLEIN_SCHEDULER_CONFIG: Final[Mapping[str, object]] = {
+    "_class_name": "FlowMatchEulerDiscreteScheduler",
+    "num_train_timesteps": 1000,
+    "shift": 3.0,
+    "base_shift": 0.5,
+    "max_shift": 1.15,
+    "use_dynamic_shifting": True,
+    "base_image_seq_len": 256,
+    "max_image_seq_len": 4096,
+    "time_shift_type": "exponential",
+    "shift_terminal": None,
+    "invert_sigmas": False,
+    "stochastic_sampling": False,
+    "use_beta_sigmas": False,
+    "use_exponential_sigmas": False,
+    "use_karras_sigmas": False,
+}
+
 SDXL_DIFFUSERS_BF16: Final = PendingContract("sdxl.diffusers-bf16", 1)
 SD15_DIFFUSERS_BF16: Final = PendingContract("sd15.diffusers-bf16", 1)
 SD2_DIFFUSERS_BF16: Final = PendingContract("sd2.diffusers-bf16", 1)
@@ -527,8 +556,12 @@ class Flux2KleinDefaults(msgspec.Struct, frozen=True):
     its own narrower wire bounds. Upper bounds are the endpoint's (``:306``,
     ``:310``).
 
-    DELIBERATELY ABSENT, same reasons as :class:`Flux1Defaults`: the noise
-    schedule, a ``.Lora`` overlay, a ``timesteps`` ladder. Also absent: the
+    The noise schedule IS recorded for this family —
+    :data:`FLUX2_KLEIN_SCHEDULER_CONFIG`, fetched verbatim from the one BFL
+    flux repo that is not HF-gated. DELIBERATELY ABSENT, same reasons as
+    :class:`Flux1Defaults`: a ``.Lora`` overlay, a ``timesteps`` ladder (the
+    flow-match sigma ladder is derived from the shift parameters, never
+    pinned by an endpoint). Also absent: the
     preset grids / megapixel tiers and the 1..4 ordered-reference bound
     (``flux.2-klein-4b/main.py:136-137``, ``:357-360``) — those are endpoint
     PAYLOAD vocabulary, and a ModelType is name + Defaults + fingerprint,
@@ -671,6 +704,7 @@ class Flux2Klein(ModelType[Flux2KleinDefaults]):
     name = "flux2-klein"
     contracts = ("flux2-klein.*",)
     canonical_contract = DIT_BLOCKS_FUSED_QKV
+    canonical_scheduler_config = FLUX2_KLEIN_SCHEDULER_CONFIG
     Defaults = Flux2KleinDefaults
 
 
@@ -765,6 +799,7 @@ _seed_sdxl_contracts()
 __all__ = [
     "CONTRACT_DTYPES",
     "DIT_BLOCKS_FUSED_QKV",
+    "FLUX2_KLEIN_SCHEDULER_CONFIG",
     "Flux1",
     "Flux1Defaults",
     "Flux2Klein",

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -537,7 +537,21 @@ def test_canonical_scheduler_configs_are_the_training_schedules() -> None:
     from gen_worker.models import Flux1, Flux2Klein
 
     assert Flux1.canonical_scheduler_config == {}
-    assert Flux2Klein.canonical_scheduler_config == {}
+    # ...but FLUX.2 Klein's IS recorded now: black-forest-labs/FLUX.2-klein-4B
+    # is the ONE BFL flux repo that is not HF-gated, so its shipped
+    # scheduler_config.json was fetched verbatim (pgw#1393 follow-up).
+    klein = Flux2Klein.canonical_scheduler_config
+    assert klein["_class_name"] == "FlowMatchEulerDiscreteScheduler"
+    # FLOW-MATCHING: a shift ladder, NOT a beta schedule. Asserting the
+    # absence is the point — this is what "don't copy SDXL across" means.
+    for beta_field in ("beta_start", "beta_end", "beta_schedule", "trained_betas"):
+        assert beta_field not in klein
+    assert (klein["base_shift"], klein["max_shift"], klein["shift"]) == (0.5, 1.15, 3.0)
+    # The reason no frozen triple could have been invented: the effective
+    # shift is a function of image sequence length.
+    assert klein["use_dynamic_shifting"] is True
+    assert (klein["base_image_seq_len"], klein["max_image_seq_len"]) == (256, 4096)
+    assert klein["num_train_timesteps"] == 1000
     # Rife is the one AUXILIARY type: no canonical lane, and inventing a
     # tensorfs contract name for its diffusers-layout artifact would be a guess.
     assert Rife.canonical_contract is None


### PR DESCRIPTION
Follow-up to #976 (merged, `0a95abd5`). That PR left `canonical_scheduler_config` empty for both flux types because BFL's `scheduler_config.json` was HF-gated — correct at the time, and the right call over inventing one.

It turns out **`black-forest-labs/FLUX.2-klein-4B` is `gated: false`** and serves the file. Fetched verbatim:

```json
{"_class_name": "FlowMatchEulerDiscreteScheduler", "num_train_timesteps": 1000,
 "shift": 3.0, "base_shift": 0.5, "max_shift": 1.15, "use_dynamic_shifting": true,
 "base_image_seq_len": 256, "max_image_seq_len": 4096, "time_shift_type": "exponential",
 "shift_terminal": null, "invert_sigmas": false, "stochastic_sampling": false,
 "use_beta_sigmas": false, "use_exponential_sigmas": false, "use_karras_sigmas": false}
```

Flow-matching: **no `beta_start`/`beta_end`/`beta_schedule`/`trained_betas` at all** — the test asserts their absence, because that is what "don't copy SDXL's `scaled_linear` across" means concretely. And `use_dynamic_shifting: true` is precisely why #976 refused to invent a frozen triple: the effective shift is a function of image sequence length between `base_image_seq_len` and `max_image_seq_len`.

9B is the same architecture (its endpoint module differs from 4B's by a single VRAM floor) and rides the same schedule.

## Measured gating split (no HF token on the box)

| repo | `gated` | `resolve/` |
|---|---|---|
| `black-forest-labs/FLUX.2-klein-4B` | **false** | **200** |
| `black-forest-labs/FLUX.2-klein-9B` | auto | 401 |
| `black-forest-labs/FLUX.1-dev` | auto | 401 |
| `black-forest-labs/FLUX.1-schnell` | auto | 401 |

So **`Flux1.canonical_scheduler_config` stays `{}`** and the constant's docstring says explicitly not to fill it by analogy with Klein's numbers. Filling FLUX.1 needs an HF token — named as a blocker in the pgw#1393 tracker section, not left as a silent gap.

`tests/test_model_defaults.py`: 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)