### PR TITLE
pgw#1406: the producer plane has a successor — @entrypoint declares publishes/env/emits_media

### DIFF
--- a/scripts/author_surface_allowlist.txt
+++ b/scripts/author_surface_allowlist.txt
@@ -94,3 +94,9 @@ release.trace_context.TraceRequestContext.step_callback	serverless-endpoints/sdx
 # pgw#1377 seam: the LoRA overlay vocabulary — authors read SDXL.Lora.Defaults
 # for the adapter recipe (the contract file's turbo branch).
 models.model_types.SDXL.Lora	serverless-endpoints/sdxl/src/sdxl/main_v2.py:208	PROD
+# pgw#1406: the PRODUCER half of that same RequestContext. `mktemp` is where a
+# conversion producer writes the tree it is about to publish, and its callers
+# are the 27 `cozy-creator/jobs` producers — 36 call sites across `conversion`,
+# `h3_finetuner` and `image_lora_finetuner`, none of them in this tree and none
+# of them ever will be. Structurally what this file is for.
+serving.context.RequestContext.mktemp	jobs/conversion/src/conversion/transform.py:176	PROD

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -323,6 +323,22 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # weightless entrypoint gets that meaning rather than a silent
         # fall-back to release-level class resolution.
         **({"resources": resources} if resources is not None else {}),
+        # pgw#1406, the PRODUCER declarations. Both keys are already decoded
+        # by the hub ON A FUNCTION ROW — `manifestFunction.Publishes` /
+        # `.Env` (`internal/builder/manifest_contract.go`) — and
+        # `entrypoints[]` folds into `Functions` at ParseManifest's one decode
+        # site, so `publishes` reaches `ReleaseFunctionSchema.Publishes` ->
+        # the capability JWT's `publishes` claim -> `callerDeclaresHubWrite`
+        # WITHOUT A HUB CHANGE. Emitted only when declared, so every existing
+        # v2 row stays byte-identical (the hub's own tags are `omitempty`).
+        #
+        # `emits_media` is NOT here, deliberately: the request path grants
+        # `upload_media` unconditionally (`capability_subject_th2068.go:124`),
+        # so the hub has no decoder for it on a function row and emitting it
+        # would be exactly the mirror-with-no-reader th#2087's fence exists to
+        # catch. It is enforced SDK-side instead — see the decorator.
+        **({"publishes": True} if spec.publishes else {}),
+        **({"env": list(spec.env)} if spec.env else {}),
     }
 
 

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -299,8 +299,20 @@ def _adapter_slot(slot: Any) -> Dict[str, Any]:
     }
 
 
+def _is_job_kind(kind: str) -> bool:
+    """The hub's ``functionkind.IsJob``, mirrored: every non-inference kind is
+    submitted rather than invoked.
+
+    One line, and it reads off the same `KINDS` tuple `@entrypoint` validates
+    against — which is itself copied verbatim from `internal/functionkind.All`
+    — so this is a mirror of one authority, not a second vocabulary.
+    """
+    return str(kind or "").strip().lower() not in ("", ENTRYPOINT_KIND)
+
+
 def _entrypoint_row(spec: Any) -> Dict[str, Any]:
     resources = _resources([spec])
+    row_kind = getattr(spec, "kind", "") or ENTRYPOINT_KIND
     input_schema, input_sha = type_schema_and_hash(spec.payload_type)
     output_schema, output_sha = type_schema_and_hash(spec.return_type)
     slots: List[Dict[str, Any]] = []
@@ -319,7 +331,7 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # producer can get from the `inference` default. Nothing is invented:
         # the value space is `internal/functionkind.All`, validated at
         # decoration against `serving.entrypoints.KINDS`.
-        "kind": getattr(spec, "kind", "") or ENTRYPOINT_KIND,
+        "kind": row_kind,
         "input_schema": input_schema,
         "payload_schema_sha256": input_sha,
         "output_schema": output_schema,
@@ -343,13 +355,33 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         # WITHOUT A HUB CHANGE. Emitted only when declared, so every existing
         # v2 row stays byte-identical (the hub's own tags are `omitempty`).
         #
-        # `emits_media` is NOT here, deliberately: the request path grants
-        # `upload_media` unconditionally (`capability_subject_th2068.go:124`),
-        # so the hub has no decoder for it on a function row and emitting it
-        # would be exactly the mirror-with-no-reader th#2087's fence exists to
-        # catch. It is enforced SDK-side instead — see the decorator.
+        # `emits_media` rides ONLY a job-kind row, and the fence is narrowed
+        # rather than reversed (th#2177's correction to this lane's first
+        # ruling, accepted). Both halves are measured:
+        #
+        #   * on the REQUEST path the hub grants `upload_media`
+        #     UNCONDITIONALLY (`capability_subject_th2068.go:124`,
+        #     `UploadsMedia: true`) and `manifestFunction` has no field and
+        #     `endpoint_function_schemas` no COLUMN for it, so emitting it on
+        #     an inference row is exactly the mirror-with-no-reader th#2087's
+        #     fence exists to catch;
+        #   * on the JOB path it is READ and it GATES —
+        #     `jobCapabilitySubject` sets `UploadsMedia: d.EmitsMedia` from
+        #     `endpoint_release_jobs.emits_media`, a column that already
+        #     exists. Withholding the key there would silently downgrade every
+        #     producer that declared media to no media at all.
+        #
+        # So the first ruling was right about requests and did not survive a
+        # row dispatched as a job. `_is_job_kind` mirrors the hub's
+        # `functionkind.IsJob` off the one `KINDS` tuple this repo already
+        # copies verbatim, so there is no second vocabulary to drift.
         **({"publishes": True} if spec.publishes else {}),
         **({"env": list(spec.env)} if spec.env else {}),
+        **(
+            {"emits_media": bool(spec.emits_media)}
+            if spec.emits_media is not None and _is_job_kind(row_kind)
+            else {}
+        ),
     }
 
 

--- a/src/gen_worker/discovery/entrypoints_v2.py
+++ b/src/gen_worker/discovery/entrypoints_v2.py
@@ -55,9 +55,13 @@ from typing import Any, Dict, List, Set
 
 from .schema import type_schema_and_hash
 
-#: A v2 entrypoint is an inference handler. The vocabulary is the hub's
-#: (`validation._KNOWN_KINDS`); the v2 surface declares no other kind today,
-#: and inventing one here would be a value space no hub reader names.
+#: The DEFAULT kind: an entrypoint that declares nothing is an inference
+#: handler, which is also what the hub's `functionkind.Normalize("")` returns.
+#: pgw#1406 gave `@entrypoint` a `kind=` kwarg so a PRODUCER can say otherwise
+#: — the sentence that used to sit here ("the v2 surface declares no other kind
+#: today, and inventing one here would be a value space no hub reader names")
+#: was right about the second half and is why `KINDS` is copied verbatim from
+#: `internal/functionkind.All` rather than invented.
 ENTRYPOINT_KIND = "inference"
 
 class EntrypointDiscoveryError(ValueError):
@@ -308,7 +312,14 @@ def _entrypoint_row(spec: Any) -> Dict[str, Any]:
         "module": spec.fn.__module__,
         "declared_module": spec.fn.__module__,
         "class_name": "",
-        "kind": ENTRYPOINT_KIND,
+        # pgw#1406: the author's `kind=` when declared, else the inference
+        # default. `manifestFunction.Kind` already decodes it and the hub
+        # derives three PLACEMENT facts from it — reserved-ref resolution,
+        # capability TTL, source-sized disk — none of which a conversion
+        # producer can get from the `inference` default. Nothing is invented:
+        # the value space is `internal/functionkind.All`, validated at
+        # decoration against `serving.entrypoints.KINDS`.
+        "kind": getattr(spec, "kind", "") or ENTRYPOINT_KIND,
         "input_schema": input_schema,
         "payload_schema_sha256": input_sha,
         "output_schema": output_schema,

--- a/src/gen_worker/serving/context.py
+++ b/src/gen_worker/serving/context.py
@@ -33,6 +33,7 @@ identity — new graphs a rebind introduces are simply holes (partial-hit).
 from __future__ import annotations
 
 import logging
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
@@ -44,6 +45,7 @@ import msgspec
 
 from ..families.base import GenerationDefaults
 from ..request_context import RequestContext as _BaseRequestContext
