### PR TITLE
pgw#1395: the v2 `entrypoints` block joins the declaration walk

### DIFF
--- a/changelog.d/pgw1395.md
+++ b/changelog.d/pgw1395.md
@@ -1,0 +1,33 @@
+- **A v2 `entrypoints`-only image imported ZERO user modules, and said so in the wrong words.**
+  `manifest_blocks.DECLARATION_BLOCKS` was `("functions", "jobs")`. `entrypoints[]` is
+  `functions[]`' successor spelling (th#2146) carrying the identical item shape — `name`,
+  `module`, `resources` — and it is the ONLY block a post-pgw#1382 endpoint declares. Bake time
+  folded it (`discovery/validation.validate_endpoint_lock`); BOOT time did not, so every reader
+  built on that walk went blind: `worker_main.get_modules_from_manifest` yielded `[]`,
+  `cuda_probe.should_probe_cuda` returned False (the gw#529 bad-host guard silently off), and the
+  boot died `no_user_modules` reporting *"declares no functions and no jobs — this image publishes
+  nothing"* over a manifest declaring its entrypoint perfectly well. Structurally pgw#1354's
+  jobs-only failure, one hardcut later, and it fires on the FIRST post-cutover endpoint: sdxl and
+  minimax-h3 on `serverless-endpoints` master are already v2-only.
+
+  Measured, not read: `python -m gen_worker.discovery` over an sdxl-shaped v2-only package emits
+  `functions = []` beside one `[[entrypoints]]` row carrying `module` and
+  `resources = {gpu = true, requires = {min_vram_gb = 12.0, min_sm = 89}}`. Driving the real boot
+  path against that lock — before: `block_counts {functions: 0, jobs: 0}`, 0 modules, probe off,
+  exit 1. After: `{functions: 0, entrypoints: 1, jobs: 0}`, `['serving_v2_fixture.main']`, probe
+  ON, module imported and its serve surface stated.
+
+- **A refusal can no longer name a subset of the blocks the walk reads.** `declared_block_summary`
+  renders the counts FROM `DECLARATION_BLOCKS`, so the boot fatal and the `manifest_loaded` phase
+  (which gains `entrypoint_count`) move together with the tuple. That mismatch is the whole reason
+  this defect read as "publishes nothing" instead of "a block this build does not walk".
+
+- **`models.download.build_provider_index_from_manifest` was a third blind reader** — it walked
+  `manifest["functions"]` directly, so a binding on a v2 row would have indexed to nothing and
+  every ref in it fallen back to the default provider. It goes through `declaration_rows` now. It
+  was the only remaining direct `functions[]` walk outside `discovery/`.
+
+- **The next wall is NAMED, not assumed.** With modules imported, `Worker.__init__` still finds no
+  serve surface: `registry.extract_specs` reads `__gen_worker_endpoint__` and `@entrypoint` stamps
+  `__cozy_entrypoint__`. That belongs to the pgw#1367/pgw#1373 serving cutover; a test arm asserts
+  the boot now reaches THAT refusal by name rather than dying at the module walk.

--- a/src/gen_worker/manifest_blocks.py
+++ b/src/gen_worker/manifest_blocks.py
@@ -1,10 +1,11 @@
 """The declaration rows of a baked ``endpoint.lock``.
 
-ONE walk over BOTH publishable shapes. A release may declare ``@endpoint``
-functions, ``@job`` functions, or both, and a release with jobs and ZERO
-functions is legal (th#2049) — so every reader that asks "what did this image
-declare" must ask it of both blocks, or it goes blind on the shape it was not
-written for.
+ONE walk over EVERY publishable shape. A release may declare ``@entrypoint``
+handlers, ``@endpoint`` functions, ``@job`` functions, or any mix, and a
+release with jobs and ZERO functions is legal (th#2049), as is an
+entrypoints-only release (pgw#1387) — so every reader that asks "what did this
+image declare" must ask it of every block, or it goes blind on the shape it was
+not written for.
 
 pgw#1354 is what blindness costs: ``entrypoint.get_modules_from_manifest`` and
 ``cuda_probe.should_probe_cuda`` each walked ``functions[]`` alone, both
@@ -31,7 +32,16 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping, Optional
 
 #: Every manifest block carrying declaration rows, in wire order.
-DECLARATION_BLOCKS = ("functions", "jobs")
+#:
+#: pgw#1395 (th#2161 D0 / G14): ``entrypoints`` was missing here. It is
+#: ``functions``' SUCCESSOR SPELLING (th#2146) carrying the identical item
+#: shape — ``name``, ``module``, ``resources`` — and it is the ONLY block a
+#: post-pgw#1382 endpoint declares. Bake time folded it (``validation.py``);
+#: boot time did not, so a v2-only image imported zero user modules, was never
+#: CUDA-probed, and died naming the wrong gap ("declares no functions and no
+#: jobs"). Exactly pgw#1354's jobs-only failure, one hardcut later. The header
+#: rule holds: every reader asking "what did this image declare" asks it here.
+DECLARATION_BLOCKS = ("functions", "entrypoints", "jobs")
 
 
 def declaration_rows(manifest: Optional[Mapping[str, Any]]) -> List[Dict[str, Any]]:
@@ -62,5 +72,17 @@ def block_counts(manifest: Optional[Mapping[str, Any]]) -> Dict[str, int]:
 
 
 def declared_row_count(manifest: Optional[Mapping[str, Any]]) -> int:
-    """How many declarations this image carries, across both blocks."""
+    """How many declarations this image carries, across every block."""
     return sum(block_counts(manifest).values())
+
+
+def declared_block_summary(manifest: Optional[Mapping[str, Any]]) -> str:
+    """``"0 functions, 3 entrypoints, 0 jobs"`` — what a refusal quotes.
+
+    Derived from :data:`DECLARATION_BLOCKS` so a refusal can never name a
+    subset of the blocks the walk reads: that mismatch is what made the
+    pgw#1395 boot failure say "declares no functions and no jobs" over a
+    manifest declaring three entrypoints.
+    """
+    counts = block_counts(manifest)
+    return ", ".join(f"{counts[block]} {block}" for block in DECLARATION_BLOCKS)

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -30,6 +30,7 @@ from urllib.parse import parse_qs, urlparse
 from ..api.errors import ValidationError
 from ..bounded_stream import copy_bounded, free_space_bound
 from ..config import Settings, current_or
+from ..manifest_blocks import declaration_rows
 
 _STANDALONE = Settings()
 from ..stall import ProgressFloor, SilenceWindow
@@ -130,16 +131,15 @@ def build_provider_index_from_manifest(manifest: Optional[Mapping[str, Any]]) ->
 
     th#1987: the release rides the ref, so there is no side-channel field to
     fold — the entry's ref is normalized through the ONE grammar module before
-    keying and ``set_provider_index`` adds the repo-identity fallback keys."""
+    keying and ``set_provider_index`` adds the repo-identity fallback keys.
+
+    pgw#1395: reads EVERY declaration block, not ``functions[]`` alone. A
+    binding on a v2 ``entrypoints[]`` row would otherwise index to nothing and
+    every ref in it would silently fall back to the default provider."""
     index: dict[str, str] = {}
     if not isinstance(manifest, Mapping):
         return index
-    functions = manifest.get("functions")
-    if not isinstance(functions, list):
-        return index
-    for fn in functions:
-        if not isinstance(fn, dict):
-            continue
+    for fn in declaration_rows(manifest):
         for entry in _collect_binding_entries(fn.get("bindings")):
             ref = str(entry.get("ref") or "").strip()
             if not ref:

--- a/src/gen_worker/worker_main.py
+++ b/src/gen_worker/worker_main.py
@@ -81,6 +81,7 @@ from .manifest_blocks import (
     DECLARATION_BLOCKS,
     block_counts,
     declaration_rows,
+    declared_block_summary,
     declared_row_count,
 )
 from .models.cache_paths import tensorhub_cas_dir
@@ -444,7 +445,9 @@ def _run_main() -> int:
             manifest_path=str(manifest_path),
             function_count=counts["functions"],
             # A boot log that counted only functions read "0 declarations" on
-            # the images the jobs program exists to run (pgw#1354).
+            # the images the jobs program exists to run (pgw#1354), and again
+            # on every v2 entrypoints-only image (pgw#1395).
+            entrypoint_count=counts["entrypoints"],
             job_count=counts["jobs"],
             module_count=len(user_modules),
         )
@@ -546,20 +549,19 @@ def _run_main() -> int:
         # different owners: no manifest at all is a Dockerfile that never ran
         # discovery, while declarations-without-modules is a manifest this wheel
         # cannot read (a block it does not walk, or rows with no `module`).
-        counts = block_counts(manifest)
         declared = declared_row_count(manifest)
         if manifest and declared:
             reason = (
                 f"the manifest at {manifest_path} declares "
-                f"{counts['functions']} function(s) and {counts['jobs']} job(s) "
-                f"but no row carries a `module`, so this image has nothing to "
-                f"import. Declaration blocks this build walks: "
-                f"{', '.join(DECLARATION_BLOCKS)}."
+                f"{declared_block_summary(manifest)} but no row carries a "
+                f"`module`, so this image has nothing to import. Declaration "
+                f"blocks this build walks: {', '.join(DECLARATION_BLOCKS)}."
             )
         elif manifest:
             reason = (
-                f"the manifest at {manifest_path} declares no functions and no "
-                f"jobs — this image publishes nothing and cannot serve."
+                f"the manifest at {manifest_path} declares nothing in any "
+                f"declaration block ({', '.join(DECLARATION_BLOCKS)}) — this "
+                f"image publishes nothing and cannot serve."
             )
         else:
             reason = (

--- a/tests/test_jobs_only_boot_pgw1354.py
+++ b/tests/test_jobs_only_boot_pgw1354.py
@@ -388,9 +388,12 @@ def test_declarations_without_modules_dial_a_typed_fatal(
     assert phase == "no_user_modules"
     assert kw.get("settings") is not None, (
         "without settings the dial is a silent no-op — the exact defect")
-    assert "1 function(s) and 2 job(s)" in message, (
+    # pgw#1395: the summary is DERIVED from DECLARATION_BLOCKS, so a refusal
+    # can never again name a subset of the blocks the walk reads.
+    assert "1 functions, 0 entrypoints, 2 jobs" in message, (
         "the fatal must name the gap it found, not merely that it exited")
-    assert "functions, jobs" in message, "and which blocks this build walks"
+    assert "functions, entrypoints, jobs" in message, (
+        "and which blocks this build walks")
     (detail,) = observed["dialed"]
     assert "no_user_modules" in detail and "exit_code=1" in detail
 
@@ -409,3 +412,101 @@ def test_a_missing_manifest_dials_the_same_typed_fatal(
     assert "no baked manifest" in message
     assert "gen_worker.discovery" in message
     assert observed["dialed"], "the hub must hear about this one too"
+
+
+# --------------------------------------------------------------------------
+# 4. pgw#1395 — the SAME defect, one hardcut later: the v2 `entrypoints[]`
+#    block. Everything below is the jobs case re-run against the shape every
+#    endpoint has AFTER the pgw#1382 cutover.
+# --------------------------------------------------------------------------
+
+_V2_SOURCE = """
+import msgspec
+from gen_worker import RequestContext, entrypoint
+
+class In_(msgspec.Struct):
+    steps: int = 1
+
+class Out_(msgspec.Struct):
+    ok: bool = True
+
+@entrypoint
+def generate(ctx: RequestContext, payload: In_) -> Out_:
+    return Out_()
+"""
+
+
+@pytest.fixture(scope="module")
+def entrypoints_only(tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, Path]:
+    """The pgw#1382 shape: ONE module-level `@entrypoint`, no `@endpoint`
+    class, no `@job` — what sdxl and minimax-h3 already are on
+    serverless-endpoints master."""
+    root = tmp_path_factory.mktemp("v2_only")
+    pkg = root / "v2_only"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_V2_SOURCE)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "v2_only"\nversion = "0.0.0"\n'
+        '[tool.gen_worker]\nmain = "v2_only.main"\n'
+    )
+    return root, _bake(root)
+
+
+def test_the_baked_v2_lock_really_is_entrypoints_only(
+    entrypoints_only: Tuple[Path, Path],
+) -> None:
+    """The fixture is the defect's shape, stated by the artifact. Note
+    `functions = []` is emitted UNCONDITIONALLY beside the real rows — which
+    is exactly why a walk that reads `functions` alone scores this release at
+    zero declarations instead of refusing."""
+    manifest = _manifest(entrypoints_only[1])
+    assert manifest.get("functions") in (None, [])
+    assert manifest.get("jobs") in (None, [])
+    assert len(manifest["entrypoints"]) == 1
+
+
+def test_a_v2_manifest_yields_its_modules(
+    entrypoints_only: Tuple[Path, Path],
+) -> None:
+    """THE headline, pgw#1395. RED on master: `[]` — a v2-only image imports
+    NOTHING, is never CUDA-probed, and dies naming the wrong gap."""
+    assert entrypoint.get_modules_from_manifest(
+        _manifest(entrypoints_only[1])) == ["v2_only.main"]
+
+
+def test_the_probe_predicate_reads_the_v2_block_too() -> None:
+    """gw#529's bad-host guard reaches a v2 GPU image. A model-bearing v2
+    entrypoint emits `resources.gpu = true` (`entrypoints_v2._resources`), so
+    the predicate has the same fact to read — it just has to look."""
+    gpu_v2 = {"entrypoints": [{"module": "m", "resources": {"gpu": True}}]}
+    cpu_v2 = {"entrypoints": [{"module": "m", "resources": {}}]}
+    assert should_probe_cuda(gpu_v2, cuda_build=False) is True
+    assert should_probe_cuda(cpu_v2, cuda_build=True) is False
+
+
+def test_a_v2_boot_clears_the_module_wall_and_names_the_next_one(
+    monkeypatch: pytest.MonkeyPatch, entrypoints_only: Tuple[Path, Path],
+) -> None:
+    """What this fix does and does NOT buy, stated rather than assumed.
+
+    The module-load wall is gone: the boot imports the author's module instead
+    of dying `no_user_modules` over a manifest declaring an entrypoint. The
+    NEXT wall is the v1 serve registry — `registry.extract_specs` reads
+    `__gen_worker_endpoint__` and `@entrypoint` stamps `__cozy_entrypoint__`,
+    so `Worker.__init__` still finds no serve surface. That wall belongs to the
+    pgw#1367/pgw#1373 serving cutover, and this arm exists so it is a NAMED
+    refusal in the record rather than a discovery nobody makes twice.
+    """
+    root, lock = entrypoints_only
+    observed = _boot(monkeypatch, root, lock)
+
+    assert observed["code"] == 1
+    phases = [phase for phase, _m, _kw in observed["fatals"]]
+    assert "no_user_modules" not in phases, (
+        "the module-load wall is what pgw#1395 removes")
+    (phase, message, _kw), = observed["fatals"]
+    assert phase == "runtime"
+    assert "no @endpoint classes and no @job functions found" in message
+    assert "v2_only.main" in message, (
+        "the module WAS imported — the gap is the serve registry, not the walk")


### PR DESCRIPTION
`manifest_blocks.DECLARATION_BLOCKS` was `("functions", "jobs")`. `entrypoints[]` is `functions[]`' successor spelling (th#2146) with the identical item shape — `name`, `module`, `resources` — and it is the ONLY block a post-pgw#1382 endpoint declares. Bake time folded it (`discovery/validation.py`); BOOT time did not.

Consequence, on the first post-cutover endpoint (sdxl and minimax-h3 on `serverless-endpoints` master are already v2-only):

- `worker_main.get_modules_from_manifest` → `[]` — zero user modules imported
- `cuda_probe.should_probe_cuda` → False — gw#529's bad-host guard silently off
- boot dies `no_user_modules` reporting *"declares no functions and no jobs — this image publishes nothing and cannot serve"* over a manifest declaring its entrypoint

Structurally pgw#1354's jobs-only failure, one hardcut later. Found by th#2161's Deliverable-0 census (G14).

## Proof — real bake, real boot path

`python -m gen_worker.discovery` over an sdxl-shaped v2-only package (`tests/fixtures/serving_v2_endpoint`) emits `functions = []` beside one `[[entrypoints]]` row with `module = "serving_v2_fixture.main"` and `resources = {gpu = true, requires = {min_vram_gb = 12.0, min_sm = 89}}`. Driving `load_manifest → block_counts → get_modules_from_manifest → should_probe_cuda → module import`:

```
BEFORE (master a9bec13e)          AFTER (this branch)
DECLARATION_BLOCKS ('functions','jobs')   ('functions','entrypoints','jobs')
block_counts {functions:0, jobs:0}        {functions:0, entrypoints:1, jobs:0}
user_modules []                           ['serving_v2_fixture.main']
should_probe_cuda False                   True
BOOT REFUSED: no user modules ... exit 1  BOOT OK: entrypoints=['generate'] models=['SdxlModel']
```

## Also in here

- **A refusal can no longer name a subset of the blocks the walk reads.** `declared_block_summary` renders counts FROM the tuple, so the boot fatal and the `manifest_loaded` phase (now carrying `entrypoint_count`) move with it. That mismatch is why this read as "publishes nothing" instead of "a block this build does not walk".
- **A third blind reader:** `models.download.build_provider_index_from_manifest` walked `manifest["functions"]` directly — a binding on a v2 row would have indexed to nothing and every ref fallen back to the default provider. Now goes through `declaration_rows`; it was the last direct `functions[]` walk outside `discovery/`.
- **The next wall is named, not assumed.** With modules imported, `Worker.__init__` still finds no serve surface — `registry.extract_specs` reads `__gen_worker_endpoint__`, `@entrypoint` stamps `__cozy_entrypoint__`. A test arm asserts the boot reaches THAT refusal by name. It belongs to the pgw#1367/pgw#1373 serving cutover.

Tests: `tests/test_jobs_only_boot_pgw1354.py` gains a v2 section (real bake, real `_run_main`), 9 → 13 arms, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)