### PR TITLE
pgw#1417: a card without its CAPABILITY is not a census that succeeded

### DIFF
--- a/src/gen_worker/procsplit/measure.py
+++ b/src/gen_worker/procsplit/measure.py
@@ -27,7 +27,7 @@ import os
 import logging
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 if TYPE_CHECKING:  # heavy edges stay off this module's import scope
     from ..hostfacts import HostFacts
@@ -60,22 +60,47 @@ def measure() -> Dict[str, Any]:
             break
         out.pop("hardware_error", None)
         out["hardware"] = facts.as_dict()
-        if not _census_is_empty(facts) or attempt == attempts - 1:
+        gaps = _census_gaps(facts)
+        if not gaps or attempt == attempts - 1:
             break
+        # Progressive: the CUDA runtime takes longer to come up than the
+        # driver does, so the attempt that closes a `capability` gap is
+        # usually later than the one that closes a `device` gap.
+        backoff = _CENSUS_BACKOFF_S * (attempt + 1)
         logger.warning(
-            "host census empty on attempt %d/%d while %s exists — a GPU was "
-            "assigned to this container, so this is UNREADABLE, not absent; "
-            "retrying in %.1fs (pgw#1414)",
-            attempt + 1, attempts,
+            "host census incomplete on attempt %d/%d (missing: %s) while %s "
+            "exists — a GPU was assigned to this container, so this is "
+            "UNREADABLE, not absent; retrying in %.1fs (pgw#1414/#1417)",
+            attempt + 1, attempts, ", ".join(gaps),
             next((n for n in _GPU_DEVICE_NODES if os.path.exists(n)), "?"),
-            _CENSUS_BACKOFF_S,
+            backoff,
         )
-        time.sleep(_CENSUS_BACKOFF_S)
+        time.sleep(backoff)
 
     if "hardware_error" not in out and gpu_devices_present():
         facts_dict = out.get("hardware") or {}