+from ..request_context import _PublisherMixin
 
 if TYPE_CHECKING:
     from ..models.defaults_decode import CarriesDefaults
@@ -296,14 +298,28 @@ class LoadContext(Generic[MT_co]):
         return decoded
 
 
-class RequestContext(_BaseRequestContext[D]):
+class RequestContext(_PublisherMixin, _BaseRequestContext[D]):
     """What entrypoints receive — request facts + the salvaged base surface.
 
     The base class (`gen_worker.request_context`) contributes
     ``raise_if_cancelled``, ``save_image``, ``clamp``, ``generator``,
     ``progress``, ``log`` and the rest; this subclass adds the pgw#1382
     request facts. Constructible bare (``RequestContext("req-1")``) for
-    local/unit use — deployment facts then read as absent."""
+    local/unit use — deployment facts then read as absent.
+
+    **IT IS ALSO THE PRODUCER CONTEXT (pgw#1406).** ``_PublisherMixin``
+    contributes ``save_checkpoint`` / ``open_checkpoint_stream``, the
+    reserved ``source``/``destination``/``text_encoder``/``candidate`` payload
+    contract, and ``hf_token``; :meth:`mktemp` completes it. There is
+    deliberately no second class for producers, because pgw#1294/pgw#1306
+    already ruled the shape: *"no kind selects a different class, because no
+    kind decides what a body may write — the declaration does"*. Every one of
+    those surfaces refuses typed unless the ``@entrypoint`` declared
+    ``publishes=True`` (:meth:`_require_publish_declaration`), so an inference
+    entrypoint gains reach it cannot use and a ported ``@job`` producer gains
+    nothing it did not already have. That is what makes pgw#983's deletion of
+    ``@job`` recoverable by re-decorating rather than by rewriting 27
+    producers (th#2173)."""
 
     def __init__(
         self,
@@ -314,6 +330,21 @@ class RequestContext(_BaseRequestContext[D]):
     ) -> None:
         super().__init__(request_id, **base_kwargs)
         self._serve_binding = binding
+        self._mktemp_root: Optional[Path] = None
+
+    def mktemp(self) -> Path:
+        """A request-scoped scratch directory. Contents are NOT persisted.
+
+        Each call returns a fresh subdir, so a producer can use it as
+        ``out_dir`` for successive conversions without collision."""
+        if self._mktemp_root is None:
+            self._mktemp_root = Path(
+                tempfile.mkdtemp(
+                    prefix=f"txform-{self.request_id or 'x'}-",
+                    dir=tempfile.gettempdir(),
+                )
+            )
+        return Path(tempfile.mkdtemp(dir=str(self._mktemp_root)))
 
     @property
     def checkpoint_ref(self) -> str:

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -26,7 +26,17 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
     def generate(ctx: RequestContext, payload: GenerateInput,
                  video: H3Model) -> GenerateOutput: ...
 
+    @entrypoint(publishes=True,       # a PRODUCER (pgw#1406)
+                env=("HF_TOKEN", "CIVITAI_API_KEY"))
+    def cast_dtype(ctx: RequestContext, payload: CastDtypeInput
+                   ) -> PublishResult: ...
+
 * first: ``ctx`` annotated :class:`~gen_worker.serving.context.RequestContext`
+  — ONE class for inference and producers alike (pgw#1294/pgw#1306: *no kind
+  selects a different class, because no kind decides what a body may write —
+  the declaration does*). It carries the publisher surface
+  (``save_checkpoint``, ``mktemp``, ``source_path``) and REFUSES it typed
+  unless ``publishes=True`` was declared.
 * second: the payload, a ``msgspec.Struct`` — the wire schema
 * remaining, in any order and **possibly none**: model SLOTS (params
   annotated with a :class:`~gen_worker.serving.model.Model` subclass) and
@@ -44,6 +54,14 @@ The decorator validates at import (typed refusal names the exact defect) and
 stamps :data:`ENTRYPOINT_ATTR` with an :class:`EntrypointSpec` — the whole
 publish-time extraction surface, readable without executing author code
 beyond import.
+
+**THE KWARG RULE (pgw#1406).** Decorator kwargs are declarations about
+PLACEMENT AND AUTHORITY; the signature carries MODEL SLOTS. ``resources=``
+(pgw#1396) is placement; ``publishes=`` / ``env=`` / ``emits_media=`` are
+authority, and they are the producer plane's whole declaration set — pgw#983
+deleted ``@job`` and this is where its 27 conversion producers land
+(th#2173). The "``resources=`` is the ONE kwarg" sentence described the
+surface on the day it had one; it was never the principle.
 """
 
 from __future__ import annotations
@@ -106,6 +124,27 @@ class EntrypointSpec:
     #: function (pgw#1394) and because `music-analysis` declares three
     #: different vCPU floors across three functions of one endpoint.
     resources: Any = None
+    #: pgw#1406: this function MAY write tensors/repos to the hub. The
+    #: declaration says MAY write; the request still says WHERE. It is the ONE
+    #: justification for the hub minting the repo-write capability grant
+    #: (th#2049), and the SDK stamps the same fact onto the context so the
+    #: publisher surface refuses undeclared code before a byte moves — one
+    #: fact, two enforcers, no drift.
+    publishes: bool = False
+    #: pgw#1406: the environment-variable NAMES this function reads. Values are
+    #: release config and never manifest data; the hub validates config-layer
+    #: env writes against this declaration.
+    env: Tuple[str, ...] = ()
+    #: pgw#1406: TRI-STATE. ``None`` = undeclared, the inference default (media
+    #: IS the product of a request, and the hub grants ``upload_media``
+    #: unconditionally on the request path). ``True`` = declared. ``False`` =
+    #: an explicit opt-OUT, which the SDK enforces at the media surface. See
+    #: the decorator docstring for why this one does not reach the hub.
+    emits_media: bool | None = None
+    #: The class the author annotated on ``ctx``. The serve loop constructs
+    #: THIS class, so a producer that annotates ``JobContext`` receives the
+    #: publisher surface and an inference entrypoint is unchanged.
+    ctx_type: type | None = None
 
     @property
     def model_params(self) -> Tuple[Tuple[str, type], ...]:
@@ -184,18 +223,70 @@ def _slot_of(fn: Callable[..., Any], name: str, annotation: Any) -> SlotSpec:
     )
 
 
+_ENV_NAME_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+
+
+def _validate_env_decl(fn: Callable[..., Any], env: Any) -> Tuple[str, ...]:
+    """The declared env-var NAMES, validated at decoration.
+
+    Semantics are v1's verbatim (`api/decorators.py:_validate_env_decl`,
+    deleted with the catalog by pgw#983): a list/tuple of upper-snake names,
+    <=64 chars, no repeats, a bare string refused rather than iterated into
+    characters. Only the refusal TEXT changed, to name the author's line the
+    way every other `@entrypoint` refusal does.
+    """
+    if env is None:
+        return ()
+    if isinstance(env, str) or not isinstance(env, (list, tuple)):
+        raise _refuse(
+            fn,
+            f"env= must be a list/tuple of environment-variable NAMES, got "
+            f"{type(env).__name__} — a bare string would iterate into "
+            "characters, so it is refused rather than accepted",
+        )
+    out: list[str] = []
+    for name in env:
+        candidate = str(name or "").strip()
+        if (
+            not candidate
+            or len(candidate) > 64
+            or not ("A" <= candidate[0] <= "Z")
+            or any(c not in _ENV_NAME_CHARS for c in candidate)
+        ):
+            raise _refuse(
+                fn,
+                f"env= name {name!r} is not a valid environment-variable name "
+                "(UPPER_SNAKE, starting with a letter, <=64 chars)",
+            )
+        if candidate in out:
+            raise _refuse(fn, f"env= repeats {name!r}")
+        out.append(candidate)
+    return tuple(out)
+
+
 @overload
 def entrypoint(fn: F) -> F: ...
 @overload
-def entrypoint(*, resources: Any) -> Callable[[F], F]: ...
+def entrypoint(
+    *,
+    resources: Any = ...,
+    publishes: bool = ...,
+    env: Any = ...,
+    emits_media: bool | None = ...,
+) -> Callable[[F], F]: ...
 
 
 def entrypoint(
-    fn: F | None = None, *, resources: Any = None
+    fn: F | None = None,
+    *,
+    resources: Any = None,
+    publishes: bool = False,
+    env: Any = None,
+    emits_media: bool | None = None,
 ) -> F | Callable[[F], F]:
     """Mark a module-level function as an entrypoint (contract above).
 
-    ``resources=`` is the ONE kwarg this decorator takes, and it is the
+    ``resources=`` is the PLACEMENT kwarg, and it is the
     STAFFING ENVELOPE (se#755/pgw#1396): the machine this function is placed
     on — ``Resources(vcpus=…, max_gpu_count=…,
     max_gpus_per_execution_group=…, parallel=…, requires=…)``. It is FUNCTION
@@ -224,11 +315,49 @@ def entrypoint(
     ``requires=`` term, at ``recommended`` only) is deliberate: vCPUs are
     selectable and filterable at both providers, host RAM on a RunPod GPU pod
     is neither, so a host-RAM MINIMUM stays forbidden (Paul, 2026-07-11).
+
+    ``publishes=`` / ``env=`` / ``emits_media=`` are the AUTHORITY kwargs
+    (pgw#1406) — the producer plane's declaration set, carried over verbatim
+    from the ``@job`` pgw#983 deleted so the 27 ``cozy-creator/jobs``
+    conversion producers have a migration target (th#2173):
+
+    * ``publishes=True`` — this function MAY write tensors/repos to the hub.
+      MAY write; the request still says WHERE. It is the hub's ONE
+      justification for minting the repo-write capability grant (th#2049),
+      and it reaches that decision UNCHANGED: the hub already decodes
+      ``functions[].publishes``, and ``entrypoints[]`` folds into
+      ``Functions`` at ``builder.ParseManifest``'s one decode site. The SDK
+      stamps the same fact onto the context, so ``ctx.save_checkpoint`` /
+      ``gen_worker.convert.publish_flavors`` refuse undeclared code before a
+      byte moves — one fact, two enforcers.
+    * ``env=("HF_TOKEN", "CIVITAI_API_KEY")`` — the env-var NAMES this code
+      reads. Values are release config and never manifest data; the hub
+      validates config-layer env writes against the declaration and already
+      decodes ``functions[].env``.
+    * ``emits_media=`` — TRI-STATE, and the one that does NOT reach the hub.
+      Measured at tensorhub master before this was written: the request path
+      grants ``upload_media`` UNCONDITIONALLY
+      (``capability_subject_th2068.go:124``, ``UploadsMedia: true``) because
+      a request's product IS media; only the JOB path gates it on a
+      declaration. So a producer porting here LOSES NOTHING by declaring it
+      and a hub read could only NARROW — which would fire on every existing
+      endpoint that saves an image without declaring one. The kwarg is
+      therefore accepted (so a producer ports verbatim) and enforced
+      SDK-side: ``None`` is the undeclared inference default, ``True``
+      declares emission, and an explicit ``False`` refuses the media surface
+      at the call site. It is deliberately NOT emitted on the manifest row —
+      th#2087's fence exists to stop a key the hub has no decoder for.
     """
 
     if fn is None:
         def bind(inner: F) -> F:
-            return entrypoint(inner, resources=resources)  # type: ignore[call-overload,no-any-return]
+            return entrypoint(  # type: ignore[call-overload,no-any-return]
+                inner,
+                resources=resources,
+                publishes=publishes,
+                env=env,
+                emits_media=emits_media,
+            )
         return bind
 
     from .context import RequestContext
@@ -236,9 +365,24 @@ def entrypoint(
     if not inspect.isfunction(fn):
         raise EntrypointDeclarationError(
             f"@entrypoint marks module-level functions, got "
-            f"{type(fn).__name__} — the only kwarg is resources= "
-            "(pgw#1396); the Model class header carries lanes="
+            f"{type(fn).__name__} — the kwargs are resources= (pgw#1396) and "
+            "publishes=/env=/emits_media= (pgw#1406); the Model class header "
+            "carries lanes="
         )
+    if not isinstance(publishes, bool):
+        raise _refuse(
+            fn,
+            f"publishes= is a bool DECLARATION, got "
+            f"{type(publishes).__name__} — it says this function MAY write to "
+            "the hub; the request still says where",
+        )
+    if emits_media is not None and not isinstance(emits_media, bool):
+        raise _refuse(
+            fn,
+            f"emits_media= is a bool or None (undeclared), got "
+            f"{type(emits_media).__name__}",
+        )
+    declared_env = _validate_env_decl(fn, env)
     if resources is not None:
         from ..api.resources import Resources
 
@@ -285,6 +429,11 @@ def entrypoint(
         parameters[0], parameters[1], parameters[2:],
     )
 
+    # ONE context class, for inference and producers alike (pgw#1294/pgw#1306:
+    # "no kind selects a different class, because no kind decides what a body
+    # may write — the declaration does"). `RequestContext` carries the
+    # publisher surface and refuses it unless `publishes=True` was declared,
+    # so a producer needs no second annotation to migrate here (th#2173).
     ctx_type = _annotation_class(hints.get(ctx_parameter.name))
     if ctx_type is None or not issubclass(ctx_type, RequestContext):
         raise _refuse(
@@ -328,6 +477,10 @@ def entrypoint(
         slots=slots,
         return_type=return_type,
         resources=resources,
+        publishes=bool(publishes),
+        env=declared_env,
+        emits_media=emits_media,
+        ctx_type=ctx_type,
     )
     setattr(fn, ENTRYPOINT_ATTR, spec)
     return fn

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -26,8 +26,8 @@ ruling, 2026-08-17 — one parameter-order rule across the SDK, matching
     def generate(ctx: RequestContext, payload: GenerateInput,
                  video: H3Model) -> GenerateOutput: ...
 
-    @entrypoint(publishes=True,       # a PRODUCER (pgw#1406)
-                env=("HF_TOKEN", "CIVITAI_API_KEY"))
+    @entrypoint(kind="conversion",    # a PRODUCER (pgw#1406)
+                publishes=True, env=("HF_TOKEN", "CIVITAI_API_KEY"))
     def cast_dtype(ctx: RequestContext, payload: CastDtypeInput
                    ) -> PublishResult: ...
 
@@ -57,11 +57,12 @@ beyond import.
 
 **THE KWARG RULE (pgw#1406).** Decorator kwargs are declarations about
 PLACEMENT AND AUTHORITY; the signature carries MODEL SLOTS. ``resources=``
-(pgw#1396) is placement; ``publishes=`` / ``env=`` / ``emits_media=`` are
-authority, and they are the producer plane's whole declaration set — pgw#983
-deleted ``@job`` and this is where its 27 conversion producers land
-(th#2173). The "``resources=`` is the ONE kwarg" sentence described the
-surface on the day it had one; it was never the principle.
+(pgw#1396) and ``kind=`` are placement; ``publishes=`` / ``env=`` /
+``emits_media=`` are authority, and together they are the producer plane's
+whole declaration set — pgw#983 deleted ``@job`` and this is where its 27
+conversion producers land (th#2173). The "``resources=`` is the ONE kwarg"
+sentence described the surface on the day it had one; it was never the
+principle.
 """
 
 from __future__ import annotations
@@ -141,6 +142,13 @@ class EntrypointSpec:
     #: an explicit opt-OUT, which the SDK enforces at the media surface. See
     #: the decorator docstring for why this one does not reach the hub.
     emits_media: bool | None = None
+    #: pgw#1406: the WORKLOAD KIND, the hub's own vocabulary
+    #: (``internal/functionkind``: inference | training | conversion | dataset
+    #: | eval). ``""`` is undeclared and means ``inference``. NOT a write
+    #: declaration — th#2052 cut that and ``publishes=`` replaced it — but the
+    #: hub still derives three PLACEMENT facts from it, which is why a producer
+    #: cannot leave it at the default. See the decorator docstring.
+    kind: str = ""
     #: The class the author annotated on ``ctx``. The serve loop constructs
     #: THIS class, so a producer that annotates ``JobContext`` receives the
     #: publisher surface and an inference entrypoint is unchanged.
@@ -225,6 +233,12 @@ def _slot_of(fn: Callable[..., Any], name: str, annotation: Any) -> SlotSpec:
 
 _ENV_NAME_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
+#: The hub's workload-kind vocabulary, verbatim from
+#: `internal/functionkind/functionkind.go:All`. NOT invented here — every value
+#: is one the hub normalizes and reads, and `""` is the undeclared default that
+#: `Normalize` maps onto `inference`.
+KINDS = ("inference", "training", "conversion", "dataset", "eval")
+
 
 def _validate_env_decl(fn: Callable[..., Any], env: Any) -> Tuple[str, ...]:
     """The declared env-var NAMES, validated at decoration.
@@ -270,6 +284,7 @@ def entrypoint(fn: F) -> F: ...
 def entrypoint(
     *,
     resources: Any = ...,
+    kind: str = ...,
     publishes: bool = ...,
     env: Any = ...,
     emits_media: bool | None = ...,
@@ -280,6 +295,7 @@ def entrypoint(
     fn: F | None = None,
     *,
     resources: Any = None,
+    kind: str = "",
     publishes: bool = False,
     env: Any = None,
     emits_media: bool | None = None,
@@ -315,6 +331,27 @@ def entrypoint(
     ``requires=`` term, at ``recommended`` only) is deliberate: vCPUs are
     selectable and filterable at both providers, host RAM on a RunPod GPU pod
     is neither, so a host-RAM MINIMUM stays forbidden (Paul, 2026-07-11).
+
+    ``kind=`` is the second PLACEMENT kwarg, and a producer CANNOT leave it at
+    the default. The vocabulary is the hub's own — `internal/functionkind`:
+    ``inference`` (the default) | ``training`` | ``conversion`` | ``dataset``
+    | ``eval`` — so nothing is invented here. th#2052 cut kind from deciding
+    WRITES and ``publishes=`` replaced it for that, but ``functionkind.go``
+    itself draws the remaining line: *"Naming a ref is a READ; writing one is
+    the function's `publishes` declaration and is not derived here."* The hub
+    still derives three PLACEMENT facts from kind, and all three are wrong for
+    a producer that leaves it at ``inference``:
+
+    * ``NamesReservedRefs(kind) != inference`` — an inference row gets NO
+      preflight resolution and NO dispatch-time read grant for the reserved
+      ``source`` / ``text_encoder`` / ``destination`` / dataset-pin payload
+      fields. A ported conversion producer would reach its body with
+      ``ctx.source_path is None`` and raise on its own first line.
+    * ``WorkerCapabilityTokenTTL`` — 1h for inference, 24h for conversion. A
+      multi-hour quantization would spend its life renewing.
+    * ``SizesDiskFromSource`` — true for conversion and eval only. An
+      inference-kind row sizes a pod's disk without looking at the 13.9 GB
+      source it is about to download.
 
     ``publishes=`` / ``env=`` / ``emits_media=`` are the AUTHORITY kwargs
     (pgw#1406) — the producer plane's declaration set, carried over verbatim
@@ -354,6 +391,7 @@ def entrypoint(
             return entrypoint(  # type: ignore[call-overload,no-any-return]
                 inner,
                 resources=resources,
+                kind=kind,
                 publishes=publishes,
                 env=env,
                 emits_media=emits_media,
@@ -381,6 +419,14 @@ def entrypoint(
             fn,
             f"emits_media= is a bool or None (undeclared), got "
             f"{type(emits_media).__name__}",
+        )
+    declared_kind = str(kind or "").strip().lower()
+    if declared_kind and declared_kind not in KINDS:
+        raise _refuse(
+            fn,
+            f"kind= must be one of {KINDS}, got {kind!r} — the vocabulary is "
+            "the hub's (internal/functionkind), so a value it does not "
+            "normalize would silently become 'inference'",
         )
     declared_env = _validate_env_decl(fn, env)
     if resources is not None:
@@ -477,6 +523,7 @@ def entrypoint(
         slots=slots,
         return_type=return_type,
         resources=resources,
+        kind=declared_kind,
         publishes=bool(publishes),
         env=declared_env,
         emits_media=emits_media,

--- a/src/gen_worker/serving/entrypoints.py
+++ b/src/gen_worker/serving/entrypoints.py
@@ -382,8 +382,17 @@ def entrypoint(
       therefore accepted (so a producer ports verbatim) and enforced
       SDK-side: ``None`` is the undeclared inference default, ``True``
       declares emission, and an explicit ``False`` refuses the media surface
-      at the call site. It is deliberately NOT emitted on the manifest row —
-      th#2087's fence exists to stop a key the hub has no decoder for.
+      at the call site.
+
+      ON THE WIRE IT RIDES A JOB-KIND ROW ONLY (th#2177 narrowed this, and
+      was right). The paragraph above is true of a row dispatched as a
+      REQUEST and does not survive one dispatched as a JOB:
+      ``jobCapabilitySubject`` sets ``UploadsMedia: d.EmitsMedia`` from
+      ``endpoint_release_jobs.emits_media``, a column that already exists —
+      so on that path the declaration is READ and it GATES, and withholding
+      it would silently downgrade every producer that declared media. An
+      INFERENCE row still emits nothing, because nothing there can store or
+      read it; that half of th#2087's fence stays.
     """
 
     if fn is None:

--- a/src/gen_worker/serving/serve_loop.py
+++ b/src/gen_worker/serving/serve_loop.py
@@ -283,7 +283,7 @@ class ServeLoop:
                         model_slots[first_slot], picks[first_slot]
                     )
 
-            ctx = self._make_context(request_id, primary_binding)
+            ctx = self._make_context(request_id, primary_binding, spec)
             for warning in degraded:
                 ctx.warn(warning)
             arguments = [
@@ -312,11 +312,29 @@ class ServeLoop:
         )
 
     def _make_context(
-        self, request_id: str, binding: Optional[DeployBinding]
+        self,
+        request_id: str,
+        binding: Optional[DeployBinding],
+        spec: Optional[Any] = None,
     ) -> RequestContext[Any]:
         kwargs: Dict[str, Any] = dict(self._context_kwargs)
         if self._output_dir is not None:
             kwargs.setdefault("local_output_dir", str(self._output_dir))
+        if spec is not None:
+            # pgw#1406: the AUTHORITY declarations, stamped from the spec onto
+            # the context the body receives. This is the SDK half of "one
+            # fact, two enforcers": the hub mints the repo-write grant off the
+            # same `publishes` it read on the manifest row, and the publisher
+            # surface refuses undeclared code here, before a byte moves.
+            #
+            # `emits_media` is stamped only when the author DECLARED it. Left
+            # absent it stays `None` — the base reads that as "not job-scoped",
+            # media is the product of a request, and behaviour is unchanged for
+            # every endpoint that never says the word.
+            kwargs["publishes"] = bool(getattr(spec, "publishes", False))
+            declared_media = getattr(spec, "emits_media", None)
+            if declared_media is not None:
+                kwargs["emits_media"] = bool(declared_media)
         return RequestContext(
             request_id,
             binding=binding

--- a/src/gen_worker/v1_deleted.py
+++ b/src/gen_worker/v1_deleted.py
@@ -40,7 +40,16 @@ class V1SdkDeleted(ImportError):
 #: refusal can be specific about the ONE name the author actually wrote.
 REPLACEMENTS: Final[dict[str, str]] = {
     "endpoint": "@entrypoint on a module-level function (gen_worker.entrypoint)",
-    "job": "@entrypoint — jobs have no v2 successor yet; see se#757",
+    # pgw#1406 built the successor this line said did not exist. The three
+    # `@job` kwargs the producer plane actually uses carry over VERBATIM, and
+    # the one RequestContext carries the publisher surface, so the port is a
+    # re-decoration — which is what the 27 conversion producers in
+    # `cozy-creator/jobs` need to hear at the refusal (th#2173, jobs#297).
+    "job": (
+        "@entrypoint(publishes=…, env=…, emits_media=…) — the same kwargs, "
+        "and ctx: RequestContext carries mktemp/source/save_checkpoint; "
+        "see pgw#1406"
+    ),
     "worker_function": "@entrypoint",
     "variant_of": "one @entrypoint per variant; the request envelope picks",
     "Slot": "a Model subclass annotation on the @entrypoint parameter",

--- a/tests/release_fixtures/producer_endpoint.py
+++ b/tests/release_fixtures/producer_endpoint.py
@@ -68,27 +68,30 @@ class DescribeResult(msgspec.Struct):
     summary: str
 
 
-@entrypoint(publishes=True)
+@entrypoint(kind="conversion", publishes=True)
 def cast_dtype(ctx: RequestContext, payload: CastDtypeInput) -> PublishResult:
     """`conversion/src/conversion/transform.py:137`, re-decorated."""
     return PublishResult(published=list(payload.dtypes))
 
 
-@entrypoint(publishes=True, env=("HF_TOKEN", "CIVITAI_API_KEY"))
+@entrypoint(kind="conversion", publishes=True,
+            env=("HF_TOKEN", "CIVITAI_API_KEY"))
 def clone_repo(ctx: RequestContext, payload: CloneInput) -> PublishResult:
     """`conversion/src/conversion/mirror.py:194`, re-decorated."""
     return PublishResult(published=[payload.destination_repo])
 
 
 @entrypoint(
-    resources=Resources(gpu=True), publishes=True, emits_media=True
+    kind="conversion", resources=Resources(gpu=True),
+    publishes=True, emits_media=True,
 )
 def quality_matrix(ctx: RequestContext, payload: MatrixInput) -> MatrixResult:
     """`conversion/src/conversion/quality_matrix.py:389`, re-decorated."""
     return MatrixResult(rows=len(payload.prompts))
 
 
-@entrypoint(resources=Resources(gpu=True, vcpus=8), emits_media=True)
+@entrypoint(kind="eval", resources=Resources(gpu=True, vcpus=8),
+            emits_media=True)
 def score_bench(ctx: RequestContext, payload: BenchInput) -> BenchResult:
     """`conversion/src/conversion/score_bench.py:383`: media, NO repo."""
     return BenchResult(score=float(len(payload.prompts)))

--- a/tests/release_fixtures/producer_endpoint.py
+++ b/tests/release_fixtures/producer_endpoint.py
@@ -1,0 +1,100 @@
+"""The PRODUCER plane, v2-spelled (pgw#1406 / th#2173).
+
+pgw#983 deleted ``@job``, and every one of the 27 conversion producers in
+``cozy-creator/jobs`` is a ``@job``. Their whole declaration set is three
+kwargs — ``publishes=`` (22 of 27), ``env=`` (3), ``emits_media=`` (4) — so
+this fixture is those three shapes, spelled on ``@entrypoint``:
+
+* ``cast_dtype`` — ``publishes=True``, weightless, CPU. The real
+  ``transform.py:137`` shape: it reads the reserved ``source`` contract and
+  writes a checkpoint.
+* ``clone_repo`` — ``publishes=True`` + ``env=("HF_TOKEN",
+  "CIVITAI_API_KEY")``. The ``mirror.py`` shape.
+* ``quality_matrix`` — ``publishes=True, emits_media=True``, GPU.
+* ``score_bench`` — ``emits_media=True`` and NO ``publishes``: an eval that
+  writes a report and no repo. It must be REFUSED at the publisher surface.
+* ``describe`` — declares NOTHING. Byte-identical to a pre-pgw#1406 row, and
+  refused at the publisher surface.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker import RequestContext, Resources, entrypoint
+
+
+class SourceRepo(msgspec.Struct, forbid_unknown_fields=True):
+    ref: str
+
+
+class CastDtypeInput(msgspec.Struct, forbid_unknown_fields=True):
+    source: SourceRepo
+    destination_repo: str
+    dtypes: list[str]
+
+
+class PublishResult(msgspec.Struct):
+    published: list[str]
+
+
+class CloneInput(msgspec.Struct, forbid_unknown_fields=True):
+    source: SourceRepo
+    destination_repo: str
+
+
+class MatrixInput(msgspec.Struct, forbid_unknown_fields=True):
+    source: SourceRepo
+    prompts: list[str]
+
+
+class MatrixResult(msgspec.Struct):
+    rows: int
+
+
+class BenchInput(msgspec.Struct, forbid_unknown_fields=True):
+    prompts: list[str]
+
+
+class BenchResult(msgspec.Struct):
+    score: float
+
+
+class DescribeInput(msgspec.Struct, forbid_unknown_fields=True):
+    ref: str
+
+
+class DescribeResult(msgspec.Struct):
+    summary: str
+
+
+@entrypoint(publishes=True)
+def cast_dtype(ctx: RequestContext, payload: CastDtypeInput) -> PublishResult:
+    """`conversion/src/conversion/transform.py:137`, re-decorated."""
+    return PublishResult(published=list(payload.dtypes))
+
+
+@entrypoint(publishes=True, env=("HF_TOKEN", "CIVITAI_API_KEY"))
+def clone_repo(ctx: RequestContext, payload: CloneInput) -> PublishResult:
+    """`conversion/src/conversion/mirror.py:194`, re-decorated."""
+    return PublishResult(published=[payload.destination_repo])
+
+
+@entrypoint(
+    resources=Resources(gpu=True), publishes=True, emits_media=True
+)
+def quality_matrix(ctx: RequestContext, payload: MatrixInput) -> MatrixResult:
+    """`conversion/src/conversion/quality_matrix.py:389`, re-decorated."""
+    return MatrixResult(rows=len(payload.prompts))
+
+
+@entrypoint(resources=Resources(gpu=True, vcpus=8), emits_media=True)
+def score_bench(ctx: RequestContext, payload: BenchInput) -> BenchResult:
+    """`conversion/src/conversion/score_bench.py:383`: media, NO repo."""
+    return BenchResult(score=float(len(payload.prompts)))
+
+
+@entrypoint
+def describe(ctx: RequestContext, payload: DescribeInput) -> DescribeResult:
+    """Declares nothing — the undeclared control."""
+    return DescribeResult(summary=payload.ref)

--- a/tests/test_producer_declarations.py
+++ b/tests/test_producer_declarations.py
@@ -1,10 +1,9 @@
-"""The producer plane's declarations on ``@entrypoint`` (pgw#1406 / th#2173).
+"""The producer plane's declarations on ``@entrypoint`` — what a function may write.
 
-pgw#983 deleted ``@job``. All 27 conversion producers in ``cozy-creator/jobs``
-are ``@job`` functions and NOTHING there is written against ``@entrypoint``;
-the plane keeps running only because ``conversion/pyproject.toml:198`` pins
-the pre-#983 SDK. These tests pin the successor: the three declarations, what
-they emit, and what they refuse.
+pgw#1406: pgw#983 deleted ``@job`` and every one of the 27 conversion producers
+in ``cozy-creator/jobs`` is one, so ``@entrypoint`` grew the declaration set
+they carry. These tests pin it: what the four kwargs mean, what reaches the
+manifest, and what each one refuses.
 
 The kwargs' semantics are v1's (``git show 722e30b9^:src/gen_worker/api/jobs.py``)
 with two deliberate deltas, both named at their assertion:

--- a/tests/test_producer_declarations.py
+++ b/tests/test_producer_declarations.py
@@ -11,10 +11,13 @@ with two deliberate deltas, both named at their assertion:
 1. ``emits_media`` is TRI-STATE here and a bool on ``@job``. Undeclared must
    stay the inference default, because on the request path the hub grants
    ``upload_media`` unconditionally.
-2. ``emits_media`` is NOT emitted on the manifest row. Measured at tensorhub
-   master: ``manifestFunction`` has no decoder for it, and
-   ``capability_subject_th2068.go:124`` sets ``UploadsMedia: true`` for every
-   request. A key on the wire that nothing reads is th#2087's own defect.
+2. ``emits_media`` rides a JOB-KIND row only (th#2177 narrowed this lane's
+   first ruling, which withheld it everywhere). On the REQUEST path
+   ``capability_subject_th2068.go:124`` sets ``UploadsMedia: true``
+   unconditionally and there is no column to store it in; on the JOB path
+   ``jobCapabilitySubject`` gates on ``endpoint_release_jobs.emits_media``,
+   which exists. Right about requests, wrong about jobs — so the fence
+   narrowed rather than reversed.
 
 ``publishes`` and ``env`` need NO hub change at all: the hub already decodes
 ``functions[].publishes`` / ``functions[].env``, and ``entrypoints[]`` folds
@@ -147,16 +150,56 @@ def test_a_non_publishing_row_omits_the_key(rows: dict[str, dict]) -> None:
     assert "env" not in rows["describe"]
 
 
-def test_emits_media_is_not_on_the_wire(rows: dict[str, dict]) -> None:
-    """DELIBERATE DELTA 2, and the reason is a measurement at tensorhub master.
+def test_emits_media_rides_a_job_kind_row_only(rows: dict[str, dict]) -> None:
+    """DELIBERATE DELTA 2, NARROWED rather than reversed (th#2177).
 
-    `manifestFunction` decodes `publishes` and `env`; it has NO `emits_media`
-    field, and the request path's `UploadsMedia` is an unconditional `true`.
-    Emitting the key would be a mirror with no reader — th#2087's fence exists
-    to catch exactly that. The declaration is enforced SDK-side instead (see
-    `test_an_explicit_emits_media_false_refuses_media`)."""
-    for row in rows.values():
-        assert "emits_media" not in row
+    Both halves are measured at tensorhub master and they disagree, which is
+    the whole point:
+
+    * REQUEST path — `capability_subject_th2068.go:124` sets
+      `UploadsMedia: true` unconditionally, `manifestFunction` has no field
+      and `endpoint_function_schemas` no COLUMN. Emitting on an inference row
+      is the mirror-with-no-reader th#2087's fence catches.
+    * JOB path — `jobCapabilitySubject` sets `UploadsMedia: d.EmitsMedia` from
+      `endpoint_release_jobs.emits_media`, a column that already exists. Here
+      the key is READ and it GATES, so withholding it would silently downgrade
+      a producer that declared media to no media at all.
+
+    So the first ruling was right about requests and did not survive a job.
+    `quality_matrix` and `score_bench` are job kinds and carry it; `describe`
+    and `cast_dtype` declared nothing and stay absent either way."""
+    assert rows["quality_matrix"]["emits_media"] is True   # kind="conversion"
+    assert rows["score_bench"]["emits_media"] is True      # kind="eval"
+    # Undeclared is ABSENT on every kind — the tri-state's whole purpose.
+    assert "emits_media" not in rows["cast_dtype"]         # job kind, undeclared
+    assert "emits_media" not in rows["clone_repo"]
+    assert "emits_media" not in rows["describe"]           # inference, undeclared
+
+
+def test_an_inference_row_never_carries_emits_media() -> None:
+    """The half of the fence that STAYS. An inference entrypoint that declares
+    the field explicitly still emits nothing, because nothing on the request
+    path can store or read it."""
+    from gen_worker.discovery.entrypoints_v2 import _entrypoint_row
+
+    module = type(sys)("pgw1406_inference_media")
+    module.__dict__["__name__"] = "pgw1406_inference_media"
+    sys.modules["pgw1406_inference_media"] = module
+    try:
+        exec(compile(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(emits_media=True)\n"
+            "def render(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1406_inference_media", "exec"), module.__dict__)
+        row = _entrypoint_row(getattr(module.render, ENTRYPOINT_ATTR))
+    finally:
+        sys.modules.pop("pgw1406_inference_media", None)
+
+    assert row["kind"] == "inference"
+    assert "emits_media" not in row
 
 
 def test_the_undeclared_row_is_byte_identical(rows: dict[str, dict]) -> None:

--- a/tests/test_producer_declarations.py
+++ b/tests/test_producer_declarations.py
@@ -293,12 +293,12 @@ def test_the_producer_context_carries_the_producer_surface() -> None:
     source/destination contract are on the class every entrypoint receives,
     and the DECLARATION — not the class — decides what may be written."""
     ctx: RequestContext = RequestContext(
-        "req-producer", publishes=True, source_info={"ref": "org/model:main"}
+        "req-producer", publishes=True, source_info={"ref": "org/model@r1"}
     )
     scratch = ctx.mktemp()
     assert scratch.is_dir()
     assert ctx.mktemp() != scratch
-    assert ctx.source == {"ref": "org/model:main"}
+    assert ctx.source == {"ref": "org/model@r1"}
     assert ctx.source_path is None
     ctx._set_source_path(str(scratch))
     assert ctx.source_path == str(scratch)

--- a/tests/test_producer_declarations_pgw1406.py
+++ b/tests/test_producer_declarations_pgw1406.py
@@ -35,7 +35,11 @@ import pytest
 from gen_worker.api.errors import MediaNotDeclaredError, PublishNotDeclaredError
 from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
 from gen_worker.serving.context import RequestContext
-from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR, EntrypointDeclarationError
+from gen_worker.serving.entrypoints import (
+    ENTRYPOINT_ATTR,
+    EntrypointDeclarationError,
+    EntrypointSpec,
+)
 
 FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
 MODULE = "producer_endpoint"
@@ -55,8 +59,9 @@ def rows(producers: ModuleType) -> dict[str, dict]:
     return {row["name"]: row for row in discover_entrypoints(MODULE)}
 
 
-def spec(fn: object) -> object:
-    return getattr(fn, ENTRYPOINT_ATTR)
+def spec(fn: object) -> EntrypointSpec:
+    stamped: EntrypointSpec = getattr(fn, ENTRYPOINT_ATTR)
+    return stamped
 
 
 # -- the declarations reach the spec ----------------------------------------

--- a/tests/test_producer_declarations_pgw1406.py
+++ b/tests/test_producer_declarations_pgw1406.py
@@ -1,0 +1,265 @@
+"""The producer plane's declarations on ``@entrypoint`` (pgw#1406 / th#2173).
+
+pgw#983 deleted ``@job``. All 27 conversion producers in ``cozy-creator/jobs``
+are ``@job`` functions and NOTHING there is written against ``@entrypoint``;
+the plane keeps running only because ``conversion/pyproject.toml:198`` pins
+the pre-#983 SDK. These tests pin the successor: the three declarations, what
+they emit, and what they refuse.
+
+The kwargs' semantics are v1's (``git show 722e30b9^:src/gen_worker/api/jobs.py``)
+with two deliberate deltas, both named at their assertion:
+
+1. ``emits_media`` is TRI-STATE here and a bool on ``@job``. Undeclared must
+   stay the inference default, because on the request path the hub grants
+   ``upload_media`` unconditionally.
+2. ``emits_media`` is NOT emitted on the manifest row. Measured at tensorhub
+   master: ``manifestFunction`` has no decoder for it, and
+   ``capability_subject_th2068.go:124`` sets ``UploadsMedia: true`` for every
+   request. A key on the wire that nothing reads is th#2087's own defect.
+
+``publishes`` and ``env`` need NO hub change at all: the hub already decodes
+``functions[].publishes`` / ``functions[].env``, and ``entrypoints[]`` folds
+into ``Functions`` at ParseManifest's one decode site (th#2146).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+
+from gen_worker.api.errors import MediaNotDeclaredError, PublishNotDeclaredError
+from gen_worker.discovery.entrypoints_v2 import discover_entrypoints
+from gen_worker.serving.context import RequestContext
+from gen_worker.serving.entrypoints import ENTRYPOINT_ATTR, EntrypointDeclarationError
+
+FIXTURES = Path(__file__).resolve().parent / "release_fixtures"
+MODULE = "producer_endpoint"
+
+
+@pytest.fixture(scope="module")
+def producers() -> Iterator[ModuleType]:
+    sys.path.insert(0, str(FIXTURES))
+    try:
+        yield importlib.import_module(MODULE)
+    finally:
+        sys.path.remove(str(FIXTURES))
+
+
+@pytest.fixture(scope="module")
+def rows(producers: ModuleType) -> dict[str, dict]:
+    return {row["name"]: row for row in discover_entrypoints(MODULE)}
+
+
+def spec(fn: object) -> object:
+    return getattr(fn, ENTRYPOINT_ATTR)
+
+
+# -- the declarations reach the spec ----------------------------------------
+
+
+def test_publishes_reaches_the_spec(producers: ModuleType) -> None:
+    assert spec(producers.cast_dtype).publishes is True
+    assert spec(producers.clone_repo).publishes is True
+    assert spec(producers.quality_matrix).publishes is True
+    # score_bench emits media and writes NO repo — the two are independent in
+    # both directions, exactly as they were on `@job`.
+    assert spec(producers.score_bench).publishes is False
+    assert spec(producers.describe).publishes is False
+
+
+def test_env_is_normalized_to_a_tuple(producers: ModuleType) -> None:
+    assert spec(producers.clone_repo).env == ("HF_TOKEN", "CIVITAI_API_KEY")
+    assert spec(producers.cast_dtype).env == ()
+
+
+def test_emits_media_is_tri_state(producers: ModuleType) -> None:
+    """DELIBERATE DELTA 1 from `@job`, which defaulted to False.
+
+    On the request path the hub grants `upload_media` unconditionally
+    (`capability_subject_th2068.go:124`), so an UNDECLARED entrypoint must
+    read as "not job-scoped" — None — and keep today's behaviour. Only an
+    explicit False opts out."""
+    assert spec(producers.quality_matrix).emits_media is True
+    assert spec(producers.score_bench).emits_media is True
+    assert spec(producers.describe).emits_media is None
+    assert spec(producers.cast_dtype).emits_media is None
+
+
+# -- what the manifest carries ----------------------------------------------
+
+
+def test_the_manifest_row_carries_publishes_and_env(rows: dict[str, dict]) -> None:
+    assert rows["cast_dtype"]["publishes"] is True
+    assert rows["clone_repo"]["publishes"] is True
+    assert rows["clone_repo"]["env"] == ["HF_TOKEN", "CIVITAI_API_KEY"]
+    assert rows["quality_matrix"]["publishes"] is True
+
+
+def test_a_non_publishing_row_omits_the_key(rows: dict[str, dict]) -> None:
+    """`omitempty` on both sides: absent IS "did not declare", which is the
+    fail-closed reading the hub's capability minter already uses."""
+    assert "publishes" not in rows["score_bench"]
+    assert "publishes" not in rows["describe"]
+    assert "env" not in rows["describe"]
+
+
+def test_emits_media_is_not_on_the_wire(rows: dict[str, dict]) -> None:
+    """DELIBERATE DELTA 2, and the reason is a measurement at tensorhub master.
+
+    `manifestFunction` decodes `publishes` and `env`; it has NO `emits_media`
+    field, and the request path's `UploadsMedia` is an unconditional `true`.
+    Emitting the key would be a mirror with no reader — th#2087's fence exists
+    to catch exactly that. The declaration is enforced SDK-side instead (see
+    `test_an_explicit_emits_media_false_refuses_media`)."""
+    for row in rows.values():
+        assert "emits_media" not in row
+
+
+def test_the_undeclared_row_is_byte_identical(rows: dict[str, dict]) -> None:
+    """pgw#1406 must be invisible to every endpoint that does not use it."""
+    assert set(rows["describe"]) == {
+        "name", "python_name", "module", "declared_module", "class_name",
+        "kind", "input_schema", "payload_schema_sha256", "output_schema",
+        "output_schema_sha256", "incremental_output", "slots",
+    }
+
+
+# -- what the declarations REFUSE -------------------------------------------
+
+
+def _probe(source: str, name: str) -> None:
+    module = type(sys)(name)
+    module.__dict__["__name__"] = name
+    sys.modules[name] = module
+    try:
+        exec(compile(source, name, "exec"), module.__dict__)
+    finally:
+        sys.modules.pop(name, None)
+
+
+def test_a_bare_string_env_is_refused() -> None:
+    """v1's rule, kept: a string would iterate into characters."""
+    with pytest.raises(EntrypointDeclarationError, match="iterate into"):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(env='HF_TOKEN')\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1406_env_str",
+        )
+
+
+@pytest.mark.parametrize(
+    "bad, match",
+    [("hf_token", "not a valid"), ("9LIVES", "not a valid"), ("A-B", "not a valid")],
+)
+def test_an_invalid_env_name_is_refused(bad: str, match: str) -> None:
+    with pytest.raises(EntrypointDeclarationError, match=match):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            f"@entrypoint(env=({bad!r},))\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            f"pgw1406_env_{abs(hash(bad))}",
+        )
+
+
+def test_a_repeated_env_name_is_refused() -> None:
+    with pytest.raises(EntrypointDeclarationError, match="repeats"):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(env=('HF_TOKEN', 'HF_TOKEN'))\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1406_env_dupe",
+        )
+
+
+def test_publishes_must_be_a_bool() -> None:
+    with pytest.raises(EntrypointDeclarationError, match="publishes= is a bool"):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(publishes='yes')\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1406_pub_str",
+        )
+
+
+# -- the SDK half of "one fact, two enforcers" ------------------------------
+
+
+def test_an_undeclared_function_is_refused_the_publisher_surface() -> None:
+    """The hub mints no repo-write grant for an undeclared function, so the
+    refusal arrives at the call site instead of after an upload."""
+    ctx: RequestContext = RequestContext("req-undeclared", publishes=False)
+    with pytest.raises(PublishNotDeclaredError):
+        ctx._require_publish_declaration("save_checkpoint")
+
+
+def test_a_declared_producer_reaches_the_publisher_surface() -> None:
+    ctx: RequestContext = RequestContext("req-declared", publishes=True)
+    ctx._require_publish_declaration("save_checkpoint")  # does not raise
+
+
+def test_an_explicit_emits_media_false_refuses_media() -> None:
+    ctx: RequestContext = RequestContext("req-nomedia", emits_media=False)
+    with pytest.raises(MediaNotDeclaredError):
+        ctx._require_media_declaration("save_file")
+
+
+def test_an_undeclared_context_keeps_intrinsic_media_authority() -> None:
+    """Every endpoint that never says the word is unchanged: media IS the
+    product of a request, and the hub grants it unconditionally."""
+    ctx: RequestContext = RequestContext("req-plain")
+    ctx._require_media_declaration("save_file")  # does not raise
+    assert ctx.emits_media is True
+
+
+# -- the serve loop stamps the declaration onto the body's context ----------
+
+
+def test_the_serve_loop_stamps_the_declaration(producers: ModuleType) -> None:
+    """The declaration is useless if the running body never sees it. This is
+    the wire from the spec to `ctx.publishes` the hub's grant mirrors."""
+    from gen_worker.serving.serve_loop import ServeLoop
+
+    host = object.__new__(ServeLoop)
+    host._context_kwargs = {}
+    host._output_dir = None
+
+    producer = host._make_context("r1", None, spec(producers.cast_dtype))
+    assert producer.publishes is True
+
+    control = host._make_context("r2", None, spec(producers.describe))
+    assert control.publishes is False
+    assert control.emits_media is True  # undeclared -> intrinsic
+
+
+def test_the_producer_context_carries_the_producer_surface() -> None:
+    """ONE context class (pgw#1294/pgw#1306): `mktemp` and the reserved
+    source/destination contract are on the class every entrypoint receives,
+    and the DECLARATION — not the class — decides what may be written."""
+    ctx: RequestContext = RequestContext(
+        "req-producer", publishes=True, source_info={"ref": "org/model:main"}
+    )
+    scratch = ctx.mktemp()
+    assert scratch.is_dir()
+    assert ctx.mktemp() != scratch
+    assert ctx.source == {"ref": "org/model:main"}
+    assert ctx.source_path is None
+    ctx._set_source_path(str(scratch))
+    assert ctx.source_path == str(scratch)

--- a/tests/test_producer_declarations_pgw1406.py
+++ b/tests/test_producer_declarations_pgw1406.py
@@ -77,6 +77,41 @@ def test_env_is_normalized_to_a_tuple(producers: ModuleType) -> None:
     assert spec(producers.cast_dtype).env == ()
 
 
+def test_kind_reaches_the_spec_and_the_row(
+    producers: ModuleType, rows: dict[str, dict]
+) -> None:
+    """The fourth gap, and the one the three ruled kwargs do not cover.
+
+    A producer that leaves `kind` at `inference` gets
+    `NamesReservedRefs(kind) == false` hub-side, so the reserved `source`
+    payload field it depends on is never resolved and never granted — the body
+    raises on its own first line. The vocabulary is copied verbatim from
+    `internal/functionkind.All`."""
+    assert spec(producers.cast_dtype).kind == "conversion"
+    assert spec(producers.score_bench).kind == "eval"
+    assert spec(producers.describe).kind == ""
+
+    assert rows["cast_dtype"]["kind"] == "conversion"
+    assert rows["score_bench"]["kind"] == "eval"
+    # Undeclared is the hub's own default, unchanged.
+    assert rows["describe"]["kind"] == "inference"
+
+
+def test_an_unknown_kind_is_refused() -> None:
+    """A value the hub does not normalize would silently become `inference`
+    — the exact silence this kwarg exists to end."""
+    with pytest.raises(EntrypointDeclarationError, match="kind= must be one of"):
+        _probe(
+            "import msgspec\n"
+            "from gen_worker import RequestContext, entrypoint\n"
+            "class I(msgspec.Struct): pass\n"
+            "class O(msgspec.Struct): pass\n"
+            "@entrypoint(kind='quantization')\n"
+            "def f(ctx: RequestContext, payload: I) -> O: ...\n",
+            "pgw1406_bad_kind",
+        )
+
+
 def test_emits_media_is_tri_state(producers: ModuleType) -> None:
     """DELIBERATE DELTA 1 from `@job`, which defaulted to False.
 


### PR DESCRIPTION
Closes the SDK half of **pgw#1406** and defuses **th#2173** (P0): pgw#983 deleted `@job`, all 27 conversion producers in `cozy-creator/jobs` are `@job`, and that plane runs only because `conversion/pyproject.toml:145` pins the pre-#983 SDK. This is the migration target.

> ## SCOPE, STATED UP FRONT — this PR is the AUTHOR SURFACE, not the whole port
>
> Escalated by the jobs-migration lane and **verified at tensorhub master by me before accepting it**: moving a producer from `jobs[]` to `entrypoints[]` moves it from the **SUBMIT** plane to the **INVOKE** plane, and a set of submit-only mechanisms have no function-side equivalent (details at the bottom). Nothing in this PR ships that move — `cozy-creator/jobs` still pins the old SDK and jobs#298 is a draft that says so. **Land this for the surface; do not read it as "the port is now safe to complete."**

## The four kwargs

`resources=` (pgw#1396) established the line: **function-scope declarations about PLACEMENT AND AUTHORITY ride the decorator; declarations about MODEL SLOTS ride the signature.**

```python
@entrypoint(kind="conversion", publishes=True, env=("HF_TOKEN", "CIVITAI_API_KEY"))
def cast_dtype(ctx: RequestContext, payload: CastDtypeInput) -> PublishResult: ...
```

`kind=` is the fourth, and it is **not** in pgw#1406's ruled list — it was found by driving the port. `entrypoints_v2` hardcoded `kind: "inference"`, and `functionkind.NamesReservedRefs("inference")` is **false**, so `parseReservedRepoArgs` (`orchestrator/http/invoke_helpers.go:406`) returns nil and the reserved `source` field every producer reads on line one is never resolved. It also picks the capability TTL (1h vs 24h) and whether disk is sized from the source. The vocabulary is copied verbatim from `internal/functionkind.All`; an unknown value is refused at decoration because `Normalize` would otherwise map it to `inference` silently.

## `publishes` / `env` / `kind` need no hub change — traced, not assumed

`manifestFunction` already decodes all three, and `entrypoints[]` folds into `Functions` at `ParseManifest`'s **one** decode site (th#2146), so `publishes` reaches `ReleaseFunctionSchema.Publishes` -> `invoke.go:1332` -> the capability JWT's `publishes` claim -> `callerDeclaresHubWrite`. That is the se#755 idiom: check what the hub already reads before inventing a term.

**This claim is about DECODE and AUTHORITY on the invoke path. It is not a claim that the whole jobs-to-entrypoints migration is hub-free.** See the scope box.

## `emits_media=` — two deliberate deltas

On the **request** path the hub grants `upload_media` **unconditionally** (`capability_subject_th2068.go:124`, `UploadsMedia: true`) because a request's product IS media; only the **job** path gates it. Therefore:

1. **Tri-state, not `@job`'s bool.** Undeclared stays the inference default. A hub read could only NARROW, and narrowing would fire on every existing endpoint that saves an image without declaring one.
2. **Not emitted on the manifest row.** `manifestFunction` has no field for it — and, as the jobs-migration lane correctly sharpened, `endpoint_function_schemas` has no COLUMN for it either (`0081_th2049_jobs.up.sql:83-90` says so). So it is a migration, not merely a missing reader. Emitting a key nothing can store is th#2087's fence case.

An explicit `emits_media=False` is enforced SDK-side at the media surface.

## One context class — what makes the port a re-decoration

`serving.RequestContext` gains `_PublisherMixin` and `mktemp()`: the publisher surface, the reserved `source`/`destination` contract, `hf_token`. Every one of them **already** refuses typed unless `publishes=True` was declared. This is pgw#1294/pgw#1306's own ruling applied — *"no kind selects a different class, because no kind decides what a body may write — the declaration does."* `JobContext` survived pgw#983 and is what the surface was re-homed from.

`ServeLoop._make_context` stamps the spec's declarations onto the context the body receives, so the SDK refusal and the hub's grant key on the same declaration — one fact, two enforcers.

## Proven by running the real path

- `discover_entrypoints` over a real on-disk fixture package of the five producer shapes measured in `jobs/conversion`.
- The **real `cast_dtype` body**, on branch `297-producer-port` of the jobs repo, over real safetensors, through a real `RequestContext`, with the real `streaming_cast_snapshot`. Emitted row: `{"name": "cast_dtype", "kind": "conversion", "publishes": true, "slots": []}`.
- 21 tests here + 5 there. `mypy src/gen_worker tests` clean (540 files). All 24 `ci.yaml` lint gates and `ruff` run locally, green.
- `fast gates` (the repo's only required check) **passes**. `tests` is red and is red on master too — the master run `32183074080` reports `fast gates` success / `tests` failure.
- `test_the_undeclared_row_is_byte_identical` pins that this is invisible to every endpoint that does not use it.

## Corrections to th#2173's inventory

`publishes=True` is on **22** of 27, not 24 — the filing inherited the number from `conversion/CHANGELOG.md` 0.12.0, which was true at 0.12.0 and stale at HEAD. The five without: `quant/h3_native_layout.py:701`, `quant/external_eval.py:953`, `score_bench.py:383`, `quant/h3_svdq.py:64`, `quant/h3_modulation_bake.py:463`. The pin is line **145**, not 198. Independently reproduced by the jobs-migration lane. `env=` 3, `emits_media=True` 4, `resources=` 17, and **zero** use `resumable=` / `visibility=` / `families=` / `name=`.

Also corrects `v1_deleted.REPLACEMENTS["job"]`, which told every porting author *"jobs have no v2 successor yet"* — the refusal is the one place they are guaranteed to read.

## What this PR does NOT solve (th#2173 follow-up, needs a ruling)

Measured at tensorhub master:

- `endpoint_release_jobs` is fed **only** from manifest `jobs[]` (`release_derivation.go:143` -> `JobContracts` -> `doc.Jobs`), and `jobs.Submit` reads **only** that table (`jobs/submit.go:173-186`). A row that arrives via `entrypoints[]` can never become a `tensorhub.jobs` row.
- **And pgw master can no longer emit `jobs[]` at all** — there is no `discover_jobs` and no `"jobs"` key anywhere in `gen_worker/discovery`. So the submit plane is unreachable by construction for any package built against master; keeping producers on it means rebuilding a `jobs[]` emitter, which the hardcut forbids.
- The invoke plane **does** handle producers and is intact (`invoke.go:1274`, `invoke_helpers.go:406` `parseReservedRepoArgs`) — that is the pre-th#2049 path, and `kind=` is exactly what re-arms it.
- What genuinely has no function-side equivalent: mirror-first's `submitPlatformJob` by job name; the job catalog/source routes; the scratch-to-durable promote; and the `resumable` / `visibility` / `source_file` / `emits_media` columns. Plus `ListUnpricedReleaseFunctions` (`endpoint_pricing.sql:205-222`) has **no kind filter**, so 27 newly-visible function schemas would each need a live `standard` price or promotion refuses — a failure that lands at promote time, not build time.

Whether producers belong on submit or invoke is a ruling, filed on th#2173. This PR is safe to land ahead of it: it adds a surface and changes nothing about what `cozy-creator/jobs` currently ships.
