### PR TITLE
pgw#1383 items 2+3: root-caused, and a wedged runtime mint now says so on the wire

### DIFF
--- a/changelog.d/pgw1383-adopt-lane.md
+++ b/changelog.d/pgw1383-adopt-lane.md
@@ -1,0 +1,21 @@
+- **A wedged runtime mint says so on the WIRE, and so does a graph this pod minted but cannot
+  serve.** Closing pgw#1383: the mint's progress guard already condemned correctly, but the
+  condemnation went to `logger.error` and a serve pod's stdout goes nowhere (pgw#760) — so from the
+  hub's side a condemned mint is simply a mint that stopped emitting, which is indistinguishable
+  from a busy healthy pod. `self_mint_wedged` (`phase=no_measured_progress`) now carries the holes,
+  the width, what landed and the guard's own sentence; `self_mint_arm_missed` carries the graph that
+  is minted and in the store but that this pod's live dispatch did not take, which is why it keeps
+  serving eager for a graph it just paid to compile.
+
+  **The root cause this closes, banked in `serving/mint.py`'s docstring so it is not re-lost.** Pod
+  `j56tate13oav13` (A40, $0.44/hr) billed for thirty minutes on a mint whose compile children had
+  both finished. 0.126.0's terminalise-on-every-exit narrowed it — every branch already emitted
+  something — and the remainder was one blocking call in the now-retired supervisor: the terminus
+  adopt (an arm plus a numerics verify per graph class, on the live pipeline) ran straight from a
+  coroutine, and `activity._emit`'s bound sink ships every report as a task on that same event loop.
+  The `seal_publish` transition declared one line earlier was created and never ran, nor was any
+  heartbeat, nor any abort. The hub's stall detector fired four times reading
+  `inductor_compile step 2/2` and was right every time — that genuinely was the last thing to reach
+  it. **The arm may never run on a loop that also ships the worker's reports.** The runtime mint
+  already honours that structurally (every arm on a mint worker thread under `arm_lock`, the guard
+  sampling on its own cadence beside them); what it was missing was the report.

--- a/src/gen_worker/serving/mint.py
+++ b/src/gen_worker/serving/mint.py
@@ -24,11 +24,26 @@ graphs it is missing. Four properties, each load-bearing:
    getting this wrong: a 36-class mint at 2-on-7 starved serving so badly
    that a 15m50s invocation never returned in 65 minutes.
 
