### PR TITLE
#1404: a lane and its machine floor are one declaration, and an under-floor machine warns and runs

### DIFF
--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -822,6 +822,61 @@ class RequirementTerms(msgspec.Struct, frozen=True, kw_only=True,
         return ", ".join(parts)
 
 
+# ── The compute-capability floor a LOAD DTYPE implies ────────────────────────
+#
+# Paul, 2026-08-18, verbatim: *"the sm_x compute floor should fall out of the
+# contract itself, rather than being a separate annotation. Only the VRAM
+# requirement needs a separate annotation, because it's not clear, based on
+# the contract, how much VRAM is needed."*
+#
+# So an 8-bit lane's need for 8-bit kernels is DERIVED here — one producer,
+# beside the element vocabulary and the requirement grammar it bridges — and
+# is NOT author-writable. The `lanes=` annotation carries VRAM only, because
+# VRAM is the one floor the contract cannot imply. A lane that genuinely needs
+# a floor its dtype does not imply is a change to THIS TABLE (or to the
+# contract's dtype), never a new annotation term: two producers for one fact
+# is exactly the drift this derivation exists to prevent.
+#
+# The numbers are the capability at which the arithmetic exists in hardware,
+# in tensorhub's bare spelling (sm_89 -> 89):
+#   sm70  fp16 tensor cores (Volta)
+#   sm75  int8 tensor cores (Turing)
+#   sm80  bf16 + int4 tensor cores (Ampere)
+#   sm89  fp8 e4m3/e5m2 tensor cores (Ada)
+#   sm100 nvfp4 / mx-fp4 tensor cores (Blackwell)
+#
+# NOT a kernel list, and it must never grow into one (Paul, same ruling):
+# a specific attention kernel (sage2, flash-*) is a SERVE-RECIPE fallback arm
+# with its own degrade path, not a placement floor. This table answers exactly
+# one question — can this card do this dtype's arithmetic at all.
+DTYPE_MIN_SM: dict[str, int] = {
+    "float32": 0, "float": 0, "fp32": 0, "tf32": 80,
+    "float16": 70, "half": 70, "fp16": 70,
+    "bfloat16": 80, "bf16": 80,
+    "int8": 75, "uint8": 75,
+    "int4": 80, "uint4": 80,
+    "float8_e4m3fn": 89, "float8_e4m3fnuz": 89, "float8_e5m2": 89,
+    "float8_e5m2fnuz": 89, "fp8_e4m3": 89, "fp8_e5m2": 89, "fp8": 89,
+    "float4_e2m1fn": 100, "nvfp4": 100, "fp4": 100, "mxfp4": 100,
+}
+
+
+def capability_floor_for_dtype(dtype: object) -> int:
+    """The ``min_sm`` a lane's load dtype implies, or ``0`` for none.
+
+    ``0`` is "this dtype implies no floor" — fp32 runs anywhere — and is also
+    what an UNKNOWN dtype answers. Unknown is deliberately silent rather than
+    a refusal: a floor invented for a dtype this table has never seen would be
+    a placement claim with nothing behind it. Teaching this table the dtype is
+    the fix, because it is the only producer of this axis.
+    """
+    if dtype is None:
+        return 0
+    name = str(getattr(dtype, "name", None) or dtype).strip().lower()
+    name = name.removeprefix("torch.")
+    return DTYPE_MIN_SM.get(name, 0)
+
+
 class LayoutRequirements(msgspec.Struct, frozen=True, kw_only=True,
                          omit_defaults=True):
     """What EXECUTING one declared contract needs of the machine, at both

--- a/src/gen_worker/serving/__init__.py
+++ b/src/gen_worker/serving/__init__.py
@@ -83,8 +83,14 @@ from .model import (
     model_requires,
     model_type,
 )
+from .placement import DeviceFacts, Shortfall, device_facts, shortfalls, warn_if_degraded
 
 __all__ = [
+    "DeviceFacts",
+    "Shortfall",
+    "device_facts",
+    "shortfalls",
+    "warn_if_degraded",
     "manifest_sizer",
     "decode_envelope",
     "ServeLoop",

--- a/src/gen_worker/serving/host.py
+++ b/src/gen_worker/serving/host.py
@@ -27,7 +27,7 @@ import threading
 import time
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
@@ -36,6 +36,7 @@ from .context import DeployBinding, LoadContext, LoaderEngine, RequestContext
 from .entrypoints import EntrypointSpec
 from .loader import LoadedEndpoint
 from .model import Model, model_type
+from .placement import warn_if_degraded
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,10 @@ class EndpointHost:
             cls: loaded.lane(cls, lane_contract) for cls in loaded.models
         }
         self.instances: Dict[type, ModelInstance] = {}
+        #: Per class, the unmet machine floors measured at residency-admit.
+        #: Non-empty = this endpoint serves DEGRADED, and says so on every
+        #: request rather than only in the boot log.
+        self.degraded: Dict[type, Tuple[str, ...]] = {}
         self.adoption: Any = None
         #: pgw#1392: "has boot run" is the real question. `instances` used to
         #: stand in for it, which a WEIGHTLESS endpoint falsifies forever —
@@ -125,7 +130,16 @@ class EndpointHost:
         if self._output_dir is not None:
             kwargs.setdefault("local_output_dir", str(self._output_dir))
         kwargs.update(overrides)
-        return RequestContext(request_id, binding=self.binding, **kwargs)
+        ctx: RequestContext[Any] = RequestContext(
+            request_id, binding=self.binding, **kwargs
+        )
+        # Degradation is a LOAD-time fact, so it rides every request the
+        # degraded instance serves — a caller must not have to read the pod's
+        # boot log to learn why its request took ten minutes.
+        for warnings in self.degraded.values():
+            for warning in warnings:
+                ctx.warn(warning)
+        return ctx
 
     def _load_context(
         self, model_cls: type, *, compile_sink: Any = None
@@ -220,6 +234,14 @@ class EndpointHost:
 
         for model_cls in self.loaded.models:
             load_started = time.monotonic()
+            # Residency-admit: the machine meets the lane's declared floors,
+            # or it is told loudly that it does not and loads anyway (Paul,
+            # 2026-08-18 — any model on any machine). Measured before the
+            # first weight moves; the warning rides every request this
+            # instance serves via `make_context`.
+            self.degraded[model_cls] = warn_if_degraded(
+                model_cls, self.lanes[model_cls]
+            )
             model: Model[Any] = model_cls()  # cheap __init__ — no GPU, by contract
             load_context = self._load_context(
                 model_cls,

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -237,6 +237,26 @@ def _parse_lanes(
             declared = parse_layout_requirements(floor, where=site)
             _refuse_non_vram_terms(declared, where=site)
 
+        # A lane with no dtype cannot state a capability floor, and a floor is
+        # the one place failing OPEN is invisible: an absent `min_sm` reads to
+        # the resolver as "runs anywhere", which is th#1754's shape with a new
+        # cause. `lane_dtype` already refuses a dtypeless contract — EXCEPT for
+        # a handle in `DTYPELESS_UPSTREAM_LANES`, where it answers None. That
+        # escape hatch predates the derivation and would now buy silence rather
+        # than the loud load crash it was traded for, so a floor closes it
+        # here: fail closed, exactly as the tuple-vs-dict hardcut does.
+        if not dtype:
+            raise ModelDeclarationError(
+                f"{site}: lane {handle} declares no load dtype, so no "
+                "compute-capability floor can be derived for it. A lane that "
+                "cannot state `min_sm` would publish a floor the resolver "
+                "reads as 'runs anywhere' — silently, which is worse than the "
+                "load crash a dtypeless contract used to cause. Declare the "
+                "dtype on the tensorfs contract document (a fused-QKV or "
+                "text-encoder COMPONENT layout is usually not a serve lane at "
+                "all, and the fix is then to name the real lane document)."
+            )
+
         # The capability floor falls out of the CONTRACT, never the header.
         min_sm = capability_floor_for_dtype(dtype)
         if declared is None and not min_sm:

--- a/src/gen_worker/serving/model.py
+++ b/src/gen_worker/serving/model.py
@@ -165,48 +165,123 @@ def lane_dtype(lane: Any, *, where: str) -> Any:
     return dtype
 
 
-def _parse_requires(
-    cls: type, requires: Mapping[Any, Any], lanes: tuple[Any, ...] | None
-) -> dict[str, Any]:
-    """``requires={contract: "vram12g, sm80+"}`` -> ``{handle: LayoutRequirements}``.
+def _parse_lanes(
+    cls: type, lanes: tuple[Any, ...] | Mapping[Any, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """``lanes=`` -> ``(lane contracts, {handle: LayoutRequirements})``.
 
-    Keyed by LANE, because what a deployment needs of a machine is a property
-    of the weight format it runs: the bf16 lane's VRAM floor is not the fp8
-    lane's. Values speak the ie#740 requirement grammar (``"vram12g"``,
-    ``"sm90+, vram80g"``, ``{"minimum": ..., "recommended": ...}``), parsed
-    HERE so the refusal names the author's own class header, and statically
-    extractable at publish so placement never has to run author code.
+    ONE declaration, two readings. The mapping form states each lane WITH the
+    machine floor that lane needs::
+
+        lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}
+
+    and the tuple form states lanes with no floor at all::
+
+        lanes=(contracts.SDXL_DIFFUSERS_BF16,)
+
+    A floor belongs to the lane and cannot be written anywhere else, which is
+    the point of the merge: the two structures used to be keyed by the same
+    contract objects and could disagree — a floor could guard a lane the model
+    did not declare, and the check for that is now impossible to need.
+    ``None``/``""`` is a legal mapping value for a floor-less lane, so a model
+    with a floor on one lane and none on another writes ONE dict.
+
+    The value carries **VRAM ONLY** (Paul, 2026-08-18): *"the sm_x compute
+    floor should fall out of the contract itself, rather than being a separate
+    annotation. Only the VRAM requirement needs a separate annotation, because
+    it's not clear, based on the contract, how much VRAM is needed."* So
+    ``min_sm`` is DERIVED from the lane contract's own load dtype
+    (:func:`capability_floor_for_dtype`) and merged in here, and an author who
+    writes it by hand is refused rather than allowed to create a second
+    producer of one fact. It is parsed HERE so the refusal names the author's
+    own class header, and statically extractable at publish so placement never
+    has to run author code.
     """
-    from ..models.tensor_layout_contract import parse_layout_requirements
+    from ..models.tensor_layout_contract import (
+        RequirementTerms,
+        capability_floor_for_dtype,
+        parse_layout_requirements,
+    )
+    import msgspec
 
-    where = f"{cls.__qualname__} requires="
-    if not isinstance(requires, Mapping):
+    where = f"{cls.__qualname__}: lanes="
+    if isinstance(lanes, Mapping):
+        items = list(lanes.items())
+    elif isinstance(lanes, tuple):
+        items = [(lane, None) for lane in lanes]
+    else:
         raise ModelDeclarationError(
-            f"{where} must be a mapping of lane contract -> requirement, "
-            f"got {type(requires).__name__}"
+            f"{where} must be a tuple of tensorfs contract objects, or a "
+            f"mapping of contract -> machine floor, got "
+            f"{type(lanes).__name__}"
         )
-    if not requires:
-        raise ModelDeclarationError(
-            f"{where}{{}} declares nothing. Omit it to leave placement "
-            "UNDECLARED; an empty mapping is not a statement that this model "
-            "runs anywhere."
-        )
-    # `lanes=()` IS a declaration, and every floor over it guards nothing.
-    # `None` reaches here only when the model type declares no canonical
-    # contract either, so there is genuinely nothing to check the keys against.
-    declared = None if lanes is None else {lane_handle(lane) for lane in lanes}
-    out: dict[str, Any] = {}
-    for lane, value in requires.items():
-        handle = lane if isinstance(lane, str) else lane_handle(lane)
-        if declared is not None and handle not in declared:
+
+    contracts: list[Any] = []
+    floors: dict[str, Any] = {}
+    for lane, floor in items:
+        if not isinstance(lane, LaneContract):
             raise ModelDeclarationError(
-                f"{where}[{handle!r}] guards a lane this model does not "
-                f"declare. Its lanes are {sorted(declared)} — add the "
-                "contract to lanes= or drop the requirement; a requirement "
-                "over nothing is never checked."
+                f"{cls.__qualname__}: lane {lane!r} is not a layout "
+                "contract (no `dtype`); a lane is an imported "
+                "tensorfs contract object, never a name string"
             )
-        out[handle] = parse_layout_requirements(value, where=f"{where}[{handle!r}]")
-    return out
+        # The isinstance above only proves the ATTRIBUTE exists; this
+        # READS it, which is the pgw#1391 difference.
+        dtype = lane_dtype(lane, where=cls.__qualname__)
+        contracts.append(lane)
+        handle = lane_handle(lane)
+        site = f"{where}[{handle!r}]"
+
+        declared = None
+        if floor is not None and floor != "":
+            declared = parse_layout_requirements(floor, where=site)
+            _refuse_non_vram_terms(declared, where=site)
+
+        # The capability floor falls out of the CONTRACT, never the header.
+        min_sm = capability_floor_for_dtype(dtype)
+        if declared is None and not min_sm:
+            continue  # nothing declared, nothing derived
+        minimum = declared.min_terms() if declared is not None else RequirementTerms()
+        if min_sm:
+            minimum = msgspec.structs.replace(minimum, min_sm=min_sm)
+        floors[handle] = (
+            msgspec.structs.replace(declared, minimum=minimum)
+            if declared is not None
+            else parse_layout_requirements(minimum, where=site)
+        )
+    return tuple(contracts), floors
+
+
+#: The lane annotation states VRAM and nothing else. `min_sm` is derived from
+#: the contract; the other axes are not lane facts at all (a CUDA/torch floor
+#: is a property of the IMAGE, and host RAM of the function).
+_LANE_FLOOR_TERMS: frozenset[str] = frozenset({"min_vram_gb"})
+
+
+def _refuse_non_vram_terms(requirements: Any, *, where: str) -> None:
+    """A lane floor that states anything but VRAM is refused at declaration."""
+    for level, terms in (
+        ("", requirements.min_terms()),
+        (" recommended", requirements.recommended_terms()),
+    ):
+        extra = sorted(set(terms.declared_terms()) - _LANE_FLOOR_TERMS)
+        if not extra:
+            continue
+        if "min_sm" in extra:
+            raise ModelDeclarationError(
+                f"{where}{level}: min_sm is DERIVED from the lane contract's "
+                "own load dtype, never written here — an 8-bit lane needs "
+                "8-bit kernels because of what it IS, and two producers of "
+                "one fact is how they drift apart. Drop the sm term; if the "
+                "derived floor is wrong for this dtype, fix the table in "
+                "`gen_worker.models.tensor_layout_contract.DTYPE_MIN_SM`."
+            )
+        raise ModelDeclarationError(
+            f"{where}{level}: a lane floor states VRAM only, got {extra}. "
+            "VRAM is the one floor the contract cannot imply, which is why it "
+            "is annotated; the rest are not lane facts (a CUDA/torch floor "
+            "belongs to the image, host RAM to the function's Resources)."
+        )
 
 
 def _declared_model_type(cls: type) -> type | None:
@@ -239,20 +314,27 @@ class Model(Generic[MT]):
             def load(self, ctx: LoadContext[SDXL]) -> None: ...
 
     ``lanes=`` omitted means one lane — the model type's canonical contract;
-    ``lanes=()`` states eager-permanent explicitly. ``requires=`` states what
-    each lane needs of the machine in the ie#740 grammar, keyed by the same
-    contract objects::
+    ``lanes=()`` states eager-permanent explicitly.
 
-        class SdxlModel(
-            Model[SDXL],
-            lanes=(contracts.SDXL_DIFFUSERS_BF16,),
-            requires={contracts.SDXL_DIFFUSERS_BF16: "vram12g"},
-        ): ...
+    The MAPPING form declares each lane together with what that lane needs of
+    a machine, in the ie#740 grammar — one line, one place::
 
-    Omitting it leaves placement UNDECLARED, and the platform's default floor
-    is what a deployment then gets. ``__init__`` stays FREE
-    (no GPU, no weights): construction and loading are separate moments, and
-    derive/introspection instantiate without weights.
+        class H3Model(Model[MiniMaxH3],
+                      lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}):
+            ...
+
+    ``None``/``""`` is a legal floor, so a mixed model still writes one dict.
+    Declaring no floor leaves placement UNDECLARED, and the platform's default
+    is what a deployment then gets.
+
+    A declared floor INFORMS, it does not permit (Paul, 2026-08-18): the hub
+    filters placement on it, and a worker that ends up under it warns loudly
+    and serves anyway. Any model runs on any machine — a poor match is slow
+    and says so, never refused, so cozy-local can run anything it has the
+    patience for.
+
+    ``__init__`` stays FREE (no GPU, no weights): construction and loading are
+    separate moments, and derive/introspection instantiate without weights.
     """
 
     __cozy_model_type__: ClassVar[Any] = None
@@ -262,10 +344,18 @@ class Model(Generic[MT]):
     def __init_subclass__(
         cls,
         *,
-        lanes: tuple[Any, ...] | None = None,
-        requires: Mapping[Any, Any] | None = None,
+        lanes: tuple[Any, ...] | Mapping[Any, Any] | None = None,
         **kwargs: Any,
     ) -> None:
+        if "requires" in kwargs:
+            raise ModelDeclarationError(
+                f"{cls.__qualname__}: `requires=` is DELETED — a lane and its "
+                "machine floor are ONE declaration now. Write "
+                "`lanes={contract: \"vram78g\"}` instead of "
+                "`lanes=(contract,), requires={contract: \"vram78g\"}`. The "
+                "mapping value is the lane's VRAM floor (None/\"\" for none); "
+                "the sm floor is derived from the contract, not written."
+            )
         super().__init_subclass__(**kwargs)
         if Model in cls.__bases__ and _declared_model_type(cls) is None and not any(
             isinstance(parameter, TypeVar)
@@ -281,29 +371,13 @@ class Model(Generic[MT]):
         declared = _declared_model_type(cls)
         if declared is not None:
             cls.__cozy_model_type__ = declared
-        # The lanes this class actually serves — declared, or the model type's
-        # canonical contract when `lanes=` is omitted. `requires=` is checked
-        # against THESE, not against the raw kwarg (pgw#1391): with `lanes=`
-        # omitted the old check had nothing to compare keys to and accepted a
-        # floor keyed to any stamp at all, including one naming no document.
-        effective_lanes: tuple[Any, ...] | None = lanes
+        # The lanes this class actually serves, and their floors, from the ONE
+        # `lanes=` declaration — or the model type's canonical contract when
+        # `lanes=` is omitted (which declares no floor).
         if lanes is not None:
-            if not isinstance(lanes, tuple):
-                raise ModelDeclarationError(
-                    f"{cls.__qualname__}: lanes= must be a tuple of tensorfs "
-                    f"contract objects, got {type(lanes).__name__}"
-                )
-            for lane in lanes:
-                if not isinstance(lane, LaneContract):
-                    raise ModelDeclarationError(
-                        f"{cls.__qualname__}: lane {lane!r} is not a layout "
-                        "contract (no `dtype`); a lane is an imported "
-                        "tensorfs contract object, never a name string"
-                    )
-                # The isinstance above only proves the ATTRIBUTE exists; this
-                # READS it, which is the pgw#1391 difference.
-                lane_dtype(lane, where=cls.__qualname__)
-            cls.__cozy_lanes__ = tuple(lanes)
+            contracts, floors = _parse_lanes(cls, lanes)
+            cls.__cozy_lanes__ = contracts
+            cls.__cozy_requires__ = floors
         elif declared is not None:
             # pgw#1391: OMITTING `lanes=` IS THE se#757 TRAP, so it is checked
             # here too. `model_lanes()` falls through to the model type's
@@ -319,9 +393,6 @@ class Model(Generic[MT]):
             canonical = getattr(declared, "canonical_contract", None)
             if canonical is not None:
                 lane_dtype(canonical, where=f"{cls.__qualname__} (lanes= omitted)")
-                effective_lanes = (canonical,)
-        if requires is not None:
-            cls.__cozy_requires__ = _parse_requires(cls, requires, effective_lanes)
 
     # -- lifecycle hooks (the load/unload contract, pgw#1382) ---------------
 

--- a/src/gen_worker/serving/placement.py
+++ b/src/gen_worker/serving/placement.py
@@ -1,0 +1,205 @@
+"""Machine-floor fit at residency-admit: warn loudly, then run anyway.
+
+Paul, 2026-08-18, verbatim: *"the way I want it to work is that we should be
+able to place any model on any machine; if the machine is a poor match, it will
+complain and warn loudly when it enters degraded mode, but still run anyway.
+That way cozy-local users can still run these models, even if they run really
+slow."*
+
+So a declared floor INFORMS, it never PERMITS. The same number is read three
+times, for three different purposes:
+
+* **route-1 buying filter** — the hub filters placement on it, so we do not
+  rent a pod that will serve this model badly;
+* **route-2 warning** — a private deployment is told its own hardware is under
+  the floor before it wonders why generation takes ten minutes;
+* **worker degraded mode** — THIS module. The floor is unmet, the load happens
+  anyway, and the fact is loud on both channels rather than inferred later
+  from a latency graph.
+
+This generalizes pgw#1312's offload ruling from "no env var gates CPU offload"
+to "no declared floor gates anything either". There is no refusal here and no
+environment variable to consult; the residency ladder does its job and the
+operator is told what it is about to cost.
+
+What this is NOT: a kernel check. Which attention kernel a serving picks
+(sage2, flash-*) is a serve-recipe fallback arm with its own degrade path, not
+a placement floor — see ``DTYPE_MIN_SM``'s header.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Wire-shared activity kind (tensorhub
+#: `internal/orchestrator/grpc/worker_activity.go`). One COMPLETED event per
+#: unmet floor per residency-admit, so "how often did we serve degraded, and on
+#: what" is a COUNT over `worker_activity_events`, not a log-scrape.
+ACTIVITY_KIND = "placement_degraded"
+
+_BYTES_PER_GIB = float(1024 ** 3)
+
+
+@dataclass(frozen=True)
+class DeviceFacts:
+    """What the machine actually is, as the floors are spelled."""
+
+    name: str
+    vram_gib: float
+    sm: int
+
+
+@dataclass(frozen=True)
+class Shortfall:
+    """One declared floor this machine does not meet."""
+
+    term: str
+    lane: str
+    declared: Any
+    actual: Any
+    device: str
+
+    @property
+    def message(self) -> str:
+        if self.term == "min_vram_gb":
+            return (
+                f"DEGRADED PLACEMENT: {self.device} has {self.actual:.1f} GiB "
+                f"of VRAM, but lane {self.lane} declares a floor of "
+                f"{self.declared:.1f} GiB. Running anyway — the residency "
+                f"ladder will engage host offload rungs, so expect a HEAVY "
+                f"slowdown (minutes where seconds are normal), not a failure. "
+                f"A declared floor is a buying hint and a warning, never "
+                f"permission: any model runs on any machine."
+            )
+        if self.term == "min_sm":
+            capability = (
+                f"is compute capability sm_{self.actual}"
+                if self.actual
+                else "reports no CUDA compute capability at all"
+            )
+            return (
+                f"DEGRADED PLACEMENT: {self.device} {capability}, but lane "
+                f"{self.lane} needs sm_{self.declared}+ for its own load "
+                f"dtype's arithmetic. "
+                f"Running anyway — where torch has a fallback the kernels "
+                f"will emulate or upcast and be MUCH slower; where it has "
+                f"none this load will fail in the kernel rather than here. "
+                f"A declared floor is a buying hint and a warning, never "
+                f"permission: any model runs on any machine."
+            )
+        return (  # pragma: no cover - the vocabulary above is closed
+            f"DEGRADED PLACEMENT: {self.device} does not meet {self.term} "
+            f"{self.declared!r} declared by lane {self.lane} (actual "
+            f"{self.actual!r}). Running anyway."
+        )
+
+
+def device_facts(index: int = 0) -> DeviceFacts:
+    """This worker's actual card. Never raises — a machine that will not
+    describe itself reads as the emptiest possible one, which makes every
+    declared floor unmet and therefore LOUD. Silence is the one answer a
+    placement report must never give.
+
+    A CPU-only host (cozy-local) is exactly that case and is not special-cased:
+    0 GiB of VRAM is under every floor, so it warns, and then it runs.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():  # noqa: SIM103
+            return DeviceFacts(name="cpu (no CUDA device)", vram_gib=0.0, sm=0)
+        properties = torch.cuda.get_device_properties(index)
+        major, minor = torch.cuda.get_device_capability(index)
+        return DeviceFacts(
+            name=str(properties.name),
+            vram_gib=float(properties.total_memory) / _BYTES_PER_GIB,
+            sm=int(major) * 10 + int(minor),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("device_facts: unreadable device", exc_info=True)
+        return DeviceFacts(name="unknown device", vram_gib=0.0, sm=0)
+
+
+def shortfalls(
+    model_cls: type, lane: Any, *, facts: Optional[DeviceFacts] = None
+) -> Tuple[Shortfall, ...]:
+    """Every floor lane ``lane`` of ``model_cls`` declares that this machine
+    does not meet. Empty for an undeclared floor, an eager-permanent model, or
+    a machine that is simply big enough.
+    """
+    from .model import lane_handle, model_requires
+
+    if lane is None:
+        return ()  # eager-permanent: no lane, so no lane floor
+    requirements = model_requires(model_cls).get(lane_handle(lane))
+    if requirements is None:
+        return ()
+    terms = requirements.min_terms()
+    if facts is None:
+        facts = device_facts()
+
+    out: list[Shortfall] = []
+    # `min_sm` first: a card that cannot do the arithmetic at all is the more
+    # fundamental complaint, and an operator reading two lines should see it
+    # before the size one.
+    if terms.min_sm and facts.sm < terms.min_sm:
+        out.append(Shortfall("min_sm", lane_handle(lane), terms.min_sm,
+                             facts.sm, facts.name))
+    if terms.min_vram_gb and facts.vram_gib < terms.min_vram_gb:
+        out.append(Shortfall("min_vram_gb", lane_handle(lane),
+                             float(terms.min_vram_gb), facts.vram_gib,
+                             facts.name))
+    return tuple(out)
+
+
+def warn_if_degraded(
+    model_cls: type, lane: Any, *, facts: Optional[DeviceFacts] = None
+) -> Tuple[str, ...]:
+    """Report every unmet floor on BOTH channels, and return the messages so
+    the caller can also make them caller-visible.
+
+    Operator-visible: one COMPLETED ``placement_degraded`` activity event per
+    unmet floor (countable, per-pod, on the channel every other worker fact
+    already lands on) plus a WARNING on the logger, which on cozy-local IS the
+    progress UI. Caller-visible: the returned messages, which the serve path
+    hands to ``ctx.warn`` so they ride the response envelope's adjustment
+    ledger on every request this instance serves.
+
+    Never raises and never refuses — best-effort reporting around a load that
+    is going to happen either way.
+    """
+    try:
+        found = shortfalls(model_cls, lane, facts=facts)
+    except Exception:  # noqa: BLE001
+        logger.debug("placement floor check failed", exc_info=True)
+        return ()
+    messages: list[str] = []
+    for shortfall in found:
+        messages.append(shortfall.message)
+        logger.warning("%s", shortfall.message)
+        try:
+            from ..activity import emit_event
+
+            emit_event(
+                ACTIVITY_KIND,
+                shortfall.message,
+                phase=shortfall.term,
+                family=f"{model_cls.__name__}/{shortfall.lane}",
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("placement_degraded event not emitted", exc_info=True)
+    return tuple(messages)
+
+
+__all__ = [
+    "ACTIVITY_KIND",
+    "DeviceFacts",
+    "Shortfall",
+    "device_facts",
+    "shortfalls",
+    "warn_if_degraded",
+]

--- a/src/gen_worker/serving/placement.py
+++ b/src/gen_worker/serving/placement.py
@@ -107,11 +107,18 @@ def device_facts(index: int = 0) -> DeviceFacts:
     A CPU-only host (cozy-local) is exactly that case and is not special-cased:
     0 GiB of VRAM is under every floor, so it warns, and then it runs.
     """
+    from ..hostfacts import cuda_ready
+
     try:
+        # `cuda_ready()` is the ONE `torch.cuda.is_available()` site in `src/`
+        # (fenced by tests/test_hostfacts_pgw896.py), and it is the right
+        # question here: this is a CAPABILITY check — "may I read a card?" —
+        # for which degrading on a device that will not answer is correct,
+        # because an unreadable device is under every floor anyway.
+        if not cuda_ready():
+            return DeviceFacts(name="cpu (no CUDA device)", vram_gib=0.0, sm=0)
         import torch
 
-        if not torch.cuda.is_available():  # noqa: SIM103
-            return DeviceFacts(name="cpu (no CUDA device)", vram_gib=0.0, sm=0)
         properties = torch.cuda.get_device_properties(index)
         major, minor = torch.cuda.get_device_capability(index)
         return DeviceFacts(

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -39,6 +39,7 @@ from .envelope import DecodedRequest, decode_envelope
 from .host import ServeDispatchError
 from .loader import LoadedEndpoint
 from .model import Model, lane_handle, model_type
+from .placement import warn_if_degraded
 from .residency import InstanceSizer, ResidencyManager
 
 logger = logging.getLogger(__name__)
@@ -83,12 +84,24 @@ class _InstanceBackend:
         self,
         model_cls: type,
         load_context: LoadContext[Any],
+        lane: Any = None,
     ) -> None:
         self.model_cls = model_cls
         self.load_context = load_context
         self.model: Optional[Model[Any]] = None
+        self.lane = lane
+        #: Unmet machine floors, measured once at residency-admit. Non-empty
+        #: means this instance is serving DEGRADED, and every request it
+        #: serves says so (`invoke` warns the caller with these).
+        self.degraded: Tuple[str, ...] = ()
 
     def load(self) -> None:
+        # Residency-admit is where the lane is picked and the load begins, so
+        # it is where the machine is compared against the lane's declared
+        # floors — BEFORE any weight moves, so the warning precedes the
+        # slowness it predicts rather than explaining it afterwards. It never
+        # refuses: any model, any machine (Paul, 2026-08-18).
+        self.degraded = warn_if_degraded(self.model_cls, self.lane)
         model: Model[Any] = self.model_cls()  # cheap __init__ — no GPU, by contract
         model.load(self.load_context)
         self.model = model
@@ -176,6 +189,7 @@ class ServeLoop:
                     engine=self._engine,
                     compile_sink=sink,
                 ),
+                lane,
             )
             with self._backends_lock:
                 self._backends[key] = backend
