### PR TITLE
pgw#1396: the v2 surface can state the machine it needs — @entrypoint(resources=Resources(...))

### DIFF
--- a/changelog.d/pgw1396.md
+++ b/changelog.d/pgw1396.md
@@ -1,36 +1,36 @@
-### The v2 surface can state the machine it needs — `@entrypoint(resources=Resources(...))`
+- **The v2 surface can state the machine it needs.** `@entrypoint` gains exactly one kwarg —
+  `@entrypoint(resources=Resources(vcpus=16, max_gpu_count=4, max_gpus_per_execution_group=4,
+  parallel=("sequence",), requires=LayoutRequirements(recommended="ram96g")))`. se#755 filed
+  minimax-h3's five staffing facts as undeclarable and `dj-utils`/`music-analysis` as unmigratable
+  for want of a CPU floor.
 
-se#755 filed the STAFFING ENVELOPE as undeclarable on the pgw#1382 surface:
-minimax-h3's `vcpus=16`, `ram96g`, `max_gpu_count=4`,
-`max_gpus_per_execution_group=4` and `parallel=("sequence",)` had no home, and
-`dj-utils` / `music-analysis` could not migrate because a CPU floor was
-unstatable.
+- **No new vocabulary was needed anywhere, in either repo.** `Resources` has carried `vcpus`,
+  `gpu_count`, `libraries`, `max_gpu_count`, `max_gpus_per_execution_group` and `parallel` all
+  along, and tensorhub has read every one of them at FUNCTION scope all along: `resources.vcpus`
+  becomes `min_vcpus` and reaches the RunPod inventory query and the Vast offer filter; the last
+  three are `extractStaffingEnvelope`; host RAM rides `requires` at `recommended` only. The gap was
+  SYNTAX — `@entrypoint` took no kwargs, and `entrypoints_v2._resources()` hand-built
+  `{gpu, requires}` from the model slots alone, so five of `Resources`' eight fields could never
+  appear in a v2 manifest no matter what an author wrote. Declared-but-unreachable, not unread.
 