-4. **PROGRESS-GATED LIVENESS.** The guard reads what the mint has ACHIEVED —
-   graphs completed, and the mint tree's own CPU — never a clock against the
-   job. A mint that lands graphs is never condemned however long it takes; a
-   mint that lands nothing AND burns no CPU is condemned inside its window.
-   No window is ever enlarged to make a stall look healthy.
+4. **PROGRESS-GATED LIVENESS, AND IT REPORTS.** The guard reads what the mint
+   has ACHIEVED — graphs completed, and the mint tree's own CPU — never a
+   clock against the job. A mint that lands graphs is never condemned however
+   long it takes; a mint that lands nothing AND burns no CPU is condemned
+   inside its window. No window is ever enlarged to make a stall look healthy.
+   And every verdict it reaches goes on the WIRE (pgw#1383): a serve pod's
+   stdout goes nowhere (pgw#760), so a condemnation that only reaches
+   ``logger.error`` is, from the hub's side, a mint that stopped emitting.
+
+**THE PROPERTY THAT MADE THE OLD PATH INVISIBLE, stated so it is not
+re-lost.** pgw#1383 root-caused pod ``j56tate13oav13``: the retired supervisor
+ran its terminus adopt — an arm plus a numerics verify per graph class, on the
+live pipeline — straight from a coroutine, and ``activity._emit``'s bound sink
+ships every report as a task on THAT event loop. The seal phase it had just
+declared was created and never ran; neither did any heartbeat or any abort. The
+hub read ``inductor_compile step 2/2`` for thirty billed minutes because that
+genuinely was the last thing to reach it. **The arm may never run on a loop
+that also ships the worker's reports**, and here it does not: every arm runs on
+a mint worker thread under ``arm_lock``, and the guard samples on its own
+cadence beside them.
 """
 
 from __future__ import annotations
@@ -43,6 +58,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
+from .. import activity as activity_mod
 from .. import compile_posture
 from ..stall import SilenceWindow
 
@@ -61,6 +77,20 @@ DEFAULT_SILENCE_WINDOW_S = 600.0
 
 #: Below this the CPU axis has not moved (sampling jitter, not work).
 _CPU_EVIDENCE_EPS = 0.5
+
+#: pgw#1383: the typed defect this worker reports about ITSELF when its own
+#: mint stops making measured progress. A serve pod exposes no logs (pgw#760),
+#: so `logger.error` is not a report — it is the mint dying in private, which
+#: is the exact shape that cost `j56tate13oav13` thirty billed minutes and a
+#: manual `DELETE /v1/admin/pods`. The hub's stall detector was right every
+#: time it fired there; what it lacked was a fact from the worker to join to.
+KIND_MINT_WEDGED = "self_mint_wedged"
+
+#: A graph that is MINTED and PUBLISHED but did not arm on this pod's live
+#: dispatch. Not a failure of the mint — the fleet has the bytes — but it is
+#: why this pod keeps serving eager for a graph it just paid to compile, and
+#: that is a wire fact rather than a pod-log line.
+KIND_ARM_MISSED = "self_mint_arm_missed"
 
 
 class MintCondemned(RuntimeError):
@@ -854,6 +884,18 @@ class BackgroundMint:
                 # interrupted from here, and it must not be allowed to hold
                 # the serving worker hostage while it is judged dead.
                 logger.error("runtime-mint: %s", exc)
+                # ...and SAY SO on the wire (pgw#1383). A serve pod's stdout
+                # goes nowhere, so a condemnation nobody can read is a mint
+                # that stopped emitting — which is precisely the defect the
+                # hub could see and could not attribute.
+                activity_mod.emit_event(
+                    KIND_MINT_WEDGED,
+                    f"{len(holes)} hole(s), {width} worker(s), "
+                    f"{progress.completed} landed, "
+                    f"{time.monotonic() - started:.0f}s elapsed: {exc}",
+                    phase="no_measured_progress",
+                    duration_ms=int((time.monotonic() - started) * 1000),
+                )
                 stop.set()
                 break
             idle.wait(sample_s)
@@ -921,6 +963,15 @@ class BackgroundMint:
             logger.warning(
                 "runtime-mint: %s published but did not arm live: %s",
                 record.graph, exc,
+            )
+            activity_mod.emit_event(
+                KIND_ARM_MISSED,
+                f"graph {record.graph} ({record.target}) is minted and in the "
+                f"store, but this pod's live dispatch did not take it "
+                f"({type(exc).__name__}: {exc}). A successor adopts it at "
+                f"boot; this worker keeps serving eager for it.",
+                phase=type(exc).__name__,
+                graph_class=str(record.graph)[:300],
             )
 
         return MintedHole(
@@ -1011,6 +1062,8 @@ def mint_holes(
 
 __all__ = [
     "BackgroundMint",
+    "KIND_ARM_MISSED",
+    "KIND_MINT_WEDGED",
     "Compiler",
     "DEFAULT_SILENCE_WINDOW_S",
     "MintCondemned",

--- a/tests/test_runtime_mint.py
+++ b/tests/test_runtime_mint.py
@@ -1,0 +1,163 @@
+"""The runtime background mint tells the HUB what happened to it, not a log file.
+
+A serve pod exposes no stdout anybody can read (pgw#760), so a mint that ends
+in `logger.error` has, from the hub's side, simply stopped emitting.
+
+# pgw#1383: that is exactly what cost `j56tate13oav13` thirty billed minutes and
+# a manual `DELETE /v1/admin/pods` — the hub's stall detector fired four times
+# and was right every time; it had no worker-side fact to attribute the silence
+# to. The condemnation and the missed arm are now typed wire events.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+from gen_worker import activity as activity_mod
+from gen_worker import compile_posture
+from gen_worker.serving import mint
+
+
+def _elf(path: Path) -> Path:
+    """A minimal 64-bit ELF with no sections.
+
+    `needed_libraries` reads DT_NEEDED off the artifact itself, and an
+    artifact naming no libraries is a legitimate answer (all-embedded
+    Triton/SASS) rather than a recording bug — so this is the honest smallest
+    fixture, not a stub of the reader.
+    """
+    raw = bytearray(64)
+    raw[:4] = b"\x7fELF"
+    raw[4:7] = bytes((2, 1, 1))          # ELFCLASS64, little-endian, v1
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(bytes(raw))
+    return path
+
+
+class _Adoption:
+    def __init__(self, arm_raises: BaseException | None = None) -> None:
+        self.env = SimpleNamespace(value="lane-a", sm="sm_89")
+        self.armed: List[str] = []
+        self.arm_raises = arm_raises
+
+    def arm(self, record: Any, artifact: Path) -> None:
+        if self.arm_raises is not None:
+            raise self.arm_raises
+        self.armed.append(record.graph)
+
+
+def _host(graphs: int, *, arm_raises: BaseException | None = None) -> Any:
+    holes = tuple(
+        SimpleNamespace(record=SimpleNamespace(
+            graph=f"unet/class={i}", target="unet", program=f"sha256:{i:064x}"))
+        for i in range(graphs))
+    return SimpleNamespace(holes=holes, adoption=_Adoption(arm_raises))
+
+
+class _Store:
+    """The fleet sink, minus the hub."""
+
+    def __init__(self) -> None:
+        self.published: List[str] = []
+
+    def fetch_program(self, digest: str, destination: Path) -> Path:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"program")
+        return destination
+
+    def publish_artifact(
+        self, graph: str, env: Any, artifact: Path, manifest: Any,
+    ) -> str:
+        self.published.append(graph)
+        return "checkpoint-1"
+
+
+@pytest.fixture()
+def wire(monkeypatch: pytest.MonkeyPatch) -> List[tuple]:
+    seen: List[tuple] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, phase="", **kw: seen.append((kind, phase, detail)))
+    return seen
+
+
+def _mint(host: Any, store: Any, tmp_path: Path, **kw: Any) -> mint.BackgroundMint:
+    return mint.BackgroundMint(
+        host=host, store=store, artifacts_dir=tmp_path / "artifacts",
+        posture=compile_posture.FLEET, vcpus=4, **kw)
+
+
+def test_a_condemned_mint_reports_itself_on_the_wire(
+    tmp_path: Path, wire: List[tuple],
+) -> None:
+    """THE regression. The guard already condemns correctly; before this the
+    condemnation went to a pod log, so from the hub's side the mint just
+    stopped emitting — indistinguishable from the pod being busy and healthy."""
+    wedged = threading.Event()
+
+    def _compiler(blob: Path, record: Any, destination: Path) -> Path:
+        wedged.wait(timeout=10.0)      # a compile that will never come back
+        return destination
+
+    box = _mint(_host(2), _Store(), tmp_path, compiler=_compiler, window_s=0.3)
+    try:
+        outcome = box.run()
+    finally:
+        wedged.set()
+
+    assert outcome.condemned, "the guard did not condemn a wedged mint"
+    events = [e for e in wire if e[0] == mint.KIND_MINT_WEDGED]
+    assert len(events) == 1, (
+        f"a condemned mint must be a wire fact, not a pod-log line: {wire}")
+    _kind, phase, detail = events[0]
+    assert phase == "no_measured_progress", phase
+    assert "hole(s)" in detail and "landed" in detail, detail
+    assert "no measured progress" in detail, detail
+
+
+def test_a_healthy_mint_is_never_called_wedged(
+    tmp_path: Path, wire: List[tuple],
+) -> None:
+    """The polarity guard. A mint that lands its graphs emits no defect —
+    otherwise the event is noise the hub learns to ignore."""
+    host = _host(3)
+
+    def _compiler(blob: Path, record: Any, destination: Path) -> Path:
+        return _elf(destination)
+
+    outcome = _mint(host, _Store(), tmp_path, compiler=_compiler).run()
+
+    assert outcome.landed == 3 and not outcome.condemned
+    assert host.adoption.armed == [f"unet/class={i}" for i in range(3)] or \
+        sorted(host.adoption.armed) == sorted(
+            f"unet/class={i}" for i in range(3))
+    assert not [e for e in wire if e[0] == mint.KIND_MINT_WEDGED], wire
+
+
+def test_a_published_graph_that_does_not_arm_is_a_wire_fact(
+    tmp_path: Path, wire: List[tuple],
+) -> None:
+    """`published but did not arm live` is why the pod keeps serving eager for
+    a graph it just paid to compile. It was a `logger.warning`."""
+    host = _host(1, arm_raises=RuntimeError("no module to arm onto"))
+    store = _Store()
+
+    def _compiler(blob: Path, record: Any, destination: Path) -> Path:
+        return _elf(destination)
+
+    outcome = _mint(host, store, tmp_path, compiler=_compiler).run()
+
+    assert outcome.landed == 1 and store.published == ["unet/class=0"]
+    assert not outcome.entries[0].armed
+    missed = [e for e in wire if e[0] == mint.KIND_ARM_MISSED]
+    assert len(missed) == 1, (
+        f"a minted-and-published graph this pod cannot serve must say so: "
+        f"{wire}")
+    assert "minted and in the" in missed[0][2], missed[0][2]
+    assert missed[0][1] == "RuntimeError", missed[0][1]


### PR DESCRIPTION
Closes the residual of pgw#1383 (item 1 shipped in `cf38885b` / 0.126.0).

> ⚠️ **RE-TARGETED mid-lane.** The first cut fixed `mint_supervisor.supervise` and `aot_compile_pool`. pgw#1373's SDK hardcut (PR #983, `722e30b9`) then **deleted** `executor.py`, `mint_supervisor.py`, `aot_mint.py` and `fleet_compiled_graphs.py` outright — 82k lines. The code fix is moot. **The finding is not**, and it is banked where the successor lives.

## Item 2 — the root cause, and it is neither candidate as filed

The retired supervisor did this:

```python
act.phase(activity_mod.PHASE_SEAL_PUBLISH)      # -> activity._emit -> bound sink
                                                #    -> loop.create_task(_ship())
fleet_compiled_graphs.adopt_delegated_mint(...) # SYNCHRONOUS: an arm + a numerics
                                                # verify PER GRAPH CLASS, on the LIVE
                                                # pipeline, on the EVENT LOOP
```

`activity.bind_sink` was bound to the executor's own running loop, so **every** report — the seal transition created one line earlier, the `activity.watchdog` heartbeats, any abort — was a task on the loop the very next statement took. The hub's four stall warnings read `inductor_compile … step 2/2` because that genuinely was the last fact to reach it.

The measured bracket proves the window: the pool ledger (emitted from `EntryCompilePool.compile`'s `finally`, so the drain loop exited and the shares were whole) landed; `seal_publish` did not; everything between them in `mint_graph_classes`'s tail is pure CPU metadata folding.

- **Candidate (a)** — `aot_compile_pool._fire_row` → `_adopt_landed` → `adopt_minted_class` — is the same call one loop down (the pool's drain loop) and *was* a real hazard. But `git show v0.125.0:src/gen_worker/aot_compile_pool.py | grep -c _fire_row` is **0**: pgw#1371's per-class adopt lands in 0.126.0, **after** the incident. It cannot have wedged `j56tate13oav13`.
- **Candidate (b)** — `_await_publish_durable` — runs only after the seal phase the pod never reached.

**The law that outlives the deleted code** is now stated in `serving/mint.py`'s module docstring: *the arm may never run on a loop that also ships the worker's reports.* The runtime mint already honours it structurally — every arm on a mint worker thread under `arm_lock`, the guard sampling on its own cadence beside them.

## Item 3 — what the runtime mint was still missing is the REPORT

Its progress guard condemns correctly and then says so to `logger.error`. A serve pod's stdout goes nowhere (pgw#760), so from the hub's side that is *a mint that stopped emitting* — the exact shape that cost `j56tate13oav13` thirty billed minutes and a manual `DELETE /v1/admin/pods`.

- `self_mint_wedged` (`phase=no_measured_progress`) — holes, width, what landed, elapsed, and the guard's own sentence.
- `self_mint_arm_missed` — a graph that IS minted and IS in the store but that this pod's live dispatch did not take, which is why it keeps serving eager for a graph it just paid to compile. Was a `logger.warning`.

Both **report**; neither condemns. pgw#1243 stands — the clock does not decide. The hub never lacked permission to act; it lacked a fact to act on.

## Proof

`tests/test_runtime_mint.py`, 3 rows over the real `BackgroundMint` (fake host/store/compiler seams, no torch compile, no mint). Red-verified by stubbing the two emits out: the condemnation row and the arm-missed row go red; the polarity guard (a mint that lands its graphs emits no defect) stays green.

`mypy` clean (538 files), `ruff` clean, every CI fast gate green locally.

**No wheel cut here** — rides the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