-        if not (facts_dict.get("gpu_count") or facts_dict.get("gpu_name")
-                or facts_dict.get("driver_version")):
+        if (facts_dict.get("gpu_count") or facts_dict.get("gpu_name")
+                or facts_dict.get("driver_version")) and not facts_dict.get("gpu_sm"):
+            # pgw#1417: the card came back, its COMPUTE CAPABILITY did not.
+            # Distinct from `census_unreadable` and distinctly worse to leave
+            # silent: this host registers as `class=gpu` and looks healthy,
+            # then refuses EVERY request with `gpu_capability_incompatible`,
+            # because pgw#984 derives `min_sm` on every v2 release. Not
+            # reporting an SM is not the same as not having one.
+            out["capability_unreadable"] = (
+                f"GPU {facts_dict.get('gpu_name') or '(unnamed)'} "
+                f"(driver {facts_dict.get('driver_version') or '?'}) was read, "
+                f"but its compute capability was not, across {attempts} "
+                f"attempt(s). `gpu_sm` is empty, so every request carrying a "
+                f"derived min_sm will refuse gpu_capability_incompatible. The "
+                f"CUDA RUNTIME, not the driver, answers this — the driver is "
+                f"clearly up."
+            )
+            logger.error(
+                "capability_unreadable: %s (pgw#1417)", out["capability_unreadable"]
+            )
+        elif not (facts_dict.get("gpu_count") or facts_dict.get("gpu_name")
+                  or facts_dict.get("driver_version")):
             # THE TYPED STATE. Not `hardware_error` — nothing raised — and not
             # silence, which is what let a cpu-class Hello leave this host.
             out["census_unreadable"] = (
@@ -156,7 +181,7 @@ _GPU_DEVICE_NODES = ("/dev/nvidiactl", "/dev/nvidia0", "/dev/nvidia-uvm")
 #: pgw#1414: a cold-start driver mount can lose a race with this census.
 #: Bounded, and short: the parent's whole measurement runs under
 #: `_MEASURE_TIMEOUT_S`, and a pod waiting here is a pod not serving.
-_CENSUS_RETRIES = 3
+_CENSUS_RETRIES = 4
 _CENSUS_BACKOFF_S = 1.5
 
 
@@ -177,9 +202,31 @@ def gpu_devices_present() -> bool:
     return any(os.path.exists(node) for node in _GPU_DEVICE_NODES)
 
 
-def _census_is_empty(facts: "HostFacts") -> bool:
-    """Nothing was learned about the silicon — not "a small GPU", nothing."""
-    return not facts.gpu_count and not facts.gpu_name and not facts.driver_version
+#: What a host holding GPU device nodes still OWES after a census attempt.
+#: pgw#1417: this was `_census_is_empty`, and "empty" was the wrong question.
+#: It asked *did we learn anything* when a GPU worker must answer *did we learn
+#: everything a GPU worker has to report*. Round 4 of the rental proof recovered
+#: `driver="580.173.02" gpu="NVIDIA GeForce RTX 4090" count=1` on the retry and
+#: BROKE OUT — because that satisfied "not empty" — while `gpu_sm` was still 0.
+#: The pod then registered `class=gpu` with no SM and every request refused
+#: `gpu_capability_incompatible`, since pgw#984 derives `min_sm` on EVERY v2
+#: release. A card with no capability is not a partial success; it is a worker
+#: that cannot be given work.
+#:
+#: The two gaps have DIFFERENT causes and appear at different times, which is
+#: why they are named separately: `device` is the driver mount (nvidia-smi/NVML)
+#: and `capability` is the CUDA RUNTIME (`cuda_ready()` +
+#: `torch.cuda.get_device_capability()`, `models/hub_policy.py:71`). The runtime
+#: comes up AFTER the driver, so a census can legitimately see the card one
+#: attempt before it can see the capability — which is exactly what round 4
+#: measured.
+def _census_gaps(facts: "HostFacts") -> Tuple[str, ...]:
+    """`()` when this census is complete enough to register a GPU worker."""
+    if not (facts.gpu_count or facts.gpu_name or facts.driver_version):
+        return ("device",)
+    if not facts.gpu_sm:
+        return ("capability",)
+    return ()
 
 
 def probe_hardware() -> "HostFacts":

--- a/tests/test_procsplit.py
+++ b/tests/test_procsplit.py
@@ -1486,8 +1486,19 @@ def _census(
     # this test's imports rather than about the code under test.
     monkeypatch.setattr("os.path.exists", lambda _p: devices)
     monkeypatch.setattr("time.sleep", lambda _s: None)
-    calls = iter(readings)
-    monkeypatch.setattr(measure_mod, "probe_hardware", lambda: next(calls))
+    # The LAST reading persists: a census condition that has not cleared by
+    # the final attempt has not cleared, and a helper that ran out of readings
+    # would raise StopIteration into the caller's `except Exception` and
+    # masquerade as `hardware_error`.
+    calls = list(readings)
+    state = {"i": 0}
+
+    def _next() -> Any:
+        reading = calls[min(state["i"], len(calls) - 1)]
+        state["i"] += 1
+        return reading
+
+    monkeypatch.setattr(measure_mod, "probe_hardware", _next)
     return measure_mod.measure()
 
 
@@ -1498,10 +1509,22 @@ def _blank_facts() -> Any:
 
 
 def _real_facts() -> Any:
+    """A COMPLETE census: card, driver AND compute capability."""
     from gen_worker.hostfacts import HostFacts
 
     return HostFacts(gpu_count=1, gpu_name="NVIDIA GeForce RTX 4090",
-                     driver_version="550.54", vram_total_bytes=24 << 30)
+                     driver_version="550.54", vram_total_bytes=24 << 30,
+                     gpu_sm="89")
+
+
+def _card_but_no_capability() -> Any:
+    """pgw#1417's ROUND-4 SHAPE, verbatim from the rented 4090: the driver is
+    up and names the card, and the CUDA runtime has not answered yet, so
+    `gpu_sm` is empty. `_census_is_empty` called this a success."""
+    from gen_worker.hostfacts import HostFacts
+
+    return HostFacts(gpu_count=1, gpu_name="NVIDIA GeForce RTX 4090",
+                     driver_version="580.173.02", vram_total_bytes=24 << 30)
 
 
 def test_an_empty_census_beside_gpu_device_nodes_is_UNREADABLE_pgw1414(
@@ -1538,3 +1561,46 @@ def test_a_genuinely_CARDLESS_host_stays_quiet_pgw1414(
     out = _census(monkeypatch, devices=False, readings=[_blank_facts()])
     assert "census_unreadable" not in out, out
     assert not out["hardware"].get("gpu_count")
+
+
+def test_a_card_without_its_CAPABILITY_keeps_retrying_pgw1417(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROUND 4 OF THE RENTAL PROOF, and the reason `empty` was the wrong test.
+
+    The retry recovered `driver=580.173.02 gpu=RTX 4090 count=1` and stopped,
+    because that is not "empty" — while `gpu_sm` was still 0. The pod then
+    registered `class=gpu` with no SM and refused every request with
+    `gpu_capability_incompatible`, since pgw#984 derives `min_sm` on every v2
+    release. The driver and the CUDA runtime come up at different times, so
+    seeing the card is NOT evidence of seeing its capability.
+    """
+    out = _census(monkeypatch, devices=True,
+                  readings=[_card_but_no_capability(), _real_facts()])
+    assert "capability_unreadable" not in out, out
+    assert "census_unreadable" not in out, out
+    assert out["hardware"]["gpu_sm"] == "89", out["hardware"]
+
+
+def test_a_capability_that_never_arrives_is_TYPED_not_silent_pgw1417(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A card whose capability never reads must not register quietly as a GPU
+    worker: it looks healthy and refuses every request, which is the shape
+    that billed for 703 declines one layer down."""
+    out = _census(monkeypatch, devices=True,
+                  readings=[_card_but_no_capability()] * 4)
+    assert out.get("capability_unreadable"), out
+    assert "gpu_capability_incompatible" in out["capability_unreadable"]
+    assert "CUDA RUNTIME" in out["capability_unreadable"]
+    # NOT the device-level state: the device was read perfectly well.
+    assert "census_unreadable" not in out, out
+
+
+def test_a_complete_census_first_time_never_retries_pgw1417(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The healthy path must not pay the backoff. One reading, no state."""
+    out = _census(monkeypatch, devices=True, readings=[_real_facts()])
+    assert "capability_unreadable" not in out and "census_unreadable" not in out
+    assert out["hardware"]["gpu_sm"] == "89"


### PR DESCRIPTION
Round 4 of the rental proof shows pgw#1414 WORKING — the retry recovered
`driver=580.173.02 gpu="NVIDIA GeForce RTX 4090" count=1`, `class=gpu gpu=1
fns=[generate]`. And then the pod refused every request with
`gpu_capability_incompatible`, because `gpu_sm` was empty.

**THE BUG IS MINE AND IT IS THE COMPLETENESS TEST.** `_census_is_empty` asked
*did we learn anything* when a GPU worker must answer *did we learn everything a
GPU worker has to report*. Recovering the card satisfied "not empty", so the
loop BROKE OUT on the attempt that read the driver — while the CUDA runtime,
which is what answers capability, had not come up yet.

The two facts have different sources and different timings, which is the whole
point and is why they are now named separately:

    device      nvidia-smi / NVML          — the DRIVER mount
    capability  cuda_ready() +
                torch.cuda.get_device_capability()   — the CUDA RUNTIME

The runtime comes up after the driver, so a census can legitimately see the card
one attempt before it can see the capability. `_census_gaps` replaces
`_census_is_empty` and retries on either gap; backoff is progressive (1.5, 3.0,
4.5 s over 4 attempts) because the attempt that closes a `capability` gap is
usually later than the one that closes a `device` gap. Still far inside the
parent's 180 s measurement budget.

A capability that never arrives gets its OWN typed state,
`capability_unreadable`, distinct from `census_unreadable` and worse to leave
silent: that host registers `class=gpu`, looks healthy, and refuses everything,
because pgw#984 derives `min_sm` on EVERY v2 release. Not reporting an SM is not
the same as not having one.

THE PLUMBING WAS NEVER THE PROBLEM — checked before writing any code:
`parent.py::_parent_resources` already passes `gpu_sm=hw.gpu_sm` into
`pb.WorkerResources`, and the proto has carried the field all along. The value
was empty because the census stopped early, not because it was dropped.

⚠️ **WHAT LOCAL PROOF CAN AND CANNOT ESTABLISH — stated, not implied.**
`python -m gen_worker.procsplit.measure` on a cardless box reports
`gpu_count 0 | gpu_sm '' | gpu_name ''`, which is BYTE-IDENTICAL to the broken
case on a GPU host. So an executable gate here passes a real fix and a no-op
alike; execution does not discriminate this one. What IS proven locally: the
classifier, red/green with injected census inputs both ways — with the
shipped-broken `_census_is_empty` restored, the round-4 case FAILS; with
`_census_gaps` it passes, and a complete first reading never pays the backoff.
What remains RENTAL-VERIFIED ONLY: that a real 4090's CUDA runtime answers
inside the retry window. That is the deploy lane's ~$0.03 verify rental, and
the rental is the gate, not a formality over one.

## Verification

| | |
|---|---|
| full `test_procsplit.py` | **58 passed** |
| pgw#1414 + pgw#1417 cases | 6 passed |
| red-verify | with the shipped-broken `_census_is_empty` restored, `test_a_card_without_its_CAPABILITY_keeps_retrying_pgw1417` **FAILS**; with `_census_gaps` it passes |
| production path | `python -m gen_worker.procsplit.measure` emits JSON, rc=0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)