@@ -221,6 +235,10 @@ class ServeLoop:
         with ExitStack() as leases:
             models: Dict[str, Model[Any]] = {}
             primary_binding: Optional[DeployBinding] = None
+            #: Unmet machine floors of the instances this request actually
+            #: uses — a load-time fact, so it stains EVERY request the
+            #: degraded instance serves, not just the one that loaded it.
+            degraded: list[str] = []
             # STABLE SLOT-NAME ORDER — the multi-model deadlock rule: every
             # request over the same slot set acquires in one global order.
             # pgw#1392: a WEIGHTLESS entrypoint's slot set is EMPTY, so this
@@ -254,6 +272,7 @@ class ServeLoop:
                         f"admission; the residency ledger is inconsistent"
                     )
                 models[slot_name] = backend.model
+                degraded.extend(backend.degraded)
                 if primary_binding is None:
                     # The FIRST slot in signature order is the request's
                     # primary routing fact (ctx.checkpoint_ref).
@@ -263,6 +282,8 @@ class ServeLoop:
                     )
 
             ctx = self._make_context(request_id, primary_binding)
+            for warning in degraded:
+                ctx.warn(warning)
             arguments = [
                 models[slot.name] if slot.kind == "model" else adapters[slot.name]
                 for slot in spec.slots

--- a/tests/fixtures/serving_v2_endpoint/src/serving_v2_fixture/main.py
+++ b/tests/fixtures/serving_v2_endpoint/src/serving_v2_fixture/main.py
@@ -232,12 +232,15 @@ class SdxlModel(
     Model[SDXL],
     # A lane IS a tensorfs layout contract — an imported object carrying the
     # actual layout. Omitting lanes= means one lane: SDXL's canonical contract.
-    lanes=(contracts.SDXL_DIFFUSERS_BF16, contracts.COZY_SDXL_FP8_ROWWISE),
-    # What each lane needs of the machine (ie#740 grammar). Per-lane because
-    # the fp8 lane both fits smaller and needs the newer decoder.
-    requires={
+    # pgw#1404: the lane and what it needs of a machine are ONE declaration,
+    # and the value is the lane's VRAM floor ONLY. Per-lane because the fp8
+    # lane fits smaller. The compute-capability floor is DERIVED from each
+    # contract's own load dtype and is not written here — it reads 0 for both
+    # of these because the stand-ins declare float32 (this fixture serves on
+    # CPU with fake weights), which is exactly the derivation being honest.
+    lanes={
         contracts.SDXL_DIFFUSERS_BF16: "vram12g",
-        contracts.COZY_SDXL_FP8_ROWWISE: "sm89+, vram8g",
+        contracts.COZY_SDXL_FP8_ROWWISE: "vram8g",
     },
 ):
     """The stateful half: weights, compile-marked modules, defaults. One

--- a/tests/release_fixtures/staffing_endpoint.py
+++ b/tests/release_fixtures/staffing_endpoint.py
@@ -65,9 +65,10 @@ class AnalyzeOutput(msgspec.Struct):
 
 class H3Model(
     Model[MiniMaxH3],
-    lanes=(H3_LANE,),
-    # The per-LANE placement floor — a property of the weight format.
-    requires={H3_LANE: "vram78g"},
+    # pgw#1404: the lane and its per-LANE placement floor are ONE declaration —
+    # the floor is a property of the weight format, so it is written as the
+    # lane's own value. VRAM only; the sm floor is derived from the contract.
+    lanes={H3_LANE: "vram78g"},
 ):
     def load(self, ctx: Any) -> None:
         self.pipe = ctx.load(H3Pipeline)

--- a/tests/test_lane_contracts.py
+++ b/tests/test_lane_contracts.py
@@ -310,3 +310,57 @@ def test_no_vendored_stamp_ties_between_two_model_types() -> None:
         if len(hits) > 1:
             ties[contract.stamp] = hits
     assert not ties, f"stamps claimed by more than one model type: {ties}"
+
+
+def test_a_dtypeless_lane_cannot_buy_a_silent_runs_anywhere_floor() -> None:
+    """pgw#1404: the derivation FAILS CLOSED on a contract with no dtype.
+
+    The h3 lane audited all eleven vendored documents against the new
+    dtype->min_sm derivation and found three with no top-level dtype —
+    `dit.blocks-fused-qkv@1` and both `sdxl.clip-g-*-qkv@1`. They are
+    component/sub-tree layouts, so they arguably never belong in a `lanes=` at
+    all — but "arguably never" is an assumption, not a fence.
+
+    Note how the hazard MUTATES under the derivation, which is why this test
+    exists rather than a comment: a dtypeless contract used to be a LOUD load
+    crash (`MissingDtype`). Deriving 0 from it would turn the same gap into a
+    SILENT floor of none, which the resolver reads as "runs anywhere" —
+    th#1754's shape with a new cause, and strictly worse because nothing
+    raises. A floor is the one place failing open is invisible.
+    """
+
+    from gen_worker._vendor.tensorfs import contracts
+    from gen_worker.models.model_types import SDXL
+    from gen_worker.serving import Model, ModelDeclarationError
+    from gen_worker.serving import model as model_module
+
+    dtypeless = [c for c in contracts.all() if getattr(c, "_dtype", None) is None]
+    assert {c.stamp for c in dtypeless} == {
+        "dit.blocks-fused-qkv@1",
+        "sdxl.clip-g-fused-qkv@1",
+        "sdxl.clip-g-split-qkv@1",
+    }, "the dtypeless set moved; re-audit the derivation against it"
+
+    for contract in dtypeless:
+        with pytest.raises(ModelDeclarationError, match="no load dtype"):
+
+            class Floored(Model[SDXL], lanes={contract: "vram12g"}):  # noqa: B903
+                def load(self, ctx: object) -> None: ...
+
+    # ...and the one path that could still buy silence is closed too.
+    # `lane_dtype` answers None instead of raising for a handle listed in
+    # `DTYPELESS_UPSTREAM_LANES` (an empty escape hatch today). If anything is
+    # ever added to it, the lane would clear declaration AND derive no floor.
+    # A floor declaration refuses on the dtype itself, so the hatch cannot
+    # reopen this hole behind someone's back.
+    original = model_module.DTYPELESS_UPSTREAM_LANES
+    try:
+        model_module.DTYPELESS_UPSTREAM_LANES = frozenset({"sdxl.clip-g-fused-qkv@1"})
+        with pytest.raises(ModelDeclarationError, match="no load dtype"):
+
+            class Hatched(
+                Model[SDXL], lanes={contracts.SDXL_CLIP_G_FUSED_QKV: "vram12g"}
+            ):
+                def load(self, ctx: object) -> None: ...
+    finally:
+        model_module.DTYPELESS_UPSTREAM_LANES = original

--- a/tests/test_lane_contracts.py
+++ b/tests/test_lane_contracts.py
@@ -267,11 +267,21 @@ def test_a_lane_naming_no_document_refuses_at_declaration() -> None:
         class Claimed(Model[SDXL], lanes=(nope,)):
             def load(self, ctx: object) -> None: ...
 
-    # ...and a `requires=` floor keyed to a stamp this model does not serve,
-    # which used to be accepted outright whenever `lanes=` was omitted.
-    with pytest.raises(ModelDeclarationError, match="does not declare"):
+    # A floor keyed to a lane the model does not serve is now UNREACHABLE
+    # rather than refused: pgw#1404 merged the two kwargs, so a floor is
+    # written as the VALUE of its own lane and cannot name a second stamp.
+    # `requires=` is deleted, and the refusal names the spelling that replaces
+    # it — a silently-ignored floor is exactly what this class of bug was.
+    with pytest.raises(ModelDeclarationError, match="requires.*is DELETED"):
 
         class Floored(Model[SDXL], requires={"nope.not-a-document@1": "vram12g"}):
+            def load(self, ctx: object) -> None: ...
+
+    # ...and the same missing document refuses through the merged spelling,
+    # so folding the kwargs did not cost this fence anything.
+    with pytest.raises(ModelDeclarationError, match="DOES NOT EXIST"):
+
+        class ClaimedWithFloor(Model[SDXL], lanes={nope: "vram12g"}):
             def load(self, ctx: object) -> None: ...
 
 

--- a/tests/test_model_authoring.py
+++ b/tests/test_model_authoring.py
@@ -103,11 +103,14 @@ def test_fixture_imports_clean_and_extracts_the_declared_surface() -> None:
     ]
     assert len(lanes) == 2
 
-    # ie#740 placement floors, per lane, from the same header — statically
-    # extractable, so a deployment is sized without running author code.
+    # ie#740 placement floors, per lane, from the SAME `lanes=` declaration
+    # (pgw#1404 merged them) — statically extractable, so a deployment is sized
+    # without running author code. VRAM only: the sm floor is derived from each
+    # contract's dtype, and both fixture stand-ins declare float32 (CPU, fake
+    # weights), which derives no floor.
     assert {h: r.render() for h, r in model_requires(SdxlModel).items()} == {
         "sdxl.diffusers-bf16@1": "vram12g",
-        "cozy.sdxl-fp8-rowwise@1": "sm89+, vram8g",
+        "cozy.sdxl-fp8-rowwise@1": "vram8g",
     }
 
 
@@ -170,9 +173,24 @@ def test_model_header_declarations_and_refusals() -> None:
 
     assert lane_handle(AnonymousContract()) == "sha256:" + "a" * 64
 
-    # A floor over a lane this model does not declare guards nothing.
-    with pytest.raises(ModelDeclarationError, match="does not.*declare"):
+    # pgw#1404: a floor over a lane this model does not declare no longer NEEDS
+    # a check — a floor is the value of its own lane key, so it cannot name a
+    # stamp the model does not serve. `requires=` is deleted, typed, and the
+    # refusal names the merged spelling.
+    with pytest.raises(ModelDeclarationError, match="requires.*is DELETED"):
         class StrayFloor(Model[SDXL], lanes=(), requires={"sdxl.other@1": "vram8g"}):
+            pass
+
+    # The merged spelling: one dict, lane -> VRAM floor. The compute-capability
+    # floor is DERIVED from the contract's dtype and is NOT author-writable
+    # (Paul 2026-08-18: "the sm_x compute floor should fall out of the contract
+    # itself... Only the VRAM requirement needs a separate annotation").
+    from gen_worker._vendor.tensorfs import contracts as _contracts
+
+    with pytest.raises(ModelDeclarationError, match="min_sm is DERIVED"):
+        class HandWrittenSm(
+            Model[SDXL], lanes={_contracts.SDXL_DIFFUSERS_BF16: "vram8g, sm90+"}
+        ):
             pass
 
     # Cheap __init__: constructing a model does not load anything.

--- a/tests/test_serve_loop_envelope.py
+++ b/tests/test_serve_loop_envelope.py
@@ -111,9 +111,31 @@ def test_the_envelope_serves_end_to_end_with_fake_tensors(tmp_path: Path) -> Non
     assert result.loras == []
     saved = tmp_path / "outputs" / result.image.ref
     assert saved.is_file() and saved.stat().st_size > 0
-    assert outcome.warnings == ()
     # The instance is resident under its reservation (weights + headroom).
     assert manager.tier_of(DREAM, "SdxlModel/sdxl.diffusers-bf16@1") is Tier.VRAM
+
+    # pgw#1404 degraded mode, end to end on the REAL serve path. This test host
+    # has no CUDA device at all, and the fixture's bf16 lane declares vram12g —
+    # so the machine is under the floor by every measure. Paul, 2026-08-18:
+    # "we should be able to place any model on any machine; if the machine is a
+    # poor match, it will complain and warn loudly when it enters degraded
+    # mode, but still run anyway." Both halves are asserted here: the request
+    # SUCCEEDED (everything above this line), and it says why it will be slow.
+    assert len(outcome.warnings) == 1
+    warning = outcome.warnings[0]
+    assert warning.startswith("DEGRADED PLACEMENT: ")
+    assert "sdxl.diffusers-bf16@1" in warning  # the lane
+    assert "12.0 GiB" in warning               # the declared floor
+    assert "0.0 GiB" in warning                # what this machine actually has
+    assert "cpu (no CUDA device)" in warning   # the card
+    assert "Running anyway" in warning         # the consequence, not a refusal
+    # It rides the adjustment ledger (JobResult.adjustments), field-less, so
+    # the hub records it against the request rather than the caller inferring
+    # it from a latency graph.
+    assert [
+        row for row in outcome.adjustments
+        if row["field"] == "" and row["reason"] == warning
+    ]
 
 
 def test_adapters_ride_the_envelope_and_the_scopes_restore(tmp_path: Path) -> None:

--- a/tests/test_staffing_envelope.py
+++ b/tests/test_staffing_envelope.py
@@ -165,10 +165,21 @@ def test_both_requires_scopes_fold_rather_than_shadow(rows: dict[str, dict]) -> 
 
 
 def test_the_undeclared_control_is_unchanged(rows: dict[str, dict]) -> None:
-    """An entrypoint with no `resources=` emits EXACTLY what it emitted
-    before pgw#1396 — the sdxl deploy pins this shape."""
+    """An entrypoint with no `resources=` emits the class header's floor and
+    nothing of its own — the sdxl deploy pins this shape.
 
-    assert rows["control"]["resources"] == {"gpu": True, "requires": {"min_vram_gb": 78.0}}
+    pgw#1404 added `min_sm` beside it, DERIVED from the lane contract's own
+    load dtype (H3_LANE is bf16 -> sm80) rather than hand-annotated. Paul,
+    2026-08-18: "the sm_x compute floor should fall out of the contract
+    itself... Only the VRAM requirement needs a separate annotation." So the
+    author wrote `lanes={H3_LANE: "vram78g"}` and the hub receives BOTH floors:
+    one producer per fact, and the capability floor can never drift from the
+    weights it describes.
+    """
+
+    assert rows["control"]["resources"] == {
+        "gpu": True, "requires": {"min_sm": 80, "min_vram_gb": 78.0},
+    }
 
 
 def test_the_block_reaches_the_real_manifest(tmp_path: Path) -> None:
@@ -210,7 +221,11 @@ def test_the_block_reaches_the_real_manifest(tmp_path: Path) -> None:
     assert list(blocks["generate"]["parallel"]) == ["sequence"]
     assert blocks["generate"]["requires"]["recommended"]["min_host_ram_gb"] == 96.0
     assert blocks["analyze"] == {"vcpus": 4}
-    assert blocks["control"] == {"gpu": True, "requires": {"min_vram_gb": 78.0}}
+    # pgw#1404: the DERIVED capability floor reaches the real manifest too —
+    # `min_sm` beside `min_vram_gb`, in the term the hub already reads.
+    assert blocks["control"] == {
+        "gpu": True, "requires": {"min_sm": 80, "min_vram_gb": 78.0},
+    }
 
 
 def test_absent_stays_absent(staffing: ModuleType) -> None:


### PR DESCRIPTION
Two changes from Paul's review of the `Model` class header.

## 1. `lanes=` and `requires=` merge into one declaration

> *"perhaps you can combine lanes + requires together into a single line?"* — and on the result, *"yeah please do this. this is a good structural change"*

```python
class H3Model(Model[MiniMaxH3], lanes={contracts.MINIMAX_H3_DIT_DIFFUSERS: "vram78g"}):
```

- **dict form** = lanes with per-lane VRAM floors. `None`/`""` is a legal floor-less value, so a model with a floor on one lane and none on another still writes ONE dict. Multi-entry dicts with differing floors are first-class.
- **tuple form** `lanes=(contract,)` stays legal (= no VRAM floor). `lanes=()` eager-permanent and omitted `lanes=` are unchanged.
- **`requires=` is DELETED** as a separate kwarg — typed `ModelDeclarationError` naming the new spelling, never silently accepted.

The old *"a floor guards a lane this model does not declare"* bug class is now **unreachable by construction** rather than checked: a floor is the value of its own lane key, so it cannot name a second stamp. Two structures keyed by the same objects could disagree; one cannot.

## 2. The compute-capability floor falls out of the contract

> *"the sm_x compute floor should fall out of the contract itself, rather than being a separate annotation. Only the VRAM requirement needs a separate annotation, because it's not clear, based on the contract, how much VRAM is needed."*

`DTYPE_MIN_SM` + `capability_floor_for_dtype()` in `models/tensor_layout_contract.py` is the **single producer** — bf16→sm80, fp8→sm89, nvfp4→sm100, fp16→sm70, int8→sm75, fp32→none. It is merged into the lane's floor at declaration and emitted as `functions[].resources.requires.min_sm` — **the term the hub's ingest already reads** (th#2030), so this needed no new term and no hub-side work.

A hand-written `sm` term in the annotation is refused, naming the table. **Extension path:** a lane needing a floor its dtype does not imply is a change to `DTYPE_MIN_SM` or to the contract's dtype, never a new annotation term. **Boundary:** specific kernels (sage2, flash-*) stay OUT of `lanes=` — those are serve-recipe fallback arms with their own degrade path, not placement floors.

## 3. Under-floor machines warn loudly and run anyway

> *"we should be able to place any model on any machine; if the machine is a poor match, it will complain and warn loudly when it enters degraded mode, but still run anyway. That way cozy-local users can still run these models, even if they run really slow."*

New `serving/placement.py` compares the real device against the selected lane's floors at residency-admit — `_InstanceBackend.load` and `EndpointHost.setup`, **before any weight moves** — and on a shortfall reports on both channels and proceeds:

| channel | what lands |
|---|---|
| operator | one countable `placement_degraded` ActivityUpdate per unmet floor on `worker_activity_events`, plus a WARNING on the logger (which IS cozy-local's progress UI) |
| caller | `ctx.warn` rows on the response envelope's adjustment ledger, on **every** request the degraded instance serves — degradation is a load-time fact, not a per-request one |

No refusal, no env-var gate, identical on cozy-local. This **generalizes pgw#1312** from "no env var gates CPU offload" to "no declared floor gates anything either": a declared floor is a buying hint for the route-1 buyer and a warning for the route-2 private deployment, never permission. Enforcement stays hub-side placement filtering.

The message names the card, the actual GiB, the lane, the declared floor and the consequence:

> DEGRADED PLACEMENT: NVIDIA GeForce RTX 3090 has 24.0 GiB of VRAM, but lane `minimax.h3-dit-diffusers@1` declares a floor of 78.0 GiB. Running anyway — the residency ladder will engage host offload rungs, so expect a HEAVY slowdown (minutes where seconds are normal), not a failure. A declared floor is a buying hint and a warning, never permission: any model runs on any machine.

## Evidence

- **Drive scripts** — 9 surface cases (all four `lanes=` forms, `requires=` refusal, hand-written-sm refusal, non-VRAM refusal, multi-entry dict) and 6 degraded-mode cases (under-floor card, CPU-only, at-floor silence, capability-only shortfall, floor-less model, never-raises).
- **End-to-end on the real serve path**: `test_the_envelope_serves_end_to_end_with_fake_tensors` now asserts both halves — the request **succeeded**, and it carries the degraded warning on the adjustment ledger.
- **Derived `min_sm` reaches the real manifest**: `test_staffing_envelope` pins `{"min_sm": 80, "min_vram_gb": 78.0}` from a header that only wrote `"vram78g"`.
- `tests_v2` **21/21**; targeted `tests/` subset **1774 passed**, 1 pre-existing failure (`test_a_torchless_discovery_ABSTAINS_out_loud`, red on master too); mypy clean on all changed modules.

## Endpoint headers are deliberately NOT here

`serverless-endpoints` pins gen-worker by **SHA**, not master (sdxl `0a95abd5`, minimax-h3 `8dbce771`), so this merge cannot break either endpoint — and changing a header *without* bumping that endpoint's pin in the same commit would break it at import against its pinned SDK. The coupling is pin-and-header-in-one-commit, per endpoint, independently. minimax-h3 is owned by the h3 lane (header + pin + fp8 lane in one commit, blocked behind pgw#1373/th#2168); sdxl is still owed on the same terms.

Both directions fail loud, which is what makes this a clean hardcut: the old spelling raises here, and the new spelling raises against an old pinned SDK (`lanes= must be a tuple..., got dict`), so a dict can never silently degrade to its keys and drop a floor.