-**No new vocabulary was needed anywhere.** `Resources` has carried every one of
-those fields all along, and tensorhub has read every one of them at FUNCTION
-scope all along — `resources.vcpus` becomes `min_vcpus` and reaches the RunPod
-inventory query and the Vast offer filter; the last three are
-`extractStaffingEnvelope`; host RAM rides `requires` at `recommended` only. The
-gap was syntax: `@entrypoint` took no kwargs, and `entrypoints_v2._resources()`
-hand-built `{gpu, requires}` from the model slots alone, so five of `Resources`'
-eight fields could never appear in a v2 manifest no matter what an author wrote.
+- **FUNCTION scope, justified from consumption.** The hub's unit of placement is the function
+  (pgw#1394); `music-analysis` declares `vcpus=2`/`8`/`8` across three functions of one endpoint and
+  `wan-2.2` carries two whole envelopes in one endpoint with "collapsing them onto one figure is the
+  defect this program exists to remove" written next to them; and a weightless entrypoint
+  (pgw#1392) has no `Model` class to hang a declaration on — which is exactly the case a CPU floor
+  unblocks. This does not reopen pgw#1382: that hardcut moved the *weight and lane* declarations
+  onto the class header because they are properties of the WEIGHTS. A machine ask is a property of
+  the code that runs. Sharing one declaration across entrypoints needs no framework surface, just a
+  module-level `Resources` constant — which is already how `wan-2.2` and `ltx-video-2.3` write it.
 
-`@entrypoint` gains exactly one kwarg. It is FUNCTION scope because the hub's
-unit of placement is the function (pgw#1394), because `music-analysis` declares
-`vcpus=2`/`8`/`8` across three functions of one endpoint, and because a
-weightless entrypoint (pgw#1392) has no `Model` class to hang it on — which is
-precisely the case a CPU floor unblocks. This does not reopen pgw#1382: that
-hardcut moved the *weight and lane* declarations onto the class header because
-they are properties of the WEIGHTS; a machine ask is a property of the code that
-runs.
+- **`vcpus` is deliberately NOT a `requires=` term and must not become one.** One axis, one
+  spelling: `resources.vcpus` is already the declared surface and the hub already normalizes it to
+  `min_vcpus` itself. The asymmetry with `min_host_ram_gb` (a `requires=` term, at `recommended`
+  only) is the standing 2026-07-11 ruling rather than an oversight — vCPUs are selectable and
+  filterable at both providers, host RAM on a RunPod GPU pod is neither, so a host-RAM MINIMUM stays
+  forbidden and no boot-time RAM gate is rebuilt.
 
-`vcpus` is deliberately NOT a `requires=` term and must not become one — one
-axis, one spelling. The asymmetry with `min_host_ram_gb` (a `requires=` term, at
-`recommended` only) is the standing ruling, not an oversight: vCPUs are
-selectable and filterable at both providers, host RAM on a RunPod GPU pod is
-neither.
-
-Both `requires=` scopes now fold rather than shadow: the model header's
-lane-keyed floor and the function's own `Resources(requires=)` collapse to the
-strictest by `term_meets`. An entrypoint that declares no `resources=` emits a
-byte-identical block.
+- Both `requires=` scopes now FOLD rather than shadow: the model class header's lane-keyed floor and
+  the function's own `Resources(requires=)` collapse to the strictest by `term_meets`. An entrypoint
+  that declares no `resources=` emits a byte-identical block, so `sdxl` and `minimax-h3` are
+  unaffected. Hub-side reads are pinned by tensorhub th#2166.

--- a/changelog.d/pgw1396.md
+++ b/changelog.d/pgw1396.md
@@ -1,0 +1,36 @@
+### The v2 surface can state the machine it needs — `@entrypoint(resources=Resources(...))`
+
+se#755 filed the STAFFING ENVELOPE as undeclarable on the pgw#1382 surface:
+minimax-h3's `vcpus=16`, `ram96g`, `max_gpu_count=4`,
+`max_gpus_per_execution_group=4` and `parallel=("sequence",)` had no home, and
+`dj-utils` / `music-analysis` could not migrate because a CPU floor was
+unstatable.
+
+**No new vocabulary was needed anywhere.** `Resources` has carried every one of
+those fields all along, and tensorhub has read every one of them at FUNCTION
+scope all along — `resources.vcpus` becomes `min_vcpus` and reaches the RunPod
+inventory query and the Vast offer filter; the last three are
+`extractStaffingEnvelope`; host RAM rides `requires` at `recommended` only. The
+gap was syntax: `@entrypoint` took no kwargs, and `entrypoints_v2._resources()`
+hand-built `{gpu, requires}` from the model slots alone, so five of `Resources`'
+eight fields could never appear in a v2 manifest no matter what an author wrote.
+
+`@entrypoint` gains exactly one kwarg. It is FUNCTION scope because the hub's
+unit of placement is the function (pgw#1394), because `music-analysis` declares
+`vcpus=2`/`8`/`8` across three functions of one endpoint, and because a
+weightless entrypoint (pgw#1392) has no `Model` class to hang it on — which is
+precisely the case a CPU floor unblocks. This does not reopen pgw#1382: that
+hardcut moved the *weight and lane* declarations onto the class header because
+they are properties of the WEIGHTS; a machine ask is a property of the code that
+runs.
+
+`vcpus` is deliberately NOT a `requires=` term and must not become one — one
+axis, one spelling. The asymmetry with `min_host_ram_gb` (a `requires=` term, at
+`recommended` only) is the standing ruling, not an oversight: vCPUs are
+selectable and filterable at both providers, host RAM on a RunPod GPU pod is
+neither.
+
+Both `requires=` scopes now fold rather than shadow: the model header's
+lane-keyed floor and the function's own `Resources(requires=)` collapse to the
+strictest by `term_meets`. An entrypoint that declares no `resources=` emits a
+byte-identical block.

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -199,7 +199,7 @@ def _merge_floors(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     return merged
 
 
-def _resources(specs: List[Any]) -> Dict[str, Any]:
+def _resources(specs: List[Any]) -> Dict[str, Any] | None:
     """The function's `resources` block: THE FUNCTION SCOPE of the one
     requirement vocabulary (`internal/builder/function_requirements.go`).
 
@@ -213,20 +213,50 @@ def _resources(specs: List[Any]) -> Dict[str, Any]:
     1. **An EMPTY block is an explicit CPU declaration** on the hub side
        ("a present-but-empty block is an explicit CPU declaration"), so a
        model-bearing entrypoint must never emit `{}`. It emits `gpu: true`.
-    2. **Absent stays absent for a slotless entrypoint.** No model slot means
-       no claim, and the hub falls back to release-level resolution exactly as
-       it does today.
+    2. **Absent stays absent for a slotless entrypoint that declares
+       nothing.** No model slot and no `resources=` means no claim, and the
+       hub falls back to release-level resolution exactly as it does today.
 
     `gpu: true` is also a fix in its own right: a v2 release previously
     declared NO accelerator anywhere (its only machine signal was the
     `layout_requirements` the hub was refusing), which is the
     `[runpod] no GPU constraint declared; buying with NO VRAM bound` path.
+
+    THE REST OF THE BLOCK — se#755/pgw#1396. This used to hand-build
+    `{gpu, requires}` from the model slots alone, so five of `Resources`'
+    eight fields could never appear in a v2 manifest no matter what an author
+    wrote: `vcpus`, `gpu_count`, `libraries`, `max_gpu_count`,
+    `max_gpus_per_execution_group`, `parallel`. Every one of them is read by
+    the hub already — `vcpus` becomes `min_vcpus` and reaches the RunPod
+    inventory query and the Vast offer filter; the last three are
+    `extractStaffingEnvelope` — so they were declared-but-unreachable, not
+    unread. `Resources.manifest_dict()` is the projection and this function
+    stops second-guessing it.
+
+    `requires` can now arrive from BOTH scopes: the model class header's
+    lane-keyed `requires=` and the function's own
+    `Resources(requires=)` (te#209's scope, and the only one a weightless
+    function has). They FOLD by `_merge_floors` — the strictest of everything
+    declared for this function — rather than one silently shadowing the other.
     """
     from ..serving import model_requires
 
     floors: List[Dict[str, Any]] = []
     has_model_slot = False
+    has_declaration = False
+    declared: Dict[str, Any] = {}
     for spec in specs:
+        resources = getattr(spec, "resources", None)
+        if resources is not None:
+            has_declaration = True
+            # `manifest_dict()` renders `requires` as a manifest ROW, the same
+            # shape `_merge_floors` folds, so it joins the lane floors rather
+            # than overwriting them.
+            block = resources.manifest_dict()
+            row = block.pop("requires", None)
+            if row:
+                floors.append(row)
+            declared.update(block)
         for slot in spec.slots:
             if slot.kind != "model":
                 continue
@@ -236,9 +266,14 @@ def _resources(specs: List[Any]) -> Dict[str, Any]:
                 for row in model_requires(slot.annotation).values()
                 if row.declared()
             )
-    if not has_model_slot:
-        return {}
-    out: Dict[str, Any] = {"gpu": True}
+    if not has_model_slot and not has_declaration:
+        return None
+    out: Dict[str, Any] = dict(declared)
+    if has_model_slot:
+        # A model-bearing entrypoint always declares the accelerator, even
+        # when the author's `Resources(...)` left `gpu` at its False default
+        # and `omit_defaults` elided it.
+        out["gpu"] = True
     merged = _merge_floors(floors)
     if merged:
         out["requires"] = merged
@@ -282,7 +317,12 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # ratified surface, so the cardinality fact is stated, never omitted.
         "incremental_output": False,
         "slots": slots,
-        **({"resources": resources} if resources else {}),
+        # `None` is ABSENT (no model slot, no `resources=`); a dict is
+        # PRESENT, and a present-but-empty block is the hub's explicit CPU
+        # declaration — so an author who writes a bare `Resources()` on a
+        # weightless entrypoint gets that meaning rather than a silent
+        # fall-back to release-level class resolution.
+        **({"resources": resources} if resources is not None else {}),
     }
 
 

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -19,6 +19,13 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
     def transform(ctx: RequestContext, payload: TransformInput
                   ) -> TransformOutput: ...
 
+    @entrypoint(resources=Resources(  # the STAFFING ENVELOPE (pgw#1396)
+        vcpus=16, max_gpu_count=4, max_gpus_per_execution_group=4,
+        parallel=("sequence",),
+        requires=LayoutRequirements(recommended="ram96g")))
+    def generate(ctx: RequestContext, payload: GenerateInput,
+                 video: H3Model) -> GenerateOutput: ...
+
 * first: ``ctx`` annotated :class:`~gen_worker.serving.context.RequestContext`
 * second: the payload, a ``msgspec.Struct`` — the wire schema
 * remaining, in any order and **possibly none**: model SLOTS (params
@@ -45,7 +52,9 @@ import inspect
 import types
 import typing
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Literal, Tuple, Type, TypeVar, get_type_hints
+from typing import (
+    Any, Callable, Dict, Literal, Tuple, Type, TypeVar, get_type_hints, overload,
+)
 
 import msgspec
 
@@ -91,6 +100,12 @@ class EntrypointSpec:
     payload_type: Type[msgspec.Struct]
     slots: Tuple[SlotSpec, ...]
     return_type: Type[msgspec.Struct]
+    #: The declared :class:`~gen_worker.api.decorators.Resources`, or ``None``.
+    #: se#755/pgw#1396: the STAFFING ENVELOPE — the machine this function is
+    #: placed on. Function scope because the hub's unit of placement is the
+    #: function (pgw#1394) and because `music-analysis` declares three
+    #: different vCPU floors across three functions of one endpoint.
+    resources: Any = None
 
     @property
     def model_params(self) -> Tuple[Tuple[str, type], ...]:
@@ -169,17 +184,72 @@ def _slot_of(fn: Callable[..., Any], name: str, annotation: Any) -> SlotSpec:
     )
 
 
-def entrypoint(fn: F) -> F:
-    """Mark a module-level function as an entrypoint (contract above)."""
+@overload
+def entrypoint(fn: F) -> F: ...
+@overload
+def entrypoint(*, resources: Any) -> Callable[[F], F]: ...
+
+
+def entrypoint(
+    fn: F | None = None, *, resources: Any = None
+) -> F | Callable[[F], F]:
+    """Mark a module-level function as an entrypoint (contract above).
+
+    ``resources=`` is the ONE kwarg this decorator takes, and it is the
+    STAFFING ENVELOPE (se#755/pgw#1396): the machine this function is placed
+    on — ``Resources(vcpus=…, max_gpu_count=…,
+    max_gpus_per_execution_group=…, parallel=…, requires=…)``. It is FUNCTION
+    scope for three reasons, none of them convenience:
+
+    * the hub's unit of placement IS the function — pgw#1394 folded the
+      per-lane VRAM floor to function scope for exactly this reason
+      (*"a function is placed on a single machine before anything knows which
+      lane it will serve"*), and every term here is placed by that same code;
+    * one endpoint's functions legitimately differ: ``music-analysis``
+      declares ``vcpus=2``, ``vcpus=8``, ``vcpus=8`` across three functions,
+      and a single endpoint- or model-scoped number is a silent over- or
+      under-buy of two of them;
+    * a WEIGHTLESS entrypoint (pgw#1392) has no ``Model`` class to hang it on,
+      and weightless endpoints are precisely the ones a CPU floor unblocks.
+
+    This does NOT reopen pgw#1382. That hardcut moved the *weight and lane*
+    declarations (``model=``, ``lanes=``) onto the ``Model`` class header
+    because they are properties of the WEIGHTS. A machine ask is a property of
+    the CODE THAT RUNS, which is this function.
+
+    ``vcpus`` is NOT a ``requires=`` term and must never become one: the hub
+    already reads ``resources.vcpus`` and normalizes it to ``min_vcpus``
+    itself, so a second spelling would land in one payload key from two
+    directions. The asymmetry with ``min_host_ram_gb`` (which IS a
+    ``requires=`` term, at ``recommended`` only) is deliberate: vCPUs are
+    selectable and filterable at both providers, host RAM on a RunPod GPU pod
+    is neither, so a host-RAM MINIMUM stays forbidden (Paul, 2026-07-11).
+    """
+
+    if fn is None:
+        def bind(inner: F) -> F:
+            return entrypoint(inner, resources=resources)  # type: ignore[call-overload,no-any-return]
+        return bind
 
     from .context import RequestContext
 
     if not inspect.isfunction(fn):
         raise EntrypointDeclarationError(
             f"@entrypoint marks module-level functions, got "
-            f"{type(fn).__name__} — decorator kwargs died with @endpoint "
-            "(pgw#1382); the Model class header carries lanes="
+            f"{type(fn).__name__} — the only kwarg is resources= "
+            "(pgw#1396); the Model class header carries lanes="
         )
+    if resources is not None:
+        from ..api.decorators import Resources
+
+        if not isinstance(resources, Resources):
+            raise _refuse(
+                fn,
+                f"resources= takes a gen_worker.Resources, got "
+                f"{type(resources).__name__} — the staffing envelope is a "
+                "typed declaration so its refusals name your line, not a "
+                "manifest key",
+            )
     if "." in fn.__qualname__:
         raise _refuse(
             fn,
@@ -257,6 +327,7 @@ def entrypoint(fn: F) -> F:
         payload_type=payload_type,
         slots=slots,
         return_type=return_type,
+        resources=resources,
     )
     setattr(fn, ENTRYPOINT_ATTR, spec)
     return fn

--- a/tests/release_fixtures/staffing_endpoint.py
+++ b/tests/release_fixtures/staffing_endpoint.py
@@ -1,0 +1,110 @@
+"""minimax-h3's STAFFING ENVELOPE, v2-spelled (se#755 / pgw#1396).
+
+The five facts H3's retired v1 ``Resources(...)`` carried and the v2 surface
+had no syntax for: a vCPU floor, a host-RAM RECOMMENDATION, a GPU-count
+ceiling, an execution-group width, and the sequence-parallel capability.
+
+Three entrypoints, deliberately different:
+
+* ``generate`` — the full envelope, model-bearing;
+* ``analyze`` — WEIGHTLESS with ``vcpus=4``, the ``dj-utils`` /
+  ``music-analysis`` shape that se#755 blocks;
+* ``control`` — model-bearing with NO ``resources=``, which must emit exactly
+  what it emitted before pgw#1396.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+from gen_worker import Model, RequestContext, Resources, entrypoint
+from gen_worker.models.tensor_layout_contract import LayoutRequirements
+
+
+class _Lane:
+    """A tensorfs layout contract stand-in: a stamp and a load dtype."""
+
+    def __init__(self, stamp: str) -> None:
+        self.stamp = stamp
+
+    @property
+    def dtype(self) -> str:
+        return "bfloat16"
+
+
+H3_LANE = _Lane("minimax.h3-dit-diffusers@1")
+
+
+class MiniMaxH3:
+    """The model type stand-in — only its name reaches the manifest."""
+
+    name = "minimax-h3"
+
+
+class H3Pipeline:
+    pass
+
+
+class GenerateInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompt: str
+
+
+class GenerateOutput(msgspec.Struct):
+    frames: int
+
+
+class AnalyzeInput(msgspec.Struct, forbid_unknown_fields=True):
+    samples: list[float]
+
+
+class AnalyzeOutput(msgspec.Struct):
+    bpm: float
+
+
+class H3Model(
+    Model[MiniMaxH3],
+    lanes=(H3_LANE,),
+    # The per-LANE placement floor — a property of the weight format.
+    requires={H3_LANE: "vram78g"},
+):
+    def load(self, ctx: Any) -> None:
+        self.pipe = ctx.load(H3Pipeline)
+
+
+#: Hoisted so the three DiT entrypoints share one declaration rather than
+#: three copies that can drift.
+H3_STAFFING = Resources(
+    # The CPU floor. H3's serve path is host-heavy by construction: the
+    # residency sequencer parks and lands components between stages.
+    vcpus=16,
+    # The SHAPE the hub may staff — a ceiling, not a floor.
+    max_gpu_count=4,
+    max_gpus_per_execution_group=4,
+    # The CAPABILITY: the vendored DiT declares `_cp_plan` and
+    # `cp_attention.py` carries the exact-arm attention.
+    parallel=("sequence",),
+    # Host RAM is a RECOMMENDATION and can never be a minimum (Paul,
+    # 2026-07-11: a RunPod GPU pod can neither select nor guarantee it).
+    requires=LayoutRequirements(recommended="ram96g"),
+)
+
+
+@entrypoint(resources=H3_STAFFING)
+def generate(
+    ctx: RequestContext, payload: GenerateInput, video: H3Model
+) -> GenerateOutput:
+    return GenerateOutput(frames=1)
+
+
+@entrypoint(resources=Resources(vcpus=4))
+def analyze(ctx: RequestContext, payload: AnalyzeInput) -> AnalyzeOutput:
+    return AnalyzeOutput(bpm=float(len(payload.samples)))
+
+
+@entrypoint
+def control(
+    ctx: RequestContext, payload: GenerateInput, video: H3Model
+) -> GenerateOutput:
+    return GenerateOutput(frames=1)

--- a/tests/test_staffing_envelope.py
+++ b/tests/test_staffing_envelope.py
@@ -1,4 +1,6 @@
-"""The v2 surface can state the machine it needs (se#755 / pgw#1396).
+"""The STAFFING ENVELOPE an entrypoint declares: which machine it is placed on.
+
+# se#755 / pgw#1396: the v2 surface can state the machine it needs.
 
 `Resources` has carried `vcpus`, `max_gpu_count`,
 `max_gpus_per_execution_group` and `parallel` all along, and tensorhub has

--- a/tests/test_staffing_envelope_pgw1396.py
+++ b/tests/test_staffing_envelope_pgw1396.py
@@ -169,6 +169,48 @@ def test_the_undeclared_control_is_unchanged(rows: dict[str, dict]) -> None:
     assert rows["control"]["resources"] == {"gpu": True, "requires": {"min_vram_gb": 78.0}}
 
 
+def test_the_block_reaches_the_real_manifest(tmp_path: Path) -> None:
+    """The whole `cozy build` discovery path, not just `discover_entrypoints`.
+
+    `discover_manifest` is what writes `endpoint.lock`; the two lines between
+    it and this block (`manifest["entrypoints"] = entrypoints_block(rows)`)
+    transform nothing, but "transforms nothing" is a claim worth a test when
+    the whole issue is a fact that was declarable and unreachable.
+
+    The rows this produces are the ones tensorhub th#2166 parses verbatim.
+    """
+    from gen_worker.discovery.discover import discover_manifest
+
+    root = tmp_path / "staffing_e2e"
+    package = root / "src" / "staffing_e2e"
+    package.mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "staffing-e2e"\nversion = "0.1.0"\n\n'
+        '[tool.gen_worker]\nmain = "staffing_e2e.main"\n'
+    )
+    (root / "endpoint.toml").write_text(
+        'schema_version = 1\nmain = "staffing_e2e.main"\n\n'
+        '[[build.profiles]]\naccelerator = "cuda"\n'
+    )
+    (package / "__init__.py").write_text("")
+    (package / "main.py").write_text((FIXTURES / f"{MODULE}.py").read_text())
+
+    sys.path.insert(0, str(root / "src"))
+    try:
+        manifest = discover_manifest(root)
+    finally:
+        sys.path.remove(str(root / "src"))
+
+    blocks = {row["name"]: row.get("resources") for row in manifest["entrypoints"]}
+    assert blocks["generate"]["vcpus"] == 16
+    assert blocks["generate"]["max_gpu_count"] == 4
+    assert blocks["generate"]["max_gpus_per_execution_group"] == 4
+    assert list(blocks["generate"]["parallel"]) == ["sequence"]
+    assert blocks["generate"]["requires"]["recommended"]["min_host_ram_gb"] == 96.0
+    assert blocks["analyze"] == {"vcpus": 4}
+    assert blocks["control"] == {"gpu": True, "requires": {"min_vram_gb": 78.0}}
+
+
 def test_absent_stays_absent(staffing: ModuleType) -> None:
     """No model slot AND no `resources=` means no claim: the key is omitted
     entirely and the hub falls back to release-level resolution. A

--- a/tests/test_staffing_envelope_pgw1396.py
+++ b/tests/test_staffing_envelope_pgw1396.py
@@ -1,0 +1,183 @@
+"""The v2 surface can state the machine it needs (se#755 / pgw#1396).
+
+`Resources` has carried `vcpus`, `max_gpu_count`,
+`max_gpus_per_execution_group` and `parallel` all along, and tensorhub has
+read every one of them at FUNCTION scope all along
+(`internal/builder/function_requirements.go` -> `payload["min_vcpus"]`, and
+`staffing_envelope.go` for the other three). What was missing was any syntax
+for reaching them from the pgw#1382 author surface: `@entrypoint` took no
+kwargs, and `entrypoints_v2._resources()` hand-built `{gpu, requires}` from
+the model slots alone, so five of `Resources`' eight fields could never
+appear in a v2 manifest.
+
+These tests pin the emission. The hub-side READ is pinned in tensorhub
+th#2166 against the exact rows this file produces.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+
+from gen_worker import Resources
+from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
+from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR, EntrypointDeclarationError
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "staffing_endpoint"
+
+
+@pytest.fixture(scope="module")
+def staffing() -> Iterator[ModuleType]:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+@pytest.fixture(scope="module")
+def rows(staffing: ModuleType) -> dict[str, dict]:
+    return {row["name"]: row for row in discover_entrypoints(MODULE)}
+
+
+# -- declaration ------------------------------------------------------------
+
+
+def test_the_declaration_reaches_the_spec(staffing: ModuleType) -> None:
+    """`@entrypoint(resources=...)` and bare `@entrypoint` both work."""
+
+    assert getattr(staffing.generate, ENTRYPOINT_ATTR).resources is staffing.H3_STAFFING
+    assert getattr(staffing.analyze, ENTRYPOINT_ATTR).resources == Resources(vcpus=4)
+    # The bare form is untouched: absence is None, not an empty Resources.
+    assert getattr(staffing.control, ENTRYPOINT_ATTR).resources is None
+
+
+def test_resources_must_be_a_resources() -> None:
+    """A typed refusal naming the author's own line, not a manifest key."""
+
+    module = type(sys)("pgw1396_probe")
+    module.__dict__["__name__"] = "pgw1396_probe"
+    sys.modules["pgw1396_probe"] = module
+    source = (
+        "import msgspec\n"
+        "from gen_worker import RequestContext, entrypoint\n"
+        "class In(msgspec.Struct): text: str\n"
+        "class Out(msgspec.Struct): text: str\n"
+        "@entrypoint(resources={'vcpus': 4})\n"
+        "def f(ctx: RequestContext, payload: In) -> Out: ...\n"
+    )
+    try:
+        with pytest.raises(EntrypointDeclarationError) as excinfo:
+            exec(source, module.__dict__)  # noqa: S102
+    finally:
+        del sys.modules["pgw1396_probe"]
+    assert "resources=" in str(excinfo.value)
+    assert "gen_worker.Resources" in str(excinfo.value)
+
+
+def test_the_envelope_refusals_fire_at_declaration_time() -> None:
+    """`Resources.__post_init__` mirrors the hub's `extractStaffingEnvelope`
+    ingest refusals, so a contradiction costs a ValueError and not a build."""
+
+    with pytest.raises(ValueError, match="below gpu_count"):
+        Resources(gpu_count=4, max_gpu_count=2)
+    with pytest.raises(ValueError, match="vcpus must be positive"):
+        Resources(vcpus=0)
+
+
+# -- emission ---------------------------------------------------------------
+
+
+def test_all_five_facts_reach_the_manifest(rows: dict[str, dict]) -> None:
+    """The five facts se#755 measured as having "no home"."""
+
+    block = rows["generate"]["resources"]
+    assert block["vcpus"] == 16                          # the CPU floor
+    assert block["max_gpu_count"] == 4                   # the SHAPE (ceiling)
+    assert block["max_gpus_per_execution_group"] == 4    # the degree axis
+    # A tuple in memory, a JSON array on the wire — `normalizeParallelMechanisms`
+    # decodes `[]any`. Asserted through `json` so the WIRE shape is the claim.
+    assert json.loads(json.dumps(block))["parallel"] == ["sequence"]
+    # Host RAM: a RECOMMENDATION, nested, and NEVER a minimum. Paul,
+    # 2026-07-11: a RunPod GPU pod can neither select nor guarantee it, so a
+    # declared floor was unenforceable theater (tensorhub
+    # `TermDef.MinimumDeclarable` is false for this term alone).
+    assert block["requires"]["recommended"] == {"min_host_ram_gb": 96.0}
+    assert "min_host_ram_gb" not in block["requires"]
+
+
+def test_host_ram_cannot_be_declared_as_a_minimum() -> None:
+    """The asymmetry with `vcpus` is the RULING, not an oversight."""
+
+    with pytest.raises(ValueError, match="RECOMMENDED only"):
+        Resources(requires="ram96g")
+
+
+def test_vcpus_is_not_a_requires_term() -> None:
+    """ONE axis, ONE spelling. `resources.vcpus` is already the declared
+    surface and the hub already normalizes it to `min_vcpus` itself; a
+    `requires.min_vcpus` term would land in one payload key from two
+    directions."""
+
+    from gen_worker.models.tensor_layout_contract import KNOWN_REQUIREMENT_TERMS
+
+    assert "min_vcpus" not in KNOWN_REQUIREMENT_TERMS
+    assert "min_cpu" not in " ".join(KNOWN_REQUIREMENT_TERMS)
+    with pytest.raises(ValueError):
+        Resources(requires={"minimum": {"min_vcpus": 4}})
+
+
+def test_a_weightless_function_can_state_its_cpu_floor(rows: dict[str, dict]) -> None:
+    """se#757 blocker C cleared the SIGNATURE; this clears the MACHINE.
+
+    `dj-utils` (vcpus=4) and `music-analysis` (2/8/8 across three functions)
+    are the shipped shape, and it is why this declaration is per-FUNCTION: a
+    single endpoint- or model-scoped number cannot express three values, and
+    a weightless function has no `Model` class to hang one on.
+    """
+
+    row = rows["analyze"]
+    assert row["slots"] == []
+    assert row["resources"] == {"vcpus": 4}
+    # No accelerator is manufactured for a function that declared none.
+    assert "gpu" not in row["resources"]
+
+
+def test_both_requires_scopes_fold_rather_than_shadow(rows: dict[str, dict]) -> None:
+    """The model header's lane-keyed `requires=` and the function's own
+    `Resources(requires=)` both target `functions[].resources.requires`, and
+    they FOLD by `term_meets` — the strictest of everything declared for this
+    function. Either one shadowing the other is a silent under-declaration
+    the buy path cannot detect."""
+
+    requires = rows["generate"]["resources"]["requires"]
+    assert requires["min_vram_gb"] == 78.0                       # from the class header
+    assert requires["recommended"]["min_host_ram_gb"] == 96.0    # from the function
+
+
+def test_the_undeclared_control_is_unchanged(rows: dict[str, dict]) -> None:
+    """An entrypoint with no `resources=` emits EXACTLY what it emitted
+    before pgw#1396 — the sdxl deploy pins this shape."""
+
+    assert rows["control"]["resources"] == {"gpu": True, "requires": {"min_vram_gb": 78.0}}
+
+
+def test_absent_stays_absent(staffing: ModuleType) -> None:
+    """No model slot AND no `resources=` means no claim: the key is omitted
+    entirely and the hub falls back to release-level resolution. A
+    present-but-EMPTY block is the hub's explicit CPU declaration, which is a
+    different statement and must not be made by accident."""
+
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        rows = {r["name"]: r for r in discover_entrypoints("weightless_endpoint")}
+    finally:
+        sys.path.remove(str(FIXTURES))
+    assert "resources" not in rows["transform"]


### PR DESCRIPTION
Closes the SDK half of **se#755**.

## se#755 is right that the facts are undeclarable and wrong about why

The filing says minimax-h3's five staffing facts have "no home" and that a fix must invent one. Measured at `origin/master` in both repos before a line was written: **no new vocabulary is needed anywhere.**

`gen_worker.api.decorators.Resources` already carries `vcpus`, `gpu_count`, `libraries`, `max_gpu_count`, `max_gpus_per_execution_group` and `parallel`, with `__post_init__` already mirroring the hub's ingest refusals. And tensorhub already READS every one of them at function scope:

| fact | manifest key | hub read | ends at |
|---|---|---|---|
| `vcpus` | `resources.vcpus` | `function_requirements.go:299` → `payload["min_vcpus"]` | `release/resolver.go:762` → `CreatePodRequest.MinVCPUCount` → RunPod `gpu_inventory.go` query filter + `vast/provider.go:279` **offer filter** |
| host RAM | `resources.requires.recommended.min_host_ram_gb` | `machinereq.ParseRequirements` | surfaced, never compared — correct |
| `max_gpu_count` | `resources.max_gpu_count` | `staffing_envelope.go:56` | `orchestrator/server/staffing_envelope.go` |
| `max_gpus_per_execution_group` | same | `staffing_envelope.go:78` | as above |
| `parallel` | same | `normalizeParallelMechanisms` | as above |

`entrypoints[]` folds into `Functions` at the one decode site (`builder/manifest.go:115`), so a v2 row goes through the identical `extractFunctionRequirements` a v1 row does.

**The gap was syntax, in two lines of this repo.** `@entrypoint` took no kwargs, and `entrypoints_v2._resources()` hand-built `{gpu, requires}` from the model slots alone — so five of `Resources`' eight fields could never appear in a v2 manifest no matter what an author wrote. Declared-but-unreachable, not unread.

## Why FUNCTION scope, not the Model class header

1. **The hub's unit of placement IS the function.** pgw#1394 settled this for the VRAM floor and folded per-lane floors to function scope for exactly this reason.
2. **`music-analysis` decides it.** Its three functions declare `vcpus=2`, `vcpus=8`, `vcpus=8`. A model- or endpoint-scoped number cannot express that, and collapsing them is a silent over- or under-buy of two of them.
3. **The blocked endpoints have no model.** `dj-utils` and `music-analysis` are weightless (pgw#1392); `cls is None` on their derive path. A `Model` class kwarg is unreachable for precisely the endpoints this unblocks.
4. **It does not reopen pgw#1382.** That hardcut moved *weight and lane* declarations (`model=`, `lanes=`) onto the class header because they are properties of the WEIGHTS — the refusal string names `lanes=` specifically. A machine ask is a property of the code that runs.

## `vcpus` is deliberately NOT a `requires=` term

`KNOWN_REQUIREMENT_TERMS` does not grow. `resources.vcpus` is already the declared axis and the hub already normalizes it to the internal name `min_vcpus`; a second author spelling would land in one payload key from two directions — the "parsed in exactly one place" invariant `function_requirements.go` states about itself. The asymmetry with `min_host_ram_gb` is not an inconsistency to fix: **RAM rides `requires=` because it is unenforceable and must stay `recommended`-only** (Paul, 2026-07-11; `TermDef.MinimumDeclarable=false`; `admit.go` cannot evaluate it), while **vCPUs ride `resources.vcpus` because they ARE selectable and filterable at both providers**. Different mechanisms, different homes. No host-RAM minimum is built and no boot-time RAM gate is rebuilt.

## Proven by running the real path

`discover_entrypoints` over a real on-disk fixture package (`tests/release_fixtures/staffing_endpoint.py`), three entrypoints:

```
--- generate  slots=['video']
{"gpu": true, "max_gpu_count": 4, "max_gpus_per_execution_group": 4,
 "parallel": ["sequence"],
 "requires": {"min_vram_gb": 78.0, "recommended": {"min_host_ram_gb": 96.0}},
 "vcpus": 16}

--- analyze   slots=[]            # the dj-utils / music-analysis shape
{"vcpus": 4}

--- control   slots=['video']     # no resources= — BYTE-IDENTICAL to today
{"gpu": true, "requires": {"min_vram_gb": 78.0}}
```

All five facts, one declaration. `generate` also shows both `requires=` scopes FOLDING (`min_vram_gb` from the model class header, `min_host_ram_gb` from the function's own `Resources(requires=)`) by the existing `term_meets` comparator rather than one shadowing the other — a naive `max()` picks `min_cuda 12.9` over `12.10`.

`87 passed` across this file plus `test_weightless_entrypoints`, `test_requirement_vocabulary_pgw1313` and `test_ram_floor_pgw670`.

## Blast radius

Zero for existing endpoints. `sdxl` and `minimax-h3` declare no `resources=` on any entrypoint, so `_resources()` returns exactly what it returns today — pinned by `test_the_undeclared_control_is_unchanged`. Nothing pgw#1394 moved is moved again. The deploy lane holding the sdxl manifest shape was notified before this branch was pushed.

**What is NOT proven here:** no real rental buy was made and no pod was booted — this PR ends at the manifest. The hub-side read is pinned by **th#2166**, a regression test against these exact rows, so this cannot silently become declared-but-never-read again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)