### PR TITLE
pgw#1397: the clone's declared position MOVES, and its refusals say which fact

### DIFF
--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -114,6 +114,24 @@ class SourceIncludeError(ValidationError):
         )
 
 
+def _no_safetensors(paths: Sequence[str]) -> RepoRefusal:
+    """The precise refusal for a repo whose safetensors selection came back
+    empty (pgw#1397).
+
+    ``pickle_only`` and ``missing_safetensors`` are DIFFERENT facts — "these
+    weights are a format we will never load" vs "this repo has no weights at
+    all" — and they want different answers from a UI. The tail of
+    :func:`classify_repo` already distinguishes them, but only for a repo that
+    reached it; a shaped repo (diffusers/peft/sentence-transformers) refuses
+    inside its own branch and lost the distinction on the way. Same evidence,
+    same tokens, decided in one place.
+    """
+    pickles = [p for p in paths if _ext(p) in _PICKLE_EXTS]
+    if pickles and not any(p.lower().endswith(".safetensors") for p in paths):
+        return RepoRefusal("pickle_only", files_seen=pickles)
+    return RepoRefusal("missing_safetensors", files_seen=paths)
+
+
 def apply_source_include(paths: Sequence[str], include: Sequence[str]) -> list[str]:
     """Filter repo-relative paths to only those matching at least one glob in
     ``include`` (``fnmatch`` against the full repo-relative path, e.g.
@@ -373,7 +391,7 @@ def classify_repo(
         weights, dtype = _pick_weight_set(
             [p for p in paths if p.lower().endswith(".safetensors")], dtype_pref)
         if not weights:
-            raise RepoRefusal("missing_safetensors", files_seen=paths)
+            raise _no_safetensors(paths)
         return _finish("sentence_transformers", "sentence-transformers", weights, [],
                        {"dtype": dtype or "fp32"}, "modules.json at root")
 
@@ -381,7 +399,7 @@ def classify_repo(
     if "adapter_config.json" in root_set:
         weights = sorted(p for p in root if p.lower().endswith(".safetensors"))
         if not weights:
-            raise RepoRefusal("missing_safetensors", files_seen=paths)
+            raise _no_safetensors(paths)
         return _finish("peft", "peft", weights, [], {}, "adapter_config.json at root")
 
     # 3. diffusers pipeline
@@ -415,7 +433,7 @@ def classify_repo(
             if comp and comp_dtype:
                 resolved[comp] = comp_dtype
         if not d_weights:
-            raise RepoRefusal("missing_safetensors", files_seen=paths)
+            raise _no_safetensors(paths)
         dtypes = sorted(set(resolved.values()))
         return _finish("diffusers", "diffusers", d_weights, d_indexes,
                        {"dtype": dtypes[0] if len(dtypes) == 1 else "",

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import tempfile
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -43,6 +44,7 @@ from .ingest import (
     ingest_huggingface,
     plan_civitai,
     plan_huggingface,
+    plan_source_facts,
 )
 from .keepalive import HubKeepalive
 from .publish import destination_release as _destination_release
@@ -89,6 +91,9 @@ _KNOWN_FILE_TYPES = {"safetensors", "gguf"}
 
 _default_quant_components = quant_candidate_components
 _MIN_CONVERT_BYTES = 100 * 1024 * 1024  # leave tiny weights (embeddings) untouched
+# The unit of the clone's declared position (pgw#1397). MiB, not bytes:
+# the hub stores an int64 and an operator reads it.
+_MIB = 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -213,6 +218,47 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = MULTI_
 # ---------------------------------------------------------------------------
 # Flavor tree construction
 # ---------------------------------------------------------------------------
+
+def refuse_unproducible_layout(plan: Any, specs: list[OutputSpec]) -> None:
+    """Refuse, BEFORE the download, a request whose every output needs a
+    layout repackage this source has no route for (jobs#294).
+
+    The verdict is a fact about the source's METADATA — its layout, its family
+    and whether that family declares the direction — so paying for 6.9 GB of
+    checkpoint to reach it is pure waste. Only an ALL-flavors refusal is
+    decided here: a request with one impossible flavor and one possible one
+    still runs, and the per-flavor refusal downstream is unchanged.
+    """
+    facts = plan_source_facts(plan)
+    if facts is None or facts.source_layout not in _KNOWN_FILE_LAYOUTS:
+        return
+    declared = repackage_family(facts.model_family)
+    supported = declared is not None and (
+        declared.supports_singlefile_to_diffusers
+        if facts.source_layout == SINGLE_FILE
+        else declared.supports_diffusers_to_singlefile
+    )
+    # publish-as-is classes never repackage, so the layout a caller asked for
+    # is simply not consulted for them (mirroring build_flavor_tree's own
+    # `publish_as_is` predicate — one rule, read twice).
+    if facts.strategy in _PUBLISH_AS_IS_STRATEGIES or (
+        facts.strategy == "aio_singlefile" and not supported
+    ):
+        return
+    if supported:
+        return
+    for spec in specs:
+        # gguf is a container conversion, decided before the layout leg.
+        if spec.file_layout == facts.source_layout or spec.file_type == "gguf":
+            return
+    wanted = "/".join(sorted({spec.file_layout for spec in specs}))
+    raise ValidationError(
+        f"clone would produce no publishable flavor: layout repackage "
+        f"{facts.source_layout}->{wanted} unsupported for "
+        f"model_family={facts.model_family!r} — decided from the source's "
+        f"metadata, before the download"
+    )
+
 
 def build_flavor_tree(
     source: IngestedSource,
@@ -765,13 +811,50 @@ def run_clone(
     explicit_outputs = bool(outputs)
     effective_hf_token = str(hf_token or "").strip() or str(getattr(ctx, "hf_token", "") or "").strip()
 
-    def _progress(p: float, stage: str) -> None:
+    # pgw#1397 — THE DECLARED POSITION HAS TO MOVE.
+    #
+    # Hub job liveness is position ADVANCE inside a phase budget (th#2050), and
+    # the position it reads is an int64 that `AdvanceJobProgress` accepts only
+    # on a STRICT increase. A clone declared its progress as a 0..1 FRACTION,
+    # which is `int(...) == 0` for the entire run — so the first tick wrote
+    # `clone.plan 0`, every later tick was dropped by the `>` predicate, the
+    # position clock froze, and a 6.9 GB fetch became indistinguishable from a
+    # wedged one at the 10-minute budget. The budget is right; the worker was
+    # not telling the truth about advancing.
+    #
+    # The position is therefore MEBIBYTES MOVED — bytes fetched, then bytes
+    # uploaded — ONE number that rises across every phase of the job. The 0..1
+    # fraction rides beside it for the user-facing feed. A phase entry counts
+    # as one MiB of movement (it IS movement, and it keeps the clock alive
+    # across a leg that moves no bytes); inside a phase only real bytes
+    # advance it, because a counter that ticks on its own would manufacture
+    # exactly the liveness this instrument exists to disprove.
+    moved = {"mib": 0, "base": 0}
+    moved_lock = threading.Lock()
+
+    def _emit(fraction: float, stage: str, total_mib: Optional[int]) -> None:
         fn = getattr(ctx, "progress", None)
-        if callable(fn):
-            try:
-                fn(p, stage=stage)
-            except Exception:
-                pass
+        if not callable(fn):
+            return
+        try:
+            fn(fraction, stage, position=float(moved["mib"]), total=total_mib)
+        except Exception:
+            pass
+
+    def _progress(p: float, stage: str) -> None:
+        with moved_lock:
+            moved["mib"] += 1
+            moved["base"] = moved["mib"]
+            _emit(p, stage, None)
+
+    def _progress_bytes(p: float, stage: str, done: int, total: Optional[int]) -> None:
+        """Advance the position by the bytes this phase has actually moved."""
+        with moved_lock:
+            mib = moved["base"] + int(done or 0) // _MIB
+            if mib <= moved["mib"]:
+                return
+            moved["mib"] = mib
+            _emit(p, stage, (moved["base"] + int(total) // _MIB) if total else None)
 
     source_key = source_ref if provider == "huggingface" else str(civitai_model_version_id or 0)
     if source_revision:
@@ -815,14 +898,17 @@ def run_clone(
         # The plan already knows every selected file's size — fail fast on an
         # undersized disk instead of ENOSPC mid-download.
         _preflight_disk(workdir, plan, specs)
+        # ...and it knows the source's layout, so a request no flavor of which
+        # could ever be produced is refused here rather than after the bytes.
+        refuse_unproducible_layout(plan, specs)
 
         _progress(0.05, "clone.ingest")
         dl_bytes = {"done": 0}
 
         def _dl_progress(done: int, total: Optional[int]) -> None:
             dl_bytes["done"] = max(dl_bytes["done"], int(done or 0))
-            if total:
-                _progress(0.05 + 0.45 * min(1.0, done / total), "clone.download")
+            fraction = 0.05 + 0.45 * min(1.0, done / total) if total else 0.05
+            _progress_bytes(fraction, "clone.download", dl_bytes["done"], total)
 
         # Download and cast are the two phases that talk to the hub NOT AT ALL
         # — an hour of them, and then the first upload discovers whatever
@@ -1039,7 +1125,20 @@ def run_clone(
             for k, v in attrs.items():
                 metadata.setdefault(f"attr_{k}", str(v))
 
-            _progress(0.55 + 0.4 * (i / max(1, len(specs))), f"clone.publish.{spec.label}")
+            publish_fraction = 0.55 + 0.4 * (i / max(1, len(specs)))
+            publish_phase = f"clone.publish.{spec.label}"
+            _progress(publish_fraction, publish_phase)
+            # The upload is the OTHER leg that can outlast the phase budget on
+            # a real-sized model, and it has a byte channel of its own — so it
+            # advances the same position the fetch does (pgw#1397). Called
+            # from the uploader's threads; `_progress_bytes` holds the lock.
+            uploaded_bytes = {"done": 0}
+
+            def _up_progress(_parts: int, _total_parts: int, n: int,
+                             *, _f: float = publish_fraction,
+                             _p: str = publish_phase) -> None:
+                uploaded_bytes["done"] += max(0, int(n or 0))
+                _progress_bytes(_f, _p, uploaded_bytes["done"], None)
             # Every file here is a real local file (`files_from_tree`), which
             # publish_v2 requires: its guarantee is that a digest is PROVEN
             # from bytes in hand. A `merge` into a prior v1/blake3 manifest is
@@ -1075,6 +1174,7 @@ def run_clone(
                     "tree": str(tree),
                     "attrs": {str(k): str(v) for k, v in attrs.items()},
                 },
+                part_progress=_up_progress,
             )
             result.published.append({
                 # The report states the DTYPE it published, not a flavor token

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -360,6 +360,78 @@ class CivitaiSourcePlan:
         return sorted(out)
 
 
+# `detect_huggingface_source_layout` touches disk for exactly one file
+# (``model_index.json``); every plan-time caller below has already established
+# there is none to read, so a path that cannot exist is the honest argument.
+_NO_REPO_DIR = Path("/nonexistent/clone-source-plan")
+
+
+@dataclass(frozen=True)
+class PlannedSourceFacts:
+    """A clone source's layout, family and ingest strategy — the three facts
+    the flavor decision turns on — derived from PROVIDER METADATA ALONE."""
+
+    source_layout: str
+    model_family: str
+    strategy: str
+
+
+def plan_source_facts(plan: Any) -> Optional[PlannedSourceFacts]:
+    """The three facts above, or ``None`` when they cannot be derived as
+    faithfully as the post-download read (jobs#294).
+
+    Callers use this to refuse an impossible request BEFORE paying for the
+    download — a 6.9 GB CivitAI checkpoint bought its whole fetch to learn its
+    requested layout had no repackage route. That is only sound while this
+    stays IDENTICAL to what :func:`ingest_huggingface` / :func:`ingest_civitai`
+    stamp from the downloaded tree, so it calls the same detector on the same
+    listing and returns ``None`` wherever the bytes could still change the
+    answer. A refusal the real ingest would not have made is worse than a
+    late one.
+    """
+    if isinstance(plan, CivitaiSourcePlan):
+        names = [str(f.get("name") or "") for f in plan.files]
+        names = [n for n in names if n]
+        if not names:
+            return None
+        info = detect_huggingface_source_layout(repo_dir=_NO_REPO_DIR, files=names)
+        base_raw = str((plan.payload or {}).get("baseModel") or "").strip()
+        base_family = ""
+        try:
+            from .base_model_families import civitai_to_family
+
+            base_family = civitai_to_family(base_raw) or ""
+        except Exception:
+            base_family = ""
+        # A civitai version is CLASSIFIED for exactly one shape — gguf-only.
+        # Every other one reaches the flavor builder with no strategy at all,
+        # which is why its layout request is taken literally.
+        strategy = "gguf" if all(n.lower().endswith(".gguf") for n in names) else ""
+        family = _resolve_civitai_family(base_family, str(info.model_family or ""))
+        return PlannedSourceFacts(
+            source_layout=str(info.source_layout),
+            model_family=family or "unknown",
+            strategy=strategy,
+        )
+    if isinstance(plan, HFSourcePlan):
+        # The family can come out of ``model_index.json``'s own ``_class_name``
+        # / ``_name_or_path``, and a file LISTING does not carry file CONTENT.
+        # For those repos only the post-download read is trustworthy.
+        if any(_norm_plan_path(p) == "model_index.json" for p in plan.paths):
+            return None
+        info = detect_huggingface_source_layout(repo_dir=_NO_REPO_DIR, files=list(plan.paths))
+        return PlannedSourceFacts(
+            source_layout=str(info.source_layout),
+            model_family=str(info.model_family or ""),
+            strategy=str(plan.classification.strategy),
+        )
+    return None
+
+
+def _norm_plan_path(path: str) -> str:
+    return str(path or "").strip().lstrip("./").lower()
+
+
 def _civitai_manifest_revision(file_names: list[str]) -> str:
     """The clone-side civitai 'revision': a hash over the downloaded file
     listing (civitai has no commit sha). MUST stay identical between
@@ -821,9 +893,11 @@ __all__ = [
     "CloneDownloadError",
     "HFSourcePlan",
     "IngestedSource",
+    "PlannedSourceFacts",
     "ingest_civitai",
     "ingest_huggingface",
     "plan_civitai",
     "plan_huggingface",
+    "plan_source_facts",
     "resolve_hf_identity",
 ]

--- a/tests/convert/test_clone_liveness_and_refusals.py
+++ b/tests/convert/test_clone_liveness_and_refusals.py
@@ -1,0 +1,167 @@
+"""What a clone SAYS while it works, and what it says when it cannot.
+
+pgw#1397 / jobs#294 — three facts, all three measured on real pods first:
+
+1.  the declared POSITION advances. Hub job liveness is position advance
+    inside a phase budget (th#2050) and the position is an int64 the hub
+    accepts only on a STRICT increase, so the old 0..1 fraction was the
+    constant 0 and a 6.9 GB fetch was indistinguishable from a wedged one.
+2.  a repo whose weights are ALL pickle refuses ``pickle_only``, not the
+    generic ``missing_safetensors`` — different facts, different advice.
+3.  a request no flavor of which could be produced is refused from the
+    source's METADATA, before the download is paid for.
+
+Revert-turns-red: restore ``fn(p, stage=stage)`` in ``run_clone._progress``
+and test 1 sees exactly one accepted position, ``clone.plan 0`` — verbatim the
+fault the battery hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.api.errors import ValidationError
+from gen_worker.convert.classifier import RepoRefusal, classify_repo
+from gen_worker.convert.clone import (
+    normalize_outputs,
+    refuse_unproducible_layout,
+    run_clone,
+)
+from gen_worker.convert.ingest import CivitaiSourcePlan, IngestedSource
+
+from fake_hub import _FakeHub
+
+# Juggernaut XL v1759168 — the exact source the battery killed.
+_JUGGERNAUT_BYTES = 6_939_220_248
+
+
+class _Ctx:
+    """Records what reached ``ctx.progress``, nothing else."""
+
+    def __init__(self, server: Any) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "tensorhub"
+        self.request_id = "req-1397"
+        self.destination = {"repo": "tensorhub/fallback"}
+        self.ticks: list[tuple[Any, Any, Any, Any]] = []
+
+    def progress(self, progress: Any = None, stage: Any = None, *,
+                 step: Any = None, total: Any = None, position: Any = None,
+                 phase: Any = None) -> None:
+        self.ticks.append((progress, stage or phase, position, total))
+
+
+def _source(dest_dir: Path) -> IngestedSource:
+    """A civitai checkpoint as `ingest_civitai` really returns one: single
+    file, NO classification (only the gguf-only shape ever gets one)."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "model.safetensors").write_bytes(b"\x00" * (300 * 1024 * 1024))
+    return IngestedSource(
+        provider="civitai", source_ref="1759168", source_revision="sha256:x",
+        dir=dest_dir, layout="single-file", model_family="unknown",
+        model_family_variant="unknown", classification=None,
+        attrs={"dtype": "fp32", "file_layout": "single-file"},
+        metadata={"source_provider": "civitai"},
+        repo_spec={"kind": "model", "library_name": ""},
+    )
+
+
+def _hub_accepts(ticks: list[tuple[Any, Any, Any, Any]]) -> list[tuple[str, int]]:
+    """The hub's own rule, verbatim: ``step = int(position)``
+    (``ParseRequestProgressPayload``), and ``AdvanceJobProgress`` updates the
+    row — and with it ``progress_at``, the stall clock — only on a STRICT
+    increase."""
+    accepted: list[tuple[str, int]] = []
+    last: int | None = None
+    for _fraction, stage, position, _total in ticks:
+        step = int(position) if position is not None else 0
+        if last is None or step > last:
+            last = step
+            accepted.append((str(stage), step))
+    return accepted
+
+
+def test_the_declared_position_advances_through_fetch_and_upload(
+    fake_hub: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    src = _source(tmp_path / "source")
+
+    def _fake_ingest(_version_id: int, _dest: Path, **kwargs: Any) -> IngestedSource:
+        report = kwargs.get("progress")
+        if report is not None:
+            for tenth in range(11):
+                report(int(_JUGGERNAUT_BYTES * tenth / 10), _JUGGERNAUT_BYTES)
+        return src
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_civitai", _fake_ingest)
+    monkeypatch.setattr("gen_worker.convert.clone.plan_civitai", lambda *a, **k: None)
+
+    ctx = _Ctx(fake_hub)
+    run_clone(
+        ctx, provider="civitai", civitai_model_version_id=1759168,
+        destination_repo="tensorhub/juggernaut-xl", destination_release="r1",
+        target_layout="single-file",
+        outputs=[{"dtype": "fp32", "file_layout": "single-file",
+                  "file_type": "safetensors"}],
+    )
+
+    accepted = _hub_accepts(ctx.ticks)
+    # Nothing is dropped: every tick this clone emits moves the clock.
+    assert len(accepted) == len(ctx.ticks)
+    phases = [stage for stage, _ in accepted]
+    assert phases[0] == "clone.plan"
+    assert phases.count("clone.download") == 10
+    # The UPLOAD advances it too — the other leg that outlasts the budget on a
+    # real-sized model.
+    assert any(stage.startswith("clone.publish.") for stage, _ in accepted)
+    assert [step for _, step in accepted] == sorted({step for _, step in accepted})
+    # MiB moved, so the numbers an operator reads are the model's own size.
+    download_end = max(step for stage, step in accepted if stage == "clone.download")
+    assert download_end == pytest.approx(_JUGGERNAUT_BYTES // (1024 * 1024), rel=0.01)
+
+
+def test_a_pickle_only_repo_refuses_by_its_own_name() -> None:
+    """`nitrosocke/mo-di-diffusion`: 5 weight files, every one a pickle."""
+    with pytest.raises(RepoRefusal) as refusal:
+        classify_repo(files=[
+            "model_index.json", "README.md", "moDi-v1-pruned.ckpt",
+            "unet/config.json", "unet/diffusion_pytorch_model.bin",
+            "vae/config.json", "vae/diffusion_pytorch_model.bin",
+            "text_encoder/config.json", "text_encoder/pytorch_model.bin",
+            "safety_checker/pytorch_model.bin",
+            "scheduler/scheduler_config.json",
+        ], config_json=None)
+    assert refusal.value.reason == "pickle_only"
+    assert refusal.value.files_seen and all(
+        f.endswith((".bin", ".ckpt")) for f in refusal.value.files_seen)
+
+    # And the OTHER fact keeps its own token: no weights at all is not the
+    # same thing as weights we will never load.
+    with pytest.raises(RepoRefusal) as empty:
+        classify_repo(files=["model_index.json", "unet/config.json"],
+                      config_json=None)
+    assert empty.value.reason == "missing_safetensors"
+
+
+def test_an_unproducible_layout_is_refused_before_the_download() -> None:
+    """The 6.9 GB refusal, decided from one metadata call."""
+    plan = CivitaiSourcePlan(
+        version_id=1759168,
+        payload={"baseModel": "SDXL 1.0", "modelId": 133005},
+        files=[{"name": "juggernautXL.safetensors",
+                "size_bytes": _JUGGERNAUT_BYTES}],
+        revision="sha256:x",
+    )
+    with pytest.raises(ValidationError) as refused:
+        refuse_unproducible_layout(plan, normalize_outputs([], layout_hint="multi-file"))
+    assert "single-file->multi-file" in str(refused.value)
+    assert "before the download" in str(refused.value)
+
+    # What CivitAI sources ARE runs, and is not second-guessed here.
+    refuse_unproducible_layout(plan, normalize_outputs([], layout_hint="single-file"))


### PR DESCRIPTION
Three defects the [[e2e#1913]] large-model ingest battery measured on real pods — all of them the worker telling the hub less than it already knows.

## 1. The declared position never moved (P1)

Hub job liveness is position ADVANCE inside a phase budget (th#2050), and the position is an `int64` that `AdvanceJobProgress` accepts **only on a strict increase**. `run_clone` declared its progress as a 0..1 **fraction** — `int(0.02) == 0` — so the first tick wrote `clone.plan 0`, every later tick was dropped by the `>` predicate, `progress_at` froze, and a 6.9 GB fetch became indistinguishable from a wedged job:

```
job_progress_stalled / origin=zero_progress
"declared position clone.plan 0 stopped advancing 10m4s ago, past the 10m0s phase budget"
```

The quoted reasoning is right, which is exactly why the position has to move. th#1243's no-magic-timeouts doctrine stays; the worker now tells the truth about advancing.

The position is **mebibytes moved** — bytes fetched, then bytes **uploaded** (the other leg that outlasts the budget on a real-sized model, wired through `publish_v2`'s `part_progress`) — one number rising across every phase, with the 0..1 fraction alongside it for the user-facing feed. A phase entry is one MiB of movement; inside a phase only real bytes advance it, because a counter that ticks on its own manufactures exactly the liveness this instrument exists to disprove.

## 2. A pickle-only repo got the generic token (P2)

`RepoRefusal` has documented `pickle_only` all along, but a *shaped* repo refused inside its own branch and fell through to `missing_safetensors` — `nitrosocke/mo-di-diffusion` (5 weight files, every one a pickle) among them. "These weights are a format we will never load" and "this repo has no weights at all" want different answers from a UI. All three branch refusals now go through one decision.

## 3. The layout verdict moves in front of the download (jobs#294)

A CivitAI checkpoint asking for `multi-file` paid for its entire 6.9 GB fetch to learn `single-file->multi-file` has no route for its family. That verdict is a fact about the source's METADATA: `plan_source_facts` derives the same layout / family / strategy the ingest stamps, from the provider listing, with the **same detector** — and returns `None` wherever the bytes could still change the answer (a repo carrying `model_index.json`, whose `_class_name` is content a listing does not have). A refusal the real ingest would not have made is worse than a late one. Only an all-flavors refusal is decided early.

## Proof by execution

`tests/convert/test_clone_liveness_and_refusals.py` drives the real `run_clone` against the fake hub with a 6.9 GB fetch and replays **the hub's own predicate** (`step = int(position)`, strict increase) over everything that reached `ctx.progress`:

```
emitted 17, accepted by the hub 17, dropped 0
  clone.plan 1 / clone.ingest 2 / clone.download 663 ... 6619
  clone.convert 6620 / clone.publish.* 6621 -> 6665 -> 6729 / clone.completed 6730
```

**Revert-turns-red, run on `origin/master`:** the same probe gets ONE accepted row — `clone.plan 0` — and the classifier answers `missing_safetensors` for the mo-di-diffusion listing.

The 13.9 GB end-to-end (a big download surviving past 10 minutes on a real pod) is deliberately left to th#2167's acceptance / the battery rerun; it is expensive and this is the structural half.

**Cross-refs:** e2e#1913 (found all three), th#2167 (the P0 in front of them), jobs#294.